### PR TITLE
Fix CONSTRAINTS_DOC formatting in modeling docs

### DIFF
--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -20,25 +20,27 @@ Note: add new models to this list
 """
 
 CONSTRAINTS_DOC = """
-    fixed: a dict
-        a dictionary ``{parameter_name: boolean}`` of parameters to not be
+    Other Parameters
+    ----------------
+    fixed : a dict
+        A dictionary ``{parameter_name: boolean}`` of parameters to not be
         varied during fitting. True means the parameter is held fixed.
         Alternatively the `~astropy.modeling.parameters.Parameter.fixed`
         property of a parameter may be used.
-    tied: dict
-        a dictionary ``{parameter_name: callable}`` of parameters which are
+    tied : dict
+        A dictionary ``{parameter_name: callable}`` of parameters which are
         linked to some other parameter. The dictionary values are callables
         providing the linking relationship.  Alternatively the
         `~astropy.modeling.parameters.Parameter.tied` property of a parameter
         may be used.
-    bounds: dict
-        a dictionary ``{parameter_name: boolean}`` of lower and upper bounds of
+    bounds : dict
+        A dictionary ``{parameter_name: boolean}`` of lower and upper bounds of
         parameters. Keys  are parameter names. Values  are a list of length 2
         giving the desired range for the parameter.  Alternatively the
         `~astropy.modeling.parameters.Parameter.min` and
         `~astropy.modeling.parameters.Parameter.max` properties of a parameter
         may be used.
-    eqcons: list
+    eqcons : list
         A list of functions of length ``n`` such that ``eqcons[j](x0,*args) ==
         0.0`` in a successfully optimized problem.
     ineqcons : list


### PR DESCRIPTION
This is one possible fix for #2119.
(sorry, I meant to attach commits to that issue)

It looks like this:

![screen shot 2014-02-22 at 10 40 42](https://f.cloud.github.com/assets/852409/2237404/3f0658cc-9ba6-11e3-847b-29955a544592.png)
