### PR TITLE
Add a "correct" category to the io.votable output

### DIFF
--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.xml
@@ -298,6 +298,7 @@
      </TABLEDATA>
     </DATA>
    </TABLE>
+   <TABLE nrows="0" ref="main_table"/>
   </RESOURCE>
  </RESOURCE>
 </VOTABLE>

--- a/astropy/io/votable/tests/data/regression.xml
+++ b/astropy/io/votable/tests/data/regression.xml
@@ -292,6 +292,11 @@ The VOTable format is an XML standard for the interchange of data represented as
 </TABLEDATA>
 </DATA>
 </TABLE>
+<TABLE ref="main_table">
+<DATA>
+<TABLEDATA/> <!-- Add an empty table because it's a useful thing to test -->
+</DATA>
+</TABLE>
 </RESOURCE>
 </RESOURCE>
 </VOTABLE>

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -79,7 +79,7 @@ def test_parse_single_table2():
 def test_parse_single_table3():
     table2 = parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
-        table_number=2, pedantic=False)
+        table_number=3, pedantic=False)
 
 
 def _test_regression(_python_based=False):
@@ -223,7 +223,7 @@ class TestReferences:
     def test_iter_groups(self):
         # Because of the ref'd table, there are more logical groups
         # than actually exist in the file
-        assert len(list(self.votable.iter_groups())) == 6
+        assert len(list(self.votable.iter_groups())) == 9
 
     def test_ref_table(self):
         tables = list(self.votable.iter_tables())

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -66,7 +66,8 @@ def _resize(masked, new_size):
     new_array = ma.zeros((new_size,), dtype=masked.dtype)
     length = min(len(masked), new_size)
     new_array.data[:length] = masked.data[:length]
-    new_array.mask[:length] = masked.mask[:length]
+    if length != 0:
+        new_array.mask[:length] = masked.mask[:length]
     return new_array
 
 
@@ -2341,7 +2342,8 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
 
         array = _resize(array, alloc_rows)
         array[numrows:] = array_chunk
-        array.mask[numrows:] = mask_chunk
+        if alloc_rows != 0:
+            array.mask[numrows:] = mask_chunk
         numrows += len(array_chunk)
 
         if (self.nrows is not None and

--- a/astropy/io/votable/validator/main.py
+++ b/astropy/io/votable/validator/main.py
@@ -30,7 +30,7 @@ def get_urls(destdir, s):
     urls = []
     for type in types:
         filename = get_pkg_data_filename(
-            'astropy/io/votable/validator/urls/cone.{0}.dat.gz'.format(type))
+            'urls/cone.{0}.dat.gz'.format(type))
         with gzip.open(filename, 'rb') as fd:
             for url in fd.readlines():
                 s.next()

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -226,6 +226,7 @@ class Result:
 
 def get_result_subsets(results, root, s=None):
     all_results      = []
+    correct          = []
     not_expected     = []
     fail_schema      = []
     schema_mismatch  = []
@@ -247,6 +248,10 @@ def get_result_subsets(results, root, s=None):
 
         x = Result(url, root=root)
         all_results.append(x)
+        if (x['nwarnings'] == 0 and
+            x['nexceptions'] == 0 and
+            x['xmllint'] is True):
+            correct.append(x)
         if not x.match_expectations():
             not_expected.append(x)
         if x['xmllint'] is False:
@@ -294,6 +299,7 @@ def get_result_subsets(results, root, s=None):
 
     tables = [
         ('all', u'All tests', all_results),
+        ('correct', u'Correct', correct),
         ('unexpected', u'Unexpected', not_expected),
         ('schema', u'Invalid against schema', fail_schema),
         ('schema_mismatch', u'Invalid against schema/Passed vo.table',


### PR DESCRIPTION
This makes it easier to see which results have no warnings or errors.

Also, fixes some bugs introduced by the masking rework -- 0-length `numpy.ma.array` objects need to be handled specially.
