### PR TITLE
Ignore astropy/extern directory for testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ show-response = 1
 
 [pytest]
 minversion = 2.3.3
-norecursedirs = build docs/_build
+norecursedirs = build docs/_build astropy/extern
 
 [bdist_dmg]
 background = .dmg_background.png


### PR DESCRIPTION
`setup.py test --pep8` was including the external code in its report.  These external projects are some of the worst PEP8 offenders, so it really skews the results.  I tried to use the pep8ignore config option, but I couldn't get it to be picked up.  The downside to this approach is that we can't actually put tests in the extern tree in the future if we want to, but I propose we cross that bridge when we get there.
