### PR TITLE
Tidied up mask, flags, error

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -207,21 +207,6 @@ class NDData(object):
         """
         return self.data.ndim
 
-    @property
-    def boolmask(self):
-        """
-        The mask as a boolean array (or None if the mask is None).
-
-        This mask is True where the data is *valid*, and False where the data
-        should be *masked*.  This is the opposite of the convention used for
-        `mask`, but allows simple retrieval of the unmasked data points as
-        ``ndd.data[ndd.boolmask]``.
-        """
-        if self.mask is None:
-            return None
-        else:
-            return ~self.mask
-
     def __array__(self):
         """
         This allows code that requests a Numpy array to use an NDData

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -97,9 +97,3 @@ def test_nddata_conversion():
     nd = NDData([[1, 2, 3], [4, 5, 6]])
     assert nd.size == 6
     assert nd.dtype == np.dtype(int)
-
-
-def test_boolmask():
-    boolmask = np.random.random((10, 10)) > 0.5  # random mask that boolmask should look like
-    nd1 = NDData(np.random.random((10, 10)), mask=~boolmask)  # mask False where valid
-    assert np.all(nd1.boolmask == boolmask)


### PR DESCRIPTION
This is just a small update to NDData to formalize what was discussed in #224, which is that it would be good to separate the concept of mask (which should ultimately just be True/False) and that of flags (which can apply equally to good and bad data). The issue with the previous approach was the there were many different kinds of bad data (mask != 0) but only one type of good data (mask == 0).

I've also changed mask, error, and flags to be checked anytime they are set, as otherwise the user could set those attributes incorrectly since they don't have to call the validating method.

The mask and flags have to be the same dimensions as the data, but the error can be different (e.g. if the error is constant over the image, if each pixel has an image, or if each pixel has a full PDF).

I removed the `validate` option from `__init__`, because at the moment, the way it was implemented, it was possible to have `copy=True` and `validate=False`, and `copy=True` would be silently ignored.

@eteq, @crawfordsm, @wkerzendorf - any thoughts?

(tests still need to be updated)
