### PR TITLE
Fix vo.validator tests on Windows

### DIFF
--- a/astropy/vo/validator/tests/test_validate.py
+++ b/astropy/vo/validator/tests/test_validate.py
@@ -25,7 +25,6 @@ Running from ``astropy/vo/validator/tests`` directory::
 
 """
 # STDLIB
-import filecmp
 import json
 import os
 import shutil
@@ -117,7 +116,10 @@ class TestConeSearchResults(object):
         out_file = os.path.join(self.out_dir, oname)
         with open(out_file, 'w') as fout:
             func(fout=fout, *args, **kwargs)
-        assert filecmp.cmp(dat_file, out_file, shallow=False)
+
+        with open(dat_file) as f1:
+            with open(out_file) as f2:
+                assert f1.read() == f2.read()
 
     def test_tally(self):
         self.gen_cmp(self.r.tally, 'tally.out')


### PR DESCRIPTION
Don't use filecmp to compare these files--it gives different results on Windows due to default newlines being different.  Instead just compare the content.

I don't _think_ there's any reason `filecmp` must be used here as opposed to just comparing the contents, but @pllim might know better.
