### PR TITLE
Add a new AstropyRegister command... 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,9 @@ cmdclassd = {'test': setup_helpers.setup_test_command('astropy'),
 
              # Use a custom install command which understands additional
              # commandline arguments
-             'install': setup_helpers.AstropyInstall
+             'install': setup_helpers.AstropyInstall,
 
+             'register': setup_helpers.AstropyRegister
              }
 
 try:


### PR DESCRIPTION
to replace the built-in setup.py register command.  This adds a 'hidden' option which makes a release hidden from the release listing by default.  This feature of PyPI is exposed through the web interface but is not made part of the distutils command (which I would consider a bit of a wart).

I'm going to submit a pull request to add a feature like this to distribute itself, but in the meantime we need to hack it on.

The issue is that when registering a release on PyPI by default it is made visible both in the front page listing of new packages, and on list of active Astropy releases.  For something like a pre-release we may not want it to become visible as the default most recent release.  Although this can easily be changed through the web interface after running `setup.py register`, it's possible to forget this step.  It's also just inconvenient.

This even makes it convenient to register "dev" releases on PyPI if we ever have some need to put one out there.

I have tested this with a different package of my own, and it works.  One item of note is that on the package management page on PyPI there's a checkbox labeled "Auto-hide old releases".  We want this disabled as a matter of policy.  Otherwise, even when pushing a "hidden" release to PyPI it automatically marks the last released as "hidden" too.
