### PR TITLE
Add functions for age and comoving_volume to cosmology

### DIFF
--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -4,6 +4,46 @@ Convenience functions for `astropy.cosmology`.
 """
 from .core import get_current as _get_current
 
+def age(z, cosmo=None):
+    """ Age of the universe in Gyr at redshift `z`.
+
+    Parameters
+    ----------
+    z : array_like
+      Input redshifts.
+
+    Returns
+    -------
+    t : astropy.units.Quantity
+      The age of the universe in Gyr at each input redshift.
+        """
+    if cosmo is None:
+        cosmo = _get_current()
+    return cosmo.age(z)
+
+
+def comoving_volume(z, cosmo=None):
+    """ Comoving volume in cubic Mpc at redshift `z`.
+
+    This is the volume of the universe encompassed by redshifts
+    less than `z`. For the case of omega_k = 0 it is a sphere of
+    radius `comoving_distance(z)` but it is less intuitive if
+    omega_k is not 0.
+
+    Parameters
+    ----------
+    z : array_like
+      Input redshifts.
+
+    Returns
+    -------
+    V : astropy.units.Quantity
+      Comoving volume in :math:`Mpc^3` at each input redshift.
+    """
+    if cosmo is None:
+        cosmo = _get_current()
+    return cosmo.comoving_volume(z)
+
 
 def kpc_comoving_per_arcmin(z, cosmo=None):
     """ Separation in transverse comoving kpc corresponding to an

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -446,6 +446,10 @@ def test_convenience():
     assert funcs.angular_diameter_distance(3).unit == u.Mpc
     assert np.allclose(funcs.luminosity_distance(3).value, 26012.402789543696)
     assert funcs.luminosity_distance(3).unit == u.Mpc
+    assert np.allclose(funcs.age(3).value, 2.20407604076062)
+    assert funcs.age(3).unit == u.Gyr
+    assert np.allclose(funcs.comoving_volume(3).value, 1151993546079.626)
+    assert funcs.comoving_volume(3).unit == u.Mpc**3
 
     # arrays
     assert np.allclose(funcs.arcsec_per_kpc_comoving([0.1, 0.5]).value,


### PR DESCRIPTION
This adds functions for `age` and `comoving_volume` corresponding to the methods of the same name. This follows discussion on the astropy list (the thread starting with this message: http://mail.scipy.org/pipermail/astropy/2013-December/002938.html) where some people mentioned they had difficulty finding this functionality because there weren't function versions.

Pinging @aconley & @eteq who might like to take a look.

I plan to open separate PRs to add an inverse function and comoving volume element, which were other changes mentioned in the same thread.
