### PR TITLE
Move documentation for `tolerance` parameter to correct function

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1184,11 +1184,6 @@ naxis kwarg.
 
         {1}
 
-        tolerance : float, optional
-            Tolerance of solution. Iteration terminates when the iterative
-            solver estimates that the true solution is within this many pixels
-            current estimate. Default value is 1e-6 (pixels).
-
         Returns
         -------
 
@@ -1281,6 +1276,11 @@ naxis kwarg.
             two-argument form must be used.
 
         {1}
+
+        tolerance : float, optional
+            Tolerance of solution. Iteration terminates when the iterative
+            solver estimates that the true solution is within this many pixels
+            current estimate. Default value is 1e-6 (pixels).
 
         Returns
         -------


### PR DESCRIPTION
The `tolerance` argument belongs to `all_world2pix`, not `all_pix2world`. It had been misplaced, in a typographical or merge error.
