### PR TITLE
Fix to removing reference to caught exception

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -113,7 +113,7 @@ if not _ASTROPY_SETUP_:
     from warnings import warn
 
     # add these here so we only need to cleanup the namespace at the end
-    config_dir = e = None
+    config_dir = None
 
     if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
         config_dir = os.path.dirname(__file__)
@@ -123,6 +123,7 @@ if not _ASTROPY_SETUP_:
             wmsg = (e.args[0] + " Cannot install default profile. If you are "
                     "importing from source, this is expected.")
             warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
+            del e
 
-    del os, warn, config_dir, e  # clean up namespace
+    del os, warn, config_dir  # clean up namespace
 


### PR DESCRIPTION
I ran into an issue in affiliated packages when the configuration file was not generated and the `try...except` block goes into the `except` block in `__init__`, because on Python 3, the exception gets deleted at the end of the exception, so the explicit `del e` then fails. Here's a demo of the problem:

```
e = 1

try:
    raise Exception()
except Exception as e:
    print('raised exception')

del e
```

on Python 2:

```
raised exception
```

on Python 3:

```
raised exception
Traceback (most recent call last):
  File "test_exception.py", line 8, in <module>
    del e
NameError: name 'e' is not defined
```

In practice, this will never normally happen in the core package because we can't import from the source tree in Python 3 because the code needs to be 2to3'd. But it's an issue in some affiliated packages, so for consistency we should fix it here. The solution is to move `del e` inside the `try...except` block.
