### PR TITLE
Fixed 3 table tests that were failing on my Windows machine

### DIFF
--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -77,8 +77,8 @@ class TestInitFromNdarrayHomo(BaseInitFromListLike):
     def test_partial_names_dtypes(self):
         t = Table(self.data, names=['a', None, 'c'], dtypes=[None, None, 'f8'])
         assert t.colnames == ['a', 'col1', 'c']
-        assert t['a'].dtype.type == np.int32
-        assert t['col1'].dtype.type == np.int32
+        assert t['a'].dtype.type == np.dtype('int').type
+        assert t['col1'].dtype.type == np.dtype('int').type
         assert t['c'].dtype.type == np.float64
         assert all(t[name].name == name for name in t.colnames)
 
@@ -96,7 +96,7 @@ class TestInitFromListOfLists(BaseInitFromListLike):
     def setup_method(self, method):
         self.data = [(1, 3),
                      Column('col1', [2, 4]),
-                     np.array([3, 5])]
+                     np.array([3, 5], dtype='i8')]
 
     def test_default_names(self):
         t = Table(self.data)
@@ -108,7 +108,7 @@ class TestInitFromListOfLists(BaseInitFromListLike):
                   dtypes=['f4', None, 'f8'])
         assert t.colnames == ['b', 'col1', 'c']
         assert t['b'].dtype.type == np.float32
-        assert t['col1'].dtype.type == np.int64
+        assert t['col1'].dtype.type == np.dtype('int').type
         assert t['c'].dtype.type == np.float64
         assert all(t[name].name == name for name in t.colnames)
 
@@ -134,7 +134,7 @@ class TestInitFromColsList(BaseInitFromListLike):
         t = Table(self.data, names=['b', None, 'c'], dtypes=['f4', None, 'f8'])
         assert t.colnames == ['b', 'col1', 'c']
         assert t['b'].dtype.type == np.float32
-        assert t['col1'].dtype.type == np.int64
+        assert t['col1'].dtype.type == np.dtype('int').type
         assert t['c'].dtype.type == np.float64
         assert all(t[name].name == name for name in t.colnames)
 

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -6,8 +6,8 @@ from .. import Column, Row, Table
 class TestRow():
 
     def setup_method(self, method):
-        self.a = Column('a', [1, 2, 3])
-        self.b = Column('b', [4, 5, 6])
+        self.a = Column('a', [1, 2, 3], dtype=np.int64)
+        self.b = Column('b', [4, 5, 6], dtype=np.int64)
         self.t = Table([self.a, self.b])
 
     def test_subclass(self):


### PR DESCRIPTION
I think these tests were failing due to my Windows machine using 32-bit
builds of Python and Numpy, so that the default integer type was int32
instead of int64.

This fixes the tests in a few places to not assume that ints will be
int64.  Another approach would be to modify the table code so that
unspecified types just use int64 by default.  I'm not sure which approach
is preferable.
