### PR TITLE
Ensure in-place ops on Angles with non-angle result do not corrupt the instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -150,6 +150,10 @@ Bug Fixes
 
   - ``Distance`` can now take a list of quantities. [#2261]
 
+  - For in-place operations for ``Angle`` instances in which the result unit
+    is not an angle, an exception is raised before the instance is corrupted.
+    [#2718]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -108,7 +108,8 @@ def test_angle_ops():
     # Angles can be added and subtracted. Multiplication and division by a
     # scalar is also permitted. A negative operator is also valid.  All of
     # these operate in a single dimension. Attempting to multiply or divide two
-    # Angle objects will raise an exception.
+    # Angle objects will return a quantity.  An exception will be raised if it
+    # is attempted to store output with a non-angular unit in an Angle [#2718].
 
     a1 = Angle(3.60827466667, unit=u.hour)
     a2 = Angle("54:07:26.832", unit=u.degree)
@@ -134,6 +135,16 @@ def test_angle_ops():
     assert a5 >= a1
     assert a1 < a5
     assert a1 <= a5
+
+    a6 = Angle(45., u.degree)
+    a7 = a6 * a5
+    assert type(a7) is u.Quantity
+
+    with pytest.raises(TypeError):
+        a6 *= a5
+
+    with pytest.raises(TypeError):
+        np.sin(a6, out=a6)
 
 
 def test_angle_convert():

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -324,8 +324,15 @@ class Quantity(np.ndarray):
             # array, which we can't do if we are doing an in-place operation.
             if result_unit is None:
                 raise TypeError("Cannot store non-quantity output from {0} "
-                                "function in Quantity object"
-                                .format(function.__name__))
+                                "function in {1} instance"
+                                .format(function.__name__, type(self)))
+
+            if self.__quantity_subclass__(result_unit)[0] is not type(self):
+                raise TypeError(
+                    "Cannot store output with unit '{0}' from {1} function "
+                    "in {2} instance.  Use {3} instance instead."
+                    .format(result_unit, function.__name__, type(self),
+                            self.__quantity_subclass__(result_unit)[0]))
 
             # If the Quantity has an integer dtype, in-place operations are
             # dangerous because in some cases the quantity will be e.g.


### PR DESCRIPTION
Currently, for an inplace operation on an Angle, an exception is raised if the result unit is not an angle unit, but this happens after the instance has been corrupted (see below). This PR solves this by checking an output instance is of the right class for the result unit.

```
In [1]: import astropy.units as u, numpy as np; from astropy.coordinates import Angle, Longitude, Latitude

In [2]: a = Angle(60., u.deg)

In [3]: np.cos(a, a)
...
UnitsError: Given unit  is not convertible to an angle

In [4]: a
Out[4]: <Angle 0.5000000000000001>
```

With this PR:

```
In [1]: import astropy.units as u, numpy as np; from astropy.coordinates import Angle, Longitude, Latitude

In [2]: a = Angle(60., u.deg)

In [3]: np.cos(a, a)
...
TypeError: Cannot store output with unit '' from cos function in <class 'astropy.coordinates.angles.Angle'> instance.  Use <class 'astropy.units.quantity.Quantity'> instance instead.

In [4]: a
Out[4]: <Angle 60.0 deg>
```
