### PR TITLE
astropy.test() gives collecting / import file mismatch errors

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -247,6 +247,15 @@ class astropy_test(Command, object):
                 shutil.rmtree('htmlcov')
             shutil.copytree(os.path.join(new_path, 'htmlcov'), 'htmlcov')
 
+        # Remove any residual __pycache__ directories, otherwise this can
+        # cause issues when installing.
+        for root, dirnames, filenames in os.walk(new_path):
+            if '__pycache__' in dirnames:
+                try:
+                    shutil.rmtree(os.path.join(root, '__pycache__'))
+                except OSError:  # probably incorrect permissions
+                    pass
+
         raise SystemExit(retcode)
 
 


### PR DESCRIPTION
I installed astropy fd65413f4d90b6242b70738238d936bb8e138ac0 on Mac OS X 10.8 via

```
python setup.py install --user
```

The tests run fine if I do

```
python setup.py test
```

but when I do

```
cd /tmp
python -c 'import astropy; astropy.test()'
```

as described at https://astropy.readthedocs.org/en/latest/development/testguide.html#astropy-test , I get collecting errors that look like this:

```
___________________________________________ ERROR collecting ../../Users/deil/Library/Python/2.7/lib/python/site-packages/astropy/config/tests/test_configs.py ____________________________________________
import file mismatch:
imported module 'astropy.config.tests.test_configs' has this __file__ attribute:
  /Users/deil/code/astropy/build/lib.macosx-10.8-x86_64-2.7/astropy/config/tests/test_configs.py
which is not the same as the test file we want to collect:
  /Users/deil/Library/Python/2.7/lib/python/site-packages/astropy/config/tests/test_configs.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
```

See full output here:
https://gist.github.com/3832332

@astrofrog Possibly this is related?
https://github.com/astropy/astropy/issues/53#issuecomment-2723026
