### PR TITLE
Anaconda update conflict for Astropy 0.4

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -188,6 +188,20 @@ may be a brief delay between the release of Astropy on PyPI and its release
 via the ``conda`` package manager; users can check the availability of new
 versions with ``conda search astropy``.
 
+When trying to update all packages after updating ``astropy`` like so::
+
+    $ conda update astropy
+    $ conda update --all
+
+the following error occurs between the ``astropy`` package and the ``anaconda``
+meta package::
+
+    Error: Unsatisfiable package specifications.
+
+The recommended fix is to run::
+
+    $ conda remove anaconda
+
 Installation fails on Mageia-2 or Mageia-3 distributions
 --------------------------------------------------------
 


### PR DESCRIPTION
I'm trying out Astropy 0.4 on an Ubuntu 12.02 machine with Python 3.4 from Anaconda.

I'm getting this error:
```
$ conda update astropy
$ conda update --all
Fetching package metadata: ..
Solving package specifications: ..
Error: Unsatisfiable package specifications.
Generating hint: ................................................................................................................................................................................................................
Hint: the following combinations of packages create a conflict with the
remaining packages:
  - anaconda >=2.0.1
  - astropy >=0.4
```
Am I using conda incorrectly or is this an issue?

The unit tests for Astropy pass, but I get a bunch of "unclosed socket" warnings at the end:
https://gist.github.com/cdeil/7946c7c65863a0a65aaf
Are those "normal" and to be ignored or is this an issue?