### PR TITLE
added rtd-pip-requirements

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,0 +1,2 @@
+numpy>=1.4.0
+Cython


### PR DESCRIPTION
This adds a special pip requirements file specifically for readthedocs.  The changes in astropy/astropy@32b16cf5c9bb0ab925437e16391bb29997e50f57 seem to have broken the readthedocs build, probably because readthedocs doesn't always have Cython available.  Adding this (and making a small change in the readthedocs settings, which I can do once this is accepted) will make it always have Cython available in the build.
