### PR TITLE
setup.py build fails without setuptools installed?

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -532,8 +532,8 @@ _unsafe_import_regex = [r'astropy\.sphinx\.ext.*',
                         r'astropy\.utils\.compat\._gzip_32',
                         r'astropy\.utils\.compat\._fractions_27',
                         r'.*.setup_package',
-                        r'astropy\.version_helper',
-                        r'astropy\.setup_helper'
+                        r'astropy\.version_helpers',
+                        r'astropy\.setup_helpers'
                         ]
 _unsafe_import_regex = [('(' + pat + ')') for pat in _unsafe_import_regex]
 _unsafe_import_regex = re.compile('|'.join(_unsafe_import_regex))


### PR DESCRIPTION
Possibly related to changes in #640 #634 #630 , `setup.py build` is now failing for me (I do **not** have setuptools installed; I'm relying on the downloaded distribute). Even with a clean master:

```
git clone git://github.com/astropy/astropy.git
cd astropy
setup.py build
```

Looks like it builds the libraries OK but then fails when trying to generate configuration:

```
Generation of default configuration item failed! Stdout and stderr are shown below.
Stdout:
ERROR: ImportError: No module named setuptools.command.install [unknown]

Stderr:
Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "astropy/config/configuration.py", line 591, in generate_all_config_items
    for cfgitem in get_config_items(nm).itervalues():
  File "astropy/config/configuration.py", line 486, in get_config_items
    __import__(packageormod)
  File "/home/kyle/Software/astropy/build/lib.linux-x86_64-2.7/astropy/io/fits/setup_package.py", line 8, in <module>
    from astropy import setup_helpers
  File "/home/kyle/Software/astropy/build/lib.linux-x86_64-2.7/astropy/setup_helpers.py", line 24, in <module>
    from setuptools.command.install import install as SetuptoolsInstall
ImportError: No module named setuptools.command.install
```

... or is there some trivial thing I'm missing?
