### PR TITLE
from astropy import stability

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -213,3 +213,26 @@ if not _ASTROPY_SETUP_:
     log = _init_log()
 
     _initialize_astropy()
+
+
+__require_stable_api__ = False
+
+def _declare_unstable_api():
+    """
+    Astropy subpackages with an unstable API should call this function
+    from their __init__.py.
+
+    If `from astropy import stability`, and the import happens not from
+    within astropy itself, a `RuntimeError` is raised.
+    """
+    if __require_stable_api__:
+        from astropy.utils.misc import find_current_module
+
+        module_name = find_current_module().__name__
+        parent_module_name = find_current_module(2).__name__
+
+        if not parent_module_name.startswith('astropy.'):
+            raise RuntimeError(
+                "{0} is an unstable API and is likely to "
+                "change in significant ways in the future.".format(
+                    module_name))

--- a/astropy/modeling/__init__.py
+++ b/astropy/modeling/__init__.py
@@ -12,3 +12,6 @@ from . import models
 from .core import *
 from . import fitting
 from .parameters import *
+
+from .. import _declare_unstable_api
+_declare_unstable_api()

--- a/astropy/stability.py
+++ b/astropy/stability.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This lets code that cares about using only stable APIs declare that
+intention.
+
+If code does::
+
+    from astropy import stability
+
+and then subsequently imports a subpackage with an unstable API, a
+RuntimeError will be raised.
+"""
+
+import astropy
+
+astropy.__require_stable_api__ = True

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -13,6 +13,13 @@ undergo some user interface changes as we work to integrate the packages
 better. Thus, we cannot guarantee complete backward-compatibility between
 versions at this stage.
 
+If you are writing code that needs long-term stability, you can ensure that you
+are only using stable APIs by putting::
+
+    from astropy import stability
+
+at the top of your script.
+
 .. |planned| image:: _static/planned.png
 
 .. |dev| image:: _static/dev.png
@@ -259,4 +266,3 @@ The current planned and existing sub-packages are:
             </td>
         </tr>
     </table>
-


### PR DESCRIPTION
This is a somewhat tongue-in-cheek PR, based on something that would make a good T-shirt, but I thought it might make sense as a point of discussion.

This adds some automation to the concept of the API stability list.  A user can do

```
from astropy import stability
```

and then if they import a module with an unstable API, they would get an exception (alternatively could be a warning).