### PR TITLE
Add some relevant trove classifiers to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,8 @@ setup(name='astropy',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: Implementation :: CPython',
-          'Topic :: Scientific/Engineering :: Astronomy'
+          'Topic :: Scientific/Engineering :: Astronomy',
+          'Topic :: Scientific/Engineering :: Physics'
       ],
       cmdclass=cmdclassd,
       zip_safe=False,


### PR DESCRIPTION
I added some trove classifiers to Astropy's setup.py.  While the usefulness of the Trove system is debatable, it can't hurt.  Here are my suggestions--this lists the specific Python 2.x versions we support, and lists that we ostensibly support any Python 3 version.  Under licenses I only listed the license for Astropy itself, and not that if anything that's bundled with it.  I think that's the preferred approach but I'm not sure sure.  I also neglected to specify a "Development Status" since as discussed recently we're all over the map on that.

Unless anyone has anything they think should be added/removed I'll go ahead and merge this before the release.  A list of Trove classifiers is here: http://pypi.python.org/pypi?%3Aaction=list_classifiers
