### PR TITLE
Complex Quantities, conversion, and dimensionless quantities

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1701,12 +1701,12 @@ def _condition_arg(value):
     ValueError
         If value is not as expected
     """
-    if isinstance(value, (float, int, long)):
+    if isinstance(value, (float, int, long, complex)):
         return value
     else:
         try:
             avalue = np.array(value)
-            if not avalue.dtype.kind in ['i', 'f']:
+            if not avalue.dtype.kind in ['i', 'f', 'c']:
                 raise ValueError("Must be convertable to int or float array")
             if ma.isMaskedArray(value):
                 return value


### PR DESCRIPTION
I could see some reasoning in not usually allowing complex quantities. I'm however not sure why I can't do this:

```
>>> u.Quantity(4+5j).to('')
ValueError: Value not scalar compatible or convertable into a float or integer array
```

If the Quantity is unscaled, surely we should be able to return the dimensionless complex number. Even if it is scaled, is there a reason we can't return the unscaled quantity?

This comes up a lot when manipulating the results of FFTs, which have units, but often have dimensionless exponentials.

I'm happy to patch astorpy.units.core to accept complex values, but that might be too lenient (I'm not sure...)
