### PR TITLE
Mark failing vo remote test as xfail

### DIFF
--- a/astropy/vo/client/tests/test_vo.py
+++ b/astropy/vo/client/tests/test_vo.py
@@ -48,6 +48,7 @@ SCS_RADIUS = SCS_SR * u.degree
 
 
 @remote_data
+@pytest.mark.xfail(reason='Non-existent remote data file')
 def test_basic_db():
     """Read dummy ``basic.json`` database to test underlying database
     functionality.


### PR DESCRIPTION
Solution for the failing `vo` test in #2290 . This will no longer be relevant when #2115 is merged. 
