### PR TITLE
configobj_py3 not included in v0.2b2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,16 @@ include setup.cfg
 include astropy/tests/coveragerc
 recursive-include astropy *.pyx *.c *.h *.map
 
+# We have to explicitly include the following modules, otherwise only the
+# Python 2 versions are included when making a source distribution in Python
+# 2, and similarly for Python 3:
+include astropy/extern/configobj_py2/*.py
+include astropy/extern/configobj_py3/*.py
+include astropy/extern/pyparsing_py2/*.py
+include astropy/extern/pyparsing_py3/*.py
+
+include astropy/table/tests/notebook_repr_html.ipynb
+
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *


### PR DESCRIPTION
It looks like configobj_py3 is missing from astropy/extern in v0.2b2.  This is needed by config.py.  The same may apply to pyparsing -- the _py2 versions are included, but not _py3.  If I manually copy them over from the development branch things seem to run in python3.
