### PR TITLE
Fix formatting of Angle objects when precision=0

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -522,7 +522,8 @@ def hours_to_string(h, precision=5, pad=False, sep=('h', 'm', 's')):
                '{sep[2]}')
     h, m, s = hours_to_hms(h)
     return literal.format(h, int(abs(m)), abs(s), sep=sep, pad=pad,
-                          width=(precision + 3), precision=precision)
+                          width=(precision + 3 if precision > 0 else 2),
+                          precision=precision)
 
 
 def degrees_to_string(d, precision=5, pad=False, sep=':'):
@@ -556,7 +557,8 @@ def degrees_to_string(d, precision=5, pad=False, sep=':'):
                '{sep[2]}')
     d, m, s = degrees_to_dms(d)
     return literal.format(d, int(abs(m)), abs(s), sep=sep, pad=pad,
-                          width=(precision + 3), precision=precision)
+                          width=(precision + 3 if precision > 0 else 2),
+                          precision=precision)
 
 
 #<----------Spherical angular distances------------->

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -1,0 +1,20 @@
+from ..angles import Angle
+from ... import units as u
+
+def test_to_string_precision():
+
+    # There are already some tests in test_api.py, but this is a regression
+    # test for issue #... which caused incorrect formatting of the seconds for
+    # precision=0
+
+    angle = Angle(-1.23456789, unit=u.degree)
+
+    assert angle.to_string(precision=3) == '-1d14m04.444s'
+    assert angle.to_string(precision=1) == '-1d14m04.4s'
+    assert angle.to_string(precision=0) == '-1d14m04s'
+
+    angle2 = Angle(-1.23456789, unit=u.hour)
+
+    assert angle2.to_string(precision=3, unit=u.hour) == '-1h14m04.444s'
+    assert angle2.to_string(precision=1, unit=u.hour) == '-1h14m04.4s'
+    assert angle2.to_string(precision=0, unit=u.hour) == '-1h14m04s'


### PR DESCRIPTION
Before:

```
In [4]: from astropy.coordinates import Angle

In [5]: from astropy import units as u

In [6]: Angle(3., unit=u.deg).to_string(precision=0)
Out[6]: array(u'3d00m000s', dtype=object)
```

(notice the three digits for the seconds)

After:

```
In [4]: from astropy.coordinates import Angle

In [5]: from astropy import units as u

In [6]: Angle(3., unit=u.deg).to_string(precision=0)
Out[6]: array(u'3d00m00s', dtype=object)
```
