### PR TITLE
stop the config tests from generating a configuration section in the astropy.cfg file

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -640,6 +640,8 @@ def generate_all_config_items(pkgornm=None, reset_to_default=False,
                              'have __file__ or __path__')
 
     for imper, nm, ispkg in walk_packages(pkgpath, package.__name__ + '.'):
+        if nm == 'astropy.config.tests.test_configs':
+            continue
         if not _unsafe_import_regex.match(nm):
             imper.find_module(nm)
             if reset_to_default:


### PR DESCRIPTION
See #1476 for details.  This fixes the problem noted there by just skipping the `astropy.config.tests.test_configs` module.  The actually tests themselves don't write there because of a bunch of sanitizing code in py.test, but this probably crept in because the module itself is inspected even when the tests aren't running.
