### PR TITLE
The identity of composite and irreducible units does not match.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -368,6 +368,8 @@ Bug Fixes
   - ``Quantity.copy`` now behaves identically to ``ndarray.copy``, and thus
     supports the ``order`` argument (for numpy >=1.6). [#2284]
 
+  - Composing base units into identical composite units now works. [#2382]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -654,11 +654,10 @@ class UnitBase(object):
         from .quantity import Quantity
         return m * Quantity(1, self)
 
-    if six.PY3:
-        def __hash__(self):
-            # Since this class defines __eq__, it will become unhashable
-            # on Python 3.x, so we need to define our own hash.
-            return id(self)
+    def __hash__(self):
+        # This must match the hash used in CompositeUnit for a unit
+        # with only one base and no scale or power.
+        return hash((str(self.scale), self.name, str('1')))
 
     def __eq__(self, other):
         if self is other:
@@ -1839,6 +1838,9 @@ class Unit(NamedUnit):
 
     def is_unity(self):
         return self._represents.is_unity()
+
+    def __hash__(self):
+        return hash(self.name) + hash(self._represents)
 
 
 class PrefixUnit(Unit):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -623,3 +623,9 @@ def test_sqrt_mag():
     sqrt_mag = u.mag ** 0.5
     assert hasattr(sqrt_mag.decompose().scale, 'imag')
     assert (sqrt_mag.decompose())**2 == u.mag
+
+
+def test_composite_compose():
+    # Issue #2382
+    composite_unit = u.s.compose(units=[u.Unit("s")])[0]
+    u.s.compose(units=[composite_unit])


### PR DESCRIPTION
I'm having a problem where I have constructed a composite unit out of what should be an irreducible unit. I think the best way to explain this issue is by example:

```
In [1]: import astropy.units as u

In [2]: composite_unit = u.s.compose(units=[u.Unit("s")])[0]

In [3]: type(composite_unit)
Out[3]: astropy.units.core.CompositeUnit

In [4]: composite_unit == u.s
Out[4]: True

In [5]: composite_unit is u.s
Out[5]: False

In [6]: composite_unit in [u.s]
Out[6]: True

In [7]: composite_unit in set([u.s])
Out[7]: False

In [8]: composite_unit
Out[8]: Unit("s")

In [9]: composite_unit.compose(units=[u.s])
Out[9]: [Unit("s")]

In [10]: u.s.compose(units=[composite_unit])
ERROR: UnitsError: Cannot represent unit s in terms of the given units [astropy.units.core]
```

This is normally not a problem, as CompositeUnit and IrreduceableUnit are `==` to each other. But because `set()` uses identity, and `list()` uses equality, this behavior can be really confusing.

This isn't a show-stopper for me (I found it because I had some old code using `.compose()` instead of `.decompose()`, since `.decompose()` was broken for a few versions), but it is an edge case that I think should be addressed.
