### PR TITLE
Make Table.read find VO tables with no names

### DIFF
--- a/astropy/io/votable/tests/data/names.xml
+++ b/astropy/io/votable/tests/data/names.xml
@@ -13,7 +13,7 @@
    Plane  (Robitaille T.P. et al.)
   </DESCRIPTION>
   <LINK href="http://dx.doi.org/10.1088/0004-6256/136/6/2413"/>
-  <TABLE ID="aj285677t2" nrows="18949">
+  <TABLE nrows="18949">
    <DESCRIPTION>
     Final red source catalog
    </DESCRIPTION>

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -121,3 +121,15 @@ def test_names_over_ids():
         'Name', 'GLON', 'GLAT', 'RAdeg', 'DEdeg', 'Jmag', 'Hmag', 'Kmag',
         'G3.6mag', 'G4.5mag', 'G5.8mag', 'G8.0mag', '4.5mag', '8.0mag',
         'Emag', '24mag', 'f_Name']
+
+
+def test_table_read_with_unnamed_tables():
+    """
+    Issue #927
+    """
+    from ....table import Table
+
+    with get_pkg_data_fileobj('data/names.xml', encoding='binary') as fd:
+        t = Table.read(fd, format='votable')
+
+    assert len(t) == 1


### PR DESCRIPTION
Some VO files have tables that have no names. Currently, `Table.read` will claim that no tables are present in this case, but if there is only one table anyway, it should be read.
