### PR TITLE
Remove extraneous print statement

### DIFF
--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -282,8 +282,6 @@ class Kernel2D(Kernel):
             else:  # odd kernel
                 y_range = (-(int(y_size) - 1) // 2, (int(y_size) - 1) // 2 + 1)
 
-            print(x_size, y_size, x_range, y_range)
-
             array = discretize_model(self._model, x_range, y_range, **kwargs)
 
         # Initialize from array


### PR DESCRIPTION
This was introduced in ba451181.  I think it's extraneous, but @astrofrog should confirm.

(I discovered this because when generating the config file fails, this line had been outputting a bunch of numbers).
