### PR TITLE
MacOS 10.8 test failures with Python 3.1

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -4,6 +4,7 @@ Handles a "generic" string format for units
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
 
 from .base import Base
 from . import utils
@@ -262,7 +263,7 @@ class Generic(Base):
             else:
                 if not isinstance(power, Fraction):
                     if power % 1.0 != 0.0:
-                        power = Fraction(power).limit_denominator(10)
+                        power = Fraction.from_float(power).limit_denominator(10)
                         if power.denominator == 1:
                             power = int(power.numerator)
                     else:


### PR DESCRIPTION
The Mac Jenkins machine was offline for a week, and now it's back up it's showing a few test failures with Python 3.1:

https://jenkins.shiningpanda.com/astropy/job/astropy-master-osx-10.8-multiconfig/

These are related to the new `compose` functionality implemented by @mdboom last week. Travis no longer has 3.1 installed, so maybe that's why we didn't see it sooner.
