### PR TITLE
add remote-data to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,28 +27,28 @@ matrix:
 
         # Try all python versions with the latest numpy
         - python: 2.6
-          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+          env: SETUP_CMD='test --parallel=8 --remote-data' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
         - python: 2.7
-          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+          env: SETUP_CMD='test --parallel=8 --remote-data' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
         # There is a bug in pytest-xdist that prevents it from working
         # on Python 3.x.  See:
         # https://bitbucket.org/hpk42/pytest/issue/301/internal-error-during-test-collecting
         - python: 3.2
-          env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
         - python: 3.3
-          env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
 
         # Now try do scipy on 2.7 and an appropriate 3.x build (with latest numpy)
         - python: 2.7
-          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
+          env: SETUP_CMD='test --parallel=8 --remote-data' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
         - python: 3.2
-          env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
+          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
 
         # Try alternate numpy versions
         - python: 3.2
-          env: NUMPY_VERSION=1.6.2 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
+          env: NUMPY_VERSION=1.6.2 SETUP_CMD='test --parallel=8 --remote-data' OPTIONAL_DEPS=false
         - python: 2.7
-          env: NUMPY_VERSION=1.5.1 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
+          env: NUMPY_VERSION=1.5.1 SETUP_CMD='test --parallel=8 --remote-data' OPTIONAL_DEPS=false
 
 before_install:
 


### PR DESCRIPTION
This is a new take on #491, aiming at turning on the ``--remote-data`` option for the Travis tests.  It implements the suggestion by @astrofrog and @mdboom of using the astropy web site for the test web page, rather than google (which was doing some odd things with encoding).  Note that this also required astropy/astropy-website@5fafaab16f2e4709a7094ef3c203336cfdf2d45e which I already pushed up.

This solves the problems encountered in #491, but it reveals a couple others.  We'll see what this round of tests shows, but you can look at  https://travis-ci.org/eteq/astropy/builds/4609134 for the results of a test build I ran of similar code.

I notice three problems there (the third should be fixed in this PR, but we'll see what Travis says): 

1. `find_api_page` seems to have problems with its request to get `objects.inv` from the astropy docs timing out.  I'm not sure if this is transient or not - I haven't seen it on local tests, but I think @iguananaut mentioned this previously.

2. `coordinates.name_resolve` seems to sometimes fail with a myserious  ``BadStatusLine: ''`` - I have no idea what that's about - @adrn, any ideas?

3. ``TypeError: Type str doesn't support the buffer API`` - this is a py2 -> py3 problem in `find_api_page`, and I believe I fixed it with the last commit here. The travis tests of this PR will determine if so.

1 and 2 seem to be intermittent, but due to the server rather than astropy itself.  What do you all (esp. @mdboom @astrofrog who were involved in #491) think we should do about this?

