### PR TITLE
Re-order TOC index to not have advanced topics at the start

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,17 +26,16 @@ User Documentation
    overview
    install
    nddata/index
-   wcs/index
-   io/fits/index
-   io/vo/index
-   io/ascii/index
    table/index
    cosmology/index
+   io/fits/index
+   io/ascii/index
+   io/vo/index
+   wcs/index
    tools/index
    utils/index
    configs/index
    logging
-
 
 .. _developer-docs:
 


### PR DESCRIPTION
This is a pretty trivial change, so I'll merge later today if there are no objections. Basically, given that the configuration system is still under construction, and we don't want to confuse most users with configuration or logging issues, I figured they should be at the end of the user docs.
