### PR TITLE
Explicitly list keyword arguments when calling test()

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -252,10 +252,18 @@ class astropy_test(Command, object):
                 set_flag = "import __builtin__; __builtin__._ASTROPY_TEST_ = True"
 
             cmd = ('{0}; import {1.package_name}, sys; sys.exit('
-                   '{1.package_name}.test({1.package!r}, {1.test_path!r}, '
-                   '{1.args!r}, {1.plugins!r}, {1.verbose_results!r}, '
-                   '{1.pastebin!r}, {1.remote_data!r}, {1.pep8!r}, {1.pdb!r}, '
-                   '{1.coverage!r}, {1.open_files!r}))')
+                   '{1.package_name}.test('
+                   'package={1.package!r}, '
+                   'test_path={1.test_path!r}, '
+                   'args={1.args!r}, '
+                   'plugins={1.plugins!r}, '
+                   'verbose={1.verbose_results!r}, '
+                   'pastebin={1.pastebin!r}, '
+                   'remote_data={1.remote_data!r}, '
+                   'pep8={1.pep8!r}, '
+                   'pdb={1.pdb!r}, '
+                   'coverage={1.coverage!r}, '
+                   'open_files={1.open_files!r}))')
             cmd = cmd.format(set_flag, self)
 
             #override the config locations to not make a new directory nor use


### PR DESCRIPTION
Explicitly list keywords when calling test(), otherwise affiliated packages will not be robust to additional keywords - they use **kwargs to capture any additional arguments, but this only works when listing the keyword arguments.

Before, in an affiliated package that doesn't yet list `open_files` as an argument (printing out `cmd` from `tests/helper.py`):

```
('COMMAND:', 'import __builtin__; __builtin__._ASTROPY_TEST_ = True; import sedfitter, sys; sys.exit(sedfitter.test(None, None, None, None, False, None, False, False, False, False, False))')
WARNING: ConfigurationDefaultMissingWarning: Requested default configuration file sedfitter/sedfitter.cfg is not a file. Cannot install default profile. If you are importing from source, this is expected. [sedfitter]
ERROR: TypeError: test() takes at most 10 arguments (11 given) [unknown]
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: test() takes at most 10 arguments (11 given)
```

Now:

```
('COMMAND:', 'import __builtin__; __builtin__._ASTROPY_TEST_ = True; import sedfitter, sys; sys.exit(sedfitter.test(package=None, test_path=None, args=None, plugins=None, verbose=False, pastebin=None, remote_data=False, pep8=False, pdb=False, coverage=False, open_files=False))')
```

and all works fine.
