### PR TITLE
Changed docstring of tab-separated values reader

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -126,9 +126,9 @@ class CommentedHeader(core.BaseReader):
 
 class Tab(Basic):
     """Read a tab-separated file.  Unlike the :class:`Basic` reader, whitespace is
-    not stripped from the beginning and end of lines.  By default whitespace is
-    still stripped from the beginning and end of individual column values.
-
+    not stripped from the beginning and end of either lines or individual column
+    values.
+    
     Example::
 
       col1 <tab> col2 <tab> col3


### PR DESCRIPTION
I was looking over the source of the `Tab` reader in `io.ascii` and was surprised to find that the docstring contradicted the actual functionality of the reader! I'm assuming the functionality is correct (i.e. preserving whitespace in table values), so this PR updates the docstring.
