### PR TITLE
Add travis PEP8 checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_install:
     # We do this to make sure we get dependencies so pip works below
     # Note that travis does *not* use python packages installed via apt - it does all the building in an isolated virtualenv
     - sudo apt-get update -qq
-    - if [[ $SETUP_CMD != egg_info ]]; then sudo apt-get install -qq python-numpy cython libatlas-dev liblapack-dev gfortran; fi
+    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install -qq python-numpy cython libatlas-dev liblapack-dev gfortran; fi
     - if $OPTIONAL_DEPS; then sudo apt-get install -qq python-scipy libhdf5-serial-1.8.4 libhdf5-serial-dev; fi
     - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install -qq python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib; fi
 
@@ -70,8 +70,8 @@ before_install:
 install:
     # these command run pip first trying a wheel, and then falling back on source build
     # see .travis.pip.wheel for details on how to map from package to wheel URL
-    - if [[ $SETUP_CMD != egg_info ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION numpy $NUMPY_VERSION -q; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION Cython 0.18 -q; fi
+    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION numpy $NUMPY_VERSION -q; fi
+    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION Cython 0.18 -q; fi
     - if $OPTIONAL_DEPS; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION scipy 0.12.0; fi
       # not doing -q in scipy because if we have to fall back on the source build it takes too long and travis times out without continuous output
     - if $OPTIONAL_DEPS; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION h5py 2.1.3 -q; fi
@@ -81,7 +81,7 @@ install:
     - if [[ $SETUP_CMD == build_sphinx* ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION matplotlib 1.2.1 -q; fi
       # this matplotlib will *not* work with py 3.x, but our sphinx build is currently 2.7, so that's fine
 
-    - if [[ $SETUP_CMD == pep8* ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION pep8  -q; fi
+    - if [[ $SETUP_CMD == pep8* ]]; then bash .travis.pip.wheel $TRAVIS_PYTHON_VERSION pep8 -q; fi
 
 script:
     - if [[ $SETUP_CMD == pep8* ]]; then $SETUP_CMD; else python setup.py $SETUP_CMD; fi


### PR DESCRIPTION
This follows #1133 by adding a build to travis (takes < 1 min) that checks for PEP8 errors (except for line > 80 chars).

Note that this is _not_ passing and shouldn't be merge - as discussed in #1133, we are not yet PEP8-compliant.  This could be modified to only check those packages that are compatible, or we can count on Jenkins to check this for now, and wait to merge this until we've got everything PEP8-ified.
