### PR TITLE
give a slightly more helpful error message when an invalid unit constructor is given

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -759,6 +759,9 @@ class _UnitMetaClass(type):
         elif s is None:
             raise ValueError("None is not a valid Unit")
 
+        else:
+            raise TypeError("{0} can not be converted to a Unit".format(s))
+
 
 class Unit(NamedUnit):
     """

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -209,3 +209,11 @@ def test_convertible_exception2():
         u.m.to(u.s)
     except u.UnitsException as e:
         assert 'time' not in str(e)
+
+
+@raises(TypeError)
+def test_invalid_type():
+    class A(object):
+        pass
+
+    u.Unit(A())


### PR DESCRIPTION
I noticed the following

```
>>> class A(object):
>>>    pass
>>> u.Unit(A())
AttributeError: 'NoneType' object has no attribute 'Unit'
```

Can this be modified to instead give an error with a message that specifically indicates that you tried to instantiate an invalid `Unit`? And perhaps be a ValueError or TypeError instead of an AttributeError?

@mdboom 
