### PR TITLE
Implemented Quantity-aware wrappers for assert_allclose and linspace

### DIFF
--- a/astropy/units/numpy_wrappers.py
+++ b/astropy/units/numpy_wrappers.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from .quantity import Quantity
+
+
+def assert_allclose(actual, desired, rtol=1.e-7, atol=0, err_msg='', verbose=True):
+    """
+    Raise an assertion if two objects are not equal up to desired tolerance.
+
+    This is a :class:`~astropy.units.Quantity`-aware version of
+    :func:`numpy.testing.assert_allclose`.
+    """
+    if isinstance(actual, Quantity) and isinstance(desired, Quantity):
+        np.testing.assert_allclose(actual.value, desired.to(actual.unit).value,
+                                   rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
+    elif isinstance(actual, Quantity):
+        raise TypeError("If `actual` is a Quantity, `desired` should also be a Quantity")
+    elif isinstance(desired, Quantity):
+        raise TypeError("If `desired` is a Quantity, `actual` should also be a Quantity")
+    else:
+        np.testing.assert_allclose(actual, desired,
+                                   rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
+
+
+def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
+    """
+    Return evenly spaced numbers over a specified interval.
+
+    This is a :class:`~astropy.units.Quantity`-aware version of
+    :func:`numpy.linspace`.
+    """
+    if isinstance(start, Quantity) and isinstance(stop, Quantity):
+        return np.linspace(start.value, stop.to(start.unit).value, num=num,
+                           endpoint=endpoint, retstep=retstep, dtype=dtype) * start.unit
+    elif isinstance(start, Quantity):
+        raise TypeError("If `start` is a Quantity, `stop` should also be a Quantity")
+    elif isinstance(stop, Quantity):
+        raise TypeError("If `stop` is a Quantity, `start` should also be a Quantity")
+    else:
+        return np.linspace(start, stop, num=num,
+                           endpoint=endpoint, retstep=retstep, dtype=dtype)

--- a/astropy/units/tests/test_numpy_wrappers.py
+++ b/astropy/units/tests/test_numpy_wrappers.py
@@ -1,0 +1,39 @@
+from ...tests.helper import pytest
+from ... import units as u
+
+from ..numpy_wrappers import assert_allclose, linspace
+
+
+def test_assert_allclose():
+
+    assert_allclose([1,2], [1,2])
+
+    assert_allclose([1,2] * u.m, [100,200] * u.cm)
+
+    with pytest.raises(AssertionError):
+        assert_allclose([1,2] * u.m, [90,200] * u.cm)
+
+    with pytest.raises(TypeError) as exc:
+        assert_allclose([1,2] * u.m, [100,200])
+    assert exc.value.args[0] == "If `actual` is a Quantity, `desired` should also be a Quantity"
+
+    with pytest.raises(TypeError) as exc:
+        assert_allclose([1,2], [100,200] * u.cm)
+    assert exc.value.args[0] == "If `desired` is a Quantity, `actual` should also be a Quantity"
+
+
+def test_linspace():
+
+    assert_allclose(linspace(1, 10, 10), [1,2,3,4,5,6,7,8,9,10])
+
+    assert_allclose(linspace(1 * u.m, 10 * u.m, 10), [1,2,3,4,5,6,7,8,9,10] * u.m)
+
+    assert_allclose(linspace(100 * u.cm, 10 * u.m, 10), [1,2,3,4,5,6,7,8,9,10] * u.m)
+
+    with pytest.raises(TypeError) as exc:
+        linspace(1 * u.m, 10, 10)
+    assert exc.value.args[0] == "If `start` is a Quantity, `stop` should also be a Quantity"
+
+    with pytest.raises(TypeError) as exc:
+        linspace(1, 10 * u.m, 10)
+    assert exc.value.args[0] == "If `stop` is a Quantity, `start` should also be a Quantity"


### PR DESCRIPTION
As discussed in https://github.com/astropy/astropy/issues/1274, it would be great to have Quantity-aware wrappers to some Numpy functions. We don't have to monkey-patch these, we can just provide them in a separate namespace. This PR can be used e.g. as:

```
In [2]: from astropy import units as u

In [3]: from astropy.units import numpy_wrappers as unp

In [4]: unp.linspace(1 * u.cm, 1. * u.m, 100)
Out[4]: 
<Quantity [   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
             11.,  12.,  13.,  14.,  15.,  16.,  17.,  18.,  19.,  20.,
             21.,  22.,  23.,  24.,  25.,  26.,  27.,  28.,  29.,  30.,
             31.,  32.,  33.,  34.,  35.,  36.,  37.,  38.,  39.,  40.,
             41.,  42.,  43.,  44.,  45.,  46.,  47.,  48.,  49.,  50.,
             51.,  52.,  53.,  54.,  55.,  56.,  57.,  58.,  59.,  60.,
             61.,  62.,  63.,  64.,  65.,  66.,  67.,  68.,  69.,  70.,
             71.,  72.,  73.,  74.,  75.,  76.,  77.,  78.,  79.,  80.,
             81.,  82.,  83.,  84.,  85.,  86.,  87.,  88.,  89.,  90.,
             91.,  92.,  93.,  94.,  95.,  96.,  97.,  98.,  99., 100.] cm>
```

I'd like to include a few functions like this in 0.4 if there are no objections.