### PR TITLE
Use major.minor format in the version string of the sphinx configuration file

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -44,7 +44,7 @@ graphviz_found = LooseVersion(get_graphviz_version())
 graphviz_broken = LooseVersion('0.30')
 
 if graphviz_found >= graphviz_broken:
-    needs_sphinx = '1.2b2'
+    needs_sphinx = '1.2'
 else:
     needs_sphinx = '1.1'
 


### PR DESCRIPTION
Only the first three characters of `sphinx.__version__` are used to compare with `needs_sphinx`. This patch fixes a bug reported to the astropy mailing list by Russell Hewett.
