### PR TITLE
Fix for issue #696

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -133,7 +133,12 @@ html_theme_path = [path.abspath(path.join(path.dirname(__file__), 'themes'))]
 html_theme = 'bootstrap-astropy'
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**': ['localtoc.html']}
+html_sidebars = {
+    '**': ['localtoc.html'],
+    'search': [],
+    'genindex': [],
+    'py-modindex': [],
+}
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
Added an empty list value to the search, genindex and py-modindex keys in the html_sidebars dictionary in astropy/sphinx/conf.py to exclude the side bar from these pages (fix for issue #696)
