### PR TITLE
Fix config-related warning

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -394,11 +394,13 @@ class ConfigItem(object):
         for alias in self.aliases:
             module, name = alias.rsplit('.', 1)
             sec = get_config(module)
+            filename, module = module.split('.', 1)
             if name in sec:
                 warn(
-                    "Config parameter '{0}' in section [{1}] is deprecated. "
-                    "Use '{2}' in section [{3}] instead.".format(
-                        name, module, self.name, self.module),
+                    "Config parameter '{0}' in section [{1}] of the file '{2}' "
+                    "is deprecated. Use '{3}' in section [{4}] instead.".format(
+                        name, module, get_config_filename(filename),
+                        self.name, self.module.split('.', 1)[1]),
                     AstropyDeprecationWarning)
                 options.append((sec[name], module, name))
 
@@ -407,12 +409,13 @@ class ConfigItem(object):
             options.append((self.defaultvalue, None, None))
 
         if len(options) > 1:
+            filename, sec = self.module.split('.', 1)
             warn(
-                "Config parameter '{0}' in section [{1}] is given by "
-                "more than one alias in the config file ({2}). "
-                "Using the first.".format(
-                    self.name, self.module,
-                    ', '.join(['.'.join(x[1:3]) for x in options])))
+                "Config parameter '{0}' in section [{1}] of the file '{2}' is "
+                "given by more than one alias ({3}). Using the first.".format(
+                    self.name, sec, get_config_filename(filename),
+                    ', '.join([
+                        '.'.join(x[1:3]) for x in options if x[1] is not None])))
 
         val = options[0][0]
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -253,10 +253,9 @@ class TestAliasRead(object):
             assert conf.remote_timeout == 42
 
         assert len(w) == 1
-        assert str(w[0].message) == (
+        assert str(w[0].message).startswith(
             "Config parameter 'name_resolve_timeout' in section "
-            "[astropy.coordinates.name_resolve] is deprecated. Use "
-            "'remote_timeout' in section [astropy.utils.data] instead.")
+            "[coordinates.name_resolve]")
 
     def teardown_class(self):
         from astropy.utils.data import conf

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -114,11 +114,6 @@ class TestRunner(object):
         """
         The docstring for this method lives in astropy/__init__.py:test
         """
-        # This prevents cyclical import problems that make it
-        # impossible to test packages that define Table types on their
-        # own.
-        from ..table import Table
-
         if coverage:
             warnings.warn(
                 "The coverage option is ignored on run_tests, since it "
@@ -256,6 +251,11 @@ class TestRunner(object):
         # case our default one in a temp directory), clear the config object
         # cache.
         configuration._cfgobjs.clear()
+
+        # This prevents cyclical import problems that make it
+        # impossible to test packages that define Table types on their
+        # own.
+        from ..table import Table
 
         try:
             result = pytest.main(args=all_args, plugins=plugins)


### PR DESCRIPTION
I haven't investigated yet, but there is a deprecation warning appearing by default which we should probably fix:

```
In [1]: import astropy

In [2]: astropy.test()
WARNING: AstropyDeprecationWarning: Config parameter 'auto_colname' in section [astropy.table.column] is deprecated. Use 'auto_colname' in section [astropy.table] instead. [astropy.config.configuration]
============================= test session starts ==============================
```
