### PR TITLE
Improves the speed of units

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -262,19 +262,20 @@ class UnitBase(object):
 
     def _validate_power(self, p):
         if isinstance(p, tuple) and len(p) == 2:
-            if p[1] in (1, 2, 4, 8, 16, 32, 64):
-                p = float(p[0] / p[1])
-            else:
-                p = Fraction(p[0] / p[1])
+            p = Fraction(p[0], p[1])
+
+        if isinstance(p, Fraction):
+            # If the fractional power can be represented *exactly* as
+            # a floating point number, we convert it to a float, to
+            # make the math much faster, otherwise, we use a
+            # `fractions.Fraction` object to avoid losing precision.
+            denom = p.denominator
+            # This is bit-twiddling hack to see if the integer is a
+            # power of two
+            if (denom & (denom - 1)) == 0:
+                p = float(p)
         else:
             p = float(p)
-
-            # allow two possible floating point fractions, all others illegal
-            if not int(2 * p) == 2 * p:
-                raise ValueError(
-                    "floating values for unit powers must be integers or "
-                    "integers + 0.5.  To use other fractions, use a tuple "
-                    "or `fractions.Fraction` instance.")
 
         return p
 

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -288,9 +288,6 @@ class TestQuantityMathFuncs(object):
         with pytest.raises(TypeError) as exc:
             np.power(3., 4. * u.m)
         assert "raise something to a dimensionless" in exc.value.args[0]
-        with pytest.raises(ValueError) as exc:
-            np.power(2. * u.m, 4.6)
-        assert "must be integers" in exc.value.args[0]
 
     def test_copysign_scalar(self):
         assert np.copysign(3 * u.m, 1.) == 3. * u.m

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -29,9 +29,12 @@ def test_getting_started():
     assert_allclose(x, [2.23693629e-02, 2.23693629e+01, 1.11846815e+02])
 
 
-@raises(ValueError)
 def test_invalid_power():
-    u.m ** 0.3
+    x = u.m ** (1, 3)
+    assert isinstance(x.powers[0], Fraction)
+
+    x = u.m ** (1, 2)
+    assert isinstance(x.powers[0], float)
 
 
 def test_invalid_compare():
@@ -402,7 +405,7 @@ def test_compose_issue_579():
 
     assert len(result) == 1
     assert result[0]._bases == [u.s, u.N, u.m]
-    assert result[0]._powers == [4, 1, -1]
+    assert result[0]._powers == [4, 1, -2]
 
 
 def test_self_compose():


### PR DESCRIPTION
- Reduces unnecessary calls to sort that were used to create unique ids.  It's faster to keep the powers and bases sorted in a canonical way all the time and then not have to re-sort on a regular basis.
- Memoize the `_compose` method by the unit -- this results in about 50% cache hits.
- Reduce the use of `fractions.Fraction` in calculations by converting Fractions with a power of 2 denominator.  `Fraction` instances are still used for other rationals that cannot be represented exactly by a floating point number, and those will still be slow-but-accurate.

I got about 2x speed up on the following:

```
const.sigma_sb.cgs
```

(this was dominating import time of astropy.coordinates).

I also get about 1.1x speedup on the unit test suite as a whole.  (Not that the unit tests are benchmarks :wink:)
