### PR TITLE
undefined symbol: XML_GetErrorCode on Ubuntu <= 12.04 and Debian <= sqeeze

### DIFF
--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -23,6 +23,8 @@ def get_extensions(build_type='release'):
     if setup_helpers.use_system_library('expat'):
         setup_helpers.pkg_config(
             ['expat'], ['expat'], include_dirs, library_dirs, libraries)
+        if not libraries:
+            libraries.append('expat')
     else:
         EXPAT_DIR = 'cextern/expat/lib'
         source_files.extend([


### PR DESCRIPTION
When I try to compile RC1 on Ubuntu 12.04 Precise, I get the following error during tests:

```
generating default astropy.cfg file
Generation of default configuration item failed! Stdout and stderr are shown below.
Stdout:
ERROR: ImportError: astropy/utils/xml/_iterparser.so: undefined symbol: XML_GetErrorCode [astropy.config.configuration]

Stderr:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "astropy/config/configuration.py", line 625, in generate_all_config_items
    for cfgitem in get_config_items(nm).itervalues():
  File "astropy/config/configuration.py", line 512, in get_config_items
    __import__(packageormod)
ImportError: astropy/utils/xml/_iterparser.so: undefined symbol: XML_GetErrorCode
```

There are then a number of errors which may be caused by this, like

```
        with get_xml_iterator(source) as iterator:
            start, tag, data, pos = iterator.next()
            if not start or tag != u'xml':
>               raise IOError('Invalid XML file')
E               IOError: Invalid XML file
```

I guess that this comes from a failure to detect the correct expat release:

```
Package expat was not found in the pkg-config search path.
Perhaps you should add the directory containing `expat.pc'
to the PKG_CONFIG_PATH environment variable
No package 'expat' found
```

The expat installation does not contain an expat.pc before version 2.1.0 (Ubuntu 12.10 and Debian wheezy). However, I would expect that the compilation fails then, or defaults are used.

See https://launchpadlibrarian.net/131226005/buildlog_ubuntu-precise-i386.python-astropy_0.2~rc1-1~test2_FAILEDTOBUILD.txt.gz for a full build log.
