### PR TITLE
Model formulae

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -54,7 +54,7 @@ from ..extern import six
 from ..extern.six.moves import zip as izip
 from ..extern.six.moves import range
 from ..table import Table
-from .utils import array_repr_oneline
+from .utils import array_repr_oneline, format_formula
 
 from .parameters import Parameter, InputParameterError
 
@@ -149,6 +149,19 @@ class _ModelMeta(abc.ABCMeta):
                     "if the name argument is not given when initializing "
                     "them.")
             parameters[value.name] = value
+
+        if '_formula_' in members:
+            # Format the _formula_ template
+            formula_templ = members['_formula_']
+            parameter_symbols = dict((p.name, p.latex) for p in
+                                     parameters.values())
+            formula = format_formula(formula_templ, **parameter_symbols)
+            members['_formula_'] = formula
+
+            # Use the formatted formula in the docstring if applicable
+            if members.get('__doc__') is not None:  # I should hope so
+                members['__doc__'] = members['__doc__'].format(
+                    formula=formula)
 
         # If no parameters were defined get out early--this is especially
         # important for PolynomialModels which take a different approach to

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -186,6 +186,19 @@ class _ModelMeta(abc.ABCMeta):
 
         return super(_ModelMeta, mcls).__new__(mcls, name, bases, members)
 
+    def _repr_latex_(cls):
+        parts = []
+        # Some versions of mathjax are missing \texttt
+        parts.append(r'\mathord{{\tt{{\text{{{0}({1})}}}}}}'.format(
+            cls.__name__, ', '.join(b.__name__ for b in cls.__bases__)))
+        parts.append(cls._formula_)
+        parts.append(r'\text{where}')
+        parts.append('\n'.join(
+            r'{0}\ \text{{is {1}}} \\'.format(getattr(cls, name).latex, name)
+            for name in cls.param_names))
+
+        return '$$\n{0}\n$$'.format(' \\\\[1em]\n'.join(parts))
+
 
 @six.add_metaclass(_ModelMeta)
 class Model(object):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -186,18 +186,20 @@ class _ModelMeta(abc.ABCMeta):
 
         return super(_ModelMeta, mcls).__new__(mcls, name, bases, members)
 
-    def _repr_latex_(cls):
-        parts = []
-        # Some versions of mathjax are missing \texttt
-        parts.append(r'\mathord{{\tt{{\text{{{0}({1})}}}}}}'.format(
-            cls.__name__, ', '.join(b.__name__ for b in cls.__bases__)))
-        parts.append(cls._formula_)
-        parts.append(r'\text{where}')
-        parts.append('\n'.join(
-            r'{0}\ \text{{is {1}}} \\'.format(getattr(cls, name).latex, name)
-            for name in cls.param_names))
+    def _repr_html_(cls):
+        parts = ['<code>{0}({1})</code>'.format(
+            cls.__name__, ', '.join(b.__name__ for b in cls.__bases__))]
+        parts.append('')
+        parts.append('<p>\n$$\n{0}\n$$\n</p>'.format(cls._formula_))
+        parts.append('<p>where</p>')
+        parts.append('<dl>\n{0}\n</dl>'.format('\n'.join(
+            '<dt>${0}$</dt><dd>{1}</dd>'.format(getattr(cls, name).latex, name)
+            for name in cls.param_names)))
 
-        return '$$\n{0}\n$$'.format(' \\\\[1em]\n'.join(parts))
+        return '<br/>\n'.join(parts)
+
+    def _repr_latex_(cls):
+        return '${0}$'.format(cls._formula_)
 
 
 @six.add_metaclass(_ModelMeta)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -156,7 +156,6 @@ class _ModelMeta(abc.ABCMeta):
             parameter_symbols = dict((p.name, p.latex) for p in
                                      parameters.values())
             formula = format_formula(formula_templ, **parameter_symbols)
-            members['_formula_'] = formula
 
             # Use the formatted formula in the docstring if applicable
             if members.get('__doc__') is not None:  # I should hope so

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -45,7 +45,7 @@ class Gaussian1D(Fittable1DModel):
 
     Model formula:
 
-        .. math:: f(x) = A e^{- \\frac{\\left(x - x_{0}\\right)^{2}}{2 \\sigma^{2}}}
+        .. math:: {formula}
 
     Examples
     --------
@@ -53,12 +53,12 @@ class Gaussian1D(Fittable1DModel):
     >>> def tie_center(model):
     ...         mean = 50 * model.stddev
     ...         return mean
-    >>> tied_parameters = {'mean': tie_center}
+    >>> tied_parameters = {{'mean': tie_center}}
 
     Specify that 'mean' is a tied parameter in one of two ways:
 
     >>> g1 = models.Gaussian1D(amplitude=10, mean=5, stddev=.3,
-    ...                             tied=tied_parameters)
+    ...                        tied=tied_parameters)
 
     or
 
@@ -72,7 +72,7 @@ class Gaussian1D(Fittable1DModel):
     Fixed parameters:
 
     >>> g1 = models.Gaussian1D(amplitude=10, mean=5, stddev=.3,
-    ...                        fixed={'stddev': True})
+    ...                        fixed={{'stddev': True}})
     >>> g1.stddev.fixed
     True
 
@@ -90,9 +90,14 @@ class Gaussian1D(Fittable1DModel):
     Gaussian2D, Box1D, Beta1D, Lorentz1D
     """
 
-    amplitude = Parameter()
-    mean = Parameter()
-    stddev = Parameter()
+    _formula_ = (
+        r'f(x) = |amplitude| '
+        r'e^{- \frac{\left(x - |mean|\right)^{2}}{2 |stddev|^{2}}}'
+    )
+
+    amplitude = Parameter(latex='A')
+    mean = Parameter(latex='x_{0}')
+    stddev = Parameter(latex=r'\sigma')
 
     def __init__(self, amplitude, mean, stddev, **constraints):
         try:

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -164,7 +164,7 @@ class Parameter(object):
             return self
 
         return self.__class__(self._name, default=self._default,
-                              getter=self._getter,
+                              latex=self._latex, getter=self._getter,
                               setter=self._setter, model=obj)
 
     def __set__(self, obj, value):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -106,9 +106,9 @@ class Parameter(object):
     # See the _nextid classmethod
     _nextid = 1
 
-    def __init__(self, name='', description='', default=None, getter=None,
-                 setter=None, fixed=False, tied=False, min=None, max=None,
-                 model=None):
+    def __init__(self, name='', description='', latex='', default=None,
+                 getter=None, setter=None, fixed=False, tied=False, min=None,
+                 max=None, model=None):
         super(Parameter, self).__init__()
 
         if model is not None and not name:
@@ -116,6 +116,13 @@ class Parameter(object):
 
         self._name = name
         self.__doc__ = description.strip()
+
+        if latex:
+            self._latex = latex
+        else:
+            # the default is just the name of the parameter
+            self._latex = r'\text{{{0}}}'.format(name)
+
         self._default = default
 
         self._default_fixed = fixed
@@ -222,6 +229,12 @@ class Parameter(object):
         """Parameter name"""
 
         return self._name
+
+    @property
+    def latex(self):
+        """LaTeX symbol for this parameter"""
+
+        return self._latex
 
     @property
     def default(self):

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -7,6 +7,8 @@ This module provides utility functions for the models package
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
+import re
+
 import numpy as np
 
 from ..extern.six.moves import xrange
@@ -61,3 +63,24 @@ def array_repr_oneline(array):
 
     r = np.array2string(array, separator=',', suppress_small=True)
     return ' '.join(l.strip() for l in r.splitlines())
+
+
+def format_formula(templ, **parameters):
+    """
+    Format a model formula with the given LaTeX symbols for its parameters.
+
+    The template strings for formulae use a special syntax that uses pipe
+    (``|``) characters around a parameter name to indicate where a given
+    parameter's LaTeX symbol should be substituted.
+
+    This format is used instead of the standard Python string template
+    formatting due to the prevalence of curly braces (``{}``) in that format as
+    well as in LaTeX.
+    """
+
+    sub_re = r'\|(?P<param>{0})\|'.format('|'.join(parameters.keys()))
+
+    def sub_repl(m):
+        return parameters[m.group('param')]
+
+    return re.sub(sub_re, sub_repl, templ)


### PR DESCRIPTION
This is a proof of concept for an idea that's been kicking around in the back of my head.

Many of the basic "functional" models in the modeling package have some formula for that model displayed a LaTeX in the model's docstring.  This PR does three main things with this:
1. It adds a `_formula_` attribute to all `Model` subclasses.  The attribute should be a string _template_
   for the model's LaTeX formula that replaces each parameter's symbol with a template variable with the same name as the parameter attribute.
2. It adds a `latex` attribute to all model `Parameter` attributes, specifying a LaTeX symbol that represents that parameter in the formula.
3. It removes the formula itself from the model's docstring, and instead treats the docstring as a string formatting template, currently with one template variable `{formula}`.  On creation of the class the `_formula_` attribute is updated by interpolating it with the actual parameter LaTeX symbols.  Then the full docstring is updated by interpolating any template variables (i.e. `{formula}`)

The end result is that `MyModel._formula_` ends up containing the same formula that previously appeared in the docstring, and the docstring itself appears the same as before.  Doing things this way has possible advantages, however.  One of those advantages is demonstrated by adding `_repr_html_` output for IPython notebook for both `Model` classes themselves, and instances of models (where in the latter case a table of all parameter values for all parameter sets is displayed).  This could likely use more work but it's a start:

![modeling_formulae](https://cloud.githubusercontent.com/assets/676149/2820609/1bbe6fa6-cefc-11e3-8511-5becb767e5f6.png)

Abstracting out the parameter symbols has some advantages as well, such as being able to change the symbol used for a parameter in one place.It can also be useful in other contexts, such as in the table displayed above.

A few further ideas and issues that need addressing:
1. Some of the models have more complicated formulas or sets of formula (see the `Gaussian2D` class for example).  It's probably not worth worrying too much about these corner cases, though one could see potential for a `_formulas_` list of multiple formulas.  They could be accessed within the docstring as `{formulas[0]}`, `{formulas[1]}`, etc.  The `_repr_html_` could be improved too so that individual models can have more control over which formulas are displayed depending on context.
2. In addition to the `latex` symbol, one could also make a case for allowing specification of a plain-text symbol to use for each parameter, perhaps either unicode or ASCII.  Perhaps this could be used in a conjunction with an optional dependency on SymPy for generating plain-text formula graphics.  These might be useful in other contexts as well.
3. Since the `Model` docstrings are now format strings, any curly braces now need to be doubled up like `{{` and `}}` since they are otherwise interpreted as part of the template format.  This does _not_ affect doctests, but it's still a bit awkward.  Perhaps an alternate template format could be used for the docstrings to avoid this.

So far I have only converted the `Gaussian1D` class to use this format.  I didn't want to go whole hog with it until I got a sense that other people think this is a good idea in general.

Note: This PR builds a little bit on top of #2381 though they aren't strictly interdependent.
