### PR TITLE
WIP: Use classes for readers/writers and use a metaclass for auto-registering

### DIFF
--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from .. import registry as io_registry
+from ..registry import core as io_registry
 from ...table import Table
 from ...extern.six.moves import zip
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -8,7 +8,7 @@ import warnings
 
 import numpy as np
 
-from ..registry import BaseIO
+from ..registry.core import BaseIO
 from ... import log
 from ... import units as u
 from ...extern.six import string_types

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -17,8 +17,9 @@ from ...nddata import NDData
 from ...utils import OrderedDict
 from ...utils.exceptions import AstropyUserWarning
 
-from . import (HDUList, TableHDU, BinTableHDU, GroupsHDU, PrimaryHDU,
-               ImageHDU, Header)
+from .hdu.base import _ValidHDU
+from .hdu.table import _TableLikeHDU
+from . import HDUList, Header
 from .hdu.hdulist import fitsopen as fits_open
 from .util import first
 
@@ -138,7 +139,7 @@ def _is_fits(origin, filepath, fileobj, *args, **kwargs):
     elif filepath is not None:
         if filepath.lower().endswith(('.fits', '.fits.gz', '.fit', '.fit.gz')):
             return True
-    elif isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU, PrimaryHDU, ImageHDU)):
+    elif isinstance(args[0], (HDUList, _ValidHDU)):
         return True
     else:
         return False
@@ -149,10 +150,12 @@ class FITSTableIO(BaseIO):
     _format_name = 'fits'
     _supported_class = Table
 
-    def identify(self, origin, filepath, fileobj, *args, **kwargs):
+    @staticmethod
+    def identify(origin, filepath, fileobj, *args, **kwargs):
         return _is_fits(origin, filepath, fileobj, *args, **kwargs)
 
-    def read(self, input, hdu=None):
+    @staticmethod
+    def read(input, hdu=None):
         """
         Read a Table object from an FITS file
 
@@ -200,7 +203,7 @@ class FITSTableIO(BaseIO):
             else:
                 raise ValueError("No table found")
 
-        elif isinstance(input, (TableHDU, BinTableHDU, GroupsHDU)):
+        elif isinstance(input, _TableLikeHDU):
 
             table = input
 
@@ -242,7 +245,8 @@ class FITSTableIO(BaseIO):
 
         return t
 
-    def write(self, input, output, overwrite=False):
+    @staticmethod
+    def write(input, output, overwrite=False):
         """
         Write a Table object to a FITS file
 
@@ -300,10 +304,12 @@ class FITSNDDataIO(BaseIO):
     _format_name = 'fits'
     _supported_class = NDData
 
-    def identify(self, origin, filepath, fileobj, *args, **kwargs):
+    @staticmethod
+    def identify(origin, filepath, fileobj, *args, **kwargs):
         return _identify_fits(origin, filepath, fileobj, *args, **kwargs)
 
-    def read(self, input, hdu=None):
+    @staticmethod
+    def read(input, hdu=None):
         """
         Read an :class:`~astropy.nddata.nddata.NDData` object from a FITS file.
 
@@ -371,7 +377,8 @@ class FITSNDDataIO(BaseIO):
 
         return d
 
-    def write(self, input, output, overwrite=False):
+    @staticmethod
+    def write(input, output, overwrite=False):
         """
         Write an :class:`~astropy.nddata.nddata.NDData` object to a FITS file.
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -8,7 +8,7 @@ import warnings
 
 import numpy as np
 
-from .. import registry as io_registry
+from ..registry import BaseIO
 from ... import log
 from ... import units as u
 from ...extern.six import string_types
@@ -16,7 +16,7 @@ from ...table import Table
 from ...utils import OrderedDict
 from ...utils.exceptions import AstropyUserWarning
 
-from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
+from . import HDUList, TableHDU, BinTableHDU, GroupsHDU, Header
 from .hdu.hdulist import fitsopen as fits_open
 from .util import first
 
@@ -50,134 +50,24 @@ def is_column_keyword(keyword):
     return False
 
 
-def is_fits(origin, filepath, fileobj, *args, **kwargs):
-    """
-    Determine whether `origin` is a FITS file.
+def header_to_meta(header):
 
-    Parameters
-    ----------
-    origin : str or readable file-like object
-        Path or file object containing a potential FITS file.
+    meta = OrderedDict()
 
-    Returns
-    -------
-    is_fits : bool
-        Returns `True` if the given file is a FITS file.
-    """
-    if fileobj is not None:
-        pos = fileobj.tell()
-        sig = fileobj.read(30)
-        fileobj.seek(pos)
-        return sig == FITS_SIGNATURE
-    elif filepath is not None:
-        if filepath.lower().endswith(('.fits', '.fits.gz', '.fit', '.fit.gz')):
-            return True
-    elif isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU)):
-        return True
-    else:
-        return False
-
-
-def read_table_fits(input, hdu=None):
-    """
-    Read a Table object from an FITS file
-
-    Parameters
-    ----------
-    input : str or file-like object or compatible `astropy.io.fits` HDU object
-        If a string, the filename to read the table from. If a file object, or
-        a compatible HDU object, the object to extract the table from. The
-        following `astropy.io.fits` HDU objects can be used as input:
-        - :class:`~astropy.io.fits.hdu.table.TableHDU`
-        - :class:`~astropy.io.fits.hdu.table.BinTableHDU`
-        - :class:`~astropy.io.fits.hdu.table.GroupsHDU`
-        - :class:`~astropy.io.fits.hdu.hdulist.HDUList`
-    hdu : int or str, optional
-        The HDU to read the table from.
-    """
-
-    if isinstance(input, HDUList):
-
-        # Parse all table objects
-        tables = OrderedDict()
-        for ihdu, hdu_item in enumerate(input):
-            if isinstance(hdu_item, (TableHDU, BinTableHDU, GroupsHDU)):
-                tables[ihdu] = hdu_item
-
-        if len(tables) > 1:
-            if hdu is None:
-                warnings.warn("hdu= was not specified but multiple tables"
-                              " are present, reading in first available"
-                              " table (hdu={0})".format(first(tables)),
-                              AstropyUserWarning)
-                hdu = first(tables)
-
-            # hdu might not be an integer, so we first need to convert it
-            # to the correct HDU index
-            hdu = input.index_of(hdu)
-
-            if hdu in tables:
-                table = tables[hdu]
-            else:
-                raise ValueError("No table found in hdu={0}".format(hdu))
-
-        elif len(tables) == 1:
-            table = tables[first(tables)]
-        else:
-            raise ValueError("No table found")
-
-    elif isinstance(input, (TableHDU, BinTableHDU, GroupsHDU)):
-
-        table = input
-
-    else:
-
-        hdulist = fits_open(input)
-
-        try:
-            return read_table_fits(hdulist, hdu=hdu)
-        finally:
-            hdulist.close()
-
-    # Check if table is masked
-    masked = False
-    for col in table.columns:
-        if col.null is not None:
-            masked = True
-            break
-
-    # Convert to an astropy.table.Table object
-    t = Table(table.data, masked=masked)
-
-    # Copy over null values if needed
-    if masked:
-        for col in table.columns:
-            if col.null is not None:
-                t[col.name].set_fill_value(col.null)
-                t[col.name].mask[t[col.name] == col.null] = True
-
-    # Copy over units
-    for col in table.columns:
-        if col.unit is not None:
-            t[col.name].unit = u.Unit(
-                col.unit, format='fits', parse_strict='warn')
-
-    # TODO: deal properly with unsigned integers
-
-    for key, value, comment in table.header.cards:
+    for key, value, comment in header.cards:
 
         if key in ['COMMENT', 'HISTORY']:
-            if key in t.meta:
-                t.meta[key].append(value)
+            if key in meta:
+                meta[key].append(value)
             else:
-                t.meta[key] = [value]
+                meta[key] = [value]
 
-        elif key in t.meta:  # key is duplicate
+        elif key in meta:  # key is duplicate
 
-            if isinstance(t.meta[key], list):
-                t.meta[key].append(value)
+            if isinstance(meta[key], list):
+                meta[key].append(value)
             else:
-                t.meta[key] = [t.meta[key], value]
+                meta[key] = [meta[key], value]
 
         elif (is_column_keyword(key.upper()) or
               key.upper() in REMOVE_KEYWORDS):
@@ -186,61 +76,16 @@ def read_table_fits(input, hdu=None):
 
         else:
 
-            t.meta[key] = value
+            meta[key] = value
 
-    # TODO: implement masking
-
-    return t
+    return meta
 
 
-def write_table_fits(input, output, overwrite=False):
-    """
-    Write a Table object to a FITS file
+def meta_to_header(meta):
 
-    Parameters
-    ----------
-    input : Table
-        The table to write out.
-    output : str
-        The filename to write the table to.
-    overwrite : bool
-        Whether to overwrite any existing file without warning.
-    """
+    header = Header()
 
-    # Check if output file already exists
-    if isinstance(output, string_types) and os.path.exists(output):
-        if overwrite:
-            os.remove(output)
-        else:
-            raise IOError("File exists: {0}".format(output))
-
-    # Create a new HDU object
-    if input.masked:
-        table_hdu = BinTableHDU(np.array(input.filled()))
-        for col in table_hdu.columns:
-            # Binary FITS tables support TNULL *only* for integer data columns
-            # TODO: Determine a schema for handling non-integer masked columns
-            # in FITS (if at all possible)
-            int_formats = ('B', 'I', 'J', 'K')
-            if not (col.format in int_formats or
-                    col.format.p_format in int_formats):
-                continue
-
-            # The astype is necessary because if the string column is less
-            # than one character, the fill value will be N/A by default which
-            # is too long, and so no values will get masked.
-            fill_value = input[col.name].get_fill_value()
-
-            col.null = fill_value.astype(input[col.name].dtype)
-    else:
-        table_hdu = BinTableHDU(np.array(input))
-
-    # Set units for output HDU
-    for col in table_hdu.columns:
-        if input[col.name].unit is not None:
-            col.unit = input[col.name].unit.to_string(format='fits')
-
-    for key, value in input.meta.items():
+    for key, value in meta.items():
 
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:
 
@@ -251,7 +96,7 @@ def write_table_fits(input, output, overwrite=False):
         if isinstance(value, list):
             for item in value:
                 try:
-                    table_hdu.header.append((key, item))
+                    header.append((key, item))
                 except ValueError:
                     warnings.warn(
                         "Attribute `{0}` of type {1} cannot be written to "
@@ -259,16 +104,187 @@ def write_table_fits(input, output, overwrite=False):
                         AstropyUserWarning)
         else:
             try:
-                table_hdu.header[key] = value
+                header[key] = value
             except ValueError:
                 warnings.warn(
                     "Attribute `{0}` of type {1} cannot be written to FITS "
                     "files - skipping".format(key, type(value)),
                     AstropyUserWarning)
 
-    # Write out file
-    table_hdu.writeto(output)
+    return header
 
-io_registry.register_reader('fits', Table, read_table_fits)
-io_registry.register_writer('fits', Table, write_table_fits)
-io_registry.register_identifier('fits', Table, is_fits)
+
+class FITSTableIO(BaseIO):
+
+    _format_name = 'fits'
+    _supported_class = Table
+
+    def identify(self, origin, filepath, fileobj, *args, **kwargs):
+        """
+        Determine whether `origin` is a FITS file.
+
+        Parameters
+        ----------
+        origin : str or readable file-like object
+            Path or file object containing a potential FITS file.
+
+        Returns
+        -------
+        is_fits : bool
+            Returns `True` if the given file is a FITS file.
+        """
+        print("IDENTIFY")
+        if fileobj is not None:
+            pos = fileobj.tell()
+            sig = fileobj.read(30)
+            fileobj.seek(pos)
+            return sig == FITS_SIGNATURE
+        elif filepath is not None:
+            if filepath.lower().endswith(('.fits', '.fits.gz', '.fit', '.fit.gz')):
+                return True
+        elif isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU)):
+            return True
+        else:
+            return False
+
+    def read(self, input, hdu=None):
+        """
+        Read a Table object from an FITS file
+
+        Parameters
+        ----------
+        input : str or file-like object or compatible `astropy.io.fits` HDU object
+            If a string, the filename to read the table from. If a file object, or
+            a compatible HDU object, the object to extract the table from. The
+            following `astropy.io.fits` HDU objects can be used as input:
+            - :class:`~astropy.io.fits.hdu.table.TableHDU`
+            - :class:`~astropy.io.fits.hdu.table.BinTableHDU`
+            - :class:`~astropy.io.fits.hdu.table.GroupsHDU`
+            - :class:`~astropy.io.fits.hdu.hdulist.HDUList`
+        hdu : int or str, optional
+            The HDU to read the table from.
+        """
+
+        if isinstance(input, HDUList):
+
+            # Parse all table objects
+            tables = OrderedDict()
+            for ihdu, hdu_item in enumerate(input):
+                if isinstance(hdu_item, (TableHDU, BinTableHDU, GroupsHDU)):
+                    tables[ihdu] = hdu_item
+
+            if len(tables) > 1:
+                if hdu is None:
+                    warnings.warn("hdu= was not specified but multiple tables"
+                                  " are present, reading in first available"
+                                  " table (hdu={0})".format(first(tables)),
+                                  AstropyUserWarning)
+                    hdu = first(tables)
+
+                # hdu might not be an integer, so we first need to convert it
+                # to the correct HDU index
+                hdu = input.index_of(hdu)
+
+                if hdu in tables:
+                    table = tables[hdu]
+                else:
+                    raise ValueError("No table found in hdu={0}".format(hdu))
+
+            elif len(tables) == 1:
+                table = tables[first(tables)]
+            else:
+                raise ValueError("No table found")
+
+        elif isinstance(input, (TableHDU, BinTableHDU, GroupsHDU)):
+
+            table = input
+
+        else:
+
+            hdulist = fits_open(input)
+
+            try:
+                return Table.read(hdulist, hdu=hdu, format='fits')
+            finally:
+                hdulist.close()
+
+        # Check if table is masked
+        masked = False
+        for col in table.columns:
+            if col.null is not None:
+                masked = True
+                break
+
+        # Convert to an astropy.table.Table object
+        t = Table(table.data, masked=masked)
+
+        # Copy over null values if needed
+        if masked:
+            for col in table.columns:
+                if col.null is not None:
+                    t[col.name].set_fill_value(col.null)
+                    t[col.name].mask[t[col.name] == col.null] = True
+
+        # Copy over units
+        for col in table.columns:
+            if col.unit is not None:
+                t[col.name].unit = u.Unit(
+                    col.unit, format='fits', parse_strict='warn')
+
+        # TODO: deal properly with unsigned integers
+
+        t.meta.update(header_to_meta(table.header))
+
+        return t
+
+    def write(self, input, output, overwrite=False):
+        """
+        Write a Table object to a FITS file
+
+        Parameters
+        ----------
+        input : Table
+            The table to write out.
+        output : str
+            The filename to write the table to.
+        overwrite : bool
+            Whether to overwrite any existing file without warning.
+        """
+
+        # Check if output file already exists
+        if isinstance(output, string_types) and os.path.exists(output):
+            if overwrite:
+                os.remove(output)
+            else:
+                raise IOError("File exists: {0}".format(output))
+
+        # Create a new HDU object
+        if input.masked:
+            table_hdu = BinTableHDU(np.array(input.filled()))
+            for col in table_hdu.columns:
+                # Binary FITS tables support TNULL *only* for integer data columns
+                # TODO: Determine a schema for handling non-integer masked columns
+                # in FITS (if at all possible)
+                int_formats = ('B', 'I', 'J', 'K')
+                if not (col.format in int_formats or
+                        col.format.p_format in int_formats):
+                    continue
+
+                # The astype is necessary because if the string column is less
+                # than one character, the fill value will be N/A by default which
+                # is too long, and so no values will get masked.
+                fill_value = input[col.name].get_fill_value()
+
+                col.null = fill_value.astype(input[col.name].dtype)
+        else:
+            table_hdu = BinTableHDU(np.array(input))
+
+        # Set units for output HDU
+        for col in table_hdu.columns:
+            if input[col.name].unit is not None:
+                col.unit = input[col.name].unit.to_string(format='fits')
+
+        table_hdu.header.update(meta_to_header(input.meta))
+
+        # Write out file
+        table_hdu.writeto(output)

--- a/astropy/io/misc/connect.py
+++ b/astropy/io/misc/connect.py
@@ -1,12 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
 # This file connects any readers/writers defined in io.misc to the
 # astropy.table.Table class
 
-from .hdf5 import read_table_hdf5, write_table_hdf5, is_hdf5
+from . import hdf5
 
-from .. import registry as io_registry
-from ...table import Table
-
-io_registry.register_reader('hdf5', Table, read_table_hdf5)
-io_registry.register_writer('hdf5', Table, write_table_hdf5)
-io_registry.register_identifier('hdf5', Table, is_hdf5)

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -13,7 +13,7 @@ import warnings
 import numpy as np
 
 from ...utils.exceptions import AstropyUserWarning
-from ..registry import BaseIO
+from ..registry.core import BaseIO
 from ...table import Table
 
 HDF5_SIGNATURE = b'\x89HDF\r\n\x1a\n'

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -60,10 +60,12 @@ class HDF5TableIO(BaseIO):
     _format_name = 'hdf5'
     _supported_class = Table
 
-    def identify(self, origin, filepath, fileobj, *args, **kwargs):
+    @classmethod
+    def identify(cls, origin, filepath, fileobj, *args, **kwargs):
         return _is_hdf5(origin, filepath, fileobj, *args, **kwargs)
 
-    def read(self, input, path=None):
+    @classmethod
+    def read(cls, input, path=None):
         """
         Read a Table object from an HDF5 file
 
@@ -147,8 +149,8 @@ class HDF5TableIO(BaseIO):
 
         return table
 
-
-    def write(self, table, output, path=None, compression=False,
+    @classmethod
+    def write(cls, table, output, path=None, compression=False,
               append=False, overwrite=False):
         """
         Write a Table object to an HDF5 file

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -399,38 +399,34 @@ def _get_valid_format(mode, cls, path, fileobj, args, kwargs):
 
 class MetaRegisterBaseIO(type):
 
-    def __init__(cls, name, bases, dct):
+    def __init__(cls, name, bases, members):
 
-        super(MetaRegisterBaseIO, cls).__init__(name, bases, dct)
+        super(MetaRegisterBaseIO, cls).__init__(name, bases, members)
 
-        format_abbreviation = dct.get('_format_name')
+        format_abbreviation = members.get('_format_name')
         if format_abbreviation is None:
             if cls.__name__ == 'BaseIO':
                 return
             else:
                 raise ValueError("_format_name is not defined")
 
-        supported_class = dct.get('_supported_class')
+        supported_class = members.get('_supported_class')
         if supported_class is None:
             raise ValueError("_supported_class is not defined")
 
-        reader = dct.get('read')
+        reader = members.get('read')
+        print(reader())
+        print(dir(reader))
         if reader is not None:
-            reader = functools.partial(reader, format_abbreviation)
-            register_reader(format_abbreviation,
-                            supported_class, reader)
+            register_reader(format_abbreviation, supported_class, reader)
 
-        writer = dct.get('write')
+        writer = members.get('write')
         if writer is not None:
-            writer = functools.partial(writer, format_abbreviation)
-            register_writer(format_abbreviation,
-                            supported_class, writer)
+            register_writer(format_abbreviation, supported_class, writer)
 
-        identifier = dct.get('identify')
-        if dct.get('identify') is not None:
-            identifier = functools.partial(identifier, format_abbreviation)
-            register_identifier(format_abbreviation,
-                                supported_class, identifier)
+        identifier = members.get('identify')
+        if members.get('identify') is not None:
+            register_identifier(format_abbreviation, supported_class, identifier)
 
 
 @six.add_metaclass(MetaRegisterBaseIO)

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -22,6 +22,14 @@ _writers = OrderedDict()
 _identifiers = OrderedDict()
 
 
+def import_connectors():
+    # TODO: there must be a more elegant way to do this
+    from ..io.ascii import connect
+    from ..io.fits import connect
+    from ..io.misc import connect
+    from ..io.votable import connect
+
+
 def get_formats(data_class=None):
     """
     Get the list of registered I/O formats as a Table.
@@ -287,6 +295,8 @@ def read(cls, *args, **kwargs):
     The arguments passed to this method depend on the format
     """
 
+    import_connectors()
+
     if 'format' in kwargs:
         format = kwargs.pop('format')
     else:
@@ -335,6 +345,8 @@ def write(data, *args, **kwargs):
 
     The arguments passed to this method depend on the format
     """
+
+    import_connectors()
 
     if 'format' in kwargs:
         format = kwargs.pop('format')

--- a/astropy/io/registry/core.py
+++ b/astropy/io/registry/core.py
@@ -6,8 +6,8 @@ import functools
 
 import numpy as np
 
-from ..utils import OrderedDict
-from ..extern import six
+from ...utils import OrderedDict
+from ...extern import six
 
 __all__ = ['register_reader', 'register_writer', 'register_identifier',
            'identify_format', 'get_reader', 'get_writer', 'read', 'write',
@@ -24,10 +24,10 @@ _identifiers = OrderedDict()
 
 def import_connectors():
     # TODO: there must be a more elegant way to do this
-    from ..io.ascii import connect
-    from ..io.fits import connect
-    from ..io.misc import connect
-    from ..io.votable import connect
+    from ...io.ascii import connect
+    from ...io.fits import connect
+    from ...io.misc import connect
+    from ...io.votable import connect
 
 
 def get_formats(data_class=None):
@@ -44,7 +44,7 @@ def get_formats(data_class=None):
     format_table: Table
         Table of available I/O formats
     """
-    from ..table import Table
+    from ...table import Table
     format_classes = sorted(set(_readers) | set(_writers))
     rows = []
 
@@ -310,7 +310,7 @@ def read(cls, *args, **kwargs):
 
             if len(args):
                 if isinstance(args[0], basestring):
-                    from ..utils.data import get_readable_fileobj
+                    from ...utils.data import get_readable_fileobj
                     path = args[0]
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary')
@@ -415,8 +415,6 @@ class MetaRegisterBaseIO(type):
             raise ValueError("_supported_class is not defined")
 
         reader = members.get('read')
-        print(reader())
-        print(dir(reader))
         if reader is not None:
             register_reader(format_abbreviation, supported_class, reader)
 

--- a/astropy/io/registry/tests/test_registry.py
+++ b/astropy/io/registry/tests/test_registry.py
@@ -6,10 +6,10 @@ from copy import copy
 
 import numpy as np
 
-from ...tests.helper import pytest
-from ..registry import _readers, _writers, _identifiers
-from .. import registry as io_registry
-from ...table import Table
+from ....tests.helper import pytest
+from ..core import _readers, _writers, _identifiers
+from .. import core as io_registry
+from ....table import Table
 
 def setup_module(module):
     module._READERS_ORIGINAL = copy(_readers)

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -11,10 +11,10 @@ from ..registry import _readers, _writers, _identifiers
 from .. import registry as io_registry
 from ...table import Table
 
-_READERS_ORIGINAL = copy(_readers)
-_WRITERS_ORIGINAL = copy(_writers)
-_IDENTIFIERS_ORIGINAL = copy(_identifiers)
-
+def setup_module(module):
+    module._READERS_ORIGINAL = copy(_readers)
+    module._WRITERS_ORIGINAL = copy(_writers)
+    module._IDENTIFIERS_ORIGINAL = copy(_identifiers)
 
 class TestData(object):
     read = classmethod(io_registry.read)
@@ -282,3 +282,8 @@ def teardown_function(function):
     _readers.update(_READERS_ORIGINAL)
     _writers.update(_WRITERS_ORIGINAL)
     _identifiers.update(_IDENTIFIERS_ORIGINAL)
+
+def teardown_module(module):
+    _readers.update(module._READERS_ORIGINAL)
+    _writers.update(module._WRITERS_ORIGINAL)
+    _identifiers.update(module._IDENTIFIERS_ORIGINAL)

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -8,7 +8,7 @@ from ...extern import six
 
 from . import parse, from_table
 from .tree import VOTableFile, Table as VOTable
-from ..registry import BaseIO
+from ..registry.core import BaseIO
 from ...table import Table
 
 

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -49,10 +49,12 @@ class VOTableIO(BaseIO):
     _format_name = 'votable'
     _supported_class = Table
 
-    def identify(self, origin, filepath, fileobj, *args, **kwargs):
+    @staticmethod
+    def identify(origin, filepath, fileobj, *args, **kwargs):
         return _is_votable(origin, filepath, fileobj, *args, **kwargs)
 
-    def read(self, input, table_id=None, use_names_over_ids=False):
+    @staticmethod
+    def read(input, table_id=None, use_names_over_ids=False):
         """
         Read a Table object from an VO table file
 
@@ -120,7 +122,8 @@ class VOTableIO(BaseIO):
         # Convert to an astropy.table.Table object
         return table.to_table(use_names_over_ids=use_names_over_ids)
 
-    def write(self, input, output, table_id=None, overwrite=False):
+    @staticmethod
+    def write(input, output, table_id=None, overwrite=False):
         """
         Write a Table object to an VO table file
 

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -11,6 +11,3 @@ be easily provided by a single array.
 from .nddata import *
 from .nduncertainty import *
 from .flag_collection import *
-
-# Import routines that connect readers/writers to astropy.nddata
-from ..io.fits import connect

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -11,3 +11,6 @@ be easily provided by a single array.
 from .nddata import *
 from .nduncertainty import *
 from .flag_collection import *
+
+# Import routines that connect readers/writers to astropy.nddata
+from ..io.fits import connect

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -14,7 +14,7 @@ from .. import log
 from .flag_collection import FlagCollection
 from .nduncertainty import IncompatibleUncertaintiesException, NDUncertainty
 from ..utils.compat.odict import OrderedDict
-from ..io import registry as io_registry
+from ..io.registry import core as io_registry
 from ..config import ConfigurationItem
 from ..utils.metadata import MetaData
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -7,9 +7,3 @@ from .column import Column, MaskedColumn
 from .table import Table, TableColumns, Row
 from .np_utils import TableMergeError
 from .operations import join, hstack, vstack
-
-# Import routines that connect readers/writers to astropy.table
-from ..io.ascii import connect
-from ..io.fits import connect
-from ..io.misc import connect
-from ..io.votable import connect

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,7 @@ import numpy as np
 from numpy import ma
 
 from .. import log
-from ..io import registry as io_registry
+from ..io.registry import core as io_registry
 from ..units import Quantity
 from ..utils import OrderedDict, isiterable, deprecated
 from ..utils.console import color_print


### PR DESCRIPTION
**This is work in progress - do not merge!**

This goes towards addressing the issue in #1046 of using classes to define readers/writers, and uses a metaclass adapted from the one currently in ``astropy.io.ascii`` to auto-register the readers/writers. I also implemented a FITS reader/writer for NDData and found that this resulted in additional circular imports which motivated some of the refactoring here.

A few things I'm still not happy with:

* I don't like the use of ``partial`` to get around the fact that the methods require the first argument to be ``self`` but we are calling them like class methods.
* Importing the connectors has now been moved to ``read`` and ``write`` to avoid circular imports. However, I find this still sub-optimal because I had to write the ``import_connectors`` function in ``registry`` which still has the hard-coded imports (this is to make sure the classes get defined, otherwise they don't and don't get auto-registered!).

In addition I still need to integrate ``astropy.io.ascii`` into this new system (if we go ahead with it).

Of course, there are tests, docs, etc. missing from here, but this is just a prototype at this stage.

@taldcroft - could you let me know what you think of this so far? How do you think we should deal with ``astropy.io.ascii``? Should it use a separate metaclass, or should it be integrated into the new system?

Once this is all in place we can also try and see whether we can use it to improve the documentation situation, by building the ``Table.read/Table.write`` and ``NDData.read/NDData.write`` docstrings dynamically using the metaclass.