### PR TITLE
Add a more explicit message when the compiler set by CC cannot be found

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -84,7 +84,19 @@ def adjust_compiler(package):
         # Check that CC is not set to llvm-gcc-4.2
         c_compiler = os.environ['CC']
 
-        version = get_compiler_version(c_compiler)
+        try:
+            version = get_compiler_version(c_compiler)
+        except OSError:
+            msg = textwrap.dedent(
+                    """
+                    The C compiler set by the CC environment variable:
+
+                        {compiler:s}
+
+                    cannot be found or executed.
+                    """.format(compiler=c_compiler))
+            log.warn(msg)
+            sys.exit(1)
 
         for broken, fixed in compiler_mapping:
             if re.match(broken, version):


### PR DESCRIPTION
This raises a more human-readable error message if the compiler specified by `CC` cannot be used:

```
$ CC=/usr/bin/gccc python setup.py install

The C compiler set by the CC environment variable:

    /usr/bin/gccc

cannot be found or executed.
```

This will be useful for cases where users try and do e.g.

```
CC=clang python setup.py install
```

following our instructions from other messages, but e.g. XCode is not installed. But it will also be useful if users have set CC in a e.g. bashrc file and forgotten about it after upgrading system/XCode. This way it will tell them that the compiler is set in CC, and what it's set to.
