### PR TITLE
Make TimeDelta a unitful Quantity

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -11,6 +11,8 @@ import time
 import itertools
 import numpy as np
 
+from .. import units
+
 __all__ = ['Time', 'TimeDelta', 'TimeFormat', 'TimeJD', 'TimeMJD',
            'TimeFromEpoch', 'TimeUnix', 'TimeCxcSec', 'TimeString',
            'TimeISO', 'TimeISOT', 'TimeYearDayTime', 'TimeEpochDate',
@@ -585,7 +587,7 @@ class Time(object):
             raise OperandTypeError(self, other)
 
 
-class TimeDelta(Time):
+class TimeDelta(Time, units.Quantity):
     """
     Represent the time difference between two times.
 
@@ -617,6 +619,14 @@ class TimeDelta(Time):
         # from Time.
         if not isinstance(val, self.__class__):
             self._init_from_vals(val, val2, format, 'tai', copy)
+
+    @property
+    def _value(self):
+        return self.sec
+
+    @property
+    def _unit(self):
+        return units.second
 
 
 class TimeFormat(object):


### PR DESCRIPTION
astropy.time.TimeDelta inherits from astropy.units.Quantity, so that it
gains the .to() method and can be converted to seconds, hours, minutes,
etc.

Now you can do this:

```
>>> from astropy import time, units
>>> t1 = time.Time('2013-01-01T05:44:00', scale='utc', format='isot')
>>> t2 = time.Time('2013-01-01T06:45:00', scale='utc', format='isot')
>>> print (t2 - t1).to(units.min)
61.0 min
```
