### PR TITLE
Make x.decompose(bases=[x]) work

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1853,6 +1853,8 @@ class Unit(NamedUnit):
                            format=format)
 
     def decompose(self, bases=set()):
+        if self in bases:
+            return self
         return self._represents.decompose(bases=bases)
 
     def is_unity(self):
@@ -2017,6 +2019,9 @@ class CompositeUnit(UnitBase):
     def decompose(self, bases=set()):
         if len(bases) == 0 and self._decomposed_cache is not None:
             return self._decomposed_cache
+
+        if self in bases:
+            return self
 
         for base in self.bases:
             if (not isinstance(base, IrreducibleUnit) or

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -629,3 +629,7 @@ def test_composite_compose():
     # Issue #2382
     composite_unit = u.s.compose(units=[u.Unit("s")])[0]
     u.s.compose(units=[composite_unit])
+
+
+def test_decompose_into_self():
+    assert u.J.decompose(bases=[u.J]) is u.J


### PR DESCRIPTION
Addresses an issue reported by John Quinn in mailing list thread "Bug in units decompose()"
