### PR TITLE
Allow comoving volume to accept arrays in non-flat case. Add unit test.

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -881,7 +881,7 @@ class FLRW(Cosmology):
         dh = self._hubble_distance
         dm = self.comoving_transverse_distance(z)
         term1 = 4. * pi * dh ** 3 / (2. * Ok0)
-        term2 = dm / dh * sqrt(1 + Ok0 * (dm / dh) ** 2)
+        term2 = dm / dh * np.sqrt(1 + Ok0 * (dm / dh) ** 2)
         term3 = sqrt(abs(Ok0)) * dm / dh
 
         if Ok0 > 0:

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -204,19 +204,22 @@ def test_comoving_volume():
     c_open = core.LambdaCDM(H0=70, Om0=0.27, Ode0=0.0, Tcmb0=0.0)
     c_closed = core.LambdaCDM(H0=70, Om0=2, Ode0=0.0, Tcmb0=0.0)
 
-    redshifts = 0.5, 1, 2, 3, 5, 9
-
     # test against ned wright's calculator (cubic Gpc)
-    wright_flat = 29.123, 159.529, 630.427, 1178.531, 2181.485, 3654.802
-    wright_open = 20.501, 99.019, 380.278, 747.049, 1558.363, 3123.814
-    wright_closed = 12.619, 44.708, 114.904, 173.709, 258.82, 358.992
-    for i, z in enumerate(redshifts):
-        assert np.allclose(c_flat.comoving_volume(z), wright_flat[i] * 1e9,
-                           rtol=1e-2)
-        assert np.allclose(c_open.comoving_volume(z), wright_open[i] * 1e9,
-                           rtol=1e-2)
-        assert np.allclose(c_closed.comoving_volume(z), wright_closed[i] * 1e9,
-                           rtol=1e-3)
+    redshifts = np.array([0.5, 1, 2, 3, 5, 9])
+    wright_flat = np.array([29.123, 159.529, 630.427, 1178.531, 2181.485, 
+                            3654.802]) * 1e9 # convert to Mpc**3
+    wright_open = np.array([20.501, 99.019, 380.278, 747.049, 1558.363, 
+                            3123.814]) * 1e9
+    wright_closed = np.array([12.619, 44.708, 114.904, 173.709, 258.82, 
+                              358.992]) * 1e9
+    # The wright calculator isn't very accurate, so we use a rather
+    # modest precision
+    assert np.allclose(c_flat.comoving_volume(redshifts), wright_flat,
+                       rtol=1e-2)
+    assert np.allclose(c_open.comoving_volume(redshifts), wright_open,
+                       rtol=1e-2)
+    assert np.allclose(c_closed.comoving_volume(redshifts), wright_closed,
+                       rtol=1e-2)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
Fix for issue #1270.  Should be considered for 0.2.4.
