### PR TITLE
Change example in registry docs to format other than FITS

### DIFF
--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -75,7 +75,7 @@ format::
 
     def identify_mtf(origin, *args, **kwargs):
         return (isinstance(args[0], six.string_types) and
-                os.path.splitext(args[0].lower())[1] == 'mtf')
+                os.path.splitext(args[0].lower())[1] == '.mtf')
 
 .. note:: Identifier functions should be prepared for arbitrary input - in
           particular, the first argument may not be a filename or file

--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -43,7 +43,7 @@ Such a function can then be registered with the I/O registry::
     from astropy.io import registry
     registry.register_reader('my-table-format', Table, my_table_reader)
 
-where the first arguent is the name of the format, the second argument is the
+where the first argument is the name of the format, the second argument is the
 class that the function returns an instance for, and the third argument is the
 reader itself.
 
@@ -70,11 +70,12 @@ expected for the format. In our example, we want to automatically recognize
 files with filenames ending in ``.mtf`` as being in the ``my-table-format``
 format::
 
+    import os
     from astropy.extern import six
 
     def identify_mtf(origin, *args, **kwargs):
         return (isinstance(args[0], six.string_types) and
-                args[0].lower().split('.')[-1] in ['mtf'])
+                os.path.splitext(args[0].lower())[1] == 'mtf')
 
 .. note:: Identifier functions should be prepared for arbitrary input - in
           particular, the first argument may not be a filename or file
@@ -109,7 +110,7 @@ We then register the writer::
 
    registry.register_writer('my-custom-format', Table, my_table_writer)
 
-and we can write the table out to a file::
+We can write the table out to a file::
 
    t.write('catalog_new.mtf', format='my-table-format')
 

--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -33,8 +33,9 @@ let's assume that we are trying to write a reader/writer for the
 :class:`~astropy.table.Table` class::
 
     from astropy.table import Table
+
     def my_table_reader(filename, some_option=1):
-        ...  # Read in the table by any means necessary
+        # Read in the table by any means necessary
         return table  # should be an instance of Table
 
 Such a function can then be registered with the I/O registry::
@@ -69,8 +70,10 @@ expected for the format. In our example, we want to automatically recognize
 files with filenames ending in ``.mtf`` as being in the ``my-table-format``
 format::
 
+    from astropy.extern import six
+
     def identify_mtf(origin, *args, **kwargs):
-        return (isinstance(args[0], basestring) and
+        return (isinstance(args[0], six.string_types) and
                 args[0].lower().split('.')[-1] in ['mtf'])
 
 .. note:: Identifier functions should be prepared for arbitrary input - in

--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -24,80 +24,96 @@ for the :class:`~astropy.table.Table` and
 Using `astropy.io.registry`
 ===========================
 
-The following example demonstrates how to create a reader for the
-:class:`~astropy.table.Table` class. First, we can create a highly
-simplistic FITS reader which just reads the data as a structured array::
+This section demonstrates how to create a custom reader/writer. A reader is
+written as a function that can take any arguments except ``format`` (which is
+needed when manually specifying the format - see below) and returns an
+instance of the :class:`~astropy.table.Table` or
+:class:`~astropy.nddata.NDData` classes (or sub-classes). For demonstration,
+let's assume that we are trying to write a reader/writer for the
+:class:`~astropy.table.Table` class::
 
     from astropy.table import Table
+    def my_table_reader(filename, some_option=1):
+        ...  # Read in the table by any means necessary
+        return table  # should be an instance of Table
 
-    def fits_table_reader(filename, hdu=1):
-        from astropy.io import fits
-        data = fits.open(filename)[hdu].data
-        return Table(data)
-
-and then register it::
+Such a function can then be registered with the I/O registry::
 
     from astropy.io import registry
-    registry.register_reader('fits', Table, fits_table_reader)
+    registry.register_reader('my-table-format', Table, my_table_reader)
 
-Reader functions can take any arguments except ``format`` (since this
-is reserved for :func:`~astropy.io.registry.read`) and should return an instance of the class specified as the second argument of ``register_reader`` (:class:`~astropy.table.Table` in the above case.)
+where the first arguent is the name of the format, the second argument is the
+class that the function returns an instance for, and the third argument is the
+reader itself.
 
-We can then read in a FITS table with::
+We can then read in a table with::
 
-    t = Table.read('catalog.fits', format='fits')
+    d = Table.read('my_table_file.mtf', format='my-table-format')
 
 In practice, it would be nice to have the ``read`` method automatically
-identify that this file was a FITS file, so we can construct a function that
-can recognize FITS files, which we refer to here as an *identifier* function.
-An identifier function should take a first argument that should be a string
+identify that this file is in the ``my-table-format`` format, so we can
+construct a function that can recognize these files, which we refer to here as
+an *identifier* function.
+
+An identifier function should take a first argument that is a string
 which indicates whether the identifier is being called from ``read`` or
 ``write``, and should then accept arbitrary number of positional and keyword
 arguments via ``*args`` and ``**kwargs``, which are the arguments passed to
-``Table.read``. We can write a simplistic function that only looks at
-filenames (but in practice, this function could even look at the first few
-bytes of the file for example). The only requirement is that it return a
-boolean indicating whether the input matches that expected for the format::
+the ``read`` method.
 
-    def fits_identify(origin, *args, **kwargs):
-        return isinstance(args[0], basestring) and \
-               args[0].lower().split('.')[-1] in ['fits', 'fit']
+In the above case, we can write a simplistic function that only looks at
+filenames (but in practice, this function could even look at the first few
+bytes of the file for example). The only requirement for the identifier
+function is that it return a boolean indicating whether the input matches that
+expected for the format. In our example, we want to automatically recognize
+files with filenames ending in ``.mtf`` as being in the ``my-table-format``
+format::
+
+    def identify_mtf(origin, *args, **kwargs):
+        return (isinstance(args[0], basestring) and
+                args[0].lower().split('.')[-1] in ['mtf'])
 
 .. note:: Identifier functions should be prepared for arbitrary input - in
           particular, the first argument may not be a filename or file
           object, so it should not assume that this is the case.
 
-We then register this identifier function::
+We then register this identifier function, similarly to the reader function::
 
-    registry.register_identifier('fits', Table, fits_identify)
+    registry.register_identifier('my-table-format', Table, identify_mtf)
 
-And we can then do::
+Having registered this function, we can then do::
 
-    t = Table.read('catalog.fits')
+    t = Table.read('catalog.mtf')
 
 If multiple formats match the current input, then an exception is
 raised, and similarly if no format matches the current input. In that
 case, the format should be explicitly given with the ``format=``
 keyword argument.
 
-Similarly, it is possible to create custom writers. To go with our simplistic FITS reader above, we can write a simplistic FITS writer::
+It is also possible to create custom writers. To go with our custom reader
+above, we can write a custom writer::
 
-   def fits_table_writer(table, filename, clobber=False):
-       import numpy as np
-       from astropy.io import fits
-       fits.writeto(filename, np.array(table), clobber=clobber)
+   def my_table_writer(table, filename, clobber=False):
+       ...  # Write the table out to a file
+
+Writer functons should take a dataset object (either an instance of the
+:class:`~astropy.table.Table` or :class:`~astropy.nddata.NDData`
+classes or sub-classes), and any number of subsequent positional and keyword
+arguments - although as for the reader, the ``format`` keyword argument cannot
+be used.
 
 We then register the writer::
 
-   io_registry.register_writer('fits', Table, fits_table_writer)
+   registry.register_writer('my-custom-format', Table, my_table_writer)
 
-And we can then write the file out to a FITS file::
+and we can write the table out to a file::
 
-   t.write('catalog_new.fits', format='fits')
+   t.write('catalog_new.mtf', format='my-table-format')
 
-If we have registered the identifier as above, we can simply do::
+Since we have already registered the identifier function, we can also simply
+do::
 
-   t.write('catalog_new.fits')
+   t.write('catalog_new.mtf')
 
 Reference/API
 =============


### PR DESCRIPTION
Once #591 is merged, the example in the I/O registry should be changed to a format other than FITS. Any suggestions?