### PR TITLE
Remove --enable-legacy functionality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,6 +313,8 @@ API Changes
 
        #include "astropy_wcs_api.h"
 
+- The ``--enable-legacy`` option for ``setup.py`` has been removed.
+
 Bug Fixes
 ^^^^^^^^^^
 

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -50,8 +50,3 @@ def get_package_data():
 
 def get_external_libraries():
     return ['cfitsio']
-
-
-def get_legacy_alias():
-    return setup_helpers.add_legacy_alias(
-        'pyfits', 'astropy.io.fits', '3.2.dev', {'__svn_revision__': '1927'})

--- a/astropy/io/votable/setup_package.py
+++ b/astropy/io/votable/setup_package.py
@@ -25,10 +25,5 @@ def get_package_data():
             'urls/*.dat.gz']}
 
 
-def get_legacy_alias():
-    return setup_helpers.add_legacy_alias(
-        'vo', 'astropy.io.votable', '0.8')
-
-
 def requires_2to3():
     return False

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -305,10 +305,6 @@ def get_package_data():
     }
 
 
-def get_legacy_alias():
-    return setup_helpers.add_legacy_alias('pywcs', 'astropy.wcs', '1.11')
-
-
 def get_external_libraries():
     return ['wcslib']
 

--- a/docs/development/building.rst
+++ b/docs/development/building.rst
@@ -37,15 +37,6 @@ process:
     it should return a list of `distutils.core.Extension` objects controlling
     the Cython/C build process (see below for more detail).
 
-* :func:`get_legacy_alias`
-    This function allows for the creation of `shims` that allow a
-    subpackage to be imported under another name.  For example,
-    `astropy.io.fits` used to be available under the namespace
-    `pyfits`.  For backward compatibility, it is helpful to have it
-    still importable under the old name.  Under most circumstances,
-    this function should call `astropy.setup_helpers.add_legacy_alias`
-    to generate a legacy module and then return what it returns.
-
 * :func:`get_build_options`
     This function allows a package to add extra build options.  It
     should return a list of tuples, where each element has:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -258,53 +258,6 @@ into.  For example to add the missing registry entries to your Python 2.7::
 
 __ https://gist.github.com/embray/6042780#file-win_register_python-py
 
-
-Compatibility packages
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. warning:: This feature is still experimental, and you may run into
-             unexpected issues with other packages, so we strongly
-             recommend simply updating your code to use Astropy if
-             possible, rather than rely on these compatibility packages.
-
-Optionally, it is possible to install 'compatibility' packages that
-emulate the behavior of previous packages that have now been
-incorporated into Astropy. These are:
-
-* `PyFITS <http://www.stsci.edu/institute/software_hardware/pyfits/>`_
-* `vo <https://trac.assembla.com/astrolib/>`_
-* `PyWCS <https://trac.assembla.com/astrolib/>`_
-
-If you build Astropy with::
-
-    python setup.py build --enable-legacy
-    python setup.py install
-
-or simply::
-
-    python setup.py install --enable-legacy
-
-then you will be able to import these modules from your scripts as if
-the original packages had been installed. Using::
-
-    import pyfits
-    import vo
-    import pywcs
-
-will then be equivalent to::
-
-    from astropy.io import fits as pyfits
-    from astropy.io import vo
-    from astropy import wcs as pywcs
-
-In order to install the compatibility packages none of the
-original packages should be present.
-
-.. note:: If you are interested in testing out existing code with Astropy
-          without modifying the import statements, but don't want to
-          uninstall existing packages, you can use `virtualenv
-          <http://www.virtualenv.org/>`_ to set up a clean environment.
-
 .. _builddocs:
 
 Building documentation

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -53,11 +53,9 @@ PyFITS (2.4 and earlier) are no longer actively supported.
 
 PyFITS is also included as a major component of upcoming Astropy_ project as
 the :mod:`astropy.io.fits` module.  The goal is for Astropy to eventually serve
-as a drop-in replacement for PyFITS (it even includes a legacy-compatibility
-mode where the :mod:`astropy.io.fits` module can still be imported as `pyfits`.
-However, for the time being PyFITS will still be released as an independent
-product as well, until such time that the Astropy project proves successful and
-widely-adopted.
+as a drop-in replacement for PyFITS. However, for the time being PyFITS will
+still be released as an independent product as well, until such time that the
+Astropy project proves successful and widely-adopted.
 
 .. _Space Telescope Science Institute: http://www.stsci.edu/
 .. _AURA: http://www.aura-astronomy.org/


### PR DESCRIPTION
As mentioned in #1488, I would like to propose removing the ability to do `--enable-legacy` altogether. I've never come across users that make use of it, and as the APIs of Astropy and other packages diverges in future, I think it will actually no longer be correct to enable these legacy layers anyway. Is there any benefit to keeping them around? (as shown in #1488, this functionality broke, and none of us caught it, so if we want to keep it, we have to test it more).
