### PR TITLE
Hide log for dependencies installs in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,23 @@ python:
     - 2.6
     - 3.2
 env:
-    - NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false OPTIONAL=false
-    - NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false OPTIONAL=false
-    - NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false OPTIONAL=false
+    - NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false OPTIONAL_DEPS=false
+    - NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false OPTIONAL_DEPS=false
+    - NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false OPTIONAL_DEPS=false
 
 matrix:
     include:
         - python: 2.7
-          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false OPTIONAL=true
+          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=false OPTIONAL_DEPS=true
         - python: 2.7
-          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=true OPTIONAL=false
+          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=true OPTIONAL_DEPS=false
         - python: 3.2
-          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=true OPTIONAL=false
+          env: NUMPY_VERSION=1.6.2 ONLY_EGG_INFO=true OPTIONAL_DEPS=false
     exclude:
         - python: 3.2
-          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false OPTIONAL=false
+          env: NUMPY_VERSION=1.5.1 ONLY_EGG_INFO=false OPTIONAL_DEPS=false
         - python: 3.2
-          env: NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false OPTIONAL=false
+          env: NUMPY_VERSION=1.4.1 ONLY_EGG_INFO=false OPTIONAL_DEPS=false
 
 before_install:
    # We do this to make sure we get the dependencies so pip works below
@@ -31,8 +31,8 @@ before_install:
 install:
    - export PYTHONIOENCODING=UTF8 # just in case
    - pip install --upgrade "numpy==$NUMPY_VERSION" -q --use-mirrors
-   - if $OPTIONAL; then pip install scipy -q --use-mirrors; fi
-   - if $OPTIONAL; then pip install h5py -q --use-mirrors; fi
+   - if $OPTIONAL_DEPS; then pip install scipy -q --use-mirrors; fi
+   - if $OPTIONAL_DEPS; then pip install h5py -q --use-mirrors; fi
    - if ! $ONLY_EGG_INFO; then pip install Cython -q --use-mirrors; fi
 script:
    - if $ONLY_EGG_INFO; then python setup.py egg_info; fi


### PR DESCRIPTION
Travis was erroring because it ran too long without output when we installed all of our dependencies, and #690 fixed this by splitting out all the builds _and_ making them verbose.  Unfortunately, that also balloned our travis logs with lots of info about building scipy and h5py (which we don't care about).

This PR silences the optional dependency builds.  But it keeps the change in #690 of splitting out the dependecy builds to run separately one at a time.  Each one individually is < 5 min, so Travis is kept happy.  But now our log is ~1k lines instead of 10k.
