### PR TITLE
AttributeError in pytest_plugins.py

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -644,7 +644,8 @@ class Pair(pytest.File):
         try:
             mod = self.fspath.pyimport(ensuresyspath=True)
         except SyntaxError:
-            excinfo = pytest.py.code.ExceptionInfo()
+            import py
+            excinfo = py.code.ExceptionInfo()
             raise self.CollectError(excinfo.getrepr(style="short"))
         except self.fspath.ImportMismatchError:
             e = sys.exc_info()[1]


### PR DESCRIPTION
As mentioned at https://github.com/astropy/astropy/commit/ed1aa6c6ff25224fe38d0be97b61cf31a3e51aef#commitcomment-6539134 I got this error:

```
___________________________________________________ ERROR collecting gammapy/spectrum/tests/test_utils.py ____________________________________________________
_pytest.runner:137: in __init__
>   ???
_pytest.main:418: in _memocollect
>   ???
_pytest.main:295: in _memoizedcall
>   ???
_pytest.main:418: in <lambda>
>   ???
/Users/deil/Library/Python/2.7/lib/python/site-packages/astropy-0.4.dev8939-py2.7-macosx-10.9-x86_64.egg/astropy/tests/pytest_plugins.py:642: in collect
>           excinfo = pytest.py.code.ExceptionInfo()
E           AttributeError: 'module' object has no attribute 'py'
```

In the meantime I have changed my code and tests in `gammapy` and I'm not seeing the error any more, but I presume that is just because this line is no longer reached.

cc @mdboom
