### PR TITLE
Attempt to fix bug with Quantity.__rmul__ and Numpy arrays

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -88,6 +88,10 @@ class Quantity(object):
         string unit.
     """
 
+    # Make sure that __rmul__ of units gets called over the __mul__ of Numpy
+    # arrays to avoid element-wise multiplication.
+    __array_priority__ = 1000
+
     def __init__(self, value, unit):
         from ..utils.misc import isiterable
 


### PR DESCRIPTION
The current behavior of multiplying arrays with quantities is inconsistent:

```
In [4]: (3. * u.m) * np.array([1,2,3])
Out[4]: <Quantity [ 3.  6.  9.] m>

In [5]: np.array([1,2,3]) * (3. * u.m)
WARNING: Converting Quantity object in units 'm' to a Numpy array [astropy.units.quantity]
Out[5]: array([ 3.,  6.,  9.])
```

the first behavior is correct. The problem is that the `Quantity` class needs `__array_priority__` to be set like `Unit` has, and this PR does this.

However, note that this doesn't yet work, because it seems that the `__array__` method takes precedence over even checking `__array_priority__`. I'll look into it a bit more, but if anyone has any ideas, please let me know!
