### PR TITLE
Make it easier to subclass Table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -983,7 +983,7 @@ class Table(object):
             data = [col.filled(fill_value) for col in self.columns.values()]
         else:
             data = self
-        return Table(data, meta=deepcopy(self.meta))
+        return self.__class__(data, meta=deepcopy(self.meta))
 
     def __array__(self, dtype=None):
         """Support converting Table to np.array via np.array(table).
@@ -1332,7 +1332,7 @@ class Table(object):
                 return self._new_from_slice(item)
             elif (all(x in self.colnames for x in item)):
                 # Item is a tuple of strings that are valid column names
-                return Table([self[x] for x in item], meta=deepcopy(self.meta))
+                return self.__class__([self[x] for x in item], meta=deepcopy(self.meta))
             else:
                 raise ValueError('Illegal item for table item access')
 

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -159,6 +159,7 @@ class TestTableItems(BaseTestItems):
         assert np.all(self.t['a'] == np.array([1, 0, 3]))
         assert t2.masked == self.t.masked
         assert t2._column_class == self.t._column_class
+        assert isinstance(t2, table_data.Table)
 
     def test_fancy_index_slice(self, table_data):
         """Table fancy slice returns COPY of data"""
@@ -172,10 +173,12 @@ class TestTableItems(BaseTestItems):
         assert t2['b'].attrs_equal(table_data.COLS[1])
         assert t2['c'].attrs_equal(table_data.COLS[2])
         t2['a'][0] = 0
+
         assert np.all(self.t._data == table_data.DATA)
         assert np.any(t2['a'] != table_data.DATA['a'][slice])
         assert t2.masked == self.t.masked
         assert t2._column_class == self.t._column_class
+        assert isinstance(t2, table_data.Table)
 
     def test_list_index_slice(self, table_data):
         """Table list index slice returns COPY of data"""
@@ -189,11 +192,12 @@ class TestTableItems(BaseTestItems):
         assert t2['b'].attrs_equal(table_data.COLS[1])
         assert t2['c'].attrs_equal(table_data.COLS[2])
         t2['a'][0] = 0
+
         assert np.all(self.t._data == table_data.DATA)
         assert np.any(t2['a'] != table_data.DATA['a'][slice])
         assert t2.masked == self.t.masked
         assert t2._column_class == self.t._column_class
-
+        assert isinstance(t2, table_data.Table)
 
     def test_select_columns(self, table_data):
         """Select columns returns COPY of data and all column
@@ -212,7 +216,6 @@ class TestTableItems(BaseTestItems):
         assert t2.masked == self.t.masked
         assert t2._column_class == self.t._column_class
 
-
     def test_np_where(self, table_data):
         """Select rows using output of np.where"""
         t = table_data.Table(table_data.COLS)
@@ -221,11 +224,13 @@ class TestTableItems(BaseTestItems):
         t2 = t[rows]
         assert np.all(t2['a'] == [2, 3])
         assert np.all(t2['b'] == [5, 6])
+        assert isinstance(t2, table_data.Table)
 
         # Select no rows
         rows = np.where(t['a'] > 100)
         t2 = t[rows]
         assert len(t2) == 0
+        assert isinstance(t2, table_data.Table)
 
     def test_select_bad_column(self, table_data):
         """Select column name that does not exist"""

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -10,6 +10,12 @@ from ...table import Column, MaskedColumn, Table
 
 numpy_lt_1p5 = version.LooseVersion(np.__version__) < version.LooseVersion('1.5')
 
+class SubclassTable(Table):
+    pass
+
+@pytest.fixture(params = [True, False])
+def tableclass(request):
+    return Table if request.param else SubclassTable
 
 class SetupData(object):
     def setup_method(self, method):
@@ -63,8 +69,8 @@ class TestFilled(object):
         assert np.all(f == ['1', '8', '9'])
         assert isinstance(f, Column)
 
-    def test_filled_masked_table(self):
-        t = Table([self.a, self.b, self.c], meta=self.meta)
+    def test_filled_masked_table(self, tableclass):
+        t = tableclass([self.a, self.b, self.c], meta=self.meta)
 
         f = t.filled()
         assert isinstance(f, Table)
@@ -80,8 +86,8 @@ class TestFilled(object):
         f['a'][2] = 100
         assert t['a'][2] == 3
 
-    def test_filled_unmasked_table(self):
-        t = Table([(1, 2), ('3', '4')], names=('a', 'b'), meta=self.meta)
+    def test_filled_unmasked_table(self, tableclass):
+        t = tableclass([(1, 2), ('3', '4')], names=('a', 'b'), meta=self.meta)
         f = t.filled()
         assert isinstance(f, Table)
         assert f.masked is False


### PR DESCRIPTION
Before this patch, every subclass of Table needed to implemented its own
`_new_from_slice`.
