### PR TITLE
Add relax= keyword argument to angle constructors

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -70,7 +70,7 @@ class Angle(object):
 
     """
 
-    def __init__(self, angle, unit=None, bounds=(-360, 360)):
+    def __init__(self, angle, unit=None, bounds=(-360, 360), relax=False):
         from ..utils import isiterable
 
         self._bounds = bounds
@@ -113,14 +113,14 @@ class Angle(object):
                         if unitStr in a:
                             a_unit = u.radian
                             a = angle.replace(unitStr, "")
-                            angle[idx] = math.radians(util.parse_degrees(a))
+                            angle[idx] = math.radians(util.parse_degrees(a, relax=relax))
                             break
                     if unit is None:
                         for unitStr in ["hours", "hour", "hr"]:
                             if unitStr in a:
                                 a_unit = u.radian
                                 a = angle.replace(unitStr, "")
-                                angle[idx] = math.radians(util.parse_hours(a) * 15.)
+                                angle[idx] = math.radians(util.parse_hours(a, relax=relax) * 15., relax=relax)
                                 break
                     if unit is None:
                         for unitStr in ["radians", "radian", "rad"]:
@@ -178,11 +178,11 @@ class Angle(object):
             pass  # already performed conversions to radians above
         else:
             if unit is u.degree:
-                self._radians = math.radians(util.parse_degrees(angle))
+                self._radians = math.radians(util.parse_degrees(angle, relax=relax))
             elif unit is u.radian:
                 self._radians = float(angle)
             elif unit is u.hour:
-                self._radians = util.hours_to_radians(util.parse_hours(angle))
+                self._radians = util.hours_to_radians(util.parse_hours(angle, relax=relax))
             else:
                 raise UnitsError("The unit value provided was not one of u.degree, u.hour, u.radian'.")
 
@@ -490,8 +490,8 @@ class RA(Angle):
         If a unit is not provided or it is not hour, radian, or degree.
     """
 
-    def __init__(self, angle, unit=None):
-        super(RA, self).__init__(angle, unit=unit, bounds=(0, 360))
+    def __init__(self, angle, unit=None, relax=False):
+        super(RA, self).__init__(angle, unit=unit, bounds=(0, 360), relax=relax)
 
     # The initializer as originally conceived allowed the unit to be unspecified
     # if it's bigger  than 24, because hours typically aren't past 24.
@@ -637,8 +637,8 @@ class Dec(Angle):
         `~astropy.coordinates.errors.UnitsError`
             If a unit is not provided or it is not hour, radian, or degree.
     """
-    def __init__(self, angle, unit=None):
-        super(Dec, self).__init__(angle, unit=unit, bounds=(-90, 90))
+    def __init__(self, angle, unit=None, relax=False):
+        super(Dec, self).__init__(angle, unit=unit, bounds=(-90, 90), relax=relax)
 
     # TODO: do here whatever is decided for the "smart" RA initializer above
     #

--- a/astropy/coordinates/coordsystems.py
+++ b/astropy/coordinates/coordsystems.py
@@ -91,7 +91,7 @@ class SphericalCoordinatesBase(object):
             `unit` must be a single unit with dimensions of length"""
 
     def _initialize_latlon(self, lonname, latname, useradec, initargs,
-        initkwargs, anglebounds=None):
+        initkwargs, anglebounds=None, relax=False):
         """
         Subclasses should use this to initialize standard lat/lon-style
         coordinates.
@@ -148,6 +148,7 @@ class SphericalCoordinatesBase(object):
         x = initkwargs.pop('x', None)
         y = initkwargs.pop('y', None)
         z = initkwargs.pop('z', None)
+        relax = initkwargs.pop('relax', False)
 
         if len(initkwargs) > 0:
             raise TypeError('{0} got unexpected keyword argument'
@@ -213,15 +214,15 @@ class SphericalCoordinatesBase(object):
 
             # now actually create the angle objects
             if useradec:
-                lonang = RA(lonval, unit=units[0])
-                latang = Dec(latval, unit=units[1])
+                lonang = RA(lonval, unit=units[0], relax=relax)
+                latang = Dec(latval, unit=units[1], relax=relax)
             else:
                 if isinstance(lonval, RA):
                     raise TypeError('Cannot provide an RA object to non-RA/Dec system {0}'.format(sclsnm))
                 if isinstance(latval, Dec):
                     raise TypeError('Cannot provide a Dec object to non-RA/Dec system {0}'.format(sclsnm))
-                lonang = Angle(lonval, unit=units[0])
-                latang = Angle(latval, unit=units[1])
+                lonang = Angle(lonval, unit=units[0], relax=relax)
+                latang = Angle(latval, unit=units[1], relax=relax)
 
             dist = None if distval is None else Distance(distval)  # copy
 
@@ -245,11 +246,11 @@ class SphericalCoordinatesBase(object):
             r, latval, lonval = cartesian_to_spherical(x, y, z)
 
             if useradec:
-                lonang = RA(lonval, unit=u.radian)
-                latang = Dec(latval, unit=u.radian)
+                lonang = RA(lonval, unit=u.radian, relax=relax)
+                latang = Dec(latval, unit=u.radian, relax=relax)
             else:
-                lonang = Angle(lonval, unit=u.radian)
-                latang = Angle(latval, unit=u.radian)
+                lonang = Angle(lonval, unit=u.radian, relax=relax)
+                latang = Angle(latval, unit=u.radian, relax=relax)
 
             dist = None if unit is None else Distance(r, unit)
 
@@ -261,8 +262,8 @@ class SphericalCoordinatesBase(object):
 
         #add in the bounds, if relevant
         if anglebounds is not None and not useradec:
-            lonang = Angle(lonang.degrees, u.degree, bounds=anglebounds[0])
-            latang = Angle(latang.degrees, u.degree, bounds=anglebounds[1])
+            lonang = Angle(lonang.degrees, u.degree, bounds=anglebounds[0], relax=relax)
+            latang = Angle(latang.degrees, u.degree, bounds=anglebounds[1], relax=relax)
 
         # now actually set the values
         setattr(self, lonname, lonang)


### PR DESCRIPTION
If set to `True`, then out-of-bounds angles (such as seconds >= 60,
as in `00:20:60.0`) result in warnings instead of exceptions. Many data
sets, including the Fermi GBM GRB catalog, give sexagesimal angles that
are improperly rounded.

The default is `relax=False`; if `relax=` is not specified, then
out-of-bounds angles continue to produce exceptions.

Example with default behavior:

```
>>> ICRSCoordinates('00:60 00:60', unit=('deg', 'deg'))
ERROR: IllegalMinuteError [astropy.coordinates.angle_utilities]
Traceback (most recent call last):
etc.
```

Example with 'relaxed' behavior:

```
>>> ICRSCoordinates('00:60 00:60', unit=('deg', 'deg'), relax=True)
WARNING:  [astropy.coordinates.angle_utilities]
<ICRSCoordinates RA=1.00000 deg, Dec=1.00000 deg>
```
