### PR TITLE
sanitize_scale: Don't do expensive complex number handling if we don't have to.

### DIFF
--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -137,11 +137,10 @@ def sanitize_scale(scale):
     if is_effectively_unity(scale):
         return 1.0
 
-    # to prevent div-by-zero errors below
-    if scale == 0:
-        return 0
+    if np.iscomplex(scale):  # scale is complex
+        if scale == 0.0:
+            return 0.0
 
-    if hasattr(scale, 'imag'):  # scale is complex
         if abs(scale.real) > abs(scale.imag):
             if is_effectively_unity(scale.imag/scale.real + 1):
                 scale = scale.real


### PR DESCRIPTION
This was found in #2315: It seems that the expensive complex number calculation is done even if the scale is not a complex number.

@mhvk: Is there a reason the original was written as it was?  `np.iscomplex` actually checks whether the value has a non-zero imaginary part, which seems to be more appropriate.
