### PR TITLE
Add ability to provide descriptions for model parameters

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -104,10 +104,12 @@ class Parameter(object):
     # See the _nextid classmethod
     _nextid = 1
 
-    def __init__(self, name, default=None, getter=None, setter=None,
-                 fixed=False, tied=False, min=None, max=None, model=None):
+    def __init__(self, name, description='', default=None, getter=None,
+                 setter=None, fixed=False, tied=False, min=None, max=None,
+                 model=None):
         super(Parameter, self).__init__()
         self._name = name
+        self.__doc__ = description.strip()
         self._default = default
         self._attr = '_' + name
 


### PR DESCRIPTION
As I mentioned in [this comment](https://github.com/astropy/astropy/pull/1086#issuecomment-27023264) it needs to be possible to provide documentation for model parameters.  And furthermore that documentation needs to override each parameter's `__doc__`, since otherwise the Sphinx generated API docs just show the entire docstring for the `Parameter` class for every single parameter of every single model.

With this change all the parameters have empty docstrings, which leaves the API docs looking a little sparse. But it's at least less confusing.

We can add docstrings for individual parameters separately, either after 0.3 or now if someone wants to volunteer to start filling them in.
