### PR TITLE
setup.py display options broken

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -175,6 +175,15 @@ def get_distutils_display_options():
     return short_display_opts.union(long_display_opts)
 
 
+def is_distutils_display_option():
+    """ Returns True if sys.argv contains any of the distutils display options
+    such as --version or --name.
+    """
+
+    display_options = get_distutils_display_options()
+    return bool(set(sys.argv[1:]).intersection(display_options))
+
+
 def get_distutils_option(option, commands):
     """ Returns the value of the given distutils option.
 
@@ -714,7 +723,7 @@ def add_legacy_alias(old_package, new_package, equiv_version, extras={}):
 
     shim_dir = os.path.join(get_legacy_alias_dir(), old_package)
 
-    if found_legacy_module:
+    if found_legacy_module and not is_distutils_display_option():
         warn('-' * 60)
         warn("The legacy package '{0}' was found.".format(old_package))
         warn("To install astropy's compatibility layer instead, uninstall")

--- a/astropy/version_helper.py
+++ b/astropy/version_helper.py
@@ -180,7 +180,7 @@ def _get_version_py_str(packagename, version, release, debug):
 def generate_version_py(packagename, version, release, debug=None):
     """Regenerate the version.py module if necessary."""
 
-    from .setup_helpers import get_distutils_display_options
+    from .setup_helpers import is_distutils_display_option
     from distutils import log
     import imp
     import os
@@ -203,15 +203,13 @@ def generate_version_py(packagename, version, release, debug=None):
         debug = bool(current_debug)
 
     version_py = os.path.join(packagename, 'version.py')
-    display_opts = get_distutils_display_options()
-    argv = set(sys.argv)
 
     if (current_version != version or current_release != release or
         current_debug != debug):
         if '-q' not in sys.argv and '--quiet' not in sys.argv:
             log.set_threshold(log.INFO)
 
-        if display_opts.intersection(argv):
+        if is_distutils_display_option():
             # Always silence unnecessary log messages when display options are
             # being used
             log.set_threshold(log.WARN)


### PR DESCRIPTION
When using the display options like `./setup.py --version` or `./setup.py --name` we're running into several issues.

For example:

```
$ ./setup.py --version
0.0.0
0.0.0
0.0.0
0.1.dev1251
```

The problem is that `setup_helpers.get_distutils_option()` causes distutils to handle those display options in the process of parsing the distutils command line arguments.  This could probably be fixed by stripping display options out of the argument list in get_disutils_option().

Another related problem is that if the version.py file doesn't exist then there will be additional output like "Freezing version number to astropy/version.py".  This could break external tools that rely on `./setup.py --version` working correctly.  We should take some steps to make sure that any additional output from Astropy is disabled when using distutils display options.
