### PR TITLE
Add latex for R_sun and L_sun, switch order with solRad

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -33,7 +33,7 @@ def_unit(['AU', 'au'], _si.au.value * si.m, register=True, prefixes=True,
 def_unit(['pc', 'parsec'], _si.pc.value * si.m, register=True, prefixes=True,
          doc="parsec: approximately 3.26 light-years.")
 
-def_unit(['R_sun', 'solRad'], _si.R_sun.value * si.m, register=True,
+def_unit(['solRad', 'R_sun'], _si.R_sun.value * si.m, register=True,
          doc="Solar radius",
          format={'latex': r'R_{\odot}', 'unicode': 'R⊙'})
 def_unit(['lyr', 'lightyear'], 9.460730e15 * si.m, register=True,
@@ -50,7 +50,7 @@ def_unit(['barn'], 10 ** -28 * si.m ** 2, register=True, prefixes=True,
 ###########################################################################
 # MASS
 
-def_unit(['M_sun', 'solMass'], _si.M_sun.value * si.kg, register=True,
+def_unit(['solMass', 'M_sun'], _si.M_sun.value * si.kg, register=True,
          prefixes=True, doc="Solar mass",
          format={'latex': r'M_{\odot}', 'unicode': 'M⊙'})
 def_unit(['M_p'], _si.m_p.value * si.kg, register=True,
@@ -76,7 +76,7 @@ def_unit(['Ry', 'rydberg'], 13.605692 * si.eV, register=True,
 ###########################################################################
 # ILLUMINATION
 
-def_unit(['L_sun', 'solLum'], _si.L_sun.value * si.W, register=True,
+def_unit(['solLum', 'L_sun'], _si.L_sun.value * si.W, register=True,
          prefixes=True, doc="Solar luminance",
          format={'latex': r'L_{\odot}', 'unicode': 'L⊙'})
 


### PR DESCRIPTION
R_sun and L_sun weren't rendering properly in iPython notebook because they didn't have latex representations:

```
>>> u.M_sun._repr_latex_()
u'$\\mathrm{M_{\\odot}}$'

>>> u.R_sun._repr_latex_()
u'$\\mathrm{solRad}$'
```

...so I fixed that! :dancer: 
