### PR TITLE
Make generator version of ProgressBar

### DIFF
--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -75,3 +75,15 @@ def test_progress_bar3():
 def test_zero_progress_bar():
     with console.ProgressBar(0) as bar:
         pass
+
+
+def test_progress_bar_as_generator():
+    sum = 0
+    for x in console.ProgressBar(range(50)):
+        sum += x
+    assert sum == 1225
+
+    sum = 0
+    for x in console.ProgressBar(50):
+        sum += x
+    assert sum == 1225


### PR DESCRIPTION
At the moment, the `ProgressBar` can be used as a context manager:

```
        with ProgressBar(len(items)) as bar:
            for item in enumerate(items):
                bar.update()
```

but what about allowing it to be used as a generator, which could cut down on the code even more:

```
        for item in ProgressBar(items):
```

which would take care of finding the length of `items` and calling `update`? Maybe one could have a convenience method with a better name for this case, but just an idea :-)
