### PR TITLE
Fix issue with sidebar on front page of docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ Welcome to Astropy's Documentation!
 ###################################
 
 .. image:: astropy_banner_96.png
+    :width: 485px
+    :height: 96px
 
 Astropy is a community-driven package intended to contain much of the
 core functionality and some common tools needed for performing astronomy


### PR DESCRIPTION
As mentioned in #657  and #284, the sidebar of the docs does not go to the bottom of the text on RTD. This is actually due to the fact that the logo is loaded after the sidebar is created, and so the height of the body of the text increases once the image has loaded. This PR fixes this by specifying the size of the logo from the start.

A better fix in future would be to figure out how to make the sidebar size change dynamically, as this is an issue with e.g. the search page:

http://docs.astropy.org/en/v0.1/search.html?q=fits&check_keywords=yes&area=default

But for now, I'd say this is good enough.
