### PR TITLE
astropy.modeling.NonLinearLeastSquares does not support bounds

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -358,7 +358,7 @@ class NonLinearLSQFitter(Fitter):
         A linear model is passed to a nonlinear fitter
     """
 
-    supported_constraints = ['fixed', 'tied', 'bounds']
+    supported_constraints = ['fixed', 'tied']
 
     def __init__(self):
 


### PR DESCRIPTION
scipy's nnls doesn't support bounds, and at present I don't think astropy's does either, so this just removes support for bounds in nnls.

@nden - you should check this and let me know if I'm mistaken. 

I'm interested to see any other bounded solvers implemented.  Note that scipy may eventually get the BVLS solver:
https://github.com/scipy/scipy/issues/3130
so it looks like there will be more bounded fitters available in the nearish future.
