### PR TITLE
Exclude git related files from astropy_helpers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,3 +30,6 @@ prune docs/_build
 prune build
 
 recursive-include astropy_helpers *
+exclude astropy_helpers/.git
+exclude astropy_helpers/.gitignore
+


### PR DESCRIPTION
As @astrofrog pointed out in #2549, we shouldn't include the `.git` files in astropy_helpers in the tarball.
