### PR TITLE
Fix the raises() decorator to support functions that take arguments

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -179,5 +179,5 @@ class raises:
     def __call__(self, func):
         @functools.wraps(func)
         def run_raises_test(*args, **kwargs):
-            pytest.raises(self._exc, func)
+            pytest.raises(self._exc, func, *args, **kwargs)
         return run_raises_test


### PR DESCRIPTION
Fix the raises() decorator to support functions that take arguments (including methods, parametrized tests, etc).

I encountered this while porting the PyFITS tests which use test classes.
