### PR TITLE
Fixed kernel multiplication with  numpy floats #2174

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -146,6 +146,8 @@ Bug Fixes
 
 - ``astropy.convolution``
 
+	- Fixed the multiplication of ``Kernel`` with numpy floats. [#2174] 
+
 - ``astropy.coordinates``
 
   - ``Distance`` can now take a list of quantities. [#2261]

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -29,6 +29,7 @@ MAX_NORMALIZATION = 100
 
 __all__ = ['Kernel', 'Kernel1D', 'Kernel2D', 'kernel_arithmetics']
 
+
 class Kernel(object):
     """
     Convolution kernel base class.
@@ -182,6 +183,15 @@ class Kernel(object):
         Array representation of the kernel.
         """
         return self._array
+
+    def __array_wrap__(self, array, context=None):
+        """
+        Wrapper for multiplication with numpy arrays.
+        """
+        if type(context[0]) == np.ufunc:
+            return NotImplemented
+        else:
+            return array
 
 
 class Kernel1D(Kernel):
@@ -359,7 +369,7 @@ def kernel_arithmetics(kernel, value, operation):
 
     # kernel and number
     elif ((isinstance(kernel, Kernel1D) or isinstance(kernel, Kernel2D))
-        and isinstance(value, (int, float))):
+        and np.isscalar(value)):
         if operation == "mul":
             new_kernel = copy.copy(kernel)
             new_kernel._array *= value
@@ -367,5 +377,5 @@ def kernel_arithmetics(kernel, value, operation):
         else:
             raise Exception("Kernel operation not supported.")
     else:
-        raise Exception("Operations between 1D and 2D kernels are not supported.")
+        raise Exception("Kernel operation not supported.")
     return new_kernel

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -32,6 +32,10 @@ KERNEL_TYPES = [Gaussian1DKernel, Gaussian2DKernel,
                 Trapezoid1DKernel, TrapezoidDisk2DKernel,
                 MexicanHat1DKernel, Tophat2DKernel, AiryDisk2DKernel, Ring2DKernel]
 
+
+NUMS = [1, 1., np.float(1.), np.float32(1.), np.float64(1.)]
+
+
 # Test data
 delta_pulse_1D = np.zeros(81)
 delta_pulse_1D[40] = 1
@@ -180,12 +184,32 @@ class TestKernels(object):
         gauss_3 = convolve(gauss_1, gauss_2)
         assert np.all(np.abs((gauss_3 - test_gauss_3).array) < 0.01)
 
-    def test_multiply_scalar(self):
+    @pytest.mark.parametrize(('number'), NUMS)
+    def test_multiply_scalar(self, number):
         """
-        Check if multiplying two kernels with each other works correctly.
+        Check if multiplying a kernel with a scalar works correctly.
         """
-        gauss = 1 * Gaussian1DKernel(3)
-        assert np.all(np.abs(3 * gauss.array - gauss * 3) < 0.000001)
+        gauss = Gaussian1DKernel(3)
+        gauss_new = number * gauss
+        assert_almost_equal(gauss_new.array, gauss.array * number, decimal=12)
+
+    @pytest.mark.parametrize(('number'), NUMS)
+    def test_multiply_scalar_type(self, number):
+        """
+        Check if multiplying a kernel with a scalar works correctly.
+        """
+        gauss = Gaussian1DKernel(3)
+        gauss_new = number * gauss
+        assert type(gauss_new) == Gaussian1DKernel
+
+    @pytest.mark.parametrize(('number'), NUMS)
+    def test_rmultiply_scalar_type(self, number):
+        """
+        Check if multiplying a kernel with a scalar works correctly.
+        """
+        gauss = Gaussian1DKernel(3)
+        gauss_new = gauss * number
+        assert type(gauss_new) == Gaussian1DKernel
 
     def test_model_1D_kernel(self):
         """


### PR DESCRIPTION
This PR fixes the multiplication of kernels with numpy floats. The bug was not easy to spot. The problem was that the `__rmul__` method of the kernel was not called, because the kernel has an `__array__` method implemented, which was used for the multiplication with numpy floats from the left. This behaviour is fixed now, by additionally implementing the `__array_wrap__` method, which checks for the context of the multiplication.  Furthermore I added some regression tests.
