### PR TITLE
Add ah_bootstrap.py to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.rst
 include CHANGES.rst
 
 include ez_setup.py
-include setuptools_bootstrap.py
+include ah_bootstrap.py
 include setup.cfg
 include astropy/tests/coveragerc
 recursive-include astropy *.pyx *.c *.h *.map


### PR DESCRIPTION
Still can't build from a source tarball, however, due to other (known) issues.
