### PR TITLE
fix bug in writing AASTex tables

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -275,7 +275,6 @@ class Latex(core.BaseReader):
         self.data.header = self.header
         self.header.data = self.data
         self.latex = {}
-        self.latex['tabletype'] = 'table'
         # The latex dict drives the format of the table and needs to be shared
         # with data and header
         self.header.latex = self.latex
@@ -391,8 +390,13 @@ class AASTex(Latex):
         self.data.comment = self.header.comment
         self.data.header = self.header
         self.header.data = self.data
-        self.latex['tabletype'] = 'deluxetable'
         # The latex dict drives the format of the table and needs to be shared
         # with data and header
         self.header.latex = self.latex
         self.data.latex = self.latex
+        # check if tabletype was explicitly set by the user
+        if not (('latexdict' in kwargs) and ('tabletype' in kwargs['latexdict'])):
+            self.latex['tabletype'] = 'deluxetable'
+        self.header.comment = '%|' + '|'.join(
+            [r'\\' + command for command in self.ignore_latex_commands])
+        self.data.comment = self.header.comment

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -96,23 +96,23 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
          ),
     dict(
         kwargs=dict(Writer=asciitable.AASTex, caption='Mag values \\label{tab1}', latexdict={
-                    'units': {'MAG': '[mag]', 'XCENTER': '[pixel]'}}),
+                    'units': {'MAG': '[mag]', 'XCENTER': '[pixel]'}, 'tabletype': 'deluxetable*'}),
         out="""\
-\\begin{deluxetable}{ccccccccccc}
+\\begin{deluxetable*}{ccccccccccc}
 \\tablecaption{Mag values \\label{tab1}}
 \\tablehead{\\colhead{ID} & \\colhead{XCENTER} & \\colhead{YCENTER} & \\colhead{MAG} & \\colhead{MERR} & \\colhead{MSKY} & \\colhead{NITER} & \\colhead{SHARPNESS} & \\colhead{CHI} & \\colhead{PIER} & \\colhead{PERROR}\\\\ \\colhead{ } & \\colhead{[pixel]} & \\colhead{ } & \\colhead{[mag]} & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{ }}
 \\startdata
 14 & 138.538 & 256.405 & 15.461 & 0.003 & 34.85955 & 4 & -0.032 & 0.802 & 0 & No_error \\\\
 18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error \\\\
 \\enddata
-\\end{deluxetable}
+\\end{deluxetable*}
 """
     ),
     dict(
         kwargs=dict(Writer=asciitable.Latex, caption='Mag values \\label{tab1}', latexdict={'preamble': '\\begin{center}', 'tablefoot': '\\end{center}', 'data_end': [
-                    '\\hline', '\\hline'], 'units':{'MAG': '[mag]', 'XCENTER': '[pixel]'}}, col_align='|lcccccccccc|'),
+                    '\\hline', '\\hline'], 'units':{'MAG': '[mag]', 'XCENTER': '[pixel]'}, 'tabletype': 'table*'}, col_align='|lcccccccccc|'),
         out="""\
-\\begin{table}
+\\begin{table*}
 \\begin{center}
 \\caption{Mag values \\label{tab1}}
 \\begin{tabular}{|lcccccccccc|}
@@ -124,7 +124,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 \\hline
 \\end{tabular}
 \\end{center}
-\\end{table}
+\\end{table*}
 """
     ),
     dict(kwargs=dict(Writer=asciitable.Latex, latexdict=asciitable.latexdicts['template']),


### PR DESCRIPTION
The old implementation did not honor `latexdict['tabletype']` for AASTex tables
due to the order in which the various defaults were set.
This fix restores that and makes it possible to write e.g. 2-column
deluxetable\* tables.
Small changes in existing tests are sufficient to make sure this bug will not
creep in again.
