### PR TITLE
Add build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ or  ``docs/install.rst`` in this source distribution.
 
 Jenkins Build Status
 --------------------
-.. image:: http://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/badge/icon
+.. image:: https://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/badge/icon
 
 Travis Build Status
 -------------------


### PR DESCRIPTION
Adds the main Shining Panda build status to the front Github project page.  Alternatively, or in addition, we could add this to somewhere on the website.
