### PR TITLE
Fix OS-X Lion build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ from astropy.version_helper import _get_git_devstr, _generate_version_py
 VERSION = '0.0dev'
 RELEASE = not VERSION.endswith('dev')
 
+# Adjust the compiler in case the default on this platform is to use a
+# broken one.
+setup_helpers.adjust_compiler()
+
 if not RELEASE:
     VERSION += _get_git_devstr(False)
 _generate_version_py(VERSION, RELEASE, setup_helpers.get_debug_option())


### PR DESCRIPTION
If the default compiler ends up being the broken one from XCode-4.2, switch to using clang instead
