### PR TITLE
Add more useful information to testing header

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -5,6 +5,8 @@ into conftest.py in the root directory.
 """
 
 import io
+import locale
+import math
 import os
 import sys
 
@@ -127,6 +129,19 @@ def pytest_report_header(config):
     s += "Platform: {0}\n\n".format(platform())
     s += "Executable: {0}\n\n".format(sys.executable)
     s += "Full Python Version: \n{0}\n\n".format(sys.version)
+
+    s += "encodings: sys: {0}, locale: {1}, filesystem: {2}".format(
+        sys.getdefaultencoding(),
+        locale.getpreferredencoding(),
+        sys.getfilesystemencoding())
+    if sys.version_info < (3, 3, 0):
+        s += ", unicode bits: {0}".format(
+            int(math.log(sys.maxunicode, 2)))
+    s += '\n'
+
+    s += "byteorder: {0}\n".format(sys.byteorder)
+    s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
+        sys.float_info)
 
     import numpy
     s += "Numpy: {0}\n".format(numpy.__version__)


### PR DESCRIPTION
All of these are things that have stumbled us up before, so it's helpful to know about.

```
Platform: Linux-3.8.11-200.fc18.x86_64-x86_64-with-fedora-18-Spherical_Cow

Executable: /home/mdboom/python/bin/python

Full Python Version: 
2.7.3 (default, Aug  9 2012, 17:23:57) 
[GCC 4.7.1 20120720 (Red Hat 4.7.1-5)]

encodings: sys: ascii, locale: ISO-8859-1, filesystem: ISO-8859-1, unicode bits: 20
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.7.1
Scipy: not available
Matplotlib: 1.2.1
h5py: not available
```
