### PR TITLE
Add link to flymake-cursor.el in Emacs dev docs

### DIFF
--- a/docs/development/codeguide_emacs.rst
+++ b/docs/development/codeguide_emacs.rst
@@ -131,7 +131,10 @@ file must be in the system path.
   pep8 --ignore=E221,E701,E202 --repeat "$1"
   true
 
-Add the following code to Emacs configurations.
+Also download `flymake-cursor.el
+<http://www.emacswiki.org/emacs/flymake-cursor.el>`_ and place it in the
+Emacs configuration directory.  Then add the following code to the Emacs
+configuration:
 
 .. code-block:: scheme
 


### PR DESCRIPTION
flymake-cursor.el doesn't appear to be part of the flymake project, so this PR is a separate note to instruct users to download the file before trying to load it (which is done in the code block below this diff).
