### PR TITLE
Change/allow  hour unit to be 'hr'

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -66,7 +66,7 @@ def_unit(['s', 'second'], register=True, prefixes=True,
      doc="second: base unit of time in SI.")
 
 def_unit(['min', 'minute'], 60 * s, register=True)
-def_unit(['h', 'hour'], 3600 * s, register=True)
+def_unit(['h', 'hour', 'hr'], 3600 * s, register=True)
 def_unit(['d', 'day'], 24 * h, register=True)
 def_unit(['sday'], 86164.09053 * s, register=True,
          doc="Sidereal day (sday) is the time of one rotation of the Earth.")


### PR DESCRIPTION
It appears that the current default representation for an hour as `'h'`.  This seems a bit ambiguous, so it would be nice if this could be `'hr'` instead.  It might be that the 'h' is required for compliance with one of the formats, though(@mdboom will likely know), in which case it would still be nice if 'hr' could be accepted as a valid string representation (i.e., `Unit('hr')` should work).
