### PR TITLE
Release instruction improvements

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -206,12 +206,13 @@ The primary modifications to the release procedure are:
 * Do not do step #20 or later, as those are tasks for an actual release.
 
 .. note::
-    ``~/.pypirc`` files necessary for uploading to the testpypi server seem to
+    ``~/.pypirc`` files necessary for uploading to the testpypi server 
     require you to include your password to be able to manage to do 
-    ``register`` properly.  This is rather insecure, because it means you have
-    to put your PyPI password in a plain-text file.  Bear this in mind when
-    creating your PyPI password, or temporarily change your password just for
-    the purpose of doing a release.
+    ``register`` properly.  This can be insecure, because it means you have
+    to put your PyPI password in a plain-text file.  So you'll want to set 
+    the ``~/.pypirc`` file permissions to be quite restrictive, use a
+    temporary PyPI password just for doing releases, or some other measure
+    to ensure your password remains secure.
 
 
 Maintaining Bug Fix Releases


### PR DESCRIPTION
This is some changes to the release instructions based on my experience doing the 0.3b1 release.  This is probably only of interest to @embray and possibly @astrofrog.

The diff looks strange because the second commit involves moving a bunch of sections around in a way that apparently confused github.  But you can examine just  the first commit to see the actual content changes.
