### PR TITLE
check for stdout.encoding before doing encoding in pytest

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -286,8 +286,9 @@ if SUPPORTS_OPEN_FILE_DETECTION:
 
 
 def pytest_report_header(config):
-
     from .. import __version__
+
+    stdoutencoding = sys.stdout.encoding or 'ascii'
 
     s = "\nRunning tests with Astropy version {0}.\n".format(__version__)
     s += "Running tests in {0}.\n\n".format(" ".join(config.args))
@@ -295,7 +296,7 @@ def pytest_report_header(config):
     from platform import platform
     plat = platform()
     if isinstance(plat, bytes):
-        plat = plat.decode(sys.stdout.encoding or 'ascii', 'replace')
+        plat = plat.decode(stdoutencoding, 'replace')
     s += "Platform: {0}\n\n".format(plat)
     s += "Executable: {0}\n\n".format(sys.executable)
     s += "Full Python Version: \n{0}\n\n".format(sys.version)
@@ -343,7 +344,7 @@ def pytest_report_header(config):
         s += "Using Astropy options: {0}.\n".format(" ".join(opts))
 
     if not six.PY3:
-        s = s.encode(sys.stdout.encoding or 'ascii', 'replace')
+        s = s.encode(stdoutencoding, 'replace')
 
     return s
 


### PR DESCRIPTION
This is a fix for a buglet I noticed when doing `python setup.py test -R >somefile 2>&1`.  Right now when running the tests, our pytest plugin encodes based on `sys.stdout.encoding`.  But apparently that's None if you redirect to a file (at least on a Mac).  So this just adds a check to make sure that encoding is present, and otherwise defaults to ascii (which is what the `plat` string does further up)
