### PR TITLE
Fix / improve error message for comparisons

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -931,7 +931,7 @@ class Time(object):
         out = self.__sub__(other)
         return -out
 
-    def _tai_difference(self, other):
+    def _tai_difference(self, other, op=None):
         """If other is of same class as self, return difference in TAI.
         Otherwise, raise OperandTypeError.
         """
@@ -939,28 +939,28 @@ class Time(object):
             try:
                 other = self.__class__(other)
             except:
-                raise OperandTypeError(self, other)
+                raise OperandTypeError(self, other, op)
         self_tai = self.tai
         other_tai = other.tai
         return (self_tai.jd1 - other_tai.jd1) + (self_tai.jd2 - other_tai.jd2)
 
     def __lt__(self, other):
-        return self._tai_difference(other) < 0.
+        return self._tai_difference(other, '<') < 0.
 
     def __le__(self, other):
-        return self._tai_difference(other) <= 0.
+        return self._tai_difference(other, '<=') <= 0.
 
     def __eq__(self, other):
-        return self._tai_difference(other) == 0.
+        return self._tai_difference(other, '==') == 0.
 
     def __ne__(self, other):
-        return self._tai_difference(other) != 0.
+        return self._tai_difference(other, '!=') != 0.
 
     def __gt__(self, other):
-        return self._tai_difference(other) > 0.
+        return self._tai_difference(other, '>') > 0.
 
     def __ge__(self, other):
-        return self._tai_difference(other) >= 0.
+        return self._tai_difference(other, '>=') >= 0.
 
 
 class TimeDelta(Time):
@@ -1030,7 +1030,7 @@ class TimeDelta(Time):
         # check needed since otherwise the self.jd1 * other multiplication
         # would enter here again (via __rmul__)
         if isinstance(other, Time):
-            raise OperandTypeError(self, other)
+            raise OperandTypeError(self, other, '*')
 
         try:   # convert to straight float if dimensionless quantity
             other = other.to(1)
@@ -1944,7 +1944,10 @@ def split(a):
 
 
 class OperandTypeError(TypeError):
-    def __init__(self, left, right):
-        self.value = ("unsupported operand type(s) for -: "
-                      "'{0}' and '{1}'".format(left.__class__.__name__,
-                                               right.__class__.__name__))
+    def __init__(self, left, right, op=None):
+        op_string = '' if op is None else ' for {0}'.format(op)
+        super(OperandTypeError, self).__init__(
+            "Unsupported operand type(s){0}: "
+            "'{1}' and '{2}'".format(op_string,
+                                     left.__class__.__name__,
+                                     right.__class__.__name__))

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -1,4 +1,7 @@
+
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import operator
+
 import numpy as np
 
 from ...tests.helper import pytest
@@ -11,6 +14,19 @@ class TestTimeComparisons():
     def setup(self):
         self.t1 = Time(np.arange(49995, 50005), format='mjd', scale='utc')
         self.t2 = Time(np.arange(49000, 51000, 200), format='mjd', scale='utc')
+
+    def test_miscompares(self):
+        t1 = Time('J2000', scale='utc')
+        for op, op_str in ((operator.eq, '=='),
+                           (operator.ge, '>='),
+                           (operator.gt, '>'),
+                           (operator.ne, '!='),
+                           (operator.le, '<='),
+                           (operator.lt, '<')):
+            with pytest.raises(OperandTypeError) as err:
+                op(t1, None)
+            assert str(err).endswith("Unsupported operand type(s) for {0}: 'Time' and 'NoneType'"
+                                     .format(op_str))
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2


### PR DESCRIPTION
As first noticed in #1832, the error message for a failed Time comparison is broken.  The current `OperandTypeError` class doesn't actually provide any error text.  This PR fixes that and makes the messages more informative.

```
In [1]: from astropy.time import Time
In [2]: t1 = Time('J2000', scale='utc')
In [3]: t1 == None
ERROR: OperandTypeError: Unsupported operand type(s) for ==: 'Time' and 'NoneType' [astropy.time.core]
```

I don't think this rises to the level of needing mention in `CHANGES.rst`.
