### PR TITLE
Initial implementation of tracking and warning about correlated error

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -5,6 +5,7 @@ __all__ = ['NDData']
 
 import numpy as np
 from uuid import UUID, uuid4
+from warnings import warn
 
 from ..units import Unit
 from .. import log
@@ -227,7 +228,7 @@ class NDData(object):
             if isinstance(value, UUID):
                 self._uid = value
             else:
-                raise TypeError("Uid must be an instance of a UUID object")
+                raise TypeError("uid must be an instance of a UUID object")
         else:
             self._uid = value
 
@@ -405,7 +406,7 @@ class NDData(object):
                          " will be propagated assuming they are uncorrelated")
             if WARN_UNSUPPORTED_CORRELATED() and \
                 len(self.correlated_set.intersection(operand.correlated_set)) > 0:
-                log.info("Correlated uncertainty in self and operand")
+                warn('Correlated uncertainty in self and operand', RuntimeWarning)
             try:
                 method = getattr(self.uncertainty, propagate_uncertainties)
                 result.uncertainty = method(operand, result.data)


### PR DESCRIPTION
Added fields uid and correlated_set to class NDData. The field uid holds a unique id for that instance generated via uuid4() of the standard library. Correlated_set holds a set of uids of previous NDData instances combined through any method implementing _arithmetic.

Added logic to initialize uid and correlated_set in `__init__` of NDData.

Added logic to set the correlated_set of result to the union of the correlated_set of self and operand in _arithmetic. Checks for intersections of the two correlated_sets (if both operand and self carry uncertainty) and issues a warning if a single uid appears in both.

Issues:

Organization. I tried to follow the existing code for figuring out where to put things, I'm not completely sure it all follows style guidelines though. Likely improvements could be made to improve extensibility of added feature, I'll keep thinking about it.

Documentation. I added a parameter 'cset' to `__init__` in NDData but did not document it in the docstring. Do I document it manually following the style of the rest of the docstring, or is it generated using a tool? I was also unsure of how verbosely to comment code, comments in the source file seemed sparse, so I avoided trying to use them liberally.

Testing. I did not run the existing tests or write one for the new functionality. I am trying to fix an error with my pytest install ("NameError: global name 'basestring' is not defined" on Arch Linux), but once I fix that I plan to work on getting comfortable with the testing framework.

Optimization. (Now fixed) _Currently if an NDData object appears twice in a chain of arithmetic operations, its uid appears twice in the result's correlated_list. I'm not sure if checking for redundancy would be too much of a performance hit for the improvement of space usage. Keeping the list ordered might be a good medium (I'm also not sure how well built in ordering functions will handle UUID objects)._

[Edited after update from list to set]

Thank you,
Mabry Cervin
mpcervin@uncg.edu
