### PR TITLE
votable failing on accessing file outside astropy tree on stdeb debian installation

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -70,9 +70,12 @@ def _is_url(string):
 
 
 def _is_inside(path, parent_path):
-    # We have to use realpath to avoid issues with symlinks
-    return os.path.realpath(path).startswith(os.path.realpath(parent_path))
-
+    # We have to try realpath too to avoid issues with symlinks, but we leave
+    # abspath because some systems like debian have the absolute path (with no
+    # symlinks followed) match, but the real directories in different
+    # locations, so need to try both cases.
+    return os.path.abspath(path).startswith(os.path.abspath(parent_path)) \
+        or os.path.realpath(path).startswith(os.path.realpath(parent_path))
 
 @contextlib.contextmanager
 def get_readable_fileobj(name_or_obj, encoding=None, cache=False):


### PR DESCRIPTION
I have installed astropy through pypi-install, which converts python packages to debian packages using [stdeb](https://pypi.python.org/pypi/stdeb). 

All votable tests fail with the following error:

```
    def _find_pkg_data_path(data_name):
        """
        Look for data in the source-included data directories and return the
        path.
        """
        from os.path import dirname, join
        from ..utils.misc import find_current_module

        module = find_current_module(1, True)
        if module is None:
            # not called from inside an astropy package.  So just pass name through
            return data_name
        rootpkgname = module.__package__.split('.')[0]

        rootpkg = __import__(rootpkgname)

        module_path = dirname(module.__file__)
        path = join(module_path, data_name)

        root_dir = dirname(rootpkg.__file__)
        assert _is_inside(path, root_dir), \
               ("attempted to get a local data file outside "
>               "of the " + rootpkgname + " tree")
E       AssertionError: attempted to get a local data file outside of the astropy tree
```

In addition, simple `Table` commands that use `votable` (e.g., `t = Table('rosat.vot',format='votable')`) fail in the same way.

@astrofrog proposed debugging by modifying the function `_is_inside` as follows:

```
def _is_inside(path, parent_path):
    # We have to use realpath to avoid issues with symlinks
    print(path, parent_path)
    print(os.path.realpath(path))
    print(os.path.realpath(parent_path))
    return os.path.realpath(path).startswith(os.path.realpath(parent_path))
```

When running astropy.test(), the three `prints` print out:

```
('/usr/lib/python2.7/dist-packages/astropy/wcs/tests/data/header_newlines.fits', '/usr/lib/python2.7/dist-packages/astropy')
/usr/share/pyshared/astropy/wcs/tests/data/header_newlines.fits
/usr/lib/python2.7/dist-packages/astropy
```

I must note that on the same system running the tests on the source tree produces no errors.

I understand this is probably related to the packaging method of `stdeb` (by moving test data files to /usr/share/pyshared and out of the astropy tree at dist-packages), but I believe this should be a valid method of installing astropy.
