### PR TITLE
Have Sphinx warnings for any public method with no docstring

### DIFF
--- a/astropy/sphinx/ext/astropyautosummary.py
+++ b/astropy/sphinx/ext/astropyautosummary.py
@@ -72,7 +72,10 @@ class AstropyAutosummary(Autosummary):
 
             # -- Grab the summary
 
-            doc = list(documenter.process_doc(documenter.get_doc()))
+            raw_doc = documenter.get_doc()
+            if len(raw_doc) == 0:
+                self.warn('[astropyautosummary] public object {0} does not have a docstring'.format(display_name))
+            doc = list(documenter.process_doc(raw_doc))
 
             while doc and not doc[0].strip():
                 doc.pop(0)


### PR DESCRIPTION
This might be controversial, given the various guidelines we already have in place, but it seems it would be reasonably easy to make Sphinx raise a warning for every undocumented 'public' function/method/class, where 'public' means that it appears in one of the API tables. Of course, if we do this then we should mention it in the contributing file as one of the requirements.
