### PR TITLE
Move _model_to_fit_params out of ParametricModel

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -656,35 +656,6 @@ class ParametricModel(Model):
             setattr(self, name, value)
 
 
-    def _model_to_fit_params(self):
-        """
-        Create a set of parameters to be fitted.
-
-        These may be a subset of the model parameters, if some of them are held
-        constant or tied.
-
-        This is an adapter of the model parameters to fitters, none of which
-        currently support parameters with tied/fixed constraints.
-
-        TODO: It may make more sense to make this adaptation on the Fitter end,
-        since one could conceivably implement a fitter from scratch (for
-        Astropy specifically) that understands how to use tied constraints, for
-        example.
-        """
-
-        fitparam_indices = list(range(len(self.param_names)))
-        if any(self.fixed.values()) or any(self.tied.values()):
-            params = list(self.parameters)
-            for idx, name in list(enumerate(self.param_names))[::-1]:
-                if self.fixed[name] or self.tied[name]:
-                    sl = self._param_metrics[name][0]
-                    del params[sl]
-                    del fitparam_indices[idx]
-            return (np.array(params), fitparam_indices)
-        else:
-            return (self.parameters, fitparam_indices)
-
-
 class LabeledInput(dict):
     """
     Create a container with all input data arrays, assigning labels for

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -301,8 +301,6 @@ class Parameter(object):
             assert isinstance(value, bool), "Fixed can be True or False"
             fixed = self._model._constraints.setdefault('fixed', {})
             fixed[self._name] = value
-            self._model._fit_parameters, self._model._fit_param_indices, \
-                = self._model._model_to_fit_params()
         else:
             raise AttributeError("can't set attribute 'fixed' on Parameter "
                                  "definition")
@@ -330,8 +328,6 @@ class Parameter(object):
                     "Tied must be a callable"
             tied = self._model._constraints.setdefault('tied', {})
             tied[self._name] = value
-            self._model._fit_parameters, self._model._fit_param_indices, \
-                = self._model._model_to_fit_params()
         else:
             raise AttributeError("can't set attribute 'tied' on Parameter "
                                  "definition")
@@ -365,7 +361,6 @@ class Parameter(object):
 
             bounds = self._model._constraints.setdefault('bounds', {})
             bounds[self._name] = (_min, _max)
-            self._model._model_to_fit_params()
         else:
             raise AttributeError("can't set attribute 'bounds' on Parameter "
                                  "definition")

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -83,16 +83,6 @@ class PolynomialBase(ParametricModel):
         else:
             super(PolynomialBase, self).__setattr__(attr, value)
 
-    def _deriv_with_constraints(self, params=None, x=None, y=None):
-        if y is None:
-            d = np.array(self.fit_deriv(x=x))
-        else:
-            d = np.array(self.fit_deriv(x=x, y=y))
-
-        if self.col_fit_deriv:
-            return d[self._fit_param_indices]
-        else:
-            return d[:, self._fit_param_indices]
 
 class PolynomialModel(PolynomialBase):
     """

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -215,15 +215,11 @@ def test_set_fixed_1():
     gauss = models.Gaussian1D(amplitude=20, mean=2, stddev=1)
     gauss.mean.fixed = True
     assert gauss.fixed == {'amplitude': False, 'mean': True, 'stddev': False}
-    fitparams, _ = gauss._model_to_fit_params()
-    assert np.all(fitparams == [20, 1])
 
 
 def test_set_fixed_2():
     gauss = models.Gaussian1D(amplitude=20, mean=2, stddev=1, fixed={'mean': True})
     assert gauss.mean.fixed is True
-    fitparams, _ = gauss._model_to_fit_params()
-    assert np.all(fitparams == [20, 1])
 
 
 def test_set_tied_1():
@@ -249,8 +245,6 @@ def test_unset_fixed():
     gauss = models.Gaussian1D(amplitude=20, mean=2, stddev=1, fixed={'mean': True})
     gauss.mean.fixed = False
     assert gauss.fixed == {'amplitude': False, 'mean': False, 'stddev': False}
-    fitparams, _  = gauss._model_to_fit_params()
-    assert np.all(fitparams == [20, 2, 1])
 
 
 def test_unset_tied():
@@ -261,8 +255,6 @@ def test_unset_tied():
                               tied={'amplitude': tie_amplitude})
     gauss.amplitude.tied = False
     assert gauss.tied == {'amplitude': False, 'mean': False, 'stddev': False}
-    fitparams, _  = gauss._model_to_fit_params()
-    assert np.all(fitparams == [20, 2, 1])
 
 
 def test_set_bounds_1():

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -188,7 +188,7 @@ def test_custom_model(amplitude=4, frequency=1):
     data = sin_model(x) + np.random.rand(len(x)) - 0.5
     fitter = fitting.NonLinearLSQFitter()
     model = fitter(sin_model, x, data)
-    fitparams, _ = model._model_to_fit_params()
+    fitparams, _ = fitter._model_to_fit_params(model)
     assert np.all((fitparams - np.array([amplitude, frequency])) < 0.001)
 
 
@@ -294,7 +294,7 @@ class TestParametricModels(object):
         fitted_parameters = [val
                              for (val, fixed) in zip(parameters, fixed)
                              if not fixed]
-        fitparams, _ = new_model._model_to_fit_params()
+        fitparams, _ = fitter._model_to_fit_params(new_model)
         utils.assert_allclose(fitparams, fitted_parameters,
                               atol=self.fit_error)
 
@@ -350,7 +350,7 @@ class TestParametricModels(object):
         data = model(xv, yv) + 0.1 * parameters[0] * (np.random.rand(self.N, self.N) - 0.5)
         fitter = fitting.NonLinearLSQFitter()
         new_model = fitter(model, xv, yv, data)
-        fitparams, _ = new_model._model_to_fit_params()
+        fitparams, _ = fitter._model_to_fit_params(new_model)
         utils.assert_allclose(fitparams, parameters, atol=self.fit_error)
 
     @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
Moved `ParametricModel._model_to_fit_params` to being a static method in `Fitter`; this is the first step in separating concerns so that only Fitters are responsible for getting their inputs into the correct format they need.  This later might even move into a separate subclass of `Fitter` since this is particular for getting parameters into the form they need to be in for use with `scipy.optimize` functions.

This allowed elimitating a lot of code rot in the process.

This did require outright removing a handful of test cases, but those tests would be better handled within the fitter tests anyways--simply marking some parameters as constrained should have no bearing on a _model's_ behavior by itself.  In a later PR I will add new tests that replace these ones--that ensure that parameter constraints are handled properly by all included fitters.

This will be the first of several PRs related to further decoupling the implementation of models from how they are used by fitters.  Most of these PRs will have some dependency on each other but I will label when that is the case.  I want to still split the work up into multiple PRs so it's easier to keep track of individual changes.  Several of these changes can also be decoupled from each other if need be.
