### PR TITLE
Include binary installer bitmaps in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,7 @@ recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
+recursive-include static *
 recursive-include astropy/sphinx/themes *
 
 exclude *.pyc *.o


### PR DESCRIPTION
Otherwise bdist_wininst and bdist_dmg commands fail when building from the source distribution.
