### PR TITLE
Remove wcsconfig.h from version control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 
 # Other generated files
 astropy/version.py
+astropy/wcs/include/wcsconfig.h
 
 # Sphinx
 _build

--- a/astropy/wcs/include/wcsconfig.h
+++ b/astropy/wcs/include/wcsconfig.h
@@ -1,7 +1,0 @@
-
-    /* WCSLIB library version number. */
-    #define WCSLIB_VERSION 4.10
-
-    /* 64-bit integer data type. */
-    #define WCSLIB_INT64 long long int
-    


### PR DESCRIPTION
Because this file can be updated depending on the platform being built on,
it shouldn't be under version control (it gets annoying because git picks
up on any modifications made to it).  Since it will be generated at build
time if it doesn't already exist, then even more reason for it to not be
there to begin with.
