### PR TITLE
Originally valid FITS unit cannot be formatted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,9 @@ Bug Fixes
     numerical types such as ``decimal.Decimal``, which are stored as objects
     by numpy. [#1419]
 
+  - The units ``count``, ``pixel``, ``voxel`` and ``dbyte`` now output
+    to FITS, OGIP and VOUnit formats correctly. [#2798]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -91,7 +91,9 @@ def_unit(['solLum', 'L_sun', 'Lsun'], _si.L_sun.value * si.W, namespace=_ns,
 ###########################################################################
 # SPECTRAL DENSITY
 
-def_unit(['ph', 'photon'], namespace=_ns)
+def_unit(['ph', 'photon'],
+         format={'ogip': 'photon'},
+         namespace=_ns)
 def_unit(['Jy', 'Jansky', 'jansky'], 1e-26 * si.W / si.m ** 2 / si.Hz,
          namespace=_ns, prefixes=True,
          doc="Jansky: spectral flux density")
@@ -115,8 +117,12 @@ def_unit(['Sun'], namespace=_ns)
 ###########################################################################
 # EVENTS
 
-def_unit(['ct', 'count'], namespace=_ns)
-def_unit(['pix', 'pixel'], namespace=_ns)
+def_unit(['ct', 'count'],
+         format={'fits': 'count', 'ogip': 'count'},
+         namespace=_ns)
+def_unit(['pix', 'pixel'],
+         format={'ogip': 'pixel'},
+         namespace=_ns)
 
 
 ###########################################################################
@@ -124,7 +130,9 @@ def_unit(['pix', 'pixel'], namespace=_ns)
 
 def_unit(['chan'], namespace=_ns)
 def_unit(['bin'], namespace=_ns)
-def_unit(['vox', 'voxel'], namespace=_ns)
+def_unit(['vox', 'voxel'],
+         format={'fits': 'voxel', 'ogip': 'voxel', 'vounit': 'voxel'},
+         namespace=_ns)
 def_unit((['bit', 'b'], ['bit']), namespace=_ns, prefixes=True)
 def_unit((['byte', 'B'], ['byte']), namespace=_ns, prefixes=True,
          exclude_prefixes=['d'])

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -19,7 +19,7 @@ from ...utils.misc import did_you_mean
 
 class UnitScaleError(ValueError):
     """
-    Used to catch the errors involving scaled units, 
+    Used to catch the errors involving scaled units,
     which are not recognized by FITS format.
     """
 
@@ -57,7 +57,7 @@ class Fits(generic.Generic):
             'y', 'z', 'a', 'f', 'p', 'n', 'u', 'm', 'c', 'd',
             '', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
 
-        special_cases = {'dbyte': u.Unit(0.1*u.byte)}
+        special_cases = {'dbyte': u.Unit('dbyte', 0.1*u.byte)}
 
         for base in bases + deprecated_bases:
             for prefix in prefixes:
@@ -75,8 +75,8 @@ class Fits(generic.Generic):
         simple_units = [
             'deg', 'arcmin', 'arcsec', 'mas', 'min', 'h', 'd', 'Ry',
             'solMass', 'u', 'solLum', 'solRad', 'AU', 'lyr', 'count',
-            'photon', 'ph', 'pixel', 'pix', 'D', 'Sun', 'chan', 'bin',
-            'voxel', 'adu', 'beam'
+            'ct', 'photon', 'ph', 'pixel', 'pix', 'D', 'Sun', 'chan',
+            'bin', 'voxel', 'adu', 'beam'
         ]
         deprecated_units = ['erg', 'Angstrom', 'angstrom']
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -178,7 +178,7 @@ def test_roundtrip():
         assert_allclose(b.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
     for key, val in u.__dict__.items():
-        if isinstance(val, core.Unit) and not isinstance(val, core.PrefixUnit):
+        if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip, val
 
 
@@ -195,7 +195,7 @@ def test_roundtrip_vo_unit():
 
     x = u_format.VOUnit()
     for key, val in x._units.items():
-        if isinstance(val, core.Unit) and not isinstance(val, core.PrefixUnit):
+        if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_vo_unit, val, val in (u.mag, u.dB)
 
 
@@ -206,7 +206,7 @@ def test_roundtrip_fits():
         assert_allclose(a.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
     for key, val in u_format.Fits()._units.items():
-        if isinstance(val, core.Unit) and not isinstance(val, core.PrefixUnit):
+        if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_fits, val
 
 
@@ -222,7 +222,7 @@ def test_roundtrip_cds():
 
     x = u_format.CDS()
     for key, val in x._units.items():
-        if isinstance(val, core.Unit) and not isinstance(val, core.PrefixUnit):
+        if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_cds, val
 
 
@@ -238,7 +238,7 @@ def test_roundtrip_ogip():
 
     x = u_format.OGIP()
     for key, val in x._units.items():
-        if isinstance(val, core.Unit) and not isinstance(val, core.PrefixUnit):
+        if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_ogip, val
 
 
@@ -258,9 +258,11 @@ def test_latex():
     fluxunit = u.erg / (u.cm ** 2 * u.s)
     assert fluxunit.to_string('latex') == r'$\mathrm{\frac{erg}{s\,cm^{2}}}$'
 
+
 def test_new_style_latex():
     fluxunit = u.erg / (u.cm ** 2 * u.s)
     assert "{0:latex}".format(fluxunit) == r'$\mathrm{\frac{erg}{s\,cm^{2}}}$'
+
 
 def test_format_styles():
     fluxunit = u.erg / (u.cm ** 2 * u.s)
@@ -277,6 +279,7 @@ def test_format_styles():
 
     for format_, s in format_s_pairs:
         yield _test_format_styles, format_, s
+
 
 def test_flatten_to_known():
     myunit = u.def_unit("FOOBAR_One", u.erg / u.Hz)
@@ -351,4 +354,3 @@ def test_scaled_dimensionless():
 
     with pytest.raises(ValueError):
         u.Unit(0.1).to_string('vounit')
-


### PR DESCRIPTION
In FITS, `count` is a valid unit. But:

```
In [32]: c = u.Unit('count', format='fits')

In [33]: c.to_string(format='fits')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-33-a8e6e1d64401> in <module>()
----> 1 c.to_string(format='fits')

/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/units/core.pyc in to_string(self, format)
    570         """
    571         f = unit_format.get_format(format)
--> 572         return f.to_string(self)
    573 
    574     def __format__(self, format_spec):

/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/units/format/fits.pyc in to_string(self, unit)
    126 
    127         # Remove units that aren't known to the format
--> 128         unit = utils.decompose_to_known_units(unit, self._get_unit_name)
    129 
    130         if isinstance(unit, core.CompositeUnit):

/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/units/format/utils.pyc in decompose_to_known_units(unit, func)
    104     elif isinstance(unit, core.NamedUnit):
    105         try:
--> 106             func(unit)
    107         except ValueError:
    108             if isinstance(unit, core.Unit):

/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/units/format/fits.pyc in _get_unit_name(self, unit)
    112         if name not in self._units:
    113             raise ValueError(
--> 114                 "Unit {0!r} is not part of the FITS standard".format(name))
    115 
    116         if name in self._deprecated_units:

ValueError: Unit u'ct' is not part of the FITS standard
```

Maybe `to_string` should check if any of the aliases would be valid instead? (`count` is an alias of `ct`).

cc @mdboom
