### PR TITLE
Minor update to optional dependency instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,7 @@ Astropy also depends on other packages for optional features:
 
 - `xmllint <http://www.xmlsoft.org/>`_: To validate VOTABLE XML files.
 
-However, not that these only need to be installed if those particular features
+However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.
 
 .. TODO: Link to the planned dependency checker/installer tool.


### PR DESCRIPTION
I've added h5py to the list of optional dependencies, and also tried to make it clearer that optional dependencies are _optional_. I came across a user the other day who thought they were _required_ so that astropy would work, even if they were only for specific functionality. This is a pretty trivial PR, so I'll merge in a couple of days.
