### PR TITLE
astropy.io.votable: no write_to method

### DIFF
--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -5,12 +5,13 @@ Observatory (VO) initiative, particularly the VOTable XML format.
 """
 
 from .table import (
-    parse, parse_single_table, validate, from_table, is_votable)
+    parse, parse_single_table, validate, from_table, is_votable, writeto)
 from .exceptions import (
     VOWarning, VOTableChangeWarning, VOTableSpecWarning, UnimplementedWarning,
     IOWarning, VOTableSpecError)
 
 __all__ = [
     'parse', 'parse_single_table', 'validate', 'from_table',
-    'is_votable', 'VOWarning', 'VOTableChangeWarning', 'VOTableSpecWarning',
-    'UnimplementedWarning', 'IOWarning', 'VOTableSpecError']
+    'is_votable', 'writeto', 'VOWarning', 'VOTableChangeWarning',
+    'VOTableSpecWarning', 'UnimplementedWarning', 'IOWarning',
+    'VOTableSpecError']


### PR DESCRIPTION
According to the documentation at
http://docs.astropy.org/en/latest/io/votable/index.html#converting-to-from-an-astropy-table-table
there should be a method to transform astropy tables into VO table, called `write_to`. However, this methods seems not to exist.
I am not sure if that is a problem with the documentation or with the implementation.

```
In [7]: import astropy.io.votable

In [8]: astropy.io.votable.
astropy.io.votable.connect
astropy.io.votable.converters
astropy.io.votable.exceptions
astropy.io.votable.from_table
astropy.io.votable.IOWarning
astropy.io.votable.is_votable
astropy.io.votable.parse
astropy.io.votable.parse_single_table
astropy.io.votable.table
astropy.io.votable.tablewriter
astropy.io.votable.tree
astropy.io.votable.ucd
astropy.io.votable.UnimplementedWarning
astropy.io.votable.util
astropy.io.votable.validate
astropy.io.votable.VOTableChangeWarning
astropy.io.votable.VOTableSpecError
astropy.io.votable.VOTableSpecWarning
astropy.io.votable.VOWarning
astropy.io.votable.xmlutil
```
