### PR TITLE
Make pure-python affiliated packages separate Python 2 and Python 3 builds

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -534,6 +534,22 @@ def generate_build_ext_command(release):
 
 class AstropyBuildPy(SetuptoolsBuildPy):
 
+    def finalize_options(self):
+        # Update build_lib settings from the build command to always put
+        # build files in platform-specific subdirectories of build/, even
+        # for projects with only pure-Python source (this is desirable
+        # specifically for support of multiple Python version).
+        build_cmd = self.get_finalized_command('build')
+        plat_specifier = '.{0}-{1}'.format(build_cmd.plat_name,
+                                           sys.version[0:3])
+        # Do this unconditionally
+        build_purelib = os.path.join(build_cmd.build_base,
+                                     'lib' + plat_specifier)
+        build_cmd.build_purelib = build_purelib
+        build_cmd.build_lib = build_purelib
+        self.build_lib = build_purelib
+        SetuptoolsBuildPy.finalize_options(self)
+
     def run(self):
         # first run the normal build_py
         SetuptoolsBuildPy.run(self)


### PR DESCRIPTION
For affiliated packages that are pure-python, the `build` directory is not subdivided into Python versions, but this causes issues if one installs using Python 2, then using Python 3 without wiping the build directory because 2to3 won't get run. Is there a way to force the build directory to be sub-divided by Python version as it is for when C code is present?

cc @iguananaut
