### PR TITLE
py3.3 doesn't download distribute correctly, fails build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,10 @@ Bug Fixes
     git clone.  This is likely only of interest to developers on Astropy.
     [#725]
 
+  - Fixes a crash with ``ImportError: No module named 'astropy.version'`` when
+    running setup.py from a source checkout for the first time on OSX with
+    Python 3.3. [#820]
+
   - Fixed an exception when creating a ``ProgressBar`` with a "total" of 0.
     [#752]
 

--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -30,6 +30,7 @@ from setuptools.command.register import register as SetuptoolsRegister
 
 from .tests.helper import astropy_test
 from .utils import silence
+from .utils.compat.misc import invalidate_caches
 from .utils.misc import walk_skip_hidden
 
 
@@ -504,6 +505,7 @@ def generate_build_ext_command(release):
                                os.path.join(self.build_lib, cython_py),
                                preserve_mode=False)
 
+            invalidate_caches()
 
         if not self.distribution.is_pure() and os.path.isdir(self.build_lib):
             # Finally, generate the default astropy.cfg; this can only be done

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 from sys import version_info
 
-__all__ = ['inspect_getmodule']
+__all__ = ['inspect_getmodule', 'invalidate_caches']
 
 
 def _patched_getmodule(object, _filename=None):
@@ -85,8 +85,18 @@ functionality with a bugfix for Python 3.1 and 3.2.
 
 #This assigns the stdlib inspect.getmodule to the variable name
 #`inspect_getmodule` if it's not buggy, and uses the matched version if it is.
-if version_info[0]<3 or version_info[1]>2:
+if version_info[0] < 3 or version_info[1] > 2:
     #in 2.x everythig is fine, as well as >=3.3
     from inspect import getmodule as inspect_getmodule
 else:
     inspect_getmodule = _patched_getmodule
+
+
+# Python 3.3's importlib caches filesystem reads for faster imports in the
+# general case. But sometimes it's necessary to manually invalidate those
+# caches so that the import system can pick up new generated files.  See
+# https://github.com/astropy/astropy/issues/820
+if version_info[:2] >= (3, 3):
+    from importlib import invalidate_caches
+else:
+    invalidate_caches = lambda: None

--- a/astropy/version_helpers.py
+++ b/astropy/version_helpers.py
@@ -194,6 +194,7 @@ def generate_version_py(packagename, version, release=None, debug=None):
     """Regenerate the version.py module if necessary."""
 
     from .setup_helpers import is_distutils_display_option
+    from .utils.compat.misc import invalidate_caches
     from distutils import log
     import imp
     import os
@@ -242,6 +243,8 @@ def generate_version_py(packagename, version, release=None, debug=None):
         with open(version_py, 'w') as f:
             # This overwrites the actual version.py
             f.write(_get_version_py_str(packagename, version, release, debug))
+
+        invalidate_caches()
 
         if version_module:
             imp.reload(version_module)


### PR DESCRIPTION
I have a vague memory of seeing this issue come up before, but I can't seem to find it now, so I'm making a new one - If it's a dup, sorry, and this can be closed.

For 0.3 we definitely want python 3.3 to be fully supported (by then, scipy should also support it).  Right now, though, if I try to do `python3.3 setup.py build`, without a system install of distribute (at least, I don't _think_ there is one...), I get the following traceback:

```
Freezing version number to astropy/version.py
Traceback (most recent call last):
  File "setup.py", line 82, in <module>
    package_dirs)
  File "/Users/erik/src/astropy/astropy/setup_helpers.py", line 961, in update_package_files
    extensions.extend(setuppkg.get_extensions())
  File "astropy/wcs/setup_package.py", line 204, in get_extensions
    from astropy.version import debug
ImportError: No module named 'astropy.version'
```

If I get it to pull down the latest distribute, though, it works fine.  It's also possible this is a distribute _versioning_ problem, because it doesn't seem to be completely reproducible (although I admit I'm not being terribly careful, so I recommend someone else cross-check that part) 

@iguananaut @astrofrog
