### PR TITLE
Typo correction ("1D" instead of "2D")

### DIFF
--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -46,7 +46,7 @@ def add_kernel_arrays_1D(array_1, array_2):
 
 def add_kernel_arrays_2D(array_1, array_2):
     """
-    Add two 1D kernel arrays of different size.
+    Add two 2D kernel arrays of different size.
 
     The arrays are added with the centers lying upon each other.
     """


### PR DESCRIPTION
Hello,

This is just a small correction for a typo in the documentation.

Thanks,

Médéric
