### PR TITLE
Changelog 0.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -656,8 +656,9 @@ Other Changes and Additions
 
   - Astropy now follows the PSF Code of Conduct. [#1216]
 
-  - Astropy's test suite now tests all doctests in both inline docstrings
-    and reST documentation.
+  - Astropy's test suite now tests all doctests in inline docstrings.  Support
+    for running doctests in the reST documentation is planned to follow in
+    v0.3.1.
 
   - Astropy's test suite can be run on multiple CPUs in parallel, often
     greatly improving runtime, using the ``--parallel`` option. [#1040]


### PR DESCRIPTION
Updates to the changelog before 0.3 release.  I tried to exhaustively include references to every user-visible change that is actually a difference between 0.3 and the 0.2.5.  This is probably not 100% perfect, but close enough.

The amount of time this took (even with the help of a bit of automation) suggests I have not applied enough pressure on people to include changelog entries for their changes (though some people have been very good about it).
