### PR TITLE
Change tests to use wheels.astropy.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,16 +63,16 @@ before_install:
     # We do this to make sure we get dependencies so pip works below
     # Note that travis does *not* use python packages installed via apt - it
     # does all the building in an isolated virtualenv
-    - sudo apt-get update -qq
+    - sudo apt-get update
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then sudo apt-get install -qq python-numpy cython libatlas-dev liblapack-dev gfortran; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then sudo apt-get install python-numpy cython libatlas-dev liblapack-dev gfortran; fi
 
     # OPTIONAL DEPENDENCIES
-    - if $OPTIONAL_DEPS; then sudo apt-get install -qq python-scipy libhdf5-serial-1.8.4 libhdf5-serial-dev; fi
+    - if $OPTIONAL_DEPS; then sudo apt-get install python-scipy libhdf5-serial-1.8.4 libhdf5-serial-dev; fi
 
     # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install -qq python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib; fi
 
 
 install:


### PR DESCRIPTION
In #1355, @astrofrog changed the travis test to use a repository for wheels by @Cadair.  This was good, but the downside is that the URL is hard-coded into `.travis.yml`, which is a problem if we need to change to a different wheelhouse for some reason.  So this PR changes it so that the tests use http://wheels.astropy.org , which I've set up to forward onto to @Cadair's site.  It also tells pip to try http://wheels2.astropy.org , which currently points to nothing, but in the future we might want as a backup mirror for temporary network outages and the like.

One other thing this does: it removes all the `-q`s from the pip calls.  @astrofrog may recall from #1355 that I specifically suggested putting these _in_, because if the build has to fall back on the source build, the logs can get pretty full.  I didn't realize at the time that this also silences pip's reporting about installing wheels and such... that's bad, because it will make it nearly impossible to diagnose pip problems.  So lets just see if the lack of `-q` causes problems like it did before, and if so, we can add it back in where necessary.
