### PR TITLE
Recommend virtualenv instead "setup.py develop" for testing

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -65,7 +65,7 @@ within those files.
 
 .. note::
     To test any compiled C/Cython extensions, you must run ``python
-    setup.py develop`` prior to running the py.test command-line
+    setup.py build_ext --inplace`` prior to running the py.test command-line
     script.  Otherwise, any tests that make use of these extensions
     will not succeed.  Similarly, in python 3, these tests will not
     run correctly in the source code, because they need the ``2to3``


### PR DESCRIPTION
Issue #424 was fundamentally caused by using `python setup.py develop`.  There was a `.pth` file with a path pointing back to the git repo, so when trying to import astropy it was always picking up files in my git repo source directory instead of the installed version.

This PR updates the testing guidelines to recommend using virtualenv instead of `develop` for using py.test.
