### PR TITLE
Fix Astropy intersphinx URL

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -54,7 +54,7 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.sourceforge.net/', None),
-    'astropy': ('http://www.astropy.org/', None),
+    'astropy': ('http://docs.astropy.org/en/stable/', None),
     'h5py': ('http://h5py.alfven.org/docs-2.1/', None)
     }
 


### PR DESCRIPTION
As reported by @Cadair, intersphinx doesn't work, because the URL is incorrect.
