### PR TITLE
Comparisons of Time and TimeDelta

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -675,39 +675,27 @@ class Time(object):
         """
         if other.__class__ is not self.__class__:
             raise OperandTypeError(self, other)
-        self_tai_time, other_tai_time = self.tai._time, other.tai._time
-        return (self_tai_time.jd1 - other_tai_time.jd1 +
-                self_tai_time.jd2 - other_tai_time.jd2)
-
-    def _shaped_like_input_if_possible(self, val):
-        if len(val) == len(self):
-            return self._shaped_like_input(val)
-        else:
-            return val
+        self_tai = self.tai
+        other_tai = other.tai
+        return (self_tai.jd1 - other_tai.jd1) + (self_tai.jd2 - other_tai.jd2)
 
     def __lt__(self, other):
-        diff = self._tai_difference(other)
-        return self._shaped_like_input_if_possible(diff < 0.)
+        return self._tai_difference(other) < 0.
 
     def __le__(self, other):
-        diff = self._tai_difference(other)
-        return self._shaped_like_input_if_possible(diff <= 0.)
+        return self._tai_difference(other) <= 0.
 
     def __eq__(self, other):
-        diff = self._tai_difference(other)
-        return self._shaped_like_input_if_possible(diff == 0.)
+        return self._tai_difference(other) == 0.
 
     def __ne__(self, other):
-        diff = self._tai_difference(other)
-        return self._shaped_like_input_if_possible(diff != 0.)
+        return self._tai_difference(other) != 0.
 
     def __gt__(self, other):
-        diff = self._tai_difference(other)
-        return self._shaped_like_input_if_possible(diff > 0.)
+        return self._tai_difference(other) > 0.
 
     def __ge__(self, other):
-        diff = self._tai_difference(other)
-        return self._shaped_like_input_if_possible(diff >= 0.)
+        return self._tai_difference(other) >= 0.
 
 
 class TimeDelta(Time):

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -16,9 +16,21 @@ class TestTimeComparisons():
         t1_lt_t2 = self.t1 < self.t2
         assert np.all(t1_lt_t2 == np.array([False, False, False, False, False,
                                             False,True, True, True, True]))
+        t1_ge_t2 = self.t1 >= self.t2
+        assert np.all(t1_ge_t2 != t1_lt_t2)
+
+        t1_le_t2 = self.t1 <= self.t2
+        assert np.all(t1_le_t2 == np.array([False, False, False, False, False,
+                                            True,True, True, True, True]))
+        t1_gt_t2 = self.t1 > self.t2
+        assert np.all(t1_gt_t2 != t1_le_t2)
+
         t1_eq_t2 = self.t1 == self.t2
         assert np.all(t1_eq_t2 == np.array([False, False, False, False, False,
                                             True, False, False, False, False]))
+        t1_ne_t2 = self.t1 != self.t2
+        assert np.all(t1_ne_t2 != t1_eq_t2)
+
         t1_0_gt_t2_0 = self.t1[0] > self.t2[0]
         assert t1_0_gt_t2_0 is True
         t1_0_gt_t2 = self.t1[0] > self.t2


### PR DESCRIPTION
Procrastinating on things I should really be doing, I implemented comparisons of `Time` and `TimeDelta` objects, with comparisons only possible if the two are the same type (when it seemed without ambiguity). Setting up with:

```
from astropy.time import Time, TimeDelta
import numpy as np
t1 = Time(np.arange(49995,50005), format='mjd', scale='utc')
t2 = Time(np.arange(49000,51000,200), format='mjd', scale='utc')
```

One gets:

```
In [5]: t1 < t2
Out[5]: array([False, False, False, False, False, False,  True,  True,  True,  True], dtype=bool)

In [6]: t1 == t2
Out[6]: array([False, False, False, False, False,  True, False, False, False, False], dtype=bool)

In [7]: t1[0] > t2[0]
Out[7]: True

In [8]: t1[0] > t2
Out[8]: array([ True,  True,  True,  True,  True, False, False, False, False, False], dtype=bool)

In [9]: t1 > t2[0]
Out[9]: array([ True,  True,  True,  True,  True,  True,  True,  True,  True,  True], dtype=bool)

In [10]: dt = t2-t1
In [11]: t1 > dt
ERROR: OperandTypeError [astropy.time.core]
... (full message omitted) ...

In [12]: dt > TimeDelta(0., format='sec')
Out[12]: array([False, False, False, False, False, False,  True,  True,  True,  True], dtype=bool)
```
