### PR TITLE
Build broken on Windows using mingw32

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -122,8 +122,6 @@ def get_compiler_option():
 
     """
 
-    adjust_compiler()
-
     compiler = get_distutils_option('compiler',
                                     ['build', 'build_ext', 'build_clib'])
     if compiler is None:


### PR DESCRIPTION
I'm trying to set up a build bot of Astropy for Windows (specifically XP). I don't have any of the Windows compilers installed, and am instead using mingw32:

```
./setup.py build_ext -c mingw32
```

Which gives me an error over the `/MANIFEST` switch that gets added. Unfortunately, Astropy adds that switch if sys.platform is windows, regardless of which compiler is being used.  It should go by compiler instead of platform using the `get_distutils_option()` function.

I confirmed by manually removing the `/MANIFEST` part, and the build succeeded (a few of the vo tests are failing on Windows for me, but everything else seems good).
