### PR TITLE
WCS should set default values for RADESYS

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -2975,8 +2975,14 @@ PyWcsprm_get_radesys(
     PyWcsprm* self,
     /*@unused@*/ void* closure) {
 
-  if (is_null(self->x.radesys)) {
-    return NULL;
+  if (self->x.radesys == NULL || self->x.radesys[0] == 0) {
+    if (isnan64(self->x.equinox)) {
+      return PyString_FromString("ICRS");
+    } else if (self->x.equinox < 1984.) {
+      return PyString_FromString("FK4");
+    } else {
+      return PyString_FromString("FK5");
+    }
   }
 
   return get_string("radesys", self->x.radesys);

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -530,7 +530,11 @@ def test_print_contents():
 
 def test_radesys():
     w = _wcs.Wcsprm()
-    assert w.radesys == ''
+    assert w.radesys == 'ICRS'
+    w.equinox = 1980
+    assert w.radesys == 'FK4'
+    w.equinox = 1984
+    assert w.radesys == 'FK5'
     w.radesys = 'foo'
     assert w.radesys == 'foo'
 

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -528,15 +528,64 @@ def test_print_contents():
     assert isinstance(str(w), str)
 
 
-def test_radesys():
-    w = _wcs.Wcsprm()
-    assert w.radesys == 'ICRS'
-    w.equinox = 1980
-    assert w.radesys == 'FK4'
-    w.equinox = 1984
-    assert w.radesys == 'FK5'
-    w.radesys = 'foo'
-    assert w.radesys == 'foo'
+def test_radesys_equinox():
+
+    # As described in Section 3.1 of the FITS standard "Equatorial and ecliptic
+    # coordinates", for those systems the RADESYS keyword can be used to
+    # indicate the equatorial/ecliptic frame to use. From the standard:
+
+    # "For RADESYSa values of FK4 and FK4-NO-E, any stated equinox is Besselian
+    # and, if neither EQUINOXa nor EPOCH are given, a default of 1950.0 is to
+    # be taken. For FK5, any stated equinox is Julian and, if neither keyword
+    # is given, it defaults to 2000.0.
+
+    # "If the EQUINOXa keyword is given it should always be accompanied by
+    # RADESYS a. However, if it should happen to ap- pear by itself then
+    # RADESYSa defaults to FK4 if EQUINOXa < 1984.0, or to FK5 if EQUINOXa
+    # 1984.0. Note that these defaults, while probably true of older files
+    # using the EPOCH keyword, are not required of them.
+
+    # By default RADESYS is empty
+    w = _wcs.Wcsprm(naxis=2)
+    assert w.radesys == ''
+    assert np.isnan(w.equinox)
+
+    # For non-ecliptic or equatorial systems it is still empty
+    w = _wcs.Wcsprm(naxis=2)
+    for ctype in [('GLON-CAR', 'GLAT-CAR'),
+                  ('SLON-SIN', 'SLAT-SIN')]:
+        w.ctype = ctype
+        assert w.radesys == ''
+        assert np.isnan(w.equinox)
+
+    for ctype in [('RA---TAN', 'DEC--TAN'),
+                  ('ELON-TAN', 'ELAT-TAN'),
+                  ('DEC--TAN', 'RA---TAN'),
+                  ('ELAT-TAN', 'ELON-TAN')]:
+
+        # Check defaults for RADESYS
+        w = _wcs.Wcsprm(naxis=2)
+        w.ctype = ctype
+        assert w.radesys == 'ICRS'
+        w.equinox = 1980
+        assert w.radesys == 'FK4'
+        w.equinox = 1984
+        assert w.radesys == 'FK5'
+        w.radesys = 'foo'
+        assert w.radesys == 'foo'
+
+        # Check defaults for EQUINOX
+        w = _wcs.Wcsprm(naxis=2)
+        w.ctype = ctype
+        assert np.isnan(w.equinox)  # frame is ICRS, no equinox
+        w.radesys = 'ICRS'
+        assert np.isnan(w.equinox)
+        w.radesys = 'FK5'
+        assert w.equinox == 2000.
+        w.radesys = 'FK4'
+        assert w.equinox == 1950
+        w.radesys = 'FK4-NO-E'
+        assert w.equinox == 1950
 
 
 def test_restfrq():


### PR DESCRIPTION
@mdboom - the FITS-WCS standard says

RADESYSa – [character; default: FK4, FK5, or ICRS: see be- low]. Name of the reference frame of equatorial or ecliptic coordinates, whose value must be one of those specified in Table 24. The default value is FK4 if the value of EQUINOXa < 1984.0, FK5 if EQUINOXa ≥ 1984.0, or ICRS if EQUINOXa is not given.

Currently ``wcs.wcs.radesys`` defaults to ``''``. Can we make it default to the above values instead? I'd be happy to try and do this, but is there a specific place this should go?