### PR TITLE
Fix astropy.config docs

### DIFF
--- a/docs/configs/index.rst
+++ b/docs/configs/index.rst
@@ -99,11 +99,11 @@ You should be able to modify the values at run-time this way::
 
 Or alternatively::
 
-    from astropy.config import get_config
+    >>> from astropy.config import get_config
 
     >>> items = get_config('astropy.config.data')
-    >>> items['DATAURL'].set('http://astropydata.mywebsite.com')
-    >>> items['REMOTE_TIMEOUT'].set('4.5')
+    >>> items['dataurl'].set('http://astropydata.mywebsite.com')
+    >>> items['remote_timeout'].set('4.5')
 
 Note that this will *not* permanently change these values in the configuration
 files - just for the current session.  To change the configuration files,


### PR DESCRIPTION
The config docs incorrectly referred to `get_config_items` which I think should be `get_config`. There is one remaining issue, in that:

```
    >>> items['DATAURL'].set('http://astropydata.mywebsite.com')
    >>> items['REMOTE_TIMEOUT'].set('4.5')
```

does not work, because the keys are lowercase in `items` but uppercase in the docs. There are four solutions:
1. explain in the docs that when using `items`, the keys need to be the same case as the file
2. always convert the keys to uppercase
3. make the dictionary case-insensitive

@eteq - what do you think? I guess 2. would be more consistent with the rest of the behavior (though it essentially amounts to 3. since the case gets lost).
