### PR TITLE
table: test_operations.py - Test implemented twice?

### DIFF
--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -374,9 +374,6 @@ class TestVStack():
                                  '  2 pez',
                                  '  3 sez']
 
-        # stacking as a list gives same result
-        t12_list = table.vstack([t1, t2], join_type='inner')
-        assert t12.pformat() == t12_list.pformat()
 
         t12 = table.vstack([t1, t2], join_type='outer')
         assert t12.pformat() == [' a   b   c ',


### PR DESCRIPTION
Either this test is just implemented twice (see the lines just above the one I removed) or the second test was supposed to test something else (e.g. merging a tuple instead of a list?)
