### PR TITLE
added quantity parse_string classmethod

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -88,6 +88,25 @@ class Quantity(object):
         string unit.
     """
 
+    @classmethod
+    def parse_string(cls, quantity_string):
+        """
+        Parses a Quantity string like "5 km/s" and returns a Quantity
+
+        Parameters
+        ----------
+        quantity_string : str
+            Quantity string like "5 km/s"
+
+        Returns
+        -------
+
+        a Quantity object
+        """
+        value, unit = quantity_string.split()
+        return cls(float(value), unit)
+
+
     def __init__(self, value, unit):
         from ..utils.misc import isiterable
 


### PR DESCRIPTION
I needed that a couple of times when reading from config files and thought that this might make an easy fix:

``` python
In [1]: from astropy import units as u

In [2]: u.Quantity.parse_string('5 km/s')
Out[2]: <Quantity 5.0 km / s>
```
