### PR TITLE
Have Parametric?DModel use Parameter attributes

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -157,8 +157,10 @@ class Parameter(object):
             return self
 
         return self.__class__(self._name, default=self._default,
-                              getter=self._getter,
-                              setter=self._setter, model=obj)
+                              getter=self._getter, setter=self._setter,
+                              fixed=self._default_fixed,
+                              tied=self._default_tied, min=self._default_min,
+                              max=self._default_max, model=obj)
 
     def __set__(self, obj, value):
         value, shape = self._validate_value(obj, value)


### PR DESCRIPTION
I noticed some non-intuitive behavior while trying to use `Parametric1DModel` or `Parametric2DModel`, illustrated below:

```
class MyModel(Parametric1DModel):
    a = Parameter(default=1)
    b = Parameter(default=0, min=0, fixed=True)

    @staticmethod
    def eval(x, a, b):
        return x*a + b

>>> m = MyModel()
>>> m.a
Parameter('a', value=1.0)
>>> m.b
Parameter('b', value=0.0)
>>> print m.b.fixed
False
>>> print m.b.min
None
```

The surprise here is the last two lines. The definition of the parameter in the class passes on the default value to an instance of the model, but it does _not_ pass on that it's fixed or min/max.  That seems counter-intuitive - is there a reason it has to be so?

cc @embray @nden
