### PR TITLE
Fix error message about acceptable unit scale data types

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1718,11 +1718,12 @@ def _condition_arg(value):
         try:
             avalue = np.array(value)
             if not avalue.dtype.kind in ['i', 'f', 'c']:
-                raise ValueError("Must be convertable to int or float array")
+                raise ValueError(
+                    "Must be convertable to int, float or complex array")
             if ma.isMaskedArray(value):
                 return value
             return avalue
         except ValueError:
             raise ValueError(
-                "Value not scalar compatible or convertable into a float or "
-                "integer array")
+                "Value not scalar compatible or convertable into a int, "
+                "float, or complex array")


### PR DESCRIPTION
Recently, we included "complex" in the acceptable types, but the error message did not get updated.
