### PR TITLE
Add references to `astroquery` and `pyvo` in `astropy.vo` docs

### DIFF
--- a/docs/vo/index.rst
+++ b/docs/vo/index.rst
@@ -8,9 +8,23 @@ Introduction
 ============
 
 The ``astropy.vo`` subpackage handles simple access for Virtual Observatory
-(VO) services. Current services include:
+(VO) services.
+
+Current services include:
 
 .. toctree::
    :maxdepth: 1
 
    conesearch
+
+There are two third-party Python packages related to ``astropy.vo``:
+
+* `PyVO <http://pyvo.readthedocs.org/en/latest/>`_
+  provides further functionality to discover
+  and query VO services. Its user guide contains a
+  `good introduction <https://pyvo.readthedocs.org/en/latest/pyvo/vo.html>`_
+  to how the VO works.
+
+* `Astroquery <http://www.astropy.org/astroquery/>`_
+  is an Astropy affiliated package that provides simply access to specific astronomical
+  web services, many of which do not support the VO protocol.


### PR DESCRIPTION
We just added a reference from `astroquery` to `astropy.vo` and `pyvo` (see [here](http://astroquery.readthedocs.org/en/latest/#introduction)).

Would it make sense to add a few sentences at the beginning of the `astropy.vo` docs (see [here](http://docs.astropy.org/en/latest/vo/index.html)) mentioning `pyvo` and `astroquery`?

What to say really depends on whether we plan to merge `pyvo` and / or `astroquery` into `astropy` core soon (say for the 0.3 or 0.4 release) or whether we want them to remain affiliated packages.

If `pyvo` is not merged into core `astropy` soon it should also be listed on the [astropy affiliated package page](http://www.astropy.org/affiliated/).

@mdboom @RayPlante @keflavich What do you think?
