### PR TITLE
Fix compilation on Python 3.4

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -30,7 +30,9 @@ def get_extensions():
             cfg['extra_compile_args'].extend([
                 '-Wno-unused-variable', '-Wno-parentheses',
                 '-Wno-uninitialized', '-Wno-format', '-Wno-strict-prototypes',
-                '-Wno-unused', '-Wno-comments', '-Wno-switch'])
+                '-Wno-unused', '-Wno-comments', '-Wno-switch',
+                '-Wno-declaration-after-statement'
+            ])
 
         cfitsio_path = os.path.join('cextern', 'cfitsio')
         cfitsio_files = glob(os.path.join(cfitsio_path, '*.c'))


### PR DESCRIPTION
Upstream Python 3.4 now includes `-Werror=declaration-after-statement` in their compiler flags.  This causes the compilation of cfitsio's `swapproc.c` to fail.  (It's kind of obnoxious that distutils forces the compiler flags for Python itself on all of the extensions that get built -- it makes sense for some, but not all of them, but in any case distutils has done that for _ages_).

```
cextern/cfitsio/swapproc.c: In function ‘ffswap2’:
cextern/cfitsio/swapproc.c:83:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
     long ii;
     ^
cc1: some warnings being treated as errors
error: command '/usr/lib64/ccache/gcc' failed with exit status 1
```

@embray: How do you normally handle changes to cfitsio like this?  With wcslib, I maintain a set of patches so that we can upgrade the library and reapply these fixes at any time (and in the meantime, I report upstream).
