### PR TITLE
Fix integer overflow in np.product

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -388,7 +388,8 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0, crop=True,
     arrayshape = array.shape
     kernshape = kernel.shape
 
-    array_size_B = np.product(arrayshape)*np.dtype(complex_dtype).itemsize
+    array_size_B = (np.product(arrayshape, dtype=np.int64) * 
+                    np.dtype(complex_dtype).itemsize)
     if array_size_B > 1024**3 and not allow_huge:
         raise ValueError("Size Error: Arrays will be %s.  Use "
                          "allow_huge=True to override this exception."


### PR DESCRIPTION
On win-amd64-py3.x, [test_convolve_fft.test_big_fail](https://github.com/astropy/astropy/blob/master/astropy/convolution/tests/test_convolve_fft.py#L462) fails to raise a ValueError due to an integer overflow in np.product. 
The following code raises a RuntimeWarning and allocates huge amounts of RAM:

```
import numpy as np
from astropy. convolution import convolve_fft
arr = np.empty([512, 512, 512], dtype=np.complex)
convolve_fft(arr, arr)
```

```
X:\Python34\lib\site-packages\astropy\convolution\convolve.py:391: RuntimeWarning: overflow encountered in long_scalars
  array_size_B = np.product(arrayshape)*np.dtype(complex_dtype).itemsize
```
