### PR TITLE
Adds rudimentary __str__ and __repr__ representations for NDData objects...

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -159,6 +159,14 @@ class NDData(object):
             self.meta = meta
             self.unit = unit
 
+    def __str__(self):
+        return str(self.data)
+
+    def __repr__(self):
+        prefix = self.__class__.__name__ + '('
+        body = np.array2string(self.data, separator=', ', prefix=prefix)
+        return ''.join([prefix, body, ')'])
+
     @property
     def mask(self):
         return self._mask

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import textwrap
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -36,6 +37,42 @@ def test_nddata_simple():
     assert nd.shape == (10, 10)
     assert nd.size == 100
     assert nd.dtype == np.dtype(float)
+
+
+def test_nddata_str():
+    arr1d = NDData([1, 2, 3])
+    assert str(arr1d) == '[1 2 3]'
+
+    arr2d = NDData([[1, 2], [3, 4]])
+    assert str(arr2d) == textwrap.dedent("""
+        [[1 2]
+         [3 4]]"""[1:])
+
+    arr3d = NDData([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    assert str(arr3d) == textwrap.dedent("""
+        [[[1 2]
+          [3 4]]
+
+         [[5 6]
+          [7 8]]]"""[1:])
+
+
+def test_nddata_repr():
+    arr1d = NDData([1, 2, 3])
+    assert repr(arr1d) == 'NDData([1, 2, 3])'
+
+    arr2d = NDData([[1, 2], [3, 4]])
+    assert repr(arr2d) == textwrap.dedent("""
+        NDData([[1, 2],
+                [3, 4]])"""[1:])
+
+    arr3d = NDData([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    assert repr(arr3d) == textwrap.dedent("""
+        NDData([[[1, 2],
+                 [3, 4]],
+
+                [[5, 6],
+                 [7, 8]]])"""[1:])
 
 
 def test_nddata_mask_valid():


### PR DESCRIPTION
Currently `NDData` doesn't have any useful string representation.  In this implementation its `__str__` exactly the same a that for a normal Numpy ndarray.  The `__repr__` is the same too but it shows that the class is `NDData` instead of `ndarray`.

These can and should be extended in the future to display things like units, and maybe even the metadata.  But for now it's better than nothing (if anyone has any immediate ideas I can add them to this PR).
