### PR TITLE
fixed autosummary tables everywhere

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -27,9 +27,9 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.pngmath',
     'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary',
     'sphinx.ext.inheritance_diagram',
     'astropy.sphinx.ext.numpydoc',
+    'astropy.sphinx.ext.astropyautosummary',
     'astropy.sphinx.ext.automodsumm',
     'astropy.sphinx.ext.automodapi'
     ]

--- a/astropy/sphinx/ext/astropyautosummary.py
+++ b/astropy/sphinx/ext/astropyautosummary.py
@@ -1,0 +1,97 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This sphinx extension builds off of `sphinx.ext.autosummary` to
+clean up some issues it presents in the Astropy docs.
+
+The main issue this fixes is the summary tables getting cut off before the
+end of the sentence in some cases.
+
+"""
+import re
+
+from sphinx.ext.autosummary import Autosummary
+
+# used in Automodsumm.get_items
+_itemsummrex = re.compile(r'^([A-Z].*?\.(?:\s|$))')
+
+
+class AstropyAutosummary(Autosummary):
+    def get_items(self, names):
+        """Try to import the given names, and return a list of
+        ``[(name, signature, summary_string, real_name), ...]``.
+        """
+        from sphinx.ext.autosummary import (get_import_prefixes_from_env,
+            import_by_name, get_documenter, mangle_signature)
+
+        env = self.state.document.settings.env
+
+        prefixes = get_import_prefixes_from_env(env)
+
+        items = []
+
+        max_item_chars = 50
+
+        for name in names:
+            display_name = name
+            if name.startswith('~'):
+                name = name[1:]
+                display_name = name.split('.')[-1]
+
+            try:
+                real_name, obj, parent = import_by_name(name, prefixes=prefixes)
+            except ImportError:
+                self.warn('failed to import %s' % name)
+                items.append((name, '', '', name))
+                continue
+
+            # NB. using real_name here is important, since Documenters
+            #     handle module prefixes slightly differently
+            documenter = get_documenter(obj, parent)(self, real_name)
+            if not documenter.parse_name():
+                self.warn('failed to parse name %s' % real_name)
+                items.append((display_name, '', '', real_name))
+                continue
+            if not documenter.import_object():
+                self.warn('failed to import object %s' % real_name)
+                items.append((display_name, '', '', real_name))
+                continue
+
+            # -- Grab the signature
+
+            sig = documenter.format_signature()
+            if not sig:
+                sig = ''
+            else:
+                max_chars = max(10, max_item_chars - len(display_name))
+                sig = mangle_signature(sig, max_chars=max_chars)
+                sig = sig.replace('*', r'\*')
+
+            # -- Grab the summary
+
+            doc = list(documenter.process_doc(documenter.get_doc()))
+
+            while doc and not doc[0].strip():
+                doc.pop(0)
+            m = _itemsummrex.search(" ".join(doc).strip())
+            if m:
+                summary = m.group(1).strip()
+            elif doc:
+                summary = doc[0].strip()
+            else:
+                summary = ''
+
+            items.append((display_name, sig, summary, real_name))
+
+        print '\ninside!'
+        for i in items:
+            print i[0]
+        print '\n'
+
+        return items
+
+
+def setup(app):
+    # need autosummary, of course
+    app.setup_extension('sphinx.ext.autosummary')
+    # this replaces the default autosummary with the astropy one
+    app.add_directive('autosummary', AstropyAutosummary)

--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -57,12 +57,10 @@ from sphinx.ext.inheritance_diagram import InheritanceDiagram
 from docutils.parsers.rst.directives import flag
 
 from ...utils.misc import find_mod_objs
-
-# used in Automodsumm.get_items
-_itemsummrex = re.compile(r'^([A-Z].*?\.(?:\s|$))')
+from .astropyautosummary import AstropyAutosummary
 
 
-class Automodsumm(Autosummary):
+class Automodsumm(AstropyAutosummary):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
@@ -111,74 +109,6 @@ class Automodsumm(Autosummary):
             return nodelist
         finally:  # has_content = False for the Automodsumm
             self.content = []
-
-    def get_items(self, names):
-        """Try to import the given names, and return a list of
-        ``[(name, signature, summary_string, real_name), ...]``.
-        """
-        from sphinx.ext.autosummary import (get_import_prefixes_from_env,
-            import_by_name, get_documenter, mangle_signature)
-
-        env = self.state.document.settings.env
-
-        prefixes = get_import_prefixes_from_env(env)
-
-        items = []
-
-        max_item_chars = 50
-
-        for name in names:
-            display_name = name
-            if name.startswith('~'):
-                name = name[1:]
-                display_name = name.split('.')[-1]
-
-            try:
-                real_name, obj, parent = import_by_name(name, prefixes=prefixes)
-            except ImportError:
-                self.warn('failed to import %s' % name)
-                items.append((name, '', '', name))
-                continue
-
-            # NB. using real_name here is important, since Documenters
-            #     handle module prefixes slightly differently
-            documenter = get_documenter(obj, parent)(self, real_name)
-            if not documenter.parse_name():
-                self.warn('failed to parse name %s' % real_name)
-                items.append((display_name, '', '', real_name))
-                continue
-            if not documenter.import_object():
-                self.warn('failed to import object %s' % real_name)
-                items.append((display_name, '', '', real_name))
-                continue
-
-            # -- Grab the signature
-
-            sig = documenter.format_signature()
-            if not sig:
-                sig = ''
-            else:
-                max_chars = max(10, max_item_chars - len(display_name))
-                sig = mangle_signature(sig, max_chars=max_chars)
-                sig = sig.replace('*', r'\*')
-
-            # -- Grab the summary
-
-            doc = list(documenter.process_doc(documenter.get_doc()))
-
-            while doc and not doc[0].strip():
-                doc.pop(0)
-            m = _itemsummrex.search(" ".join(doc).strip())
-            if m:
-                summary = m.group(1).strip()
-            elif doc:
-                summary = doc[0].strip()
-            else:
-                summary = ''
-
-            items.append((display_name, sig, summary, real_name))
-
-        return items
 
 
 #<-------------------automod-diagram stuff------------------------------------>
@@ -504,8 +434,8 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
 
 
 def setup(app):
-    # need autosummary for automodsumm
-    app.setup_extension('sphinx.ext.autosummary')
+    # need our autosummary
+    app.setup_extension('astropy.sphinx.ext.astropyautosummary')
     # need inheritance-diagram for automod-diagram
     app.setup_extension('sphinx.ext.inheritance_diagram')
 


### PR DESCRIPTION
#231 included a fix to the `astropy.sphinx.ext.automodsumm` that kept it from cutting off the first sentence of a docstring at the end of a line (in certain cases).  However, that fix only applied to `automodsumm` directive, meaning the problem still existed for `autosummary` directives. (Which are used in the pages `automodsumm` generates...) This implements the fix as an AstropyAutosummary class that overrides the standard sphinx `autosummary`.

This may eventually be fixed if https://bitbucket.org/birkenfeld/sphinx/issue/943/autosummary-doesnt-always-get-first is addressed, but for now it's necessary to make the summary tables look right.  In the future, we might only have this get included if the version of sphinx is too old.
