### PR TITLE
Fix read out of bounds error in `wcs`

### DIFF
--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -161,7 +161,7 @@ wcsprm_fix_values(
 
   unsigned int naxis = (unsigned int)x->naxis;
 
-  value_fixer(x->cd, 4);
+  value_fixer(x->cd, naxis * naxis);
   value_fixer(x->cdelt, naxis);
   value_fixer(x->crder, naxis);
   value_fixer(x->crota, naxis);


### PR DESCRIPTION
This fixes a theoretical bug in `wcs`, detected with valgrind.
