### PR TITLE
Config file md5 calculation broken on Windows 7

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.fits    -text
+astropy.0.3.windows.cfg eol=crlf

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -738,8 +738,14 @@ def is_unedited_config_file(filename):
       Astropy 0.4, when APE3 was implemented and the config file
       contained commented-out values by default.
     """
-    with io.open(filename, 'rb') as fd:
+    # We want to calculate the md5sum using universal line endings, so
+    # that even if the files had their line endings converted to \r\n
+    # on Windows, this will still work.
+
+    with io.open(filename, 'rt', encoding='latin-1') as fd:
         content = fd.read()
+
+    content = content.encode('latin-1')
 
     # First determine if the config file has any effective content
     buffer = io.BytesIO(content)
@@ -753,8 +759,6 @@ def is_unedited_config_file(filename):
 
     # Now determine if it matches the md5sum of a known, unedited
     # config file.
-    # TODO: How does this work with Windows line endings...?  Probably
-    # doesn't...
     known_configs = set([
         '5df7e409425e5bfe7ed041513fda3288',  # v0.3
         '8355f99a01b3bdfd8761ef45d5d8b7e5',  # v0.2

--- a/astropy/config/tests/data/astropy.0.3.windows.cfg
+++ b/astropy/config/tests/data/astropy.0.3.windows.cfg
@@ -1,0 +1,149 @@
+
+# Use Unicode characters when outputting values, and writing widgets to the
+# console.
+unicode_output = False
+[utils.console]
+
+# When True, use ANSI color escape sequences when writing to the console.
+use_color = True
+
+[logger]
+
+# Threshold for the logging messages. Logging messages that are less severe
+# than this level will be ignored. The levels are 'DEBUG', 'INFO', 'WARNING',
+# 'ERROR'
+log_level = INFO
+
+# Whether to use color for the level names
+use_color = True
+
+# Whether to log warnings.warn calls
+log_warnings = True
+
+# Whether to log exceptions before raising them
+log_exceptions = False
+
+# Whether to always log messages to a log file
+log_to_file = False
+
+# The file to log messages to. When '', it defaults to a file 'astropy.log' in
+# the astropy config directory.
+log_file_path = ""
+
+# Threshold for logging messages to log_file_path
+log_file_level = INFO
+
+# Format for log file entries
+log_file_format = "%(asctime)r, %(origin)r, %(levelname)r, %(message)r"
+
+[coordinates.name_resolve]
+
+# The URL to Sesame's web-queryable database.
+sesame_url = http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/, http://vizier.cfa.harvard.edu/viz-bin/nph-sesame/
+
+# This specifies the default database that SESAME will query when using the
+# name resolve mechanism in the coordinates subpackage. Default is to search
+# all databases, but this can be 'all', 'simbad', 'ned', or 'vizier'.
+# Options: all, simbad, ned, vizier
+sesame_database = all
+
+# This is the maximum time to wait for a response from a name resolve query to
+# SESAME in seconds.
+name_resolve_timeout = 5
+
+[table.pprint]
+
+# Maximum number of lines for the pretty-printer to use if it cannot determine
+# the terminal size. Negative numbers mean no limit.
+max_lines = 25
+
+# Maximum number of characters for the pretty-printer to use per line if it
+# cannot determine the terminal size.  Negative numbers mean no limit.
+max_width = 80
+
+[table.table]
+
+# The template that determines the name of a column if it cannot be
+# determined. Uses new-style (format method) string formatting
+auto_colname = col{0}
+
+[utils.data]
+
+# URL for astropy remote data site.
+dataurl = http://data.astropy.org/
+
+# Time to wait for remote data query (in seconds).
+remote_timeout = 3.0
+
+# Block size for computing MD5 file hashes.
+hash_block_size = 65536
+
+# Number of bytes of remote data to download per step.
+download_block_size = 65536
+
+# Number of times to try to get the lock while accessing the data cache before
+# giving up.
+download_cache_lock_attempts = 5
+
+# If True, temporary download files created when the cache is inacessible will
+# be deleted at the end of the python session.
+delete_temporary_downloads_at_exit = True
+
+[io.fits]
+
+# If True, enable support for record-valued keywords as described by FITS WCS
+# Paper IV. Otherwise they are treated as normal keywords.
+enabled_record_valued_keyword_cards = True
+
+# If True, extension names (i.e. the EXTNAME keyword) should be treated as
+# case-sensitive.
+extension_name_case_sensitive = False
+
+# If True, automatically remove trailing whitespace for string values in
+# headers.  Otherwise the values are returned verbatim, with all whitespace
+# intact.
+strip_header_whitespace = True
+
+# If True, use memory-mapped file access to read/write the data in FITS files.
+# This generally provides better performance, especially for large files, but
+# may affect performance in I/O-heavy applications.
+use_memmap = True
+
+[io.votable.table]
+
+# When True, treat fixable violations of the VOTable spec as exceptions.
+pedantic = False
+
+[cosmology.core]
+
+# The default cosmology to use. Note this is only read on import, so changing
+# this value at runtime has no effect.
+default_cosmology = no_default
+
+[nddata.nddata]
+
+# Whether to issue a warning if NDData arithmetic is performed with
+# uncertainties and the uncertainties do not support the propagation of
+# correlated uncertainties.
+warn_unsupported_correlated = True
+
+[vo.client.vos_catalog]
+
+# URL where VO Service database file is stored.
+vos_baseurl = http://stsdas.stsci.edu/astrolib/vo_databases/
+
+[vo.client.conesearch]
+
+# Conesearch database name.
+conesearch_dbname = conesearch_good
+
+[vo.validator.validate]
+
+# Cone Search services master list for validation.
+cs_mstr_list = http://vao.stsci.edu/directory/NVORegInt.asmx/VOTCapabilityPredOpt?predicate=1%3D1&capability=conesearch&VOTStyleOption=2
+
+# Only check these Cone Search URLs.
+cs_urls = http://archive.noao.edu/nvo/usno.php?cat=a&amp;, http://gsss.stsci.edu/webservices/vo/ConeSearch.aspx?CAT=GSC23&amp;, http://irsa.ipac.caltech.edu/cgi-bin/Oasis/CatSearch/nph-catsearch?CAT=fp_psc&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/220/out&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/243/out&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/252/out&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/254/out&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/255/out&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/284/out&amp;, http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=II/246/out&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=field&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=photoobjall&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=phototag&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=specobjall&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=specphotoall&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=sppparams&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=psc&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=xsc&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=usnoa2&amp;tab=main&amp;, http://vo.astronet.ru/sai_cas/conesearch?cat=usnob1&amp;tab=main&amp;, http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=Galaxy&amp;, http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=PhotoObj&amp;, http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=PhotoObjAll&amp;, http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=Star&amp;, http://wfaudata.roe.ac.uk/sdssdr8-dsa/DirectCone?DSACAT=SDSS_DR8&amp;DSATAB=PhotoObjAll&amp;, http://wfaudata.roe.ac.uk/sdssdr8-dsa/DirectCone?DSACAT=SDSS_DR8&amp;DSATAB=SpecObjAll&amp;, http://wfaudata.roe.ac.uk/twomass-dsa/DirectCone?DSACAT=TWOMASS&amp;DSATAB=twomass_psc&amp;, http://wfaudata.roe.ac.uk/twomass-dsa/DirectCone?DSACAT=TWOMASS&amp;DSATAB=twomass_xsc&amp;, http://www.nofs.navy.mil/cgi-bin/vo_cone.cgi?CAT=USNO-A2&amp;, http://www.nofs.navy.mil/cgi-bin/vo_cone.cgi?CAT=USNO-B1&amp;
+
+# VO Table warning codes that are considered non-critical
+noncrit_warnings = W03, W06, W07, W09, W10, W15, W17, W20, W21, W22, W27, W28, W29, W41, W42, W48, W50

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -184,6 +184,9 @@ def test_empty_config_file():
     fn = get_pkg_data_filename('data/astropy.0.3.cfg')
     assert is_unedited_config_file(fn)
 
+    fn = get_pkg_data_filename('data/astropy.0.3.windows.cfg')
+    assert is_unedited_config_file(fn)
+
 
 def test_alias():
     import astropy


### PR DESCRIPTION
As reported by @anizami in #1802, the test that checks the calculation of the md5 sum of the config file fails on Windows 7.

https://gist.github.com/anizami/4127d40c8a4cc39ec4c2

Not sure why yet, but wanted to create an issue for this.

While fixing the test would be nice, I don't consider this a high priority or indicative of a serious bug.  The worst that will happen here is that a user with a default astropy 0.3 config file will not have it automatically replaced by an astropy 0.4 config file.  Annoying to be sure, but it shouldn't result in loss of data or config settings etc.
