### PR TITLE
Need an option for setup.py to disable legacy packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,24 @@ cmdclassd = {'test': setup_helpers.setup_test_command('astropy'),
              # Use distutils' sdist because it respects package_data.
              # setuptools/distributes sdist requires duplication of
              # information in MANIFEST.in
-             'sdist': sdist.sdist}
+             'sdist': sdist.sdist,
+
+             # Use a custom build command which understands additional
+             # commandline arguments
+             'build': setup_helpers.AstropyBuild
+             }
+
+if setup_helpers.HAVE_CYTHON and not release:
+    from Cython.Distutils import build_ext
+    # Builds Cython->C if in dev mode and Cython is present
+    cmdclassd['build_ext'] = build_ext
+
+if setup_helpers.AstropyBuildSphinx is not None:
+    cmdclassd['build_sphinx'] = setup_helpers.AstropyBuildSphinx
+
+# Set our custom command class mapping in setup_helpers, so that
+# setup_helpers.get_distutils_option will use the custom classes.
+setup_helpers.cmdclassd = cmdclassd
 
 # Additional C extensions that are not Cython-based should be added here.
 extensions = []
@@ -79,15 +96,6 @@ package_dirs = {}
 # more details.
 setup_helpers.update_package_files('astropy', extensions, package_data,
                                    packagenames, package_dirs)
-
-if setup_helpers.HAVE_CYTHON and not release:
-    from Cython.Distutils import build_ext
-    # Builds Cython->C if in dev mode and Cython is present
-    cmdclassd['build_ext'] = build_ext
-
-if setup_helpers.AstropyBuildSphinx is not None:
-    cmdclassd['build_sphinx'] = setup_helpers.AstropyBuildSphinx
-
 
 # Currently the only entry points installed by Astropy are hooks to
 # zest.releaser for doing Astropy's releases


### PR DESCRIPTION
When Astropy is installed with MacPorts, it fails if pyfits is already installed, because it tries to install the legacy shim:

```
Error: org.macports.activate for port py27-astropy returned: Image error: /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pyfits/__init__.py is being used by the active py27-pyfits port.  Please deactivate this port first, or use 'port -f activate py27-astropy' to force the activation.
Please see the log file for port py27-astropy for details:
    /opt/local/var/macports/logs/_opt_local_var_macports_sources_rsync.macports.org_release_ports_python_py-astropy/py27-astropy/main.log
To report a bug, follow the instructions in the guide:
    http://guide.macports.org/#project.tickets
Error: Processing of port py27-astropy failed
```

This is due to the fact that the package is built in a pristine environment before being moved to the final location, so it doesn't detect if the real packages are already there. We need an option like:

```
python setup.py build --disable-legacy
```

To force legacy packages to not be installed.
