### PR TITLE
Fix repetitive warning handling in io.votable

### DIFF
--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -56,7 +56,9 @@ __all__ = [
 MAX_WARNINGS = 10
 
 
-def _format_message(message, name, config={}, pos=None):
+def _format_message(message, name, config=None, pos=None):
+    if config is None:
+        config = {}
     if pos is None:
         pos = ('?', '?')
     filename = config.get('filename', '?')
@@ -65,7 +67,7 @@ def _format_message(message, name, config={}, pos=None):
 
 def _suppressed_warning(warning, config, stacklevel=2):
     warning_class = type(warning)
-    config.setdefault('_warning_counts', {}).setdefault(warning_class, 0)
+    config.setdefault('_warning_counts', dict()).setdefault(warning_class, 0)
     config['_warning_counts'][warning_class] += 1
     message_count = config['_warning_counts'][warning_class]
     if message_count <= MAX_WARNINGS:
@@ -75,11 +77,13 @@ def _suppressed_warning(warning, config, stacklevel=2):
         warn(warning, stacklevel=stacklevel+1)
 
 
-def warn_or_raise(warning_class, exception_class=None, args=(), config={},
+def warn_or_raise(warning_class, exception_class=None, args=(), config=None,
                   pos=None, stacklevel=1):
     """
     Warn or raise an exception, depending on the pedantic setting.
     """
+    if config is None:
+        config = {}
     if config.get('pedantic'):
         if exception_class is None:
             exception_class = warning_class
@@ -88,20 +92,24 @@ def warn_or_raise(warning_class, exception_class=None, args=(), config={},
         vo_warn(warning_class, args, config, pos, stacklevel=stacklevel+1)
 
 
-def vo_raise(exception_class, args=(), config={}, pos=None):
+def vo_raise(exception_class, args=(), config=None, pos=None):
     """
     Raise an exception, with proper position information if available.
     """
+    if config is None:
+        config = {}
     raise exception_class(args, config, pos)
 
 
-def vo_reraise(exc, config={}, pos=None, additional=''):
+def vo_reraise(exc, config=None, pos=None, additional=''):
     """
     Raise an exception, with proper position information if available.
 
     Restores the original traceback of the exception, and should only
     be called within an "except:" block of code.
     """
+    if config is None:
+        config = {}
     message = _format_message(str(exc), exc.__class__.__name__, config, pos)
     if message.split()[0] == str(exc).split()[0]:
         message = str(exc)
@@ -111,10 +119,12 @@ def vo_reraise(exc, config={}, pos=None, additional=''):
     raise exc
 
 
-def vo_warn(warning_class, args=(), config={}, pos=None, stacklevel=1):
+def vo_warn(warning_class, args=(), config=None, pos=None, stacklevel=1):
     """
     Warn, with proper position information if available.
     """
+    if config is None:
+        config = {}
     warning = warning_class(args, config, pos)
     _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 
@@ -183,7 +193,9 @@ class VOWarning(AstropyWarning):
     default_args = ()
     message_template = ''
 
-    def __init__(self, args, config={}, pos=None):
+    def __init__(self, args, config=None, pos=None):
+        if config is None:
+            config = {}
         msg = self.message_template % args
         self.formatted_message = _format_message(
             msg, self.__class__.__name__, config, pos)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -188,7 +188,7 @@ def _get_unit_format(config):
 
 ######################################################################
 # ATTRIBUTE CHECKERS
-def check_astroyear(year, field, config={}, pos=None):
+def check_astroyear(year, field, config=None, pos=None):
     """
     Raises a `~astropy.io.votable.exceptions.VOTableSpecError` if
     *year* is not a valid astronomical year as defined by the VOTABLE
@@ -213,7 +213,7 @@ def check_astroyear(year, field, config={}, pos=None):
     return True
 
 
-def check_string(string, attr_name, config={}, pos=None):
+def check_string(string, attr_name, config=None, pos=None):
     """
     Raises a `~astropy.io.votable.exceptions.VOTableSpecError` if
     *string* is not a string or Unicode string.
@@ -236,14 +236,14 @@ def check_string(string, attr_name, config={}, pos=None):
     return True
 
 
-def resolve_id(ID, id, config={}, pos=None):
+def resolve_id(ID, id, config=None, pos=None):
     if ID is None and id is not None:
         warn_or_raise(W09, W09, (), config, pos)
         return id
     return ID
 
 
-def check_ucd(ucd, config={}, pos=None):
+def check_ucd(ucd, config=None, pos=None):
     """
     Warns or raises a
     `~astropy.io.votable.exceptions.VOTableSpecError` if *ucd* is not
@@ -258,6 +258,8 @@ def check_ucd(ucd, config={}, pos=None):
     config, pos : optional
         Information about the source of the value
     """
+    if config is None:
+        config = {}
     if config.get('version_1_1_or_later'):
         try:
             ucd_mod.parse_ucd(
@@ -493,7 +495,9 @@ class Link(SimpleElement, _IDProperty):
     _element_name = 'LINK'
 
     def __init__(self, ID=None, title=None, value=None, href=None, action=None,
-                 id=None, config={}, pos=None, **kwargs):
+                 id=None, config=None, pos=None, **kwargs):
+        if config is None:
+            config = {}
         self._config = config
         self._pos = pos
 
@@ -601,7 +605,9 @@ class Info(SimpleElementWithContent, _IDProperty, _XtypeProperty,
 
     def __init__(self, ID=None, name=None, value=None, id=None, xtype=None,
                  ref=None, unit=None, ucd=None, utype=None,
-                 config={}, pos=None, **extra):
+                 config=None, pos=None, **extra):
+        if config is None:
+            config = {}
         self._config = config
         self._pos = pos
 
@@ -763,7 +769,9 @@ class Values(Element, _IDProperty):
     name, documented below.
     """
     def __init__(self, votable, field, ID=None, null=None, ref=None,
-                 type="legal", id=None, config={}, pos=None, **extras):
+                 type="legal", id=None, config=None, pos=None, **extras):
+        if config is None:
+            config = {}
         self._config  = config
         self._pos = pos
 
@@ -1085,7 +1093,9 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
                  arraysize=None, ucd=None, unit=None, width=None,
                  precision=None, utype=None, ref=None, type=None, id=None,
                  xtype=None,
-                 config={}, pos=None, **extra):
+                 config=None, pos=None, **extra):
+        if config is None:
+            config = {}
         self._config = config
         self._pos = pos
 
@@ -1506,7 +1516,7 @@ class Param(Field):
 
     def __init__(self, votable, ID=None, name=None, value=None, datatype=None,
                  arraysize=None, ucd=None, unit=None, width=None,
-                 precision=None, utype=None, type=None, id=None, config={},
+                 precision=None, utype=None, type=None, id=None, config=None,
                  pos=None, **extra):
         self._value = value
         Field.__init__(self, votable, ID=ID, name=name, datatype=datatype,
@@ -1558,7 +1568,9 @@ class CooSys(SimpleElement):
     _element_name = 'COOSYS'
 
     def __init__(self, ID=None, equinox=None, epoch=None, system=None, id=None,
-                 config={}, pos=None, **extra):
+                 config=None, pos=None, **extra):
+        if config is None:
+            config = {}
         self._config = config
         self._pos = pos
 
@@ -1659,7 +1671,7 @@ class FieldRef(SimpleElement, _UtypeProperty, _UcdProperty):
     _utype_in_v1_2 = True
     _ucd_in_v1_2 = True
 
-    def __init__(self, table, ref, ucd=None, utype=None, config={}, pos=None,
+    def __init__(self, table, ref, ucd=None, utype=None, config=None, pos=None,
                  **extra):
         """
         *table* is the :class:`Table` object that this :class:`FieldRef`
@@ -1668,6 +1680,8 @@ class FieldRef(SimpleElement, _UtypeProperty, _UcdProperty):
         *ref* is the ID to reference a :class:`Field` object defined
         elsewhere.
         """
+        if config is None:
+            config = {}
         self._config = config
         self._pos = pos
 
@@ -1730,7 +1744,10 @@ class ParamRef(SimpleElement, _UtypeProperty, _UcdProperty):
     _utype_in_v1_2 = True
     _ucd_in_v1_2 = True
 
-    def __init__(self, table, ref, ucd=None, utype=None, config={}, pos=None):
+    def __init__(self, table, ref, ucd=None, utype=None, config=None, pos=None):
+        if config is None:
+            config = {}
+
         self._config = config
         self._pos = pos
 
@@ -1791,7 +1808,9 @@ class Group(Element, _IDProperty, _NameProperty, _UtypeProperty,
     """
 
     def __init__(self, table, ID=None, name=None, ref=None, ucd=None,
-                 utype=None, id=None, config={}, pos=None, **extra):
+                 utype=None, id=None, config=None, pos=None, **extra):
+        if config is None:
+            config = {}
         self._config     = config
         self._pos        = pos
 
@@ -1937,8 +1956,10 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
     name, documented below.
     """
     def __init__(self, votable, ID=None, name=None, ref=None, ucd=None,
-                 utype=None, nrows=None, id=None, config={}, pos=None,
+                 utype=None, nrows=None, id=None, config=None, pos=None,
                  **extra):
+        if config is None:
+            config = {}
         self._config = config
         self._pos = pos
         self._empty = False
@@ -2110,7 +2131,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         """
         return self._empty
 
-    def create_arrays(self, nrows=0, config={}):
+    def create_arrays(self, nrows=0, config=None):
         """
         Create a new array to hold the data based on the current set
         of fields, and store them in the *array* and member variable.
@@ -2888,7 +2909,9 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
     name, documented below.
     """
     def __init__(self, name=None, ID=None, utype=None, type='results',
-                 id=None, config={}, pos=None, **kwargs):
+                 id=None, config=None, pos=None, **kwargs):
+        if config is None:
+            config = {}
         self._config           = config
         self._pos              = pos
 
@@ -3105,7 +3128,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
     tests for building the rest of the structure depend on it.
     """
 
-    def __init__(self, ID=None, id=None, config={}, pos=None, version="1.2"):
+    def __init__(self, ID=None, id=None, config=None, pos=None, version="1.2"):
+        if config is None:
+            config = {}
         self._config             = config
         self._pos                = pos
 

--- a/astropy/io/votable/xmlutil.py
+++ b/astropy/io/votable/xmlutil.py
@@ -21,7 +21,7 @@ __all__ = [
     ]
 
 
-def check_id(ID, name='ID', config={}, pos=None):
+def check_id(ID, name='ID', config=None, pos=None):
     """
     Raises a `~astropy.io.votable.exceptions.VOTableSpecError` if *ID*
     is not a valid XML ID_.
@@ -35,7 +35,7 @@ def check_id(ID, name='ID', config={}, pos=None):
     return True
 
 
-def fix_id(ID, config={}, pos=None):
+def fix_id(ID, config=None, pos=None):
     """
     Given an arbitrary string, create one that can be used as an xml id.
 
@@ -53,7 +53,7 @@ def fix_id(ID, config={}, pos=None):
 _token_regex = r"(?![\r\l\t ])[^\r\l\t]*(?![\r\l\t ])"
 
 
-def check_token(token, attr_name, config={}, pos=None):
+def check_token(token, attr_name, config=None, pos=None):
     """
     Raises a `ValueError` if *token* is not a valid XML token.
 
@@ -64,7 +64,7 @@ def check_token(token, attr_name, config={}, pos=None):
     return True
 
 
-def check_mime_content_type(content_type, config={}, pos=None):
+def check_mime_content_type(content_type, config=None, pos=None):
     """
     Raises a `~astropy.io.votable.exceptions.VOTableSpecError` if
     *content_type* is not a valid MIME content type.
@@ -78,7 +78,7 @@ def check_mime_content_type(content_type, config={}, pos=None):
     return True
 
 
-def check_anyuri(uri, config={}, pos=None):
+def check_anyuri(uri, config=None, pos=None):
     """
     Raises a `~astropy.io.votable.exceptions.VOTableSpecError` if
     *uri* is not a valid URI.


### PR DESCRIPTION
This fixes a rather obscure and somewhat theoretical bug in `io.votable`.  The code was doing a class Python "no-no" by including a mutable sequence as a keyword argument initializer in many places.  This didn't matter in the general case when the keyword argument was passed a value, but the test suite doesn't always do that because it doesn't always read things from a whole VOTable file, but instead tests lower-level parts.  When I was investigating #2065, I decided to run all the tests _many_ times in the same session and discovered the bug (where keeping track of how many times a particular vo warning was seen was not resetting between each test like it should).

All this is to say, you probably don't care, but this should probably be fixed.
