### PR TITLE
fix coordinate frames wheb bool(frame._data) is False

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -299,7 +299,9 @@ class BaseCoordinateFrame(object):
 
         self._data = representation
 
-        if self._data:
+        # We do ``is not None`` because self._data might evaluate to false for
+        # empty arrays or data == 0
+        if self._data is not None:
             self._rep_cache = dict()
             self._rep_cache[representation.__class__.__name__, False] = representation
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -401,3 +401,10 @@ def test_nodata_error():
     with pytest.raises(ValueError):
         i.data
 
+def test_len0_data():
+    from ..builtin_frames import ICRS
+
+    i = ICRS([]*u.deg, []*u.deg)
+    assert i.has_data
+    repr(i)
+


### PR DESCRIPTION
This fixes an odd corner case I encountered: if you have some operation that yields an array of length-0 in a coordinate frame object, the coordinate frame freaks out because it's initialized for the no-data case.  This fixes that and adds a regression test.

cc @taldcroft @astrofrog
