### PR TITLE
Makes some of the documentation titles more consistently cased

### DIFF
--- a/docs/development/building_packaging.rst
+++ b/docs/development/building_packaging.rst
@@ -1,5 +1,5 @@
 ==========================================
-Building, packaging and distribution guide
+Building, Packaging and Distribution Guide
 ==========================================
 
 There is a central `setup.py`.  It defines which Python packages to

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -132,7 +132,7 @@ Coding Style/Conventions
 * Affiliated packages are required to follow the layout and documentation form
   of the template package included in the core package source distribution.
 
-Including C code
+Including C Code
 ----------------
 
 * C extensions are only allowed when they provide a significant performance
@@ -156,7 +156,7 @@ Including C code
   Style Guide for C Code <http://www.python.org/dev/peps/pep-0007/>`_ is
   recommended.
 
-Requirements specific to Affiliated Packages
+Requirements Specific to Affiliated Packages
 --------------------------------------------
 
 * Affiliated packages must be registered on the `Python Package Index
@@ -204,7 +204,7 @@ a get/set method. For lengthy or complex calculations, however, use a method::
     >>> print s.compute_color(5800, age=5e9)
     0.4
 
-super() vs. direct calling
+super() vs. Direct Calling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This example shows why the use of :func:`super` leads to a more consistent

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -405,8 +405,8 @@ The sections of the docstring are:
 Documenting classes
 ^^^^^^^^^^^^^^^^^^^
 
-Class docstring
-```````````````
+Class docstrings
+````````````````
 
 Use the same sections as outlined above (all except ``Returns`` are
 applicable). The constructor (``__init__``) should also be documented here,

--- a/docs/development/vision.rst
+++ b/docs/development/vision.rst
@@ -1,50 +1,110 @@
 .. _vision:
 
-Vision for a common Astronomy Python package
+============================================
+Vision for a Common Astronomy Python Package
 ============================================
 
-The following document summarizes a vision for a common Astronomy Python package, and how we can best all work together to achieve this. In the following document, this common package will be referred to as the core package. This vision is not set in stone, and we are committed to adapting it to whatever process and guidelines work in practice.
+The following document summarizes a vision for a common Astronomy Python
+package, and how we can best all work together to achieve this. In the
+following document, this common package will be referred to as the core
+package. This vision is not set in stone, and we are committed to adapting it
+to whatever process and guidelines work in practice.
 
-The ultimate goal that we seek is a package that would contain much of the core functionality and some common tools required across Astronomy, but not *everything* Astronomers will ever need. The aim is primarily to avoid duplication for common core tasks, and to provide a robust framework upon which to build more complex tools.
+The ultimate goal that we seek is a package that would contain much of the core
+functionality and some common tools required across Astronomy, but not
+*everything* Astronomers will ever need. The aim is primarily to avoid
+duplication for common core tasks, and to provide a robust framework upon which
+to build more complex tools.
 
-Such a common package should not preclude any other Astronomy package from existing, because there will always be more complex and/or specialized tools required. These tools will be able to rely on a single core library for many tasks, and thus reduce the number of dependencies, reduce duplication of functionality, and increase consistency of their interfaces.
+Such a common package should not preclude any other Astronomy package from
+existing, because there will always be more complex and/or specialized tools
+required. These tools will be able to rely on a single core library for many
+tasks, and thus reduce the number of dependencies, reduce duplication of
+functionality, and increase consistency of their interfaces.
 
 Procedure
 ---------
 
-With the help of the community, the coordination committee will start by identifying a few of key areas where initial development/consolidation will be needed (such as FITS, WCS, coordinates, tables, photometry, spectra, etc.) and will encourage teams to be formed to build standalone packages implementing this functionality. These packages will be referred to as affiliated packages (meaning that they are intended for future integration in the core package).
+With the help of the community, the coordination committee will start by
+identifying a few of key areas where initial development/consolidation will be
+needed (such as FITS, WCS, coordinates, tables, photometry, spectra, etc.) and
+will encourage teams to be formed to build standalone packages implementing
+this functionality. These packages will be referred to as affiliated packages
+(meaning that they are intended for future integration in the core package).
 
-A set of requirements will be set out concerning the interfaces and classes/methods that affiliated packages will need to make available in order to ensure consistency between the different components. As the core package grows, new potential areas/components for the core package will be identified. Competition cannot be avoided, and will not be actively discouraged, but whenever possible, developers should strive to work as a team to provide a single and robust affiliated package, for the benefit of the community.
+A set of requirements will be set out concerning the interfaces and
+classes/methods that affiliated packages will need to make available in order
+to ensure consistency between the different components. As the core package
+grows, new potential areas/components for the core package will be identified.
+Competition cannot be avoided, and will not be actively discouraged, but
+whenever possible, developers should strive to work as a team to provide a
+single and robust affiliated package, for the benefit of the community.
 
-The affiliated packages will be developed outside the core package in independent repositories, which will allow the teams the choice of tool and organization. Once an affiliated package has implemented the desired functionality, and satisfies quality criteria for coding style, documentation, and testing, it will be considered for inclusion in the core package, and further development will be done directly in the core package either via direct access to the repository, or via patches/pull requests (exactly how this will be done will be decided later).
+The affiliated packages will be developed outside the core package in
+independent repositories, which will allow the teams the choice of tool and
+organization. Once an affiliated package has implemented the desired
+functionality, and satisfies quality criteria for coding style, documentation,
+and testing, it will be considered for inclusion in the core package, and
+further development will be done directly in the core package either via direct
+access to the repository, or via patches/pull requests (exactly how this will
+be done will be decided later).
 
-To ensure uniformity across affiliated packages, and to facilitate integration with the core package, developers who wish to submit their affiliated packages for inclusion in the core will need to follow the layout of a ‘template’ package that will be provided before development starts.
+To ensure uniformity across affiliated packages, and to facilitate integration
+with the core package, developers who wish to submit their affiliated packages
+for inclusion in the core will need to follow the layout of a ‘template’
+package that will be provided before development starts.
 
 Dependencies
 ------------
 
-Affiliated packages should be able to be imported with only the following dependencies:
+Affiliated packages should be able to be imported with only the following
+dependencies:
 
-* The Python Standard Library
-* NumPy, SciPy, and Matplotlib
-* Components already in the core Astronomy package
+* The Python Standard Library NumPy, SciPy, and Matplotlib Components already
+  * in the core Astronomy package
 
-Other packages may be used, but must be imported as needed rather than during the initial import of the package.
+Other packages may be used, but must be imported as needed rather than during
+the initial import of the package.
 
-If a dependency is needed, but is an affiliated package, the dependent package will need to wait until the dependency is integrated into the core package before being itself considered for inclusion. In the mean time, it can make use of the other affiliated package in its current form, or other packages, so as not to stall development. Thus, the first packages to be included in the core will be those only requiring the standard library, NumPy, SciPy, and Matplotlib.
+If a dependency is needed, but is an affiliated package, the dependent package
+will need to wait until the dependency is integrated into the core package
+before being itself considered for inclusion. In the mean time, it can make use
+of the other affiliated package in its current form, or other packages, so as
+not to stall development. Thus, the first packages to be included in the core
+will be those only requiring the standard library, NumPy, SciPy, and
+Matplotlib.
 
-If the required dependency will never be part of a main package, then by default the dependency can be included but should be imported as needed (meaning that it only prevents the importing of that component, not the entire core package), unless a strong case is made and a general consensus is reached by the community that this dependency is important enough to be required at a higher level.
+If the required dependency will never be part of a main package, then by
+default the dependency can be included but should be imported as needed
+(meaning that it only prevents the importing of that component, not the entire
+core package), unless a strong case is made and a general consensus is reached
+by the community that this dependency is important enough to be required at a
+higher level.
 
-This system means that packages will be integrated into the core package in an order depending on the dependency tree, and also ensures that the interfaces of packages being integrated into the core package are consistent with those already in the core package.
+This system means that packages will be integrated into the core package in an
+order depending on the dependency tree, and also ensures that the interfaces of
+packages being integrated into the core package are consistent with those
+already in the core package.
 
-Initially, no dependency on GUI toolkits will be allowed in the core package. If the community reaches agrees on a single toolkit that could be used, then this toolkit will be allowed (but will only be imported as needed).
+Initially, no dependency on GUI toolkits will be allowed in the core package.
+If the community reaches agrees on a single toolkit that could be used, then
+this toolkit will be allowed (but will only be imported as needed).
 
 Keeping track of affiliated packages
 ------------------------------------
 
-Affiliated packages will be listed in a central location (in addition to PyPI) that will allow an easy installation of all the affiliated packages, for example with a script that will seamlessly download and install all the affiliated packages. The core package will also include mechanisms to facilitate this installation process.
+Affiliated packages will be listed in a central location (in addition to PyPI)
+that will allow an easy installation of all the affiliated packages, for
+example with a script that will seamlessly download and install all the
+affiliated packages. The core package will also include mechanisms to
+facilitate this installation process.
 
 Existing Packages
 -----------------
 
-Developers who already have existing packages will be encouraged to continue supporting them for the benefit of users until the core library is considered stable, contains this functionality, and is released to the community. Thereafter, developers should encourage users to transition to using the functionality in the core package, and eventually phase out their own packages, unless they provide added value over the core package.
+Developers who already have existing packages will be encouraged to continue
+supporting them for the benefit of users until the core library is considered
+stable, contains this functionality, and is released to the community.
+Thereafter, developers should encourage users to transition to using the
+functionality in the core package, and eventually phase out their own packages,
+unless they provide added value over the core package.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,14 @@
-.. Astropy documentation master file, created by
+.. AstroPy documentation master file, created by
    sphinx-quickstart on Tue Jul 26 02:59:34 2011.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Astropy's documentation!
+Welcome to AstroPy's Documentation!
 ===================================
 
-The current AstroPy documentation is limited, as no code has yet been developed.
-For more information, see the `github wiki <http://github.com/astropy/astropy/wiki>`_ page of the project.
+The current AstroPy documentation is limited, as not much code has yet been
+developed.  For more information, see the `github wiki
+<http://github.com/astropy/astropy/wiki>`_ page of the project.
 
 .. toctree::
    :maxdepth: 2
@@ -16,7 +17,7 @@ For more information, see the `github wiki <http://github.com/astropy/astropy/wi
    development/index
    wcs/index
 
-Indices and tables
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/docs/wcs/api.rst
+++ b/docs/wcs/api.rst
@@ -1,6 +1,6 @@
 .. include:: references.txt
 
-API documentation
+API Documentation
 =================
 
 :mod:`astropy.wcs`

--- a/docs/wcs/history.rst
+++ b/docs/wcs/history.rst
@@ -1,4 +1,4 @@
-astropy.wcs history
+astropy.wcs History
 ===================
 
 `astropy.wcs` began life as `pywcs`.  Earlier version numbers refer to

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -3,7 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-astropy.wcs documentation
+=========================
+astropy.wcs Documentation
 =========================
 
 Python wrappers, SIP, Paper IV support (BSD License):


### PR DESCRIPTION
This is really pedantic and low-priority.  But I noticed while working on porting the pyfits docs that some of the existing documentation wasn't consistent about title casing.

I don't necessarily think that all headings must use Title Case.  It should just be consistent across a heading level.  This attempts to make all headings that appear at the same level use the same casing.

This also inserted line breaks in one document that had long single-line paragraphs.
