### PR TITLE
Make automodsumm references support multi-directory toctree paths

### DIFF
--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -476,9 +476,8 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
             ns['objtype'] = doc.objtype
             ns['underline'] = len(name) * '='
 
-            # We now check whether a reference file exists for the module
-            # being documented. This assumes that we are in 'api', and
-            # that ../ gives us the root of the docs. We first check if the
+            # We now check whether a file for reference footnotes exists for 
+            # the module being documented. We first check if the
             # current module is a file or a directory, as this will give a
             # different path for the reference file. For example, if
             # documenting astropy.wcs then the reference file is at
@@ -490,15 +489,21 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
                 mod_name_dir = mod_name.replace('.', '/').split('/', 1)[1]
             else:
                 mod_name_dir = mod_name
-            if not os.path.isdir(os.path.join(path, '..', mod_name_dir)) \
-               and os.path.isdir(os.path.join(path, '..', mod_name_dir.rsplit('/', 1)[0])):
+            if not os.path.isdir(os.path.join(base_path, mod_name_dir)) \
+               and os.path.isdir(os.path.join(base_path, mod_name_dir.rsplit('/', 1)[0])):
                 mod_name_dir = mod_name_dir.rsplit('/', 1)[0]
 
             # We then have to check whether it exists, and if so, we pass it
-            # to the template
-            reference_file = os.path.join('..', mod_name_dir, 'references.txt')
-            if os.path.exists(os.path.join(path, reference_file)):
-                ns['referencefile'] = reference_file
+            # to the template.  
+            if os.path.exists(os.path.join(base_path, mod_name_dir, 'references.txt')):
+                # An important subtlety here is that the path we pass in has 
+                # to be relative to the file being generated, so we have to
+                # figure out the right number of '..'s 
+                ndirsback = path.replace(base_path, '').count('/')
+                ref_file_rel_segments = ['..'] * ndirsback
+                ref_file_rel_segments.append(mod_name_dir)
+                ref_file_rel_segments.append('references.txt')
+                ns['referencefile'] = os.path.join(*ref_file_rel_segments)
 
             rendered = template.render(**ns)
             f.write(rendered)


### PR DESCRIPTION
This fixes a really subtle bug that I discovered while investigating #1608 .  It turns out that if you give a directory that has more than one level to `automodsumm` (indirectly using `automodapi`), the astropy docs fail to build (see https://travis-ci.org/eteq/astropy/jobs/12864617 ) .

The problem stems from the fact that we use some path magic to locate the `references.txt` files used in `wcs` and `io.fits` (and possibly other places?).  But that magic isn't magical enough to deal with changes to where the `_generated` directory lives if they are multiple levels/layers.   This PR fixes the problem by being a bit trickier about deriving the path to pass into the text that `atuomodsumm` generates. 

It's pretty hard to figure out how to write a test for this, as it would require running sphinx on a bunch of fake docs.  So hopefully it will suffice to see that the travis job I linked above fails, while this one, which includes this PR, succeeds (the one warning is mostly unrelated): https://travis-ci.org/eteq/astropy/jobs/12864916

@astrofrog - I think you wrote at least part of this originally, so you might want to glance at this and see if any of it looks odd to you
