### PR TITLE
Fix setup.py sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 *.c
 
 # Other generated files
+MANIFEST
 astropy/version.py
 astropy/wcs/include/wcsconfig.h
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,15 +1,16 @@
 include README.rst
 
 include distribute_setup.py
-recursive-include astropy/data *
+include setup.cfg
 recursive-include astropy *.pyx *.c *.h
 
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
+recursive-include astropy/wcs/src/wcslib *
 
-exclude *.pyc *.o 
+exclude *.pyc *.o
 prune docs/_build
 prune build
 

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -10,11 +10,13 @@ from ... import setup_helpers
 
 def get_extensions():
     return [
-        Extension('astropy.io.fits.compression',
-                  glob(os.path.join(os.path.dirname(__file__), 'src/*.c')),
-                  include_dirs=[setup_helpers.get_numpy_include_path()],
-                  extra_compile_args=['-Wno-unused-function',
-                                      '-Wno-strict-prototypes'])
+        Extension(
+            'astropy.io.fits.compression',
+            [os.path.relpath(x) for x in
+             glob(os.path.join(os.path.dirname(__file__), 'src/*.c'))],
+            include_dirs=[setup_helpers.get_numpy_include_path()],
+            extra_compile_args=['-Wno-unused-function',
+                                '-Wno-strict-prototypes'])
     ]
 
 

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -11,7 +11,7 @@ import sys
 
 from astropy import setup_helpers
 
-WCSROOT = os.path.dirname(__file__)
+WCSROOT = os.path.relpath(os.path.dirname(__file__))
 WCSVERSION = "4.10"
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@
 from distribute_setup import use_setuptools
 use_setuptools()
 
+from distutils.command import sdist
+
 import glob
 import os
 from setuptools import setup, find_packages
@@ -46,7 +48,12 @@ scripts.remove(os.path.join('scripts', 'README.rst'))
 setup_helpers.check_numpy()
 
 # This dictionary stores the command classes used in setup below
-cmdclassd = {'test': setup_helpers.setup_test_command('astropy')}
+cmdclassd = {'test': setup_helpers.setup_test_command('astropy'),
+
+             # Use distutils' sdist because it respects package_data.
+             # setuptools/distributes sdist requires duplication of
+             # information in MANIFEST.in
+             'sdist': sdist.sdist}
 
 # Additional C extensions that are not Cython-based should be added here.
 extensions = []


### PR DESCRIPTION
Fixes the sdist command so it produces a reasonable tarball, which includes generated Cython *.c files if any.
- The sdist command in setuptools/distribute is annoying because it doesn't respect package_data -- that information has to be duplicated in MANIFEST.in.  It appears to work well enough to just use the distutils one instead, which on Python 2.7 and later respects package_data.
- sdist requires that all paths are relative to the source root -- some of the code that was generating C extensions was using absolute paths.
