### PR TITLE
Make WCS transformations preserve input shape

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -271,3 +271,37 @@ def test_3d_shapes():
     result = w.wcs_pix2sky(
         data[..., 0], data[..., 1], data[..., 2], 1)
     assert len(result) == 3
+
+
+def test_preserve_shape():
+
+    w = wcs.WCS(naxis=2)
+
+    x = np.random.random((2,3,4))
+    y = np.random.random((2,3,4))
+
+    xw, yw = w.wcs_pix2world(x, y, 1)
+
+    assert xw.shape == (2,3,4)
+    assert yw.shape == (2,3,4)
+
+    xp, yp = w.wcs_world2pix(x, y, 1)
+
+    assert xp.shape == (2,3,4)
+    assert yp.shape == (2,3,4)
+
+
+def test_shape_mismatch():
+
+    w = wcs.WCS(naxis=2)
+
+    x = np.random.random((2,3,4))
+    y = np.random.random((3,2,4))
+
+    with pytest.raises(ValueError) as exc:
+        xw, yw = w.wcs_pix2world(x, y, 1)
+    assert exc.value.args[0] == "coordinate arrays are not the same shape"
+
+    with pytest.raises(ValueError) as exc:
+        xp, yp = w.wcs_world2pix(x, y, 1)
+    assert exc.value.args[0] == "coordinate arrays are not the same shape"

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -862,6 +862,12 @@ naxis kwarg.
                     raise ValueError(
                         "coordinate arrays are not the same size")
 
+            shape = axes[0].shape
+            for axis in axes[1:]:
+                if axis.shape != shape:
+                    raise ValueError(
+                        "coordinate arrays are not the same shape")
+
             axes = [x.reshape((size, 1)) for x in axes]
             xy = np.hstack(axes)
             if ra_dec_order and sky == 'input':
@@ -869,8 +875,8 @@ naxis kwarg.
             sky = func(xy, origin)
             if ra_dec_order and sky == 'output':
                 sky = self._normalize_sky_output(sky)
-                return sky[:, 0], sky[:, 1]
-            return [sky[:, i] for i in range(sky.shape[1])]
+                return sky[:, 0].reshape(shape), sky[:, 1].reshape(shape)
+            return [sky[:, i].reshape(shape) for i in range(sky.shape[1])]
 
         raise TypeError(
             "Expected 2 or {0} arguments, {0} given".format(


### PR DESCRIPTION
@mdboom - this is an improvement to astropy.wcs to preserve the shape of input arrays when doing e.g.

```
xw, yw = wcs.wcs_pix2world(x, y, 0)
```

In the above case, `xw` will have the same shape as `x`, and also shapes of the input are checked, so `x.shape` should be the same as `y.shape`. Do you see any undesirable side effects from this?
