### PR TITLE
Remove CSV reader from the guess list

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -697,3 +697,15 @@ def test_header_start_exception():
                    ascii.BaseReader, ascii.FixedWidthNoHeader, ascii.Cds, ascii.Daophot]:
         with pytest.raises(ValueError):
             reader = ascii.core._get_reader(readerclass, header_start=5)
+
+
+def test_csv_table_read():
+    """
+    Check for a regression introduced by #1935.  Pseudo-CSV file with
+    commented header line.
+    """
+    lines = ['# a, b',
+             '1, 2',
+             '3, 4']
+    t = ascii.read(lines)
+    assert t.colnames == ['a', 'b']

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -228,7 +228,6 @@ def _guess(table, read_kwargs):
 def _get_guess_kwargs_list():
     guess_kwargs_list = [dict(Reader=basic.Rdb),
                          dict(Reader=basic.Tab),
-                         dict(Reader=basic.Csv),
                          dict(Reader=cds.Cds),
                          dict(Reader=daophot.Daophot),
                          dict(Reader=sextractor.SExtractor),


### PR DESCRIPTION
As discussed in #1935, adding the new CSV reader to the list of readers used in the format guessing process introduced at least one regression (and possibly others).
