### PR TITLE
Move the py.test conftest.py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ distribute-*.tar.gz
 # Other
 .*.swp
 *~
+
+# Mac OSX
+.DS_Store

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -2,4 +2,4 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the astropy tree.
 
-from astropy.tests.pytest_plugins import *
+from .tests.pytest_plugins import *


### PR DESCRIPTION
Moved the conftest.py file one directory level up in the to the astropy directory so that it gets installed with the rest of astropy. Changed the import of plugins accordingly. See #128.

Also updated the .gitignore file so it ignores the Mac OS X .DS_Store file.
