### PR TITLE
wcs: Windows C linking fixes

### DIFF
--- a/astropy/wcs/include/astropy_wcs_api.h
+++ b/astropy/wcs/include/astropy_wcs_api.h
@@ -1,6 +1,7 @@
 #ifndef ASTROPY_WCS_API_H
 #define ASTROPY_WCS_API_H
 
+#include "wcsconfig.h"
 #include "pyutil.h"
 #include "distortion.h"
 #include "pipeline.h"

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -77,6 +77,34 @@ def write_wcsconfig_h():
 
     /* 64-bit integer data type. */
     #define WCSLIB_INT64 {1}
+
+    /* Windows needs some other defines to prevent inclusion of wcsset()
+       which conflicts with wcslib's wcsset().  These need to be set
+       on code that *uses* astropy.wcs, in addition to astropy.wcs itself.
+       */
+    #if defined(_WIN32) || defined(_MSC_VER) || defined(__MINGW32__) || defined (__MINGW64__)
+
+    #ifndef YY_NO_UNISTD_H
+    #define YY_NO_UNISTD_H
+    #endif
+
+    #ifndef _CRT_SECURE_NO_WARNINGS
+    #define _CRT_SECURE_NO_WARNINGS
+    #endif
+
+    #ifndef _NO_OLDNAMES
+    #define _NO_OLDNAMES
+    #endif
+
+    #ifndef NO_OLDNAMES
+    #define NO_OLDNAMES
+    #endif
+
+    #ifndef __STDC__
+    #define __STDC__ 1
+    #endif
+
+    #endif
     """.format(WCSVERSION, determine_64_bit_int()))
     setup_helpers.write_if_different(
         join(WCSROOT, 'include', 'wcsconfig.h'),


### PR DESCRIPTION
Make astropy.wcs linkable from C on Windows.

This is a backport of r2510 in pywcs.

On Windows, we need to define some macros to prevent importing wcsset() from the "standard" library, which conflicts with the wcsset() in wcslib.  These macros need to be defined both for building astropy.wcs itself and for any external C libraries that link to it.
