### PR TITLE
add warning about instability of modeling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,11 @@ templates_path.append('_templates')
 # be used globally.
 rst_epilog += """
 .. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
+
+.. Astropy
+.. _Astropy: http://astropy.org
+.. _`Astropy mailing list`: http://mail.scipy.org/mailman/listinfo/astropy
+.. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev
 """.format(astropy)
 
 # -- Project information ------------------------------------------------------

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -14,7 +14,9 @@ uniform way.
 .. warning::
     `~astropy.coordinates` is currently a work-in-progress, and thus it is
     possible there will be significant API changes in later versions of
-    Astropy.
+    Astropy. If you have specific ideas for how it might be improved, 
+    feel free to let us know on the `astropy-dev mailing list`_ or at 
+    http://feedback.astropy.org 
 
 
 Getting Started

--- a/docs/development/workflow/this_project.inc
+++ b/docs/development/workflow/this_project.inc
@@ -1,6 +1,2 @@
-.. Astropy
-.. _Astropy: http://astropy.org
 .. _`Astropy GitHub`: http://github.com/astropy/astropy
 
-.. _`Astropy mailing list`: http://mail.scipy.org/mailman/listinfo/astropy
-.. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,8 +105,7 @@ Getting help
 
 If you want to get help or discuss issues with other Astropy users, you can
 sign up for the `astropy mailing list <http://mail.scipy.org/mailman/listinfo/astropy>`_.
-Alternatively, the `astropy-dev
-<http://groups.google.com/group/astropy-dev>`_ list is where you should go to
+Alternatively, the `astropy-dev mailing list`_ is where you should go to
 discuss more technical aspects of Astropy with the developers.
 
 ***********************

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -24,7 +24,9 @@ hard to do if it is necessary).
 .. warning::
     `~astropy.modeling` is currently a work-in-progress, and thus it is
     likely there will be significant API changes in later versions of
-    Astropy.
+    Astropy. If you have specific ideas for how it might be improved, 
+    feel free to let us know on the `astropy-dev mailing list`_ or at 
+    http://feedback.astropy.org 
 
 
 Getting started


### PR DESCRIPTION
As discussed in the coordination telecon today, this adds a warning at the top of `modeling` like that in `coordinates` so that people know the API might change.

It also makes a few changes so that the ``astropy-dev mailing list`_` link is accessible from all astropy docs without having to define it in every document, but none of that actually changes the look of the output.
