### PR TITLE
Fix test that was failing in Python 3.3

### DIFF
--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -10,7 +10,7 @@ np.random.seed(12345)
 
 
 class FakeErrors(NDError):
-    
+
     def propagate_add(self, data, final_data):
         pass
 
@@ -25,14 +25,8 @@ class FakeErrors(NDError):
 
 
 def test_nddata_empty():
-
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError):
         NDData()  # empty initializer should fail
-    if isinstance(exc.value, basestring):
-        assert exc.value.startswith('__init__() takes at least')
-    else:
-        assert exc.value.args[0].startswith('__init__() takes at least')
-
 
 def test_nddata_simple():
     nd = NDData(np.random.random((10, 10)))


### PR DESCRIPTION
`TypeError` exception messages are formatted differently in Python 3.3. Since it's probably not a good idea to test the message for these kinds of exception, I've removed the checking of the message, and just check that a `TypeError` is raised.

This is trivial, but just wanted to test Travis. I will merge as soon as it passes.
