### PR TITLE
Fix "'astropy' not loaded, cannot perform relative import" error in test

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -813,7 +813,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
 
     if path.exists(cfgfn):
         doupdate = is_unedited_config_file(cfgfn)
-    else:
+    elif path.exists(path.dirname(cfgfn)):
         doupdate = True
 
     if version is None:

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -529,47 +529,6 @@ def pytest_report_header(config):
     return s
 
 
-@pytest.fixture(autouse=True)
-def modarg(request):
-    """Sets up environment variables to fake the config and cache
-    directories, then removes the temporary directories.
-
-    Does nothing if we are inside the sphinx testing command, as it
-    should have already done this for us.
-    """
-
-    # check if we're inside the distutils test command, which sets the
-    # _ASTROPY_TEST_ builtin
-    try:
-        _ASTROPY_TEST_
-        insidetestcmd = True
-    except NameError:
-        insidetestcmd = False
-
-    if not insidetestcmd:
-        oldconfigdir = os.environ.get('XDG_CONFIG_HOME')
-        oldcachedir = os.environ.get('XDG_CACHE_HOME')
-        os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
-        os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
-        os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
-        os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
-
-        def teardown():
-            # wipe the config/cache tmpdirs and restore the envars
-            shutil.rmtree(os.environ['XDG_CONFIG_HOME'])
-            shutil.rmtree(os.environ['XDG_CACHE_HOME'])
-            if oldconfigdir is None:
-                del os.environ['XDG_CONFIG_HOME']
-            else:
-                os.environ['XDG_CONFIG_HOME'] = oldconfigdir
-            if oldcachedir is None:
-                del os.environ['XDG_CACHE_HOME']
-            else:
-                os.environ['XDG_CACHE_HOME'] = oldcachedir
-
-        request.addfinalizer(teardown)
-
-
 def pytest_pycollect_makemodule(path, parent):
     # This is where we set up testing both with and without
     # from __future__ import unicode_literals


### PR DESCRIPTION
suite.

This fixes an occasional issue we've seen on Travis where one sees:
"'astropy' not loaded, cannot perform relative import".  I was able to
reproduce it consistently, by installing and running the tests with
`python -c "import astropy; astropy.test()"`.

The issue here is that when the `test/test_imports.py:test_imports` test
runs, it ends up importing astropy for a second time (i.e. reloading).
I'm not sure why, but `astropy` is not in `sys.modules` at that
point (though many of its submodules are) so it effectively does a
reload.  This reload causes it to try to write the configuration file
again.  The problem is that we have a `py.test` fixture that creates a
new temporary directory to store the config file and then deletes it
when done on each and every test.  So when astropy is reloaded, it tries
to create a config file in the old temporary directory (used by an
earlier test in the `configuration` subpackage), but now that temporary
directory no longer exists (since the location of all loaded
configuration files is cached, its location really can not change during
the life of the interpreter).

There are two independent ways to fix this, and I would advocate doing
both:
1. Don't update the config file if the config file directory doesn't
    exist.  (There is already code to create the config directory in
    the "normal" case, but it falls down here because the temporary
    config directory gets deleted underneath us).  That is a corner
    case that I don't think we have to handle.
2. Remove the py.test fixture that creates a temporary configuration
    directory with each test.  There is already code to do this for the
    entire test run, and I don't see the need to do this more than
    once.  It saves a lot of busy work and system calls if nothing
    else.

I've tried the tests in as many modes and environments as I can, and this doesn't seem to have any negative impact -- in fact the test suite runs about 5% faster.  @eteq: since I think you wrote the test fixture originally, I'd appreciate your feedback on this.
