### PR TITLE
BoolMask

### DIFF
--- a/astropy/nddata/masks.py
+++ b/astropy/nddata/masks.py
@@ -1,0 +1,26 @@
+# Collections of different masks for nddata object
+
+import numpy as np
+
+class BoolMask(np.ndarray):
+
+    def __new__(cls, input_array):
+        obj = np.asarray(input_array, dtype='bool').view(cls)
+        return obj
+
+    def arithmetic_operation(self, operand):
+        if not isinstance(operand, BoolMask):
+            raise ValueError('unsupported operand type(s) for +: %s and %s' %\
+                             (type(self), type(operand)))
+        return np.logical_or(self, operand)
+        
+    __add__ = arithmetic_operation
+    __sub__ = arithmetic_operation
+    __mul__ = arithmetic_operation
+    __div__ = arithmetic_operation
+    
+    __radd__ = arithmetic_operation
+    __rsub__ = arithmetic_operation
+    __rmul__ = arithmetic_operation
+    __rdiv__ = arithmetic_operation
+    


### PR DESCRIPTION
While developing the Spectrum1D class, we realized that there's a need for masks and errors that can deal with arithmetic. 
The BoolMask is a first attempt to write a simple ndarray subclass that will create a new mask (in the maskedarray sense, masked=True) by applying a logical or to the mask of both operands.

mask1 = BoolMask(ones((100,100)))
mask2 = BoolMask(ones((100,100)))

mask1 + 5 -> ValueError unsupported operand types

mask1 + mask2 -> logical_or of the whole bool array.

There's obviously documentation missing, but I wanted to get some initial feedback before proceeding further. 
