### PR TITLE
Make sure polynomials can be fit with non-liner fitters

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -425,18 +425,16 @@ class Chebyshev1DModel(PolynomialModel):
                 c1 = tmp + c1 * x2
         return c0 + c1 * x
 
-    def deriv(self, params=None, x=None, y=None):
+    def deriv(self, x, *params):
         """
         Computes the Vandermonde matrix.
 
         Parameters
         ----------
-        params : throw away parameter
-            parameter list returned by non-linear fitters
         x : ndarray
             input
-        y : throw away parameter
-            Present here so that the non-linear fitting algorithms can work
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------
@@ -515,18 +513,16 @@ class Legendre1DModel(PolynomialModel):
                 c1 = tmp + (c1 * x * (2 * nd - 1)) / nd
         return c0 + c1 * x
 
-    def deriv(self, params=None, x=None, y=None):
+    def deriv(self, x, *params):
         """
         Computes the Vandermonde matrix.
 
         Parameters
         ----------
-        params : throw away parameter
-            parameter list returned by non-linear fitters
         x : ndarray
             input
-        y : throw away parameter
-            Present here so that the non-linear fitting algorithms can work
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------
@@ -590,12 +586,10 @@ class Polynomial1DModel(PolynomialModel):
 
         Parameters
         ----------
-        params : throw away parameter
-            parameter list returned by non-linear fitters
         x : ndarray
             input
-        y : throw away parameter
-            Present here so that the non-linear fitting algorithms can work
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------
@@ -699,14 +693,12 @@ class Polynomial2DModel(PolynomialModel):
 
         Parameters
         ----------
-        params : throw away parameter
-            parameter list returned by non-linear fitters
         x : ndarray
             input
         y : ndarray
             input
-        z : throw away parameter
-            Present here so that the non-linear fitting algorithms can work
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------
@@ -824,7 +816,7 @@ class Chebyshev2DModel(OrthoPolynomialBase):
             kfunc[n] = 2 * y * kfunc[n - 1] - kfunc[n - 2]
         return kfunc
 
-    def deriv(self, params=None, x=None, y=None, z=None):
+    def deriv(self, x, y, *params):
         """
         Derivatives with respect to the coefficients.
 
@@ -834,14 +826,12 @@ class Chebyshev2DModel(OrthoPolynomialBase):
 
         Parameters
         ----------
-        params : throw away parameter
-            parameter list returned by non-linear fitters
         x : ndarray
             input
         y : ndarray
             input
-        z : throw away parameter
-            Present here so that the non-linear fitting algorithms can work
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------
@@ -941,7 +931,7 @@ class Legendre2DModel(OrthoPolynomialBase):
                                   (n - 1) * kfunc[n + x_terms - 2]) / (n)
         return kfunc
 
-    def deriv(self, params=None, x=None, y=None, z=None):
+    def deriv(self, x, y, *params):
         """
         Derivatives with repect to the coefficients.
         This is an array with Legendre polynomials:
@@ -950,14 +940,12 @@ class Legendre2DModel(OrthoPolynomialBase):
 
         Parameters
         ----------
-        params : throw away parameter
-            parameter list returned by non-linear fitters
         x : ndarray
             input
         y : ndarray
             input
-        z : throw away parameter
-            Present here so that the non-linear fitting algorithms can work
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -45,6 +45,13 @@ class TestPolynomial2D(object):
         self.fitter(self.x, self.y, self.z)
         utils.assert_allclose(self.model(self.x, self.y), self.z)
 
+    @pytest.mark.skipif('not HAS_SCIPY')
+    def test_polynomial2D_nonlinear_fitting(self):
+        self.model.parameters = [.6, 1.8, 2.9, 3.7, 4.9, 6.7]
+        nlfitter = fitting.NonLinearLSQFitter(self.model)
+        nlfitter(self.x, self.y, self.z)
+        utils.assert_allclose(self.model.parameters, [1, 2, 3, 4, 5, 6])
+
 
 class TestICheb2D(object):
 
@@ -74,6 +81,16 @@ class TestICheb2D(object):
         self.fitter(self.x, self.y, self.z)
         z1 = self.cheb2(self.x, self.y)
         utils.assert_almost_equal(self.z, z1)
+
+    @pytest.mark.skipif('not HAS_SCIPY')
+    def test_chebyshev2D_nonlinear_fitting(self):
+        cheb2d = models.Chebyshev2DModel(2, 2)
+        cheb2d.parameters = np.arange(9)
+        z = cheb2d(self.x, self.y)
+        cheb2d.parameters = [0.1, .6, 1.8, 2.9, 3.7, 4.9, 6.7, 7.5, 8.9]
+        nlfitter = fitting.NonLinearLSQFitter(cheb2d)
+        nlfitter(self.x, self.y, z)
+        utils.assert_allclose(cheb2d.parameters, [0, 1, 2, 3, 4, 5, 6, 7, 8], atol=10**-9)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
Allows fitting of all polynomial models with non-linear fitters. This was already possible for `Polynomial1DModel` and `Polynomial2DModel`, not sure if the rest of the polynomials were just missed or overwritten.
