### PR TITLE
Cannot create Angle objects with decimal.Decimal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,10 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - By default, ``Quantity`` and its subclasses will now convert to float also
+    numerical types such as ``decimal.Decimal``, which are stored as objects
+    by numpy. [#1419]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -232,7 +232,8 @@ class Quantity(np.ndarray):
                             "Numpy numeric type.")
 
         # by default, cast any integer, boolean, etc., to float
-        if dtype is None and not np.can_cast(np.float32, value.dtype):
+        if dtype is None and (not np.can_cast(np.float32, value.dtype)
+                              or value.dtype.kind == 'O'):
             value = value.astype(np.float)
 
         if rescale_value is not None:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 import copy
+import decimal
 
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
@@ -80,7 +81,10 @@ class TestQuantityCreation(object):
             q1.unit = u.cm
 
     def test_preserve_dtype(self):
-
+        """Test that if an explicit dtype is given, it is used, while if not,
+        numbers are converted to float (including decimal.Decimal, which
+        numpy converts to an object; closes #1419)
+        """
         # If dtype is specified, use it, but if not, convert int, bool to float
         q1 = u.Quantity(12, unit=u.m / u.s, dtype=int)
         assert q1.dtype == int
@@ -94,6 +98,13 @@ class TestQuantityCreation(object):
         a3 = np.array([1.,2.], dtype=np.float32)
         q3 = u.Quantity(a3, u.yr)
         assert q3.dtype == a3.dtype
+        # items stored as objects by numpy should be converted to float
+        # by default
+        q4 = u.Quantity(decimal.Decimal('10.25'), u.m)
+        assert q4.dtype == float
+
+        q5 = u.Quantity(decimal.Decimal('10.25'), u.m, dtype=object)
+        assert q5.dtype == object
 
     def test_copy(self):
 


### PR DESCRIPTION
Angle constructors should be able to take `decimal.Decimal` objects.

```
from astropy.coordinates import Angle
import astropy.units as u
from decimal import Decimal

d = Decimal(12.34)

a = Angle(d, unit=u.degree)
print a.hms
```

This fails with:

```
ERROR: ValueError: Value not scalar compatible or convertable into a float or integer array [astropy.units.core]
```

It is, of course, pretty easily convertible into a float. Also, the word “convertable” is misspelled in the error above.
