### PR TITLE
Improve error message in wcs.sub

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1672,7 +1672,7 @@ PyWcsprm_sub(
 
   if (py_axes == NULL || py_axes == Py_None) {
     /* leave all variables as is */
-  } else if (PySequence_Check(py_axes)) {
+  } else if (PyList_Check(py_axes) || PyTuple_Check(py_axes)) {
     tmp = PySequence_Size(py_axes);
     if (tmp == -1) {
       goto exit;

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -737,3 +737,11 @@ def test_sub_segfault():
 def test_bounds_check():
     w = _wcs.Wcsprm()
     w.bounds_check(False)
+
+
+def test_wcs_sub_error_message():
+    # Issue #1587
+    w = _wcs.Wcsprm()
+    with pytest.raises(TypeError) as e:
+        w.sub('latitude')
+    assert str(e).endswith("axes must None, a sequence or an integer")


### PR DESCRIPTION
We should get a TypeError rather, rather than a ValueError when passing
a single string to `wcs.sub`.

Partially addresses #1587.
