### PR TITLE
Change parameter definition to not require stating the name twice

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -131,8 +131,23 @@ class _ModelMeta(abc.ABCMeta):
 
     def __new__(mcls, name, bases, members):
         param_names = members.get('param_names', [])
-        parameters = dict((value.name, value) for value in members.values()
-                          if isinstance(value, Parameter))
+        parameters = {}
+        for key, value in members.items():
+            if not isinstance(value, Parameter):
+                continue
+            if not value.name:
+                # Name not explicitly given in the constructor; add the name
+                # automatically via the attribute name
+                value._name = key
+                value._attr = '_' + key
+            if value.name != key:
+                raise ModelDefinitionError(
+                    "Parameters must be defined with the same name as the "
+                    "class attribute they are assigned to.  Parameters may "
+                    "take their name from the class attribute automatically "
+                    "if the name argument is not given when initializing "
+                    "them.")
+            parameters[value.name] = value
 
         # If no parameters were defined get out early--this is especially
         # important for PolynomialModels which take a different approach to

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -90,9 +90,9 @@ class Gaussian1D(Parametric1DModel):
     Gaussian2D, Box1D, Beta1D, Lorentz1D
     """
 
-    amplitude = Parameter('amplitude')
-    mean = Parameter('mean')
-    stddev = Parameter('stddev')
+    amplitude = Parameter()
+    mean = Parameter()
+    stddev = Parameter()
 
     def __init__(self, amplitude, mean, stddev, **constraints):
         try:
@@ -175,12 +175,12 @@ class Gaussian2D(Parametric2DModel):
     Gaussian1D, Box2D, Beta2D
     """
 
-    amplitude = Parameter('amplitude')
-    x_mean = Parameter('x_mean')
-    y_mean = Parameter('y_mean')
-    x_stddev = Parameter('x_stddev')
-    y_stddev = Parameter('y_stddev')
-    theta = Parameter('theta')
+    amplitude = Parameter()
+    x_mean = Parameter()
+    y_mean = Parameter()
+    x_stddev = Parameter()
+    y_stddev = Parameter()
+    theta = Parameter()
 
     def __init__(self, amplitude, x_mean, y_mean, x_stddev=None, y_stddev=None,
                  theta=0.0, cov_matrix=None, **constraints):
@@ -287,7 +287,7 @@ class Shift(Model):
         column in the input coordinate array
     """
 
-    offsets = Parameter('offsets')
+    offsets = Parameter()
 
     def __init__(self, offsets, param_dim=1):
         if not isinstance(offsets, collections.Sequence):
@@ -329,7 +329,7 @@ class Scale(Model):
         scale for a coordinate
     """
 
-    factors = Parameter('factors')
+    factors = Parameter()
 
     def __init__(self, factors, param_dim=1):
         if not isinstance(factors, collections.Sequence):
@@ -384,8 +384,8 @@ class Sine1D(Parametric1DModel):
         .. math:: f(x) = A \\sin(2 \\pi f x)
     """
 
-    amplitude = Parameter('amplitude')
-    frequency = Parameter('frequency')
+    amplitude = Parameter()
+    frequency = Parameter()
 
     def __init__(self, amplitude, frequency, **constraints):
         super(Sine1D, self).__init__(amplitude=amplitude,
@@ -431,8 +431,8 @@ class Linear1D(Parametric1DModel):
         .. math:: f(x) = a x + b
     """
 
-    slope = Parameter('slope')
-    intercept = Parameter('intercept')
+    slope = Parameter()
+    intercept = Parameter()
     linear = True
 
     def __init__(self, slope, intercept, **constraints):
@@ -480,9 +480,9 @@ class Lorentz1D(Parametric1DModel):
         f(x) = \\frac{A \\gamma^{2}}{\\gamma^{2} + \\left(x - x_{0}\\right)^{2}}
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    fwhm = Parameter('fwhm')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    fwhm = Parameter()
 
     def __init__(self, amplitude, x_0, fwhm, **constraints):
         super(Lorentz1D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -526,7 +526,7 @@ class Const1D(Parametric1DModel):
         .. math:: f(x) = A
     """
 
-    amplitude = Parameter('amplitude')
+    amplitude = Parameter()
 
     def __init__(self, amplitude, **constraints):
         super(Const1D, self).__init__(amplitude=amplitude, **constraints)
@@ -565,7 +565,7 @@ class Const2D(Parametric2DModel):
         .. math:: f(x, y) = A
     """
 
-    amplitude = Parameter('amplitude')
+    amplitude = Parameter()
 
     def __init__(self, amplitude, **constraints):
         super(Const2D, self).__init__(amplitude=amplitude, **constraints)
@@ -610,10 +610,10 @@ class Disk2D(Parametric2DModel):
                    \\right.
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    R_0 = Parameter('R_0')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    R_0 = Parameter()
 
     def __init__(self, amplitude, x_0, y_0, R_0, **constraints):
         super(Disk2D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -667,11 +667,11 @@ class Ring2D(Parametric2DModel):
     Where :math:`r_{out} = r_{in} + r_{width}`.
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    r_in = Parameter('r_in')
-    width = Parameter('width')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    r_in = Parameter()
+    width = Parameter()
 
     def __init__(self, amplitude, x_0, y_0, r_in, width=None, r_out=None,
                  **constraints):
@@ -738,9 +738,9 @@ class Box1D(Parametric1DModel):
                    \\right.
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    width = Parameter('width')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    width = Parameter()
 
     def __init__(self, amplitude, x_0, width, **constraints):
         super(Box1D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -801,11 +801,11 @@ class Box2D(Parametric2DModel):
 
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    x_width = Parameter('x_width')
-    y_width = Parameter('y_width')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    x_width = Parameter()
+    y_width = Parameter()
 
     def __init__(self, amplitude, x_0, y_0, x_width, y_width, **constraints):
         super(Box2D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -842,10 +842,10 @@ class Trapezoid1D(Parametric1DModel):
     Box1D, Gaussian1D, Beta1D
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    width = Parameter('width')
-    slope = Parameter('slope')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    width = Parameter()
+    slope = Parameter()
 
     def __init__(self, amplitude, x_0, width, slope, **constraints):
         super(Trapezoid1D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -894,11 +894,11 @@ class TrapezoidDisk2D(Parametric2DModel):
     Disk2D, Box2D
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    R_0 = Parameter('R_0')
-    slope = Parameter('slope')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    R_0 = Parameter()
+    slope = Parameter()
 
     def __init__(self, amplitude, x_0, y_0, R_0, slope, **constraints):
         super(TrapezoidDisk2D, self).__init__(amplitude=amplitude,
@@ -945,9 +945,9 @@ class MexicanHat1D(Parametric1DModel):
 
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    sigma = Parameter('sigma')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    sigma = Parameter()
 
     def __init__(self, amplitude, x_0, sigma, **constraints):
         super(MexicanHat1D, self).__init__(amplitude=amplitude,
@@ -993,10 +993,10 @@ class MexicanHat2D(Parametric2DModel):
         - \\left(y - y_{0}\\right)^{2}}{2 \\sigma^{2}}}
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    sigma = Parameter('sigma')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    sigma = Parameter()
 
     def __init__(self, amplitude, x_0, y_0, sigma, **constraints):
         super(MexicanHat2D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -1040,10 +1040,10 @@ class AiryDisk2D(Parametric2DModel):
     Where J1 is the first order Bessel function of first kind.
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    width = Parameter('width')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    width = Parameter()
 
     _j1 = None
 
@@ -1112,10 +1112,10 @@ class Beta1D(Parametric1DModel):
         f(x) = A \\left(1 + \\frac{\\left(x - x_{0}\\right)^{2}}{\\gamma^{2}}\\right)^{- \\alpha}
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    gamma = Parameter('gamma')
-    alpha = Parameter('alpha')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    gamma = Parameter()
+    alpha = Parameter()
 
     def __init__(self, amplitude, x_0, gamma, alpha, **constraints):
         super(Beta1D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -1172,11 +1172,11 @@ class Beta2D(Parametric2DModel):
         \\left(y - y_{0}\\right)^{2}}{\\gamma^{2}}\\right)^{- \\alpha}
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    y_0 = Parameter('y_0')
-    gamma = Parameter('gamma')
-    alpha = Parameter('alpha')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    y_0 = Parameter()
+    gamma = Parameter()
+    alpha = Parameter()
 
     def __init__(self, amplitude, x_0, y_0, gamma, alpha, **constraints):
         super(Beta2D, self).__init__(amplitude=amplitude, x_0=x_0,

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -105,10 +105,14 @@ class Parameter(object):
     # See the _nextid classmethod
     _nextid = 1
 
-    def __init__(self, name, description='', default=None, getter=None,
+    def __init__(self, name='', description='', default=None, getter=None,
                  setter=None, fixed=False, tied=False, min=None, max=None,
                  model=None):
         super(Parameter, self).__init__()
+
+        if model is not None and not name:
+            raise TypeError('Bound parameters must have a name specified.')
+
         self._name = name
         self.__doc__ = description.strip()
         self._default = default

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -42,9 +42,9 @@ class PowerLaw1D(Parametric1DModel):
 
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    alpha = Parameter('alpha')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    alpha = Parameter()
 
     def __init__(self, amplitude, x_0, alpha, **constraints):
         super(PowerLaw1D, self).__init__(amplitude=amplitude, x_0=x_0,
@@ -104,10 +104,10 @@ class BrokenPowerLaw1D(Parametric1DModel):
                    \\right.
     """
 
-    amplitude = Parameter('amplitude')
-    x_break = Parameter('x_break')
-    alpha_1 = Parameter('alpha_1')
-    alpha_2 = Parameter('alpha_2')
+    amplitude = Parameter()
+    x_break = Parameter()
+    alpha_1 = Parameter()
+    alpha_2 = Parameter()
 
     def __init__(self, amplitude, x_break, alpha_1, alpha_2, **constraints):
         super(BrokenPowerLaw1D, self).__init__(
@@ -165,10 +165,10 @@ class ExponentialCutoffPowerLaw1D(Parametric1DModel):
 
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    alpha = Parameter('alpha')
-    x_cutoff = Parameter('x_cutoff')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    alpha = Parameter()
+    x_cutoff = Parameter()
 
     def __init__(self, amplitude, x_0, alpha, x_cutoff, **constraints):
         super(ExponentialCutoffPowerLaw1D, self).__init__(
@@ -224,10 +224,10 @@ class LogParabola1D(Parametric1DModel):
 
     """
 
-    amplitude = Parameter('amplitude')
-    x_0 = Parameter('x_0')
-    alpha = Parameter('alpha')
-    beta = Parameter('beta')
+    amplitude = Parameter()
+    x_0 = Parameter()
+    alpha = Parameter()
+    beta = Parameter()
 
     def __init__(self, amplitude, x_0, alpha, beta, **constraints):
         super(LogParabola1D, self).__init__(

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -89,8 +89,8 @@ class Pix2Sky_AZP(Zenithal):
             raise ValueError("AZP projection is not defined for mu=-1")
         return mu
 
-    mu = Parameter('mu', setter=_validate_mu)
-    gamma = Parameter('gamma', getter=np.rad2deg, setter=np.deg2rad)
+    mu = Parameter(setter=_validate_mu)
+    gamma = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, mu=0.0, gamma=0.0):
         self.check_mu(mu)
@@ -154,8 +154,8 @@ class Sky2Pix_AZP(Zenithal):
             raise ValueError("AZP projection is not defined for mu=-1")
         return mu
 
-    mu = Parameter('mu', setter=_validate_mu)
-    gamma = Parameter('gamma', getter=np.rad2deg, setter=np.deg2rad)
+    mu = Parameter(setter=_validate_mu)
+    gamma = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, mu=0.0, gamma=0.0):
         super(Sky2Pix_AZP, self).__init__()
@@ -342,8 +342,8 @@ class Pix2Sky_CYP(Cylindrical):
             pass
         return lam
 
-    mu = Parameter('mu', setter=_validate_mu)
-    lam = Parameter('lam', setter=_validate_lam)
+    mu = Parameter(setter=_validate_mu)
+    lam = Parameter(setter=_validate_lam)
 
     def __init__(self, mu, lam):
         super(Pix2Sky_CYP, self).__init__()
@@ -387,8 +387,8 @@ class Sky2Pix_CYP(Cylindrical):
             pass
         return lam
 
-    mu = Parameter('mu', setter=_validate_mu)
-    lam = Parameter('lam', setter=_validate_lam)
+    mu = Parameter(setter=_validate_mu)
+    lam = Parameter(setter=_validate_lam)
 
     def __init__(self, mu, lam):
         super(Sky2Pix_CYP, self).__init__()
@@ -411,7 +411,7 @@ class Pix2Sky_CEA(Cylindrical):
     CEA : Cylindrical equal area projection - pixel to sky.
     """
 
-    lam = Parameter('lam')
+    lam = Parameter()
 
     def __init__(self, lam=1):
         super(Pix2Sky_CEA, self).__init__()
@@ -431,7 +431,7 @@ class Sky2Pix_CEA(Cylindrical):
     CEA: Cylindrical equal area projection - sky to pixel.
     """
 
-    lam = Parameter('lam')
+    lam = Parameter()
 
     def __init__(self, lam=1):
         super(Sky2Pix_CEA, self).__init__()

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -42,9 +42,9 @@ class EulerAngleRotation(Model):
 
     n_inputs = 2
     n_outputs = 2
-    phi = Parameter('phi', getter=np.rad2deg, setter=np.deg2rad)
-    theta = Parameter('theta', getter=np.rad2deg, setter=np.deg2rad)
-    psi = Parameter('psi', getter=np.rad2deg, setter=np.deg2rad)
+    phi = Parameter(getter=np.rad2deg, setter=np.deg2rad)
+    theta = Parameter(getter=np.rad2deg, setter=np.deg2rad)
+    psi = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, phi, theta, psi):
         super(EulerAngleRotation, self).__init__()
@@ -172,8 +172,8 @@ class MatrixRotation2D(Model):
     n_inputs = 2
     n_outputs = 2
 
-    angle = Parameter('angle', getter=np.rad2deg, setter=_validate_angle)
-    matrix = Parameter('matrix', setter=_validate_matrix)
+    angle = Parameter(getter=np.rad2deg, setter=_validate_angle)
+    matrix = Parameter(setter=_validate_matrix)
 
     def __init__(self, matrix=None, angle=None):
         if matrix is None and angle is None:

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -15,7 +15,7 @@ from .. import models
 class NonFittableModel(Model):
     """An example class directly subclassing Model for testing"""
 
-    a = Parameter('a')
+    a = Parameter()
 
     def __init__(self, a):
         if not isinstance(a, collections.Sequence):

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -11,7 +11,7 @@ from numpy.testing import utils
 
 from . import irafutil
 from .. import models, fitting
-from ..core import ParametricModel
+from ..core import ParametricModel, ModelDefinitionError
 from ..parameters import Parameter, InputParameterError
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
@@ -22,8 +22,8 @@ class TestParModel(ParametricModel):
     A toy model to test parameters machinery
     """
 
-    coeff = Parameter('coeff')
-    e = Parameter('e')
+    coeff = Parameter()
+    e = Parameter()
 
     def __init__(self, coeff, e, param_dim=1):
         super(TestParModel, self).__init__(
@@ -94,6 +94,29 @@ def test_parameter_operators():
     assert par == par
     assert -par == -num
     assert abs(par) == abs(num)
+
+
+def test_parameter_name_attribute_mismatch():
+    """It should not be possible to define Parameters on a model with different
+    names from the attributes they are assigned to.
+    """
+
+    def make_bad_class():
+        class BadModel(ParametricModel):
+            foo = Parameter('bar')
+
+            def __call__(self): pass
+
+    def make_good_class():
+        class GoodModel(ParametricModel):
+            # This is redundant but okay
+            foo = Parameter('foo')
+
+            def __call__(self): pass
+
+    make_good_class()
+    pytest.raises(ModelDefinitionError, make_bad_class)
+
 
 class TestParameters(object):
 

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -58,11 +58,14 @@ from `~astropy.modeling.ParametricModel`; if not it should subclass
 
 If the model takes parameters they should be specified as class attributes in
 the model's class definition using the `~astropy.modeling.Parameter`
-descriptor.  The first argument for defining the parameter must be a unique (
-to that model) name of the parameter, and it must be identical to the class
-attribute being assigned that parameter.  Subsequent arguments are optional,
-and may include a default value for that parameter as well default constraints
-and custom getters/setters for the parameter value.
+descriptor.  All arguments to the Parameter constructor are optional, and may
+include a default value for that parameter as well default constraints and
+custom getters/setters for the parameter value.  If the first argument ``name``
+is specified it must be identical to the class attribute being assigned that
+Parameter.  As such, Parameters take their name from this attribute by default.
+In other words, ``amplitude = Parameter('amplitude')`` is equivalent to
+``amplitude = Parameter()``.  This differs from Astropy v0.3.x, where it was
+necessary to provide the name twice.
 
 .. note::
 
@@ -76,9 +79,9 @@ and custom getters/setters for the parameter value.
     from astropy.modeling import *
 
     class Gaussian1DModel(ParametricModel):
-        amplitude = Parameter('amplitude')
-        mean = Parameter('mean')
-        stddev = Parameter('stddev')
+        amplitude = Parameter()
+        mean = Parameter()
+        stddev = Parameter()
 
 At a minimum, the ``__init__`` method takes all parameters and the number of
 parameter sets, `~astropy.modeling.Model.param_dim`::
@@ -163,8 +166,8 @@ A full example of a LineModel
     import numpy as np
 
     class LineModel(models.PolynomialModel):
-        slope = Parameter('slope')
-        intercept = Parameter('intercept')
+        slope = Parameter()
+        intercept = Parameter()
         linear = True
 
     def __init__(self, slope, intercept, param_dim=1, **constraints):


### PR DESCRIPTION
This implements a change @wkerzendorf and I had tossed around some time back of eliminating the need to provide a parameter's name twice whendefining the Parameter attributes on a Model subclass.

In other words, rather than having to write `amplitude = Parameter('amplitude')` one should be able to write just `ampltiude = Parameter()` and have the name automatically taken from the class attribute (in fact, it is required that they be the same or else other parts of the code will break--this requirement has now been made explicit with a check in `_ModelMeta.__new__`).

This might be considered very "magic", but it's not the only aspect of Parameter that's magical to begin with.  It also makes the code I think terser and easier to read.
