### PR TITLE
A method to get the path to the C API headers is missing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,6 +231,9 @@ Bug Fixes
   - `astropy.wcs.Wcs.printwcs` will no longer warn that `cdelt` is
     being ignored when none was present in the FITS file. [#1845]
 
+  - A new function, `astropy.wcs.get_include`, has been added to get
+    the location of the `astropy.wcs` C header files. [#1755]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -239,7 +242,7 @@ Other Changes and Additions
   testing of doctests in docstrings that was already being performed.
   See ``docs/development/testguide.rst`` for more information. [#1771]
 
-- Fix a problem where import fails on Python 3 if setup.py exists 
+- Fix a problem where import fails on Python 3 if setup.py exists
   in current directory. [#1877]
 
 0.3 (2013-11-20)

--- a/astropy/wcs/__init__.py
+++ b/astropy/wcs/__init__.py
@@ -28,3 +28,11 @@ try:
 except ImportError:
     if not _ASTROPY_SETUP_:
         raise
+
+
+def get_include():
+    """
+    Get the path to astropy.wcs's C header files.
+    """
+    import os
+    return os.path.join(os.path.dirname(__file__), "include")


### PR DESCRIPTION
There are C header files in astropy/wcs/include, but there is not a method to get the path to these files, the equivalent of

> > > numpy.get_include()
> > > '/usr/lib64/python2.7/site-packages/numpy/core/include'

Without a function like this, it can be quite difficult to find the headers in a platform independent way.

Regards, Sergio
