### PR TITLE
astropy.log: The process cannot access the file because it is being used by another process

### DIFF
--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -945,39 +945,10 @@ class TestImageFunctions(FitsTestCase):
                 hdul2[0].data[0] = 0
                 assert (hdul[1].data == hdul2[0].data).all()
 
-    @pytest.mark.skipif("sys.platform.startswith('win')")
-    def test_insufficient_compression_allocation(self):
-        """
-        Test the scenario where not enough space is allocated to hold the
-        compressed data, and a realloc is necessary.
-
-        For some reason this test *sometimes* breaks Jenkins when run on
-        Windows. It passes when the test suite is run outside Jenkins. I intend
-        to track down the cause of this but in the meantime it's disabled on
-        Windows.  See Astropy #507.
-        """
-
-        data = np.arange(10000, dtype='int32').reshape(100, 100)
-        hdu = fits.CompImageHDU(data=data)
-        old_compress_hdu = fits.compression.compress_hdu
-
-        def hacked_compress_hdu(hdu):
-            # Long enough to hold the table, but not enough for the full heap
-            hdu.compData = np.zeros((2880,), dtype=np.uint8)
-            return old_compress_hdu(hdu)
-
-        fits.compression.compress_hdu = hacked_compress_hdu
-
-        try:
-            hdu.updateCompressedData()
-            assert (data == fits.compression.decompress_hdu(hdu)).all()
-        finally:
-            fits.compression.compress_hdu = old_compress_hdu
-
     def test_lossless_gzip_compression(self):
         """Regression test for #198."""
 
-        noise = np.random.normal(size=(100, 100))
+        noise = np.random.normal(size=(1000, 1000))
 
         chdu1 = fits.CompImageHDU(data=noise, compressionType='GZIP_1')
         # First make a test image with lossy compression and make sure it


### PR DESCRIPTION
`c:\windows\temp\tmpyzcvmqastropy_config\astropy\astropy.log: The process cannot access the file because it is being used by another process`

This is an error I get sometimes when the tests are run in Windows on Jenkins.  Right now this is only happening in my staging branch where I'm testing #495, though I'd like to merge that work.

It always happens at the exact same point in the tests.  To give a little further context:

```
astropy\io\fits\tests\test_image.py:883: TestImageFunctions.test_scale_back PASSED
astropy\io\fits\tests\test_image.py:907: TestImageFunctions.test_scale_back_compressed PASSED
astropy\io\fits\tests\test_image.py:948: TestImageFunctions.test_insufficient_compression_allocation error: c:\windows\temp\tmpyzcvmqastropy_config\astropy\astropy.log: The process cannot access the file because it is being used by another process

E:\Builds\astropy-winxp32-staging-iguananaut\workspaces\COMPILER\mingw32\NUMPY_VER\numpy-1.5.1\PYTHON_VER\python-2.7>exit 1 
```

It seems like the test runner itself is crashing, because the tests just stop there.  The test it's stopping at is a slightly bizarre one, but it doesn't do anything I can think of that would affect the log, so I'm not convinced the test itself is relevant (though I might try disabling it).  This occurs on some test configurations but not others, though I haven't discerned any pattern so I think it's more or less non-deterministic.  When I run the tests manually in the same configuration it does not occur, so it seems like it might be due to an interaction with Jenkins.

Any hypotheses?
