### PR TITLE
WCS build fails on Mac

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -356,7 +356,7 @@ def adjust_compiler():
     import re
 
     compiler_mapping = [
-        (b'i686-apple-darwin[0-9]*-llvm-gcc-4.2', b'clang')
+        (b'i686-apple-darwin[0-9]*-llvm-gcc-4.2', 'clang')
         ]
 
     c = ccompiler.new_compiler()


### PR DESCRIPTION
I'm not sure when this was introduced, but as of 7a7884fef8747dc90c5dd4abfe76c8dad4da1b8b, astropy does not compile on Mac:

```
/Developer/usr/bin/llvm-gcc-4.2 -fno-strict-aliasing -fno-common -dynamic -pipe -O2 -fwrapv -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DECHO -DWCSTRIG_MACRO -DASTROPY_WCS_BUILD -D_GNU_SOURCE -DWCSVERSION=4.8.2 -DNDEBUG -UDEBUG -I/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/numpy/core/include -I/Users/tom/tmp/astropy/astropy/wcs/src/wcslib/C -I/Users/tom/tmp/astropy/astropy/wcs/src -I/opt/local/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c /Users/tom/tmp/astropy/astropy/wcs/src/wcslib/C/wcserr.c -o build/temp.macosx-10.6-x86_64-2.7/Users/tom/tmp/astropy/astropy/wcs/src/wcslib/C/wcserr.o
/Users/tom/tmp/astropy/astropy/wcs/src/wcslib/C/wcserr.c:140: internal compiler error: Segmentation fault
Please submit a full bug report,
with preprocessed source if appropriate.
See <URL:http://developer.apple.com/bugreporter> for instructions.
{standard input}:0:End-of-File not at end of a line
{standard input}:116:End-of-File not at end of a line
{standard input}:unknown:Partial line at end of file ignored
{standard input}:unknown:Undefined local symbol L_.str
{standard input}:unknown:Undefined local symbol L_.str1
{standard input}:unknown:Undefined local symbol L_.str2
error: command '/Developer/usr/bin/llvm-gcc-4.2' failed with exit status 1
```

I'm assigning this to @mdboom since the error occurs with compiling the WCS files.
