### PR TITLE
Should I be able to initialize a masked table by passing in a mask?

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -881,13 +881,6 @@ class Table(object):
         Copy the input data (default=True).
 
     """
-    '''
-    There should be a way to initialize a table object with a mask.
-    This functionality is currently not provided and will be implented in
-    the future. This will be the API.
-    mask : numpy ndarray, dict, list, optional
-        The mask to initialize the table
-    '''
 
     def __init__(self, data=None, masked=None, names=None, dtypes=None,
                  meta=None, copy=True):

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -130,7 +130,6 @@ The actual mask for the table as a whole or a single column can be
 viewed and modified via the ``mask`` attribute::
 
   >>> t = Table([(1, 2), (3, 4)], names=('a', 'b'), masked=True)
-  >>> t.mask['a'] = [False, True]  # Modify table mask (structured array)
   >>> t['b'].mask = [True, False]  # Modify column mask (boolean array)
   >>> print(t)
    a   b 


### PR DESCRIPTION
In the initial implementation it was forseen that users could initialize a table object with a mask to create a masked table from e.g. a list of lists of values and a list of lists of boolean values as a mask.

This feature made it into the docstring, but not into the code.

```
mask : numpy ndarray, dict, list, optional
   The mask to initialize the table
```

https://github.com/astropy/astropy/blob/master/astropy/table/table.py#L885

In #1187 (when changing other parts of the docstring) this was discovered and moved from the docstring into a comment in the code.

This issue is here to remind us that either am implementation of this should be added or we should have a conscious decision not not offer this functionality.
