### PR TITLE
Warn when a VOTable 1.2 file contains no RESOURCEs

### DIFF
--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1037,6 +1037,15 @@ class W52(VOTableSpecWarning):
     default_args = ('1.2',)
 
 
+class W53(VOTableSpecWarning):
+    """
+    The VOTABLE element must contain at least one RESOURCE element.
+    """
+
+    message = ("VOTABLE element must contain at least one RESOURCE element.")
+    default_args = ()
+
+
 class E01(VOWarning, ValueError):
     """
     The size specifier for a ``char`` or ``unicode`` field must be

--- a/astropy/io/votable/tests/data/no_resource.txt
+++ b/astropy/io/votable/tests/data/no_resource.txt
@@ -1,0 +1,5 @@
+Validation report for no_resource.xml
+
+5: W53: VOTABLE element must contain at least one RESOURCE element.
+xmlns="http://www.ivoa.net/xml/VOTable/v1.2">
+                                             ^

--- a/astropy/io/votable/tests/data/no_resource.xml
+++ b/astropy/io/votable/tests/data/no_resource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE version="1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:noNamespaceSchemaLocation="xmlns:http://www.ivoa.net/xml/VOTable/VOTable-1.2.xsd"
+xmlns="http://www.ivoa.net/xml/VOTable/v1.2">
+</VOTABLE>

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -940,3 +940,40 @@ def test_resource_structure():
         res = vtf2.resources[r]
         assert len(res.tables) == 2
         assert len(res.resources) == 0
+
+
+def test_no_resource_check():
+    output = io.StringIO()
+
+    # We can't test xmllint, because we can't rely on it being on the
+    # user's machine.
+    result = validate(get_pkg_data_filename('data/no_resource.xml'),
+                      output, xmllint=False)
+
+    assert result == False
+
+    output.seek(0)
+    output = output.readlines()
+
+    # Uncomment to generate new groundtruth
+    # with io.open('no_resource.txt', 'wt', encoding='utf-8') as fd:
+    #     fd.write(u''.join(output))
+
+    with io.open(
+        get_pkg_data_filename('data/no_resource.txt'),
+        'rt', encoding='utf-8') as fd:
+        truth = fd.readlines()
+
+    truth = truth[1:]
+    output = output[1:-1]
+
+    for line in difflib.unified_diff(truth, output):
+        if six.PY3:
+            sys.stdout.write(
+                line.replace('\\n', '\n'))
+        else:
+            sys.stdout.write(
+                line.encode('unicode_escape').
+                replace('\\n', '\n'))
+
+    assert truth == output

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -27,8 +27,8 @@ from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
     warn_unknown_attrs,
     W06, W07, W08, W09, W10, W11, W12, W13, W15, W17, W18, W19, W20,
     W21, W22, W26, W27, W28, W29, W32, W33, W35, W36, W37, W38, W40,
-    W41, W42, W43, W44, W45, W50, W52, E06, E08, E09, E10, E11, E12,
-    E13, E14, E15, E16, E17, E18, E19, E20, E21)
+    W41, W42, W43, W44, W45, W50, W52, W53, E06, E08, E09, E10, E11,
+    E12, E13, E14, E15, E16, E17, E18, E19, E20, E21)
 from . import ucd as ucd_mod
 from . import util
 from . import xmlutil
@@ -3253,6 +3253,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                 if self.description is not None:
                     warn_or_raise(W17, W17, 'VOTABLE', config, pos)
                 self.description = data or None
+
+        if not len(self.resources) and config['version_1_2_or_later']:
+            warn_or_raise(W53, W53, (), config, pos)
 
         return self
 


### PR DESCRIPTION
The schema for VOTable 1.2 actually insists that there is at least one resource.  `astropy.io.votable` should also enforce schema compliance.
