### PR TITLE
``Table.sort`` failing on MacOS X

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -7,6 +7,8 @@ from itertools import izip
 import functools
 import warnings
 import operator
+import platform
+from distutils import version
 
 import numpy as np
 from numpy import ma
@@ -23,6 +25,16 @@ from ..extern import six
 
 from ..utils.exceptions import AstropyDeprecationWarning
 from . import groups
+
+# In Python 3, prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
+# sorting of structured arrays to silently fail under certain circumstances (for
+# example if the Table contains string columns) on MacOS X
+SKIP_STRING_SORT = (platform.system() == 'Darwin' and six.PY3 and
+                    version.LooseVersion(np.__version__) < version.LooseVersion('1.6.2'))
+
+if SKIP_STRING_SORT:
+    __doctest_skip__ = ['Table.sort']
+
 
 # Python 2 and 3 source compatibility
 try:
@@ -2401,7 +2413,7 @@ class Table(object):
         Examples
         --------
         Create a table with three columns::
-        
+
             >>> t = Table([['Max', 'Jo', 'John'], ['Miller','Miller','Jackson'],
             ...         [12,15,18]], names=('firstname','name','tel'))
             >>> t.pprint()

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1,11 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
+import platform
 from distutils import version
 import numpy as np
 
+from ...extern import six
 from ...tests.helper import pytest
 from ... import table
 from ... import units as u
 
+
+# In Python 3, prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
+# sorting of structured arrays to silently fail under certain circumstances (for
+# example if the Table contains string columns) on MacOS X
+SKIP_STRING_SORT = (platform.system() == 'Darwin' and six.PY3 and
+                    version.LooseVersion(np.__version__) < version.LooseVersion('1.6.2'))
 
 class MaskedTable(table.Table):
     def __init__(self, *args, **kwargs):
@@ -882,6 +891,7 @@ class TestSort():
         assert np.all(t['a'] == np.array([2, 1, 3, 1, 3, 2]))
         assert np.all(t['b'] == np.array([3, 4, 4, 5, 5, 6]))
 
+    @pytest.mark.skipif('SKIP_STRING_SORT')
     def test_multiple_with_strings(self, table_types):
         # Before Numpy 1.6.2, and on Python 3.x, Numpy had a bug that meant
         # that sorting with multiple column names failed when a string column

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -89,12 +89,12 @@ Colored printing of log messages and other colored text does work in Windows
 but only when running in the IPython console.  Colors are not currently
 supported in the basic Python command-line interpreter on Windows.
 
-Table sorting can silently fail in Python 3 with Numpy < 1.6.2
---------------------------------------------------------------
+Table sorting can silently fail on MacOS X with Python 3 and Numpy < 1.6.2
+--------------------------------------------------------------------------
 
 In Python 3, prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
 sorting of structured arrays to silently fail under certain circumstances (for
-example if the Table contains string columns). Since ``Table.sort`` relies on
-Numpy to internally sort the data, it is also affected by this bug. If you are
-using Python 3, and need the sorting functionality for tables, we recommend
-updating to a more recent version of Numpy.
+example if the Table contains string columns) on MacOS X. Since ``Table.sort``
+relies on Numpy to internally sort the data, it is also affected by this bug.
+If you are using Python 3, and need the sorting functionality for tables, we
+recommend updating to a more recent version of Numpy.


### PR DESCRIPTION
Thanks to the doctests that @healther added, Jenkins found that `Table.sort` also does not work correctly on MacOS X with Numpy < 1.7:

https://jenkins.shiningpanda-ci.com/astropy/view/MacOS%20X/job/astropy-master-osx-10.8-multiconfig/

@taldcroft - is there an easy way to fix this one?
