### PR TITLE
Minor addition to `io.ascii` docstrings

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -833,6 +833,7 @@ class BaseReader(object):
         one of:
 
         * File name
+        * File-like object
         * String (newline separated) with all header and data lines (must have at least 2 lines)
         * List of strings
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -87,7 +87,7 @@ def read(table, guess=None, **kwargs):
     the default behavior for various parameters is determined by the Reader
     class.
 
-    :param table: input table (file name, list of strings, or single newline-separated string)
+    :param table: input table (file name, file-like object, list of strings, or single newline-separated string)
     :param guess: try to guess the table format (default=True)
     :param format: input table format
     :param Inputter: Inputter class


### PR DESCRIPTION
This should make it clearer that the `io.ascii` readers will accept a file or file-like object as a parameter for `read()`.
