### PR TITLE
Allow non-strings to be logged without raising a TypeError

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -337,7 +337,7 @@ class AstropyLogger(Logger):
             color_print(record.levelname, 'brown', end='')
         else:
             color_print(record.levelname, 'red', end='')
-        print(": " + record.msg + " [{0:s}]".format(record.origin))
+        print(": {0} [{1:s}]".format(record.msg, record.origin))
 
     @contextmanager
     def log_to_file(self, filename, filter_level=None, filter_origin=None):


### PR DESCRIPTION
There are times you want to log something that is not strictly a string, e.g.

```
from astropy import log
log.info(42)
```

At present this raises a `TypeError: cannot concatenate 'str' and 'int' objects`

This minor pull request ensures that the string representation of any object can be logged, which brings the behaviour in line with Python's built-in logging module. 
