### PR TITLE
astropy.vo tests fail with current master on my system

### DIFF
--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2637,7 +2637,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         from ...table import Table
 
         meta = {}
-        for key in [u'ID', u'name', u'ref', u'ucd', u'utype', u'description']:
+        for key in ['ID', 'name', 'ref', 'ucd', 'utype', 'description']:
             val = getattr(self, key, None)
             if val is not None:
                 meta[key] = val
@@ -2657,7 +2657,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         instance.
         """
         kwargs = {}
-        for key in [u'ID', u'name', u'ref', u'ucd', u'utype']:
+        for key in ['ID', 'name', 'ref', 'ucd', 'utype']:
             val = table.meta.get(key)
             if val is not None:
                 kwargs[key] = val

--- a/astropy/utils/xml/iterparser.py
+++ b/astropy/utils/xml/iterparser.py
@@ -114,6 +114,13 @@ def _fast_iterparse(fd, buffersize=2 ** 10):
                       (parser.CurrentLineNumber, parser.CurrentColumnNumber)))
         del text[:]
 
+    if sys.version_info[:3] < (2, 6, 5):
+        # Due to Python issue #4978, convert all keys to byte strings
+        _start = start
+        def start(name, attr):
+            attr = dict((k.encode('utf-8'), v) for (k, v) in attr.iteritems())
+            return _start(name, attr)
+
     def end(name):
         queue.append((False, name, u''.join(text).strip(),
                       (parser.CurrentLineNumber, parser.CurrentColumnNumber)))

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -338,7 +338,19 @@ startElement(IterParser *self, const XML_Char *name, const XML_Char **atts)
             }
             do {
                 if (*(*(att_ptr + 1)) != 0) {
+                    /* Python < 2.6.5 can't handle unicode keyword
+                       arguments.  Since those were coming from here
+                       (the dictionary of attributes), we use byte
+                       strings for the keys instead.  Should be fine
+                       for VOTable, since it has ascii attribute
+                       names, but that's not true of XML in
+                       general. */
+                    #if PY_VERSION_HEX < 0x02060500
+                    /* Due to Python issue #4978 */
+                    key = PyBytes_FromString(*att_ptr);
+                    #else
                     key = PyUnicode_FromString(*att_ptr);
+                    #endif
                     if (key == NULL) {
                         Py_DECREF(tuple);
                         XML_StopParser(self->parser, 0);
@@ -927,7 +939,12 @@ IterParser_init(IterParser *self, PyObject *args, PyObject *kwds)
     }
     text_clear(self);
 
+    #if PY_VERSION_HEX < 0x02060500
+    /* Due to Python issue #7249 */
+    self->read_args = PyTuple_Pack(1, PyInt_FromSsize_t(buffersize));
+    #else
     self->read_args = PyTuple_Pack(1, PyLong_FromSsize_t(buffersize));
+    #endif
     if (self->read_args == NULL) {
         goto fail;
     }


### PR DESCRIPTION
I just tried to install the current master of astropy.
Running astropy.test() looks good and all goes well, except. astropy.vo

The total summary is

```
== 15 failed, 3058 passed, 271 skipped, 1 xfailed, 96 error in 89.49 seconds ===
```

All of the failed tests are astropy.vo.
Since this is a module I have not used yet, I don't know how to debug that usefully.
(And I don't need it at the moment, so there is no hurry to solve this from my side, I just wanted to report it here).

All failures look very similar (TypeError). I paste the output of one of them below.
The system is Linux (CentOS 5)
Python 2.6.3 (r263:75183, Oct 29 2009, 10:05:51) 
IPython 0.10 

```
/data/hguenther/soft/lib/python/astropy/io/votable/tree.py:2846: TypeError
------------------------------- Captured stdout --------------------------------
WARNING: W22: /data/hguenther/soft/lib/python/astropy/io/votable/tests/data/too_many_columns.xml.gz:8:0: W22: The DEFINITIONS element is deprecated in VOTable 1.1.  Ignoring [astropy.io.votable.exceptions]
___________________________ test_parse_single_table3 ___________________________

    @functools.wraps(func)
    def run_raises_test(*args, **kwargs):
>       pytest.raises(self._exc, func, *args, **kwargs)

/data/hguenther/soft/lib/python/astropy/tests/helper.py:300:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    @raises(IndexError)
    def test_parse_single_table3():
        table2 = parse_single_table(
            get_data_filename('data/regression.xml'),
>           table_number=2, pedantic=False)

/data/hguenther/soft/lib/python/astropy/io/votable/tests/vo_test.py:84:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source = '/data/hguenther/soft/lib/python/astropy/io/votable/tests/data/regression.xml'

    def parse_single_table(source, **kwargs):
        """
        Parses a VOTABLE_ xml file (or file-like object), reading and
        returning only the first `~astropy.io.votable.tree.Table`
        instance.

        See `parse` for a description of the keyword arguments.

        Returns
        -------
        votable : `astropy.io.votable.tree.Table` object
        """
        if kwargs.get('table_number') is None:
            kwargs['table_number'] = 0

>       votable = parse(source, **kwargs)

/data/hguenther/soft/lib/python/astropy/io/votable/table.py:127:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source = '/data/hguenther/soft/lib/python/astropy/io/votable/tests/data/regression.xml'
columns = None, invalid = 'exception', pedantic = False, chunk_size = 256
table_number = 2, filename = None, _debug_python_based_parser = False

    def parse(source, columns=None, invalid='exception', pedantic=None,
              chunk_size=tree.DEFAULT_CHUNK_SIZE, table_number=None,
              filename=None,
              _debug_python_based_parser=False):
        """
        Parses a VOTABLE_ xml file (or file-like object), and returns a
        `~astropy.io.votable.tree.VOTable` object.

        Parameters
        ----------
        source : str or readable file-like object
            Path or file object containing a VOTABLE_ xml file.

        columns : sequence of str, optional
            List of field names to include in the output.  The default is
            to include all fields.

        invalid : str, optional
            One of the following values:

                - 'exception': throw an exception when an invalid value is
                  encountered (default)

                - 'mask': mask out invalid values

        pedantic : bool, optional
            When `True`, raise an error when the file violates the spec,
            otherwise issue a warning.  Warnings may be controlled using
            the standard Python mechanisms.  See the `warnings`
            module in the Python standard library for more information.
            When not provided, uses the configuration setting
            `astropy.io.votable.pedantic`, which defaults to True.

        chunk_size : int, optional
            The number of rows to read before converting to an array.
            Higher numbers are likely to be faster, but will consume more
            memory.

        table_number : int, optional
            The number of table in the file to read in.  If `None`, all
            tables will be read.  If a number, 0 refers to the first table
            in the file, and only that numbered table will be parsed and
            read in.

        filename : str, optional
            A filename, URL or other identifier to use in error messages.
            If *filename* is None and *source* is a string (i.e. a path),
            then *source* will be used as a filename for error messages.
            Therefore, *filename* is only required when source is a
            file-like object.

        Returns
        -------
        votable : `astropy.io.votable.tree.VOTableFile` object

        See also
        --------
        astropy.io.votable.exceptions : The exceptions this function may raise.
        """
        invalid = invalid.lower()
        assert invalid in ('exception', 'mask')

        if pedantic is None:
            pedantic = PEDANTIC()

        config = {
            'columns'      :      columns,
            'invalid'      :      invalid,
            'pedantic'     :     pedantic,
            'chunk_size'   :   chunk_size,
            'table_number' : table_number,
            'filename'     :     filename}

        if filename is None and isinstance(source, basestring):
            config['filename'] = source

        with iterparser.get_xml_iterator(
            source,
            _debug_python_based_parser=_debug_python_based_parser) as iterator:
            return tree.VOTableFile(
>               config=config, pos=(1, 1)).parse(iterator, config)


    def parse_single_table(source, **kwargs):

/data/hguenther/soft/lib/python/astropy/io/votable/table.py:109:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <contextlib.GeneratorContextManager object at 0x1519de50>
type = <type 'exceptions.TypeError'>
value = '__init__() keywords must be strings'
traceback = <traceback object at 0x1519c7e8>

    def __exit__(self, type, value, traceback):
        if type is None:
            try:
                self.gen.next()
            except StopIteration:
                return
            else:
                raise RuntimeError("generator didn't stop")
        else:
            if value is None:
                # Need to force instantiation so we can reliably
                # tell if we get the same exception back
                value = type()
            try:
>               self.gen.throw(type, value, traceback)

/usr/local/lib/python2.6/contextlib.py:34:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source = '/data/hguenther/soft/lib/python/astropy/io/votable/tests/data/regression.xml'
_debug_python_based_parser = False

    @contextlib.contextmanager
    def get_xml_iterator(source, _debug_python_based_parser=False):
        """
        Returns an iterator over the elements of an XML file.

        The iterator doesn't ever build a tree, so it is much more memory
        and time efficient than the alternative in `cElementTree`.

        Parameters
        ----------
        fd : readable file-like object or read function

        Returns
        -------
        parts : iterator

            The iterator returns 4-tuples (*start*, *tag*, *data*, *pos*):

                - *start*: when `True` is a start element event, otherwise
                  an end element event.

                - *tag*: The name of the element

                - *data*: Depends on the value of *event*:

                    - if *start* == `True`, data is a dictionary of
                      attributes

                    - if *start* == `False`, data is a string containing
                      the text content of the element

                - *pos*: Tuple (*line*, *col*) indicating the source of the
                  event.
        """
        with _convert_to_fd_or_read_function(source) as fd:
            if _debug_python_based_parser:
                context = _slow_iterparse(fd)
            else:
                context = _fast_iterparse(fd)
>           yield iter(context)


    def get_xml_encoding(source):

/data/hguenther/soft/lib/python/astropy/utils/xml/iterparser.py:213:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source = '/data/hguenther/soft/lib/python/astropy/io/votable/tests/data/regression.xml'
columns = None, invalid = 'exception', pedantic = False, chunk_size = 256
table_number = 2, filename = None, _debug_python_based_parser = False

    def parse(source, columns=None, invalid='exception', pedantic=None,
              chunk_size=tree.DEFAULT_CHUNK_SIZE, table_number=None,
              filename=None,
              _debug_python_based_parser=False):
        """
        Parses a VOTABLE_ xml file (or file-like object), and returns a
        `~astropy.io.votable.tree.VOTable` object.

        Parameters
        ----------
        source : str or readable file-like object
            Path or file object containing a VOTABLE_ xml file.

        columns : sequence of str, optional
            List of field names to include in the output.  The default is
            to include all fields.

        invalid : str, optional
            One of the following values:

                - 'exception': throw an exception when an invalid value is
                  encountered (default)

                - 'mask': mask out invalid values

        pedantic : bool, optional
            When `True`, raise an error when the file violates the spec,
            otherwise issue a warning.  Warnings may be controlled using
            the standard Python mechanisms.  See the `warnings`
            module in the Python standard library for more information.
            When not provided, uses the configuration setting
            `astropy.io.votable.pedantic`, which defaults to True.

        chunk_size : int, optional
            The number of rows to read before converting to an array.
            Higher numbers are likely to be faster, but will consume more
            memory.

        table_number : int, optional
            The number of table in the file to read in.  If `None`, all
            tables will be read.  If a number, 0 refers to the first table
            in the file, and only that numbered table will be parsed and
            read in.

        filename : str, optional
            A filename, URL or other identifier to use in error messages.
            If *filename* is None and *source* is a string (i.e. a path),
            then *source* will be used as a filename for error messages.
            Therefore, *filename* is only required when source is a
            file-like object.

        Returns
        -------
        votable : `astropy.io.votable.tree.VOTableFile` object

        See also
        --------
        astropy.io.votable.exceptions : The exceptions this function may raise.
        """
        invalid = invalid.lower()
        assert invalid in ('exception', 'mask')

        if pedantic is None:
            pedantic = PEDANTIC()

        config = {
            'columns'      :      columns,
            'invalid'      :      invalid,
            'pedantic'     :     pedantic,
            'chunk_size'   :   chunk_size,
            'table_number' : table_number,
            'filename'     :     filename}

        if filename is None and isinstance(source, basestring):
            config['filename'] = source

        with iterparser.get_xml_iterator(
            source,
            _debug_python_based_parser=_debug_python_based_parser) as iterator:
            return tree.VOTableFile(
>               config=config, pos=(1, 1)).parse(iterator, config)


    def parse_single_table(source, **kwargs):

/data/hguenther/soft/lib/python/astropy/io/votable/table.py:109:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <astropy.io.votable.tree.VOTableFile object at 0x1519db50>
iterator = <astropy.utils.xml._iterparser.IterParser object at 0x14005d00>
config = {'_current_table_number': 0, 'chunk_size': 256, 'columns': None, 'filename': '/data/hguenther/soft/lib/python/astropy/io/votable/tests/data/regression.xml', ...}

    def parse(self, iterator, config):
        config['_current_table_number'] = 0

        for start, tag, data, pos in iterator:
            if start:
                if tag == 'xml':
                    pass
                elif tag == 'VOTABLE':
                    if 'version' not in data:
                        warn_or_raise(W20, W20, self.version, config, pos)
                        config['version'] = self.version
                    else:
                        config['version'] = self._version = data['version']
                        if config['version'].lower().startswith('v'):
                            warn_or_raise(
                                W29, W29, config['version'], config, pos)
                            self._version = config['version'] = \
                                            config['version'][1:]
                        if config['version'] not in ('1.1', '1.2'):
                            vo_warn(W21, config['version'], config, pos)

                    if 'xmlns' in data:
                        correct_ns = ('http://www.ivoa.net/xml/VOTable/v%s' %
                                      config['version'])
                        if data['xmlns'] != correct_ns:
                            vo_warn(
                                W41, (correct_ns, data['xmlns']), config, pos)
                    else:
                        vo_warn(W42, (), config, pos)

                    break
                else:
                    vo_raise(E19, (), config, pos)
        config['version_1_1_or_later'] = \
            util.version_compare(config['version'], '1.1') >= 0
        config['version_1_2_or_later'] = \
            util.version_compare(config['version'], '1.2') >= 0

        tag_mapping = {
            'PARAM'       : self._add_param,
            'RESOURCE'    : self._add_resource,
            'COOSYS'      : self._add_coosys,
            'INFO'        : self._add_info,
            'DEFINITIONS' : self._add_definitions,
            'DESCRIPTION' : self._ignore_add,
            'GROUP'       : self._add_group}

        for start, tag, data, pos in iterator:
            if start:
                tag_mapping.get(tag, self._add_unknown_tag)(
>                   iterator, tag, data, config, pos)

/data/hguenther/soft/lib/python/astropy/io/votable/tree.py:2912:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <astropy.io.votable.tree.VOTableFile object at 0x1519db50>
iterator = <astropy.utils.xml._iterparser.IterParser object at 0x14005d00>
tag = u'COOSYS'
data = {u'ID': u'J2000', u'equinox': u'J2000', u'system': u'eq_FK5'}
config = {'_current_table_number': 0, 'chunk_size': 256, 'columns': None, 'filename': '/data/hguenther/soft/lib/python/astropy/io/votable/tests/data/regression.xml', ...}
pos = (10L, 0L)

    def _add_coosys(self, iterator, tag, data, config, pos):
>       coosys = CooSys(config=config, pos=pos, **data)
E       TypeError: __init__() keywords must be strings
```
