### PR TITLE
Fix doctests test path

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -328,10 +328,11 @@ class astropy_test(Command, object):
          "The name of a specific package to test, e.g. 'io.fits' or 'utils'.  "
          "If nothing is specified, all default tests are run."),
         ('test-path=', 't',
-         'Specify a test location by path.  If a relative path to a '
-         '.py file, it is relative to the built package.  If a relative '
-         'path to a .rst file, it is relative to the docs directory '
-         '(see --docs-path).  May also be an absolute path.'),
+         'Specify a test location by path.  If a relative path to a  .py file, '
+         'it is relative to the built package, so e.g., a  leading "astropy/" '
+         'is necessary.  If a relative  path to a .rst file, it is relative to '
+         'the directory *below* the --docs-path directory, so a leading '
+         '"docs/" is usually necessary.  May also be an absolute path.'),
         ('verbose-results', 'V',
          'Turn on verbose output from pytest.'),
         ('plugins=', 'p',


### PR DESCRIPTION
While testing for #2512 and #2513 I noticed that the `docs-path` option to `python setup.py test` is not respected.  This is because it uses a relative path even when the docs build happens in a temporary directory that doesn't include the sphinx source.  So this just locks in the absolute path at the time the test command is triggered, rather then when the tests are actually running (which is in a separate process).

It also clarifies the help information for the `-t` option, which I realized interacts in a confusing way with the `docs-path` descritpion
