### PR TITLE
SAMP: Documentation does not match calling signature

### DIFF
--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -85,14 +85,6 @@ class SAMPHubServer(object):
         A string used to label the Hub with a human readable name. This string
         is written in the lock-file assigned to the ``hub.label`` token.
 
-    owner : str, optional
-        General purpose Hub owner name. This value is written in the lock-file
-        and assigned to the ``hub.owner.name`` token.
-
-    owner_group : str, optional
-        General purpose Hub owner group name. This value is written in the
-        lock-file and assigned to the ``hub.owner.group`` token.
-
     https : bool, optional
         Set the Hub running on a Secure Sockets Layer connection (HTTPS). By
         default SSL is disabled.

--- a/astropy/vo/samp/hub_proxy.py
+++ b/astropy/vo/samp/hub_proxy.py
@@ -38,7 +38,7 @@ class SAMPHubProxy(object):
         """
         return self._connected
 
-    def connect(self, hub=None, hub_params=None, user=None, password=None,
+    def connect(self, hub=None, hub_params=None,
                 key_file=None, cert_file=None, cert_reqs=0,
                 ca_certs=None, ssl_version=None, pool_size=20):
         """

--- a/astropy/vo/samp/integrated_client.py
+++ b/astropy/vo/samp/integrated_client.py
@@ -113,7 +113,7 @@ class SAMPIntegratedClient(object):
         """
         return self.hub.is_connected and self.client.is_running
 
-    def connect(self, hub=None, hub_params=None, user=None, password=None,
+    def connect(self, hub=None, hub_params=None,
                 key_file=None, cert_file=None, cert_reqs=0,
                 ca_certs=None, ssl_version=None, pool_size=20):
         """
@@ -167,7 +167,7 @@ class SAMPIntegratedClient(object):
             The number of socket connections opened to communicate with the
             Hub.
         """
-        self.hub.connect(hub, hub_params, user, password, key_file, cert_file,
+        self.hub.connect(hub, hub_params, key_file, cert_file,
                          cert_reqs, ca_certs, ssl_version, pool_size)
         self.client.start()
         self.client.register()


### PR DESCRIPTION
While working on #1196 I discovered this and I could not make out what the extra parameters in the signature are supposed to do:

http://docs.astropy.org/en/latest/api/astropy.vo.samp.SAMPHubProxy.html#astropy.vo.samp.SAMPHubProxy.connect

http://docs.astropy.org/en/latest/api/astropy.vo.samp.SAMPHubServer.html#astropy.vo.samp.SAMPHubServer

@astrofrog 
