### PR TITLE
Fix minor issue in fhe io.fits tests

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -175,6 +175,13 @@ class TestCore(FitsTestCase):
                 hdu.req_cards('TESTKW', None, None, None, 'fix', errs)
                 return errs
 
+            @classmethod
+            def match_header(cls, header):
+                # Since creating this HDU class adds it to the registry we
+                # don't want the file reader to possibly think any actual
+                # HDU from a file should be handled by this class
+                return False
+
         hdu = TestHDU(header=fits.Header())
         hdu.verify('fix')
 


### PR DESCRIPTION
Fixes a minor issue in the tests where if run in a specific order the FitsHDU tests could fail due to modification of global state by one of the other tests.

This occurred, seemingly randomly, in some of the test configurations on Windows. I haven't even been able to reproduce it myself, but this is the fix at any rate.
