### PR TITLE
Angle.to_string() returns a 0-d array with dtype=object

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -478,7 +478,10 @@ class Angle(u.Quantity):
             return s
 
         format_ufunc = np.vectorize(do_format, otypes=[np.object])
-        return format_ufunc(values)
+        result = format_ufunc(values)
+        if result.ndim == 0:
+            result = result[()]
+        return result
 
     @deprecated("0.3", name="format", alternative="to_string")
     def format(self, unit=u.degree, decimal=False, sep='fromunit', precision=5,

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -79,3 +79,8 @@ def test_sexagesimal_rounding_up():
     assert a.to_string(fields=2, precision=5) == '4d00m'
     assert a.to_string(fields=1, precision=1) == '4d'
     assert a.to_string(fields=1, precision=5) == '4d'
+
+
+def test_to_string_scalar():
+    a = Angle(1.113355, unit=u.deg)
+    assert isinstance(a.to_string(), unicode)


### PR DESCRIPTION
Not sure if this is intended:

```
In [1]: from astropy.coordinates.angles import Angle
In [2]: a = Angle('45d')
In [3]: a.to_string()
Out[3]: array(u'45d00m00.00000s', dtype=object)
```

I would have expected a plain string (or unicode obj) here.

In the case where the `Angle` is representing an array of angles, I would expect `to_string()` to return a numpy array with `dtype='S..'`.
