### PR TITLE
column cannot be renamed in masked tables ...

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -166,6 +166,8 @@ class BaseColumn(object):
             table = self.parent_table
             table.columns._rename_column(self.name, val)
             table._data.dtype.names = table.columns.keys()
+            if table.masked:
+                table._data.mask.dtype.names = table.columns.keys()
 
         self._name = val
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -635,6 +635,8 @@ class TestRename(SetupData):
         t.rename_column('b', 'a')
         assert t.columns.keys() == ['c', 'a']
         assert t._data.dtype.names == ('c', 'a')
+        if t.masked:
+            assert t._data.mask.dtype.names == ('c', 'a')
         assert np.all(t['c'] == np.array([1, 2, 3]))
         assert np.all(t['a'] == np.array([4, 5, 6]))
 


### PR DESCRIPTION
or to me more precise: Column can be renames in tables with a mask, but after renaming those column cannot be acessed any longer.

```
In [1]: import astropy

In [2]: import astropy.table

In [3]: tab = astropy.table.Table({'a':[1,2,3]})

In [4]: tab.add_column(astropy.table.Column(name='b', dtype=np.float, length=3)) 
In [5]: tab.rename_column('b','c')

In [6]: tab
Out[6]: 
<Table rows=3 names=('a','c')>
array([(1, 0.0), (2, 0.0), (3, 0.0)], 
      dtype=[('a', '<i8'), ('c', '<f8')])
```

This works as expected. No let's do the same thing, but add a `MaskedColumn`, so that the tables gets converted to a masked array:

```
In [7]: tabm = astropy.table.Table({'a':[1,2,3]})

In [8]: tabm.add_column(astropy.table.MaskedColumn(name='b', dtype=np.float, length=3))
INFO: Upgrading Table to masked Table [astropy.table.table]

In [9]: tabm.rename_column('b','c')

In [10]: tabm
Out[10]: ERROR: ValueError: field named c not found. [numpy.ma.core]
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-3b52ee52afab> in <module>()
----> 1 tabm

/data/guenther/anaconda/lib/python2.7/site-packages/IPython/core/displayhook.pyc in __call__(self, result)
    236             self.start_displayhook()
    237             self.write_output_prompt()
--> 238             format_dict = self.compute_format_data(result)
    239             self.write_format_data(format_dict)
    240             self.update_user_ns(result)

/data/guenther/anaconda/lib/python2.7/site-packages/IPython/core/displayhook.pyc in compute_format_data(self, result)
    148             MIME type representation of the object.
    149         """
--> 150         return self.shell.display_formatter.format(result)
    151 
    152     def write_format_data(self, format_dict):

/data/guenther/anaconda/lib/python2.7/site-packages/IPython/core/formatters.pyc in format(self, obj, include, exclude)
    124                     continue
    125             try:
--> 126                 data = formatter(obj)
    127             except:
    128                 # FIXME: log the exception

/data/guenther/anaconda/lib/python2.7/site-packages/IPython/core/formatters.pyc in __call__(self, obj)
    445                 type_pprinters=self.type_printers,
    446                 deferred_pprinters=self.deferred_printers)
--> 447             printer.pretty(obj)
    448             printer.flush()
    449             return stream.getvalue()

/data/guenther/anaconda/lib/python2.7/site-packages/IPython/lib/pretty.pyc in pretty(self, obj)
    358                             if callable(meth):
    359                                 return meth(obj, self, cycle)
--> 360             return _default_pprint(obj, self, cycle)
    361         finally:
    362             self.end_group()

/data/guenther/anaconda/lib/python2.7/site-packages/IPython/lib/pretty.pyc in _default_pprint(obj, p, cycle)
    478     if getattr(klass, '__repr__', None) not in _baseclass_reprs:
    479         # A user-provided repr.
--> 480         p.text(repr(obj))
    481         return
    482     p.begin_group(1, '<')

/data/guenther/anaconda/lib/python2.7/site-packages/astropy-0.3.dev3598-py2.7-linux-x86_64.egg/astropy/table/table.pyc in __repr__(self)
   1169         names = ("'{0}'".format(x) for x in self.colnames)
   1170         s = "<Table rows={0} names=({1})>\n{2}".format(
-> 1171             self.__len__(),  ','.join(names), repr(self._data))
   1172         return s
   1173 

/data/guenther/anaconda/lib/python2.7/site-packages/numpy/ma/core.pyc in __repr__(self)
   3551         name = repr(self._data).split('(')[0]
   3552         parameters = dict(name=name, nlen=" " * len(name),
-> 3553                            data=str(self), mask=str(self._mask),
   3554                            fill=str(self.fill_value), dtype=str(self.dtype))
   3555         if self.dtype.names:

/data/guenther/anaconda/lib/python2.7/site-packages/numpy/ma/core.pyc in __str__(self)
   3539                     rdtype = _recursive_make_descr(self.dtype, "O")
   3540                     res = self._data.astype(rdtype)
-> 3541                     _recursive_printoption(res, m, f)
   3542         else:
   3543             res = self.filled(self.fill_value)

/data/guenther/anaconda/lib/python2.7/site-packages/numpy/ma/core.pyc in _recursive_printoption(result, mask, printopt)
   2292     names = result.dtype.names
   2293     for name in names:
-> 2294         (curdata, curmask) = (result[name], mask[name])
   2295         if curdata.dtype.names:
   2296             _recursive_printoption(curdata, curmask, printopt)

ValueError: field named c not found.
```
