### PR TITLE
Distance to quantity

### DIFF
--- a/astropy/coordinates/coordsystems.py
+++ b/astropy/coordinates/coordsystems.py
@@ -323,9 +323,8 @@ class SphericalCoordinatesBase(object):
             self._distance = None
         elif isinstance(val, tuple):
             self._distance = Distance(*val)
-        elif isinstance(val, Distance):
-            self._distance = val
         elif isinstance(val, u.Quantity):
+            #includes giving a Distance, as Distance is a Quantity subclass
             self._distance = Distance(val)
         else:
             raise TypeError(

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -17,8 +17,7 @@ __all__ = ['Distance', 'CartesianPoints', 'cartesian_to_spherical',
            'spherical_to_cartesian']
 
 
-# FIXME: make this subclass Quantity once Quantity is in master
-class Distance(object):
+class Distance(u.Quantity):
     """
     A one-dimensional distance.
 


### PR DESCRIPTION
(Note that this is based on #793, so _only_ the last commit is unique to this PR)

This makes the change of converting `Distance` objects in `coordinates` to subclass from `Quantity`.  They already use the same internal naming scheme (`_value` and `_unit`), so no substansive changes are needed.  As @astrofrog mentions in #793, though, this does mean `Distance` picks up the methods from `Quantity`.

An alternative approach (which wouldn't actually be _that_ much more work) would be to drop the `Distance` class completely, and just require a `Quantity` that is a length.  I'm mildly against this, because the current API is slightly more convenient - `d.kpc` is easier than `d.to('kpc').value`.  Also, with a `Distance` class, we can have the initializer that allows providing a `z`, and hopefully in the near future, `distmod` (and similar acessors).  With a raw `Quantity` that's not possible.
