### PR TITLE
Changed Numpy version to 1.6.1 in .travis.yml (1.6.2 does not install)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 python:
     - 2.7
     - 2.6
-    - 3.2
-    - 3.1
 env:
     # Setting NUMPY_VERSION=999.9 guarantees the latest version. However, Numpy
     # 1.6.2 does not currently install out of the box, so cannot test against
@@ -23,19 +21,6 @@ matrix:
           env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=true
         - python: 3.2
           env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=true
-    exclude:
-        - python: 3.2
-          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=false
-        - python: 3.1
-          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=false
-        - python: 3.2
-          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=false
-        - python: 3.1
-          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=false
-        - python: 3.2
-          env: NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=false
-        - python: 3.1
-          env: NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false UPGRADE_DISTRIBUTE=false
 
 
 before_install:


### PR DESCRIPTION
If the Travis tests pass, I will merge this.
