### PR TITLE
Running ``python setup.py egg_info`` should not install Numpy

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -973,7 +973,15 @@ def get_distutils_display_options():
     short_display_opts.add('-h')
     long_display_opts.add('--help')
 
-    return short_display_opts.union(long_display_opts)
+    # This isn't the greatest approach to hardcode these commands.
+    # However, there doesn't seem to be a good way to determine
+    # whether build *will be* run as part of the command at this
+    # phase.
+    display_commands = set([
+        'clean', 'register', 'setopt', 'saveopts', 'egg_info',
+        'alias'])
+
+    return short_display_opts.union(long_display_opts.union(display_commands))
 
 
 def is_distutils_display_option():


### PR DESCRIPTION
@mdboom - this is a follow-up of #1483. In my view, Numpy should _not_ be installed for `python setup.py egg_info` or any other non-build command. What do you think?
