### PR TITLE
Don’t use devdocs.astropy.org in astropy.utils

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -760,7 +760,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
         else:
             baseurl = version + '/'
     elif version == 'dev' or version == 'latest':
-        baseurl = 'http://devdocs.astropy.org/'
+        baseurl = 'http://docs.astropy.org/en/latest/'
     else:
         baseurl = 'http://docs.astropy.org/en/{vers}/'.format(vers=version)
 

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -148,7 +148,7 @@ def test_api_lookup():
     objurl = misc.find_api_page(misc, 'dev', False, timeout=3)
 
     assert strurl == objurl
-    assert strurl == 'http://devdocs.astropy.org/utils/index.html#module-astropy.utils.misc'
+    assert strurl == 'http://docs.astropy.org/en/latest/utils/index.html#module-astropy.utils.misc'
 
 
 def test_skip_hidden():


### PR DESCRIPTION
@eteq - apparently `devdocs` doesn't work like it used to so the test is failing. I think this is cleaner in any csae. What do you think?
