### PR TITLE
Raise an OSError if xmllint was terminated by the OS.

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -676,3 +676,18 @@ def find_api_page(obj, version='dev', openinbrowser=True, timeout=None):
         webbrowser.open(resurl)
 
     return resurl
+
+
+def signal_number_to_name(signum):
+    """
+    Given an OS signal number, returns a signal name.  If the signal
+    number is unknown, returns ``'UNKNOWN'``.
+    """
+    # Since these numbers and names are platform specific, we use the
+    # builtin signal module and build a reverse mapping.
+
+    import signal
+    signal_to_name_map = dict(
+        (k, v) for v, k in signal.__dict__.iteritems() if v.startswith('SIG'))
+
+    return signal_to_name_map.get(signum, 'UNKNOWN')

--- a/astropy/utils/xml/validate.py
+++ b/astropy/utils/xml/validate.py
@@ -45,5 +45,10 @@ def validate_schema(filename, schema_file):
     if p.returncode == 127:
         raise OSError(
             "xmllint not found, so can not validate schema")
+    elif p.returncode < 0:
+        from ..misc import signal_number_to_name
+        raise OSError(
+            "xmllint was terminated by signal '{0}'".format(
+                signal_number_to_name(-p.returncode)))
 
     return p.returncode, stdout, stderr


### PR DESCRIPTION
Mark Sienkiewicz reported that a test was failing on a machine at STScI.  It turns out that `xmllint` was segfaulting for some unknown reason.  Since that's sort of beyond our control, our test should probably not fail when that happens.  This patch throws an OSError when xmllint is terminated by the OS.
