### PR TITLE
pip install of astropy broken

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -21,8 +21,8 @@ from distutils.errors import DistutilsError, DistutilsFileError
 from distutils.core import Extension
 from distutils.core import Command
 from distutils.command.build import build as DistutilsBuild
-from distutils.command.install import install as DistutilsInstall
-from distutils.command.build_ext import build_ext as DistutilsBuildExt
+from setuptools.command.install import install as SetuptoolsInstall
+from setuptools.command.build_ext import build_ext as SetuptoolsBuildExt
 
 from setuptools.command.register import register as SetuptoolsRegister
 
@@ -88,17 +88,17 @@ class AstropyBuild(DistutilsBuild):
         cls.custom_options.append(name)
 
 
-class AstropyInstall(DistutilsInstall):
+class AstropyInstall(SetuptoolsInstall):
     """
     A custom 'install' command that allows for adding extra install
     options.
     """
-    user_options = DistutilsInstall.user_options[:]
-    boolean_options = DistutilsInstall.boolean_options[:]
+    user_options = SetuptoolsInstall.user_options[:]
+    boolean_options = SetuptoolsInstall.boolean_options[:]
     custom_options = []
 
     def initialize_options(self):
-        DistutilsInstall.initialize_options(self)
+        SetuptoolsInstall.initialize_options(self)
         # Create member variables for all of the custom options that
         # were added.
         for option in self.custom_options:
@@ -192,7 +192,7 @@ AstropyInstall.__name__ = 'install'
 AstropyRegister.__name__ = 'register'
 
 
-def wrap_build_ext(basecls=DistutilsBuildExt):
+def wrap_build_ext(basecls=SetuptoolsBuildExt):
     """
     Creates a custom 'build_ext' command that allows for manipulating some of
     the C extension options at build time.  We use a function to build the
@@ -1194,7 +1194,9 @@ class bdist_dmg(Command):
         # at the start of the script, our pkg should be the only file there.
         files = os.listdir(pkg_dir)
         if len(files) != 1:
-            raise DistutilsFileError("Expected a single file in the {pkg_dir} directory".format(pkg_dir=pkg_dir))
+            raise DistutilsFileError(
+                "Expected a single file in the {pkg_dir} "
+                "directory".format(pkg_dir=pkg_dir))
         pkg_file = os.path.basename(files[0])
         pkg_name = os.path.splitext(pkg_file)[0]
 


### PR DESCRIPTION
Testing installation of the new 0.2b1 release with pip revealed a serious bug with installation with pip:

```
$ pip install -i http://testpypi.python.org/simple astropy
Downloading/unpacking astropy
  Downloading astropy-0.2b1.tar.gz (4.4MB): 4.4MB downloaded
  Running setup.py egg_info for package astropy

Requirement already satisfied (use --upgrade to upgrade): numpy in /bray/sc1/root/lib/python2.7/site-packages (from astropy)
Installing collected packages: astropy
  Running setup.py install for astropy
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: option --single-version-externally-managed not recognized
    Complete output from command /bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/bin/python2.7 -c "import setuptools;__file__='/bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/build/astropy/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-lGI0kV-record/install-record.txt --single-version-externally-managed --install-headers /bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/include/site/python2.7:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]

   or: -c --help [cmd1 cmd2 ...]

   or: -c --help-commands

   or: -c cmd --help



error: option --single-version-externally-managed not recognized

----------------------------------------
Command /bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/bin/python2.7 -c "import setuptools;__file__='/bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/build/astropy/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-lGI0kV-record/install-record.txt --single-version-externally-managed --install-headers /bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/include/site/python2.7 failed with error code 1 in /bray/sc1/root/home/embray/.virtualenvs/astropy-release-test/build/astropy
Storing complete log in /bray/sc1/root/home/embray/.pip/pip.log
```

This happens whether Astropy is installed from PyPI, an already downloaded tarball, a git clone, or any other method.

Needless to say this is terribly cryptic.  But I think I know what the problem is, and it stems from the fact that some of our customized `setup.py` commands are inherting from the distutils versions of those commands and _not_ from the setuptools versions.  In particular `AstropyInstall` is probably causing this.
