### PR TITLE
Broken example in coordinates docs

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -204,7 +204,7 @@ class CartesianPoints(u.Quantity):
 
     Parameters
     ----------
-    xorarr : `~astropy.units.Quantity` or array-like
+    x : `~astropy.units.Quantity` or array-like
         The first cartesian coordinate or a single array or
         `~astropy.units.Quantity` where the first dimension is length-3.
     y : `~astropy.units.Quantity` or array-like, optional
@@ -224,9 +224,9 @@ class CartesianPoints(u.Quantity):
     astropy.units.UnitsError
         If the units on `x`, `y`, and `z` do not match or an invalid unit is given
     ValueError
-        If `y` and `z` don't match `xorarr`'s shape or `xorarr` is not length-3
+        If `y` and `z` don't match `x`'s shape or `x` is not length-3
     TypeError
-        If incompatible array types are passed into `xorarr`, `y`, or `z`
+        If incompatible array types are passed into `x`, `y`, or `z`
 
     """
 
@@ -234,17 +234,15 @@ class CartesianPoints(u.Quantity):
     #where a quantity is first, like ``3*u.m + c``
     __array_priority__ = 10001
 
-    def __new__(cls, xorarr, y=None, z=None, unit=None, dtype=None, copy=True):
+    def __new__(cls, x, y=None, z=None, unit=None, dtype=None, copy=True):
         if y is None and z is None:
-            if len(xorarr) != 3:
+            if len(x) != 3:
                 raise ValueError('input to CartesianPoints is not length 3')
 
-            qarr = xorarr
+            qarr = x
             if unit is None and hasattr(qarr, 'unit'):
                 unit = qarr.unit  # for when a Quantity is given
         elif y is not None and z is not None:
-            x = xorarr
-
             if unit is None:
                 #they must all match units or this fails
                 for coo in (x, y, z):


### PR DESCRIPTION
`distances.rst` contains the following example, that doesn't work for me:

```
    >>> from astropy.coordinates import CartesianPoints
    >>> ICRSCoordinates(x=568.7129, y=107.3009, z=507.8899, unit=u.kpc)
    <ICRSCoordinates RA=10.68458 deg, Dec=41.26917 deg, Distance=7.7e+02 kpc>
    >>> cp = CartesianPoints(x=568.7129, y=107.3009, z=507.8899, unit=u.kpc)
```

This raises the exception `__new__() got an unexpected keyword argument 'x'`.
