### PR TITLE
Reading a VOTable with astropy does not get the table structure correct

### DIFF
--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -893,3 +893,50 @@ def test_nonstandard_units():
 
     assert not isinstance(
         votable.get_first_table().fields[0].unit, u.UnrecognizedUnit)
+
+
+def test_resource_structure():
+    # Based on issue #1223, as reported by @astro-friedel and @RayPlante
+    from astropy.io.votable import tree as vot
+
+    vtf = vot.VOTableFile()
+
+    r1 = vot.Resource()
+    vtf.resources.append(r1)
+    t1 = vot.Table(vtf)
+    t1.name = "t1"
+    t2 = vot.Table(vtf)
+    t2.name = 't2'
+    r1.tables.append(t1)
+    r1.tables.append(t2)
+
+    r2 = vot.Resource()
+    vtf.resources.append(r2)
+    t3 = vot.Table(vtf)
+    t3.name = "t3"
+    t4 = vot.Table(vtf)
+    t4.name = "t4"
+    r2.tables.append(t3)
+    r2.tables.append(t4)
+
+    r3 = vot.Resource()
+    vtf.resources.append(r3)
+    t5 = vot.Table(vtf)
+    t5.name = "t5"
+    t6 = vot.Table(vtf)
+    t6.name = "t6"
+    r3.tables.append(t5)
+    r3.tables.append(t6)
+
+    buff = io.BytesIO()
+    vtf.to_xml(buff)
+
+    buff.seek(0)
+    vtf2 = parse(buff)
+
+    assert len(vtf2.resources) == 3
+
+    for r in xrange(len(vtf2.resources)):
+        res = vtf2.resources[r]
+        assert len(res.tables) == 2
+        assert len(res.resources) == 0

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3032,6 +3032,8 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
                 if self.description is not None:
                     warn_or_raise(W17, W17, 'RESOURCE', config, pos)
                 self.description = data or None
+            elif tag == 'RESOURCE':
+                break
 
         del self._votable
 


### PR DESCRIPTION
I am using astropy.io.votable.tree.VOTableFile to create and write a VOTable for a python application. When I create the table it has the structure:

```
<VOTABLE>
  <RESOURCE>
    <TABLE>
    ....
    </TABLE>
    <TABLE>
    ....
    </TABLE>
  </RESOURCE>
  <RESOURCE>
    <TABLE>
    ....
    </TABLE>
    <TABLE>
    ....
    </TABLE>
  </RESOURCE>
  <RESOURCE>
    <TABLE>
    ....
    </TABLE>
    <TABLE>
    ....
    </TABLE>
  </RESOURCE>
</VOTABLE>
```

When I write it out to xml (with to_xml) I see this structure. However when I read in the table with astropy.io.votable.parse the structure I get is:

```
<VOTABLE>
  <RESOURCE>
    <TABLE>
    ....
    </TABLE>
    <TABLE>
    ....
    </TABLE>
    <RESOURCE>
      <TABLE>
      ....
      </TABLE>
      <TABLE>
      ....
      </TABLE>
      <RESOURCE>
        <TABLE>
        ....
        </TABLE>
        <TABLE>
        ....
        </TABLE>
      </RESOURCE>
    </RESOURCE>
  </RESOURCE>
</VOTABLE>
```

I verify this structure by writing out what I read in. This is obviously not what I intended. Is this a bug in astropy?
