### PR TITLE
'Edit on GitHub' is not useful for tagged versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,8 @@ extensions += ['astropy.sphinx.ext.edit_on_github']
 from astropy import version as versionmod
 edit_on_github_project = "astropy/astropy"
 if versionmod.release:
-    edit_on_github_branch = "v" + versionmod.version
+    edit_on_github_branch = "v{0}.{1}.x".format(
+        versionmod.major, versionmod.minor)
 else:
     edit_on_github_branch = "master"
 edit_on_github_source_root = ""


### PR DESCRIPTION
I tried using 'Edit on GitHub' from the latest stable docs, but the 'Edit' button is grayed out on GitHub. One can only do this from the latest developer docs. We either need to remote 'Edit from GitHub' for stable versions (not ideal) or have it point to the latest master version, not the stable version, on GitHub.
