### PR TITLE
Bug with char fields in io.vo

### DIFF
--- a/docs/vo/intro_table.rst
+++ b/docs/vo/intro_table.rst
@@ -157,8 +157,8 @@ and populate it with data::
 
   # Define some fields
   table.fields.extend([
-          Field(votable, ID="filename", datatype="char"),
-          Field(votable, ID="matrix", datatype="double", arraysize="2x2")])
+          Field(votable, name="filename", datatype="char", arraysize="*"),
+          Field(votable, name="matrix", datatype="double", arraysize="2x2")])
 
   # Now, use those field definitions to create the numpy record arrays, with
   # the given number of rows


### PR DESCRIPTION
If I run the script to create a VO table from http://astropy.readthedocs.org/en/latest/vo/intro_table.html#building-a-new-table-from-scratch, then the char field only has a single character in each cell:

```
<!-- Produced with astropy.io.vo version 0.0.dev617
     http://www.astropy.org/ -->
<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
 <RESOURCE type="results">
  <TABLE>
   <FIELD ID="filename" arraysize="1" datatype="char" name="filename"/>
   <FIELD ID="matrix" arraysize="2x2" datatype="double" name="matrix"/>
   <DATA>
    <TABLEDATA>
     <TR>
      <TD>t</TD>
      <TD>1 0 0 1</TD>
     </TR>
     <TR>
      <TD>t</TD>
      <TD>0.5 0.3 0.2 0.1</TD>
     </TR>
    </TABLEDATA>
   </DATA>
  </TABLE>
 </RESOURCE>
</VOTABLE>
```

I also get the following two warnings:

```
/Volumes/Raptor/Library/Python/2.7/lib/python/site-packages/astropy-0.0.dev984-py2.7-macosx-10.7-x86_64.egg/astropy/io/vo/exceptions.py:71: W15: ?:?:?: W15: FIELD element missing required 'name' attribute
  warn(warning)
/Volumes/Raptor/Library/Python/2.7/lib/python/site-packages/astropy-0.0.dev984-py2.7-macosx-10.7-x86_64.egg/astropy/io/vo/exceptions.py:71: W47: ?:?:?: W47: Missing arraysize indicates length 1
  warn(warning)
```

I also see the issue in the standalone vo module.
