### PR TITLE
Table Add row yields "*** ValueError: Setting void-array with object members using buffer."

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2069,7 +2069,7 @@ class Table(object):
                 raise TypeError("Mismatch between type of vals and mask")
 
             if len(self.columns) != len(vals):
-                raise ValueError('Mismatch bETWEEN NUMBer of vals and columns')
+                raise ValueError('Mismatch between number of vals and columns')
 
             if not isinstance(vals, tuple):
                 vals = tuple(vals)
@@ -2099,7 +2099,7 @@ class Table(object):
             self._data.resize((newlen,), refcheck=False)
 
         # Assign the new row
-        self._data[-1] = test_data[-1]
+        self._data[-1:] = test_data
 
         self._rebuild_table_column_views()
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -62,6 +62,13 @@ class SetupData(object):
             return self._d
 
     @property
+    def obj(self):
+        if self._column_type is not None:
+            if not hasattr(self, '_obj'):
+                self._obj = self._column_type(name='obj', data=[1, 'string', 3], dtype='O')
+            return self._obj
+
+    @property
     def t(self):
         if self._table_type is not None:
             if not hasattr(self, '_t'):
@@ -486,25 +493,29 @@ class TestAddRow(SetupData):
 
     def test_add_none_to_empty_table(self, table_types):
         self._setup(table_types)
-        t = table_types.Table(names=('a', 'b'), dtype=('i', 'S4'))
+        t = table_types.Table(names=('a', 'b', 'c'), dtype=('i', 'S4', 'O'))
         t.add_row()
         assert t['a'][0] == 0
         assert t['b'][0] == b''
+        assert t['c'][0] == 0
         t.add_row()
         assert t['a'][1] == 0
         assert t['b'][1] == b''
+        assert t['c'][1] == 0
 
     def test_add_stuff_to_empty_table(self, table_types):
         self._setup(table_types)
-        t = table_types.Table(names=('a', 'b'), dtype=('i', 'S8'))
-        t.add_row([1, 'hello'])
+        t = table_types.Table(names=('a', 'b', 'obj'), dtype=('i', 'S8', 'O'))
+        t.add_row([1, 'hello', 'world'])
         assert t['a'][0] == 1
         assert t['b'][0] == b'hello'
+        assert t['obj'][0] == 'world'
         # Make sure it is not repeating last row but instead
         # adding zeros (as documented)
         t.add_row()
         assert t['a'][1] == 0
         assert t['b'][1] == b''
+        assert t['obj'][1] == 0
 
     def test_add_table_row(self, table_types):
         self._setup(table_types)
@@ -515,6 +526,15 @@ class TestAddRow(SetupData):
         assert np.all(t['a'] == np.array([1, 2, 3, 1]))
         assert np.allclose(t['b'], np.array([4.0, 5.1, 6.2, 4.0]))
         assert np.all(t['c'] == np.array(['7', '8', '9', '7']))
+
+    def test_add_table_row_obj(self, table_types):
+        self._setup(table_types)
+        t = table_types.Table([self.a, self.b, self.obj])
+        t.add_row([1, 4.0, [10]])
+        assert len(t) == 4
+        assert np.all(t['a'] == np.array([1, 2, 3, 1]))
+        assert np.allclose(t['b'], np.array([4.0, 5.1, 6.2, 4.0]))
+        assert np.all(t['obj'] == np.array([1, 'string', 3, [10]], dtype='O'))
 
     def test_add_with_tuple(self, table_types):
         self._setup(table_types)


### PR DESCRIPTION
Sometime in the last week or two (I think; this is based on recent travis failures encountered in astroquery), a change in astropy.table has resulted in the above error.  The code below will reproduce the error:

```
>>> data = '::script::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\n\nquery bibcode wildcard  2006ApJ*\n\n::console:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\n\nC.D.S.  -  SIMBAD4 rel 1.207  -  2013.06.28CEST19:58:02\ntotal execution time: 2.191 secs\nsimbatch done\n\n::data::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\n\n2006ApJ...636....1K  --  ?\nAstrophys. J., 636, 1-7 (2006)\nKOBAYASHI M.A.R., KAMAYA H. and YONEHARA A.\nLy{alpha} line spectra of the first galaxies: dependence on observed direction to the underlying cold dark matter filament.\nFiles: (abstract) (no object)\n2006ApJ...636....8H  --  ?\nAstrophys. J., 636, 8-20 (2006)\nHARKO T. and CHENG K.S.\nGalactic metric, dark radiation, dark pressure, and gravitational lensing in brane world models.\nFiles: (abstract)\n'
>>> splitter='2006ApJ'
>>> ref_list = [splitter + ref for ref in data.split(splitter)][2:]
>>> from astropy.table import Table
>>> table = Table(names=['References'], dtypes=['object'])
>>> for ref in ref_list:
>>>         table.add_row([ref.decode('utf-8')])

ERROR: ValueError: Setting void-array with object members using buffer. [astropy.table.table]
Traceback (most recent call last):
  File "<ipython-input-6-6668743468aa>", line 2, in <module>
    table.add_row([ref.decode('utf-8')])
  File "/Users/adam/repos/astropy/astropy/table/table.py", line 2102, in add_row
    self._data[-1] = test_data[-1]
ValueError: Setting void-array with object members using buffer.

```

(note: in order to see this error, I had to use `git clean -fxd` prior to `python setup.py develop`, which I think means that this is associated with a compiled module)
