### PR TITLE
astropy.wcs returns nan when galactic longitude >= 180 degrees

### DIFF
--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -119,6 +119,14 @@ keywords in a FITS file::
           'length': have 'Hz', want 'm''.
         - 'unitfix' made the change 'Changed units: 'HZ      ' -> 'Hz''.
 
+Bounds checking
+---------------
+
+Bounds checking is enabled by default, and any computed world
+coordinates outside of [-180°, 180°] for longitude and [-90°, 90°] in
+latitude are marked as invalid.  To disable this behavior, use
+`astropy.wcs.Wcsprm.bounds_check`.
+
 Supported projections
 =====================
 


### PR DESCRIPTION
astropy.wcs returns nans if the cube contains pixels beyond 180 degrees. 

For example, with the following header:

SIMPLE  =                    T / Fits standard
BITPIX  =                   16 / Bits per pixel 
NAXIS   =                    3 / Number of axes 
NAXIS1  =                  256 / Axis length
NAXIS2  =                  256 / Axis length 
NAXIS3  =                 1024 / Axis length
EXTEND  =                    F / File may contain extensions
CTYPE3  = 'VELO-LSR'           /
CRVAL3  =                  0.0 / M/S
CRPIX3  =                512.5
CTYPE1  = 'GLON-CAR'           /
CRVAL1  =                  0.0 / DEGREES
CRPIX1  =              30977.0 
CTYPE2  = 'GLAT-CAR'           / 
CRVAL2  =                  0.0 / DEGREES
CRPIX2  =                305.0 
CDELT1  =             -0.00625 / DEGREES 
CDELT2  =              0.00625 / DEGREES
CDELT3  =     127.000209090909 / M/S

the commands:

wcs=astropy.wcs.WCS(header.copy())
wcs.wcs_pix2world([[0,0,0]],0)

returns:

array([[ nan,  nan,  nan]])

when it should return:

array([193.6,-1.9,-64.96]])
