### PR TITLE
Fixes path arguments to the test command on Windows.  When pytest.main()...

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -4,6 +4,7 @@ This module prvoides the tools used to internally run the astropy test suite
 from the installed astropy.  It makes use of the `pytest` testing framework.
 """
 
+import shlex
 import sys
 import base64
 import zlib
@@ -145,6 +146,9 @@ class TestRunner(object):
                                   'http://pypi.python.org/pypi/pytest-pep8')
             else:
                 all_args += ' --pep8 -k pep8'
+
+        all_args = shlex.split(all_args,
+                               posix=not sys.platform.startswith('win'))
 
         return pytest.main(args=all_args, plugins=plugins)
 


### PR DESCRIPTION
... is passed the arguments as it string, it runs that string through shlex.split().  However, it does not use the 'posix' argument to shlex--or more specifically it doesn't set it to false for Windows as I did here.  That causes Windows paths to be mangled.  So we can fix that on our end.

Sorry, I meant to push this branch to my fork, but I think I typed 'upstream' by accident.  We can delete it once it's merged.
