### PR TITLE
Quantity behavior strange with strings as values

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -62,11 +62,15 @@ def _validate_value(value, dtype, copy):
     if (isinstance(value, (numbers.Number, np.number, np.ndarray)) or
             isiterable(value)):
         value_obj = np.array(value, dtype=dtype, copy=copy)
-    else:
-        raise TypeError("The value must be a valid Python or Numpy numeric "
-                        "type.")
 
-    return value_obj
+        # It would seem reasonable to exclude object arrays here also,
+        # but then long integers do not work.
+        if value_obj.dtype.kind not in 'SU':
+            return value_obj
+
+    raise TypeError("The value must be a valid Python or Numpy numeric "
+                    "type.")
+
 
 
 class Quantity(np.ndarray):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -683,6 +683,7 @@ def test_equality_numpy_scalar():
     assert np.int64(10) != 10 * u.m
     assert 10 * u.m != np.int64(10)
 
+
 def test_quantity_pickelability():
     """
     Testing pickleability of quantity
@@ -695,3 +696,17 @@ def test_quantity_pickelability():
 
     assert np.all(q1.value == q2.value)
     assert q1.unit is q2.unit
+
+
+def test_quantity_from_string():
+    with pytest.raises(ValueError):
+        q = "5" * u.m
+
+    with pytest.raises(TypeError):
+        q = u.Quantity('5', u.m)
+
+    with pytest.raises(TypeError):
+        q = u.Quantity(['5'], u.m)
+
+    with pytest.raises(TypeError):
+        q = u.Quantity(np.array(['5']), u.m)


### PR DESCRIPTION
I noticed some rather confusing behavior in `Quantity` when you provide strings as values- this connects to some of the oddities noted in #949 :

```
>>> q1 = u.Quantity('1', 'km/s')
>>> q1n = u.Quantity(1, 'km/s')
>>> q1 
<Quantity 1 km / s>
>>> q1n
<Quantity 1 km / s>
```

So they look like the same thing, but:

```
>>> q1 == q1n
False
>>> q1 + q1n
 ...
ValueError: Value not scalar compatible or convertable into a float or integer array
>>> q1.value
array('1', 
      dtype='|S1')
>>> q1n.value
1
```

they aren't.

I'm not sure exactly what solution we want for this.  One possibility is to just fail if a string is passed in.  Another option is to auto-convert to a float (or array if commas are present?).  @adrn @mdboom @astrofrog - any opinions?
