### PR TITLE
Make tests compatible with pytest 2.4.0

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -51,7 +51,7 @@ else:
             zlib.decompress(base64.decodestring(extern_pytest.sources)))
 
     importer = extern_pytest.DictImporter(unpacked_sources)
-    sys.meta_path.append(importer)
+    sys.meta_path.insert(0, importer)
 
     pytest = importer.load_module('pytest')
 
@@ -62,7 +62,7 @@ from _pytest.assertion import rewrite as _rewrite
 _orig_write_pyc = _rewrite._write_pyc
 
 
-def _write_pyc_wrapper(co, source_path, pyc):
+def _write_pyc_wrapper(*args):
     """Wraps the internal _write_pyc method in py.test to recognize
     PermissionErrors and just stop trying to cache its generated pyc files if
     it can't write them to the __pycache__ directory.
@@ -79,7 +79,7 @@ def _write_pyc_wrapper(co, source_path, pyc):
     """
 
     try:
-        return _orig_write_pyc(co, source_path, pyc)
+        return _orig_write_pyc(*args)
     except IOError as e:
         if e.errno == errno.EACCES:
             return False

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -16,14 +16,14 @@ from ... import units as u
 functions = [u.doppler_optical, u.doppler_radio, u.doppler_relativistic]
 
 
-@pytest.mark.parametrize(('function',), zip(functions))
+@pytest.mark.parametrize(('function'), functions)
 def test_doppler_frequency_0(function):
     rest = 105.01 * u.GHz
     velo0 = rest.to(u.km/u.s, equivalencies=function(rest))
     assert velo0.value == 0
 
 
-@pytest.mark.parametrize(('function',), zip(functions))
+@pytest.mark.parametrize(('function'), functions)
 def test_doppler_wavelength_0(function):
     rest = 105.01 * u.GHz
     q1 = 0.00285489437196 * u.m
@@ -31,7 +31,7 @@ def test_doppler_wavelength_0(function):
     np.testing.assert_almost_equal(velo0.value, 0, decimal=6)
 
 
-@pytest.mark.parametrize(('function',), zip(functions))
+@pytest.mark.parametrize(('function'), functions)
 def test_doppler_energy_0(function):
     rest = 105.01 * u.GHz
     q1 = 0.000434286445543 * u.eV
@@ -39,7 +39,7 @@ def test_doppler_energy_0(function):
     np.testing.assert_almost_equal(velo0.value, 0, decimal=6)
 
 
-@pytest.mark.parametrize(('function',), zip(functions))
+@pytest.mark.parametrize(('function'), functions)
 def test_doppler_frequency_circle(function):
     rest = 105.01 * u.GHz
     shifted = 105.03 * u.GHz
@@ -48,7 +48,7 @@ def test_doppler_frequency_circle(function):
     np.testing.assert_almost_equal(freq.value, shifted.value, decimal=7)
 
 
-@pytest.mark.parametrize(('function',), zip(functions))
+@pytest.mark.parametrize(('function'), functions)
 def test_doppler_wavelength_circle(function):
     rest = 105.01 * u.nm
     shifted = 105.03 * u.nm
@@ -57,7 +57,7 @@ def test_doppler_wavelength_circle(function):
     np.testing.assert_almost_equal(wav.value, shifted.value, decimal=7)
 
 
-@pytest.mark.parametrize(('function',), zip(functions))
+@pytest.mark.parametrize(('function'), functions)
 def test_doppler_energy_circle(function):
     rest = 1.0501 * u.eV
     shifted = 1.0503 * u.eV
@@ -67,7 +67,7 @@ def test_doppler_energy_circle(function):
 
 
 values_ghz = (999.899940784289,999.8999307714406,999.8999357778647)
-@pytest.mark.parametrize(('function','value'),
+@pytest.mark.parametrize(('function', 'value'),
                          zip(functions, values_ghz))
 def test_30kms(function, value):
     rest = 1000 * u.GHz


### PR DESCRIPTION
This allows the tests to pass with pytest 2.4.0

In a subsequent commit, I will turn on pytest 2.4.0 on Travis, but first I want to confirm this doesn't break on pytest 2.3.
