### PR TITLE
Add support for intensities in erg/cm^2/s in unit equivalencies

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -34,9 +34,10 @@ def spectral_density(sunit, sfactor):
     """
     c_Aps = _si.c * 10 ** 10
 
-    flambda = cgs.erg / si.angstrom / si.cm ** 2 / si.s
+    fla = cgs.erg / si.angstrom / si.cm ** 2 / si.s
     fnu = cgs.erg / si.Hz / si.cm ** 2 / si.s
     nufnu = cgs.erg / si.cm ** 2 / si.s
+    lafla = nufnu
 
     def converter(x):
         return x * (sunit.to(si.AA, sfactor, spectral()) ** 2 / c_Aps)
@@ -50,10 +51,17 @@ def spectral_density(sunit, sfactor):
     def iconverter_fnu_nufnu(x):
         return x / sunit.to(si.Hz, sfactor, spectral())
 
+    def converter_fla_lafla(x):
+        return x * sunit.to(si.AA, sfactor, spectral())
+
+    def iconverter_fla_lafla(x):
+        return x / sunit.to(si.AA, sfactor, spectral())
+
     return [
         (si.AA, fnu, converter, iconverter),
-        (flambda, fnu, converter, iconverter),
+        (fla, fnu, converter, iconverter),
         (si.AA, si.Hz, converter, iconverter),
-        (flambda, si.Hz, converter, iconverter),
+        (fla, si.Hz, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
+        (fla, lafla, converter_fla_lafla, iconverter_fla_lafla),
         ]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -105,8 +105,10 @@ def test_spectral3():
 
 
 def test_spectraldensity():
+
     a = u.AA.to(u.Jy, 1, u.spectral_density(u.eV, 2.2))
     assert_allclose(a, 1059416252057.8357, rtol=1e-4)
+
     b = u.Jy.to(u.AA, a, u.spectral_density(u.eV, 2.2))
     assert_allclose(b, 1)
 
@@ -117,6 +119,30 @@ def test_spectraldensity2():
 
     a = flambda.to(fnu, 1, u.spectral_density(u.AA, 3500))
     assert_allclose(a, 4.086160166177361e-12)
+
+
+def test_spectraldensity3():
+
+    # Define F_nu in Jy
+    f_nu = u.Jy
+
+    # Convert to ergs / cm^2 / s / Hz
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.Hz, 1.), 1.e-23, 10)
+
+    # Convert to ergs / cm^2 / s at 10 Ghz
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.GHz, 10)), 1.e-13, 10)
+
+    # Convert to ergs / cm^2 / s / micron at 1 Ghz
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.micron, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 3.335640951981521e-20, 10)
+
+    # Define F_lambda in ergs / cm^2 / s / micron
+    f_lambda = u.erg / u.cm ** 2 / u.s / u.micron
+
+    # Convert to Jy at 1 Ghz
+    assert_allclose(f_lambda.to(u.Jy, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 1. / 3.335640951981521e-20, 10)
+
+    # Convert to ergs / cm^2 / s at 10 microns
+    assert_allclose(f_lambda.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10., 10)
 
 
 def test_units_conversion():


### PR DESCRIPTION
I would like to easily be able to convert between Fnu, Flambda, and nuFnu (same as lambdaFlambda). Technically speaking, nuFnu is not a spectral density, but it _would_ be nice to do:

```
>>> (u.erg / u.cm**2 / u.s).to('mJy', 1, u.sd('microns', 40))
```

since this is unambiguous. Maybe we should just have one equivalency called 'spectral' which encompasses the current `sp`, `sd`, and also nu*Fnu or something like that? I don't think there is any ambiguity between the equivalencies in `sp` and `sd`, right?

EDIT: fixed code above
