### PR TITLE
made travis build_sphinx command not do intersphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - python: 3.2
           env: NUMPY_VERSION=1.6.2 SETUP_CMD='egg_info' OPTIONAL_DEPS=false
         - python: 2.7
-          env: NUMPY_VERSION=1.6.2 SETUP_CMD='build_sphinx -w' OPTIONAL_DEPS=false
+          env: NUMPY_VERSION=1.6.2 SETUP_CMD='build_sphinx -w -n' OPTIONAL_DEPS=false
     exclude:
         - python: 3.2
           env: NUMPY_VERSION=1.5.1 SETUP_CMD='test' OPTIONAL_DEPS=false


### PR DESCRIPTION
By default, the sphinx build uses intersphinx, which links documentation to other sphinx docs like scipy or numpy. This is good for the actual docs, but causes a sphinx build warning if any of the other sites are offline or the web momentarily hiccups.  In #760 this led to a false sphinx build warning on travis.  So this just turns off intersphinx for the travis doc build to prevent that in the future.
