### PR TITLE
Remove doctest-skip markers from output

### DIFF
--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -299,7 +299,7 @@ equivalencies that will by default be used, in a way similar to which
 one can :ref:`enable other units <enabling-other-units>`.
 
 For instance, to enable radian to be treated as a dimensionless unit,
-simply do::
+simply do:
 
 .. doctest-skip::
 
@@ -316,7 +316,7 @@ lists, they should indeed be combined by adding them together).
 
 The disadvantage of the above approach is that you may forget to turn
 the default off (done by giving an empty argument). To automate this,
-a context manager is provided::
+a context manager is provided:
 
 .. doctest-skip::
 

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -85,9 +85,9 @@ knows about::
     >>> (u.s ** -1).compose()  # doctest: +SKIP
     [Unit("Bq"), Unit("Hz"), Unit("3.7e+10 Ci")]
 
-And it can convert between unit systems, such as SI or CGS::
+And it can convert between unit systems, such as SI or CGS:
 
-.. doctest-skip-all::
+.. doctest-skip::
 
     >>> (1.0 * u.Pa).cgs
     <Quantity 10.0 Ba>


### PR DESCRIPTION
Should be uncontroversial, but I want to give Travis a go at this.  Only affects development docs, not 0.3 docs.
