### PR TITLE
updated test_hdulist to work properly if extension names are case-sensitive

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -18,7 +18,10 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.open(self.data('o4sp040b0_raw.fits'))
         hdul[4].update_ext_name('Jim', "added by Jim")
         hdul[4].update_ext_version(9, "added by Jim")
-        assert hdul[('JIM', 9)].header['extname'] == 'JIM'
+        if fits.EXTENSION_NAME_CASE_SENSITIVE():
+            assert hdul[('JIM', 9)].header['extname'] == 'Jim'
+        else:
+            assert hdul[('JIM', 9)].header['extname'] == 'JIM'
 
     def test_hdu_file_bytes(self):
         hdul = fits.open(self.data('checksum.fits'))


### PR DESCRIPTION
I came across this when I set fits.EXTENSION_NAME_CASE_SENSITIVE to True in the configuration file.  It turns out one of the tests depends on it being False (to match the name of an extension correctly).  This tweak fixes that so that it works regardless of what the user has set for the case sensitivity.  @iguananaut - can you confirm this is fine?
