### PR TITLE
Automate the package naming in coveragerc

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -406,7 +406,8 @@ class astropy_test(Command, object):
                 elif six.PY2:
                     ignore_python_version = '3'
                 coveragerc_content = coveragerc_content.replace(
-                    "{ignore_python_version}", ignore_python_version)
+                    "{ignore_python_version}", ignore_python_version).replace(
+                        "{packagename}", self.package_name)
                 tmp_coveragerc = os.path.join(tmp_dir, 'coveragerc')
                 with open(tmp_coveragerc, 'wb') as tmp:
                     tmp.write(coveragerc_content.encode('utf-8'))


### PR DESCRIPTION
This means that affiliated packages do not have to update their coveragerc, unless they want to customize it for any reason.

This is really just a refinement of the very recent change to enable coverage testing in affiliated packages in #2132 and astropy/package-template#39.  This is required to enable astropy/package-template#41.
