### PR TITLE
Astropy.io.fits and DS9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -500,6 +500,9 @@ Bug Fixes
 
   - Several other bug fixes ported from PyFITS v3.2.3 [#2368]
 
+  - Fixed a crash on Python 2.x when writing a FITS file directly to a
+    ``StringIO.StringIO`` object. [#2463]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -10,11 +10,18 @@ import zipfile
 
 import numpy as np
 
+try:
+    import StringIO
+    HAVE_STRINGIO = True
+except ImportError:
+    HAVE_STRINGIO = False
+
 from ....io import fits
 from ....tests.helper import pytest, raises, catch_warnings
 from . import FitsTestCase
 from .util import ignore_warnings
 from ..convenience import _getext
+from ..diff import FITSDiff
 from ..file import _File
 
 
@@ -710,6 +717,37 @@ class TestFileFunctions(FitsTestCase):
                         assert hdu1.header == hdu2.header
                         if hdu1.data is not None and hdu2.data is not None:
                             assert np.all(hdu1.data == hdu2.data)
+
+    @pytest.mark.skipif('not HAVE_STRINGIO')
+    def test_write_stringio(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/2463
+
+        Only test against `StringIO.StringIO` on Python versions that have it.
+        Note: `io.StringIO` is not supported for this purpose as it does not
+        accept a bytes stream.
+        """
+
+        self._test_write_string_bytes_io(StringIO.StringIO())
+
+    def test_write_bytesio(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/2463
+
+        Test againt `io.BytesIO`.  `io.StringIO` is not supported.
+        """
+
+        self._test_write_string_bytes_io(io.BytesIO())
+
+    def _test_write_string_bytes_io(self, fileobj):
+        """
+        Implemented for both test_write_stringio and test_write_bytesio.
+        """
+
+        with fits.open(self.data('test0.fits')) as hdul:
+            hdul.writeto(fileobj)
+            hdul2 = fits.HDUList.fromstring(fileobj.getvalue())
+            assert FITSDiff(hdul, hdul2).identical
 
     def _make_gzip_file(self, filename='test0.fits.gz'):
         gzfile = self.temp(filename)

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -586,7 +586,11 @@ def _array_to_file(arr, outfile):
         # treat as file-like object with "write" method and write the array
         # via its buffer interface
         def write(a, f):
-            f.write(a.flatten().view(np.ubyte))
+            # StringIO in some versions of Python ask 'if not s' before
+            # writing, which fails for Numpy arrays.  Test ahead of time that
+            # the array is non-empty, then pass in the array buffer directly
+            if len(a):
+                f.write(a.data)
 
     # Implements a workaround for a bug deep in OSX's stdlib file writing
     # functions; on 64-bit OSX it is not possible to correctly write a number


### PR DESCRIPTION
I am trying to run some code that takes an fits image and displays it in ds9 (pyds9 version 1.7, astropy version 0.3.1)

```
from math import *
import astropy.io.fits as pyfits
import ds9

print ds9.__version__
d = ds9.ds9()
d.set("frame frameno 1")
fname = "02530a148-w3-int-1b_ra82.4458_dec21.8963_asec600.000.fits"
img = pyfits.open(fname)
d.set_pyfits(img)
```

But the code results in this error message

```
Traceback (most recent call last):
  File "test.py", line 10, in <module>
    d.set_pyfits(img)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ds9.py", line 474, in set_pyfits
    hdul.writeto(newFitsFile)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/hdu/hdulist.py", line 655, in writeto
    hdu._writeto(hdulist.__file)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/hdu/base.py", line 695, in _writeto
    self._writedata(fileobj)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/hdu/base.py", line 642, in _writedata
    size += self._writedata_direct_copy(fileobj)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/hdu/base.py", line 682, in _writedata_direct_copy
    _array_to_file(raw, fileobj)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/util.py", line 536, in _array_to_file
    write(arr, outfile)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/util.py", line 517, in write
    f.write(a.flatten().view(np.ubyte))
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/file.py", line 274, in write
    _write_string(self.__file, string)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy-0.3.1-py2.7-macosx-10.5-intel.egg/astropy/io/fits/util.py", line 553, in _write_string
    f.write(s)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/StringIO.py", line 214, in write
    if not s: return
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
