### PR TITLE
Ensure lon, lat are passed on in Time addition/subtraction

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -859,14 +859,14 @@ class Time(object):
             if self_time:
                 # Note: jd1 is exact; jd2 carry-over done in TimeDelta init.
                 tai = TimeDelta(jd1, jd2, format='jd')
-                tai.isscalar = len(jd1) == 1
+                tai.isscalar = self_tai.isscalar and other_tai.isscalar
                 return tai
             else:
                 raise OperandTypeError(self, other)
 
         tai = self_tai.replicate()
         tai._time.jd1, tai._time.jd2 = day_frac(jd1, jd2)
-        tai.isscalar = len(jd1) == 1
+        tai.isscalar = self_tai.isscalar and other_tai.isscalar
 
         if self_time:
             # remove attributes that are invalidated by changing time
@@ -900,7 +900,7 @@ class Time(object):
         jd2 = self_tai._time.jd2 + other_tai._time.jd2
         tai = (other_tai if other_time else self_tai).replicate()
         tai._time.jd1, tai._time.jd2 = day_frac(jd1, jd2)
-        tai.isscalar = len(jd1) == 1
+        tai.isscalar = self_tai.isscalar and other_tai.isscalar
 
         if self_time or other_time:
             # remove attributes that are invalidated by changing time

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -66,44 +66,77 @@ class TestTimeDelta():
         assert t2.iso == self.t2.iso
 
     def test_add_vector(self):
+        """Check time arithmetic as well as properly keeping track of whether
+        a time is a scalar or a vector"""
         t = Time(0.0, format='mjd', scale='utc')
         t2 = Time([0.0, 1.0], format='mjd', scale='utc')
         dt = TimeDelta(100.0, format='jd')
         dt2 = TimeDelta([100.0, 200.0], format='jd')
+
+        out = t + dt
+        assert allclose_jd(out.mjd, 100.0)
+        assert out.isscalar
 
         out = t + dt2
         assert allclose_jd(out.mjd, [100.0, 200.0])
+        assert not out.isscalar
 
         out = t2 + dt
         assert allclose_jd(out.mjd, [100.0, 101.0])
+        assert not out.isscalar
+
+        out = dt + dt
+        assert allclose_jd(out.jd, 200.0)
+        assert out.isscalar
 
         out = dt + dt2
         assert allclose_jd(out.jd, [200.0, 300.0])
+        assert not out.isscalar
 
         # Reverse the argument order
+        out = dt + t
+        assert allclose_jd(out.mjd, 100.0)
+        assert out.isscalar
+
         out = dt2 + t
         assert allclose_jd(out.mjd, [100.0, 200.0])
+        assert not out.isscalar
 
         out = dt + t2
         assert allclose_jd(out.mjd, [100.0, 101.0])
+        assert not out.isscalar
 
         out = dt2 + dt
         assert allclose_jd(out.jd, [200.0, 300.0])
+        assert not out.isscalar
 
     def test_sub_vector(self):
+        """Check time arithmetic as well as properly keeping track of whether
+        a time is a scalar or a vector"""
         t = Time(0.0, format='mjd', scale='utc')
         t2 = Time([0.0, 1.0], format='mjd', scale='utc')
         dt = TimeDelta(100.0, format='jd')
         dt2 = TimeDelta([100.0, 200.0], format='jd')
 
+        out = t - dt
+        assert allclose_jd(out.mjd, -100.0)
+        assert out.isscalar
+
         out = t - dt2
         assert allclose_jd(out.mjd, [-100.0, -200.0])
+        assert not out.isscalar
 
         out = t2 - dt
         assert allclose_jd(out.mjd, [-100.0, -99.0])
+        assert not out.isscalar
+
+        out = dt - dt
+        assert allclose_jd(out.jd, 0.0)
+        assert out.isscalar
 
         out = dt - dt2
         assert allclose_jd(out.jd, [0.0, -100.0])
+        assert not out.isscalar
 
     def test_copy_timedelta(self):
         """Test copying the values of a TimeDelta object by passing it into the


### PR DESCRIPTION
Another PR addressing #1924.  Now:

```
In [1]: from astropy.time import Time, TimeDelta
In [2]: t = Time(54555.0, 0.12345, scale='utc', format='mjd', lat=30, lon=-75)
In [3]: print(t.lat, t.lon, t.tdb.jd1, t.tdb.jd2, t.tdb.delta_tdb_tt)
30d00m00s -75d00m00s 2454555.5 0.1242044693704408 [ 0.00215361]
In [4]: t += TimeDelta(0, format='sec')
In [5]: print(t.lat, t.lon, t.tdb.jd1, t.tdb.jd2, t.tdb.delta_tdb_tt)
30d00m00s -75d00m00s 2454556.0 -0.37579553062955917 [ 0.00215361]
In [6]: 0.1242044693704408 - -0.37579553062955917
Out[6]: 0.5
```
