### PR TITLE
Docs won't build on Sphinx 1.2b1 due to WCSBase

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -62,7 +62,7 @@ else:  # pragma: py2
 
 __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
            'DistortionLookupTable', 'Sip', 'Tabprm', 'UnitConverter',
-           'Wcsprm']
+           'Wcsprm', 'WCSBase']
 
 
 if _wcs is not None:


### PR DESCRIPTION
This problem was discussed some in #934 and #908.

Sphinx recently put out v1.2 beta 1 on PyPI - this was killing the travis build, so you can see the error for this in e.g. https://s3.amazonaws.com/archive.travis-ci.org/jobs/5958983/log.txt .

The underlying problem is twofold: First, `WCSBase` is not picklable.  Sphinx 1.2b1 tries to pickle it where 1.1.3 did not, and that leads to this failure.  The second part is why Sphinx 1.2 is pickling `WCSBase` at all.  I can't see anything in the sphinx 1.2 changelog that would cause this, so I posted to the sphinx mailing list asking about it (https://groups.google.com/forum/?fromgroups=#!topic/sphinx-users/kpMScxmeMMc).  

@mdboom - do you have any thoughts here?  A workaround might be to make `WCSBase` support pickling, although I'm not sure how much work that would be.
