### PR TITLE
Angle repr should use flexible float representation

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -241,7 +241,7 @@ class Angle(u.Quantity):
         return util.degrees_to_dms(self.degree)
 
     def to_string(self, unit=None, decimal=False, sep='fromunit',
-                  precision=5, alwayssign=False, pad=False,
+                  precision=None, alwayssign=False, pad=False,
                   fields=3, format=None):
         """ A string representation of the angle.
 
@@ -269,7 +269,9 @@ class Angle(u.Quantity):
             The level of decimal precision.  If `decimal` is True,
             this is the raw precision, otherwise it gives the
             precision of the last place of the sexagesimal
-            representation (seconds).
+            representation (seconds).  If `None`, or not provided, the
+            number of decimal places is determined by the value, and
+            will be between 0-8 decimal places as required.
 
         alwayssign : bool, optional
             If `True`, include the sign no matter what.  If `False`,
@@ -332,7 +334,10 @@ class Angle(u.Quantity):
         if unit is u.degree:
             if decimal:
                 values = self.degree
-                func = ("{0:0." + str(precision) + "f}").format
+                if precision is not None:
+                    func = ("{0:0." + str(precision) + "f}").format
+                else:
+                    func = '{0:g}'.format
             else:
                 if sep == 'fromunit':
                     sep = 'dms'
@@ -344,7 +349,10 @@ class Angle(u.Quantity):
         elif unit is u.hourangle:
             if decimal:
                 values = self.hour
-                func = ("{0:0." + str(precision) + "f}").format
+                if precision is not None:
+                    func = ("{0:0." + str(precision) + "f}").format
+                else:
+                    func = '{0:g}'.format
             else:
                 if sep == 'fromunit':
                     sep = 'hms'
@@ -356,17 +364,25 @@ class Angle(u.Quantity):
         elif unit.is_equivalent(u.radian):
             if decimal:
                 values = self.to(unit).value
-                func = ("{0:0." + str(precision) + "f}").format
+                if precision is not None:
+                    func = ("{0:1." + str(precision) + "f}").format
+                else:
+                    func = "{0:g}".format
             elif sep == 'fromunit':
                 values = self.to(unit).value
                 unit_string = unit.to_string(format=format)
                 if format == 'latex':
                     unit_string = unit_string[1:-1]
 
-                def plain_unit_format(val):
-                    return ("{0:0." + str(precision) + "f}{1}").format(
-                        val, unit_string)
-                func = plain_unit_format
+                if precision is not None:
+                    def plain_unit_format(val):
+                        return ("{0:0." + str_precision) + "f}{1}".format(
+                            val, unit_string)
+                    func = plain_unit_format
+                else:
+                    def plain_unit_format(val):
+                        return "{0:g}{1}".format(val, unit_string)
+                    func = plain_unit_format
             else:
                 raise ValueError(
                     "'{0}' can not be represented in sexagesimal "

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -92,13 +92,13 @@ def test_angle_to_quantity():
 
 def test_angle_string():
     a = Angle('00:00:60', u.deg)
-    assert str(a) == '0d01m00.00000s'
+    assert str(a) == '0d01m00s'
     a = Angle('-00:00:10', u.hour)
-    assert str(a) == '-0h00m10.00000s'
+    assert str(a) == '-0h00m10s'
     a = Angle(3.2, u.radian)
-    assert str(a) == '3.20000rad'
+    assert str(a) == '3.2rad'
     a = Angle(4.2, u.microarcsecond)
-    assert str(a) == '4.20000uarcsec'
+    assert str(a) == '4.2uarcsec'
     a = Angle('1.0uarcsec')
     assert a.value == 1.0
     assert a.unit == u.microarcsecond

--- a/astropy/coordinates/tests/test_api.py
+++ b/astropy/coordinates/tests/test_api.py
@@ -229,10 +229,10 @@ def test_angle_formatting():
     #__str__ is the default `format`
     assert str(angle) == angle.to_string()
 
-    res = 'Angle as HMS: 3h36m29.78880s'
+    res = 'Angle as HMS: 3h36m29.7888s'
     assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour)) == res
 
-    res = 'Angle as HMS: 3:36:29.78880'
+    res = 'Angle as HMS: 3:36:29.7888'
     assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour, sep=":")) == res
 
     res = 'Angle as HMS: 3:36:29.79'
@@ -263,10 +263,10 @@ def test_angle_formatting():
 
     angle = Angle("3 36 29.78880", unit=u.degree)
 
-    res = 'Angle as DMS: 3d36m29.78880s'
+    res = 'Angle as DMS: 3d36m29.7888s'
     assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree)) == res
 
-    res = 'Angle as DMS: 3:36:29.78880'
+    res = 'Angle as DMS: 3:36:29.7888'
     assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, sep=":")) == res
 
     res = 'Angle as DMS: 3:36:29.79'
@@ -293,10 +293,10 @@ def test_angle_formatting():
     assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, precision=4,
                                                   pad=True)) == res
 
-    res = 'Angle as rad: 0.06298rad'
+    res = 'Angle as rad: 0.0629763rad'
     assert "Angle as rad: {0}".format(angle.to_string(unit=u.radian)) == res
 
-    res = 'Angle as rad decimal: 0.06298'
+    res = 'Angle as rad decimal: 0.0629763'
     assert "Angle as rad decimal: {0}".format(angle.to_string(unit=u.radian, decimal=True)) == res
 
 
@@ -305,11 +305,11 @@ def test_angle_formatting():
     angle = Angle(-1.23456789, unit=u.degree)
     angle2 = Angle(-1.23456789, unit=u.hour)
 
-    assert angle.to_string() == '-1d14m04.44440s'
-    assert angle.to_string(pad=True) == '-01d14m04.44440s'
-    assert angle.to_string(unit=u.hour) == '-0h04m56.29629s'
-    assert angle2.to_string(unit=u.hour, pad=True) == '-01h14m04.44440s'
-    assert angle.to_string(unit=u.radian, decimal=True) == '-0.02155'
+    assert angle.to_string() == '-1d14m04.4444s'
+    assert angle.to_string(pad=True) == '-01d14m04.4444s'
+    assert angle.to_string(unit=u.hour) == '-0h04m56.2963s'
+    assert angle2.to_string(unit=u.hour, pad=True) == '-01h14m04.4444s'
+    assert angle.to_string(unit=u.radian, decimal=True) == '-0.0215473'
 
 def test_angle_format_roundtripping():
     """

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -52,12 +52,12 @@ def test_to_string_decimal():
 
 def test_to_string_formats():
     a = Angle(1.113355, unit=u.deg)
-    assert a.to_string(format='latex') == r'$1^\circ06{}^\prime48.07800{}^{\prime\prime}$'
-    assert a.to_string(format='unicode') == '1\xb006\u203248.07800\u2033'
+    assert a.to_string(format='latex') == r'$1^\circ06{}^\prime48.078{}^{\prime\prime}$'
+    assert a.to_string(format='unicode') == '1\xb006\u203248.078\u2033'
 
     a = Angle(1.113355, unit=u.hour)
-    assert a.to_string(format='latex') == r'$1^\mathrm{h}06^\mathrm{m}48.07800^\mathrm{s}$'
-    assert a.to_string(format='unicode') == '1\u02b006\u1d5048.07800\u02e2'
+    assert a.to_string(format='latex') == r'$1^\mathrm{h}06^\mathrm{m}48.078^\mathrm{s}$'
+    assert a.to_string(format='unicode') == '1\u02b006\u1d5048.078\u02e2'
 
     a = Angle(1.113355, unit=u.radian)
     assert a.to_string(format='latex') == r'$1.11336\mathrm{rad}$'
@@ -68,18 +68,20 @@ def test_to_string_fields():
     a = Angle(1.113355, unit=u.deg)
     assert a.to_string(fields=1) == r'1d'
     assert a.to_string(fields=2) == r'1d07m'
-    assert a.to_string(fields=3) == r'1d06m48.07800s'
+    assert a.to_string(fields=3) == r'1d06m48.078s'
 
 
 def test_sexagesimal_rounding_up():
     a = Angle(359.9999999999, unit=u.deg)
 
+    assert a.to_string(precision=None) == '360d00m00s'
     assert a.to_string(precision=4) == '360d00m00.0000s'
     assert a.to_string(precision=5) == '360d00m00.00000s'
     assert a.to_string(precision=6) == '360d00m00.000000s'
     assert a.to_string(precision=7) == '359d59m59.9999996s'
 
     a = Angle(3.999999, unit=u.deg)
+    assert a.to_string(fields=2, precision=None) == '4d00m'
     assert a.to_string(fields=2, precision=1) == '4d00m'
     assert a.to_string(fields=2, precision=5) == '4d00m'
     assert a.to_string(fields=1, precision=1) == '4d'


### PR DESCRIPTION
`30d20m00s`, rather than `30d20m00.00000s`
