### PR TITLE
Check FITS unit compatibility

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -24,7 +24,7 @@ def_unit(['micron'], um, register=True,
          doc="micron: alias for micrometer (um)",
          format={'latex': r'\mu', 'unicode': 'μ'})
 
-def_unit(['AA', 'Angstrom', 'angstrom'], 0.1 * nm, register=True, prefixes=True,
+def_unit(['Angstrom', 'AA', 'angstrom'], 0.1 * nm, register=True,
          doc="ångström: 10 ** -10 m",
          format={'latex': r'\AA', 'unicode': 'Å', 'vounit': 'angstrom'})
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -64,14 +64,11 @@ def test_roundtrip_vo_unit():
 
 def test_roundtrip_fits():
     def _test_roundtrip_fits(unit):
-        try:
-            s = unit.to_string('fits')
-        except ValueError:
-            return
+        s = unit.to_string('fits')
         a = core.Unit(s, format='fits')
         assert_allclose(a.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
-    for key, val in u.__dict__.items():
+    for key, val in format.Fits()._units.items():
         if isinstance(val, core.Unit) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_fits, val
 


### PR DESCRIPTION
This fixes a test so that we should be able to catch deviations from the FITS unit standard more easily.  It also fixes a problem it found with Angstrom.
