### PR TITLE
Raise exception when running tests inside IPython.

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -114,6 +114,14 @@ class TestRunner(object):
         """
         The docstring for this method lives in astropy/__init__.py:test
         """
+        try:
+            get_ipython()
+        except NameError:
+            pass
+        else:
+            raise RuntimeError(
+                "Running astropy tests inside of IPython is not supported.")
+
         if coverage:
             warnings.warn(
                 "The coverage option is ignored on run_tests, since it "


### PR DESCRIPTION
I believe in the past we've punted on supporting running the tests inside of IPython, since it changes the environment in various ways (such as logging, importing) that have been difficult to support.  Of course, it's not easy for the end user helping us with testing to know that.  This raises an exception if the tests are run inside IPython.  I realize this is a somewhat heavy-handed approach, but it might be a good thing to do for now until tests-in-IPython is working.
