### PR TITLE
WCS: handle non-standard keywords by default

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1647,7 +1647,7 @@ PyWcsprm_to_header(
   if (relax_obj == Py_True) {
     relax = WCSHDO_all;
   } else if (relax_obj == NULL || relax_obj == Py_False) {
-    relax = WCSHDO_none;
+    relax = WCSHDO_safe;
   } else {
     #if PY3K
     relax = (int)PyLong_AsLong(relax_obj);

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1267,8 +1267,8 @@ naxis kwarg.
         relax : bool or int, optional
             Degree of permissiveness:
 
-            - `False` (default): Write out only FITS keywords defined
-              by the published WCS standard.
+            - `False` (default): Write all extensions that are
+              considered to be safe and recommended.
 
             - `True`: Write all recognized informal extensions of the
               WCS standard.
@@ -1310,10 +1310,10 @@ naxis kwarg.
         relax : bool or int, optional
             Degree of permissiveness:
 
-            - `False` (default): Recognize only FITS keywords defined by the
-              published WCS standard.
+            - `False` (default): Write all extensions that are
+              considered to be safe and recommended.
 
-            - `True`: Admit all recognized informal extensions of the
+            - `True`: Write all recognized informal extensions of the
               WCS standard.
 
             - `int`: a bit field selecting specific extensions to

--- a/docs/wcs/relax.rst
+++ b/docs/wcs/relax.rst
@@ -277,8 +277,8 @@ has a *relax* argument which may be either `True`, `False` or an
 
 - If `True`, write all recognized extensions.
 
-- If `False` (default), none of the extensions (even those in the
-  errata) will be written.
+- If `False` (default), write all extensions that are considered to be
+  safe and recommended, equivalent to `WCSHDO_safe` (described below).
 
 - If an `int`, is is a bit field to provide fine-grained control over
   what non-standard WCS keywords to accept.  The flag bits are subject


### PR DESCRIPTION
As suggested in #583:

This changes astropy.wcs so that when reading WCS FITS keywords, it supports handling non-standard keywords by default.  

When writing out FITS headers, the new default is WCSHDO_safe, defined by wcslib as "write all extensions that are considered to be safe and recommended".

This doesn't break any unit tests -- I wonder whether it will cause files to fail that used to work, though.  I think (as usual) our users will help to find wacky FITS files for us ;)
