### PR TITLE
Reading FITS file with boolean column gives incorrect result

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -427,6 +427,9 @@ Bug Fixes
   - Improved behavior when writing large compressed images on OSX by removing
     an unncessary check for platform architecture. [#2345]
 
+  - Fixed an issue where Astropy ``Table`` objects containing boolean columns
+    were not correctly written out to FITS files. [#1953]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``


### PR DESCRIPTION
As reported by R. Finn on the astropy mailing list, there seems to be a problem reading a boolean column in a FITS file created with astropy.  Using astropy 0.3 on linux-64:

```
>>> from astropy.table import Table
>>> from astropy.io import fits
>>> t = Table([np.ones(5, dtype=bool)])
>>> t.write('test.fits', overwrite=True)
>>> 
>>> hdus = fits.open('test.fits')
>>> dat = hdus[1].data
>>> 
>>> print t
col0
----
True
True
True
True
True
>>> print dat
[(False) (False) (False) (False) (False)]
```

Using CIAO `dmlist` the file appears to be correct:

```
XTENSION     = BINTABLE             / binary table extension
BITPIX       = 8                    / array data type     
NAXIS        = 2                    / number of array dimensions
NAXIS1       = 1                    / length of dimension 1
NAXIS2       = 5                    / length of dimension 2
PCOUNT       = 0                    / number of group parameters
GCOUNT       = 1                    / number of groups    
TFIELDS      = 1                    / number of table fields
TTYPE1       = col0                 /                     
TFORM1       = L                    /    

--------------------------------------------------------------------------------
Data for Table Block HDU2
--------------------------------------------------------------------------------

ROW    col0

     1  TRUE 
     2  TRUE 
     3  TRUE 
     4  TRUE 
     5  TRUE                  
```
