### PR TITLE
Skip a Test in ipython, which fail due to some ipython magic

### DIFF
--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -12,9 +12,16 @@ from ..util import ignore_sigint
 
 from . import FitsTestCase
 
+def _in_ipython():
+    try:
+        temp = __IPYTHON__ 
+        return True
+    except: 
+        return False
 
 class TestUtils(FitsTestCase):
     @pytest.mark.skipif("sys.platform.startswith('win')")
+    @pytest.mark.skipif("_in_ipython()")
     def test_ignore_sigint(self):
         @ignore_sigint
         def test():


### PR DESCRIPTION
One of the tests passes perfectly in python, but fails in ipython for
no apparent reason. I am pretty sue that some of the ipython magic is
responsible for this (although I have to admit that I could not track down
where exectly ipython interferes with this test).
However, it's slightly annyoing and confuses my every time when I try
to debug some change doe a PR interactively in ipython.
This PR suggests to skip this test in ipython.
