### PR TITLE
Catch timeout socket errors in download_file

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -814,6 +814,11 @@ def download_file(remote_url, cache=False, show_progress=True):
     -------
     local_path : str
         Returns the local path that the file was download to.
+
+    Raises
+    ------
+    `urllib2.URLError`
+        Whenever there's a problem getting the remote file.
     """
 
     import hashlib


### PR DESCRIPTION
This addresses a problem mentioned in #1094, but that has been irregularly appearing on Travis for a while.

Basically, for some reason, once in a while (for no cause I can see), `urllib2.urlopen`, as called in `astropy.utils.data.download_file`, throws a `socket.timeout` exception. It's supposed to instead yield a `urllib2.URLError` which _wraps_ the `socket.timeout`, but sometimes this doesn't happen (again, I have no idea why).  So this just catches the `socket.timeout` and replaces it with the appropriate `urllib2.URLError`, and hence preventing the test referenced in #1094 from failing in that way.  
