### PR TITLE
Crash running setup.py test on Python 3 in Jenkins

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -210,7 +210,7 @@ class astropy_test(Command, object):
                          self.remote_data, self.pep8)
 
         raise SystemExit(subprocess.call([sys.executable, '-c', cmd],
-                                         cwd=new_path))
+                                         cwd=new_path, close_fds=False))
 
 
 class raises:


### PR DESCRIPTION
I'm trying to add a build for Astropy on Windows with Python 3.2.  The build stage goes fine, but when it gets to running the tests, Python crashes with:

```
Traceback (most recent call last):
  File "py._io.capture", line 54, in start
WindowsError: [Error 6] The handle is invalid

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "astropy\tests\helper.py", line 149, in run_tests
    return pytest.main(args=all_args, plugins=plugins)
  File "_pytest.core", line 467, in main
  File "_pytest.core", line 460, in _prepareconfig
  File "_pytest.core", line 419, in __call__
  File "_pytest.core", line 430, in _docall
  File "_pytest.core", line 348, in execute
  File "_pytest.helpconfig", line 25, in pytest_cmdline_parse
  File "_pytest.core", line 348, in execute
  File "_pytest.config", line 10, in pytest_cmdline_parse
  File "_pytest.config", line 343, in parse
  File "_pytest.config", line 321, in _preparse
  File "_pytest.config", line 297, in _setinitialconftest
  File "_pytest.capture", line 101, in resumecapture
  File "py._io.capture", line 229, in startall
  File "py._io.capture", line 56, in start
ValueError: saved filedescriptor not valid, did you call start() twice?
```

This is related to py.tests's stdio capture.  It's trying to call `os.fstat()` on the stdin file descriptor (0) and failing.  My guess is that it has something to do with Jenkins also messing with stdio capture.  I don't have any problem if I run the exact same commands outside Jenkins.

What's odd is that this is only happening in Python 3--not Python 2.  I don't see why that should matter.  I will also see about raising this issue with py.test's devs.
