### PR TITLE
0.2b2 doesn't install on python 2.6

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -1339,7 +1339,8 @@ def pkg_config(packages, default_libraries, include_dirs, library_dirs,
     command = "pkg-config --libs --cflags {0}".format(' '.join(packages)),
 
     try:
-        output = subprocess.check_output(command, shell=True)
+        pipe = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        output = pipe.communicate()[0].strip()
     except subprocess.CalledProcessError as e:
         lines = [
             "pkg-config failed.  This may cause the build to fail below.",

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -150,9 +150,10 @@ class TestRunner(object):
         # check for opened files after each test
         if open_files:
             try:
-                subprocess.check_output(
+                subprocess.Popen(
                     ['lsof -F0 -n -p {0}'.format(os.getpid())],
-                    shell=True)
+                    shell=True, stdout=subprocess.PIPE)
+                output = subprocess.communicate()[0].strip()
             except subprocess.CalledProcessError:
                 raise SystemError(
                     "open file detection requested, but could not "

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -40,9 +40,10 @@ def _get_open_file_list():
     import subprocess
     fsencoding = sys.getfilesystemencoding()
 
-    output = subprocess.check_output(
+    proc = subprocess.Popen(
         ['lsof -F0 -n -p {0}'.format(os.getpid())],
-        shell=True)
+        shell=True, stdout=subprocess.PIPE)
+    output = process.communicate()[0].strip()
     files = []
     for line in output.split(b'\n'):
         columns = line.split(b'\0')


### PR DESCRIPTION
When I do a

python setup.py --use-system-libraries --enable-legacy

on a 2.6 system, the installation fails with

```
  File "/tmp/buildd/python-astropy-0.2~b2/astropy/setup_helpers.py", line 1247, in pkg_config
    output = subprocess.check_output(command, shell=True)
```

The problem is similar to issue #42 that under 2.6, subprocess.check_output does still not exist.

Similarly, it could be fixed with

``` diff
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -1244,7 +1244,8 @@
     command = "pkg-config --libs --cflags {0}".format(' '.join(packages)),

     try:
-        output = subprocess.check_output(command, shell=True)
+        process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        output = process.communicate()[0].strip()
     except subprocess.CalledProcessError as e:
         lines = [
             "pkg-config failed.  This may cause the build to fail below.",
```
