### PR TITLE
Changed remaining astropy.io.fits instances in docs to fits for new import style

### DIFF
--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -25,13 +25,7 @@ Reading and Updating Existing FITS Files
 Opening a FITS file
 ^^^^^^^^^^^^^^^^^^^
 
-Once the `astropy.io.fits` package is loaded, we can open an existing FITS
-file:
-
-    >>> import astropy.io.fits
-    >>> hdulist = astropy.io.fits.open('input.fits')
-
-For the sake of brevity, one may also use `astropy.io.fits` like so:
+Once the `astropy.io.fits` package is loaded using the standard convention\ [#f1]_, we can open an existing FITS file:
 
     >>> from astropy.io import fits
     >>> hdulist = fits.open('input.fits')
@@ -267,7 +261,7 @@ with record arrays is not a prerequisite for this Guide.
 Like images, the data portion of a FITS table extension is in the ``.data``
 attribute:
 
-    >>> hdulist = astropy.io.fits.open('table.fits')
+    >>> hdulist = fits.open('table.fits')
     >>> tbdata = hdulist[1].data # assuming the first extension is a table
 
 To see the first row of the table:
@@ -354,7 +348,7 @@ also be used to write all the changes made since :func:`open`, back to the
 original file. The :meth:`~HDUList.close` method will do the same for a FITS
 file opened with update mode.
 
-    >>> f = astropy.io.fits.open('original.fits', mode='update')
+    >>> f = fits.open('original.fits', mode='update')
     ... # making changes in data and/or header
     >>> f.flush() # changes are written back to original.fits
 
@@ -377,12 +371,12 @@ First, we create a numpy object for the data part:
 
 Next, we create a :class:`PrimaryHDU` object to encapsulate the data:
 
-    >>> hdu = astropy.io.fits.PrimaryHDU(n)
+    >>> hdu = fits.PrimaryHDU(n)
 
 We then create a HDUList to contain the newly created primary HDU, and write to
 a new file:
 
-    >>> hdulist = astropy.io.fits.HDUList([hdu])
+    >>> hdulist = fits.HDUList([hdu])
     >>> hdulist.writeto('new.fits')
 
 That's it! In fact, Astropy even provides a shortcut for the last two lines to
@@ -404,21 +398,21 @@ constructing the :class:`Column` objects and their data. Suppose we have two
 columns, the first containing strings, and the second containing floating point
 numbers:
 
-    >>> import astropy.io.fits
+    >>> from astropy.io import fits
     >>> import numpy as np
     >>> a1 = np.array(['NGC1001', 'NGC1002', 'NGC1003'])
     >>> a2 = np.array([11.1, 12.3, 15.2])
-    >>> col1 = astropy.io.fits.Column(name='target', format='20A', array=a1)
-    >>> col2 = astropy.io.fits.Column(name='V_mag', format='E', array=a2)
+    >>> col1 = fits.Column(name='target', format='20A', array=a1)
+    >>> col2 = fits.Column(name='V_mag', format='E', array=a2)
 
 Next, create a :class:`ColDefs` (column-definitions) object for all columns:
 
-    >>> cols = astropy.io.fits.ColDefs([col1, col2])
+    >>> cols = fits.ColDefs([col1, col2])
 
 Now, create a new binary table HDU object by using the :func:`new_table()`
 function:
 
-    >>> tbhdu = astropy.io.fits.new_table(cols)
+    >>> tbhdu = fits.new_table(cols)
 
 This function returns (in this case) a :class:`BinTableHDU`.
 
@@ -431,12 +425,12 @@ Of course, you can do this more concisely:
 
 As before, we create a :class:`PrimaryHDU` object to encapsulate the data:
 
-    >>> hdu = astropy.io.fits.PrimaryHDU(n)
+    >>> hdu = fits.PrimaryHDU(n)
 
 We then create a HDUList containing both the primary HDU and the newly created
 table extension, and write to a new file:
 
-    >>> thdulist = astropy.io.fits.HDUList([hdu, tbhdu])
+    >>> thdulist = fits.HDUList([hdu, tbhdu])
     >>> thdulist.writeto('table.fits')
 
 If this will be the only extension of the new FITS file and you only have a
@@ -521,12 +515,12 @@ both data and header, otherwise only data is returned.
 The functions introduced above are for reading. The next few functions
 demonstrate convenience functions for writing:
 
-    >>> astropy.io.fits.writeto('out.fits', data, header)
+    >>> fits.writeto('out.fits', data, header)
 
 The :func:`writeto` function uses the provided data and an optional header to
 write to an output FITS file.
 
-    >>> astropy.io.fits.append('out.fits', data, header)
+    >>> fits.append('out.fits', data, header)
 
 The :func:`append` function will use the provided data and the optional header
 to append to an existing FITS file. If the specified output file does not
@@ -549,7 +543,7 @@ also be keyword arguments.
 Finally, the :func:`info` function will print out information of the specified
 FITS file:
 
-    >>> astropy.io.fits.info('test0.fits')
+    >>> fits.info('test0.fits')
     Filename: test0.fits
     No. Name    Type       Cards Dimensions Format
     0   PRIMARY PrimaryHDU   138 ()         Int16
@@ -596,3 +590,9 @@ Reference/API
     api/images.rst
     api/diff.rst
     api/verification.rst
+
+
+.. rubric:: Footnotes
+
+.. [#f1]  For legacy code only that already depends on PyFITS, it's acceptable to continue using "from astropy.io import fits as pyfits".
+

--- a/docs/io/fits/usage/headers.rst
+++ b/docs/io/fits/usage/headers.rst
@@ -22,7 +22,7 @@ an existing HDU's header and the data value from  a numpy array. If the
 defaults (``None``) are used, the new HDU will have the minimal required
 keywords for an HDU of that type:
 
-    >>> hdu = astropy.io.fits.PrimaryHDU()
+    >>> hdu = fits.PrimaryHDU()
     >>> hdu.header # show the all of the header cards
     SIMPLE = T / conforms to FITS standard
     BITPIX = 8 / array data type
@@ -46,7 +46,7 @@ Value Access, Updating, and Creating
 As shown in the Quick Tutorial, keyword values can be accessed via keyword name
 or index of an HDU's header attribute. Here is a quick summary:
 
-    >>> hdulist = astropy.io.fits.open('input.fits') # open a FITS file
+    >>> hdulist = fits.open('input.fits') # open a FITS file
     >>> prihdr = hdulist[0].header # the primary HDU header
     >>> print prihdr[3] # get the 4th keyword's value
     10
@@ -221,12 +221,12 @@ to the header.
 A new Card object is created with the :class:`Card` constructor:
 ``Card(key, value, comment)``. For example:
 
-    >>> c1 = astropy.io.fits.Card('TEMP', 80.0, 'temperature, floating value')
-    >>> c2 = astropy.io.fits.Card('DETECTOR', 1) # comment is optional
-    >>> c3 = astropy.io.fits.Card('MIR_REVR', True,
-    ...                           'mirror reversed? Boolean value)
-    >>> c4 = astropy.io.fits.Card('ABC', 2+3j, 'complex value')
-    >>> c5 = astropy.io.fits.Card('OBSERVER', 'Hubble', 'string value')
+    >>> c1 = fits.Card('TEMP', 80.0, 'temperature, floating value')
+    >>> c2 = fits.Card('DETECTOR', 1) # comment is optional
+    >>> c3 = fits.Card('MIR_REVR', True,
+    ...                'mirror reversed? Boolean value)
+    >>> c4 = fits.Card('ABC', 2+3j, 'complex value')
+    >>> c5 = fits.Card('OBSERVER', 'Hubble', 'string value')
 
     >>> print c1; print c2; print c3; print c4; print c5 # show the card images
     TEMP = 80.0 / temperature, floating value
@@ -248,8 +248,8 @@ Cards can be verified with :meth:`Card.verify`. The non-standard card ``c2`` in
 the example below is flagged by such verification. More about verification in
 Astropy will be discussed in a later chapter.
 
-    >>> c1 = astropy.io.fits.Card.fromstring('ABC = 3.456D023')
-    >>> c2 = astropy.io.fits.Card.fromstring("P.I. ='Hubble'")
+    >>> c1 = fits.Card.fromstring('ABC = 3.456D023')
+    >>> c2 = fits.Card.fromstring("P.I. ='Hubble'")
     >>> print c1; print c2
     ABC = 3.456D023
     P.I. ='Hubble'
@@ -279,7 +279,7 @@ keyword. Astropy does support this convention, even though it is not a FITS
 standard. The examples below show the use of CONTINUE is automatic for long
 string values.
 
-    >>> header = astropy.io.fits.Header()
+    >>> header = fits.Header()
     >>> header['abc'] = 'abcdefg' * 20
     >>> header
     ABC = 'abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcd&'
@@ -325,15 +325,15 @@ case-sensitive.
 
 Examples follow:
 
-    >>> c = astropy.io.fits.Card('abcdefghi', 10)
+    >>> c = fits.Card('abcdefghi', 10)
     Keyword name 'abcdefghi' is greater than 8 characters; a HIERARCH card will
     be created.
     >>> print c
     HIERARCH abcdefghi = 10
-    >>> c = astropy.io.fits.Card('hierarch abcdefghi', 10)
+    >>> c = fits.Card('hierarch abcdefghi', 10)
     >>> print c
     HIERARCH abcdefghi = 10
-    >>> h = astropy.io.fits.PrimaryHDU()
+    >>> h = fits.PrimaryHDU()
     >>> h.header['hierarch abcdefghi'] =  99
     >>> h.header['abcdefghi']
     99

--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -31,7 +31,7 @@ the numpy array of its data will have the shape of (400, 300).
 
 Here is a summary of reading and updating image data values:
 
-    >>> f = astropy.io.fits.open('image.fits') # open a FITS file
+    >>> f = fits.open('image.fits') # open a FITS file
     >>> scidata = f[1].data # assume the first extension is an image
     >>> print scidata[1,4] # get the pixel value at x=5, y=2
     >>> scidata[30:40, 10:20] # get values of the subsection
@@ -88,7 +88,7 @@ For integer data type, the scaled data will always be single precision floating
 point (numpy.float32). Here is an example of what happens to such a file,
 before and after the data is touched
 
-    >>> f = astropy.io.fits.open('scaled_uint16.fits')
+    >>> f = fits.open('scaled_uint16.fits')
     >>> hdu = f[1]
     >>> print hdu.header['bitpix'], hdu.header['bzero']
     16 32768
@@ -112,7 +112,7 @@ before and after the data is touched
     when saving could result in a loss of information.
 
     To prevent this automatic scaling, open the file with the
-    ``do_not_scale_image_data=True`` argument to ``pyfits.open()``.  This is
+    ``do_not_scale_image_data=True`` argument to ``fits.open()``.  This is
     especially useful for updating some header values, while ensuring that the
     data is not modified.
 
@@ -147,7 +147,7 @@ files, i.e. calls of :meth:`~HDUList.writeto`, :meth:`~HDUList.flush`, or
 an example of what happens to the :attr:`~ImageHDU.data` attribute after the
 :meth:`~ImageHDU.scale` call:
 
-    >>> hdu = astropy.io.fits.PrimaryHDU(numpy.array([0., 1, 2, 3]))
+    >>> hdu = fits.PrimaryHDU(numpy.array([0., 1, 2, 3]))
     >>> print hdu.data
     [ 0. 1. 2. 3.]
     >>> hdu.scale('int16', bzero=32768)
@@ -181,9 +181,9 @@ such cases it may be necessary to use sections.
 Here is an example of getting the median image from 3 input images of the size
 5000x5000:
 
-    >>> f1 = astropy.io.fits.open('file1.fits')
-    >>> f2 = astropy.io.fits.open('file2.fits')
-    >>> f3 = astropy.io.fits.open('file3.fits')
+    >>> f1 = fits.open('file1.fits')
+    >>> f2 = fits.open('file2.fits')
+    >>> f3 = fits.open('file3.fits')
     >>> output = numpy.zeros(5000 * 5000)
     >>> for i in range(50):
     ... j = i * 100

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -57,7 +57,7 @@ Reading a FITS Table
 Like images, the .data attribute of a table HDU contains the data of the table.
 To recap, the simple example in the Quick Tutorial:
 
-    >>> f = astropy.io.fits.open('bright_stars.fits') # open a FITS file
+    >>> f = fits.open('bright_stars.fits') # open a FITS file
     >>> tbdata = f[1].data # assume the first extension is a table
     >>> print tbdata[:2] # show the first two rows
     [(1, 'Sirius', -1.4500000476837158, 'A1V'),
@@ -114,11 +114,11 @@ Merging Tables
 Merging different tables is straightforward in Astropy. Simply merge the column
 definitions of the input tables:
 
-    >>> t1 = astropy.io.fits.open('table1.fits')
-    >>> t2 = astropy.io.fits.open('table2.fits')
+    >>> t1 = fits.open('table1.fits')
+    >>> t2 = fits.open('table2.fits')
     # the column attribute is the column definitions
     >>> t = t1[1].columns + t2[1].columns
-    >>> hdu = astropy.io.fits.new_table(t)
+    >>> hdu = fits.new_table(t)
     >>> hdu.writeto('newtable.fits')
 
 The number of fields in the output table will be the sum of numbers of fields
@@ -137,15 +137,15 @@ append by field indices, the second one is to append by field names. In both
 cases, the output table will inherit column attributes (name, format, etc.) of
 the first table.
 
-    >>> t1 = astropy.io.fits.open('table1.fits')
-    >>> t2 = astropy.io.fits.open('table2.fits')
+    >>> t1 = fits.open('table1.fits')
+    >>> t2 = fits.open('table2.fits')
     # one way to find the number of records
     >>> nrows1 = t1[1].data.shape[0]
     # another way to find the number of records
     >>> nrows2 = t2[1].header['naxis2']
     # total number of rows in the table to be generated
     >>> nrows = nrows1 + nrows2
-    >>> hdu = astropy.io.fits.new_table(t1[1].columns, nrows=nrows)
+    >>> hdu = fits.new_table(t1[1].columns, nrows=nrows)
     # first case, append by the order of fields
     >>> for i in range(len(t1[1].columns)):
     ... hdu.data.field(i)[nrows1:]=t2[1].data.field(i)
@@ -233,7 +233,7 @@ header keywords and descriptions:
 Here are a few Columns using various combination of these arguments:
 
     >>> import numpy as np
-    >>> from astropy.io.fits import Column
+    >>> from fits import Column
     >>> counts = np.array([312, 334, 308, 317])
     >>> names = np.array(['NGC1', 'NGC2', 'NGC3', 'NGC4'])
     >>> c1 = Column(name='target', format='10A', array=names)
@@ -255,12 +255,12 @@ dimension number must be before the letter code, not after.
 After the columns are constructed, the :func:`new_table` function can be used to
 construct a table HDU. We can either go through the column definition object:
 
-    >>> coldefs = astropy.io.fits.ColDefs([c1, c2, c3, c4, c5])
-    >>> tbhdu = astropy.io.fits.new_table(coldefs)
+    >>> coldefs = fits.ColDefs([c1, c2, c3, c4, c5])
+    >>> tbhdu = fits.new_table(coldefs)
 
 or directly use the :func:`new_table` function:
 
-    >>> tbhdu = astropy.io.fits.new_table([c1, c2, c3, c4, c5])
+    >>> tbhdu = fits.new_table([c1, c2, c3, c4, c5])
 
 A look of the newly created HDU's header will show that relevant keywords are
 properly populated:
@@ -302,7 +302,7 @@ any copying.  First, create the Columns as before, but without using the
 
 Then call :func:`new_table`:
 
-    >>> tbhdu = astropy.io.fits.new_table([c1, c2, c3, c4, c5])
+    >>> tbhdu = fits.new_table([c1, c2, c3, c4, c5])
 
 This will create a new table HDU as before, with the correct column
 definitions, but an empty data section.  Now simply assign your array directly

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -20,7 +20,8 @@ same, i.e. the data is in the ``.data`` attribute and the ``field()`` method
 is used to refer to the columns and returns a numpy array. When reading the
 table, Astropy will automatically detect what kind of table it is.
 
-    >>> hdus = astropy.io.fits.open('ascii_table.fits')
+    >>> from astropy.io import fits
+    >>> hdus = fits.open('ascii_table.fits')
     >>> hdus[1].data[:1]
     FITS_rec(
     ... [(10.123000144958496, 37)],
@@ -70,18 +71,18 @@ The default value for tbtype is ``BinTableHDU``.
      >>>
      # Define the columns
      >>> import numpy as np
-     >>> import astropy.io.fits
+     >>> from astropy.io import fits
      >>> a1 = np.array(['abcd', 'def'])
      >>> r1 = np.array([11., 12.])
-     >>> c1 = astropy.io.fits.Column(name='abc', format='A3', array=a1)
-     >>> c2 = astropy.io.fits.Column(name='def', format='E', array=r1,
-     ...                             bscale=2.3, bzero=0.6)
-     >>> c3 = astropy.io.fits.Column(name='t1', format='I', array=[91, 92, 93])
+     >>> c1 = fits.Column(name='abc', format='A3', array=a1)
+     >>> c2 = fits.Column(name='def', format='E', array=r1,
+     ...                  bscale=2.3, bzero=0.6)
+     >>> c3 = fits.Column(name='t1', format='I', array=[91, 92, 93])
      # Create the table
-     >>> x = astropy.io.fits.ColDefs([c1, c2, c3], tbtype='TableHDU')
-     >>> hdu = astropy.io.fits.new_table(x, tbtype='TableHDU')
+     >>> x = fits.ColDefs([c1, c2, c3], tbtype='TableHDU')
+     >>> hdu = fits.new_table(x, tbtype='TableHDU')
      # Or, simply,
-     >>> hdu = astropy.io.fits.new_table([c1, c2, c3], tbtype='TableHDU')
+     >>> hdu = fits.new_table([c1, c2, c3], tbtype='TableHDU')
      >>> hdu.writeto('ascii.fits')
      >>> hdu.data
      FITS_rec([('abcd', 11.0, 91), ('def', 12.0, 92), ('', 0.0, 93)],
@@ -115,7 +116,7 @@ length array field in Astropy), and max is the maximum number of elements. So,
 for a variable length field of int32, The corresponding format spec is,
 e.g. 'PJ(100)'.
 
-    >>> f = astropy.io.fits.open('variable_length_table.fits')
+    >>> f = fits.open('variable_length_table.fits')
     >>> print f[1].header['tform5']
     1PI(20)
     >>> print f[1].data.field(4)[:3]
@@ -206,7 +207,7 @@ other HDU. Just use the .header attribute.
 The content of the HDU can similarly be summarized by using the
 :meth:`HDUList.info` method:
 
-    >>> f = astropy.io.fits.open('random_group.fits')
+    >>> f = fits.open('random_group.fits')
     >>> print f[0].header['groups']
     True
     >>> print f[0].header['gcount']
@@ -337,10 +338,10 @@ to create the HDU itself:
     # in lists assigned to their corresponding arguments.
     # If the data type (bitpix) is not specified, the data type of the image
     # will be used.
-    >>> x = astropy.io.fits.GroupData(imdata, parnames=['abc', 'xyz'],
-             ...                      pardata=[pdata1, pdata2], bitpix=-32)
+    >>> x = fits.GroupData(imdata, parnames=['abc', 'xyz'],
+    ...                    pardata=[pdata1, pdata2], bitpix=-32)
     # Now, create the GroupsHDU and write to a FITS file.
-    >>> hdu = astropy.io.fits.GroupsHDU(x)
+    >>> hdu = fits.GroupsHDU(x)
     >>> hdu.writeto('test_group.fits')
     >>> print hdu.header.ascardlist()[:]
     SIMPLE =            T / conforms to FITS standard
@@ -409,7 +410,7 @@ a FITS file.
 
 The content of the HDU header may be accessed using the ``.header`` attribute:
 
-    >>> f = astropy.io.fits.open('compressed_image.fits')
+    >>> f = fits.open('compressed_image.fits')
     >>> print f[1].header
     XTENSION= 'IMAGE   '           / extension type
     BITPIX  =                   16 / array data type
@@ -424,7 +425,7 @@ The contents of the corresponding binary table HDU may be accessed using the
 hidden ``._header`` attribute.  However, all user interface with the HDU header
 should be accomplished through the image header (the ``.header`` attribute).
 
-    >>> f = astropy.io.fits.open('compressed_image.fits')
+    >>> f = fits.open('compressed_image.fits')
     >>> print f[1]._header
     XTENSION= 'BINTABLE'           / binary table extension
     BITPIX  =                    8 / 8-bit bytes
@@ -451,13 +452,13 @@ should be accomplished through the image header (the ``.header`` attribute).
 The contents of the HDU can be summarized by using either the :func:`info`
 convenience function or method:
 
-    >>> astropy.io.fits.info('compressed_image.fits')
+    >>> fits.info('compressed_image.fits')
     Filename: compressed_image.fits
     No.    Name         Type      Cards   Dimensions   Format
     0    PRIMARY     PrimaryHDU       6  ()            int16
     1    COMPRESSED  CompImageHDU    52  (512, 512)    int16
     >>>
-    >>> f = astropy.io.fits.open('compressed_image.fits')
+    >>> f = fits.open('compressed_image.fits')
     >>> f.info()
     Filename: compressed_image.fits
     No.    Name         Type      Cards   Dimensions   Format
@@ -483,7 +484,7 @@ any) in the image.
 
 The content of the HDU data may be accessed using the ``.data`` attribute:
 
-    >>> f = astropy.io.fits.open('compressed_image.fits')
+    >>> f = fits.open('compressed_image.fits')
     >>> f[1].data
     array([[38, 43, 35, ..., 45, 43, 41],
            [36, 41, 37, ..., 42, 41, 39],
@@ -502,7 +503,7 @@ To create a compressed image HDU from scratch, simply construct a
 associated image header.  From there, the HDU can be treated just like any
 other image HDU.
 
-    >>> hdu = astropy.io.fits.CompImageHDU(imageData, imageHeader)
+    >>> hdu = fits.CompImageHDU(imageData, imageHeader)
     >>> hdu.writeto('compressed_image.fits')
     >>>
 

--- a/docs/io/fits/usage/verification.rst
+++ b/docs/io/fits/usage/verification.rst
@@ -215,7 +215,7 @@ Unfixable Cards:
 
 We'll summarize the verification with a "life-cycle" example:
 
-    >>> h = astropy.io.fits.PrimaryHDU() # create a PrimaryHDU
+    >>> h = fits.PrimaryHDU() # create a PrimaryHDU
     # Try to add an non-standard FITS keyword 'P.I.' (FITS does no allow '.'
     # in the keyword), if using the update() method - doesn't work!
     >>> h['P.I.'] = 'Hubble'
@@ -223,7 +223,7 @@ We'll summarize the verification with a "life-cycle" example:
     # Have to do it the hard way (so a user will not do this by accident)
     # First, create a card image and give verbatim card content (including
     # the proper spacing, but no need to add the trailing blanks)
-    >>> c = astropy.io.fits.Card.fromstring("P.I. = 'Hubble'")
+    >>> c = fits.Card.fromstring("P.I. = 'Hubble'")
     # then append it to the header
     >>> h.header.append(c)
     # Now if we try to write to a FITS file, the default output verification
@@ -241,7 +241,7 @@ We'll summarize the verification with a "life-cycle" example:
     >>> h.writeto('pi.fits', output_verify='ignore')
     # Now reading a non-standard FITS file
     # astropy.io.fits is magnanimous in reading non-standard FITS files
-    >>> hdus = astropy.io.fits.open('pi.fits')
+    >>> hdus = fits.open('pi.fits')
     >>> hdus[0].header
     SIMPLE =            T / conforms to FITS standard
     BITPIX =            8 / array data type
@@ -296,16 +296,16 @@ header by supplying the checksum keyword argument with a value of 'datasum'.
 Here are some examples:
 
      >>> # Open the file pix.fits verifying the checksum values for all HDUs
-     >>> hdul = astropy.io.fits.open('pix.fits', checksum=True)
+     >>> hdul = fits.open('pix.fits', checksum=True)
      >>>
      >>> # Open the file in.fits where checksum verification fails for the
      >>> # primary HDU
-     >>> hdul = astropy.io.fits.open('in.fits', checksum=True)
+     >>> hdul = fits.open('in.fits', checksum=True)
      Warning:  Checksum verification failed for HDU #0.
      >>>
      >>> # Create file out.fits containing an HDU constructed from data and
      >>> # header containing both CHECKSUM and DATASUM cards.
-     >>> astropy.io.fits.writeto('out.fits', data, header, checksum=True)
+     >>> fits.writeto('out.fits', data, header, checksum=True)
      >>>
      >>> # Create file out.fits containing all the HDUs in the HDULIST
      >>> # hdul with each HDU header containing only the DATASUM card
@@ -318,4 +318,4 @@ Here are some examples:
      >>> # Append a new HDU constructed from array data to the end of
      >>> # the file existingfile.fits with only the appended HDU
      >>> # containing both CHECKSUM and DATASUM cards.
-     >>> astropy.io.fits.append('existingfile.fits', data, checksum=True)
+     >>> fits.append('existingfile.fits', data, checksum=True)


### PR DESCRIPTION
as discussed. There are still references to pyfits in docs/io/fits/appendix/, but I believe that's intentional.
