### PR TITLE
Skip unnecessary copy of wcslib headers on each build.

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -5,12 +5,15 @@ from __future__ import (absolute_import, division, print_function,
 CONTACT = "Michael Droettboom"
 EMAIL = "mdroe@stsci.edu"
 
-from distutils.core import Extension
 import io
 from os.path import join
 import os.path
 import shutil
 import sys
+
+from distutils.core import Extension
+from distutils.dep_util import newer_group
+
 
 from astropy_helpers import setup_helpers
 from astropy.extern import six
@@ -311,8 +314,10 @@ def get_package_data():
         ]
     if not setup_helpers.use_system_library('wcslib'):
         for header in wcslib_headers:
-            shutil.copy(join('cextern', 'wcslib', 'C', header),
-                    join('astropy', 'wcs', 'include', 'wcslib', header))
+            source = join('cextern', 'wcslib', 'C', header)
+            dest = join('astropy', 'wcs', 'include', 'wcslib', header)
+            if newer_group([source], dest, 'newer'):
+                shutil.copy(source, dest)
             api_files.append(join('include', 'wcslib', header))
 
     return {


### PR DESCRIPTION
As I reported [here](https://github.com/astropy/astropy-helpers/issues/19#issuecomment-44312018). Avoid copying the wcslib header files from cextern unnecessarily on each run of setup.py build.  This will only copy them if they are missing/out of date.
