### PR TITLE
Fixed pragma typo in _open_shelve

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1145,9 +1145,9 @@ def _open_shelve(shelffn, withclosing=False):
     """
     import shelve
 
-    if not PY3K:  # pragma: py3
+    if not PY3K:  # pragma: py2
         shelf = shelve.open(shelffn, protocol=2)
-    else:  # pragma: py2
+    else:  # pragma: py3
         shelf = shelve.open(shelffn + '.db', protocol=2)
 
     if withclosing:


### PR DESCRIPTION
`not PY3K` means Python 2.x but its corresponding `pragma` indicates otherwise. Since tests are passing, I can only assume it is a typo on the `pragma` part. Maybe @mdboom can confirm.
