### PR TITLE
adjusted isatty to return True when ipython qtconsole is in use

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -34,7 +34,19 @@ def isatty(file):
     Most built-in Python file-like objects have an `isatty` member,
     but some user-defined types may not, so this assumes those are not
     ttys.
+
+    This also returns `True` if an IPython two-process shell is in use and
+    `file` is stdout.  This is because even though it's technically not a tty,
+    the IPython shell works as one for most console-related purposes.
+
     """
+    try:
+        ipnm = get_ipython().__class__.__name__
+        if ipnm == 'ZMQInteractiveShell' and file is sys.stdout:
+            return True
+    except NameError:
+        pass
+
     if hasattr(file, 'isatty'):
         return file.isatty()
     return False


### PR DESCRIPTION
This adds an extra change to `astropy.utils.console.isatty` to return True when the IPython qtconsole is in use.  the `stdout` for the qtconsole says it is not a tty, but for all the purposes we are concerned about (color printing, download indicators, etc), it basically acts as one.  Given how nice it the qtconsole is, it seems better to special-case it as a "known-good" configuration.

@mdboom, given you wrote most of this module, does it seem ok to you?  It might be a minor performance hit, but I don't think it should be very noticeable in any reasonable situations...
