### PR TITLE
Allow passing a FITS filename to the WCS constructor

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -7,7 +7,15 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 
 from ... import wcs
-from ...config import get_data_filenames, get_data_contents
+from ...config import get_data_filenames, get_data_contents, get_data_filename
+from ...tests.helper import pytest
+
+try:
+    import pyfits
+    HAS_PYFITS = True
+except ImportError:
+    HAS_PYFITS = False
+
 
 # test_maps() is a generator
 def test_maps():
@@ -228,3 +236,8 @@ def test_outside_sky():
     assert np.all(np.isnan(w.wcs_pix2sky([[200.,200.]], 0)))  # outside sky
     assert not np.any(np.isnan(w.wcs_pix2sky([[1000.,1000.]], 0)))
 
+
+@pytest.mark.skipif("not HAS_PYFITS")
+def test_load_fits_path():
+    fits = get_data_filename('data/sip.fits')
+    w = wcs.WCS(fits)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -31,6 +31,7 @@ from __future__ import division  # confidence high
 # STDLIB
 import copy
 import io
+import os
 import sys
 import warnings
 
@@ -55,7 +56,7 @@ if _wcs is not None:
            "on your platform."
 
 if sys.version_info[0] >= 3:
-    string_types = (bytes,)
+    string_types = (bytes, str)
 else:
     string_types = (str, unicode)
 
@@ -244,7 +245,16 @@ class WCS(WCSBase):
             keysel_flags = _parse_keysel(keysel)
 
             if isinstance(header, string_types):
-                header_string = header
+                if HAS_PYFITS and os.path.exists(header):
+                    if fobj is not None:
+                        raise ValueError(
+                            "Can not provide both a FITS filename to "
+                            "argument 1 and a FITS file object to argument 2")
+                    fobj = pyfits.open(header)
+                    header = fobj[0].header
+                    header_string = repr(header.ascard).encode('latin1')
+                else:
+                    header_string = header
             elif HAS_PYFITS:
                 assert isinstance(header, pyfits.Header)
                 header_string = repr(header.ascard).encode('latin1')


### PR DESCRIPTION
The docs have said you could for a long time -- however, it turns out
you can't.

This is a backport of r2480 in pywcs.
