### PR TITLE
Rounding errors in Time and TimeDelta and internal representation of times

### DIFF
--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -27,5 +27,6 @@ def get_extensions():
 
     return [time_ext]
 
+
 def get_external_libraries():
     return ['sofa']

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -7,12 +7,12 @@ import numpy as np
 from ...tests.helper import pytest
 from .. import Time, ScaleValueError, sofa_time
 
-allclose_jd = functools.partial(np.allclose, rtol=2.**-52, atol=0)
-allclose_jd2 = functools.partial(np.allclose, rtol=2.**-52,
-                                 atol=2.**-52)  # 20 ps atol
-allclose_sec = functools.partial(np.allclose, rtol=2.**-52,
-                                 atol=2.**-52*24*3600)  # 20 ps atol
-allclose_year = functools.partial(np.allclose, rtol=2.**-52,
+allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
+allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52)  # 20 ps atol
+allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+allclose_year = functools.partial(np.allclose, rtol=2. ** -52,
                                   atol=0.)  # 14 microsec at current epoch
 
 
@@ -330,7 +330,7 @@ class TestSubFormat():
         times = ['2000-01-01 01:01',
                  '2000-01-01 01:01:01', '2000-01-01 01:01:01.123']
         t = Time(times, format='iso', scale='tai',
-                     in_subfmt='date_*')
+                 in_subfmt='date_*')
         assert np.all(t.iso == np.array(['2000-01-01 01:01:00.000',
                                          '2000-01-01 01:01:01.000',
                                          '2000-01-01 01:01:01.123']))
@@ -339,13 +339,13 @@ class TestSubFormat():
         """Failed format matching"""
         with pytest.raises(ValueError):
             Time('2000-01-01 01:01', format='iso', scale='tai',
-                     in_subfmt='date')
+                 in_subfmt='date')
 
     def test_bad_input_subformat(self):
         """Non-existent input subformat"""
         with pytest.raises(ValueError):
             Time('2000-01-01 01:01', format='iso', scale='tai',
-                     in_subfmt='doesnt exist')
+                 in_subfmt='doesnt exist')
 
     def test_output_subformat(self):
         """Input subformat selection"""
@@ -353,7 +353,7 @@ class TestSubFormat():
         times = ['2000-01-01', '2000-01-01 01:01',
                  '2000-01-01 01:01:01', '2000-01-01 01:01:01.123']
         t = Time(times, format='iso', scale='tai',
-                     out_subfmt='date_hm')
+                 out_subfmt='date_hm')
         assert np.all(t.iso == np.array(['2000-01-01 00:00',
                                          '2000-01-01 01:01',
                                          '2000-01-01 01:01',
@@ -437,8 +437,8 @@ class TestSofaErrors():
 
     def test_bad_time(self):
         iy = np.array([2000], dtype=np.intc)
-        im = np.array([2000], dtype=np.intc) # bad month
-        id = np.array([2000], dtype=np.intc) # bad day
+        im = np.array([2000], dtype=np.intc)  # bad month
+        id = np.array([2000], dtype=np.intc)  # bad day
         djm0 = np.array([0], dtype=np.double)
         djm = np.array([0], dtype=np.double)
         with pytest.raises(ValueError):  # bad month, fatal error
@@ -531,8 +531,9 @@ def test_now():
     # py < 2.7 and py3 < 3.2 doesn't have `total_seconds`
     if ((version_info[0] == 2 and version_info[1] < 7) or
         (version_info[0] == 3 and version_info[1] < 2) or
-        version_info[0] < 2):
-        total_secs = lambda td: (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6.
+            version_info[0] < 2):
+        total_secs = lambda td: (td.microseconds + (
+            td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6.
     else:
         total_secs = lambda td: td.total_seconds()
     assert total_secs(dt) < 0.1

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -9,19 +9,19 @@ class TestTimeComparisons():
     """Test Comparisons of Time and TimeDelta classes"""
 
     def setup(self):
-        self.t1 = Time(np.arange(49995,50005), format='mjd', scale='utc')
-        self.t2 = Time(np.arange(49000,51000,200), format='mjd', scale='utc')
+        self.t1 = Time(np.arange(49995, 50005), format='mjd', scale='utc')
+        self.t2 = Time(np.arange(49000, 51000, 200), format='mjd', scale='utc')
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2
         assert np.all(t1_lt_t2 == np.array([False, False, False, False, False,
-                                            False,True, True, True, True]))
+                                            False, True, True, True, True]))
         t1_ge_t2 = self.t1 >= self.t2
         assert np.all(t1_ge_t2 != t1_lt_t2)
 
         t1_le_t2 = self.t1 <= self.t2
         assert np.all(t1_le_t2 == np.array([False, False, False, False, False,
-                                            True,True, True, True, True]))
+                                            True, True, True, True, True]))
         t1_gt_t2 = self.t1 > self.t2
         assert np.all(t1_gt_t2 != t1_le_t2)
 

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -6,11 +6,12 @@ import numpy as np
 from ...tests.helper import pytest
 from .. import Time, TimeDelta, OperandTypeError
 
-allclose_jd = functools.partial(np.allclose, rtol=2.**-52, atol=0)
-allclose_jd2 = functools.partial(np.allclose, rtol=2.**-52,
-                                 atol=2.**-52)  # 20 ps atol
-allclose_sec = functools.partial(np.allclose, rtol=2.**-52,
-                                 atol=2.**-52*24*3600)  # 20 ps atol
+allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
+allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52)  # 20 ps atol
+allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+
 
 class TestTimeDelta():
     """Test TimeDelta class"""
@@ -19,7 +20,7 @@ class TestTimeDelta():
         self.t = Time('2010-01-01', scale='utc')
         self.t2 = Time('2010-01-02 00:00:01', scale='utc')
         self.dt = TimeDelta(100.0, format='sec')
-        self.dt_array = TimeDelta(np.arange(100,1000,100), format='sec')
+        self.dt_array = TimeDelta(np.arange(100, 1000, 100), format='sec')
 
     def test_sub(self):
         # time - time
@@ -133,31 +134,17 @@ class TestTimeDelta():
 
     def test_mul_div(self):
         for dt in (self.dt, self.dt_array):
-            dt2 = dt+dt+dt
-            dt3 = 3.*dt
+            dt2 = dt + dt + dt
+            dt3 = 3. * dt
             assert allclose_jd(dt2.jd, dt3.jd)
             dt4 = dt3 / 3.
             assert allclose_jd(dt4.jd, dt.jd)
-        dt5 = self.dt*np.arange(3)
+        dt5 = self.dt * np.arange(3)
         assert dt5[0].jd == 0.
-        assert dt5[-1].jd == (self.dt+self.dt).jd
+        assert dt5[-1].jd == (self.dt + self.dt).jd
         with pytest.raises(OperandTypeError):
             self.dt * self.dt
         with pytest.raises(OperandTypeError):
             self.dt * self.t
         with pytest.raises(TypeError):
             2. / self.dt
-
-    def test_precision(self):
-        t = Time(2455555., 0.5, format='jd', scale='utc')
-        dt_tiny = TimeDelta(2.**-52, format='jd')
-        t_dt = t+dt_tiny
-        assert t_dt.jd1 == t.jd1 and t_dt.jd2 != t.jd2
-        t2 = t_dt - dt_tiny
-        assert t2.jd1 == t.jd1 and t2.jd2 == t.jd2
-        dt_small = 6*dt_tiny
-        # pick a number that will leave remainder if divided by 6.
-        dt_big = TimeDelta(20000., format='jd')
-        dt_big_small_by_6 = (dt_big+dt_small)/6.
-        dt_frac = dt_big_small_by_6 - TimeDelta(3333., format='jd')
-        assert allclose_jd2(dt_frac.jd2, 0.33333333333333354)

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -1,0 +1,101 @@
+import functools
+
+import numpy as np
+
+from ...tests.helper import pytest
+from .. import Time, TimeDelta
+
+allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
+allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52)  # 20 ps atol
+allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+
+
+dt_tiny = TimeDelta(2. ** -52, format='jd')
+
+
+def test_addition():
+    """Check that an addition at the limit of precision (2^-52) is seen"""
+    t = Time(2455555., 0.5, format='jd', scale='utc')
+
+    t_dt = t + dt_tiny
+    assert t_dt.jd1 == t.jd1 and t_dt.jd2 != t.jd2
+
+    # Check that the addition is exactly reversed by the corresponding subtraction
+    t2 = t_dt - dt_tiny
+    assert t2.jd1 == t.jd1 and t2.jd2 == t.jd2
+
+
+def test_mult_div():
+    """Test precision with multiply and divide"""
+    dt_small = 6 * dt_tiny
+    # pick a number that will leave remainder if divided by 6.
+    dt_big = TimeDelta(20000., format='jd')
+    dt_big_small_by_6 = (dt_big + dt_small) / 6.
+    dt_frac = dt_big_small_by_6 - TimeDelta(3333., format='jd')
+    assert allclose_jd2(dt_frac.jd2, 0.33333333333333354)
+
+
+def test_init_variations():
+    """Check that 3 ways of specifying a time + small offset are equivalent"""
+    dt_tiny_sec = dt_tiny.jd2 * 86400.
+    t1 = Time(1e11, format='cxcsec') + dt_tiny
+    t2 = Time(1e11, dt_tiny_sec, format='cxcsec')
+    t3 = Time(dt_tiny_sec, 1e11, format='cxcsec')
+    assert t1.jd1 == t2.jd1
+    assert t1.jd2 == t3.jd2
+    assert t1.jd1 == t2.jd1
+    assert t1.jd2 == t3.jd2
+
+
+def test_precision_exceeds_64bit():
+    """
+    Check that Time object really holds more precision than float64 by looking at the
+    (naively) summed 64-bit result and asserting equality at the bit level.
+    """
+    t1 = Time(1.23456789e11, format='cxcsec')
+    t2 = t1 + dt_tiny
+    assert t1.jd == t2.jd
+
+
+def test_through_scale_change():
+    """Check that precision holds through scale change (cxcsec is TT)"""
+    t0 = Time(1.0, format='cxcsec')
+    t1 = Time(1.23456789e11, format='cxcsec')
+    dt_tt = t1 - t0
+    dt_tai = t1.tai - t0.tai
+    assert allclose_jd(dt_tt.jd1, dt_tai.jd1)
+    assert allclose_jd2(dt_tt.jd2, dt_tai.jd2)
+
+
+def test_iso_init():
+    """Check when initializing from ISO date"""
+    t1 = Time('2000:001:00:00:00.00000001', scale='tai')
+    t2 = Time('3000:001:13:00:00.00000002', scale='tai')
+    dt = t2 - t1
+    assert allclose_jd2(dt.jd2, 13. / 24. + 1e-8 / 86400. - 1.0)
+
+
+def test_jd1_is_mult_of_half_or_one():
+    """
+    Check that jd1 is a multiple of 0.5 (note the difference from when Time is created
+    with a format like 'jd' or 'cxcsec', where jd1 is a multiple of 1.0).
+    """
+    t1 = Time('2000:001:00:00:00.00000001', scale='tai')
+    assert np.round(t1.jd1 * 2) == t1.jd1 * 2
+    t1 = Time(1.23456789, 12345678.90123456, format='jd', scale='tai')
+    assert np.round(t1.jd1) == t1.jd1
+
+
+@pytest.mark.xfail
+def test_precision_neg():
+    """
+    Check precision when jd1 is negative.  Currently fails because ERFA routines use a
+    test like jd1 > jd2 to decide which component to update.  Should be
+    abs(jd1) > abs(jd2).
+    """
+    t1 = Time(-100000.123456, format='jd', scale='tt')
+    assert np.round(t1.jd1) == t1.jd1
+    t1_tai = t1.tai
+    assert np.round(t1_tai.jd1) == t1_tai.jd1

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -16,6 +16,14 @@ It uses Cython to wrap the C language `SOFA`_ time and calendar
 routines.  All time scale conversions are done by Cython vectorized versions
 of the `SOFA`_ routines and are fast and memory efficient.
 
+All time manipulations and arithmetic operations are done internally using two
+64-bit floats to represent time.  Floating point algorithms from [#]_ are used so
+that the |Time| object maintains sub-nanosecond precision over times spanning
+the age of the universe.
+
+.. [#] `Shewchuk, 1997, Discrete & Computational Geometry 18(3):305-363
+        <http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf>`_
+
 Getting Started
 ===============
 


### PR DESCRIPTION
This is partly a placeholder, to be sure we address that currently the arithmetic in `Time` suffers from rounding errors, since there is no carrying between the two parts of the JD. This follows on discussions on astropy-dev [1] and as part of #1082 (also see #366). Copying the specific example of a problem that might easily catch someone by surprise:

```
Time('2012-01-01', scale='utc')+TimeDelta(1.e-6/24./3600., format='jd')
```

Here, one looses the microsecond (but adding `TimeDelta(0., 1.e-6/24/3600, format='jd')` does not).

A complication is that the `sofa_time` internals do not properly carry between the two either, but rather just add to the smaller of the two if what is added is small, or have constructions like `t = ((date1 - DJ00) + date2) / DJC`, which are safe only when `date1-DJ00` can be represented exactly.

Two possible solutions are
1) Use a double-double technique [2,3] to mimic `float128` with two `float64`'s (cannot do `np.float128` directly since it is not supported on all platforms; this was tried for #1082 and #366)
2) Always split the JD by (half-)integer and fractional parts.

The advantage of (1) is better precision (1e-19 s for current time, so good to ns even at the big bang), but care would have to be taken in `sofa` calls. Disadvantage is that double-double only works if the intermediate results are  strictly stored as `float64` (_not_ the default for 64-bit intel/amd); currently, easy to do, but might break with if, e.g., the python interpreter starts to try to "optimize" math (pypy?).
Advantage of (2) is that `sofa_time` is OK (numbers subtracted are always (half-)integer, so one has no rounding errors), the format is easy to understand (and is in fact what one gets already when entering ISO dates+times), and the span and precision seem "good enough" ( (2**52 day = 1e13 yr; 1day/2**52 ~ 10 ps).

So far, the discussion has been leaning towards (2); an implementation may soon be added here, but in the meantime, it would be good to collect test cases.

[1] https://groups.google.com/forum/#!topic/astropy-dev/JVifTBx8w50
[2] http://en.wikipedia.org/wiki/Quadruple_precision#Double-double_arithmetic
[3] http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
