### PR TITLE
Speedup of initialization for cosmology objects

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -31,30 +31,22 @@ __all__ = ["FLRW", "LambdaCDM", "FlatLambdaCDM", "wCDM", "FlatwCDM",
 
 __doctest_requires__ = {'*': ['scipy.integrate']}
 
-# Constants
-
-# Mpc in km
-Mpc_km = (1 * u.Mpc).to(u.km)
-
 # Some conversion constants -- useful to compute them once here
 #  and reuse in the initialization rather than have every object do them
-#  Note that the call to const.G.cgs.value is actually extremely expensive,
-#   so it is very useful to preload that one.  In fact, we skip using
-#   units for that as well, which is suprisingly expensive, because
-#   the conversion from G in mks to G in cgs is a rather trivial one.
-#   This assumes that constants will always return mks by default --
-#   if this is made faster for simple cases like this, it should
-#   be changed to just using const.G.cgs.value
+# Note that the call to cgs is actually extremely expensive,
+#  so we actually skip using the units package directly, and
+#  hardwire the conversion from mks to cgs. This assumes that constants
+#  will always return mks by default -- if this is made faster for simple
+#  cases like this, it should be changed back.
+# Note that the unit tests should catch it if this happens
 H0units_to_invs = (u.km / (u.s * u.Mpc)).to(1.0 / u.s)
 sec_to_Gyr = u.s.to(u.Gyr)
-critdens_const = 3. / (8. * pi * const.G.value * 1000)  # cgs const in critdens
-
-arcsec_in_radians = 1 / 3600. * pi / 180
-arcmin_in_radians = 1 / 60. * pi / 180
-
-# Radiation parameter over c^2 in cgs
-a_B_c2 = 4 * const.sigma_sb.cgs.value / const.c.cgs.value ** 3
-
+# const in critical density in cgs units (g cm^-3)
+critdens_const = 3. / (8. * pi * const.G.value * 1000)
+arcsec_in_radians = pi / (3600. * 180)
+arcmin_in_radians = pi / (60. * 180)
+# Radiation parameter over c^2 in cgs (g cm^-3 K^-4)
+a_B_c2 = 4e-3 * const.sigma_sb.value / const.c.value ** 3
 # Boltzmann constant in eV / K
 kB_evK = const.k_B.to(u.eV / u.K)
 
@@ -153,8 +145,8 @@ class FLRW(Cosmology):
         cd0value = critdens_const * H0_s ** 2
         self._critical_density0 = u.Quantity(cd0value, u.g / u.cm ** 3)
 
-        # Load up neutrino masses.
-        self._nneutrinos = int(floor(self._Neff))  # In Py2.x, floor is floating
+        # Load up neutrino masses.  Note: in Py2.x, floor is floating
+        self._nneutrinos = int(floor(self._Neff))
 
         # We are going to share Neff between the neutrinos equally.
         # In detail this is not correct, but it is a standard assumption
@@ -2374,12 +2366,14 @@ for key in parameters.available:
                               Neff=par['Neff'],
                               m_nu=u.Quantity(par['m_nu'], u.eV),
                               name=key)
-        cosmo.__doc__ = "%s instance of FlatLambdaCDM cosmology\n\n(from %s)" % (key, par['reference'])
+        docstr = "%s instance of FlatLambdaCDM cosmology\n\n(from %s)"
+        cosmo.__doc__ = docstr % (key, par['reference'])
     else:
         cosmo = LambdaCDM(par['H0'], par['Om0'], par['Ode0'],
                           Tcmb0=par['Tcmb0'], Neff=par['Neff'],
                           m_nu=u.Quantity(par['m_nu'], u.eV), name=key)
-        cosmo.__doc__ = "%s instance of LambdaCDM cosmology\n\n(from %s)" % (key, par['reference'])
+        docstr = "%s instance of LambdaCDM cosmology\n\n(from %s)"
+        cosmo.__doc__ = docstr % (key, par['reference'])
     setattr(sys.modules[__name__], key, cosmo)
 
 # don't leave these variables floating around in the namespace

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -54,6 +54,8 @@ def test_basic():
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=2.0, Neff=3.04)
     assert np.allclose(cosmo.Om0, 0.27)
     assert np.allclose(cosmo.Ode0, 0.729975, rtol=1e-4)
+    # This next test will fail if astropy.const starts returning non-mks
+    #  units by default; see the comment at the top of core.py
     assert np.allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
     assert np.allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
     assert np.allclose(cosmo.Ok0, 0.0)
@@ -411,6 +413,7 @@ def test_tcmb():
     assert np.allclose(cosmo.Tcmb(z).value,
                        [2.5, 5.0, 7.5, 10.0, 25.0], rtol=1e-6)
 
+
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_tnu():
     cosmo = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=3.0)
@@ -555,6 +558,7 @@ def test_comoving_volume():
     assert np.allclose(c_closed.comoving_volume(redshifts).value,
                        wright_closed, rtol=1e-2)
 
+
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_differential_comoving_volume():
     from scipy.integrate import quad
@@ -563,7 +567,8 @@ def test_differential_comoving_volume():
     c_open = core.LambdaCDM(H0=70, Om0=0.27, Ode0=0.0, Tcmb0=0.0)
     c_closed = core.LambdaCDM(H0=70, Om0=2, Ode0=0.0, Tcmb0=0.0)
 
-    # test that integration of differential_comoving_volume() yields same as comoving_volume()
+    # test that integration of differential_comoving_volume()
+    #  yields same as comoving_volume()
     redshifts = np.array([0.5, 1, 2, 3, 5, 9])
     wright_flat = np.array([29.123, 159.529, 630.427, 1178.531, 2181.485,
                             3654.802]) * 1e9  # convert to Mpc**3
@@ -586,6 +591,7 @@ def test_differential_comoving_volume():
     assert np.allclose(np.array([4.0 * np.pi * quad(ctemp, 0, redshift)[0]
                                  for redshift in redshifts]),
                        wright_closed, rtol=1e-2)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_flat_open_closed_icosmo():
@@ -724,7 +730,8 @@ def test_integral():
     assert np.allclose(cosmo.comoving_distance(3),
                        cosmo.comoving_distance(3.0), rtol=1e-7)
     assert np.allclose(cosmo.comoving_distance([1, 2, 3, 5]),
-                       cosmo.comoving_distance([1.0, 2.0, 3.0, 5.0]), rtol=1e-7)
+                       cosmo.comoving_distance([1.0, 2.0, 3.0, 5.0]),
+                       rtol=1e-7)
     assert np.allclose(cosmo.efunc(6), cosmo.efunc(6.0), rtol=1e-7)
     assert np.allclose(cosmo.efunc([1, 2, 6]),
                        cosmo.efunc([1.0, 2.0, 6.0]), rtol=1e-7)
@@ -864,6 +871,8 @@ def test_neg_distmod():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_critical_density():
     # WMAP7 but with Omega_relativisitic = 0
+    # These tests will fail if astropy.const starts returning non-mks
+    #  units by default; see the comment at the top of core.py
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     assert np.allclose(tcos.critical_density0.value,
                        9.31000324385361e-30)
@@ -1040,18 +1049,10 @@ def test_z_at_value():
 
     # test behaviour when the solution is outside z limits (should
     # raise a CosmologyError)
-    try:
+    with pytest.raises(core.CosmologyError):
         z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc, zmax=0.5)
-    except core.CosmologyError:
-        pass
-    else:
-        raise RuntimeError('Test did not raise expected CosmologyError')
-    try:
+    with pytest.raises(core.CosmologyError):
         z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc, zmin=4.)
-    except core.CosmologyError:
-        pass
-    else:
-        raise RuntimeError('Test did not raise expected CosmologyError')
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
- Speed up initialization by about a factor of 100 by pre-computing
  some unit conversion quantities.  It turns out this was the
  dominant cost, particularly the call to const.G.cgs.
- import astropy.cosmology time falls by about 50%
- Passes all unit tests
- Partially addresses #2479; some more sophisticated options were
  also discussed there, and this just does the simple bit.
