### PR TITLE
Fix up use of API doc references in the changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,9 +18,9 @@ New Features
 
 - ``astropy.coordinates``
 
-  - Updated `Angle.dms` and `Angle.hms` to return `namedtuple`s instead of
-    regular tuples, and added `Angle.signed_dms` attribute that gives the
-    absolute value of the `d`, `m`, and `s` along with the sign.  [#1988]
+  - Updated ``Angle.dms`` and ``Angle.hms`` to return ``namedtuple``s instead
+    of regular tuples, and added ``Angle.signed_dms`` attribute that gives the
+    absolute value of the ``d``, ``m``, and ``s`` along with the sign.  [#1988]
 
   - By default, `Distance` objects are now required to be positive. To
     allow negative values, set ``allow_negative=True`` in the `Distance`
@@ -28,11 +28,11 @@ New Features
 
 - ``astropy.cosmology``
 
-  - `age` and `comoving_volume` convenience functions have been added to
-    `astropy.cosmology`. [#1902]
+  - ``age` and ``comoving_volume` convenience functions have been added to
+    ``astropy.cosmology``. [#1902]
 
-  - Added `astropy.cosmology.z_at_value` to find the redshift at which a
-    cosmology function matches a desired value. [#1909]
+  - Added ``z_at_value`` function to find the redshift at which a cosmology
+    function matches a desired value. [#1909]
 
 - ``astropy.io.ascii``
 
@@ -92,9 +92,9 @@ New Features
 
 - ``astropy.sphinx``
 
-  - The `automodapi` and `automodsumm` extensions now include sphinx
-    configuration options to write out what `automidapi` and
-    `automodsumm` generate, mainly for debugging purposes. [#1975, #2022]
+  - The ``automodapi`` and ``automodsumm`` extensions now include sphinx
+    configuration options to write out what ``automodapi`` and ``automodsumm``
+    generate, mainly for debugging purposes. [#1975, #2022]
 
   - Reference documentation now shows functions/class docstrings at the
     inteded user-facing API location rather than the actual file where
@@ -107,7 +107,7 @@ New Features
 - ``astropy.time``
 
   - Mean and apparent sidereal time can now be calculated using the
-    `sidereal_time` method [#1418].
+    ``sidereal_time`` method [#1418].
 
   - The time scale now defaults to UTC if no scale is provided. [#2091]
 
@@ -120,15 +120,15 @@ New Features
 
 - ``astropy.units``
 
-  - Support for the unit format `Office of Guest Investigator Programs
-    (OGIP) FITS files
+  - Support for the unit format `Office of Guest Investigator Programs (OGIP)
+    FITS files
     <http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`__
     has been added. [#377]
 
-  - :func:`astropy.units.equivalencies.spectral` can now handle angular
-    wave number. [#1306 and #1899]
+  - The ``spectral`` equivalency can now handle angular wave number. [#1306 and
+    #1899]
 
-  - Added `one` as a shortcut to `dimensionless_unscaled`. [#1980]
+  - Added ``one`` as a shorthand for ``dimensionless_unscaled``. [#1980]
 
   - Added `dex` and `dB` units. [#1628]
 
@@ -137,13 +137,14 @@ New Features
 
 - ``astropy.utils``
 
-  - `astropy.utils.timer.RunTimePredictor` now uses `astropy.modeling`
-    in its ``do_fit()`` method. [#1896]
+  - ``timer.RunTimePredictor`` now uses ``astropy.modeling`` in its
+    ``do_fit()`` method. [#1896]
 
 - ``astropy.vo``
 
-  - A new sub-package, `astropy.vo.samp`, is now available (this was previously
-    the SAMPy package, which has been refactored for use in Astropy). [#1907]
+  - A new sub-package, ``astropy.vo.samp``, is now available (this was
+    previously the SAMPy package, which has been refactored for use in
+    Astropy). [#1907]
 
 - ``astropy.wcs``
 
@@ -183,7 +184,7 @@ API Changes
 
   - The method computing the derivative of the model with respect
     to parameters was renamed from `deriv` to `fit_deriv`. [#1739]
-    
+
   - `ParametricModel` and the associated `Parametric1DModel` and `Parametric2DModel` classes have been renamed
     `FittableModel`, `Fittable1DModel`, and `Fittable2DModel` respectively.  The base `Model` class has
     subsumed the functionality of the old `ParametricModel` class so that all models support parameter
@@ -196,8 +197,8 @@ API Changes
 
 - ``astropy.table``
 
-  - The default table printing function now shows a table header row
-    for units if any columns have the unit attribute set.  [#1282]
+  - The default table printing function now shows a table header row for units
+    if any columns have the unit attribute set.  [#1282]
 
 - ``astropy.time``
 
@@ -207,8 +208,8 @@ API Changes
 
 - ``astropy.units``
 
-  - ``Quantity`` now converts input to float by default, as this is
-    physically most sensible for nearly all units [#1776].
+  - ``Quantity`` now converts input to float by default, as this is physically
+    most sensible for nearly all units [#1776].
 
 - ``astropy.utils``
 
@@ -233,7 +234,7 @@ Bug Fixes
     negative distances, which can occur in certain closed cosmologies. [#2008]
 
   - Removed accidental imports of some extraneous variables in
-    `astropy.cosmology` [#2025]
+    ``astropy.cosmology`` [#2025]
 
 - ``astropy.io.ascii``
 
@@ -278,12 +279,12 @@ Bug Fixes
 
 - ``astropy.wcs``
 
-  - astropy now requires wcslib version 4.20 or later.  The version of
+  - Astropy now requires wcslib version 4.20 or later.  The version of
     wcslib included with astropy has been updated to version 4.21.  The
     following is the relevant parts of the ``wcslib`` changelog:
 
-    - This version of wcslib brings some bugfixes from the astropy
-      project (described below) and tighter bounds checking.
+    - This version of wcslib brings some bugfixes from the astropy project
+      (described below) and tighter bounds checking.
 
     - Bug fixes in the projection routines: in ``hpxx2s`` [the
       cartesian-to-spherical operation of the ``HPX`` projection]
@@ -295,18 +296,17 @@ Bug Fixes
       in ``xphx2s`` relating to setting an out-of-bounds value of
       *phi*.
 
-  - A new method, `astropy.wcs.Wcsprm.bounds_check` (corresponding to
-    wcslib's ``wcsbchk``) has been added to control what bounds
-    checking is performed by wcslib.
+  - A new method, ``Wcsprm.bounds_check`` (corresponding to wcslib's
+    ``wcsbchk``) has been added to control what bounds checking is performed by
+    wcslib.
 
-  - `astropy.wcs.WCS.to_header` will now raise a more meaningful
-    exception when the WCS information is inavlid or inconsistent in
-    some way. [#1854]
+  - ``WCS.to_header`` will now raise a more meaningful exception when the WCS
+    information is inavlid or inconsistent in some way. [#1854]
 
-  - If the C extension for `astropy.wcs` was not built or fails to
-    import for any reason, ``import astropy.wcs`` will result in an
-    `ImportError`, rather than getting obscure errors once the
-    `astropy.wcs` is used. [#2061]
+  - If the C extension for ``astropy.wcs`` was not built or fails to import for
+    any reason, ``import astropy.wcs`` will result in an ``ImportError``,
+    rather than getting obscure errors once the ``astropy.wcs`` is used.
+    [#2061]
 
 
 Other Changes and Additions
@@ -402,8 +402,8 @@ Bug Fixes
 
 - ``astropy.stats``
 
-  - Ensure the ``axis`` keyword in :func:`astropy.stats.funcs` can now
-    be used for all axes. [#2173]
+  - Ensure the ``axis`` keyword in ``astropy.stats.funcs`` can now be used for
+    all axes. [#2173]
 
 - ``astropy.table``
 
@@ -429,7 +429,7 @@ Bug Fixes
   - ``data.download_file()`` now evaluates ``REMOTE_TIMEOUT()`` at runtime
     rather than import time. Previously, setting ``REMOTE_TIMEOUT`` after
     import had no effect on the function's behavior. [#2302]
-    
+
 - ``astropy.vo``
 
   - Fixed ``format()`` compatibility with Python 2.6. [#2129]
@@ -467,30 +467,29 @@ Bug Fixes
   - Fixed a bug where using ``==`` on two array coordinates wouldn't
     work. [#1832]
 
-  - Fixed bug which caused `len()` not to work for coordinate objects
-    and added a `shape` property to get appropriately array-like
-    behavior. [#1761, #2014]
+  - Fixed bug which caused ``len()`` not to work for coordinate objects and
+    added a ``.shape`` property to get appropriately array-like behavior.
+    [#1761, #2014]
 
   - Fixed a bug where sexagesimal notation would sometimes include
     exponential notation in the last field. [#1908, #1913]
 
-  - ``astropy.coordinates.transformations.CompositeStaticMatrixTransform``
-    no longer attempts to reference the undefined variable
-    ``self.matrix`` during instantiation. [#1944]
+  - ``CompositeStaticMatrixTransform`` no longer attempts to reference the
+    undefined variable ``self.matrix`` during instantiation. [#1944]
 
-  - Fixed pickling of ``Longitude``, ensuring ``wrap_angle`` is
-    preserved [#1961]
+  - Fixed pickling of ``Longitude``, ensuring ``wrap_angle`` is preserved
+    [#1961]
 
-  - Allow `sep` argument in `Angle.to_string` to be empty (resulting in no
+  - Allow ``sep`` argument in ``Angle.to_string`` to be empty (resulting in no
     separators) [#1989]
 
 - ``astropy.io.ascii``
 
-  - Allow passing unicode delimiters when reading or writing tables.
-    The delimiter must be convertible to pure ASCII.  [#1949]
+  - Allow passing unicode delimiters when reading or writing tables.  The
+    delimiter must be convertible to pure ASCII.  [#1949]
 
-  - Fix a problem when reading a table and renaming the columns to names
-    that already exist. [#1991]
+  - Fix a problem when reading a table and renaming the columns to names that
+    already exist. [#1991]
 
 - ``astropy.io.fits``
 
@@ -504,22 +503,22 @@ Bug Fixes
 
 - ``astropy.io.votable``
 
-  - The `write_null_values` kwarg to `VOTable.to_xml`, when set to `False`
-    (the default) would produce non-standard VOTable files.  Therefore,
-    this functionality has been replaced by a better understanding that
-    knows which fields in a VOTable may be left empty (only `char`,
-    `float` and `double` in VOTable 1.1 and 1.2, and all fields in VOTable
-    1.3).  The kwarg is still accepted but it will be ignored, and a
-    warning is emitted. [#1809]
+  - The ``write_null_values`` kwarg to ``VOTable.to_xml``, when set to `False`
+    (the default) would produce non-standard VOTable files.  Therefore, this
+    functionality has been replaced by a better understanding that knows which
+    fields in a VOTable may be left empty (only ``char``, ``float`` and
+    ``double`` in VOTable 1.1 and 1.2, and all fields in VOTable 1.3).  The
+    kwarg is still accepted but it will be ignored, and a warning is emitted.
+    [#1809]
 
-  - Printing out a `astropy.io.votable.tree.Table` object using `repr`
-    or `str` now uses the pretty formatting in `astropy.table`, so
-    it's possible to easily preview the contents of a
-    `VOTable`. [#1766]
+  - Printing out a ``astropy.io.votable.tree.Table`` object using `repr` or
+    `str` now uses the pretty formatting in ``astropy.table``, so it's possible
+    to easily preview the contents of a ``VOTable``. [#1766]
 
 - ``astropy.modeling``
 
-  - Fixed bug in computation of model derivatives in `LinearLSQFitter`. [#1903]
+  - Fixed bug in computation of model derivatives in ``LinearLSQFitter``.
+    [#1903]
 
   - Raise a `NotImplementedError` when fitting composite models. [#1915]
 
@@ -536,18 +535,18 @@ Bug Fixes
   - The column string representation for n-dimensional cells with only
     one element has been fixed. [#1522]
 
-  - Fix a problem that caused MaskedColumn.__getitem__ to not preserve column
-    metadata. [#1471, #1872]
+  - Fix a problem that caused ``MaskedColumn.__getitem__`` to not preserve
+    column metadata. [#1471, #1872]
 
   - With Numpy prior to version 1.6.2, tables with Unicode columns now
     sort correctly. [#1867]
 
-  - `astropy.table` can now print out tables with Unicode columns
-    containing non-ascii characters. [#1864]
+  - ``astropy.table`` can now print out tables with Unicode columns containing
+    non-ascii characters. [#1864]
 
   - Columns can now be named with Unicode strings, as long as they contain only
-    ascii characters.  This makes using `astropy.table` easier on Python 2 when
-    `from __future__ import unicode_literals` is used. [#1864]
+    ascii characters.  This makes using ``astropy.table`` easier on Python 2
+    when ``from __future__ import unicode_literals`` is used. [#1864]
 
   - Allow pickling of ``Table``, ``Column``, and ``MaskedColumn`` objects. [#792]
 
@@ -559,9 +558,9 @@ Bug Fixes
   - Fix a problem where scale conversion problem in TimeFromEpoch
     was not showing a useful error [#2046]
 
-  - Fix a problem when converting to one of the formats `unix`,
-    `cxcsec`, `gps` or `plot_date` when the time scale is `UT1`, `TDB`
-    or `TCB` [#1732]
+  - Fix a problem when converting to one of the formats ``unix``, ``cxcsec``,
+    ``gps`` or ``plot_date`` when the time scale is ``UT1``, ``TDB`` or ``TCB``
+    [#1732]
 
   - Ensure that ``delta_ut1_utc`` gets calculated when accessed directly,
     instead of failing and giving a rather obscure error message [#1925]
@@ -583,8 +582,8 @@ Bug Fixes
 
   - Fix error for inplace operations on non-contiguous quantities [#1834].
 
-  - The definition of the unit `bar` has been corrected to `1e5
-    Pascal` from `100 Pascal` [#1910]
+  - The definition of the unit ``bar`` has been corrected to "1e5
+    Pascal" from "100 Pascal" [#1910]
 
   - For units that are close to known units, but not quite, for
     example due to differences in case, the exception will now include
@@ -597,13 +596,12 @@ Bug Fixes
     standard, due to the ambiguity of parsing, so a warning is raised
     when it is encountered. [#1911]
 
-  - The use of ``angstrom`` (with a lower case ``a``) is now accepted
-    in FITS unit strings, since it is in common usage.  However, since
-    it is not officially part of the FITS standard, a warning will be
-    issued when it is encountered.  [#1911]
+  - The use of "angstrom" (with a lower case "a") is now accepted in FITS unit
+    strings, since it is in common usage.  However, since it is not officially
+    part of the FITS standard, a warning will be issued when it is encountered.
+    [#1911]
 
-  - Pickling unrecognized units will not raise a
-    `AttributeError`. [#2047]
+  - Pickling unrecognized units will not raise a `AttributeError`. [#2047]
 
   - `astropy.units` now correctly preserves the precision of
     fractional powers. [#2070]
@@ -616,54 +614,49 @@ Bug Fixes
 
 - ``astropy.utils``
 
-  - Bug fix for :func:`astropy.utils.timer.RunTimePredictor.do_fit`. [#1905]
+  - Fixed crash in ``timer.RunTimePredictor.do_fit``. [#1905]
 
-  - Fixed `astropy.utils.compat.argparse` for Python 3.1. [#2017]
+  - Fixed ``astropy.utils.compat.argparse`` for Python 3.1. [#2017]
 
 - ``astropy.wcs``
 
-  - `astropy.wcs.WCS`, `astropy.wcs.WCS.fix` and
-    `astropy.wcs.find_all_wcs` now have a `translate_units` keyword
-    argument that is passed down to `astropy.wcs.Wcsprm.fix`.  This
-    can be used to specify any unsafe translations of units from
-    rarely used ones to more commonly used ones.
+  - ``astropy.wcs.WCS``, ``astropy.wcs.WCS.fix`` and
+    ``astropy.wcs.find_all_wcs`` now have a ``translate_units`` keyword
+    argument that is passed down to ``astropy.wcs.Wcsprm.fix``.  This can be
+    used to specify any unsafe translations of units from rarely used ones to
+    more commonly used ones.
 
-    Although ``"S"`` is commonly used to represent seconds,
-    its translation to ``"s"`` is potentially unsafe since the
-    standard recognizes ``"S"`` formally as Siemens, however
-    rarely that may be used.  The same applies to ``"H"`` for
-    hours (Henry), and ``"D"`` for days (Debye).
+    Although ``"S"`` is commonly used to represent seconds, its translation to
+    ``"s"`` is potentially unsafe since the standard recognizes ``"S"``
+    formally as Siemens, however rarely that may be used.  The same applies to
+    ``"H"`` for hours (Henry), and ``"D"`` for days (Debye).
 
     When these sorts of changes are performed, a warning is emitted.
     [#1854]
 
-  - When a unit is "fixed" by `astropy.wcs.WCS.fix` or
-    `astropy.wcs.Wcsprm.unitfix`, it now correctly reports the
-    ``CUNIT`` field that was changed. [#1854]
+  - When a unit is "fixed" by ``astropy.wcs.WCS.fix`` or
+    ``astropy.wcs.Wcsprm.unitfix``, it now correctly reports the ``CUNIT``
+    field that was changed. [#1854]
 
-  - `astropy.wcs.Wcs.printwcs` will no longer warn that `cdelt` is
-    being ignored when none was present in the FITS file. [#1845]
+  - ``astropy.wcs.Wcs.printwcs`` will no longer warn that ``cdelt`` is being
+    ignored when none was present in the FITS file. [#1845]
 
-  - A new function, `astropy.wcs.get_include`, has been added to get
-    the location of the `astropy.wcs` C header files. [#1755]
+  - ``astropy.wcs.Wcsprm.set`` is called from within the ``astropy.wcs.WCS``
+    constructor, therefore any invalid information in the keywords will be
+    raised from the constructor, rather than on a subsequent call to a
+    transformation method. [#1918]
 
-  - `astropy.wcs.Wcsprm.set` is called from within the
-    `astropy.wcs.WCS` constructor, therefore any invalid information
-    in the keywords will be raised from the constructor, rather than
-    on a subsequent call to a transformation method. [#1918]
+  - Fix a memory corruption bug when using ``astropy.wcs.Wcs.sub`` with
+    ``astropy.wcs.WCSSUB_CELESTIAL``. [#1960]
 
-  - Fix a memory corruption bug when using `astropy.wcs.Wcs.sub` with
-    `~astropy.wcs.WCSSUB_CELESTIAL`. [#1960]
+  - Fixed the `AttributeError` exception that was raised when using
+    ``astropy.wcs.WCS.footprint_to_file``. [#1912]
 
-  - Fixed the AttributeError exception which was raised when using
-    :func:`astropy.wcs.WCS.footprint_to_file`. [#1912]
+  - Fixed a `NameError` exception that was raised when using
+    ``astropy.wcs.validate`` or the ``wcslint`` script. [#2053]
 
-  - Fixed a NameError exception which was raised when using
-    :func:`astropy.wcs.validate` or the `wcslint` script. [#2053]
-
-  - Fixed a bug where named WCSes may be erroneously reported as ``'
-    '`` when using :func:`astropy.wcs.validate` or the `wcslint`
-    script. [#2053]
+  - Fixed a bug where named WCSes may be erroneously reported as ``' '`` when
+    using ``astropy.wcs.validate`` or the ``wcslint`` script. [#2053]
 
   - Fixed a bug where error messages about incorrect header keywords
     may not be propagated correctly, resulting in a "NULL error object
@@ -671,15 +664,17 @@ Bug Fixes
 
 - Misc
 
-  - There are a number of improvements to make `astropy` work better
-    on big endian platforms, such as MIPS, PPC, s390x and
-    SPARC. [#1849]
+  - There are a number of improvements to make Astropy work better on big
+    endian platforms, such as MIPS, PPC, s390x and SPARC. [#1849]
 
-  - The test suite will now raise exceptions when a deprecated feature
-    of Python or Numpy is used.  [#1948]
+  - The test suite will now raise exceptions when a deprecated feature of
+    Python or Numpy is used.  [#1948]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- A new function, ``astropy.wcs.get_include``, has been added to get the
+  location of the ``astropy.wcs`` C header files. [#1755]
 
 - The doctests in the ``.rst`` files in the ``docs`` folder are now
   tested along with the other unit tests.  This is in addition to the
@@ -713,9 +708,11 @@ New Features
         >>> print(unicode(u.degree))
         °
 
-    See :ref:`handling-unicode` for more information. [#1441]
+    See `handling-unicode
+    <http://docs.astropy.org/en/v0.3/development/codeguide.html#unicode-guidelines>`_
+    for more information. [#1441]
 
-    - `astropy.utils.misc.find_api_page` is now imported into the top-level.
+    - ``astropy.utils.misc.find_api_page`` is now imported into the top-level.
       This allows usage like ``astropy.find_api_page(astropy.units.Quantity)``.
       [#1779]
 
@@ -723,29 +720,30 @@ New Features
 
   - New class-based system for generating kernels, replacing ``make_kernel``.
     [#1255] The ``astropy.nddata.convolution`` sub-package has now been moved
-    to `astropy.convolution`. [#1451]
+    to ``astropy.convolution``. [#1451]
 
 - ``astropy.coordinates``
 
-  - Two classes `astropy.coordinates.Longitude` and `astropy.coordinates.Latitude`
-    have been added.  These are derived from the new `Angle` class and used for
-    all longitude-like (RA, azimuth, galactic L) and latitude-like coordinates
-    (Dec, elevation, galactic B) respectively.  The `Longitude` class provides
-    auto-wrapping capability and `Latitude` performs bounds checking.
+  - Two classes ``astropy.coordinates.Longitude`` and
+    ``astropy.coordinates.Latitude`` have been added.  These are derived from
+    the new ``Angle`` class and used for all longitude-like (RA, azimuth,
+    galactic L) and latitude-like coordinates (Dec, elevation, galactic B)
+    respectively.  The ``Longitude`` class provides auto-wrapping capability
+    and ``Latitude`` performs bounds checking.
 
-  - `astropy.coordinates.Distance` supports conversion to and from distance
+  - ``astropy.coordinates.Distance`` supports conversion to and from distance
     modulii. [#1472]
 
-  - `astropy.coordinates.SphericalCoordinateBase` and derived classes now
-    support arrays of coordinates, enabling large speed-ups for some
-    operations on multiple coordinates at the same time. These coordinates
-    can also be indexed using standard slicing or any Numpy-compatible
-    indexing. [#1535, #1615]
+  - ``astropy.coordinates.SphericalCoordinateBase`` and derived classes now
+    support arrays of coordinates, enabling large speed-ups for some operations
+    on multiple coordinates at the same time. These coordinates can also be
+    indexed using standard slicing or any Numpy-compatible indexing. [#1535,
+    #1615]
 
   - Array coordinates can be matched to other array coordinates, finding the
     closest matches between the two sets of coordinates (see the
-    `~astropy.coordinates.matching.match_coordinates_3d` and
-    `~astropy.coordinates.matching.match_coordinates_sky` functions). [#1535]
+    ``astropy.coordinates.matching.match_coordinates_3d`` and
+    ``astropy.coordinates.matching.match_coordinates_sky`` functions). [#1535]
 
 - ``astropy.cosmology``
 
@@ -799,15 +797,15 @@ New Features
 - ``astropy.stats``
 
   - Added robust statistics functions
-    `~astropy.stats.funcs.median_absolute_deviation`,
-    `~astropy.stats.funcs.biweight_location`, and
-    `~astropy.stats.funcs.biweight_midvariance`. [#621]
+    ``astropy.stats.funcs.median_absolute_deviation``,
+    ``astropy.stats.funcs.biweight_location``, and
+    ``astropy.stats.funcs.biweight_midvariance``. [#621]
 
-  - Added `~astropy.stats.funcs.signal_to_noise_oir_ccd` for computing the
+  - Added ``astropy.stats.funcs.signal_to_noise_oir_ccd`` for computing the
     signal to noise ratio for source being observed in the optical/IR using a
     CCD. [#870]
 
-  - Add ``axis=int`` option to `astropy.stats.funcs.sigma_clip` to allow
+  - Add ``axis=int`` option to ``stropy.stats.funcs.sigma_clip`` to allow
     clipping along a given axis for multidimensional data. [#1083]
 
 - ``astropy.table``
@@ -921,9 +919,9 @@ New Features
     method returns ``True`` if the unit is equivalent to any of the units
     listed in the tuple. [#1521]
 
-  - `def_unit` can now take a 2-tuple of names of the form (short, long), where
-    each entry is a list.  This allows for handling strange units that might
-    have multiple short names. [#1543]
+  - ``def_unit`` can now take a 2-tuple of names of the form (short, long),
+    where each entry is a list.  This allows for handling strange units that
+    might have multiple short names. [#1543]
 
   - Added ``dimensionless_angles`` equivalency, which allows conversion of any
     power of radian to dimensionless. [#1161]
@@ -1011,62 +1009,63 @@ API Changes
 
 - ``astropy.coordinates``
 
-  - The `astropy.coordinates.Angle` class is now a subclass of
-    `astropy.units.Quantity`. This means it has all of the methods of a
+  - The ``astropy.coordinates.Angle`` class is now a subclass of
+    ``astropy.units.Quantity``. This means it has all of the methods of a
     `numpy.ndarray`. [#1006]
 
-  - The `astropy.coordinates.Distance` class is now a subclass of
-    `astropy.units.Quantity`. This means it has all of the methods of a
+  - The ``astropy.coordinates.Distance`` class is now a subclass of
+    ``astropy.units.Quantity``. This means it has all of the methods of a
     `numpy.ndarray`. [#1472]
 
-    - All angular units are now supported, not just `radian`, `degree`
-      and `hour`, but now `arcsecond` and `arcminute` as well.  The
-      object will retain its native unit, so when printing out a value
-      initially provided in hours, its `to_string()` will, by default,
-      also be expressed in hours.
+    - All angular units are now supported, not just ``radian``, ``degree`` and
+      ``hour``, but now ``arcsecond`` and ``arcminute`` as well.  The object
+      will retain its native unit, so when printing out a value initially
+      provided in hours, its ``to_string()`` will, by default, also be
+      expressed in hours.
 
-    - The `Angle` class now supports arrays of angles.
+    - The ``Angle`` class now supports arrays of angles.
 
-    - To be consistent with `units.Unit`, `Angle.format` has been deprecated
-      and renamed to `Angle.to_string`.
+    - To be consistent with ``units.Unit``, ``Angle.format`` has been
+      deprecated and renamed to ``Angle.to_string``.
 
-    - To be consistent with `astropy.units`, all plural forms of unit names
+    - To be consistent with ``astropy.units``, all plural forms of unit names
       have been removed.  Therefore, the following properties of
-      `astropy.coordinates.Angle` should be renamed:
+      ``astropy.coordinates.Angle`` should be renamed:
 
       - ``radians`` -> ``radian``
       - ``degrees`` -> ``degree``
       - ``hours`` -> ``hour``
 
-    - Multiplication and division of two `Angle` objects used to raise
+    - Multiplication and division of two ``Angle`` objects used to raise
       `NotImplementedError`.  Now they raise `TypeError`.
 
-  - The `astropy.coordinates.Angle` class no longer has a ``bounds`` attribute
-    so there is no bounds-checking or auto-wrapping at this level.  This allows
-    ``Angle`` objects to be used in arbitrary arithmetic expressions
-    (e.g. coordinate distance computation).
+  - The ``astropy.coordinates.Angle`` class no longer has a ``bounds``
+    attribute so there is no bounds-checking or auto-wrapping at this level.
+    This allows ``Angle`` objects to be used in arbitrary arithmetic
+    expressions (e.g. coordinate distance computation).
 
-  - The `astropy.coordinates.RA`and `astropy.coordinates.Dec` classes have
-    been removed and replaced with `astropy.coordinates.Longitude` and
-    `astropy.coordinates.Latitude` respectively.  These are now used for
-    the components of Galactic and Horizontal (Alt-Az) coordinates as well
-    instead of plain `Angle` objects.
+  - The ``astropy.coordinates.RA`` and ``astropy.coordinates.Dec`` classes have
+    been removed and replaced with ``astropy.coordinates.Longitude`` and
+    ``astropy.coordinates.Latitude`` respectively.  These are now used for the
+    components of Galactic and Horizontal (Alt-Az) coordinates as well instead
+    of plain ``Angle`` objects.
 
-  - `astropy.coordinates.angles.rotation_matrix` and
-    `astropy.coordinates.angles.angle_axis` now take a `unit` kwarg
-    instead of `degrees` kwarg to specify the units of the angles.
-    `rotation_matrix` will also take the unit from the given `Angle`
-    object if no unit is provided.
+  - ``astropy.coordinates.angles.rotation_matrix`` and
+    ``astropy.coordinates.angles.angle_axis`` now take a ``unit`` kwarg instead
+    of ``degrees`` kwarg to specify the units of the angles.
+    ``rotation_matrix`` will also take the unit from the given ``Angle`` object
+    if no unit is provided.
 
   - The ``AngularSeparation`` class has been removed.  The output of the
-    coordinates `separation()` method is now an `astropy.coordinates.Angle`.
-    [#1007]
+    coordinates ``separation()`` method is now an
+    ``astropy.coordinates.Angle``.  [#1007]
 
-  - The coordinate classes have been renamed in a way that remove the ``Coordinates``
-    at the end of the class names.  E.g., `ICRSCoordinates` from previous versions is
-    now called `ICRS`. [#1614]
+  - The coordinate classes have been renamed in a way that remove the
+    ``Coordinates`` at the end of the class names.  E.g., ``ICRSCoordinates``
+    from previous versions is now called ``ICRS``. [#1614]
 
-  - `HorizontalCoordinates` are now named `AltAz`, to reflect more common terminology.
+  - ``HorizontalCoordinates`` are now named ``AltAz``, to reflect more common
+    terminology.
 
 - ``astropy.cosmology``
 
@@ -1171,8 +1170,8 @@ API Changes
 
 - ``astropy.nddata``
 
-  - The `astropy.nddata.convolution` sub-package has now been moved to
-    `astropy.convolution`, and the `make_kernel` function has been removed.
+  - The ``astropy.nddata.convolution`` sub-package has now been moved to
+    ``astropy.convolution``, and the ``make_kernel`` function has been removed.
     (the kernel classes should be used instead) [#1451]
 
 - ``astropy.stats.funcs``
@@ -1530,9 +1529,8 @@ Bug Fixes
 - ``astropy.wcs``
 
   - When passing a single array to the wcs transformation functions,
-    (`astropy.wcs.Wcs.all_pix2world`, etc.), its second dimension must
-    now exactly match the number of dimensions in the
-    transformation. [#1395]
+    (``astropy.wcs.Wcs.all_pix2world``, etc.), its second dimension must now
+    exactly match the number of dimensions in the transformation. [#1395]
 
   - Improved error message when incorrect arguments are passed to
     ``WCS.wcs_world2pix``. [#1394]
@@ -1716,7 +1714,7 @@ Bug Fixes
 
   - Slightly refactored how tables containing variable-length array columns are
     handled to add two improvements: Fixes an issue where accessing the data
-    after a call to the `astropy.io.fits.getdata` convenience function caused
+    after a call to the ``astropy.io.fits.getdata`` convenience function caused
     an exception, and allows the VLA data to be read from an existing mmap of
     the FITS file.
 
@@ -1938,9 +1936,9 @@ Bug Fixes
 
   - Fixed ``TypeError`` when calling ``WCS.to_header_string()``. [#822]
 
-  - Added new method `WCS.all_world2pix` for converting from world coordinates
-    to pixel space, including inversion of the astrometric distortion
-    correction. [#1066, #1281]
+  - Added new method ``WCS.all_world2pix`` for converting from world
+    coordinates to pixel space, including inversion of the astrometric
+    distortion correction. [#1066, #1281]
 
 
 - Misc
@@ -2113,9 +2111,9 @@ see the "What's New" section of the documentation for more details.
 
   - From updating the the underlying wcslib 4.16:
 
-    - When `astropy.wcs.WCS` constructs a default coordinate
-      representation it will give it the special name "DEFAULTS", and
-      will not report "Found one coordinate representation".
+    - When ``astropy.wcs.WCS`` constructs a default coordinate representation
+      it will give it the special name "DEFAULTS", and will not report "Found
+      one coordinate representation".
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2158,17 +2156,17 @@ Other Changes and Additions
   system-installed version of CFITSIO.  This corresponds to PyFITS ticket 169.
   [#318]
 
-- Moved `astropy.config.data` to `astropy.utils.data` and re-factored the I/O
-  routines to separate out the generic I/O code that can be used to open any
-  file or resource from the code used to access Astropy-related data. The
-  'core' I/O routine is now `get_readable_fileobj`, which can be used to
-  access any local as well as remote data, supports caching, and can
-  decompress gzip and bzip2 files on-the-fly. [#425]
+- Moved ``astropy.config.data`` to ``astropy.utils.data`` and re-factored the
+  I/O routines to separate out the generic I/O code that can be used to open
+  any file or resource from the code used to access Astropy-related data. The
+  'core' I/O routine is now ``get_readable_fileobj``, which can be used to
+  access any local as well as remote data, supports caching, and can decompress
+  gzip and bzip2 files on-the-fly. [#425]
 
 - Added a classmethod to
-  `astropy.coordinates.coordsystems.SphericalCoordinatesBase` that performs a
+  ``astropy.coordinates.coordsystems.SphericalCoordinatesBase`` that performs a
   name resolve query using Sesame to retrieve coordinates for the requested
-  object. This works for any subclass of `SphericalCoordinatesBase`, but
+  object. This works for any subclass of ``SphericalCoordinatesBase``, but
   requires an internet connection. [#556]
 
 - ``astropy.nddata.convolution`` removed requirement of PyFFTW3; uses Numpy's
@@ -2283,14 +2281,14 @@ Bug Fixes
 
 - ``astropy.io.votable``
 
-  - The `Table` class now maintains a single array object which is a
+  - The ``Table`` class now maintains a single array object which is a
     Numpy masked array.  For variable-length columns, the object that
     is stored there is also a Numpy masked array.
 
   - Changed the ``pedantic`` configuration option to be ``False`` by default
     due to the vast proliferation of non-compliant VO Tables. [#296]
 
-  - Renamed `astropy.io.vo` to `astropy.io.votable`.
+  - Renamed ``astropy.io.vo`` to ``astropy.io.votable``.
 
 - ``astropy.table``
 


### PR DESCRIPTION
Removed several instances where single-backticks were used around words that do not correspond to any references in the docs.  But also converted those that _were_ references to the API docs to double-backticks, for two reasons:

 1) Use of double vs single backticks have not been used consistently
    in the changelog to begin with; for the sake of consistency
    double-backticks is by far the easier default to fall back on.

 2) This is intended to be a long-term document, and many API references
    will become invalid over its history.  Several are already invalid.
    While it is highly useful to link to _valid_ API docs from a
    long-term maintenance view it is easier not to.

Also a few small typo and wording fixes here and there.

It's a shame to give up the API references that _did_ work, and if anyone feels strongly about it I can go back at least through those that are still relevant and update them. 

In the future I'm thinking of adopting a slightly different changelog format, where instead we only use CHANGES.rst for the "current" release series, and maybe a HISTORY.rst for older releases.  That might also alleviate this issue, though I haven't given it full consideration yet.
