### PR TITLE
TestComparisonUfuncs.test_comparison_valid_units failing with Numpy 1.8.0 and Numpy dev

### DIFF
--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import imp
 import sys
 import warnings
 
@@ -26,9 +27,9 @@ except NameError:
 
 def setup_function(function):
 
-    # Reset hooks to original values
-    sys.excepthook = _excepthook
-    warnings.showwarning = _showwarning
+    # Reset modules to default
+    imp.reload(warnings)
+    imp.reload(sys)
 
     # Reset internal original hooks
     log._showwarning_orig = None
@@ -43,13 +44,7 @@ def setup_function(function):
     if log.exception_logging_enabled():
         log.disable_exception_logging()
 
-
-def teardown_module(function):
-
-    # Ensure that hooks are restored to original values
-    sys.excepthook = _excepthook
-    warnings.showwarning = _showwarning
-
+teardown_module = setup_function
 
 def test_warnings_logging_disable_no_enable():
     with pytest.raises(LoggingError) as e:


### PR DESCRIPTION
I don't quite understand this failure, but here goes:

```
=================================== FAILURES ===================================
___________ TestComparisonUfuncs.test_comparison_valid_units[ufunc0] ___________

self = <astropy.units.tests.test_quantity_ufuncs.TestComparisonUfuncs object at 0x10934d710>
ufunc = <ufunc 'greater'>

    @pytest.mark.parametrize(('ufunc'), [np.greater, np.greater_equal,
                                         np.less, np.less_equal,
                                         np.not_equal, np.equal])
    def test_comparison_valid_units(self, ufunc):
        q_i1 = np.array([-3.3, 2.1, 10.2]) * u.kg / u.s
        q_i2 = np.array([10., -5., 1.e6]) * u.g / u.Ms
        q_o = ufunc(q_i1, q_i2)
        assert not isinstance(q_o, u.Quantity)
        assert q_o.dtype == np.bool
        assert np.all(q_o == ufunc(q_i1.value, q_i2.to(q_i1.unit).value))
        q_o2 = ufunc(q_i1 / q_i2, 2.)
        assert not isinstance(q_o2, u.Quantity)
        assert q_o2.dtype == np.bool
        assert np.all(q_o2 == ufunc((q_i1 / q_i2).to(1).value, 2.))
        # comparison with 0., inf, nan is OK even for dimensional quantities
        for arbitrary_unit_value in (0., np.inf, np.nan):
>           ufunc(q_i1, arbitrary_unit_value)

astropy/units/tests/test_quantity_ufuncs.py:487: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in greater',), <class 'RuntimeWarning'>, '/private/var/folders/tx/7205v3_143n82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in greater',), <class 'RuntimeWarning'>, '/private/var/folders/tx/7205v3_143n82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
!!! Recursion detected (same locals & position)
___________ TestComparisonUfuncs.test_comparison_valid_units[ufunc1] ___________

self = <astropy.units.tests.test_quantity_ufuncs.TestComparisonUfuncs object at 0x10933dcd0>
ufunc = <ufunc 'greater_equal'>

    @pytest.mark.parametrize(('ufunc'), [np.greater, np.greater_equal,
                                         np.less, np.less_equal,
                                         np.not_equal, np.equal])
    def test_comparison_valid_units(self, ufunc):
        q_i1 = np.array([-3.3, 2.1, 10.2]) * u.kg / u.s
        q_i2 = np.array([10., -5., 1.e6]) * u.g / u.Ms
        q_o = ufunc(q_i1, q_i2)
        assert not isinstance(q_o, u.Quantity)
        assert q_o.dtype == np.bool
        assert np.all(q_o == ufunc(q_i1.value, q_i2.to(q_i1.unit).value))
        q_o2 = ufunc(q_i1 / q_i2, 2.)
        assert not isinstance(q_o2, u.Quantity)
        assert q_o2.dtype == np.bool
        assert np.all(q_o2 == ufunc((q_i1 / q_i2).to(1).value, 2.))
        # comparison with 0., inf, nan is OK even for dimensional quantities
        for arbitrary_unit_value in (0., np.inf, np.nan):
>           ufunc(q_i1, arbitrary_unit_value)

astropy/units/tests/test_quantity_ufuncs.py:487: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in greater_equal',), <class 'RuntimeWarning'>, '/private/var/folders/tx/720...82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in greater_equal',), <class 'RuntimeWarning'>, '/private/var/folders/tx/720...82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
!!! Recursion detected (same locals & position)
___________ TestComparisonUfuncs.test_comparison_valid_units[ufunc2] ___________

self = <astropy.units.tests.test_quantity_ufuncs.TestComparisonUfuncs object at 0x1063827d0>
ufunc = <ufunc 'less'>

    @pytest.mark.parametrize(('ufunc'), [np.greater, np.greater_equal,
                                         np.less, np.less_equal,
                                         np.not_equal, np.equal])
    def test_comparison_valid_units(self, ufunc):
        q_i1 = np.array([-3.3, 2.1, 10.2]) * u.kg / u.s
        q_i2 = np.array([10., -5., 1.e6]) * u.g / u.Ms
        q_o = ufunc(q_i1, q_i2)
        assert not isinstance(q_o, u.Quantity)
        assert q_o.dtype == np.bool
        assert np.all(q_o == ufunc(q_i1.value, q_i2.to(q_i1.unit).value))
        q_o2 = ufunc(q_i1 / q_i2, 2.)
        assert not isinstance(q_o2, u.Quantity)
        assert q_o2.dtype == np.bool
        assert np.all(q_o2 == ufunc((q_i1 / q_i2).to(1).value, 2.))
        # comparison with 0., inf, nan is OK even for dimensional quantities
        for arbitrary_unit_value in (0., np.inf, np.nan):
>           ufunc(q_i1, arbitrary_unit_value)

astropy/units/tests/test_quantity_ufuncs.py:487: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in less',), <class 'RuntimeWarning'>, '/private/var/folders/tx/7205v3_143n82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in less',), <class 'RuntimeWarning'>, '/private/var/folders/tx/7205v3_143n82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
!!! Recursion detected (same locals & position)
___________ TestComparisonUfuncs.test_comparison_valid_units[ufunc3] ___________

self = <astropy.units.tests.test_quantity_ufuncs.TestComparisonUfuncs object at 0x109353810>
ufunc = <ufunc 'less_equal'>

    @pytest.mark.parametrize(('ufunc'), [np.greater, np.greater_equal,
                                         np.less, np.less_equal,
                                         np.not_equal, np.equal])
    def test_comparison_valid_units(self, ufunc):
        q_i1 = np.array([-3.3, 2.1, 10.2]) * u.kg / u.s
        q_i2 = np.array([10., -5., 1.e6]) * u.g / u.Ms
        q_o = ufunc(q_i1, q_i2)
        assert not isinstance(q_o, u.Quantity)
        assert q_o.dtype == np.bool
        assert np.all(q_o == ufunc(q_i1.value, q_i2.to(q_i1.unit).value))
        q_o2 = ufunc(q_i1 / q_i2, 2.)
        assert not isinstance(q_o2, u.Quantity)
        assert q_o2.dtype == np.bool
        assert np.all(q_o2 == ufunc((q_i1 / q_i2).to(1).value, 2.))
        # comparison with 0., inf, nan is OK even for dimensional quantities
        for arbitrary_unit_value in (0., np.inf, np.nan):
>           ufunc(q_i1, arbitrary_unit_value)

astropy/units/tests/test_quantity_ufuncs.py:487: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in less_equal',), <class 'RuntimeWarning'>, '/private/var/folders/tx/7205v3...82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x101a76f90>
args = (RuntimeWarning('invalid value encountered in less_equal',), <class 'RuntimeWarning'>, '/private/var/folders/tx/7205v3...82yw2cbsgjwzh00007c/T/astropy-test-5_t4z5/lib.macosx-10.4-x86_64-3.2/astropy/units/tests/test_quantity_ufuncs.py', 487)
kwargs = {}

    def _showwarning(self, *args, **kwargs):

        # Bail out if we are not catching a warning from Astropy
        if not isinstance(args[0], AstropyWarning):
>           return self._showwarning_orig(*args, **kwargs)

astropy/logger.py:166: 
!!! Recursion detected (same locals & position)
 generated xml file: /Users/Shared/Jenkins/Home/jobs/astropy-master-numpydev-osx-10.8-multiconfig/workspace/PV/3.2/junit.xml 
======= 4 failed, 4687 passed, 237 skipped, 10 xfailed in 281.52 seconds =======
```

only this function is failing (4 times for different input).
