### PR TITLE
Add momentum and angular momentum physical types

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -82,6 +82,8 @@ for unit, name in [
     (si.J, 'energy'),
     (si.Pa, 'pressure'),
     (si.W, 'power'),
+    (si.kg * si.m / si.s, 'momentum'),
+    (si.kg * si.m ** 2 / si.s, 'angular momentum'),
     (si.g / (si.m * si.s), 'dynamic viscosity'),
     (si.m ** 2 / si.s, 'kinematic viscosity'),
     (si.m ** -1, 'wavenumber'),

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 
 from ... import units as u
+from ...constants import hbar
 
 
 def test_simple():
@@ -29,3 +30,7 @@ def test_unknown():
 
 def test_dimensionless():
     assert (u.m / u.m).physical_type == 'dimensionless'
+
+
+def test_angular_momentum():
+    assert hbar.unit.physical_type == 'angular momentum'


### PR DESCRIPTION
I'm not sure, but it seemed like an omission to me--for example the physical type of hbar was 'unknown', previously. Now it will show up as 'angular momentum'.
