### PR TITLE
Numpy should not be installed for egg_info tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 
 install:
    - export PYTHONIOENCODING=UTF8 # just in case
-   - pip install --upgrade "numpy==$NUMPY_VERSION" -q --use-mirrors
+   - if [[ $SETUP_CMD != egg_info ]]; then pip install --upgrade "numpy==$NUMPY_VERSION" -q --use-mirrors; fi
    - if $OPTIONAL_DEPS; then pip install scipy --use-mirrors; fi # this can't be quiet because it takes so long that travis times out
    - if $OPTIONAL_DEPS; then pip install h5py -q --use-mirrors; fi
    - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install sphinx --use-mirrors; fi


### PR DESCRIPTION
 The point of the `egg_info` tests is to check that 'python setup.py egg_info' works if no other dependencies are installed (as required by pip when using pip requirements files).
