### PR TITLE
Documentation: Edit on github button leads to Error 404

### DIFF
--- a/astropy/sphinx/ext/edit_on_github.py
+++ b/astropy/sphinx/ext/edit_on_github.py
@@ -120,8 +120,9 @@ def doctree_read(app, doctree):
                 else:
                     anchor = '#L%d' % lineno
             if anchor:
+                real_modname = inspect.getmodule(obj).__name__
                 path = '%s%s%s.py%s' % (
-                    url, source_root, modname.replace('.', '/'), anchor)
+                    url, source_root, real_modname.replace('.', '/'), anchor)
                 onlynode = addnodes.only(expr='html')
                 onlynode += nodes.reference(
                     reftitle=app.config.edit_on_github_help_message,


### PR DESCRIPTION
The "edit on github" button on the top right of this page throws a 404 error:
http://astropy.readthedocs.org/en/latest/api/astropy.io.ascii.Daophot.html#astropy.io.ascii.Daophot
