### PR TITLE
Raise exception if coverage is used in conjunction with parallel

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -379,6 +379,10 @@ class astropy_test(Command, object):
 
         try:
             if self.coverage:
+                if self.parallel != 0:
+                    raise ValueError(
+                        "--coverage can not be used with --parallel")
+
                 try:
                     import coverage
                 except ImportError:


### PR DESCRIPTION
If coverage is used in parallel, you end up getting results from only one of the cores, which isn't terribly useful.
