### PR TITLE
Merge table metadata properly for astropy.vizier.vizquery

### DIFF
--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -4,6 +4,7 @@ This module contains helper functions for handling metadata.
 """
 
 from copy import deepcopy
+import numpy as np
 
 
 class MergeConflictError(TypeError):
@@ -32,6 +33,10 @@ def concat(left, right):
         raise MergeConflictError()
     if any(isinstance(left, cls) for cls in (tuple, list)):
         return left + right
+    elif left == right:
+        return left
+    elif np.isnan(left) and np.isnan(right):
+        return left
     else:
         raise MergeConflictError()
 


### PR DESCRIPTION
astropy.vizier.vizquery returns Table instances whose columns have
(unicode) string metadata for UCDs and floating point metadata (which is
sometimes NaN). This patch adds support for concatenating
(astropy.table.vstack) tables returned by astropy.vizier.vizquery.

Here is an example:

```
import astropy.table
import astroquery.vizier

astropy.table.vstack([
    astroquery.vizier.vizquery({
        '-source': 'USNO-B1.0',
        '-c': astropy.table.Table([
            astropy.table.Column([100], '_RAJ2000'),
            astropy.table.Column([20], '_DEJ2000')
        ]),
        '-c.rs': '10'
    }),
    astroquery.vizier.vizquery({
        '-source': 'USNO-B1.0',
        '-c': astropy.table.Table([
            astropy.table.Column([90], '_RAJ2000'),
            astropy.table.Column([20], '_DEJ2000')
        ]),
        '-c.rs': '10'
    })
])
```
