### PR TITLE
Quantity's _repr_latex_ does not work on arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -365,6 +365,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - ``Quantity._repr_latex_()`` returns ``NotImplementedError`` for quantity
+    arrays instead of an uninformative formatting exception. [#2258]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -798,14 +798,20 @@ class Quantity(np.ndarray):
 
     def _repr_latex_(self):
         """
-        Generate latex representation of unit name.  This is used by
-        the IPython notebook to show it all latexified.
+        Generate latex representation of the quantity and its unit.
+        This is used by the IPython notebook to show it all latexified.
+        It only works for scalar quantities; for arrays, the standard
+        reprensation is returned.
 
         Returns
         -------
         lstr
             LaTeX string
         """
+
+        if not self.isscalar:
+            raise NotImplementedError('Cannot represent Quantity arrays '
+                                      'in LaTex format')
 
         # Format value
         latex_value = "{0:g}".format(self.value)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -587,6 +587,15 @@ class TestQuantityDisplay(object):
         assert str(bad_quantity).endswith(_UNIT_NOT_INITIALISED)
         assert repr(bad_quantity).endswith(_UNIT_NOT_INITIALISED + '>')
 
+    def test_repr_latex(self):
+        q2 = u.Quantity(1.5e14, 'm/s')
+        assert self.scalarintq._repr_latex_() == '$1 \\; \\mathrm{m}$'
+        assert self.scalarfloatq._repr_latex_() == '$1.3 \\; \\mathrm{m}$'
+        assert (q2._repr_latex_() ==
+                '$1.5\\times 10^{+14} \\; \\mathrm{\\frac{m}{s}}$')
+        with pytest.raises(NotImplementedError):
+            self.arrq._repr_latex_()
+
 
 def test_decompose():
     q1 = 5 * u.N


### PR DESCRIPTION
Currently, one cannot get a latex representation of `Quantity` arrays:

```
import astropy.units as u
q = u.Quantity(1e14, 'm')
q._repr_latex_()
# '$1\\times 10^{+14} \\; \\mathrm{m}$'
q = u.Quantity([1e14, 1.1e14], 'm')
q._repr_latex_()
# ERROR: DeprecationWarning: object.__format__ with a non-empty format string is deprecated [astropy.units.quantity]
```

Obviously, the error message is rather uninformative here!

We should either raise a more informative message, or make arrays work (not sure the latter is either feasible or very useful).
