### PR TITLE
Fix issue with table tests on 32-bit systems

### DIFF
--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -705,8 +705,8 @@ class TestRemove(SetupData):
         self.t.add_column(self.b)
         self.t.remove_rows([0, 2])
         assert self.t['a'].meta == {'aa': [0, 1, 2, 3, 4]}
-        assert self.t.dtype == np.dtype([('a', '<i8'),
-                                         ('b', '<i8')])
+        assert self.t.dtype == np.dtype([('a', 'int'),
+                                         ('b', 'int')])
 
     def test_delitem1(self, table_types):
         self._setup(table_types)


### PR DESCRIPTION
Fixes a test that has been failing on the Windows builds for some time since they are on a 32-bit system. When comparing integer dtypes always use 'int' (unless the dtypes/arrays were constructed with a specific int type to begin with), which Numpy will replace with the default integer type for the system.

This test only exists on dev.
