### PR TITLE
Add standard for deep section levels in package docs template

### DIFF
--- a/docs/_pkgtemplate.rst
+++ b/docs/_pkgtemplate.rst
@@ -73,6 +73,9 @@ should be ``docs/packagename/index.rst``, and the other documents should
 be ``docs/packagename/subdoc1.rst``, ``docs/packagename/subdoc2.rst``,
 and ``docs/packagename/subdoc3.rst``.
 
+In the "more complicated" case of using ``subdoc.rst`` files, each of those
+should likewise use the section character header order of ``* = - ^ " + : ~``.
+
 
 See Also (optional)
 ===================


### PR DESCRIPTION
This adds to the package documentation template _pkgtemplate.rst to define a standard for the section characters down to 8 levels deep.  This matches the existing convention and adds a few levels for good measure.  I chose the final 3 levels somewhat randomly, so if there is any precedent for a better choice I'm open to that.
