### PR TITLE
Should missing .c files from .pyx raise an error?

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -317,7 +317,8 @@ def update_package_files(srcdir, extensions, package_data, packagenames,
                         ext.sources[jdx] = cfn
                     else:
                         raise IOError(
-                            'Could not find C file {0} for Cython file {1}; '
+                            'Could not find C file {0} for Cython file {1} '
+                            'when building extension {2}. '
                             'Cython must be installed to build from a git '
                             'checkout'.format(cfn, pyxfn, ext.name))
 


### PR DESCRIPTION
I came across something surprising when setting up a new machine which didn't yet have Cython on it.

If a `.c` file generated from a `.pyx` file is missing and Cython is not available, it merely logs a warning.  Shouldn't this be an exception, since it means we can't build a working astropy?  (It still works to build astropy from a source tarball -- those users still don't need to have Cython installed -- this is only a problem with a `git` checkout.)

```
                        log.warn('Could not find c file {0} for {1}; skipping '
                                 'extension {2}.'.format(cfn, pyxfn, ext.name))
```
