### PR TITLE
fixing gzip import issue 2774

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -146,7 +146,7 @@ class Parameter(object):
 
         if model is not None:
             with ignored(AttributeError):
-                # This can only work if the paramter's value has been set by
+                # This can only work if the parameter's value has been set by
                 # the model
                 _, self._shape = self._validate_value(model, self.value)
         else:

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -187,7 +187,8 @@ single missing-value specification ``<missing_spec>`` or a list of ``<missing_sp
   fill_values = <missing_spec> | [<missing_spec1>, <missing_spec2>, ...]
   <missing_spec> = (<match_string>, '0', <optional col name 1>, <optional col name 2>, ...)
 
-The second element of a ``<missing_spec>`` should always be the string ``'0'``,
+When reading a table the second element of a ``<missing_spec>`` should always
+be the string ``'0'``,
 otherwise you may get unexpected behavior [#f1]_.  By default the
 ``<missing_spec>`` is applied to all columns unless column name strings are
 supplied.  An alterate way to limit the columns is via the
@@ -219,7 +220,9 @@ values in with typical placeholders::
 
 
 .. [#f1] The requirement to put the ``'0'`` there is the legacy of an old
-         interface which is maintained for backward compatibility.  The second
+         interface which is maintained for backward compatibility and also to
+         match the format of ``fill_value`` for reading with the format of
+         ``fill_value`` used for writing tables. On reading, the second
          element of the ``<missing_spec>`` tuple can actually be an arbitrary
          string value which replaces occurrences of the ``<match_string>``
          string in the input stream prior to type conversion.  This ends up

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -202,9 +202,9 @@ details.
 
 **fill_values**: fill value specifier of lists
   This can be used to fill missing values in the table or replace values with special meaning.
-  The syntax is the same as used on input.
-  See the :ref:`replace_bad_or_missing_values` section for more information on the syntax.
 
+  See the :ref:`replace_bad_or_missing_values` section for more information on the syntax.
+  The syntax is almost the same as when reading a table.
   There is a special value ``astropy.io.ascii.masked`` that is used a say "output this string
   for all masked values in a masked table (the default is to use a ``'--'``)::
 
@@ -244,6 +244,10 @@ details.
       "no data" 3
       2.00 4
 
+  Similarly, if you replace a value in a column that has a fixed length format,
+  e.g. ``'f4.2'``, then the string you want to replace must have the same
+  number of characters, in the example above ``fill_values=[(' nan',' N/A')]``
+  would work.
 
 **fill_include_names**: list of column names, which are affected by ``fill_values``.
   If not supplied, then ``fill_values`` can affect all columns.


### PR DESCRIPTION
Changed import from:
import gzip
to:
from ...utils.compat import gzip

ran setup.py test and all io/fits tests passed. I don't have Python 2.6 to test that this really fixed the problem, but it should based on the comments in issue #2774
