### PR TITLE
Added check for RA with negative zero in Cone Search.

### DIFF
--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -487,17 +487,28 @@ def _local_conversion(func, x):
 
 
 def _validate_coord(center):
+    """Validate coordinates."""
     if isinstance(center, SphericalCoordinatesBase):
         icrscoord = center.transform_to(ICRS)
     else:
         icrscoord = ICRS(*center, unit=(u.degree, u.degree))
 
-    return icrscoord.ra.degree, icrscoord.dec.degree
+    ra = icrscoord.ra.degree
+    dec = icrscoord.dec.degree
+
+    # RA has tendency to go negative in Longitude class.
+    ra_sign = '{0:+}'.format(ra)[0]
+    if ra_sign == '-' and ra == 0:  # -0 is okay
+        ra = 0
+    else:  # pragma: no cover
+        raise ConeSearchError('Cone Search cannot accept negative RA value '
+                              '({0} deg)'.format(ra))
+
+    return ra, dec
 
 
 def _validate_sr(radius):
     """Validate search radius."""
-        # Validate search radius
     if isinstance(radius, Angle):
         sr_angle = radius
     else:

--- a/astropy/vo/client/tests/test_vo.py
+++ b/astropy/vo/client/tests/test_vo.py
@@ -40,8 +40,8 @@ __doctest_skip__ = ['*']
 
 
 # Global variables for TestConeSearch
-SCS_RA = 0.01
-SCS_DEC = 0.01
+SCS_RA = 0
+SCS_DEC = 0
 SCS_SR = 0.1
 SCS_CENTER = ICRS(SCS_RA, SCS_DEC, unit=(u.degree, u.degree))
 SCS_RADIUS = SCS_SR * u.degree


### PR DESCRIPTION
See discussions in #2037 . Tested successfully under Python 2.7 and 3.3 with this command:

```
import astropy
astropy.test('vo', remote_data=True)
```
