### PR TITLE
Document issue with binary installers on Windows 7

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -202,6 +202,30 @@ use the system `libexpat`, add the following to the `setup.cfg` file::
     [build]
     use_system_expat=1
 
+
+The Windows installer can't find Python in the registry
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is a common issue with Windows installers for Python packages that do not
+support the new User Access Control (UAC) framework added in Windows Vista and
+later.  In particular, when a Python is installed "for all users" (as opposed
+to for a single user) it adds entries for that Python installation under the
+``HKEY_LOCAL_MACHINE`` (HKLM) hierarchy and *not* under the
+``HKEY_CURRENT_USER`` (HKCU) hierarchy.  However, depending on your UAC
+settings, if the Astropy installer is not executed with elevated privileges it
+will not be able to check in HKLM for the required information about your
+Python installation.
+
+In short: If you encounter this problem it's because you need the appropriate
+entries in the Windows registry for Python. You can download `this script`__
+and execute it with the same Python as the one you want to install Astropy
+into.  For example to add the missing registry entries to your Python 2.7::
+
+    C:\>C:\Python27\python.exe C:\Path\To\Downloads\win_register_python.py
+
+__ https://gist.github.com/iguananaut/6042780#file-win_register_python-py
+
+
 Compatibility packages
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I had a PyFITS user bring to me an odd problem he was having installing PyFITS on Windows 7 from the pre-built binary installer exe.  This does not necessarily affect all users on Windows 7.  In fact I didn't have this problem at all on my Windows 7 laptop.  But on further investigation it seems this problem _can_ affect users depending on exactly how they installed Python and other system settings.  I describe the issue in more detail here: spacetelescope/PyFITS#26.

Eventually I'd like Astropy to distribute Wheel packages for Windows. But currently it's more feasible to distribute executable installers, so as long as we're doing that it's worth mentioning this issue in the installation docs.
