### PR TITLE
Add Numpy 1.8.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,6 @@ matrix:
           env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
 
         # Try alternate numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.7.1 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
-        - python: 3.2
-          env: NUMPY_VERSION=1.7.1 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
-        - python: 2.7
-          env: NUMPY_VERSION=1.6.2 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
         - python: 3.2
           env: NUMPY_VERSION=1.6.2 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
         - python: 2.7


### PR DESCRIPTION
This requires ensuring that the wheel for Numpy 1.8.0 is on the primary wheelhouse. I'll see to this.
