### PR TITLE
IOError from unit tests in disable_internet.py in localhost check

### DIFF
--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -3,7 +3,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import contextlib
 import socket
-import urllib2
+
+from ..extern.six.moves import urllib
 
 # save original socket method for restoration
 # These are global so that re-calling the turn_off_internet function doesn't
@@ -74,10 +75,10 @@ def turn_off_internet(verbose=False):
     # Update urllib2 to force it not to use any proxies
     # Must use {} here (the default of None will kick off an automatic search
     # for proxies)
-    _orig_opener = urllib2.build_opener()
-    no_proxy_handler = urllib2.ProxyHandler({})
-    opener = urllib2.build_opener(no_proxy_handler)
-    urllib2.install_opener(opener)
+    _orig_opener = urllib.request.build_opener()
+    no_proxy_handler = urllib.request.ProxyHandler({})
+    opener = urllib.request.build_opener(no_proxy_handler)
+    urllib.request.install_opener(opener)
 
     socket.create_connection = check_internet_off(socket_create_connection)
     socket.socket.bind = check_internet_off(socket_bind)
@@ -102,7 +103,7 @@ def turn_on_internet(verbose=False):
     if verbose:
         print("Internet access enabled")
 
-    urllib2.install_opener(_orig_opener)
+    urllib.request.install_opener(_orig_opener)
 
     socket.create_connection = socket_create_connection
     socket.socket.bind = socket_bind


### PR DESCRIPTION
On a Linux Server at work when I run the Astropy unit tests I get

```
args = (('www-cache.mpi-hd.mpg.de', 3128), 3.0, None), kwargs = {}, host = 'www-cache.mpi-hd.mpg.de', valid_hosts = ('localhost', '127.0.0.1'), h = '127.0.0.1'

    def new_function(*args, **kwargs):
        if isinstance(args[0], socket.socket):
            host = args[1][0]
            valid_hosts = ('localhost', '127.0.0.1', '::1')
        else:
            host = args[0][0]
            valid_hosts = ('localhost', '127.0.0.1')
        if any([h in host for h in valid_hosts]):
            return original_function(*args, **kwargs)
        else:
>           raise IOError("An attempt was made to connect to the internet "
                          "by a test that was not marked `remote_data`.")
E           IOError: An attempt was made to connect to the internet by a test that was not marked `remote_data`.

astropy/tests/disable_internet.py:28: IOError
```

This occurs in two places:
- `test_localconnect_succeeds` in `astropy/tests/tests/test_socketblocker.py:51`
- `TestWebProfile.test_web_profile` in `astropy/vo/samp/tests/test_web_profile.py:77`

Full output here: https://gist.github.com/cdeil/10577755

For some reason the institute HTTP proxy (`www-cache.mpi-hd.mpg.de`) is passed as `host` on this machine instead of `localhost` or `127.0.0.1`.

@astrofrog @keflavich What's the right fix here? Should I mark the tests as `remote_data` or do I need to set some HTTP configuration or do you want to rewrite the check in `disable_internet.py` somehow?
