### PR TITLE
Fix get_graphviz_version()

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -36,7 +36,7 @@ def get_graphviz_version():
         return '0'
     tokens = output.split()
     for token in tokens:
-        if re.match(b'[0-9.]*', token):
+        if re.match(b'[0-9.]+', token):
             return token.decode('ascii')
     return '0'
 


### PR DESCRIPTION
Fix `get_graphviz_version()`'s regexp searching for a version number.  Because this used `'*'`, any string matched the expression.  On my version of graphviz, `dot -V` returned `'dot - graphviz version 2.30.1 (20130214.1330)'`, so `get_graphviz_version()` returned `'dot'` as the version.
