### PR TITLE
Remove Jenkins Build Status from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,6 @@ and development is occuring at the
 For installation instructions, see the `online documentation <http://docs.astropy.org/>`_
 or  ``docs/install.rst`` in this source distribution.
 
-Jenkins Build Status
---------------------
-.. image:: https://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/badge/icon
-    :target: https://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/
-    
 Travis Build Status
 -------------------
 .. image:: https://travis-ci.org/astropy/astropy.png


### PR DESCRIPTION
This is quite straightforward - it just removes the testing badge for jenkins from the README (and thereby also http://github.com/astropy/astropy ), and is necessary because Shining Panda is now defunct.

At some point there was discussion of setting up our own jenkins, but I'm thinking it makes sense to remove this for now and we can always add it back in later if we think that's wise.

cc @astrofrog @mdboom @embray 
