### PR TITLE
For initialisation from list of quantities, default to unit of first

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -129,6 +129,8 @@ class Quantity(np.ndarray):
             else:
                 _value = _validate_value(value.to(unit).value, dtype, copy)
         elif isiterable(value) and all(isinstance(v, Quantity) for v in value):
+            if unit is None:
+                unit = value[0].unit
             _value = _validate_value([q.to(unit).value for q in value], dtype,
                                      copy)
         else:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -599,6 +599,11 @@ def test_quantity_initialized_with_quantity():
     assert q3[0].value == 60
     assert q3[1].value == 60
 
+    q4 = u.Quantity([q2, q1])
+    assert q4.unit == q2.unit
+    assert q4[0].value == 1
+    assert q4[1].value == 1
+
 
 def test_quantity_string_unit():
     q1 = "m" / u.s


### PR DESCRIPTION
This follows on a discussion on astropy-dev, where it was asked how to easily append quantities to a longer array. The best method so far would seem `Quantity([q1,q2], unit)`; this PR ensures that if no `unit` is given, it defaults to `q1.unit`:

```
w1 = u.Quantity(1000, u.AA)
w2 = u.Quantity(900, u.nm)
u.Quantity([w1, w2])
```

yields

```
<Quantity [ 1000., 9000.] Angstrom>
```

(Also includes a test case).

[1] https://groups.google.com/forum/#!topic/astropy-dev/zH98DFp0YKM
