### PR TITLE
3 io.vo tests failing on Windows

### DIFF
--- a/astropy/config/tests/test_data.py
+++ b/astropy/config/tests/test_data.py
@@ -43,7 +43,7 @@ def test_local_data_obj():
 
     with get_data_fileobj('data/local.dat') as f:
         f.readline()
-        assert f.read()==b'CONTENT\n'
+        assert f.read().rstrip() == b'CONTENT'
 
 def test_local_data_name():
     from ..data import get_data_filename

--- a/astropy/io/vo/util.py
+++ b/astropy/io/vo/util.py
@@ -56,7 +56,7 @@ def convert_to_writable_filelike(fd):
                     real_fd.flush()
                     return
             else:
-                with io.open(fd, 'w', encoding='utf8') as real_fd:
+                with io.open(fd, 'wt', encoding='utf8') as real_fd:
                     yield real_fd
                     return
         else:
@@ -67,7 +67,7 @@ def convert_to_writable_filelike(fd):
                     real_fd.flush()
                     return
             else:
-                with open(fd, 'wb') as real_fd:
+                with io.open(fd, 'wb') as real_fd:
                     yield real_fd
                     return
     elif hasattr(fd, 'write'):


### PR DESCRIPTION
Here's a snipped copy of the error output:

```
=================================== FAILURES ===================================
_____________________________ test_local_data_obj ______________________________

    def test_local_data_obj():
        from ..data import get_data_fileobj

        with get_data_fileobj('data/local.dat') as f:
            f.readline()
>           assert f.read()==b'CONTENT\n'
E           assert 'CONTENT\r\n' == 'CONTENT\n'
E               CONTENT

astropy\config\tests\test_data.py:46: AssertionError
_______________________________ test_regression ________________________________

    @pytest.mark.xfail('pyfits304x')
    def test_regression():
>       _test_regression(False)

astropy\io\vo\tests\vo_test.py:190: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

_python_based = False

    def _test_regression(_python_based=False):
        # Read the VOTABLE
        votable = parse(
            get_data_filename('data/regression.xml'),
            pedantic=False,
            _debug_python_based_parser=_python_based)
        table = votable.get_first_table()

        assert table.array.dtype == [
            (('string test', 'string_test'), '|O8'),
            (('fixed string test', 'string_test_2'), '|S10'),
            ('unicode_test', '|O8'),
            (('unicode test', 'fixed_unicode_test'), '<U10'),
            (('string array test', 'string_array_test'), '|S4'),
            ('unsignedByte', '|u1'),
            ('short', '<i2'),
            ('int', '<i4'),
            ('long', '<i8'),
            ('double', '<f8'),
            ('float', '<f4'),
            ('array', '|O8'),
            ('bit', '|b1'),
            ('bitarray', '|b1', (3, 2)),
            ('bitvararray', '|O8'),
            ('bitvararray2', '|O8'),
            ('floatComplex', '<c8'),
            ('doubleComplex', '<c16'),
            ('doubleComplexArray', '|O8'),
            ('doubleComplexArrayFixed', '<c16', (2,)),
            ('boolean', '|b1'),
            ('booleanArray', '|b1', (4,)),
            ('nulls', '<i4'),
            ('nulls_array', '<i4', (2, 2)),
            ('precision1', '<f8'),
            ('precision2', '<f8'),
            ('doublearray', '|O8'),
            ('bitarray2', '|b1', (16,))
            ]

        votable.to_xml(join(TMP_DIR, "regression.tabledata.xml"),
                       _debug_python_based_parser=_python_based)
        assert_validate_schema(join(TMP_DIR, "regression.tabledata.xml"))
        votable.get_first_table().format = 'binary'
        votable.to_xml(join(TMP_DIR, "regression.binary.xml"),
                       _debug_python_based_parser=_python_based)
        assert_validate_schema(join(TMP_DIR, "regression.binary.xml"))
        votable2 = parse(join(TMP_DIR, "regression.binary.xml"), pedantic=False,
                         _debug_python_based_parser=_python_based)
        votable2.get_first_table().format = 'tabledata'
        votable2.to_xml(join(TMP_DIR, "regression.bin.tabledata.xml"),
                        _astropy_version="testing",
                        _debug_python_based_parser=_python_based)
        assert_validate_schema(join(TMP_DIR, "regression.bin.tabledata.xml"))

        with get_data_fileobj(
            'data/regression.bin.tabledata.truth.xml') as fd:
            truth = fd.readlines()
        with open(join(TMP_DIR, "regression.bin.tabledata.xml"), 'rb') as fd:
            output = fd.readlines()

        # If the lines happen to be different, print a diff
        # This is convenient for debugging
        for line in difflib.unified_diff(truth, output):
            if IS_PY3K:
                sys.stdout.write(
                    line.decode('utf-8').
                    encode('string_escape').
                    replace('\\n', '\n'))
            else:
                sys.stdout.write(
                    line.encode('string_escape').
                    replace('\\n', '\n'))

>       assert truth == output
E       assert ['<?xml versi...ata\r\n', ...] == ['<?xml versio... data\n', ...]
E         At index 0 diff: '<?xml version="1.0" encoding="utf-8"?>\r\n' != '<?xml version="1.0" encoding="utf-8"?>\n'

astropy\io\vo\tests\vo_test.py:175: AssertionError
------------------------------- Captured stdout --------------------------------
astropy\io\vo\exceptions.py:71: E02: c:\windows\temp\tmpvr5w9j\regression.binary.xml:16:1: E02: Incorrect number of elements in array. Expected multiple of 0, got 2
  warn(warning)
astropy\io\vo\exceptions.py:71: W48: c:\windows\temp\tmpvr5w9j\regression.binary.xml:45:5: W48: Unknown attribute 'value' on OPTION
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: c:\windows\temp\tmpvr5w9j\regression.binary.xml:167:7: E02: Incorrect number of elements in array. Expected multiple of 4, got 1
  warn(warning)
astropy\io\vo\exceptions.py:71: W49: c:\windows\temp\tmpvr5w9j\regression.binary.xml:167:7: W49: Empty cell illegal for integer fields.
  warn(warning)
--- 
+++ 
@@ -1,302 +1,302 @@
-<?xml version="1.0" encoding="utf-8"?>\r
-<!-- Produced with astropy.io.vo version testing\r
-     http://www.astropy.org/ -->\r
-<VOTABLE version="1.1" xmlns="http://www.ivoa.net/xml/VOTable/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.1">\r
- <DESCRIPTION>\r
-  The VOTable format is an XML standard for the interchange of data\r
-  represented as a set of tables. In this context, a table is an\r
-  unordered set of rows, each of a uniform format, as specified in the\r
-  table metadata. Each row in a table is a sequence of table cells,\r
-  and each of these contains either a primitive data type, or an array\r
-  of such primitives. VOTable is derived from the Astrores format [1],\r
-  itself modeled on the FITS Table format [2]; VOTable was designed to\r
-  be closer to the FITS Binary Table format.\r
- </DESCRIPTION>\r
- <COOSYS ID="J2000" equinox="J2000" system="eq_FK5"/>\r
- <PARAM ID="wrong_arraysize" arraysize="0" datatype="float" name="wrong_arraysize" value=" "/>\r
- <PARAM ID="INPUT" arraysize="*" datatype="float" name="INPUT" ucd="phys.size;instr.tel" unit="deg" value="0 0">\r
-  <DESCRIPTION>\r
-   This is the most interesting parameter in the world, and it drinks\r
-   Dos Equis\r
-  </DESCRIPTION>\r
- </PARAM>\r
...snip...
-</VOTABLE>\r
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Produced with astropy.io.vo version testing
+     http://www.astropy.org/ -->
+<VOTABLE version="1.1" xmlns="http://www.ivoa.net/xml/VOTable/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.1">
+ <DESCRIPTION>
+  The VOTable format is an XML standard for the interchange of data
+  represented as a set of tables. In this context, a table is an
+  unordered set of rows, each of a uniform format, as specified in the
+  table metadata. Each row in a table is a sequence of table cells,
+  and each of these contains either a primitive data type, or an array
+  of such primitives. VOTable is derived from the Astrores format [1],
+  itself modeled on the FITS Table format [2]; VOTable was designed to
+  be closer to the FITS Binary Table format.
+ </DESCRIPTION>
+ <COOSYS ID="J2000" equinox="J2000" system="eq_FK5"/>
+ <PARAM ID="wrong_arraysize" arraysize="0" datatype="float" name="wrong_arraysize" value=" "/>
+ <PARAM ID="INPUT" arraysize="*" datatype="float" name="INPUT" ucd="phys.size;instr.tel" unit="deg" value="0 0">
+  <DESCRIPTION>
+   This is the most interesting parameter in the world, and it drinks
+   Dos Equis
+  </DESCRIPTION>
+ </PARAM>
...snip...
+</VOTABLE>
_____________________ test_regression_python_based_parser ______________________

    @pytest.mark.xfail('pyfits304x')
    def test_regression_python_based_parser():
>       _test_regression(True)

astropy\io\vo\tests\vo_test.py:195: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

_python_based = True

    def _test_regression(_python_based=False):
        # Read the VOTABLE
        votable = parse(
            get_data_filename('data/regression.xml'),
            pedantic=False,
            _debug_python_based_parser=_python_based)
        table = votable.get_first_table()

        assert table.array.dtype == [
            (('string test', 'string_test'), '|O8'),
            (('fixed string test', 'string_test_2'), '|S10'),
            ('unicode_test', '|O8'),
            (('unicode test', 'fixed_unicode_test'), '<U10'),
            (('string array test', 'string_array_test'), '|S4'),
            ('unsignedByte', '|u1'),
            ('short', '<i2'),
            ('int', '<i4'),
            ('long', '<i8'),
            ('double', '<f8'),
            ('float', '<f4'),
            ('array', '|O8'),
            ('bit', '|b1'),
            ('bitarray', '|b1', (3, 2)),
            ('bitvararray', '|O8'),
            ('bitvararray2', '|O8'),
            ('floatComplex', '<c8'),
            ('doubleComplex', '<c16'),
            ('doubleComplexArray', '|O8'),
            ('doubleComplexArrayFixed', '<c16', (2,)),
            ('boolean', '|b1'),
            ('booleanArray', '|b1', (4,)),
            ('nulls', '<i4'),
            ('nulls_array', '<i4', (2, 2)),
            ('precision1', '<f8'),
            ('precision2', '<f8'),
            ('doublearray', '|O8'),
            ('bitarray2', '|b1', (16,))
            ]

        votable.to_xml(join(TMP_DIR, "regression.tabledata.xml"),
                       _debug_python_based_parser=_python_based)
        assert_validate_schema(join(TMP_DIR, "regression.tabledata.xml"))
        votable.get_first_table().format = 'binary'
        votable.to_xml(join(TMP_DIR, "regression.binary.xml"),
                       _debug_python_based_parser=_python_based)
        assert_validate_schema(join(TMP_DIR, "regression.binary.xml"))
        votable2 = parse(join(TMP_DIR, "regression.binary.xml"), pedantic=False,
                         _debug_python_based_parser=_python_based)
        votable2.get_first_table().format = 'tabledata'
        votable2.to_xml(join(TMP_DIR, "regression.bin.tabledata.xml"),
                        _astropy_version="testing",
                        _debug_python_based_parser=_python_based)
        assert_validate_schema(join(TMP_DIR, "regression.bin.tabledata.xml"))

        with get_data_fileobj(
            'data/regression.bin.tabledata.truth.xml') as fd:
            truth = fd.readlines()
        with open(join(TMP_DIR, "regression.bin.tabledata.xml"), 'rb') as fd:
            output = fd.readlines()

        # If the lines happen to be different, print a diff
        # This is convenient for debugging
        for line in difflib.unified_diff(truth, output):
            if IS_PY3K:
                sys.stdout.write(
                    line.decode('utf-8').
                    encode('string_escape').
                    replace('\\n', '\n'))
            else:
                sys.stdout.write(
                    line.encode('string_escape').
                    replace('\\n', '\n'))

>       assert truth == output
E       assert ['<?xml versi...ata\r\n', ...] == ['<?xml versio... data\n', ...]
E         At index 0 diff: '<?xml version="1.0" encoding="utf-8"?>\r\n' != '<?xml version="1.0" encoding="utf-8"?>\n'

astropy\io\vo\tests\vo_test.py:175: AssertionError
------------------------------- Captured stdout --------------------------------
astropy\io\vo\exceptions.py:71: W17: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:89:2: W17: GROUP element contains more than one DESCRIPTION element
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:103:28: W46: char value is too long for specified length of 10
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:105:28: W46: unicodeChar value is too long for specified length of 10
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:106:11: W46: char value is too long for specified length of 4
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:125:7: E02: Incorrect number of elements in array. Expected multiple of 4, got 1
  warn(warning)
astropy\io\vo\exceptions.py:71: W49: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:125:7: W49: Empty cell illegal for integer fields.
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:133:17: W46: char value is too long for specified length of 10
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:136:17: W46: char value is too long for specified length of 4
  warn(warning)
astropy\io\vo\exceptions.py:71: W49: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:140:6: W49: Empty cell illegal for integer fields.
  warn(warning)
astropy\io\vo\exceptions.py:71: W01: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:143:18: W01: Array uses commas rather than whitespace
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:159:7: E02: Incorrect number of elements in array. Expected multiple of 16, got 0
  warn(warning)
astropy\io\vo\exceptions.py:71: W49: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:159:7: W49: Empty cell illegal for integer fields.
  warn(warning)
astropy\io\vo\exceptions.py:71: W49: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:159:7: W49: Empty cell illegal for integer fields. (suppressing further warnings of this type...)
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:165:17: W46: unicodeChar value is too long for specified length of 10
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:189:7: E02: Incorrect number of elements in array. Expected multiple of 16, got 0
  warn(warning)
astropy\io\vo\exceptions.py:71: W01: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:203:13: W01: Array uses commas rather than whitespace
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:205:7: E02: Incorrect number of elements in array. Expected multiple of 6, got 0
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:213:7: E02: Incorrect number of elements in array. Expected multiple of 4, got 1
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:219:7: E02: Incorrect number of elements in array. Expected multiple of 16, got 0
  warn(warning)
astropy\io\vo\exceptions.py:71: W01: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:233:12: W01: Array uses commas rather than whitespace
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:235:7: E02: Incorrect number of elements in array. Expected multiple of 6, got 0
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:243:7: E02: Incorrect number of elements in array. Expected multiple of 4, got 1
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:245:7: E02: Incorrect number of elements in array. Expected multiple of 4, got 1 (suppressing further warnings of this type...)
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:263:28: W46: char value is too long for specified length of 10
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:265:28: W46: unicodeChar value is too long for specified length of 10
  warn(warning)
astropy\io\vo\exceptions.py:71: W46: C:\Program Files\Jenkins\jobs\astropy-winxp-py2.7-np1.6\workspace\build\lib.win32-2.7\astropy\io\vo\tests\data/regression.xml:266:11: W46: char value is too long for specified length of 4
  warn(warning)
astropy\io\vo\exceptions.py:71: W39: ?:?:?: W39: Bit values can not be masked (suppressing further warnings of this type...)
  warn(warning)
astropy\io\vo\exceptions.py:71: E02: c:\windows\temp\tmpvr5w9j\regression.binary.xml:167:12: E02: Incorrect number of elements in array. Expected multiple of 4, got 1
  warn(warning)
astropy\io\vo\exceptions.py:71: W49: c:\windows\temp\tmpvr5w9j\regression.binary.xml:167:12: W49: Empty cell illegal for integer fields.
  warn(warning)
--- 
+++ 
@@ -1,302 +1,302 @@
-<?xml version="1.0" encoding="utf-8"?>\r
-<!-- Produced with astropy.io.vo version testing\r
-     http://www.astropy.org/ -->\r
-<VOTABLE version="1.1" xmlns="http://www.ivoa.net/xml/VOTable/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.1">\r
- <DESCRIPTION>\r
-  The VOTable format is an XML standard for the interchange of data\r
-  represented as a set of tables. In this context, a table is an\r
-  unordered set of rows, each of a uniform format, as specified in the\r
-  table metadata. Each row in a table is a sequence of table cells,\r
-  and each of these contains either a primitive data type, or an array\r
-  of such primitives. VOTable is derived from the Astrores format [1],\r
-  itself modeled on the FITS Table format [2]; VOTable was designed to\r
-  be closer to the FITS Binary Table format.\r
- </DESCRIPTION>\r
- <COOSYS ID="J2000" equinox="J2000" system="eq_FK5"/>\r
- <PARAM ID="wrong_arraysize" arraysize="0" datatype="float" name="wrong_arraysize" value=" "/>\r
- <PARAM ID="INPUT" arraysize="*" datatype="float" name="INPUT" ucd="phys.size;instr.tel" unit="deg" value="0 0">\r
-  <DESCRIPTION>\r
-   This is the most interesting parameter in the world, and it drinks\r
-   Dos Equis\r
-  </DESCRIPTION>\r
- </PARAM>\r
...snip...
-</VOTABLE>\r
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Produced with astropy.io.vo version testing
+     http://www.astropy.org/ -->
+<VOTABLE version="1.1" xmlns="http://www.ivoa.net/xml/VOTable/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.1">
+ <DESCRIPTION>
+  The VOTable format is an XML standard for the interchange of data
+  represented as a set of tables. In this context, a table is an
+  unordered set of rows, each of a uniform format, as specified in the
+  table metadata. Each row in a table is a sequence of table cells,
+  and each of these contains either a primitive data type, or an array
+  of such primitives. VOTable is derived from the Astrores format [1],
+  itself modeled on the FITS Table format [2]; VOTable was designed to
+  be closer to the FITS Binary Table format.
+ </DESCRIPTION>
+ <COOSYS ID="J2000" equinox="J2000" system="eq_FK5"/>
+ <PARAM ID="wrong_arraysize" arraysize="0" datatype="float" name="wrong_arraysize" value=" "/>
+ <PARAM ID="INPUT" arraysize="*" datatype="float" name="INPUT" ucd="phys.size;instr.tel" unit="deg" value="0 0">
+  <DESCRIPTION>
+   This is the most interesting parameter in the world, and it drinks
+   Dos Equis
+  </DESCRIPTION>
+ </PARAM>
...snip...
+</VOTABLE>
------------------ generated xml file: ..\..\testresults.xml -------------------
============== 3 failed, 2182 passed, 50 skipped in 10.84 seconds ==============
```

The problem appears to just have something to do with newlines, but I haven't looked much at it beyond that.
