### PR TITLE
Sort the list of options in the ambiguous format error message so that t...

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1557,7 +1557,9 @@ class Table(object):
             if len(valid_formats) == 0:
                 raise Exception("Format could not be identified")
             elif len(valid_formats) > 1:
-                raise Exception("Format is ambiguous - options are: {0:s}".format(', '.join(valid_formats)))
+                raise Exception(
+                    "Format is ambiguous - options are: {0:s}".format(
+                        ', '.join(sorted(valid_formats))))
             else:
                 format = valid_formats[0]
 
@@ -1586,7 +1588,9 @@ class Table(object):
             if len(valid_formats) == 0:
                 raise Exception("Format could not be identified")
             elif len(valid_formats) > 1:
-                raise Exception("Format is ambiguous - options are: {0:s}".format(', '.join(valid_formats)))
+                raise Exception(
+                    "Format is ambiguous - options are: {0:s}".format(
+                        ', '.join(sorted(valid_formats))))
             else:
                 format = valid_formats[0]
 


### PR DESCRIPTION
I was getting this test failure on Python 3:

```
______________________________________________________________________________________ test_read_toomanyformats _______________________________________________________________________________________

    def test_read_toomanyformats():
        io_registry.register_identifier('test1', lambda o, x, y: True)
        io_registry.register_identifier('test2', lambda o, x, y: True)
        with pytest.raises(Exception) as exc:
            Table.read()
>       assert exc.value.args[0] == "Format is ambiguous - options are: test1, test2"
E       assert 'Format is am... test2, test1' == 'Format is amb... test1, test2'
E         - Format is ambiguous - options are: test2, test1
E         ?                                         -------
E         + Format is ambiguous - options are: test1, test2
E         ?                                   +++++++

astropy/table/tests/test_table_io.py:134: AssertionError
```

It's just that the options presented in the error message are in a different order than expected by the unit test.  I suspect this failure is highly random which is why we haven't seen it elsewhere.  I've fixed this so the options are sorted.  We could also fix the unit test to not care about the order, but that seemed like more work :wink: 
