### PR TITLE
Reusable Fittable1DModelTester and Fittabel2DModelTester classes

### DIFF
--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -35,7 +35,7 @@ def test_pixel_sum_1D(model_class, mode):
     """
     if model_class == Box1D and mode == "center":
         pytest.skip("Non integrating mode. Skip integral test.")
-    parameters = models_1D[model_class]['parameters']
+    parameters = models_1D[model_class]
     model = create_model(model_class, parameters)
 
     values = discretize_model(model, models_1D[model_class]['x_lim'], mode=mode)
@@ -63,7 +63,7 @@ def test_pixel_sum_2D(model_class, mode):
     if model_class == Box2D and mode == "center":
         pytest.skip("Non integrating mode. Skip integral test.")
 
-    parameters = models_2D[model_class]['parameters']
+    parameters = models_2D[model_class]
     model = create_model(model_class, parameters)
 
     values = discretize_model(model, models_2D[model_class]['x_lim'],

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -417,18 +417,17 @@ class Fittable1DModelTester(object):
         # add 10% noise to the amplitude
         relative_noise_amplitude = 0.01
         data = (1 + relative_noise_amplitude * np.random.randn(len(x))) * model(x)
-        fitter = fitting.NonLinearLSQFitter()
+        fitter = fitting.LevMarLSQFitter()
         new_model = fitter(model, x, data)
 
         # Only check parameters that were free in the fit
         params = [getattr(new_model, name) for name in new_model.param_names]
-        fixed = [par.fixed for par in params]
-        fitted_parameters = [val
-                             for (val, fixed) in zip(parameters, fixed)
-                             if not fixed]
-        fitparams, _ = fitter._model_to_fit_params(new_model)
-        utils.assert_allclose(fitparams, fitted_parameters,
-                              atol=self.fit_error)
+        fixed = [param.fixed for param in params]
+        expected = np.array([val for val, fixed in zip(parameters, fixed)
+                             if not fixed])
+        fitted = np.array([param.value for param in params
+                           if not param.fixed])
+        utils.assert_allclose(fitted, expected, atol=self.fit_error)
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_deriv_1D(self, model_class, test_parameters):


### PR DESCRIPTION
This PR modifies the `FittableModel` testing, that it can be easily reused in affiliated packages.  Therefore the classes `FittabelModel1DTester` and `FittabelModel2DTester` were introduced, which can be used as base classes for user defined model testing. To give you an idea here is the corresponding code snippet, which defines the model test:

```
@pytest.mark.parametrize(('model_class', 'test_parameters'), list(models_1D.items()))
class TestFittable1DModels(Fittable1DModelTester):
    pass
```

Were `models_1D` is the dictionary with the test parameters as defined in `modeling.tests.example_models`. The class can now be used with any user defined dictionary for the test parameters, as long as it follows the definitions in `modeling.tests.example_models`.
