### PR TITLE
Strange warning on first import of astropy

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -99,7 +99,7 @@ def get_config_dir(create=True):
     #first look for XDG_CONFIG_HOME
     xch = environ.get('XDG_CONFIG_HOME')
 
-    if xch is not None:
+    if xch is not None and path.exists(xch):
         xchpth = path.join(xch, 'astropy')
         if not path.islink(xchpth):
             if path.exists(xchpth):
@@ -133,7 +133,7 @@ def get_cache_dir():
     #first look for XDG_CACHE_HOME
     xch = environ.get('XDG_CACHE_HOME')
 
-    if xch is not None:
+    if xch is not None and path.exists(xch):
         xchpth = path.join(xch, 'astropy')
         if not path.islink(xchpth):
             if path.exists(xchpth):


### PR DESCRIPTION
The first time I import astropy on a macintosh:

```
>>> import astropy
/Users/sienkiew/Ureka/variants/common/lib/python/astropy/config/configuration.py:392: ConfigurationMissingWarning: Configuration defaults will be used, and configuration cannot be saved due to OSError:2
  warn(ConfigurationMissingWarning(wmsg))
>>> 
```

Since this happens to everybody the first time they import astropy, I expect many of my users will ask me about this.  I suggest a more useful error message.

I tried to figure out what the problem is, and I found that this seems to be happening:
- astropy wants a config file in ~/.astropy - when it does not find one, it creates it.  So far, so good.
- When it creates the default config directory, it tries to make a symlink in ~/.config/astropy.

The actual problem that this warning is complaining about is that I do not have a directory named ~/.config

The problem is in paths.py _find_or_create_astropy_dir(), where there is no exception handling for the symlink.

From what I can tell so far, the absence of .config does not appear to be a real problem, so it should not complain if it is missing.  If it is essential that .config be present, then create it.
