### PR TITLE
changed travis numpy from latest to 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ before_install:
    - sudo apt-get update -qq
    - sudo apt-get install -qq python-numpy python-scipy cython libatlas-dev liblapack-dev gfortran
 install: 
-   - if ! $ONLY_EGG_INFO; then pip -q install "numpy<=$NUMPY_VERSION" --use-mirrors; fi
+   - if ! $ONLY_EGG_INFO; then pip -v install "numpy<=$NUMPY_VERSION" --use-mirrors; fi
    - if ! $ONLY_EGG_INFO; then pip -q install Cython --use-mirrors; fi
 script: if $ONLY_EGG_INFO;then python setup.py egg_info;else python setup.py test;fi


### PR DESCRIPTION
As discussed on astropy-dev, this should make travis use numpy v 1.6.1 instead of "999.9" ( meaning latest, 1.6.2), as there are some unexplained and not necessarily important proplems getting numpy to install on travis with that version.

Once the numpy problems are fixed, this can be reverted by just deleting the added line and uncommenting the one with "999.9"
