### PR TITLE
Fix WCS tests on Windows with Python 3.3

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -303,7 +303,12 @@ class WCS(WCSBase):
             keysel_flags = _parse_keysel(keysel)
 
             if isinstance(header, string_types):
-                if os.path.exists(header):
+                try:
+                    is_path = os.path.exists(header)
+                except (IOError, ValueError):
+                    is_path = False
+
+                if is_path:
                     if fobj is not None:
                         raise ValueError(
                             "Can not provide both a FITS filename to "


### PR DESCRIPTION
On Windows I've been having a strange bug in the WCS tests where, when passing a FITS header to `wcs.WCS()`, it would crash on testing whether the string is a filename like:

```
astropy\wcs\wcs.py:306:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = b"SIMPLE  =                    T / Uncompressed file's conforms to FITS           BITPIX  =                   16 / dat...defined pixels                     ZBLANK  =                32767 / Value for undefined pixels                     END"

    def exists(path):
        """Test whether a path exists.  Returns False for broken symbolic links"""
        try:
>           os.stat(path)
E           ValueError: path too long for Windows

c:\Python33\lib\genericpath.py:18: ValueError
```

It seems like the upper limit `os.path.exists()` will accept for a pathname is 260 characters--the traditional limit for Windows paths.  Interestingly, it doesn't throw up this error if you use longer paths as unicode strings (NTFS does allow longer paths so I'm guessing that if it gets a unicode string it can be a full NTFS path whereas if it gets a bytestring it's limited to DOS paths?)

In any case, while there are some pretty decent ways we could determine ahead of time if the string is actually a FITS header, a less ambiguous check is to just wrap the `os.path.exists` call in a try/except.
