### PR TITLE
Run tests from temporary directory

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -209,7 +209,7 @@ class astropy_test(Command, object):
         # Copy the build to a temporary directory for the purposes of testing
         # - this avoids creating pyc and __pycache__ directories inside the
         # build directory
-        tmp_dir = tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp(prefix='astropy-test-')
         testing_path = os.path.join(tmp_dir, os.path.basename(new_path))
         shutil.copytree(new_path, testing_path)
 


### PR DESCRIPTION
This is an alternative fix to #403, which runs the tests in a temporary directory. I originally had

```
        try:
            tmp_dir = tempfile.mkdtemp()
        except OSError:  # if permissions don't allow above, create local dir
            tmp_dir = 'tmp_testing'
            if os.path.exists(tmp_dir):
                shutil.rmtree(tmp_dir)
            os.mkdir(tmp_dir)
```

for the creation of the temporary directory, in case permissions don't allow users to use `mkdtemp` - however, what I don't like about the above is that if for some reason a user has a directory called `tmp_testing`, it would get removed without warning. Maybe instead I should generate a random directory name to avoid any potential clashes? Any thoughts?
