### PR TITLE
travis fails when remote data option is on in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,4 @@ install:
 script:
    - if $ONLY_EGG_INFO; then python setup.py egg_info; fi
    - if ! $ONLY_EGG_INFO; then python setup.py test --remote-data; fi
+


### PR DESCRIPTION
As discussed in #481, turning on the `--remote-data` option in the tests causes the tests to all fail on travis.  This is probably some permissions issue that may or may not be fixable.  The error messages can be viewed at  https://travis-ci.org/astropy/astropy/builds/3229836
