### PR TITLE
Add sections Getting help and Reporting issues to main doc index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,8 +48,8 @@ Getting help
 ***********************
 
 If you want to get help or discuss issues with other Astropy users, you can
-sign up for the `astropy <http://mail.scipy.org/mailman/listinfo/astropy>`_
-mailing list.  Alternatively, the `astropy-dev
+sign up for the `astropy mailing list <http://mail.scipy.org/mailman/listinfo/astropy>`_.
+Alternatively, the `astropy-dev
 <http://groups.google.com/group/astropy-dev>`_ list is where you should go to
 discuss more technical aspects of Astropy with the developers.
 


### PR DESCRIPTION
This adds information on getting help and reporting issues, expanding somewhat on the text from www.astropy.org. 

I think it's good to have this info on the landing page for astropy docs.  The Getting Started section is another candidate location that would make sense if people don't think this belongs on the main index.

Preview at http://hea-www.harvard.edu/~aldcroft/tmp/astropy/html/index.html
