### PR TITLE
Make q[:,np.newaxis] work by using __quantity_view__ for __getitem__

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -680,8 +680,13 @@ class Quantity(np.ndarray):
                 "'{cls}' object with a scalar value does not support "
                 "indexing".format(cls=self.__class__.__name__))
         else:
-            return self.__quantity_instance__(self.value[key], unit=self.unit,
-                                              copy=False)
+            out = self.value[key]
+            if type(out) != np.ndarray:  # array scalar; cannot view
+                return self.__quantity_instance__(out, self.unit)
+
+            out = self.__quantity_view__(out, self.unit)
+            out._unit = self.unit
+            return out
 
     def __setitem__(self, i, value):
         self.view(np.ndarray).__setitem__(i, self._to_own_unit(value))

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -39,11 +39,20 @@ class TestQuantityArrayCopy(object):
         q[0] = -1.*u.m/u.s
         assert q[0].value != q2[0].value
 
-    def test_getitem_does_not_copy(self):
+    def test_getitem_is_view(self):
+        """Check that [keys] work, and that, like ndarray, it returns
+        a view, so that changing one changes the other.
+
+        Also test that one can add axes (closes #1422)
+        """
         q = u.Quantity(np.arange(100.), "m/s")
         q_sel = q[10:20]
         q_sel[0] = -1.*u.m/u.s
         assert q_sel[0] == q[10]
+        # also check that getitem can do new axes
+        q2 = q[:, np.newaxis]
+        q2[10,0] = -9*u.m/u.s
+        assert np.all(q2.flatten() == q)
 
 
 class TestQuantityStatsFuncs(object):


### PR DESCRIPTION
The addition of `copy=False` caused an error in `__getitem__` when one expands an axis (as in `q[:, np.newaxis]`; as this is done in matplotlib for 1D arrays, this is painful...) This is because `__getitem__` used `__quantity_instance__` when really it should have been using a view, `__quantity_view__`. This is corrected in this PR (plus test to ensure it doesn't recur).
