### PR TITLE
astropy.units parsing error messages

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -99,13 +99,13 @@ class CDS(Base):
              p.StringEnd()))
 
         product_of_units << (
-            (unit_expression + p.StringEnd()) |
-            (division + unit_expression) |
-            (unit_expression + product + product_of_units) |
+            (unit_expression + p.StringEnd()) ^
+            (division + unit_expression) ^
+            (unit_expression + product + product_of_units) ^
             (unit_expression + division + product_of_units))
 
         unit_expression << (
-            (unit_with_power) |
+            (unit_with_power) ^
             (p.Suppress(open_p) + product_of_units + p.Suppress(close_p)))
 
         factor << (
@@ -215,7 +215,8 @@ class CDS(Base):
         try:
             return self._parser.parseString(s, parseAll=True)[0]
         except p.ParseException as e:
-            raise ValueError("{0} in {1:r}".format(str(e), s))
+            raise ValueError("{0} in {1!r}".format(
+                utils.cleanup_pyparsing_error(e), s))
 
     def _get_unit_name(self, unit):
         return unit.get_format_name('cds')

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -66,7 +66,7 @@ class Generic(Base):
         unit_with_power = p.Forward()
 
         main << (
-            (factor_product_of_units) |
+            (factor_product_of_units) ^
             (division_product_of_units))
 
         factor_product_of_units << (
@@ -83,7 +83,7 @@ class Generic(Base):
              p.StringEnd()))
 
         product_of_units << (
-            (unit_expression + p.Suppress(product) + product_of_units) |
+            (unit_expression + p.Suppress(product) + product_of_units) ^
             (unit_expression))
 
         function << (
@@ -91,31 +91,31 @@ class Generic(Base):
             p.Suppress(open_p) + unit_expression + p.Suppress(close_p))
 
         unit_expression << (
-            (function) |
-            (unit_with_power) |
+            (function) ^
+            (unit_with_power) ^
             (p.Suppress(open_p) + product_of_units + p.Suppress(close_p))
             )
 
         factor << (
-            (unsigned_integer + signed_integer) |
-            (unsigned_integer + p.Suppress(power) + numeric_power) |
+            (unsigned_integer + signed_integer) ^
+            (unsigned_integer + p.Suppress(power) + numeric_power) ^
             (floating_point + p.Suppress(p.White()) +
-             unsigned_integer + signed_integer) |
+             unsigned_integer + signed_integer) ^
             (floating_point + p.Suppress(p.White()) +
-             unsigned_integer + p.Suppress(power) + numeric_power) |
+             unsigned_integer + p.Suppress(power) + numeric_power) ^
             (floating_point)
             )
 
         unit << p.Word(p.alphas, p.alphas + '_')
 
         unit_with_power << (
-            (unit + p.Suppress(power) + numeric_power) |
+            (unit + p.Suppress(power) + numeric_power) ^
             (unit))
 
         numeric_power << (
             integer |
-            (p.Suppress(open_p) + integer + p.Suppress(close_p)) |
-            (p.Suppress(open_p) + floating_point + p.Suppress(close_p)) |
+            (p.Suppress(open_p) + integer + p.Suppress(close_p)) ^
+            (p.Suppress(open_p) + floating_point + p.Suppress(close_p)) ^
             (p.Suppress(open_p) + frac + p.Suppress(close_p)))
 
         frac << (
@@ -236,7 +236,8 @@ class Generic(Base):
         try:
             return self._parser.parseString(s, parseAll=True)[0]
         except p.ParseException as e:
-            raise ValueError("{0} in {1!r}".format(str(e), s))
+            raise ValueError("{0} in {1!r}".format(
+                utils.cleanup_pyparsing_error(e), s))
 
     def _get_unit_name(self, unit):
         return unit.get_format_name('generic')

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -5,6 +5,7 @@ Utilities shared by the different formats.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
+import re
 
 
 def get_grouped_by_powers(bases, powers):
@@ -115,3 +116,11 @@ def _trace(func):
         return result
 
     return functools.update_wrapper(run, func)
+
+
+def cleanup_pyparsing_error(e):
+    """
+    Given a pyparsing.ParseException, returns a string that has the
+    line and column numbers removed.
+    """
+    return re.sub(", \(line:[0-9]+, col:[0-9]+\)", "", str(e))


### PR DESCRIPTION
`astropy.units` needs to coerce some more transparent error messages out of `pyparsing`.
