### PR TITLE
Error with install --enable-legacy

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -1409,6 +1409,11 @@ def add_legacy_alias(old_package, new_package, equiv_version, extras={}):
     """
     import imp
 
+    # distutils doesn't handle unicode package names on Python 2.x
+    if not PY3:
+        old_package = old_package.encode('ascii')
+        new_package = new_package.encode('ascii')
+
     # If legacy shims have not been enabled at the commandline, simply do
     # nothing.
     if not get_distutils_build_or_install_option('enable_legacy'):


### PR DESCRIPTION
On Mac and Linux I can't manage to install astropy with the `--enable-legacy` option any more:

```
$ python setup.py install --enable-legacy
...
copying build/legacy-aliases/vo/__init__.py -> build/lib.macosx-10.8-x86_64-2.7/vo
Traceback (most recent call last):
  File "setup.py", line 101, in <module>
    **package_info
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/install.py", line 73, in run
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/install.py", line 93, in do_egg_install
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/bdist_egg.py", line 185, in run
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/bdist_egg.py", line 171, in call_command
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/install_lib.py", line 20, in run
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/install_lib.py", line 109, in build
    self.run_command('build_py')
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/private/tmp/astropy/astropy/setup_helpers.py", line 586, in run
    SetuptoolsBuildPy.run(self)
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/build_py.py", line 89, in run
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/build_py.py", line 372, in build_packages
    self.build_module(module, module_file, package)
  File "build/bdist.macosx-10.8-x86_64/egg/setuptools/command/build_py.py", line 106, in build_module
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/build_py.py", line 333, in build_module
    "'package' must be a string (dot-separated), list, or tuple")
TypeError: 'package' must be a string (dot-separated), list, or tuple
```

This might be the same issue: http://bugs.python.org/issue13943
