### PR TITLE
correct units of cgs.k_B to erg/K

### DIFF
--- a/astropy/_constants/cgs.py
+++ b/astropy/_constants/cgs.py
@@ -25,7 +25,7 @@ hbar = ConstantDefinition(si.hbar * 1.e7, si.hbar.uncertainty * 1.e7,
 
 # Boltzmann constant [CODATA]
 k_B = ConstantDefinition(si.k_B * 1.e7, si.k_B.uncertainty * 1.e7,
-                         si.k_B.name, si.k_B.reference, 'erg.s')
+                         si.k_B.name, si.k_B.reference, 'erg/K')
 
 # Speed of light [CODATA]
 c = ConstantDefinition(si.c * 1.e2, si.c.uncertainty * 1.e2,


### PR DESCRIPTION
Units of k_B in constants.cgs were incorrectly set to 'erg s' instead of 'erg/K'. Should I submit a pull request too for branch v0.2.x? This should be corrected in v0.2 final.
