### PR TITLE
Failure to install on Python 2.6

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -289,6 +289,8 @@ def get_extensions():
 
     cfg['sources'] = [str(x) for x in cfg['sources']]
 
+    cfg = dict((str(key), val) for key, val in six.iteritems(cfg))
+
     return [Extension(str('astropy.wcs._wcs'), **cfg)]
 
 


### PR DESCRIPTION
I tried installing Astropy on a Linux machine with Python 2.6, and I get:

```
Freezing version number to astropy/version.py
Traceback (most recent call last):
  File "setup.py", line 58, in <module>
    package_info = get_package_info(NAME)
  File "/home/robitaille/astropy/astropy/setup_helpers.py", line 1111, in get_package_info
    ext_modules.extend(setuppkg.get_extensions())
  File "astropy/wcs/setup_package.py", line 292, in get_extensions
    return [Extension(str('astropy.wcs._wcs'), **cfg)]
TypeError: __init__() keywords must be strings
```

cc @mdboom (since it relates to WCS)

```
> python --version
Python 2.6.2
> uname -a
Linux aida62 2.6.31.12-0.2-desktop #1 SMP PREEMPT 2010-03-16 21:25:39 +0100 x86_64 x86_64 x86_64 GNU/Linux
```
