### PR TITLE
Different input formats for Angle confuse unit parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,7 +60,7 @@ New Features
 
   - Added support for inputting column descriptions and column units
     with the ``io.ascii.SExtractor`` reader. [#2372]
-    
+
   - Allow the use of non-local ReadMe files in the CDS reader. [#2329]
 
 - ``astropy.io.fits``
@@ -419,6 +419,9 @@ Bug Fixes
 
   - Fixed ``Angle.to_string`` functionality so that negative angles have the
     correct amount of padding when ``pad=True``. [#2337]
+
+  - Mixing strings and quantities in the ``Angle`` constructor now
+    works.  For example: ``Angle(['1d', 1. * u.d])``.  [#2398]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -263,7 +263,7 @@ class _AngleParser(object):
                     "Syntax error parsing angle {0!r}".format(angle))
 
         if unit is None and found_unit is None:
-                raise u.UnitsError("No unit specified")
+            raise u.UnitsError("No unit specified")
 
         return found_angle, found_unit
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 """Test initalization of angles not already covered by the API tests"""
 
 import numpy as np
-from numpy.testing.utils import assert_allclose
+from numpy.testing.utils import assert_allclose, assert_array_equal
 
 from ..angles import Longitude, Latitude, Angle
 from ...tests.helper import pytest
@@ -345,3 +345,12 @@ def test_multiply_divide():
     a3 = a1 / a2
     assert_allclose(a3.value, [.25, .4, .5])
     assert a3.unit == u.dimensionless_unscaled
+
+def test_mixed_string_and_quantity():
+    a1 = Angle(['1d', 1. * u.deg])
+    assert_array_equal(a1.value, [1., 1.])
+    assert a1.unit == u.deg
+
+    a2 = Angle(['1d', 1 * u.rad * np.pi, '3d'])
+    assert_array_equal(a2.value, [1., 180., 3.])
+    assert a2.unit == u.deg


### PR DESCRIPTION
Both of the following work fine:

```
In [17]: Angle(['1d'])
Out[17]: <Angle [ 1.] deg>

In [18]: Angle([1 * u.deg])
Out[18]: <Angle [ 1.] deg>
```

But if I mix the two formats I get a `No unit specified` exception:

```
In [11]: Angle(['1d', 1 * u.deg])
ERROR: UnitsError: No unit specified [astropy.coordinates.angle_utilities]
---------------------------------------------------------------------------
UnitsError                                Traceback (most recent call last)
<ipython-input-11-e4e8f92c96e1> in <module>()
----> 1 Angle(['1d', 1 * u.deg])

/Users/aldcroft/git/astropy/astropy/coordinates/angles.pyc in __new__(cls, angle, unit, dtype, copy)
    116             except ValueError as e:
    117                 raise TypeError(str(e))
--> 118             angle, unit = cls._convert_string_array_to_angles(angle, unit)
    119 
    120         self = super(Angle, cls).__new__(cls, angle, unit, dtype=dtype,

/Users/aldcroft/git/astropy/astropy/coordinates/angles.pyc in _convert_string_array_to_angles(cls, angle, unit)
    159             otypes=[np.float_])
    160 
--> 161         return convert_string_to_angle_ufunc(angle), determined_unit[0]
    162 
    163     @staticmethod

/Users/aldcroft/anaconda/envs/astropy-ape5/lib/python2.7/site-packages/numpy/lib/function_base.pyc in __call__(self, *args, **kwargs)
   1570             vargs.extend([kwargs[_n] for _n in names])
   1571 
-> 1572         return self._vectorize_call(func=func, args=vargs)
   1573 
   1574     def _get_ufunc_and_otypes(self, func, args):

/Users/aldcroft/anaconda/envs/astropy-ape5/lib/python2.7/site-packages/numpy/lib/function_base.pyc in _vectorize_call(self, func, args)
   1636                       for _a in args]
   1637 
-> 1638             outputs = ufunc(*inputs)
   1639 
   1640             if ufunc.nout == 1:

/Users/aldcroft/git/astropy/astropy/coordinates/angles.pyc in convert_string_to_angle(x)
    146 
    147         def convert_string_to_angle(x):
--> 148             ang, new_unit = util.parse_angle(six.text_type(x), unit)
    149             if determined_unit[0] is None:
    150                 determined_unit[0] = new_unit

/Users/aldcroft/git/astropy/astropy/coordinates/angle_utilities.pyc in parse_angle(angle, unit, debug)
    345         string.
    346     """
--> 347     return _AngleParser().parse(angle, unit, debug=debug)
    348 
    349 

/Users/aldcroft/git/astropy/astropy/coordinates/angle_utilities.pyc in parse(self, angle, unit, debug)
    264 
    265         if unit is None and found_unit is None:
--> 266                 raise u.UnitsError("No unit specified")
    267 
    268         return found_angle, found_unit

UnitsError: No unit specified

In [12]: 
```
