### PR TITLE
Attempt to fix Astropy installation with vanilla setuptools

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -846,9 +846,7 @@ def get_cython_extensions(srcdir, prevextensions=tuple(), extincludedirs=None):
     prevsourcepaths = []
     for ext in prevextensions:
         for s in ext.sources:
-            if s.endswith('.pyx'):
-                prevsourcepaths.append(os.path.realpath(os.path.splitext(s)[0]))
-            elif s.endswith('.c'):
+            if s.endswith(('.pyx', '.c')):
                 prevsourcepaths.append(os.path.realpath(os.path.splitext(s)[0]))
 
     ext_modules = []


### PR DESCRIPTION
At the moment, with vanilla setuptools, `sofa_time.c` is build twice, and the second time it is not linked against the SOFA library, causing a build failure. I am investigating to see if this can be fixed.
