### PR TITLE
Fix the order of subclasses in doctest

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -30,12 +30,12 @@ def itersubclasses(cls, _seen=None):
     >>> class D(B,C): pass
     >>> class E(D): pass
     >>>
-    >>> for cls in itersubclasses(A):
+    >>> for cls in sorted(itersubclasses(A), key=lambda cls: cls.__name__):
     ...     print(cls.__name__)
     B
+    C
     D
     E
-    C
     >>> # get ALL (new-style) classes currently defined
     >>> [cls.__name__ for cls in itersubclasses(object)]
     ['type', ...'tuple', ...]


### PR DESCRIPTION
The order of **subclasses**() is not fixed in the Python API. So the doctest of itersubclasses() may fail if this changes, like in the [i386 build on Python 3.4 on Ubuntu Trusty](https://launchpadlibrarian.net/162632981/buildlog_ubuntu-trusty-i386.python-astropy_0.3-5~u2_FAILEDTOBUILD.txt.gz). For fixing, we sort the output first.
