### PR TITLE
Set primary unit symbol for the astronomical unit to 'au'.

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -23,7 +23,7 @@ UnitBase._set_namespace(globals())
 ###########################################################################
 # LENGTH
 
-def_unit(['AU'], _si.au * si.m, register=True, prefixes=True,
+def_unit(['AU', 'au'], _si.au * si.m, register=True, prefixes=True,
          doc="astronomical unit: approximately the mean Earth--Sun "
          "distance.")
 


### PR DESCRIPTION
The correct symbol for the astronomical unit is `au`, so I've fixed that and set `AU` as an alias.
