### PR TITLE
No handlers could be found for logger "root"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,13 @@
 0.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bug Fixes
+^^^^^^^^^
+
+- Fixed an unrelated error message that could occur when trying to import
+  astropy from a source checkout without having build the extension modules
+  first. This issue was claimed to be fixed in v0.2.1, but the fix itself had
+  a bug. [#971]
 
 
 0.2.1 (2013-04-03)

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -130,6 +130,8 @@ if not _ASTROPY_SETUP_:
     import sys
     from warnings import warn
 
+    log = _init_log()
+
     try:
         from .utils import _compiler
     except ImportError:
@@ -143,14 +145,10 @@ if not _ASTROPY_SETUP_:
             # Outright broken installation; don't be nice.
             raise
 
-
-
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None
-
-    log = _init_log()
-
     config_dir = os.path.dirname(__file__)
+
     try:
         config.configuration.update_default_config(__package__, config_dir)
     except config.configuration.ConfigurationDefaultMissingError as e:


### PR DESCRIPTION
`python setup.py sdist` is failing on Jenkins:

https://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-sdist/511/console

The error is:

```
hard linking scripts/volint -> astropy-0.3.dev3744/scripts
Creating tar archive
removing 'astropy-0.3.dev3744' (and everything under it)
+ /home/slave/env2.7-numpy1.6.1/bin/python -c import astropy.version; import sys; sys.stdout.write(astropy.version.version)
No handlers could be found for logger "root"
+ ASTROPY_VERSION=
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```
