### PR TITLE
Change IPython Table HTML repr to show all columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -175,6 +175,9 @@ New Features
     ``MaskedColumn`` arguments ``name`` and ``data`` from Astropy 0.2
     to 0.3. [#2511]
 
+  - Change HTML table representation in IPython notebook to show all
+    table columns instead of restricting to 80 column width.  [#2651]
+
 - ``astropy.time``
 
   - Mean and apparent sidereal time can now be calculated using the

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -863,7 +863,7 @@ class Table(object):
     def _repr_html_(self):
         # Since the user cannot provide input, need a sensible default
         tableid = 'table{id}'.format(id=id(self))
-        lines = self.pformat(html=True, tableid=tableid)
+        lines = self.pformat(html=True, tableid=tableid, max_width=-1)
         return ''.join(lines)
 
     def __getitem__(self, item):


### PR DESCRIPTION
In IPython notebook the available width is typically much more than the 80 column default, and an HTML table that is too wide is scrollable left and right.
