### PR TITLE
Modeling test failure on MacOS X

### DIFF
--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -43,7 +43,7 @@ Fitting examples
     >>> p2 = models.Polynomial1D(3, param_dim=2)
     >>> pfit = fitting.LinearLSQFitter()
     >>> new_model = pfit(p2, x, yy)
-    >>> print(new_model.param_sets)
+    >>> print(new_model.param_sets)  # doctest: +SKIP
     [[  1.00000000e+00   1.00000000e+00]
      [  2.00000000e+00   2.00000000e+00]
      [  3.88335494e-16   3.88335494e-16]


### PR DESCRIPTION
I'm seeing a failure on MacOS X for one of the modeling tests:

```
=================================== FAILURES ===================================
____________________________ [doctest] fitting.rst _____________________________
037     >>> p1.c1 = 2
038     >>> p1.parameters
039     array([ 1.,  2.,  0.,  0.])
040     >>> x = np.arange(10)
041     >>> y = p1(x)
042     >>> yy = np.array([y, y]).T
043     >>> p2 = models.Polynomial1D(3, param_dim=2)
044     >>> pfit = fitting.LinearLSQFitter()
045     >>> new_model = pfit(p2, x, yy)
046     >>> print(new_model.param_sets)
Differences (unified diff with -expected +actual):
    @@ -1,4 +1,4 @@
     [[  1.00000000e+00   1.00000000e+00]
      [  2.00000000e+00   2.00000000e+00]
    - [  3.88335494e-16   3.88335494e-16]
    - [ -2.997...e-17  -2.997...e-17]]
    + [  1.35314993e-16   1.35314993e-16]
    + [ -1.65733755e-17  -1.65733755e-17]]

/Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.7.1/PV/2.7/docs/modeling/fitting.rst:46: DocTestFailure
 generated xml file: /Users/Shared/Jenkins/Home/jobs/astropy-master-osx-10.8-multiconfig/workspace/NV/1.7.1/PV/2.7/junit.xml 
======= 1 failed, 4812 passed, 238 skipped, 11 xfailed in 280.93 seconds =======
```

cc @nden

Strangely, it only happens with Python 2.6 and 2.7
