### PR TITLE
units: quantity bug with adding units to an array view?

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -409,6 +409,18 @@ class TestArrayConversion(object):
         q5 = q4.view(u.Quantity)
         assert q5.unit is q1.unit
 
+    def test_slice_to_quantity(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/2003
+        """
+
+        a = np.random.uniform(size=(10, 8))
+        x, y, z = a[:,1:4].T * u.km/u.s
+        total = np.sum(a[:, 1] * u.km / u.s - x)
+
+        assert isinstance(total, u.Quantity)
+        assert total == (0.0 * u.km / u.s)
+
     def test_byte_type_view_field_changes(self):
         q1 = np.array([1, 2, 3], dtype=np.int64) * u.m / u.km
         q2 = q1.byteswap()


### PR DESCRIPTION
This code doesn't work as expected:

```
a = np.random.uniform(size=(400,8))

x,y,z = a[:,1:4].T*u.km/u.s
print np.sum(a[:,1]*u.km/u.s - x) # non-zero

x,y,z = a[:,1:4].T
print np.sum(a[:,1] - x) # zero
```

Could this have something to do with how numpy views of arrays are turned into `Quantity`'s? Don't have time to look at code today to investigate...
