### PR TITLE
pip installation fails if distribute version is too old

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # Use "distribute" - the setuptools fork that supports python 3.
-from distribute_setup import use_setuptools
-use_setuptools()
+try:
+    import setuptools
+except ImportError:
+    from distribute_setup import use_setuptools
+    use_setuptools()
+    import setuptools
 
 from distutils.command import sdist
 


### PR DESCRIPTION
@iguananaut - I tried installing astropy using pip into a virtualenv that I created a little while back and that has distribute 0.6.24 inside, and I get the following error after running:

```
pip install -e git+https://github.com/astropy/astropy.git#egg=astropy
```

```
----------------------------------------
Command python setup.py egg_info failed with error code 2 in /Users/Shared/Jenkins/Home/virtualenvs/hyperion.dev/python3.2-numpy1.6.2-h5py2.0.1/src/astropy
Storing complete log in /Users/Shared/Jenkins/Home/.pip/pip.log
Obtaining astropy from git+https://github.com/astropy/astropy.git#egg=astropy
  Cloning https://github.com/astropy/astropy.git to ./python3.2-numpy1.6.2-h5py2.1.0-beta/src/astropy
  Running setup.py egg_info for package astropy
    The required version of distribute (>=0.6.28) is not available,
    and can't be installed while this script is running. Please
    install a more recent version first, using
    'easy_install -U distribute'.

    (Currently using distribute 0.6.24 (/Users/Shared/Jenkins/Home/virtualenvs/hyperion.dev/python3.2-numpy1.6.2-h5py2.1.0-beta/lib/python3.2/site-packages/distribute-0.6.24-py3.2.egg))
    Complete output from command python setup.py egg_info:
    The required version of distribute (>=0.6.28) is not available,

and can't be installed while this script is running. Please

install a more recent version first, using

'easy_install -U distribute'.



(Currently using distribute 0.6.24 (/Users/Shared/Jenkins/Home/virtualenvs/hyperion.dev/python3.2-numpy1.6.2-h5py2.1.0-beta/lib/python3.2/site-packages/distribute-0.6.24-py3.2.egg))
```

This rings a bell, but I thought we'd solved this somehow. This is using Python 3.2 by the way, but I think it's more to do with the version of distribute that is already installed.
