### PR TITLE
In Quantity initialization, short-circuit one test for iterables for speed-up

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -105,7 +105,7 @@ class Quantity(object):
 
         if isinstance(value, Quantity):
             self._value = _validate_value(value.to(self._unit).value)
-        elif isiterable(value) and all([isinstance(v, Quantity) for v in value]):
+        elif isiterable(value) and all(isinstance(v, Quantity) for v in value):
             self._value = _validate_value([q.to(self._unit).value for q in value])
         else:
             self._value = _validate_value(value)


### PR DESCRIPTION
@mdboom, @astrofrog: While checking out #929, I noticed that some array arithmetic was very slow:

```
In [3]: a = np.arange(1000000.)*u.deg

In [4]: %timeit a/60.123
1 loops, best of 3: 504 ms per loop

In [5]: %timeit a.value/60.123
100 loops, best of 3: 8.43 ms per loop
```

Looking through the initialisation code, the culprit is the following test:

```
        elif isiterable(value) and all([isinstance(v, Quantity) for v in value]):
```

This first makes a list and then checks every element for being a Quantity. This obviously takes a long time if the array is big. One can get a major speed-up by removing the square brackets, so that the `all()` properly short-circuits:

```
In [6]: %timeit a/60.123
10 loops, best of 3: 22.7 ms per loop
```

This is probably the best I ever did for removing all of two characters!

p.s. Initially, I wrote an alternative using try/except. Would that not be more pythonesque?
