### PR TITLE
Add an __array__ method to NDData

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -72,6 +72,29 @@ class NDData(object):
         If the `error` or `mask` inputs cannot be broadcast (e.g., match
         shape) onto `data`.
 
+    Notes
+    -----
+    `NDData` objects can be easily converted to a regular Numpy array
+    using `numpy.asarray`
+
+    For example::
+
+        >>> from astropy.nddata import NDData
+        >>> import numpy as np
+        >>> x = NDData([1,2,3])
+        >>> np.asarray(x)
+        array([1, 2, 3])
+
+    If the `NDData` object has a `mask`, `numpy.asarray` will return a
+    Numpy masked array.
+
+    This is useful, for example, when plotting a 2D image using
+    matplotlib::
+
+        >>> from astropy.nddata import NDData
+        >>> from matplotlib import pyplot as plt
+        >>> x = NDData([[1,2,3], [4,5,6]])
+        >>> plt.imshow(x)
     """
     def __init__(self, data, error=None, mask=None, wcs=None, meta=None,
                  units=None, copy=True, validate=True):
@@ -183,20 +206,6 @@ class NDData(object):
         """
         This allows code that requests a Numpy array to use an NDData
         object as a Numpy array.
-
-        For example::
-
-            >>> from astropy.nddata import NDData
-            >>> import numpy as np
-            >>> x = NDData([1,2,3])
-            >>> np.asarray(x)
-            array([1, 2, 3])
-
-        This is useful, for example, when plotting a 2D image using
-        matplotlib::
-
-            >>> from matplotlib import pyplot as plt
-            >>> plt.imshow(x)
         """
         if self.mask is not None:
             return np.ma.masked_array(self.data, self.mask)


### PR DESCRIPTION
This makes them easier to plot in matplotlib, such as:

```
In [1]: from astropy.nddata import nddata

In [2]: x = nddata.NDData([[0, 1, 2], [4, 5, 6], [7, 8, 9]], mask=[[False, True, True], [True, True, False], [True, True, True]])                                                                      

In [3]: from matplotlib import pyplot as plt                                                                                                                                                           

In [4]: plt.imshow(x, interpolation='nearest')                                                                                                                                                         
Out[4]: <matplotlib.image.AxesImage at 0x4911950>

In [5]: plt.show()
```

Note, this creates zero dependency on matplotlib.

Inspired by the mailing list thread "NDData plot proposal"
