### PR TITLE
Fixed missed inline import for subprocess.Popen

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -924,7 +924,7 @@ if HAVE_SPHINX:
                     log.warn(msg)
 
             else:
-                proc = Popen([sys.executable], stdin=PIPE)
+                proc = subprocess.Popen([sys.executable], stdin=PIPE)
                 proc.communicate(subproccode.encode('utf-8'))
 
             if proc.returncode == 0:


### PR DESCRIPTION
The little bug was triggered by this build of astroquery: https://travis-ci.org/astropy/astroquery/jobs/13965996
