### PR TITLE
Make representations sub-classable and demonstrate with Wrap180 test

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -213,18 +213,18 @@ class CartesianRepresentation(BaseRepresentation):
         elif (y is None and z is not None) or (y is not None and z is None):
             raise ValueError("x, y, and z are required to instantiate CartesianRepresentation")
 
-        if not isinstance(x, u.Quantity):
-            raise TypeError('x should be a Quantity')
+        if not isinstance(x, self.attr_classes['x']):
+            raise TypeError('x should be a {0}'.format(self.attr_classes['x'].__name__))
 
-        if not isinstance(y, u.Quantity):
-            raise TypeError('y should be a Quantity')
+        if not isinstance(y, self.attr_classes['x']):
+            raise TypeError('y should be a {0}'.format(self.attr_classes['y'].__name__))
 
-        if not isinstance(z, u.Quantity):
-            raise TypeError('z should be a Quantity')
+        if not isinstance(z, self.attr_classes['x']):
+            raise TypeError('z should be a {0}'.format(self.attr_classes['z'].__name__))
 
-        x = u.Quantity(x, copy=copy)
-        y = u.Quantity(y, copy=copy)
-        z = u.Quantity(z, copy=copy)
+        x = self.attr_classes['x'](x, copy=copy)
+        y = self.attr_classes['y'](y, copy=copy)
+        z = self.attr_classes['z'](z, copy=copy)
 
         if not (x.unit.physical_type == y.unit.physical_type == z.unit.physical_type):
             raise u.UnitsError("x, y, and z should have matching physical types")
@@ -307,10 +307,10 @@ class SphericalRepresentation(BaseRepresentation):
             raise TypeError('lat should be a Quantity, Angle, or Latitude')
 
         # Let the Longitude and Latitude classes deal with e.g. parsing
-        lon = Longitude(lon, copy=copy)
-        lat = Latitude(lat, copy=copy)
+        lon = self.attr_classes['lon'](lon, copy=copy)
+        lat = self.attr_classes['lat'](lat, copy=copy)
 
-        distance = u.Quantity(distance, copy=copy)
+        distance = self.attr_classes['distance'](distance, copy=copy)
         if distance.unit.physical_type == 'length':
             distance = distance.view(Distance)
 
@@ -386,7 +386,7 @@ class SphericalRepresentation(BaseRepresentation):
         lon = np.arctan2(cart.y, cart.x)
         lat = np.arctan2(cart.z, s)
 
-        return SphericalRepresentation(lon=lon, lat=lat, distance=r)
+        return cls(lon=lon, lat=lat, distance=r)
 
 
 class UnitSphericalRepresentation(BaseRepresentation):
@@ -407,7 +407,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
     """
 
     attr_classes = OrderedDict([('lon', Longitude),
-                                 ('lat', Latitude)])
+                                ('lat', Latitude)])
     recommended_units = {'lon': u.deg, 'lat': u.deg}
 
     def __init__(self, lon, lat, copy=True):
@@ -419,8 +419,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
             raise TypeError('lat should be a Quantity, Angle, or Latitude')
 
         # Let the Longitude and Latitude classes deal with e.g. parsing
-        lon = Longitude(lon, copy=copy)
-        lat = Latitude(lat, copy=copy)
+        lon = self.attr_classes['lon'](lon, copy=copy)
+        lat = self.attr_classes['lat'](lat, copy=copy)
 
         try:
             lon, lat = broadcast_quantity(lon, lat, copy=copy)
@@ -470,7 +470,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         lon = np.arctan2(cart.y, cart.x)
         lat = np.arctan2(cart.z, s)
 
-        return UnitSphericalRepresentation(lon=lon, lat=lat)
+        return cls(lon=lon, lat=lat)
 
     def represent_as(self, other_class):
         # Take a short cut if the other clsss is a spherical representation
@@ -522,8 +522,8 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             raise TypeError('phi should be a Quantity or Angle')
 
         # Let the Longitude and Latitude classes deal with e.g. parsing
-        phi = Angle(phi, copy=copy)
-        theta = Angle(theta, copy=copy)
+        phi = self.attr_classes['phi'](phi, copy=copy)
+        theta = self.attr_classes['theta'](theta, copy=copy)
 
         # Wrap/validate phi/theta
         if copy:
@@ -535,7 +535,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             raise ValueError('Inclination angle(s) must be within 0 deg <= angle <= 180 deg, '
                              'got {0}'.format(theta.to(u.degree)))
 
-        r = u.Quantity(r, copy=copy)
+        r = self.attr_classes['r'](r, copy=copy)
         if r.unit.physical_type == 'length':
             r = r.view(Distance)
 
@@ -612,7 +612,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         phi = np.arctan2(cart.y, cart.x)
         theta = np.arctan2(s, cart.z)
 
-        return PhysicsSphericalRepresentation(phi=phi, theta=theta, r=r)
+        return cls(phi=phi, theta=theta, r=r)
 
 
 class CylindricalRepresentation(BaseRepresentation):
@@ -646,9 +646,9 @@ class CylindricalRepresentation(BaseRepresentation):
         if not isinstance(phi, u.Quantity) or isinstance(phi, Latitude):
             raise TypeError('phi should be a Quantity or Angle')
 
-        rho = u.Quantity(rho, copy=copy)
-        phi = Angle(phi, copy=copy)
-        z = u.Quantity(z, copy=copy)
+        rho = self.attr_classes['rho'](rho, copy=copy)
+        phi = self.attr_classes['phi'](phi, copy=copy)
+        z = self.attr_classes['z'](z, copy=copy)
 
         if not (rho.unit.physical_type == z.unit.physical_type):
             raise u.UnitsError("rho and z should have matching physical types")
@@ -694,7 +694,7 @@ class CylindricalRepresentation(BaseRepresentation):
         phi = np.arctan2(cart.y, cart.x)
         z = cart.z
 
-        return CylindricalRepresentation(rho=rho, phi=phi, z=z)
+        return cls(rho=rho, phi=phi, z=z)
 
     def to_cartesian(self):
         """


### PR DESCRIPTION
This should partly address #2690 by making it convenient to subclass representations, and in particular change the `attr_classes` only.  In the currently implementation the `attr_classes` are not actually used in the class but instead are hardwired.

It also provides a new test that serves as a demonstration of how to make a new frame and representation to accomplish some specific behavior.
