### PR TITLE
Fix exception type in configuration

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -677,8 +677,8 @@ def update_default_config(pkg, default_cfg_dir_or_fn):
             default_cfgfn = default_cfg_dir_or_fn
 
         if not os.path.isfile(default_cfgfn):
-            raise ValueError('Requested default configuration file {0} is '
-                             'not a file.'.format(default_cfgfn))
+            raise ConfigurationDefaultMissingError('Requested default configuration file {0} is '
+                                                   'not a file.'.format(default_cfgfn))
 
         with open(cfgfn, 'w') as fw:
             with open(default_cfgfn) as fr:


### PR DESCRIPTION
@eteq - I think this is correct? I came across it because I was trying to import from source in an affiliated package. This is needed because the code in `__init__.py` will catch only `ValueError`.
