### PR TITLE
Homogenized "using" sections in subpackage docs

### DIFF
--- a/docs/_pkgtemplate.rst
+++ b/docs/_pkgtemplate.rst
@@ -16,8 +16,8 @@ Short tutorial-like examples of how to do common-tasks - should be
 fairly quick, with any more detailed examples in the next section.
 
 
-Using packagename
------------------
+Using `packagename`
+-------------------
 
 .. THIS SECTION SHOULD BE EITHER
 

--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -54,8 +54,8 @@ want to see your changes immediately in your current Astropy session, just do::
     access the ``$HOME/.astropy`` directory.
 
 
-Using `astropy.config`
-----------------------
+Using `config`
+--------------
 
 Changing Values at Run-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -147,7 +147,7 @@ Or if you want to reload all astropy configuration at once, use the
 
 
 Developer Usage
----------------
+^^^^^^^^^^^^^^^
 
 Configuration items should be used wherever an option or setting is
 needed that is either tied to a system configuration or should persist

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -102,8 +102,8 @@ the option to send the output to ``sys.stdout`` instead of a file::
   \end{tabular}
   \end{table}
 
-Using `astropy.io.ascii`
--------------------------
+Using `io.ascii`
+----------------
 
 The details of using `astropy.io.ascii` are provided in the following sections:
 

--- a/docs/io/vo/index.rst
+++ b/docs/io/vo/index.rst
@@ -155,8 +155,8 @@ format can be set on a per-table basis using the
   votable.set_all_tables_format('binary')
   votable.to_xml('binary.xml')
 
-Using astropy.io.vo
--------------------
+Using `io.vo`
+-------------
 
 Standard compliance
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -38,8 +38,8 @@ You can also use `make_kernel` to generate n-dimensional kernels::
 
 See the documentation below for more information.
 
-Using NDData
-------------
+Using `nddata`
+--------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -4,7 +4,7 @@
 
 
 Data Tables (`astropy.table`)
-===============================================
+=============================
 
 Introduction
 ------------
@@ -33,7 +33,7 @@ Getting Started
 The basic workflow for creating a table, accessing table elements,
 and modifying the table is shown below.  These examples show a very simple
 case, while the full `astropy.table` documentation is available from the
-`Using Tables`_ section.
+:ref:`using_astropy_table` section.
 
 First create a simple table with three columns of data named ``a``, ``b``,
 and ``c``.  These columns have integer, float, and string values respectively::
@@ -136,8 +136,10 @@ Lastly, adding a new row of data to the table is as follows::
   >>> len(t)
   4
 
-Using Tables
-------------
+.. _using_astropy_table:
+
+Using `table`
+-------------
 
 The details of using `astropy.table` are provided in the following sections:
 


### PR DESCRIPTION
This makes all of the "using packagename" sections in the subpackage documentation use the same conventions (and slightly clarifies the template to reflect this).  Also, @taldcroft, you may want to glance at the change in the `table` doc index - I did that because I couldn't figure out how to link-by-name to a section with a backtick in it.
