### PR TITLE
Fix mismatched integer sizes in compressionmodule.c on 32-bit

### DIFF
--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -771,7 +771,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
 
     PyArrayObject* indata;
     PyArrayObject* tmp;
-    long znaxis;
+    npy_intp znaxis;
     int datatype;
     int npdatatype;
     unsigned long long heapsize;
@@ -825,7 +825,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
     if (orig_outbuf != outbuf || orig_outbufsize != outbufsize) {
         // It's possible, albeit unlikely, that realloc can return a block of
         // memory with the same address but different size.
-        znaxis = (long) outbufsize;  // The output array is just one dimension.
+        znaxis = (npy_intp) outbufsize;  // The output array is just one dimension.
         tmp = (PyArrayObject*) PyArray_SimpleNewFromData(1, &znaxis, NPY_UBYTE,
                                                          outbuf);
         PyObject_SetAttrString(hdu, "compData", (PyObject*) tmp);
@@ -869,8 +869,8 @@ PyObject* compression_decompress_hdu(PyObject* self, PyObject* args)
     PyArrayObject* outdata;
     int datatype;
     int npdatatype;
-    int zndim;
-    long* znaxis;
+    npy_intp zndim;
+    npy_intp* znaxis;
     long arrsize;
     unsigned int idx;
 
@@ -894,8 +894,8 @@ PyObject* compression_decompress_hdu(PyObject* self, PyObject* args)
         return NULL;
     }
 
-    zndim = fileptr->Fptr->zndim;
-    znaxis = (long*) PyMem_Malloc(sizeof(long) * zndim);
+    zndim = (npy_intp)fileptr->Fptr->zndim;
+    znaxis = (npy_intp*) PyMem_Malloc(sizeof(npy_intp) * zndim);
     arrsize = 1;
     for (idx = 0; idx < zndim; idx++) {
         znaxis[zndim - idx - 1] = fileptr->Fptr->znaxis[idx];


### PR DESCRIPTION
On 32-bit plaftorms, including Travis, we get this compiler warning.

```
astropy/io/fits/src/compressionmodule.c: In function ‘compression_compress_hdu’:
astropy/io/fits/src/compressionmodule.c:829:9: warning: passing argument 3 of ‘(struct PyObject * (*)(struct PyTypeObject *, int,  npy_intp *, int,  npy_intp *, void *, int,  int,  struct PyObject *)
)*(PyArray_API + 372u)’ from incompatible pointer type [enabled by default]
astropy/io/fits/src/compressionmodule.c:829:9: note: expected ‘npy_intp *’ but argument is of type ‘long int *’
astropy/io/fits/src/compressionmodule.c: In function ‘compression_decompress_hdu’:
astropy/io/fits/src/compressionmodule.c:906:5: warning: passing argument 3 of ‘(struct PyObject * (*)(struct PyTypeObject *, int,  npy_intp *, int,  npy_intp *, void *, int,  int,  struct PyObject *)
)*(PyArray_API + 372u)’ from incompatible pointer type [enabled by default]
astropy/io/fits/src/compressionmodule.c:906:5: note: expected ‘npy_intp *’ but argument is of type ‘long int *’
```

Particular when passing the list of dimensions, this could result in the very wrong array size being created.  

This uses `npy_intp` instead of `long` so the array sizes match on 32-bit and 64-bit.

This may or may not be the cause of the segfaults on Travis, but either way we should probably fix this.
