### PR TITLE
VOTable INFO element content not getting loaded

### DIFF
--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.xml
@@ -20,7 +20,7 @@
    Dos Equis
   </DESCRIPTION>
  </PARAM>
- <INFO ID="QUERY_STATUS" name="QUERY_STATUS" value="OK"/>
+ <INFO ID="QUERY_STATUS" name="QUERY_STATUS" value="OK">This is some information.</INFO>
  <RESOURCE type="results">
   <DESCRIPTION>
    This is a resource description

--- a/astropy/io/votable/tests/data/regression.xml
+++ b/astropy/io/votable/tests/data/regression.xml
@@ -12,7 +12,7 @@ The VOTable format is an XML standard for the interchange of data represented as
 <PARAM datatype="float" name="INPUT" value="0.000000,0.000000" arraysize="*" unit="km/h" ucd="phys.size;instr.tel">
   <DESCRIPTION>This is the most interesting parameter in the world, and it drinks Dos Equis</DESCRIPTION>
 </PARAM>
-<INFO name="QUERY_STATUS" value="OK"/>
+<INFO name="QUERY_STATUS" value="OK">This is some information.</INFO>
 <RESOURCE type="results">
 <DESCRIPTION>
   This is a resource description


### PR DESCRIPTION
When parsing a VOTable via astropy.io.vo.parse(), the text content for the INFO elements are apparently not getting loaded.  This is important when the VOTable is the response from a standard VO DAL service (e.g. SIA) in which an INFO element's content provides an error message.  

I looked into the code found that the INFO content gets consumed in astropy.io.vo.tree.info.parse() but is not stored.  This method is actually inherited from astropy.io.vo.SimpleElement.  I note that the parse methods for both the Resource and VOTableFile classes have code that suggest that they expect to see the closing INFO tag and pick up the INFO content then.  

```
        for start, tag, data, pos in iterator:
        if start:
            tag_mapping.get(tag, self._add_unknown_tag)(
                iterator, tag, data, config, pos)
        elif tag == 'DESCRIPTION':
            ...
        elif tag == 'INFO':
            self.infos[-1].content = data
```

This never happens since parse method invoked when the start tag is seen (_add_info()) consumes the closing tag.  

It seems the proper place to fix this would be in astropy.io.vo.SimpleElementWithContent (which Info also inherits from); I get INFOs properly parsed if I add a parse() method:

```
def parse(self, iterator, config):
    for start, tag, data, pos in iterator:
        if start and tag != self._element_name:
            self._add_unknown_tag(iterator, tag, data, config, pos)
        elif tag == self._element_name:
            # added this bit to fill INFO content
            if data:
                self.content = data
            ###
            break

    return self
```

When I next get a chance, I'll fork the respository, apply this fix, and request a merge, unless someone beats me to it.
