### PR TITLE
Don't generate .pyc files when running tests

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -458,7 +458,7 @@ class astropy_test(Command, object):
             # new extension modules may have appeared, and this is the
             # easiest way to set up a new environment
             try:
-                retcode = subprocess.call([sys.executable, '-c', cmd],
+                retcode = subprocess.call([sys.executable, '-B', '-c', cmd],
                                           cwd=testing_path, close_fds=False)
             finally:
                 # kill the temporary dirs


### PR DESCRIPTION
This is an experiment to try to fix the recent test failures (when parallel testing) of the form:

```
>           from ..utils.iers import IERS
E           SystemError: Parent module 'astropy' not loaded, cannot perform relative import
```
