### PR TITLE
Fix bug in Quantity._decompose()

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -581,10 +581,16 @@ class Quantity(object):
             A new object equal to this quantity with units decomposed.
 
         """
-        newu = self.unit.decompose(bases=bases)
-        newval = self.value
-        if not allowscaledunits and hasattr(newu, 'scale'):
-            newval *= newu.scale
-            newu = newu / Unit(newu.scale)
 
-        return Quantity(newval, newu)
+        new_unit = self.unit.decompose(bases=bases)
+
+        if not allowscaledunits and hasattr(new_unit, 'scale'):
+            # Be careful here because self.value might be an array, so if the
+            # following is changed, always be sure that the original value is
+            # not being modified.
+            new_value = self.value * new_unit.scale
+            new_unit = new_unit / Unit(new_unit.scale)
+        else:
+            new_value = self.value
+
+        return Quantity(new_value, new_unit)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -378,6 +378,21 @@ def test_decompose():
     assert q1.decompose() == (5 * u.kg * u.m * u.s ** -2)
 
 
+def test_decompose_regression():
+    """
+    Regression test for bug #1163
+
+    If decompose was called multiple times on a Quantity with an array and a
+    scale != 1, the result changed every time. This is because the value was
+    being referenced not copied, then modified, which changed the original
+    value.
+    """
+    q = np.array([1, 2, 3]) * u.m / (2. * u.km)
+    assert np.all(q.decompose().value == np.array([0.0005, 0.001, 0.0015]))
+    assert np.all(q == np.array([1, 2, 3]) * u.m / (2. * u.km))
+    assert np.all(q.decompose().value == np.array([0.0005, 0.001, 0.0015]))
+
+
 def test_arrays():
     """
     Test using quantites with array values


### PR DESCRIPTION
This fixes the following bug in `Quantity._decompose`:

```
 In [17]: q2 = np.array([1,2,3]) * u.m / (2. * u.km)

In [18]: q2.decompose()
Out[18]: <Quantity [ 0.0005  0.001   0.0015] >

In [19]: q2.decompose()
Out[19]: <Quantity [  5.00000000e-07   1.00000000e-06   1.50000000e-06] >

In [20]: q2.decompose()
Out[20]: <Quantity [  5.00000000e-10   1.00000000e-09   1.50000000e-09] >
```

The original quantity is being modified every time `decompose` is called, because the code was incorrectly assuming the value was being copied, but it was being references for arrays.

@mdboom - can you review this?
