### PR TITLE
Allow the ``spectral_density`` equivalency to take a Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,9 @@ New Features
   - Added new spectroscopic equivalencies for velocity conversions
     (relativistic, optical, and radio conventions are supported)
 
+  - The ``spectral_density`` equivalency now also accepts a Quantity for the
+    frequency or wavelength.
+
   - Added Brightness Temperature (antenna gain) equivalency for conversion
     between :math:`T_B` and flux density.
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -42,11 +42,29 @@ def spectral():
     ]
 
 
-def spectral_density(sunit, sfactor):
+def spectral_density(disp, factor=None):
     """
     Returns a list of equivalence pairs that handle spectral density
     with regard to wavelength and frequency.
+
+    Parameters
+    ----------
+    disp : Quantity
+        The frequency/wavelength/energy to do the conversion at.
+
+    Notes
+    -----
+    The ``factor`` argument is left for backward-compatibility with the syntax
+    ``spectral_density(unit, factor)`` but users are encouraged to use
+    ``spectral_density(factor * unit)`` instead.
     """
+
+    from .core import UnitBase
+    if isinstance(disp, UnitBase):
+        if factor is None:
+            raise ValueError("If ``disp`` is specified as a unit, ``factor`` should be set")
+        disp = factor * disp
+
     c_Aps = _si.c.value * 10 ** 10
 
     fla = cgs.erg / si.angstrom / si.cm ** 2 / si.s
@@ -55,22 +73,22 @@ def spectral_density(sunit, sfactor):
     lafla = nufnu
 
     def converter(x):
-        return x * (sunit.to(si.AA, sfactor, spectral()) ** 2 / c_Aps)
+        return x * (disp.unit.to(si.AA, disp.value, spectral()) ** 2 / c_Aps)
 
     def iconverter(x):
-        return x / (sunit.to(si.AA, sfactor, spectral()) ** 2 / c_Aps)
+        return x / (disp.unit.to(si.AA, disp.value, spectral()) ** 2 / c_Aps)
 
     def converter_fnu_nufnu(x):
-        return x * sunit.to(si.Hz, sfactor, spectral())
+        return x * disp.unit.to(si.Hz, disp.value, spectral())
 
     def iconverter_fnu_nufnu(x):
-        return x / sunit.to(si.Hz, sfactor, spectral())
+        return x / disp.unit.to(si.Hz, disp.value, spectral())
 
     def converter_fla_lafla(x):
-        return x * sunit.to(si.AA, sfactor, spectral())
+        return x * disp.unit.to(si.AA, disp.value, spectral())
 
     def iconverter_fla_lafla(x):
-        return x / sunit.to(si.AA, sfactor, spectral())
+        return x / disp.unit.to(si.AA, disp.value, spectral())
 
     return [
         (si.AA, fnu, converter, iconverter),
@@ -87,7 +105,7 @@ def doppler_radio(rest):
     Return the equivalency pairs for the radio convention for velocity.
 
     The radio convention for the relation between velocity and frequency is:
-    
+
     :math:`V = c \frac{f_0 - f}{f_0}  ;  f(V) = f_0 ( 1 - V/c )`
 
     Parameters
@@ -294,10 +312,10 @@ def mass_energy():
 
     return [(si.kg, si.J, lambda x: x * _si.c.value ** 2,
              lambda x: x / _si.c.value ** 2),
-            (si.kg / si.m ** 2, si.J / si.m ** 2 , 
+            (si.kg / si.m ** 2, si.J / si.m ** 2 ,
              lambda x: x * _si.c.value ** 2,
              lambda x: x / _si.c.value ** 2),
-            (si.kg / si.m ** 3, si.J / si.m ** 3 , 
+            (si.kg / si.m ** 3, si.J / si.m ** 3 ,
              lambda x: x * _si.c.value ** 2,
              lambda x: x / _si.c.value ** 2),
             (si.kg / si.s, si.J / si.s , lambda x: x * _si.c.value ** 2,

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -203,6 +203,12 @@ def test_spectraldensity():
     b = u.Jy.to(u.AA, a, u.spectral_density(u.eV, 2.2))
     assert_allclose(b, 1)
 
+    c = u.AA.to(u.Jy, 1, u.spectral_density(2.2 * u.eV))
+    assert_allclose(c, 1059416252057.8357, rtol=1e-4)
+
+    d = u.Jy.to(u.AA, c, u.spectral_density(2.2 * u.eV))
+    assert_allclose(d, 1)
+
 
 def test_spectraldensity2():
     flambda = u.erg / u.angstrom / u.cm ** 2 / u.s

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -108,11 +108,11 @@ The function that handles these unit conversions is
 arguments the unit and value for the spectral location. For example::
 
   >>> u.Jy.to(u.erg / u.cm**2 / u.s / u.Hz, 1.,
-              equivalencies=u.spectral_density(u.AA, 3500))
+              equivalencies=u.spectral_density(3500 * u.AA))
   1.0000000000000001e-23
 
   >>> u.Jy.to(u.erg / u.cm**2 / u.s / u.micron, 1.,
-              equivalencies=u.spectral_density(u.AA, 3500))
+              equivalencies=u.spectral_density(3500 * u.AA))
   2.4472853714285712e-08
 
 Brightness Temperature / Flux Density Equivalency


### PR DESCRIPTION
@mdboom - what do you think? I had to use the current API today and it felt clunky (also, other equivalencies now take quantities). Should we actually deprecate the previous API?
