### PR TITLE
pkg-config file for wcslib is 'wcslib.pc', not 'wcs.pc'

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -249,7 +249,7 @@ def get_extensions():
         include_dirs.append(wcslib_cpath)
     else:
         setup_helpers.pkg_config(
-            ['wcs'], ['wcs'], include_dirs, library_dirs, libraries)
+            ['wcslib'], ['wcs'], include_dirs, library_dirs, libraries)
 
     astropy_wcs_files = [  # List of astropy.wcs files to compile
         'distortion.c',


### PR DESCRIPTION
The `--use-system-wcslib` option uses `pkg-config` to determine the compiling and linking flags for `wcslib`, but it uses the wrong name for the pkg-config file. This patch changes the pkg-config name for wcslib from `wcs` to  `wcslib`.
