### PR TITLE
Improved error message for WCS when incorrect number of arguments is passed

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -974,8 +974,11 @@ naxis kwarg.
                     for i in range(sky.shape[1])]
 
         raise TypeError(
-            "Expected 2 or {0} arguments, {1} given".format(
-                self.naxis + 1, len(args)))
+            "WCS projection has {0} dimensions, so expected 2 (an Nx{0} array "
+            "and the origin argument) or {1} arguments (the position in each "
+            "dimension, and the origin argument). Instead, {2} arguments were "
+            "given.".format(
+                self.naxis, self.naxis + 1, len(args)))
 
     def all_pix2world(self, *args, **kwargs):
         return self._array_converter(


### PR DESCRIPTION
Before:

```
In [3]: w.wcs_world2pix(1,2,3,1)
[traceback]
TypeError: Expected 2 or 3 arguments, 4 given
```

After:

```
In [3]: w.wcs_world2pix(1,2,3,1)
[traceback]
TypeError: WCS projection has 2 dimensions, so expected 2 (an Nx2 array
and the origin argument) or 3 arguments (the position in each dimension,
and the origin argument). Instead, 4 arguments were given.
```

Several users have pointed out that the original error message is not very informative.
