### PR TITLE
Set locale to C on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ matrix:
 
         # now try do scipy on 2.7 and an appropriate 3.x build (with latest numpy)
         - python: 2.7
-          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.7.1 OPTIONAL_DEPS=true
+          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.7.1 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
         - python: 3.2
-          env: SETUP_CMD='test' NUMPY_VERSION=1.7.1 OPTIONAL_DEPS=true
+          env: SETUP_CMD='test' NUMPY_VERSION=1.7.1 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
 
         # try alternate numpy versions
         - python: 2.7


### PR DESCRIPTION
I think most of the developers are on systems that are configured for `utf-8`, so we miss a certain class of bugs that reveal themselves when the encoding is `ascii`.

As a backstop for this, should we set at least some of the Travis tests to run with `ascii` as the preferred encoding?

```
LC_CTYPE=C python setup.py test ...
```

should be sufficient.
