### PR TITLE
Windows builds failing due to weird crash

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -485,7 +485,8 @@ def generate_default_config(build_lib, package):
     else:
         log.info('generating default {0}.cfg file'.format(package))
 
-    env = {'ASTROPY_SKIP_CONFIG_UPDATE': 'True'}
+    env = os.environ.copy()
+    env['ASTROPY_SKIP_CONFIG_UPDATE'] = 'True'
 
     subproccode = (
         'from astropy.config.configuration import generate_all_config_items;'


### PR DESCRIPTION
Depending on how far down the rabbit hole this goes I might just make a temporary workaround for this on Windows.

Right now the builds are failing on Windows due to the automatic generation of the default astropy.cfg file, which is run in a subprocess.  The call the `Popen.communicate()` is crashing, and from trial and error it seems to have something to do with passing environment variables. More as I investigate this...
