### PR TITLE
move creation of test's temporary cache/config directory to a py.test fixture

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -138,25 +138,6 @@ class TestRunner(object):
                 all_args += (
                     ' --cov-report html --cov astropy'
                     ' --cov-config {0}'.format(tmp.name))
-
-        # check if we're inside the distutils test command, which sets the
-        # _ASTROPY_TEST_ builtin
-        try:
-            _ASTROPY_TEST_
-            insidetestcmd = True
-        except NameError:
-            insidetestcmd = False
-
-        #set up environment variables to fake the config and cache systems,
-        #unless this has already been done by the distutils test command
-        if not insidetestcmd:
-            oldconfigdir = os.environ.get('XDG_CONFIG_HOME')
-            oldcachedir = os.environ.get('XDG_CACHE_HOME')
-            os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
-            os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
-            os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
-            os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
-
         try:
             all_args = shlex.split(
                 all_args, posix=not sys.platform.startswith('win'))
@@ -168,20 +149,8 @@ class TestRunner(object):
                     tmp.close()
                 os.remove(tmp.name)
 
-            if not insidetestcmd:
-                #wipe the config/cache tmpdirs and restore the envars
-                shutil.rmtree(os.environ['XDG_CONFIG_HOME'])
-                shutil.rmtree(os.environ['XDG_CACHE_HOME'])
-                if oldconfigdir is None:
-                    del os.environ['XDG_CONFIG_HOME']
-                else:
-                    os.environ['XDG_CONFIG_HOME'] = oldconfigdir
-                if oldcachedir is None:
-                    del os.environ['XDG_CACHE_HOME']
-                else:
-                    os.environ['XDG_CACHE_HOME'] = oldcachedir
-
         return result
+
     run_tests.__doc__ = test.__doc__
 
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -33,3 +33,47 @@ def pytest_report_header(config):
         s += "Using Astropy options: {0}.\n".format(" ".join(opts))
 
     return s
+
+
+@pytest.fixture(autouse=True)
+def modarg(request):
+    """Sets up environment variables to fake the config and cache
+    directories, then removes the temporary directories.
+
+    Does nothing if we are inside the sphinx testing command, as it
+    should have already done this for us.
+    """
+    import os
+    import shutil
+    import tempfile
+
+    # check if we're inside the distutils test command, which sets the
+    # _ASTROPY_TEST_ builtin
+    try:
+        _ASTROPY_TEST_
+        insidetestcmd = True
+    except NameError:
+        insidetestcmd = False
+
+    if not insidetestcmd:
+        oldconfigdir = os.environ.get('XDG_CONFIG_HOME')
+        oldcachedir = os.environ.get('XDG_CACHE_HOME')
+        os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
+        os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
+        os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
+        os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
+
+        def teardown():
+            #wipe the config/cache tmpdirs and restore the envars
+            shutil.rmtree(os.environ['XDG_CONFIG_HOME'])
+            shutil.rmtree(os.environ['XDG_CACHE_HOME'])
+            if oldconfigdir is None:
+                del os.environ['XDG_CONFIG_HOME']
+            else:
+                os.environ['XDG_CONFIG_HOME'] = oldconfigdir
+            if oldcachedir is None:
+                del os.environ['XDG_CACHE_HOME']
+            else:
+                os.environ['XDG_CACHE_HOME'] = oldcachedir
+
+        request.addfinalizer(teardown)


### PR DESCRIPTION
Does exactly what it says.  This is important because before this, if you invoke py.test directly instead of via `astropy.test` or `setup.py test`, this code does not run, and you will overwrite your current configuration when you run the tests.

Note however this is not ready for merging.  The py.test fixtures framework requires py.test >= 2.3, which  #446 will address.  Once #446 is merged, I'll rebase against it, and this can be merged.  In the meantime, this should serve as a warning to be careful when invoking py.test and your astropy config directory.
