### PR TITLE
Parse minutes or seconds equal to 60 with warning

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 import re
 import math
 import inspect # NB: get the function name with: inspect.stack()[0][3]
+from warnings import warn
 
 from .errors import *
 from ..utils import format_exception
@@ -24,15 +25,21 @@ def _check_hour_range(hrs):
 
 
 def _check_minute_range(min):
-    ''' Checks that the given value is in the range [0,60). '''
-    if not 0. <= min < 60.:
+    ''' Checks that the given value is in the range [0,60].
+    If the value is equal to 60, then a warning is raised. '''
+    if min == 60.:
+        warn(str(IllegalMinuteError(min)))
+    elif not 0. <= min < 60.:
         # "Error: minutes not in range [0,60) ({0}).".format(min))
         raise IllegalMinuteError(min)
 
 
 def _check_second_range(sec):
-    ''' Checks that the given value is in the range [0,60). '''
-    if not 0. <= sec < 60.:
+    ''' Checks that the given value is in the range [0,60].
+    If the value is equal to 60, then a warning is raised. '''
+    if sec == 60.:
+        warn(str(IllegalSecondError(sec)))
+    elif not 0. <= sec < 60.:
         # "Error: seconds not in range [0,60) ({0}).".format(sec))
         raise IllegalSecondError(sec)
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -29,3 +29,39 @@ def test_negative_zero_hm():
     # Test for HM parser
     a = Angle('-00:10', u.hour)
     assert_allclose(a.hours, -10. / 60.)
+
+
+def test_negative_sixty_hm():
+    # Test for HM parser
+    a = Angle('-00:60', u.hour)
+    assert_allclose(a.hours, -1.)
+
+
+def test_plus_sixty_hm():
+    # Test for HM parser
+    a = Angle('00:60', u.hour)
+    assert_allclose(a.hours, 1.)
+
+
+def test_negative_fifty_nine_sixty_dms():
+    # Test for DMS parser
+    a = Angle('-00:59:60', u.deg)
+    assert_allclose(a.degrees, -1.)
+
+
+def test_plus_fifty_nine_sixty_dms():
+    # Test for DMS parser
+    a = Angle('+00:59:60', u.deg)
+    assert_allclose(a.degrees, 1.)
+
+
+def test_negative_sixty_dms():
+    # Test for DMS parser
+    a = Angle('-00:00:60', u.deg)
+    assert_allclose(a.degrees, -1. / 60.)
+
+
+def test_plus_sixty_dms():
+    # Test for DMS parser
+    a = Angle('+00:00:60', u.deg)
+    assert_allclose(a.degrees, 1. / 60.)


### PR DESCRIPTION
Out-of-bounds angles with seconds == 60 or minutes == 60 result in
warnings instead of exceptions. Many data sets, including the Fermi GBM
GRB catalog, give sexagesimal angles that are improperly rounded.

Example:

```
>>> ICRSCoordinates('00:60 00:60', unit=('deg', 'deg'))
WARNING: An invalid value for 'minute' was found ('60'); must be in
the range [0,60). [astropy.coordinates.angle_utilities]
<ICRSCoordinates RA=1.00000 deg, Dec=1.00000 deg>
```

Some new test cases are included.

This addresses #947, without introducing any new arguments.
