### PR TITLE
Two tests failing in 0.2rc1

### DIFF
--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -156,6 +156,7 @@ def test_exception_logging_overridden():
     assert e.value.args[0] == 'Cannot disable exception logging: sys.excepthook was not set by this logger, or has been overridden'
 
 
+@pytest.mark.xfail("ip is not None")
 def test_exception_logging():
 
     # Without exception logging
@@ -197,6 +198,7 @@ def test_exception_logging():
     assert len(log_list) == 0
 
 
+@pytest.mark.xfail("ip is not None")
 def test_exception_logging_origin():
     # The point here is to get an exception raised from another location
     # and make sure the error's origin is reported correctly


### PR DESCRIPTION
The two tests are in test_exception_logging and test_exception_logging_origin, full output is at https://gist.github.com/mwcraig/4951074

Running on Mac, 10.8.2, EPD 7.3-2.
