### PR TITLE
updated coordinates to stable status

### DIFF
--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -87,10 +87,11 @@ The current planned and existing sub-packages are:
                 astropy.coordinates
             </td>
             <td align='center'>
-                <img alt="dev" src="_images/dev.png">
+                <img alt="dev" src="_images/stable.png">
             </td>
             <td>
-                New in v0.2, significant API changes in v0.3
+                New in v0.2, major changes in v0.4.  Subsequent versions should
+                maintain a stable/backwards-compatible API.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
I just noticed the stability document shows coordinates as still "dev".  For 0.4 I think we want this to be "stable", right?  While we expect new frames and features to be added in upcoming versions, the plan is now for at least stability in the backwards-compatible sense.  Does that make sense to you,@astrofrog ?
