### PR TITLE
Fix failures in astropy.stats with Numpy 1.4.1

### DIFF
--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -2,8 +2,9 @@
 from __future__ import division
 
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
+from numpy.testing import assert_equal, assert_almost_equal
 from ...tests.helper import pytest
+from ...tests.compat import assert_allclose
 
 from .. import funcs
 from ...utils.misc import NumpyRNGContext


### PR DESCRIPTION
This is a trivial change - I know we said we'd probably drop support for 1.4.1 in Astropy 0.3, but given that this is an easy fix, just thought I'd make it anyway.
