### PR TITLE
importing standards needed

### DIFF
--- a/docs/importing.rst
+++ b/docs/importing.rst
@@ -1,0 +1,43 @@
+*****************
+Importing Astropy
+*****************
+
+In order to encourage consistency amongst users in importing and using Astropy
+functionality, we have put together the following guidelines.
+
+Since most of the functionality in Astropy resides in sub-packages, importing
+astropy as::
+
+    >>> import astropy
+
+is not very useful. Instead, it is best to import the desired sub-pacakge
+with the syntax:
+
+    >>> from astropy import subpackage
+
+For example, to access the FITS-related functionality, you can import
+`astropy.io.fits` with::
+
+    >>> from astropy.io import fits
+    >>> hdulist = fits.open('data.fits')
+
+In specific cases, we have recommended shortcuts in the documentation for
+specific sub-packages, for example::
+
+    >>> from astropy import units as u
+    >>> from astropy import coordinates as coord
+    >>> coord.ICRSCoordinates(ra=10.68458, dec=41.26917, unit=(u.degree, u.degree)))
+    <ICRSCoordinates RA=10.68458 deg, Dec=41.26917 deg>
+
+Finally, in some cases, most of the required functionality is contained in a
+single class (or a few classes). In those cases, the class can be directly
+imported::
+
+    >>> from astropy.cosmology import WMAP7
+    >>> from astropy.table import Table
+    >>> from astropy.wcs import WCS
+
+Note that for clarity, and to avoid any issues, we recommend to **never**
+import any Astropy functionality using ``*``, for example::
+
+    >>> from astropy.io.fits import *  # NOT recommended

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ User Documentation
 
    overview
    install
+   importing
    nddata/index
    units/index
    time/index


### PR DESCRIPTION
The numpy and scipy communities wrestled with the issue of importing into the top level and decided it was poor practice, for a variety of reasons I won't rehash here.  Hence, there is the standard "import numpy as np" and its friends.  In the astropy docs, however, there is a lot of importing into the top level.  Usually this is just single functions, but it breaks when you try to get example code to work in your own function, where you imported all of astropy and need to say "astropy." before each call.

Most important is the standard that we NEVER import \* into the top level, since future versions could include names that conflict with standard Python names.  Then, provide a standard way to import each module (and the top level if there are useful things there).  These might include:

import astropy as ap

for the top level.  Some names will require thought.  It was suggested on the mailing list that we NOT:

import astropy.io as api

since "API" is already a standard abbreviation and this might cause confusion.  Also,

import astropy.io.fits as fits

would be a clean standard.  However, given the history of pyfits,

import astropy.io.fits as pyfits

would be seamless for a lot of existing code.  A decision is needed between the two and should include input from the pyfits maintainers and from anyone with code that must be long-term stable.

Given the large number of modules contemplated, a help() page giving the importation standard should be created:
help(astropy.import)

--jh--
