### PR TITLE
adjust equality behavior to only compare quantity-like objects

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -268,21 +268,16 @@ class Quantity(object):
 
     # Comparison operations
     def __eq__(self, other):
-        if isinstance(other, UnitBase):
-            if self.value == 1:
-                return self.unit == other
-            else:
-                raise TypeError("Quantity object cannot be compared to an object of type {0}".format(other.__class__))
-        elif isinstance(other, Quantity):
+        if hasattr(other, 'value') and hasattr(other, 'to'):
             return self.value == other.to(self.unit).value
         else:
-            raise TypeError("Quantity object cannot be compared to an object of type {0}".format(other.__class__))
+            return False
 
     def __ne__(self, other):
-        if isinstance(other, Quantity):
+        if hasattr(other, 'value') and hasattr(other, 'to'):
             return self.value != other.to(self.unit).value
         else:
-            raise TypeError("Quantity object cannot be compared to an object of type {0}".format(other.__class__))
+            return True
 
     def __lt__(self, other):
         if isinstance(other, Quantity):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -189,9 +189,17 @@ class TestQuantityOperations():
         assert area.unit == u.cm*u.cm
 
     def test_comparison(self):
+        # equality/ non-equality is straightforward for quantity objects
+        assert (1 / (u.cm * u.cm)) == 1 * u.cm ** -2
+        assert 1 * u.m == 100 * u.cm
+        assert 1 * u.m != 1 * u.cm
 
-        assert (1 / (u.cm * u.cm)) == u.cm ** -2
-        assert 1. * u.cm * u.cm * u.cm == u.cm ** 3
+        #here one is a unit, which is an invalid comparison
+        assert 1. * u.cm * u.cm * u.cm != u.cm ** 3
+
+        #mismatched types should never work
+        assert not 1. * u.cm == 1.
+        assert 1. * u.cm != 1.
 
 
 


### PR DESCRIPTION
As I promised in #445, this PR makes it so that quantity objects are only equal when being compared to other quantity-like objects (e.g. things that have `to` and `value`).  

It also makes it so `quantity == something` and `quantity != something` never result in an error, and beefs up the tests in this area a bit.

@astrofrog and @adrn were involved in the earlier discussion - see the latter comments of #445 for details.
