### PR TITLE
Fix compatibility with Numpy 1.4.1

### DIFF
--- a/astropy/nddata/convolution/tests/test_make_kernel.py
+++ b/astropy/nddata/convolution/tests/test_make_kernel.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from numpy.testing import assert_allclose
 
+from ....tests.compat import assert_allclose
 from ....tests.helper import pytest
 
 from ..make_kernel import make_kernel


### PR DESCRIPTION
@iguananaut - this should be merged and included in 0.2.2 as otherwise tests are failing with Numpy 1.4.1 (which 0.2 should support)

My Mac Jenkins is having issues again - the builds are not getting published because of some obscure error with the plugin. [facedesk]
