### PR TITLE
astropy_helpers not found in "cd docs; make html"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,20 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
+try:
+    import astropy_helpers
+except ImportError:
+    # Building from inside the docs/ directory?
+    import os
+    import sys
+    if os.path.basename(os.getcwd()) == 'docs':
+        a_h_path = os.path.abspath(os.path.join('..', 'astropy_helpers'))
+        if os.path.isdir(a_h_path):
+            sys.path.insert(1, a_h_path)
+
+    # If that doesn't work trying to import from astropy_helpers below will
+    # still blow up
+
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 from astropy.extern import six


### PR DESCRIPTION
After updating to use astropy-helpers, it is no longer possible to do:

```
python setup.py develop
cd docs
make html
```

The result of this is:

```
(astropy)neptune$ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.1.3

Exception occurred:
  File "/Users/aldcroft/git/astropy/docs/conf.py", line 33, in <module>
    from astropy_helpers.sphinx.conf import *
ImportError: No module named astropy_helpers.sphinx.conf
```

One patch that fixes this case is inserting the following into `docs/conf.py`:

```
import sys
import os
sys.path.append(os.path.join('..', 'astropy_helpers'))
```
