### PR TITLE
Raise exception if creating a unit with the same name as an existing unit

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -74,6 +74,8 @@ class _UnitRegistry(object):
         if not unit._names:
             raise UnitsException("unit has no string representation")
 
+        # Loop through all of the names first, to ensure all of them
+        # are new, then add them all as a single "transaction" below.
         for st in unit._names:
             if not re.match("^[A-Za-z_]+$", st):
                 # will cause problems for simple string parser in
@@ -81,11 +83,15 @@ class _UnitRegistry(object):
                 raise ValueError(
                     "Invalid unit name {0!r}".format(st))
 
+            if ((add_to_namespace and st in cls._namespace) or
+                st in cls._registry and unit != cls._registry[st]):
+                raise ValueError(
+                    "Object with name {0!r} already exists in namespace.  To "
+                    "redefine a unit, call its deregister() method "
+                    "first".format(st))
+
+        for st in unit._names:
             if add_to_namespace:
-                if st in cls._namespace:
-                    raise ValueError(
-                        "Object with name {0!r} already exists "
-                        "in namespace".format(st))
                 cls._namespace[st] = unit
 
             cls._registry[st] = unit

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -160,15 +160,20 @@ def test_wcs_parse():
 
 def test_flatten_to_known():
     myunit = u.def_unit("FOOBAR", u.erg / u.Hz)
-    assert myunit.to_string('fits') == 'erg Hz-1'
-    myunit2 = myunit * u.bit ** 3
-    assert myunit2.to_string('fits') == 'bit3 erg Hz-1'
-
+    try:
+        assert myunit.to_string('fits') == 'erg Hz-1'
+        myunit2 = myunit * u.bit ** 3
+        assert myunit2.to_string('fits') == 'bit3 erg Hz-1'
+    finally:
+        myunit.deregister()
 
 @raises(ValueError)
 def test_flatten_impossible():
     myunit = u.def_unit("FOOBAR")
-    myunit.to_string('fits')
+    try:
+        myunit.to_string('fits')
+    finally:
+        myunit.deregister()
 
 
 def test_console_out():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -80,7 +80,7 @@ def test_parallax():
     assert_allclose(a, 0.10)
     b = u.pc.to(u.arcsecond, a, u.parallax())
     assert_allclose(b, 10)
-    
+
     a = u.arcminute.to(u.au, 1, u.parallax())
     assert_allclose(a, 3437.7467916)
     b = u.au.to(u.arcminute, a, u.parallax())
@@ -90,7 +90,7 @@ def test_parallax():
 def test_parallax2():
     a = u.arcsecond.to(u.pc, [0.1, 2.5], u.parallax())
     assert_allclose(a, [10, 0.4])
-    
+
 
 def test_spectral():
     a = u.AA.to(u.Hz, 1, u.spectral())
@@ -486,9 +486,14 @@ def test_pickling():
 
     assert other is u.m
 
-    new_unit = u.IrreducibleUnit(['foo'], register=False, format={'baz': 'bar'})
+    new_unit = u.IrreducibleUnit(['foo'], register=True, format={'baz': 'bar'})
+    new_unit.deregister()
     p = cPickle.dumps(new_unit)
     new_unit_copy = cPickle.loads(p)
-    assert new_unit is not new_unit_copy
     assert new_unit_copy.names == ['foo']
     assert new_unit_copy.get_format_name('baz') == 'bar'
+
+
+@raises(ValueError)
+def test_duplicate_define():
+    u.def_unit('m')


### PR DESCRIPTION
Found this whopper of a bug while giving a demo of `astropy.units` today.

If the user does:

```
def_unit('m')
```

that should definitely raise an exception.  Otherwise, really strange things happen when `meter` gets redefined.
