### PR TITLE
Change docs `_generated` folder name to `api`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ astropy/wcs/include/wcsconfig.h
 # Sphinx
 _build
 _generated
+docs/api
+
 
 # Packages/installer info
 *.egg

--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -806,7 +806,7 @@ if HAVE_SPHINX:
         def finalize_options(self):
             #Clear out previous sphinx builds, if requested
             if self.clean_docs:
-                dirstorm = ['docs/_generated']
+                dirstorm = ['docs/api']
                 if self.build_dir is None:
                     dirstorm.append('docs/_build')
                 else:

--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -152,7 +152,7 @@ numpydoc_show_class_members = False
 
 autosummary_generate = True
 
-automodapi_toctreedirnm = '_generated'
+automodapi_toctreedirnm = 'api'
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/astropy/sphinx/ext/automodapi.py
+++ b/astropy/sphinx/ext/automodapi.py
@@ -40,7 +40,7 @@ This extension also adds a sphinx configuration option
 `automodapi_toctreedirnm`. It must be a string that specifies the name of
 the directory the automodsumm generated documentation ends up in. This
 directory path should be relative to the documentation root (e.g., same
-place as ``index.rst``). It defaults to '_generated'
+place as ``index.rst``). It defaults to 'api'
 
 """
 
@@ -118,7 +118,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         If True, a ":toctree:" option will be added in the "..
         automodsumm::" sections of the template, pointing to the
         appropriate "generated" directory based on the Astropy convention
-        (e.g. in ``docs/_generated``)
+        (e.g. in ``docs/api``)
     docname : str
         The name of the file for this `sourcestr` (if known - if not, it
         can be None). If not provided and `dotoctree` is True, the
@@ -268,4 +268,4 @@ def setup(app):
 
     app.connect('source-read', process_automodapi)
 
-    app.add_config_value('automodapi_toctreedirnm', '_generated', True)
+    app.add_config_value('automodapi_toctreedirnm', 'api', True)

--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -477,7 +477,7 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
             ns['underline'] = len(name) * '='
 
             # We now check whether a reference file exists for the module
-            # being documented. This assumes that we are in _generated, and
+            # being documented. This assumes that we are in 'api', and
             # that ../ gives us the root of the docs. We first check if the
             # current module is a file or a directory, as this will give a
             # different path for the reference file. For example, if

--- a/astropy/sphinx/ext/tests/test_automodapi.py
+++ b/astropy/sphinx/ext/tests/test_automodapi.py
@@ -53,7 +53,7 @@ Functions
 
 .. automodsumm:: astropy.sphinx.ext.tests.test_automodapi
     :functions-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 Classes
@@ -61,7 +61,7 @@ Classes
 
 .. automodsumm:: astropy.sphinx.ext.tests.test_automodapi
     :classes-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 Class Inheritance Diagram
@@ -82,7 +82,7 @@ def test_am_replacer_basic():
     """
     from ..automodapi import automodapi_replace
 
-    fakeapp = FakeApp(automodapi_toctreedirnm='_generated')
+    fakeapp = FakeApp(automodapi_toctreedirnm='api')
     result = automodapi_replace(am_replacer_str.format(options=''), fakeapp)
 
     assert result == am_replacer_basic_expected
@@ -100,7 +100,7 @@ Functions
 
 .. automodsumm:: astropy.sphinx.ext.tests.test_automodapi
     :functions-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 Classes
@@ -108,7 +108,7 @@ Classes
 
 .. automodsumm:: astropy.sphinx.ext.tests.test_automodapi
     :classes-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 
@@ -123,7 +123,7 @@ def test_am_replacer_noinh():
     """
     from ..automodapi import automodapi_replace
 
-    fakeapp = FakeApp(automodapi_toctreedirnm='_generated')
+    fakeapp = FakeApp(automodapi_toctreedirnm='api')
     ops = ['', ':no-inheritance-diagram:']
     ostr = '\n    '.join(ops)
     result = automodapi_replace(am_replacer_str.format(options=ostr), fakeapp)
@@ -143,7 +143,7 @@ Functions
 
 .. automodsumm:: astropy.sphinx.ext.tests.test_automodapi
     :functions-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 Classes
@@ -151,7 +151,7 @@ Classes
 
 .. automodsumm:: astropy.sphinx.ext.tests.test_automodapi
     :classes-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 Class Inheritance Diagram
@@ -172,7 +172,7 @@ def test_am_replacer_titleandhdrs():
     """
     from ..automodapi import automodapi_replace
 
-    fakeapp = FakeApp(automodapi_toctreedirnm='_generated')
+    fakeapp = FakeApp(automodapi_toctreedirnm='api')
     ops = ['', ':title: A new title', ':headings: &*']
     ostr = '\n    '.join(ops)
     result = automodapi_replace(am_replacer_str.format(options=ostr), fakeapp)
@@ -202,7 +202,7 @@ Functions
 
 .. automodsumm:: astropy.sphinx.ext.automodapi
     :functions-only:
-    :toctree: _generated/
+    :toctree: api/
     {empty}
 
 
@@ -216,7 +216,7 @@ def test_am_replacer_nomain():
     """
     from ..automodapi import automodapi_replace
 
-    fakeapp = FakeApp(automodapi_toctreedirnm='_generated')
+    fakeapp = FakeApp(automodapi_toctreedirnm='api')
     result = automodapi_replace(am_replacer_nomain_str, fakeapp)
 
     assert result == am_replacer_nomain_expected
@@ -245,7 +245,7 @@ Functions
 
 .. automodsumm:: astropy.sphinx.ext.automodapi
     :functions-only:
-    :toctree: _generated/
+    :toctree: api/
     :skip: something1,something2
 
 
@@ -259,7 +259,7 @@ def test_am_replacer_skip():
     """
     from ..automodapi import automodapi_replace
 
-    fakeapp = FakeApp(automodapi_toctreedirnm='_generated')
+    fakeapp = FakeApp(automodapi_toctreedirnm='api')
     result = automodapi_replace(am_replacer_skip_str, fakeapp)
 
     assert result == am_replacer_skip_expected
@@ -281,7 +281,7 @@ def test_am_replacer_invalidop():
     """
     from ..automodapi import automodapi_replace
 
-    fakeapp = FakeApp(automodapi_toctreedirnm='_generated')
+    fakeapp = FakeApp(automodapi_toctreedirnm='api')
     automodapi_replace(am_replacer_invalidop_str, fakeapp)
 
     expected_warnings = [('Found additional options invalid-option in '

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,7 +38,7 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)
-	-rm -rf _generated
+	-rm -rf api
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
As discussed on astropy-dev [here](https://groups.google.com/forum/#!topic/astropy-dev/xrQaI8lxp5o),
I think it's nicer to have `api` than `_generated` for our API docs.

@eteq suggested other folder renames [here](https://groups.google.com/d/msg/astropy-dev/xrQaI8lxp5o/PJzhD6hXLxgJ):
1. `_static` -> `static`
2. `_templates` -> `templates`
3. keep `_generated` but then rename to `api` in the html output
1. and 2. I could easily do if others think it's useful ... 3. I don't know how to do.
