### PR TITLE
Better support for $HOME in msys shells on Windows

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -42,8 +42,12 @@ def _find_home():
             raise OSError('Could not find unix home directory to search for '
                           'astropy config dir')
     elif os.name == 'nt':  # This is for all modern Windows (NT or after)
-        # Try for a network home first
-        if 'HOMESHARE' in os.environ:
+        if 'MSYSTEM' in os.environ and os.environ.get('HOME'):
+            # Likely using an msys shell; use whatever it is using for its
+            # $HOME directory
+            homedir = decodepath(os.environ['HOME'])
+        # Next try for a network home
+        elif 'HOMESHARE' in os.environ:
             homedir = decodepath(os.environ['HOMESHARE'])
         # See if there's a local home
         elif 'HOMEDRIVE' in os.environ and 'HOMEPATH' in os.environ:


### PR DESCRIPTION
If running in an msys shell, use the /home/embray environment variable set in that shell to find the user's home.  The surest way to determine this is if the MSYSTEM environment variable is set (it doesn't matter what it's set to).  Obviously this isn't foolproof but there are few better alternatives (one might be to try calling 'uname').

This specifically came up because some versions of msys (including the one I have installed) screw up the `$HOMEPATH` environment variable such that the `.astropy` directory ends up being created in `C:\.astropy` (if you even have permission to write there, if not it blows up).
