### PR TITLE
fits.PrimaryHDU doesn't properly initialize from scaled data

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -319,6 +319,8 @@ class _ImageBaseHDU(_ValidHDU):
             except KeyError:
                 pass
 
+        self._update_uint_scale_keywords()
+
         self._modified = False
 
     def _update_header_scale_info(self, dtype=None):


### PR DESCRIPTION
Creating a new `PrimaryHDU` from an HDU containing scaled data results in a new HDU with the data scaled but `BITPIX` dropped from the header.

To reproduce:

``` python
>>> scaled = np.uint16(np.random.random_integers(0, 65535, size=[100, 100]))
>>> scaled_hdu = fits.PrimaryHDU(scaled)
>>> scaled[0, 0] == scaled_hdu.data[0, 0]
True
>>> 'bzero' not in scaled_hdu.header
True
>>> # so far, so good. now scale...
>>> scaled_hdu.scale('int16', bzero=32768)
>>> scaled_hdu.header['bzero'] # still good
32768
>>> scaled[0, 0] == scaled_hdu.data[0, 0] + 32768
True
>>> new_scaled_hdu = fits.PrimaryHDU(scaled_hdu.data, header=scaled_hdu.header)
>>> # expect that this new HDU will know how to scale the data
>>> original_data == new_scaled_hdu.data[0, 0]
False
>>> original_data - new_scaled_hdu.data[0, 0]
32768
>>> # Try again, without scaling image data to see what happens to BZERO
>>> new_scaled_hdu = fits.PrimaryHDU(scaled_hdu.data, header=scaled_hdu.header, do_not_scale_image_data=True)
>>> 'bzero' in new_scaled_hdu.header
False
>>> # BZERO in scaled_hdu.header was dropped, apparently
>>> new_scaled_hdu.header
SIMPLE  =                    T / conforms to FITS standard
BITPIX  =                   16 / array data type
NAXIS   =                    2 / number of array dimensions
NAXIS1  =                  100
NAXIS2  =                  100
```
