### PR TITLE
Fix tests on Python 2.6.4

### DIFF
--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -214,7 +214,7 @@ class Box1DKernel(Kernel1D):
     def __init__(self, width, **kwargs):
         self._model = models.Box1D(1. / width, 0, width)
         self._default_size = _round_up_to_odd_integer(width)
-        kwargs['mode'] = 'linear_interp'
+        kwargs.update(mode='linear_interp')
         super(Box1DKernel, self).__init__(**kwargs)
         self._truncation = 0
         self.normalize()
@@ -284,7 +284,7 @@ class Box2DKernel(Kernel2D):
     def __init__(self, width, **kwargs):
         self._model = models.Box2D(1. / width ** 2, 0, 0, width, width)
         self._default_size = _round_up_to_odd_integer(width)
-        kwargs['mode'] = 'linear_interp'
+        kwargs.update(mode='linear_interp')
         super(Box2DKernel, self).__init__(**kwargs)
         self._truncation = 0
         self.normalize()

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -661,7 +661,7 @@ class Longitude(Angle):
         if unit is not None and unit.is_equivalent(u.radian):
             # by default, wrap_angle remains the same
             if 'wrap_angle' not in kwargs:
-                kwargs['wrap_angle'] = getattr(self, 'wrap_angle')
+                kwargs.update(wrap_angle=getattr(self, 'wrap_angle'))
             return Longitude(val, unit, **kwargs)
         return super(Angle, self).__quantity_instance__(val, unit, **kwargs)
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -875,7 +875,7 @@ def test_z_at_value_roundtrip():
         f = getattr(funcs, name)
         if not hasattr(f, '__call__'):
             continue
-        print('Round-trip testing {}'.format(name))
+        print('Round-trip testing {0}'.format(name))
         fval = f(z)
         # we need zmax here to pick the right solution for
         # angular_diameter_distance and related methods.

--- a/astropy/io/ascii/tests/test_read_unicode.py
+++ b/astropy/io/ascii/tests/test_read_unicode.py
@@ -6,6 +6,7 @@ import re
 import numpy as np
 
 from ....utils import OrderedDict
+from ....utils.compat import normalize_kwargs
 from ....tests.helper import pytest
 from ... import ascii as asciitable  # TODO: delete this line, use ascii.*
 from ... import ascii
@@ -89,7 +90,8 @@ def test_read_all_files():
             test_opts = testfile['opts'].copy()
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
-            table = asciitable.read(testfile['name'], **test_opts)
+            table = asciitable.read(testfile['name'],
+                                    **normalize_kwargs(test_opts))
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
                 assert_equal(len(table[colname]), testfile['nrows'])
@@ -110,7 +112,8 @@ def test_read_all_files_via_table():
                 del test_opts['Reader']
             else:
                 format = 'ascii'
-            table = Table.read(testfile['name'], format=format, **test_opts)
+            table = Table.read(testfile['name'], format=format,
+                               **normalize_kwargs(test_opts))
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
                 assert_equal(len(table[colname]), testfile['nrows'])
@@ -128,7 +131,8 @@ def test_guess_all_files():
             # Copy read options except for those in filter_read_opts
             guess_opts = dict((k, v) for k, v in testfile['opts'].items()
                               if k not in filter_read_opts)
-            table = asciitable.read(testfile['name'], guess=True, **guess_opts)
+            table = asciitable.read(testfile['name'], guess=True,
+                                    **normalize_kwargs(guess_opts))
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
                 assert_equal(len(table[colname]), testfile['nrows'])
@@ -290,7 +294,7 @@ def test_from_string():
     with open(f) as fd:
         table = fd.read()
     testfile = get_testfiles(f)
-    data = asciitable.read(table, **testfile['opts'])
+    data = asciitable.read(table, **normalize_kwargs(testfile['opts']))
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
@@ -299,7 +303,7 @@ def test_from_filelike():
     f = 't/simple.txt'
     testfile = get_testfiles(f)
     with open(f, 'rb') as fd:
-        data = asciitable.read(fd, **testfile['opts'])
+        data = asciitable.read(fd, **normalize_kwargs(testfile['opts']))
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
@@ -309,7 +313,7 @@ def test_from_lines():
     with open(f) as fd:
         table = fd.readlines()
     testfile = get_testfiles(f)
-    data = asciitable.read(table, **testfile['opts'])
+    data = asciitable.read(table, **normalize_kwargs(testfile['opts']))
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
@@ -323,7 +327,8 @@ def test_comment_lines():
 def test_fill_values():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=('a', '1'), **testfile['opts'])
+    data = asciitable.read(f, fill_values=('a', '1'),
+                           **normalize_kwargs(testfile['opts']))
     assert_true((data['a'].mask == [False, True]).all())
     assert_true((data['a'] == [1, 1]).all())
     assert_true((data['b'].mask == [False, True]).all())
@@ -333,7 +338,8 @@ def test_fill_values():
 def test_fill_values_col():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=('a', '1', 'b'), **testfile['opts'])
+    data = asciitable.read(f, fill_values=('a', '1', 'b'),
+                           **normalize_kwargs(testfile['opts']))
     check_fill_values(data)
 
 
@@ -341,7 +347,8 @@ def test_fill_values_include_names():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
     data = asciitable.read(f, fill_values=('a', '1'),
-                           fill_include_names = ['b'], **testfile['opts'])
+                           fill_include_names = ['b'],
+                           **normalize_kwargs(testfile['opts']))
     check_fill_values(data)
 
 
@@ -349,7 +356,8 @@ def test_fill_values_exclude_names():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
     data = asciitable.read(f, fill_values=('a', '1'),
-                           fill_exclude_names = ['a'], **testfile['opts'])
+                           fill_exclude_names = ['a'],
+                           **normalize_kwargs(testfile['opts']))
     check_fill_values(data)
 
 
@@ -368,7 +376,7 @@ def test_fill_values_list():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
     data = asciitable.read(f, fill_values=[('a', '42'), ('1', '42', 'a')],
-                           **testfile['opts'])
+                           **normalize_kwargs(testfile['opts']))
     data['a'].mask = False  # explicitly unmask for comparison
     assert_true((data['a'] == [42, 42]).all())
 
@@ -376,8 +384,7 @@ def test_fill_values_list():
 def test_masking_Cds():
     f = 't/cds.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f,
-                           **testfile['opts'])
+    data = asciitable.read(f, **normalize_kwargs(testfile['opts']))
     assert_true(data['AK'].mask[0])
     assert_true(not data['Fit'].mask[0])
 
@@ -385,7 +392,7 @@ def test_masking_Cds():
 def test_null_Ipac():
     f = 't/ipac.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, **testfile['opts'])
+    data = asciitable.read(f, **normalize_kwargs(testfile['opts']))
     dtype= [(str(x), str(y)) for x, y in [('ra', '|b1'), ('dec', '|b1'), ('sai', '|b1'),
                                           ('v2', '|b1'), ('sptype', '|b1')]]
     mask = np.array([(True, False, True, False, True),
@@ -402,7 +409,7 @@ def test_Ipac_meta():
     comments = ['This is an example of a valid comment']
     f = 't/ipac.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, **testfile['opts'])
+    data = asciitable.read(f, **normalize_kwargs(testfile['opts']))
     assert data.meta['keywords'].keys() == keywords.keys()
     for data_kv, kv in zip(data.meta['keywords'].values(), keywords.values()):
         assert data_kv['value'] == kv
@@ -687,7 +694,7 @@ def get_testfiles(name=None):
 
 def test_header_start_exception():
     '''Check certain Readers throw an exception if ``header_start`` is set
-    
+
     For certain Readers it does not make sense to set the ``header_start``, they
     throw an exception if you try.
     This was implemented in response to issue #885.

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -146,8 +146,9 @@ def parse_single_table(source, **kwargs):
     -------
     votable : `astropy.io.votable.tree.Table` object
     """
+
     if kwargs.get('table_number') is None:
-        kwargs['table_number'] = 0
+        kwargs.update(table_number=0)
 
     votable = parse(source, **kwargs)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1607,9 +1607,9 @@ class Table(object):
             keys = [keys]
         kwargs = {}
         if keys:
-            kwargs['order'] = keys
+            kwargs.update(order=keys)
         if kind:
-            kwargs['kind'] = kind
+            kwargs.update(kind=kind)
 
         data = self._data
 

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -7,8 +7,7 @@ OrderedDict and slightly customized (and renamed) the modules
 test_support.py and mapping_tests.py that provide support for those
 tests.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 from ...extern import six
 
@@ -228,7 +227,7 @@ class TestOrderedDict(unittest.TestCase):
     def test_repr(self):
         od = OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])
         self.assertEqual(repr(od),
-            "OrderedDict([(u'c', 1), (u'b', 2), (u'a', 3), (u'd', 4), (u'e', 5), (u'f', 6)])")
+            "OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])")
         self.assertEqual(eval(repr(od)), od)
         self.assertEqual(repr(OrderedDict()), "OrderedDict()")
 

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -59,7 +59,7 @@ the 5-year WMAP parameters:
 
   >>> from astropy.cosmology import WMAP5
   >>> WMAP5.comoving_distance(4)
-  <Quantity 7329.328093495547 Mpc>
+  <Quantity 7329.32809349554... Mpc>
 
 An important point is that the cosmological parameters of each
 instance are immutable -- that is, if you want to change, say,


### PR DESCRIPTION
There is a bug in Python 2.6 below 2.6.5
(http://bugs.python.org/issue2646) where dictionaries passed as keyword
args to a function via the `**kwargs` syntax blow up if any of the
keywords are unicode strings.  Enabling unicode_literals on most modules
made a lot of tests start failing, though it probably wasn't caught
since most users with 2.6 are using a more recent version (due security
fixes if nothing else).

This mostly handles the kwargs issue, but also fixes a couple other
minor 2.6 bugs in the tests.

The kwargs issue can be handled in two ways:  One is very straightforward, which is to replace instances of 

```
kwargs['foo'] = bar
```

with

```
kwargs.update(foo=bar)
```

However, there are some cases where that does not work.  In these cases I had to employ a kind of ugly workaround of using a `normalize_kwargs` function to convert the dictionary keys to non-unicode strings.  This is only used on Python < 2.6.5, however, and can go away once we drop 2.6 entirely.

I think these issues _should_ be fixed, but I'm also happy to accept "just upgrade your bloody Python" as an answer.
