### PR TITLE
votable/tests/vo_test.py failure on Python 3.3.2

### DIFF
--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -233,7 +233,9 @@ def validate(source, output=sys.stdout, xmllint=False, filename=None):
             votable = parse(content_buffer, pedantic=False, filename=filename)
         except ValueError as e:
             lines.append(str(e))
-    lines = [str(x.message) for x in warning_lines] + lines
+
+    lines = [str(x.message) for x in warning_lines if
+             issubclass(x.category, exceptions.VOWarning)] + lines
 
     content_buffer.seek(0)
     output.write(u"Validation report for {0}\n\n".format(filename))


### PR DESCRIPTION
Hi, I have again a failure on some exotic architecture: on Debian/mips and mipsel (MIPS, big and little endian), the following test fails:

astropy/io/votable/tests/vo_test.py:749: AssertionError

The same test works for Python 2.7.3, and 3.2.4, as well as for other architectures.

Versions:
Full Python Version: 
3.3.2+ (default, May 28 2013, 22:51:23) 
[GCC 4.6.3]

Numpy: 1.7.1
Scipy: not available
Matplotlib: not available
h5py: not available

``` python
    def test_validate():
[...]    
        result = validate(get_pkg_data_filename('data/regression.xml'),
                          output, xmllint=False)
[...]
        with io.open(
            get_pkg_data_filename('data/validation.txt'),
            'rt', encoding='utf-8') as fd:
            truth = fd.readlines()

        truth = truth[1:]
        output = output[1:-1]

        for line in difflib.unified_diff(truth, output):
            if IS_PY3K:
                sys.stdout.write(
                    line.replace('\\n', '\n'))
[...]
>       assert truth == output
E       assert ['\n', '11: W...le of\n', ...] == ['\n', '11: W0...le of\n', ...]
E         At index 118 diff: '161: E02: Incorrect number of elements in array. Expected multiple of\n' != 'invalid value encountered in equal\n'
E         Right contains more items, first extra item: '268: W46: char value is too long for specified length of 4\n'

astropy/io/votable/tests/vo_test.py:749: AssertionError
```

```
------------------------------- Captured stdout --------------------------------
--- 
+++ 
@@ -116,6 +116,9 @@
   <TD>42 32, 12 32</TD>
       ^

+invalid value encountered in equal
+
+
 161: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
======= 1 failed, 3795 passed, 103 skipped, 3 xfailed in 1075.56 seconds =======
```

Full log: https://buildd.debian.org/status/fetch.php?pkg=python-astropy&arch=mipsel&ver=0.2.3-1&stamp=1371011371
