### PR TITLE
./setup.py develop doesn't work in a fresh checkout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,11 @@
 0.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bug Fixes
+^^^^^^^^^
+
+Fixed a minor issue when installing with ``./setup.py develop`` on a fresh git
+clone.  This is likely only of interest to developers on Astropy. [#725]
 
 
 0.2 (2013-02-19)


### PR DESCRIPTION
A typical workflow for myself, and many others, is to check out a repository, create a virtualenv, and then run `./setup.py develop` in the virtualenv.  Normally this should just work out of the box, but with Astropy I'm now getting an error about `cython_version.py` being missing.

Normally `./setup.py develop` should automatically run the build command first so I'm not sure why exactly this is happening.  There's no problem if I manually run `./setup.py build` followed by `./setup.py develop` so this really isn't a big deal, but I'd still like to get to the bottom of it at some point because it is a bug.
