### PR TITLE
Present a better warning about no .rst doctesting on Python 3

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -248,8 +248,6 @@ class DoctestPlus(object):
         self._run_rst_doctests = run_rst_doctests
 
         if run_rst_doctests and six.PY3:
-            warnings.warn(
-                "Running doctests in .rst files is not yet supported on Python 3")
             self._run_rst_doctests = False
 
     def pytest_ignore_collect(self, path, config):
@@ -520,6 +518,9 @@ def pytest_report_header(config):
             opts.append(op)
     if opts:
         s += "Using Astropy options: {0}.\n".format(" ".join(opts))
+
+    if six.PY3 and (config.getini('doctest_rst') or config.option.doctest_rst):
+        s += "Running doctests in .rst files is not supported on Python 3.x\n"
 
     if not six.PY3:
         s = s.encode(stdoutencoding, 'replace')


### PR DESCRIPTION
Prior to this, you get this hunk of junk when testing on Python 3:

``````
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")
/tmp/astropy-test-fk1jae/lib.linux-x86_64-3.3/astropy/tests/pytest_plugins.py:252: UserWarning: Running doctests in .rst files is not yet supported on Python 3
  "Running doctests in .rst files is not yet supported on Python 3")```
``````

Now it's part of the informational header:

```
Numpy: 1.8.0
Scipy: not available
Matplotlib: not available
h5py: not available
Running doctests in .rst files is not supported on Python 3.x
```
