### PR TITLE
Refactor io.ascii to use six without unicode_literals

### DIFF
--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -28,7 +28,7 @@
 ## Copyright: Smithsonian Astrophysical Observatory (2010)
 ## Author: Tom Aldcroft (aldcroft@head.cfa.harvard.edu)
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 from .core import (InconsistentTableError,
                    NoType, StrType, NumType, FloatType, IntType, AllType,

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -32,6 +32,8 @@ basic.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import re
 
 from . import core

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -31,6 +31,8 @@ cds.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import fnmatch
 import itertools
 import re

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # This file connects the readers/writers to the astropy.table.Table class
 
+from __future__ import absolute_import, division, print_function
+
 import re
 
 from .. import registry as io_registry
 from ...table import Table
+from ...extern.six.moves import zip
 
 __all__ = []
 
@@ -59,7 +62,7 @@ def _get_connectors_table():
 
         rows.append((io_format, suffix, can_write,
                      '{}: {}'.format(class_link, description)))
-    out = Table(zip(*rows), names=('Format', 'Suffix', 'Write', 'Description'))
+    out = Table(list(zip(*rows)), names=('Format', 'Suffix', 'Write', 'Description'))
     for colname in ('Format', 'Description'):
         width = max(len(x) for x in out[colname])
         out[colname].format = '%-{}s'.format(width)

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -31,6 +31,8 @@ daophot.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import re
 import numpy as np
 from . import core
@@ -67,7 +69,7 @@ class Daophot(core.BaseReader):
       >>> filename = os.path.join(ascii.__path__[0], 'tests/t/daophot.dat')
       >>> data = ascii.read(filename)
       >>> for name, keyword in data.meta['keywords'].items():
-      ...     print name, keyword['value'], keyword['units'], keyword['format']
+      ...     print(name, keyword['value'], keyword['units'], keyword['format'])
       ...
       MERGERAD INDEF scaleunit %-23.7g
       IRAF NOAO/IRAFV2.10EXPORT version %-23s
@@ -78,7 +80,7 @@ class Daophot(core.BaseReader):
 
       >>> for colname in data.colnames:
       ...     col = data[colname]
-      ...     print colname, col.unit, col.format
+      ...     print(colname, col.unit, col.format)
       ...
       ID None %-9d
       XCENTER pixels %-10.3f

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -31,7 +31,9 @@ fixedwidth.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import itertools
+from __future__ import absolute_import, division, print_function
+
+from ...extern.six.moves import zip
 
 from . import core
 from .core import InconsistentTableError
@@ -230,7 +232,7 @@ class FixedWidthData(core.BaseData):
         vals_list = []
         # Col iterator does the formatting defined above so each val is a string
         # and vals is a tuple of strings for all columns of each row
-        for vals in itertools.izip(*col_str_iters):
+        for vals in zip(*col_str_iters):
             vals_list.append(vals)
 
         for i, col in enumerate(self.cols):

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -31,10 +31,15 @@ ipac.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import re
 from collections import defaultdict
 from textwrap import wrap
 from warnings import warn
+
+from ...extern import six
+from ...extern.six.moves import zip
 
 from . import core
 from . import fixedwidth
@@ -81,10 +86,10 @@ class Ipac(fixedwidth.FixedWidth):
       >>> from astropy.io import ascii
       >>> filename = os.path.join(ascii.__path__[0], 'tests/t/ipac.dat')
       >>> data = ascii.read(filename)
-      >>> print data.meta['comments']
+      >>> print(data.meta['comments'])
       ['This is an example of a valid comment']
       >>> for name, keyword in data.meta['keywords'].items():
-      ...     print name, keyword['value']
+      ...     print(name, keyword['value'])
       ...
       intval 1
       floatval 2300.0
@@ -162,8 +167,8 @@ class Ipac(fixedwidth.FixedWidth):
                                           self.exclude_names, self.strict_names)
 
         # link information about the columns to the writer object (i.e. self)
-        self.header.cols = table.columns.values()
-        self.data.cols = table.columns.values()
+        self.header.cols = list(six.itervalues(table.columns))
+        self.data.cols = list(six.itervalues(table.columns))
 
         # Write header and data to lines list
         lines = []
@@ -310,12 +315,12 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
                 # IPAC allows for continuation keywords, e.g.
                 # \SQL     = 'WHERE '
                 # \SQL     = 'SELECT (25 column names follow in next row.)'
-                if name in keywords and isinstance(val, basestring):
+                if name in keywords and isinstance(val, six.string_types):
                     prev_val = keywords[name]['value']
-                    if isinstance(prev_val, basestring):
+                    if isinstance(prev_val, six.string_types):
                         val = prev_val + val
 
-                table_meta['keywords'][name] = {'value': val}
+                keywords[name] = {'value': val}
             else:
                 # Comment is required to start with "\ "
                 if line.startswith('\\ '):
@@ -463,7 +468,7 @@ class IpacData(fixedwidth.FixedWidthData):
         # just to make sure
         self._set_col_formats()
         col_str_iters = [col.iter_str_vals() for col in self.cols]
-        for vals in core.izip(*col_str_iters):
+        for vals in zip(*col_str_iters):
             vals_list.append(vals)
 
         return vals_list

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -31,7 +31,11 @@ latex.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import re
+
+from ...extern import six
 from . import core
 
 latexdicts = {'AA':  {'tabletype': 'table',
@@ -57,8 +61,8 @@ def add_dictval_to_list(adict, key, alist):
     :param key: key of value
     :param list: list where value should be added
     '''
-    if key in adict.keys():
-        if isinstance(adict[key], basestring):
+    if key in adict:
+        if isinstance(adict[key], six.string_types):
             alist.append(adict[key])
         else:
             alist.extend(adict[key])

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -57,3 +57,7 @@ def get_package_data():
                                    't/simple_csv.csv',
                                    ]
     }
+
+
+def requires_2to3():
+    return False

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -30,7 +30,11 @@ Built on daophot.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import re
+
+from ...extern import six
 from . import core
 
 
@@ -107,7 +111,7 @@ class SExtractorHeader(core.BaseHeader):
                     colname = words[1]   # second string is the column name
                     columns[colnumber] = colname
         # Handle skipped column numbers
-        colnumbers = sorted(columns.iterkeys())
+        colnumbers = sorted(columns)
         previous_column = 0
         for n in colnumbers:
             if n != previous_column + 1:
@@ -117,7 +121,7 @@ class SExtractorHeader(core.BaseHeader):
             previous_column = n
 
         # Add the columns in order to self.names
-        colnumbers = sorted(columns.iterkeys())
+        colnumbers = sorted(columns)
         self.names = []
         for n in colnumbers:
             self.names.append(columns[n])

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -33,6 +33,8 @@ ui.py:
 ## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import re
 import os
 import sys


### PR DESCRIPTION
This is an alternative to #1950 which is basically the same except that it does not `import unicode_literals` in any files.  The motivation is:
- The basis for `io.ascii` is the std. lib `csv` module, which explicitly does not support unicode directly in Python 2.
- `csv` breaks if any of the inputs are unicode.
- Solutions for Python 2 unicode support in `csv` basically involve encoding in UTF-8 and then working with the resulting bytestrings.
- There is processing in `io.ascii` that involves mixing user-provided input (i.e. lines of table strings) and code literals.  If any of those literals are unicode then strings get upcast to unicode and everything breaks.

With this, the current state is that `io.ascii` really only supports ASCII data in Python 2.  Using `unicode_literals` in the source just forces a lot of explicit `str()` conversions back to the `str` type.  Subsequent code maintenance will be require remembering to always wrap string literals with `str()`.

In theory we could provide some support for parsing unicode input files, but that is a separate issue.  I would say this is better handled by using Python 3.

cc: @mdboom (resident six / unicode expert)
