### PR TITLE
Error in configuration deprecation warning

### DIFF
--- a/astropy/config/tests/data/deprecated.cfg
+++ b/astropy/config/tests/data/deprecated.cfg
@@ -1,0 +1,2 @@
+[table.pprint]
+max_lines = 25

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -11,6 +11,7 @@ import io
 
 from ...utils.data import get_pkg_data_filename
 from .. import configuration
+from ...utils.exceptions import AstropyDeprecationWarning
 
 
 def test_paths():
@@ -275,3 +276,20 @@ def test_configitem_unicode(tmpdir):
     assert isinstance(cio(), six.text_type)
     assert cio() == 'ასტრონომიის'
     assert sec['астрономия'] == 'ასტრონომიის'
+
+
+def test_warning_move_to_top_level():
+    # Check that the warning about deprecation config items in the
+    # file works.  See #2514
+    from ... import conf
+
+    configuration._override_config_file = get_pkg_data_filename('data/deprecated.cfg')
+
+    try:
+        with catch_warnings(AstropyDeprecationWarning) as w:
+            conf.reload()
+            conf.max_lines
+        assert len(w) == 1
+    finally:
+        configuration._override_config_file = None
+        conf.reload()


### PR DESCRIPTION
If I use a wrong format for `Table.read`, I get a cryptic exception:

```
In [4]: Table.read('hhsf14_participants.csv', format='csv')
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-4-69343da3d1ca> in <module>()
----> 1 Table.read('hhsf14_participants.csv', format='csv')

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/table/table.pyc in read(cls, *args, **kwargs)
   1850         passed through to the underlying data reader (e.g. `~astropy.io.ascii.ui.read`).
   1851         """
-> 1852         return io_registry.read(cls, *args, **kwargs)
   1853 
   1854     def write(self, *args, **kwargs):

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/io/registry.pyc in read(cls, *args, **kwargs)
    327                 'read', cls, path, fileobj, args, kwargs)
    328 
--> 329         reader = get_reader(format, cls)
    330         data = reader(*args, **kwargs)
    331 

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/io/registry.pyc in get_reader(data_format, data_class)
    271             return _readers[(reader_format, reader_class)]
    272     else:
--> 273         format_table_str = _get_format_table_str(data_class, 'Read')
    274         raise Exception("No reader defined for format '{0}' and class '{1}'.\n"
    275                         'The available formats are:\n'

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/io/registry.pyc in _get_format_table_str(data_class, readwrite)
    260         format_table = format_table[has_readwrite]
    261     format_table.remove_column('Data class')
--> 262     format_table_str = '\n'.join(format_table.pformat(max_lines=-1))
    263     return format_table_str
    264 

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/table/table.pyc in pformat(self, max_lines, max_width, show_name, show_unit, html, tableid)
    827         lines, n_header = self.formatter._pformat_table(self, max_lines, max_width,
    828                                                         show_name, show_unit, html,
--> 829                                                         tableid=tableid)
    830         return lines
    831 

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/table/pprint.pyc in _pformat_table(self, table, max_lines, max_width, show_name, show_unit, html, tableid)
    282         # "Print" all the values into temporary lists by column for subsequent
    283         # use and to determine the width
--> 284         max_lines, max_width = self._get_pprint_size(max_lines, max_width)
    285         cols = []
    286 

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/table/pprint.pyc in _get_pprint_size(max_lines, max_width)
     97         """
     98         if max_lines is None or max_width is None:
---> 99             lines, width = terminal_size()
    100 
    101         if max_lines is None:

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/utils/console.pyc in terminal_size(file)
    128         except TypeError:
    129             # fall back on configuration variables
--> 130             return conf.max_lines, conf.max_width
    131 
    132 

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/config/configuration.pyc in __get__(self, obj, objtype)
    274         if obj is None:
    275             return self
--> 276         return self()
    277 
    278     def set(self, value):

/Users/tom/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8784-py2.7-macosx-10.8-x86_64.egg/astropy/config/configuration.pyc in __call__(self)
    401                     "is deprecated. Use '{3}' in section [{4}] instead.".format(
    402                         name, module, get_config_filename(filename),
--> 403                         self.name, self.module.split('.', 1)[1]),
    404                     AstropyDeprecationWarning)
    405                 options.append((sec[name], module, name))

IndexError: list index out of range
```
