### PR TITLE
Table.write failing for VO table

### DIFF
--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -3,6 +3,7 @@
 Test the conversion to/from astropy.table
 """
 
+import io
 import os
 import shutil
 import tempfile
@@ -133,3 +134,12 @@ def test_table_read_with_unnamed_tables():
         t = Table.read(fd, format='votable')
 
     assert len(t) == 1
+
+
+def test_from_table_without_mask():
+    from ....table import Table, Column
+    t = Table()
+    c = Column(data=[1,2,3], name='a')
+    t.add_column(c)
+    output = io.BytesIO()
+    t.write(output, format='votable')

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2758,7 +2758,10 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
             column = table[colname]
             new_table.fields.append(Field.from_table_column(votable, column))
 
-        new_table.array = ma.array(np.asarray(table), mask=table.mask)
+        if table.mask is None:
+            new_table.array = ma.array(np.asarray(table))
+        else:
+            new_table.array = ma.array(np.asarray(table), mask=table.mask)
 
         return new_table
 


### PR DESCRIPTION
The following code:

```
import numpy as np
from astropy.table import Table, Column
t = Table()
c = Column(data=[1,2,3], name='a')
t.add_column(c)
t.write('new.xml', format='votable')
```

produces an exception:

```
ERROR: TypeError: 'NoneType' object is not iterable [numpy.ma.core]
Traceback (most recent call last):
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/numpy/ma/core.py", line 2699, in __new__
    mask = np.array(mask, copy=copy, dtype=mdtype)
TypeError: expected an object with a buffer interface

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "do2.py", line 6, in <module>
    t.write('new.xml', format='votable')
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/astropy-0.3.dev3665-py3.2-macosx-10.8-x86_64.egg/astropy/io/registry.py", line 179, in write
    writer(data, *args, **kwargs)
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/astropy-0.3.dev3665-py3.2-macosx-10.8-x86_64.egg/astropy/io/votable/connect.py", line 120, in write_table_votable
    table_file = from_table(input, table_id=table_id)
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/astropy-0.3.dev3665-py3.2-macosx-10.8-x86_64.egg/astropy/io/votable/table.py", line 318, in from_table
    return tree.VOTableFile.from_table(table, table_id=table_id)
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/astropy-0.3.dev3665-py3.2-macosx-10.8-x86_64.egg/astropy/io/votable/tree.py", line 3403, in from_table
    votable = Table.from_table(votable_file, table)
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/astropy-0.3.dev3665-py3.2-macosx-10.8-x86_64.egg/astropy/io/votable/tree.py", line 2761, in from_table
    new_table.array = ma.array(np.asarray(table), mask=table.mask)
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/numpy/ma/core.py", line 5801, in array
    fill_value=fill_value, ndmin=ndmin, shrink=shrink)
  File "/Volumes/Raptor/Library/Python/3.2/lib/python/site-packages/numpy/ma/core.py", line 2702, in __new__
    mask = np.array([tuple([m] * len(mdtype)) for m in mask],
TypeError: 'NoneType' object is not iterable
```

@taldcroft @mdboom - I won't have time to try and fix this this week, so feel free to take a stab at it.

@iguananaut - I think this should be fixed for 0.2.1 if possible, it's a pretty big bug.
