### PR TITLE
Installation fails 

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -65,9 +65,9 @@ from source, unless you are installing a numbered release. (The releases
 packages have the necessary C files packaged with them, and hence do not
 require Cython.)
 
-.. note:: If you are using MacOS X, you will need the developer tools (XCode)
-          installed in order to have a functional compiler suite. As of XCode
-          4.3, the command-line compilers are no longer installed by default -
+.. note:: If you are using MacOS X, the easiest way to install a compiler
+          suite is to install the MacOS X developer tools (XCode) As of XCode
+          4.3, the command-line compilers are no longer installed by default:
           you will need to open the XCode application, go to **Preferences**,
           then **Downloads**, and then under **Components**, click on the
           Install button to the right of **Command Line Tools**.


### PR DESCRIPTION
I can't get installation using pip to work:

Downloading/unpacking astropy
  Downloading astropy-0.1.tar.gz (3.1MB): 3.1MB downloaded
  Running setup.py egg_info for package astropy
    Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.19.tar.gz
    Extracting in /tmp/tmpu4wIPX
    Now working in /tmp/tmpu4wIPX/distribute-0.6.19
    Building a Distribute egg in /private/tmp/pip-build/astropy
    /private/tmp/pip-build/astropy/distribute-0.6.19-py2.7.egg
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/tmp/pip-build/astropy/setup.py", line 38, in <module>
        setup_helpers.adjust_compiler()
      File "astropy/setup_helpers.py", line 547, in adjust_compiler
        shlex.split(c_compiler) + ['--version'], stdout=subprocess.PIPE)
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 679, in **init**
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1228, in _execute_child
    OSError: [Errno 2] No such file or directory
    Complete output from command python setup.py egg_info:
    Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.19.tar.gz

Extracting in /tmp/tmpu4wIPX

Now working in /tmp/tmpu4wIPX/distribute-0.6.19

Building a Distribute egg in /private/tmp/pip-build/astropy

/private/tmp/pip-build/astropy/distribute-0.6.19-py2.7.egg

Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/tmp/pip-build/astropy/setup.py", line 38, in <module>

```
setup_helpers.adjust_compiler()
```

  File "astropy/setup_helpers.py", line 547, in adjust_compiler

```
shlex.split(c_compiler) + ['--version'], stdout=subprocess.PIPE)
```

  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 679, in **init**

  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1228, in _execute_child

OSError: [Errno 2] No such file or directory

---

Command python setup.py egg_info failed with error code 1 in /tmp/pip-build/astropy
