### PR TITLE
Avoid errors in cases where ``traceback`` is None

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -241,10 +241,14 @@ class AstropyLogger(Logger):
     _excepthook_orig = None
 
     def _excepthook(self, etype, value, traceback):
-        tb = traceback
-        while tb.tb_next is not None:
-            tb = tb.tb_next
-        mod = inspect_getmodule(tb)
+
+        if traceback is None:
+            mod = None
+        else:
+            tb = traceback
+            while tb.tb_next is not None:
+                tb = tb.tb_next
+            mod = inspect_getmodule(tb)
 
         # include the the error type in the message.
         if len(value.args) > 0:


### PR DESCRIPTION
When logging of exceptions is used, in some cases `traceback` can be `None`, which caused the following error:

```
AttributeError: 'NoneType' object has no attribute 'tb_next'
```

This patch fixes this error.
