### PR TITLE
Make `AstropyDeprecationWarning`s appear by default in py2.7

### DIFF
--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -24,7 +24,7 @@ class AstropyUserWarning(UserWarning, AstropyWarning):
     """
 
 
-class AstropyDeprecationWarning(DeprecationWarning, AstropyWarning):
+class AstropyDeprecationWarning(AstropyWarning):
     """
     A warning class to indicate a deprecated feature.
     """


### PR DESCRIPTION
This came up in a discussion in astropy/astropy-APEs#2 .  As it stands right now, `AstropyDeprecationWarning`s are _not_ shown when they are raised with `warnings.warn` in python 2.7.  This is due to python's default behavior of hiding `DeprecationWarning` (which is `AstropyDeprecationWarning`'s superclass) in py2.7 given that it is the last 2.x release.

This makes sense for _python_ deprecations, but we probably _do_ want user's to see our deprecation warnings, as they often deal with something they'll have to change in future astropy releases.  So we should figure out how to adjust the defaults so that `AstropyDeprecationWarning` is shown by default and has to be manually turned off by the user.

cc @embray @astrofrog 
