### PR TITLE
Table column subsetting gives incorrect ValueError message

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -848,8 +848,12 @@ class Table(object):
             return self.columns[item]
         elif isinstance(item, int):
             return self.Row(self, item)
-        elif isinstance(item, (tuple, list)) and all(x in self.colnames
+        elif isinstance(item, (tuple, list)) and all(isinstance(x, six.string_types)
                                                      for x in item):
+            bad_names = [x for x in item if x not in self.colnames]
+            if bad_names:
+                raise ValueError('Slice name(s) {0} not valid column name(s)'
+                                 .format(', '.join(bad_names)))
             out = self.__class__([self[x] for x in item], meta=deepcopy(self.meta))
             out._groups = groups.TableGroups(out, indices=self.groups._indices,
                                              keys=self.groups._keys)

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -195,6 +195,18 @@ class TestTableItems(BaseTestItems):
             assert t2.masked == self.t.masked
             assert t2._column_class == self.t._column_class
 
+    def test_select_columns_fail(self, table_data):
+        """Selecting a column that doesn't exist fails"""
+        self.t = table_data.Table(table_data.COLS)
+
+        with pytest.raises(ValueError) as err:
+            self.t[['xxxx']]
+        assert 'Slice name(s) xxxx not valid column name(s)' in str(err)
+
+        with pytest.raises(ValueError) as err:
+            self.t[['xxxx', 'yyyy']]
+        assert 'Slice name(s) xxxx, yyyy not valid column name(s)' in str(err)
+
     def test_np_where(self, table_data):
         """Select rows using output of np.where"""
         t = table_data.Table(table_data.COLS)


### PR DESCRIPTION
Here's a small testcase of what I mean:

``` python
>>> from astropy.table import Table
>>> table = Table(dict(apple=[1,2,3], orange=[2,3,4]))
>>> table[['apple']]
<Table rows=3 names=('apple')>
array([(1,), (2,), (3,)], 
      dtype=[('apple', '<i8')])
>>> table[['peach']]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8326-py2.7-macosx-10.9-x86_64.egg/astropy/table/table.py", line 856, in __getitem__
    return self._new_from_slice(item)
  File "/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8326-py2.7-macosx-10.9-x86_64.egg/astropy/table/table.py", line 591, in _new_from_slice
    self._update_table_from_cols(table, data, cols, names)
  File "/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8326-py2.7-macosx-10.9-x86_64.egg/astropy/table/table.py", line 604, in _update_table_from_cols
    newcol = col.copy(data=data[name], copy_data=False)
ValueError: field named orange not found
```

The `ValueError` should complain that the field `'peach'` wasn't found instead of `'orange'`, no?
