### PR TITLE
py.test cannot run if sys.stdout.encoding is None

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -296,7 +296,10 @@ def pytest_report_header(config):
     from platform import platform
     plat = platform()
     if isinstance(plat, bytes):
-        plat = plat.decode(sys.stdout.encoding)
+        if sys.stdout.encoding:
+            plat = plat.decode(sys.stdout.encoding)
+        else:
+            plat = plat.decode('ascii', 'replace')
     s += "Platform: {0}\n\n".format(plat)
     s += "Executable: {0}\n\n".format(sys.executable)
     s += "Full Python Version: \n{0}\n\n".format(sys.version)


### PR DESCRIPTION
If for any reason `sys.stdout.encoding` is `None`, then one cannot currently run the tests:

```
============================= test session starts ==============================
platform darwin -- Python 2.7.5 -- pytest-2.4.0
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "_pytest.main", line 81, in wrap_session
INTERNALERROR>     config.hook.pytest_sessionstart(session=session)
INTERNALERROR>   File "_pytest.core", line 364, in __call__
INTERNALERROR>     return self._docall(methods, kwargs)
INTERNALERROR>   File "_pytest.core", line 375, in _docall
INTERNALERROR>     res = mc.execute()
INTERNALERROR>   File "_pytest.core", line 293, in execute
INTERNALERROR>     res = method(**kwargs)
INTERNALERROR>   File "_pytest.terminal", line 276, in pytest_sessionstart
INTERNALERROR>     config=self.config, startdir=self.startdir)
INTERNALERROR>   File "_pytest.core", line 364, in __call__
INTERNALERROR>     return self._docall(methods, kwargs)
INTERNALERROR>   File "_pytest.core", line 375, in _docall
INTERNALERROR>     res = mc.execute()
INTERNALERROR>   File "_pytest.core", line 293, in execute
INTERNALERROR>     res = method(**kwargs)
INTERNALERROR>   File "astropy/tests/pytest_plugins.py", line 299, in pytest_report_header
INTERNALERROR>     plat = plat.decode(sys.stdout.encoding)
INTERNALERROR> TypeError: decode() argument 1 must be string, not None
```

It might be good to add a workaround for this case.
