### PR TITLE
Speed up convolve_fft in a few small ways

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -599,6 +599,20 @@ Bug Fixes
 
 astropy.constants
 ^^^^^^^^^^^^^^^^^
+  - Convolution with un-normalized and un-normalizable kernels is now possible.
+    [#5782]
+
+  - Add a new argument, ``normalization_rtol``, to ``convolve_fft``, allowing
+    the user to specify the relative error tolerance in the normalization of
+    the convolution kernel. [#5649, #5177]
+  - Models can now be convoluted using ``convolve`` or ``convolve_fft``,
+    which generates a regular compound model. [#6015]
+
+  - ``convolve_fft`` will pad to the nearest regular value (power of 2, 3, or
+    5) instead of the nearest power of 2, which can save memory.  Real-only
+    FFTs are also supported, which can again save time and memory. [#2792]
+
+- ``astropy.coordinates``
 
 - Fixed Earth radius to be the IAU2015 value for the equatorial radius.
   The polar value had erroneously been used in 2.0. [#6400]

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -424,11 +424,14 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         ``ifft(fft(image)*fft(kernel))``).  Useful for making PSDs.
     fftn, ifftn : functions, optional
         The fft and inverse fft functions.  Can be overridden to use your own
-        ffts, e.g. an fftw3 wrapper or scipy's fftn,
-        ``fft=scipy.fftpack.fftn``
-    complex_dtype : numpy.complex, optional
+        ffts, e.g. an fftw3 wrapper or scipy's fftn, e.g.
+        ``fftn=scipy.fftpack.fftn``
+    real : bool
+        Use the real fft instead of complex?  rfft and irfft must be passed as
+        ``fftn``, ``ifftn`` for this to work.
+    complex_dtype : `numpy.complex`, optional
         Which complex dtype to use.  `numpy` has a range of options, from 64 to
-        256.
+        256.  Ignored if ``real==True``
     quiet : bool, optional
         Silence warning message about NaN interpolation
     allow_huge : bool, optional
@@ -510,10 +513,13 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     if nan_treatment not in ('interpolate', 'fill'):
         raise ValueError("nan_treatment must be one of 'interpolate','fill'")
 
-    # Convert array dtype to complex
-    # and ensure that list inputs become arrays
-    array = np.asarray(array, dtype=complex)
-    kernel = np.asarray(kernel, dtype=complex)
+    if real:
+        complex_dtype = array.dtype
+    else:
+        # Convert array dtype to complex
+        # and ensure that list inputs become arrays
+        array = np.asarray(array, dtype=complex_dtype)
+        kernel = np.asarray(kernel, dtype=complex_dtype)
 
     # Check that the number of dimensions is compatible
     if array.ndim != kernel.ndim:
@@ -616,20 +622,22 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     if fft_pad:  # default=True
         if psf_pad:  # default=False
             # add the dimensions and then take the max (bigger)
-            fsize = 2 ** np.ceil(np.log2(
-                np.max(np.array(arrayshape) + np.array(kernshape))))
+            newshape = [_next_regular(x)
+                        for x in (np.array(arrayshape) +
+                                  np.array(kernshape))]
         else:
             # add the shape lists (max of a list of length 4) (smaller)
-            # also makes the shapes square
-            fsize = 2 ** np.ceil(np.log2(np.max(arrayshape + kernshape)))
-        newshape = np.array([fsize for ii in range(array.ndim)], dtype=int)
+            newshape = [max(_next_regular(x),
+                            _next_regular(y)) 
+                        for x,y in zip(arrayshape,kernshape)]
     else:
         if psf_pad:
             # just add the biggest dimensions
             newshape = np.array(arrayshape) + np.array(kernshape)
         else:
             newshape = np.array([np.max([imsh, kernsh])
-                                 for imsh, kernsh in zip(arrayshape, kernshape)])
+                                 for imsh, kernsh in
+                                 zip(arrayshape, kernshape)])
 
     # perform a second check after padding
     array_size_C = (np.product(newshape, dtype=np.int64) *
@@ -813,3 +821,9 @@ def convolve_models(model, kernel, mode='convolve_fft', **kwargs):
         raise ValueError('Mode {} is not supported.'.format(mode))
 
     return _CompoundModelMeta._from_operator(mode, model, kernel)
+
+try:
+    from scipy.signal.signaltools import _next_regular
+except ImportError:
+    def _next_regular(x):
+        return int(2 ** np.ceil(np.log2(x)))

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -618,18 +618,19 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
                                   "for fft-based convolution")
 
     # find ideal size (power of 2) for fft.
+    # Forces array to be square - it should be possible to avoid this, in
+    # principle, but that may require manipulating the tests too
     # Can add shapes because they are tuples
     if fft_pad:  # default=True
         if psf_pad:  # default=False
             # add the dimensions and then take the max (bigger)
-            newshape = [_next_regular(x)
-                        for x in (np.array(arrayshape) +
-                                  np.array(kernshape))]
+            fsize = max([_next_regular(x)
+                         for x in (np.array(arrayshape) +
+                                   np.array(kernshape))])
         else:
             # add the shape lists (max of a list of length 4) (smaller)
-            newshape = [max(_next_regular(x),
-                            _next_regular(y)) 
-                        for x,y in zip(arrayshape,kernshape)]
+            fsize = _next_regular(np.max(arrayshape + kernshape))
+        newshape = np.array([fsize for ii in range(array.ndim)], dtype=int)
     else:
         if psf_pad:
             # just add the biggest dimensions

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -321,7 +321,8 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
                  fft_pad=None, psf_pad=None, quiet=False,
                  min_wt=0.0, allow_huge=False,
                  fftn=np.fft.fftn, ifftn=np.fft.ifftn,
-                 complex_dtype=complex):
+                 real=False,
+                 complex_dtype=np.complex):
     """
     Convolve an ndarray with an nd-kernel.  Returns a convolved image with
     ``shape = array.shape``.  Assumes kernel is centered.

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 from functools import partial
+from scipy.fftpack import next_fast_len
 
 from .core import Kernel, Kernel1D, Kernel2D, MAX_NORMALIZATION
 from ..utils.exceptions import AstropyUserWarning


### PR DESCRIPTION
As suggested by @jtaylor:
1. Pad to nearest power of 2, 3, 5 (if scipy is available)
2. Allow real ffts, which will use less memory and may be better optimized.  This is awkward to use for now.

WIP - should have feedback before merging is considered
