### PR TITLE
Raise error if fits.open(memmap=True) is impossible.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -244,6 +244,8 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Setting ``memmap=True`` in ``fits.open`` and related functions now raises a ValueError if opening a file in memory-mapped mode is impossible. [#2298]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -371,7 +373,7 @@ Bug Fixes
   - Operations on quantities with incompatible types now raises a much
     more informative ``TypeError``. [#2934]
 
-  - ``Quantity.tolist`` now overrides the ``ndarray`` method to give a 
+  - ``Quantity.tolist`` now overrides the ``ndarray`` method to give a
     ``NotImplementedError`` (by renaming the previous ``list`` method). [#3050]
 
 - ``astropy.utils``

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -81,7 +81,11 @@ class _File(object):
     # See self._test_mmap
     _mmap_available = None
 
-    def __init__(self, fileobj=None, mode=None, memmap=False, clobber=False):
+    def __init__(self, fileobj=None, mode=None, memmap=None, clobber=False):
+
+        self.strict_memmap = bool(memmap)
+        memmap = True if memmap is None else memmap
+
         if fileobj is None:
             self.__file = None
             self.closed = False

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -107,7 +107,11 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False, **kwargs):
 
     if memmap is None:
         from .. import conf
-        memmap = conf.use_memmap
+        # distinguish between True (kwarg explicitly set)
+        # and None (preference for memmap in config, might be ignored)
+        memmap = None if conf.use_memmap else False
+    else:
+        memmap = bool(memmap)
 
     if 'uint16' in kwargs and 'uint' not in kwargs:
         kwargs['uint'] = kwargs['uint16']
@@ -237,7 +241,7 @@ class HDUList(list, _Verify):
         self.close()
 
     @classmethod
-    def fromfile(cls, fileobj, mode=None, memmap=False,
+    def fromfile(cls, fileobj, mode=None, memmap=None,
                  save_backup=False, **kwargs):
         """
         Creates an `HDUList` instance from a file-like object.
@@ -755,7 +759,7 @@ class HDUList(list, _Verify):
 
     @classmethod
     def _readfrom(cls, fileobj=None, data=None, mode=None,
-                  memmap=False, save_backup=False, **kwargs):
+                  memmap=None, save_backup=False, **kwargs):
         """
         Provides the implementations from HDUList.fromfile and
         HDUList.fromstring, both of which wrap this method, as their

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -592,6 +592,14 @@ class _ImageBaseHDU(_ValidHDU):
             # No further conversion of the data is necessary
             return raw_data
 
+        try:
+            if self._file.strict_memmap:
+                raise ValueError("Cannot load a memory-mapped image: "
+                                 "BZERO/BSCALE/BLANK header keywords present. "
+                                 "Set memmap=False.")
+        except AttributeError:  # strict_memmap not set
+            pass
+
         data = None
         if not (self._orig_bzero == 0 and self._orig_bscale == 1):
             data = self._convert_pseudo_unsigned(raw_data)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1059,3 +1059,8 @@ class TestStreamingFunctions(FitsTestCase):
 
         with fits.open(self.data('blank.fits'), ignore_blank=True) as f:
             assert f[0].data.flat[0] == 2
+
+    def test_error_if_memmap_impossible(self):
+        pth = self.data('blank.fits')
+        with pytest.raises(ValueError):
+            fits.open(pth, memmap=True)[0].data


### PR DESCRIPTION
Also ignore BLANK if do_not_scale_image_data=True

Fixes #2295
