### PR TITLE
units: don't play nice with multiprocessing

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -446,3 +446,19 @@ def test_no_as():
     # do want to define the long form (`attosecond`).
     assert not hasattr(u, 'as')
     assert hasattr(u, 'attosecond')
+
+
+def test_pickling():
+    import cPickle
+
+    p = cPickle.dumps(u.m)
+    other = cPickle.loads(p)
+
+    assert other is u.m
+
+    new_unit = u.IrreducibleUnit(['foo'], register=False, format={'baz': 'bar'})
+    p = cPickle.dumps(new_unit)
+    new_unit_copy = cPickle.loads(p)
+    assert new_unit is not new_unit_copy
+    assert new_unit_copy.names == ['foo']
+    assert new_unit_copy.get_format_name('baz') == 'bar'


### PR DESCRIPTION
This one hurts...just rewrote a large chunk of code to use `astropy.units` and then find this :sweat:

Anyway, here's some code that works fine on a single process (e.g., copy and paste into interpreter):

```
import astropy.units as u
import numpy as np

def some_func(r):
    return r.to(u.kpc)

print(map(some_func, [np.random.random()*u.km for ii in range(16)]))
```

Now try it with multiprocessing:

```
import astropy.units as u
import numpy as np
import multiprocessing

def some_func(r):
    return r.to(u.kpc)

pool = multiprocessing.Pool(processes=4)
print(pool.map(some_func, [np.random.random()*u.km for ii in range(16)]))
```

and you get:

```
    ERROR: UnitsException: 'km' (length) and 'kpc' (length) are not convertible [multiprocessing.pool]
---------------------------------------------------------------------------
UnitsException                            Traceback (most recent call last)
<ipython-input-14-77e4c6c6f7bb> in <module>()
      8
      9 pool = multiprocessing.Pool(processes=4)
---> 10 print(pool.map(some_func, [np.random.random()*u.km for ii in range(16)]))

/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/pool.pyc in map(self, func, iterable, chunksize)
    197         '''
    198         assert self._state == RUN
--> 199         return self.map_async(func, iterable, chunksize).get()
    200
    201     def imap(self, func, iterable, chunksize=1):

/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/pool.pyc in get(self, timeout)
    489             return self._value
    490         else:
--> 491             raise self._value
    492
    493     def _set(self, i, obj):

UnitsException: 'km' (length) and 'kpc' (length) are not convertible
```
