### PR TITLE
Raise an explicit error if compiler is set to a version that will fail if CC environment variable is set.

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -554,7 +554,6 @@ def adjust_compiler():
     """
 
     from distutils import ccompiler, sysconfig
-    import subprocess
     import re
 
     compiler_mapping = [
@@ -573,11 +572,7 @@ def adjust_compiler():
         # Check that CC is not set to llvm-gcc-4.2
         c_compiler = os.environ['CC']
 
-        process = subprocess.Popen(
-            shlex.split(c_compiler) + ['--version'], stdout=subprocess.PIPE)
-
-        output = process.communicate()[0].strip()
-        version = output.split()[0]
+        version = get_compiler_version(c_compiler)
 
         for broken, fixed in compiler_mapping:
             if re.match(broken, version):
@@ -598,14 +593,24 @@ def adjust_compiler():
         # compiler as returned by ccompiler.new_compiler()
         c_compiler = sysconfig.get_config_var('CC')
 
-        process = subprocess.Popen(
-            shlex.split(c_compiler) + ['--version'], stdout=subprocess.PIPE)
-        output = process.communicate()[0].strip()
-        version = output.split()[0]
+        version = get_compiler_version(c_compiler)
+
         for broken, fixed in compiler_mapping:
             if re.match(broken, version):
                 os.environ['CC'] = fixed
                 break
+
+def get_compiler_version(compiler):
+
+    import subprocess
+
+    process = subprocess.Popen(
+    shlex.split(compiler) + ['--version'], stdout=subprocess.PIPE)
+
+    output = process.communicate()[0].strip()
+    version = output.split()[0]
+
+    return version
 
 
 def is_in_build_mode():


### PR DESCRIPTION
Some people have the CC variable set unknowingly, and it can in some cases point to the faulty apple `llvm-gcc-4.2`. This PR implements a fix, by checking the compiler specified by the CC environment variable and giving an error if it is a faulty one. I decided to:
- print an error message and call `sys.exit` manually, as the traceback is not useful and confusing for most users.
- _not_ automatically switch to clang (or other) as if the user does:
  
  ```
  CC=whatever python setup.py build
  ```
  
  they will not understand if the compiler magically changes to something else.

@mdboom - any thoughts since you implemented the original version of this?
