### PR TITLE
Allow inclusive list in automodapi

### DIFF
--- a/astropy/sphinx/ext/automodapi.py
+++ b/astropy/sphinx/ext/automodapi.py
@@ -193,7 +193,10 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
 
             # Check that skip and include were not both used
             if toskip and toinclude:
-                raise ValueError("Cannot use both :skip: and :include: in an automodapi directive")
+                if warnings:
+                    app.warn("Cannot use both :skip: and :include: in an automodapi directive. Ignoring both options.", location)
+                toskip = []
+                toinclude = []
 
             # get the two heading chars
             if len(hds) < 2:
@@ -229,7 +232,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             elif toinclude:
                 skips_or_includes = ':include: ' + ','.join(toinclude)
             else:
-                skips_or_includes = None
+                skips_or_includes = ''
 
             if hasfuncs:
                 newstrs.append(automod_templ_funcs.format(modname=modnm,

--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -96,13 +96,14 @@ class Automodsumm(AstropyAutosummary):
 
     def run(self):
 
-        if 'skip' in self.options and 'include' in self.options:
-            raise ValueError("Cannot use both :skip: and :include: in an automodsumm directive")
-
         from inspect import isclass, isfunction
 
         self.warnings = []
         nodelist = []
+
+        if 'skip' in self.options and 'include' in self.options:
+            self.warn("Cannot use both :skip: and :include: in an automodsumm directive. Skipping this automodsumm directive.")
+            return self.warnings
 
         try:
             mod_objs = zip(*find_mod_objs(self.arguments[0]))


### PR DESCRIPTION
The `automodapi` sphinx directive allows a list of methods to be skipped to be included. It might be nice to allow _only_ listed methods to be included, in cases where there might be many to skip. Something like:

```
.. automodapi:: astropy.table
   :only: Table
```

(not that we need it for the above example, but just for demonstration)
