### PR TITLE
Make coverage testing work for affiliated packages

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -390,7 +390,7 @@ class astropy_test(Command, object):
                 # requires importing astropy.config and thus screwing
                 # up coverage results for those packages.
                 coveragerc = os.path.join(
-                    os.path.dirname(__file__), 'coveragerc')
+                    testing_path, self.package_name, 'tests', 'coveragerc')
 
                 # We create a coveragerc that is specific to the version
                 # of Python we're running, so that we can mark branches


### PR DESCRIPTION
At the moment, coverage testing does not work properly for affiliated packages:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev7527-py2.7-macosx-10.8-x86_64.egg/astropy/tests/helper.py", line 292, in _save_coverage
    cov.html_report(directory=os.path.join(rootdir, 'htmlcov'))
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/coverage/control.py", line 615, in html_report
    return reporter.report(morfs)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/coverage/html.py", line 90, in report
    self.report_files(self.html_file, morfs, self.config.html_dir)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/coverage/report.py", line 84, in report_files
    report_fn(cu, self.coverage._analyze(cu))
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/coverage/control.py", line 545, in _analyze
    return Analysis(self, it)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/coverage/results.py", line 28, in __init__
    exclude=self.coverage._exclude_regex('exclude')
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/coverage/parser.py", line 35, in __init__
    "No source for code: '%s': %s" % (self.filename, err)
coverage.misc.NoSource: No source for code: '/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev7527-py2.7-macosx-10.8-x86_64.egg/astropy/extern/pytest.pyc/_pytest.helpconfig': [Errno 20] Not a directory: '/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev7527-py2.7-macosx-10.8-x86_64.egg/astropy/extern/pytest.pyc/_pytest.helpconfig'
```

I think the culprit is that `astropy_test.run` uses the `coveragerc` file bundled with Astropy:

```
                coveragerc = os.path.join(
                    os.path.dirname(__file__), 'coveragerc')
```

which contains a hard-coded reference to `astropy` as being the source directory.

We should look into a way to make this more general so as to work with affiliated packages.

cc @mdboom @wkerzendorf 
