### PR TITLE
CompositeUnit object has not attribute name

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -222,6 +222,34 @@ class UnitBase(object):
         r = tuple(r)
         return r
 
+    @property
+    def names(self):
+        """
+        Returns all of the names associated with this unit.
+        """
+        raise AttributeError(
+            "Can not get names from unnamed units. "
+            "Perhaps you meant to_string()?")
+        return self._names
+
+    @property
+    def name(self):
+        """
+        Returns the canonical (short) name associated with this unit.
+        """
+        raise AttributeError(
+            "Can not get names from unnamed units. "
+            "Perhaps you meant to_string()?")
+
+    @property
+    def aliases(self):
+        """
+        Returns the alias (long) names for this unit.
+        """
+        raise AttributeError(
+            "Can not get aliases from unnamed units. "
+            "Perhaps you meant to_string()?")
+
     def to_string(self, format='generic'):
         """
         Output the unit in the given format as a string.


### PR DESCRIPTION
I have the following problem:

``` python
>>> from astropy import units as u
>>> x1 = u.Quantity(1.0, u.m)
>>> x1.unit.name
u'm'
>>> x2 = u.Quantity(2.0, u.dimensionless_unscaled)
>>> x3 = x1 * x2
>>> x3
<Quantity 2.0 m>
>>> x3.unit
Unit("m")
>>> x3.unit.name
AttributeError: 'CompositeUnit' object has no attribute 'name'
```

`x2.unit.name` also gives me the same error.

Is this a bug? In `pysynphot`, filter bandpass is unitless. I wish to multiply it with a given stellar spectrum, and then extract the unit name of the product. Theoretically, the product should have same unit as stellar spectrum, but the example above shows that it is not the case via `astropy.units`.
