### PR TITLE
Added Wien wavelength displacement law constant

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ New Features
 
 - ``astropy.constants``
 
+  - Added ``b_wien`` to represent Wien wavelength displacement law constant.
+    [#2194]
+
 - ``astropy.convolution``
 
 - ``astropy.coordinates``

--- a/astropy/constants/si.py
+++ b/astropy/constants/si.py
@@ -114,6 +114,10 @@ kpc = Constant('kpc', "Kiloparsec",
                1000. * au.uncertainty / np.tan(np.radians(1. / 3600.)),
                "Derived from au", system='si')
 
+# Wien wavelength displacement law constant
+b_wien = Constant('b_wien', 'Wien wavelength displacement law constant',
+                  2.8977721e-3, 'm K', 0.0000026e-3, 'CODATA 2010', system='si')
+
 # SOLAR QUANTITIES
 
 # Solar luminosity

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -90,6 +90,18 @@ def test_g0():
     assert g0.unit.physical_type == 'acceleration'
 
 
+def test_b_wien():
+    """b_wien should give the correct peak wavelength for
+    given blackbody temperature. The Sun is used in this test.
+
+    """
+    from .. import b_wien
+    from ... import units as u
+    t = 5778 * u.K
+    w = (b_wien / t).to(u.nm)
+    assert round(w.value) == 502
+
+
 def test_unit():
 
     from ... import units as u


### PR DESCRIPTION
As given in http://physics.nist.gov/cgi-bin/cuu/Value?bwien|search_for=wien

This constant is useful for calculating the peak wavelength of a blackbody of given temperature.
