### PR TITLE
Table.convert_unicode_to_bytestring doesn't work

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1477,7 +1477,7 @@ class Table(object):
         python3_only : bool
             Only do this operation for Python 3
         """
-        self._convert_string_dtype('S', 'U', python3_only)
+        self._convert_string_dtype('U', 'S', python3_only)
 
     def keep_columns(self, names):
         '''

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1251,3 +1251,28 @@ def test_unicode_policy():
                           ' 1 a 1.0 7',
                          ], format='ascii')
     assert_follows_unicode_guidelines(t)
+
+
+def test_unicode_bytestring_conversion(table_types):
+    t = table_types.Table([['abc'], ['def'], [1]], dtype=('S', 'U', 'i'))
+    assert t['col0'].dtype.kind == 'S'
+    assert t['col1'].dtype.kind == 'U'
+    assert t['col2'].dtype.kind == 'i'
+
+    t1 = t.copy()
+    t1.convert_unicode_to_bytestring()
+    assert t1['col0'].dtype.kind == 'S'
+    assert t1['col1'].dtype.kind == 'S'
+    assert t1['col2'].dtype.kind == 'i'
+    assert t1['col0'][0] == 'abc'.encode('ascii')
+    assert t1['col1'][0] == 'def'.encode('ascii')
+    assert t1['col2'][0] == 1
+
+    t1 = t.copy()
+    t1.convert_bytestring_to_unicode()
+    assert t1['col0'].dtype.kind == 'U'
+    assert t1['col1'].dtype.kind == 'U'
+    assert t1['col2'].dtype.kind == 'i'
+    assert t1['col0'][0] == six.text_type('abc')
+    assert t1['col1'][0] == six.text_type('def')
+    assert t1['col2'][0] == 1


### PR DESCRIPTION
@taldcroft [Table.convert_unicode_to_bytestring](http://astropy.readthedocs.org/en/latest/_modules/astropy/table/table.html#Table.convert_unicode_to_bytestring) is currently implemented as

```
self._convert_string_dtype('S', 'U', python3_only)
```

but I think it should be

```
self._convert_string_dtype('U', 'S', python3_only)
```

?

It doesn't have any tests, so I'm not 100% sure.

I noticed this in https://github.com/astropy/astroquery/pull/41 where I'm struggling to write string data that contains the character `\u2212` to FITS via an Astropy table in Python 3 ... can anyone give an example how to do that or maybe even add this as a unit test?
