### PR TITLE
Add py.test minimum version to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,5 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [pytest]
+minversion = 2.2
 norecursedirs = build docs/_build


### PR DESCRIPTION
Added `minversion = 2.2` to `[pytest]` section of `setup.cfg` so that py.test checks its own version.
