### PR TITLE
Units: speed improvement

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1217,6 +1217,13 @@ class CompositeUnit(UnitBase):
     _simplify.__doc__ = UnitBase._simplify.__doc__
 
     def decompose(self, bases=[]):
+        for base in self.bases:
+            if (not isinstance(base, IrreducibleUnit) or
+                    (len(bases) and base not in bases)):
+                break
+        else:
+            return self
+
         x = CompositeUnit(self.scale, self.bases, self.powers)
         x._expand_and_gather(True, bases=bases)
         return x


### PR DESCRIPTION
By not re-decomposing units repeatedly, we get a 25% speedup in compose and decompose.

Not much controversial here -- mainly just submitting as a pull request to get Travis to give it a once over.
