### PR TITLE
Unit conversion on quantities mishandles long values

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1396,7 +1396,6 @@ def _condition_arg(value):
     Parameters
     ----------
     value: int or float value, or sequence of such values
-        that can be converted into an array if not scalar
 
     Returns
     -------
@@ -1407,7 +1406,7 @@ def _condition_arg(value):
     ValueError
         If value is not as expected
     """
-    if isinstance(value, float) or isinstance(value, int):
+    if isinstance(value, (float, int, long)):
         return value
     else:
         try:

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -396,3 +396,10 @@ def test_compose_no_duplicates():
     new = u.kg / u.s**3 * u.au ** 2.5 / u.yr ** 0.5 / u.sr ** 2
     composed = new.compose(units=u.cgs.bases)
     assert len(composed) == 1
+
+def test_long_int():
+    """
+    Issue #672
+    """
+    sigma = 10 ** 21 * u.M_p / u.cm ** 2
+    sigma.to(u.M_sun / u.pc ** 2)


### PR DESCRIPTION
I came across the inconsistency below using the units module. Unfortunately I don't have time to explore what's going on...

This works fine:

``` python
>>> import astropy.units as u
>>> sigma = (100 * u.M_sun / u.pc**2)
>>> print sigma.to(u.M_p / u.cm**2)
1.24898660319e+22 M_p / (cm2)
```

but going the opposite way doesn't work:

``` python
>>> sigma = 10**21 * u.M_p / u.cm**2
>>> sigma.to(u.M_sun / u.pc**2)

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-751caefcb775> in <module>()
----> 1 sigma.to(u.M_sun / u.pc**2)

/usr/local/lib/python2.7/dist-packages/astropy/units/quantity.pyc in to(self, unit, equivalencies)
     84             directly convertible.  See :ref:`unit_equivalencies`.
     85         """
---> 86         new_val = self.unit.to(unit, self.value, equivalencies=equivalencies)
     87         new_unit = Unit(unit)
     88         return Quantity(new_val, new_unit)

/usr/local/lib/python2.7/dist-packages/astropy/units/core.pyc in to(self, other, value, equivalencies)
    368         other = Unit(other)
    369         return self.get_converter(
--> 370             other, equivalencies=equivalencies)(value)
    371 
    372     def in_units(self, other, value=1.0, equivalencies=[]):

/usr/local/lib/python2.7/dist-packages/astropy/units/core.pyc in <lambda>(val)
    336             return self._apply_equivalences(
    337                 self, other, equivalencies)
--> 338         return lambda val: scale * _condition_arg(val)
    339 
    340     def to(self, other, value=1.0, equivalencies=[]):

/usr/local/lib/python2.7/dist-packages/astropy/units/core.pyc in _condition_arg(value)
   1163         except ValueError:
   1164             raise ValueError(
-> 1165                 "Value not scalar compatible or convertable into a float or "
   1166                 "integer array")

ValueError: Value not scalar compatible or convertable into a float or integer array
```
