### PR TITLE
Return status code from `python setup.py test`

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -164,7 +164,7 @@ class astropy_test(Command):
         # Run the tests in a subprocess--this is necessary since new extension
         # modules may have appeared, and this is the easiest way to set up a
         # new environment
-        cmd = 'import astropy; astropy.test({0!r}, {1!r}, {2!r}, {3!r}, {4!r})'
+        cmd = 'import astropy, sys; sys.exit(astropy.test({0!r}, {1!r}, {2!r}, {3!r}, {4!r}))'
         cmd = cmd.format(self.module, self.args, self.plugins,
                          self.verbose_results, self.pastebin)
         raise SystemExit(subprocess.call([sys.executable, '-c', cmd],


### PR DESCRIPTION
When the tests fail running `python setup.py test`, a non-zero error status code should be returned to the shell.  This makes integrating with a CI system such as buildbot easier, as well as writing shell scripts that continue only if the tests pass, etc.
