### PR TITLE
Is Time handling leap seconds correctly?

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -866,7 +866,7 @@ class TimeString(TimeFormat):
                 raise ValueError('Time {0} does not match {1} format'
                                  .format(timestr, self.name))
 
-        self.jd1, self.jd2 = sofa_time.dtf_jd(self.scale.encode('utf8'),
+        self.jd1, self.jd2 = sofa_time.dtf_jd(self.scale.upper().encode('utf8'),
                                               iy, im, id, ihr, imin, dsec)
 
     def str_kwargs(self):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -165,6 +165,33 @@ class TestBasic():
         with pytest.raises(ValueError):
             Time(50000.0, 'bad', format='mjd', scale='tai')
 
+    def test_utc_leap_sec(self):
+        """Time behaves properly near or in UTC leap second.  This
+        uses the 2012-06-30 leap second for testing."""
+
+        # Start with a day without a leap second and note rollover
+        t1 = Time('2012-06-01 23:59:60.0', scale='utc')
+        assert t1.iso == '2012-06-02 00:00:00.000'
+
+        # Leap second is different
+        t1 = Time('2012-06-30 23:59:59.900', scale='utc')
+        assert t1.iso == '2012-06-30 23:59:59.900'
+
+        t1 = Time('2012-06-30 23:59:60.000', scale='utc')
+        assert t1.iso == '2012-06-30 23:59:60.000'
+
+        t1 = Time('2012-06-30 23:59:60.999', scale='utc')
+        assert t1.iso == '2012-06-30 23:59:60.999'
+
+        t1 = Time('2012-06-30 23:59:61.0', scale='utc')
+        assert t1.iso == '2012-07-01 00:00:00.000'
+
+        # Delta time gives 2 seconds here as expected
+        t0 = Time('2012-06-30 23:59:59', scale='utc')
+        t1 = Time('2012-07-01 00:00:00', scale='utc')
+        assert np.allclose((t1 - t0).sec, 2.0)
+
+
 class TestVal2():
     """Tests related to val2"""
 


### PR DESCRIPTION
I'm confused (this may just be me) about what's going on here:

```
In [1]: t = Time(['2012-06-30 12:00:00', '2012-06-20 12:00:00','2012-06-30 23:59:59', '2012-06-20 23:59:59'],format='iso',scale='utc')

In [2]: t 
Out[2]: <Time object: scale='utc' format='iso' vals=['2012-06-30 12:00:00.500' '2012-06-20 12:00:00.000' '2012-06-30 23:59:60.000' '2012-06-20 23:59:59.000']>

In [3]: t.utc
Out[3]: <Time object: scale='utc' format='iso' vals=['2012-06-30 12:00:00.500' '2012-06-20 12:00:00.000' '2012-06-30 23:59:60.000' '2012-06-20 23:59:59.000']>
```

Haven't the first and third times effectively been expressed as something more like UT1? (I know it's not UT1, but it shares the property of UT1 that a day has 86400 seconds, spread out -- nearly -- uniformly over the day, so that the leap second is spread out over the day.)

Weirder:

```
In [4]: Time(['2012-06-30 12:00:00', '2012-06-30 12:00:00.500'],format='iso',scale='utc')
Out[4]: <Time object: scale='utc' format='iso' vals=['2012-06-30 12:00:00.500' '2012-06-30 12:00:01.000']>
```

The second time is just the first time, according to [2] and [3], but now the first becomes the second while the second gets turned into something else.

What am I missing?
