### PR TITLE
Fixes an annoying warning that can come from pkg_resources...

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -14,6 +14,11 @@ import subprocess
 import shutil
 import tempfile
 
+try:
+    import pkg_resources
+except ImportError:
+    pass
+
 from distutils.core import Command
 
 from .. import test


### PR DESCRIPTION
... when running astropy.test():

```
>>>> astropy.test()
> ^[[0;33mWARNING^[[0m: Module _pytest was already imported from
> c:\python27\lib\site-packages\astropy\extern\pytest.pyc/_pytest, but c:
> \python27\lib\site-packages\pytest-2.2.1-py2.7.egg is being added to
> sys.path [_pytest.core]
> ^[[0;33mWARNING^[[0m: Module pytest was already imported from
> c:\python27\lib\site-packages\astropy\extern\pytest.pyc/pytest, but c:\p
> ython27\lib\site-packages\pytest-2.2.1-py2.7.egg is being added to sys.path
> [_pytest.core]
> ^[[0;33mWARNING^[[0m: Module py was already imported from
> c:\python27\lib\site-packages\astropy\extern\pytest.pyc\py, but c:\python27\
> lib\site-packages\py-1.4.7-py2.7.egg is being added to sys.path
> [_pytest.core]
```

This happens if you have a package installed in site-packages, but you import it from somewhere else _before_ pkg_resources is imported.  That's exactly what's happening in this case, where we're using the bundled py.test to run astropy.test().  But in the process of importing py.test, pkg_resources gets imported.

When pkg_resources is first imported it builds a "working_set" of all packages available on the path (by processing .egg-info directories).  Here's it's saying "Ah, there's a package called py.test in your site-packages, but you already have a package of the same name in your sys.modules imported from elsewhere, so I'm going to skip this one".

The fix is to simply make sure pkg_resources, if available, is imported before py.test.
