### PR TITLE
Fix pytest imports

### DIFF
--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -10,7 +10,7 @@ import urllib,urllib2
 
 # Third party
 import numpy as np
-import pytest
+from ...tests.helper import pytest
 
 # Astropy
 from ..name_resolve import get_icrs_coordinates, NameResolveError, \

--- a/astropy/tests/tests/test_open_file_detection.py
+++ b/astropy/tests/tests/test_open_file_detection.py
@@ -1,7 +1,6 @@
 import sys
 
-import pytest
-
+from ...tests.helper import pytest
 from ...utils.data import get_pkg_data_filename
 
 fd = None

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -4,7 +4,7 @@ from ...tests.helper import remote_data, raises
 import os
 import io
 
-import pytest
+from ...tests.helper import pytest
 from ..data import _get_download_cache_locs
 
 TESTURL = 'http://www.google.com/index.html'


### PR DESCRIPTION
This fixes a few `pytest` imports - what I'm confused about is why this doesn't raise any errors otherwise in Travis if we aren't installing `pytest` separately?
