### PR TITLE
Fix allocation of temporary buffer in `Wcsprm.set`.  

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -461,6 +461,10 @@ Bug Fixes
 
 - ``astropy.wcs``
 
+  - Fixed a bug where calling ``astropy.wcs.Wcsprm.sub`` with
+    ``WCSSUB_CELESTIAL`` may cause memory corruption due to
+    underallocation of a temporary buffer. [#2350]
+
 - Misc
 
   - Fixes for compatibility with Python 3.4. [#1945]

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1677,7 +1677,7 @@ PyWcsprm_sub(
     }
     nsub = (int)tmp;
 
-    axes = malloc(nsub * sizeof(int));
+    axes = malloc(nsub * sizeof(int) * 2);
     if (axes == NULL) {
       PyErr_SetString(PyExc_MemoryError, "Out of memory");
       goto exit;


### PR DESCRIPTION
The number of axes returned may be up to twice as many as requested.  Rather than being smart about it, just allocate the buffer to be twice as large -- these are very small buffers in any case (one int per dimension).
