### PR TITLE
Fix evaluating a SCompositeModel with labeled input

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -43,6 +43,7 @@ from __future__ import division
 import abc
 from itertools import izip
 import numpy as np
+from ..utils import misc
 from . import parameters
 from . import constraints
 from .utils import InputParameterError
@@ -725,14 +726,16 @@ class SCompositeModel(_CompositeModel):
                                                  "input is a labeled object")
                 assert self._outmap is not None, ("Parameter 'outmap' must be "
                                                   "provided when input is a labeled object")
-                for i in range(len(self._transforms)):
-                    inlist = [labeled_input[label] for label in self._inmap[i]]
-                    result = [self._transforms[i](*inlist)]
-                    output = self._outmap[i]
-                    for label, res in zip(output, result):
-                        labeled_input.update({label: res})
-                        if label not in self._inmap[i]:
-                            setattr(labeled_input, label, res)
+                for transform, incoo, outcoo in izip(self._transforms, self._inmap, self._outmap):
+                    inlist = [labeled_input[label] for label in incoo]
+                    result = transform(*inlist)
+                    if len(outcoo) == 1:
+                        result = [result]
+                    for label, res in zip(outcoo, result):
+
+                        if label not in labeled_input.labels:
+                            labeled_input[label] = res
+                        setattr(labeled_input, label, res)
                 return labeled_input
         else:
             assert self.n_inputs == len(data), "This transform expects "

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -9,7 +9,7 @@ from . import parameters
 from .core import ParametricModel, Model, _convert_input, _convert_output
 from .utils import InputParameterError
 
-__all__ = ['Gaussian1DModel', 'Gaussian2DModel',  'ScaleModel', 'ShiftModel', 'PowerLawModel']
+__all__ = ['Gaussian1DModel', 'Gaussian2DModel', 'ScaleModel', 'ShiftModel', 'PowerLawModel']
 
 
 class Gaussian1DModel(ParametricModel):

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -35,7 +35,7 @@ class TestSComposite(object):
         xx = self.p11(self.p1(self.x))
         utils.assert_almost_equal(xx, sresult)
 
-    def test_labeledinput(self):
+    def test_labeledinput_1(self):
         ado = LabeledInput([self.x, self.y], ['x', 'y'])
         scomptr = SCompositeModel([self.p2, self.p1],
                                   [['x', 'y'], ['z']],
@@ -44,6 +44,36 @@ class TestSComposite(object):
         z = self.p2(self.x, self.y)
         z1 = self.p1(z)
         utils.assert_almost_equal(z1, sresult.z)
+
+    def test_labeledinput_2(self):
+        labeled_input = LabeledInput([self.x, self.y], ['x', 'y'])
+        rot = models.MatrixRotation2D(angle=23.4)
+        offx = models.ShiftModel(-2)
+        offy = models.ShiftModel(1.2)
+        scomptr = SCompositeModel([rot, offx, offy],
+                                  [['x', 'y'], ['x'], ['y']],
+                                  [['x', 'y'], ['x'], ['y']])
+        sresult = scomptr(labeled_input)
+        x, y = rot(self.x, self.y)
+        x = offx(x)
+        y = offy(y)
+        utils.assert_almost_equal(x, sresult.x)
+        utils.assert_almost_equal(y, sresult.y)
+
+    def test_labeledinput_3(self):
+        labeled_input = LabeledInput([2, 4.5], ['x', 'y'])
+        rot = models.MatrixRotation2D(angle=23.4)
+        offx = models.ShiftModel(-2)
+        offy = models.ShiftModel(1.2)
+        scomptr = SCompositeModel([rot, offx, offy],
+                                  [['x', 'y'], ['x'], ['y']],
+                                  [['x', 'y'], ['x'], ['y']])
+        sresult = scomptr(labeled_input)
+        x, y = rot(2, 4.5)
+        x = offx(x)
+        y = offy(y)
+        utils.assert_almost_equal(x, sresult.x)
+        utils.assert_almost_equal(y, sresult.y)
 
     def test_multiple_arrays(self):
         scomptr = SCompositeModel([self.p2, self.p1],


### PR DESCRIPTION
This fixes a problem with updating the labeled input object when evaluating an SCompositeModel.
