### PR TITLE
Adding autoclass_content=both to sphinx conf

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -163,6 +163,10 @@ autosummary_generate = True
 
 automodapi_toctreedirnm = 'api'
 
+# Class documentation should contain *both* the class docstring and
+# the __init__ docstring
+autoclass_content = "both"
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Many classes miss half of their documentation that is under their `__init__` method and left out as the current default. 

With this patch both the class and the `__init__` docsstrings are used.
