### PR TITLE
Fix x, y order with numpy.mgrid usage

### DIFF
--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -80,7 +80,7 @@ def test_gaussian_eval_2D(mode):
     model = Gaussian2D(1, 0, 0, 20, 20)
     x = np.arange(-100, 101)
     y = np.arange(-100, 101)
-    y, x = np.meshgrid(y, x)
+    x, y = np.meshgrid(x, y)
     values = model(x, y)
     disc_values = discretize_model(model, (-100, 101), (-100, 101), mode=mode)
     assert_allclose(values, disc_values, atol=0.001)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -691,21 +691,21 @@ class LabeledInput(dict):
 
     Examples
     --------
-    >>> x,y = np.mgrid[:5, :5]
+    >>> y, x = np.mgrid[:5, :5]
     >>> l = np.arange(10)
     >>> labeled_input = LabeledInput([x, y, l], ['x', 'y', 'pixel'])
     >>> labeled_input.x
-    array([[0, 0, 0, 0, 0],
-           [1, 1, 1, 1, 1],
-           [2, 2, 2, 2, 2],
-           [3, 3, 3, 3, 3],
-           [4, 4, 4, 4, 4]])
+    array([[0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4]])
     >>> labeled_input['x']
-    array([[0, 0, 0, 0, 0],
-           [1, 1, 1, 1, 1],
-           [2, 2, 2, 2, 2],
-           [3, 3, 3, 3, 3],
-           [4, 4, 4, 4, 4]])
+    array([[0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4],
+           [0, 1, 2, 3, 4]])
     """
 
     def __init__(self, data, labels):
@@ -846,7 +846,7 @@ class SerialCompositeModel(_CompositeModel):
 
         >>> import numpy as np
         >>> from astropy.modeling import models, LabeledInput, SerialCompositeModel
-        >>> x, y = np.mgrid[:5, :5]
+        >>> y, x = np.mgrid[:5, :5]
         >>> rotation = models.MatrixRotation2D(angle=23.5)
         >>> offset_x = models.Shift(-4.23)
         >>> offset_y = models.Shift(2)

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -31,7 +31,7 @@ class TestPolynomial2D(object):
     """
     def setup_class(self):
         self.model = models.Polynomial2D(2)
-        self.x, self.y = np.mgrid[:5, :5]
+        self.y, self.x = np.mgrid[:5, :5]
 
         def poly2(x, y):
             return 1 + 2 * x + 3 * x ** 2 + 4 * y + 5 * y ** 2 + 6 * x * y
@@ -67,7 +67,7 @@ class TestICheb2D(object):
     """
     def setup_class(self):
         self.pmodel = models.Polynomial2D(2)
-        self.x, self.y = np.mgrid[:5, :5]
+        self.y, self.x = np.mgrid[:5, :5]
         self.z = self.pmodel(self.x, self.y)
         self.cheb2 = models.Chebyshev2D(2, 2)
         self.fitter = fitting.LinearLSQFitter()

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -46,7 +46,7 @@ class TestInputType(object):
         self.y = 6.7
         self.x1 = np.arange(1, 10, .1)
         self.y1 = np.arange(1, 10, .1)
-        self.x2, self.y2 = np.mgrid[:10, :8]
+        self.y2, self.x2 = np.mgrid[:10, :8]
 
     @pytest.mark.parametrize(('model', 'params'), model1d_params)
     def test_input1D(self, model, params):
@@ -70,7 +70,7 @@ class TestFitting(object):
     """
     def setup_class(self):
         self.x1 = np.arange(10)
-        self.x, self.y = np.mgrid[:10, :10]
+        self.y, self.x = np.mgrid[:10, :10]
 
     def test_linear_fitter_1set(self):
         """
@@ -229,7 +229,7 @@ class TestEvaluation(object):
     """
     def setup_class(self):
         self.x1 = np.arange(20)
-        self.x, self.y = np.mgrid[:10, :10]
+        self.y, self.x = np.mgrid[:10, :10]
 
     def test_non_linear_NYset(self):
         """
@@ -304,5 +304,5 @@ class TestEvaluation(object):
     def test_evaluate_gauss2d(self):
         cov = np.array([[1., 0.8], [0.8, 3]])
         g = models.Gaussian2D(1., 5., 4., cov_matrix=cov)
-        x, y = np.mgrid[:10, :10]
+        y, x = np.mgrid[:10, :10]
         g(x, y)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -42,7 +42,7 @@ class TestSerialComposite(object):
     Test composite models evaluation in series
     """
     def setup_class(self):
-        self.x, self.y = np.mgrid[:5, :5]
+        self.y, self.x = np.mgrid[:5, :5]
         self.p1 = models.Polynomial1D(3)
         self.p11 = models.Polynomial1D(3)
         self.p2 = models.Polynomial2D(3)
@@ -240,7 +240,7 @@ class TestParametricModels(object):
         self.y = 6.7
         self.x1 = np.arange(1, 10, .1)
         self.y1 = np.arange(1, 10, .1)
-        self.x2, self.y2 = np.mgrid[:10, :8]
+        self.y2, self.x2 = np.mgrid[:10, :8]
 
     @pytest.mark.parametrize(('model_class'), models_1D.keys())
     def test_input1D(self, model_class):

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -271,7 +271,7 @@ class TestMultipleParameterSets(object):
 
     def setup_class(self):
         self.x1 = np.arange(1, 10, .1)
-        self.x, self.y = np.mgrid[:10, :7]
+        self.y, self.x = np.mgrid[:10, :7]
         self.x11 = np.array([self.x1, self.x1]).T
         self.gmodel = models.Gaussian1D([12, 10], [3.5, 5.2], stddev=[.4, .7])
 

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -56,7 +56,7 @@ class TestFitting(object):
         self.N = 100
         self.M = 100
         self.x1 = np.linspace(1, 10, 100)
-        self.x2, self.y2 = np.mgrid[:100, :83]
+        self.y2, self.x2 = np.mgrid[:100, :83]
         rsn = np.random.RandomState(0)
         self.n1 = rsn.randn(self.x1.size) * .1
         self.n2 = rsn.randn(self.x2.size)

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -141,7 +141,7 @@ Similarly to the 1-d example, we can create a simulated 2-d data dataset, and fi
 
     # Generate fake data
     np.random.seed(0)
-    x, y = np.mgrid[:128, :128]
+    y, x = np.mgrid[:128, :128]
     z = 2. * x ** 2 - 0.5 * x ** 2 + 1.5 * x * y - 1.
     z += np.random.normal(0., 0.1, z.shape) * 50000.
 

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -159,7 +159,7 @@ The examples here assume this import statement was executed::
 
 In more complex cases the input and output may be mapped to transformations::
 
-    >>> x, y = np.mgrid[:5, :5]
+    >>> y, x = np.mgrid[:5, :5]
     >>> off = models.Shift(-3.2)
     >>> poly2 = models.Polynomial2D(2)
     >>> serial_composite_model = SerialCompositeModel(
@@ -176,16 +176,16 @@ The output is also a `~astropy.modeling.core.LabeledInput` object and the
 result is stored in label 'z'::
 
     >>> print(result)  # doctest: +SKIP
-    {'x': array([[-3.2, -3.2, -3.2, -3.2, -3.2],
-           [-2.2, -2.2, -2.2, -2.2, -2.2],
-           [-1.2, -1.2, -1.2, -1.2, -1.2],
-           [-0.2, -0.2, -0.2, -0.2, -0.2],
-           [ 0.8,  0.8,  0.8,  0.8,  0.8]]),
-     'y': array([[0, 1, 2, 3, 4],
-           [0, 1, 2, 3, 4],
-           [0, 1, 2, 3, 4],
-           [0, 1, 2, 3, 4],
-           [0, 1, 2, 3, 4]]),
+    {'x': array([[-3.2, -2.2, -1.2, -0.2,  0.8],
+           [-3.2, -2.2, -1.2, -0.2,  0.8],
+           [-3.2, -2.2, -1.2, -0.2,  0.8],
+           [-3.2, -2.2, -1.2, -0.2,  0.8],
+           [-3.2, -2.2, -1.2, -0.2,  0.8]]),
+     'y':  array([[0, 0, 0, 0, 0],
+           [1, 1, 1, 1, 1],
+           [2, 2, 2, 2, 2],
+           [3, 3, 3, 3, 3],
+           [4, 4, 4, 4, 4]]),
      'z': array([[ 0.,  0.,  0.,  0.,  0.],
            [ 0.,  0.,  0.,  0.,  0.],
            [ 0.,  0.,  0.,  0.,  0.],


### PR DESCRIPTION
As discussed in #2038 with @larrybradley and illustrated [here](http://nbviewer.ipython.org/gist/cdeil/9134816), the correct way to use [np.mgrid](http://docs.scipy.org/doc/numpy/reference/generated/numpy.mgrid.html) to create coordinate arrays `x` and `y` is `y, x = np.mgrid[0:100, 0:200]`.
For [np.meshgrid](http://docs.scipy.org/doc/numpy/reference/generated/numpy.meshgrid.html) it is `X, Y = np.meshgrid(x, y)` for the default `indexing='xy'` order.

This PR fixes a few cases in the modeling tests and docs where the wrong order was used.
