### PR TITLE
Daophot reader crashes on null USER

### DIFF
--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -87,17 +87,17 @@ class Daophot(core.BaseReader):
         if len(self.comment_lines) > 0:
             re_header_keyword = re.compile(r'[#]K'
                                            r'\s+ (?P<name> \w+)'
-                                           r'\s* ='
-                                           r'\s* (?P<value> \S*)'  # Allow blank field
-                                           r'\s+ (?P<units> \S+)'
-                                           r'\s+ (?P<format> \S+)'
-                                           r'\s* $', re.VERBOSE)
+                                           r'\s* = (?P<stuff> .+) $',
+                                           re.VERBOSE)
 
             out.meta['keywords'] = OrderedDict()
             for line in self.comment_lines:
                 m = re_header_keyword.match(line)
                 if m:
-                    keyword_dict = dict((x, m.group(x)) for x in ('value', 'units', 'format'))
+                    vals = m.group('stuff').strip().rsplit(None, 2)
+                    keyword_dict = {'units': vals[-2],
+                                    'format': vals[-1]}
+                    keyword_dict['value'] = (vals[0] if len(vals) > 2 else "")
                     out.meta['keywords'][m.group('name')] = keyword_dict
 
         self.cols = self.header.cols

--- a/astropy/io/ascii/tests/t/daophot.dat
+++ b/astropy/io/ascii/tests/t/daophot.dat
@@ -10,7 +10,7 @@
 #K GRPFILE = test.psg.1 filename %-23s
 #K PSFIMAGE = test.psf.1 imagename %-23s
 #K NSTARFILE = test.nst.1 filename %-23s
-#K REJFILE = hello_world filename %-23s
+#K REJFILE = "hello world" filename %-23s
 #K SCALE = 1. units/pix %-23.7g
 #K DATAMIN = 50. counts %-23.7g
 #K DATAMAX = 24500. counts %-23.7g

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -49,7 +49,7 @@ def test_guess_all_files():
 def test_daophot_header_keywords():
     table = asciitable.read('t/daophot.dat', Reader=asciitable.Daophot)
     expected_keywords = (('NSTARFILE', 'test.nst.1', 'filename', '%-23s'),
-                         ('REJFILE', 'hello_world', 'filename', '%-23s'),
+                         ('REJFILE', '"hello world"', 'filename', '%-23s'),
                          ('SCALE', '1.',  'units/pix', '%-23.7g'),)
 
     keywords = table.meta['keywords']  # Ordered dict of keyword structures


### PR DESCRIPTION
Hi,

`io.ascii.daophot.Daophot` reader crashes when USER field in the header (comment) section is empty. This happens when IRAF user is not defined when `phot` task is run.

```
#K IRAF       = NOAO/IRAFV2.16    version    %-23s     
#K USER       =                              name       %-23s     
#K HOST       = blah.blah.com         computer   %-23s
...
```

Currently, the fix is to manually modify the file to look like this:

```
#K IRAF       = NOAO/IRAFV2.16          version    %-23s     
#K USER       =  ""                               name       %-23s     
#K HOST       = blah.blah.com              computer   %-23s
...
```

Can the reader not be so sensitive and automatically replace a null user with an empty string (or something similar)?
