### PR TITLE
Remove platform.architecture() in FITS _array_to_file to improve speed on Mac

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -410,6 +410,9 @@ Bug Fixes
 
   - Allow pickling of ``FITS_rec`` objects. [#1597]
 
+  - Improved behavior when writing large compressed images on OSX by removing
+    an unncessary check for platform architecture. [#2345]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -8,7 +8,6 @@ import itertools
 import io
 import mmap
 import os
-import platform
 import signal
 import string
 import sys
@@ -597,8 +596,8 @@ def _array_to_file(arr, outfile):
     # implemented there yet: https://github.com/astropy/astropy/issues/839
     osx_write_limit = (2 ** 32) - 1
 
-    if (sys.platform == 'darwin' and platform.architecture()[0] == '64bit' and
-            arr.nbytes >= osx_write_limit + 1 and arr.nbytes % 4096 == 0):
+    if (sys.platform == 'darwin' and arr.nbytes >= osx_write_limit + 1 and
+            arr.nbytes % 4096 == 0):
         idx = 0
         # chunksize is a count of elements in the array, not bytes
         chunksize = osx_write_limit // arr.itemsize


### PR DESCRIPTION
In #2317 I noticed that `TestImageFunctions::test_lossless_gzip_compression` in `astropy/io/fits/tests/test_image.py` is very slow on Mac (~12 seconds).

The problem is https://github.com/astropy/astropy/blob/master/astropy/io/fits/util.py#L600 where you introduced a call to `platform.architecture()` in #839.

This is called 2002 times by `TestImageFunctions::test_lossless_gzip_compression` and [platform.architecture()](https://docs.python.org/2/library/platform.html#platform.architecture) takes 5.3 milli-seconds on my Mac.

@embray I'm not sure what the best fix is here ... probably cache the platform somewhere?
