### PR TITLE
Cannot index Table with np.where output

### DIFF
--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -209,6 +209,20 @@ class TestTableItems(BaseTestItems):
         assert np.all(self.t._data == DATA)
         assert np.any(t2['a'] != DATA['a'])
 
+    def test_np_where(self):
+        """Select rows using output of np.where"""
+        t = Table(COLS)
+        # Select last two rows
+        rows = np.where(t['a'] > 1.5)
+        t2 = t[rows]
+        assert np.all(t2['a'] == [2, 3])
+        assert np.all(t2['b'] == [5, 6])
+
+        # Select no rows
+        rows = np.where(t['a'] > 100)
+        t2 = t[rows]
+        assert len(t2) == 0
+
     def test_select_bad_column(self):
         """Select column name that does not exist"""
         self.t = Table(COLS)


### PR DESCRIPTION
From David Buscher:

It appears that the astropy.tables module does not accept the same row
indexing syntax as the corresponding ndarray, particularly the syntax
output by np.where(), which is a tuple containing an ndarray. Example
below:

```
Python 2.7.3 |EPD 7.3-1 (64-bit)| (default, Apr 12 2012, 11:14:05)
[GCC 4.0.1 (Apple Inc. build 5493)] on darwin
Type "credits", "demo" or "enthought" for more information.
>>> import numpy as np
>>> from astropy.table import Table

>>> t=Table(np.reshape(np.arange(12),(4,3)))
>>> print t
col0 col1 col2
---- ---- ----
   0    1    2
   3    4    5
   6    7    8
   9   10   11

>>> rows=np.where(t["col0"]>5)
>>> print rows
(array([2, 3]),)

# ndarray version
>>> print np.array(t)[rows]
[(6, 7, 8) (9, 10, 11)]

# Tables version
>>> print t[rows[0]]
col0 col1 col2
---- ---- ----
   6    7    8
   9   10   11

>>> print t[rows]
ERROR: TypeError: unhashable type: 'numpy.ndarray' [astropy.table.table]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/EPD64.framework/Versions/7.3/lib/python2.7/site-packages/astropy/table/table.py",
line 1282, in __getitem__
    if any(x not in set(self.colnames) for x in item):
  File "/Library/Frameworks/EPD64.framework/Versions/7.3/lib/python2.7/site-packages/astropy/table/table.py",
line 1282, in <genexpr>
    if any(x not in set(self.colnames) for x in item):
TypeError: unhashable type: 'numpy.ndarray'
```
