### PR TITLE
Quantity.__array_ufunc__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,6 +187,11 @@ New Features
   - ``Quantity`` now supports the ``@`` operator for matrix multiplication that
     was introduced in Python 3.5, for all supported versions of numpy. [#6144]
 
+  - ``Quantity`` supports the new ``__array_ufunc__`` protocol introduced in
+    numpy 1.13.  As a result, operations that involve unit conversion will be
+    sped up considerably (by up to a factor of two for costly operations such
+    as trigonometric ones). [#2583]
+
 - ``astropy.utils``
 
   - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -444,6 +444,18 @@ class Angle(u.SpecificTypeQuantity):
                                    formatter={'str_kind': lambda x: x})
 
 
+def _no_angle_subclass(obj):
+    """Return any Angle subclass objects as an Angle objects.
+
+    This is used to ensure that Latitute and Longitude change to Angle
+    objects when they are used in calculations (such as lon/2.)
+    """
+    if isinstance(obj, tuple):
+        return tuple(_no_angle_subclass(_obj) for _obj in obj)
+
+    return obj.view(Angle) if isinstance(obj, Angle) else obj
+
+
 class Latitude(Angle):
     """
     Latitude-like angle(s) which must be in the range -90 to +90 deg.
@@ -525,11 +537,11 @@ class Latitude(Angle):
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
         obj = super(Angle, self).__array_wrap__(obj, context=context)
+        return _no_angle_subclass(obj)
 
-        if isinstance(obj, Angle):
-            return obj.view(Angle)
-
-        return obj
+    def __numpy_ufunc__(self, *args, **kwargs):
+        results = super(Latitude, self).__numpy_ufunc__(*args, **kwargs)
+        return _no_angle_subclass(results)
 
 
 class Longitude(Angle):
@@ -644,8 +656,8 @@ class Longitude(Angle):
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
         obj = super(Angle, self).__array_wrap__(obj, context=context)
+        return _no_angle_subclass(obj)
 
-        if isinstance(obj, Angle):
-            return obj.view(Angle)
-
-        return obj
+    def __numpy_ufunc__(self, *args, **kwargs):
+        results = super(Longitude, self).__numpy_ufunc__(*args, **kwargs)
+        return _no_angle_subclass(results)

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -539,8 +539,8 @@ class Latitude(Angle):
         obj = super(Angle, self).__array_wrap__(obj, context=context)
         return _no_angle_subclass(obj)
 
-    def __numpy_ufunc__(self, *args, **kwargs):
-        results = super(Latitude, self).__numpy_ufunc__(*args, **kwargs)
+    def __array_ufunc__(self, *args, **kwargs):
+        results = super(Latitude, self).__array_ufunc__(*args, **kwargs)
         return _no_angle_subclass(results)
 
 
@@ -658,6 +658,6 @@ class Longitude(Angle):
         obj = super(Angle, self).__array_wrap__(obj, context=context)
         return _no_angle_subclass(obj)
 
-    def __numpy_ufunc__(self, *args, **kwargs):
-        results = super(Longitude, self).__numpy_ufunc__(*args, **kwargs)
+    def __array_ufunc__(self, *args, **kwargs):
+        results = super(Longitude, self).__array_ufunc__(*args, **kwargs)
         return _no_angle_subclass(results)

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -2185,19 +2185,21 @@ class AiryDisk2D(Fittable2DModel):
         r = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2) / (radius / cls._rz)
 
         if isinstance(r, Quantity):
-            r = r.decompose().value
+            # scipy function cannot handle Quantity, so turn into array.
+            r = r.to_value(u.dimensionless_unscaled)
 
         # Since r can be zero, we have to take care to treat that case
         # separately so as not to raise a numpy warning
         z = np.ones(r.shape)
         rt = np.pi * r[r > 0]
         z[r > 0] = (2.0 * cls._j1(rt) / rt) ** 2
-        z *= amplitude
 
         if isinstance(amplitude, Quantity):
-            return Quantity(z, unit=amplitude.unit, copy=False)
-        else:
-            return z
+            # make z quantity too, otherwise in-place multiplication fails.
+            z = Quantity(z, u.dimensionless_unscaled, copy=False)
+
+        z *= amplitude
+        return z
 
     @property
     def input_units(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -430,7 +430,8 @@ class Quantity(np.ndarray):
             # and that we can handle the type (e.g., that we are not int when
             # float is required).
             check_output(obj, result_unit, (args + tuple(
-                (float if converter and converter(1.) % 1. != 0. else int)
+                (np.float16 if converter and converter(1.) % 1. != 0.
+                 else np.int8)
                 for converter in converters)),
                          function=function)
             result = obj  # no view needed since already a Quantity.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -625,10 +625,11 @@ class Quantity(np.ndarray):
         result = super(Quantity, self).__array_ufunc__(function, method,
                                                        *arrays, **kwargs)
         # If unit is None, a plain array is expected (e.g., comparisons and
-        # np.frexp), which means we're done. We're also done if the result was
+        # np.frexp), which means we're done.
+        # We're also done if the result was None (for method is 'at') or
         # NotImplemented, which can happen if other inputs/outputs override
         # __array_ufunc__; hopefully, they can then deal with us.
-        if unit is None or result is NotImplemented:
+        if unit is None or result is None or result is NotImplemented:
             return result
 
         return self._result_as_quantity(result, unit, outputs)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -616,8 +616,8 @@ class Quantity(np.ndarray):
             kwargs['out'] = (out_array,) if function.nout == 1 else out_array
 
         # Same for inputs, but here also convert if necessary.
-        arrays = tuple(((converter(input_.value) if converter else input_.value)
-                        if isinstance(input_, Quantity) else input_)
+        arrays = tuple((converter(input_.value) if converter else
+                        getattr(input_, 'value', input_))
                        for input_, converter in zip(inputs, converters))
 
         # Call our superclass's __array_ufunc__

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -580,7 +580,7 @@ class Quantity(np.ndarray):
             else:
                 return obj
 
-    def __numpy_ufunc__(self, function, method, i, inputs, **kwargs):
+    def __array_ufunc__(self, function, method, inputs, **kwargs):
         """Wrap numpy ufunc and other functions, taking care of units.
 
         Parameters
@@ -590,9 +590,6 @@ class Quantity(np.ndarray):
         method : str
             Callable attribute of ``function`` to use.  Should generally be
             ``__call__``, but can also be ``at``, ``reduce``, etc., for ufuncs.
-        i : int
-            Position of ``self`` among the inputs.  Part of the standard
-            ``__numpy_ufunc__`` signature, but not used here.
         inputs : tuple
             Input arrays and other positional arguments.
         kwargs : keyword arguments
@@ -1474,7 +1471,7 @@ class Quantity(np.ndarray):
             Result of the function call, with the unit set properly.
         """
         kwargs.setdefault('unit', self.unit)
-        return self.__numpy_ufunc__(function, '__call__', 0, (self,) + args,
+        return self.__array_ufunc__(function, '__call__', (self,) + args,
                                     **kwargs)
 
     def clip(self, a_min, a_max, out=None):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -23,6 +23,7 @@ from ..extern.six.moves import zip
 from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
                    UnitBase, UnitsError, UnitTypeError)
 from .format.latex import Latex
+from ..utils.compat import NUMPY_LT_1_13
 from ..utils.compat.misc import override__dir__
 from ..utils.compat.numpy import matmul
 from ..utils.misc import isiterable, InheritDocstrings
@@ -1094,12 +1095,17 @@ class Quantity(np.ndarray):
         result_array = matmul(getattr(other, 'value', other), self.value)
         return self._new_view(result_array, result_unit)
 
-    def __pos__(self):
-        """
-        Plus the quantity. This is implemented in case users use +q where q is
-        a quantity.  (Required for scalar case.)
-        """
-        return self.copy()
+    if NUMPY_LT_1_13:
+        # In numpy >=1.13, ndarray.__pos__ goes through the np.positive ufunc,
+        # and this is no longer needed.
+        def __pos__(self):
+            """
+            Plus the quantity.
+
+            This is implemented in case users use +q where q is a quantity.
+            (Required for scalar case.)
+            """
+            return self.copy()
 
     # other overrides of special functions
     def __hash__(self):

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -579,8 +579,9 @@ def check_output(output, unit, inputs, function=None):
                                     .format(function.__name__)))
 
     # check we can handle the dtype (e.g., that we are not int
-    # when float is required)
-    if not np.can_cast(np.result_type(*inputs), output.dtype):
+    # when float is required); specifically exclude None for numpy <=1.7.
+    if not np.can_cast(np.result_type(*[i for i in inputs if i is not None]),
+                       output.dtype):
         raise TypeError("Arguments cannot be cast safely to output "
                         "with dtype={0}".format(output.dtype))
     return output

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -425,7 +425,7 @@ def converters_and_unit(function, method, *args):
         raise TypeError("Cannot use function '{0}' with quantities"
                         .format(function.__name__))
 
-    if method == '__call__':
+    if method == '__call__' or (method == 'outer' and function.nin == 2):
         # Find out the units of the arguments passed to the ufunc; usually,
         # at least one is a quantity, but for two-argument ufuncs, the second
         # could also be a Numpy array, etc.  These are given unit=None.
@@ -494,17 +494,51 @@ def converters_and_unit(function, method, *args):
                     else:
                         result_unit = dimensionless_unscaled
 
-    else:
-        # methods other than __call__, e.g., reduce, accumulate; these make
-        # sense only for two-argument functions that leave the unit intact.
-        if UFUNC_HELPERS[function] is helper_twoarg_invariant:
-            converters = [None]
-            result_unit = getattr(args[0], 'unit', None)
+    else:  # methods for which the unit should stay the same
+        if method == 'at':
+            unit = getattr(args[0], 'unit', None)
+            units = [unit]
+            if function.nin == 2:
+                units.append(getattr(args[2], 'unit', None))
+
+            converters, result_unit = UFUNC_HELPERS[function](function, *units)
+
+            # ensure there is no 'converter' for indices (2nd argument)
+            converters.insert(1, None)
+
+        elif (method in ('reduce', 'accumulate', 'reduceat') and
+              function.nin == 2):
+            unit = getattr(args[0], 'unit', None)
+            converters, result_unit = UFUNC_HELPERS[function](function,
+                                                              unit, unit)
+            converters = converters[:1]
+            if method == 'reduceat':
+                # add 'scale' for indices (2nd argument)
+                converters += [None]
+
         else:
-            raise TypeError("Unknown ufunc {0} for method {1}.  "
-                            "If this should work, please raise an issue on "
+            if method in ('reduce', 'accumulate', 'reduceat',
+                          'outer') and function.nin != 2:
+                raise ValueError("{0} only supported for binary functions"
+                                 .format(method))
+
+            raise TypeError("Unexpected ufunc method {0}.  If this should "
+                            "work, please raise an issue on"
                             "https://github.com/astropy/astropy"
-                            .format(function.__name__, method))
+                            .format(method))
+
+        # for all but __call__ method, scaling is not allowed
+        if unit is not None and result_unit is None:
+            raise TypeError("Cannot use '{1}' method on ufunc {0} with a "
+                            "Quantity instance as the result is not a "
+                            "Quantity.".format(function.__name__, method))
+
+        if converters[0] is not None or (unit is not None and
+                                         (not result_unit.is_equivalent(unit) or
+                                          result_unit.to(unit) != 1.)):
+            raise UnitsError("Cannot use '{1}' method on ufunc {0} with a "
+                             "Quantity instance as it would change the unit."
+                             .format(function.__name__, method))
 
     return converters, result_unit
 

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -587,7 +587,7 @@ def check_output(output, unit, inputs, function=None):
         if unit is None:
             raise TypeError("Cannot store non-quantity output{0} in {1} "
                             "instance".format(
-                                ("from {0} function".format(function.__name__)
+                                (" from {0} function".format(function.__name__)
                                  if function is not None else ""),
                                 type(output)))
 
@@ -595,7 +595,7 @@ def check_output(output, unit, inputs, function=None):
             raise UnitTypeError(
                 "Cannot store output with unit '{0}'{1} "
                 "in {2} instance.  Use {3} instance instead."
-                .format(unit, ("from {0} function".format(function.__name__)
+                .format(unit, (" from {0} function".format(function.__name__)
                                if function is not None else ""), type(output),
                         output.__quantity_subclass__(unit)[0]))
 

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -662,6 +662,11 @@ class TestLogQuantityArithmetic(object):
                 with pytest.raises(u.UnitsError):
                     t.to(u.dimensionless_unscaled)
 
+    def test_error_on_lq_as_power(self):
+        lq = u.Magnitude(np.arange(1., 4.)*u.Jy)
+        with pytest.raises(TypeError):
+            lq ** lq
+
     @pytest.mark.parametrize('other', pu_sample)
     def test_addition_subtraction_to_normal_units_fails(self, other):
         lq = u.Magnitude(np.arange(1.,10.)*u.Jy)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -16,9 +16,9 @@ import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_almost_equal)
 
-
 from ...tests.helper import raises, pytest
 from ...utils import isiterable, minversion
+from ...utils.compat import NUMPY_LT_1_10
 from ...utils.compat.numpy import matmul
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
@@ -571,7 +571,7 @@ class TestQuantityOperations(object):
             assert long(q3) == 1
 
         with pytest.raises(TypeError) as exc:
-            q1.__index__()
+            q3.__index__()
         assert exc.value.args[0] == index_err_msg
 
         # integer dimensionless unscaled is good for all
@@ -602,6 +602,15 @@ class TestQuantityOperations(object):
         with pytest.raises(TypeError) as exc:
             q5.__index__()
         assert exc.value.args[0] == index_err_msg
+
+    # Fails for numpy >=1.10; see https://github.com/numpy/numpy/issues/5074
+    # It seems unlikely this will be resolved, so xfail'ing it.
+    @pytest.mark.xfail(not NUMPY_LT_1_10,
+                       reason="list multiplication only works for numpy <=1.10")
+    def test_numeric_converter_to_index_in_practice(self):
+        """Test that use of __index__ actually works."""
+        q4 = u.Quantity(2, u.dimensionless_unscaled, dtype=int)
+        assert q4 * ['a', 'b', 'c'] == ['a', 'b', 'c', 'a', 'b', 'c']
 
     def test_array_converters(self):
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from ... import units as u
-from ...utils.compat import NUMPY_LT_1_9_1, NUMPY_LT_1_10_4, NUMPY_LT_1_13
+from ...utils.compat import NUMPY_LT_1_9_1, NUMPY_LT_1_10_4
 
 
 class TestQuantityArrayCopy(object):
@@ -340,7 +340,7 @@ class TestQuantityStatsFuncs(object):
         assert np.all(q1.ediff1d() == np.array([1., 2., 6.]) * u.m)
         assert np.all(np.ediff1d(q1) == np.array([1., 2., 6.]) * u.m)
 
-    @pytest.mark.xfail(NUMPY_LT_1_13, reason=".dot only works for numpy>=1.13")
+    @pytest.mark.xfail
     def test_dot_func(self):
 
         q1 = np.array([1., 2., 4., 10.]) * u.m

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from ... import units as u
-from ...utils.compat import NUMPY_LT_1_9_1, NUMPY_LT_1_10, NUMPY_LT_1_10_4
+from ...utils.compat import NUMPY_LT_1_9_1, NUMPY_LT_1_10_4, NUMPY_LT_1_13
 
 
 class TestQuantityArrayCopy(object):
@@ -340,7 +340,7 @@ class TestQuantityStatsFuncs(object):
         assert np.all(q1.ediff1d() == np.array([1., 2., 6.]) * u.m)
         assert np.all(np.ediff1d(q1) == np.array([1., 2., 6.]) * u.m)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NUMPY_LT_1_13, reason=".dot only works for numpy>=1.13")
     def test_dot_func(self):
 
         q1 = np.array([1., 2., 4., 10.]) * u.m
@@ -541,10 +541,15 @@ class TestArrayConversion(object):
 class TestRecArray(object):
     """Record arrays are not specifically supported, but we should not
     prevent their use unnecessarily"""
-    def test_creation(self):
-        ra = (np.array(np.arange(12.).reshape(4,3))
+    def setup(self):
+        self.ra = (np.array(np.arange(12.).reshape(4,3))
               .view(dtype=('f8,f8,f8')).squeeze())
-        qra = u.Quantity(ra, u.m)
-        assert np.all(qra[:2].value == ra[:2])
+
+    def test_creation(self):
+        qra = u.Quantity(self.ra, u.m)
+        assert np.all(qra[:2].value == self.ra[:2])
+
+    def test_equality(self):
+        qra = u.Quantity(self.ra, u.m)
         qra[1] = qra[2]
         assert qra[1] == qra[2]

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -30,3 +30,10 @@ class TestQuantityLinAlgFuncs(object):
         q2 = np.array([4., 5., 6.]) / u.s
         o = np.dot(q1, q2)
         assert o == 32. * u.m / u.s
+
+    @pytest.mark.xfail
+    def test_matmul(self):
+        q1 = np.eye(3) * u.m
+        q2 = np.array([4., 5., 6.]) / u.s
+        o = np.matmul(q1, q2)
+        assert o == q2 / u.s

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,4 +1,5 @@
 import numpy as np
+from ...utils.compat import NUMPY_LT_1_13
 
 import pytest
 
@@ -23,3 +24,10 @@ class TestQuantityLinAlgFuncs(object):
         q2 = np.array([4, 5, 6]) / u.s
         o = np.inner(q1, q2)
         assert o == 32 * u.m / u.s
+
+    @pytest.mark.xfail(NUMPY_LT_1_13, reason="dot only works for numpy>=1.13")
+    def test_dot(self):
+        q1 = np.array([1., 2., 3.]) * u.m
+        q2 = np.array([4., 5., 6.]) / u.s
+        o = np.dot(q1, q2)
+        assert o == 32. * u.m / u.s

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,5 +1,4 @@
 import numpy as np
-from ...utils.compat import NUMPY_LT_1_13
 
 import pytest
 
@@ -25,7 +24,7 @@ class TestQuantityLinAlgFuncs(object):
         o = np.inner(q1, q2)
         assert o == 32 * u.m / u.s
 
-    @pytest.mark.xfail(NUMPY_LT_1_13, reason="dot only works for numpy>=1.13")
+    @pytest.mark.xfail
     def test_dot(self):
         q1 = np.array([1., 2., 3.]) * u.m
         q2 = np.array([4., 5., 6.]) / u.s

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -19,7 +19,7 @@ class TestUfuncCoverage(object):
         all_np_ufuncs = set([ufunc for ufunc in np.core.umath.__dict__.values()
                              if type(ufunc) == np.ufunc])
 
-        # in numpy >=1.10, with __numpy_ufunc__, np.dot behaves like a ufunc.
+        # in numpy >=1.13, with __array_ufunc__, np.dot behaves like a ufunc.
         if not NUMPY_LT_1_13:
             all_np_ufuncs |= set([np.dot])
 
@@ -663,7 +663,7 @@ class TestInplaceUfuncs(object):
         np.modf(v3, v3, tmp)
         assert check3 is v3
         assert check3.unit == u.dimensionless_unscaled
-        # in np<1.12, without __numpy_ufunc__, one cannot replace input with
+        # in np<1.13, without __array_ufunc__, one cannot replace input with
         # first output when scaling
         v4 = v_copy.copy()
         if NUMPY_LT_1_13:

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -19,10 +19,6 @@ class TestUfuncCoverage(object):
         all_np_ufuncs = set([ufunc for ufunc in np.core.umath.__dict__.values()
                              if type(ufunc) == np.ufunc])
 
-        # in numpy >=1.13, with __array_ufunc__, np.dot behaves like a ufunc.
-        if not NUMPY_LT_1_13:
-            all_np_ufuncs |= set([np.dot])
-
         from .. import quantity_helper as qh
 
         all_q_ufuncs = (qh.UNSUPPORTED_UFUNCS |

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -10,6 +10,7 @@ from numpy.testing.utils import assert_allclose
 from ... import units as u
 from ...tests.helper import raises
 from ...extern.six.moves import zip
+from ...utils.compat import NUMPY_LT_1_13
 
 
 class TestUfuncCoverage(object):
@@ -17,6 +18,10 @@ class TestUfuncCoverage(object):
     def test_coverage(self):
         all_np_ufuncs = set([ufunc for ufunc in np.core.umath.__dict__.values()
                              if type(ufunc) == np.ufunc])
+
+        # in numpy >=1.10, with __numpy_ufunc__, np.dot behaves like a ufunc.
+        if not NUMPY_LT_1_13:
+            all_np_ufuncs |= set([np.dot])
 
         from .. import quantity_helper as qh
 
@@ -658,9 +663,17 @@ class TestInplaceUfuncs(object):
         np.modf(v3, v3, tmp)
         assert check3 is v3
         assert check3.unit == u.dimensionless_unscaled
-        # but cannot replace input with first output if scaling is needed
-        with pytest.raises(TypeError):
-            np.modf(v_copy, v_copy, tmp)
+        # in np<1.12, without __numpy_ufunc__, one cannot replace input with
+        # first output when scaling
+        v4 = v_copy.copy()
+        if NUMPY_LT_1_13:
+            with pytest.raises(TypeError):
+                np.modf(v4, v4, tmp)
+        else:
+            check4 = v4
+            np.modf(v4, v4, tmp)
+            assert check4 is v4
+            assert check4.unit == u.dimensionless_unscaled
 
     @pytest.mark.parametrize(('value'), [1., np.arange(10.)])
     def test_two_argument_ufunc_inplace_1(self, value):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -767,3 +767,205 @@ class TestInplaceUfuncs(object):
         a4 = u.Quantity([1, 2, 3, 4], u.m, dtype=np.int32)
         with pytest.raises(TypeError):
             a4 += u.Quantity(10, u.mm, dtype=np.int64)
+
+@pytest.mark.xfail("NUMPY_LT_1_13")
+class TestUfuncAt(object):
+    """Test that 'at' method for ufuncs (calculates in-place at given indices)
+
+    For Quantities, since calculations are in-place, it makes sense only
+    if the result is still a quantity, and if the unit does not have to change
+    """
+    def test_one_argument_ufunc_at(self):
+        q = np.arange(10.) * u.m
+        i = np.array([1, 2])
+        qv = q.value.copy()
+        np.negative.at(q, i)
+        np.negative.at(qv, i)
+        assert np.all(q.value == qv)
+        assert q.unit is u.m
+
+        # cannot change from quantity to bool array
+        with pytest.raises(TypeError):
+            np.isfinite.at(q, i)
+
+        # for selective in-place, cannot change the unit
+        with pytest.raises(u.UnitsError):
+            np.square.at(q, i)
+
+        # except if the unit does not change (i.e., dimensionless)
+        d = np.arange(10.) * u.dimensionless_unscaled
+        dv = d.value.copy()
+        np.square.at(d, i)
+        np.square.at(dv, i)
+        assert np.all(d.value == dv)
+        assert d.unit is u.dimensionless_unscaled
+
+        d = np.arange(10.) * u.dimensionless_unscaled
+        dv = d.value.copy()
+        np.log.at(d, i)
+        np.log.at(dv, i)
+        assert np.all(d.value == dv)
+        assert d.unit is u.dimensionless_unscaled
+
+        # also for sine it doesn't work, even if given an angle
+        a = np.arange(10.) * u.radian
+        with pytest.raises(u.UnitsError):
+            np.sin.at(a, i)
+
+        # except, for consistency, if we have made radian equivalent to
+        # dimensionless (though hopefully it will never be needed)
+        av = a.value.copy()
+        with u.add_enabled_equivalencies(u.dimensionless_angles()):
+            np.sin.at(a, i)
+            np.sin.at(av, i)
+            assert_allclose(a.value, av)
+
+            # but we won't do double conversion
+            ad = np.arange(10.) * u.degree
+            with pytest.raises(u.UnitsError):
+                np.sin.at(ad, i)
+
+    def test_two_argument_ufunc_at(self):
+        s = np.arange(10.) * u.m
+        i = np.array([1, 2])
+        check = s.value.copy()
+        np.add.at(s, i, 1.*u.km)
+        np.add.at(check, i, 1000.)
+        assert np.all(s.value == check)
+        assert s.unit is u.m
+
+        with pytest.raises(u.UnitsError):
+            np.add.at(s, i, 1.*u.s)
+
+        # also raise UnitsError if unit would have to be changed
+        with pytest.raises(u.UnitsError):
+            np.multiply.at(s, i, 1*u.s)
+
+        # but be fine if it does not
+        s = np.arange(10.) * u.m
+        check = s.value.copy()
+        np.multiply.at(s, i, 2.*u.dimensionless_unscaled)
+        np.multiply.at(check, i, 2)
+        assert np.all(s.value == check)
+        s = np.arange(10.) * u.m
+        np.multiply.at(s, i, 2.)
+        assert np.all(s.value == check)
+
+        # of course cannot change class of data either
+        with pytest.raises(TypeError):
+            np.greater.at(s, i, 1.*u.km)
+
+
+@pytest.mark.xfail("NUMPY_LT_1_13")
+class TestUfuncReduceReduceatAccumulate(object):
+    """Test 'reduce', 'reduceat' and 'accumulate' methods for ufuncs
+
+    For Quantities, it makes sense only if the unit does not have to change
+    """
+    def test_one_argument_ufunc_reduce_accumulate(self):
+        # one argument cannot be used
+        s = np.arange(10.) * u.radian
+        i = np.array([0, 5, 1, 6])
+        with pytest.raises(ValueError):
+            np.sin.reduce(s)
+        with pytest.raises(ValueError):
+            np.sin.accumulate(s)
+        with pytest.raises(ValueError):
+            np.sin.reduceat(s, i)
+
+    def test_two_argument_ufunc_reduce_accumulate(self):
+        s = np.arange(10.) * u.m
+        i = np.array([0, 5, 1, 6])
+        check = s.value.copy()
+        s_add_reduce = np.add.reduce(s)
+        check_add_reduce = np.add.reduce(check)
+        assert s_add_reduce.value == check_add_reduce
+        assert s_add_reduce.unit is u.m
+
+        s_add_accumulate = np.add.accumulate(s)
+        check_add_accumulate = np.add.accumulate(check)
+        assert np.all(s_add_accumulate.value == check_add_accumulate)
+        assert s_add_accumulate.unit is u.m
+
+        s_add_reduceat = np.add.reduceat(s, i)
+        check_add_reduceat = np.add.reduceat(check, i)
+        assert np.all(s_add_reduceat.value == check_add_reduceat)
+        assert s_add_reduceat.unit is u.m
+
+        # reduce(at) or accumulate on comparisons makes no sense,
+        # as intermediate result is not even a Quantity
+        with pytest.raises(TypeError):
+            np.greater.reduce(s)
+
+        with pytest.raises(TypeError):
+            np.greater.accumulate(s)
+
+        with pytest.raises(TypeError):
+            np.greater.reduceat(s, i)
+
+        # raise UnitsError if unit would have to be changed
+        with pytest.raises(u.UnitsError):
+            np.multiply.reduce(s)
+
+        with pytest.raises(u.UnitsError):
+            np.multiply.accumulate(s)
+
+        with pytest.raises(u.UnitsError):
+            np.multiply.reduceat(s, i)
+
+        # but be fine if it does not
+        s = np.arange(10.) * u.dimensionless_unscaled
+        check = s.value.copy()
+        s_multiply_reduce = np.multiply.reduce(s)
+        check_multiply_reduce = np.multiply.reduce(check)
+        assert s_multiply_reduce.value == check_multiply_reduce
+        assert s_multiply_reduce.unit is u.dimensionless_unscaled
+        s_multiply_accumulate = np.multiply.accumulate(s)
+        check_multiply_accumulate = np.multiply.accumulate(check)
+        assert np.all(s_multiply_accumulate.value == check_multiply_accumulate)
+        assert s_multiply_accumulate.unit is u.dimensionless_unscaled
+        s_multiply_reduceat = np.multiply.reduceat(s, i)
+        check_multiply_reduceat = np.multiply.reduceat(check, i)
+        assert np.all(s_multiply_reduceat.value == check_multiply_reduceat)
+        assert s_multiply_reduceat.unit is u.dimensionless_unscaled
+
+
+@pytest.mark.xfail("NUMPY_LT_1_13")
+class TestUfuncOuter(object):
+    """Test 'outer' methods for ufuncs
+
+    Just a few spot checks, since it uses the same code as the regular
+    ufunc call
+    """
+    def test_one_argument_ufunc_outer(self):
+        # one argument cannot be used
+        s = np.arange(10.) * u.radian
+        with pytest.raises(ValueError):
+            np.sin.outer(s)
+
+    def test_two_argument_ufunc_outer(self):
+        s1 = np.arange(10.) * u.m
+        s2 = np.arange(2.) * u.s
+        check1 = s1.value
+        check2 = s2.value
+        s12_multiply_outer = np.multiply.outer(s1, s2)
+        check12_multiply_outer = np.multiply.outer(check1, check2)
+        assert np.all(s12_multiply_outer.value == check12_multiply_outer)
+        assert s12_multiply_outer.unit == s1.unit * s2.unit
+
+        # raise UnitsError if appropriate
+        with pytest.raises(u.UnitsError):
+            np.add.outer(s1, s2)
+
+        # but be fine if it does not
+        s3 = np.arange(2.) * s1.unit
+        check3 = s3.value
+        s13_add_outer = np.add.outer(s1, s3)
+        check13_add_outer = np.add.outer(check1, check3)
+        assert np.all(s13_add_outer.value == check13_add_outer)
+        assert s13_add_outer.unit is s1.unit
+
+        s13_greater_outer = np.greater.outer(s1, s3)
+        check13_greater_outer = np.greater.outer(check1, check3)
+        assert type(s13_greater_outer) is np.ndarray
+        assert np.all(s13_greater_outer == check13_greater_outer)

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -9,7 +9,7 @@ from ...utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_9_1', 'NUMPY_LT_1_10', 'NUMPY_LT_1_10_4',
-           'NUMPY_LT_1_11', 'NUMPY_LT_1_12']
+           'NUMPY_LT_1_11', 'NUMPY_LT_1_12', 'NUMPY_LT_1_13']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -19,3 +19,4 @@ NUMPY_LT_1_10 = not minversion('numpy', '1.10.0')
 NUMPY_LT_1_10_4 = not minversion('numpy', '1.10.4')
 NUMPY_LT_1_11 = not minversion('numpy', '1.11.0')
 NUMPY_LT_1_12 = not minversion('numpy', '1.12')
+NUMPY_LT_1_13 = not minversion('numpy', '1.13dev')

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -100,9 +100,9 @@ Angles will also behave correctly for appropriate arithmetic operations::
     <Angle 3.5 rad>
     >>> np.sin(a / 2)  # doctest: +FLOAT_CMP
     <Quantity 0.479425538604203>
-    >>> a == a
+    >>> a == a  # doctest: +SKIP
     array(True, dtype=bool)
-    >>> a == (a + a)
+    >>> a == (a + a)    # doctest: +SKIP
     array(False, dtype=bool)
 
 |Angle| objects can also be used for creating coordinate objects::


### PR DESCRIPTION
EDIT (28-Apr-2017): in the end, the numpy implementation is called `__array_ufunc__`.

Following issue #2492, here is an implementation of `__numpy_ufunc__` that at least locally passes all the tests (and allows some previous `xfail`s to be removed!). It also addresses #2483, so hopefully will help set us up for testing against numpy 1.9 in travis.

Notes:
- this requires #2571.
- Rather rough is the implementation of `__numpy_ufunc__` with methods other than `__call__` (e.g., `accumulate`, `reduce`). Right now, I only allow two-argument `ufunc`s that do not change the unit (this is in the new `scales_and_result_unit` function, which is in `quantity_helper`). Do comment if this is wrong! Or if it is true for only some of those methods.
- I let overrides of some methods depend on the numpy version; let me know if this is done the right way.
