### PR TITLE
Close Multiprocess progressbar Pool

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -556,6 +556,8 @@ class ProgressBar(object):
                     p.imap_unordered(function, items, steps)):
                     bar.update(i)
                     results.append(result)
+                p.close()
+                p.join()
 
         return results
 


### PR DESCRIPTION
The multiprocess option in ProgressBar needs to be closed and joined, to prevent it spinning off into oblivion.

See:
- http://docs.python.org/2/library/multiprocessing.html#multiprocessing.pool.multiprocessing.Pool.close
- http://docs.python.org/2/library/multiprocessing.html#multiprocessing.pool.multiprocessing.Pool.join

This doesn't matter most of the time, but sometimes I get a ton of threads in the background driving me nuts!
