### PR TITLE
Error: A 0.7-series setuptools cannot be installed with distribute

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -14,11 +14,14 @@ the appropriate options to ``use_setuptools()``.
 This file can also be run as a script to install or upgrade setuptools.
 """
 import os
+import shutil
 import sys
 import time
 import fnmatch
 import tempfile
 import tarfile
+import optparse
+
 from distutils import log
 
 try:
@@ -46,7 +49,7 @@ except ImportError:
             args = [quote(arg) for arg in args]
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
-DEFAULT_VERSION = "0.6.28"
+DEFAULT_VERSION = "0.6.45"
 DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
@@ -84,8 +87,11 @@ def _install(tarball, install_args=()):
         if not _python_cmd('setup.py', 'install', *install_args):
             log.warn('Something went wrong during the installation.')
             log.warn('See the error message above.')
+            # exitcode will be 2
+            return 2
     finally:
         os.chdir(old_wd)
+        shutil.rmtree(tmpdir)
 
 
 def _build_egg(egg, tarball, to_dir):
@@ -110,6 +116,7 @@ def _build_egg(egg, tarball, to_dir):
 
     finally:
         os.chdir(old_wd)
+        shutil.rmtree(tmpdir)
     # returning the result
     log.warn(egg)
     if not os.path.exists(egg):
@@ -137,6 +144,16 @@ def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     try:
         try:
             import pkg_resources
+
+            # Setuptools 0.7b and later is a suitable (and preferable)
+            # substitute for any Distribute version.
+            try:
+                pkg_resources.require("setuptools>=0.7b")
+                return
+            except (pkg_resources.DistributionNotFound,
+                    pkg_resources.VersionConflict):
+                pass
+
             if not hasattr(pkg_resources, '_distribute'):
                 if not no_fake:
                     _fake_setuptools()
@@ -232,7 +249,9 @@ def _no_sandbox(function):
 
 def _patch_file(path, content):
     """Will backup the file then patch it"""
-    existing_content = open(path).read()
+    f = open(path)
+    existing_content = f.read()
+    f.close()
     if existing_content == content:
         # already patched
         log.warn('Already patched.')
@@ -250,12 +269,15 @@ _patch_file = _no_sandbox(_patch_file)
 
 
 def _same_content(path, content):
-    return open(path).read() == content
+    f = open(path)
+    existing_content = f.read()
+    f.close()
+    return existing_content == content
 
 
 def _rename_path(path):
     new_name = path + '.OLD.%s' % time.time()
-    log.warn('Renaming %s into %s', path, new_name)
+    log.warn('Renaming %s to %s', path, new_name)
     os.rename(path, new_name)
     return new_name
 
@@ -273,7 +295,7 @@ def _remove_flat_installation(placeholder):
         log.warn('Could not locate setuptools*.egg-info')
         return
 
-    log.warn('Removing elements out of the way...')
+    log.warn('Moving elements out of the way...')
     pkg_info = os.path.join(placeholder, file)
     if os.path.isdir(pkg_info):
         patched = _patch_egg_dir(pkg_info)
@@ -314,11 +336,12 @@ def _create_fake_setuptools_pkg_info(placeholder):
         log.warn('%s already exists', pkg_info)
         return
 
-    if not os.access(pkg_info, os.W_OK):
-        log.warn("Don't have permissions to write %s, skipping", pkg_info)
-
     log.warn('Creating %s', pkg_info)
-    f = open(pkg_info, 'w')
+    try:
+        f = open(pkg_info, 'w')
+    except EnvironmentError:
+        log.warn("Don't have permissions to write %s, skipping", pkg_info)
+        return
     try:
         f.write(SETUPTOOLS_PKG_INFO)
     finally:
@@ -432,7 +455,7 @@ def _fake_setuptools():
         res = _patch_egg_dir(setuptools_location)
         if not res:
             return
-    log.warn('Patched done.')
+    log.warn('Patching complete.')
     _relaunch()
 
 
@@ -440,8 +463,9 @@ def _relaunch():
     log.warn('Relaunching...')
     # we have to relaunch the process
     # pip marker to avoid a relaunch bug
-    _cmd = ['-c', 'install', '--single-version-externally-managed']
-    if sys.argv[:3] == _cmd:
+    _cmd1 = ['-c', 'install', '--single-version-externally-managed']
+    _cmd2 = ['-c', 'install', '--record']
+    if sys.argv[:3] == _cmd1 or sys.argv[:3] == _cmd2:
         sys.argv[0] = 'setup.py'
     args = [sys.executable] + sys.argv
     sys.exit(subprocess.call(args))
@@ -494,22 +518,39 @@ def _extractall(self, path=".", members=None):
                 self._dbg(1, "tarfile: %s" % e)
 
 
-def _build_install_args(argv):
+def _build_install_args(options):
+    """
+    Build the arguments to 'python setup.py install' on the distribute package
+    """
     install_args = []
-    user_install = '--user' in argv
-    if user_install and sys.version_info < (2, 6):
-        log.warn("--user requires Python 2.6 or later")
-        raise SystemExit(1)
-    if user_install:
+    if options.user_install:
+        if sys.version_info < (2, 6):
+            log.warn("--user requires Python 2.6 or later")
+            raise SystemExit(1)
         install_args.append('--user')
     return install_args
 
+def _parse_args():
+    """
+    Parse the command line for options
+    """
+    parser = optparse.OptionParser()
+    parser.add_option(
+        '--user', dest='user_install', action='store_true', default=False,
+        help='install in user site package (requires Python 2.6 or later)')
+    parser.add_option(
+        '--download-base', dest='download_base', metavar="URL",
+        default=DEFAULT_URL,
+        help='alternative URL from where to download the distribute package')
+    options, args = parser.parse_args()
+    # positional arguments are ignored
+    return options
 
-def main(argv, version=DEFAULT_VERSION):
+def main(version=DEFAULT_VERSION):
     """Install or upgrade setuptools and EasyInstall"""
-    tarball = download_setuptools()
-    _install(tarball, _build_install_args(argv))
-
+    options = _parse_args()
+    tarball = download_setuptools(download_base=options.download_base)
+    return _install(tarball, _build_install_args(options))
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    sys.exit(main())


### PR DESCRIPTION
When trying to install Astropy from the latest master (b32293e58319be23528787b62d1cf7cd0e5fd46f) on my system, I get:

```
Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    exec(open(init_path).read(), d)
  File "<string>", line 8, in <module>
  File "build/src/setuptools/__init__.py", line 2, in <module>
    from setuptools.extension import Extension, Library
  File "build/src/setuptools/extension.py", line 5, in <module>
    from setuptools.dist import _get_unpatched
  File "build/src/setuptools/dist.py", line 6, in <module>
    from setuptools.command.install import install
  File "build/src/setuptools/command/__init__.py", line 8, in <module>
    from setuptools.command import install_scripts
  File "build/src/setuptools/command/install_scripts.py", line 3, in <module>
    from pkg_resources import Distribution, PathMetadata, ensure_directory
  File "build/src/pkg_resources.py", line 2836, in <module>
    add_activation_listener(lambda dist: dist.activate())
  File "build/src/pkg_resources.py", line 704, in subscribe
    callback(dist)
  File "build/src/pkg_resources.py", line 2836, in <lambda>
    add_activation_listener(lambda dist: dist.activate())
  File "build/src/pkg_resources.py", line 2260, in activate
    self.insert_on(path)
  File "build/src/pkg_resources.py", line 2361, in insert_on
    "with distribute. Found one at %s" % str(self.location))
ValueError: A 0.7-series setuptools cannot be installed with distribute. Found one at /opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages
/Volumes/Raptor/Dropbox/Code/development/astropy/astropy/distribute-0.6.28-py3.2.egg
```

Likely a consequence of the setuptools and distribute merger...
