### PR TITLE
Allow null SkyCoord transform from NoFrame to NoFrame

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -209,9 +209,8 @@ class SkyCoord(object):
         """
         from astropy.coordinates.errors import ConvertError
 
-        if frame is None or isinstance(self.frame, NoFrame):
-            raise ValueError('Cannot transform to/from this SkyCoord because '
-                             'the frame was not specified at creation.')
+        if frame is None:
+            frame = NoFrame
 
         frame_kwargs = {}
 
@@ -241,6 +240,14 @@ class SkyCoord(object):
                     frame_kwargs[attr] = self_val
         else:
             raise ValueError('Transform `frame` must be a frame name, class, or instance')
+
+        if issubclass(new_frame_cls, NoFrame) or isinstance(self.frame, NoFrame):
+            # Allow the null transform NoFrame => NoFrame
+            if issubclass(new_frame_cls, NoFrame) and isinstance(self.frame, NoFrame):
+                return self.__class__(self)
+            else:
+                raise ValueError('Cannot transform to/from this SkyCoord because '
+                                 'the frame was not specified at creation.')
 
         # Get the composite transform to the new frame
         trans = frame_transform_graph.get_transform(self.frame.__class__, new_frame_cls)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -356,9 +356,10 @@ def test_to_string():
         assert with_kwargs == wrap('+01h02m03.000s +01d02m03.000s')
 
 
-def test_seps():
-    sc1 = SkyCoord('icrs', 0 * u.deg, 1 * u.deg)
-    sc2 = SkyCoord('icrs', 0 * u.deg, 2 * u.deg)
+@pytest.mark.parametrize('frame', (None, 'icrs', 'fk5'))
+def test_seps(frame):
+    sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame=frame)
+    sc2 = SkyCoord(0 * u.deg, 2 * u.deg, frame=frame)
 
     sep = sc1.separation(sc2)
 
@@ -367,8 +368,8 @@ def test_seps():
     with pytest.raises(ValueError):
         sc1.separation_3d(sc2)
 
-    sc3 = SkyCoord('icrs', 1 * u.deg, 1 * u.deg, distance=1 * u.kpc)
-    sc4 = SkyCoord('icrs', 1 * u.deg, 1 * u.deg, distance=2 * u.kpc)
+    sc3 = SkyCoord(1 * u.deg, 1 * u.deg, distance=1 * u.kpc, frame=frame)
+    sc4 = SkyCoord(1 * u.deg, 1 * u.deg, distance=2 * u.kpc, frame=frame)
     sep3d = sc3.separation_3d(sc4)
 
     assert sep3d == 1 * u.kpc
@@ -419,7 +420,8 @@ def test_ops():
 
 def test_none_transform():
     """
-    Ensure that transforming from a SkyCoord with no frame provided always fails
+    Ensure that transforming from a SkyCoord with no frame provided always fails,
+    but that transforming from NoFrame to NoFrame works.
     """
     sc = SkyCoord(0 * u.deg, 1 * u.deg)
     sc_arr = SkyCoord(0 * u.deg, [1, 2] * u.deg)
@@ -433,6 +435,9 @@ def test_none_transform():
         sc_arr.transform_to(ICRS)
     with pytest.raises(ValueError):
         sc_arr.transform_to('fk5')
+
+    assert sc.transform_to(None).frame.name == 'noframe'
+    assert sc_arr.transform_to(None).frame.name == 'noframe'
 
 
 def test_position_angle():


### PR DESCRIPTION
In particular this allows computing sky separation for NoFrame coordinates.
