### PR TITLE
Fix errors if build_ext is invoked on a fresh checkout

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -513,13 +513,22 @@ def generate_build_ext_command(release):
             # after extension modules are built as some extension modules include
             # config items.  We only do this if it's not pure python, though,
             # because if it is, we already did it in build_py
+            acceptfailure = {}
             default_cfg = generate_default_config(os.path.abspath(self.build_lib),
-                                                  self.distribution.packages[0])
+                                                  self.distribution.packages[0],
+                                                  acceptfailure=acceptfailure)
+
             if default_cfg:
                 default_cfg = os.path.relpath(default_cfg)
                 self.copy_file(default_cfg,
                                os.path.join(self.build_lib, default_cfg),
                                preserve_mode=False)
+            else:  # failed, but acceptfailure has the reason
+                msg = ('Generation of default configuuration failed. This may '
+                       'be fine if you intentionally are running build_ext '
+                       'before build_py. Stdout and stderr are shown below.\n'
+                       'Stdout:\n{stdout}\nStderr:\n{stderr}')
+                log.warn(msg.format(**acceptfailure))
 
     attrs['run'] = run
     attrs['finalize_options'] = finalize_options
@@ -547,7 +556,7 @@ class AstropyBuildPy(SetuptoolsBuildPy):
                                preserve_mode=False)
 
 
-def generate_default_config(build_lib, package):
+def generate_default_config(build_lib, package, acceptfailure=False):
     config_path = os.path.relpath(package)
     filename = os.path.join(config_path, package + '.cfg')
 
@@ -575,11 +584,19 @@ def generate_default_config(build_lib, package):
     if proc.returncode == 0 and os.path.exists(filename):
         return filename
     else:
-        msg = ('Generation of default configuration item failed! Stdout '
-               'and stderr are shown below.\n'
-               'Stdout:\n{stdout}\nStderr:\n{stderr}')
-        log.error(msg.format(stdout=stdout.decode('UTF-8'),
-                             stderr=stderr.decode('UTF-8')))
+        output = {'stdout': stdout.decode('UTF-8'),
+                  'stderr': stderr.decode('UTF-8')}
+
+        #acceptfailure can be an empty dictionary that should be filled with 'stdout' and 'stderr'
+        if acceptfailure or hasattr(acceptfailure, 'update'):
+            if hasattr(acceptfailure, 'update'):
+                acceptfailure.update(output)
+            return False
+        else:
+            msg = ('Generation of default configuration item failed! Stdout '
+                   'and stderr are shown below.\n'
+                   'Stdout:\n{stdout}\nStderr:\n{stderr}')
+            log.error(msg.format(**output))
 
 
 def add_command_option(command, name, doc, is_bool=False):


### PR DESCRIPTION
This addresses a problem encountered in #824 .  It turns out that a fresh checkout of astropy master gives an error if you do `python setup.py build_ext` before doing `python setup.py build` or  `python setup.py build_py`.  There are two different causes for this problem, which each of the two commits in this PR address.

@keflavich - you might try the RTD build from #824 off of this branch to see if that fixes your problem.  We want this fixed regardless, though, so merging this is not contingent on that being fixed

@iguananaut - it'd be good if you glanced over this to make sure I'm not subtly mis-interpreting some of the build_ext related code (which I believe you mostly wrote).
