### PR TITLE
Tweaks to make `Unit` and `Quantity` interfaces more similar

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -930,6 +930,19 @@ class UnitBase(object):
         """
         return False
 
+    @property
+    def unit(self):
+        """
+        This provides a uniform interface with ``Quantity`` and returns the unit itself.
+        """
+        return self
+
+    @property
+    def value(self):
+        """
+        This provides a uniform interface with ``Quantity`` and returns 1.
+        """
+        return 1.
 
 class NamedUnit(UnitBase):
     """

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -609,6 +609,28 @@ def test_quantity_string_unit():
     assert q2.unit == ((u.m * u.m) / u.s)
 
 
+def test_unit_quantity_interface():
+    """
+    Check that Unit.value and Unit.unit exist to make Unit behave like a Quantity [#1201].
+    """
+
+    q1 = u.m  # Unit
+    assert q1.unit == u.m
+    assert q1.value == 1.
+
+    q2 = 1. * u.m  # Quantity
+    assert q2.unit == u.m
+    assert q2.value == 1.
+
+    q3 = u.m / u.s  # Unit
+    assert q3.unit == u.m / u.s
+    assert q3.value == 1.
+
+    q4 = 1. * u.m / u.s  # Quantity
+    assert q4.unit == u.m / u.s
+    assert q4.value == 1.
+
+
 @raises(ValueError)
 def test_quantity_invalid_unit_string():
     "foo" * u.m


### PR DESCRIPTION
I've been using astropy's units module today (which is awesome). 

As far as I can tell, the easiest way to determine the units of something which could be either a unit or a quantity is:

```
u = (1 * x).unit
```

Which is a slightly non-obvious type cast. It would be handy if Unit had a `.unit` attribute (a property which returns `self`) to match `Quantity.unit`. Also handy (but maybe slightly more controversial) would be a `.value` property that returns 1.

These tweaks would make it easier to write code that's agnostic about Quantities vs Units

I've also been using the following utility function:

```
def split(x):
    if isinstance(1 * x, Quantity)
       return x.unit, x.value
    return 1, x

u, v = split(x)
return u * np.sin(v)
```

This unpacks and repacks a Unit/Quantity to avoid the implicit conversion warning. Importantly (and unlike `decompose`), it also works if x is just a number or array. 

It might be nice to include a function like split in the units module and docs, unless you recommend a different approach (perhaps an `asquantity` method to match `np.asarray`?)
