### PR TITLE
Remove current context managers from vo.samp

### DIFF
--- a/astropy/vo/samp/client.py
+++ b/astropy/vo/samp/client.py
@@ -181,12 +181,6 @@ class SAMPClient(object):
                                                             self._port),
                                            '', '', '', ''))
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, tb):
-        self.stop()
-
     def start(self):
         """
         Start the client in a separate thread (non-blocking).

--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -361,12 +361,6 @@ class SAMPHubServer(object):
         """
         return self._id
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, tb):
-        self.stop()
-
     def _launch_thread(self, group=None, target=None, name=None, args=None):
 
         # Remove inactive threads

--- a/astropy/vo/samp/integrated_client.py
+++ b/astropy/vo/samp/integrated_client.py
@@ -92,13 +92,6 @@ class SAMPIntegratedClient(object):
                                  port, https, key_file, cert_file, cert_reqs,
                                  ca_certs, ssl_version, callable)
 
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, tb):
-        self.disconnect()
-
     # GENERAL
 
     @property


### PR DESCRIPTION
(will be re-written in future to work on start/connect rather than initialization). See #2026.
