### PR TITLE
Simplify units for multiplication and division of Quantities

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -948,6 +948,27 @@ class NamedUnit(UnitBase):
         return self._format.get(format, self.name)
 
     @property
+    def scale(self):
+        """
+        Return the scale of the unit.
+        """
+        return 1.0
+
+    @property
+    def bases(self):
+        """
+        Return the bases of the unit.
+        """
+        return [self]
+
+    @property
+    def powers(self):
+        """
+        Return the powers of the unit.
+        """
+        return [1.0]
+
+    @property
     def names(self):
         """
         Returns all of the names associated with this unit.
@@ -1032,27 +1053,6 @@ class IrreducibleUnit(NamedUnit):
         return (_recreate_irreducible_unit,
                 (list(self.names), self.name in namespace),
                 self.__dict__)
-
-    @property
-    def scale(self):
-        """
-        Return the scale of the unit.
-        """
-        return 1.0
-
-    @property
-    def bases(self):
-        """
-        Return the bases of the unit.
-        """
-        return [self]
-
-    @property
-    def powers(self):
-        """
-        Return the powers of the unit.
-        """
-        return [1.0]
 
     def decompose(self, bases=set()):
         if len(bases) and not self in bases:

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -240,7 +240,7 @@ class CDS(Base):
                 out.append(self._get_unit_name(base))
             else:
                 out.append('{0}{1}'.format(
-                    self._get_unit_name(base), power))
+                    self._get_unit_name(base), int(power)))
         return '.'.join(out)
 
     def to_string(self, unit):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -99,13 +99,13 @@ class TestQuantityOperations(object):
     def test_multiplication(self):
         # Take units from left object, q1
         new_quantity = self.q1 * self.q2
-        assert new_quantity.value == 91.36
-        assert new_quantity.unit == (u.meter * u.centimeter)
+        assert new_quantity.value == 0.9136
+        assert new_quantity.unit == (u.meter * u.meter)
 
         # Take units from left object, q2
         new_quantity = self.q2 * self.q1
-        assert new_quantity.value == 91.36
-        assert new_quantity.unit == (u.centimeter * u.meter)
+        assert new_quantity.value == 9136
+        assert new_quantity.unit == (u.centimeter * u.centimeter)
 
         # Multiply with a number
         new_quantity = 15. * self.q1
@@ -121,14 +121,14 @@ class TestQuantityOperations(object):
         # Take units from left object, q1
         new_quantity = self.q1 / self.q2
         np.testing.assert_array_almost_equal(
-            new_quantity.value, 1.4275, decimal=5)
-        assert new_quantity.unit == (u.meter / u.centimeter)
+            new_quantity.value, 142.75, decimal=5)
+        assert new_quantity.unit == u.dimensionless_unscaled
 
         # Take units from left object, q2
         new_quantity = self.q2 / self.q1
         np.testing.assert_array_almost_equal(
-            new_quantity.value, 0.70052539404553416, decimal=16)
-        assert new_quantity.unit == (u.centimeter / u.meter)
+            new_quantity.value, 0.0070052539404553416, decimal=16)
+        assert new_quantity.unit == u.dimensionless_unscaled
 
         q1 = u.Quantity(11.4, unit=u.meter)
         q2 = u.Quantity(10.0, unit=u.second)
@@ -237,6 +237,13 @@ class TestQuantityOperations(object):
         area = side1 * side2
         np.testing.assert_array_almost_equal(area.value, 77., decimal=15)
         assert area.unit == u.cm * u.cm
+
+        # Area
+        side1 = u.Quantity(11., u.meter)
+        side2 = u.Quantity(7., u.centimeter)
+        area = side1 * side2
+        np.testing.assert_array_almost_equal(area.value, 0.77, decimal=15)
+        assert area.unit == u.m * u.m
 
     def test_comparison(self):
         # equality/ non-equality is straightforward for quantity objects


### PR DESCRIPTION
This may have already been discussed and a determination made (so I will not be offended if this just gets closed as "already ruled on"), but I found this behavior surprising as I was reading through and making a units/quantities tutorial today.

This is the current behavior:

```
>>> (5.0 * u.m) * (2.0 * u.cm)
<Quantity 10.0 m cm>
```

Personally I find that surprising -- I would have expected the equivalent units to simplify.  "m cm" is an odd unit.  Are there other examples of units that are made up of a multiplication of equivalent units that are in common usage?  

The new behavior in this PR is:

```
>>> (5.0 * u.m) * (2.0 * u.cm)
<Quantity 0.1 m2>
```

that is, it takes the unit from the left hand side (and there is precedence for this already in the addition and subtraction operators on Quantity).

Division is also updated with the converse operation and will always return a dimensionless unit when the units are equivalent.

Any thoughts?  Good reasons for status quo?
