### PR TITLE
Issue with loading a VO table

### DIFF
--- a/astropy/io/vo/converters.py
+++ b/astropy/io/vo/converters.py
@@ -977,7 +977,7 @@ class BooleanArray(NumericArray):
     """
     Handles an array of boolean values.
     """
-    vararray_type = VarArray
+    vararray_type = ArrayVarArray
 
     def __init__(self, field, base, arraysize, config={}, pos=None):
         NumericArray.__init__(self, field, base, arraysize, config, pos)
@@ -1014,7 +1014,7 @@ class Boolean(Converter):
     """
     format = 'b1'
     array_type = BooleanArray
-    vararray_type = VarArray
+    vararray_type = ScalarVarArray
     default = False
     binary_question_mark = b'?'
     binary_true = b'T'

--- a/astropy/io/vo/tests/converter_test.py
+++ b/astropy/io/vo/tests/converter_test.py
@@ -1,5 +1,6 @@
 # THIRD-PARTY
 import numpy as np
+from numpy.testing import assert_array_equal
 
 # LOCAL
 from .. import converters
@@ -168,6 +169,16 @@ def test_boolean():
     c.parse('YES')
 
 
+def test_boolean_array():
+    config = {'pedantic': True}
+    field = tree.Field(
+        None, name='c', datatype='boolean', arraysize='*',
+        config=config)
+    c = converters.get_converter(field, config=config)
+    r, mask = c.parse('TRUE FALSE T F 0 1')
+    assert_array_equal(r, [True, False, True, False, False, True])
+
+
 @raises(exceptions.E06)
 def test_invalid_type():
     config = {'pedantic': True}
@@ -175,5 +186,3 @@ def test_invalid_type():
         None, name='c', datatype='foobar',
         config=config)
     c = converters.get_converter(field, config=config)
-
-


### PR DESCRIPTION
The following file:

http://vao.stsci.edu/portal/Mashup/Mashup.asmx/invoke?request=%7B%22service%22%3A%22Mashup.Url.Download%22%2C%22params%22%3A%7B%22url%22%3A%22http%3A%2F%2Fheasarc.gsfc.nasa.gov%2Fvo%2Fcache%2F86.8211987_-51.06651143_0.016666666666666666%2FESO_SSAP.7670.xml%22%2C%22filename%22%3A%22ESO_SSAP.7670.xml%22%2C%22attachment%22%3A%22true%22%7D%7D,%20http://vao.stsci.edu/portal/Mashup/Clients/Portal/DataDiscovery.html?useAV

causes an exception when trying to parse or validate:

```
$ volint ESO_SSAP.7670.xml 
ERROR: NotImplementedError: This datatype must implement a 'parse' method. [astropy.io.vo.converters]
Traceback (most recent call last):
  File "/Users/tom/Library/Python/2.7/bin/volint", line 5, in <module>
    pkg_resources.run_script('astropy==0.2.dev1548', 'volint')
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources.py", line 499, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources.py", line 1239, in run_script
    execfile(script_filename, namespace, namespace)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/EGG-INFO/scripts/volint", line 5, in <module>
    astropy.io.vo.volint.main()
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/volint.py", line 19, in main
    table.validate(args.filename[0])
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/table.py", line 177, in validate
    votable = parse(input, pedantic=False, filename=filename)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/table.py", line 108, in parse
    config=config, pos=(1, 1)).parse(iterator, config)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 2881, in parse
    iterator, tag, data, config, pos)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 2812, in _add_resource
    resource.parse(self, iterator, config)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 2666, in parse
    iterator, tag, data, config, pos)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 2623, in _add_table
    table.parse(iterator, config)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 2010, in parse
    iterator, tag, data, config, pos)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 1944, in _add_param
    param = Param(self._votable, config=config, pos=pos, **data)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 1293, in __init__
    id=id, config=config, pos=pos, **extra)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 1012, in __init__
    self._setup(config, pos)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 1316, in _setup
    self.value = self._value
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/tree.py", line 1310, in value
    value, self._config, self._pos)[0]
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1548-py2.7-macosx-10.6-x86_64.egg/astropy/io/vo/converters.py", line 89, in parse
    "This datatype must implement a 'parse' method.")
NotImplementedError: This datatype must implement a 'parse' method.
```
