### PR TITLE
0.4rc1: DocTestFailure on  docs/time/index.rst

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -626,9 +626,9 @@ calculations following different IAU resolutions.  Sample usage::
   >>> t.sidereal_time('mean')
   <Longitude 13.089521870640... hourangle>
   >>> t.sidereal_time('apparent')
-  <Longitude 13.089503675087... hourangle>
+  <Longitude 13.08950367508... hourangle>
   >>> t.sidereal_time('apparent', 'greenwich')
-  <Longitude 5.089503675087... hourangle>
+  <Longitude 5.08950367508... hourangle>
   >>> t.sidereal_time('apparent', '-90d')
   <Longitude 23.08950367508... hourangle>
   >>> t.sidereal_time('apparent', '-90d', 'IAU1994')


### PR DESCRIPTION
On Debian/Powerpc and Debian/s390x, the 0.4rc1 version fails with

```
619 :meth:`~astropy.time.Time.sidereal_time`.  [...]
625   >>> t = Time('2006-01-15 21:24:37.5', scale='utc', location=('120d', '45d'))
626   >>> t.sidereal_time('mean')
627   <Longitude 13.089521870640... hourangle>
628   >>> t.sidereal_time('apparent')
Expected:
    <Longitude 13.089503675087... hourangle>
Got:
    <Longitude 13.089503675086998 hourangle>
```
- [powerpc build log](https://buildd.debian.org/status/fetch.php?pkg=python-astropy&arch=powerpc&ver=0.4~rc1-1&stamp=1404749162)
- [s390x build log](https://buildd.debian.org/status/fetch.php?pkg=python-astropy&arch=s390x&ver=0.4~rc1-1&stamp=1404755898)
