### PR TITLE
Fix for  "python setup.py --help"

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -19,9 +19,7 @@ except ImportError:
 
 
 def get_distutils_option(option, commands):
-    """
-    Returns the value of the given distutils option.  If the option is not
-    set, returns None.
+    """ Returns the value of the given distutils option.  
 
     Parameters
     ----------
@@ -30,6 +28,12 @@ def get_distutils_option(option, commands):
 
     commands : list of str
         The list of commands on which this option is available
+        
+    Returns
+    -------
+    val : str or None
+        the value of the given distutils option. If the option is not set,
+        returns None.
     """
     # Pre-parse the Distutils command-line options and config files to
     # if the option is set.
@@ -40,7 +44,10 @@ def get_distutils_option(option, commands):
     except DistutilsError:
         # Let distutils handle this itself
         return None
-
+    except AttributeError:
+        # This seems to get thrown for ./setup.py --help
+        return None
+    
     for cmd in commands:
         if cmd in dist.commands:
             break


### PR DESCRIPTION
In the current version, `python setup.py --help` leads to a traceback, due to setup_helpers triggering a bug (or perhaps feature?) in distutils.   This patch gets around it by simply catching the exception distutils throws and continuing on with the astropy script.

This is quite simple, but I'm not entirely sure what this function is used for, so @iguananaut may want to glance at it before I merge it.
