### PR TITLE
Bugfix: Array * TimeDelta fails for mysterious reason

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -107,6 +107,10 @@ class Time(object):
     FORMATS = TIME_FORMATS
     """Dict of time formats"""
 
+    # Make sure that reverse arithmetic (e.g., TimeDelta.__rmul__)
+    # gets called over the __mul__ of Numpy arrays.
+    __array_priority__ = 1000
+
     def __new__(cls, val, val2=None, format=None, scale=None,
                 precision=None, in_subfmt=None, out_subfmt=None,
                 lat=0.0, lon=0.0, copy=False):
@@ -567,9 +571,9 @@ class Time(object):
         val, ndim = _make_1d_array(val, copy=True)  # be conservative and copy
         if len(val) == 1:
             oval = val
-            val = np.empty(len(self), dtype=np.double)
+            val = np.empty(len(self._time), dtype=np.double)
             val[:] = oval
-        elif len(val) != len(self):
+        elif len(val) != len(self._time):
             raise ValueError('Attribute length must match Time object length')
         return val
 
@@ -702,7 +706,7 @@ class Time(object):
     """TDB - TT time scale offset"""
 
     def __len__(self):
-        return len(self._time)
+        return len(self.jd1)
 
     def __sub__(self, other):
         self_tai = self.tai

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -274,7 +274,7 @@ class TestBasic():
 
         # Init from a single Time object without a scale
         t3 = Time(t1)
-        assert len(t1) == 1
+        assert t3.isscalar
         assert t3.scale == t1.scale
         assert t3.format == t1.format
         assert np.all(t3.value == t1.value)


### PR DESCRIPTION
Multiplying an `nd.array` with a `TimeDelta` fails, as the numpy function tries to get an item that does not exist (independent of whether `TimeDelta` is an array or not. It seems `TimeDelta` never gets a chance to try (the reverse -- `TimeDelta * Array` works fine); somehow, numpy fails to return `NotImplemented`? Mysterious.

```
In [1]: from astropy.time import Time, TimeDelta; import numpy as np

In [2]: np.array(1)*TimeDelta(100., format='sec')
ERROR: TypeError: scalar 'TimeDelta' object is not subscriptable. [astropy.time.core]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-91a8a4ea9a5c> in <module>()
----> 1 np.array(1)*TimeDelta(100., format='sec')

/home/mhvk/packages/astropy/astropy/time/core.py in __getitem__(self, item)
    506         if self.isscalar:
    507             raise TypeError('scalar {0!r} object is not subscriptable.'.format(
--> 508                 self.__class__.__name__))
    509         tm = self.replicate()
    510         jd1 = self._time.jd1[item]

TypeError: scalar 'TimeDelta' object is not subscriptable.
```
