### PR TITLE
Install config file.

### DIFF
--- a/astropy/setup_package.py
+++ b/astropy/setup_package.py
@@ -1,0 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+def get_package_data():
+    return {'astropy': ['astropy.cfg']}

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))
 package_info = get_package_info()
 
 # Add the project-global data
-package_info['package_data']['astropy'] = ['data/*']
+package_info['package_data'].setdefault('astropy', []).append('data/*')
 
 # Currently the only entry points installed by Astropy are hooks to
 # zest.releaser for doing Astropy's releases


### PR DESCRIPTION
The installation of the config file used to be handled inside of `get_package_info` in these lines:

```
    # Add the package's .cfg file
    package_data[''] = [srcdir + ".cfg"]
```

which appear to have been removed in `astropy-helpers`.  I'd like to just put it back, but the name of the main source package is no longer passed to `get_package_info`.  So instead, I'm just handling it on an astropy-specific basis by adding a `setup_package.py` file to the top-level.

Affiliated packages have the same problem at present, whether they are using the 0.3 generated config file or the 0.4 explicit config file.
