### PR TITLE
Wcs/windows compilation

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -245,10 +245,13 @@ def get_extensions():
         undef_macros.append('DEBUG')
 
     if sys.platform == 'win32':
-        define_macros.append(('YY_NO_UNISTD_H', None))
-        define_macros.append(('_CRT_SECURE_NO_WARNINGS', None))
-        define_macros.append(('_NO_OLDNAMES', None))  # for mingw32
-        define_macros.append(('NO_OLDNAMES', None))  # for mingw64
+        define_macros.extend([
+            ('YY_NO_UNISTD_H', None),
+            ('_CRT_SECURE_NO_WARNINGS', None),
+            ('_NO_OLDNAMES', None),  # for mingw32
+            ('NO_OLDNAMES', None),  # for mingw64
+            ('__STDC__', None)  # for MSVC
+            ])
 
     if sys.platform.startswith('linux'):
         define_macros.append(('HAVE_SINCOS', None))

--- a/astropy/wcs/src/util.c
+++ b/astropy/wcs/src/util.c
@@ -7,6 +7,7 @@
 
 #include "util.h"
 #include <math.h>
+#include <float.h>
 
 void set_invalid_to_nan(
     const int ncoord,
@@ -20,7 +21,12 @@ void set_invalid_to_nan(
   const int* s_end = stat + ncoord;
   double n;
 
-  n = nan("");
+  #ifndef NAN
+    #define INF (DBL_MAX+DBL_MAX)
+    #define NAN (INF-INF)
+  #endif
+
+  n = NAN;
 
   for ( ; s != s_end; ++s) {
     if (*s) {

--- a/astropy/wcs/src/wcslib_units_wrap.c
+++ b/astropy/wcs/src/wcslib_units_wrap.c
@@ -146,7 +146,7 @@ PyUnits_init(
 PyUnits___str__(
     PyUnits* self) {
 
-  const size_t BUF_SIZE = 1 << 8;
+  #define BUF_SIZE (1 << 8)
   char buffer[BUF_SIZE];
   char scale[BUF_SIZE];
   char offset[BUF_SIZE];


### PR DESCRIPTION
This is just some minor fixes to make WCS compile under Microsoft Visual Studio 9.0 and 10.0, ported from pywcs.
