### PR TITLE
Fix a segfault in `astropy.wcs._wcs`.

### DIFF
--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -331,6 +331,9 @@ set_unit_list(
   }
 
   proxy = PyUnitListProxy_New(owner, len, dest);
+  if (proxy == NULL) {
+      return -1;
+  }
 
   for (i = 0; i < len; ++i) {
     unit = PySequence_GetItem(value, i);


### PR DESCRIPTION
At a certain point in our test suite under certain conditions, the interpreter stops being able to allocate even fairly small objects.  I haven't gotten to the bottom of why that is, but this fix at least prevents that case from becoming an out-and-out segfault.
