### PR TITLE
Bug with Table sorting?

### DIFF
--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -151,6 +151,14 @@ class TestReverse():
         assert np.all(t2['col0'] == np.array([1, 2, 3]))
         assert np.all(t2['col1'] == np.array(['a', 'b', 'cc']))
 
+    def test_reverse_big(self):
+        x = np.arange(10000)
+        y = x + 1
+        t = Table([x, y], names=('x', 'y'))
+        t.reverse()
+        assert np.all(t['x'] == x[::-1])
+        assert np.all(t['y'] == y[::-1])
+
 
 @pytest.mark.usefixtures('set_global_Table')
 class TestColumnAccess():
@@ -561,6 +569,16 @@ class TestSort():
         t.sort('b')
         assert np.all(t['a'] == np.array([3, 1, 2]))
         assert np.all(t['b'] == np.array([4, 5, 6]))
+
+    def test_single_big(self):
+        """Sort a big-ish table with a non-trivial sort order"""
+        x = np.arange(10000)
+        y = np.sin(x)
+        t = Table([x, y], names=('x', 'y'))
+        t.sort('y')
+        idx = np.argsort(y)
+        assert np.all(t['x'] == x[idx])
+        assert np.all(t['y'] == y[idx])
 
     def test_multiple(self):
         t = Table()


### PR DESCRIPTION
If I try and read in the following file:

http://www.mpia.de/~robitaille/python/rosat.vot

and sort according to the counts:

```
In [1]: from astropy.table import Table

In [2]: t = Table.read('rosat.vot')

In [3]: t.keep_columns(['RAJ2000', 'DEJ2000', 'Count'])

In [4]: t.sort('Count')
```

I get some weird results:
- `print(t)` shows an unsorted table:

```
In [5]: print(t)
 RAJ2000   DEJ2000    Count  
--------- --------- ---------
  0.00000 -39.48403      0.13
  0.02917   8.28153      0.19
  0.04167 -63.59528      0.19
  0.04958   5.38833      0.26
  0.05250   1.77250     0.081
  0.05625  57.94125      0.12
  0.08125 -26.17556      0.12
  0.14792 -28.09819     0.072
  0.16000  79.67694       0.1
  0.17708  62.17611      0.16
  0.18417 -26.08931      0.12
  0.18583 -25.84181      0.05
```
- `t.more()` shows a sorted table:

```
In [7]: t.more()

 RAJ2000   DEJ2000    Count  
--------- --------- ---------
  2.24333 -23.88486      0.05
  7.83833  30.26611      0.05
 17.45833  19.65736      0.05
 20.64042 -22.90139      0.05
 36.40958  37.54028      0.05
 39.69792  40.18306      0.05
 64.73541  13.23681      0.05
 82.30708  -6.25097      0.05
 93.72875 -60.65736      0.05
 97.19500 -68.13250      0.05
107.63583  -8.70889      0.05
110.80459  58.69194      0.05
125.11417 -22.92417      0.05
```
- `t['Count']` shows an unsorted column:

```
In [8]: t['Count']
Out[8]: 
<MaskedColumn name='Count' units='ct / (s)' format='%9.2g' description='? Source countrate (4)'>
masked_array(data = [0.13099999725818634 0.18700000643730164 0.1899999976158142 ...,
 0.06639999896287918 0.05249999836087227 0.11500000208616257],
             mask = [False False False ..., False False False],
       fill_value = 1e+20)
```

Not sure what's going on! Any ideas?
