### PR TITLE
Change docs fixed width to a maximum width

### DIFF
--- a/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -431,7 +431,7 @@ div.body {
 
 div.bodywrapper {
     margin: 0 0 0 230px;
-    width: 55em;
+    max-width: 55em;
 }
 
 


### PR DESCRIPTION
This changes the fixed width of the documentation content (introduced in #657) to a maximum width. This allows the content to resize to narrower browser windows to avoid the need to scroll horizontally.

This will mitigate (but not solve) the following problem: When a browser window is small enough that there is a horizontal scroll bar, the arrow on the sidebar button moves off the sidebar button (since the position of the arrow is fixed w.r.t. the browser window rather than the page content. Unfortunately, I don't think it is possible to position the arrow as "fixed" vertically but not fixed horizontally. The arrow problem even occurs in python's docs (docs.python.org).
