### PR TITLE
Definition of units.bar is off by a factor of 1000

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,11 +24,11 @@ New Features
     now possible to specify the table alignment within the text via the
     ``tablealign`` keyword. [#1838]
 
-  - If ``header_start`` is specified in a call to ``ascii.get_reader`` or any 
+  - If ``header_start`` is specified in a call to ``ascii.get_reader`` or any
     method that calls ``get_reader`` (e.g. ``ascii.read``) but ``data_start``
     is not specified at the same time, then ``data_start`` is calculated so
-    that the data starts after the header. Before this, the default was 
-    that the header line was read again as the first data line 
+    that the data starts after the header. Before this, the default was
+    that the header line was read again as the first data line
     [#855 and #1844].
 
 - ``astropy.io.fits``
@@ -248,10 +248,13 @@ Bug Fixes
 
   - Fix error for inplace operations on non-contiguous quantities [#1834].
 
+  - The definition of the unit `bar` has been corrected to `1e5
+    Pascal` from `100 Pascal` [#1910]
+
 - ``astropy.utils``
 
   - Bug fix for :func:`astropy.utils.timer.RunTimePredictor.do_fit`. [#1905]
-  
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -148,7 +148,7 @@ def_unit(['eV', 'electronvolt'], _si.e.value * J, namespace=_ns, prefixes=True,
          doc="Electron Volt")
 def_unit(['Pa', 'Pascal', 'pascal'], J * m ** -3, namespace=_ns, prefixes=True,
          doc="Pascal: pressure")
-def_unit(['bar'], 100 * Pa, namespace=_ns,
+def_unit(['bar'], 1e5 * Pa, namespace=_ns,
          doc="bar: pressure")
 
 


### PR DESCRIPTION
(first time using GitHub and nowhere near proficient enough to fork and change things myself, so I hope this is in the right place!)

The definition of the bar (astropy/units/si.py:151)

``` python
def_unit(['bar'], 100 * Pa, namespace=_ns,
doc="bar: pressure")
```

is off by a factor of 1000. It should be something like `1e5 * Pa` or `100 * kPa`.
