### PR TITLE
BUG is_equivalent for units sometimes fails

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1667,7 +1667,7 @@ class CompositeUnit(UnitBase):
                 scale = add_unit(b, p, scale)
 
         new_parts = [x for x in six.iteritems(new_parts) if x[1] != 0]
-        new_parts.sort(key=lambda x: x[1], reverse=True)
+        new_parts.sort(key=lambda x: (-x[1], getattr(x[0], 'name', '')))
 
         self._bases = [x[0] for x in new_parts]
         self._powers = [x[1] for x in new_parts]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -479,3 +479,8 @@ def test_unit_division_by_string():
     us = 'kg'
     assert us / u1 == u.Unit(us) / u1
     assert u1 / us == u1 / u.Unit(us)
+
+
+def test_sorted_bases():
+    """See #1616."""
+    assert (u.m * u.Jy).bases == (u.Jy * u.m).bases


### PR DESCRIPTION
@mdboom - there is an odd problem with `is_equivalent`:

```
In [1]: import astropy.units as u

In [2]: (u.Jy*u.m).is_equivalent(u.m*u.Jy)
Out[2]: False

In [3]: (u.Jy*u.m)._get_physical_type_id()
Out[3]: (('kg', 1.0), ('m', 1.0), ('s', -2.0))

In [4]: (u.m*u.Jy)._get_physical_type_id()
Out[4]: (('m', 1.0), ('kg', 1.0), ('s', -2.0))
```

In `_get_physical_type_id()`, one finds

```
    def _get_physical_type_id(self):
        """
        Returns an identifier that uniquely identifies the physical
        type of this unit.  It is comprised of the bases and powers of
        this unit, without the scale.  Since it is hashable, it is
        useful as a dictionary key.
        """
        unit = self.decompose()
        r = zip([x.name for x in unit.bases], unit.powers)
        # bases and powers are already sorted in a unique way
        # r.sort()
        r = tuple(r)
        return r
```

but apparently the statement that bases and powers are stored in a unique way is not (no longer?) True. Any ideas?
