### PR TITLE
HDF5 I/O tests fail on Windows 7 Anaconda installation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -276,6 +276,9 @@ Bug Fixes
 
 - ``astropy.io.misc``
 
+  - Fixed issues in the HDF5 Table reader/writer functions that occurred on
+    Windows. [#2099]
+
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -130,7 +130,7 @@ def test_read_write_existing_table(tmpdir):
 
 @pytest.mark.skipif('not HAS_H5PY')
 def test_read_write_memory(tmpdir):
-    with h5py.File('test', driver='core', backing_store=False) as output_file:
+    with h5py.File('test', 'w', driver='core', backing_store=False) as output_file:
         t1 = Table()
         t1.add_column(Column(name='a', data=[1, 2, 3]))
         t1.write(output_file, path='the_table')


### PR DESCRIPTION
I will look into this in more detail later, but I'm seeing this error for all the HDF5 tests:

```
Compression filter "gzip" is unavailable
```

I think this may be an h5py bug because no compression has been requested.
