### PR TITLE
Bug: votable.conesearch fails with `NameError: global name 'votable' is not defined`

### DIFF
--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -79,7 +79,7 @@ class TestConeSearch(object):
 
         """
         tab_1 = conesearch.conesearch(
-            center, radius, pedantic=self.pedantic, verbose=self.verbose)
+            center, radius, pedantic=None, verbose=self.verbose)
 
         assert tab_1.array.size > 0
 

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 
 # LOCAL
 from .exceptions import VOSError, MissingCatalog, DuplicateCatalogName, DuplicateCatalogURL, InvalidAccessURL
-from ...io.votable import parse_single_table, table, tree
+from ...io.votable import parse_single_table, table, tree, conf
 from ...config import ConfigAlias
 from ...io.votable.exceptions import vo_raise, vo_warn, E19, W24, W25
 from ...utils.console import color_print
@@ -845,7 +845,7 @@ def call_vo_service(service_type, catalog_db=None, pedantic=None,
                              verbose=verbose)
 
     if pedantic is None:  # pragma: no cover
-        pedantic = votable.conf.pedantic
+        pedantic = conf.pedantic
 
     for name, catalog in catalogs:
         if isinstance(catalog, six.string_types):


### PR DESCRIPTION
The attempt to do a conesearch fails in the current master with:

```
IPython 2.1.0 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.
Using matplotlib backend: Qt4Agg

In [1]: from astropy.vo.client import conesearch

In [2]: from astropy.coordinates import SkyCoord

In [3]: from astropy import units as u 

In [4]: coord = SkyCoord.from_name("AA Tau")

In [5]: my_catname = "2MASS All-Sky Point Source Catalog 1" 

In [6]: coord = SkyCoord.from_name("AA Tau")

In [7]: print "Coords", coord.ra, coord.dec 
Coords 68d43m51.3599s 24d28m53.1599s

In [8]: result = conesearch.conesearch(coord, 0.1 * u.degree, catalog_db=my_catname)
ERROR: NameError: global name 'votable' is not defined [astropy.vo.client.vos_catalog]
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-8-190720cd16bd> in <module>()
----> 1 result = conesearch.conesearch(coord, 0.1 * u.degree, catalog_db=my_catname)

/data/guenther/anaconda/lib/python2.7/site-packages/astropy-0.4rc2.dev-py2.7-linux-x86_64.egg/astropy/vo/client/conesearch.pyc in conesearch(center, radius, verb, **kwargs)
    189 
    190     return vos_catalog.call_vo_service(conf.conesearch_dbname,
--> 191                                        kwargs=args, **kwargs)
    192 
    193 

/data/guenther/anaconda/lib/python2.7/site-packages/astropy-0.4rc2.dev-py2.7-linux-x86_64.egg/astropy/vo/client/vos_catalog.pyc in call_vo_service(service_type, catalog_db, pedantic, verbose, cache, kwargs)
    846 
    847     if pedantic is None:  # pragma: no cover
--> 848         pedantic = votable.conf.pedantic
    849 
    850     for name, catalog in catalogs:

NameError: global name 'votable' is not defined
```
