### PR TITLE
Added fix for Issue#977

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -858,7 +858,7 @@ if HAVE_SPHINX:
 
             else:
                 proc = Popen([sys.executable], stdin=PIPE)
-                proc.communicate(subproccode)
+                proc.communicate(subproccode.encode('utf-8'))
 
             if proc.returncode == 0:
                 if self.open_docs_in_browser:


### PR DESCRIPTION
I have added the fix for python setup.py build_sphinx failure for Python 3.x pathname2url ImportError.

Note the import error has now disappeared, but there are other Python 3.x
incompatibilities present:
1. No member attribute decode in str
2. str doesn't support buffer interface in Python3
3. unicode encoding in this way u'...' is no longer permitted
   4?.....

I believe the code needs to be examined thoroughly to make it suitable for
Python 3.x 
