### PR TITLE
Add a .gitignore file for the wcslib headers that are copied from `cextern/wcslib/C`

### DIFF
--- a/astropy/wcs/include/wcslib/.gitignore
+++ b/astropy/wcs/include/wcslib/.gitignore
@@ -1,0 +1,4 @@
+# We copy header files here from `cextern/wcslib/C`, but they should
+# be ignored by git.
+
+*.h


### PR DESCRIPTION
As mentioned by @eteq in #2389.
