### PR TITLE
Failures with developer version of Numpy

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1766,7 +1766,12 @@ class Table(object):
               2 0.2   y
               3 0.3   z
         """
-        table = np.delete(self._data, row_specifier, axis=0)
+        try:
+            table = np.delete(self._data, row_specifier, axis=0)
+        except (ValueError, IndexError):
+            # Numpy <= 1.7 raises ValueError while Numpy >= 1.8 raises IndexError
+            raise IndexError('Removing row(s) {0} from table with {1} rows failed'
+                             .format(row_specifier, len(self._data)))
         self._data = table
 
         # after updating the row data, the column views will be out of date

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -657,7 +657,7 @@ class TestRemove(SetupData):
 
     def test_remove_nonexistent_row(self, table_types):
         self._setup(table_types)
-        with pytest.raises(ValueError):
+        with pytest.raises(IndexError):
             self.t.remove_row(4)
 
     def test_remove_row_0(self, table_types):


### PR DESCRIPTION
There are (and have been for a little while) test failures with the latest dev versions of Numpy:

https://jenkins.shiningpanda.com/astropy/job/astropy-master-debian-py2.7-numpy-dev/1211/testReport/

@taldcroft - these concern the `astropy.table` and `astropy.io.ascii`, so would you mind looking into them?
