### PR TITLE
Don't hardcode sys.stdout at import time

### DIFF
--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -277,7 +277,7 @@ def get_writer(Writer=None, **kwargs):
     return writer
 
 
-def write(table, output=sys.stdout,  format=None, Writer=None, **kwargs):
+def write(table, output=None,  format=None, Writer=None, **kwargs):
     """Write the input ``table`` to ``filename``.  Most of the default behavior
     for various parameters is determined by the Writer class.
 
@@ -294,6 +294,8 @@ def write(table, output=sys.stdout,  format=None, Writer=None, **kwargs):
     :param exclude_names: list of names to exlude from output (applied after ``include_names``)
     :param Writer: Writer class (DEPRECATED) (default=``ascii.Basic``)
     """
+    if output is None:
+        output = sys.stdout
 
     table = Table(table, names=kwargs.get('names'))
 

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -171,7 +171,7 @@ def writeto(table, file):
     table.to_xml(file, _debug_python_based_parser=True)
 
 
-def validate(source, output=sys.stdout, xmllint=False, filename=None):
+def validate(source, output=None, xmllint=False, filename=None):
     """
     Prints a validation report for the given file.
 
@@ -202,6 +202,9 @@ def validate(source, output=sys.stdout, xmllint=False, filename=None):
     """
     import textwrap
     from ...utils.console import print_code_line, color_print
+
+    if output is None:
+        output = sys.stdout
 
     return_as_str = False
     if output is None:

--- a/astropy/vo/validator/inspect.py
+++ b/astropy/vo/validator/inspect.py
@@ -47,16 +47,19 @@ class ConeSearchResults(object):
                 'conesearch_' + typ, cache=cache, verbose=verbose)
             self.catkeys[typ] = self.dbs[typ].list_catalogs()
 
-    def tally(self, fout=sys.stdout):
+    def tally(self, fout=None):
         """
         Tally databases.
 
         Parameters
         ----------
         fout : output stream
-            Default is screen output.
+            Default is sys.stdout.
 
         """
+        if fout is None:
+            fout = sys.stdout
+
         str_list = []
         n_tot = 0
 
@@ -69,7 +72,7 @@ class ConeSearchResults(object):
             str_list.append('total: {0} catalog(s)\n'.format(n_tot))
             fout.write('\n'.join(str_list))
 
-    def list_cats(self, typ, fout=sys.stdout, ignore_noncrit=False):
+    def list_cats(self, typ, fout=None, ignore_noncrit=False):
         """
         List catalogs in given database.
 
@@ -94,6 +97,9 @@ class ConeSearchResults(object):
             This is useful to see why a catalog failed validation.
 
         """
+        if fout is None:
+            fout = sys.stdout
+
         assert typ in self.dbtypes
         str_list = []
 
@@ -123,7 +129,7 @@ class ConeSearchResults(object):
         if len(str_list) > 0:
             fout.write('\n'.join(str_list))
 
-    def print_cat(self, key, fout=sys.stdout):
+    def print_cat(self, key, fout=None):
         """
         Display a single catalog of given key.
 
@@ -138,6 +144,9 @@ class ConeSearchResults(object):
             Default is screen output.
 
         """
+        if fout is None:
+            fout = sys.stdout
+
         str_list = []
 
         for typ in self.dbtypes:


### PR DESCRIPTION
This fixes a class of bugs that were found during doctest testing.

These functions all set a kwarg to a default of `sys.stdout`.  However, many tools, such as py.test or doctest replace sys.stdout with their own.  These functions will still use the `sys.stdout` defined at import time, not the "current" `sys.stdout` and thus subtle disappearance of output ensues.

This shouldn't affect the public API -- I consider it a bugfix.
