### PR TITLE
astropy.utils.data.download_file() crashes when show_progress=False

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -863,7 +863,7 @@ def download_file(remote_url, cache=False, show_progress=True):
             if show_progress:
                 progress_stream = sys.stdout
             else:
-                progress_stream = io.BytesIO()
+                progress_stream = io.StringIO()
 
             dlmsg = "Downloading {0}".format(remote_url)
             with ProgressBarOrSpinner(size, dlmsg, file=progress_stream) as p:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -22,6 +22,12 @@ def test_download_nocache():
 
 
 @remote_data
+def test_download_noprogress():
+    fnout = download_file(TESTURL, show_progress=False)
+    assert os.path.isfile(fnout)
+
+
+@remote_data
 def test_download_cache():
 
     from ..data import download_file, clear_download_cache


### PR DESCRIPTION
This is a follow-up of #865 by @mdboom .

```
>>> from astropy.utils.data import download_file
>>> download_file('https://github.com/astropy/astropy/blob/master/README.rst')
Downloading https://github.com/astropy/astropy/blob/master/README.rst
|===========================================|  24k/ 24k (100.00%)        00s
'/tmp/tmptcOh_V'
```

So far so good. But when I try to suppress the progress bar:

```
>>> download_file('https://github.com/astropy/astropy/blob/master/README.rst',
...               show_progress=False)
ERROR: TypeError: 'unicode' does not have the buffer interface [astropy.utils.console]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-15-8afb32881abb> in <module>()
----> 1 download_file('https://github.com/astropy/astropy/blob/master/README.rst', show_progress=False)

/home/lim/rhel6/lib/python2.7/site-packages/astropy-0.3.dev3725-py2.7-linux-x86_64.egg/astropy/utils/data.pyc in download_file(remote_url, cache, show_progress)
    881                         if os.path.exists(f.name):
    882                             os.remove(f.name)
--> 883                         raise
    884 
    885         if cache:

/home/lim/rhel6/lib/python2.7/site-packages/astropy-0.3.dev3725-py2.7-linux-x86_64.egg/astropy/utils/console.pyc in __exit__(self, exc_type, exc_value, traceback)
    634 
    635     def __exit__(self, exc_type, exc_value, traceback):
--> 636         return self._obj.__exit__(exc_type, exc_value, traceback)
    637 
    638     def update(self, value):

/home/lim/rhel6/lib/python2.7/site-packages/astropy-0.3.dev3725-py2.7-linux-x86_64.egg/astropy/utils/console.pyc in __exit__(self, exc_type, exc_value, traceback)
    565             color_print(u' [Done]', 'green', file=file)
    566         else:
--> 567             color_print(u' [Failed]', 'red', file=file)
    568         flush()
    569 

/home/lim/rhel6/lib/python2.7/site-packages/astropy-0.3.dev3725-py2.7-linux-x86_64.egg/astropy/utils/console.pyc in color_print(*args, **kwargs)
    159             if isinstance(msg, bytes):
    160                 msg = msg.decode('ascii')
--> 161             write(msg)
    162         write(end)
    163 

TypeError: 'unicode' does not have the buffer interface
```
