### PR TITLE
Update list of contributors in docs

### DIFF
--- a/docs/creditsandlicense.rst
+++ b/docs/creditsandlicense.rst
@@ -17,6 +17,7 @@ package as of the most recent release:
  * Simon Conseil
  * Matt Davis
  * Christoph Deil
+ * Nadia Dencheva
  * Michael Droettboom
  * Henry Ferguson
  * Adam Ginsburg


### PR DESCRIPTION
This page needs to be updated to reflect the current contributors:

http://astropy.readthedocs.org/en/latest/creditsandlicense.html

I can do that.
