### PR TITLE
Remote test failures due to config changes

### DIFF
--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -21,6 +21,7 @@ from ..extern import six
 from ..extern.six.moves import urllib
 from .. import units as u
 from .builtin_systems import ICRS
+from ..utils import data
 from ..utils import state
 
 __all__ = ["get_icrs_coordinates"]
@@ -48,17 +49,14 @@ class sesame_database(state.ScienceState):
     This specifies the default database that SESAME will query when
     using the name resolve mechanism in the coordinates
     subpackage. Default is to search all databases, but this can be
-    'all', 'simbad', 'ned', or 'vizier'.)
+    'all', 'simbad', 'ned', or 'vizier'.
     """
     _value = 'all'
 
     @classmethod
     def validate(cls, value):
-        if isinstance(value, six.string_types):
-            value = [value]
-        for subvalue in value:
-            if subvalue not in ['all', 'simbad', 'ned', 'vizier']:
-                raise ValueError("Unknown database '{0}'".format(subvalue))
+        if value not in ['all', 'simbad', 'ned', 'vizier']:
+            raise ValueError("Unknown database '{0}'".format(value))
         return value
 
 
@@ -152,7 +150,7 @@ def get_icrs_coordinates(name):
     for url in urls:
         try:
             # Retrieve ascii name resolve data from CDS
-            resp = urllib.request.urlopen(url, timeout=conf.remote_timeout)
+            resp = urllib.request.urlopen(url, timeout=data.conf.remote_timeout)
             resp_data = resp.read()
             break
         except urllib.error.URLError as e:

--- a/astropy/vo/validator/tests/test_validate.py
+++ b/astropy/vo/validator/tests/test_validate.py
@@ -17,11 +17,13 @@ import sys
 import tempfile
 
 # LOCAL
+from .. import conf
 from .. import validate
 from ..exceptions import ValidationMultiprocessingError
 from ...client.vos_catalog import VOSDatabase
 from ....tests.helper import pytest, remote_data
 from ....utils.data import get_pkg_data_filename
+from ....utils import data
 
 
 __doctest_skip__ = ['*']

--- a/astropy/vo/validator/validate.py
+++ b/astropy/vo/validator/validate.py
@@ -18,8 +18,7 @@ from ...io.votable.exceptions import E19
 from ...io.votable.validator import html, result
 from ...logger import log
 from ...utils import OrderedDict  # For 2.6 compatibility
-from ...utils.data import get_pkg_data_contents
-from ...utils.data import REMOTE_TIMEOUT
+from ...utils import data
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.timer import timefunc
 from ...utils.xml.unescaper import unescape_all
@@ -96,7 +95,7 @@ def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
         Multiprocessing failed.
 
     """
-    from .. import conf
+    from . import conf
     global _OUT_ROOT
 
     if url_list == 'default':
@@ -311,7 +310,7 @@ def _categorize_result(r):
         Unhandled validation result attributes.
 
     """
-    from .. import conf
+    from . import conf
 
     if 'network_error' in r and r['network_error'] is not None:  # pragma: no cover
         r['out_db_name'] = 'nerr'


### PR DESCRIPTION
There are a few small failures in remote tests due to the config changes: http://bpaste.net/show/256228

Actually I don't understand why `sesame_database` is a list - I think it should be a string (one of 'all', 'simbad', etc.).
