### PR TITLE
Fix coding tag.

### DIFF
--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 


### PR DESCRIPTION
I think this works with Python, where `utf8` is an alias for `utf-8`, but it emacs doesn't like it, giving the warning:

```
Warning (mule): Invalid coding system `utf8' is specified
for the current buffer/file by the :coding tag.
It is highly recommended to fix it before writing to a file.
```

@embray
