### PR TITLE
Use bundled pytest

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -13,10 +13,16 @@ import subprocess
 
 from distutils.core import Command
 
-try:
+from ..config import ConfigurationItem
+
+USE_SYSTEM_PYTEST = ConfigurationItem('use_system_pytest', False,
+                                      'Set to True to load system pytest',
+                                      'boolean', 'astropy.tests.helper')
+
+if USE_SYSTEM_PYTEST():
     import pytest
 
-except ImportError:
+else:
     from ..extern import pytest as extern_pytest
 
     if sys.version_info >= (3, 0):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,5 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [pytest]
+minversion = 2.2
 norecursedirs = build docs/_build


### PR DESCRIPTION
Since #76 doesn't seem to work this is my next favorite option: `astropy.tests.helper` loads the bundled py.test unless the user has set a config option called `use_system_pytest`. I've also added the `minversion=2.2` option to `setup.cfg` to warn users of the version requirement. I've confirmed that this setup works even with py.test version 2.1 installed on my system.

@eteq, let me know if I've misused the config system.
