### PR TITLE
don't run doctests when -t option given

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -140,7 +140,7 @@ class TestRunner(object):
                 warnings.warn(
                     "Can not test .rst docs, since docs path "
                     "({0}) does not exist.".format(docs_path))
-            else:
+            elif not test_path:  # don't do  doctests if specific file is requested
                 all_args += ' ' + docs_path + ' --doctest-rst '
 
         # add any additional args entered by the user


### PR DESCRIPTION
Before the doctests were added, doing `python setup.py -t astropy/path/to/test_file.py` would just run that one file.  But now it runs that file _and_ all the doctests.  So this PR changes it to only run the file and not the doctests. It's pretty straightforward, but I figured I should check with @mdboom : the current behavior isn't intentional, is it?
