### PR TITLE
Table.remove_columns on a string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -575,6 +575,8 @@ Bug Fixes
 
   - Fix initialisation of ``TableColumns`` with lists or tuples.  [#2647]
 
+  - Fix removal of single column using ``remove_columns``. [#2699]
+
 - ``astropy.time``
 
   - Correct UT1->UTC->UT1 round-trip being off by 1 second if UT1 is

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1379,6 +1379,8 @@ class Table(object):
 
         This gives the same as using remove_column.
         '''
+        if isinstance(names, six.string_types):
+            names = [names]
 
         for name in names:
             if name not in self.columns:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -709,6 +709,15 @@ class TestRemove(SetupData):
         assert self.t._data.dtype.names == ('b',)
         assert np.all(self.t['b'] == np.array([4, 5, 6]))
 
+    def test_3(self, table_types):
+        """Check remove_columns works for a single column with a name of
+        more than one character.  Regression test against #2699"""
+        self._setup(table_types)
+        self.t['new_column'] = self.t['a']
+        assert 'new_column' in self.t.columns.keys()
+        self.t.remove_columns('new_column')
+        assert 'new_column' not in self.t.columns.keys()
+
     def test_remove_nonexistent_row(self, table_types):
         self._setup(table_types)
         with pytest.raises(IndexError):


### PR DESCRIPTION
someone at the SciPy tutorial ran into trouble by trying to call `.remove_columns` on a single column, rather than `.remove_column`.  The result of `.remove_columns('foo')` on a string is to try to iterate over each character in the string as a column name.

I think for strings we should do like Pandas--treat it as a comma-separated list of colnames.  Granted this breaks in bizarro case where one of the column names contains a comma. But in that case we can throw up an error, maybe, or just not support it.  For most cases I think it could be useful and would prevent this common mistake.
