### PR TITLE
import coordinates: cannot import name sofa_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,9 @@ Other Changes and Additions
 - ``ConfigurationItem``\s now have a more useful and informative ``__repr__``
   and improved documentation for how to use them. [#855]
 
+- Added a friendlier error message when trying to import astropy from a source
+  checkout without first building the extension modules inplace. [#864]
+
 - ``py.test`` now outputs more system information for help in debugging issues
   from users. [#869]
 

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -121,7 +121,23 @@ if not _ASTROPY_SETUP_:
     from . import config
 
     import os
+    import sys
     from warnings import warn
+
+    try:
+        from .utils import _compiler
+    except ImportError:
+        if os.path.exists('setup.py'):
+            log.error('You appear to be trying to import astropy from within '
+                      'a source checkout; please run `./setup.py develop` or '
+                      '`./setup.py --inplace` first so that extension '
+                      'modules can be compiled and made importable.')
+            sys.exit(1)
+        else:
+            # Outright broken installation; don't be nice.
+            raise
+
+
 
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None


### PR DESCRIPTION
I have installed astropy-0.2 on a mac.

```
from astropy import coordinates  gives these errors:
RROR: ImportError: cannot import name sofa_time [unknown]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "astropy/coordinates/__init__.py", line 14, in <module>
    from .builtin_systems import *
  File "astropy/coordinates/builtin_systems.py", line 12, in <module>
    from ..time import Time
  File "astropy/time/__init__.py", line 2, in <module>
    from .core import *
  File "astropy/time/core.py", line 25, in <module>
    from . import sofa_time
ImportError: cannot import name sofa_time
```

my python version info is:

```
Python 2.7.3 |EPD 7.3-2 (64-bit)| (default, Apr 12 2012, 11:14:05)
[GCC 4.0.1 (Apple Inc. build 5493)] on darwin
```

I am using MacOS Mountain Lion: 10.8.2
