### PR TITLE
Decompose/rescale on floor division of quantities by units -- alternative to conversion members?

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -603,7 +603,7 @@ class Quantity(np.ndarray):
             return self.__quantity_instance__(
                 1. / self.value, unit=other / self.unit, copy=False)
         else:
-            return np.divide(other, self)
+            return np.true_divide(other, self)
 
     def __truediv__(self, other):
         """ Division between `Quantity` objects. """
@@ -616,6 +616,50 @@ class Quantity(np.ndarray):
     def __rtruediv__(self, other):
         """ Division between `Quantity` objects. """
         return self.__rdiv__(other)
+
+    def __floordiv__(self, other):
+        """ Division between `Quantity` objects and other objects."""
+
+        if isinstance(other, basestring):
+            other = Unit(other)
+
+        if isinstance(other, UnitBase):
+            unit = (self.unit / other).decompose()
+            return self.__quantity_instance__(self.value * unit.scale,
+                                              unit / unit.scale)
+        else:
+            return np.floor_divide(self, other)
+
+    def __ifloordiv__(self, other):
+        """Inplace division between `Quantity` objects and other objects."""
+
+        if isinstance(other, basestring):
+            other = Unit(other)
+
+        if isinstance(other, UnitBase):
+            unit = (self.unit / other).decompose()
+            if unit.scale == 1.:
+                self._unit = unit
+                return self
+            else:
+                unit_scale = unit.scale
+                unit._scale = 1.
+                return np.multiply(self.value, unit_scale * unit, self)
+
+        return np.floor_divide(self, other, self)
+
+    def __rfloordiv__(self, other):
+        """ Right Division between `Quantity` objects and other objects."""
+
+        if isinstance(other, basestring):
+            other = Unit(other)
+
+        if isinstance(other, UnitBase):
+            unit = (other / self.unit).decompose()
+            return self.__quantity_instance__(unit.scale / self.value,
+                                              unit / unit.scale, copy=False)
+        else:
+            return np.floor_divide(other, self)
 
     def __divmod__(self, other):
         from . import dimensionless_unscaled


### PR DESCRIPTION
In #1326, there has been discussion on whether/when/how many conversion members to include with quantities. I wondered if much of the wished-for convenience couldn't be gotten in a way that neither pollutes name space, nor sets us up for problems once quantities have uncertainties.  So, as a trial, I defined `__floordiv__` for quantities (which was not yet defined), to behave a bit like `__div__` in that division by strings/Units is treated like a division by a quantity 1 of that unit, but with the difference that the resulting unit is decomposed and the value rescaled. Hence, with this addition,

```
In [1]: import astropy.units as u

In [2]: l = u.Quantity(10.,"pc")

In [3]: l/'m'
Out[3]: <Quantity 10.0 pc / m>

In [4]: l//'m'
Out[4]: <Quantity 3.08567758147e+17 >

In [5]: l//u.au
Out[5]: <Quantity 2062648.06245 >
```

It seems to me this is a safe addition, no matter what is decided on #1326, and, for me at least, finally a reason to like the idea of multiplication/division by strings (contrary to my sentiment in #1408).
