### PR TITLE
test_wcsapi_extension failure

### DIFF
--- a/astropy/wcs/tests/extension/setup.py
+++ b/astropy/wcs/tests/extension/setup.py
@@ -3,8 +3,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import sys
 
 if __name__ == '__main__':
+    astropy_path = sys.argv[-1]
+    sys.argv = sys.argv[:-1]
+    sys.path.insert(0, astropy_path)
+
     from astropy import wcs
     from astropy import setup_helpers
     from distutils.core import setup, Extension

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -23,7 +23,7 @@ def test_wcsapi_extension(tmpdir):
     # Build the extension
     subprocess.check_call(
         [sys.executable, 'setup.py',
-         'install', '--install-lib={0}'.format(tmpdir)],
+         'install', '--install-lib={0}'.format(tmpdir), astropy_path],
         cwd=setup_path,
         env=env
     )


### PR DESCRIPTION
@mdboom I am getting this test failure from `test_wcsapi_extension` with current Astropy master:

```
___________________________________________________________________ test_wcsapi_extension ____________________________________________________________________

tmpdir = local('/tmp/pytest-7/test_wcsapi_extension0')

    def test_wcsapi_extension(tmpdir):
        # Test that we can build a simple C extension with the astropy.wcs C API

        setup_path = os.path.dirname(__file__)
        astropy_path = os.path.abspath(
            os.path.join(setup_path, '..', '..', '..', '..'))

        env = os.environ.copy()
        paths = [str(tmpdir), astropy_path]
        if env.get('PYTHONPATH'):
            paths.append(env.get('PYTHONPATH'))
        env['PYTHONPATH'] = ':'.join(paths)

        # Build the extension
        subprocess.check_call(
            [sys.executable, 'setup.py',
             'install', '--install-lib={0}'.format(tmpdir)],
            cwd=setup_path,
>           env=env
        )

astropy/wcs/tests/extension/test_extension.py:28: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

popenargs = (['/usr/local/bin/python2.7', 'setup.py', 'install', '--install-lib=/tmp/pytest-7/test_wcsapi_extension0'],)
kwargs = {'cwd': '/tmp/astropy-test-majJ6e/lib.linux-x86_64-2.7/astropy/wcs/tests/extension', 'env': {'CLICOLOR': 'yes', 'CODE': '/home/hfm/deil/code', 'CVSEDITOR': 'emacs', 'CVS_RSH': 'ssh', ...}}
retcode = 1, cmd = ['/usr/local/bin/python2.7', 'setup.py', 'install', '--install-lib=/tmp/pytest-7/test_wcsapi_extension0']

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.

        The arguments are the same as for the Popen constructor.  Example:

        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           CalledProcessError: Command '['/usr/local/bin/python2.7', u'setup.py', u'install', u'--install-lib=/tmp/pytest-7/test_wcsapi_extension0']' returned non-zero exit status 1

/usr/local/Packages/python-modules/lib/python2.7/subprocess.py:542: CalledProcessError
---------------------------------------------------------------------- Captured stdout -----------------------------------------------------------------------
ERROR: AttributeError: 'module' object has no attribute 'get_include' [__main__]
---------------------------------------------------------------------- Captured stderr -----------------------------------------------------------------------
Traceback (most recent call last):
  File "setup.py", line 16, in <module>
    os.path.join(wcs.get_include(), 'astropy_wcs'),
AttributeError: 'module' object has no attribute 'get_include'
```

Full log here: https://gist.github.com/cdeil/a5131cb4ca91397b9103#file-gistfile1-txt-L1534
