### PR TITLE
automodsumm: created self.warnings at start of run

### DIFF
--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -89,6 +89,7 @@ class Automodsumm(AstropyAutosummary):
     def run(self):
         from inspect import isclass, isfunction
 
+        self.warnings = []
         nodelist = []
 
         try:
@@ -137,7 +138,7 @@ class Automodsumm(AstropyAutosummary):
             #can't use super because Sphinx/docutils has trouble
             #return super(Autosummary,self).run()
             nodelist.extend(Autosummary.run(self))
-            return nodelist
+            return self.warnings + nodelist
         finally:  # has_content = False for the Automodsumm
             self.content = []
 


### PR DESCRIPTION
This was prompted by #552 - sphinx was crapping out when it issued warnings in a certain way, due to an error in how `Automodsumm` is run.  I'm not sure if this is because autosummary in sphinx changed since `Automodsumm` was written or just a mistake when it was first made, but either way, the warnings should now pass through correctly instead of triggering an exception.
