### PR TITLE
Make update_package_files backward-compatible

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -970,7 +970,7 @@ def is_distutils_display_option():
 
 
 def update_package_files(srcdir, extensions, package_data, packagenames,
-                         package_dirs, skip_2to3):
+                         package_dirs, skip_2to3=[]):
     """
     Extends existing extensions, package_data, packagenames and
     package_dirs collections by iterating through all packages in


### PR DESCRIPTION
@mdboom - without this change, all affiliated packages are broken because `update_package_files` requires a different number of arguments. By setting a sensible default as suggested here, this can be avoided. Would this be ok?
