### PR TITLE
Change order or arguments in spherical distance routines

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -514,7 +514,7 @@ def degrees_to_string(d, precision=5, pad=False, sep=':'):
 
 
 #<----------Spherical angular distances------------->
-def small_angle_sphere_dist(lat1, lon1, lat2, lon2):
+def small_angle_sphere_dist(lon1, lat1, lon2, lat2):
     """
     Euclidean angular distance "on a sphere" - only valid on sphere in the
     small-angle approximation.
@@ -535,7 +535,7 @@ def small_angle_sphere_dist(lat1, lon1, lat2, lon2):
     return (dlat ** 2 + dlon ** 2) ** 0.5
 
 
-def simple_sphere_dist(lat1, lon1, lat2, lon2):
+def simple_sphere_dist(lon1, lat1, lon2, lat2):
     """
     Simple formula for angular distance on a sphere: numerically unstable
     for small distances.
@@ -550,7 +550,7 @@ def simple_sphere_dist(lat1, lon1, lat2, lon2):
     return acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(-lat2) * cdlon)
 
 
-def haversine_sphere_dist(lat1, lon1, lat2, lon2):
+def haversine_sphere_dist(lon1, lat1, lon2, lat2):
     """
     Haversine formula for angular distance on a sphere: more stable at poles
 
@@ -567,7 +567,7 @@ def haversine_sphere_dist(lat1, lon1, lat2, lon2):
     return 2 * asin((sdlat ** 2 + coslats * sdlon ** 2) ** 0.5)
 
 
-def haversine_atan_sphere_dist(lat1, lon1, lat2, lon2):
+def haversine_atan_sphere_dist(lon1, lat1, lon2, lat2):
     """
     Haversine formula for angular distance on a sphere: more stable at poles.
     This version uses arctan instead of arcsin and thus does better with sign
@@ -588,7 +588,7 @@ def haversine_atan_sphere_dist(lat1, lon1, lat2, lon2):
     return 2 * atan2(numerator ** 0.5, (1 - numerator) ** 0.5)
 
 
-def vincenty_sphere_dist(lat1, lon1, lat2, lon2):
+def vincenty_sphere_dist(lon1, lat1, lon2, lat2):
     """
     Vincenty formula for angular distance on a sphere: stable at poles and
     antipodes but more complex/computationally expensive.

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -685,7 +685,7 @@ class AngularSeparation(Angle):
             lat2 = units.to(u.radian, lat2)
             lon2 = units.to(u.radian, lon2)
 
-            sepval = util.vincenty_sphere_dist(lat1, lon1, lat2, lon2)
+            sepval = util.vincenty_sphere_dist(lon1, lat1, lon2, lat2)
 
         super(AngularSeparation, self).__init__(sepval, u.radian)
 

--- a/astropy/coordinates/tests/test_sphere_ang_dists.py
+++ b/astropy/coordinates/tests/test_sphere_ang_dists.py
@@ -50,10 +50,10 @@ def test_2dseparations(coord, correctsep, dfunc):
     lat1, lon1, lat2, lon2 = coord
 
     print('distance function', dfunc)
-    print('({0},{1}) - ({2},{3})'.format(lat1, lon1, lat2, lon2))
+    print('({0},{1}) - ({2},{3})'.format(lon1, lat1, lon2, lat2))
     print('Correct separation', correctsep)
 
-    inputs = (radians(lat1), radians(lon1), radians(lat2), radians(lon2))
+    inputs = (radians(lon1), radians(lat1), radians(lon2), radians(lat2))
     sep = degrees(dfunc(*inputs))
     print('Reported:', sep)
     print('Deviation from correct:', sep - correctsep)


### PR DESCRIPTION
I just got had by the order of the arguments in the spherical distance routines, e.g. `vincenty_sphere_dist(lat1, lon1, lat2, lon2)`. Having latitude then longitude is counter-intuitive, as is means specifying e.g. dec, ra. @eteq - can we change it to longitude, latitude?
