### PR TITLE
'console' and 'unicode' formats fail for some units

### DIFF
--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -67,7 +67,8 @@ class Console(base.Base):
                 s = ''
 
             if len(unit.bases):
-                positives, negatives = utils.get_grouped_by_powers(unit)
+                positives, negatives = utils.get_grouped_by_powers(
+                    unit.bases, unit.powers)
                 if len(negatives):
                     if len(positives):
                         positives = self._format_unit_list(positives)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -169,3 +169,10 @@ def test_flatten_to_known():
 def test_flatten_impossible():
     myunit = u.def_unit("FOOBAR")
     myunit.to_string('fits')
+
+
+def test_console_out():
+    """
+    Issue #436.
+    """
+    u.Jy.decompose().to_string('console')


### PR DESCRIPTION
If I use the `to_string` method of a `Unit`, I sometimes get an error.  I _think_ it only happens when the unit in question is not one of the irreducable units, but I'm not entirely sure that's the common theme.  At any rate, here's a way to reproduce it:

```
from astropy import units as u
(u.m/u.s).to_string('console')
#OR
(u.m/u.s).to_string('unicode')
```

In either case I get an error like:

```
/Users/erik/src/astropy/astropy/units/core.py in to_string(self, format)
     86         """
     87         f = unit_format.get_format(format)
---> 88         return f.to_string(self)
     89 
     90     @staticmethod

/Users/erik/src/astropy/astropy/units/format/console.py in to_string(self, unit)
     68 
     69             if len(unit.bases):
---> 70                 positives, negatives = utils.get_grouped_by_powers(unit)
     71                 if len(negatives):
     72                     if len(positives):

TypeError: get_grouped_by_powers() takes exactly 2 arguments (1 given)
```
