### PR TITLE
Prevent VOTable validator from crashing when xmllint encounters SIGKILL

### DIFF
--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -180,9 +180,16 @@ class Result:
         if 'xmllint' not in self:
             # Now check the VO schema based on the version in
             # the file.
-            success, stdout, stderr = xmlutil.validate_schema(path, version)
-            self['xmllint'] = (success == 0)
-            self['xmllint_content'] = stderr
+            try:
+                success, stdout, stderr = xmlutil.validate_schema(path, version)
+            # OSError is raised when XML file eats all memory and
+            # system sends kill signal.
+            except OSError as e:
+                self['xmllint'] = None
+                self['xmllint_content'] = str(e)
+            else:
+                self['xmllint'] = (success == 0)
+                self['xmllint_content'] = stderr
 
         warning_types = set()
         for line in lines:


### PR DESCRIPTION
This happened when 'vo.xml' was too large (400+ MB), causing memory problem and resulted in system sending kill signal to the process. 

The offending URL was a Cone Search query http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&tab=photoobjall&SR=1&DEC=0&RA=0&VERB=3

```
>>> from astropy.io.votable.validator.result import Result
>>> r = Result(url)
>>> r.validate_vo()
```

This fix was suggested by @mdboom and would just set `xmllint` result as `None` instead of crashing. However, it does not fix the memory issue, it just catches the resultant error.

```
>>> r._attributes
{u'network_error': None, ...,
 u'xmllint': None,
 u'xmllint_content': "xmllint was terminated by signal 'SIGKILL'"}
```

There are no change log entry nor test for `Result` because it is not documented and not meant to be an end-user facing API.
