### PR TITLE
Parallel testing fixes

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from .. import units as u
+from ..utils import OrderedDict
 from . import Longitude, Latitude
 
 try:
@@ -16,7 +17,7 @@ except ImportError:
 __all__ = ['EarthLocation']
 
 # translation between ellipsoid names and corresponding number used in ERFA
-ELLIPSOIDS = {'WGS84': 1, 'GRS80': 2, 'WGS72': 3}
+ELLIPSOIDS = OrderedDict([('WGS84', 1), ('GRS80', 2), ('WGS72', 3)])
 
 
 def _check_ellipsoid(ellipsoid=None, default='WGS84'):


### PR DESCRIPTION
Parallel testing doesn't work on my Mac at the moment because apparently there's two problems with non-deterministic test case collection:
https://gist.github.com/cdeil/9611d070beb593ce0f4c

9bfee8f008b43a571b3aa74f0412f92dfb344f1b fixes the first issue, but there's still this one in `astropy.table`:

```
INTERNALERROR> -astropy/table/table.py::astropy.table.table.Row
INTERNALERROR> +astropy/table/table.py::astropy.table.table.Table.Row
```

@taldcroft Can you reproduce? Any idea how to fix this?
(I think #1402 is unrelated?)
