### PR TITLE
Consider adding GPS time scale

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1331,9 +1331,12 @@ class TimeCxcSec(TimeFromEpoch):
 class TimeGPS(TimeFromEpoch):
     """GPS time: seconds from 1980-01-06 00:00:00 UTC
 
-    Note that this implementation is strictly a representation of the number of
-    seconds (including leap seconds) since midnight UTC on 1980-01-06.  GPS can
-    also be considered as a time scale which is ahead of TAI by a fixed offset.
+    Notes
+    =====
+    This implementation is strictly a representation of the number of seconds
+    (including leap seconds) since midnight UTC on 1980-01-06.  GPS can also be
+    considered as a time scale which is ahead of TAI by a fixed offset (to within
+    about 100 nanoseconds).
 
     For details, see http://tycho.usno.navy.mil/gpstt.html
     """


### PR DESCRIPTION
Coming out of [this discussion on astropy](http://mail.scipy.org/pipermail/astropy/2013-December/002944.html) there was a suggestion to add GPS as a time _scale_ instead of just a time _format_.  As a time scale, GPS is 19 seconds behind TAI.  As a format it represents the number of TAI seconds since the GPS epoch.

Ideally we would stick with the three-letter acronyms for time scales so that the `gps` property would convert a time object to the GPS scale.  But `gps` is already used for the GPS format.  So either:
1. Find a different property name for the GPS scale, _or_
2. Rename the GPS format to something else, for instance `gps_sec` or `gps_seconds`

I like option 2 somewhat better, but of course it means an API change.  I think GPS is not the most widely-used format so maybe it's tolerable.

cc: @mhvk @astrofrog @eteq @scottransom
