### PR TITLE
added note in install docs indicating minimum cython version required

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -130,10 +130,10 @@ The `instructions for building Numpy from source
 <http://docs.scipy.org/doc/numpy/user/install.html>`_ are also a good
 resource for setting up your environment to build Python packages.
 
-You will also need `Cython <http://cython.org/>`_ installed to build
-from source, unless you are installing a numbered release. (The releases
-packages have the necessary C files packaged with them, and hence do not
-require Cython.)
+You will also need `Cython <http://cython.org/>`_ (v0.15 or later) installed 
+to build from source, unless you are installing a numbered release. (The 
+releases packages have the necessary C files packaged with them, and hence do 
+not require Cython.)
 
 .. note:: If you are using MacOS X, you will need to the XCode command line
           tools.  One way to get them is to install `XCode


### PR DESCRIPTION
I confirmed that astropy builds using Cython v0.15 (and ran the tests).  The latest version available at this time is v0.20.1.
