### PR TITLE
fix for deprecated self.naxis1/2

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1754,7 +1754,7 @@ naxis kwarg.
             print('CDELT    : {!r} {!r}'.format(
                 self.wcs.cdelt[0], self.wcs.cdelt[1]))
         print('NAXIS    : {!r} {!r}'.format(
-            self.naxis1, self.naxis2))
+            self._naxis1, self._naxis2))
 
     def get_axis_types(self):
         """


### PR DESCRIPTION
WCS.naxis1/2 were deprecated but are still used in `printwcs()`. This provides a simple fix  for now.
If I get some time today I will try to rewrite this method and make it a bit more general. Will also add a test.
But if not I'd like to merge this today because it breaks our internal software.
