### PR TITLE
Minor fix needed in py.test message

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -118,7 +118,7 @@ if SUPPORTS_OPEN_FILE_DETECTION:
 
 def pytest_report_header(config):
     from .. import __version__
-    s = "\nTesting Astropy version {0}.\n".format(__version__)
+    s = "\nRunning tests with Astropy version {0}.\n".format(__version__)
     s += "Running tests in {0}.\n".format(" ".join(config.args))
 
     special_opts = ["remote_data", "pep8"]


### PR DESCRIPTION
When testing an affiliated package, the following message pops up

```
============================= test session starts ==============================
platform linux2 -- Python 2.7.3 -- pytest-2.3.3

Testing Astropy version 0.2.
Running tests in aplpy.
```

Maybe it should say `Running tests using Astropy version 0.2` instead of `Testing Astropy version 0.2.`?

(don't have time to fix it right now, so if someone else gets to it first, feel free to fix)
