### PR TITLE
A few miscellanous tweaks to the test runs:

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -144,6 +144,7 @@ class TestRunner(object):
                 warnings.warn(
                     "Can not test .rst docs, since docs path "
                     "({0}) does not exist.".format(docs_path))
+                docs_path = None
 
         if test_path:
             base, ext = os.path.splitext(test_path)

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -267,6 +267,9 @@ class DoctestPlus(object):
         self._doctest_textfile_item_cls = doctest_textfile_item_cls
         self._run_rst_doctests = run_rst_doctests
 
+        # Directories to ignore when adding doctests
+        self._ignore_paths = []
+
         if run_rst_doctests and six.PY3:
             self._run_rst_doctests = False
 
@@ -275,7 +278,13 @@ class DoctestPlus(object):
 
         for pattern in config.getini("doctest_norecursedirs"):
             if path.check(fnmatch=pattern):
-                return True
+                # Apparently pytest_ignore_collect causes files not to be
+                # collected by any test runner; for DoctestPlus we only want to
+                # avoid creating doctest nodes for them
+                self._ignore_paths.append(path)
+                break
+
+        return False
 
     def pytest_collect_file(self, path, parent):
         """Implements an enhanced version of the doctest module from py.test
@@ -308,6 +317,11 @@ class DoctestPlus(object):
             __doctest_requires__ = {('func1', 'func2'): ['scipy']}
 
         """
+
+        for ignore_path in self._ignore_paths:
+            if ignore_path.common(path) == ignore_path:
+                return None
+
         if path.ext == '.py':
             if path.basename == 'conf.py':
                 return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ show-response = 1
 
 [pytest]
 minversion = 2.3.3
-norecursedirs = "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat"
+norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat"
 doctest_plus = enabled
 doctest_norecursedirs = "astropy[\/]sphinx"
 


### PR DESCRIPTION
- Fix an issue where an error could occur when running setup.py test
  with the -P option but there are no Sphinx docs for the selected
  package
- It turns out running pytest_ignore_collect causes paths to be
  ignore for all of pytest, not just a single plugin.  Kind of a pain,
  that.  This tweaks how DoctestPlus uses pytest_ignore_collect to
  implement the doctest_norecursedirs option.

It should also be pointed out that prior to these fixes the tests for the `astropy.sphinx.ext` package were not being run due to the `doctest_norecursedirs` issue.  Now that they run it turns out that they're failing with Sphinx 1.2.2.  That should be looked into as a separate issue.

I came across this problem in the first place in the context of trying to transfer `astropy.sphinx.ext` to live in `astropy_helpers` per the discussion in astropy/astropy-APEs#5
