### PR TITLE
WCS object from default constructor results in strange errors

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import glob
 import os
 import sys
 import warnings
@@ -395,3 +394,8 @@ def test_to_header_string():
 
     w = wcs.WCS()
     assert w.to_header_string().strip() == header_string.strip()
+
+
+def test_to_fits():
+    w = wcs.WCS()
+    w.to_fits()

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1365,11 +1365,11 @@ naxis kwarg.
           8. Keyword order may be changed.
         """
 
-        do_sip = (relax is True or
-                  relax == WCSHDO_all or
-                  (relax & WCSHDO_SIP))
         if relax not in (True, False):
+            do_sip = relax & WCSHDO_SIP
             relax &= ~WCSHDO_SIP
+        else:
+            do_sip = relax
 
         if self.wcs is not None:
             header_string = self.wcs.to_header(relax)


### PR DESCRIPTION
I'm not saying this makes too much sense, but it is possible to create a WCS object with the default constructor and print it. But then calling other methods on it give strange errors that indicate that the object is in a bad state.

Can this be improved somehow?

```
In [31]: from astropy.wcs import WCS

In [32]: w = WCS()

In [33]: w.to_header()
Out[33]: 
WCSAXES =                    2 / Number of coordinate axes                      
CRPIX1  =                    0 / Pixel coordinate of reference point            
CRPIX2  =                    0 / Pixel coordinate of reference point            
CDELT1  =                    1 / Coordinate increment at reference point        
CDELT2  =                    1 / Coordinate increment at reference point        
CRVAL1  =                    0 / Coordinate value at reference point            
CRVAL2  =                    0 / Coordinate value at reference point            
LATPOLE =                   90 / [deg] Native latitude of celestial pole        
RESTFRQ =                    0 / [Hz] Line rest frequency                       
RESTWAV =                    0 / [Hz] Line rest wavelength                      

In [34]: w.to_header_string()
ERROR: TypeError: to_header() takes at most 2 arguments (3 given) [astropy.wcs.wcs]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-34-0b49da432a11> in <module>()
----> 1 w.to_header_string()

/Users/deil/software/anaconda/1.3/lib/python2.7/site-packages/astropy/wcs/wcs.pyc in to_header_string(self, relax)
   1387         header cards.
   1388         """
-> 1389         return str(self.to_header(self, relax))
   1390 
   1391     def footprint_to_file(self, filename=None, color='green', width=2):

TypeError: to_header() takes at most 2 arguments (3 given)

In [35]: w.to_fits('w.fits')
ERROR: TypeError: unsupported operand type(s) for &: 'str' and 'int' [astropy.wcs.wcs]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-35-6241f1ab6aec> in <module>()
----> 1 w.to_fits('w.fits')

/Users/deil/software/anaconda/1.3/lib/python2.7/site-packages/astropy/wcs/wcs.pyc in to_fits(self, relax)
   1289         """
   1290 
-> 1291         header = self.to_header(relax=relax)
   1292 
   1293         hdu = fits.PrimaryHDU(header=header)

/Users/deil/software/anaconda/1.3/lib/python2.7/site-packages/astropy/wcs/wcs.pyc in to_header(self, relax)
   1366         do_sip = (relax is True or
   1367                   relax == WCSHDO_all or
-> 1368                   (relax & WCSHDO_SIP))
   1369         if relax not in (True, False):
   1370             relax &= ~WCSHDO_SIP

TypeError: unsupported operand type(s) for &: 'str' and 'int'
```
