### PR TITLE
Fix trivial differences in wcs/src/docstrings.c between Python versions

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -30,7 +30,11 @@ if sys.version_info[0] >= 3:
 else:
 
     def string_escape(s):
-        return s.encode('string_escape')
+        # string_escape has subtle differences with the escaping done in Python
+        # 3 so correct for those too
+        s = s.encode('string_escape')
+        s = s.replace(r'\x00', r'\0')
+        return s.replace(r"\'", "'")
 
     from cStringIO import StringIO
     string_types = (str, unicode)


### PR DESCRIPTION
I've been noticing that every time I did a build with a different Python version I was still having to rebuild the wcs module every time I switched between versions, even if there were no code changes.  The reason was due to subtle string escape differences--Python 3 was writing `'\0'` while Python 2 was writing `'\x00'`.  Likewise Python 2 was escaping `'` as `\'` while Python 3 was not escaping it.
