### PR TITLE
Example reordering columns in table docs broken

### DIFF
--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -117,8 +117,12 @@ created as shown in the following example::
 
   >>> t = Table(arr, names=('a', 'b', 'c'))
   >>> t_acb = t['a', 'c', 'b']
-  >>> new_order = ['a', 'c']  # List or tuple
-  >>> t_ac = t[neworder]
+
+Another way to do the same thing is to provide a list or tuple
+as the item as shown below::
+
+  >>> new_order = ['a', 'c', 'b']  # List or tuple
+  >>> t_acb = t[new_order]
 
 
 Caveats


### PR DESCRIPTION
The following example in `modify_table.rst` (which runs in the context of all of the code above it):

```
  >>> t_acb = t['a','c','b']
  >>> neworder = ('a','c','b')
  >>> t_acb = t[neworder]
```

gives the following exception:

`ValueError: Illegal type <type 'tuple'> for table item access`

```
Traceback (most recent call last):

  File "/usr/lib64/python2.7/doctest.py", line 1289, in __run
    compileflags, 1) in test.globs

  File "<doctest modify_table.rst[35]>", line 1, in <module>

  File "astropy/table/table.py", line 1571, in __getitem__
    .format(type(item)))

ValueError: Illegal type <type 'tuple'> for table item access
```
