### PR TITLE
Make sure the list of modules being iterated over cannot change during iteration

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -409,7 +409,7 @@ class catch_warnings(warnings.catch_warnings):
         assert len(w) > 0
     """
     def __init__(self, *classes):
-        for module in six.itervalues(sys.modules):
+        for module in list(six.itervalues(sys.modules)):
             if hasattr(module, '__warningregistry__'):
                 del module.__warningregistry__
         super(catch_warnings, self).__init__(record=True)


### PR DESCRIPTION
@mdboom - I'm not sure why, but under certain circumstances, I see the following error when testing:

```


self = <astropy.table.tests.test_row.TestRow instance at 0x108336f38>, table_types = <astropy.table.tests.test_row.TableTypes instance at 0x10833e098>

    def test_deprecated_attributes(self, table_types):
        self._setup(table_types)
        r = Row(self.t, 2)

>       with catch_warnings(AstropyDeprecationWarning) as warning_lines:
            r.dtypes

astropy/table/tests/test_row.py:168: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[AttributeError("'catch_warnings' object has no attribute '_record'") raised in repr()] SafeRepr object at 0x1082a8cb0>
classes = (<class 'astropy.utils.exceptions.AstropyDeprecationWarning'>,), module = <email.LazyImporter object at 0x106bf7b90>

    def __init__(self, *classes):
>       for module in six.itervalues(sys.modules):
            if hasattr(module, '__warningregistry__'):
E           RuntimeError: dictionary changed size during iteration

astropy/tests/helper.py:412: RuntimeError
```

By ensuring that the items being iterated over can't change during the iteration, the problem goes away. Is this pull request sensible, or do you think it's an issue I need to fix on my end?
