### PR TITLE
LaTeX unicode support required for building docs

### DIFF
--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -5,12 +5,12 @@ Writing Documentation
 =====================
 
 High-quality, consistent documentation for astronomy code is one of
-the major goals of the Astropy project.  Hence, we describe our 
+the major goals of the Astropy project.  Hence, we describe our
 documentation procedures and rules here.  For the astropy core
 project we try to keep to these as closely as possible, while the
-standards for affiliated packages are somewhat looser.  
+standards for affiliated packages are somewhat looser.
 (These procedures and guidelines are still recommended for affilated
-packages, as they encourage useful documentation, a characteristic 
+packages, as they encourage useful documentation, a characteristic
 often lacking in professional astronomy software.)
 
 
@@ -118,17 +118,17 @@ edit_on_github Extension
 numpydoc Extension
 ^^^^^^^^^^^^^^^^^^
 This extension (and some related extensions) are a port of the
-`numpydoc <http://pypi.python.org/pypi/numpydoc/0.3.1>`_ extension 
-written by the NumPy_ and SciPy_, projects, with some tweaks for 
+`numpydoc <http://pypi.python.org/pypi/numpydoc/0.3.1>`_ extension
+written by the NumPy_ and SciPy_, projects, with some tweaks for
 Astropy.  Its main purposes is to reprocess docstrings from code into
 a form sphinx understands. Generally, there's no need to interact with
-it directly, as docstrings following the doc:`docrules` will be 
+it directly, as docstrings following the doc:`docrules` will be
 processed automatically.
 
 
 Other Extensions
 ^^^^^^^^^^^^^^^^
-`astropy.spinx.ext` includes a few other extensions that are primarily 
+`astropy.spinx.ext` includes a few other extensions that are primarily
 helpers for the other extensions or workarounds for undesired behavior.
 Their APIs are not included here because we may change them in the
 future.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -82,7 +82,7 @@ The tests should run and print out any failures, which you can report at
 the `Astropy issue tracker <http://github.com/astropy/astropy/issues>`_.
 
 .. note::
-    
+
     This way of running the tests may not work if you do it in the
     astropy source distribution.  See :ref:`sourcebuildtest` for how to
     run the tests from the source code directory, or :ref:`running-tests`
@@ -265,6 +265,20 @@ packages:
     - `Sphinx <http://sphinx.pocoo.org>`_ (and its dependencies) 1.0 or later
 
     - `Graphviz <http://www.graphviz.org>`_
+
+.. note::
+
+    Sphinx also requires a reasonably modern LaTeX installation to render
+    equations.  Per the `Sphinx documentation
+    <http://sphinx-doc.org/builders.html?highlight=latex#sphinx.builders.latex.LaTeXBuilder>`_,
+    For the TexLive distribution the following packages are required to be
+    installed:
+
+    * latex-recommended
+    * latex-extra
+    * font-recommended
+
+    For other LaTeX distributions your mileage may vary.
 
 There are two ways to build the Astropy documentation. The most straightforward
 way is to execute the command (from the astropy source directory)::


### PR DESCRIPTION
As of the merging of the units package, now when I build the docs, even the HTML docs, I was slightly surprised to see a slew of errors like:

```
WARNING: display latex u'H_z = H_0 /\nE': latex exited with error:
[stderr]

[stdout]
This is pdfeTeX, Version 3.141592-1.21a-2.2 (Web2C 7.5.4)
entering extended mode
(./math.tex
LaTeX2e <2003/12/01>
Babel <v3.8d> and hyphenation patterns for american, french, german, ngerman, b
ahasa, basque, bulgarian, catalan, croatian, czech, danish, dutch, esperanto, e
stonian, finnish, greek, icelandic, irish, italian, latin, magyar, norsk, polis
h, portuges, romanian, russian, serbian, slovak, slovene, spanish, swedish, tur
kish, ukrainian, nohyphenation, loaded.
(/usr/share/texmf/tex/latex/base/article.cls
Document Class: article 2004/02/16 v1.4f Standard LaTeX document class
(/usr/share/texmf/tex/latex/base/size12.clo))
(/usr/share/texmf/tex/latex/base/inputenc.sty

! LaTeX Error: File `utf8x.def' not found.

Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: def)

Enter file name: 
! Emergency stop.
<read *> 

l.121 \endinput
               ^^M
No pages of output.
Transcript written on math.log.
```

This is because the docs for the units package make use of equations to an extent that we didn't before.  Most people trying to build the docs won't have this problem since they're on modern OS's whose LaTeX installations come with unicode support, but on my junky RHEL5 machine I had to manually install http://ctan.org/tex-archive/macros/latex/contrib/ucs to get that working, and it might be worth documenting that in build docs for the docs somewhere :)
