### PR TITLE
update nduncertainty for multiple/divide

### DIFF
--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -178,6 +178,7 @@ class StdDevUncertainty(NDUncertainty):
         else:
             if value.shape != self.array.shape:
                 raise ValueError("parent shape does not match array data shape")
+        self._parent_nddata=value
 
     @property
     def array(self):
@@ -305,7 +306,7 @@ class StdDevUncertainty(NDUncertainty):
             raise ValueError("standard deviation values are not set in other_nddata")
 
         result_uncertainty = StdDevUncertainty()
-        result_uncertainty.array = (np.sqrt((self.array / self.data) ** 2
+        result_uncertainty.array = (np.sqrt((self.array / self.parent_nddata.data) ** 2
                                             + (other_nddata.uncertainty.array / other_nddata.data) ** 2)
                                     * result_data)
 
@@ -343,7 +344,7 @@ class StdDevUncertainty(NDUncertainty):
             raise ValueError("standard deviation values are not set in other_nddata")
 
         result_uncertainty = StdDevUncertainty()
-        result_uncertainty.array = (np.sqrt((self.array / self.data) ** 2
+        result_uncertainty.array = (np.sqrt((self.array / self.parent_nddata.data) ** 2
                                             + (other_nddata.uncertainty.array / other_nddata.data) ** 2)
                                     * result_data)
 

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -225,6 +225,25 @@ def test_nddata_subtract_uncertainties():
     assert np.all(d3.data == -1.)
     assert_array_equal(d3.uncertainty.array, np.sqrt(10.))
 
+def test_nddata_multiply_uncertainties():
+    u1 = StdDevUncertainty(array=np.ones((5, 5)) * 3)
+    u2 = StdDevUncertainty(array=np.ones((5, 5)))
+    d1 = NDData(np.ones((5, 5)), uncertainty=u1)
+    d2 = NDData(np.ones((5, 5)) * 2., uncertainty=u2)
+    d3 = d1.multiply(d2)
+    assert np.all(d3.data == 2.)
+    assert_array_equal(d3.uncertainty.array, 2*np.sqrt(9.25))
+
+def test_nddata_divide_uncertainties():
+    u1 = StdDevUncertainty(array=np.ones((5, 5)) * 3)
+    u2 = StdDevUncertainty(array=np.ones((5, 5)))
+    d1 = NDData(np.ones((5, 5)), uncertainty=u1)
+    d2 = NDData(np.ones((5, 5)) * 2., uncertainty=u2)
+    d3 = d1.divide(d2)
+    assert np.all(d3.data == 0.5)
+    assert_array_equal(d3.uncertainty.array, 0.5*np.sqrt(9.25))
+
+
 
 def test_nddata_subtract_uncertainties_mismatch():
     u1 = StdDevUncertainty(array=np.ones((5, 5)) * 3)


### PR DESCRIPTION
While trying out the nddata and nduncertainity classes, I noticed that the propagation of errors for multiple/divide did not work.   The problem was that in propagate_divide and propagate_multiply they were calling a self.data that didn't exist.   To fix this problem, I changed self.data to self.parent_nddata.data in those two tasks.  I also added 'self._parent_nddata=value' to the setter function for parent_nddata.   

In addition, I added two tests to test_nddata to test for propogation of errors when using multiply and divide. 
