### PR TITLE
Add more system/dependency information to py.test output

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -138,6 +138,12 @@ def pytest_report_header(config):
         s += "Scipy: not available\n"
 
     try:
+        import matplotlib
+        s += "Matplotlib: {0}\n".format(matplotlib.__version__)
+    except:
+        s += "Matplotlib: not available\n"
+
+    try:
         import h5py
         s += "h5py: {0}\n".format(h5py.__version__)
     except:


### PR DESCRIPTION
When debugging reported tests, we often try and find out more about the exact system version, how Python was installed, Numpy version, etc. This PR adds this information to the py.test header.
