### PR TITLE
sqrt in units -> should return unit**0.5, not unit**-2

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -304,7 +304,7 @@ class Generic(Base):
             function : function_name OPEN_PAREN unit_expression CLOSE_PAREN
             '''
             if p[1] == 'sqrt':
-                p[0] = p[3] ** -2.0
+                p[0] = p[3] ** 0.5
             else:
                raise ValueError(
                    '{0!r} is not a recognized function'.format(p[1]))

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -34,7 +34,7 @@ def test_unit_grammar():
         (["10+8m"], u.Unit(u.m * 1e8)),
         # This is the VOUnits documentation, but doesn't seem to follow the
         # unity grammar (["3.45 10**(-4)Jy"], 3.45 * 1e-4 * u.Jy)
-        (["sqrt(m)"], u.m ** -2)
+        (["sqrt(m)"], u.m ** 0.5)
     ]
 
     for strings, unit in data:


### PR DESCRIPTION
Currently, `Unit('sqrt(m)')` returns `Unit("1 / m2")`. This is corrected here (as is the test that tested the wrong behaviour).
