### PR TITLE
Bump minimum Numpy version to 1.4

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -191,8 +191,8 @@ def check_numpy():
     import numpy
 
     major, minor, rest = numpy.__version__.split(".", 2)
-    if (int(major), int(minor)) < (1, 3):
-        msg = "numpy version 1.3 or later must be installed to build astropy"
+    if (int(major), int(minor)) < (1, 4):
+        msg = "numpy version 1.4 or later must be installed to build astropy"
         raise ImportError(msg)
 
 


### PR DESCRIPTION
1.3 has some problems with byteswapping complex numbers that makes supporting them in `io.vo` almost impossible.  I know @iguananaut had mentioned that 1.3 support for the upcoming `io.fits` is also annoying.  Should we just bite the bullet and drop 1.3?
