### PR TITLE
Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,25 @@
+Adam Ginsburg       <keflavich@gmail.com> 
+Adam Ginsburg       <keflavich@gmail.com> Adam Ginsburg <adam.g.ginsburg@gmail.com>
+Alex Conley         <alexander.conley@colorado.edu> Alexander Conley <alexander.conley@colorado.edu>
+Alex Hagen          <mr.alex.hagen@gmail.com>
+Daniel Bell         <stampsrule@gmail.com> Daniel <idaniel@me.com>
+Daniel Bell         <stampsrule@gmail.com> stampsrule <stampsrule@gmail.com>
+Demitri Muna        <demitri.muna@gmail.com> <demitri@me.com>
+Demitri Muna        <demitri.muna@gmail.com> <beswiftly@gmail.com>
+Dylan Gregersen     <gregersen.dylan@gmail.com>
+Emma Hogan          <ehogan@gemini.edu>
+Erik M. Bray        <erik.m.bray@gmail.com> <embray@stsci.edu>
+Erik M. Bray        <erik.m.bray@gmail.com> Erik Bray <erik.m.bray@gmail.com>
+Gustavo Bragança    <ga.braganca@gmail.com>
+Hans Moritz Günther <moritz.guenther@gmx.de>
+Jeff Taylor         <jeff.c.taylor@gmail.com>
+Kacper Kowalik      <xarthisius@gentoo.org>
+Kirill Tchernyshyov <ktchernyshyov@pha.jhu.edu>
+Marten van Kerkwijk <mhvk@astro.utoronto.ca> <mhvk@swan.astro.utoronto.ca>
+Matt Davis          <jiffyclub.programatic@gmail.com>
+Nadia Dencheva      <nadia.astropy@gmail.com> <nadia.dencheva@gmail.com>
+Neil Crighton       <neilcrighton@gmail.com>
+Simon Conseil       <contact@saimon.org>
+Thomas Erben        <terben@astro.uni-bonn.de> <thomas@astro.uni-bonn.de>
+Tom Aldcroft        <taldcroft@gmail.com> <aldcroft@dhcp-131-142-152-173.cfa.harvard.edu>
+Zach Edwards        <Zachary.Astro@Gmail.com>


### PR DESCRIPTION
This file canonicalizes the names and e-mail address of committers to the mail astropy repository as displayed by

```
git shortlog -se
```

This includes removing duplicate entries (in my case where I've referred to myself with our without a middle initial), normalizing spelling (preferably to human names) and also normalizes which e-mail address is used.  You can read more about the format of this file with `git shortlog --help`.  Try running the shortlog command yourself to see if you're happy with your name and e-mail address.

I think with the file I've included all duplicates are take care of, though I wasn't sure for some people which e-mail address they'd prefer as their "canonical" address, or whether they'd like to be listed in this file at all (and keep their astropy commits somewhat more "anonymous").  Even if you've only had a small number of commits to Astropy we still want to be able to credit you properly.

So tagging everyone who's mentioned in this file so can have a chance to confirm that this looks okay: @keflavich, @aconley, @stampsrule, @demitri, @ehogan, @gabraganca, @hamogu, @durga2112, @xarthisius, @mhvk, @jiffyclub, @nden, @nhmc, @saimn, @terben, @taldcroft, @zachastro
