### PR TITLE
Fix bug when building with --use-system-cfitsio and CFITSIO < 3.35

### DIFF
--- a/astropy/io/fits/src/compressionmodule.h
+++ b/astropy/io/fits/src/compressionmodule.h
@@ -33,6 +33,10 @@
     #if CFITSIO_MINOR >= 35
         #define CFITSIO_SUPPORTS_Q_FORMAT_COMPRESSION
         #define CFITSIO_SUPPORTS_SUBTRACTIVE_DITHER_2
+    #else
+        /* This constant isn't defined in older versions and has a different */
+        /* value anyways. */
+        #define NO_DITHER 0
     #endif
     #if CFITSIO_MINOR >= 28
         #define CFITSIO_SUPPORTS_GZIPDATA


### PR DESCRIPTION
This is required in order to build the io.fits.compression module with --use-system-cfitsio on systems where CFITSIO < 3.35 (the NO_DITHER macro is not defined in older versions, and the value used where NO_DITHER _is_ used in 3.35 is 0, not -1 which is what NO_DITHER is defined in 3.35)"

Thanks @pllim for testing this.
