### PR TITLE
nose dependency

### DIFF
--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -62,7 +62,7 @@ def test_maps():
             "test_maps has wrong number data files: found %d, expected "
             " %d, looking in %s" % (
                 len(hdr_file_list), n_data_files, ROOT_DIR))
-        # b.t.w.  If this assert happens, nose reports one more test
+        # b.t.w.  If this assert happens, py.test reports one more test
         # than it would have otherwise.
 
 
@@ -107,5 +107,5 @@ def test_spectra():
             "test_spectra has wrong number data files: found %d, expected "
             " %d, looking in %s" % (
                 len(hdr_file_list), n_data_files, ROOT_DIR))
-        # b.t.w.  If this assert happens, nose reports one more test
+        # b.t.w.  If this assert happens, py.test reports one more test
         # than it would have otherwise.

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -71,7 +71,7 @@ def test_maps():
             "test_maps has wrong number data files: found %d, expected "
             " %d, looking in %s" % (
                 len(hdr_file_list), n_data_files, ROOT_DIR))
-        # b.t.w.  If this assert happens, nose reports one more test
+        # b.t.w.  If this assert happens, py.test reports one more test
         # than it would have otherwise.
 
 
@@ -123,7 +123,7 @@ def test_spectra():
             "test_spectra has wrong number data files: found %d, expected "
             " %d, looking in %s" % (
                 len(hdr_file_list), n_data_files, ROOT_DIR))
-        # b.t.w.  If this assert happens, nose reports one more test
+        # b.t.w.  If this assert happens, py.test reports one more test
         # than it would have otherwise.
 
 

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import os
 import sys
 
-from nose.tools import raises
+from astropy.tests.helper import raises
 from numpy.testing import assert_array_equal
 import numpy as np
 


### PR DESCRIPTION
Hello,

I got this error while running tests:

```
========================================= ERRORS =========================================
___________________ ERROR collecting astropy/wcs/tests/test_wcsprm.py ____________________
astropy/wcs/tests/test_wcsprm.py:6: in <module>
>   from nose.tools import raises
E   ImportError: No module named nose.tools
========================== 851 passed, 1 error in 4.73 seconds ===========================
```

Should nose be added as a dependency?

Thanks,
Prasanth
