### PR TITLE
added comments where we should allow natural fractions.

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -264,6 +264,9 @@ class UnitBase(object):
             p = Fraction(p[0], p[1])
         else:
             # allow two possible floating point fractions, all others illegal
+            # wkerzendorf that's not quite right. we want to allow natural fractions
+            # so here's a method http://stackoverflow.com/questions/95727/how-to-convert-floats-to-human-readable-fractions
+
             if not int(2 * p) == 2 * p:
                 raise ValueError(
                     "floating values for unit powers must be integers or "


### PR DESCRIPTION
I'm integrating units tightly into my code and stumbled upon a limitation:

``` python
In [1]: from astropy import units as u, constants

In [2]: constants.L_sun / (4 * np.pi * constants.R
constants.R        constants.R_earth  constants.R_jup    constants.R_sun    constants.Ryd      

In [2]: constants.L_sun / (4 * np.pi * constants.R_sun**2 * constants.sigma_sb)
Out[2]: <Quantity 1.11579273247e+15 K4>

In [3]: (constants.L_sun / (4 * np.pi * constants.R_sun**2 * constants.sigma_sb))**.25
ERROR: ValueError: floating values for unit powers must be integers or integers + 0.5 [astropy.units.core]
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-0da59a4116fc> in <module>()
----> 1 (constants.L_sun / (4 * np.pi * constants.R_sun**2 * constants.sigma_sb))**.25

/Users/wkerzend/scripts/python/astropy/build/lib.macosx-10.8-intel-2.7/astropy/units/quantity.pyc in __pow__(self, p)
    357                 'Cannot raise a Quantity object to a power of something '
    358                 'with a unit')
--> 359         return Quantity(self.value ** p, unit=self.unit ** p)
    360 
    361     def __neg__(self):

/Users/wkerzend/scripts/python/astropy/build/lib.macosx-10.8-intel-2.7/astropy/units/core.pyc in __pow__(self, p)
    267             if not int(2 * p) == 2 * p:
    268                 raise ValueError(
--> 269                     "floating values for unit powers must be integers or "
    270                     "integers + 0.5")
    271         return CompositeUnit(1, [self], [p])._simplify()

ValueError: floating values for unit powers must be integers or integers + 0.5
```

The current fix is obviously 

``` python
((constants.L_sun / (4 * np.pi * constants.R_sun**2 * constants.sigma_sb))**.5)**.5
```

But I think we should convert the number to a natural fraction (e.g. 2/5) and in the end just allow integer units being left over. I haven't implemented as I wanted to gauge the general enthusiasm first (and maybe there's a reason why this is the way it is).

@mdboom you're the unit lord - suggestions?
