### PR TITLE
Can't write third-party tests that depend on Astropy

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -11,9 +11,11 @@ import sys
 import time
 
 try:
-    from IPython.zmq.iostream import OutStream
-except ImportError:
+    get_ipython()
+except NameError:
     OutStream = None
+else:
+    from IPython.zmq.iostream import OutStream
 
 from ..config import ConfigurationItem
 


### PR DESCRIPTION
This is quite a major issue. If I write a Python script with:

```
from astropy.io import fits

def test():
    pass
```

and try and run it through py.test, I end up with the following exception:

```
$ py.test test_example.py 
============================= test session starts ==============================
platform darwin -- Python 2.7.3 -- pytest-2.2.4
collected 0 items / 1 errors 

==================================== ERRORS ====================================
_______________________ ERROR collecting test_example.py _______________________
test_example.py:1: in <module>
>   from astropy.io import fits
../../Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1568-py2.7-macosx-10.6-x86_64.egg/astropy/__init__.py:104: in <module>
>       from .logger import log
../../Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1568-py2.7-macosx-10.6-x86_64.egg/astropy/logger.py:15: in <module>
>   from .utils.console import color_print
../../Library/Python/2.7/lib/python/site-packages/astropy-0.2.dev1568-py2.7-macosx-10.6-x86_64.egg/astropy/utils/console.py:14: in <module>
>       from IPython.zmq.iostream import OutStream
../../Library/Python/2.7/lib/python/site-packages/IPython/__init__.py:43: in <module>
>   from .config.loader import Config
../../Library/Python/2.7/lib/python/site-packages/IPython/config/loader.py:27: in <module>
>   from IPython.utils.path import filefind, get_ipython_dir
../../Library/Python/2.7/lib/python/site-packages/IPython/utils/path.py:24: in <module>
>   from IPython.utils.process import system
../../Library/Python/2.7/lib/python/site-packages/IPython/utils/process.py:27: in <module>
>       from ._process_posix import _find_cmd, system, getoutput, arg_split
../../Library/Python/2.7/lib/python/site-packages/IPython/utils/_process_posix.py:27: in <module>
>   from IPython.utils import text
../../Library/Python/2.7/lib/python/site-packages/IPython/utils/text.py:30: in <module>
>   from IPython.utils.io import nlprint
../../Library/Python/2.7/lib/python/site-packages/IPython/utils/io.py:90: in <module>
>   stdin = IOStream(sys.stdin)
../../Library/Python/2.7/lib/python/site-packages/IPython/utils/io.py:32: in __init__
>               raise ValueError("fallback required, but not specified")
E               ValueError: fallback required, but not specified
=========================== 1 error in 0.30 seconds ============================
```
