### PR TITLE
Build failure in build_ext

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -178,7 +178,8 @@ def wrap_build_ext(basecls=DistutilsBuildExt):
                             raise IOError(errno.ENOENT, msg, cfn)
 
         if orig_run is not None:
-            # This shouldn't happen.
+            # This should always be the case for a correctly implemented
+            # distutils command.
             orig_run(self)
 
     attrs['run'] = run


### PR DESCRIPTION
I suspect that I'm responsible for this failure and that it has nothing to do with astropy, but nonetheless I have this error and I think it's causing a related error in installing astroquery:

```
$ python setup.py build
Traceback (most recent call last):
  File "setup.py", line 82, in <module>
    cmdclassd['build_ext'] = setup_helpers.wrap_build_ext(build_ext)
  File "/Users/adam/repos/astropy/astropy/setup_helpers.py", line 142, in wrap_build_ext
    orig_run = attrs['run']
KeyError: 'run'
```

I'm running commit 052adaf16d5f6316ca45350c60ec101d160be372; the line in question was last changed in ff42034a8064e844894f996a10af902a0aa84d91.  If I go back to the prior commit, I get a gcc error.
