### PR TITLE
Fix for Issue #966 (in progress)

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1701,7 +1701,6 @@ class Table(object):
 
         def _revert_table():
             """In case of an error, revert the table back to its previous state"""
-            """This is just a test edit - please ignore"""
             if self.masked:
                 self._data = ma.resize(self._data, (oldlen,))
             else:


### PR DESCRIPTION
I am working on a fix for Issue #966 and would gladly welcome any feedback that anyone may have. I have created a new function called _revert_table() within add_row(); the purpose of this function is to revert the table back to its previous state in case of an error. Currently, the only two errors I have been able to trigger are ValueError('Mismatch between number of values and columns') and ValueError('Mismatch between number of masks and columns'). The former error is what causes this particular issue, but it would be nice to know if there are any other cases that also need to be handled.
