### PR TITLE
Problems with logging in some systems

### DIFF
--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import io
+import locale
 import sys
 
 from ...tests.helper import pytest, raises
@@ -55,6 +56,32 @@ def test_color_print_unicode():
 
 def test_color_print_invalid_color():
     console.color_print("foo", "unknown")
+
+
+@pytest.mark.skipif('sys.version_info[0] > 2')
+def test_color_print_no_default_encoding():
+    """Regression test for #1244
+
+    In some environments `locale.getpreferredencoding` can return ``''``;
+    make sure there are some reasonable fallbacks.
+    """
+
+    # Not sure of a reliable way to force getpreferredencoding() to return
+    # an empty string other than to temporarily patch it
+    orig_func = locale.getpreferredencoding
+    locale.getpreferredencoding = lambda: ''
+    try:
+        # Try printing a string that can be utf-8 decoded (the default)
+        stream = io.StringIO()
+        console.color_print(b'\xe2\x98\x83', 'white', file=stream)
+        assert stream.getvalue() == u'☃\n'
+
+        # Test the latin-1 fallback
+        stream = io.StringIO()
+        console.color_print(b'\xcd\xef', 'red', file=stream)
+        assert stream.getvalue() == u'Íï\n'
+    finally:
+        locale.getpreferredencoding = orig_func
 
 
 def test_progress_bar():


### PR DESCRIPTION
In some systems the function locale.getpreferredencoding() may return an empty string. It this is used as an input to "decode" it will raise an error.
The code "msg = msg.decode(locale.getpreferredencoding())" that can be found in astropy/utils/console.py raises an error when it is run within the Python console emulator of PyCharm and a Warning is issued.

```
Traceback (most recent call last):
  File "/Users/jsm/Documents/proyectos/test_AMIGA_data/test_error1.py", line 11, in <module>
    vo_table = parse(vo_table_raw)
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/io/votable/table.py", line 116, in parse
    config=config, pos=(1, 1)).parse(iterator, config)
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/io/votable/tree.py", line 3066, in parse
    vo_warn(W21, config['version'], config, pos)
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/io/votable/exceptions.py", line 115, in vo_warn
    _suppressed_warning(warning, config, stacklevel=stacklevel+1)
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/io/votable/exceptions.py", line 71, in _suppressed_warning
    warn(warning, stacklevel=stacklevel+1)
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/logger.py", line 167, in _showwarning
    self.warning(message)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1161, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1268, in _log
    self.handle(record)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1278, in handle
    self.callHandlers(record)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1318, in callHandlers
    hdlr.handle(record)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 749, in handle
    self.emit(record)
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/logger.py", line 337, in _stream_formatter
    color_print(record.levelname, 'brown', end='')
  File "/Users/jsm/test_AMIGA/lib/python2.7/site-packages/astropy/utils/console.py", line 205, in color_print
    msg = msg.decode(locale.getpreferredencoding())
LookupError: unknown encoding: 
```

Although this problem can be unusual, I think that it could be solved if a safe fallback encoding (probably "US-ASCII") is specified for these cases.
