### PR TITLE
Equivalencies should be passed on more generally

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -326,7 +326,8 @@ class Quantity(np.ndarray):
 
                 if obj_array is None:
                     if type(out) != np.ndarray:  # array scalar; cannot view
-                        return self.__quantity_instance__(out, result_unit)
+                        return self.__quantity_instance__(out, result_unit,
+                                                          equivalencies=[])
                     else:
                         obj = self.__quantity_view__(out, result_unit)
 
@@ -370,6 +371,10 @@ class Quantity(np.ndarray):
 
         The parameters are the same as those to `Quantity.__new__`.
         """
+        # if unit remains the same, by default equivalencies do too
+        if 'equivalencies' not in kwargs and self.unit is unit:
+            kwargs['equivalencies'] = self.equivalencies
+
         return Quantity(val, unit, **kwargs)
 
     def __reduce__(self):
@@ -408,7 +413,8 @@ class Quantity(np.ndarray):
             constructor will be used.
         """
         if equivalencies is None:
-            equivalencies = self._equivalencies
+            equivalencies = self.equivalencies
+
         new_val = self.unit.to(unit, self.value, equivalencies=equivalencies)
         new_unit = Unit(unit)
         return self.__quantity_instance__(new_val, new_unit,
@@ -456,7 +462,7 @@ class Quantity(np.ndarray):
         si_unit = self.unit.to_system(si)[0]
         return self.__quantity_instance__(
             self.value * si_unit.scale, si_unit / si_unit.scale,
-            copy=False)
+            equivalencies=self.equivalencies, copy=False)
 
     @property
     def cgs(self):
@@ -469,7 +475,7 @@ class Quantity(np.ndarray):
         cgs_unit = self.unit.to_system(cgs)[0]
         return self.__quantity_instance__(
             self.value * cgs_unit.scale, cgs_unit / cgs_unit.scale,
-            copy=False)
+            equivalencies=self.equivalencies, copy=False)
 
     @lazyproperty
     def isscalar(self):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -365,14 +365,27 @@ def test_quantity_conversion_with_equiv():
 
 
 def test_quantity_conversion_equivalency_passed_on():
-    q1 = u.Quantity([1000,2000], unit=u.Hz, equivalencies=u.spectral())
+    q1 = u.Quantity([1000, 2000, 3000], unit=u.Hz, equivalencies=u.spectral())
     q2 = q1.to(u.nm).to(u.Hz)
     assert q2.unit == u.Hz
     assert_allclose(q2.value, q1.value)
-    q3 = u.Quantity([1000, 2000], unit=u.nm)
+    q3 = u.Quantity([1000, 2000, 3000], unit=u.nm)
     q4 = q3.to(u.Hz, equivalencies=u.spectral()).to(u.nm)
     assert q4.unit == u.nm
     assert_allclose(q4.value, q3.value)
+    q5 = q4.si
+    assert q5.equivalencies == q4.equivalencies
+    q6 = q4[0]
+    assert q6.equivalencies == q4.equivalencies
+
+
+def test_quantity_conversion_equivalency_not_passed_on():
+    # equivalencies should not be passed on when the unit changes
+    q1 = u.Quantity([1000, 2000, 3000], unit=u.Hz, equivalencies=u.spectral())
+    q2 = q1 / u.s
+    assert q2.equivalencies == []
+    q3 = q1.var()
+    assert q3.equivalencies == []
 
 
 def test_si():


### PR DESCRIPTION
@embray - looking further at `quantity.py`, I noticed that my PR for passing on equivalencies in `q.to()` (#1356) was incomplete: equivalences are also not passed on in `q.si`, `q.cgs`, `q.getitem()`, etc. Before adding boilerplate code in all those, I thought I would check whether it would not make more sense to change `__new__`.  Specifically, I would suggest setting the default in the call sequence to `equivalencies=None`, and then changing this to `value._equivalencies` if value is a Quantity, and to `[]` otherwise. Does this make sense? If so, I'll do a PR (preferably after #1271 is closed, to avoid needless rebasing).
