### PR TITLE
Make SkyCoord support lists of object inputs

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -34,11 +34,12 @@ class SkyCoord(object):
     """High-level object providing a flexible interface for celestial coordinate
     representation, manipulation, and transformation between systems.
 
-    The `SkyCoord` class accepts a wide variety of inputs for initialization.
-    At a minimum these must provide one or more celestial coordinate values
-    with unambiguous units.  Typically one also specifies the coordinate
-    frame, though this is not required.  The general pattern is for spherical
-    representations is::
+    The `SkyCoord` class accepts a wide variety of inputs for initialization. At
+    a minimum these must provide one or more celestial coordinate values with
+    unambiguous units.  Inputs may be scalars or lists/tuples/arrays, yielding
+    scalar or array coordinates (can be checked via ``SkyCoord.isscalar``).
+    Typically one also specifies the coordinate frame, though this is not
+    required. The general pattern for spherical representations is::
 
       SkyCoord(COORD, [FRAME], keyword_args ...)
       SkyCoord(LON, LAT, [FRAME], keyword_args ...)
@@ -82,6 +83,8 @@ class SkyCoord(object):
       >>> c = SkyCoord(c, obstime='J2010.11', equinox='B1965')  # Override defaults
 
       >>> c = SkyCoord(w=0, u=1, v=2, unit='kpc', frame='galactic', representation='cartesian')
+
+      >>> c = SkyCoord([ICRS(ra=1*u.deg, dec=2*u.deg), ICRS(ra=3*u.deg, dec=4*u.deg)])
 
     As shown, the frame can be a `~astropy.coordinates.BaseCoordinateFrame`
     class or the corresponding string alias.  The frame classes that are built in

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -722,9 +722,12 @@ def test_create_w_list_of_reprs():
     assert scsc.ra[0] == rscalar1.lon
     assert scsc.ra[1] == rscalar2.lon
 
-    rarr = SphericalRepresentation(lon=[8]*u.deg, lat=[5]*u.deg, distance=[1]*u.kpc)
-    with pytest.raises(ValueError):
-        SkyCoord([rscalar1, rarr])
+    rarr = SphericalRepresentation(lon=[8, 8.1]*u.deg, lat=[5, 5.1]*u.deg, distance=[1, 1.1]*u.kpc)
+    scarr = SkyCoord([rscalar1, rarr])
+    assert len(scarr) == 3
+
+    r2d = SphericalRepresentation([[1,2],[3,4]]*u.deg, [[5,6],[7,8]]*u.deg, distance=1*u.kpc)
+    assert SkyCoord([r2d, rscalar1]).shape == (5,)
 
 
 def test_create_w_list_of_frames():
@@ -756,10 +759,13 @@ def test_create_w_list_of_frames():
     assert not np.allclose(framescfk4.ra[0], frame1.ra, rtol=1e-8)
     assert not np.allclose(framescfk4.ra[1], frame2.ra, rtol=1e-8)
 
-    with pytest.raises(ValueError):
-        #arrays of arrays get confusing/ambiguous, so fail
-        SkyCoord([framesc, scsc])
+    scarr = SkyCoord([framesc, scalarsc1])
+    assert len(scarr) == 3
+
+    #check that nd arrays get flattened
+    sc2d = SkyCoord([[1,2],[3,4]]*u.deg, [[5,6],[7,8]]*u.deg)
+    assert SkyCoord([sc2d, scalarsc1]).shape == (5,)
 
     with pytest.raises(ValueError):
-        #data-less frame should also fail
+        #data-less frame should fail
         SkyCoord([frame1, ICRS()])

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -705,6 +705,34 @@ def test_units_known_fail():
     with pytest.raises(u.UnitsError):
         SkyCoord(1, 2, 3, unit=u.deg, representation='spherical')
 
+
 def test_nodata_failure():
     with pytest.raises(ValueError):
         SkyCoord()
+
+
+def test_create_w_list_of_reprs():
+    """
+    Try to create a single skycoord with a list of scalar representations
+    """
+    rscalar = SphericalRepresentation(lon=8*u.deg, lat=5*u.deg, distance=1*u.kpc)
+    SkyCoord([rscalar, rscalar])
+
+    rarr = SphericalRepresentation(lon=[8]*u.deg, lat=[5]*u.deg, distance=[1]*u.kpc)
+    with pytest.raises(ValueError):
+        SkyCoord([rscalar, rarr])
+
+
+def test_create_w_list_of_frames():
+    """
+    Try to create a single skycoord with a list of frame objects or SkyCoords
+    """
+    frame = ICRS(1*u.deg, 2*u.deg)
+    scalarsc = SkyCoord(1*u.deg, 2*u.deg)
+
+    SkyCoord([frame, frame])
+    arrsc = SkyCoord([scalarsc, scalarsc])
+
+    with pytest.raises(ValueError):
+        #arrays of arrays get confusing/ambiguous, so fail
+        SkyCoord([arrsc, arrsc])


### PR DESCRIPTION
While doing some work with 0.4rc1, I noticed some odd behavior demonstrated with this snippet:
```
>>> sc = SkyCoord(ra=[1,2,3]*u.deg,dec=[4,5,6]*u.deg)
>>> sc0 = sc[0]
>>> sc2 = sc[2]
>>> SkyCoord([sc0, sc2])
ValueError: One or more elements of input sequence does not have a length
```

This is counter-intuitive for two reasons:
* it means you can "take apart" `SkyCoord`s, but there's no way to put them back together again easily
* ``SkyCoord(sc)`` works, so I would have thought other ways of passing in frame or `SkyCoord` objects should work.  It seems strange to support lists of `Quantity`s or strings but not lists of our native coordinate objects.

So this PR adjusts the `SkyCoord` initializer so that it can accept lists of `SkyCoord`s, frames, or representation.  So my example becomes:
```
>>> SkyCoord([sc0, sc2])
<SkyCoord (ICRS): (ra, dec) in deg
    [(1.0, 4.0), (3.0, 6.0)]>
```

This may be stretching the definition of "bug" so close to release.  I'll leave it to @embray to make the final call if this goes in 0.4 vs. 0.4.1 (tagged it to 0.4 for now).

cc @astrofrog @taldcroft @Cadair