### PR TITLE
Sort the methods and attributes of classes in the class summary

### DIFF
--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -453,6 +453,8 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
                                  get_members_class(obj, 'method', ['__init__'])
                 ns['attributes'], ns['all_attributes'] = \
                                  get_members_class(obj, 'attribute')
+                ns['methods'].sort()
+                ns['attributes'].sort()
 
             parts = name.split('.')
             if doc.objtype in ('method', 'attribute'):


### PR DESCRIPTION
Otherwise, they just show up in arbitrary dictionary order, which isn't very useful.

Module summaries is not updated to be sorted, since there the elements show up in file order, which may be more useful than alphabetical order in many cases.
