### PR TITLE
Coerce pytest args to str to fix assertion error in pytest

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -234,7 +234,7 @@ class TestRunner(object):
                 parallel = multiprocessing.cpu_count()
             all_args.extend(['-n', six.text_type(parallel)])
 
-        if sys.version_info < (2, 7, 3):
+        if six.PY2:
             all_args = [x.encode('utf-8') for x in all_args]
 
         # override the config locations to not make a new directory nor use
@@ -256,9 +256,6 @@ class TestRunner(object):
         from ..table import Table
 
         try:
-            # need to convert to `str` because pytest does a check
-            # isinstance(..., str) that fails if you pass in unicode in py2.x
-            all_args = [str(arg) for arg in all_args]
             result = pytest.main(args=all_args, plugins=plugins)
         finally:
             shutil.rmtree(os.environ['XDG_CONFIG_HOME'])


### PR DESCRIPTION
This fixes a problem I encountered when running the tests with `-t` on an rst file.  E.g., `python setup.py test -t coordinates/index.rst`  That should run the doctests for just that file, but instead, it yields the cryptic traceback I've included at the bottom of this message.  I traced the cause to a line deep in the bowels of pytest that does `isinstance(arg, str)`, which fails for unicode arguments.  So this PR  just forces the arguments passed into pytest for setting plugins to be `str`.  

```
running build_scripts
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "astropy/__init__.py", line 196, in test
    skip_docs=skip_docs)
  File "astropy/tests/helper.py", line 259, in run_tests
    result = pytest.main(args=all_args, plugins=plugins)
  File "_pytest.config", line 18, in main
  File "_pytest.config", line 62, in _prepareconfig
  File "_pytest.core", line 376, in __call__
  File "_pytest.core", line 387, in _docall
  File "_pytest.core", line 288, in execute
  File "_pytest.helpconfig", line 25, in pytest_cmdline_parse
  File "_pytest.core", line 288, in execute
  File "_pytest.config", line 617, in pytest_cmdline_parse
  File "_pytest.config", line 710, in parse
  File "_pytest.config", line 686, in _preparse
  File "_pytest.core", line 185, in consider_preparse
  File "_pytest.core", line 195, in consider_pluginarg
  File "_pytest.core", line 210, in import_plugin
AssertionError
```
