### PR TITLE
Python 3.4 failures

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -244,14 +244,14 @@ class FLRW(Cosmology):
     def _namelead(self):
         """ Helper function for constructing __repr__"""
         if self.name is None:
-            return "{0:s}(".format(self.__class__.__name__)
+            return "{0}(".format(self.__class__.__name__)
         else:
-            return "{0:s}(name=\"{1:s}\", ".format(self.__class__.__name__,
+            return "{0}(name=\"{1}\", ".format(self.__class__.__name__,
                                                    self.name)
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, Ode0={3:.3g}, "\
-                 "Tcmb0={4:.4g}, Neff={5:.3g}, m_nu={6:s})"
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, Ode0={3:.3g}, "\
+                 "Tcmb0={4:.4g}, Neff={5:.3g}, m_nu={6})"
         return retstr.format(self._namelead(), self._H0, self._Om0, self._Ode0,
                              self._Tcmb0, self._Neff, self.m_nu)
 
@@ -1465,8 +1465,8 @@ class FlatLambdaCDM(LambdaCDM):
         return 1.0 / np.sqrt(zp1 ** 3 * (Or * zp1 + Om0) + Ode0)
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, Tcmb0={3:.4g}, "\
-                 "Neff={4:.3g}, m_nu={5:s})"
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, Tcmb0={3:.4g}, "\
+                 "Neff={4:.3g}, m_nu={5})"
         return retstr.format(self._namelead(), self._H0, self._Om0, 
                              self._Tcmb0, self._Neff, self.m_nu)
 
@@ -1643,8 +1643,8 @@ class wCDM(FLRW):
                              Ode0 * zp1 ** (3 * (1 + w0)))
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, Ode0={3:.3g}, w0={4:.3g}, "\
-                 "Tcmb0={5:.4g}, Neff={6:.3g}, m_nu={7:s})"
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, Ode0={3:.3g}, w0={4:.3g}, "\
+                 "Tcmb0={5:.4g}, Neff={6:.3g}, m_nu={7})"
         return retstr.format(self._namelead(), self._H0, self._Om0, 
                              self._Ode0, self._w0, self._Tcmb0, self._Neff, 
                              self.m_nu)
@@ -1769,8 +1769,8 @@ class FlatwCDM(wCDM):
                              Ode0 * zp1 ** (3 * (1 + w0)))
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, w0={3:.3g}, Tcmb0={4:.4g}, "\
-                 "Neff={5:.3g}, m_nu={6:s})"
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, w0={3:.3g}, Tcmb0={4:.4g}, "\
+                 "Neff={5:.3g}, m_nu={6})"
         return retstr.format(self._namelead(), self._H0, self._Om0, self._w0,
                              self._Tcmb0, self._Neff, self.m_nu)
 
@@ -1906,9 +1906,9 @@ class w0waCDM(FLRW):
             np.exp(-3 * self._wa * z / zp1)
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, "\
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, "\
                  "Ode0={3:.3g}, w0={4:.3g}, wa={5:.3g}, Tcmb0={6:.4g}, "\
-                 "Neff={7:.3g}, m_nu={8:s})"
+                 "Neff={7:.3g}, m_nu={8})"
         return retstr.format(self._namelead(), self._H0, self._Om0,
                              self._Ode0, self._w0, self._wa,
                              self._Tcmb0, self._Neff, self.m_nu)
@@ -1978,8 +1978,8 @@ class Flatw0waCDM(w0waCDM):
         self._wa = float(wa)
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, "\
-                 "w0={3:.3g}, Tcmb0={4:.4g}, Neff={5:.3g}, m_nu={6:s})"
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, "\
+                 "w0={3:.3g}, Tcmb0={4:.4g}, Neff={5:.3g}, m_nu={6})"
         return retstr.format(self._namelead(), self._H0, self._Om0, self._w0,
                              self._Tcmb0, self._Neff, self.m_nu)
 
@@ -2134,9 +2134,9 @@ class wpwaCDM(FLRW):
             np.exp(-3 * self._wa * z / zp1)
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, Ode0={3:.3g}, wp={4:.3g}, "\
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, Ode0={3:.3g}, wp={4:.3g}, "\
                  "wa={5:.3g}, zp={6:.3g}, Tcmb0={7:.4g}, Neff={8:.3g}, "\
-                 "m_nu={9:s})"
+                 "m_nu={9})"
         return retstr.format(self._namelead(), self._H0, self._Om0,
                              self._Ode0, self._wp, self._wa, self._zp,
                              self._Tcmb0, self._Neff, self.m_nu)
@@ -2279,9 +2279,9 @@ class w0wzCDM(FLRW):
             np.exp(-3 * self._wz * z)
 
     def __repr__(self):
-        retstr = "{0:s}H0={1:.3g}, Om0={2:.3g}, "\
+        retstr = "{0}H0={1:.3g}, Om0={2:.3g}, "\
                  "Ode0={3:.3g}, w0={4:.3g}, wz={5:.3g} Tcmb0={6:.4g}, "\
-                 "Neff={7:.3g}, m_nu={8:s})"
+                 "Neff={7:.3g}, m_nu={8})"
         return retstr.format(self._namelead(), self._H0, self._Om0, 
                              self._Ode0, self._w0, self._wz, self._Tcmb0, 
                              self._Neff, self.m_nu)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -95,40 +95,40 @@ def test_repr():
     """ Test string representation of built in classes"""
     cosmo = core.LambdaCDM(70, 0.3, 0.5)
     expected = 'LambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Ode0=0.5, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.LambdaCDM(70, 0.3, 0.5, m_nu=u.Quantity(0.01, u.eV))
     expected = 'LambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Ode0=0.5, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.01  0.01  0.01] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.FlatLambdaCDM(50.0, 0.27)
     expected = 'FlatLambdaCDM(H0=50 km / (Mpc s), Om0=0.27, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.wCDM(60.0, 0.27, 0.6, w0=-0.8, name='test1')
     expected = 'wCDM(name="test1", H0=60 km / (Mpc s), Om0=0.27, Ode0=0.6, w0=-0.8, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.FlatwCDM(65.0, 0.27, w0=-0.6, name='test2')
     expected = 'FlatwCDM(name="test2", H0=65 km / (Mpc s), Om0=0.27, w0=-0.6, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.w0waCDM(60.0, 0.25, 0.4, w0=-0.6, wa=0.1, name='test3')
     expected = 'w0waCDM(name="test3", H0=60 km / (Mpc s), Om0=0.25, Ode0=0.4, w0=-0.6, wa=0.1, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.Flatw0waCDM(55.0, 0.35, w0=-0.9, wa=-0.2, name='test4')
     expected = 'Flatw0waCDM(name="test4", H0=55 km / (Mpc s), Om0=0.35, w0=-0.9, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.wpwaCDM(50.0, 0.3, 0.3, wp=-0.9, wa=-0.2, zp=0.3, name='test5')
     expected = 'wpwaCDM(name="test5", H0=50 km / (Mpc s), Om0=0.3, Ode0=0.3, wp=-0.9, wa=-0.2, zp=0.3, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
     cosmo = core.w0wzCDM(55.0, 0.4, 0.8, w0=-1.05, wz=-0.2,
                          m_nu=u.Quantity([0.001, 0.01, 0.015], u.eV))
     expected = 'w0wzCDM(H0=55 km / (Mpc s), Om0=0.4, Ode0=0.8, w0=-1.05, wz=-0.2 Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.001  0.01   0.015] eV)'
-    assert "{0:s}".format(str(cosmo)) == expected
+    assert str(cosmo) == expected
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_flat_z1():

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -552,13 +552,12 @@ def _checkLevel(level):
         rv = level
     elif str(level) == level:
         if sys.version_info[:2] >= (3, 4):
-            if level not in logging._nameToLevel:
-                raise ValueError("Unknown level: %r" % level)
-            rv = logging._nameToLevel[level]
+            names = logging._nameToLevel
         else:
-            if level not in logging._levelNames:
-                raise ValueError("Unknown level: %r" % level)
-            rv = logging._levelNames[level]
+            names = logging._levelNames
+        if level not in names:
+            raise ValueError("Unknown level: %r" % level)
+        rv = names[level]
     else:
         raise TypeError("Level not an integer or a valid string: %r" % level)
     return rv

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -40,6 +40,6 @@ class FlagCollection(OrderedDict):
             if value.shape == self.shape:
                 OrderedDict.__setitem__(self, item, value, **kwargs)
             else:
-                raise ValueError("flags array shape {0:s} does not match data shape {1:s}".format(str(value.shape), str(self.shape)))
+                raise ValueError("flags array shape {0} does not match data shape {1}".format(value.shape, self.shape))
         else:
             raise TypeError("flags should be given as a Numpy array")

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -85,9 +85,9 @@ def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name
     col_name_count = _counter(col_name_list)
     repeated_names = [name for name, count in six.iteritems(col_name_count) if count > 1]
     if repeated_names:
-        raise TableMergeError('Merging column names resulted in duplicates: {0:s}.  '
+        raise TableMergeError('Merging column names resulted in duplicates: {0}.  '
                               'Change uniq_col_name or table_names args to fix this.'
-                              .format(str(repeated_names)))
+                              .format(repeated_names))
 
     # Convert col_name_map to a regular dict with tuple (immutable) values
     col_name_map = OrderedDict((name, col_name_map[name]) for name in col_name_list)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -831,9 +831,6 @@ class Quantity(np.ndarray):
         try:
             value = format(self.value, format_spec)
             full_format_spec = "s"
-        except TypeError:  # For Python 3.4 and above
-            value = format(str(self.value), format_spec)
-            full_format_spec = "s"
         except ValueError:
             value = self.value
             full_format_spec = format_spec


### PR DESCRIPTION
I got a [report](http://bugs.debian.org/734293) that astropy fails to build and tested on python-3.4. The issues are:
1. astropy/logger.py: logging._levelNames does not exist anymore
   
   This can be fixed with [a simple patch](http://launchpadlibrarian.net/161653497/python-astropy_0.3-4build1_0.3-4ubuntu1.diff.gz).
2. With this patch, the following tests failed:
   - astropy/cosmology/tests/test_cosmology.py:94: test_repr
   - stropy/nddata/tests/test_flag_collection.py:43: test_setitem_invalid_shape
   - astropy/table/tests/test_operations.py:266: TestJoin.test_rename_conflict
   - stropy/vo/validator/tests/test_validate.py:135: TestConeSearchResults.test_printcat

I couldn't see a particular pattern in the failures. See [full build log](https://launchpadlibrarian.net/161654270/buildlog_ubuntu-trusty-amd64.python-astropy_0.3-4ubuntu1_FAILEDTOBUILD.txt.gz).
