### PR TITLE
WCS.sub fails on adding a new axis

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -493,6 +493,8 @@ PyWcsprm_copy(
     return NULL;
   }
 
+  wcsini(0, self->x.naxis, &copy->x);
+
   wcsprm_python2c(&self->x);
   status = wcscopy(1, &self->x, &copy->x);
   wcsprm_c2python(&self->x);
@@ -1656,7 +1658,6 @@ PyWcsprm_sub(
   char*      element_str    = NULL;
   int        element_val    = 0;
   int        nsub           = 0;
-  int        alloc_size     = 0;
   int*       axes           = NULL;
   int        status         = -1;
   const char*    keywords[] = {"axes", NULL};
@@ -1768,11 +1769,9 @@ PyWcsprm_sub(
     goto exit;
   }
 
-  alloc_size = self->x.naxis;
-
   py_dest_wcs = (PyWcsprm*)PyWcsprm_cnew();
   py_dest_wcs->x.flag = -1;
-  status = wcsini(0, alloc_size, &py_dest_wcs->x);
+  status = wcsini(0, nsub, &py_dest_wcs->x);
   if (status != 0) {
     goto exit;
   }

--- a/cextern/wcslib/C/wcs.c
+++ b/cextern/wcslib/C/wcs.c
@@ -564,7 +564,7 @@ int wcssub(
       "naxis must be positive (got %d)", naxis);
   }
 
-  if (!(map = calloc(naxis, sizeof(int)))) {
+  if (!(map = calloc(wcsdst->naxis, sizeof(int)))) {
     return wcserr_set(WCS_ERRMSG(WCSERR_MEMORY));
   }
 


### PR DESCRIPTION
In trying to extend the WCS utilities to create new axis (or merge two independent WCS), I came across this error:

```
In [1]: w = wcs.WCS()

In [2]: w.naxis
Out[2]: 2

In [3]: w.sub([1,2,0])
python(266,0x7fff7eb43310) malloc: *** error for object 0x10773ac18: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
Out[3]: Abort trap: 6
```

According to the WCS docs, "Use an axis number of 0 to create a new axis using the defaults."  (see http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/wcs_8h.html#a864c99fef9f3eee29085ce42d0ee0d64 or http://astropy.readthedocs.org/en/latest/api/astropy.wcs.Wcsprm.html#astropy.wcs.Wcsprm.sub)

Note that this is an intermittent error; I got it 2 out of 3 attempts.

I suspect this is an issue with wcslib rather than `astropy.wcs`, since the same occurs using the c-wrapped routine:

```
In [2]: w.wcs.sub([1,2,0])
```

but I'm not sure - it could have to do with the memory allocation used by the python wrapper.

@mdboom - can you advise?
