### PR TITLE
Ensure equivalencies are copied over in conversions

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -393,7 +393,8 @@ class Quantity(np.ndarray):
             equivalencies = self._equivalencies
         new_val = self.unit.to(unit, self.value, equivalencies=equivalencies)
         new_unit = Unit(unit)
-        return self.__quantity_instance__(new_val, new_unit)
+        return self.__quantity_instance__(new_val, new_unit,
+                                          equivalencies=equivalencies)
 
     @property
     def value(self):


### PR DESCRIPTION
While trying to address #1271, I noticed that equivalencies are lost during conversions, and hence the following fails:

```
import astropy.units as u; from astropy.units import Quantity
f = u.Quantity([1000.,2000.],u.Hz, equivalencies=u.spectral())
f.to(u.nm).to(u.Hz)
ERROR: UnitsException: 'nm' (length) and 'Hz' (frequency) are not convertible [astropy.units.core]
```

(just `f.to(u.nm)` works fine)
This one-line-change ensures that whatever equivalencies are used in `q.to(...)` are kept in the newly created quantity.
