### PR TITLE
test_new_masked_col_existing_table needs to be skipped when Numpy 1.4.1 is used

### DIFF
--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -17,6 +17,7 @@ class MaskedTable(table.Table):
         table.Table.__init__(self, *args, **kwargs)
 
 
+@pytest.mark.skipif("numpy_lt_1p5")
 def test_masked_row_with_object_col():
     """
     Numpy < 1.8 has a bug in masked array that prevents access a row if there is


### PR DESCRIPTION
I am seeing the following test failure with Numpy 1.4.1:

```
=================================== FAILURES ===================================
_______ TestSetTableColumn.test_set_new_masked_col_existing_table[False] _______

self = <astropy.table.tests.test_table.TestSetTableColumn object at 0x106c40390>

    def test_set_new_masked_col_existing_table(self):
        """Create a new column in an existing table using the item access syntax"""
        t = Table([self.a])  # masked or unmasked
>       b = table.MaskedColumn(name='b', data=[1, 2, 3])  # masked

astropy/table/tests/test_table.py:150: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<class 'astropy.table.table.MaskedColumn'>,)
kwargs = {'data': [1, 2, 3], 'name': 'b'}

    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        if len(args) > 1 and isinstance(args[1], basestring):
            cls = args[0]  # Column or MaskedColumn class from __new__(cls, ..)
            raise ValueError(ERROR_COLUMN_ARGS_MESSAGE.format(class_name=cls.__name__,
                                                              first_arg=repr(args[1])))
>       return func(*args, **kwargs)

astropy/table/table.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'astropy.table.table.MaskedColumn'>, data = [1, 2, 3], name = 'b'
mask = None, fill_value = None, dtype = None, shape = (), length = 0
description = None, units = None, format = None, meta = None

    @_check_column_new_args
    def __new__(cls, data=None, name=None, mask=None, fill_value=None,
                 dtype=None, shape=(), length=0,
                 description=None, units=None, format=None, meta=None):

        if NUMPY_LT_1P5:
>           raise ValueError('MaskedColumn requires NumPy version 1.5 or later')
E           ValueError: MaskedColumn requires NumPy version 1.5 or later

astropy/table/table.py:597: ValueError
```

I think the test should be skipped. I've tagged this 0.3.0 as I don't think this test exists in the 0.2.x branch - @taldcroft, could you double check, and fix as you see fit?
