### PR TITLE
Units: Improve arcsecond definitions

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -29,3 +29,5 @@ dimensionless_unscaled = Unit(1)
 # After importing the unit definitions above, set the unit namespace
 # to this top-level module so that new units are added here.
 UnitBase._set_namespace(locals())
+
+del bases

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1287,16 +1287,12 @@ def _add_prefixes(u, excludes=[], register=False):
         namespace.  Default is `False`.
     """
     for short, long, factor in si_prefixes:
-        exclude = False
-        for prefix in short:
-            if prefix in excludes:
-                exclude = True
-        if exclude:
-            continue
-
         names = []
         format = {}
         for prefix in short:
+            if prefix in excludes:
+                continue
+
             for alias in [u.name] + [x for x in u.aliases if len(x) <= 2]:
                 names.append(prefix + alias)
 
@@ -1310,12 +1306,16 @@ def _add_prefixes(u, excludes=[], register=False):
                     format.setdefault(key, prefix + val)
 
         for prefix in long:
+            if prefix in excludes:
+                continue
+
             for alias in u.aliases:
                 if len(alias) > 2:
                     names.append(prefix + alias)
 
-        PrefixUnit(names, CompositeUnit(factor, [u], [1]), register=register,
-                   format=format)
+        if len(names):
+            PrefixUnit(names, CompositeUnit(factor, [u], [1]),
+                       register=register, format=format)
 
 
 def def_unit(s, represents=None, register=None, doc=None,

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -31,6 +31,7 @@ class CDS(Base):
 
     @staticmethod
     def _generate_unit_names():
+        import keyword
         from ... import units as u
         names = {}
 
@@ -48,6 +49,8 @@ class CDS(Base):
         for base in bases:
             for prefix in prefixes:
                 key = prefix + base
+                if keyword.iskeyword(key):
+                    continue
                 names[key] = getattr(u, key)
 
         simple_bases = [

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -31,6 +31,7 @@ class Fits(generic.Generic):
 
     @staticmethod
     def _generate_unit_names():
+        import keyword
         from ... import units as u
         names = {}
         deprecated_names = set()
@@ -49,6 +50,8 @@ class Fits(generic.Generic):
         for base in bases + deprecated_bases:
             for prefix in prefixes:
                 key = prefix + base
+                if keyword.iskeyword(key):
+                    continue
                 names[key] = getattr(u, key)
         for base in deprecated_bases:
             for prefix in prefixes:

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -28,6 +28,7 @@ class VOUnit(generic.Generic):
 
     @staticmethod
     def _generate_unit_names():
+        import keyword
         from ... import units as u
         names = {}
         deprecated_names = set()
@@ -42,6 +43,8 @@ class VOUnit(generic.Generic):
         for base in bases:
             for prefix in prefixes:
                 key = prefix + base
+                if keyword.iskeyword(key):
+                    continue
                 names[key] = getattr(u, key)
 
         simple_units = [

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -47,12 +47,19 @@ def_unit(['deg', 'degree'], _numpy.pi / 180.0 * rad, register=True,
          doc="degree: angular measurement 1/360 of full rotation",
          format={'latex': r'{}^{\circ}', 'unicode': '°'})
 def_unit(['arcmin', 'arcminute'], 1.0 / 60.0 * deg, register=True,
+         prefixes=True,
          doc="arc minute: angular measurement",
          format={'latex': r'\prime', 'unicode': '′'})
-def_unit(['as', 'arcsec', 'arcsecond'], 1.0 / 3600.0 * deg, register=True,
-         prefixes=True, exclude_prefixes=['d'],
+def_unit(['arcsec', 'arcsecond'], 1.0 / 3600.0 * deg, register=True,
+         prefixes=True,
          doc="arc second: angular measurement",
          format={'latex': r'\second', 'unicode': '″'})
+def_unit(['mas'], 0.001 * arcsec, register=True,
+         doc="arc second: angular measurement",
+         format={'latex': r'\third', 'unicode': '‴'})
+def_unit(['uas'], 0.000001 * arcsec, register=True,
+         doc="arc second: angular measurement",
+         format={'latex': r'\mu as', 'unicode': 'μas'})
 
 def_unit(['sr', 'steradian'], rad ** 2, register=True, prefixes=True,
          doc="steradian: unit of solid angle in SI")
@@ -91,7 +98,7 @@ def_unit(['Hz', 'Hertz', 'hertz'], 1 / s, register=True, prefixes=True,
 def_unit(['kg', 'kilogram'], register=True,
          doc="kilogram: base unit of mass in SI.")
 def_unit(['g', 'gram'], 1.0e-3 * kg, register=True, prefixes=True,
-         exclude_prefixes=['k'])
+         exclude_prefixes=['k', 'kilo'])
 
 def_unit(['t', 'tonne'], 1000 * kg, register=True,
          doc="Metric tonne")

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -439,3 +439,10 @@ def test_radian_base():
     Issue #863
     """
     assert (1 * u.degree).si.unit == u.rad
+
+
+def test_no_as():
+    # We don't define 'as', since it is a keyword, but we
+    # do want to define the long form (`attosecond`).
+    assert not hasattr(u, 'as')
+    assert hasattr(u, 'attosecond')


### PR DESCRIPTION
Improves on #876: Doesn't define `as` for `arcsecond`, only `mas` and `uas`.  Also makes up for the fact that we don't have a unit called `as` (which used to correspond `attosecond`) anymore, since it's a Python keyword and is quite confusing, though `attosecond` still exists for those crazy people that might need it.
