### PR TITLE
(DO NOT MERGE) Allow table columns to be hidden from print output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,8 @@ New Features
   - Allow subclassing of `Table` and the component classes `Row`, `Column`,
     `MaskedColumn`, `TableColumns`, and `TableFormatter`. [#2287]
 
+  - Allow table columns to be hidden from print output. [#2466]
+
 - ``astropy.time``
 
   - Mean and apparent sidereal time can now be calculated using the

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -87,11 +87,13 @@ class BaseColumn(np.ndarray):
     __gt__ = _column_compare(operator.gt)
     __ge__ = _column_compare(operator.ge)
 
+    _attr_names = ('name', 'unit', 'format', 'description', 'meta', 'hidden')
+
     @_check_column_new_args
     def __new__(cls, data=None, name=None,
                 dtype=None, shape=(), length=0,
                 description=None, unit=None, format=None, meta=None,
-                dtypes=None, units=None):
+                dtypes=None, units=None, hidden=None):
 
         if dtypes is not None:
             dtype = dtypes
@@ -106,6 +108,7 @@ class BaseColumn(np.ndarray):
         if data is None:
             dtype = (np.dtype(dtype).str, shape)
             self_data = np.zeros(length, dtype=dtype)
+
         elif isinstance(data, BaseColumn) and hasattr(data, '_name'):
             # When unpickling a MaskedColumn, ``data`` will be a bare BaseColumn with none
             # of the expected attributes.  In this case do NOT execute this block which
@@ -121,12 +124,16 @@ class BaseColumn(np.ndarray):
                 meta = deepcopy(data.meta)
             if name is None:
                 name = data.name
+            if hidden is None:
+                hidden = data.hidden
+
         elif isinstance(data, Quantity):
             if unit is None:
                 self_data = np.asarray(data, dtype=dtype)
                 unit = data.unit
             else:
                 self_data = np.asarray(data.to(unit), dtype=dtype)
+
         else:
             self_data = np.asarray(data, dtype=dtype)
 
@@ -137,6 +144,7 @@ class BaseColumn(np.ndarray):
         self.description = description
         self.parent_table = None
         self.meta = meta
+        self.hidden = True if hidden else False
 
         return self
 
@@ -178,8 +186,10 @@ class BaseColumn(np.ndarray):
                 data = data.copy(order)
 
         # Create the new instance with all available kwargs.
-        kwargs = dict(name=self.name, data=data, unit=self.unit, format=self.format,
-                      description=self.description, meta=deepcopy(self.meta))
+        kwargs = {'data': data}
+        for attr in self._attr_names:
+            kwargs[attr] = deepcopy(getattr(self, attr))
+
         # Use `kwargs.update` instead of `kwargs['fill_value'] =` since some
         # versions of Python 2.6.x will blow up on unicode keyword arguments
         if hasattr(self, 'fill_value'):
@@ -198,7 +208,7 @@ class BaseColumn(np.ndarray):
         state values.
         """
         # Get the Column attributes and meta
-        name, unit, format, description, meta = state[-1]
+        column_attrs = dict(zip(self._attr_names, state[-1]))
         state = state[:-1]
 
         # Using super(type(self), self).__setstate__() gives an infinite recursion.
@@ -207,11 +217,12 @@ class BaseColumn(np.ndarray):
         super_class.__setstate__(self, state)
 
         # Set the Column attributes and meta
-        self._name = name
-        self.unit = unit
-        self.format = format
-        self.description = description
-        self.meta = meta
+        self._name = column_attrs['name']
+        self.unit = column_attrs['unit']
+        self.format = column_attrs['format']
+        self.description = column_attrs['description']
+        self.meta = column_attrs['meta']
+        self.hidden = column_attrs.get('hidden', False)  # Might not be there for pre-0.4.
 
     def __reduce__(self):
         """
@@ -222,7 +233,7 @@ class BaseColumn(np.ndarray):
         reconstruct_func, reconstruct_func_args, state = super_class.__reduce__(self)
 
         # Define Column-specific attrs and meta that gets added to state.
-        column_state = (self.name, self.unit, self.format, self.description, self.meta)
+        column_state = tuple(getattr(self, attr) for attr in self._attr_names)
         state = state + (column_state,)
 
         return reconstruct_func, reconstruct_func_args, state
@@ -239,10 +250,9 @@ class BaseColumn(np.ndarray):
         # or viewcast e.g. obj.view(Column).  In either case we want to
         # init Column attributes for self from obj if possible.
         self.parent_table = None
-        for attr in ('name', 'unit', 'format', 'description'):
-            val = getattr(obj, attr, None)
-            setattr(self, attr, val)
-        self.meta = deepcopy(getattr(obj, 'meta', {}))
+        for attr in self._attr_names:
+            val = getattr(obj, attr, {} if attr == 'meta' else None)
+            setattr(self, attr, deepcopy(val))
 
     def __array_wrap__(self, out_arr, context=None):
         """
@@ -560,6 +570,8 @@ class Column(BaseColumn):
         accepts a single value and returns a string.
     meta : dict-like or None
         Meta-data associated with the column
+    hidden : bool
+        Hide the column when printing a table
 
     Examples
     --------
@@ -617,7 +629,7 @@ class Column(BaseColumn):
     def __new__(cls, data=None, name=None,
                 dtype=None, shape=(), length=0,
                 description=None, unit=None, format=None, meta=None,
-                dtypes=None, units=None):
+                dtypes=None, units=None, hidden=None):
 
         if isinstance(data, MaskedColumn) and np.any(data.mask):
             raise TypeError("Cannot convert a MaskedColumn with masked value to a Column")
@@ -625,7 +637,7 @@ class Column(BaseColumn):
         self = super(Column, cls).__new__(cls, data=data, name=name, dtype=dtype,
                                           shape=shape, length=length, description=description,
                                           unit=unit, format=format, meta=meta,
-                                          dtypes=dtypes, units=units)
+                                          dtypes=dtypes, units=units, hidden=hidden)
         return self
 
     def __repr__(self):
@@ -741,7 +753,7 @@ class MaskedColumn(Column, ma.MaskedArray):
     def __new__(cls, data=None, name=None, mask=None, fill_value=None,
                 dtype=None, shape=(), length=0,
                 description=None, unit=None, format=None, meta=None,
-                units=None, dtypes=None):
+                units=None, dtypes=None, hidden=None):
 
         if mask is None and hasattr(data, 'mask'):
             mask = data.mask
@@ -758,7 +770,7 @@ class MaskedColumn(Column, ma.MaskedArray):
         # with MaskedArray.
         self_data = BaseColumn(data, dtype=dtype, shape=shape, length=length, name=name,
                                unit=unit, format=format, description=description, meta=meta,
-                               units=units, dtypes=dtypes)
+                               units=units, dtypes=dtypes, hidden=hidden)
         self = ma.MaskedArray.__new__(cls, data=self_data, mask=mask)
 
         # Note: do not set fill_value in the MaskedArray constructor because this does not
@@ -847,5 +859,6 @@ class MaskedColumn(Column, ma.MaskedArray):
         # Use parent table definition of Column if available
         column_cls = self.parent_table.Column if (self.parent_table is not None) else Column
         out = column_cls(name=self.name, data=data, unit=self.unit, format=self.format,
-                         description=self.description, meta=deepcopy(self.meta))
+                         description=self.description, meta=deepcopy(self.meta),
+                         hidden=self.hidden)
         return out

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -301,9 +301,10 @@ class TableFormatter(object):
             show_unit = any([col.unit for col in six.itervalues(table.columns)])
 
         for col in six.itervalues(table.columns):
-            lines, n_header = self._pformat_col(col, max_lines, show_name,
-                                                show_unit)
-            cols.append(lines)
+            if not col.hidden:
+                lines, n_header = self._pformat_col(col, max_lines, show_name,
+                                                    show_unit)
+                cols.append(lines)
 
         if not cols:
             return []

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -7,16 +7,18 @@ from ...table import Table, Column, MaskedColumn
 
 
 def test_pickle_column(protocol):
-    c = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
+    c = Column(data=[1, 2], name='a', format='%05d', description='col a',
+               unit='cm', meta={'a': 1}, hidden=True)
     cs = pickle.dumps(c)
     cp = pickle.loads(cs)
     assert np.all(cp == c)
     assert cp.attrs_equal(c)
+    assert cp.hidden is True
 
 
 def test_pickle_masked_column(protocol):
     c = MaskedColumn(data=[1, 2], name='a', format='%05d', description='col a', unit='cm',
-                     meta={'a': 1})
+                     meta={'a': 1}, hidden=True)
     c.mask[1] = True
     c.fill_value = -99
 
@@ -27,12 +29,13 @@ def test_pickle_masked_column(protocol):
     assert np.all(cp.mask == c.mask)
     assert cp.attrs_equal(c)
     assert cp.fill_value == -99
+    assert cp.hidden is True
 
 
 def test_pickle_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
     b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',
-               meta={'b': 1})
+               meta={'b': 1}, hidden=True)
     t = Table([a, b], meta={'a': 1})
     ts = pickle.dumps(t)
     tp = pickle.loads(ts)
@@ -41,13 +44,15 @@ def test_pickle_table(protocol):
     assert np.all(tp['b'] == t['b'])
     assert tp['a'].attrs_equal(t['a'])
     assert tp['b'].attrs_equal(t['b'])
+    assert tp['a'].hidden is False
+    assert tp['b'].hidden is True
     assert tp.meta == t.meta
 
 
 def test_pickle_masked_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
     b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',
-               meta={'b': 1})
+               meta={'b': 1}, hidden=True)
     t = Table([a, b], meta={'a': 1}, masked=True)
     t['a'].mask[1] = True
     t['a'].fill_value = -99
@@ -61,4 +66,6 @@ def test_pickle_masked_table(protocol):
 
     assert tp['a'].attrs_equal(t['a'])
     assert tp['b'].attrs_equal(t['b'])
+    assert tp['a'].hidden is False
+    assert tp['b'].hidden is True
     assert tp.meta == t.meta

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -327,6 +327,13 @@ class TestFormat():
         with pytest.raises(ValueError):
             str(t['a'])
 
+    def test_pprint_hidden_col(self, table_type):
+        t = table_type([[1], [2]], names=['a', 'b'])
+        t['a'].hidden = True
+        assert t.pformat() == [' b ',
+                               '---',
+                               '  2']
+
 
 def test_pprint_py3_bytes():
     """
@@ -345,3 +352,5 @@ def test_pprint_nameless_col():
     """
     col = table.Column([1.,2.])
     assert str(col).startswith('None')
+
+

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -413,3 +413,36 @@ any array::
           [30, 40]],
          [[ 5,  6],
           [50, 60]]])
+
+
+Hiding columns
+''''''''''''''''
+
+Sometimes it is desirable to hide certain columns from the print output, for
+instance if these columns are very wide (and make reading the screen output
+difficult) or if they contain information that is not relevant for the
+particular situation.
+
+This can be done by setting the column ``hidden`` attribute to ``True``.  For
+example::
+
+  >>> t = Table([['jim', 'joe'], [3, 4], [5, 6]], names=['name', 'b', 'c'])
+  >>> print t
+  name  b   c 
+  ---- --- ---
+   jim   3   5
+   joe   4   6
+
+  >>> t['name'].hidden = True
+  >>> print t
+   b   c 
+  --- ---
+    3   5
+    4   6
+
+  >>> t['name'].hidden = False
+  >>> print t
+  name  b   c 
+  ---- --- ---
+   jim   3   5
+   joe   4   6


### PR DESCRIPTION
I've had occasions where a table contains one or more very wide columns that obscure the print output.  It would be nice to be able to hide those columns selectively.
