### PR TITLE
"setup.py --help" prints help string five times.

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -192,6 +192,11 @@ def get_distutils_display_options():
                              if o[1])
     long_display_opts = set('--' + o[0] for o in Distribution.display_options)
 
+    # Include -h and --help which are not explicitly listed in
+    # Distribution.display_options (as they are handled by optparse)
+    short_display_opts.add('-h')
+    long_display_opts.add('--help')
+
     return short_display_opts.union(long_display_opts)
 
 


### PR DESCRIPTION
This is obviously a pretty minor issue, but it would be nice to fix if it is not too hard.  It is the first thing some people (at least, me) will do upon downloading the package. 
#259 fixed a lot of the other issues with things being printed multiple times in setup.py but I just noticed that this problem remains.
