### PR TITLE
Added `_` as shortcut to `dimensionless_unscaled`

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -27,6 +27,8 @@ from .equivalencies import *
 
 del bases
 
+_ = dimensionless_unscaled
+
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
 


### PR DESCRIPTION
I find creating dimensionless `Quantity`es overly painful compared to quantities with dimensions. Currently the two existing options are:
1. Putting `u.km`, `u.s` next to `u.dimensionless_unscaled`. Too large.
2. Putting `u.km`, `u.s` next to `u.Unit('')` or `u.Unit(1)`. Why the inconsistency?

I find dimensionless quantities very convenient, and hence this tiny addition. It's the shortest and least obstrusive way I found to use them.

```
a = 1.0 * u.AU
ecc = 0.0167 * u._
inc = 0.0 * u.deg
...
```
