### PR TITLE
Restore compatibility with Python 3.1?

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -56,6 +56,12 @@ else:
     importer = extern_pytest.DictImporter(unpacked_sources)
     sys.meta_path.insert(0, importer)
 
+    # On Python 3.1, we need to forcibly import the py.test-"bundled"
+    # argparse before importing py.test, since it isn't in the
+    # standard library, and py.test's workaround doesn't appear to
+    # work with the "absolute imports" of Python 3.x.
+    if sys.version_info[0] == 3 and sys.version_info[1] <= 1:
+        argparse = importer.load_module(str('argparse'))
     pytest = importer.load_module(str('pytest'))
 
 


### PR DESCRIPTION
The tests are currently failing on Python 3.1:

```
Traceback (most recent call last):
  File "setup.py", line 21, in <module>
    from astropy.setup_helpers import (register_commands, adjust_compiler,
  File "/Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.5.0/PV/3.1/astropy/setup_helpers.py", line 33, in <module>
    from .tests.helper import astropy_test
  File "/Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.5.0/PV/3.1/astropy/tests/__init__.py", line 10, in <module>
    from . import helper
  File "/Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.5.0/PV/3.1/astropy/tests/helper.py", line 59, in <module>
    pytest = importer.load_module(str('pytest'))
  File "/Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.5.0/PV/3.1/astropy/extern/pytest.py", line 3137, in load_module
    do_exec(co, module.__dict__)
  File "<string>", line 1, in do_exec_def
  File "pytest", line 14, in <module>
  File "/Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.5.0/PV/3.1/astropy/extern/pytest.py", line 3137, in load_module
    do_exec(co, module.__dict__)
  File "<string>", line 1, in do_exec_def
  File "_pytest.config", line 376, in <module>
  File "py._std", line 15, in __getattr__
AttributeError: py.std: could not import argparse
```

Do we want to fix this, or drop support for Python 3.1?

cc @mdboom @embray @taldcroft @eteq 
