### PR TITLE
angle_utilities - fix to enable padding of negative angles

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -460,7 +460,10 @@ def hours_to_string(h, precision=5, pad=False, sep=('h', 'm', 's')):
     """
 
     if pad:
-        pad = 2
+        if h < 0:
+            pad = 3
+        else:
+            pad = 2
     else:
         pad = 0
 
@@ -491,7 +494,10 @@ def degrees_to_string(d, precision=5, pad=False, sep=':'):
     """
 
     if pad:
-        pad = 2
+        if d < 0:
+            pad = 3
+        else:
+            pad = 2
     else:
         pad = 0
 

--- a/astropy/coordinates/tests/test_api.py
+++ b/astropy/coordinates/tests/test_api.py
@@ -361,9 +361,12 @@ def test_angle_formatting():
     # check negative angles
 
     angle = Angle(-1.23456789, unit=u.degree)
+    angle2 = Angle(-1.23456789, unit=u.hour)
 
     assert angle.format() == '-1d14m04.44440s'
+    assert angle.format(pad=True) == '-01d14m04.44440s'
     assert angle.format(unit=u.hour) == '-0h04m56.29629s'
+    assert angle2.format(unit=u.hour, pad=True) == '-01h14m04.44440s'
     assert angle.format(unit=u.radian, decimal=True) == '-0.021547'
 
 def test_angle_format_roundtripping():


### PR DESCRIPTION
In response to issue <a href="https://github.com/astropy/astropy/issues/684">#684</a>.

Angle.format was not padding negative angles, despite passing in pad=True. The problem was in angle_utilities.degrees_to_string and hours_to_string - they both needed a small change to account for the extra character when a negative sign is present. Also added some test assertions to ensure the fix is working correctly.
