### PR TITLE
Recommend using virtualenv instead of setup.py develop with py.test

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -64,11 +64,11 @@ in the currect directory and all recursive directories then run all the code tha
 within those files.
 
 .. note::
-    To test any compiled C/Cython extensions, you must run ``python
-    setup.py develop`` prior to running the py.test command-line
-    script.  Otherwise, any tests that make use of these extensions
-    will not succeed.  Similarly, in python 3, these tests will not
-    run correctly in the source code, because they need the ``2to3``
+    To test any compiled C/Cython extensions, you should install astropy within a
+    virtual environment and then run `py.test astropy`
+    from outside the source directory.  Otherwise, any tests that make use of these extensions
+    will not succeed.  Similarly, in Python 3, the built-in tests will not
+    run correctly in the source code because they need the ``2to3``
     tool to be run on them.
 
 You may specify a specific test file or directory at the command line::


### PR DESCRIPTION
Issue #424 was fundamentally caused by using python setup.py develop. There was a .pth file with a path pointing back to the git repo, so when trying to import astropy it was always picking up files in my git repo source directory instead of the installed version.

This PR updates the testing guidelines to recommend using virtualenv instead of develop for using py.test.

This is a re-work of PR #426 based on comments from @mdboom.
