### PR TITLE
Fix locations / links in astropy.modeling Sphinx API docs

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -12,7 +12,7 @@ possible the transformation is done using multiple parameter sets, `param_sets`.
 The number of parameter sets is stored in an attribute `param_dim`.
 
 Parametric models also store a flat list of all parameters as an instance of
-`~astropy.modeling.parameters.Parameters`. When fitting, this list-like object is modified by a
+`~astropy.modeling.Parameter`. When fitting, this list-like object is modified by a
 subclass of `~astropy.modeling.fitting.Fitter`. When fitting nonlinear models, the values of the
 parameters are used as initial guesses by the fitting class. Normally users
 will not have to use the `~astropy.modeling.parameters` module directly.
@@ -298,20 +298,20 @@ class ParametricModel(Model):
     fixed : dict
         Dictionary ``{parameter_name: boolean}`` of parameters to not be
         varied during fitting. True means the parameter is held fixed.
-        Alternatively the `~astropy.modeling.parameters.Parameter.fixed`
+        Alternatively the `~astropy.modeling.Parameter.fixed`
         property of a parameter may be used.
     tied : dict
         Dictionary ``{parameter_name: callable}`` of parameters which are
         linked to some other parameter. The dictionary values are callables
         providing the linking relationship.
-        Alternatively the `~astropy.modeling.parameters.Parameter.tied`
+        Alternatively the `~astropy.modeling.Parameter.tied`
         property of a parameter may be used.
     bounds : dict
         Dictionary ``{parameter_name: boolean}`` of lower and upper bounds of
         parameters. Keys are parameter names. Values are a list of length 2
         giving the desired range for the parameter.  Alternatively the
-        `~astropy.modeling.parameters.Parameter.min` and
-        `~astropy.modeling.parameters.Parameter.max` properties of a parameter
+        `~astropy.modeling.Parameter.min` and
+        `~astropy.modeling.Parameter.max` properties of a parameter
         may be used.
     eqcons : list
         List of functions of length n such that ``eqcons[j](x0, *args) == 0.0``

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -7,9 +7,9 @@ as input and define a ``__call__`` method which fits the model to the data and c
 model's parameters attribute. The idea is to make this extensible and allow
 users to easily add other fitters.
 
-Linear fitting is done using Numpy's `~numpy.linalg.lstsq` function.
-There are currently two non-linear fitters which use `~scipy.optimize.leastsq` and
-`~scipy.optimize.slsqp` functions in scipy.optimize.\
+Linear fitting is done using the `numpy.linalg.lstsq` function.
+There are currently two non-linear fitters which use `scipy.optimize.leastsq` and
+`scipy.optimize.slsqp` functions in `scipy.optimize`.
 """
 
 from __future__ import (absolute_import, unicode_literals, division,
@@ -163,7 +163,8 @@ class LinearLSQFitter(Fitter):
 
     Parameters
     ----------
-    model : an instance of `~astropy.modeling.ParametricModel`
+    model : `~astropy.modeling.ParametricModel`
+        Model
 
     Raises
     ------
@@ -488,7 +489,7 @@ class NonLinearLSQFitter(Fitter):
         fitters using function derivative are added or when the statistic is
         separated from the fitting routines.
 
-        `~scipy.optimize.leastsq` expects the function derivative to have the
+        `scipy.optimize.leastsq` expects the function derivative to have the
         above signature (parlist, (argtuple)). In order to accomodate model
         constraints, instead of using p directly, we set the parameter list in
         this function.

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -23,20 +23,20 @@ CONSTRAINTS_DOC = """
     fixed: a dict
         a dictionary ``{parameter_name: boolean}`` of parameters to not be
         varied during fitting. True means the parameter is held fixed.
-        Alternatively the `~astropy.modeling.parameters.Parameter.fixed`
+        Alternatively the `~astropy.modeling.Parameter.fixed`
         property of a parameter may be used.
     tied: dict
         a dictionary ``{parameter_name: callable}`` of parameters which are
         linked to some other parameter. The dictionary values are callables
         providing the linking relationship.  Alternatively the
-        `~astropy.modeling.parameters.Parameter.tied` property of a parameter
+        `~astropy.modeling.Parameter.tied` property of a parameter
         may be used.
     bounds: dict
         a dictionary ``{parameter_name: boolean}`` of lower and upper bounds of
         parameters. Keys  are parameter names. Values  are a list of length 2
         giving the desired range for the parameter.  Alternatively the
-        `~astropy.modeling.parameters.Parameter.min` and
-        `~astropy.modeling.parameters.Parameter.max` properties of a parameter
+        `~astropy.modeling.Parameter.min` and
+        `~astropy.modeling.Parameter.max` properties of a parameter
         may be used.
     eqcons: list
         A list of functions of length ``n`` such that ``eqcons[j](x0,*args) ==

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -6,7 +6,7 @@ Implements sky projections defined in WCS Paper II [1]_
 All angles are set and reported in deg but internally the code works and keeps
 all angles in radians. For this to work, the mechanism of setting Model's
 properties is bypassed by passing an empty parlist to
-`~astropy.modeling.core.Model.__init__`.  This also has the effect of not
+`~astropy.modeling.Model.__init__`.  This also has the effect of not
 creating Projection.parameters.  Projection.param_names is created within the
 Projection class.  For an example see the AZP classes.
 

--- a/docs/modeling/design.rst
+++ b/docs/modeling/design.rst
@@ -4,17 +4,17 @@
 Models Design Goals
 *******************
 
-The `~astropy.modeling` and `~astropy.modeling.fitting` modules described here
+The `astropy.modeling` and `astropy.modeling.fitting` modules described here
 are designed to work as peers. The goal is to be able to add models without
 explicit reference to fitting algorithms and likewise, add different fitting
 algorithms without changing the existing models.
 
 Furthermore, the models are designed to be combined in many ways. It is
 possible, for example, to combine models `serially
-<astropy.modeling.core.SerialCompositeModel>` so that the output values of one
+<astropy.modeling.SerialCompositeModel>` so that the output values of one
 model are used as input values to another.  It is also possible to form a new
 model by combining models in `parallel
-<astropy.modeling.core.SummedCompositeModel>` (each model is evaluated
+<astropy.modeling.SummedCompositeModel>` (each model is evaluated
 separately with the original input and the deltas are summed).  Since models
 may have multiple input values, machinery is provided that allows assigning
 outputs from one model into the appropriate input of another in a flexible way,

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -5,12 +5,12 @@ Fitting Models to Data
 This module provides wrappers, called Fitters, around some Numpy and Scipy
 fitting functions. All Fitters can be called as functions. They take an
 instance of `~astropy.modeling.ParametricModel` as input and modify
-`~astropy.modeling.core.ParametricModel.parameters` attribute. The idea is to
+`~astropy.modeling.ParametricModel.parameters` attribute. The idea is to
 make this extensible and allow users to easily add other fitters.
 
-Linear fitting is done using Numpy's `~numpy.linalg.lstsq` function.  There are
-currently two non-linear fitters which use `~scipy.optimize.leastsq` and
-`~scipy.optimize.fmin_slsqp`.
+Linear fitting is done using Numpy's `numpy.linalg.lstsq` function.  There are
+currently two non-linear fitters which use `scipy.optimize.leastsq` and
+`scipy.optimize.fmin_slsqp`.
 
 The rules for passing input to fitters are:
 
@@ -52,7 +52,7 @@ Fitting examples
 Fitters support constrained fitting.
 
 - All fitters support fixed (frozen) parameters through the ``fixed`` argument
-  to models or setting the `~astropy.modeling.parameters.Parameter.fixed`
+  to models or setting the `~astropy.modeling.Parameter.fixed`
   attribute directly on a parameter.
 
   For linear fitters, freezing a polynomial coefficient means that a polynomial
@@ -78,7 +78,7 @@ Fitters support constrained fitting.
              [ 2.96827886,  2.96827886]])
 
 
-- A parameter can be `~astropy.modeling.parameters.Parameter.tied` (linked to
+- A parameter can be `~astropy.modeling.Parameter.tied` (linked to
   another parameter). This can be done in two ways::
 
       >>> def tiedfunc(g1):
@@ -94,8 +94,8 @@ Fitters support constrained fitting.
       >>> gfit = fitting.NonLinearLSQFitter()
 
 Bounded fitting is supported through the ``bounds`` arguments to models or by
-setting `~astropy.modeling.parameters.Parameter.min` and
-`~astropy.modeling.parameters.Parameter.max` attributes on a parameter.  Bounds
+setting `~astropy.modeling.Parameter.min` and
+`~astropy.modeling.Parameter.max` attributes on a parameter.  Bounds
 for the `~astropy.modeling.fitting.NonLinearLSQFitter` are always exactly
 satisfied--if the value of the parameter is outside the fitting interval, it
 will be reset to the value at the bounds. The

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -7,7 +7,7 @@ Models And Fitting (`astropy.modeling`)
 Introduction
 ============
 
-`~astropy.modeling` provides a framework for representing models and
+`astropy.modeling` provides a framework for representing models and
 performing model evaluation and fitting. It supports 1D and 2D models
 and fitting with parameter constraints.
 
@@ -23,7 +23,7 @@ new model classes, nor special purpose fitting routines (but not making that
 hard to do if it is necessary).
 
 .. warning::
-    `~astropy.modeling` is currently a work-in-progress, and thus it is
+    `astropy.modeling` is currently a work-in-progress, and thus it is
     likely there will be significant API changes in later versions of
     Astropy. If you have specific ideas for how it might be improved,
     feel free to let us know on the `astropy-dev mailing list`_ or at
@@ -88,10 +88,9 @@ Simple 1D model fitting
 -----------------------
 
 In this section, we look at a simple example of fitting a Gaussian to a
-simulated dataset. We use the :class:`~astropy.modeling.functional_models.Gaussian1D`
-and :class:`~astropy.modeling.functional_models.Trapezoid1D` models and the
-:class:`~astropy.modeling.fitting.NonLinearLSQFitter` fitter to
-fit the data:
+simulated dataset. We use the `~astropy.modeling.models.Gaussian1D`
+and `~astropy.modeling.models.Trapezoid1D` models and the
+`~astropy.modeling.fitting.NonLinearLSQFitter` fitter to fit the data:
 
 .. plot::
    :include-source:
@@ -131,7 +130,8 @@ that takes the initial model (``t_init`` or ``g_init``) and the data values
 Simple 2D model fitting
 -----------------------
 
-Similarly to the 1-d example, we can create a simulated 2-d data dataset, and fit a polynomial model to it. This could be used for example to fit the background in an image.
+Similarly to the 1-d example, we can create a simulated 2-d data dataset, and fit a polynomial model to it.
+This could be used for example to fit the background in an image.
 
 .. plot::
    :include-source:

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -8,9 +8,9 @@ Parametric models can be linear or nonlinear in a regression analysis sense.
 
 Model instances are callabale, that is, o evaluate a model it is called like a
 function. When possible the transformation is done using multiple
-:attr:`param_sets <astropy.modeling.core.Model.param_sets>`.  The number of
+:attr:`param_sets <astropy.modeling.Model.param_sets>`.  The number of
 parameter sets is stored in an attribute
-`~astropy.modeling.core.Model.param_dim`.
+`~astropy.modeling.Model.param_dim`.
 
 Parametric models also store a flat array of all parameter values.  When
 fitting, this array is directly modified by a subclass of
@@ -18,7 +18,7 @@ fitting, this array is directly modified by a subclass of
 parameter values simultaneously.  When fitting nonlinear models, the values of
 the parameters are used as initial guesses by the fitting class.
 
-Models have an `~astropy.modeling.core.Model.n_inputs` attribute, which shows
+Models have an `~astropy.modeling.Model.n_inputs` attribute, which shows
 how many coordinates the model expects as an input. All models expect
 coordinates as separate arguments.  For example a 2D model expects x and y to
 be passed separately, e.g. as two arrays or two lists. When a model has
@@ -29,13 +29,13 @@ parameter sets and ``x_shape, y_shape`` is the shape of the input array.  In
 all other cases the shape of the output array is the same as the shape of the
 input arrays.
 
-Models also have an attribute `~astropy.modeling.core.Model.n_outputs`, which
+Models also have an attribute `~astropy.modeling.Model.n_outputs`, which
 shows the number of output coordinates. The
-`~astropy.modeling.core.Model.n_inputs` and
-`~astropy.modeling.core.Model.n_outputs` attributes are used to chain
+`~astropy.modeling.Model.n_inputs` and
+`~astropy.modeling.Model.n_outputs` attributes are used to chain
 transforms by adding models in :class:`series
-<astropy.modeling.core.SerialCompositeModel>` or in :class:`parallel
-<astropy.modeling.core.SummedCompositeModel>`. Because composite models can
+<astropy.modeling.SerialCompositeModel>` or in :class:`parallel
+<astropy.modeling.SummedCompositeModel>`. Because composite models can
 be nested within other composite models, creating theoretically infinitely
 complex models, a mechanism to map input data to models is needed. In this case
 the input may be wrapped in a `~astropy.modeling.LabeledInput` object-- a

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -12,7 +12,7 @@ if a linear fitting algorithm is to be used and optional if a non-linear fitter 
 Custom 1D models
 ----------------
 
-For 1D models, the `~astropy.modeling.functional_models.custom_model_1d`
+For 1D models, the `~astropy.modeling.models.custom_model_1d`
 decorator is provided to make it very easy to define new models. The following
 example demonstrates how to set up a model consisting of two Gaussians:
 
@@ -67,9 +67,9 @@ and custom getters/setters for the parameter value.
 .. note::
 
     If the method which evaluates the model cannot work with multiple parameter
-    sets, `~astropy.modeling.core.Model.param_dim` should not be given as an
+    sets, `~astropy.modeling.Model.param_dim` should not be given as an
     argument in the ``__init__`` method. The default for
-    `~astropy.modeling.core.Model.param_dim` is set in the base class to 1.
+    `~astropy.modeling.Model.param_dim` is set in the base class to 1.
 
 ::
 
@@ -81,7 +81,7 @@ and custom getters/setters for the parameter value.
         stddev = Parameter('stddev')
 
 At a minimum, the ``__init__`` method takes all parameters and the number of
-parameter sets, `~astropy.modeling.core.Model.param_dim`::
+parameter sets, `~astropy.modeling.Model.param_dim`::
 
     def __init__(self, amplitude, mean, stddev, param_dim=1, **constraints):
         # Note that this __init__ does nothing different from the base class's
@@ -99,11 +99,11 @@ parameter sets, `~astropy.modeling.core.Model.param_dim`::
     the parameters have default values.
 
 Parametric models can be linear or nonlinear in a regression sense. The default
-value of the `~astropy.modeling.core.Model.linear` attribute is ``True``.
+value of the `~astropy.modeling.Model.linear` attribute is ``True``.
 Nonlinear models should define the ``linear`` class attribute as ``False``.
-The `~astropy.modeling.core.Model.n_inputs` attribute stores the number of
+The `~astropy.modeling.Model.n_inputs` attribute stores the number of
 input variables the model expects.  The
-`~astropy.modeling.core.Model.n_outputs` attribute stores the number of output
+`~astropy.modeling.Model.n_outputs` attribute stores the number of output
 variables returned after evaluating the model.  These two attributes are used
 with composite models.
 

--- a/docs/modeling/parameters.rst
+++ b/docs/modeling/parameters.rst
@@ -6,7 +6,7 @@ Parameters are used in three different contexts within this package:
 communicating with fitters, model evaluation and getting values to/from users.
 
 Models maintain a list of parameter names,
-`~astropy.modeling.core.Model.param_names`.  Single parameters are instances of
+`~astropy.modeling.Model.param_names`.  Single parameters are instances of
 `~astropy.modeling.Parameter` which provide a proxy for the actual
 parameter values.  Simple mathematical operations can be performed with them,
 but they also contain additional attributes specific to model parameters, such
@@ -15,14 +15,14 @@ with models is through individual parameters.
 
 The goal of this package is, when possible, to allow simultaneous model
 evaluation and fitting with multiple parameter sets. Because of this, all
-models have a `~astropy.modeling.core.Model.param_sets` attribute, an array of
+models have a `~astropy.modeling.Model.param_sets` attribute, an array of
 shape ``(len(param_names), param_dim)``, where
-`~astropy.modeling.core.Model.param_dim` is the number of parameter sets.
+`~astropy.modeling.Model.param_dim` is the number of parameter sets.
 Typically the array is of type float but can become an object array in some
-cases. `~astropy.modeling.core.Model.param_sets` is used for model evaluation.
+cases. `~astropy.modeling.Model.param_sets` is used for model evaluation.
 
 In addition, fittable models maintain an attribute,
-`~astropy.modeling.core.ParametricModel.parameters`, which is a flattened 1D
+`~astropy.modeling.ParametricModel.parameters`, which is a flattened 1D
 array of parameter values. It serves as the primary storage of the raw values
 of fittable models' parameters, and is used directly by fitters as an efficient
 means of reading and updating a model's parameters.
@@ -41,7 +41,7 @@ Parameter examples
     array([ 0.,  0.,  0.,  0.,  0.])
 
 - Coefficients can be set using the
-  `~astropy.modeling.core.ParametricModel.parameters` attribute::
+  `~astropy.modeling.ParametricModel.parameters` attribute::
 
     >>> p1.parameters = [0, 1, 2, 3, 4]
     >>> p1.parameters
@@ -89,7 +89,7 @@ Parameter examples
     Parameter('c0_0', value=[-34.2  10. ])
 
 - The number of parameter sets is stored in an attribute
-  `~astropy.modeling.core.Model.param_dim`::
+  `~astropy.modeling.Model.param_dim`::
 
     >>> ch2.param_dim
     2


### PR DESCRIPTION
As mentioned in #1826, there is still a problem with locations of things in the Sphinx API docs for (at least some) sub-packages that have an extra layer in the hierarchy.
E.g.  [`astropy.modeling.functional_models.Gaussian1D`](http://docs.astropy.org/en/latest/api/astropy.modeling.functional_models.Gaussian1D.html)
should show up at `astropy.modeling.models.Gaussian1D` and I think e.g. [`astropy.io.votable.tree.VOTableFile`](http://docs.astropy.org/en/latest/api/astropy.io.votable.tree.VOTableFile.html) should show up at `astropy.io.votable.VOTableFile`.

This is a first attempt at putting everything in the appropriate place (i.e. where the user is supposed to import from) for `astropy.modeling`.

You can see the resulting html docs [here](http://www.mpi-hd.mpg.de/personalhomes/deil/public/modeling_api_sphinx/modeling/index.html#reference-api) ... it doesn't work, i.e. there are no entries under `astropy.modeling.models`.

@kbarbary @astrofrog @eteq Why is `.. automodapi:: astropy.modeling.models` not picking up the `astropy.modeling.models.__all__` entries?

```
$ python -c 'import astropy.modeling as m; print(m.models.__all__)'
[u'Pix2Sky_AZP', u'Sky2Pix_AZP', u'Pix2Sky_CAR', u'Sky2Pix_CAR', u'Pix2Sky_CEA', u'Sky2Pix_CEA', u'Pix2Sky_CYP', u'Sky2Pix_CYP', u'Pix2Sky_MER', u'Sky2Pix_MER', u'Pix2Sky_SIN', u'Sky2Pix_SIN', u'Pix2Sky_STG', u'Sky2Pix_STG', u'Pix2Sky_TAN', u'Sky2Pix_TAN', u'RotateCelestial2Native', u'RotateNative2Celestial', u'MatrixRotation2D', u'Chebyshev1D', u'Chebyshev2D', u'InverseSIP', u'Legendre1D', u'Legendre2D', u'Polynomial1D', u'Polynomial2D', u'SIP', u'OrthoPolynomialBase', u'PolynomialModel', u'AiryDisk2D', u'Beta1D', u'Beta2D', u'Box1D', u'Box2D', u'Const1D', u'Const2D', u'Disk2D', u'Gaussian1D', u'Gaussian2D', u'Linear1D', u'Lorentz1D', u'MexicanHat1D', u'MexicanHat2D', u'Ring2D', u'Scale', u'Shift', u'Sine1D', u'Trapezoid1D', u'TrapezoidDisk2D', u'custom_model_1d', u'BrokenPowerLaw1D', u'ExponentialCutoffPowerLaw1D', u'LogParabola1D', u'PowerLaw1D']
```
