### PR TITLE
Unit.decompose into compound units broken

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1493,7 +1493,7 @@ class CompositeUnit(UnitBase):
                 scale = add_unit(b, p, scale)
 
         new_parts = [x for x in new_parts.items() if x[1] != 0]
-        new_parts.sort(key=lambda x: (x[1], x[0].name), reverse=True)
+        new_parts.sort(key=lambda x: x[1], reverse=True)
 
         self._bases = [x[0] for x in new_parts]
         self._powers = [x[1] for x in new_parts]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -458,3 +458,9 @@ def test_comparison():
 
     with pytest.raises(u.UnitsException):
         u.m > u.kg
+
+
+def test_compose_into_arbitrary_units():
+    # Issue #1438
+    from ...constants import G
+    G.decompose([u.kg, u.km, u.Unit("15 s")])


### PR DESCRIPTION
As reported by @adrn on the astropy-dev mailing list

Prior to this commit:
https://github.com/astropy/astropy/commit/a81d6af977920c8a8044d04c19f928a0556e7ab6

I was able to decompose to any arbitrary set of units, even
CompositeUnits, e.g.:

from astropy.constants import G
G.decompose([u.kg, u.km, u.Unit("15 s")])

But this line was changed in the above commit:

(1452)
-        new_parts.sort(key=lambda x: x[1], reverse=True)
-        new_parts.sort(key=lambda x: (x[1], x[0].name), reverse=True)

And now, because CompositeUnit has no .name, it fails. Was this intentional?

It's very handy for me to decompose constants to arbitrary sets of
units. I work a lot with dynamical simulations which are often done in
scaled units which then have to be converted back and forth to
physical values.

Thanks!
