### PR TITLE
Make Quantity and Time/TimeDelta consistent attribute naming

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -244,7 +244,7 @@ class Time(object):
         return self._format
 
     def __repr__(self):
-        return ("<{0} object: scale='{1}' format='{2}' vals={3}>"
+        return ("<{0} object: scale='{1}' format='{2}' value={3}>"
                 .format(self.__class__.__name__, self.scale, self.format,
                         getattr(self, self.format)))
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -23,7 +23,7 @@ class TestBasic():
         times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
         t = Time(times, format='iso', scale='utc')
         assert (repr(t) == "<Time object: scale='utc' format='iso' "
-                "vals=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
+                "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
         assert allclose_jd(t.jd1, np.array([2451179.5, 2455197.5]))
         assert allclose_jd2(t.jd2, np.array([1.4288980208333335e-06,
                                              0.00000000e+00]))
@@ -31,7 +31,7 @@ class TestBasic():
         # Set scale to TAI
         t = t.tai
         assert (repr(t) == "<Time object: scale='tai' format='iso' "
-                "vals=['1999-01-01 00:00:32.123' '2010-01-01 00:00:34.000']>")
+                "value=['1999-01-01 00:00:32.123' '2010-01-01 00:00:34.000']>")
         assert allclose_jd(t.jd1, np.array([2451179.5, 2455197.5]))
         assert allclose_jd2(t.jd2, np.array([0.00037179926839122024, 0.00039351851851851852]))
 
@@ -39,7 +39,7 @@ class TestBasic():
         # (internal JD1 and JD1 are now with respect to TT scale)"""
 
         assert (repr(t.tt) == "<Time object: scale='tt' format='iso' "
-                "vals=['1999-01-01 00:01:04.307' '2010-01-01 00:01:06.184']>")
+                "value=['1999-01-01 00:01:04.307' '2010-01-01 00:01:06.184']>")
 
         # Get the representation of the ``Time`` object in a particular format
         # (in this case seconds since 1998.0).  This returns either a scalar or

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -26,7 +26,7 @@ class TestTimeDelta():
         # time - time
         dt = self.t2 - self.t
         assert (repr(dt).startswith("<TimeDelta object: scale='tai' "
-                                    "format='jd' vals=1.00001157407"))
+                                    "format='jd' value=1.00001157407"))
         assert allclose_jd(dt.jd, 86401.0 / 86400.0)
         assert allclose_sec(dt.sec, 86401.0)
 

--- a/astropy/time/tests/test_guess.py
+++ b/astropy/time/tests/test_guess.py
@@ -10,7 +10,7 @@ class TestGuess():
         times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
         t = Time(times, scale='utc')
         assert (repr(t) == "<Time object: scale='utc' format='iso' "
-                "vals=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
+                "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
 
     def test_guess2(self):
         times = ['1999-01-01 00:00:00.123456789', '2010-01 00:00:00']
@@ -21,7 +21,7 @@ class TestGuess():
         times = ['1999:001:00:00:00.123456789', '2010:001']
         t = Time(times, scale='utc')
         assert (repr(t) == "<Time object: scale='utc' format='yday' "
-                "vals=['1999:001:00:00:00.123' '2010:001:00:00:00.000']>")
+                "value=['1999:001:00:00:00.123' '2010:001:00:00:00.000']>")
 
     def test_guess4(self):
         times = [10, 20]

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -15,7 +15,7 @@ the default IERS B table is loaded as necessary in `Time`::
     ...           '2012-06-30 23:59:60', '2012-07-01 00:00:00',
     ...           '2012-07-01 12:00:00'], scale='utc')
     >>> t.ut1
-    <Time object: scale='ut1' format='iso' vals=['2012-06-30 11:59:59.413'
+    <Time object: scale='ut1' format='iso' value=['2012-06-30 11:59:59.413'
      '2012-06-30 23:59:58.413' '2012-06-30 23:59:59.413'
      '2012-07-01 00:00:00.413' '2012-07-01 12:00:00.413']>
 
@@ -39,7 +39,7 @@ configurable or automatic, but currently it requires handiwork.  For
     >>> t2.delta_ut1_utc = iers_a.ut1_utc(t2)      # doctest: +SKIP
     >>> t2.ut1.iso                                 # doctest: +SKIP
     <Time object: scale='ut1' format='datetime'
-     vals=2013-06-22 17:01:13.446632>
+     value=2013-06-22 17:01:13.446632>
 
 Instead of local copies of IERS files, one can also download them, using
 `iers.IERS_A_URL` and `iers.IERS_B_URL`::

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -38,9 +38,9 @@ In general any output values have the same shape (scalar or array) as the input.
   >>> times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
   >>> t = Time(times, format='iso', scale='utc')
   >>> t
-  <Time object: scale='utc' format='iso' vals=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>
+  <Time object: scale='utc' format='iso' value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>
   >>> t[1]
-  <Time object: scale='utc' format='iso' vals=2010-01-01 00:00:00.000>
+  <Time object: scale='utc' format='iso' value=2010-01-01 00:00:00.000>
 
 The ``format`` argument specifies how to interpret the input values, e.g. ISO
 or JD or Unix time.  The ``scale`` argument specifies the `time scale`_ for the
@@ -60,7 +60,7 @@ TT.  This uses the same attribute mechanism as above but now returns a new
 
   >>> t2 = t.tt
   >>> t2
-  <Time object: scale='tt' format='iso' vals=['1999-01-01 00:01:04.307' '2010-01-01 00:01:06.184']>
+  <Time object: scale='tt' format='iso' value=['1999-01-01 00:01:04.307' '2010-01-01 00:01:06.184']>
   >>> t2.jd
   array([ 2451179.5007443 ,  2455197.50076602])
 
@@ -196,9 +196,9 @@ appropriate::
   >>> t.jd
   array([ 2400100.5,  2400200.5,  2400300.5])
   >>> t[:2]
-  <Time object: scale='utc' format='mjd' vals=[ 100.  200.]>
+  <Time object: scale='utc' format='mjd' value=[ 100.  200.]>
   >>> t[2]
-  <Time object: scale='utc' format='mjd' vals=300.0>
+  <Time object: scale='utc' format='mjd' value=300.0>
 
 Inferring input format
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -297,7 +297,7 @@ first object unless explicitly specified.
 ::
 
   >>> Time([t1, t2])
-  <Time object: scale='tt' format='mjd' vals=[ 50100.  55197.00076602]>
+  <Time object: scale='tt' format='mjd' value=[ 50100.  55197.00076602]>
 
 val2
 ^^^^
@@ -361,7 +361,7 @@ heterogeous subformat::
 
   >>> Time(['2000:001', '2000:002:03:04', '2001:003:04:05:06.789'], scale='utc')
   <Time object: scale='utc' format='yday'
-   vals=['2000:001:00:00:00.000' '2000:002:03:04:00.000' '2001:003:04:05:06.789']>
+   value=['2000:001:00:00:00.000' '2000:002:03:04:00.000' '2001:003:04:05:06.789']>
 
 One can explicitly specify `in_subfmt` in order to strictly require a
 certain subformat::
@@ -465,9 +465,9 @@ Examples::
 
   >>> t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
   >>> t.tt        # TT scale
-  <Time object: scale='tt' format='iso' vals=2010-01-01 00:01:06.184>
+  <Time object: scale='tt' format='iso' value=2010-01-01 00:01:06.184>
   >>> t.tai
-  <Time object: scale='tai' format='iso' vals=2010-01-01 00:00:34.000>
+  <Time object: scale='tai' format='iso' value=2010-01-01 00:00:34.000>
 
 In this process the ``format`` and other object attributes like ``lat``,
 ``lon``, and ``precision`` are also propagated to the new object.
@@ -591,7 +591,7 @@ Use of the |TimeDelta| object is easily illustrated in the few examples below::
   >>> t2 = Time('2010-02-01 00:00:00', scale='utc')
   >>> dt = t2 - t1  # Difference between two Times
   >>> dt
-  <TimeDelta object: scale='tai' format='jd' vals=31.0>
+  <TimeDelta object: scale='tai' format='jd' value=31.0>
   >>> dt.sec
   2678400.0
 
@@ -602,13 +602,13 @@ Use of the |TimeDelta| object is easily illustrated in the few examples below::
   '2010-02-01 00:00:50.000'
 
   >>> t2 - dt2  # Subtract a TimeDelta from a Time
-  <Time object: scale='utc' format='iso' vals=2010-01-31 23:59:10.000>
+  <Time object: scale='utc' format='iso' value=2010-01-31 23:59:10.000>
 
   >>> dt + dt2
-  <TimeDelta object: scale='tai' format='jd' vals=31.0005787037>
+  <TimeDelta object: scale='tai' format='jd' value=31.0005787037>
 
   >>> t1 + dt * np.linspace(0, 1, 5)
-  <Time object: scale='utc' format='iso' vals=['2010-01-01 00:00:00.000' 
+  <Time object: scale='utc' format='iso' value=['2010-01-01 00:00:00.000' 
   '2010-01-08 18:00:00.000' '2010-01-16 12:00:00.000' '2010-01-24 06:00:00.000'
   '2010-02-01 00:00:00.000']>
 


### PR DESCRIPTION
As @taldcroft  noted in #751, the `Time` object and `Quantity` objects have some similar-sounding attributes that are not quite the same.  `val` and `vals` for `Time`/`value` for `Quantity`, and `is_scalar` for `Time`/`isscalar` for `Quantity`.  We should probably adjust these to be the same.  Then people don't have to try to remember which is which.

Personally, I'm for `value`/`values` over `val`/`vals` - it's only a couple more characters and quite a bit more readable. 

`isscalar` vs `is_scalar`:  I think I wrote `isscalar`, and I think I did it that way because it's how the `numpy` function is named.  Also, it's a property rather than a method and attributes/properties in my head aren't underscore-delimited.  But I don't think that's in PEP8, so I have no strong opinion.

I'm tagging this for 0.3, but if this quickly settles on an answer and is easy to implement, we might slip it into 0.2 to keep from breaking compatibility (@iguananaut ?)
