### PR TITLE
Fix the iterator mode in ProgressBar to call update before returning.

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -337,12 +337,13 @@ class ProgressBar(object):
 
     def next(self):
         try:
-            return next(self._items)
+            rv =  next(self._items)
         except StopIteration:
             self.__exit__(None, None, None)
             raise
         else:
             self.update()
+            return rv
 
     def update(self, value=None):
         """


### PR DESCRIPTION
The ProgressBar class doesn't properly operate as an iterator. In the current implementation, `return` is called in the `try/except` block, and so `self.update` is never called. This is odd behavior to me, as I would expect that in python, things in the `else` part of a `try/except` statement should be called anyways, but I guess not! See http://stackoverflow.com/questions/7442133/try-else-with-return-in-try-block and http://docs.python.org/2/reference/compound_stmts.html#the-try-statement
