### PR TITLE
Docs: warn users about `astropy.test()` from within repository.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -59,7 +59,7 @@ the `Astropy issue tracker <http://github.com/astropy/astropy/issues>`_.
 
 .. note::
     
-    This way of running the tests will *not* work if you do it within the
+    This way of running the tests may not work if you do it in the
     astropy source distribution.  See :ref:`sourcebuildtest` for how to
     run the tests from the source code directory, or :ref:`running-tests`
     for more details.


### PR DESCRIPTION
The most prominent instructions for testing astropy on the installation page say to do

```
>>> import astropy
>>> astropy.test()
```

However, if this is done from the root directory of the source repository, the source `astropy` is used rather than the built/installed version, and many tests fail as a result. We should add a note to the installation page explicitly warning about this.
