### PR TITLE
Record compiler used in version.py

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -128,7 +128,16 @@ def get_compiler_option():
                                     ['build', 'build_ext', 'build_clib'])
     if compiler is None:
         import distutils.ccompiler
-        return distutils.ccompiler.get_default_compiler()
+        compiler = distutils.ccompiler.get_default_compiler()
+
+    try:
+        from astropy.version import compiler as current_compiler
+    except ImportError:
+        current_compiler = None
+
+    if current_compiler is not None and current_compiler != compiler:
+        # Force rebuild of extension modules
+        sys.argv.extend(['build', '--force'])
 
     return compiler
 

--- a/astropy/version_helper.py
+++ b/astropy/version_helper.py
@@ -154,12 +154,13 @@ bugfix = {bugfix}
 
 release = {rel}
 debug = {debug}
+compiler = {compiler!r}
 
 
 """[1:]
 
 
-def _get_version_py_str(packagename, version, release, debug):
+def _get_version_py_str(packagename, version, release, debug, compiler):
 
     import datetime
 
@@ -175,10 +176,12 @@ def _get_version_py_str(packagename, version, release, debug):
                                               major=major,
                                               minor=minor,
                                               bugfix=bugfix,
-                                              rel=release, debug=debug)
+                                              rel=release, debug=debug,
+                                              compiler=compiler)
 
 
-def generate_version_py(packagename, version, release, debug=None):
+def generate_version_py(packagename, version, release, debug=None,
+                        compiler=None):
     """Regenerate the version.py module if necessary."""
 
     import os
@@ -186,15 +189,18 @@ def generate_version_py(packagename, version, release, debug=None):
 
     try:
         version_module = __import__(packagename + '.version',
-                                    fromlist=['version', 'release', 'debug'])
-        current_version = version_module.version
-        current_release = version_module.release
-        current_debug = version_module.debug
+                                    fromlist=['version', 'release', 'debug',
+                                              'compiler'])
+        current_version = getattr(version_module, 'version', None)
+        current_release = getattr(version_module, 'release', None)
+        current_debug = getattr(version_module, 'debug', None)
+        current_compiler = getattr(version_module, 'compiler', None)
     except ImportError:
         version_module = None
         current_version = None
         current_release = None
         current_debug = None
+        current_compiler = None
 
     if debug is None:
         # Keep whatever the current value is, if it exists
@@ -203,14 +209,15 @@ def generate_version_py(packagename, version, release, debug=None):
     version_py = os.path.join(packagename, 'version.py')
 
     if (current_version != version or current_release != release or
-        current_debug != debug):
+        current_debug != debug or current_compiler != compiler):
         if '-q' not in sys.argv and '--quiet' not in sys.argv:
             log.set_threshold(log.INFO)
         log.info('Freezing version number to {0}'.format(version_py))
 
         with open(version_py, 'w') as f:
             # This overwrites the actual version.py
-            f.write(_get_version_py_str(packagename, version, release, debug))
+            f.write(_get_version_py_str(packagename, version, release, debug,
+                                        compiler))
 
         if version_module:
             imp.reload(version_module)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup_helpers.set_build_mode()
 if not release:
     version += get_git_devstr(False)
 generate_version_py('astropy', version, release,
-                    setup_helpers.get_debug_option())
+                    setup_helpers.get_debug_option(),
+                    setup_helpers.get_compiler_option())
 
 # Use the find_packages tool to locate all packages and modules
 packagenames = find_packages()


### PR DESCRIPTION
This patch depends on the pull request in #139.

While working on #139 I thought it might be useful, for diagnostic purposes if nothing else, to record the compiler that was used to build extension modules.  For example, if a user is having some odd problem with an extension module we could ask them to give us astropy.version.compiler.

There are a couple things lacking in this current implementation:

1) This is only based on the `--compiler` option to setup.py.  This is not useless, but it may mean different actual compilers on different platforms.  It would be more useful if we also included the compiler version.  Unfortunately there's no one guaranteed way to get this.  Some variant of `CC --version` should work most of the time, but can't be counted on.  Perhaps we could _try_ something obvious like that, and if it fails then just go with "Unknown version" or some such.

2) This will include a 'compiler' value in version.py even when making a source distribution--a context in which it's mostly meaningless.  This is mostly harmless, since when the user builds from source the version.py will be rewritten with the correct compiler.  But I might consider amending this to somehow leave compiler out of version.py when running the `sdist` command.
