### PR TITLE
Fix console ``human_time``: Changing xrange to six.range for PY3 compatibility

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -320,12 +320,12 @@ def human_time(seconds):
     seconds = int(seconds)
 
     if seconds < 60:
-        return '   {0:02d}s'.format(seconds)
+        return '   {0:2d}s'.format(seconds)
     for i in range(len(units) - 1):
         unit1, limit1 = units[i]
         unit2, limit2 = units[i + 1]
         if seconds >= limit1:
-            return '{0:02d}{1}{2:02d}{3}'.format(
+            return '{0:2d}{1}{2:2d}{3}'.format(
                 seconds // limit1, unit1,
                 (seconds % limit1) // limit2, unit2)
     return '  ~inf'

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -191,14 +191,14 @@ def test_progress_bar_as_generator():
     assert sum == 1225
 
 @pytest.mark.parametrize("seconds,string",
-       [(864088,"01w03d"),
-       (187213,"02d04h"),
-       (3905,"01h05m"),
-       (64,"01m04s"),
-       (15,"   15s")]
+       [(864088," 1w 3d"),
+       (187213, " 2d 4h"),
+       (3905,   " 1h 5m"),
+       (64,     " 1m 4s"),
+       (15,     "   15s"),
+       (2,      "    2s")]
 )
 def test_human_time(seconds, string):
     human_time = console.human_time(seconds)
-    print(human_time)
     assert human_time == string
 


### PR DESCRIPTION
There was one leftover use of `xrange` in `human_time`. This PR changes that to use `six.range`.
