### PR TITLE
ProgressBar(0) raises exception

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -261,7 +261,10 @@ class ProgressBar(object):
                 rows, cols = parts
                 terminal_width = int(cols)
         self._bar_length = terminal_width - 36
-        num_scale = int(math.floor(math.log(self._total) / math.log(1000)))
+        if self._total == 0:
+            num_scale = 0
+        else:
+            num_scale = int(math.floor(math.log(self._total) / math.log(1000)))
         if num_scale > 7:
             self._suffix = '?'
         else:

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -70,3 +70,8 @@ def test_progress_bar3():
         pass
 
     console.ProgressBar.map(do_nothing, range(50))
+
+
+def test_zero_progress_bar():
+    with console.ProgressBar(0) as bar:
+        pass


### PR DESCRIPTION
I'm using ProgressBar for a number of processes, and in some cases I end up calling it with `0` because there are no files to process in a directory, but this raises an exception:

```
In [1]: from astropy.utils.console import ProgressBar

In [2]: ProgressBar(0)
ERROR: ValueError: math domain error [astropy.utils.console]
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-a7b74efda110> in <module>()
----> 1 ProgressBar(0)

/Users/tom/Library/Python/3.2/lib/python/site-packages/astropy-0.3.dev3193-py3.2-macosx-10.6-x86_64.egg/astropy/utils/console.py in __init__(self, total, file)
    262                 terminal_width = int(cols)
    263         self._bar_length = terminal_width - 36
--> 264         num_scale = int(math.floor(math.log(self._total) / math.log(1000)))
    265         if num_scale > 7:
    266             self._suffix = '?'

ValueError: math domain error
```

One could argue that this is maybe 'correct' behavior, bit I think that either we should raise a better exception, or it should then show anyway, and default to 100%.
