### PR TITLE
table.join: support for int datatype as key 

### DIFF
--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -159,8 +159,8 @@ def join(left, right, keys=None, join_type='inner',
     right : structured array
         Right side table in the join
     keys : str or list of str
-        Column(s) used to match rows of left and right tables.  Default
-        is to use all columns which are common to both tables.
+        Name(s) of column(s) used to match rows of left and right tables.
+        Default is to use all columns which are common to both tables.
     join_type : str
         Join type ('inner' | 'outer' | 'left' | 'right'), default is 'inner'
     uniq_col_name : str or None

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -87,8 +87,8 @@ def join(left, right, keys=None, join_type='inner',
     right : Table object or a value that will initialize a Table object
         Right side table in the join
     keys : str or list of str
-        Column(s) used to match rows of left and right tables.  Default
-        is to use all columns which are common to both tables.
+        Name(s) of column(s) used to match rows of left and right tables.
+        Default is to use all columns which are common to both tables.
     join_type : str
         Join type ('inner' | 'outer' | 'left' | 'right'), default is 'inner'
     uniq_col_name : str or None


### PR DESCRIPTION
table.join currently supports only strings as the join key. It would be useful if more datatypes where supported. 

int would be my highest priority and int is a widely used datatype for primary keys.

int should include int64
