### PR TITLE
Subclass OrderedDict to provide pretty-printed str representation

### DIFF
--- a/astropy/utils/compat/odict.py
+++ b/astropy/utils/compat/odict.py
@@ -8,18 +8,21 @@ except ImportError:
     from ._odict_py2 import OrderedDict as NativeOrderedDict
 
 class OrderedDict(NativeOrderedDict):
-    """
-    Dictionary that remembers insertion order
+    r"""Dictionary that remembers insertion order
+
+    The native OrderedDict class is extended here in order to
+    provide a more pleasing printed or string representation.
+
     """
     def __init__(self, *args, **kwds):
-        """
-        Initialize an ordered dictionary, The signature is the same as
+        r"""
+        Initialize an ordered dictionary. The signature is the same as
         regular dictionaries, but keyword arguments are not recommended
         because their insertion order is arbitrary.
         """
         NativeOrderedDict.__init__(self, *args, **kwds)
     def __str__(self):
-        """
+        r"""
         Pretty-printed string representation of OrderedDict.
         x.__str__() <==> str(x)
         """

--- a/astropy/utils/compat/odict.py
+++ b/astropy/utils/compat/odict.py
@@ -1,7 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import
+from pprint import pformat
 
 try:
-    from collections import OrderedDict
+    from collections import OrderedDict as NativeOrderedDict
 except ImportError:
-    from ._odict_py2 import *
+    from ._odict_py2 import OrderedDict as NativeOrderedDict
+
+class OrderedDict(NativeOrderedDict):
+    def __init__(self, *args, **kwds):
+        NativeOrderedDict.__init__(self, *args, **kwds)
+    def __str__(self):
+        return('OrderedDict('+ pformat(dict(self),width=1)[1:-1]+')')

--- a/astropy/utils/compat/odict.py
+++ b/astropy/utils/compat/odict.py
@@ -20,7 +20,7 @@ class OrderedDict(NativeOrderedDict):
         NativeOrderedDict.__init__(self, *args, **kwds)
     def __str__(self):
         """
-        Pretty-printed string representation.
+        Pretty-printed string representation of OrderedDict.
         x.__str__() <==> str(x)
         """
         return('OrderedDict('+ pformat(dict(self),width=1)[1:-1]+')')

--- a/astropy/utils/compat/odict.py
+++ b/astropy/utils/compat/odict.py
@@ -8,7 +8,20 @@ except ImportError:
     from ._odict_py2 import OrderedDict as NativeOrderedDict
 
 class OrderedDict(NativeOrderedDict):
+    """
+    Dictionary that remembers insertion order
+    """
     def __init__(self, *args, **kwds):
+        """
+        Initialize an ordered dictionary, The signature is the same as
+        regular dictionaries, but keyword arguments are not recommended
+        because their insertion order is arbitrary.
+        """
         NativeOrderedDict.__init__(self, *args, **kwds)
     def __str__(self):
+        """
+        Pretty-printed string representation.
+        x.__str__() <==> str(x)
+        """
         return('OrderedDict('+ pformat(dict(self),width=1)[1:-1]+')')
+

--- a/astropy/utils/compat/odict.py
+++ b/astropy/utils/compat/odict.py
@@ -23,5 +23,5 @@ class OrderedDict(NativeOrderedDict):
         Pretty-printed string representation of OrderedDict.
         x.__str__() <==> str(x)
         """
-        return('OrderedDict('+ pformat(dict(self),width=1)[1:-1]+')')
+        return('OrderedDict('+ pformat(self.items(),width=80)+')')
 

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -46,8 +46,8 @@ class TestOrderedDict(unittest.TestCase):
                                           c=3, e=5).items()), pairs)                # mixed input
 
         # make sure no positional args conflict with possible kwdargs
-        #self.assertEqual(inspect.getargspec(OrderedDict.__dict__['__init__']).args,
-        #                 ['self'])
+        self.assertEqual(inspect.getargspec(OrderedDict.__dict__['__init__']).args,
+                         ['self'])
 
         # Make sure that direct calls to __init__ do not clear previous contents
         d = OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 44), ('e', 55)])

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -257,7 +257,7 @@ class TestOrderedDict(unittest.TestCase):
     def test_str(self):
         od = OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])
         self.assertEqual(str(od),
-            "OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])")
+            "OrderedDict([(u'c', 1), (u'b', 2), (u'a', 3), (u'd', 4), (u'e', 5), (u'f', 6)])")
         self.assertEqual(str(OrderedDict()), "OrderedDict([])")
 
     def assertIn(self, key, d):

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -254,6 +254,15 @@ class TestOrderedDict(unittest.TestCase):
         od['a'] = 1
         self.assertEqual(list(od.items()), [('b', 2), ('a', 1)])
 
+    def test_str(self):
+        od = OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])
+        self.assertEqual(str(od),
+            "OrderedDict(u'a': 3,\n u'b': 2,\n u'c': 1,\n u'd': 4,\n u'e': 5,\n u'f': 6)")
+        self.assertEqual(str(OrderedDict()), "OrderedDict()")
+
+    def test_setdefault(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+
     def assertIn(self, key, d):
         self.assertTrue(key in d)
 

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -260,9 +260,6 @@ class TestOrderedDict(unittest.TestCase):
             "OrderedDict(u'a': 3,\n u'b': 2,\n u'c': 1,\n u'd': 4,\n u'e': 5,\n u'f': 6)")
         self.assertEqual(str(OrderedDict()), "OrderedDict()")
 
-    def test_setdefault(self):
-        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
-
     def assertIn(self, key, d):
         self.assertTrue(key in d)
 

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -257,8 +257,8 @@ class TestOrderedDict(unittest.TestCase):
     def test_str(self):
         od = OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])
         self.assertEqual(str(od),
-            "OrderedDict(u'a': 3,\n u'b': 2,\n u'c': 1,\n u'd': 4,\n u'e': 5,\n u'f': 6)")
-        self.assertEqual(str(OrderedDict()), "OrderedDict()")
+            "OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])")
+        self.assertEqual(str(OrderedDict()), "OrderedDict([])")
 
     def assertIn(self, key, d):
         self.assertTrue(key in d)

--- a/astropy/utils/tests/test_odict.py
+++ b/astropy/utils/tests/test_odict.py
@@ -23,7 +23,7 @@ from ..compat.odict import OrderedDict
 from ...tests.helper import pytest
 
 #Skips all of these tests if the builtin ordered dict is available
-pytestmark = pytest.mark.skipif(str("sys.version_info >= (2,7)"))
+#pytestmark = pytest.mark.skipif(str("sys.version_info >= (2,7)"))
 
 
 class TestOrderedDict(unittest.TestCase):
@@ -46,8 +46,8 @@ class TestOrderedDict(unittest.TestCase):
                                           c=3, e=5).items()), pairs)                # mixed input
 
         # make sure no positional args conflict with possible kwdargs
-        self.assertEqual(inspect.getargspec(OrderedDict.__dict__['__init__']).args,
-                         ['self'])
+        #self.assertEqual(inspect.getargspec(OrderedDict.__dict__['__init__']).args,
+        #                 ['self'])
 
         # Make sure that direct calls to __init__ do not clear previous contents
         d = OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 44), ('e', 55)])


### PR DESCRIPTION
This pull request fixes #905

I've added one test on the new `__str__` method.

I didn't modify CHANGES.rst as I'm not sure if this is a new feature or an API change.
