### PR TITLE
Make sure dtype.names ends up with  the "name" attribute instead of "id"

### DIFF
--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -67,10 +67,11 @@ in the ``array`` member variable::
 
   data = table.array
 
-This data is a Numpy record array.  The columns get their names from
-both the ``ID`` and ``name`` attributes of the ``FIELD`` elements in
-the ``VOTABLE`` file.  For example, suppose we had a ``FIELD``
-specified as follows:
+This data is a Numpy record array.
+
+The columns get their names from both the ``ID`` and ``name``
+attributes of the ``FIELD`` elements in the ``VOTABLE`` file.  For
+example, suppose we had a ``FIELD`` specified as follows:
 
 .. code-block:: xml
 
@@ -80,6 +81,27 @@ specified as follows:
      representing the ICRS declination of the center of the image.
     </DESCRIPTION>
    </FIELD>
+
+.. note::
+
+    The mapping from VOTable ``name`` and ``ID`` attributes to Numpy
+    dtype ``names`` and ``titles`` is highly confusing.
+
+    In VOTable, ``ID`` is guaranteed to be unique, but is not
+    required. ``name`` is not guaranteed to be unique, but is
+    required.
+
+    In Numpy record dtypes, ``names`` are required to be unique and
+    are required.  ``titles`` are not required, and are not required
+    to be unique.
+
+    Therefore, VOTable's ``ID`` most closely maps to Numpy's
+    ``names``, and VOTable's ``name`` most closely maps to Numpy's
+    ``titles``.  However, in some cases where a VOTable ``ID`` is not
+    provided, a Numpy ``name`` will be generated based on the VOTable
+    ``name``.  Unfortunately, VOTable fields do not have an attribute
+    that is both unique and required, which would be the most
+    convenient mechanism to uniquely identify a column.
 
 This column of data can be extracted from the record array using::
 


### PR DESCRIPTION
This is prompted by a question by Susana Sanchez on the astropy mailing list (http://mail.scipy.org/pipermail/astropy/2013-February/002303.html) - see that discussion for additional info.

The current VOTable behavior is that if you have an XML VO Table with `FIELD`s that have both an `ID` attribute and a `name` attribute, when `io.vo` parses the file, it puts both the `name` and the `id` in the resulting numpy dtype.  That is, for a particular example where the id's are "col#", the first entry of the thing that comes from `table.dtype` is `('CIG Number', 'col1'), '|O8')`.  This is all fine so far - it's good to record both of those.

The problem is that if you then do `table.dtype.names`, the resulting list has the `ID`s, not the `name`s from the XML `Field`.  It seems more natural for the `name` attribute to end up as the numpy dtype's name.  

If I understand multi-name dtypes, I think the fix is to simply construct the dtypes so that the _last_ name for each column is the `name` attribute, rather than the _first_.  But @mdboom will likely know if this might have unintended side effects.

I'm not sure if this is a bug or feature request, as I'm not sure if this is intended or not.
