### PR TITLE
Astropy will no longer install on Python 3.2 with latest version of ``markupsafe`` package

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -49,6 +49,8 @@ try:
     HAVE_SPHINX = True
 except ImportError:
     HAVE_SPHINX = False
+except SyntaxError:  # occurs if markupsafe is recent version, which doesn't support Python 3.2
+    HAVE_SPHINX = False
 
 
 PY3 = sys.version_info[0] >= 3


### PR DESCRIPTION
Astropy no longer installs correctly on Python 3.2 if one has the latest version of the `markupsafe` package:

```

mac-robitaille2:astropy tom$ python3.2 setup.py install --user
Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    from astropy.setup_helpers import (register_commands, adjust_compiler,
  File "/Users/tom/Dropbox/Code/development/Astropy/astropy/astropy/setup_helpers.py", line 48, in <module>
    from sphinx.setup_command import BuildDoc as SphinxBuildDoc
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/sphinx/setup_command.py", line 20, in <module>
    from sphinx.application import Sphinx
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/sphinx/application.py", line 26, in <module>
    from sphinx.roles import XRefRole
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/sphinx/roles.py", line 20, in <module>
    from sphinx.util import ws_re
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/sphinx/util/__init__.py", line 27, in <module>
    import jinja2
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/jinja2/__init__.py", line 33, in <module>
    from jinja2.environment import Environment, Template
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/jinja2/environment.py", line 13, in <module>
    from jinja2 import nodes
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/jinja2/nodes.py", line 18, in <module>
    from jinja2.utils import Markup, MethodType, FunctionType
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/jinja2/utils.py", line 585, in <module>
    from markupsafe import Markup, escape, soft_unicode
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/markupsafe/__init__.py", line 68
    def __new__(cls, base=u'', encoding=None, errors='strict'):
                            ^
SyntaxError: invalid syntax
```

The developers have decided to discontinue Python 3.2 support:

https://github.com/mitsuhiko/markupsafe/pull/13

So this leaves us either with the option of using a `try...except` around the Sphinx import, or also discontinuing support for Python 3.2.
