### PR TITLE
Units power rounding

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -890,7 +890,8 @@ class UnitBase(object):
         # `is_equivalent`, because it doesn't generate the entire
         # physical type list of both units.  In other words it "fails
         # fast".
-        if(np.allclose(self_decomposed.powers, other_decomposed.powers) and
+        if((len(self_decomposed.powers) == len(other_decomposed.powers) and
+            np.allclose(self_decomposed.powers, other_decomposed.powers)) and
            all(self_base is other_base for (self_base, other_base)
                in zip(self_decomposed.bases, other_decomposed.bases))):
             return self_decomposed.scale / other_decomposed.scale

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -564,3 +564,18 @@ def test_fits_hst_unit():
     """See #1911."""
     x = u.Unit("erg /s /cm**2 /angstrom")
     assert x == u.erg * u.s ** -1 * u.cm ** -2 * u.angstrom ** -1
+    
+
+def test_conversion_with_close_powers():
+    """
+    Regression test for a case where floating point error would
+    cause unit conversion to fail.
+    """
+    m = 1. * u.Msun
+    tH =  1./(1. * u.km/u.s/u.Mpc)
+    vc = 1. * u.km/u.s
+    G = 1. * u.m**3/(u.kg*u.s**2)
+
+    x = (G**2 * m**2 * tH)**(1./3) / vc  # Should have units of length
+    x.to('pc') # This will fail with a UnitsError if a regression occurs
+


### PR DESCRIPTION
I found the following strange occurrence in the units package, where a conversion works when using quantity `tH.cgs`, but not when using the unadorned quantity `tH`:

```
m = 1e9 * u.Msun
tH =  1./(70. * u.km/u.s/u.Mpc)
vc = 200 * u.km/u.s

x = (c.G**2 * m**2 * tH.cgs)**(1./3) / vc # Units of length
x.to('pc') # Succeeds

x = (c.G**2 * m**2 * tH)**(1./3) / vc # Units of length
x.to('pc') # Fails with a UnitsError
```

The cause is that `x.cgs.unit.powers[0]` is `1.0` in the first case, and `1.0000000000000002` in the second.

It seemed to me that this could be dealt with using `np.allclose` in the `_to()` function of `core.py` instead of a strict equality, but I'd like to know if others think this is an acceptable solution.  I've written a regression test for the issue as well.

Lehman
