### PR TITLE
Add link to Simple-Cone-Search-Creator to VO docs

### DIFF
--- a/docs/vo/index.rst
+++ b/docs/vo/index.rst
@@ -20,14 +20,19 @@ Current services include:
    conesearch
    samp/index
 
-There are two third-party Python packages related to ``astropy.vo``:
+Other third-party Python packages and tools related to ``astropy.vo``:
 
-* `PyVO <http://pyvo.readthedocs.org/en/latest/>`_
+* `PyVO <http://pyvo.readthedocs.org/en/latest/>`__
   provides further functionality to discover
   and query VO services. Its user guide contains a
-  `good introduction <https://pyvo.readthedocs.org/en/latest/pyvo/vo.html>`_
+  `good introduction <https://pyvo.readthedocs.org/en/latest/pyvo/vo.html>`__
   to how the VO works.
 
-* `Astroquery <http://www.astropy.org/astroquery/>`_
+* `Astroquery <http://www.astropy.org/astroquery/>`__
   is an Astropy affiliated package that provides simply access to specific astronomical
   web services, many of which do not support the VO protocol.
+
+* `Simple-Cone-Search-Creator <https://github.com/tboch/Simple-Cone-Search-Creator/>`_
+  shows how to ingest a catalog into a cone search service and serve it in VO
+  standard format using Python
+  (using CSV files and `healpy <https://github.com/healpy/healpy/>`__).


### PR DESCRIPTION
@pllim @mdboom Do you think adding this link and one-sentence description of [Simple-Cone-Search-Creator](https://github.com/tboch/Simple-Cone-Search-Creator) by @tboch to the [astropy.vo](http://docs.astropy.org/en/latest/vo/index.html) docs is useful?
