### PR TITLE
Avoid downloading file twice when reading remote table with Table.read

### DIFF
--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import sys
+
 from ..utils import OrderedDict
 
 __all__ = ['register_reader', 'register_writer', 'register_identifier',
@@ -171,7 +173,7 @@ def read(cls, *args, **kwargs):
                 "reader should return a {0:s} instance".format(cls.__name__))
     finally:
         if ctx is not None:
-            ctx.__exit__(None, None, None)
+            ctx.__exit__(*sys.exc_info())
 
     return table
 


### PR DESCRIPTION
The following example demonstrates the issue:

```
In [2]: t = Table.read('http://www.mpia.de/~robitaille/python/rosat.vot')
Downloading http://www.mpia.de/~robitaille/python/rosat.vot
|==========================================|   3/  3M (100.00%)        00s
Downloading http://www.mpia.de/~robitaille/python/rosat.vot
|==========================================|   3/  3M (100.00%)        00s
WARNING: W27: http://www.mpia.de/~robitaille/python/rosat.vot:46:2: W27: COOSYS deprecated in VOTable 1.2 [astropy.io.votable.tree]
WARNING: W03: http://www.mpia.de/~robitaille/python/rosat.vot:51:4: W03: Implictly generating an ID from a name '1RXS' -> '_1RXS' [astropy.io.votable.xmlutil]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:155:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:244:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:1694:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:1795:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:2029:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:3472:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:3559:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:4112:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:4145:65: W49: Empty cell illegal for integer fields. [astropy.io.votable.converters]
WARNING: W49: http://www.mpia.de/~robitaille/python/rosat.vot:4238:65: W49: Empty cell illegal for integer fields. (suppressing further warnings of this type...) [astropy.io.votable.converters]
```

I'd be happy to look into how we can avoid this, but just opening this issue for now to keep track of it. If anyone wants to take a stab at it, feel free to!
