### PR TITLE
Import units on top so u.day, etc., can be used throughout

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -823,10 +823,10 @@ class Time(object):
 
             # Compute geocentric vector in km (era_gd2gc returns m)
             xyz = erfa_time.era_gd2gc(1, elon, phi, 0.0) / 1000.0
-            u = np.sqrt(xyz[0] ** 2 + xyz[1] ** 2)
-            v = xyz[2]
+            rxy = np.hypot(xyz[0], xyz[1])
+            z = xyz[2]
 
-            self._delta_tdb_tt = erfa_time.d_tdb_tt(jd1, jd2, ut, elon, u, v)
+            self._delta_tdb_tt = erfa_time.d_tdb_tt(jd1, jd2, ut, elon, rxy, z)
 
         return self._delta_tdb_tt
 


### PR DESCRIPTION
Partially inspired by the speed penalty for initialising `TimeDelta` from a quantity (#1933), this PR imports `units` on top, and removes all use of strings for units.  With it,

```
from astropy.time import TimeDelta; import astropy.units as u
%timeit TimeDelta(10.*u.us)
#1000 loops, best of 3: 300 us per loop
```

This is 24.4 ms in current master, and was 463 us before the problematic advising for units was introduced (#1870).
