### PR TITLE
Add a maximum width to the main text body in the docs

### DIFF
--- a/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -431,6 +431,7 @@ div.body {
 
 div.bodywrapper {
     margin: 0 0 0 230px;
+    width: 55em;
 }
 
 


### PR DESCRIPTION
This is a minor css tweak that keeps the main text field in the docs at a width that's comfortable for reading even on wide screens. For example:

Before the change:

![before](https://f.cloud.github.com/assets/174640/80100/12ff1890-6209-11e2-8974-aaf20686974e.png)

After:

![after](https://f.cloud.github.com/assets/174640/80101/1611b916-6209-11e2-92c8-060ad845afc9.png)

One minor issue is that the length of sidebar is now sometimes slightly shorter than the length of the main text (the length is correctly reset after collapsing and re-opening the sidebar).  I'm not sure how to fix this.
