### PR TITLE
Fixed sample code in docstring of ConfigItem.

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -174,7 +174,7 @@ class ConfigItem(object):
 
         class _Conf(config.ConfigNamespace):
             unicode_output = config.ConfigItem(
-                'unicode_output', False,
+                False,
                 'Use Unicode characters when outputting values, and writing widgets '
                 'to the console.')
         conf = _Conf()


### PR DESCRIPTION
The example code in the docstring of configuration.ConfigItem used to have a `name` parameter in the call as if it was the deprecated class ConfigurationItem even though the new class doesn't have this parameter anymore. This tiny pull request fixes this.
