### PR TITLE
Turn numpy warnings into exceptions

### DIFF
--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.testing import utils
 from numpy.random import RandomState
 from ...tests.helper import pytest
+np.seterr(all='raise')
 
 try:
     from scipy import optimize

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -13,6 +13,7 @@ from numpy.testing import utils
 from numpy.random import RandomState
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
+np.seterr(all='raise')
 
 try:
     from scipy import optimize

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -9,6 +9,8 @@ from .. import fitting
 from numpy.testing import utils
 from ...tests.helper import pytest
 
+np.seterr(all='raise')
+
 try:
     from scipy import optimize
     HAS_SCIPY = True

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -12,6 +12,7 @@ from numpy.testing import utils
 from ...tests.helper import pytest
 from .. import fitting
 from .model_lists import models_1D, models_2D
+np.seterr(all='raise')
 
 try:
     from scipy import optimize

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -10,7 +10,7 @@ from numpy.testing import utils
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
 from .. import ParametricModel, Parameter
-
+np.seterr(all='raise')
 
 class TestParModel(ParametricModel):
 

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -11,7 +11,7 @@ from ...io import fits
 from ... import wcs
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
-
+n.seterr(all='raise')
 
 def test_Projection_properties():
     projection = projections.Sky2Pix_CAR()

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -2,6 +2,7 @@
 from .. import models
 from numpy.testing import utils
 from ...tests.helper import pytest
+np.seterr(all='raise')
 
 def test_RotateNative2Celestial():
     phi, theta, psi = 42, 43, 44


### PR DESCRIPTION
I've notice that some of the tests in modeling give numpy runtime warnings (e.g. overflow error) and Travis silently ignores them. I wonder if we should instead turn the warnings into exceptions, the rationale being that we should write tests that always pass. I am submitting this PR so that Travis runs and it's easier to see the difference.
