### PR TITLE
Adds Model and Fitter class registries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,10 @@ New Features
     the old one but is less limited in the types of models it can be used to
     created.  [#1763]
 
+  - The ``Model`` and ``Fitter`` classes have ``.registry`` attributes which
+    provide sets of all loaded ``Model`` and ``Fitter`` classes (this is
+    useful for building UIs for models and fitting). [#2725]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -69,7 +69,23 @@ class UnsupportedConstraintError(ModelsError, ValueError):
     """
 
 
-@six.add_metaclass(abc.ABCMeta)
+class _FitterMeta(abc.ABCMeta):
+    """
+    Currently just provides a registry for all Fitter classes.
+    """
+
+    registry = set()
+
+    def __new__(mcls, name, bases, members):
+        cls = super(_FitterMeta, mcls).__new__(mcls, name, bases, members)
+
+        if not inspect.isabstract(cls) and not name.startswith('_'):
+            mcls.registry.add(cls)
+
+        return cls
+
+
+@six.add_metaclass(_FitterMeta)
 class Fitter(object):
     """
     Base class for all fitters.
@@ -137,6 +153,10 @@ class Fitter(object):
         raise NotImplementedError("Subclasses should implement this method.")
 
 
+# TODO: I have ongoing branch elsewhere that's refactoring this module so that
+# all the fitter classes in here are Fitter subclasses.  In the meantime we
+# need to specify that _FitterMeta is its metaclass.
+@six.add_metaclass(_FitterMeta)
 class LinearLSQFitter(object):
     """
     A class performing a linear least square fitting.
@@ -322,6 +342,7 @@ class LinearLSQFitter(object):
         return model_copy
 
 
+@six.add_metaclass(_FitterMeta)
 class LevMarLSQFitter(object):
     """
     Levenberg-Marquardt algorithm and least squares statistic.
@@ -629,6 +650,7 @@ class SimplexLSQFitter(Fitter):
         return model_copy
 
 
+@six.add_metaclass(_FitterMeta)
 class JointFitter(object):
     """
     Fit models which share a parameter.


### PR DESCRIPTION
Initial implementation of simply registries of Model and Fitter classes.  This is something that will be useful for some other features I'm working on.  This might evolve a bit more as I use it, but I wanted to go ahead and make a separate feature PR for it.
