### PR TITLE
setup.py: `--use-system-sofa` missing

### DIFF
--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -1,13 +1,30 @@
 import os
 from distutils.extension import Extension
 
+from astropy import setup_helpers
+
 TIMEROOT = os.path.relpath(os.path.dirname(__file__))
 
 
 def get_extensions():
+    sources = [os.path.join(TIMEROOT, "sofa_time.pyx")]
+    include_dirs = ['numpy']
+    libraries = []
+
+    if setup_helpers.use_system_library('sofa'):
+        libraries.append('sofa_c')
+    else:
+        sources.append("cextern/sofa/sofa.c")
+        include_dirs.append('cextern/sofa')
+
     time_ext = Extension(
-    name="astropy.time.sofa_time",
-    sources=[os.path.join(TIMEROOT, "sofa_time.pyx"), "cextern/sofa/sofa.c"],
-    include_dirs=['numpy', 'cextern/sofa'],
-    language="c",)
+        name="astropy.time.sofa_time",
+        sources=sources,
+        include_dirs=include_dirs,
+        libraries=libraries,
+        language="c",)
+
     return [time_ext]
+
+def get_external_libraries():
+    return ['sofa']


### PR DESCRIPTION
The option to use a system provided SOFA library is missing in

```
python setup.py build --help
```

Debian and Ubuntu provide them as separate packages, so it may be worth to allow their usage.
Is an external SOFA library used with the `--use-system-libraries` flag?
