### PR TITLE
Fix minor issue with build_sphinx on Windows

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -834,8 +834,8 @@ if HAVE_SPHINX:
             subproccode = textwrap.dedent("""
             from sphinx.setup_command import *
 
-            os.chdir('{srcdir}')
-            sys.path.insert(0,'{build_cmd_path}')
+            os.chdir({srcdir!r})
+            sys.path.insert(0, {build_cmd_path!r})
 
             """).format(build_cmd_path=build_cmd_path, srcdir=self.source_dir)
             #runlines[1:] removes 'def run(self)' on the first line


### PR DESCRIPTION
In general when generating Python source code like this one should use the `repr` format of a string rather than try to manually enclose it in quotes--this way any escaping is handled properly.
