### PR TITLE
wcs: only install headers that are part of the C API

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -298,10 +298,20 @@ def get_extensions():
 
 def get_package_data():
     # Installs the testing data files
+    api_files = [
+        'astropy_wcs_api.h',
+        'wcsconfig.h',
+        'pyutil.h',
+        'util.h',
+        'distortion.h',
+        'pipeline.h',
+        'sip.h'
+        ]
+    api_files = [join('include', x) for x in api_files]
     return {
         'astropy.wcs.tests': ['data/*.hdr', 'data/*.fits',
                               'maps/*.hdr', 'spectra/*.hdr'],
-        'astropy.wcs': ['include/*.h']}
+        'astropy.wcs': api_files}
 
 
 def get_legacy_alias():


### PR DESCRIPTION
This is a backport to 0.2.x of #1665.

@sergiopasra, @embray
