### PR TITLE
Make tests pass on Scipy 0.12.1

### DIFF
--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import types
+
 from ..core import Fittable1DModel
 from ..parameters import Parameter
 from .. import models
@@ -12,6 +13,7 @@ import numpy as np
 from numpy.testing import utils
 from numpy.random import RandomState
 from ...tests.helper import pytest
+from .utils import ignore_non_integer_warning
 
 try:
     from scipy import optimize
@@ -133,7 +135,8 @@ class TestBounds(object):
         bounds = {'slope': (-1.5, 5.0), 'intercept': (-1.0, 1.0)}
         line_model = models.Linear1D(guess_slope, guess_intercept, bounds=bounds)
         fitter = fitting.SLSQPLSQFitter()
-        model = fitter(line_model, self.x, self.y)
+        with ignore_non_integer_warning():
+            model = fitter(line_model, self.x, self.y)
         slope = model.slope.value
         intercept = model.intercept.value
         assert slope + 10 ** -5 >= bounds['slope'][0]
@@ -175,7 +178,8 @@ class TestBounds(object):
                                   x_stddev=4., y_stddev=4., theta=0.5,
                                   bounds=bounds)
         gauss_fit = fitting.SLSQPLSQFitter()
-        model = gauss_fit(gauss, X, Y, self.data)
+        with ignore_non_integer_warning():
+            model = gauss_fit(gauss, X, Y, self.data)
         x_mean = model.x_mean.value
         y_mean = model.y_mean.value
         x_stddev = model.x_stddev.value

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -20,6 +20,7 @@ from ..fitting import *
 from ...utils import NumpyRNGContext
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
+from .utils import ignore_non_integer_warning
 
 try:
     from scipy import optimize
@@ -278,7 +279,8 @@ class TestNonLinearFitters(object):
 
         levmar = LevMarLSQFitter()
         fitter = fitter_class()
-        new_model = fitter(self.gauss, self.xdata, self.ydata)
+        with ignore_non_integer_warning():
+            new_model = fitter(self.gauss, self.xdata, self.ydata)
         model = levmar(self.gauss, self.xdata, self.ydata)
         assert_allclose(model.parameters, new_model.parameters,
                         rtol=10 ** (-4))
@@ -293,7 +295,8 @@ class TestNonLinearFitters(object):
         g1.mean.fixed = True
         fitter = LevMarLSQFitter()
         fslsqp = SLSQPLSQFitter()
-        slsqp_model = fslsqp(g1, self.xdata, self.ydata)
+        with ignore_non_integer_warning():
+            slsqp_model = fslsqp(g1, self.xdata, self.ydata)
         model = fitter(g1, self.xdata, self.ydata)
         assert_allclose(model.parameters, slsqp_model.parameters,
                         rtol=10 ** (-4))

--- a/astropy/modeling/tests/utils.py
+++ b/astropy/modeling/tests/utils.py
@@ -1,0 +1,20 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import contextlib
+import warnings
+from ...tests.helper import catch_warnings
+
+
+@contextlib.contextmanager
+def ignore_non_integer_warning():
+    # We need to ignore this warning on Scipy < 0.14.
+    # When our minimum version of Scipy is bumped up, this can be
+    # removed.
+    with catch_warnings():
+        warnings.filterwarnings(
+            "always", "using a non-integer number instead of an integer "
+            "will result in an error in the future", DeprecationWarning)
+        yield


### PR DESCRIPTION
This makes some tests pass on Scipy 0.12.1 as reported by @sergiopasra in #1802.  This just ignores some deprecation warnings that Scipy (not astropy directly) triggers.
