### PR TITLE
Add 0.2.5 release date to CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -453,7 +453,7 @@ Bug Fixes
     first the units were not preserved in the output). [#899]
 
 
-0.2.5 (unreleased)
+0.2.5 (2013-10-25)
 ------------------
 
 Bug Fixes


### PR DESCRIPTION
The correct release date shows up in the 0.2.x and stable branches but not in master.
