### PR TITLE
Test failures with Python 3.1 and 3.2 with Numpy 1.5.x

### DIFF
--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -47,7 +47,12 @@ def get_formats(data_class=None):
         # Check if this is a short name (e.g. 'rdb') which is deprecated in favor
         # of the full 'ascii.rdb'.
         ascii_format_class = ('ascii.' + format_class[0], format_class[1])
-        deprecated = 'Yes' if ascii_format_class in format_classes else ''
+
+        # In the following, we use '   ' instead of '' because if the first
+        # format that is added is not deprecated, the data type for this
+        # element would be U0, which Numpy 1.5.x in Python 3 doesn't support,
+        # so we have to give it a non-zero length.
+        deprecated = 'Yes' if ascii_format_class in format_classes else '   '
 
         rows.append((format_class[1].__name__, format_class[0], has_read, has_write,
                      has_identify, deprecated))


### PR DESCRIPTION
Jenkins MacOS X is showing failures with Python 3.1 and 3.2 and Numpy 1.5.x, with the following error:

```
___________________ ERROR collecting astropy/table/groups.py ___________________
_pytest.runner:137: in __init__
>   ???
_pytest.main:396: in _memocollect
>   ???
_pytest.main:296: in _memoizedcall
>   ???
_pytest.main:396: in <lambda>
>   ???
astropy/tests/pytest_plugins.py:60: in collect
>           module = self.fspath.pyimport()
py._path.local:613: in pyimport
>   ???
astropy/table/__init__.py:7: in <module>
>   from ..io.ascii import connect
astropy/io/ascii/__init__.py:33: in <module>
>   from .core import (InconsistentTableError,
astropy/io/ascii/core.py:45: in <module>
>   from . import connect
astropy/io/ascii/connect.py:20: in <module>
>   io_registry.register_reader('ascii', Table, read_asciitable)
astropy/io/registry.py:144: in register_reader
>                                                    data_class.__name__))
E           Exception: Reader for format 'ascii' and class 'Table' is already defined
```

There are many of these. I'm not quite sure exactly yet what is causing this.

cc @taldcroft
