### PR TITLE
Installation issue with 0.2b2

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -124,7 +124,25 @@ def adjust_compiler(package):
         # compiler as returned by ccompiler.new_compiler()
         c_compiler = sysconfig.get_config_var('CC')
 
-        version = get_compiler_version(c_compiler)
+        try:
+            version = get_compiler_version(c_compiler)
+        except OSError:
+            msg = textwrap.dedent(
+                    """
+                    The C compiler used to compile Python {compiler:s}, and
+                    which is normally used to compile C extensions, is not
+                    available. You can explicitly specifiy which compiler to
+                    use by setting the CC environment variable, for example:
+
+                        CC=gcc python setup.py <command>
+
+                    or if you are using MacOS X, you can try:
+
+                        CC=clang python setup.py <command>
+                    """.format(compiler=c_compiler))
+            log.warn(msg)
+            sys.exit(1)
+
 
         for broken, fixed in compiler_mapping:
             if re.match(broken, version):


### PR DESCRIPTION
This was reported by Peter Erwin on the astropy-dev mailing list:

When I try building Astropy v0.2b2 with

```
python setupy.py build
```

I get the following:

```
Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.28.tar.gz
Extracting in /var/folders/fb/1rtt9wrr8xj6170059bb0rv80000gp/T/tmpiNILxN
Now working in /var/folders/fb/1rtt9wrr8xj6170059bb0rv80000gp/T/tmpiNILxN/distribute-0.6.28
Building a Distribute egg in /Beleriand/build/astropy-0.2b2
/Beleriand/build/astropy-0.2b2/distribute-0.6.28-py2.7.egg
Traceback (most recent call last):
  File "setup.py", line 56, in <module>
    adjust_compiler(NAME)
  File "/Beleriand/build/astropy-0.2b2/astropy/setup_helpers.py", line 118, in adjust_compiler
    version = get_compiler_version(c_compiler)
  File "/Beleriand/build/astropy-0.2b2/astropy/setup_helpers.py", line 130, in get_compiler_version
    shlex.split(compiler) + ['--version'], stdout=subprocess.PIPE)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1249, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

Python 2.7.3 (64-bit), running on Mac OS X 10.7.5 (MacBook Pro 15-inch, early 2011 version,
8 GB memory).
(Installed version of Xcode is 4.5.2)
