### PR TITLE
Fixed ExpatError caused by mal-formatted USVO query XML

### DIFF
--- a/astropy/vo/validator/data/conesearch_urls.txt
+++ b/astropy/vo/validator/data/conesearch_urls.txt
@@ -1,5 +1,4 @@
 http://archive.noao.edu/nvo/usno.php?cat=a&amp;
-http://camelot.star.le.ac.uk:8080/dsa-catalog/SubmitCone?DSACAT=ledas&amp;DSATAB=gsc&amp;
 http://gsss.stsci.edu/webservices/vo/ConeSearch.aspx?CAT=GSC23&amp;
 http://irsa.ipac.caltech.edu/cgi-bin/Oasis/CatSearch/nph-catsearch?CAT=fp_psc&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/220/out&amp;

--- a/astropy/vo/validator/tstquery.py
+++ b/astropy/vo/validator/tstquery.py
@@ -2,6 +2,13 @@
 """Temporary solution until ``astropy.vo.validator.validate.CS_MSTR_LIST``
 includes ``<testQuery>`` fields.
 
+In case USVO service is unstable, it does the following:
+
+    #. Try USVO production server.
+    #. If fails, try USVO test server (has latest bug fix, but does not
+       contain all registered services).
+    #. If fails, use RA=0 DEC=0 SR=1.
+
 """
 from __future__ import print_function, division
 
@@ -18,21 +25,49 @@ def parse_cs(id):
     """Return ``<testQuery>`` pars as dict for given Resource ID."""
     if isinstance(id, bytes):  # pragma: py3
         id = id.decode('ascii')
-    url = 'http://nvo.stsci.edu/vor10/getRecord.aspx?' \
+
+    # Production server.
+    url = 'http://vao.stsci.edu/directory/getRecord.aspx?' \
         'id={0}&format=xml'.format(id)
+
+    # Test server (in case production server fails).
+    backup_url = 'http://vaotest.stsci.edu/directory/getRecord.aspx?' \
+        'id={0}&format=xml'.format(id)
+
     tqp = ['ra', 'dec', 'sr']
     d = OrderedDict()
-    with get_readable_fileobj(url, encoding='binary',
-                              show_progress=False) as fd:
-        dom = minidom.parse(fd)
-    tq = dom.getElementsByTagName('testQuery')
+    urls_failed = False
+    urls_errmsg = ''
+
+    try:
+        with get_readable_fileobj(url, encoding='binary',
+                                  show_progress=False) as fd:
+            dom = minidom.parse(fd)
+    except Exception as e: # pragma: no cover
+        try:
+            log.warn('{0} raised {1}, trying {2}'.format(
+                    url, str(e), backup_url))
+            with get_readable_fileobj(backup_url, encoding='binary',
+                                      show_progress=False) as fd:
+                dom = minidom.parse(fd)
+        except Exception as e:
+            urls_failed = True
+            urls_errmsg = '{0} raised {1}, using default'.format(
+                    backup_url, str(e))
+
+    if not urls_failed:
+        tq = dom.getElementsByTagName('testQuery')
+        if tq:
+            for key in tqp:
+                d[key.upper()] = tq[0].getElementsByTagName(
+                    key)[0].firstChild.nodeValue.strip()
+        else: # pragma: no cover
+            urls_failed = True
+            urls_errmsg = 'No testQuery found for {0}, using default'.format(id)
 
     # If no testQuery found, use RA=0 DEC=0 SR=1
-    if tq:
-        for key in tqp:
-            d[key.upper()] = \
-                tq[0].getElementsByTagName(key)[0].firstChild.nodeValue.strip()
-    else:  # pragma: no cover
+    if urls_failed:  # pragma: no cover
         d = OrderedDict({'RA': '0', 'DEC': '0', 'SR': '1'})
-        log.info('No testQuery found for {0}, using default'.format(id))
+        log.warn(urls_errmsg)
+
     return d


### PR DESCRIPTION
Fixed ExpatError caused by mal-formatted USVO query XML as mentioned in #1664. Removed a stale Cone Search service that has been giving Connection Refused for months.
