### PR TITLE
Don't import IPython

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -51,13 +51,6 @@ else:
         IPythonIOStream = None
         stdio = sys
 
-try:
-    import IPython  # pylint: disable=W0611
-    # This is just to set a flag that IPython is installed at all
-    _HAVE_IPYTHON = True
-except ImportError:
-    _HAVE_IPYTHON = False
-
 from ..config import ConfigAlias
 from ..extern import six
 from ..extern.six.moves import range


### PR DESCRIPTION
I'm investigating various things that make importing astropy slow.

One thing we're doing here is importing `IPython` unconditionally -- which is fairly expensive, as IPython is a large project.  I think we did that at one time to change console behavior depending on the IPython context, but since changed it to using the `get_ipython()` trick, which only has effect if the user is already running inside of IPython.
