### PR TITLE
Logging tests not using default config values?

### DIFF
--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -4,7 +4,7 @@ import warnings
 
 from .helper import pytest, catch_warnings
 from .. import log
-from ..logger import LoggingError
+from ..logger import LoggingError, LOG_LEVEL
 
 
 # Save original values of hooks. These are not the system values, but the
@@ -240,10 +240,14 @@ def test_log_to_list(level):
     finally:
         log.setLevel(orig_level)
 
+    if level is None:
+        # The log level *should* be set to whatever it was in the config
+        level = LOG_LEVEL()
+
     # Check list length
     if level == 'DEBUG':
         assert len(log_list) == 4
-    elif level is None or level == 'INFO':
+    elif level == 'INFO':
         assert len(log_list) == 3
     elif level == 'WARN':
         assert len(log_list) == 2
@@ -325,10 +329,14 @@ def test_log_to_file(tmpdir, level):
     log_entries = log_file.readlines()
     log_file.close()
 
+    if level is None:
+        # The log level *should* be set to whatever it was in the config
+        level = LOG_LEVEL()
+
     # Check list length
     if level == 'DEBUG':
         assert len(log_entries) == 4
-    elif level is None or level == 'INFO':
+    elif level == 'INFO':
         assert len(log_entries) == 3
     elif level == 'WARN':
         assert len(log_entries) == 2


### PR DESCRIPTION
In the process of testing the 0.2.4 release I experienced two test failures on my own system when running `astropy.test()` in a Python session.  Both failures were in the logging module and looked something like this:

```
_______________________________________________ test_log_to_file[level0] _______________________________________________

tmpdir = local('/tmp/pytest-70/test_log_to_file_level0_0'), level = None

    @pytest.mark.parametrize(('level'), [None, 'DEBUG', 'INFO', 'WARN', 'ERROR'])
    def test_log_to_file(tmpdir, level):

        local_path = tmpdir.join('test.log')
        log_file = local_path.open('wb')
        log_path = str(local_path.realpath())

        if level is not None:
            log.setLevel(level)

        with log.log_to_file(log_path):
            log.error("Error message")
            log.warning("Warning message")
            log.info("Information message")
            log.debug("Debug message")

        log_file.close()

        log_file = local_path.open('rb')
        log_entries = log_file.readlines()
        log_file.close()

        # Check list length
        if level == 'DEBUG':
            assert len(log_entries) == 4
        elif level is None or level == 'INFO':
>           assert len(log_entries) == 3
E           assert 4 == 3
E            +  where 4 = len(["'2013-07-24 14:40:15,046', 'astropy.tests.test_logger', 'ERROR', 'Error message'\n", "'2013-07-24 14:40:15,046', 'as...'INFO', 'Information message'\n", "'2013-07-24 14:40:15,047', 'astropy.tests.test_logger', 'DEBUG', 'Debug message'\n"])

../../home/embray/.virtualenvs/astropy-release-test/lib/python2.7/site-packages/astropy/tests/test_logger.py:323: AssertionError
--------------------------------------------------- Captured stdout ----------------------------------------------------
ERROR: Error message [astropy.tests.test_logger]
WARNING: Warning message [astropy.tests.test_logger]
INFO: Information message [astropy.tests.test_logger]
DEBUG: Debug message [astropy.tests.test_logger]
```

I realized that this was just occurring because in my `~/.astropy/config/astropy.cfg` I set the log level to `DEBUG`, whereas the default should be `INFO`.  I thought we had fixed the tests to always use the default config settings...  Or am I mistaken on that?  (Note: I do see potential value in being able to run the tests with different local config values, but if that's a desirable thing to do the tests need to be designed to support different configurations where applicable).
