### PR TITLE
astropy.constants doesn't import in python3.3

### DIFF
--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -29,9 +29,6 @@ class Constant(Quantity):
         self.name = name
         self.reference = reference
 
-    def __new__(cls, value, uncertainty, name, reference, units):
-        return super(Constant, cls).__new__(cls, value)
-
     def __repr__(self):
         s = "<Constant: "
         s += "name='{0}' ".format(self.name)


### PR DESCRIPTION
In the 0.2b1 release, astropy.constants doesn't import in python 3.3,
although they do in python 3.2.  This was also the case for pre-beta
versions of 0.2.

```
/sw/lib/python3.3/site-packages/astropy/constants/cgs.py in <module>()
     19 for nm, val in sorted(_cgs.__dict__.items()):
     20     if isinstance(val, ConstantDefinition):
---> 21         _c = Constant(val.value, val.units, val.uncertainty, val.name, val.reference)
     22         locals()[nm] = _c
     23 

/sw/lib/python3.3/site-packages/astropy/constants/constant.py in __new__(cls, value, uncertainty, name, reference, units)
     31 
     32     def __new__(cls, value, uncertainty, name, reference, units):
---> 33         return super(Constant, cls).__new__(cls, value)
     34 
     35     def __repr__(self):

TypeError: object.__new__() takes no parameters
```

In python3.2, this works correctly.  

This problem affects importing pretty much all of the other sub-packages, many of
which do a 

from .core import *

resulting in

from ..constants import cgs

This is the current fink version of python33 (3.3.0-3), if that is any help.
