### PR TITLE
Add numpy version to all conda install commands to ensure numpy is not u...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,14 @@ install:
     - if [[ $SETUP_CMD != egg_info ]]; then pip install pytest-xdist; fi
 
     # OPTIONAL DEPENDENCIES
-    - if $OPTIONAL_DEPS; then conda install --yes scipy h5py; fi
+    - if $OPTIONAL_DEPS; then conda install --yes numpy=$NUMPY_VERSION scipy h5py; fi
     - if $OPTIONAL_DEPS; then pip install beautifulsoup4; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then conda install --yes Sphinx matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then conda install --yes numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage coveralls; fi


### PR DESCRIPTION
...pgraded

@astrofrog --  this is needed to prevent the scipy/matplotlib `conda install`s from upgrading numpy.
