### PR TITLE
Fix to failing pkg_data test on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -354,6 +354,9 @@ Bug Fixes
   - Fixed a crash on Python 3.2 when affiliated packages try to use the
     ``astropy.utils.data.get_pkg_data_*`` functions. [#1256]
 
+  - Fixed a minor path normalization issue that could occur on Windows in
+    ``astropy.utils.data.get_pkg_data_filename``. [#1444]
+
   - Miscellaneous documentation fixes and improvements [#1308, #1317, #1377,
     #1393, #1362]
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -78,6 +78,7 @@ def _is_inside(path, parent_path):
     return os.path.abspath(path).startswith(os.path.abspath(parent_path)) \
         or os.path.realpath(path).startswith(os.path.realpath(parent_path))
 
+
 @contextlib.contextmanager
 def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                          show_progress=True):
@@ -131,6 +132,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     -------
     file : readable file-like object
     """
+
     import tempfile
 
     # close_fds is a list of file handles created by this function
@@ -455,6 +457,8 @@ def get_pkg_data_filename(data_name, show_progress=True):
     get_pkg_data_contents : returns the contents of a file or url as a bytes object
     get_pkg_data_fileobj : returns a file-like object with the data
     """
+
+    data_name = os.path.normpath(data_name)
 
     if data_name.startswith('hash/'):
         # first try looking for a local version if a hash is specified


### PR DESCRIPTION
This is really just a followup to my fix for #1257, where the test I added for that revealed an unrelated bug in Windows with path separator normalization.
