### PR TITLE
Issues with byte strings in ASCII table output

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
+from ..extern.six import text_type
 from ..extern.six.moves import zip as izip
 from ..extern.six.moves import xrange
 
@@ -13,7 +14,16 @@ from .. import log
 from ..utils.console import Getch, color_print
 from ..config import ConfigurationItem
 
-_format_funcs = {None: lambda format_, val: six.text_type(val)}
+
+if six.PY3:
+    def default_format_func(format_, val):
+        if isinstance(val, bytes):
+            return val.decode('utf-8')
+        else:
+            return str(val)
+    _format_funcs = {None: default_format_func}
+else:
+    _format_funcs = {None: lambda format_, val: text_type(val)}
 
 MAX_LINES = ConfigurationItem('max_lines', 25, 'Maximum number of lines for '
                               'the pretty-printer to use if it cannot determine the terminal size. '

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -5,6 +5,7 @@ import numpy as np
 from ...tests.helper import pytest
 from ... import table
 from ...table import pprint
+from ...extern.six import PY3
 
 BIG_WIDE_ARR = np.arange(2000, dtype=np.float).reshape(100, 20)
 SMALL_ARR = np.arange(12, dtype=np.int).reshape(4, 3)
@@ -278,3 +279,14 @@ class TestFormat():
         t['a'].format = lambda x: x * 3
         with pytest.raises(ValueError):
             str(t['a'])
+
+
+def test_pprint_py3_bytes():
+    """
+    Test for #1346.  Make sure a bytestring (dtype=S<N>) in Python 3 is printed
+    correctly (without the "b" prefix like b'string').
+    """
+    val = bytes('val', encoding='utf-8') if PY3 else 'val'
+    dat = np.array([(val,)], dtype=[('col', 'S3')])
+    t = table.Table(dat)
+    assert t['col'].pformat() == ['col', '---', 'val']


### PR DESCRIPTION
When writing the following table to an ASCII file in Python 3:

```
from astropy.table import Table
table = Table.read('http://mpia.de/~robitaille/astropy/test.vot')
table.write('test.txt', format='ascii.fixed_width')
```

The output is:

```

|    Prog |        Name |           Obs |   tos |   Type |    Vel | n_Vel |   Flow | n_Flow |  Fhigh | n_Fhigh |   Conf |        RAJ2000 |        DEJ2000 |
| b'N032' | b'AFGL2591' | b'2003-12-06' | 16800 | b'MAP' |   -5.5 |  b'L' |  80578 |   b'L' | 203407 |    b'L' | b'6Cp' | b'20:29:24.87' | b'+40:11:19.8' |
| b'N032' | b'AFGL2591' | b'2004-05-15' |  1140 | b'MAP' |   -5.5 |  b'L' |  80578 |   b'L' | 203407 |    b'L' | b'6Dp' | b'20:29:24.87' | b'+40:11:19.8' |
| b'N032' | b'AFGL2591' | b'2004-05-15' |  7740 | b'MAP' |   -5.5 |  b'L' |  80578 |   b'L' | 203407 |    b'L' | b'6Dp' | b'20:29:24.87' | b'+40:11:19.8' |
| b'N032' | b'AFGL2591' | b'2004-05-16' | 24060 | b'MAP' |   -5.5 |  b'L' |  80578 |   b'L' | 203407 |    b'L' | b'6Dp' | b'20:29:24.87' | b'+40:11:19.8' |
| b'N032' | b'AFGL2591' | b'2004-05-17' |  3060 | b'MAP' |   -5.5 |  b'L' |  80578 |   b'L' | 203407 |    b'L' | b'6Dp' | b'20:29:24.87' | b'+40:11:19.8' |
| b'PB3F' | b'AFGL2591' | b'2005-12-25' |  4050 | b'MAP' |    0.0 |  b'L' |  86610 |   b'L' | 230538 |    b'L' | b'6Cq' | b'20:29:24.80' | b'+40:11:19.0' |
| b'PB3F' | b'AFGL2591' | b'2005-12-26' |  4050 | b'MAP' |    0.0 |  b'L' |  86610 |   b'L' | 230538 |    b'L' | b'6Cq' | b'20:29:24.80' | b'+40:11:19.0' |
| b'P04A' | b'AFGL2591' | b'2006-02-03' |  9000 | b'MAP' |   -5.5 |  b'L' |  80578 |   b'L' | 203407 |    b'L' | b'6Aq' | b'20:29:24.87' | b'+40:11:19.5' |
| b'PB3F' | b'AFGL2591' | b'2006-06-03' |   675 | b'MAP' |    0.0 |  b'L' |  86610 |   b'L' | 230538 |    b'L' | b'5Dq' | b'20:29:24.80' | b'+40:11:19.0' |
| b'PB3F' | b'AFGL2591' | b'2006-06-04' |  7425 | b'MAP' |    0.0 |  b'L' |  86610 |   b'L' | 230538 |    b'L' | b'5Dq' | b'20:29:24.80' | b'+40:11:19.0' |
| b'PB4A' | b'AFGL2591' | b'2007-02-19' |  9450 | b'MAP' |   -5.5 |  b'L' |  80126 |   b'L' |  81030 |    b'L' | b'6Aq' | b'20:29:24.87' | b'+40:11:19.5' |
| b'PA4A' | b'AFGL2591' | b'2007-03-04' | 10800 | b'MAP' |   -5.5 |  b'L' | 203055 |   b'L' | 203739 |    b'L' | b'6Aq' | b'20:29:24.87' | b'+40:11:19.5' |
| b'PA4A' | b'AFGL2591' | b'2007-03-13' | 10935 | b'MAP' |   -5.5 |  b'L' | 203055 |   b'L' | 203739 |    b'L' | b'6Bq' | b'20:29:24.87' | b'+40:11:19.5' |
| b'PA4A' | b'AFGL2591' | b'2007-03-15' |  9450 | b'MAP' |   -5.5 |  b'L' | 203055 |   b'L' | 203739 |    b'L' | b'6Bq' | b'20:29:24.87' | b'+40:11:19.5' |
```

but I think the writers need to be smarter and not show the `b'...'`.
