### PR TITLE
Fixes spacetelescope/PyFITS#71

### DIFF
--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1326,6 +1326,10 @@ class TestHeaderFunctions(FitsTestCase):
         assert list(header.keys())[-1] == 'TEST2'
         assert list(header.keys())[-3] == 'TEST1'
 
+    def test_remove(self):
+        # TODO: Test the Header.remove() method; add support for ignore_missing
+        pass
+
     def test_header_comments(self):
         header = fits.Header([('A', 'B', 'C'), ('DEF', 'G', 'H')])
         assert (repr(header.comments) ==

--- a/docs/io/fits/appendix/history.rst
+++ b/docs/io/fits/appendix/history.rst
@@ -130,6 +130,10 @@ Bug Fixes
   image to a file (in this case there is nothing to compress, hence the
   quotes, but trying to do so caused a crash). (spacetelescope/PyFITS#69)
 
+- Fixed a regression that may have been introduced in v3.2.1 with writing
+  compressed image HDUs, particularly compressed images using a non-empty
+  GZIP_COMPRESSED_DATA column. (spacetelescope/#71)
+
 
 3.2.4 (unreleased)
 ------------------


### PR DESCRIPTION
This is a fix I merged in from PyFITS (see spacetelescope/PyFITS#71).  I've already tested this on the PyFITS end, so if the tests pass here it should be merged in.  It's a bug that can lead to writing corrupt data which is always bad.
