### PR TITLE
Turn off -q on the travis' pip install scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 install:
    - export PYTHONIOENCODING=UTF8 # just in case
    - pip install --upgrade "numpy==$NUMPY_VERSION" -q --use-mirrors
-   - if $OPTIONAL_DEPS; then pip install scipy -q --use-mirrors; fi
+   - if $OPTIONAL_DEPS; then pip install scipy --use-mirrors; fi #this cannot be quiet, because it can take long enough to get killed by travis
    - if $OPTIONAL_DEPS; then pip install h5py -q --use-mirrors; fi
    - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install sphinx --use-mirrors; fi
    - if [[ $SETUP_CMD != egg_info ]]; then pip -q install Cython --use-mirrors; fi


### PR DESCRIPTION
From examining the travis build log, you can see quite a few branch (and PR) builds are erroring.  If you look more closely, it's apparent that a lot of that is due to travis killing the builds that include scipy, because scipy takes too long to build, and travis kills a build if it doesn't output after a certain amount of time.  This fixes the problem by getting rid of `-q` in the `pip install scipy`

The curious thing (and reason isn't in right now) is that it does _sometimes_ work.  But I guess it must be near the limit, and depend on what the load is on the travis build bots for any given build.  

This has the side effect of making the travis logs for the scipy builds really long (~9000 lines), but I guess that can't be helped.
