### PR TITLE
Add support for TimeDelta dog year format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ New Features
 
   - `Time` now supports ISO format strings that end in "Z". [#2211, #2203]
 
+  - `TimeDelta` now supports a dog year format. [#????]
+
 - ``astropy.units``
 
   - Support for the unit format `Office of Guest Investigator Programs

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -30,7 +30,7 @@ __all__ = ['Time', 'TimeDelta', 'TimeFormat', 'TimeJD', 'TimeMJD',
            'TimePlotDate', 'TimeDatetime', 'TimeString',
            'TimeISO', 'TimeISOT', 'TimeYearDayTime', 'TimeEpochDate',
            'TimeBesselianEpoch', 'TimeJulianEpoch', 'TimeDeltaFormat',
-           'TimeDeltaSec', 'TimeDeltaJD', 'ScaleValueError',
+           'TimeDeltaSec', 'TimeDeltaJD', 'TimeDeltaDogYear', 'ScaleValueError',
            'OperandTypeError', 'TimeEpochDateString',
            'TimeBesselianEpochString', 'TimeJulianEpochString',
            'TIME_FORMATS', 'TIME_DELTA_FORMATS', 'TIME_SCALES',
@@ -2010,6 +2010,12 @@ class TimeDeltaJD(TimeDeltaFormat):
     """Time delta in Julian days (86400 SI seconds)"""
     name = 'jd'
     unit = 1.
+
+
+class TimeDeltaDogYear(TimeDeltaFormat):
+    """Time delta in Dog Years (7 dog years = 365.25 Julian days)"""
+    name = 'dog_year'
+    unit = 365.25 / 7
 
 
 class ScaleValueError(Exception):

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -57,6 +57,11 @@ class TestTimeDelta():
         t2 = self.t + dt
         assert t2.iso == self.t2.iso
 
+        # Dog years
+        t3 = Time('2000-01-01')
+        t4 = t3 + TimeDelta(100.0, format='dog_year')
+        assert t4.iso == '2014-04-14 20:34:14.143'
+
         # delta_time + delta_time
         dt2 = dt + self.dt
         assert allclose_sec(dt2.sec, 86501.0)

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -656,6 +656,7 @@ Format            Class
 =========  ===================================================
 sec        :class:`~astropy.time.TimeDeltaSec`
 jd         :class:`~astropy.time.TimeDeltaJD`
+dog_year   :class:`~astropy.time.TimeDeltaDogYear`
 =========  ===================================================
 
 Examples
@@ -688,6 +689,11 @@ Use of the |TimeDelta| object is easily illustrated in the few examples below::
   <Time object: scale='utc' format='iso' value=['2010-01-01 00:00:00.000'
   '2010-01-08 18:00:00.000' '2010-01-16 12:00:00.000' '2010-01-24 06:00:00.000'
   '2010-02-01 00:00:00.000']>
+
+To see when your dog born on midnight of 2000-Jan-1 turns 100 in dog years::
+
+   >>> print Time('2000-01-01') + TimeDelta(100.0, format='dog_year')
+   2014-04-14 20:34:14.143
 
 Time Scales for Time Deltas
 ---------------------------


### PR DESCRIPTION
Human time scales aren't the only important ones in the universe.  The current PR just handles dogs, but maybe this can be generalized to handle other species, both Earth-bound and alien.
