### PR TITLE
Support the wacky prefixes in CDS unit format

### DIFF
--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -58,7 +58,18 @@ def test_cds_grammar():
         (["m2"], u.m ** 2),
         (["10+21m"], u.Unit(u.m * 1e21)),
         (["2.54cm"], u.Unit(u.cm * 2.54)),
-        (["20%"], 0.20)]
+        (["20%"], 0.20),
+        (["ma"], u.ma),
+        (["mAU"], u.mAU),
+        (["uarcmin"], u.uarcmin),
+        (["uarcsec"], u.uarcsec),
+        (["kbarn"], u.kbarn),
+        (["Gbit"], u.Gbit),
+        (["kbyte"], u.kbyte),
+        (["mRy"], 0.001 * u.Ry),
+        (["mmag"], u.mmag),
+        (["Mpc"], u.Mpc),
+        (["Gyr"], u.Gyr)]
 
     for strings, unit in data:
         for s in strings:


### PR DESCRIPTION
This is an alternative to #1172, in which prefixes on units that don't usually have them are supported by the CDS parser (since CDS requires it).  Unlike #1172, this does not add those prefixed units to the astropy.units namespace.

Fix #1169 (the original issue).
