### PR TITLE
Make AffineTransformation2D fittable

### DIFF
--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -16,7 +16,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import numpy as np
 
-from .core import (Model, format_input)
+from .core import Model, FittableModel, format_input
 from .parameters import Parameter, InputParameterError
 
 from ..utils.compat import ignored
@@ -481,7 +481,7 @@ class Sky2Pix_MER(Cylindrical):
         return x, y
 
 
-class AffineTransformation2D(Model):
+class AffineTransformation2D(FittableModel):
     """
     Perform an affine transformation in 2 dimensions.
 


### PR DESCRIPTION
#2269 (yet to be merged) introduced a new `AffineTransformation2D` model.  It was suggested in that PR that it would be good to make instances of this class fittable.  Unfortunately this would _currently_ require making it a type of `ParametricModel`, which is currently broken for models that require multi-dimensional parameter values (such as the transformation matrix used by `AffineTransformation2D`).

Implementing this requires some combination of #2149 and/or #2276 to be merged first. So I decided to create a separate issue for this so that it isn't forgotten.
