### PR TITLE
Make steradian and radian ** 2 units equivalent?

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -55,8 +55,8 @@ def_unit(['mas'], 1.0 / 3600000 * deg, register=True,
          doc="milliarc second: angular measurement",
          format={'latex': r'\third', 'unicode': '‴'})
 
-def_unit(['sr', 'steradian'], register=True, prefixes=True,
-         doc="steradian: base unit of solid angle in SI")
+def_unit(['sr', 'steradian'], rad ** 2, register=True, prefixes=True,
+         doc="steradian: unit of solid angle in SI")
 
 
 ###########################################################################

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -217,3 +217,10 @@ def test_invalid_type():
         pass
 
     u.Unit(A())
+
+
+def test_steradian():
+    """
+    Issue #599
+    """
+    assert u.sr.is_equivalent(u.rad * u.rad)


### PR DESCRIPTION
I wanted to compute the area of the whole sky in `deg^2` with `astropy.units`.
Currently this gives a `UnitsException` because steradian `sr` and `radian^2` are not equivalent.
Is there a reason they shouldn't be equivalent?
If not, could you please make them equivalent?

```
In [1]: import astropy.units as u

In [2]: u.sr.is_equivalent(u.radian ** 2)
Out[2]: False

In [3]: import numpy as np

In [4]: all_sky_solid_angle = (4 * np.pi * u.sr).to(u.deg ** 2)
ERROR: UnitsException: 'sr' (solid angle) and 'deg2' are not convertible [astropy.units.core]
---------------------------------------------------------------------------
UnitsException                            Traceback (most recent call last)
<ipython-input-4-a177453d6e1d> in <module>()
----> 1 all_sky_solid_angle = (4 * np.pi * u.sr).to(u.deg ** 2)

/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy/units/quantity.pyc in to(self, unit)
     81             object or a string parseable by the `units` package.
     82         """
---> 83         new_val = self.unit.to(unit, self.value)
     84         new_unit = Unit(unit)
     85         return Quantity(new_val, new_unit)

/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy/units/core.pyc in to(self, other, value, equivs)
    364         """
    365         other = Unit(other)
--> 366         return self.get_converter(other, equivs=equivs)(value)
    367 
    368     def in_units(self, other, value=1.0, equivs=[]):

/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy/units/core.pyc in get_converter(self, other, equivs)
    332         except UnitsException:
    333             return self._apply_equivalences(
--> 334                 self, other, equivs)
    335         return lambda val: scale * _condition_arg(val)
    336 

/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy/units/core.pyc in _apply_equivalences(self, unit, other, equivs)
    298         raise UnitsException(
    299             "{0} and {1} are not convertible".format(
--> 300                 unit_str, other_str))
    301 
    302     def get_converter(self, other, equivs=[]):

UnitsException: 'sr' (solid angle) and 'deg2' are not convertible
```
