### PR TITLE
Units legal under CDS cat standard (e.g. mJy, kbyte, Mpc etc.) not allowed by cds format impl.

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -44,25 +44,28 @@ class CDS(Base):
             'A', 'C', 'cd', 'eV', 'F', 'g', 'H', 'Hz', 'J', 'K',
             'lm', 'lx', 'm', 'mol', 'N', 'Ohm', 'Pa', 'rad', 's', 'S',
             'sr', 'T', 'V', 'W', 'Wb']
+        astro_bases = [
+            'a', 'AU', 'arcmin', 'arcsec', 'barn', 'bit',
+            'byte', 'Jy', 'mag', 'pc', 'yr']
 
         prefixes = [
             'y', 'z', 'a', 'f', 'p', 'n', 'u', 'm', 'c', 'd',
             '', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
 
-        for base in bases:
+        for base in bases + astro_bases:
             for prefix in prefixes:
                 key = prefix + base
                 if keyword.iskeyword(key):
                     continue
                 names[key] = getattr(u, key)
 
-        simple_bases = [
-            'a', 'AU', 'arcmin', 'arcsec', 'barn', 'bit',
-            'byte', 'ct', 'D', 'd', 'deg', 'h', 'Jy', 'mag', 'mas',
-            'min', 'pc', 'pix', 'Ry', 'solLum', 'solMass', 'solRad',
-            'Sun', 'yr']
+        unprefixable = [ 
+            'mas',                        # as specified by the CDS standard
+            'ct', 'D', 'd', 'deg', 'h',   # as limited by the units module
+            'min', 'pix', 'Ry', 'solLum', 'solMass', 'solRad', 'Sun'
+            ]
 
-        for base in simple_bases:
+        for base in unprefixable:
             names[base] = getattr(u, base)
 
         return names

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -54,7 +54,19 @@ def test_cds_grammar():
         (["m2"], u.m ** 2),
         (["10+21m"], u.Unit(u.m * 1e21)),
         (["2.54cm"], u.Unit(u.cm * 2.54)),
-        (["20%"], 0.20)]
+        (["20%"], 0.20),
+        (["ma"], u.ma),
+        (["mAU"], u.mAU),
+        (["uarcmin"], u.uarcmin),
+        (["uarcsec"], u.uarcsec),
+        (["kbarn"], u.kbarn),
+        (["Gbit"], u.Gbit),
+        (["kbyte"], u.kbyte),
+        (["mJy"], u.mJy),
+        (["mmag"], u.mmag),
+        (["Mpc"], u.Mpc),
+        (["Gyr"], u.Gyr),
+        ]
 
     for strings, unit in data:
         for s in strings:


### PR DESCRIPTION
The units.format.cds module is a unit string parser that implements the CDS catalog standard for units documented at http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx.  It is the standard used for expressing units in a VOTable.  This implementation explicitly disallows the combination of metric prefixes with non-SI base units, making a number of commonly used units, such as mJy, kbyte, and Mpc, unsupported.  When a VOTable is parsed which invoke these units, an warning is issued, and the unit is instantiated as an `UnrecognizedUnit`

The text on above mentioned standard does _not_ actually disallow these units, and they are certainly used within CDS/Vizier tables (according to CDS's Francois Ochenbein).  (The text actually makes explicit recommendation of one such unit not supported by the cds module, uarcsec).  These units, of course, are supported generally by the units module's core implementation.  

I'm attaching a pull request for a fix to the cds module.  The cds implementation segregates units that can have metric prefixes from those that can't.  In my fix, I moved those units previously in the latter category for which the units module supports prefixes generally into the former category.  I augmented the units.tests to check these explicitly.  

It's worth noting that as the standard is written, there is really only one unit in the CDS base unit list that cannot be combined with a prefix, and that is "mas" (milli-arcsecs).  A strict implementation would follow suit, but my fix does not because of the limits set in the units core module.  This is probably reasonable in some cases--I don't think people use, say, "MSun", "MsolLum", or "kmin"; however, people do talk about kilodays and kilocounts, there shouldn't be anything wrong with a kiloDebye, and LSST is building a Gigapixel camera.  These are all undefined in the core units module.  
