### PR TITLE
Change models to one doc section

### DIFF
--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -19,7 +19,7 @@ Attach a docstring explaining constraints to all models which support them.
 Note: add new models to this list
 """
 
-CONSTRAINTS_DOC = """
+_CONSTRAINTS_DOC = """
     fixed: a dict
         a dictionary ``{parameter_name: boolean}`` of parameters to not be
         varied during fitting. True means the parameter is held fixed.
@@ -47,7 +47,7 @@ CONSTRAINTS_DOC = """
 """
 
 
-MODELS_WITH_CONSTRAINTS = [
+_MODELS_WITH_CONSTRAINTS = [
     AiryDisk2D, Beta1D, Beta2D, Box1D, Box2D,
     Const1D, Const2D, Disk2D, Gaussian1D, Gaussian2D,
     Linear1D, Lorentz1D, MexicanHat1D, MexicanHat2D,
@@ -57,6 +57,6 @@ MODELS_WITH_CONSTRAINTS = [
 ]
 
 
-for item in MODELS_WITH_CONSTRAINTS:
-    item.__doc__ += CONSTRAINTS_DOC
+for item in _MODELS_WITH_CONSTRAINTS:
+    item.__doc__ += _CONSTRAINTS_DOC
 del item  # sanitize namespace

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -59,3 +59,4 @@ MODELS_WITH_CONSTRAINTS = [
 
 for item in MODELS_WITH_CONSTRAINTS:
     item.__doc__ += CONSTRAINTS_DOC
+del item  # sanitize namespace

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -1,7 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-Creates a common namespace for all pre-defined models.
+A common namespace for all models included in Astropy.
+
+These models are actually implemented in distinct sub-modules, but the preferred
+usage is from this module, e.g., ``from astropy.models import Gaussian1D``
 """
 
 from .projections import *

--- a/astropy/sphinx/ext/automodapi.py
+++ b/astropy/sphinx/ext/automodapi.py
@@ -175,7 +175,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             toskip = []
             inhdiag = maindocstr = top_head = True
             hds = '-^'
-            vpkgnms = ''
+            vpkgnms = []
 
             #look for actual options
             unknownops = []
@@ -191,9 +191,17 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 elif opname == 'no-heading':
                     top_head = False
                 elif opname == 'valid-package-names':
-                    vpkgnms = ':valid-package-names:' + args
+                    vpkgnms.append(args.strip())
                 else:
                     unknownops.append(opname)
+
+            #join all the vpkgnms
+            if len(vpkgnms) == 0:
+                vpkgnms = ''
+                onlylocals = True
+            else:
+                vpkgnms = ':valid-package-names: ' + ','.join(vpkgnms)
+                onlylocals = vpkgnms
 
             # get the two heading chars
             if len(hds) < 2:
@@ -210,7 +218,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 if warnings:
                     app.warn(msg, location)
 
-            ispkg, hascls, hasfuncs = _mod_info(modnm, toskip)
+            ispkg, hascls, hasfuncs = _mod_info(modnm, toskip, onlylocals=onlylocals)
 
             #add automodule directive only if no-main-docstr isn't present
             if maindocstr:
@@ -267,7 +275,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         return sourcestr
 
 
-def _mod_info(modname, toskip=[]):
+def _mod_info(modname, toskip=[], onlylocals=True):
     """
     Determines if a module is a module or a package and whether or not
     it has classes or functions.
@@ -277,7 +285,7 @@ def _mod_info(modname, toskip=[]):
 
     hascls = hasfunc = False
 
-    for localnm, fqnm, obj in zip(*find_mod_objs(modname, onlylocals=True)):
+    for localnm, fqnm, obj in zip(*find_mod_objs(modname, onlylocals=onlylocals)):
         if localnm not in toskip:
             hascls = hascls or inspect.isclass(obj)
             hasfunc = hasfunc or inspect.isfunction(obj)

--- a/astropy/sphinx/ext/automodapi.py
+++ b/astropy/sphinx/ext/automodapi.py
@@ -39,6 +39,13 @@ It accepts the following options:
     * ``:no-heading:```
         If specified do not create a top level heading for the section.
 
+    * ``:valid-package-names: str``
+        If present, specifies a comma-seperated last of package names that
+        should be considered valid for the *real* names of the objects (as
+        opposed to their name within the package).  If not given, only objects
+        that are actually in a subpackage of the package currently being
+        documented are included.
+
 This extension also adds a sphinx configuration option
 `automodapi_toctreedirnm`. It must be a string that specifies the name of
 the directory the automodsumm generated documentation ends up in. This
@@ -74,6 +81,7 @@ Classes
 .. automodsumm:: {modname}
     :classes-only:
     {toctree}
+    {vpkgnms}
     {skips}
 """
 
@@ -84,6 +92,7 @@ Functions
 .. automodsumm:: {modname}
     :functions-only:
     {toctree}
+    {vpkgnms}
     {skips}
 """
 
@@ -93,6 +102,7 @@ Class Inheritance Diagram
 
 .. automod-diagram:: {modname}
     :private-bases:
+    {vpkgnms}
 """
 
 _automodapirex = re.compile(r'^(?:\s*\.\.\s+automodapi::\s*)([A-Za-z0-9_.]+)'
@@ -169,6 +179,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             toskip = []
             inhdiag = maindocstr = top_head = True
             hds = '-^'
+            vpkgnms = ''
 
             #look for actual options
             unknownops = []
@@ -183,6 +194,8 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     hds = args
                 elif opname == 'no-heading':
                     top_head = False
+                elif opname == 'valid-package-names':
+                    vpkgnms = ':valid-package-names:' + args
                 else:
                     unknownops.append(opname)
 
@@ -215,22 +228,35 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     pkgormodhds=h1 * (8 if ispkg else 7),
                     automoduleline=automodline))
 
+            newstrs.append(automod_templ_modheader.format(
+                modname=modnm,
+                modhds=h1 * len(modnm),
+                pkgormod='Package' if ispkg else 'Module',
+                pkgormodhds=h1 * (8 if ispkg else 7),
+                automoduleline=automodline))
+
             if hasfuncs:
-                newstrs.append(automod_templ_funcs.format(modname=modnm,
+                newstrs.append(automod_templ_funcs.format(
+                    modname=modnm,
                     funchds=h2 * 9,
                     toctree=toctreestr,
-                    skips=':skip: ' + ','.join(toskip) if toskip else ''))
+                    skips=':skip: ' + ','.join(toskip) if toskip else '',
+                    vpkgnms=vpkgnms))
 
             if hascls:
-                newstrs.append(automod_templ_classes.format(modname=modnm,
+                newstrs.append(automod_templ_classes.format(
+                    modname=modnm,
                     clshds=h2 * 7,
                     toctree=toctreestr,
-                    skips=':skip: ' + ','.join(toskip) if toskip else ''))
+                    skips=':skip: ' + ','.join(toskip) if toskip else '',
+                    vpkgnms=vpkgnms))
 
             if inhdiag and hascls:
                 # add inheritance diagram if any classes are in the module
                 newstrs.append(automod_templ_inh.format(
-                    modname=modnm, clsinhsechds=h2 * 25))
+                    modname=modnm,
+                    clsinhsechds=h2 * 25,
+                    vpkgnms=vpkgnms))
 
             newstrs.append(spl[grp * 3 + 3])
         return ''.join(newstrs)

--- a/astropy/sphinx/ext/automodapi.py
+++ b/astropy/sphinx/ext/automodapi.py
@@ -80,9 +80,7 @@ Classes
 
 .. automodsumm:: {modname}
     :classes-only:
-    {toctree}
-    {vpkgnms}
-    {skips}
+    {clsfuncoptions}
 """
 
 automod_templ_funcs = """
@@ -91,9 +89,7 @@ Functions
 
 .. automodsumm:: {modname}
     :functions-only:
-    {toctree}
-    {vpkgnms}
-    {skips}
+    {clsfuncoptions}
 """
 
 automod_templ_inh = """
@@ -235,21 +231,28 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 pkgormodhds=h1 * (8 if ispkg else 7),
                 automoduleline=automodline))
 
+            #construct the options for the class/function sections
+            #start out indented at 4 spaces, but need to keep the indentation.
+            clsfuncoptions = []
+            if toctreestr:
+                clsfuncoptions.append(toctreestr)
+            if toskip:
+                clsfuncoptions.append(':skip: ' + ','.join(toskip))
+            if vpkgnms:
+                clsfuncoptions.append(vpkgnms)
+            clsfuncoptionstr = '\n    '.join(clsfuncoptions)
+
             if hasfuncs:
                 newstrs.append(automod_templ_funcs.format(
                     modname=modnm,
                     funchds=h2 * 9,
-                    toctree=toctreestr,
-                    skips=':skip: ' + ','.join(toskip) if toskip else '',
-                    vpkgnms=vpkgnms))
+                    clsfuncoptions=clsfuncoptionstr))
 
             if hascls:
                 newstrs.append(automod_templ_classes.format(
                     modname=modnm,
                     clshds=h2 * 7,
-                    toctree=toctreestr,
-                    skips=':skip: ' + ','.join(toskip) if toskip else '',
-                    vpkgnms=vpkgnms))
+                    clsfuncoptions=clsfuncoptionstr))
 
             if inhdiag and hascls:
                 # add inheritance diagram if any classes are in the module

--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -258,7 +258,7 @@ def automodsumm_to_autosummary_lines(fn, app):
     #loop over all automodsumms in this document
     for i, (i1, i2, modnm, ops, rem) in enumerate(zip(indent1s, indent2s, mods,
                                                     opssecs, remainders)):
-        allindent = i1 + i2
+        allindent = i1 + ('' if i2 is None else i2)
 
         #filter out functions-only and classes-only options if present
         oplines = ops.split('\n')

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -161,9 +161,10 @@ def find_mod_objs(modname, onlylocals=False):
     ----------
     modname : str
         The name of the module to search.
-    onlylocals : bool
+    onlylocals : bool or list of str
         If True, only attributes that are either members of `modname` OR one of
-        its modules or subpackages will be included.
+        its modules or subpackages will be included. If it is a list of strings,
+        those specify the possible packages that will be considered "local".
 
     Returns
     -------
@@ -204,7 +205,9 @@ def find_mod_objs(modname, onlylocals=False):
             fqnames.append(modname + '.' + lnm)
 
     if onlylocals:
-        valids = [fqn.startswith(modname) for fqn in fqnames]
+        if onlylocals is True:
+            onlylocals = [modname]
+        valids = [any([fqn.startswith(nm) for nm in onlylocals]) for fqn in fqnames]
         localnames = [e for i, e in enumerate(localnames) if valids[i]]
         fqnames = [e for i, e in enumerate(fqnames) if valids[i]]
         objs = [e for i, e in enumerate(objs) if valids[i]]

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -186,9 +186,7 @@ Reference/API
 =============
 
 .. automodapi:: astropy.modeling
+
 .. automodapi:: astropy.modeling.fitting
-.. automodapi:: astropy.modeling.functional_models
-.. automodapi:: astropy.modeling.powerlaws
-.. automodapi:: astropy.modeling.polynomial
-.. automodapi:: astropy.modeling.projections
-.. automodapi:: astropy.modeling.rotations
+
+.. automodapi:: astropy.modeling.models

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -190,3 +190,4 @@ Reference/API
 .. automodapi:: astropy.modeling.fitting
 
 .. automodapi:: astropy.modeling.models
+     :valid-package-names: astropy.modeling


### PR DESCRIPTION
In the current master, the models from `astropy.modeling` are each documented in their own section (e.g. `astropy.modeling.polynomial`, `astropy.modeling.powerlaws`, etc.).  This strikes me as less than ideal, because it leads to people doing things like `from astropy.modeling.polynomial import Chebyshev1D`, while what we really want is for people to do `from astropy.modeling.models import Chebyshev1D`, so that they don't have to worry about the internal organization of the `modeling` package. This PR corrects that by changing it so that just `astropy.modeling.models` is documented, which contains all the same classes, but makes it clearer that it's intended that they use `astropy.modeling.models`.

There's a bunch of changes in `astropy.sphinx.ext`  because it turns out enabling this required some rather substantial changes to how `automodapi` finds modules.  The details are not terribly important unless you're interested, but even if we end up leaving the `modeling` doc the way it is, the _rest_ of this should be included, as it contains some bug fixes.

cc @nden
