### PR TITLE
Fix a bug when generating the error message in `generate_config_file`

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -575,7 +575,7 @@ def generate_default_config(build_lib, package):
     else:
         msg = ('Generation of default configuration item failed! Stdout '
                'and stderr are shown below.\n'
-               'Stdout:\n{stdout}\nStderr:\n{stderr}')
+               'Stdout:\n{stdout}\nStderr:\n{stderr}').decode('UTF-8')
         log.error(msg.format(stdout=stdout.decode('UTF-8'),
                              stderr=stderr.decode('UTF-8')))
 


### PR DESCRIPTION
The stdout and stderr parts are rightly decoded as UTF-8, but then they are formatted into a byte string which (at least on my platform) treats the UTF-8 as ascii and boom! exception is raised trying to generate the error message.

Cc: @eteq for confirmation
