### PR TITLE
Properly verify the `unit` attribute in VOTable files

### DIFF
--- a/astropy/io/vo/exceptions.py
+++ b/astropy/io/vo/exceptions.py
@@ -990,6 +990,17 @@ class W49(VOTableSpecWarning):
     message = "Empty cell illegal for integer fields."
 
 
+class W50(VOTableSpecWarning):
+    """
+    Invalid unit string as defined in the `Standards for Astronomical
+    Catalogues, Version 2.0
+    <http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx>`_.
+    """
+
+    message = "Invalid unit string '%s'"
+    default_args = ('x',)
+
+
 class E01(VOWarning, ValueError):
     """
     The size specifier for a ``char`` or ``unicode`` field must be

--- a/astropy/io/vo/tests/unit_test.py
+++ b/astropy/io/vo/tests/unit_test.py
@@ -1,0 +1,54 @@
+from .. import unit
+
+
+def test_units():
+    strings = [
+        # These first few are from the spec document itself
+        ('mW/m2'       , True),
+        ('0.1nm'       , True),
+        ('solMass3/2'  , False),
+        ('[solMass]'   , True),
+        ('0.1 nm'      , False),
+        ('km/s'        , True),
+        ('km / s'      , False),
+        ('km s-1.'     , False),
+        ('10pix/nm'    , True),
+        ('pix/0.1nm'   , False),
+        ('pix/(0.1nm)' , False),
+        ('1.5x10+11m'  , True),
+        ('kW.h'        , True),
+        ('kWh'         , False),
+        ('m2'          , True),
+        ('uarcsec'     , True),
+
+        # These are additional tests
+        ('w'                  , False),
+        ('+1.0m/s'            , True),
+        ('1.0x10+11m/s+10+11' , True),
+        ('mm'                 , True),
+        ('Om'                 , False)
+        ]
+
+    def run(args):
+        s, correct = args
+        print s, correct
+        assert unit.is_unit(s) == correct
+
+    for s, correct in strings:
+        yield run, (s, correct)
+
+
+def test_basic_units():
+    def run(args):
+        prefix, u = args
+        print prefix, u
+        assert unit.is_unit(prefix + u)
+        assert unit.is_unit('[' + prefix + u + ']')
+
+    for u in unit.unit_names:
+        yield run, ('', u)
+
+    for p in unit.unit_prefixes:
+        for u in unit.unit_names:
+            yield run, (p, u)
+

--- a/astropy/io/vo/tree.py
+++ b/astropy/io/vo/tree.py
@@ -39,6 +39,7 @@ from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
     W41, W42, W43, W44, W45, W48, E06, E08, E09, E10, E11, E12, E13,
     E14, E15, E16, E17, E18, E19, E20, E21)
 from . import ucd as ucd_mod
+from .unit import check_unit
 from . import util
 from . import xmlutil
 
@@ -642,10 +643,9 @@ class Info(SimpleElementWithContent, _IDProperty, _XtypeProperty,
 
     @unit.setter
     def unit(self, unit):
-        # TODO: Validate unit more accurately
         if unit is not None and not self._config.get('version_1_2_or_later'):
             warn_or_raise(W28, W28, ('unit', 'INFO', '1.2'), config, pos)
-        xmlutil.check_token(unit, 'unit', self._config, self._pos)
+        check_unit(unit, 'unit', self._config, self._pos)
         self._unit = unit
 
     @unit.deleter
@@ -1166,8 +1166,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
 
     @unit.setter
     def unit(self, unit):
-        # TODO: Validate unit more accurately
-        xmlutil.check_token(unit, 'unit', self._config, self._pos)
+        check_unit(unit, 'unit', self._config, self._pos)
         self._unit = unit
 
     @unit.deleter

--- a/astropy/io/vo/unit.py
+++ b/astropy/io/vo/unit.py
@@ -1,0 +1,61 @@
+"""
+Tools to verify the syntax of unit attributes according to the
+`Standards for Astronomical Catalogues, Version 2.0
+<http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx>`_
+"""
+
+# STDLIB
+import re
+
+# LOCAL
+from .exceptions import warn_or_raise, W50
+
+
+__all__ = ['unit_names', 'unit_prefixes', 'is_unit', 'check_unit']
+
+
+unit_names = """
+    - % a A AU arcmin arcsec barn bit byte C cd ct D d deg eV F g h H
+    Hz J Jy K lm lx m mag mas min mol N Ohm Pa pc pix rad Ry s S
+    solLum solMass solRad Sun sr T V W Wb yr
+    """.split()
+
+
+unit_prefixes = """
+    d c m u n p f a z y da h k M G T P E Z Y
+    """.split()
+
+
+_unit_name_regex = '|'.join('(?:{0})'.format(x) for x in unit_names)
+_unit_prefix_regex = '|'.join('(?:{0})'.format(x) for x in unit_prefixes)
+
+
+def is_unit(s):
+    """
+    Returns `True` if *s* is a valid unit string as defined by
+    `Standards for Astronomical Catalogues, Version 2.0
+    <http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx>`_
+    """
+    number = r'[+\-]?[0-9]+(?:\.[0-9]*)?(?:[+\-][0-9]+)?'
+    factor = r'{0}(?:x{0})?'.format(number)
+    unit = r'(?:{0})?(?:{1})'.format(_unit_prefix_regex, _unit_name_regex)
+    bracketed_unit = r'(?:{0})|(?:\[{0}\])'.format(unit)
+    expression = (
+        r'^(?P<factor>{0})?(?P<unit>{1})(?P<subunit>[/.]{1})?(?P<power>{2})?$'.format(
+        factor, bracketed_unit, number))
+
+    match = re.match(expression, s)
+    return match is not None
+
+
+def check_unit(unit, attr_name, config={}, pos=None):
+    """
+    Raises a `ValueError` if *unit* is not a valid unit as defined by
+    `Standards for Astronomical Catalogues, Version 2.0
+    <http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx>`_
+    """
+    if (unit is not None and not is_unit(unit)):
+        warn_or_raise(W50, W50, unit, config, pos)
+        return False
+    return True
+

--- a/docs/vo/api.rst
+++ b/docs/vo/api.rst
@@ -13,6 +13,7 @@ Public API
    api_converters.rst
    api_exceptions.rst
    api_ucd.rst
+   api_unit.rst
    api_util.rst
    api_validator.rst
    api_xmlutil.rst

--- a/docs/vo/api_unit.rst
+++ b/docs/vo/api_unit.rst
@@ -1,0 +1,10 @@
+.. include:: references.txt
+
+`astropy.io.vo.unit`: Verification of units as defined in the VOTable standard
+==============================================================================
+
+.. automodule:: astropy.io.vo.unit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+


### PR DESCRIPTION
This performs verification on unit attributes.  It doesn't really parse them and know anything about them, but once we have a units framework in astropy, it would be useful to be able to convert to and from the format used by VOTABLE files (and this is hopefully a starting point for that).
