### PR TITLE
Fixed failures in Python 3.3 due to absolute imports

### DIFF
--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -8,8 +8,6 @@ just `numpy.ndarray` objects, because it provides metadata that cannot
 be easily provided by a single array.
 """
 
-from astropy import setup_helpers
-
 from .nddata import *
 from .nduncertainty import *
 from .flag_collection import *

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -12,12 +12,11 @@ import unittest
 import inspect
 import pickle
 import copy
-from ...tests.helper import pytest
 from random import shuffle
 
-import astropy.utils.tests.odict_mapping as mapping_tests
-
-from astropy.utils.compat.odict import OrderedDict
+from . import odict_mapping as mapping_tests
+from ..compat.odict import OrderedDict
+from ...tests.helper import pytest
 
 #Skips all of these tests if the builtin ordered dict is available
 pytestmark = pytest.mark.skipif("sys.version_info >= (2,7)")


### PR DESCRIPTION
Just checking that this passes on Travis before merging into master.
