### PR TITLE
Hide deprecation warning about io.votable.voexceptions in setup mode

### DIFF
--- a/astropy/io/votable/voexceptions.py
+++ b/astropy/io/votable/voexceptions.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import warnings
-warnings.warn(
-    "astropy.io.votable.voexceptions is deprecated. "
-    "Use astropy.io.votable.exceptions",
-    DeprecationWarning)
+if not _ASTROPY_SETUP_:
+    import warnings
+    warnings.warn(
+        "astropy.io.votable.voexceptions is deprecated. "
+        "Use astropy.io.votable.exceptions",
+        DeprecationWarning)
 
 from .exceptions import *


### PR DESCRIPTION
This is just noise spewed by the setup.py script otherwise.
