### PR TITLE
1 test failure in vo_test

### DIFF
--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -905,6 +905,7 @@ IterParser_init(IterParser *self, PyObject *args, PyObject *kwds)
             goto fail;
         }
         self->fd = fd;   Py_INCREF(self->fd);
+        lseek(self->file, 0, SEEK_SET);
     } else
 #endif
     if (PyCallable_Check(fd)) {


### PR DESCRIPTION
http://paste.pocoo.org/show/551253/

This is on OS X 10.6, with 32-bit python 2.7.2 (EPD 7.1-2, although I test it on the macport python 2.7.2 and saw the same error).  The error does _not_ appear in python 3.2.2 on the same computer.
