### PR TITLE
Don't fail -P if docs missing

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -144,6 +144,7 @@ class TestRunner(object):
                 warnings.warn(
                     "Can not test .rst docs, since docs path "
                     "({0}) does not exist.".format(docs_path))
+                docs_path = None
 
         if test_path:
             base, ext = os.path.splitext(test_path)


### PR DESCRIPTION
As reported in astropy/astroquery#270
