### PR TITLE
Don't install wcs header files that aren't part of the API

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -301,7 +301,7 @@ def get_package_data():
                                    'data/*.txt',
                                    'maps/*.hdr', 'spectra/*.hdr'],
         str('astropy.wcs'): ['include/astropy_wcs/*.h',
-                             'include/*.h']
+                             'include/astropy_wcs_api.h']
     }
 
 


### PR DESCRIPTION
Based on a request from the Fedora packager, Sergio Pascual, this should prevent the unnecessary installation of header files.
