### PR TITLE
CompositeUnit has no 'get_format_name' method

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -498,3 +498,11 @@ def test_megabit():
 
     assert u.Mbyte is u.MB
     assert u.megabyte is u.MB
+
+
+def test_composite_unit_get_format_name():
+    """See #1576"""
+    unit1 = u.Unit('nrad/s')
+    unit2 = u.Unit('Hz(1/2)')
+    assert (str(u.CompositeUnit(1, [unit1, unit2], [1, -1])) ==
+            'nrad / (Hz(1/2) s)')


### PR DESCRIPTION
Printing CompositeUnits doesn't seem to work, at least for me:

``` python
>>> from astropy.units import (Unit, CompositeUnit)
>>> unit1 = Unit('nrad/s')
>>> unit2 = Unit('Hz(1/2)')
>>> print(CompositeUnit(1, [unit1, unit2], [1, -1]))
ERROR: AttributeError: 'CompositeUnit' object has no attribute 'get_format_name' [astropy.units.format.generic]
...
```

Any help is great.
