### PR TITLE
CHANGES.rst entry for #1961 (Longitude keeping wrap_angle)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,9 @@ Bug Fixes
     no longer attempts to reference the undefined variable
     ``self.matrix`` during instantiation. [#1944]
 
+  - Fixed pickling of ``Longitude``, ensuring ``wrap_angle`` is
+    preserved [#1961]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``


### PR DESCRIPTION
And of course I forgot to ask @ryanfox to add an entry to `CHANGES.rst`, so am correcting that herewith.  This essentially is a bug fix.
