### PR TITLE
Various logging fixes

### DIFF
--- a/astropy/config/logging_helper.py
+++ b/astropy/config/logging_helper.py
@@ -11,6 +11,7 @@ import warnings
 from contextlib import contextmanager
 
 from . import ConfigurationItem
+from ..utils.compat import inspect_getmodule
 from ..utils.console import color_print
 from ..utils.misc import find_current_module
 
@@ -147,10 +148,42 @@ class AstropyLogger(Logger):
     _showwarning_orig = None
 
     def _showwarning(self, *args, **kwargs):
-        try:
-            self.warn(args[0].args[0])
-        except IndexError:  # necessary for astropy.io.vo warnings
-            self.warn(args[0].message)
+        warning = args[0]
+        # Deliberately not using isinstance here: We want to display
+        # the class name only when it's not the default class,
+        # UserWarning.  The name of subclasses of UserWarning should
+        # be displayed.
+        if type(warning) != UserWarning:
+            message = '{0}: {1}'.format(warning.__class__.__name__, args[0])
+        else:
+            message = unicode(args[0])
+
+        mod_path = args[2]
+        # Now that we have the module's path, we look through
+        # sys.modules to find the module object and thus the
+        # fully-package-specified module name.  On Python 2, the
+        # module.__file__ is the compiled file name, not the .py, so
+        # we have to ignore the extension.  On Python 3,
+        # module.__file__ is the original source file name, so things
+        # are more direct.
+        mod_name = None
+        if sys.version_info[0] < 3:
+            for name, mod in sys.modules.items():
+                if getattr(mod, '__file__', '') == mod_path:
+                    mod_name = mod.__name__
+                    break
+        else:
+            mod_path, ext = os.path.splitext(mod_path)
+            for name, mod in sys.modules.items():
+                path = os.path.splitext(getattr(mod, '__file__', ''))[0]
+                if path == mod_path:
+                    mod_name = mod.__name__
+                    break
+
+        if mod_name is not None:
+            self.warn(message, extra={'origin': mod_name})
+        else:
+            self.warn(message)
 
     def warnings_logging_enabled(self):
         return self._showwarning_orig is not None
@@ -165,7 +198,7 @@ class AstropyLogger(Logger):
 
         This can be disabled with ``disable_warnings_logging``.
         '''
-        if self._showwarning_orig is not None:
+        if self.warnings_logging_enabled():
             raise LoggingError("Warnings logging has already been enabled")
         self._showwarning_orig = warnings.showwarning
         warnings.showwarning = self._showwarning
@@ -179,7 +212,7 @@ class AstropyLogger(Logger):
 
         This can be re-enabled with ``enable_warnings_logging``.
         '''
-        if self._showwarning_orig is None:
+        if not self.warnings_logging_enabled():
             raise LoggingError("Warnings logging has not been enabled")
         if warnings.showwarning != self._showwarning:
             raise LoggingError("Cannot disable warnings logging: "
@@ -191,11 +224,14 @@ class AstropyLogger(Logger):
     _excepthook_orig = None
 
     def _excepthook(self, type, value, traceback):
-        try:
-            origin = inspect.getmodule(traceback.tb_next).__name__
-        except:
-            origin = inspect.getmodule(traceback).__name__
-        self.error(value.args[0], extra={'origin': origin})
+        tb = traceback
+        while tb.tb_next is not None:
+            tb = tb.tb_next
+        mod = inspect_getmodule(tb)
+        if mod is not None:
+            self.error(value.args[0], extra={'origin': mod.__name__})
+        else:
+            self.error(value.args[0])
         self._excepthook_orig(type, value, traceback)
 
     def exception_logging_enabled(self):
@@ -210,7 +246,7 @@ class AstropyLogger(Logger):
 
         This can be disabled with ``disable_exception_logging``.
         '''
-        if self._excepthook_orig is not None:
+        if self.exception_logging_enabled():
             raise LoggingError("Exception logging has already been enabled")
         self._excepthook_orig = sys.excepthook
         sys.excepthook = self._excepthook
@@ -224,7 +260,7 @@ class AstropyLogger(Logger):
 
         This can be re-enabled with ``enable_exception_logging``.
         '''
-        if self._excepthook_orig is None:
+        if not self.exception_logging_enabled():
             raise LoggingError("Exception logging has not been enabled")
         if sys.excepthook != self._excepthook:
             raise LoggingError("Cannot disable exception logging: "
@@ -364,9 +400,9 @@ class AstropyLogger(Logger):
         '''
 
         # Reset any previously installed hooks
-        if self._showwarning_orig is not None:
+        if self.warnings_logging_enabled():
             self.disable_warnings_logging()
-        if self._excepthook_orig is not None:
+        if self.exception_logging_enabled():
             self.disable_exception_logging()
 
         # Remove all previous handlers

--- a/astropy/io/vo/exceptions.py
+++ b/astropy/io/vo/exceptions.py
@@ -58,7 +58,7 @@ def _format_message(message, name, config={}, pos=None):
     return '%s:%s:%s: %s: %s' % (filename, pos[0], pos[1], name, message)
 
 
-def _suppressed_warning(warning, config):
+def _suppressed_warning(warning, config, stacklevel=2):
     warning_class = type(warning)
     config.setdefault('_warning_counts', {}).setdefault(warning_class, 0)
     config['_warning_counts'][warning_class] += 1
@@ -67,11 +67,11 @@ def _suppressed_warning(warning, config):
         if message_count == MAX_WARNINGS:
             warning.formatted_message += \
                 ' (suppressing further warnings of this type...)'
-        warn(warning)
+        warn(warning, stacklevel=stacklevel+1)
 
 
 def warn_or_raise(warning_class, exception_class=None, args=(), config={},
-                  pos=None):
+                  pos=None, stacklevel=1):
     """
     Warn or raise an exception, depending on the pedantic setting.
     """
@@ -80,7 +80,7 @@ def warn_or_raise(warning_class, exception_class=None, args=(), config={},
             exception_class = warning_class
         vo_raise(exception_class, args, config, pos)
     else:
-        vo_warn(warning_class, args, config, pos)
+        vo_warn(warning_class, args, config, pos, stacklevel=stacklevel+1)
 
 
 def vo_raise(exception_class, args=(), config={}, pos=None):
@@ -106,18 +106,18 @@ def vo_reraise(exc, config={}, pos=None, additional=''):
     raise exc
 
 
-def vo_warn(warning_class, args=(), config={}, pos=None):
+def vo_warn(warning_class, args=(), config={}, pos=None, stacklevel=1):
     """
     Warn, with proper position information if available.
     """
     warning = warning_class(args, config, pos)
-    _suppressed_warning(warning, config)
+    _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 
 
-def warn_unknown_attrs(element, attrs, config, pos, good_attr=[]):
+def warn_unknown_attrs(element, attrs, config, pos, good_attr=[], stacklevel=1):
     for attr in attrs:
         if attr not in good_attr:
-            vo_warn(W48, (attr, element), config, pos)
+            vo_warn(W48, (attr, element), config, pos, stacklevel=stacklevel+1)
 
 
 _warning_pat = re.compile(

--- a/astropy/io/vo/table.py
+++ b/astropy/io/vo/table.py
@@ -156,6 +156,7 @@ def validate(filename, output=sys.stdout, xmllint=False):
         `None`, the return value will be a string.
     """
     import textwrap
+    from . import converters, unit, xmlutil
     from ...utils.console import print_code_line, color_print
 
     return_as_str = False
@@ -168,9 +169,10 @@ def validate(filename, output=sys.stdout, xmllint=False):
     # This is a special variable used by the Python warnings
     # infrastructure to keep track of warnings that have already been
     # seen.  Since we want to get every single warning out of this, we
-    # have to delete it first.
-    if hasattr(exceptions, '__warningregistry__'):
-        del exceptions.__warningregistry__
+    # have to delete all of them first.
+    for module in (exceptions, converters, tree, unit, xmlutil):
+        if hasattr(module, '__warningregistry__'):
+            del module.__warningregistry__
 
     with io.open(filename, 'rb') as input:
         with warnings.catch_warnings(record=True) as warning_lines:
@@ -235,4 +237,3 @@ def validate(filename, output=sys.stdout, xmllint=False):
     if return_as_str:
         return output.getvalue()
     return len(lines) == 0 and success == 0
-


### PR DESCRIPTION
This is a number of bugfixes for the `logging_helper` module that were hard to unbundle.  Sorry for the lack of individual commits.  @astropy: You may want to vet this.

1) Use our compat `inspect_getmodule` to get around a bug in py 3.1, 3.2

2) Display the warning class in the log message as suggested by @eteq in #221.  Adds a new test `test_warnings_logging_with_custom_class` to test that functionality.

3) Correctly extract the source of the warning when logging it.  Since `warnings.warn` may have been called with a `stacklevel` argument, the logical source of the warning may not be the first "different" module up the call stack (as found by `find_current_module`'s `finddiff` functionality).  Instead, the third argument passed to `showwarning`, the file path is used.  There doesn't seem to be a direct way to get from a file path to a module name, so it iterates through sys.modules to find a module that matches the given path.  On Python 3 this is trivial.  On Python 2, we need to ignore the file extension, since module.**file** is set to the .pyc file, but `showwarnings`'s file argument gives us the path to the source file.  That hacky mess could be eliminated if we'd rather display the file path to the source rather than the module path (and the exception logger should be updated to match, but that's easy since going from module to file is much easier than file to module).

4) A minor refactoring to call `self.warnings_logging_enabled()`/`self.exception_logging_enabled()` rather than duplicating the test for that everywhere.

5) Fix the determination of origin in the exception logger.  The traceback passed to excepthook starts pointing at the outermost stack frame, but I believe what we want to log is the innermost stack frame.  It's been changed so it recurses into the stack until reaching the innermost stack frame and getting the module name from that.  A test has been added (`test_exception_loggin_origin`) to test that the origin of exceptions is correctly determined over in disparate parts of the source tree.

6) Since `io.vo.exceptions.VOWarning` has been fixed, there is no longer a need to special case those warnings in `logging_helper`.  A test has been added, (`test_warning_logging_with_io_vo_warning`), to make sure that remains the case.

7) The warning utilities in `io.vo` now use `warnings.warn`'s `stacklevel` kwarg to show that the warning comes from the source of the warning and not the `exceptions` utilities module.  This required cleaning out the `__warningregistry__` in more modules in order for `io.vo.validate` to continue working.
