### PR TITLE
Updated h5py's intersphinx URL to one that actually works

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -55,7 +55,7 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.sourceforge.net/', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'h5py': ('http://h5py.alfven.org/docs-2.1/', None)
+    'h5py': ('http://docs.h5py.org/en/latest/', None)
     }
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
`h5py` seems to have changed their docs url - http://h5py.alfven.org/docs-2.1/objects.inv now fails (although with one of the better 404 errors I've seen...).  This updates it to readthdocs, where presumably they intend to keep it.
