### PR TITLE
Remove temporary fix from .travis.yml once Numpy builds out of the box on Python 3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ python:
     - 2.7
     - 2.6
     - 3.2
-    - 3.1
 env:
-    # NUMPY_VERSION=999.9 guarantees the latest version, but we cannot use this
-    # for now, since we are using a temporary fix due to a bug in distribute
-    # or pip. See https://github.com/travis-ci/travis-cookbooks/issues/48 for
-    # more details.
     - NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false
     - NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false
     - NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false
@@ -21,23 +16,18 @@ matrix:
         - python: 3.2 
           env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=true
     exclude:
-        - python: 3.2
-          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false
-        - python: 3.1 
-          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false
         - python: 3.2 
-          env: NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false
-        - python: 3.1 
+          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false
+        - python: 3.2
           env: NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false
 
 
 before_install:
-   #we do this to make sure we get the dependencies so pip works below
+   # We do this to make sure we get the dependencies so pip works below
    - sudo apt-get update -qq
    - sudo apt-get install -qq python-numpy python-scipy cython libatlas-dev liblapack-dev gfortran
 install: 
    - export PYTHONIOENCODING=UTF8 # just in case
-   - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install "numpy==$NUMPY_VERSION" --use-mirrors; fi'
-   - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then pip install https://github.com/y-p/numpy/archive/1.6.2_with_travis_fix.tar.gz; fi'
+   - pip install --upgrade "numpy==$NUMPY_VERSION" --use-mirrors
    - if ! $ONLY_EGG_INFO; then pip -q install Cython --use-mirrors; fi
 script: if $ONLY_EGG_INFO;then python setup.py egg_info;else python setup.py test;fi


### PR DESCRIPTION
As discussed in #504, #508, and #514, Travis builds on Python 3 with Numpy stopped working due to an incompatibility between virtualenv 1.8.3 and Numpy, so we had to include a temporary fix (merged in #514). This is a reminder that we should remove this workaround once Python 3 + Numpy is properly supported again.
