### PR TITLE
Up Time's __array_priority__ to above Quantity's

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,6 +145,9 @@ Bug Fixes
   - Ensure that ``delta_ut1_utc`` gets calculated when accessed directly,
     instead of failing and giving a rather obscure error message [#1925]
 
+  - Increase ``__array_priority__`` so that ``TimeDelta`` can convert itself
+    to a ``Quantity`` also in reverse operations [#1940]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -152,7 +152,7 @@ class Time(object):
 
     # Make sure that reverse arithmetic (e.g., TimeDelta.__rmul__)
     # gets called over the __mul__ of Numpy arrays.
-    __array_priority__ = 1000
+    __array_priority__ = 20000
 
     @kwargs_after_scale
     def __new__(cls, val, val2=None, format=None, scale=None,

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -139,11 +139,6 @@ class TestTimeDeltaQuantity():
         q = np.log10(t0/u.second)
         assert isinstance(q, u.Quantity)
         assert q.value == np.log10(t0.sec)
-
-    @pytest.mark.xfail
-    def test_valid_quantity_operations3(self):
-        """These should work too, but do not yet -- see #1455"""
-        t0 = TimeDelta(100000., format='sec')
         s = 1.*u.m
         v = s/t0
         assert isinstance(v, u.Quantity)


### PR DESCRIPTION
`TimeDelta` should have priority over `Quantity` so that constructions like `(1.*u.m)/TimeDelta(100., format='sec')` get handled correctly. With this, one `xfail` test no longer fails.
