### PR TITLE
building convolve breaks on Windows with MSVC

### DIFF
--- a/astropy/nddata/convolution/boundary_extend.pyx
+++ b/astropy/nddata/convolution/boundary_extend.pyx
@@ -8,8 +8,8 @@ ctypedef np.float_t DTYPE_t
 cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
 
-cdef extern from "math.h":
-    bint isnan(double x)
+cdef extern from "numpy/npy_math.h":
+    bint npy_isnan(double x)
 
 cimport cython
 
@@ -38,7 +38,7 @@ def convolve1d_boundary_extend(np.ndarray[DTYPE_t, ndim=1] f,
     # Need a first pass to replace NaN values with value convolved from
     # neighboring values
     for i in range(nx):
-        if isnan(f[i]):
+        if npy_isnan(f[i]):
             top = 0.
             bot = 0.
             iimin = i - wkx
@@ -46,7 +46,7 @@ def convolve1d_boundary_extend(np.ndarray[DTYPE_t, ndim=1] f,
             for ii in range(iimin, iimax):
                 iii = int_min(int_max(ii, 0), nx - 1)
                 val = f[iii]
-                if not isnan(val):
+                if not npy_isnan(val):
                     ker = g[<unsigned int>(wkx + ii - i)]
                     top += val * ker
                     bot += ker
@@ -60,7 +60,7 @@ def convolve1d_boundary_extend(np.ndarray[DTYPE_t, ndim=1] f,
 
     # Now run the proper convolution
     for i in range(nx):
-        if not isnan(fixed[i]):
+        if not npy_isnan(fixed[i]):
             top = 0.
             bot = 0.
             iimin = i - wkx
@@ -69,7 +69,7 @@ def convolve1d_boundary_extend(np.ndarray[DTYPE_t, ndim=1] f,
                 iii = int_min(int_max(ii, 0), nx - 1)
                 val = fixed[iii]
                 ker = g[<unsigned int>(wkx + ii - i)]
-                if not isnan(val):
+                if not npy_isnan(val):
                     top += val * ker
                     bot += ker
             if bot != 0:
@@ -110,7 +110,7 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
     # neighboring values
     for i in range(nx):
         for j in range(ny):
-            if isnan(f[i, j]):
+            if npy_isnan(f[i, j]):
                 top = 0.
                 bot = 0.
                 iimin = i - wkx
@@ -122,7 +122,7 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
                         iii = int_min(int_max(ii, 0), nx - 1)
                         jjj = int_min(int_max(jj, 0), ny - 1)
                         val = f[iii, jjj]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             ker = g[<unsigned int>(wkx + ii - i),
                                     <unsigned int>(wky + jj - j)]
                             top += val * ker
@@ -138,7 +138,7 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
     # Now run the proper convolution
     for i in range(nx):
         for j in range(ny):
-            if not isnan(fixed[i, j]):
+            if not npy_isnan(fixed[i, j]):
                 top = 0.
                 bot = 0.
                 iimin = i - wkx
@@ -152,7 +152,7 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
                         val = fixed[iii, jjj]
                         ker = g[<unsigned int>(wkx + ii - i),
                                 <unsigned int>(wky + jj - j)]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             top += val * ker
                             bot += ker
                 if bot != 0:
@@ -197,7 +197,7 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(nx):
         for j in range(ny):
             for k in range(nz):
-                if isnan(f[i, j, k]):
+                if npy_isnan(f[i, j, k]):
                     top = 0.
                     bot = 0.
                     iimin = i - wkx
@@ -213,7 +213,7 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = int_min(int_max(jj, 0), ny - 1)
                                 kkk = int_min(int_max(kk, 0), nz - 1)
                                 val = f[iii, jjj, kkk]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     ker = g[<unsigned int>(wkx + ii - i),
                                             <unsigned int>(wky + jj - j),
                                             <unsigned int>(wkz + kk - k)]
@@ -231,7 +231,7 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(nx):
         for j in range(ny):
             for k in range(nz):
-                if not isnan(fixed[i, j, k]):
+                if not npy_isnan(fixed[i, j, k]):
                     top = 0.
                     bot = 0.
                     iimin = i - wkx
@@ -250,7 +250,7 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                                 ker = g[<unsigned int>(wkx + ii - i),
                                         <unsigned int>(wky + jj - j),
                                         <unsigned int>(wkz + kk - k)]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker
                     if bot != 0:

--- a/astropy/nddata/convolution/boundary_fill.pyx
+++ b/astropy/nddata/convolution/boundary_fill.pyx
@@ -5,8 +5,8 @@ cimport numpy as np
 DTYPE = np.float
 ctypedef np.float_t DTYPE_t
 
-cdef extern from "math.h":
-    bint isnan(double x)
+cdef extern from "numpy/npy_math.h":
+    bint npy_isnan(double x)
 
 cimport cython
 
@@ -36,7 +36,7 @@ def convolve1d_boundary_fill(np.ndarray[DTYPE_t, ndim=1] f,
     # Need a first pass to replace NaN values with value convolved from
     # neighboring values
     for i in range(nx):
-        if isnan(f[i]):
+        if npy_isnan(f[i]):
             top = 0.
             bot = 0.
             iimin = i - wkx
@@ -46,7 +46,7 @@ def convolve1d_boundary_fill(np.ndarray[DTYPE_t, ndim=1] f,
                     val = fill_value
                 else:
                     val = f[ii]
-                if not isnan(val):
+                if not npy_isnan(val):
                     ker = g[<unsigned int>(wkx + ii - i)]
                     top += val * ker
                     bot += ker
@@ -59,7 +59,7 @@ def convolve1d_boundary_fill(np.ndarray[DTYPE_t, ndim=1] f,
 
     # Now run the proper convolution
     for i in range(nx):
-        if not isnan(fixed[i]):
+        if not npy_isnan(fixed[i]):
             top = 0.
             bot = 0.
             iimin = i - wkx
@@ -70,7 +70,7 @@ def convolve1d_boundary_fill(np.ndarray[DTYPE_t, ndim=1] f,
                 else:
                     val = fixed[ii]
                 ker = g[<unsigned int>(wkx + ii - i)]
-                if not isnan(val):
+                if not npy_isnan(val):
                     top += val * ker
                     bot += ker
             if bot != 0:
@@ -112,7 +112,7 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
     # neighboring values
     for i in range(nx):
         for j in range(ny):
-            if isnan(f[i, j]):
+            if npy_isnan(f[i, j]):
                 top = 0.
                 bot = 0.
                 iimin = i - wkx
@@ -125,7 +125,7 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
                             val = fill_value
                         else:
                             val = f[ii, jj]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             ker = g[<unsigned int>(wkx + ii - i),
                                     <unsigned int>(wky + jj - j)]
                             top += val * ker
@@ -140,7 +140,7 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
     # Now run the proper convolution
     for i in range(nx):
         for j in range(ny):
-            if not isnan(fixed[i, j]):
+            if not npy_isnan(fixed[i, j]):
                 top = 0.
                 bot = 0.
                 iimin = i - wkx
@@ -155,7 +155,7 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
                             val = fixed[ii, jj]
                         ker = g[<unsigned int>(wkx + ii - i),
                                 <unsigned int>(wky + jj - j)]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             top += val * ker
                             bot += ker
                 if bot != 0:
@@ -201,7 +201,7 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(nx):
         for j in range(ny):
             for k in range(nz):
-                if isnan(f[i, j, k]):
+                if npy_isnan(f[i, j, k]):
                     top = 0.
                     bot = 0.
                     iimin = i - wkx
@@ -217,7 +217,7 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                                     val = fill_value
                                 else:
                                     val = f[ii, jj, kk]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     ker = g[<unsigned int>(wkx + ii - i),
                                             <unsigned int>(wky + jj - j),
                                             <unsigned int>(wkz + kk - k)]
@@ -234,7 +234,7 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(nx):
         for j in range(ny):
             for k in range(nz):
-                if not isnan(fixed[i, j, k]):
+                if not npy_isnan(fixed[i, j, k]):
                     top = 0.
                     bot = 0.
                     iimin = i - wkx
@@ -253,7 +253,7 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                                 ker = g[<unsigned int>(wkx + ii - i),
                                         <unsigned int>(wky + jj - j),
                                         <unsigned int>(wkz + kk - k)]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker
                     if bot != 0:

--- a/astropy/nddata/convolution/boundary_none.pyx
+++ b/astropy/nddata/convolution/boundary_none.pyx
@@ -5,8 +5,8 @@ cimport numpy as np
 DTYPE = np.float
 ctypedef np.float_t DTYPE_t
 
-cdef extern from "math.h":
-    bint isnan(double x)
+cdef extern from "numpy/npy_math.h":
+    bint npy_isnan(double x)
 
 cimport cython
 
@@ -38,12 +38,12 @@ def convolve1d_boundary_none(np.ndarray[DTYPE_t, ndim=1] f,
     # Need a first pass to replace NaN values with value convolved from
     # neighboring values
     for i in range(wkx, nx - wkx):
-        if isnan(f[i]):
+        if npy_isnan(f[i]):
             top = 0.
             bot = 0.
             for ii in range(i - wkx, i + wkx + 1):
                 val = f[ii]
-                if not isnan(val):
+                if not npy_isnan(val):
                     ker = g[<unsigned int>(wkx + ii - i)]
                     top += val * ker
                     bot += ker
@@ -56,13 +56,13 @@ def convolve1d_boundary_none(np.ndarray[DTYPE_t, ndim=1] f,
 
     # Now run the proper convolution
     for i in range(wkx, nx - wkx):
-        if not isnan(fixed[i]):
+        if not npy_isnan(fixed[i]):
             top = 0.
             bot = 0.
             for ii in range(i - wkx, i + wkx + 1):
                 val = fixed[ii]
                 ker = g[<unsigned int>(wkx + ii - i)]
-                if not isnan(val):
+                if not npy_isnan(val):
                     top += val * ker
                     bot += ker
             if bot != 0:
@@ -106,13 +106,13 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
     # neighboring values
     for i in range(wkx, nx - wkx):
         for j in range(wky, ny - wky):
-            if isnan(f[i, j]):
+            if npy_isnan(f[i, j]):
                 top = 0.
                 bot = 0.
                 for ii in range(i - wkx, i + wkx + 1):
                     for jj in range(j - wky, j + wky + 1):
                         val = f[ii, jj]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             ker = g[<unsigned int>(wkx + ii - i),
                                     <unsigned int>(wky + jj - j)]
                             top += val * ker
@@ -127,7 +127,7 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
     # Now run the proper convolution
     for i in range(wkx, nx - wkx):
         for j in range(wky, ny - wky):
-            if not isnan(fixed[i, j]):
+            if not npy_isnan(fixed[i, j]):
                 top = 0.
                 bot = 0.
                 for ii in range(i - wkx, i + wkx + 1):
@@ -135,7 +135,7 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
                         val = fixed[ii, jj]
                         ker = g[<unsigned int>(wkx + ii - i),
                                 <unsigned int>(wky + jj - j)]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             top += val * ker
                             bot += ker
                 if bot != 0:
@@ -183,14 +183,14 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(wkx, nx - wkx):
         for j in range(wky, ny - wky):
             for k in range(wkz, nz - wkz):
-                if isnan(f[i, j, k]):
+                if npy_isnan(f[i, j, k]):
                     top = 0.
                     bot = 0.
                     for ii in range(i - wkx, i + wkx + 1):
                         for jj in range(j - wky, j + wky + 1):
                             for kk in range(k - wkz, k + wkz + 1):
                                 val = f[ii, jj, kk]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     ker = g[<unsigned int>(wkx + ii - i),
                                             <unsigned int>(wky + jj - j),
                                             <unsigned int>(wkz + kk - k)]
@@ -207,7 +207,7 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(wkx, nx - wkx):
         for j in range(wky, ny - wky):
             for k in range(wkz, nz - wkz):
-                if not isnan(fixed[i, j, k]):
+                if not npy_isnan(fixed[i, j, k]):
                     top = 0.
                     bot = 0.
                     for ii in range(i - wkx, i + wkx + 1):
@@ -217,7 +217,7 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
                                 ker = g[<unsigned int>(wkx + ii - i),
                                         <unsigned int>(wky + jj - j),
                                         <unsigned int>(wkz + kk - k)]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker
                     if bot != 0:

--- a/astropy/nddata/convolution/boundary_wrap.pyx
+++ b/astropy/nddata/convolution/boundary_wrap.pyx
@@ -5,8 +5,8 @@ cimport numpy as np
 DTYPE = np.float
 ctypedef np.float_t DTYPE_t
 
-cdef extern from "math.h":
-    bint isnan(double x)
+cdef extern from "numpy/npy_math.h":
+    bint npy_isnan(double x)
 
 cimport cython
 
@@ -35,7 +35,7 @@ def convolve1d_boundary_wrap(np.ndarray[DTYPE_t, ndim=1] f,
     # Need a first pass to replace NaN values with value convolved from
     # neighboring values
     for i in range(nx):
-        if isnan(f[i]):
+        if npy_isnan(f[i]):
             top = 0.
             bot = 0.
             iimin = i - wkx
@@ -43,7 +43,7 @@ def convolve1d_boundary_wrap(np.ndarray[DTYPE_t, ndim=1] f,
             for ii in range(iimin, iimax):
                 iii = ii % nx
                 val = f[iii]
-                if not isnan(val):
+                if not npy_isnan(val):
                     ker = g[<unsigned int>(wkx + ii - i)]
                     top += val * ker
                     bot += ker
@@ -57,7 +57,7 @@ def convolve1d_boundary_wrap(np.ndarray[DTYPE_t, ndim=1] f,
 
     # Now run the proper convolution
     for i in range(nx):
-        if not isnan(fixed[i]):
+        if not npy_isnan(fixed[i]):
             top = 0.
             bot = 0.
             iimin = i - wkx
@@ -66,7 +66,7 @@ def convolve1d_boundary_wrap(np.ndarray[DTYPE_t, ndim=1] f,
                 iii = ii % nx
                 val = fixed[iii]
                 ker = g[<unsigned int>(wkx + ii - i)]
-                if not isnan(val):
+                if not npy_isnan(val):
                     top += val * ker
                     bot += ker
             if bot != 0:
@@ -107,7 +107,7 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
     # neighboring values
     for i in range(nx):
         for j in range(ny):
-            if isnan(f[i, j]):
+            if npy_isnan(f[i, j]):
                 top = 0.
                 bot = 0.
                 iimin = i - wkx
@@ -119,7 +119,7 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
                         iii = ii % nx
                         jjj = jj % ny
                         val = f[iii, jjj]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             ker = g[<unsigned int>(wkx + ii - i),
                                     <unsigned int>(wky + jj - j)]
                             top += val * ker
@@ -135,7 +135,7 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
     # Now run the proper convolution
     for i in range(nx):
         for j in range(ny):
-            if not isnan(fixed[i, j]):
+            if not npy_isnan(fixed[i, j]):
                 top = 0.
                 bot = 0.
                 iimin = i - wkx
@@ -149,7 +149,7 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
                         val = fixed[iii, jjj]
                         ker = g[<unsigned int>(wkx + ii - i),
                                 <unsigned int>(wky + jj - j)]
-                        if not isnan(val):
+                        if not npy_isnan(val):
                             top += val * ker
                             bot += ker
                 if bot != 0:
@@ -194,7 +194,7 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(nx):
         for j in range(ny):
             for k in range(nz):
-                if isnan(f[i, j, k]):
+                if npy_isnan(f[i, j, k]):
                     top = 0.
                     bot = 0.
                     iimin = i - wkx
@@ -210,7 +210,7 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = jj % ny
                                 kkk = kk % nz
                                 val = f[iii, jjj, kkk]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     ker = g[<unsigned int>(wkx + ii - i),
                                             <unsigned int>(wky + jj - j),
                                             <unsigned int>(wkz + kk - k)]
@@ -228,7 +228,7 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
     for i in range(nx):
         for j in range(ny):
             for k in range(nz):
-                if not isnan(fixed[i, j, k]):
+                if not npy_isnan(fixed[i, j, k]):
                     top = 0.
                     bot = 0.
                     iimin = i - wkx
@@ -247,7 +247,7 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                                 ker = g[<unsigned int>(wkx + ii - i),
                                         <unsigned int>(wky + jj - j),
                                         <unsigned int>(wkz + kk - k)]
-                                if not isnan(val):
+                                if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker
                     if bot != 0:


### PR DESCRIPTION
This is the output I get when I try to run setup.py build on Windows using MSVC as the compiler:

```
cythoning astropy\nddata\convolution\boundary_extend.pyx to astropy\nddata\convo
lution\boundary_extend.c
building 'astropy.nddata.convolution.boundary_extend' extension
creating build\temp.win32-2.7\Release\astropy\nddata
creating build\temp.win32-2.7\Release\astropy\nddata\convolution
C:\Program Files\Microsoft Visual Studio 9.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Python27\lib\site-packages\numpy-1.6.1-py2.7-win32.egg\numpy\core\include -IC:\Python27\include -IC:\Python27\PC /Tcastropy\nddata\convolution\boundary_extend.c /Fobuild\temp.win32-2.7\Release\astropy\nddata\convolution\boundary_extend.obj
boundary_extend.c
astropy\nddata\convolution\boundary_extend.c(1368) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(1379) : warning C4013: 'isnan' undefined; assuming extern returning int
astropy\nddata\convolution\boundary_extend.c(1555) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(2193) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(2204) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(2439) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(2450) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(3217) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(3228) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(3239) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(3522) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(3533) : warning C4018: '<' : signed/unsigned mismatch
astropy\nddata\convolution\boundary_extend.c(3544) : warning C4018: '<' : signed/unsigned mismatch
C:\Program Files\Microsoft Visual Studio 9.0\VC\BIN\link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:C:\Python27\libs /LIBPATH:C:\Python27\PCbuild /EXPORT:initboundary_extend build\temp.win32-2.7\Release\astropy\nddata\convolution\boundary_extend.obj /OUT:build\lib.win32-2.7\astropy\nddata\convolution\boundary_extend.pyd /IMPLIB:build\temp.win32-2.7\Release\astropy\nddata\convolution\boundary_extend.lib /MANIFESTFILE:build\temp.win32-2.7\Release\astropy\nddata\convolution\boundary_extend.pyd.manifest /MANIFEST
   Creating library build\temp.win32-2.7\Release\astropy\nddata\convolution\boundary_extend.lib and object build\temp.win32-2.7\Release\astropy\nddata\convolution\boundary_extend.exp
boundary_extend.obj : error LNK2019: unresolved external symbol _isnan referenced in function ___pyx_pf_7astropy_6nddata_11convolution_15boundary_extend_convolve1d_boundary_extend
build\lib.win32-2.7\astropy\nddata\convolution\boundary_extend.pyd : fatal error
 LNK1120: 1 unresolved externals
error: command '"C:\Program Files\Microsoft Visual Studio 9.0\VC\BIN\link.exe"'
failed with exit status 1120
```

I'm not sure.  Could this be a Cython bug?  For what it's worth, the Cython on this Python installation was built with MSVC, and the build succeeds no problem when I compile in mingw.
