### PR TITLE
planck function addition

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1156,7 +1156,7 @@ def planck(w, temp):
 			temperature quantity
 	Returns
 	-------
-	flux	: blackbody flux, in units W/m2/um
+	flux	: blackbody flux, in units W/m2/um/sr
 
 	Note: This function should be turned into a model once model parameters can be quantities
 	
@@ -1176,8 +1176,8 @@ def planck(w, temp):
 	    raise InputParameterError("Input temperature quantity must be in temperature units")
 
         
-	flux = 2 * const.h * const.c**2 / w**5 / (np.exp(const.h*const.c/(w * const.k_B * temp)) - 1)
-	flux = flux.to(u.Watt / (u.m * u.m * u.um))	
+	flux = 2 * const.h * const.c**2 / w**5 / (np.exp(const.h*const.c/(w * const.k_B * temp)) - 1) / u.sr
+	flux = flux.to(u.Watt / (u.m * u.m * u.um * u.sr))	
 	return flux
 
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -303,4 +303,20 @@ def create_model(model_class, parameters):
 
     elif issubclass(model_class, PolynomialModel):
         return model_class(**parameters)
-    
+
+def test_planck():
+    from astropy import units as u
+    from astropy import constants as const
+    import matplotlib.pyplot as plt
+    import math
+    from scipy import integrate
+    #generate some input wavelengths tha should work
+    t = 100.*u.K
+    l = np.logspace(0, 8, 1e6)
+    l = l*u.AA
+    full = planck(l, t)
+    lum = l.to(u.um)
+    intflux = integrate.trapz(full.value, x=lum.value)
+    check = const.sigma_sb * t**4 / math.pi
+    assert ((intflux/check).value >= 0.99)
+    return (intflux/check).value


### PR DESCRIPTION
Added the planck() function to functional_models, and a corresponding test function test_planck() to test_models. The test compares the planck() output integrated over a range of wavelengths with the Stefan-Boltzmann law.
