### PR TITLE
Table with generalized columns

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -177,7 +177,8 @@ class BaseColumn(object):
             return
 
         if getattr(self, '_content', None) is not None:
-            obj = self._content['__class__'].__array_finalize__(self, obj)
+            obj = self._content['__class__'].__array_finalize__(
+                self._data, obj)
 
         # Self was created from template (e.g. obj[slice] or (obj * 2))
         # or viewcast e.g. obj.view(Column).  In either case we want to
@@ -190,8 +191,10 @@ class BaseColumn(object):
 
     def __array_prepare__(self, obj, context=None):
         if getattr(self, '_content', None) is not None:
-            return self._content['__class__'].__array_prepare__(
-                self, obj, context)
+            # return self._content['__class__'].__array_prepare__(
+            #     self.content, obj, context)
+            print(repr(obj), context)
+            return self.content.__array_prepare__(obj, context)
 
         return obj
 
@@ -211,10 +214,10 @@ class BaseColumn(object):
         """
         if getattr(self, '_content', None) is not None:
             out_arr = self._content['__class__'].__array_wrap__(
-                self, out_arr, context)
+                self._data, out_arr, context)
 
         if self.shape == out_arr.shape:
-            return np.ndarray.__array_wrap__(self, out_arr, context)
+            return np.ndarray.__array_wrap__(self._data, out_arr, context)
         else:
             return out_arr.view(np.ndarray)[()]
 
@@ -240,7 +243,7 @@ class BaseColumn(object):
         This returns a 3-tuple (name, type, shape) that can always be
         used in a structured array dtype definition.
         """
-        return (self.name, self.dtype.str, self.shape[1:])
+        return (self.name, self.data.dtype.str, self.data.shape[1:])
 
     def __repr__(self):
         unit = None if self.unit is None else str(self.unit)
@@ -489,7 +492,7 @@ class BaseColumn(object):
             out._groups = groups.ColumnGroups(out, indices=self._groups._indices)
 
 
-class Column(BaseColumn, np.ndarray):
+class Column(BaseColumn):
     """Define a data column for use in a Table object.
 
     Parameters
@@ -571,10 +574,10 @@ class Column(BaseColumn, np.ndarray):
     _content = None
 
     @_check_column_new_args
-    def __new__(cls, data=None, name=None,
-                dtype=None, shape=(), length=0,
-                description=None, unit=None, format=None, meta=None,
-                dtypes=None, units=None):
+    def __init__(self, data=None, name=None,
+                 dtype=None, shape=(), length=0,
+                 description=None, unit=None, format=None, meta=None,
+                 dtypes=None, units=None):
 
         if dtypes is not None:
             dtype = dtypes
@@ -618,7 +621,7 @@ class Column(BaseColumn, np.ndarray):
         else:
             self_data = np.asarray(data, dtype=dtype)
 
-        self = self_data.view(cls)
+        self._data = self_data  # .view(cls)
         if content is None:
             self._content = {'__class__': self_data.__class__}
             if hasattr(self_data, '__dict__'):
@@ -633,7 +636,17 @@ class Column(BaseColumn, np.ndarray):
         self.parent_table = None
         self.meta = meta
 
-        return self
+        # return self
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, key):
+        data = self.content[key]
+        if getattr(data, 'ndim', 0.) == 0:
+            return data
+        else:
+            return self.copy(data=data)
 
     def __getattr__(self, attr):
         if self._content is not None:
@@ -645,7 +658,7 @@ class Column(BaseColumn, np.ndarray):
     @property
     def content(self):
         if self._content is None:
-            return self.data
+            return self._data
 
         content = self.view(self._content['__class__'])
         if hasattr(content, '__dict__'):
@@ -658,6 +671,9 @@ class Column(BaseColumn, np.ndarray):
     @property
     def data(self):
         return self.view(np.ndarray)
+
+    def view(self, *args, **kwargs):
+        return self._data.view(*args, **kwargs)
 
     def copy(self, order='C', data=None, copy_data=True):
         """Return a copy of the current Column instance.  If ``data`` is supplied
@@ -674,6 +690,26 @@ class Column(BaseColumn, np.ndarray):
         self._copy_groups(out)
 
         return out
+
+
+def op_overload(op):
+    def operate(self, *args, **kwargs):
+        self_content = self.content
+        result = op(self_content, *args, **kwargs)
+        if result is self_content:  # did in-place operation
+            return self
+        else:
+            return result
+
+    return operate
+
+
+ops = [key for key in operator.__dict__.keys() if '__' in key]
+for op in ops:
+    func = getattr(operator, op)
+    if(not hasattr(Column, op) and
+       isinstance(func, operator.__add__.__class__)):
+        setattr(Column, op, op_overload(func))
 
 
 class MaskedColumn(BaseColumn, ma.MaskedArray):
@@ -1652,9 +1688,6 @@ class Table(object):
         if isinstance(item, basestring) and item not in self.colnames:
             NewColumn = MaskedColumn if self.masked else Column
 
-            # Make sure value is an ndarray so we can get the dtype
-            if not isinstance(value, np.ndarray):
-                value = np.asarray(value)
 
             # Make new column and assign the value.  If the table currently has no rows
             # (len=0) of the value is already a Column then define new column directly
@@ -1664,12 +1697,17 @@ class Table(object):
             if isinstance(value, BaseColumn):
                 new_column = value.copy(copy_data=False)
                 new_column.name = item
-            elif len(self) == 0:
-                new_column = NewColumn(name=item, data=value)
             else:
-                new_column = NewColumn(name=item, length=len(self), dtype=value.dtype,
-                                       shape=value.shape[1:])
-                new_column[:] = value
+                # Make sure value is an ndarray so we can get the dtype
+                if not isinstance(value, np.ndarray):
+                    value = np.asarray(value)
+
+                if len(self) == 0:
+                    new_column = NewColumn(name=item, data=value)
+                else:
+                    new_column = NewColumn(name=item, length=len(self), dtype=value.dtype,
+                                           shape=value.shape[1:])
+                    new_column[:] = value
 
                 if isinstance(value, Quantity):
                     new_column.unit = value.unit

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -28,7 +28,7 @@ class TestColumn():
         assert isinstance(c, np.ndarray)
         c2 = c * 2
         assert isinstance(c2, Column)
-        assert isinstance(c2, np.ndarray)
+        assert isinstance(c2, table.BaseColumn)
 
     def test_numpy_ops(self, Column):
         """Show that basic numpy operations with Column behave sensibly"""

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -509,51 +509,7 @@ class Time(object):
         return tm
 
     def _get_array_repr(self):
-        from collections import OrderedDict
-        optinfo = {attr: getattr(self, attr) for attr in
-                   ('scale', 'format', 'precision', 'in_subfmt', 'out_subfmt')}
-        arrays = OrderedDict()
-        arrays['jd1'] = self._time.jd1
-        arrays['jd2'] = self._time.jd2
-        for attr in '_delta_ut1_utc', '_delta_tdb_tt', 'lat', 'lon':
-            if hasattr(self, attr):
-                self_attr = getattr(self, attr)
-                try:
-                    assert len(self_attr) == len(self)
-                    arrays[attr] = self_attr
-                except(AssertionError, TypeError):
-                    optinfo[attr] = self_attr
-
-        optinfo['arrays'] = list(arrays.keys())
-        array = np.hstack((np.expand_dims(array, -1)
-                           for array in arrays.values()))
-
-        # need a subclass with a restore method and able to hold a __dict__
-        class TimeArrayRepr(np.ndarray):
-            def restore(self):
-                return Time._from_array_repr(self)
-
-        array = array.view(TimeArrayRepr)
-        array.__dict__.update(optinfo)
-        return array
-
-    @classmethod
-    def _from_array_repr(cls, array):
-        tm = super(Time, cls).__new__(cls)
-        optinfo = array.__dict__
-        array = array.view(np.ndarray)
-        optinfo.update({key: np.atleast_1d(array[..., i])
-                        for i, key in enumerate(optinfo.pop('arrays'))})
-        tm._time = TimeJD(optinfo.pop('jd1'), optinfo.pop('jd2'),
-                          optinfo.pop('scale'), optinfo.pop('precision'),
-                          optinfo.pop('in_subfmt'), optinfo.pop('out_subfmt'),
-                          from_jd=True)
-        tm._format = optinfo.pop('format')
-        tm.isscalar = len(tm._time) == 1
-        # any remaining ones just get updated
-        tm.__dict__.update(optinfo)
-
-        return tm
+        return TimeArrayRepr(self)
 
     def __copy__(self):
         """
@@ -1844,3 +1800,51 @@ class OperandTypeError(TypeError):
         self.value = ("unsupported operand type(s) for -: "
                       "'{0}' and '{1}'".format(left.__class__.__name__,
                                                right.__class__.__name__))
+
+
+class TimeArrayRepr(np.ndarray):
+
+    def __new__(cls, tm):
+        from collections import OrderedDict
+        optinfo = {attr: getattr(tm, attr) for attr in
+                   ('__class__', 'scale', 'format', 'precision',
+                    'in_subfmt', 'out_subfmt')}
+        arrays = OrderedDict()
+        arrays['jd1'] = tm._time.jd1
+        arrays['jd2'] = tm._time.jd2
+        for attr in '_delta_ut1_utc', '_delta_tdb_tt', 'lat', 'lon':
+            if hasattr(tm, attr):
+                tm_attr = getattr(tm, attr)
+                try:
+                    assert len(tm_attr) == len(tm)
+                    arrays[attr] = tm_attr
+                except(AssertionError, TypeError):
+                    optinfo[attr] = tm_attr
+
+        optinfo['arrays'] = list(arrays.keys())
+        array = np.hstack((np.expand_dims(array, -1)
+                           for array in arrays.values()))
+
+        # need a subclass with a restore method and able to hold a __dict__
+
+        array = array.view(cls)
+        array.__dict__.update(optinfo)
+        return array
+
+    def restore(self):
+        optinfo = self.__dict__
+        cls = optinfo.pop('__class__')
+        tm = super(Time, cls).__new__(cls)
+        array = self.view(np.ndarray)
+        optinfo.update({key: np.atleast_1d(array[..., i])
+                        for i, key in enumerate(optinfo.pop('arrays'))})
+        tm._time = TimeJD(optinfo.pop('jd1'), optinfo.pop('jd2'),
+                          optinfo.pop('scale'), optinfo.pop('precision'),
+                          optinfo.pop('in_subfmt'), optinfo.pop('out_subfmt'),
+                          from_jd=True)
+        tm._format = optinfo.pop('format')
+        tm.isscalar = len(tm._time) == 1
+        # any remaining ones just get updated
+        tm.__dict__.update(optinfo)
+
+        return tm

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -286,8 +286,7 @@ class Quantity(np.ndarray):
                                     "to quantities with in-place replacement "
                                     "of an input by any but the last output."
                                     .format(function.__name__))
-                result = self.copy()
-                result._result = self
+                result._result = self.copy()
 
             # ensure we remember the scales we need
             result._scales = scales
@@ -316,7 +315,8 @@ class Quantity(np.ndarray):
                 # junk. To avoid that, we hid it in a new object in
                 # __array_prepare__ and retrieve it here.
                 if hasattr(obj, '_result'):
-                    obj = obj._result
+                    obj[()] = obj._result
+                    del obj._result
 
                 # take array view to which output can be written without
                 # getting back here

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -585,3 +585,12 @@ class TestInplaceUfuncs(object):
         np.arctan2(np.array([1., 2., 3.]), np.array([1., 2., 3.]) * 2., out=s)
         assert_allclose(s.value, np.arctan2(1., 2.))
         assert s.unit == u.radian
+
+    def test_ufunc_inplace_non_contiguous_data(self):
+        # ensure inplace works also for non-contiguous data (closes #1834)
+        s = np.arange(10.) * u.m
+        s_copy = s.copy()
+        s2 = s[::2]
+        s2 += 1. * u.cm
+        assert np.all(s[::2] > s_copy[::2])
+        assert np.all(s[1::2] == s_copy[1::2])


### PR DESCRIPTION
Triggered by #1833, I thought I would also put the implementation @wkerzendorf and I have been working on for making generalized columns, which can hold any type of array.  This is by no means finished, but as our approach is quite different, I thought it was useful to put it out there.

In the `Column` class, the addition to properly support `Quantity` and its sub-classes is remarkably trivial; one just needs to keep track of the few attributes that are needed beyond just the `__class__` (`_unit` for `Quantity`; also `_wrap_angle` for `Longitude`; can just get these from `__dict__`).

For things other than `ndarray` subclasses, the main concept is that anything can become a column as long as it can turn itself into a properly sequenced array. We tried only for `Time` where one turns either just `jd1, jd2` into a 2-item array (to be made structured), and stores all relevant attributes in a dictionary (e.g., `lon`, `lat`). If any of the attributes are also arrays, they get stored in the full array as well (e.g., `delta_ut1_utc1`, or indeed `lon` and `lat`). The class can take a `Time` view of this by letting `jd1`, etc., point to the appropriate parts of the combined array.

Note that in this implementation, `Column` no longer is a subclass of `ndarray` itself; it seemed essentially impossible to have it be that, and have things like `np.sum(table['q'])` return a `Quantity` if the corresponding column holds a `Quantity`. One advantage is that this holds the promise of just storing a `MaskedArray` in a `Column`, thus obliviating the need for `MaskedColumn`, or indeed having whole tables be masked when really only a single column needs to be.

Anyway, maybe best to give an example of what's possible now (ignoring that many test cases are now broken...):
```
In [1]: from astropy.time import Time, TimeDelta; from astropy.table import Table, Column; from astropy.coordinates import Angle, Longitude, Latitude; import numpy as np; import astropy.units as u

In [2]: t = Time(['2012-01-01', '2013-01-01'], scale='utc')

In [3]: l = Longitude(np.arange(10.,12.), 'deg')

In [4]: q = np.arange(2.)*u.m

In [5]: b = Table([q,t,l], names=['q','t','l'])

In [6]: b['t'], b['q'], b['l']
Out[6]: 
(<Column name='t' unit=None format=None description=None>
<Time object: scale='utc' format='iso' value=['2012-01-01 00:00:00.000' '2013-01-01 00:00:00.000']>,
 <Column name='q' unit='m' format=None description=None>
<Quantity [ 0., 1.] m>,
 <Column name='l' unit='deg' format=None description=None>
<Longitude [ 10., 11.] deg>)

In [7]: b['q'].to(u.cm)
Out[7]: <Quantity [   0., 100.] cm>

In [8]: b['t'].tdb
Out[8]: <Time object: scale='tdb' format='iso' value=['2012-01-01 00:01:06.184' '2013-01-01 00:01:07.184']>

In [9]: b['t'] + 1.*u.min
Out[9]: <Time object: scale='utc' format='iso' value=['2012-01-01 00:01:00.000' '2013-01-01 00:01:00.000']>

In [10]: b['q'] += 1.*u.cm

In [11]: b['q']
Out[11]: 
<Column name='q' unit='m' format=None description=None>
<Quantity [ 0.01, 1.01] m>
```