### PR TITLE
Fix reporting of h5py version in the test runner

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -317,8 +317,8 @@ def pytest_report_header(config):
         s += "Matplotlib: not available\n"
 
     try:
-        import h5py
-        s += "h5py: {0}\n".format(h5py.__version__)
+        import h5py.version
+        s += "h5py: {0}\n".format(h5py.version.version)
     except:
         s += "h5py: not available\n"
 


### PR DESCRIPTION
Some older versions of h5py do not have an `h5py.__version__` attribute.  This is of course a bug on its part, but since we skip it if `h5py.__version__` raises an exception we report it as not available, even though the h5py tests still run.

This uses `h5py.version.version` instead.  I checked the latest version of h5py and even it just defines:

```
__version__ = version.version
```

so this should be fine.
