### PR TITLE
Refactored ndim and outdim

### DIFF
--- a/astropy/models/core.py
+++ b/astropy/models/core.py
@@ -71,20 +71,20 @@ def _convert_input(x, pdim):
     x = np.asarray(x) + 0.
     fmt = 'N'
     if pdim == 1:
-        if x.ndim == 0:
+        if x.number_input_variables == 0:
             fmt = 'S'
             return x, fmt
         else:
             return x, fmt
     else:
-        if x.ndim < 2:
+        if x.number_input_variables < 2:
             fmt = 'N'
             return np.array([x]).T, fmt
-        elif x.ndim == 2:
+        elif x.number_input_variables == 2:
             assert x.shape[-1] == pdim, "Cannot broadcast with shape"\
                                             "({0}, {1})".format(x.shape[0], x.shape[1])
             return x, fmt
-        elif x.ndim > 2:
+        elif x.number_input_variables > 2:
             assert x.shape[0] == pdim, "Cannot broadcast with shape " \
                    "({0}, {1}, {2})".format(x.shape[0], x.shape[1], x.shape[2])
             fmt = 'T'
@@ -188,14 +188,14 @@ class Model(object):
             setattr(self.__class__, par, _ParameterProperty(par))
     
     @property 
-    def ndim(self):
+    def number_input_variables(self):
         """
         Number of input variables in model evaluation.
         """
         return self._ndim
 
     @property
-    def outdim(self):
+    def number_output_variables(self):
         """
         Number of output valiables returned when a model is evaluated.
         """
@@ -316,9 +316,9 @@ class ParametricModel(Model):
     ----------
     param_names: list
         parameter names
-    ndim: int
+    number_input_variables: int
         model dimensions (number of inputs)
-    outdim: int
+    number_output_variables: int
         number of output quantities
     param_dim: int
         number of parameter sets
@@ -421,7 +421,7 @@ class ParametricModel(Model):
                    {4}
         """.format(
               self.__class__.__name__,
-              self.ndim,
+              self.number_input_variables,
               degree,
               self.param_dim,
               "\n                   ".join(i+': ' + 
@@ -669,9 +669,9 @@ class SCompositeModel(_CompositeModel):
             outmap = [None]  * len(transforms)
         
         self._init_comptr(transforms, inmap, outmap)
-        self.ndim = np.array([tr.ndim for tr in self]).max()
+        self.ndim = np.array([tr.number_input_variables for tr in self]).max()
         # the output dimension is equal to the output dim of the last transform
-        self.outdim = self.keys()[-1].outdim
+        self.outdim = self.keys()[-1].number_output_variables
         
     def _init_comptr(self, transforms, inmap, outmap):
         for tr, inm, outm in zip(transforms, inmap, outmap):
@@ -681,11 +681,11 @@ class SCompositeModel(_CompositeModel):
         lendata = len(data)
         tr = self.keys()[0]
         
-        if tr.ndim != lendata:
+        if tr.number_input_variables != lendata:
             
             raise ValueError("Required number of coordinates not matched for "
                              "transform # {0}: {1} required, {2} supplied ".format( 
-                             self.keys().index(tr)+1, tr.ndim, lendata))
+                             self.keys().index(tr)+1, tr.number_input_variables, lendata))
 
     def invert(self, inmap, outmap):
         scomptr = SCompositeModel(self[::-1], inmap=inmap, outmap=outmap)
@@ -714,7 +714,7 @@ class SCompositeModel(_CompositeModel):
                     outmap = self[tr][1]
                     inlist = [getattr(linp, co) for co in inmap]
                     result = tr(*inlist)
-                    if tr.outdim == 1:
+                    if tr.number_output_variables == 1:
                         result = [result]
                     for outcoo, res in zip(outmap, result):
                         if outcoo not in inmap:
@@ -760,7 +760,7 @@ class PCompositeModel(_CompositeModel):
         super(PCompositeModel, self).__init__(transforms,
                                               inmap=None, outmap=None)
         self._init_comptr(transforms, inmap, outmap)
-        self.ndim = self.keys()[0].ndim
+        self.ndim = self.keys()[0].number_input_variables
         self.outdim = self.ndim
         self.inmap = inmap
         self.outmap = outmap
@@ -770,10 +770,10 @@ class PCompositeModel(_CompositeModel):
             self[tr] = [inmap, outmap]
 
     def _verify_no_mapper_input(self, *data):
-        ndim = self.keys()[0].ndim
+        ndim = self.keys()[0].number_input_variables
         for tr in self.keys():
-            if tr.ndim != ndim:
-                raise ValueError("tr.ndim ...")
+            if tr.number_input_variables != ndim:
+                raise ValueError("tr.number_input_variables ...")
     
     def invert(self, inmap, outmap):
         pcomptr = PCompositeModel(self.keys()[::-1], inmap=inmap, outmap=outmap)

--- a/astropy/models/fitting.py
+++ b/astropy/models/fitting.py
@@ -289,7 +289,7 @@ class LinearLSQFitter(Fitter):
         x = np.asarray(x, dtype=np.float)
         y = np.asarray(y, dtype=np.float)
 
-        if self.model.ndim == 2 and z is None:
+        if self.model.number_input_variables == 2 and z is None:
             raise ValueError("Expected x, y and z for a 2 dimensional model.")
 
         if z is None:
@@ -368,9 +368,9 @@ class LinearLSQFitter(Fitter):
         self.fit_info['singular_values'] = sval
 
         self.model._parameters._changed = True
-        # If y.ndim > model.ndim we are doing a simultanious 1D fitting
+        # If y.number_input_variables > model.number_input_variables we are doing a simultanious 1D fitting
         # of several 1D arrays. Otherwise the model is 2D.
-        #if y.ndim > self.model.ndim:
+        #if y.number_input_variables > self.model.number_input_variables:
         if multiple:
             self.model._parameters.param_dim = multiple
         lacoef = (lacoef.T/scl).T
@@ -636,8 +636,8 @@ class JointFitter(object):
             m.set_joint_parameters(self.jointpars[m])
         self.fitpars = self._model_to_fit_pars()
 
-        # a list of model.ndim
-        self.modeldims = [m.ndim for m in self.models]
+        # a list of model.number_input_variables
+        self.modeldims = [m.number_input_variables for m in self.models]
         # sum all model dimensions
         self.ndim = np.sum(self.modeldims)
 
@@ -670,8 +670,8 @@ class JointFitter(object):
         del fitpars[:numjp]
 
         for model in self.models:
-            margs = lstsqargs[:model.ndim+1]
-            del lstsqargs[:model.ndim+1]
+            margs = lstsqargs[:model.number_input_variables+1]
+            del lstsqargs[:model.number_input_variables+1]
             #separate each model separately fitted parameters
             numfp = len(model._parameters) - len(model.joint)
             mfpars = fitpars[:numfp]

--- a/astropy/models/polynomial.py
+++ b/astropy/models/polynomial.py
@@ -110,13 +110,13 @@ class PolynomialModel(ParametricModel):
         """
         Map the input data into a [-1, 1] window
         """
-        if self.ndim == 1:
+        if self.number_input_variables == 1:
             if not self.domain:
                 self.domain = [x.min(), x.max()]
             if not self.window:
                 self.window = [-1, 1]
             return pmapdomain(x, self.domain, self.window)
-        if self.ndim == 2:
+        if self.number_input_variables == 2:
             assert y is not None, ("Expected 2 input coordinates")
             if not self.xdomain:
                 self.xdomain = [x.min(), x.max()]
@@ -562,9 +562,9 @@ class Poly2DModel(PolynomialModel):
         """
         Derivatives with respect to parameters
         """
-        if x.ndim == 2:
+        if x.number_input_variables == 2:
             x = x.flatten()
-        if y.ndim == 2:
+        if y.number_input_variables == 2:
             y = y.flatten()
         if x.size != y.size:
             raise ValueError('Expected x and y to be of equal size')

--- a/astropy/models/projections.py
+++ b/astropy/models/projections.py
@@ -45,11 +45,11 @@ class Projection(Model):
         self.r0 = 180/np.pi
         
     @property
-    def ndim(self):
+    def number_input_variables(self):
         return self._ndim
     
     @property
-    def outdim(self):
+    def number_output_variables(self):
         return self._outdim
     
     @property

--- a/astropy/models/rotations.py
+++ b/astropy/models/rotations.py
@@ -180,7 +180,7 @@ class MatrixRotation2D(Model):
             self._rotmat = Parameter('rotmat', self._compute_matrix(angle),
                                       self, 1)
         self._ndim = self._rotmat[0].shape[0]
-        self._outdim = self.ndim
+        self._outdim = self.number_input_variables
         self._parcheck = {'rotmat': self._validate_rotmat,
                                      'angle': self._validate_angle}
     
@@ -193,7 +193,7 @@ class MatrixRotation2D(Model):
         self._angle = Parameter('angle', np.deg2rad(val), self, param_dim=1)
         
     def _validate_rotmat(self, rotmat):
-        assert rotmat.ndim == 2, "Expected rotation matrix to be a 2D array"
+        assert rotmat.number_input_variables == 2, "Expected rotation matrix to be a 2D array"
                     
     def _validate_angle(self, angle):
         a = np.asarray(angle)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1303,7 +1303,7 @@ def _make_1d_array(val, copy=False):
         Array version of ``val`` and the number of dims in original.
     """
     val = np.array(val, copy=copy)
-    val_ndim = val.ndim  # remember original ndim
+    val_ndim = val.ndim  # remember original number_input_variables
     if val.ndim == 0:
         val = (val.reshape(1) if val.dtype.kind == 'O' else np.array([val]))
     elif val_ndim > 1:

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -521,7 +521,7 @@ correction in the *y*-axis.
 """
 
 dims = """
-``int array[ndim]`` (read-only)
+``int array[number_input_variables]`` (read-only)
 
 The dimensions of the tabular array
 `~astropy.wcs._astropy.wcs.Wtbarr.data`.

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -639,7 +639,7 @@ naxis kwarg.
                 (len(cpdis.data.shape),
                  'Number of independent variables in distortion function'))
 
-            for i in range(cpdis.data.ndim):
+            for i in range(cpdis.data.number_input_variables):
                 hdulist[0].header.update(
                     '{0}{1:d}.AXIS.{2:d}'.format(d_kw, num, i + 1),
                     (i + 1, 'Axis number of the jth independent variable in a '

--- a/docs/models/fitting.rst
+++ b/docs/models/fitting.rst
@@ -20,7 +20,7 @@ The rules for passing input to fitters are:
 * The linear fitter can fit single input to multiple data sets creating multiple 
   parameter sets. For example fitting a 2D model with input x, y arrays 
   of shape (n, m) to a z array of shape (p, n, m), will set 
-  model.parameters.ndim to p, even if it was 1 when the model was created.
+  model.parameters.number_input_variables to p, even if it was 1 when the model was created.
 
 * Attempting to fit a model with multiple parameter sets to a single 
   data set results in an error.

--- a/docs/models/models.rst
+++ b/docs/models/models.rst
@@ -17,7 +17,7 @@ Parametric models also store a flat list of all parameters as an instance of
 modified by a subclass of `~astropy.models.fitting.Fitter`. When fitting nonlinear models,
 the values of the parameters are used as initial guesses by the fitting class.
 
-Models have an `~astropy.models.core.Model.ndim` attribute, which shows
+Models have an `~astropy.models.core.Model.number_input_variables` attribute, which shows
 how many coordinates the 
 model expects as an input. All models expect coordinates as separate arguments.
 For example a 2D model expects x and y to be passed separately, 
@@ -28,9 +28,9 @@ of parameter sets and x_shape, y_shape is the shape of the input array.
 In all other cases the shape of the output array is the same as the shape of the 
 input arrays. 
 
-Models also have an attribute `~astropy.models.core.Model.outdim`, which shows
-the number of output coordinates. The `~astropy.models.core.Model.ndim` and
-`~astropy.models.core.Model.outdim` attributes are used to chain transforms by
+Models also have an attribute `~astropy.models.core.Model.number_output_variables`, which shows
+the number of output coordinates. The `~astropy.models.core.Model.number_input_variables` and
+`~astropy.models.core.Model.number_output_variables` attributes are used to chain transforms by
 adding models in series, `~astropy.models.core.SCompositeModel`, or in parallel,
 `~astropy.models.core.PCompositeModel`. Because composite models can 
 be nested within other composite models, creating 

--- a/docs/models/new.rst
+++ b/docs/models/new.rst
@@ -37,12 +37,12 @@ parameter sets, `~astropy.models.Model.param_dim`::
         self._amplitude = Parameter(name='amplitude', val=amplitude, mclass=self, param_dim=param_dim)
         self._stddev = Parameter(name='stddev', val=stddev, mclass=self, param_dim=param_dim)
         self._mean = Parameter(name='mean', val=mean, mclass=self, param_dim=param_dim)
-        ParametricModel.__init__(self, self.param_names, ndim=1, outdim=1, param_dim=param_dim)
+        ParametricModel.__init__(self, self.param_names, number_input_variables=1, number_output_variables=1, param_dim=param_dim)
     
 Parametric models can be linear or nonlinear in a regression sense. The default 
 value of the `~astropy.models.core.Model.linear` attribute is True. 
-The `~astropy.models.core.Model.ndim` attribute stores the number of input
-variables the model expects.. The `~astropy.models.core.Model.outdim` attribute
+The `~astropy.models.core.Model.number_input_variables` attribute stores the number of input
+variables the model expects.. The `~astropy.models.core.Model.number_output_variables` attribute
 stores the number of output variables returned after evaluating the model.
 These two attributes are used with composite models.
 Each parameter must be defined as a private attribute of the model class. 
@@ -88,7 +88,7 @@ A Full Example of a LineModel
         self.linear = True 
         self._slope = parameters.Parameter(name='slope', val=slope, mclass=self, param_dim=param_dim)
         self._intercept = parameters.Parameter(name='intercept', val=intercept, mclass=self, param_dim=param_dim)
-        models.ParametricModel.__init__(self, self.param_names, ndim=1, outdim=1, param_dim=param_dim)
+        models.ParametricModel.__init__(self, self.param_names, number_input_variables=1, number_output_variables=1, param_dim=param_dim)
         self.domain = [-1, 1]
         self.window = [-1, 1]
         self._order = 2

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -31,6 +31,15 @@ n-dimensional Numpy array::
 
 This object has a few attributes in common with Numpy:
 
+    >>> ndd.number_input_variables
+    3
+    >>> ndd.shape
+    (12, 12, 12)
+    >>> ndd.dtype
+    dtype('float64')
+
+The underlying Numpy array can be accessed via the
+
     >>> ndd.ndim
     3
     >>> ndd.shape

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -19,6 +19,21 @@ or by passing it an `~astropy.nddata.nddata.NDData` object:
 
 This object has a few attributes in common with Numpy:
 
+    >>> ndd.number_input_variables
+    3
+    >>> ndd.shape
+    (12, 12, 12)
+    >>> ndd.dtype
+    dtype('float64')
+
+The underlying Numpy array can be accessed via the
+
+    >>> ndd1 = NDData(array)
+    >>> ndd2 = NDData(ndd1)
+
+
+This object has a few attributes in common with Numpy:
+
     >>> ndd.ndim
     3
     >>> ndd.shape


### PR DESCRIPTION
The variable names `ndim` and `outdim` are very misleading in the `Models` class. 
They do not describe the dimensionality of input and output, but describe the number of variables in and out of a model. I have for now renamed them to `number_input_variables` and `number_output_variables` (but am happy for other suggestions). 

To illustrate my point:

``` python
In [31]: mylittlepoly = models.builtin_models.Poly1DModel(5)

In [32]: myinputdata = np.random.random((100, 100, 100))

#myinputdata.ndim == 3

In [33]: mylittlepoly(myinputdata)

...
```

**Do not merge** as only a small part of the code has been refactored. 
