### PR TITLE
added brief paragraph in README directing to install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,3 +9,6 @@ astronomy and astrophysics with Python.
 Releases are `registered on PyPI <http://pypi.python.org/pypi/astropy>`_,
 and development is occuring at the
 `project's github page <http://github.com/astropy/astropy>`_.
+
+For installation instructions, see the `online documentation <http://docs.astropy.org/>`_ 
+or  ``docs/install.rst`` in this source distribution.


### PR DESCRIPTION
prompted by @demitri's message to astropy-dev, this adds a note to README.rst that makes it clear there are install instructions in the docs directory of the source distribution.

I don't see a need (and indeed, a detriment) to duplicating the install instructions in both places, but hopefully this makes it clear that you should just go look at the other file.
