### PR TITLE
Minor cleanup in `coordinates` sub-package

### DIFF
--- a/astropy/coordinates/angle_lextab.py
+++ b/astropy/coordinates/angle_lextab.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 

--- a/astropy/coordinates/angle_parsetab.py
+++ b/astropy/coordinates/angle_parsetab.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
@@ -13,18 +14,18 @@ _lr_action_items = {'HOUR':([2,8,10,17,18,21,25,26,27,28,34,],[-15,12,-14,20,-16
 
 _lr_action = { }
 for _k, _v in _lr_action_items.items():
-   for _x,_y in zip(_v[0],_v[1]):
-      if not _x in _lr_action:  _lr_action[_x] = { }
-      _lr_action[_x][_k] = _y
+    for _x,_y in zip(_v[0],_v[1]):
+        if not _x in _lr_action:  _lr_action[_x] = { }
+        _lr_action[_x][_k] = _y
 del _lr_action_items
 
 _lr_goto_items = {'arcminute':([0,],[1,]),'angle':([0,],[3,]),'simple':([0,],[4,]),'arcsecond':([0,],[6,]),'hms':([0,],[7,]),'generic':([0,],[8,]),'dms':([0,],[9,]),'colon':([0,],[10,]),'spaced':([0,],[2,]),'sign':([0,],[11,]),'ufloat':([21,29,30,31,],[25,32,33,34,]),}
 
 _lr_goto = { }
 for _k, _v in _lr_goto_items.items():
-   for _x,_y in zip(_v[0],_v[1]):
-       if not _x in _lr_goto: _lr_goto[_x] = { }
-       _lr_goto[_x][_k] = _y
+    for _x,_y in zip(_v[0],_v[1]):
+        if not _x in _lr_goto: _lr_goto[_x] = { }
+        _lr_goto[_x][_k] = _y
 del _lr_goto_items
 _lr_productions = [
   ("S' -> angle","S'",1,None,None,None),

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -14,7 +14,9 @@ from warnings import warn
 
 import numpy as np
 
-from .errors import *
+from .errors import (IllegalHourWarning, IllegalHourError,
+                     IllegalMinuteWarning, IllegalMinuteError,
+                     IllegalSecondWarning, IllegalSecondError)
 from ..utils import format_exception
 from .. import units as u
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from ..extern import six
 from . import angle_utilities as util
-from .errors import *
 from .. import units as u
 from ..utils import deprecated
 
@@ -674,7 +673,7 @@ def rotation_matrix(angle, axis='z', unit=None):
     """
     # TODO: This doesn't handle arrays of angles
 
-    from numpy import sin, cos, radians, sqrt
+    from numpy import sin, cos, sqrt
 
     if unit is None:
         unit = u.degree

--- a/astropy/coordinates/builtin_systems.py
+++ b/astropy/coordinates/builtin_systems.py
@@ -638,7 +638,7 @@ def fk4_no_e_to_fk4(fk4c):
     # Apply E-terms of aberration
     eterms_a = fk4_e_terms(fk4c.equinox)
     r0 = r.copy()
-    for j in range(10):
+    for _ in range(10):
         r = (r0 + eterms_a) / (1. + np.dot(r, eterms_a))
 
     # Find new distance (for re-normalization)

--- a/astropy/coordinates/coordsystems.py
+++ b/astropy/coordinates/coordsystems.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 from ..extern import six
 from .. import units as u
 from .angles import Longitude, Latitude, Angle
-from .distances import *
+from .distances import Distance, CartesianPoints, cartesian_to_spherical, spherical_to_cartesian
 from ..utils.compat.misc import override__dir__
 from . import angle_utilities
 

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -219,7 +219,6 @@ def _load_nutation_data(datastr, seriestype):
 
     Seriestype can be 'lunisolar' or 'planetary'
     """
-    from os.path import join
 
     if seriestype == 'lunisolar':
         dtypes = [('nl', int),
@@ -256,7 +255,7 @@ def _load_nutation_data(datastr, seriestype):
 
     lines = [l for l in datastr.split('\n') if not l.startswith('#') if not l.strip() == '']
 
-    lists = [[] for n in dtypes]
+    lists = [[] for _ in dtypes]
     for l in lines:
         for i, e in enumerate(l.split(' ')):
             lists[i].append(dtypes[i][1](e))

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -16,9 +16,6 @@ import re
 from ..extern.six.moves import urllib
 import socket
 
-# Third party
-import numpy as np
-
 # Astropy
 from ..config import ConfigurationItem
 from .builtin_systems import ICRSCoordinates

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -2,13 +2,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from __future__ import unicode_literals
-
 # Test initalization of angles not already covered by the API tests
 
 import numpy as np
 from numpy.testing.utils import assert_allclose
-from ..angles import *
+from ..angles import Longitude, Latitude, Angle
 from ...tests.helper import pytest
 from ... import units as u
 

--- a/astropy/coordinates/tests/test_api.py
+++ b/astropy/coordinates/tests/test_api.py
@@ -10,7 +10,7 @@ raises = pytest.raises
 from ...extern import six
 
 from ... import units as u
-from ..errors import *
+from ..errors import ConvertError, IllegalSecondError, IllegalMinuteError, IllegalHourError
 
 
 try:

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -8,19 +8,16 @@ from __future__ import (absolute_import, division, print_function,
 
 from ...extern.six.moves import urllib
 
-# Standard library
 import time
 
-# Third party
 import numpy as np
 from ...tests.helper import pytest
 
-# Astropy
 from ..name_resolve import get_icrs_coordinates, NameResolveError, \
                            SESAME_DATABASE, _parse_response
-from ..builtin_systems import ICRSCoordinates, FK5Coordinates, FK4Coordinates, \
-                              GalacticCoordinates
+from ..builtin_systems import ICRSCoordinates
 from ...tests.helper import remote_data
+from ... import units as u
 
 _cached_ngc3642 = dict()
 _cached_ngc3642["simbad"] = """# ngc 3642	#Q22523669


### PR DESCRIPTION
Some very minor cleanup in `coordinates` that my editor points out, e.g. no `import *`.

@eteq Can the `angle_axis` function in `angles.py` be removed or should it be fixed and added to `__all__`? (It uses `from numpy import acos` which doesn't exist (it's called `arccos`), so must be unused.)
