### PR TITLE
Column.null not used when writing FITS table?

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,10 +24,17 @@
 Bug Fixes
 ^^^^^^^^^
 
-- Fixed an unrelated error message that could occur when trying to import
-  astropy from a source checkout without having build the extension modules
-  first. This issue was claimed to be fixed in v0.2.1, but the fix itself had
-  a bug. [#971]
+- ``astropy.io.fits``
+
+  - Improved round-tripping and preservation of manually assigned column
+    attributes (``TNULLn``, ``TSCALn``, etc.) in table HDU headers. [#996]
+
+- Misc
+
+  - Fixed an unrelated error message that could occur when trying to import
+    astropy from a source checkout without having build the extension modules
+    first. This issue was claimed to be fixed in v0.2.1, but the fix itself had
+    a bug. [#971]
 
 
 0.2.1 (2013-04-03)

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -501,13 +501,14 @@ class ColDefs(object):
 
         cname = name[:-1]
         if cname in KEYWORD_ATTRIBUTES and name[-1] == 's':
-            attr = [''] * len(self)
-            for idx in range(len(self)):
-                val = getattr(self[idx], cname)
+            attr = []
+            for col in self:
+                val = getattr(col, cname)
                 if val is not None:
-                    attr[idx] = val
-            self.__dict__[name] = attr
-            return self.__dict__[name]
+                    attr.append(val)
+                else:
+                    attr.append('')
+            return attr
         raise AttributeError(name)
 
     @property
@@ -765,11 +766,11 @@ class _ASCIIColDefs(ColDefs):
         # a field may not be the column right after the last field
         end = 0
         spans = [0] * len(self)
-        for idx in range(len(self)):
-            format, width = _convert_ascii_format(self.formats[idx])
-            if not self.starts[idx]:
-                self.starts[idx] = end + 1
-            end = self.starts[idx] + width - 1
+        for idx, col in enumerate(self):
+            format, width = _convert_ascii_format(col.format)
+            if not col.start:
+                col.start = end + 1
+            end = col.start + width - 1
             spans[idx] = width
         self._width = end
         return spans

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -79,8 +79,8 @@ class TestCore(FitsTestCase):
         hdulist.writeto(self.temp('test.fits'), clobber=True)
         with fits.open(self.temp('test.fits')) as hdulist:
             table = hdulist[1]
-            assert table.data.dtype.names == ('c1', 'c2', 'c3')
-            assert table.columns.names == ['c1', 'c2', 'c3']
+            assert table.data.dtype.names == ('c2', 'c4', 'foo')
+            assert table.columns.names == ['c2', 'c4', 'foo']
 
     def test_update_header_card(self):
         """A very basic test for the Header.update method--I'd like to add a


### PR DESCRIPTION
In the process of working on #591 I ran across the following issue:

```
import numpy as np
from astropy.io.fits import BinTableHDU

NULLS = {}
NULLS['a'] = 2
NULLS['b'] = 'b'
NULLS['c'] = 2.3

data = np.array(list(zip([1, 2, 3, 4],
                         ['a', 'b', 'c', 'd'],
                         [2.3, 4.5, 6.7, 8.9])),
                dtype=[('a', int), ('b', 'S1'), ('c', float)])

b = BinTableHDU(data)
for col in b.get_coldefs():
    col.null = NULLS[col.name]

# check that null is set
print b.get_coldefs()

b.writeto('test.fits', clobber=True)
```

produces a FITS file which doesn't have any TNULL keywords in the header - any idea why? The print statement shows:

```
ColDefs(
    name = 'a'; format = 'K'; null = 2
    name = 'b'; format = 'A1'; null = 'b'
    name = 'c'; format = 'D'; null = 2.3
)
```
