### PR TITLE
Fix doctest-requires with multiple module inputs

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -316,7 +316,8 @@ class DocTestFinderPlus(doctest.DocTestFinder):
     def check_required_modules(cls, mods):
         for mod in mods:
             if mod in cls._import_cache:
-                return cls._import_cache[mod]
+                if not cls._import_cache[mod]:
+                    return False
             try:
                 imp.find_module(mod)
             except ImportError:


### PR DESCRIPTION
When `doctest-requires` had multiple modules, it would _not_ skip the doctest if the first module listed was available.  This is because `DocTestFinderPlus` would return `True` in the middle of the `for` loop over all of the modules (and thus run the doctest).  In this PR, it only stops the `for` loop if the return is `False`.
