### PR TITLE
Skip Time.TimePlotDate doc-string example that imports matplotlib

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1209,12 +1209,12 @@ class TimePlotDate(TimeFromEpoch):
 
     This can be used directly in the matplotlib `~matplotlib.pyplot.plot_date` function::
 
-      >>> import matplotlib.pyplot as plt
-      >>> jyear = np.linspace(2000, 2001, 20)
-      >>> t = Time(jyear, format='jyear', scale='utc')
-      >>> plt.plot_date(t.plot_date, jyear)
-      >>> plt.gcf().autofmt_xdate()  # orient date labels at a slant
-      >>> plt.draw()
+      >> import matplotlib.pyplot as plt
+      >> jyear = np.linspace(2000, 2001, 20)
+      >> t = Time(jyear, format='jyear', scale='utc')
+      >> plt.plot_date(t.plot_date, jyear)
+      >> plt.gcf().autofmt_xdate()  # orient date labels at a slant
+      >> plt.draw()
     """
     # This corresponds to the zero reference time for matplotlib plot_date().
     # Note that TAI and UTC are equivalent at the reference time, but


### PR DESCRIPTION
Running `astropy.test()` fails when one does not have `matplotlib` installed because of a doc-string example in `TimePlotDate`:

```
      >>> import matplotlib.pyplot as plt
      >>> jyear = np.linspace(2000, 2001, 20)
      >>> t = Time(jyear, format='jyear', scale='utc')
      >>> plt.plot_date(t.plot_date, jyear)
      >>> plt.gcf().autofmt_xdate()  # orient date labels at a slant
      >>> plt.draw()
```

I think tests should only rely on numpy being present, so this PR skips the test by changing all `>>>` to `>>`. If there is a more elegant way, let me know.
