### PR TITLE
add logvalue attribute to quantity

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -110,6 +110,22 @@ class Quantity(object):
         self._value = _validate_value(obj)
 
     @property
+    def logvalue(self):
+        """ The (base 10) log of the numerical value of this quantity. """
+        import math
+
+        if self.isscalar:
+            return math.log10(self._value)
+        else:
+            return np.log10(self._value)
+
+    @logvalue.setter
+    def logvalue(self, logval):
+        newval = 10 ** logval
+        self._value = _validate_value(newval)
+
+
+    @property
     def unit(self):
         """ A `~astropy.units.UnitBase` object representing the unit of this quantity. """
         return self._unit

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -413,3 +413,21 @@ def test_arrays():
         int(qsec)
     with pytest.raises(TypeError):
         long(qsec)
+
+
+def test_logvalue():
+    """
+    Test the logvalue attribute of Quantity
+    """
+    from numpy.testing import assert_array_equal
+
+    q = u.Quantity(100, u.second)
+    assert q.logvalue == 2
+
+    #also check setting
+    q.logvalue = 3
+    assert q.value == 1000
+
+    #check that it works for arrays
+    q = u.Quantity([10, 100], u.kilometer)
+    assert_array_equal(q.logvalue, [1, 2])


### PR DESCRIPTION
This PR does something quite straightforward: it adds a `logvalue` attribute to `Quantity`. 

While in general I wouldn't advocate having a whole set of attributes like this (e.g. `expvalue` or `lnvalue` or whatever), I thought adding this might be useful mainly because this is astronomy, and the first thing we generally do to a number is take the log of it :)

That said, I understand if it's judged that we're better off telling people to do `np.log10(q.value)`.  This is pretty much syntactic sugar for that. But I think this is something that I would already use in my scientific code.

(cc @adrn @mdboom as the `Quantity` and `units` masters) 
