### PR TITLE
made default value for vo PEDANTIC config item False

### DIFF
--- a/astropy/io/vo/table.py
+++ b/astropy/io/vo/table.py
@@ -22,7 +22,7 @@ __all__ = ['parse', 'parse_single_table', 'validate']
 
 PEDANTIC = ConfigurationItem(
     'pedantic',
-    True,
+    False,
     'When True, treat fixable violations of the VOTable spec as exceptions.')
 
 


### PR DESCRIPTION
This is a very simple thing, but needs to be run by @mdboom  

It changes the default value for the `PEDANTIC` configuration item to False.  I'm suggesting this because I find that a _lot_ of VO Tables I download from various places are not fully-compliant (in fact I have yet to find one from a real science source that will parse with `pedantic=True`!). I suspect a lot of users will try to do this and not understand that they need to change this setting, so I suggest it _default_ to False instead of True.
