### PR TITLE
Test what will be installed, not the source tree.

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -190,13 +190,10 @@ class astropy_test(Command, object):
         pass
 
     def run(self):
-        self.reinitialize_command('build_py', inplace=False)
-        self.run_command('build_py')
-        build_py_cmd = self.get_finalized_command('build_py')
-        new_path = os.path.abspath(build_py_cmd.build_lib)
-
-        self.reinitialize_command('build_ext', inplace=True)
-        self.run_command('build_ext')
+        self.reinitialize_command('build', inplace=False)
+        self.run_command('build')
+        build_cmd = self.get_finalized_command('build')
+        new_path = os.path.abspath(build_cmd.build_lib)
 
         # Run the tests in a subprocess--this is necessary since new extension
         # modules may have appeared, and this is the easiest way to set up a


### PR DESCRIPTION
I know I'm been pushing on this issue for a while -- I think it would be helpful to have a discussion on this topic in one place.

The current implementation of `python setup.py test` builds C extensions "in place" in the source tree and then tests in the source tree.  On python3, since 2to3 needs to be run over the source tree, it builds and then tests under the `build` directory.

This has a number of problems that I encounter on a regular basis:

1) Fundamentally, we're not testing what's being delivered.  If a data file was inadvertently not added to `package_data`, a test will still pass even though the file is not being installed and the feature will break for real users.  This means running `python setup.py test` and then building a tarball from that directory does not ensure that the tarball will also pass the tests.

2) Anything that relies on code generation doesn't work.  `2to3` is one example, but we also code-generate the compatibility shims for `pywcs` and `vo.table`.  There is currently no way to test these using `python setup.py test`.

3) Forcing a rebuild of C extensions requires doing something like `git clean -fd`, which may delete things other than just build products and is therefore potentially dangerous.  `rm -rf build` is much safer.

4) python2 and 3 are being tested in a different way.  This means that tests that pass under 2 may fail under 3, for reasons that have nothing to do with the differences between the languages.  (See the missing data file example).

So what are the advantages of testing in-place?  Besides shaving a few seconds off of copying files, I can't see any.  (And that's made moot by the present implementation which actually first builds under `build` and then inplace anyway.)  Is there anything others are relying on that would be missed by making this change?
