### PR TITLE
Adds "unclosed file detection" to the test framework

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -141,11 +141,10 @@ class BaseInputter(object):
         :returns: list of lines
         """
         try:
-
-            if hasattr(table, 'read') or ('\n' not in table and '\r' not in table + ''):
+            if (hasattr(table, 'read') or
+                ('\n' not in table and '\r' not in table + '')):
                 with get_readable_fileobj(table) as file_obj:
                     table = file_obj.read()
-
             lines = table.splitlines()
         except TypeError:
             try:
@@ -155,7 +154,8 @@ class BaseInputter(object):
                 iter(table)
                 lines = table
             except TypeError:
-                raise TypeError('Input "table" must be a string (filename or data) or an iterable')
+                raise TypeError(
+                    'Input "table" must be a string (filename or data) or an iterable')
 
         return self.process_lines(lines)
 
@@ -773,7 +773,7 @@ class BaseReader(object):
         self.data = BaseData()
         self.inputter = BaseInputter()
         self.outputter = TableOutputter()
-        self.meta = {}                  # Placeholder for storing table metadata 
+        self.meta = {}                  # Placeholder for storing table metadata
         # Data and Header instances benefit from a little cross-coupling.  Header may need to
         # know about number of data columns for auto-column name generation and Data may
         # need to know about header (e.g. for fixed-width tables where widths are spec'd in header.

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -158,7 +158,7 @@ def test_custom_splitters():
     assert_almost_equal(data.field('p1.ampl')[2], 0.000696444029148)
     assert_equal(data.field('statname')[2], 'chi2modvar')
     assert_almost_equal(data.field('statval')[2], 497.56468441)
-    
+
 
 def test_start_end():
     data = asciitable.read('t/test5.dat', header_start=1, data_start=3, data_end=-5)
@@ -179,7 +179,8 @@ def test_set_converters():
 
 def test_from_string():
     f = 't/simple.txt'
-    table = open(f).read()
+    with open(f) as fd:
+        table = fd.read()
     testfile = get_testfiles(f)
     data = asciitable.read(table, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])
@@ -188,16 +189,17 @@ def test_from_string():
 
 def test_from_filelike():
     f = 't/simple.txt'
-    table = open(f, 'rb')
     testfile = get_testfiles(f)
-    data = asciitable.read(table, **testfile['opts'])
+    with open(f) as fd:
+        data = asciitable.read(fd, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
 
 def test_from_lines():
     f = 't/simple.txt'
-    table = open(f).readlines()
+    with open(f) as fd:
+        table = fd.readlines()
     testfile = get_testfiles(f)
     data = asciitable.read(table, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])
@@ -273,7 +275,7 @@ def test_fill_values_list():
 def test_masking_Cds():
     f = 't/cds.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, 
+    data = asciitable.read(f,
                            **testfile['opts'])
     assert_true(data['AK'].mask[0])
     assert_true(not data['Fit'].mask[0])

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -419,6 +419,7 @@ class AstropyLogger(Logger):
         fh.setFormatter(f)
         self.addHandler(fh)
         yield
+        fh.close()
         self.removeHandler(fh)
 
     @contextmanager

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -4,7 +4,14 @@ These plugins modify the behavior of py.test and are meant to be imported
 into conftest.py in the root directory.
 """
 
+import io
+import os
+import sys
+import traceback
+
 from .helper import pytest
+
+PY3K = sys.version_info[0] >= 3
 
 # these pytest hooks allow us to mark tests and run the marked tests with
 # specific command line options.
@@ -12,11 +19,96 @@ def pytest_addoption(parser):
     parser.addoption("--remote-data", action="store_true",
         help="run tests with online data")
 
+# Open file detection.
+#
+# This works by replacing the built-in "open" with one that keeps
+# track of all of the currently open files.  When each test is started,
+# this list is copied.  At the end of the test, that list is compared
+# with the set of currently open files.  If the latter is larger, the
+# newly opened files that were not closed are displayed in an error
+# message and the test fails.
+#
+# This is not thread-safe.  We're not currently running our tests
+# multi-threaded, but that is worth noting.
+#
+# Note that this doesn't work with Python 3.  Since Python 3 has a
+# hierarchy of classes for I/O written in C, it doesn't seem possible
+# to monkey-patch the base file class with our own in order to keep
+# track of opening and closing like we do here.  Further investigation
+# and perhaps a wholly different approach is needed.  In the meantime,
+# this functionality is just turned off for Python 3.
+if not PY3K:
+    import __builtin__
+    _open_files = dict()
+    _old_file = __builtin__.file
+
+    class _new_file(_old_file):
+        def __init__(self, *args, **kwargs):
+            self.x = args[0]
+            _old_file.__init__(self, *args, **kwargs)
+            __builtin__.open = _old_open
+            _open_files[self] = traceback.format_stack()
+            __builtin__.open = _new_open
+
+        def close(self):
+            _old_file.close(self)
+            try:
+                del _open_files[self]
+            except KeyError:
+                pass
+
+    _old_open = __builtin__.open
+    def _new_open(*args, **kwargs):
+        return _new_file(*args, **kwargs)
+    __builtin__.open = _new_open
+    __builtin__.file = _new_file
+
 
 def pytest_runtest_setup(item):
+    # Store a list of the currently opened files so we can compare
+    # against them when the test is done.
+    if not PY3K:
+        item.open_files = dict(_open_files)
+
     if ('remote_data' in item.keywords and
         not item.config.getvalue("remote_data")):
         pytest.skip("need --remote-data option to run")
+
+
+if not PY3K:
+    def pytest_runtest_teardown(item, nextitem):
+        # a "skipped" test will not have been called with
+        # pytest_runtest_setup, so therefore won't have an
+        # "open_files" member
+        if not hasattr(item, 'open_files'):
+            return
+
+        start_open_files = item.open_files
+        del item.open_files
+
+        # This works in tandem with the test_open_file_detection test to
+        # ensure that it creates one extra open file.
+        if item.name == 'test_open_file_detection':
+            assert len(start_open_files) + 1 == len(_open_files)
+            return
+
+        if len(start_open_files) != len(_open_files):
+            not_closed = {}
+            for fd, stack in _open_files.items():
+                # astropy.log files are allowed to continue to exist
+                # between test runs
+                if os.path.basename(fd.name) == 'astropy.log':
+                    continue
+
+                if fd not in start_open_files:
+                    not_closed[fd.name] = stack
+
+            if len(not_closed):
+                msg = ['File(s) not closed:']
+                for name, stack in not_closed.items():
+                    msg.append('  {0} opened from:'.format(name))
+                    msg.extend('    {0}'.format(x) for x in stack)
+                raise AssertionError('\n'.join(msg))
 
 
 def pytest_report_header(config):

--- a/astropy/tests/setup_package.py
+++ b/astropy/tests/setup_package.py
@@ -2,4 +2,5 @@
 
 def get_package_data():
     return {
-        'astropy.tests': ['coveragerc']}
+        'astropy.tests': ['coveragerc'],
+        'astropy.tests.tests': ['data/open_file_detection.txt']}

--- a/astropy/tests/tests/data/open_file_detection.txt
+++ b/astropy/tests/tests/data/open_file_detection.txt
@@ -1,0 +1,1 @@
+CONTENTS

--- a/astropy/tests/tests/test_open_file_detection.py
+++ b/astropy/tests/tests/test_open_file_detection.py
@@ -1,0 +1,16 @@
+import sys
+
+import pytest
+
+from ...utils.data import get_pkg_data_filename
+
+fd = None
+@pytest.mark.skipif("sys.version_info >= (3, 0)")
+def test_open_file_detection():
+    global fd
+    fd = open(get_pkg_data_filename('data/open_file_detection.txt'))
+
+
+def teardown():
+    if fd is not None:
+        fd.close()

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -699,7 +699,7 @@ def test_header_parse():
             'data/header_newlines.fits', encoding='binary') as test_file:
         hdulist = fits.open(test_file)
         w = wcs.WCS(hdulist[0].header)
-        assert w.wcs.ctype[0] == b'RA---TAN-SIP'
+    assert w.wcs.ctype[0] == b'RA---TAN-SIP'
 
 
 def test_locale():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -259,6 +259,8 @@ class WCS(WCSBase):
     def __init__(self, header=None, fobj=None, key=' ', minerr=0.0,
                  relax=True, naxis=None, keysel=None, colsel=None,
                  fix=True):
+        close_fds = []
+
         if header is None:
             if naxis is None:
                 naxis = 2
@@ -279,6 +281,7 @@ class WCS(WCSBase):
                             "Can not provide both a FITS filename to "
                             "argument 1 and a FITS file object to argument 2")
                     fobj = fits.open(header)
+                    close_fds.append(fobj)
                     header = fobj[0].header
                     header_string = header.tostring()
                 else:
@@ -359,6 +362,9 @@ naxis kwarg.
 
         self._get_naxis(header)
         WCSBase.__init__(self, sip, cpdis, wcsprm, det2im)
+
+        for fd in close_fds:
+            fd.close()
 
     def __copy__(self):
         new_copy = self.__class__()


### PR DESCRIPTION
This replaces the built-in `open` with one that keeps track of open files, and raises an exception if a test has more open files when it finishes than when it began.

This has helped find (in separate commits) some file closing bugs in `io.ascii`, `wcs` and `logger`.  There are bunch remaining in `io.fits`, (probably mostly in the test code itself) but I haven't worked through them yet.

This also doesn't work in Python 3 yet.

I thought I'd share this early because it will be useful to verify the craziness that is #425 :)
