### PR TITLE
Supporting ndarray subclasses in table columns

### DIFF
--- a/astropy/table/tests/test_ndarray_subclasses.py
+++ b/astropy/table/tests/test_ndarray_subclasses.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+
+from ...tests.helper import pytest
+from ...table import Column, Table
+from ... import units as u
+
+
+class TestQuantityColumn():
+    """Test that quantities are properly represented in Columns"""
+
+    def test_examples_from_eteq(self):
+        """From make tables work consistently with quantites [#2000]"""
+        t = Table()
+        t['length'] = np.arange(10.) * u.km
+        t['time'] = np.arange(1.,11.) * u.s
+        v = t['length']/t['time']
+        assert isinstance(v, u.Quantity)
+        assert v.unit == u.Unit('km/s')
+        check = t['length']*u.km / (t['time']*u.second)
+        assert isinstance(check, u.Quantity)
+        assert check.unit == u.Unit('km2/s2')
+        v2 = u.Quantity(t['length'])/u.Quantity(t['time'])
+        assert isinstance(v2, u.Quantity)
+        assert v2.unit == u.Unit('km/s')

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -124,11 +124,14 @@ class TestSetTableColumn(SetupData):
         t = table_types.Table()
 
         t['aa'] = np.array([1,2,3]) * u.m
-        assert np.all(t['aa'] == np.array([1,2,3]))
-        assert t['aa'].unit == u.m
-
         t['bb'] = 3 * u.m
-        assert np.all(t['bb'] == 3)
+        if t.masked:
+            assert np.all(t['aa'] == np.array([1,2,3]))
+            assert np.all(t['bb'] == 3)
+        else:
+            assert np.all(t['aa'] == np.array([1,2,3]) * u.m)
+            assert np.all(t['bb'] == 3 * u.m)
+        assert t['aa'].unit == u.m
         assert t['bb'].unit == u.m
 
     def test_set_new_col_existing_table(self, table_types):

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -73,15 +73,16 @@ columns to a table.  In both cases the new columns must be specified as |Column|
   >>> t2 = Table(np.arange(25).reshape(5, 5), names=('e', 'f', 'g', 'h', 'i'))
   >>> t.add_columns(t2.columns.values())
 
-Finally, columns can also be added from
-:class:`~astropy.units.Quantity` objects, which automatically sets the
-``.unit`` attribute on the column:
+Finally, columns can also be added from :class:`~astropy.units.Quantity`
+objects (as well as from other ``ndarray`` subclasses).  This will produce
+hybrid columns, which behave as columns as part of the table, but as
+quantities when used separately.::
 
   >>> from astropy import units as u
   >>> t['d'] = np.arange(1., 6.) * u.m
   >>> t['d']
-  <Column name='d' unit='m' format=None description=None>
-  array([ 1., 2., 3., 4., 5.])
+  <QuantityColumn name='d' unit='m' format=None description=None>
+  <Quantity [ 1., 2., 3., 4., 5.] m>
 
 **Remove columns**
 ::


### PR DESCRIPTION
I made another attempt at getting `Column`'s to hold `Quantity` and other `ndarray` subclasses, one which I think is mostly complementary to @taldcroft's #1833, as I on purpose did not (yet) include `Time` here. It is also simpler than my other attempt (#1835), a bit more in the spirit of #1583, in that the essence is to create a new `Column` subclass whose other subclass is `Quantity` (or whatever; note that I did not adjust `MaskedColumn` yet, since we do not really have other `MaskedArray` subclasses yet). The new piece is that new subclasses are defined automatically (with `Quantity` input -> `QuantityColumn` class, etc.)

With this PR:
```
from astropy.table import Table; from astropy.coordinates import Angle, Longitude, Latitude; import numpy as np; import astropy.units as u
q = np.arange(3.)*u.m
l = Longitude(np.arange(10.,13.), 'deg')
b = Table([q,l], names=['q','l'])

In [7]: print(b)
  q       l    
----- ---------
0.0 m 10d00m00s
1.0 m 11d00m00s
2.0 m 12d00m00s

In [8]: b['q'], b['l']
Out[8]: 
(QuantityColumn name='q' unit='m' format=None description=None>
<Quantity [ 0., 1., 2.] m>
<LongitudeColumn name='l' unit='deg' format=None description=None>
<Longitude [ 10., 11., 12.] deg>)

In [9]: b['q'] += 1.*u.cm

In [10]: print(b)
  q        l    
------ ---------
0.01 m 10d00m00s
1.01 m 11d00m00s
2.01 m 12d00m00s
```