### PR TITLE
change API documentation from time.core to just time

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -548,7 +548,7 @@ Use of the |TimeDelta| object is easily illustrated in the few examples below::
 Reference/API
 =============
 
-.. automodapi:: astropy.time.core
+.. automodapi:: astropy.time
 
 
 Acknowledgments and Licenses


### PR DESCRIPTION
This is a pretty trivial PR that probably only @taldcroft will care about.

This changes the documentation for the `time` subpackage to be an API for `astropy.time` instead of `astropy.time.core`.  Right now, this doesn't change what classes/functions are documented because `astropy/time/__init__.py` just has `from .core import *` in it.  

I think it's better to do it this way, though, because now if I put ``astropy.time`` in the docs (or someone else does via intersphinx) it will link to that page, instead of having no link (because it thinks it's documentiong `astropy.time.core`).  It's also marginally clearer this way to users that they should do `from astropy.time import foo` instead of `from astropy.time.core import foo`.

Or is there some other reason you had for using `core` over the base package, @taldcroft?
