### PR TITLE
Removed 2 duplicate access URLs in default cone search validation list

### DIFF
--- a/astropy/vo/validator/data/conesearch_urls.txt
+++ b/astropy/vo/validator/data/conesearch_urls.txt
@@ -15,8 +15,6 @@ http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=specobjall&amp;
 http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=specphotoall&amp;
 http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=sppparams&amp;
 http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=psc&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=psc&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=xsc&amp;
 http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=xsc&amp;
 http://vo.astronet.ru/sai_cas/conesearch?cat=usnoa2&amp;tab=main&amp;
 http://vo.astronet.ru/sai_cas/conesearch?cat=usnob1&amp;tab=main&amp;


### PR DESCRIPTION
Removed 2 duplicate access URLs in default cone search validation list. This has no impact on how the code works.

I must have overlooked it when I first auto-generated this file. Two of the services must have had duplicate entries in the master registry. Since the validation code removes duplicates anyway, this does not impact the results in any way.
