### PR TITLE
Remove explicit inclusion of css file

### DIFF
--- a/astropy/sphinx/themes/bootstrap-astropy/layout.html
+++ b/astropy/sphinx/themes/bootstrap-astropy/layout.html
@@ -1,8 +1,5 @@
 {% extends "basic/layout.html" %}
 
-{# Explicitly include the css file because it is overridden by conf settings #}
-{% set css_files = ['_static/bootstrap-astropy.css'] + css_files %}
-
 {# Collapsible sidebar script from default/layout.html in Sphinx #}
 {% set script_files = script_files + ['_static/sidebar.js'] %}
 


### PR DESCRIPTION
In the theme layout, I originally had to explicitly include the path to the css file for some reason. I forget why and it seems to no longer be necessary.

The explicit include means the css file is linked twice. More importantly it prevents one from easily overriding the stylesheet using the `html_style` sphinx setting.

This PR simply removes the explicit include of the css file.
