### PR TITLE
vo: gzip handling

### DIFF
--- a/astropy/io/vo/tests/vo_test.py
+++ b/astropy/io/vo/tests/vo_test.py
@@ -732,3 +732,19 @@ def test_validate():
 
     assert truth == output
 
+
+def test_gzip_filehandles():
+    votable = parse(
+        get_data_filename('data/regression.xml'),
+        pedantic=False)
+
+    with open(join(TMP_DIR, "regression.compressed.xml"), 'wb') as fd:
+        votable.to_xml(
+            fd,
+            compressed=True,
+            _astropy_version="testing")
+
+    with open(join(TMP_DIR, "regression.compressed.xml"), 'rb') as fd:
+        votable = parse(
+            fd,
+            pedantic=False)

--- a/astropy/io/vo/tree.py
+++ b/astropy/io/vo/tree.py
@@ -2897,6 +2897,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         return self
 
     def to_xml(self, fd, write_null_values=False,
+               compressed=False,
                _debug_python_based_parser=False,
                _astropy_version=None):
         """
@@ -2907,10 +2908,14 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         fd : str path or writable file-like object
            Where to write the file.
 
-        write_null_values : bool
+        write_null_values : bool, optional
            When `True`, write the 'null' value (specified in the null
            attribute of the VALUES element for each FIELD) for empty
            values.  When False (default), simply write no value.
+
+        compressed : bool, optional
+           When `True`, write to a gzip-compressed file.  (Default:
+           `False`)
         """
         kwargs = {
             'write_null_values': write_null_values,
@@ -2921,7 +2926,8 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                 util.version_compare(self.version, u'1.2') >= 0,
             '_debug_python_based_parser': _debug_python_based_parser}
 
-        with util.convert_to_writable_filelike(fd) as fd:
+        with util.convert_to_writable_filelike(
+            fd, compressed=compressed) as fd:
             w = XMLWriter(fd)
             version = self.version
             if _astropy_version is None:

--- a/astropy/io/vo/util.py
+++ b/astropy/io/vo/util.py
@@ -26,7 +26,7 @@ IS_PY3K = sys.hexversion >= 0x03000000
 
 
 @contextlib.contextmanager
-def convert_to_writable_filelike(fd):
+def convert_to_writable_filelike(fd, compressed=False):
     """
     Returns a writable file-like object suitable for streaming output.
 
@@ -41,12 +41,15 @@ def convert_to_writable_filelike(fd):
             - an object with a :meth:`write` method, in which case that
               object.
 
+    compressed : bool, optional
+        If `True`, create a gzip-compressed file.  (Default is `False`).
+
     Returns
     -------
     fd : writable file-like object
     """
     if isinstance(fd, basestring):
-        if fd.endswith('.gz'):
+        if fd.endswith('.gz') or compressed:
             from ...utils.compat import gzip
             with gzip.GzipFile(fd, 'wb') as real_fd:
                 encoded_fd = io.TextIOWrapper(real_fd, encoding='utf8')
@@ -60,6 +63,10 @@ def convert_to_writable_filelike(fd):
                 return
     elif hasattr(fd, 'write'):
         assert is_callable(fd.write)
+
+        if compressed:
+            from ...utils.compat import gzip
+            fd = gzip.GzipFile(fileobj=fd)
 
         # If we can't write Unicode strings, use a codecs.StreamWriter
         # object


### PR DESCRIPTION
For writing, this adds a "compressed" kwarg, which when True, writes to a gzip-compressed xml file.  The old behavior of going off of the file extension is still supported.

For reading, it reads the gzip magic number to decide if the file should be read as a gzip file.
