### PR TITLE
Add progressbar support for the IPython qtconsole

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -39,7 +39,9 @@ def isatty(file):
     but some user-defined types may not, so this assumes those are not
     ttys.
     """
-    if OutStream is not None and isinstance(file, OutStream):
+    if (OutStream is not None and
+        isinstance(file, OutStream) and
+        file.name == 'stdout'):
         return True
     elif hasattr(file, 'isatty'):
         return file.isatty()


### PR DESCRIPTION
This is an alternative to #241 that will also work with the IPython notebook, once some changes on ipython's end are merged.  See ipython PR 1674.
