### PR TITLE
Use astropy.tests.helpers.catch_warnings instead of warnings.catch_warnings

### DIFF
--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from distutils import version
 import numpy as np
-import warnings
 
 from ... import units as u
-from ...tests.helper import pytest
+from ...tests.helper import pytest, catch_warnings
 from ... import table
 
 numpy_lt_1p5 = version.LooseVersion(np.__version__) < version.LooseVersion('1.5')
@@ -80,28 +79,22 @@ class TestColumn():
         d = Column([1, 2, 3], name='a', dtype="f8", unit="m")
         d.convert_unit_to("km")
         assert np.all(d.data == [0.001, 0.002, 0.003])
-    
+
     def test_deprecated_attributes(self, Column, recwarn):
         d = Column([1, 2, 3], name='a', dtype="f8", unit="m")
-        
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", DeprecationWarning, append=True)
+
+        with catch_warnings(DeprecationWarning) as warning_lines:
             d.units
             assert warning_lines[0].category == DeprecationWarning
-        
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", DeprecationWarning, append=True)
+
+        with catch_warnings(DeprecationWarning) as warning_lines:
             c = Column([1,2,3], name='a', dtypes="f8", unit="m")
             assert warning_lines[0].category == DeprecationWarning
-        
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", DeprecationWarning, append=True)
+
+        with catch_warnings(DeprecationWarning) as warning_lines:
             c = Column([1,2,3], name='a', dtype="f8", units="m")
             assert warning_lines[0].category == DeprecationWarning
-        
+
     def test_array_wrap(self):
         """Test that the __array_wrap__ method converts a reduction ufunc
         output that has a different shape into an ndarray view.  Without this a

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from distutils import version
 import numpy as np
-import warnings
 
-from ...tests.helper import pytest
+from ...tests.helper import pytest, catch_warnings
 from ...table import Table
 from ...utils import OrderedDict, metadata
 from .. import np_utils
@@ -303,10 +302,7 @@ class TestJoin():
         t2['c'].format = '%6s'
         t2['c'].description = 't2_c'
 
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", metadata.MergeConflictWarning, append=True)
-
+        with catch_warnings(metadata.MergeConflictWarning) as warning_lines:
             t12 = table.join(t1, t2, keys=['a', 'b'])
 
             assert t12['a'].unit == 'cm'
@@ -453,9 +449,7 @@ class TestVStack():
         t2['c'].format = '%6s'
         t2['c'].description = 't2_c'
 
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", metadata.MergeConflictWarning, append=True)
+        with catch_warnings(metadata.MergeConflictWarning) as warning_lines:
             out = table.vstack([t1, t2, t4], join_type='outer')
 
             assert out['a'].unit == 'cm'
@@ -592,10 +586,7 @@ class TestHStack():
         t3['d'].format = '%6s'
         t3['d'].description = 't3_c'
 
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", metadata.MergeConflictWarning, append=True)
-
+        with catch_warnings(metadata.MergeConflictWarning) as warning_lines:
             out = table.vstack([t1, t3, t4], join_type='outer')
 
             for t in [t1, t3, t4]:

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -3,9 +3,8 @@ import sys
 
 from distutils import version
 import numpy as np
-import warnings
 
-from ...tests.helper import pytest
+from ...tests.helper import pytest, catch_warnings
 from ... import table
 from ...table import Row
 
@@ -140,13 +139,11 @@ class TestRow():
         table = self.t
         row = table[0]
         assert format(row, "").startswith("<Row 0 of table")
-    
+
     def test_deprecated_attributes(self, table_types):
         self._setup(table_types)
         r = Row(self.t, 2)
-        
-        with warnings.catch_warnings(record=True) as warning_lines:
-            warnings.resetwarnings()
-            warnings.simplefilter("always", DeprecationWarning, append=True)
+
+        with catch_warnings(DeprecationWarning) as warning_lines:
             r.dtypes
             assert warning_lines[0].category == DeprecationWarning

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -486,14 +486,14 @@ Testing warnings
 -----------------
 
 In order to test that warnings are triggered as expected in certain
-situations, you can use the `astropy.tests.helpers.catch_warnings`
+situations, you can use the `astropy.tests.helper.catch_warnings`
 context manager.  Unlike the `warnings.catch_warnings` context manager
 in the standard library, this one will reset all warning state before
 hand so one is assured to get the warnings reported, regardless of
 what errors may have been emitted by other tests previously.  Here is
 a real-world example::
 
-  from astropy.tests.helpers import catch_warnings
+  from astropy.tests.helper import catch_warnings
 
   with catch_warnings(MergeConflictWarning) as warning_lines:
       # Test code which triggers a MergeConflictWarning
@@ -508,7 +508,7 @@ function argument to test that warnings are triggered.  This method
 has been found to be problematic in at least one case (`pull request
 1174
 <https://github.com/astropy/astropy/pull/1174#issuecomment-20249309>`_)
-so the `astropy.tests.helpers.catch_warnings` context manager is
+so the `astropy.tests.helper.catch_warnings` context manager is
 preferred.
 
 .. _doctests:


### PR DESCRIPTION
We have a context manager that correctly and completely clears all warning state before catching warnings.  We should use that throughout the test suite so that it can be properly parallelized.

Also updates the testing documentation to point this out.

This is in response to me not being around to suggest this in #1174.
