### PR TITLE
Link _iterparse.so with -Bsymbolic

### DIFF
--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -7,6 +7,14 @@ def get_extensions(build_type='release'):
     EXPAT_DIR = 'cextern/expat/lib'
     XML_DIR = 'astropy/utils/xml/src'
 
+    if sys.platform.startswith('linux'):
+        # This is to ensure that _iterparser uses the libexpat functions it was
+        # compiled with, and not the system libexpat (which can happen if the
+        # latter is loaded first).
+        extra_link_args = ['-Wl,-Bsymbolic']
+    else:
+        extra_link_args = []
+
     defines = [("HAVE_EXPAT_CONFIG_H", 1)]
     if sys.byteorder == 'big':
         defines.append(('BYTEORDER', '4321'))
@@ -24,4 +32,4 @@ def get_extensions(build_type='release'):
          join(EXPAT_DIR, "xmltok_impl.c")],
         define_macros=defines,
         include_dirs=[XML_DIR, EXPAT_DIR],
-        extra_link_args=['-Wl,-Bsymbolic'])]
+        extra_link_args=extra_link_args)]


### PR DESCRIPTION
This had me beating my head against the wall for a while.
For some reason one of the vo tests has always been failing for me, due to what appeared to be some problem deep within the XML parsing.

It turns out the problem is that something in my Python is loading my system's libexpat.so well before _iterparse gets imported.  So it ends up using libexpat functions from my system's expat instead of the one it was compiled with.  My system's libexpat is old and has some incompatibilities with the one we're compiling with, the details of which are unimportant.

Admittedly, this patch in its current form may not work on all platforms, but I thought I'd put it out there for comment.
