### PR TITLE
Distribution instance has no attribute 'exclude_package_data'

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -131,6 +131,14 @@ def _do_download(version, download_base, to_dir, download_delay):
                                       to_dir, download_delay)
         _build_egg(egg, tarball, to_dir)
     sys.path.insert(0, egg)
+    # Modified for Astropy by Erik Bray <erik.m.bray@gmail.com>
+    # Make absolutely certain that pkg_resources is not already imported before
+    # importing setuptools; on Ubuntu and other Debian-based distros there may
+    # be a separate pkg_resources module already imported, because
+    # pkg_resources is shipped as its own OS package separate from
+    # Distribute/setuptools
+    if 'pkg_resources' in sys.modules:
+        del sys.modules['pkg_resources']
     import setuptools
     setuptools.bootstrap_install_from = egg
 


### PR DESCRIPTION
I just tried installing acfbd8a196ae1ee03e750f931d89a102c6662eee on an Ubuntu 32-bit machine, and if I start from a clean repository and I run:

```
python setup.py build
```

I get:

```
Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.28.tar.gz
Extracting in /tmp/tmpQb5QEh
Now working in /tmp/tmpQb5QEh/distribute-0.6.28
Building a Distribute egg in /home/tom/astropy
/home/tom/astropy/distribute-0.6.28-py2.7.egg
Freezing version number to astropy/version.py
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'zip_safe'
  warnings.warn(msg)
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'use_2to3'
  warnings.warn(msg)
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'entry_points'
  warnings.warn(msg)
running build
running build_py
Traceback (most recent call last):
  File "setup.py", line 128, in <module>
    entry_points=entry_points
  File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/build.py", line 128, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 971, in run_command
    cmd_obj.ensure_finalized()
  File "/usr/lib/python2.7/distutils/cmd.py", line 109, in ensure_finalized
    self.finalize_options()
  File "/home/tom/astropy/astropy/setup_helpers.py", line 561, in finalize_options
    SetuptoolsBuildPy.finalize_options(self)
  File "build/bdist.linux-i686/egg/setuptools/command/build_py.py", line 77, in finalize_options
AttributeError: Distribution instance has no attribute 'exclude_package_data'
```

However, if I run `build` a second time, it runs fine. This may be related to astropy/package-template#15.

Strangely, after the first `build` command, the `build/` directory does not exist and it is only created after the second.

@iguananaut - any idea what might be going on?
