### PR TITLE
find_current_module finddiff option

### DIFF
--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -6,3 +6,4 @@ def test_pkg_finder():
     #note that this also implicitly tests compat.misc._patched_getmodule
     assert misc.find_current_module(0).__name__ == 'astropy.utils.misc'
     assert misc.find_current_module(1).__name__ == 'astropy.utils.tests.test_misc'
+    assert misc.find_current_module(0,True).__name__ == 'astropy.utils.tests.test_misc'


### PR DESCRIPTION
This adjusts the `astropy.utils.misc.find_current_module` function to have a `finddiff` keyword that, if True, searches back in the call stack until a different module is found.  This is needed for both  PR #108 and PR #104
