### PR TITLE
Introduce units corresponding to AB and ST flux density zeropoints

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -95,6 +95,12 @@ def_unit(['ph', 'photon'], namespace=_ns)
 def_unit(['Jy', 'Jansky', 'jansky'], 1e-26 * si.W / si.m ** 2 / si.Hz,
          namespace=_ns, prefixes=True,
          doc="Jansky: spectral flux density")
+def_unit(['AB', 'ABflux'], 10.**(-0.4*48.6) * 1.e-3 * si.W / si.m**2 / si.Hz,
+         namespace=_ns, prefixes=False,
+         doc="ABflux: flux density for which AB magnitudes are 0.")
+def_unit(['ST', 'STflux'], 10.**(-0.4*21.1) * 1.e-3 * si.W / si.m**2 / si.AA,
+         namespace=_ns, prefixes=False,
+         doc="STflux: flux density for which ST magnitudes are 0.")
 def_unit(['R', 'Rayleigh', 'rayleigh'],
          (1e10 / (4 * _numpy.pi)) *
          ph * si.m ** -2 * si.s ** -1 * si.sr ** -1,
@@ -103,7 +109,6 @@ def_unit(['R', 'Rayleigh', 'rayleigh'],
 
 def_unit(['mag'], namespace=_ns, prefixes=True,
          doc="Astronomical magnitude.")
-
 
 ###########################################################################
 # MISCELLANEOUS


### PR DESCRIPTION
The discussion on magnitudes in #1577 made me realise we should have the flux densities for which the AB and ST magnitudes are 0 as predefined units.  They are introduces with the PR.

Note that I considered whether they should be under astrophysical constants instead, but ended up deciding against it, as I think the way one should think of it is "magnitudes for fluxes in units of..." rather than "magnitudes for fluxes normalised by ...", ie., just like `logg = log(g.cgs)`, so `STmag=-2.5*log(f.to(STflux))`, and what one has is properly a functional unit, not a dimensional quantity.
