### PR TITLE
Fix monospaced fonts in docs

### DIFF
--- a/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -128,14 +128,13 @@ address {
 }
 code, pre {
   padding: 0 3px 2px;
-  font-family: Monaco, Andale Mono, Courier New, monospace;
-  font-size: 12px;
+  font-family: monospace;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
 }
 tt {
-  font-family: Monaco, Andale Mono, Courier New, monospace;
+  font-family: monospace;
 }
 code {
   color: rgba(0, 0, 0, 0.75);
@@ -146,7 +145,6 @@ pre {
   padding: 8.5px;
   margin: 0 0 18px;
   line-height: 18px;
-  font-size: 12px;
   border: 1px solid #ddd;
   border: 1px solid rgba(0, 0, 0, 0.12);
   -webkit-border-radius: 3px;
@@ -168,7 +166,6 @@ tt {
     border: 1px solid #ddd;
     border: 1px solid rgba(0, 0, 0, 0.12);
     border-radius: 3px;
-    font-size: 0.95em;
 }
 
 /* all code has same box background color, even in headers */


### PR DESCRIPTION
The monospaced font used in `tt` and `code` elements does not match.  This is only made obvious if the monospaced font is customized in the browser to something other than the ones specified for `code` in our css.

![screenshot](https://f.cloud.github.com/assets/38294/1360166/b8f8a8f2-37f0-11e3-9cf1-bb44ac13d9fa.png)

This PR is in two commits.  The first should be uncontroversial (it just makes the fonts match).  The second changes to using the open source `Inconsolata` font, downloaded from the Google font service.  This will make the docs look the same on all platforms.  Using "Monaco" as the default was not a great choice because it comes from Apple and is only licensed for use on a Mac.  (This is also the font we use in the LaTeX version of the docs, FWIW).
