### PR TITLE
Additional spectral density equivalencies

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -34,8 +34,10 @@ def spectral_density(sunit, sfactor):
     """
     c_Aps = _si.c * 10 ** 10
 
-    flambda = cgs.erg / si.angstrom / si.cm ** 2 / si.s
+    fla = cgs.erg / si.angstrom / si.cm ** 2 / si.s
     fnu = cgs.erg / si.Hz / si.cm ** 2 / si.s
+    nufnu = cgs.erg / si.cm ** 2 / si.s
+    lafla = nufnu
 
     def converter(x):
         return x * (sunit.to(si.AA, sfactor, spectral()) ** 2 / c_Aps)
@@ -43,9 +45,23 @@ def spectral_density(sunit, sfactor):
     def iconverter(x):
         return x / (sunit.to(si.AA, sfactor, spectral()) ** 2 / c_Aps)
 
+    def converter_fnu_nufnu(x):
+        return x * sunit.to(si.Hz, sfactor, spectral())
+
+    def iconverter_fnu_nufnu(x):
+        return x / sunit.to(si.Hz, sfactor, spectral())
+
+    def converter_fla_lafla(x):
+        return x * sunit.to(si.AA, sfactor, spectral())
+
+    def iconverter_fla_lafla(x):
+        return x / sunit.to(si.AA, sfactor, spectral())
+
     return [
         (si.AA, fnu, converter, iconverter),
-        (flambda, fnu, converter, iconverter),
+        (fla, fnu, converter, iconverter),
         (si.AA, si.Hz, converter, iconverter),
-        (flambda, si.Hz, converter, iconverter)
+        (fla, si.Hz, converter, iconverter),
+        (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
+        (fla, lafla, converter_fla_lafla, iconverter_fla_lafla),
         ]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -58,10 +58,7 @@ def spectral_density(sunit, sfactor):
         return x / sunit.to(si.AA, sfactor, spectral())
 
     return [
-        (si.AA, fnu, converter, iconverter),
         (fla, fnu, converter, iconverter),
-        (si.AA, si.Hz, converter, iconverter),
-        (fla, si.Hz, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
         (fla, lafla, converter_fla_lafla, iconverter_fla_lafla),
         ]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from .._constants import si as _si
 from . import si
 from . import cgs
+from . import astrophys
 
 __all__ = ['spectral', 'spectral_density']
 
@@ -64,6 +65,14 @@ def spectral_density(sunit, sfactor):
     def iconverter_fla_lafla(x):
         return x / sunit.to(si.AA, sfactor, spectral())
 
+    # Photons
+
+    def converter_photons_to_ergs(x):
+        return x * _si.h * sunit.to(si.Hz, sfactor, spectral())
+
+    def converter_ergs_to_photons(x):
+        return x / _si.h / sunit.to(si.Hz, sfactor, spectral())
+
     return [
         (fla, fnu, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
@@ -71,4 +80,5 @@ def spectral_density(sunit, sfactor):
         (lla, lnu, converter, iconverter),
         (lnu, nulnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
         (lla, lalla, converter_fla_lafla, iconverter_fla_lafla),
+        (astrophys.photon, cgs.erg, converter_photons_to_ergs, converter_ergs_to_photons),
         ]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -34,10 +34,17 @@ def spectral_density(sunit, sfactor):
     """
     c_Aps = _si.c * 10 ** 10
 
+    # Flux density
     fla = cgs.erg / si.angstrom / si.cm ** 2 / si.s
     fnu = cgs.erg / si.Hz / si.cm ** 2 / si.s
     nufnu = cgs.erg / si.cm ** 2 / si.s
     lafla = nufnu
+
+    # Luminosity density
+    lla = cgs.erg / si.angstrom / si.s
+    lnu = cgs.erg / si.Hz / si.s
+    nulnu = cgs.erg / si.s
+    lalla = nulnu
 
     def converter(x):
         return x * (sunit.to(si.AA, sfactor, spectral()) ** 2 / c_Aps)
@@ -61,4 +68,7 @@ def spectral_density(sunit, sfactor):
         (fla, fnu, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
         (fla, lafla, converter_fla_lafla, iconverter_fla_lafla),
+        (lla, lnu, converter, iconverter),
+        (lnu, nulnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
+        (lla, lalla, converter_fla_lafla, iconverter_fla_lafla),
         ]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -105,8 +105,10 @@ def test_spectral3():
 
 
 def test_spectraldensity():
+
     a = u.AA.to(u.Jy, 1, u.spectral_density(u.eV, 2.2))
     assert_allclose(a, 1059416252057.8357, rtol=1e-4)
+
     b = u.Jy.to(u.AA, a, u.spectral_density(u.eV, 2.2))
     assert_allclose(b, 1)
 
@@ -117,6 +119,30 @@ def test_spectraldensity2():
 
     a = flambda.to(fnu, 1, u.spectral_density(u.AA, 3500))
     assert_allclose(a, 4.086160166177361e-12)
+
+
+def test_spectraldensity3():
+
+    # Define F_nu in Jy
+    f_nu = u.Jy
+
+    # Convert to ergs / cm^2 / s / Hz
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.Hz, 1.), 1.e-23, 10)
+
+    # Convert to ergs / cm^2 / s at 10 Ghz
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.GHz, 10)), 1.e-13, 10)
+
+    # Convert to ergs / cm^2 / s / micron at 1 Ghz
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.micron, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 3.335640951981521e-20, 10)
+
+    # Define F_lambda in ergs / cm^2 / s / micron
+    f_lambda = u.erg / u.cm ** 2 / u.s / u.micron
+
+    # Convert to Jy at 1 Ghz
+    assert_allclose(f_lambda.to(u.Jy, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 1. / 3.335640951981521e-20, 10)
+
+    # Convert to ergs / cm^2 / s at 10 microns
+    assert_allclose(f_lambda.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10., 10)
 
 
 def test_units_conversion():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -114,26 +114,48 @@ def test_spectraldensity1():
 
 def test_spectraldensity2():
 
+    # Flux density (power / area / spectral unit)
+
     # Define F_nu in Jy
     f_nu = u.Jy
 
     # Convert to ergs / cm^2 / s / Hz
-    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.Hz, 1.), 1.e-23, 10)
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.Hz, 1.), 1.e-23)
 
     # Convert to ergs / cm^2 / s at 10 Ghz
-    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.GHz, 10)), 1.e-13, 10)
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.GHz, 10)), 1.e-13)
 
     # Convert to ergs / cm^2 / s / micron at 1 Ghz
-    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.micron, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 3.335640951981521e-20, 10)
+    assert_allclose(f_nu.to(u.erg / u.cm ** 2 / u.s / u.micron, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 3.335640951981521e-20)
 
     # Define F_lambda in ergs / cm^2 / s / micron
     f_lambda = u.erg / u.cm ** 2 / u.s / u.micron
 
     # Convert to Jy at 1 Ghz
-    assert_allclose(f_lambda.to(u.Jy, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 1. / 3.335640951981521e-20, 10)
+    assert_allclose(f_lambda.to(u.Jy, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 1. / 3.335640951981521e-20)
 
     # Convert to ergs / cm^2 / s at 10 microns
-    assert_allclose(f_lambda.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10., 10)
+    assert_allclose(f_lambda.to(u.erg / u.cm ** 2 / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10.)
+
+    # Luminosity density (power / spectral unit)
+
+    # Define F_nu in ergs / s / Hz
+    f_nu = u.erg / u.s / u.Hz
+
+    # Convert to ergs / s at 10 Ghz
+    assert_allclose(f_nu.to(u.erg / u.s, 1., equivalencies=u.spectral_density(u.GHz, 10)), 1.e10)
+
+    # Convert to ergs / s / micron at 1 Ghz
+    assert_allclose(f_nu.to(u.erg / u.s / u.micron, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 3.335640951981521e+03)
+
+    # Define F_lambda in ergs / s / micron
+    f_lambda = u.erg / u.s / u.micron
+
+    # Convert to ergs / s at 1 Ghz
+    assert_allclose(f_lambda.to(u.erg / u.s, 1., equivalencies=u.spectral_density(u.Hz, 1.e9)), 1. / 3.335640951981521e-06)
+
+    # Convert to ergs / s at 10 microns
+    assert_allclose(f_lambda.to(u.erg / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10.)
 
 
 def test_units_conversion():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -157,6 +157,9 @@ def test_spectraldensity2():
     # Convert to ergs / s at 10 microns
     assert_allclose(f_lambda.to(u.erg / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10.)
 
+    # Convert ergs / s to ph / s
+    assert_allclose((u.erg / u.s).to(u.ph / u.s, equivalencies=u.spectral_density(u.micron, 10.)), 5.0341170081942266e+19)
+
 
 def test_units_conversion():
     assert_allclose(u.kpc.to(u.Mpc), 0.001)

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -104,16 +104,7 @@ def test_spectral3():
     assert_allclose(a, [2.99792458e+14, 1.49896229e+14])
 
 
-def test_spectraldensity():
-
-    a = u.AA.to(u.Jy, 1, u.spectral_density(u.eV, 2.2))
-    assert_allclose(a, 1059416252057.8357, rtol=1e-4)
-
-    b = u.Jy.to(u.AA, a, u.spectral_density(u.eV, 2.2))
-    assert_allclose(b, 1)
-
-
-def test_spectraldensity2():
+def test_spectraldensity1():
     flambda = u.erg / u.angstrom / u.cm ** 2 / u.s
     fnu = u.erg / u.Hz / u.cm ** 2 / u.s
 
@@ -121,7 +112,7 @@ def test_spectraldensity2():
     assert_allclose(a, 4.086160166177361e-12)
 
 
-def test_spectraldensity3():
+def test_spectraldensity2():
 
     # Define F_nu in Jy
     f_nu = u.Jy


### PR DESCRIPTION
This implements some of the spectral density equivalencies described in #440. I/We still need to add conversion to/from ``photons s^-1 [area^-1] spectralunit^-1``, and optionally including conversions where the spectral unit is energy rather than wavelength or frequency.

@eteq - feel free to add some of these if you want, as I probably won't be able to do it this week. I don't think it's 0.2 crucial though.