### PR TITLE
Fix misspelled word ("Deletetion")

### DIFF
--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -220,7 +220,7 @@ class Header(object):
                 # TODO: Remove this warning and make KeyError the default after
                 # a couple versions (by 3.2 or 3.3, say)
                 warnings.warn(
-                    'Deletetion of non-existent keyword %r: '
+                    'Deletion of non-existent keyword %r: '
                     'In a future Astropy version Header.__delitem__ may be '
                     'changed so that this raises a KeyError just like a dict '
                     'would. Please update your code so that KeyErrors are '


### PR DESCRIPTION
The `DeprecationWarning` emitted by `Header.__delitem__()` starts with "Deletetion...".
