### PR TITLE
_ImageBaseHDU._get_scaled_image_data returns a raw data if bzero==0 and bscale==1 even though blank is not None

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -523,8 +523,7 @@ class _ImageBaseHDU(_ValidHDU):
         raw_data = self._get_raw_data(shape, code, offset)
         raw_data.dtype = raw_data.dtype.newbyteorder('>')
 
-        if (self._orig_bzero == 0 and self._orig_bscale == 1 and
-            self._blank is None):
+        if (self._orig_bzero == 0 and self._orig_bscale == 1):
             # No further conversion of the data is necessary
             return raw_data
 


### PR DESCRIPTION
This PR is to trigger discussion regarding the memmap support.

```python
import astropy.io.fits as pyfits
f = pyfits.open("some.fits", memmap=True,
                do_not_scale_image_data=True)
```
With the above code, I expected `f[0].data` returns a memmap'd numpy array, but it does not for files w/ "BLANK" header values. And I think this is something that needed to be fixed.

I think there are a few ways to fix this.
* As in this PR, just remove a check for the blank value.
* introduce new keyword argument, e.g., `ignore_blank`.
* do nothing, but update the docs so that people expect this behavior.

On the other hand, wouldn't it be good to have a method like `get_raw_data` (similar to `_get_raw_data` but with a simpler signature)?
