### PR TITLE
Check that py.test 2.2.0 or later is being used for external installation

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -28,7 +28,7 @@ try:
        version.LooseVersion('2.2.0'):
        
         msg = ("py.test 2.2.0 or later is required, but version {0} found." +
-               " Falling back on py.test budled with astropy.")
+               " Falling back on py.test bundled with astropy.")
         warn(VersionWarning(msg.format(pytest.__version__)))
         raise ImportError(msg.format(pytest.__version__))
 


### PR DESCRIPTION
This implements something similar to what Mark suggested on the astropy-dev mailing list. This is just a suggestion, but just so we actually have some code to discuss. This would mean that we can safely make use of modern features of py.test, and only affects people with old system installations. One possible modification would be to raise an ImportError which would then import the built-in one. Then the only thing I'm not sure about is what happens if someone runs the tests with py.test 2.1 on the command-line, and the bundled one gets imported in tests/helper.py...
