### PR TITLE
WCS ra_dec_order not working

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -222,6 +222,9 @@ Bug Fixes
   - Fixed a memory leak when ``astropy.wcs.WCS`` objects are copied
     [#2754]
 
+  - Fixed a crash when passing ``ra_dec_order=True`` to any of the
+    ``*2world`` methods. [#2791]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -183,6 +183,9 @@ def test_pix2world():
     pixels = (np.arange(n)*np.ones((2, n))).T
     result = ww.wcs_pix2world(pixels, 0, ra_dec_order=True)
 
+    # Catch #2791
+    ww.wcs_pix2world(pixels[..., 0], pixels[..., 1], 0, ra_dec_order=True)
+
     close_enough = 1e-8
     # assuming that the data of sip2.fits doesn't change
     answer = np.array([[0.00024976, 0.00023018],
@@ -572,4 +575,3 @@ def test_printwcs():
     h = get_pkg_data_contents('data/3d_cd.hdr', encoding='binary')
     w = wcs.WCS(h)
     w.printwcs()
-

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1043,7 +1043,7 @@ naxis kwarg.
                 xy = self._denormalize_sky(xy)
             output = func(xy, origin)
             if ra_dec_order and sky == 'output':
-                output = self._normalize_sky_output(output)
+                output = self._normalize_sky(output)
                 return (output[:, 0].reshape(axes[0].shape),
                         output[:, 1].reshape(axes[0].shape))
             return [output[:, i].reshape(axes[0].shape)


### PR DESCRIPTION
When using `all_pix2world` with `ra_dec_order=True` I get:

``` python
  File ".../site-packages/astropy/wcs/wcs.py", line 1099, in all_pix2world
    self._all_pix2world, 'output', *args, **kwargs)
  File ".../site-packages/astropy/wcs/wcs.py", line 1088, in _array_converter
    return _return_list_of_arrays(axes, origin)
  File ".../site-packages/astropy/wcs/wcs.py", line 1046, in _return_list_of_arrays
    output = self._normalize_sky_output(output)
AttributeError: 'WCS' object has no attribute '_normalize_sky_output'
```

Which makes sense as there is no method named `_normalize_sky_output`, only `_normalize_sky`.

I use astropy 0.4.
