### PR TITLE
log exception-capturing fixes

### DIFF
--- a/astropy/config/logging_helper.py
+++ b/astropy/config/logging_helper.py
@@ -223,16 +223,25 @@ class AstropyLogger(Logger):
 
     _excepthook_orig = None
 
-    def _excepthook(self, type, value, traceback):
+    def _excepthook(self, etype, value, traceback):
         tb = traceback
         while tb.tb_next is not None:
             tb = tb.tb_next
         mod = inspect_getmodule(tb)
-        if mod is not None:
-            self.error(value.args[0], extra={'origin': mod.__name__})
+
+        # include the the error type in the message.
+        if len(value.args) > 0:
+            message = '{0}: {1}'.format(etype.__name__, str(value))
         else:
-            self.error(value.args[0])
-        self._excepthook_orig(type, value, traceback)
+            message = unicode(etype.__name__)
+
+
+
+        if mod is not None:
+            self.error(message, extra={'origin': mod.__name__})
+        else:
+            self.error(message)
+        self._excepthook_orig(etype, value, traceback)
 
     def exception_logging_enabled(self):
         return self._excepthook_orig is not None


### PR DESCRIPTION
This makes two minor changes to how the astropy logger fomats exceptions:
- It adds the name of the exception to the message (like the warnings)
- it uses `str(exc)` to get the message itself, instead of `exc.args[0]`.  The latter was failing for cases like `raise ValueError` because it has no `args`.
