### PR TITLE
Followup to #2811

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -19,6 +19,7 @@ import signal
 import sys
 import textwrap
 import traceback
+import types
 import unicodedata
 import warnings
 
@@ -405,7 +406,11 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                 # classmethods in Python2.6 and below lack the __func__
                 # attribute so we need to hack around to get it
                 method = func.__get__(None, object)
-                if hasattr(method, '__func__'):
+                if isinstance(method, types.FunctionType):
+                    # For staticmethods anyways the wrapped object is just a
+                    # plain function (not a bound method or anything like that)
+                    func = method
+                elif hasattr(method, '__func__'):
                     func = method.__func__
                 elif hasattr(method, 'im_func'):
                     func = method.im_func

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -142,6 +142,38 @@ def test_deprecated_class():
     pickle.dumps(TestA)
 
 
+def test_deprecated_static_and_classmethod():
+    """
+    Regression test for issue introduced by
+    https://github.com/astropy/astropy/pull/2811 and mentioned also here:
+    https://github.com/astropy/astropy/pull/2580#issuecomment-51049969
+    where it appears that deprecated staticmethods didn't work on Python 2.6.
+    """
+
+    class A(object):
+        @misc.deprecated('1.0')
+        @staticmethod
+        def B():
+            pass
+
+        @misc.deprecated('1.0')
+        @classmethod
+        def C(cls):
+            pass
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        A.B()
+
+    assert len(w) == 1
+    assert 'deprecated' in A.B.__doc__
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        A.C()
+
+    assert len(w) == 1
+    assert 'deprecated' in A.C.__doc__
+
+
 @remote_data
 def test_api_lookup():
     strurl = misc.find_api_page('astropy.utils.misc', 'dev', False, timeout=3)


### PR DESCRIPTION
#2811 made a couple small fixes to the `deprecated` decorator.  But this adds an actual test for deprecated staticmethods and classmethods after reports that it didn't work on Python 2.6
