### PR TITLE
Move top-level config items to top of file.

### DIFF
--- a/astropy/astropy.cfg
+++ b/astropy/astropy.cfg
@@ -1,3 +1,13 @@
+### CONSOLE SETTINGS
+
+## Use Unicode characters when outputting values, and writing widgets to the
+## console.
+# unicode_output = False
+
+## When True, use ANSI color escape sequences when writing to the console.
+# use_color = True
+
+
 ### CORE DATA STRUCTURES AND TRANSFORMATIONS
 
 [nddata]
@@ -50,13 +60,6 @@
 
 
 ### NUTS AND BOLTS OF ASTROPY
-
-## Use Unicode characters when outputting values, and writing widgets to the
-## console.
-# unicode_output = False
-
-## When True, use ANSI color escape sequences when writing to the console.
-# use_color = True
 
 [logger]
 


### PR DESCRIPTION
Due to the limitations of the ini-file format.
