### PR TITLE
Allow scalar and array Quantity objects to be converted to Numpy arrays

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -348,7 +348,7 @@ class Quantity(object):
         else:
             return len(self.value)
 
-    #Numerical types
+    # Numerical types
     def __float__(self):
         if not self.isscalar:
             raise TypeError('Only scalar quantities can be converted to Python scalars')
@@ -363,6 +363,10 @@ class Quantity(object):
         if not self.isscalar:
             raise TypeError('Only scalar quantities can be converted to Python scalars')
         return long(self.value)
+
+    # Array types
+    def __array__(self):
+        return np.array(self.value)
 
     # Display
     # TODO: we may want to add a hook for dimensionless quantities?

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -208,6 +208,16 @@ class TestQuantityOperations():
         assert int(q) == 1
         assert long(q) == 1L
 
+    def test_array_converters(self):
+
+        # Scalar quantity
+        q = u.Quantity(1.23, u.m)
+        assert np.all(np.array(q) == np.array([1.23]))
+
+        # Array quantity
+        q = u.Quantity([1., 2., 3.], u.m)
+        assert np.all(np.array(q) == np.array([1., 2., 3.]))
+
 
 def test_quantity_conversion():
     q1 = u.Quantity(0.1, unit=u.meter)


### PR DESCRIPTION
At the moment, if `q` is a quantity, then `float(q)` works, but there is no equivalent for arrays. This PR adds the ability to do `np.array(q)` and therefore also allows quantities to be used in plotting.
