### PR TITLE
Added support for constructing a table from a list of dicts

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -895,7 +895,7 @@ class Table(object):
         if isinstance(data, (list, tuple)):
             init_func = self._init_from_list
             if data and all(isinstance(row, dict) for row in data):
-                n_cols = len(data[0].keys())
+                n_cols = len(data[0])
             else:
                 n_cols = len(data)
 
@@ -1056,18 +1056,20 @@ class Table(object):
         def_names = _auto_names(n_cols)
 
         if data and all(isinstance(row, dict) for row in data):
-            names = set()
+            names_from_data = set()
             for row in data:
-                names.update(row.keys())
+                names_from_data.update(row)
             
             cols = {}
-            for name in names:
+            for name in names_from_data:
                 cols[name] = []
                 for i, row in enumerate(data):
                     try:
                         cols[name].append(row[name])
                     except KeyError:
                         raise ValueError('Row {0} has no value for column {1}'.format(i, name))
+            if all(name is None for name in names):
+                names = sorted(names_from_data)
             self._init_from_dict(cols, names, dtypes, n_cols, copy)
             return
                 

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -152,24 +152,14 @@ class TestInitFromListOfDicts(BaseInitFromListLike):
     def setup_method(self, method):
         self.data = [{'a': 1, 'b': 2, 'c': 3},
                      {'a': 3, 'b': 4, 'c': 5}]
-                     
-    def test_basic_init(self):
-        t = Table(self.data)
-        # Dicts aren't guaranteed to have columns in same order
-        assert all(colname in set(['a', 'b', 'c']) for colname in t.colnames)
-        assert np.all(t['a'] == np.array([1, 3]))
-        assert np.all(t['b'] == np.array([2, 4]))
-        assert np.all(t['c'] == np.array([3, 5]))
-        assert all(t[name].name == name for name in t.colnames)
-
-    @pytest.mark.xfail
-    def test_set_dtypes(self):
-        # Can't specify dtypes with list-of-dicts initialization
-        pass
     
     def test_names(self):
         t = Table(self.data)
         assert all(colname in set(['a', 'b', 'c']) for colname in t.colnames)
+    
+    def test_names_ordered(self):
+        t = Table(self.data, names=('c', 'b', 'a'))
+        assert t.colnames == ['c', 'b', 'a']
     
     def test_bad_data(self):
         with pytest.raises(ValueError):

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -396,11 +396,11 @@ for the ``data`` argument.
     Similar to Python's builtin ``csv.DictReader``, each item in the 
     ``data`` list provides a row of data values and must be a dict.  The
     key values in each dict define the column names and each row must
-    have identical column names.  As the column names are specified by each
-    row, if the ``names`` argument is supplied, it will be ignored.  The
-    ``dtypes`` list (optional) may be specified, but as vanilla dicts are
-    unordered, your columns are not guaranteed to have the right type
-    unless an OrderedDict_ is used.
+    have identical column names.  The ``names`` argument may be supplied
+    to specify colum ordering.  If it is not provided, the column order will
+    default to alphabetical.  The ``dtypes`` list may be specified, and must
+    correspond to the order of output columns.  If any row's keys do no match
+    the rest of the rows, a ValueError will be thrown.
     
 
 **None**


### PR DESCRIPTION
Implemented [ticket #647](https://github.com/astropy/astropy/issues/647).  I did not implement anything with regard to recognizing None as missing data, as that got split off into another ticket.

As every dict may not have the same keys, it compiles a set of all the keys across all dicts first, then compiles columns from those key names.  Missing values are taken to be None.

After the list of row-dicts is converted to a dict of col-lists, the _init_from_dict() method is called and the function returns.
