### PR TITLE
`setup.py build_sphinx` broken on Sphinx 1.2

### DIFF
--- a/astropy/sphinx/conf.py
+++ b/astropy/sphinx/conf.py
@@ -17,42 +17,11 @@
 
 import warnings
 from os import path
-from distutils.version import LooseVersion
-import re
-
-from ..utils.compat import subprocess
 
 
 # -- General configuration ----------------------------------------------------
 
-# Some of the docs require the autodoc special-members option, in 1.1.
-# If using graphviz 2.30 or later, Sphinx < 1.2b2 will not work with
-# it.  Unfortunately, there are other problems with Sphinx 1.2b2, so
-# we need to use "dev" until a release is made post 1.2b2.  If
-# affiliated packages don't want this automatic determination, they
-# may simply override needs_sphinx in their local conf.py.
-
-def get_graphviz_version():
-    try:
-        output = subprocess.check_output(
-            ['dot', '-V'], stdin=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            shell=True)
-    except subprocess.CalledProcessError:
-        return '0'
-    tokens = output.split()
-    for token in tokens:
-        if re.match(b'[0-9.]+', token):
-            return token.decode('ascii')
-    return '0'
-
-graphviz_found = LooseVersion(get_graphviz_version())
-graphviz_broken = LooseVersion('0.30')
-
-if graphviz_found >= graphviz_broken:
-    needs_sphinx = '1.2'
-else:
-    needs_sphinx = '1.1'
+needs_sphinx = '1.2.1'
 
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {


### PR DESCRIPTION
f0f9bc7c appears to have broken compatibility with building the docs on Sphinx 1.2, resulting in this error:

```
Traceback (most recent call last):
  File "<stdin>", line 30, in <module>
  File "/home/mdboom/python/lib/python2.7/site-packages/sphinx/application.py", line 208, in build
    self.builder.build_all()
  File "/home/mdboom/python/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 177, in build_all
    self.build(None, summary='all source files', method='all')
  File "/home/mdboom/python/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 234, in build
    purple, length):
  File "/home/mdboom/python/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 134, in status_iterator
    for item in iterable:
  File "/home/mdboom/python/lib/python2.7/site-packages/sphinx/environment.py", line 470, in update_generator
    self.read_doc(docname, app=app)
  File "/home/mdboom/python/lib/python2.7/site-packages/sphinx/environment.py", line 689, in read_doc
    pickle.dump(doctree, f, pickle.HIGHEST_PROTOCOL)
cPickle.PicklingError: Can't pickle <class 'astropy.coordinates.baseframe.RepresentationMapping'>: it's not the same object as astropy.coordinates.baseframe.RepresentationMapping
```

Upgrading to Sphinx 1.2.2 does resolve the error.

So, the question is:

1) Is this a legitmate bug in the pickling of `astropy.coordinates.baseframe.RepresentationMapping` that needs to be fixed?  (I plan to do some further investigation).

2) Is this a bug in Sphinx 1.2 that it can't handle this class (now fixed in 1.2.2), and therefore we just update our minimum version of Sphinx to 1.2.2 and get on with it?

Either way, I think this is probably a blocker for 0.4...
