### PR TITLE
With quantity output, ensure non-quantity input is treated as dimensionless

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -305,7 +305,7 @@ class Quantity(np.ndarray):
         # amount that depends on one of the input values, so we need to treat
         # this as a special case.
         # TODO: find a better way to deal with this case
-        if function is np.power and result_unit is not None:
+        if function is np.power and result_unit is not dimensionless_unscaled:
 
             if units[1] is None:
                 p = args[1]

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -517,6 +517,29 @@ class TestInplaceUfuncs(object):
         assert check2.unit == u.dimensionless_unscaled
         assert_allclose(s.value, s2.value)
 
+    @pytest.mark.skipif("NUMPY_LT_1P6")
+    @pytest.mark.parametrize(('value'), [1., np.arange(10.)])
+    def test_one_argument_ufunc_inplace_2(self, value):
+        """Check inplace works with non-quantity input and quantity output"""
+        s = value * u.m
+        check = s
+        np.absolute(value, out=s)
+        assert check is s
+        assert np.all(check.value == np.absolute(value))
+        assert check.unit is u.dimensionless_unscaled
+        np.sqrt(value, out=s)
+        assert check is s
+        assert np.all(check.value == np.sqrt(value))
+        assert check.unit is u.dimensionless_unscaled
+        np.exp(value, out=s)
+        assert check is s
+        assert np.all(check.value == np.exp(value))
+        assert check.unit is u.dimensionless_unscaled
+        np.arcsin(value/10., out=s)
+        assert check is s
+        assert np.all(check.value == np.arcsin(value/10.))
+        assert check.unit is u.radian
+
     @pytest.mark.parametrize(('value'), [1., np.arange(10.)])
     def test_one_argument_two_output_ufunc_inplace(self, value):
         v = 100. * value * u.cm / u.m
@@ -580,9 +603,12 @@ class TestInplaceUfuncs(object):
     @pytest.mark.skipif("NUMPY_LT_1P6")
     def test_two_argument_ufunc_inplace_3(self):
         s = np.array([1., 2., 3.]) * u.dimensionless_unscaled
+        np.add(np.array([1., 2., 3.]), np.array([1., 2., 3.]) * 2., out=s)
+        assert np.all(s.value == np.array([3., 6., 9.]))
+        assert s.unit is u.dimensionless_unscaled
         np.arctan2(np.array([1., 2., 3.]), np.array([1., 2., 3.]) * 2., out=s)
         assert_allclose(s.value, np.arctan2(1., 2.))
-        assert s.unit == u.radian
+        assert s.unit is u.radian
 
     def test_ufunc_inplace_non_contiguous_data(self):
         # ensure inplace works also for non-contiguous data (closes #1834)


### PR DESCRIPTION
With current master, output from a `ufunc` to a quantity works for two argument functions, but not for one-argument ones (see below). This PR fixes this, even though it will rarely be used.

```
In [1]: import astropy.units as u, numpy as np

In [2]: s = 1.*u.m

In [3]: np.arctan2(1., 1., out=s)
Out[3]: <Quantity 0.7853981633974483 rad>

In [4]: s
Out[4]: <Quantity 0.7853981633974483 rad>

In [5]: np.arctan(1., out=s)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-5673edf1ef20> in <module>()
----> 1 np.arctan(1., out=s)

/usr/lib/python2.7/dist-packages/astropy/units/quantity.pyc in __array_prepare__(self, obj, context)
    200         # the unit the output from the ufunc will have.
    201         if function in UFUNC_HELPERS:
--> 202             scales, result_unit = UFUNC_HELPERS[function](function, *units)
    203         else:
    204             raise TypeError("Unknown ufunc {0}.  Please raise issue on "

/usr/lib/python2.7/dist-packages/astropy/units/quantity_helper.pyc in helper_dimensionless_to_radian(f, unit)
     94     from .si import radian
     95     try:
---> 96         scale = unit.to(dimensionless_unscaled)
     97     except UnitsError:                                                  
     98         raise TypeError("Can only apply '{0}' function to "             

AttributeError: 'NoneType' object has no attribute 'to'
```
