### PR TITLE
Include astropy-helpers in the tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -28,3 +28,5 @@ recursive-include astropy/sphinx/themes *
 exclude *.pyc *.o
 prune docs/_build
 prune build
+
+recursive-include astropy_helpers *


### PR DESCRIPTION
This has come out of a long discussion with @stsci-sienkiew about building astropy in the new astropy-helpers regime.  I'm not necessarily suggesting what is attached is the ultimate fix, but it should probably be discussed.

For testing at STScI, astropy is checked out from git, a tarball is made from the checkout, and then that tarball is distributed to multiple machines to build and test.  Whether you do `python setup.py sdist` or just `tar czf` (neglecting to do `git submodule update` first) to create the tarball doesn't really matter: either way, the tarball doesn't contain `astropy_helpers`.  When building the tarball on the slave machines, they may not have `git` installed, and they may not have an internet connection at all, so `pip install astropy-helpers` fails (and it fails at present anyway, since `astropy-helpers` hasn't been uploaded to PyPI).

One way out of this is to just declare `astropy-helpers` as a hard dependency of `astropy` (in the same way that `numpy` is), and require users to install it first.  That's probably fine for Linux distros, who will just package `astropy-helpers` and make it a requirement of `astropy`.  However, it's a bit at odds with the approach we've taken thus far wrt the number of other packages that we "ship with" rather than "require".  Also, you end up with different installation instructions when installing from a tarball vs. from a git checkout.

Note that if we ship `astropy-helpers` in the tarball, the magic auto-updating to a new version of `astropy-helpers` still works, if an internet connection is available and PyPI is reachable etc.  However, if that fails, we'd still have a way to install astropy.

Cc: @embray, @astrofrog
