### PR TITLE
What's new for 0.4 updates

### DIFF
--- a/docs/whatsnew/0.4.rst
+++ b/docs/whatsnew/0.4.rst
@@ -34,8 +34,8 @@ motivation was to implement coordinates within an extensible framework that
 cleanly separates the distinct aspects of data representation, coordinate
 frame representation and transformation, and user interface.  This is described
 in the `APE5 <https://github.com/astropy/astropy-APEs/blob/master/APE5.rst>`_
-document. Details of the new usage is covered in detail in the
-:ref:`astropy-coordinates` documentation section.
+document. Details of the new usage are given in the :ref:`astropy-coordinates`
+section of the documentation.
 
 *An important point is that this sub-package is now considered stable and we do
 not expect any further major interface changes.*
@@ -113,8 +113,9 @@ Quantity
 --------
 The `~astropy.units.Quantity` class has seen a series of optimizations
 and is now substantially faster.  Additionally, the `~astropy.time`,
-`~astropy.table`, and `~astropy.coordinates` subpackages integrate better
-with `~astropy.units.Quantity`. See :doc:`/units/quantity` and the other
+`~astropy.coordinates`, and `~astropy.table` subpackages integrate
+better with `~astropy.units.Quantity`, with further improvements on the
+way for `~astropy.table`. See :doc:`/units/quantity` and the other
 subpackage documentation sections for more details.
 
 Inspecting FITS headers from the command line
@@ -174,8 +175,8 @@ Deprecation and backward-incompatible changes
   used to be raised).  [#2328]
 
 - The functional interface for `astropy.cosmology` (e.g.
-  ``cosmology.H(0.5)`` is now deprecated in favor of the objected-oriented
-  approach (``WMAP9.H(0.5)``). [#2343]
+  ``cosmology.H(z=0.5)`` is now deprecated in favor of the
+  objected-oriented approach (``WMAP9.H(z=0.5)``). [#2343]
 
 - The `astropy.coordinates` sub-package has undergone major changes for
   implementing the


### PR DESCRIPTION
This PR adds to and polishes the what's new page, based more-or-less on some discussion from #2416 .

It adds a new `Quantity` section (@mhvk, you might want to glance over that), adds a variety of cleanup/missing stuff, and re-works the introduction to include some numbers about how many issues, PRs, and contributors were involved in this version.

For that last step, I used https://gist.github.com/eteq/9faf252ec8aa41188dcb, which uses the github api to search through all the issues and PRs closed since v0.3.  That's worth noting for future versions, as it probably makes sense to reproduce this there.

cc @astrofrog @embray
