### PR TITLE
EarthLocation touchup's, mostly in documentation

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -15,6 +15,7 @@ except ImportError:
 
 __all__ = ['EarthLocation']
 
+# translation between ellipsoid names and corresponding number used in ERFA
 ELLIPSOIDS = {'WGS84': 1, 'GRS80': 2, 'WGS72': 3}
 
 
@@ -40,6 +41,11 @@ class EarthLocation(u.Quantity):
     class methods (`from_geocentric` and `from_geodetic`) or initialize the
     arguments with names (``x``, ``y``, ``z`` for geocentric; ``lon``, ``lat``,
     ``height`` for geodetic).  See the class methods for details.
+
+    Notes
+    -----
+    For conversion to and from geodetic coordinates, the ERFA routines
+    ``gc2gd`` and ``gd2gc`` are used.  See https://github.com/liberfa/erfa
     """
 
     _ellipsoid = 'WGS84'
@@ -61,7 +67,7 @@ class EarthLocation(u.Quantity):
         return self
 
     @classmethod
-    def from_geocentric(cls, x, y=None, z=None, unit=None):
+    def from_geocentric(cls, x, y, z, unit=None):
         """
         Location on Earth, initialized from geocentric coordinates.
 
@@ -136,6 +142,11 @@ class EarthLocation(u.Quantity):
         ValueError
             If ``lon``, ``lat``, and ``height`` do not have the same shape, or
             if ``ellipsoid`` is not recognized as among the ones implemented.
+
+        Notes
+        -----
+        For the conversion to geocentric coordinates, the ERFA routine
+        ``gd2gc`` is used.  See https://github.com/liberfa/erfa
         """
         ellipsoid = _check_ellipsoid(ellipsoid, default=cls._ellipsoid)
         lon = Longitude(lon, u.degree, wrap_angle=180*u.degree, copy=False)
@@ -189,6 +200,11 @@ class EarthLocation(u.Quantity):
         ------
         ValueError
             if ``ellipsoid`` is not recognized as among the ones implemented.
+
+        Notes
+        -----
+        For the conversion to geodetic coordinates, the ERFA routine
+        ``gc2gd`` is used.  See https://github.com/liberfa/erfa
         """
         ellipsoid = _check_ellipsoid(ellipsoid, default=self.ellipsoid)
         self_array = self.to(u.meter).view(self._array_dtype, np.ndarray)

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -102,6 +102,17 @@ class TestInput():
         self.location = EarthLocation.from_geodetic(self.lon, self.lat, self.h)
         self.x, self.y, self.z = self.location.to_geocentric()
 
+    def test_default_ellipsoid(self):
+        assert self.location.ellipsoid == EarthLocation._ellipsoid
+
+    def test_geo_attributes(self):
+        assert all([np.all(_1 == _2)
+                    for _1, _2 in zip(self.location.geodetic,
+                                      self.location.to_geodetic())])
+        assert all([np.all(_1 == _2)
+                    for _1, _2 in zip(self.location.geocentric,
+                                      self.location.to_geocentric())])
+
     def test_attribute_classes(self):
         """Test that attribute classes are correct (and not EarthLocation)"""
         assert type(self.location.x) is u.Quantity
@@ -192,8 +203,12 @@ class TestInput():
         assert not loc_slice1.shape
         with pytest.raises(IndexError):
             loc_slice1[0]
+        with pytest.raises(IndexError):
+            len(loc_slice1)
+
         loc_slice2 = locwgs72[4:6]
         assert isinstance(loc_slice2, EarthLocation)
+        assert len(loc_slice2) == 2
         assert loc_slice2.unit is locwgs72.unit
         assert loc_slice2.ellipsoid == locwgs72.ellipsoid
         assert loc_slice2.shape == (2,)


### PR DESCRIPTION
Mostly dots at the ends of sentences in the documentation, but also removed `__eq__`, `__ne__` (not needed anymore given #2328), and made `ellipsoid` a private properly, ensuring that it gets passed on when slices are made.

This is still pending discussion whether the arguments to the `from_geodetic` class method should have the long names; see #1928.
