### PR TITLE
Table row access failure with masked tables

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -805,17 +805,36 @@ class Row(object):
     def __init__(self, table, index):
         self._table = table
         self._index = index
-        self._data = table._data[index]
+        try:
+            self._data = table._data[index]
 
-        # MaskedArray __getitem__ has a strange behavior where if a
-        # row mask is all False then it returns a np.void which
-        # has no mask attribute. This makes it impossible to then set
-        # the mask. Here we recast back to mvoid. This was fixed in
-        # Numpy following issue numpy/numpy#483, and the fix should be
-        # included in Numpy 1.8.0.
-        if self._table.masked and isinstance(self._data, np.void):
-            self._data = ma.core.mvoid(self._data,
-                                       mask=self._table._mask[index])
+            # MaskedArray __getitem__ has a strange behavior where if a
+            # row mask is all False then it returns a np.void which
+            # has no mask attribute. This makes it impossible to then set
+            # the mask. Here we recast back to mvoid. This was fixed in
+            # Numpy following issue numpy/numpy#483, and the fix should be
+            # included in Numpy 1.8.0.
+            if self._table.masked and isinstance(self._data, np.void):
+                self._data = ma.core.mvoid(self._data,
+                                           mask=self._table._mask[index])
+        except ValueError as err:
+            # Another bug (or maybe same?) that is fixed in 1.8 prevents accessing
+            # a row in masked array if it has object-type members.
+            # >>> x = np.ma.empty(1, dtype=[('a', 'O')])
+            # >>> x['a'] = 1
+            # >>> x['a'].mask = True
+            # >>> x[0]
+            # ValueError: Setting void-array with object members using buffer. [numpy.ma.core]
+            #
+            # All we do here is re-raise with a more informative message
+            from distutils import version
+            if (str(err).startswith('Setting void-array with object members')
+                    and version.LooseVersion(np.__version__) < version.LooseVersion('1.8')):
+                raise ValueError('Cannot access table row with Object type columns, due to '
+                                 'a bug in numpy {0}.  Please upgrade to numpy 1.8 or newer.'
+                                 .format(np.__version__))
+            else:
+                raise
 
     def __getitem__(self, item):
         return self.data[item]

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -17,6 +17,27 @@ class MaskedTable(table.Table):
         table.Table.__init__(self, *args, **kwargs)
 
 
+def test_masked_row_with_object_col():
+    """
+    Numpy < 1.8 has a bug in masked array that prevents access a row if there is
+    a column with object type.
+    """
+    numpy_lt_1p8 = version.LooseVersion(np.__version__) < version.LooseVersion('1.8')
+    t = table.Table([[1]], dtypes=['O'], masked=True)
+    if numpy_lt_1p8:
+        with pytest.raises(ValueError):
+            t['col0'].mask = False
+            t[0]
+        with pytest.raises(ValueError):
+            t['col0'].mask = True
+            t[0]
+    else:
+        t['col0'].mask = False
+        assert t[0]['col0'] == 1
+        t['col0'].mask = True
+        assert t[0]['col0'] is np.ma.masked
+
+
 # Fixture to run all tests for both an unmasked (ndarray) and masked (MaskedArray) column.
 @pytest.fixture(params=[False] if numpy_lt_1p5 else [False, True])
 def table_types(request):


### PR DESCRIPTION
I get this ugly error when trying to index a table:

```
ValueError: Setting void-array with object members using buffer.
```

A complete example, using the freshly completed `astroquery.simbad` module:

```
>>> from astroquery import simbad
>>> T = simbad.Simbad.query_bibobj('2005ApJ...635.1166G')
>>> T[0]
ERROR: ValueError: Setting void-array with object members using buffer. [numpy.ma.core]
Traceback (most recent call last):
  File "<ipython-input-25-38e23a3d0a31>", line 1, in <module>
    T[0]
  File "/Users/adam/repos/astropy/astropy/table/table.py", line 1327, in __getitem__
    return Row(self, item)
  File "/Users/adam/repos/astropy/astropy/table/table.py", line 769, in __init__
    self._data = table._data[index]
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/numpy/ma/core.py", line 2954, in __getitem__
    dout = mvoid(dout, mask=mask)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/numpy/ma/core.py", line 5515, in __new__
    _data[()] = data
ValueError: Setting void-array with object members using buffer.
```

I suspect this is actually a numpy error, but I'd like some confirmation before trying to push it upstream.
