### PR TITLE
"Other parameters" sections have weird formatting

### DIFF
--- a/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -568,3 +568,18 @@ div.figures .figure {
 .field-list th {
     white-space: nowrap;
 }
+
+table.field-list {
+    border-spacing: 0px;
+    margin-left: 1px;
+    border-left: 5px solid rgb(238, 238, 238) !important;
+}
+
+table.field-list th.field-name {
+    display: inline-block;
+    padding: 1px 8px 1px 5px;
+    white-space: nowrap;
+    background-color: rgb(238, 238, 238);
+    border-radius: 0 3px 3px 0;
+    -webkit-border-radius: 0 3px 3px 0;
+}


### PR DESCRIPTION
The "Other parameters" heading extends across the entire text width.

See http://docs.astropy.org/en/stable/api/astropy.convolution.convolve_fft.html#astropy.convolution.convolve_fft

![otherparameters](https://cloud.githubusercontent.com/assets/38294/3780199/734731a8-198a-11e4-8900-24c74d072b8b.png)

I suspect this requires some CSS wizardry.  @kbarbary ?
