### PR TITLE
Standard plotting configuration

### DIFF
--- a/astropy/utils/plotting.py
+++ b/astropy/utils/plotting.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+""" This module contains changes to matplotlib rc parameters in order
+to adopt an astropy plotting style.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import matplotlib as mpl
+
+def set_astropy_plot_style():
+    """ 
+    matplotlib configuration parameters for astropy plotting style.
+    """
+
+    pass

--- a/astropy/utils/plotting.py
+++ b/astropy/utils/plotting.py
@@ -10,8 +10,81 @@ from __future__ import (absolute_import, division, print_function,
 import matplotlib as mpl
 
 def set_astropy_plot_style():
-    """ 
+    """
     matplotlib configuration parameters for astropy plotting style.
     """
 
-    pass
+    # Lines
+    mpl.rcParams['lines.linewidth'] = 1.0
+    mpl.rcParams['lines.antialiased'] = True
+
+    # Patches
+    mpl.rcParams['patch.linewidth'] = 0.5
+    mpl.rcParams['patch.facecolor'] = '348ABD'
+    mpl.rcParams['patch.edgecolor'] = 'eeeeee'
+    mpl.rcParams['patch.antialiased'] = True
+
+    # Font
+    mpl.rcParams['font.family'] = 'monospace'
+    mpl.rcParams['font.size'] = 12.0
+    mpl.rcParams['font.monospace'] = ['Andale Mono', 'Nimbus Mono L', 'Courier New', 'Courier', 'Fixed', 'Terminal', 'monospace']
+
+    # Axes
+    mpl.rcParams['axes.facecolor'] = 'eeeeee'
+    mpl.rcParams['axes.edgecolor'] = 'bcbcbc'
+    mpl.rcParams['axes.linewidth'] = 1
+    mpl.rcParams['axes.grid'] = True
+    mpl.rcParams['axes.titlesize'] = 'x-large'
+    mpl.rcParams['axes.labelsize'] = 'large'
+    mpl.rcParams['axes.labelcolor'] = '555555'
+    mpl.rcParams['axes.axisbelow'] = True
+    mpl.rcParams['axes.color_cycle'] = ['348ABD', '7A68A6', 'A60628', '467821', 'CF4457', '188487', 'E24A33']
+        # 348ABD : blue
+        # 7A68A6 : purple
+        # A60628 : red
+        # 467821 : green
+        # CF4457 : pink
+        # 188487 : turquoise
+        # E24A33 : orange
+
+    # Ticks
+    mpl.rcParams['xtick.major.size'] = 0
+    mpl.rcParams['xtick.minor.size'] = 0
+    mpl.rcParams['xtick.major.pad'] = 6
+    mpl.rcParams['xtick.minor.pad'] = 6
+    mpl.rcParams['xtick.color'] = '555555'
+    mpl.rcParams['xtick.direction'] = 'in'
+    mpl.rcParams['ytick.major.size'] = 0
+    mpl.rcParams['ytick.minor.size'] = 0
+    mpl.rcParams['ytick.major.pad'] = 6
+    mpl.rcParams['ytick.minor.pad'] = 6
+    mpl.rcParams['ytick.color'] = '555555'
+    mpl.rcParams['ytick.direction'] = 'in'
+
+    # Legend
+    mpl.rcParams['legend.fancybox'] = True
+
+    # Figure
+    mpl.rcParams['figure.figsize'] = [8, 6]
+    mpl.rcParams['figure.facecolor'] = '0.85'
+    mpl.rcParams['figure.edgecolor'] = '0.50'
+    mpl.rcParams['figure.subplot.hspace'] = 0.5
+
+    # Keymap
+    mpl.rcParams['keymap.fullscreen'] = 'f'
+    mpl.rcParams['keymap.home'] = ['h', 'r', 'home']
+    mpl.rcParams['keymap.back'] = ['left', 'c', 'backspace']
+    mpl.rcParams['keymap.forward'] = ['right', 'v']
+    mpl.rcParams['keymap.pan'] = 'p'
+    mpl.rcParams['keymap.zoom'] = 'o'
+    mpl.rcParams['keymap.save'] = 's'
+    mpl.rcParams['keymap.grid'] = 'g'
+    mpl.rcParams['keymap.yscale'] = 'l'
+    mpl.rcParams['keymap.xscale'] = ['L', 'k']
+    mpl.rcParams['keymap.all_axes'] = 'a'
+
+    # Other
+    mpl.rcParams['savefig.dpi'] = 72
+    mpl.rcParams['interactive'] = True
+    mpl.rcParams['toolbar'] = 'toolbar2'
+    mpl.rcParams['timezone'] = 'UTC'

--- a/astropy/utils/plotting.py
+++ b/astropy/utils/plotting.py
@@ -9,82 +9,92 @@ from __future__ import (absolute_import, division, print_function,
 
 import matplotlib as mpl
 
-def set_astropy_plot_style():
+def set_astropy_plot_style(version=1):
     """
     matplotlib configuration parameters for astropy plotting style.
     """
 
-    # Lines
-    mpl.rcParams['lines.linewidth'] = 1.0
-    mpl.rcParams['lines.antialiased'] = True
+    if version == 1:
 
-    # Patches
-    mpl.rcParams['patch.linewidth'] = 0.5
-    mpl.rcParams['patch.facecolor'] = '348ABD'
-    mpl.rcParams['patch.edgecolor'] = 'eeeeee'
-    mpl.rcParams['patch.antialiased'] = True
+        params = {
 
-    # Font
-    mpl.rcParams['font.family'] = 'monospace'
-    mpl.rcParams['font.size'] = 12.0
-    mpl.rcParams['font.monospace'] = ['Andale Mono', 'Nimbus Mono L', 'Courier New', 'Courier', 'Fixed', 'Terminal', 'monospace']
+            # Lines
+            'lines.linewidth': 1.0,
+            'lines.antialiased': True,
 
-    # Axes
-    mpl.rcParams['axes.facecolor'] = 'eeeeee'
-    mpl.rcParams['axes.edgecolor'] = 'bcbcbc'
-    mpl.rcParams['axes.linewidth'] = 1
-    mpl.rcParams['axes.grid'] = True
-    mpl.rcParams['axes.titlesize'] = 'x-large'
-    mpl.rcParams['axes.labelsize'] = 'large'
-    mpl.rcParams['axes.labelcolor'] = '555555'
-    mpl.rcParams['axes.axisbelow'] = True
-    mpl.rcParams['axes.color_cycle'] = ['348ABD', '7A68A6', 'A60628', '467821', 'CF4457', '188487', 'E24A33']
-        # 348ABD : blue
-        # 7A68A6 : purple
-        # A60628 : red
-        # 467821 : green
-        # CF4457 : pink
-        # 188487 : turquoise
-        # E24A33 : orange
+            # Patches
+            'patch.linewidth': 0.5,
+            'patch.facecolor': '#348ABD',
+            'patch.edgecolor': '#EEEEEE',
+            'patch.antialiased': True,
 
-    # Ticks
-    mpl.rcParams['xtick.major.size'] = 0
-    mpl.rcParams['xtick.minor.size'] = 0
-    mpl.rcParams['xtick.major.pad'] = 6
-    mpl.rcParams['xtick.minor.pad'] = 6
-    mpl.rcParams['xtick.color'] = '555555'
-    mpl.rcParams['xtick.direction'] = 'in'
-    mpl.rcParams['ytick.major.size'] = 0
-    mpl.rcParams['ytick.minor.size'] = 0
-    mpl.rcParams['ytick.major.pad'] = 6
-    mpl.rcParams['ytick.minor.pad'] = 6
-    mpl.rcParams['ytick.color'] = '555555'
-    mpl.rcParams['ytick.direction'] = 'in'
+            # Font
+            'font.family': 'monospace',
+            'font.size': 12.0,
+            'font.monospace': ['Andale Mono', 'Nimbus Mono L', 'Courier New', 'Courier', 'Fixed', 'Terminal', 'monospace'],
 
-    # Legend
-    mpl.rcParams['legend.fancybox'] = True
+            # Axes
+            'axes.facecolor': '#EEEEEE',
+            'axes.edgecolor': '#BCBCBC',
+            'axes.linewidth': 1,
+            'axes.grid': True,
+            'axes.titlesize': 'x-large',
+            'axes.labelsize': 'large',
+            'axes.labelcolor': '#555555',
+            'axes.axisbelow': True,
+            'axes.color_cycle': ['#348ABD', '#7A68A6', '#A60628', '#467821', '#CF4457', '#188487', '#E24A33'],
+                # 348ABD : blue
+                # 7A68A6 : purple
+                # A60628 : red
+                # 467821 : green
+                # CF4457 : pink
+                # 188487 : turquoise
+                # E24A33 : orange
 
-    # Figure
-    mpl.rcParams['figure.figsize'] = [8, 6]
-    mpl.rcParams['figure.facecolor'] = '0.85'
-    mpl.rcParams['figure.edgecolor'] = '0.50'
-    mpl.rcParams['figure.subplot.hspace'] = 0.5
+            # Ticks
+            'xtick.major.size': 0,
+            'xtick.minor.size': 0,
+            'xtick.major.pad': 6,
+            'xtick.minor.pad': 6,
+            'xtick.color': '#555555',
+            'xtick.direction': 'in',
+            'ytick.major.size': 0,
+            'ytick.minor.size': 0,
+            'ytick.major.pad': 6,
+            'ytick.minor.pad': 6,
+            'ytick.color': '#555555',
+            'ytick.direction': 'in',
 
-    # Keymap
-    mpl.rcParams['keymap.fullscreen'] = 'f'
-    mpl.rcParams['keymap.home'] = ['h', 'r', 'home']
-    mpl.rcParams['keymap.back'] = ['left', 'c', 'backspace']
-    mpl.rcParams['keymap.forward'] = ['right', 'v']
-    mpl.rcParams['keymap.pan'] = 'p'
-    mpl.rcParams['keymap.zoom'] = 'o'
-    mpl.rcParams['keymap.save'] = 's'
-    mpl.rcParams['keymap.grid'] = 'g'
-    mpl.rcParams['keymap.yscale'] = 'l'
-    mpl.rcParams['keymap.xscale'] = ['L', 'k']
-    mpl.rcParams['keymap.all_axes'] = 'a'
+            # Legend
+            'legend.fancybox': True,
 
-    # Other
-    mpl.rcParams['savefig.dpi'] = 72
-    mpl.rcParams['interactive'] = True
-    mpl.rcParams['toolbar'] = 'toolbar2'
-    mpl.rcParams['timezone'] = 'UTC'
+            # Figure
+            'figure.figsize': [8, 6],
+            'figure.facecolor': '0.85',
+            'figure.edgecolor': '0.50',
+            'figure.subplot.hspace': 0.5,
+
+            # Keymap
+            'keymap.fullscreen': 'f',
+            'keymap.home': ['h', 'r', 'home'],
+            'keymap.back': ['left', 'c', 'backspace'],
+            'keymap.forward': ['right', 'v'],
+            'keymap.pan': 'p',
+            'keymap.zoom': 'o',
+            'keymap.save': 's',
+            'keymap.grid': 'g',
+            'keymap.yscale': 'l',
+            'keymap.xscale': ['L', 'k'],
+            'keymap.all_axes': 'a',
+
+            # Other
+            'savefig.dpi': 72,
+            'interactive': True,
+            'toolbar': 'toolbar2',
+            'timezone': 'UTC'
+        }
+
+    else:
+        raise ValueError('Unrecognized astropy_plot_style verion')
+
+    mpl.rcParams.update(params)


### PR DESCRIPTION
This pull request will provide a standard plotting configuration for astropy.  The new `set_astropy_plot_style()` function sets matplotlibrc parameters to reflect the style used in `astropy/astropy-tutorials/templates/matplotlibrc`.  This can be used in tutorials as such:

```python
from astropy.utils.plotting import set_astropy_plot_style
set_astropy_plot_style()
```

This pull request is in regards to issue #2719.