### PR TITLE
Fix configuration generation to not crash source import

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -115,7 +115,8 @@ if not _ASTROPY_SETUP_:
         try:
             config.configuration.update_default_config(__package__, config_dir)
         except config.configuration.ConfigurationDefaultMissingError as e:
-            warn(e.args[0] + " Cannot install default profile. (If you are "
-                "importing from source, this is expected.)")
+            wmsg = (e.args[0] + " Cannot install default profile. If you are "
+                "importing from source, this is expected.")
+            warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
 
     del os, warn, config_dir, e  # clean up namespace

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -37,9 +37,16 @@ class ConfigurationMissingWarning(Warning):
     """
 
 
-# this is not in __all__ because it's not intended that a user ever see it
+# these are not in __all__ because it's not intended that a user ever see them
 class ConfigurationDefaultMissingError(ValueError):
     """ An exception that is raised when the configuration defaults (which
+    should be generated at build-time) are missing.
+    """
+
+
+#this is used in astropy/__init__.py
+class ConfigurationDefaultMissingWarning(Warning):
+    """ A warning that is issued when the configuration defaults (which
     should be generated at build-time) are missing.
     """
 


### PR DESCRIPTION
As pointed out by @iguananaut in #498 (after it was merged), the changes in #498 cause astropy to fail if you import it directly from source instead of building first.  This PR corrects that by allowing the import to succeed (but not installing the configuration files, as it has no defaults to copy from).
