### PR TITLE
Add default libraries to the list if the pkg-config lookup fails

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -1351,8 +1351,17 @@ def pkg_config(packages, default_libraries, include_dirs, library_dirs,
         log.warn('\n'.join(lines))
         libraries.extend(default_libraries)
     else:
-        for token in output.split():
-            locals()[flag_map.get(token[:2])].append(token[2:])
+        if pipe.returncode != 0:
+            lines = [
+                "pkg-config could not lookup up package(s) {0}.".format(
+                    ", ".join(packages)),
+                "This may cause the build to fail below."
+                ]
+            log.warn('\n'.join(lines))
+            libraries.extend(default_libraries)
+        else:
+            for token in output.split():
+                locals()[flag_map.get(token[:2])].append(token[2:])
 
 
 def add_external_library(library):


### PR DESCRIPTION
Previously, the default libraries would only be used if pkg-config
itself was not installed.  Now they are also used if pkg-config works
but can not find the requested package.

Fixes #777.
