### PR TITLE
SLSQPFitter tries to fit all parameters

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -97,15 +97,18 @@ class Fitter(object):
         self.bounds = []
         self.fixed = []
         self.tied = []
+        self.eqcons = []
+        self.ineqcons = []
+
         self._set_constraints()
-        self._fitpars = self._model_to_fit_pars()
+        self._fitpars, self._fitpar_indices = self._model_to_fit_pars()
         self._validate_constraints()
         self._weights = None
 
     def _set_constraints(self):
         pars = [getattr(self.model, name) for name in self.model.param_names]
-        self.fixed = [par.fixed for par in pars]
-        self.tied = [par.tied for par in pars]
+        self.fixed = np.array([par.fixed for par in pars])
+        self.tied = np.array([par.tied for par in pars])
         min_values = [par.min for par in pars]
         max_values = [par.max for par in pars]
         b = []
@@ -115,7 +118,10 @@ class Fitter(object):
             if j is None:
                 j = 10 ** 12
             b.append((i, j))
-        self.bounds = b[:]
+        self.bounds = np.array(b)
+
+        self.eqcons = np.array(self.model.eqcons)
+        self.ineqcons = np.array(self.model.ineqcons)
 
     @property
     def model(self):
@@ -151,13 +157,13 @@ class Fitter(object):
             fitpars = list(fps[:])
             mpars = []
             for i, name in enumerate(self.model.param_names):
-                if self.fixed[i] is True:
+                if self.fixed[i] == True:
                     par = getattr(self.model, name)
                     if len(par.parshape) == 0:
                         mpars.extend([par.value])
                     else:
                         mpars.extend(par.value)
-                elif self.tied[i] is not False:
+                elif self.tied[i] != False:
                     val = self.tied[i](self.model)
                     if isinstance(val, numbers.Number):
                         mpars.append(val)
@@ -169,7 +175,7 @@ class Fitter(object):
                     mpars.extend(fitpars[:plen])
                     del fitpars[:plen]
             self.model.parameters = mpars
-        elif any([b != (-1E12, 1E12) for b in self.bounds]):
+        elif any([tuple(b) != (-1E12, 1E12) for b in self.bounds]):
             self._set_bounds(fps)
         else:
             self.model.parameters[:] = fps
@@ -180,15 +186,20 @@ class Fitter(object):
         These may be a subset of the model parameters, if some
         of them are held constant or tied.
         """
+
+        fitpar_indices = []
         if any(self.model.fixed.values()) or any(self.model.tied.values()):
             pars = self.model._parameters[:]
-            for item in self.model.param_names[::-1]:
-                if self.model.fixed[item] or self.model.tied[item]:
-                    sl = self.model._parameters.parinfo[item][0]
+            for idx, name in enumerate(self.model.param_names[::-1]):
+                if self.model.fixed[name] or self.model.tied[name]:
+                    sl = self.model._parameters.parinfo[name][0]
                     del pars[sl]
-            return pars
+                else:
+                    fitpar_indices.append(idx)
+            return np.array(pars), fitpar_indices
         else:
-            return self.model._parameters
+            return (np.array(self.model._parameters),
+                    range(len(self.model.param_names)))
 
     def _set_bounds(self, pars):
         """
@@ -252,7 +263,8 @@ class Fitter(object):
         if any(self.tied) and 'tied' not in c:
             raise ValueError("{0} cannot handle tied parameter",
                              "constraints ".format(fname))
-        if any([b != (-1E12, 1E12) for b in self.bounds]) and 'bounds' not in c:
+        if (any([tuple(b) != (-1E12, 1E12) for b in self.bounds]) and
+                'bounds' not in c):
             raise ValueError("{0} cannot handle bound parameter",
                              "constraints".format(fname))
         if self.model.eqcons and 'eqcons' not in c:
@@ -282,7 +294,7 @@ class Fitter(object):
 
     def _update_constraints(self):
         self._set_constraints()
-        self._fitpars = self._model_to_fit_pars()
+        self._fitpars, self._fitpar_indices = self._model_to_fit_pars()
 
     @abc.abstractmethod
     def __call__(self):
@@ -683,12 +695,28 @@ class SLSQPFitter(Fitter):
             # for now only single data sets ca be fitted
             raise ValueError("NonLinearLSQFitter can only fit "
                              "one data set at a time")
-        p0 = self.model._parameters[:]
-        self.fitpars, final_func_val, numiter, exit_mode, mess = optimize.fmin_slsqp(
-            self.errorfunc, p0, args=farg, disp=verblevel, full_output=1,
-            bounds=self.bounds, eqcons=self.model.eqcons,
-            ieqcons=self.model.ineqcons, iter=maxiter, acc=1.E-6,
-            epsilon=EPS)
+
+        p0 = self.fitpars
+        if self.bounds.size:
+            bounds = self.bounds[self._fitpar_indices]
+        else:
+            bounds = []
+
+        if self.eqcons.size:
+            eqcons = self.eqcons[self._fitpar_indices]
+        else:
+            eqcons = []
+
+        if self.ineqcons.size:
+            ineqcons = self.ineqcons[self._fitpar_indices]
+        else:
+            ineqcons = []
+
+        self.fitpars, final_func_val, numiter, exit_mode, mess = \
+            optimize.fmin_slsqp(
+                self.errorfunc, p0, args=farg, disp=verblevel, full_output=1,
+                bounds=bounds, eqcons=eqcons, ieqcons=ineqcons, iter=maxiter,
+                acc=1.E-6, epsilon=EPS)
         self.fit_info['final_func_val'] = final_func_val
         self.fit_info['numiter'] = numiter
         self.fit_info['exit_mode'] = exit_mode

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -213,7 +213,7 @@ def test_set_fixed_1():
     gauss.mean.fixed = True
     assert gauss.fixed == {'amplitude': False, 'mean': True, 'stddev': False}
     gfit = fitting.NonLinearLSQFitter(gauss)
-    assert gfit.fixed == [False, True, False]
+    assert np.all(gfit.fixed == [False, True, False])
 
 
 def test_set_fixed_2():
@@ -247,7 +247,7 @@ def test_unset_fixed():
     gauss.mean.fixed = False
     assert gauss.fixed == {'amplitude': False, 'mean': False, 'stddev': False}
     gfit._update_constraints()
-    assert gfit.fixed == [False, False, False]
+    assert np.all(gfit.fixed == [False, False, False])
 
 
 def test_unset_tied():
@@ -260,7 +260,7 @@ def test_unset_tied():
     gauss.amplitude.tied = False
     assert gauss.tied == {'amplitude': False, 'mean': False, 'stddev': False}
     gfit._update_constraints()
-    assert gfit.fixed == [False, False, False]
+    assert np.all(gfit.fixed == [False, False, False])
 
 
 def test_set_bounds_1():
@@ -270,7 +270,9 @@ def test_set_bounds_1():
     assert gauss.bounds == {'amplitude': (None, None),
                             'mean': (None, None),
                             'stddev': (0.0, None)}
-    assert gfit.bounds == [(-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12), (0.0, 10 ** 12)]
+    assert np.all(gfit.bounds ==
+                  [(-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12),
+                   (0.0, 10 ** 12)])
 
 
 def test_set_bounds_2():
@@ -281,7 +283,9 @@ def test_set_bounds_2():
                             'mean': (None, None),
                             'stddev': (0.0, None)}
     gfit._update_constraints()
-    assert gfit.bounds == [(-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12), (0.0, 10 ** 12)]
+    assert np.all(gfit.bounds ==
+                  [(-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12),
+                   (0.0, 10 ** 12)])
 
 
 def test_unset_bounds():
@@ -293,4 +297,6 @@ def test_unset_bounds():
                             'mean': (None, None),
                             'stddev': (None, None)}
     gfit = fitting.NonLinearLSQFitter(gauss)
-    assert gfit.bounds == [(-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12)]
+    assert np.all(gfit.bounds ==
+                  [(-10 ** 12, 10 ** 12), (-10 ** 12, 10 ** 12),
+                   (-10 ** 12, 10 ** 12)])


### PR DESCRIPTION
The `FItter` classes have an internal attribute called `Fitter._fitpars` which is a list of all parameters from the model being fitted _excluding_ tied and fixed parameters.

So for example if a model has 3 parameters, one of which is fixed, a fitter for that model has only 2 parameters in its `_fitpars` list.

However, in the `SLSQPFitter`, all of the model's parameters were being used.  When the fitter goes to set its `_fitpars` with newly fitted values after a pass through the `fmin_slsqp` it changes the size of `_fitpars`.  This doesn't break anything obviously, but it can lead to inconsistent and incorrect results, I think.  @nden thinks this is a bug too.
