### PR TITLE
Angstrom does not render correctly in latex

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -36,7 +36,8 @@ def_unit(['micron'], um, namespace=_ns,
 
 def_unit(['Angstrom', 'AA', 'angstrom'], 0.1 * nm, namespace=_ns,
          doc="ångström: 10 ** -10 m",
-         format={'latex': r'\AA', 'unicode': 'Å', 'vounit': 'angstrom'})
+         format={'latex': r'\overset{\circ}{A}', 'unicode': 'Å',
+                 'vounit': 'angstrom'})
 
 
 ###########################################################################


### PR DESCRIPTION
When I do something like this in the ipython notebook:

```
from astropy import units as u
(4000 * u.AA)
```

instead of seeing the angstrom symbol, I see `4000\AA` in the output. 

I think I understand the source of the problem: `\AA`, which generally maps to `\r{A}`, is not supported by mathjax, the latex library used by ipython (see ipython/ipython#5533 ).  What I'm not sure of is the solution... Two possible options come to mind: `$\mathring A$` sort of works, but it leaves space between the ring and the top of the "A".  An alternative is the actual unicode symbol:`\unicode{xC5}`.  That worked for me, but I'm not sure how font-dependent it is...
