### PR TITLE
Update supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
     - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
@@ -33,8 +32,6 @@ matrix:
           env: SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test'
-        - python: 3.2
-          env: SETUP_CMD='test'
         - python: 3.3
           env: SETUP_CMD='test'
         - python: 3.4
@@ -47,8 +44,6 @@ matrix:
           env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
 
         # Try older numpy versions
-        - python: 3.2
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
         - python: 2.7

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -332,7 +332,7 @@ def read(cls, *args, **kwargs):
         if not isinstance(data, cls):
             if issubclass(cls, data.__class__):
                 # User has read with a subclass where only the parent class is
-                # registered.  This returns the parent class, so try coercing to 
+                # registered.  This returns the parent class, so try coercing to
                 # desired subclass.
                 try:
                     data = cls(data)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -60,12 +60,6 @@ else:
     importer = extern_pytest.DictImporter(unpacked_sources)
     sys.meta_path.insert(0, importer)
 
-    # On Python 3.1, we need to forcibly import the py.test-"bundled"
-    # argparse before importing py.test, since it isn't in the
-    # standard library, and py.test's workaround doesn't appear to
-    # work with the "absolute imports" of Python 3.x.
-    if six.PY3 and sys.version_info[1] <= 1:
-        argparse = importer.load_module(str('argparse'))
     pytest = importer.load_module(str('pytest'))
 
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -640,11 +640,8 @@ def test_now():
     # times are more like microseconds.  But it seems safer in case some
     # platforms have slow clock calls or something.
 
-    version_info = sys.version_info
-    # py < 2.7 and py3 < 3.2 doesn't have `total_seconds`
-    if ((version_info[0] == 2 and version_info[1] < 7) or
-        (version_info[0] == 3 and version_info[1] < 2) or
-            version_info[0] < 2):
+    # py < 2.7 doesn't have `total_seconds`
+    if sys.version_info[:2] < (2, 7):
         total_secs = lambda td: (td.microseconds + (
             td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6.
     else:

--- a/astropy/utils/compat/argparse.py
+++ b/astropy/utils/compat/argparse.py
@@ -4,7 +4,5 @@ import sys
 
 if sys.version_info[:2] <= (2, 6):
     from ._argparse import *
-elif sys.version_info[0] == 3 and sys.version_info[:2] <= (3, 1):
-    from ._argparse import *
 else:
     from argparse import *

--- a/astropy/utils/compat/gzip.py
+++ b/astropy/utils/compat/gzip.py
@@ -4,18 +4,12 @@ Handles backports of the standard library's `gzip.py`.
 
 Python 2.6 has a `gzip.py` without support for the `with` statement.
 Here, the version that ships with Python 2.7 is used instead.
-
-Python 3.1 has a `gzip.py` that can not be wrapped by an
-`io.TextIOWrapper`.  Here, the version that ships with Python 3.2 is
-used instead.
 """
 
 from __future__ import absolute_import
 
 import sys
-if sys.version_info[:2] == (3, 1):
-    from ._gzip_py3 import *
-elif sys.version_info[:2] == (2, 6):
+if sys.version_info[:2] == (2, 6):
     from ._gzip_py2 import *
 else:
     from gzip import *

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -7,11 +7,6 @@ be accessed from there.
 
 Includes the following fixes:
 
-* The `inspect.getmodule` function does not always work in Python 3.1 and 3.2.
-  This package includes a function `inspect_getmodule` that will simply be an
-  alias to `inspect.getmodule` if the stdlib version is correct, but for
-  versions of python with the bug, it uses an internal patched version.
-
 * The `contextlib.ignored` context manager, which is only available in Python
   3.4 or greater.
 
@@ -27,8 +22,8 @@ import sys
 from functools import wraps
 
 
-__all__ = ['inspect_getmodule', 'invalidate_caches', 'override__dir__',
-           'ignored', 'possible_filename']
+__all__ = ['invalidate_caches', 'override__dir__', 'ignored',
+           'possible_filename']
 
 
 def possible_filename(filename):
@@ -50,75 +45,6 @@ def possible_filename(filename):
                     sys.version_info[:2] >= (3, 3))
 
     return False
-
-
-def _patched_getmodule(object, _filename=None):
-    """Return the module an object was defined in, or None if not found.
-
-    This replicates the functionality of the stdlib `inspect.getmodule`
-    function but includes a fix for a bug present in Python 3.1 and 3.2.
-    """
-    #these imports mock up what would otherwise have been in inspect
-    from inspect import modulesbyfile, _filesbymodname, getabsfile, ismodule
-
-    if ismodule(object):
-        return object
-    if hasattr(object, '__module__'):
-        return sys.modules.get(object.__module__)
-    # Try the filename to modulename cache
-    if _filename is not None and _filename in modulesbyfile:
-        return sys.modules.get(modulesbyfile[_filename])
-    # Try the cache again with the absolute file name
-    try:
-        file = getabsfile(object, _filename)
-    except TypeError:
-        return None
-    if file in modulesbyfile:
-        return sys.modules.get(modulesbyfile[file])
-    # Update the filename to module name cache and check yet again
-    # Copy sys.modules in order to cope with changes while iterating
-    # This is where the fix is made - the adding of the "list" call:
-    for modname, module in list(sys.modules.items()):
-        if ismodule(module) and hasattr(module, '__file__'):
-            f = module.__file__
-            if f == _filesbymodname.get(modname, None):
-                # Have already mapped this module, so skip it
-                continue
-            _filesbymodname[modname] = f
-            f = getabsfile(module)
-            # Always map to the name the module knows itself by
-            modulesbyfile[f] = modulesbyfile[
-                os.path.realpath(f)] = module.__name__
-    if file in modulesbyfile:
-        return sys.modules.get(modulesbyfile[file])
-    # Check the main module
-    main = sys.modules['__main__']
-    if not hasattr(object, '__name__'):
-        return None
-    if hasattr(main, object.__name__):
-        mainobject = getattr(main, object.__name__)
-        if mainobject is object:
-            return main
-    # Check builtins
-    builtin = sys.modules['builtins']
-    if hasattr(builtin, object.__name__):
-        builtinobject = getattr(builtin, object.__name__)
-        if builtinobject is object:
-            return builtin
-
-inspect_getmodule = None
-"""
-An alias to `inspect.getmodule`, or a patched version that replicates the
-functionality with a bugfix for Python 3.1 and 3.2.
-"""
-
-#This assigns the stdlib inspect.getmodule to the variable name
-#`inspect_getmodule` if it's not buggy, and uses the matched version if it is.
-if sys.version_info[0] < 3 or sys.version_info[1] > 2:
-    #in 2.x everythig is fine, as well as >=3.3
-    from inspect import getmodule as inspect_getmodule
-else:
-    inspect_getmodule = _patched_getmodule
 
 
 # Python 3.3's importlib caches filesystem reads for faster imports in the

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -116,10 +116,6 @@ def find_current_module(depth=1, finddiff=False):
 
     """
 
-    # using a patched version of getmodule because the py 3.1 and 3.2 stdlib
-    # is broken if the list of modules changes during import
-    from .compat import inspect_getmodule
-
     frm = inspect.currentframe()
     for i in range(depth):
         frm = frm.f_back
@@ -127,7 +123,7 @@ def find_current_module(depth=1, finddiff=False):
             return None
 
     if finddiff:
-        currmod = inspect_getmodule(frm)
+        currmod = inspect.getmodule(frm)
         if finddiff is True:
             diffmods = [currmod]
         else:
@@ -144,12 +140,12 @@ def find_current_module(depth=1, finddiff=False):
 
         while frm:
             frmb = frm.f_back
-            modb = inspect_getmodule(frmb)
+            modb = inspect.getmodule(frmb)
             if modb not in diffmods:
                 return modb
             frm = frmb
     else:
-        return inspect_getmodule(frm)
+        return inspect.getmodule(frm)
 
 
 def find_mod_objs(modname, onlylocals=False):

--- a/astropy/vo/samp/standard_profile.py
+++ b/astropy/vo/samp/standard_profile.py
@@ -36,9 +36,7 @@ class SAMPSimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             self.end_headers()
             self.wfile.write(SAMP_ICON)
 
-    if ((six.PY2 and sys.version_info[:2] >= (2,7))
-        or (six.PY3 and sys.version_info[:2] >= (3,2))):
-
+    if sys.version_info[:2] >= (2, 7):
         def do_POST(self):
             """
             Handles the HTTP POST request.

--- a/astropy/vo/samp/tests/test_standard_profile.py
+++ b/astropy/vo/samp/tests/test_standard_profile.py
@@ -25,8 +25,6 @@ TEST_KEY1 = get_pkg_data_filename('data/test1.key')
 TEST_CERT2 = get_pkg_data_filename('data/test2.crt')
 TEST_KEY2 = get_pkg_data_filename('data/test2.key')
 
-PY31 = sys.version_info[:2] == (3, 1)
-
 
 class TestStandardProfile(object):
 

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -15,7 +15,7 @@ both for the core package and for affiliated packages.
 Interface and Dependencies
 --------------------------
 
-* All code must be compatible with Python 2.6, 2.7, as well as 3.1 and
+* All code must be compatible with Python 2.6, 2.7, as well as 3.3 and
   later.  The use of `six`_ for writing code that is portable between Python
   2.x and 3.x is encouraged going forward.  However, much of our legacy code
   still uses `2to3`_ to process Python 2.x files to be compatible with

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,9 @@ Requirements
 
 Astropy has the following strict requirements:
 
-- `Python <http://www.python.org/>`_ 2.6 (>=2.6.5), 2.7, 3.1, 3.2, 3.3, or 3.4
+- `Python <http://www.python.org/>`_ 2.6 (>=2.6.5), 2.7, 3.3, or 3.4
+
+  - Prior to Astropy v1.0 Python 3.1 and 3.2 are also supported.
 
 - `Numpy`_ |minimum_numpy_version| or later
 
@@ -97,7 +99,7 @@ run::
 Binary installers
 -----------------
 
-Binary installers are available on Windows for Python 2.6, 2.7, 3.1, and 3.2
+Binary installers are available on Windows for Python 2.6, 2.7, and >= 3.3
 at `PyPI <https://pypi.python.org/pypi/astropy>`_.
 
 .. _testing_installed_astropy:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34
+envlist = py26,py27,py33,py34
 
 [testenv]
 deps =


### PR DESCRIPTION
I propose:
- For 0.3.x, we update the docs to explicitly say we support Python 3.3 (we have in a practical sense for some time).
- For 0.4, we drop support for Python 3.1 (this recently became an issue in #2017, and we should try to limit the number of versions we support at all costs).

I don't (personally) think we should claim 3.4 support until the final release of 3.4 as things there are subject to change.

If we all agree, I'll create two separate pull requests for this.

EDIT: Updated reference to #2017.
