### PR TITLE
stats: sigma_clip: bug in definition of standard deviation

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -25,7 +25,7 @@ __doctest_skip__ = ['binned_binom_proportion']
 __doctest_requires__ = {'binom_conf_interval': ['scipy.special']}
 
 
-def sigma_clip(data, sig=3, iters=1, cenfunc=np.median, varfunc=np.var,
+def sigma_clip(data, sig=3, iters=1, cenfunc=np.ma.median, varfunc=np.ma.std,
                axis=None, copy=True):
     """Perform sigma-clipping on the provided data.
 
@@ -56,7 +56,7 @@ def sigma_clip(data, sig=3, iters=1, cenfunc=np.median, varfunc=np.var,
     varfunc : callable
         The technique to compute the standard deviation about the center. Must
         be a callable that takes in a masked array and outputs a width
-        estimator.  Defaults to the standard deviation (numpy.var).
+        estimator.  Defaults to the standard deviation (numpy.std).
     axis : int or `None`
         If not `None`, clip along the given axis.  For this case, axis=int will
         be passed on to cenfunc and varfunc, which are expected to return an


### PR DESCRIPTION
In the docstring to stats.sigma_clip is says `Defaults to the standard deviation (numpy.var)`. That is an error: `np.var` is the variance, not the standard deviation (that would be `np.std`).
For deviations close to 1 that is not an issue in practice, since sqrt(var) = std, but particularly for smaller numbers `np.var` will not result in a useful clipping.

Also, the `np.ma.xxx` version should be used, just to make sure it works if data is already a masked array.
If there is agreement that this is a bug to be fixed, I will add changelog and tests in a separate commit.
