### PR TITLE
Possible bug in Sphinx?

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -102,7 +102,8 @@ extensions = [
     'astropy.sphinx.ext.numpydoc',
     'astropy.sphinx.ext.astropyautosummary',
     'astropy.sphinx.ext.automodsumm',
-    'astropy.sphinx.ext.automodapi'
+    'astropy.sphinx.ext.automodapi',
+    'astropy.sphinx.ext.tocdepthfix'
     ]
 
 try:

--- a/astropy/sphinx/ext/tocdepthfix.py
+++ b/astropy/sphinx/ext/tocdepthfix.py
@@ -1,0 +1,18 @@
+from sphinx import addnodes
+
+
+def fix_toc_entries(app, doctree):
+    # Get the docname; I don't know why this isn't just passed in to the
+    # callback
+    # This seems a bit unreliable as it's undocumented, but it's not "private"
+    # either:
+    docname = app.builder.env.temp_data['docname']
+    if app.builder.env.metadata[docname].get('tocdepth', 0) != 0:
+        # We need to reprocess any TOC nodes in the doctree and make sure all
+        # the files listed in any TOCs are noted
+        for treenode in doctree.traverse(addnodes.toctree):
+            app.builder.env.note_toctree(docname, treenode)
+
+
+def setup(app):
+    app.connect('doctree-read', fix_toc_entries)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+:tocdepth: 2
+
 ###################################
 Welcome to Astropy's Documentation!
 ###################################
@@ -21,6 +23,7 @@ User Documentation
 
 :ref:`whatsnew-0.2`
 ===================
+
 
 .. toctree::
    :maxdepth: 1
@@ -46,6 +49,7 @@ User Documentation
    stability
    whatsnew/index
    creditsandlicense
+
 
 ***********************
 Getting help


### PR DESCRIPTION
Assigning this to 0.2 for now since I just created this bug, but I'm not sure what the quickest resolution will be.

If you look at the latest docs (http://docs.astropy.org/en/latest/) you'll see that in 3febebdbd5841410109a09129f1d1b3f98845740 I added a link on the index to "What's New in Astropy 0.2".  I added it as a heading just so that it pops out more, but the problem is that now it shows up under the page's table of contents on the sidebar as "whatsnew-0.2".  Really it shouldn't show up there at all.

According to the Sphinx documentation I should be able to add `:tocdepth: 2` to the top of the page to control this, and indeed that works as expected and should solve the problem.  Except when I do that and rebuild the docs I get a bunch of these warnings:

```
/bray/sc1/root/src/astropy/astropy/docs/changelog.rst:: WARNING: document isn't included in any toctree
/bray/sc1/root/src/astropy/astropy/docs/configs/index.rst:: WARNING: document isn't included in any toctree
/bray/sc1/root/src/astropy/astropy/docs/coordinates/index.rst:: WARNING: document isn't included in any toctree
/bray/sc1/root/src/astropy/astropy/docs/cosmology/index.rst:: WARNING: document isn't included in any toctree
/bray/sc1/root/src/astropy/astropy/docs/creditsandlicense.rst:: WARNING: document isn't included in any toctree
/bray/sc1/root/src/astropy/astropy/docs/development/building_packaging.rst:: WARNING: document isn't included in any toctree
<...and so on...>
```

This makes no sense, as those pages are included in TOCs on the main index, and those TOCs are still being rendered just fine.  So I think that has to be a bug.

In the meantime, does anyone have any better ideas for displaying this link in such a way that it pops out a bit?
