### PR TITLE
Sample implementation allowing Quantity initialisation from Columns

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -522,6 +522,8 @@ class Column(BaseColumn, np.ndarray):
     def data(self):
         return self.view(np.ndarray)
 
+    value = data
+
     def copy(self, order='C', data=None, copy_data=True):
         """Return a copy of the current Column instance.  If ``data`` is supplied
         then a view (reference) of ``data`` is used, and ``copy_data`` is ignored.


### PR DESCRIPTION
This follows a question from @taldcroft in #732 whether one could set a Quantity with a table column. With this:

```
from astropy.table import Table; import astropy.units as u
t = Table([[1.,2.],[3.,4.]], names=('a','b'))
t['a'].unit = u.km
u.Quantity(t['a']), u.Quantity(t['a'], u.m), u.Quantity(t['b']), u.Quantity(t['b'], u.Mpc/u.m)
```

yields

```
(<Quantity [ 1., 2.] km>,
 <Quantity [ 1000., 2000.] m>,
 <Quantity [ 3., 4.] >,
 <Quantity [ 3., 4.] Mpc / m>)
```

Hence, an unset unit is taken as "treat this as a float array" rather than dimensionless unscaled.

Notes:
1) This trial implementation goes the route of making quantity initialisation duck type; instead of looking whether one is dealing with a `Quantity` instance, it looks whether there is an `unit` attribute; the one extra part required was for `Column` to have a `value` attribute (just equal to `data`).
2) Miraculously, it doesn't break any test cases!
