### PR TITLE
Masking example broken in table docs

### DIFF
--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -124,12 +124,13 @@ The actual mask for the table as a whole or a single column can be
 viewed and modified via the ``mask`` attribute::
 
   >>> t = Table([(1, 2), (3, 4)], names=('a', 'b'), masked=True)
+  >>> t['a'].mask = [False, True]  # Modify column mask (boolean array)
   >>> t['b'].mask = [True, False]  # Modify column mask (boolean array)
   >>> print(t)
    a   b
   --- ---
     1  --
-    2   4
+   --   4
 
 Masked entries are shown as ``--`` when the table is printed.
 


### PR DESCRIPTION
The last example in `masking.rst` seems to be broken.

It reads as

```
  >>> t['a'].fill_value = -99
  >>> t['b'].fill_value = 33

  >>> print t.filled()
   a   b
  --- ---
    1  33
  -99   4

  >>> print t['a'].filled()
   a
  ---
    1
  -99

  >>> print t['a'].filled(999)
   a
  ---
    1
  999

  >>> print t.filled(1000)
   a    b
  ---- ----
     1 1000
  1000    4
```

But when I run it through the doctest module (which perhaps importantly runs all of the code preceding it first), I get the following:

```
  >>> t['a'].fill_value = -99
  >>> t['b'].fill_value = 33

  >>> print t.filled()
   a   b
  --- ---
    1  33
    2   4

  >>> print t['a'].filled()
   a
  ---
    1
    2

  >>> print t['a'].filled(999)
   a
  ---
    1
    2

  >>> print t.filled(1000)
   a   b
  --- ----
    1 1000
    2    4
```

Any thoughts?
