### PR TITLE
Classes documentation cluttered with 'None' strings

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -11,7 +11,7 @@
    :show-inheritance:
 
    {% if '__init__' in methods %}
-     {{ methods.remove('__init__') }}
+     {% set caught_result = methods.remove('__init__') %}
    {% endif %}
 
    {% block attributes_summary %}


### PR DESCRIPTION
This is a very small PR, but it has bothered me for almost the whole day...

In short, there are 'None' strings that wander in almost every Class documentation pages as generated by sphinx, like [here](http://astropy.readthedocs.org/en/v0.1/_generated/astropy.table.table.Row.html#astropy.table.table.Row) (at the end of the example block) or [here](http://astropy.readthedocs.org/en/v0.1/_generated/astropy.table.table.Table.html#astropy.table.table.Table) (end of parameters list) and many others.

It took me some time to track the problem down to the templating system, but there it is.

I'm not sure however that my solution is the most elegant one, but at least it works.
