### PR TITLE
adding Table.psave method

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -766,6 +766,19 @@ class Table(object):
                                          show_name, show_units)
         return lines
 
+    def psave(self, fn, show_name=True, show_units=False):
+        """ Save the contents of this table as in the text format `pprint`
+        and `pformat` produce.
+
+        Needs full docstring
+        """
+        lines, n_header = _pformat_table(self, -1, -1, show_name, show_units)
+
+        with open(fn, 'w') as f:
+            for l in lines:
+                f.write(l)
+                f.write('\n')
+
     def more(self, max_lines=None, max_width=None, show_name=True,
                show_units=False):
         """Interactively browse table with a paging interface.


### PR DESCRIPTION
Note that this is _not_ ready for merging immediately - it needs tests/docs/polish before merging/

The main thing this does is add a `psave` method to `astropy.table.Table`.  This just generates text as the `pformat` and `pprint` functions do, and saves it to a file instead of the terminal. 

The main question is whether or not this method should exist at all - @taldcroft and @astrofrog, in particular, may have some thoughts on this.  This seems reasonable to me because it's simple enough to implement that I've already found myself doing it by hand semi-regularly, so a convinience method might make sense here.  On the other hand, in principal that's what `Table.write` and the I/O framework for `table` is for, so this sort of duplicates some efforts.

Should I go ahead and flesh this out more, or do we not want such a thing in `astropy.table` right now? 
