### PR TITLE
Add constant-like solar unit definitions

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -30,9 +30,9 @@ def_unit(['AU', 'au'], _si.au * si.m, register=True, prefixes=True,
 def_unit(['pc', 'parsec'], _si.pc * si.m, register=True, prefixes=True,
          doc="parsec: approximately 3.26 light-years.")
 
-def_unit(['solRad'], _si.R_sun * si.m, register=True,
+def_unit(['solRad', 'R_sun'], _si.R_sun * si.m, register=True,
          doc="Solar radius")
-def_unit(['lyr'], 9.460730e15 * si.m, register=True,
+def_unit(['lyr', 'lightyear'], 9.460730e15 * si.m, register=True,
          doc="Light year")
 
 
@@ -46,7 +46,7 @@ def_unit(['barn'], 10 ** -28 * si.m ** 2, register=True, prefixes=True,
 ###########################################################################
 # MASS
 
-def_unit(['solMass'], _si.M_sun * si.kg, register=True, prefixes=True,
+def_unit(['solMass', 'M_sun'], _si.M_sun * si.kg, register=True, prefixes=True,
          doc="Solar mass",
          format={'latex': r'M_{\odot}', 'unicode': 'M⊙'})
 def_unit(['M_p'], _si.m_p * si.kg, register=True,
@@ -72,7 +72,7 @@ def_unit(['Ry', 'rydberg'], 13.605692 * si.eV, register=True,
 ###########################################################################
 # ILLUMINATION
 
-def_unit(['solLum'], _si.L_sun * si.W, register=True, prefixes=True,
+def_unit(['solLum', 'L_sun'], _si.L_sun * si.W, register=True, prefixes=True,
          doc="Solar luminance")
 
 


### PR DESCRIPTION
In the `units` subpackage, solar mass is defined as `solMass`, radius as `solRad`, and luminosity as `solLum`. I just added other definitions to be consistent with `constants` : `M_sun`, `L_sun`, and `R_sun`. I also snuck in a verbose spelling of `lightyear`. 
