### PR TITLE
Failures in tests with Python 3.2

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -239,5 +239,5 @@ def test_fixes():
         assert len(w) == 3
         for item in w:
             assert issubclass(item.category, wcs.FITSFixedWarning)
-            if 'unitfix' in item.message:
-                assert 'Hz' in item.message
+            if 'unitfix' in str(item.message):
+                assert 'Hz' in str(item.message)


### PR DESCRIPTION
As of 7946471129146d93abcbe731171a4a5adbdc3454, two tests have issues with Python 3.2:

```
============================= test session starts ==============================
platform darwin -- Python 3.2.2 -- pytest-2.1.2
collected 940 items / 1 errors 

Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/tests/tests/test_run_tests.py ..
Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/tests/tests/test_skip_remote_data.py s
Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/utils/tests/test_odict.py sssssssssssssssssssssssssssssssssssssssssss
Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/wcs/tests/test_profiling.py..................................
Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/wcs/tests/test_wcs.py ......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F
Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/wcs/tests/test_wcsprm.py .....................................................................................

==================================== ERRORS ====================================
 ERROR collecting Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/constants/tests/test_constant.py 
_pytest.runner:99: in __init__
>   ???
_pytest.main:290: in _memocollect
>   ???
_pytest.main:214: in _memoizedcall
>   ???
_pytest.main:290: in <lambda>
>   ???
_pytest.python:175: in collect
>   ???
_pytest.python:99: in fget
>   ???
_pytest.python:225: in _getobj
>   ???
_pytest.main:214: in _memoizedcall
>   ???
_pytest.python:230: in _importtestmodule
>   ???
py._path.local:529: in pyimport
>   ???
Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/constants/__init__.py:29: in <module>
>   for nm, val in sorted(si.__dict__.iteritems()):
E   AttributeError: 'dict' object has no attribute 'iteritems'
=================================== FAILURES ===================================
__________________________________ test_fixes __________________________________

    def test_fixes():
        """
        From github issue #36
        """
        def run():
            header = open(os.path.join(ROOT_DIR, 'data', 'nonstandard_units.hdr'),
                          'rb').read()
            w = wcs.WCS(header)

        import warnings
        with warnings.catch_warnings(record=True) as w:
            warnings.simplefilter("always")
            run()
>           assert len(w) == 3
E           assert 4 == 3
E            +  where 4 = len([<warnings.WarningMessage object at 0x104194650>, <warnings.WarningMessage object at 0x104194690>, <warnings.WarningMessage object at 0x1041946d0>, <warnings.WarningMessage object at 0x104194710>])

Library/Python/3.2/lib/python/site-packages/astropy-0.0dev_r255-py3.2-macosx-10.6-x86_64.egg/astropy/wcs/tests/test_wcs.py:238: AssertionError
========== 1 failed, 895 passed, 44 skipped, 1 error in 9.86 seconds ===========
```

@eteq and @mdboom, these relate to code you wrote in constants/**init**.py and wcs/tests respectively.
