### PR TITLE
More setup.py/version fixes

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -3,8 +3,105 @@ This module contains a number of utilities for use during
 setup/build/packaging that are useful to astropy as a whole.
 """
 
-import os.path
+import os
 import sys
+from warnings import warn
+
+from distutils.dist import Distribution
+from distutils.errors import DistutilsError
+
+try:
+    import Cython
+    HAVE_CYTHON = True
+except ImportError:
+    HAVE_CYTHON = False
+
+
+def get_debug_option():
+    # Pre-parse the Distutils command-line options and config files to
+    # determine whether or not the --debug option was set.
+    # Normally the only options that allow the debug option are build,
+    # build_ext, and build_clib.  So for the sake of generality it's best to
+    # just use the build command.
+    dist = Distribution()
+    try:
+        dist.parse_config_files()
+        dist.parse_command_line()
+    except DistutilsError:
+        # Let distutils handle this itself
+        return None
+
+    debug_build_cmds = ['build', 'build_ext', 'build_clib']
+
+    # First ensure that one of the commands that accepts --debug is being run
+    for cmd in debug_build_cmds:
+        if cmd in dist.commands:
+            break
+    else:
+        return None
+
+    for cmd in debug_build_cmds:
+        cmd_opts = dist.get_option_dict(cmd)
+        if 'debug' in cmd_opts:
+            debug = bool(cmd_opts['debug'][1])
+            break
+    else:
+        debug = False
+
+    try:
+        from astropy.version import debug as current_debug
+    except ImportError:
+        current_debug is None
+
+    if current_debug is not None and current_debug != debug:
+        # Force rebuild of extension modules
+        sys.argv.extend(['build', '--force'])
+
+    return debug
+
+
+def iter_setup_packages():
+    # Find all of the setup_package.py modules, import them, and add them
+    # to the setup_packages list.
+    for root, dirs, files in os.walk('astropy'):
+        if 'setup_package.py' in files:
+            name = root.replace(os.path.sep, '.') + '.setup_package'
+            module = import_module(name)
+            yield module
+
+
+def iter_pyx_files():
+    for dirpath, dirnames, filenames in os.walk('astropy'):
+        modbase = dirpath.replace(os.sep, '.')
+        for fn in filenames:
+            if fn.endswith('.pyx'):
+                fullfn = os.path.join(dirpath, fn)
+                # Package must match file nam
+                extmod = modbase + '.' + fn[:-4]
+                yield (extmod, fullfn)
+
+
+def get_cython_extensions():
+    # Look for Cython files - compile with Cython if it is not a release
+    # and Cython is installed. Otherwise, use the .c files that live next
+    # to the Cython files.
+    from astropy.version import release
+
+    ext_modules = []
+    if not release and HAVE_CYTHON:
+        # Add .pyx files
+        for extmod, pyxfn in iter_pyx_files():
+            ext_modules.append(Extension(extmod, [pyxfn]))
+    else:
+        # Add .c files
+        for extmod, pyxfn in iter_pyx_files():
+            cfn = pyxfn[:-4] + '.c'
+            if os.path.exists(cfn):
+                ext_modules.append(Extension(extmod, [cfn]))
+            else:
+                warn('Could not find Cython-generated C extension {0} - '
+                     'The {1} module will be skipped.'.format(cfn, extmod))
+    return ext_modules
 
 
 def write_if_different(filename, data):

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -165,7 +165,7 @@ MSVC, do not support string literals greater than 256 characters.
 
 
 def get_extensions():
-    from astropy.version import release
+    from astropy.version import debug
 
     write_wcsconfig_h()
     generate_c_docstrings()
@@ -228,7 +228,7 @@ def get_extensions():
     extra_compile_args = []
     extra_link_args = []
 
-    if not release:
+    if debug:
         define_macros.append(('DEBUG', None))
         undef_macros.append('NDEBUG')
         if not sys.platform.startswith('sun') and \

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ use_setuptools()
 
 import os
 import glob
-from setuptools import setup, find_packages, Extension
-from warnings import warn
+from setuptools import setup, find_packages
 
 import astropy
+from astropy import setup_helpers
 from astropy.version_helper import _get_git_devstr, _generate_version_py
 
 
@@ -18,18 +18,7 @@ RELEASE = not VERSION.endswith('dev')
 
 if not RELEASE:
     VERSION += _get_git_devstr(False)
-_generate_version_py(VERSION, RELEASE)
-
-from astropy import setup_helpers
-
-# Find all of the setup_package.py modules, import them, and add them
-# to the setup_packages list.
-setup_packages = []
-for root, dirs, files in os.walk('astropy'):
-    if 'setup_package.py' in files:
-        name = root.replace(os.path.sep, '.') + '.setup_package'
-        module = setup_helpers.import_module(name)
-        setup_packages.append(module)
+_generate_version_py(VERSION, RELEASE, setup_helpers.get_debug_option())
 
 # Use the find_packages tool to locate all packages and modules other than
 # those that are in tests/
@@ -52,7 +41,7 @@ cmdclassd = {}
 # A dictionary to keep track of all package data to install
 package_data = {'astropy': ['data/*']}
 
-# C extensions that are not Cython-based should be added here.
+# Additional C extensions that are not Cython-based should be added here.
 extensions = []
 
 # Extra data files
@@ -60,7 +49,7 @@ data_files = []
 
 # For each of the setup_package.py modules, extract any information
 # that is needed to install them.
-for package in setup_packages:
+for package in setup_helpers.iter_setup_packages():
     if hasattr(package, 'get_extensions'):
         extensions.extend(package.get_extensions())
     if hasattr(package, 'get_package_data'):
@@ -68,45 +57,11 @@ for package in setup_packages:
     if hasattr(package, 'get_data_files'):
         data_files.extend(package.get_data_files())
 
-# Look for Cython files - compile with Cython if it is not a release
-# and Cython is installed. Otherwise, use the .c files that live next
-# to the Cython files.
+extensions.extend(setup_helpers.get_cython_extensions())
 
-try:
-    import Cython
-    have_cython = True
-except ImportError:
-    have_cython = False
-
-pyxfiles = []
-for  dirpath, dirnames, filenames in os.walk('astropy'):
-    modbase = dirpath.replace(os.sep, '.')
-    for fn in filenames:
-        if fn.endswith('.pyx'):
-            fullfn = os.path.join(dirpath, fn)
-            extmod = modbase + '.' + fn[:-4]  # Package must match file name
-            pyxfiles.append((extmod, fullfn))
-
-if not RELEASE and have_cython:
-
-    from Cython.Distutils import build_ext as cython_build_ext
-    cmdclassd['build_ext'] = cython_build_ext
-
-    # Add .pyx files
-    for extmod, pyxfn in pyxfiles:
-        extensions.append(Extension(extmod, [pyxfn]))
-
-else:
-
-    # Add .c files
-    for extmod, pyxfn in pyxfiles:
-        cfn = pyxfn[:-4] + '.c'
-        if os.path.exists(cfn):
-            extensions.append(Extension(extmod, [cfn]))
-        else:
-            warnstr = 'Could not find Cython-generated C extension ' + \
-                 '{0} - The {1} module will be skipped.'.format(cfn, extmod)
-            warn(warnstr)
+if setup_helpers.HAVE_CYTHON and not RELEASE:
+    from Cython.Distutils import build_ext
+    cmdclassd['build_ext'] = build_ext
 
 # Implement a version of build_sphinx that automatically creates the
 # docs/_build dir - this is needed because github won't create the _build dir
@@ -134,8 +89,6 @@ try:
 
 except ImportError:  # Sphinx not present
     pass
-
-
 
 
 setup(name='astropy',


### PR DESCRIPTION
These are two fixes that resulted from an exchange I had with @eteq earlier.

The first is the get rid of a `BUILD` variable in setup.py that was an artifact of PyWCS's setup.py.  Instead it uses `astropy.version.release` which has in effect the same semantics (theoretically one might want to do a 'release' build while still under development, but in that remote case the developer may manually remove 'dev' from the version).

The second is another fix to the version.py template.  It's now much simpler than before and does not rely on any obscure (and unreliable) machinery in pkg_resources.  Instead it just checks if astropy is being imported from within a git working copy, and if so it updates the version string if necessary.  If astropy is not being imported from within a git working dir then the version is left "frozen".
