### PR TITLE
Use of deprecated 'key' member in error message

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -972,7 +972,7 @@ class Card(_Verify):
 
         if m is None:
             raise VerifyError("Unparsable card (%s), fix it first with "
-                              ".verify('fix')." % self.key)
+                              ".verify('fix')." % self.keyword)
 
         if m.group('bool') is not None:
             value = m.group('bool') == 'T'


### PR DESCRIPTION
When parsing invalid card, the error itself raises an error due to use of deprecated self.key.
