### PR TITLE
python3 incompatibility in configuration.py when using virtualenv + python setup.py develop

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -40,8 +40,9 @@ the same applies to other packages:
 
    .. image:: forking_button.png
 
-   After a short pause and some 'Hardcore forking action', you should find
-   yourself at the home page for your own forked copy of Astropy_.
+   After a short pause and an animation of Octocat scanning a book on a flatbed
+   scanner, you should find yourself at the home page for your own forked copy
+   of Astropy_.
 
 Setting up the fork to work on
 ------------------------------


### PR DESCRIPTION
This error occurs if I install astropy with `python3 setup.py develop` using virtual python.  It does not occur if I use `python3 setup.py install`, or if I use the system-wide `python3` with `setup.py develop`.  I'm testing with `astropy-0.2.2` (stable branch)

Here's the error:

```
regenerating default astroquery.cfg file
Generation of default configuration item failed! Stdout and stderr are shown below.
Stdout:

Stderr:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/config/configuration.py", line 626, in generate_all_config_items
    if isinstance(pkgornm, basestring):
NameError: global name 'basestring' is not defined

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "./astroquery/__init__.py", line 16, in <module>
    from .version import version as __version__
  File "./astroquery/version.py", line 3, in <module>
    from astropy.version_helpers import update_git_devstr, get_git_devstr
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/__init__.py", line 126, in <module>
    from .logger import _init_log
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/logger.py", line 45, in <module>
    "Threshold for the logging messages. Logging "
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/config/configuration.py", line 140, in __init__
    isinstance(defaultvalue, basestring)):
NameError: global name 'basestring' is not defined
```
