### PR TITLE
Add Table fancy index slicing using list

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -654,7 +654,8 @@ class Table(object):
                 raise ValueError('Table column slice must contain only valid '
                                  'column names')
             return Table([self[x] for x in item], meta=deepcopy(self.meta))
-        elif isinstance(item, slice) or isinstance(item, np.ndarray):
+        elif (isinstance(item, slice) or isinstance(item, np.ndarray)
+              or isinstance(item, list)):
             return self._new_from_slice(item)
         else:
             raise ValueError('Illegal type {0} for table item access'

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -123,6 +123,18 @@ class TestTableItems(BaseTestItems):
         assert np.all(self.t._data == DATA)
         assert np.any(t2['a'] != DATA['a'])
 
+    def test_list_index_slice(self):
+        """Table list index slice returns COPY of data"""
+        slice = [0, 2]
+        t2 = self.t[slice]
+        assert np.all(t2['a'] == DATA['a'][slice])
+        assert t2['a'].attrs_equal(COLS[0])
+        assert t2['b'].attrs_equal(COLS[1])
+        assert t2['c'].attrs_equal(COLS[2])
+        t2['a'][0] = 0
+        assert np.all(self.t._data == DATA)
+        assert np.any(t2['a'] != DATA['a'])
+
     def test_select_columns(self):
         """Select columns returns COPY of data and all column
         attributes"""

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -45,6 +45,7 @@ the data contained in that object relate to the original table data
   t[1]         # Row obj for with row 1 values
   t[1]['a']    # Column 'a' of row 1
   t[2:5]       # Table object with rows 2:5
+  t[[1, 3, 4]]  # Table object with rows 1, 3, 4 (copy)
   t[np.array([1, 3, 4])]  # Table object with rows 1, 3, 4 (copy)
   t['a', 'c']  # Table with cols 'a', 'c' (copy)
   dat = np.array(t)  # Copy table data to numpy structured array object
@@ -133,6 +134,11 @@ It is possible to select table rows with an array of indexes or by providing
 specifying multiple column names.  This returns a copy of the original table
 for the selected rows.  ::
 
+  >>> t[[1, 3, 4]]  # Table object with rows 1, 3, 4 (copy)
+  <Table rows=3 names=('a','b','c')>
+  array([(3, 4, 5), (9, 10, 11), (12, 13, 14)], 
+        dtype=[('a', '<i8'), ('b', '<i8'), ('c', '<i8')])
+  
   >>> t[np.array([1, 3, 4])]  # Table object with rows 1, 3, 4 (copy)
   <Table rows=3 names=('a','b','c')>
   array([(3, 4, 5), (9, 10, 11), (12, 13, 14)], 


### PR DESCRIPTION
Previously fancy row slicing was only possible using an `np.array` as the item, e.g. `table[np.array([1, 3, 4])]`. This commit adds slicing using a Python list like `table[[1, 3, 4]]`.

There is an open question about whether this is actually a good thing or if it would be confusing for users.  It was suggested by a user as a convenience but I'm interested in opinions from the group.  It seems OK to me and is consistent with structured arrays and recarray.
