### PR TITLE
Masked tables: Bug in documentation

### DIFF
--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -135,7 +135,7 @@ viewed and modified via the ``mask`` attribute::
    a   b 
   --- ---
     1  --
-   --   4
+    2   4
 
 Masked entries are shown as ``--`` when the table is printed.
 


### PR DESCRIPTION
From:
http://docs.astropy.org/en/latest/table/masking.html#masking-and-filling

In this example in the documentation why is there anything masked on output in column `a`? As far as I understand it it should just say `2` there.

```
>>> t = Table([(1, 2), (3, 4)], names=('a', 'b'), masked=True)
>>> t['b'].mask = [True, False]  # Modify column mask (boolean array)
>>> print(t)
 a   b
--- ---
  1  --
 --   4
```

I am not quite sure what the relation to #746 is: If this part of the documenation is tested, then how can this happen? If not, then why is this part not tested?
