### PR TITLE
some cleanup in io/ascii/tests

### DIFF
--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -1,24 +1,24 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ....tests.helper import pytest
-from ... import ascii as asciitable
+from ... import ascii
 from .common import (assert_equal, assert_almost_equal, has_isnan,
                      setup_function, teardown_function)
 
 
 def read_table1(readme, data):
-    reader = asciitable.Cds(readme)
+    reader = ascii.Cds(readme)
     return reader.read(data)
 
 
 def read_table2(readme, data):
-    reader = asciitable.get_reader(Reader=asciitable.Cds, readme=readme)
-    reader.outputter = asciitable.TableOutputter()
+    reader = ascii.get_reader(Reader=ascii.Cds, readme=readme)
+    reader.outputter = ascii.TableOutputter()
     return reader.read(data)
 
 
 def read_table3(readme, data):
-    return asciitable.read(data, readme=readme)
+    return ascii.read(data, readme=readme)
 
 
 def test_multi_header():
@@ -48,7 +48,7 @@ def test_glob_header():
 
 
 def test_header_from_readme():
-    r = asciitable.Cds("t/vizier/ReadMe")
+    r = ascii.Cds("t/vizier/ReadMe")
     table = r.read("t/vizier/table1.dat")
     assert len(r.data.data_lines) == 15
     assert len(table) == 15

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from ... import ascii as asciitable
+from ... import ascii
 from .common import (assert_equal, assert_almost_equal,
                      setup_function, teardown_function)
 
@@ -24,7 +24,7 @@ def test_read_normal():
 |  1.2   | "hello" |
 |  2.4   |'s worlds|
 """
-    reader = asciitable.get_reader(Reader=asciitable.FixedWidth)
+    reader = ascii.get_reader(Reader=ascii.FixedWidth)
     dat = reader.read(table)
     assert_equal(dat.colnames, ['Col1', 'Col2'])
     assert_almost_equal(dat[1][0], 2.4)
@@ -40,7 +40,7 @@ def test_read_normal_names():
 |  1.2   | "hello" |
 |  2.4   |'s worlds|
 """
-    reader = asciitable.get_reader(Reader=asciitable.FixedWidth,
+    reader = ascii.get_reader(Reader=ascii.FixedWidth,
                                    names=('name1', 'name2'))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['name1', 'name2'])
@@ -55,7 +55,7 @@ def test_read_normal_names_include():
 |  1.2   | "hello" |     3 |
 |  2.4   |'s worlds|     7 |
 """
-    reader = asciitable.get_reader(Reader=asciitable.FixedWidth,
+    reader = ascii.get_reader(Reader=ascii.FixedWidth,
                                    names=('name1', 'name2', 'name3'),
                                    include_names=('name1', 'name3'))
     dat = reader.read(table)
@@ -72,7 +72,7 @@ def test_read_normal_exclude():
 |  1.2   | "hello" |
 |  2.4   |'s worlds|
 """
-    reader = asciitable.get_reader(Reader=asciitable.FixedWidth,
+    reader = ascii.get_reader(Reader=ascii.FixedWidth,
                                    exclude_names=('Col1',))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['Col2'])
@@ -86,7 +86,7 @@ def test_read_weird():
   1.2       "hello"
   2.4   sdf's worlds
 """
-    reader = asciitable.get_reader(Reader=asciitable.FixedWidth)
+    reader = ascii.get_reader(Reader=ascii.FixedWidth)
     dat = reader.read(table)
     assert_equal(dat.colnames, ['Col1', 'Col2'])
     assert_almost_equal(dat[1][0], 2.4)
@@ -102,7 +102,7 @@ def test_read_double():
 |  Mary  | 555-2134 |192.168.1.12X|
 |   Bob  | 555-4527 | 192.168.1.9X|
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidth, guess=False)
+    dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False)
     assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[0][1], "555-1234")
@@ -117,7 +117,7 @@ def test_read_space_delimiter():
  Mary  555-2134    192.168.1.12
   Bob  555-4527     192.168.1.9
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidth, guess=False,
+    dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False,
                           delimiter=' ')
     assert_equal(tuple(dat.dtype.names), ('Name', '--Phone-', '----TCP-----'))
     assert_equal(dat[1][0], "Mary")
@@ -132,7 +132,7 @@ def test_read_no_header_autocolumn():
 |  Mary  | 555-2134 |192.168.1.12|
 |   Bob  | 555-4527 | 192.168.1.9|
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidth, guess=False,
+    dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False,
                           header_start=None, data_start=0)
     assert_equal(tuple(dat.dtype.names), ('col1', 'col2', 'col3'))
     assert_equal(dat[1][0], "Mary")
@@ -148,7 +148,7 @@ def test_read_no_header_names():
 |  Mary  | 555-2134 |192.168.1.12|
 |   Bob  | 555-4527 | 192.168.1.9|
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidth, guess=False,
+    dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False,
                           header_start=None, data_start=0,
                           names=('Name', 'Phone', 'TCP'))
     assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
@@ -164,7 +164,7 @@ def test_read_no_header_autocolumn_NoHeader():
 |  Mary  | 555-2134 |192.168.1.12|
 |   Bob  | 555-4527 | 192.168.1.9|
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthNoHeader)
+    dat = ascii.read(table, Reader=ascii.FixedWidthNoHeader)
     assert_equal(tuple(dat.dtype.names), ('col1', 'col2', 'col3'))
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[0][1], "555-1234")
@@ -179,7 +179,7 @@ def test_read_no_header_names_NoHeader():
 |  Mary  | 555-2134 |192.168.1.12|
 |   Bob  | 555-4527 | 192.168.1.9|
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthNoHeader,
+    dat = ascii.read(table, Reader=ascii.FixedWidthNoHeader,
                           names=('Name', 'Phone', 'TCP'))
     assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
     assert_equal(dat[1][0], "Mary")
@@ -196,7 +196,7 @@ def test_read_col_starts():
   Mary   555- 2134 192.168.1.12
    Bob   555- 4527  192.168.1.9
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthNoHeader,
+    dat = ascii.read(table, Reader=ascii.FixedWidthNoHeader,
                           names=('Name', 'Phone', 'TCP'),
                           col_starts=(0, 9, 18),
                           col_ends=(5, 17, 28),
@@ -213,13 +213,13 @@ table = """\
 | 1.2  | "hello"   |  1        |  a        |
 | 2.4  | 's worlds |         2 |         2 |
 """
-dat = asciitable.read(table, Reader=asciitable.FixedWidth)
+dat = ascii.read(table, Reader=ascii.FixedWidth)
 
 
 def test_write_normal():
     """Write a table as a normal fixed width table."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidth)
+    ascii.write(dat, out, Writer=ascii.FixedWidth)
     assert_equal_splitlines(out.getvalue(), """\
 | Col1 |      Col2 | Col3 | Col4 |
 |  1.2 |   "hello" |    1 |    a |
@@ -230,7 +230,7 @@ def test_write_normal():
 def test_write_fill_values():
     """Write a table as a normal fixed width table."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidth,
+    ascii.write(dat, out, Writer=ascii.FixedWidth,
                      fill_values=('a', 'N/A'))
     assert_equal_splitlines(out.getvalue(), """\
 | Col1 |      Col2 | Col3 | Col4 |
@@ -242,7 +242,7 @@ def test_write_fill_values():
 def test_write_no_pad():
     """Write a table as a fixed width table with no padding."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidth,
+    ascii.write(dat, out, Writer=ascii.FixedWidth,
                      delimiter_pad=None)
     assert_equal_splitlines(out.getvalue(), """\
 |Col1|     Col2|Col3|Col4|
@@ -254,7 +254,7 @@ def test_write_no_pad():
 def test_write_no_bookend():
     """Write a table as a fixed width table with no bookend."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidth, bookend=False)
+    ascii.write(dat, out, Writer=ascii.FixedWidth, bookend=False)
     assert_equal_splitlines(out.getvalue(), """\
 Col1 |      Col2 | Col3 | Col4
  1.2 |   "hello" |    1 |    a
@@ -265,7 +265,7 @@ Col1 |      Col2 | Col3 | Col4
 def test_write_no_delimiter():
     """Write a table as a fixed width table with no delimiter."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidth, bookend=False,
+    ascii.write(dat, out, Writer=ascii.FixedWidth, bookend=False,
                      delimiter=None)
     assert_equal_splitlines(out.getvalue(), """\
 Col1       Col2  Col3  Col4
@@ -277,7 +277,7 @@ Col1       Col2  Col3  Col4
 def test_write_noheader_normal():
     """Write a table as a normal fixed width table."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthNoHeader)
+    ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader)
     assert_equal_splitlines(out.getvalue(), """\
 | 1.2 |   "hello" | 1 | a |
 | 2.4 | 's worlds | 2 | 2 |
@@ -287,7 +287,7 @@ def test_write_noheader_normal():
 def test_write_noheader_no_pad():
     """Write a table as a fixed width table with no padding."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthNoHeader,
+    ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader,
                      delimiter_pad=None)
     assert_equal_splitlines(out.getvalue(), """\
 |1.2|  "hello"|1|a|
@@ -298,7 +298,7 @@ def test_write_noheader_no_pad():
 def test_write_noheader_no_bookend():
     """Write a table as a fixed width table with no bookend."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthNoHeader,
+    ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader,
                      bookend=False)
     assert_equal_splitlines(out.getvalue(), """\
 1.2 |   "hello" | 1 | a
@@ -309,7 +309,7 @@ def test_write_noheader_no_bookend():
 def test_write_noheader_no_delimiter():
     """Write a table as a fixed width table with no delimiter."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthNoHeader, bookend=False,
+    ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader, bookend=False,
                      delimiter=None)
     assert_equal_splitlines(out.getvalue(), """\
 1.2    "hello"  1  a
@@ -320,7 +320,7 @@ def test_write_noheader_no_delimiter():
 def test_write_formats():
     """Write a table as a fixed width table with no delimiter."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidth,
+    ascii.write(dat, out, Writer=ascii.FixedWidth,
                      formats={'Col1': '%-8.3f', 'Col2': '%-15s'})
     assert_equal_splitlines(out.getvalue(), """\
 |     Col1 |            Col2 | Col3 | Col4 |
@@ -338,7 +338,7 @@ def test_read_twoline_normal():
    1.2xx"hello"
   2.4   's worlds
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthTwoLine)
+    dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine)
     assert_equal(dat.dtype.names, ('Col1', 'Col2'))
     assert_almost_equal(dat[1][0], 2.4)
     assert_equal(dat[0][1], '"hello"')
@@ -355,7 +355,7 @@ def test_read_twoline_ReST():
   2.4   's worlds
 ======= ===========
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthTwoLine,
+    dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine,
                           header_start=1, position_line=2, data_end=-1)
     assert_equal(dat.dtype.names, ('Col1', 'Col2'))
     assert_almost_equal(dat[1][0], 2.4)
@@ -374,7 +374,7 @@ def test_read_twoline_human():
 |  2.4 | 's worlds|
 +------+----------+
 """
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthTwoLine,
+    dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine,
                           delimiter='+',
                           header_start=1, position_line=0,
                           data_start=3, data_end=-1)
@@ -387,7 +387,7 @@ def test_read_twoline_human():
 def test_write_twoline_normal():
     """Write a table as a normal fixed width table."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthTwoLine)
+    ascii.write(dat, out, Writer=ascii.FixedWidthTwoLine)
     assert_equal_splitlines(out.getvalue(), """\
 Col1      Col2 Col3 Col4
 ---- --------- ---- ----
@@ -399,7 +399,7 @@ Col1      Col2 Col3 Col4
 def test_write_twoline_no_pad():
     """Write a table as a fixed width table with no padding."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthTwoLine,
+    ascii.write(dat, out, Writer=ascii.FixedWidthTwoLine,
                      delimiter_pad=' ', position_char='=')
     assert_equal_splitlines(out.getvalue(), """\
 Col1        Col2   Col3   Col4
@@ -412,7 +412,7 @@ Col1        Col2   Col3   Col4
 def test_write_twoline_no_bookend():
     """Write a table as a fixed width table with no bookend."""
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.FixedWidthTwoLine,
+    ascii.write(dat, out, Writer=ascii.FixedWidthTwoLine,
                      bookend=True, delimiter='|')
     assert_equal_splitlines(out.getvalue(), """\
 |Col1|     Col2|Col3|Col4|

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from ....utils import OrderedDict
 from ....tests.helper import pytest
-from ... import ascii as asciitable  # TODO: delete this line, use ascii.*
 from ... import ascii
 from ....table import Table
 from distutils import version
@@ -107,7 +106,7 @@ def test_read_all_files():
             test_opts = testfile['opts'].copy()
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
-            table = asciitable.read(testfile['name'], **test_opts)
+            table = ascii.read(testfile['name'], **test_opts)
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
                 assert_equal(len(table[colname]), testfile['nrows'])
@@ -146,7 +145,7 @@ def test_guess_all_files():
             # Copy read options except for those in filter_read_opts
             guess_opts = dict((k, v) for k, v in testfile['opts'].items()
                               if k not in filter_read_opts)
-            table = asciitable.read(testfile['name'], guess=True, **guess_opts)
+            table = ascii.read(testfile['name'], guess=True, **guess_opts)
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
                 assert_equal(len(table[colname]), testfile['nrows'])
@@ -154,7 +153,7 @@ def test_guess_all_files():
 
 def test_daophot_indef():
     """Test that INDEF is correctly interpreted as a missing value"""
-    table = asciitable.read('t/daophot2.dat', Reader=asciitable.Daophot)
+    table = ascii.read('t/daophot2.dat', Reader=ascii.Daophot)
     for colname in table.colnames:
         # Three columns have all INDEF values and are masked
         mask_value = colname in ('OTIME', 'MAG', 'MERR', 'XAIRMASS')
@@ -167,7 +166,7 @@ def test_daophot_types():
     inferred automatically based only data values.  DAOphot reader uses
     the header information to assign types.
     """
-    table = asciitable.read('t/daophot2.dat', Reader=asciitable.Daophot)
+    table = ascii.read('t/daophot2.dat', Reader=ascii.Daophot)
     assert table['LID'].dtype.char in 'fd'  # float or double
     assert table['MAG'].dtype.char in 'fd'  # even without any data values
     assert table['PIER'].dtype.char in 'US'  # string (data values are consistent with int)
@@ -175,7 +174,7 @@ def test_daophot_types():
 
 
 def test_daophot_header_keywords():
-    table = asciitable.read('t/daophot.dat', Reader=asciitable.Daophot)
+    table = ascii.read('t/daophot.dat', Reader=ascii.Daophot)
     expected_keywords = (('NSTARFILE', 'test.nst.1', 'filename', '%-23s'),
                          ('REJFILE', '"hello world"', 'filename', '%-23s'),
                          ('SCALE', '1.',  'units/pix', '%-23.7g'),)
@@ -188,61 +187,61 @@ def test_daophot_header_keywords():
         assert_equal(keyword['format'], format_)
 
 
-@raises(asciitable.InconsistentTableError)
+@raises(ascii.InconsistentTableError)
 def test_empty_table_no_header():
-    table = asciitable.read('t/no_data_without_header.dat', Reader=asciitable.NoHeader,
+    table = ascii.read('t/no_data_without_header.dat', Reader=ascii.NoHeader,
                             guess=False)
 
 
-@raises(asciitable.InconsistentTableError)
+@raises(ascii.InconsistentTableError)
 def test_wrong_quote():
-    table = asciitable.read('t/simple.txt', guess=False)
+    table = ascii.read('t/simple.txt', guess=False)
 
 
-@raises(asciitable.InconsistentTableError)
+@raises(ascii.InconsistentTableError)
 def test_extra_data_col():
-    table = asciitable.read('t/bad.txt')
+    table = ascii.read('t/bad.txt')
 
 
-@raises(asciitable.InconsistentTableError)
+@raises(ascii.InconsistentTableError)
 def test_extra_data_col2():
-    table = asciitable.read('t/simple5.txt', delimiter='|')
+    table = ascii.read('t/simple5.txt', delimiter='|')
 
 
 @raises(IOError)
 def test_missing_file():
-    table = asciitable.read('does_not_exist')
+    table = ascii.read('does_not_exist')
 
 
 def test_set_names():
     names = ('c1', 'c2', 'c3', 'c4', 'c5', 'c6')
-    data = asciitable.read('t/simple3.txt', names=names, delimiter='|')
+    data = ascii.read('t/simple3.txt', names=names, delimiter='|')
     assert_equal(data.dtype.names, names)
 
 
 def test_set_include_names():
     names = ('c1', 'c2', 'c3', 'c4', 'c5', 'c6')
     include_names = ('c1', 'c3')
-    data = asciitable.read('t/simple3.txt', names=names, include_names=include_names,
+    data = ascii.read('t/simple3.txt', names=names, include_names=include_names,
                            delimiter='|')
     assert_equal(data.dtype.names, include_names)
 
 
 def test_set_exclude_names():
     exclude_names = ('Y', 'object')
-    data = asciitable.read('t/simple3.txt', exclude_names=exclude_names, delimiter='|')
+    data = ascii.read('t/simple3.txt', exclude_names=exclude_names, delimiter='|')
     assert_equal(data.dtype.names, ('obsid', 'redshift', 'X', 'rad'))
 
 
 def test_include_names_daophot():
     include_names = ('ID', 'MAG', 'PIER')
-    data = asciitable.read('t/daophot.dat', include_names=include_names)
+    data = ascii.read('t/daophot.dat', include_names=include_names)
     assert_equal(data.dtype.names, include_names)
 
 
 def test_exclude_names_daophot():
     exclude_names = ('ID', 'YCENTER', 'MERR', 'NITER', 'CHI', 'PERROR')
-    data = asciitable.read('t/daophot.dat', exclude_names=exclude_names)
+    data = ascii.read('t/daophot.dat', exclude_names=exclude_names)
     assert_equal(data.dtype.names, ('XCENTER', 'MAG', 'MSKY', 'SHARPNESS', 'PIER'))
 
 
@@ -251,7 +250,7 @@ def test_custom_process_lines():
         bars_at_ends = re.compile(r'^\| | \|$', re.VERBOSE)
         striplines = (x.strip() for x in lines)
         return [bars_at_ends.sub('', x) for x in striplines if len(x) > 0]
-    reader = asciitable.get_reader(delimiter='|')
+    reader = ascii.get_reader(delimiter='|')
     reader.inputter.process_lines = process_lines
     data = reader.read('t/bars_at_ends.txt')
     assert_equal(data.dtype.names, ('obsid', 'redshift', 'X', 'Y', 'object', 'rad'))
@@ -262,7 +261,7 @@ def test_custom_process_line():
     def process_line(line):
         line_out = re.sub(r'^\|\s*', '', line.strip())
         return line_out
-    reader = asciitable.get_reader(data_start=2, delimiter='|')
+    reader = ascii.get_reader(data_start=2, delimiter='|')
     reader.header.splitter.process_line = process_line
     reader.data.splitter.process_line = process_line
     data = reader.read('t/nls1_stackinfo.dbout')
@@ -271,9 +270,9 @@ def test_custom_process_line():
 
 
 def test_custom_splitters():
-    reader = asciitable.get_reader()
-    reader.header.splitter = asciitable.BaseSplitter()
-    reader.data.splitter = asciitable.BaseSplitter()
+    reader = ascii.get_reader()
+    reader.header.splitter = ascii.BaseSplitter()
+    reader.data.splitter = ascii.BaseSplitter()
     f = 't/test4.dat'
     data = reader.read(f)
     testfile = get_testfiles(f)
@@ -287,18 +286,18 @@ def test_custom_splitters():
 
 
 def test_start_end():
-    data = asciitable.read('t/test5.dat', header_start=1, data_start=3, data_end=-5)
+    data = ascii.read('t/test5.dat', header_start=1, data_start=3, data_end=-5)
     assert_equal(len(data), 13)
     assert_equal(data.field('statname')[0], 'chi2xspecvar')
     assert_equal(data.field('statname')[-1], 'chi2gehrels')
 
 
 def test_set_converters():
-    converters = {'zabs1.nh': [asciitable.convert_numpy('int32'),
-                               asciitable.convert_numpy('float32')],
-                  'p1.gamma': [asciitable.convert_numpy('str')]
+    converters = {'zabs1.nh': [ascii.convert_numpy('int32'),
+                               ascii.convert_numpy('float32')],
+                  'p1.gamma': [ascii.convert_numpy('str')]
                   }
-    data = asciitable.read('t/test4.dat', converters=converters)
+    data = ascii.read('t/test4.dat', converters=converters)
     assert_equal(str(data['zabs1.nh'].dtype), 'float32')
     assert_equal(data['p1.gamma'][0], '1.26764544642')
 
@@ -308,7 +307,7 @@ def test_from_string():
     with open(f) as fd:
         table = fd.read()
     testfile = get_testfiles(f)
-    data = asciitable.read(table, **testfile['opts'])
+    data = ascii.read(table, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
@@ -317,7 +316,7 @@ def test_from_filelike():
     f = 't/simple.txt'
     testfile = get_testfiles(f)
     with open(f, 'rb') as fd:
-        data = asciitable.read(fd, **testfile['opts'])
+        data = ascii.read(fd, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
@@ -327,13 +326,13 @@ def test_from_lines():
     with open(f) as fd:
         table = fd.readlines()
     testfile = get_testfiles(f)
-    data = asciitable.read(table, **testfile['opts'])
+    data = ascii.read(table, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])
     assert_equal(len(data), testfile['nrows'])
 
 
 def test_comment_lines():
-    table = asciitable.get_reader(Reader=asciitable.Rdb)
+    table = ascii.get_reader(Reader=ascii.Rdb)
     data = table.read('t/apostrophe.rdb')
     assert_equal(table.comment_lines, ['# first comment', '  # second comment'])
 
@@ -341,7 +340,7 @@ def test_comment_lines():
 def test_fill_values():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=('a', '1'), **testfile['opts'])
+    data = ascii.read(f, fill_values=('a', '1'), **testfile['opts'])
     assert_true((data['a'].mask == [False, True]).all())
     assert_true((data['a'] == [1, 1]).all())
     assert_true((data['b'].mask == [False, True]).all())
@@ -351,14 +350,14 @@ def test_fill_values():
 def test_fill_values_col():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=('a', '1', 'b'), **testfile['opts'])
+    data = ascii.read(f, fill_values=('a', '1', 'b'), **testfile['opts'])
     check_fill_values(data)
 
 
 def test_fill_values_include_names():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=('a', '1'),
+    data = ascii.read(f, fill_values=('a', '1'),
                            fill_include_names = ['b'], **testfile['opts'])
     check_fill_values(data)
 
@@ -366,7 +365,7 @@ def test_fill_values_include_names():
 def test_fill_values_exclude_names():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=('a', '1'),
+    data = ascii.read(f, fill_values=('a', '1'),
                            fill_exclude_names = ['a'], **testfile['opts'])
     check_fill_values(data)
 
@@ -385,7 +384,7 @@ def check_fill_values(data):
 def test_fill_values_list():
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, fill_values=[('a', '42'), ('1', '42', 'a')],
+    data = ascii.read(f, fill_values=[('a', '42'), ('1', '42', 'a')],
                            **testfile['opts'])
     data['a'].mask = False  # explicitly unmask for comparison
     assert_true((data['a'] == [42, 42]).all())
@@ -394,7 +393,7 @@ def test_fill_values_list():
 def test_masking_Cds():
     f = 't/cds.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f,
+    data = ascii.read(f,
                            **testfile['opts'])
     assert_true(data['AK'].mask[0])
     assert_true(not data['Fit'].mask[0])
@@ -403,7 +402,7 @@ def test_masking_Cds():
 def test_null_Ipac():
     f = 't/ipac.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, **testfile['opts'])
+    data = ascii.read(f, **testfile['opts'])
     mask = np.array([(True, False, True, False, True),
                      (False, False, False, False, False)],
                     dtype=[(str('ra'), '|b1'),
@@ -422,7 +421,7 @@ def test_Ipac_meta():
     comments = ['This is an example of a valid comment']
     f = 't/ipac.dat'
     testfile = get_testfiles(f)
-    data = asciitable.read(f, **testfile['opts'])
+    data = ascii.read(f, **testfile['opts'])
     assert data.meta['keywords'].keys() == keywords.keys()
     for data_kv, kv in zip(data.meta['keywords'].values(), keywords.values()):
         assert data_kv['value'] == kv
@@ -431,19 +430,19 @@ def test_Ipac_meta():
 
 def test_set_guess_kwarg():
     """Read a file using guess with one of the typical guess_kwargs explicitly set."""
-    data = asciitable.read('t/space_delim_no_header.dat',
+    data = ascii.read('t/space_delim_no_header.dat',
                            delimiter=',', guess=True)
     assert(data.dtype.names == ('1 3.4 hello',))
     assert(len(data) == 1)
 
 
-@raises(asciitable.InconsistentTableError)
+@raises(ascii.InconsistentTableError)
 def test_read_rdb_wrong_type():
     """Read RDB data with inconstent data type (except failure)"""
     table = """col1\tcol2
 N\tN
 1\tHello"""
-    asciitable.read(table, Reader=asciitable.Rdb)
+    ascii.read(table, Reader=ascii.Rdb)
 
 
 def test_default_missing():
@@ -451,7 +450,7 @@ def test_default_missing():
     table = '\n'.join(['a,b,c,d',
                        '1,3,,',
                        '2, , 4.0 , ss '])
-    dat = asciitable.read(table)
+    dat = ascii.read(table)
     assert dat.masked is True
     assert dat.pformat() == [' a   b   c   d ',
                              '--- --- --- ---',
@@ -460,7 +459,7 @@ def test_default_missing():
 
     # Single row table with a single missing element
     table = """ a \n "" """
-    dat = asciitable.read(table)
+    dat = ascii.read(table)
     assert dat.pformat() == [' a ',
                              '---',
                              ' --']
@@ -471,14 +470,14 @@ def test_default_missing():
                        '--- --- --- ---',
                        '  1   3        ',
                        '  2     4.0  ss'])
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthTwoLine)
+    dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine)
     assert dat.masked is True
     assert dat.pformat() == [' a   b   c   d ',
                              '--- --- --- ---',
                              '  1   3  --  --',
                              '  2  -- 4.0  ss']
 
-    dat = asciitable.read(table, Reader=asciitable.FixedWidthTwoLine, fill_values=None)
+    dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine, fill_values=None)
     assert dat.masked is False
     assert dat.pformat() == [' a   b   c   d ',
                              '--- --- --- ---',
@@ -494,11 +493,11 @@ def get_testfiles(name=None):
         {'cols': ('agasc_id', 'n_noids', 'n_obs'),
          'name': 't/apostrophe.rdb',
          'nrows': 2,
-         'opts': {'Reader': asciitable.Rdb}},
+         'opts': {'Reader': ascii.Rdb}},
         {'cols': ('agasc_id', 'n_noids', 'n_obs'),
          'name': 't/apostrophe.tab',
          'nrows': 2,
-         'opts': {'Reader': asciitable.Tab}},
+         'opts': {'Reader': ascii.Tab}},
         {'cols': ('Index',
                   'RAh',
                   'RAm',
@@ -513,7 +512,7 @@ def get_testfiles(name=None):
                   'Fit'),
          'name': 't/cds.dat',
          'nrows': 1,
-         'opts': {'Reader': asciitable.Cds}},
+         'opts': {'Reader': ascii.Cds}},
         # Test malformed CDS file (issues #2241 #467)
         {'cols': ('Index',
                   'RAh',
@@ -529,20 +528,20 @@ def get_testfiles(name=None):
                   'Fit'),
          'name': 't/cds_malformed.dat',
          'nrows': 1,
-         'opts': {'Reader': asciitable.Cds, 'data_start': 'guess'}},
+         'opts': {'Reader': ascii.Cds, 'data_start': 'guess'}},
         {'cols': ('a', 'b', 'c'),
          'name': 't/commented_header.dat',
          'nrows': 2,
-         'opts': {'Reader': asciitable.CommentedHeader}},
+         'opts': {'Reader': ascii.CommentedHeader}},
         {'cols': ('a', 'b', 'c'),
          'name': 't/commented_header2.dat',
          'nrows': 2,
-         'opts': {'Reader': asciitable.CommentedHeader, 'header_start': -1, 'data_start': 0}},
+         'opts': {'Reader': ascii.CommentedHeader, 'header_start': -1, 'data_start': 0}},
         {'cols': ('col1', 'col2', 'col3', 'col4', 'col5'),
          'name': 't/continuation.dat',
          'nrows': 2,
-         'opts': {'Inputter': asciitable.ContinuationLinesInputter,
-                  'Reader': asciitable.NoHeader}},
+         'opts': {'Inputter': ascii.ContinuationLinesInputter,
+                  'Reader': ascii.NoHeader}},
         {'cols': ('ID',
                   'XCENTER',
                   'YCENTER',
@@ -556,8 +555,7 @@ def get_testfiles(name=None):
                   'PERROR'),
          'name': 't/daophot.dat',
          'nrows': 2,
-         'requires_numpy': True,
-         'opts': {'Reader': asciitable.Daophot}},
+         'opts': {'Reader': ascii.Daophot}},
         {'cols': ('NUMBER',
                   'FLUX_ISO',
                   'FLUXERR_ISO',
@@ -566,12 +564,11 @@ def get_testfiles(name=None):
                   'FLAG'),
          'name': 't/sextractor.dat',
          'nrows': 3,
-         'requires_numpy': True,
-         'opts': {'Reader': asciitable.SExtractor}},
+         'opts': {'Reader': ascii.SExtractor}},
         {'cols': ('ra', 'dec', 'sai', 'v2', 'sptype'),
          'name': 't/ipac.dat',
          'nrows': 2,
-         'opts': {'Reader': asciitable.Ipac}},
+         'opts': {'Reader': ascii.Ipac}},
         {'cols': ('col0',
                   'objID',
                   'osrcid',
@@ -608,7 +605,7 @@ def get_testfiles(name=None):
                   'Fit'),
          'name': 't/no_data_cds.dat',
          'nrows': 0,
-         'opts': {'Reader': asciitable.Cds}},
+         'opts': {'Reader': ascii.Cds}},
         {'cols': ('ID',
                   'XCENTER',
                   'YCENTER',
@@ -622,8 +619,7 @@ def get_testfiles(name=None):
                   'PERROR'),
          'name': 't/no_data_daophot.dat',
          'nrows': 0,
-         'requires_numpy': True,
-         'opts': {'Reader': asciitable.Daophot}},
+         'opts': {'Reader': ascii.Daophot}},
         {'cols': ('NUMBER',
                   'FLUX_ISO',
                   'FLUXERR_ISO',
@@ -632,16 +628,15 @@ def get_testfiles(name=None):
                   'FLAG'),
          'name': 't/no_data_sextractor.dat',
          'nrows': 0,
-         'requires_numpy': True,
-         'opts': {'Reader': asciitable.SExtractor}},
+         'opts': {'Reader': ascii.SExtractor}},
         {'cols': ('ra', 'dec', 'sai', 'v2', 'sptype'),
          'name': 't/no_data_ipac.dat',
          'nrows': 0,
-         'opts': {'Reader': asciitable.Ipac}},
+         'opts': {'Reader': ascii.Ipac}},
         {'cols': ('ra', 'v2'),
          'name': 't/ipac.dat',
          'nrows': 2,
-         'opts': {'Reader': asciitable.Ipac, 'include_names': ['ra', 'v2']}},
+         'opts': {'Reader': ascii.Ipac, 'include_names': ['ra', 'v2']}},
         {'cols': ('a', 'b', 'c'),
          'name': 't/no_data_with_header.dat',
          'nrows': 0,
@@ -649,11 +644,11 @@ def get_testfiles(name=None):
         {'cols': ('agasc_id', 'n_noids', 'n_obs'),
          'name': 't/short.rdb',
          'nrows': 7,
-         'opts': {'Reader': asciitable.Rdb}},
+         'opts': {'Reader': ascii.Rdb}},
         {'cols': ('agasc_id', 'n_noids', 'n_obs'),
          'name': 't/short.tab',
          'nrows': 7,
-         'opts': {'Reader': asciitable.Tab}},
+         'opts': {'Reader': ascii.Tab}},
         {'cols': ('test 1a', 'test2', 'test3', 'test4'),
          'name': 't/simple.txt',
          'nrows': 2,
@@ -681,15 +676,15 @@ def get_testfiles(name=None):
         {'cols': ('col1', 'col2', 'col3', 'col4', 'col5', 'col6'),
          'name': 't/simple4.txt',
          'nrows': 3,
-         'opts': {'Reader': asciitable.NoHeader, 'delimiter': '|'}},
+         'opts': {'Reader': ascii.NoHeader, 'delimiter': '|'}},
         {'cols': ('col1', 'col2', 'col3'),
          'name': 't/space_delim_no_header.dat',
          'nrows': 2,
-         'opts': {'Reader': asciitable.NoHeader}},
+         'opts': {'Reader': ascii.NoHeader}},
         {'cols': ('col1', 'col2', 'col3'),
          'name': 't/space_delim_no_header.dat',
          'nrows': 2,
-         'opts': {'Reader': asciitable.NoHeader, 'header_start': None}},
+         'opts': {'Reader': ascii.NoHeader, 'header_start': None}},
         {'cols': ('obsid', 'offset', 'x', 'y', 'name', 'oaa'),
          'name': 't/space_delim_blank_lines.txt',
          'nrows': 3,
@@ -709,15 +704,15 @@ def get_testfiles(name=None):
         {'name': 't/simple_csv.csv',
          'cols': ('a','b','c'),
          'nrows': 2,
-         'opts': {'Reader': asciitable.Csv}},
+         'opts': {'Reader': ascii.Csv}},
         {'cols': ('cola', 'colb', 'colc'),
          'name': 't/latex1.tex',
          'nrows': 2,
-         'opts': {'Reader': asciitable.Latex}},
+         'opts': {'Reader': ascii.Latex}},
         {'cols': ('Facility', 'Id', 'exposure', 'date'),
          'name': 't/latex2.tex',
          'nrows': 3,
-         'opts': {'Reader': asciitable.AASTex}},
+         'opts': {'Reader': ascii.AASTex}},
     ]
 
     try:
@@ -725,7 +720,7 @@ def get_testfiles(name=None):
         testfiles.append({'cols': ('Column 1', 'Column 2', 'Column 3'),
                           'name': 't/html.html',
                           'nrows': 3,
-                          'opts': {'Reader': asciitable.HTML}})
+                          'opts': {'Reader': ascii.HTML}})
     except ImportError:
         pass
 

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -10,17 +10,17 @@ except ImportError:
 import numpy as np
 
 from ....tests.helper import pytest
-from ... import ascii as asciitable
+from ... import ascii
 
 from .common import assert_equal, setup_function, teardown_function
 
 
 def test_types_from_dat():
-    converters = {'a': [asciitable.convert_numpy(np.float)],
-                  'e': [asciitable.convert_numpy(np.str)]}
+    converters = {'a': [ascii.convert_numpy(np.float)],
+                  'e': [ascii.convert_numpy(np.str)]}
 
-    dat = asciitable.read(['a b c d e', '1 1 cat 2.1 4.2'],
-                          Reader=asciitable.Basic,
+    dat = ascii.read(['a b c d e', '1 1 cat 2.1 4.2'],
+                          Reader=ascii.Basic,
                           converters=converters)
 
     assert dat['a'].dtype.kind == 'f'
@@ -31,10 +31,10 @@ def test_types_from_dat():
 
 
 def test_rdb_write_types():
-    dat = asciitable.read(['a b c d', '1 1.0 cat 2.1'],
-                          Reader=asciitable.Basic)
+    dat = ascii.read(['a b c d', '1 1.0 cat 2.1'],
+                          Reader=ascii.Basic)
     out = StringIO()
-    asciitable.write(dat, out, Writer=asciitable.Rdb)
+    ascii.write(dat, out, Writer=ascii.Rdb)
     outs = out.getvalue().splitlines()
     assert_equal(outs[1], 'N\tN\tS\tN')
 
@@ -47,12 +47,12 @@ def test_ipac_read_types():
 |    null  |   null   |   null  |    null  |     -999         |
    2.09708   2956        73765    2.06000   B8IVpMnHg
 """
-    reader = asciitable.get_reader(Reader=asciitable.Ipac)
+    reader = ascii.get_reader(Reader=ascii.Ipac)
     dat = reader.read(table)
-    types = [asciitable.FloatType,
-             asciitable.FloatType,
-             asciitable.IntType,
-             asciitable.FloatType,
-             asciitable.StrType]
+    types = [ascii.FloatType,
+             ascii.FloatType,
+             ascii.IntType,
+             ascii.FloatType,
+             ascii.StrType]
     for (col, expected_type) in zip(reader.cols, types):
         assert_equal(col.type, expected_type)

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from ... import ascii as asciitable
+from ... import ascii
 
 from .common import setup_function, teardown_function
 
@@ -38,7 +38,7 @@ XCENTER YCENTER
 "        18.1" 280.2
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.Rdb, exclude_names=['CHI']),
+    dict(kwargs=dict(Writer=ascii.Rdb, exclude_names=['CHI']),
          out="""\
 ID	XCENTER	YCENTER	MAG	MERR	MSKY	NITER	SHARPNESS	PIER	PERROR
 N	N	N	N	N	N	N	N	N	S
@@ -46,41 +46,41 @@ N	N	N	N	N	N	N	N	N	S
 18	18.114	280.170	22.329	0.206	30.12784	4	-2.544	0	No_error
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.Tab),
+    dict(kwargs=dict(Writer=ascii.Tab),
          out="""\
 ID	XCENTER	YCENTER	MAG	MERR	MSKY	NITER	SHARPNESS	CHI	PIER	PERROR
 14	138.538	256.405	15.461	0.003	34.85955	4	-0.032	0.802	0	No_error
 18	18.114	280.170	22.329	0.206	30.12784	4	-2.544	1.104	0	No_error
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.Csv),
+    dict(kwargs=dict(Writer=ascii.Csv),
          out="""\
 ID,XCENTER,YCENTER,MAG,MERR,MSKY,NITER,SHARPNESS,CHI,PIER,PERROR
 14,138.538,256.405,15.461,0.003,34.85955,4,-0.032,0.802,0,No_error
 18,18.114,280.170,22.329,0.206,30.12784,4,-2.544,1.104,0,No_error
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.NoHeader),
+    dict(kwargs=dict(Writer=ascii.NoHeader),
          out="""\
 14 138.538 256.405 15.461 0.003 34.85955 4 -0.032 0.802 0 No_error
 18 18.114 280.170 22.329 0.206 30.12784 4 -2.544 1.104 0 No_error
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.CommentedHeader),
+    dict(kwargs=dict(Writer=ascii.CommentedHeader),
          out="""\
 # ID XCENTER YCENTER MAG MERR MSKY NITER SHARPNESS CHI PIER PERROR
 14 138.538 256.405 15.461 0.003 34.85955 4 -0.032 0.802 0 No_error
 18 18.114 280.170 22.329 0.206 30.12784 4 -2.544 1.104 0 No_error
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.CommentedHeader, comment='&'),
+    dict(kwargs=dict(Writer=ascii.CommentedHeader, comment='&'),
          out="""\
 &ID XCENTER YCENTER MAG MERR MSKY NITER SHARPNESS CHI PIER PERROR
 14 138.538 256.405 15.461 0.003 34.85955 4 -0.032 0.802 0 No_error
 18 18.114 280.170 22.329 0.206 30.12784 4 -2.544 1.104 0 No_error
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.Latex),
+    dict(kwargs=dict(Writer=ascii.Latex),
          out="""\
 \\begin{table}
 \\begin{tabular}{ccccccccccc}
@@ -91,7 +91,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 \\end{table}
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.AASTex),
+    dict(kwargs=dict(Writer=ascii.AASTex),
          out="""\
 \\begin{deluxetable}{ccccccccccc}
 \\tablehead{\\colhead{ID} & \\colhead{XCENTER} & \\colhead{YCENTER} & \\colhead{MAG} & \\colhead{MERR} & \\colhead{MSKY} & \\colhead{NITER} & \\colhead{SHARPNESS} & \\colhead{CHI} & \\colhead{PIER} & \\colhead{PERROR}}
@@ -103,7 +103,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 """
          ),
     dict(
-        kwargs=dict(Writer=asciitable.AASTex, caption='Mag values \\label{tab1}', latexdict={
+        kwargs=dict(Writer=ascii.AASTex, caption='Mag values \\label{tab1}', latexdict={
                     'units': {'MAG': '[mag]', 'XCENTER': '[pixel]'}, 'tabletype': 'deluxetable*',
                     'tablealign':'htpb'}),
         out="""\
@@ -118,7 +118,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 """
     ),
     dict(
-        kwargs=dict(Writer=asciitable.Latex, caption='Mag values \\label{tab1}', latexdict={'preamble': '\\begin{center}', 'tablefoot': '\\end{center}', 'data_end': [
+        kwargs=dict(Writer=ascii.Latex, caption='Mag values \\label{tab1}', latexdict={'preamble': '\\begin{center}', 'tablefoot': '\\end{center}', 'data_end': [
                     '\\hline', '\\hline'], 'units':{'MAG': '[mag]', 'XCENTER': '[pixel]'},
                     'tabletype': 'table*',
                     'tablealign': 'h'},
@@ -139,7 +139,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 \\end{table*}
 """
     ),
-    dict(kwargs=dict(Writer=asciitable.Latex, latexdict=asciitable.latexdicts['template']),
+    dict(kwargs=dict(Writer=ascii.Latex, latexdict=ascii.latexdicts['template']),
          out="""\
 \\begin{tabletype}[tablealign]
 preamble
@@ -158,7 +158,7 @@ tablefoot
 \\end{tabletype}
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.HTML, htmldict={'css':'table,th,td{border:1px solid black;'}),
+    dict(kwargs=dict(Writer=ascii.HTML, htmldict={'css':'table,th,td{border:1px solid black;'}),
          out="""\
 <html>
  <head>
@@ -213,7 +213,7 @@ table,th,td{border:1px solid black;  </style>
 </html>
 """
          ),
-    dict(kwargs=dict(Writer=asciitable.Ipac),
+    dict(kwargs=dict(Writer=ascii.Ipac),
          out="""\
 \\MERGERAD='INDEF'
 \\IRAF='NOAO/IRAFV2.10EXPORT'
@@ -319,7 +319,7 @@ a b c
 
 def check_write_table(test_def, table):
     out = StringIO()
-    asciitable.write(table, out, **test_def['kwargs'])
+    ascii.write(table, out, **test_def['kwargs'])
     print('Expected:\n%s' % test_def['out'])
     print('Actual:\n%s' % out.getvalue())
     assert [x.strip() for x in out.getvalue().strip().splitlines()] == [
@@ -344,7 +344,7 @@ def check_write_table_via_table(test_def, table):
 
 
 def test_write_table():
-    table = asciitable.get_reader(Reader=asciitable.Daophot)
+    table = ascii.get_reader(Reader=ascii.Daophot)
     data = table.read('t/daophot.dat')
 
     for test_def in test_defs:
@@ -353,7 +353,7 @@ def test_write_table():
 
 
 def test_write_fill_values():
-    data = asciitable.read(tab_to_fill)
+    data = ascii.read(tab_to_fill)
 
     for test_def in test_defs_fill_value:
         check_write_table(test_def, data)


### PR DESCRIPTION
Some of the tests still had import ... as asciitable as a heritage
from the old asciitable package. Similarly, there was some
require_numpy from times when asciitable worked without numpy.
Nothing important, but hey, why not fix that when I am sitting at a
bus station anyway.

@taldcroft
