### PR TITLE
Use np.intp_t for indices

### DIFF
--- a/astropy/table/_np_utils.pyx
+++ b/astropy/table/_np_utils.pyx
@@ -12,7 +12,7 @@ from numpy.lib.recfunctions import drop_fields
 cimport cython
 cimport numpy as np
 DTYPE = np.int
-ctypedef np.int_t DTYPE_t
+ctypedef np.intp_t DTYPE_t
 
 @cython.wraparound(False)
 @cython.boundscheck(False)


### PR DESCRIPTION
Fixes many test failures of the following kind on win-amd64:

```
X:\Python27-x64\lib\site-packages\astropy\table\np_utils.py:233:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   ValueError: Buffer dtype mismatch, expected 'DTYPE_t' but got 'long long'

_np_utils.pyx:19: ValueError
```
