### PR TITLE
Add PyPI shields to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,12 @@
 Astropy
 =======
 
+.. image:: https://pypip.in/v/astropy/badge.png
+    :target: https://pypi.python.org/pypi/astropy
+
+.. image:: https://pypip.in/d/astropy/badge.png
+    :target: https://pypi.python.org/pypi/astropy
+
 Astropy (http://astropy.org/) is a package intended to contain much of
 the core functionality and some common tools needed for performing
 astronomy and astrophysics with Python.


### PR DESCRIPTION
This is a simple PR that just adds "shields" from http://pypip.in to the README file.  To see what this looks like, check out https://github.com/eteq/astropy/tree/add-shields-to-readme - the change adds the two gray/blue shields right after the "Astropy" heading.
