### PR TITLE
Configuration file generation fails in Python 3.x

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -529,7 +529,9 @@ def _fix_section_blank_lines(sec, recurse=True, gotoroot=True):
             _fix_section_blank_lines(sec[snm], True, False)
 
 _unsafe_import_regex = [r'astropy\.sphinx\.ext.*',
-                           r'astropy\.utils\.compat\._gzip_32']
+                        r'astropy\.utils\.compat\._gzip_32',
+                        r'astropy\.utils\.compat\._fractions_27',
+                        ]
 _unsafe_import_regex = [('(' + pat + ')') for pat in _unsafe_import_regex]
 _unsafe_import_regex = re.compile('|'.join(_unsafe_import_regex))
 


### PR DESCRIPTION
@eteq - when #498 was merged, installation started failing on Python 3.x (curious as to why this wasn't picked up by Travis in the PR). Here's the failure:

https://travis-ci.org/astropy/astropy/builds/4098531

and specifically, from the log:

```
Stderr:
Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "astropy/config/configuration.py", line 589, in generate_all_config_items
    for cfgitem in get_config_items(nm).values():
  File "astropy/config/configuration.py", line 486, in get_config_items
    __import__(packageormod)
  File "astropy/utils/compat/_fractions_27.py", line 44, in <module>
    class Fraction(Rational):
  File "astropy/utils/compat/_fractions_27.py", line 415, in Fraction
    __div__, __rdiv__ = _operator_fallbacks(_div, operator.div)
AttributeError: 'module' object has no attribute 'div'
```

so it looks like in Python 3.x, it's trying to import `_fractions_27.py` which is Python 2.x code that has not been 2to3'd.
