### PR TITLE
Prevent py.test from looking for conftest.py files above source directory

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -146,6 +146,11 @@ class TestRunner(object):
             else:
                 all_args += ' --pep8 -k pep8'
 
+        # Prevent py.test from searching for conftest.py files above the
+        # astropy source directory. This assumes that py.test is run in
+        # build/lib...
+        all_args += ' --confcutdir=../../'
+
         return pytest.main(args=all_args, plugins=plugins)
 
 


### PR DESCRIPTION
This implements a fix for #127. Since tests are built in build/lib*/ py.test should not look at conftest.py files more that two directories away.
