### PR TITLE
Fix logger 'warn' to 'warning' since 'warn' was deprecated in Python 3.3

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -196,9 +196,9 @@ class AstropyLogger(Logger):
                     break
 
         if mod_name is not None:
-            self.warn(message, extra={'origin': mod_name})
+            self.warning(message, extra={'origin': mod_name})
         else:
-            self.warn(message)
+            self.warning(message)
 
     def warnings_logging_enabled(self):
         return self._showwarning_orig is not None

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -228,7 +228,7 @@ def test_log_to_list(level):
 
     with log.log_to_list() as log_list:
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
         log.info("Information message")
         log.debug("Debug message")
 
@@ -268,7 +268,7 @@ def test_log_to_list_level():
 
     with log.log_to_list(filter_level='ERROR') as log_list:
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
 
     assert len(log_list) == 1 and log_list[0].levelname == 'ERROR'
 
@@ -277,7 +277,7 @@ def test_log_to_list_origin1():
 
     with log.log_to_list(filter_origin='astropy.tests') as log_list:
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
 
     assert len(log_list) == 2
 
@@ -286,7 +286,7 @@ def test_log_to_list_origin2():
 
     with log.log_to_list(filter_origin='astropy.wcs') as log_list:
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
 
     assert len(log_list) == 0
 
@@ -303,7 +303,7 @@ def test_log_to_file(tmpdir, level):
 
     with log.log_to_file(log_path):
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
         log.info("Information message")
         log.debug("Debug message")
 
@@ -345,7 +345,7 @@ def test_log_to_file_level(tmpdir):
 
     with log.log_to_file(log_path, filter_level='ERROR'):
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
 
     log_file.close()
 
@@ -364,7 +364,7 @@ def test_log_to_file_origin1(tmpdir):
 
     with log.log_to_file(log_path, filter_origin='astropy.tests'):
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
 
     log_file.close()
 
@@ -383,7 +383,7 @@ def test_log_to_file_origin2(tmpdir):
 
     with log.log_to_file(log_path, filter_origin='astropy.wcs'):
         log.error("Error message")
-        log.warn("Warning message")
+        log.warning("Warning message")
 
     log_file.close()
 


### PR DESCRIPTION
On Python 3.3, some of the logger tests fail because there's an extra warning being raised:

```
WARNING: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead [astropy.tests.test_logger]
```

The Python 3.3 docs seem to only talk about `warning`, not `warn`, so it must have been deprecated in Python 3.3.

If the tests pass, I'll merge.
