### PR TITLE
Test failure on upcoming Ubuntu 13.04 release

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -154,7 +154,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False):
             from .compat import gzip
             fileobj_new = gzip.GzipFile(fileobj=fileobj, mode='rb')
             fileobj_new.read(1)  # need to check that the file is really gzip
-        except IOError:  # invalid gzip file
+        except (IOError, EOFError):  # invalid gzip file
             fileobj.seek(0)
             fileobj_new.close()
         except struct.error:  # invalid gzip file on Python 3


### PR DESCRIPTION
I tried to build the 0.2b2 package on the Ubuntu 13.04 release and got the following test output:

```
astropy/wcs/tests/test_wcsprm.py ........................................................................................x

=================================== FAILURES ===================================
_________________ test_local_data_obj_invalid[invalid.dat.gz] __________________

filename = 'invalid.dat.gz'

    @pytest.mark.parametrize(('filename'), ['invalid.dat.gz', 'invalid.dat.bz2'])
    def test_local_data_obj_invalid(filename):
        from ..data import get_pkg_data_fileobj

>       with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
            assert f.read().rstrip().endswith(b'invalid')

astropy/utils/tests/test_data.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <contextlib.GeneratorContextManager object at 0x7152550>

    def __enter__(self):
        try:
>           return self.gen.next()

/usr/lib/python2.7/contextlib.py:17: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

name_or_obj = '/tmp/astropy-test-PLegHu/lib.linux-x86_64-2.7/astropy/utils/tests/data/invalid.dat.gz'
encoding = 'binary', cache = False

    @contextlib.contextmanager
    def get_readable_fileobj(name_or_obj, encoding=None, cache=False):
[...]
        if signature[:3] == b'\x1f\x8b\x08':  # gzip
            import struct
            try:
                from .compat import gzip
                fileobj_new = gzip.GzipFile(fileobj=fileobj, mode='rb')
>               fileobj_new.read(1)  # need to check that the file is really gzip

astropy/utils/data.py:156: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <gzip open file '/tmp/astropy-test-PLegHu/lib.linux-x86_64-2.7/astropy/utils/tests/data/invalid.dat.gz', mode 'rb' at 0x1e70660 0x7152910>
size = 1

    def read(self, size=-1):
[...]
        if size < 0:        # get the whole thing
[...]
        else:               # just get some more of it
            while size > self.extrasize:
>               if not self._read(readsize):

/usr/lib/python2.7/gzip.py:258: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <gzip open file '/tmp/astropy-test-PLegHu/lib.linux-x86_64-2.7/astropy/utils/tests/data/invalid.dat.gz', mode 'rb' at 0x1e70660 0x7152910>
size = 1024

    def _read(self, size=1024):
[...]
        if buf == "":
            uncompress = self.decompress.flush()
            self.fileobj.seek(-len(self.decompress.unused_data), 1)
>           self._read_eof()

/usr/lib/python2.7/gzip.py:306: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <gzip open file '/tmp/astropy-test-PLegHu/lib.linux-x86_64-2.7/astropy/utils/tests/data/invalid.dat.gz', mode 'rb' at 0x1e70660 0x7152910>

    def _read_eof(self):
        # We've read to the end of the file.
        # We check the that the computed CRC and size of the
        # uncompressed data matches the stored values.  Note that the size
        # stored is the true file size mod 2**32.
>       crc32, isize = struct.unpack("<II", self._read_exact(8))

/usr/lib/python2.7/gzip.py:340: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <gzip open file '/tmp/astropy-test-PLegHu/lib.linux-x86_64-2.7/astropy/utils/tests/data/invalid.dat.gz', mode 'rb' at 0x1e70660 0x7152910>
n = 8

    def _read_exact(self, n):
        data = self.fileobj.read(n)
        while len(data) < n:
            b = self.fileobj.read(n - len(data))
            if not b:
>               raise EOFError("Compressed file ended before the "
                               "end-of-stream marker was reached")
E               EOFError: Compressed file ended before the end-of-stream marker was reached

/usr/lib/python2.7/gzip.py:189: EOFError
======= 1 failed, 3568 passed, 102 skipped, 3 xfailed in 128.33 seconds ========
```

I am not sure whether this is a Python problem on 2.7 or a astropy bug.
Python version is 2.7.3.
The Problem appears on i386 and on x86_64. Other Ubuntu releases (12.04, 12.10) are fine.
Full build log (for x86_64) is https://launchpadlibrarian.net/129927731/buildlog_ubuntu-raring-amd64.python-astropy_0.2~b2-1~test1_FAILEDTOBUILD.txt.gz
