### PR TITLE
utils.data fixes

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -137,19 +137,24 @@ def test_get_pkg_data_contents():
 @remote_data
 def test_data_noastropy_fallback(monkeypatch, recwarn):
     """
-    Tests to make sure configuration items fall back to their defaults when
-    there's a problem accessing the astropy directory
+    Tests to make sure the default behavior when the cache directory can't
+    be located is correct
     """
     from pytest import raises
     from .. import data
     from ...config import paths
 
+    # needed for testing the *real* lock at the end
+    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+
     #better yet, set the configuration to make sure the temp files are deleted
     data.DELETE_TEMPORARY_DOWNLOADS_AT_EXIT.set(True)
 
-    #make sure the config directory is not searched
+    #make sure the config and cache directories are not searched
     monkeypatch.setenv('XDG_CONFIG_HOME', 'foo')
     monkeypatch.delenv('XDG_CONFIG_HOME')
+    monkeypatch.setenv('XDG_CACHE_HOME', 'bar')
+    monkeypatch.delenv('XDG_CACHE_HOME')
 
     # make sure the _find_or_create_astropy_dir function fails as though the
     # astropy dir could not be accessed
@@ -162,7 +167,7 @@ def test_data_noastropy_fallback(monkeypatch, recwarn):
         paths.get_cache_dir()
 
     #first try with cache
-    fnout = data.get_pkg_data_filename(TESTURL)
+    fnout = data.download_file(TESTURL, cache=True)
     assert os.path.isfile(fnout)
 
     assert len(recwarn.list) > 1
@@ -172,7 +177,7 @@ def test_data_noastropy_fallback(monkeypatch, recwarn):
     assert w1.category == data.CacheMissingWarning
     assert 'Remote data cache could not be accessed' in w1.message.args[0]
     assert w2.category == data.CacheMissingWarning
-    assert 'File downloaded to temp file' in w2.message.args[0]
+    assert 'File downloaded to temporary location' in w2.message.args[0]
     assert fnout == w2.message.args[1]
 
     #clearing the cache should be a no-up that doesn't affect fnout
@@ -192,13 +197,14 @@ def test_data_noastropy_fallback(monkeypatch, recwarn):
     assert 'Not clearing data cache - cache inacessable' in str(w3.message)
 
     #now try with no cache
-    with data.get_pkg_data_fileobj(TESTURL, cache=False) as googlepage:
+    fnnocache = data.download_file(TESTURL, cache=False)
+    with open(fnnocache) as googlepage:
         assert googlepage.read().decode().find('oogle</title>') > -1
 
     #no warnings should be raise in fileobj because cache is unnecessary
     assert len(recwarn.list) == 0
 
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+    # lockdir determined above as the *real* lockdir, not the temp one
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 


### PR DESCRIPTION
This is a few fixes in `utils.data` spurred by #480. This should now let `data.clear_data_cache` cache work correctly (although note that it has been renamed `data.clear_download_cache`).

@pllim, can you confirm that this fixes #480 for you? (although again not that it should now be modified to be `clear_download_cache` instead of `clear_data_cache`.

@astrofrog, you might want to look at this, as it deals with some of the changes from #425. Mostly cosmetic, in that it changes "data" to "download" to reflect the broader scope of the cache now.  But there was one place where it seemed the cache option was not going through (incorrectly, I believe).
