### PR TITLE
Always quote pip requirements otherwise stdout gets redirected when using > or >=

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,20 +80,20 @@ install:
     # CORE DEPENDENCIES
     # These command run pip first trying a wheel, and then falling back on
     # source build
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND numpy==$NUMPY_VERSION; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND Cython>=0.18; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND pytest-xdist; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "numpy==$NUMPY_VERSION"; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "Cython>=0.18"; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "pytest-xdist"; fi
 
     # OPTIONAL DEPENDENCIES
-    - if $OPTIONAL_DEPS; then $PIP_WHEEL_COMMAND scipy==0.12.0; fi
-    - if $OPTIONAL_DEPS; then $PIP_WHEEL_COMMAND h5py==2.1.3; fi
+    - if $OPTIONAL_DEPS; then $PIP_WHEEL_COMMAND "scipy==0.12.0"; fi
+    - if $OPTIONAL_DEPS; then $PIP_WHEEL_COMMAND "h5py==2.1.3"; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_COMMAND Sphinx==1.1.3; fi
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_COMMAND matplotlib>=1.3.0; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_COMMAND "Sphinx==1.1.3"; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_COMMAND "matplotlib>=1.3.0"; fi
 
 script:
     - python setup.py $SETUP_CMD


### PR DESCRIPTION
This was preventing proper error diagnosis, e.g. in #1269, because pip commands using > or >= would fail or succeed silently.
