### PR TITLE
ImportErrors possible within AstropyLogger

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -199,6 +199,11 @@ Bug Fixes
 
 - ``astropy.io.votable``
 
+- ``astropy.logger``
+
+  - Fixed a crash that could occur in rare cases when (such as in bundled
+    apps) where submodules of the ``email`` package are not importable. [#2671]
+
 - ``astropy.modeling``
 
 - ``astropy.nddata``

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -200,16 +200,24 @@ class AstropyLogger(Logger):
         mod_name = None
         if sys.version_info[0] < 3:  # pragma: py2
             for name, mod in sys.modules.items():
-                if getattr(mod, '__file__', '') == mod_path:
-                    mod_name = mod.__name__
-                    break
+                try:
+                    # Believe it or not this can fail in some cases:
+                    # https://github.com/astropy/astropy/issues/2671
+                    if getattr(mod, '__file__', '') == mod_path:
+                        mod_name = mod.__name__
+                        break
+                except:
+                    continue
         else:  # pragma: py3
             mod_path, ext = os.path.splitext(mod_path)
             for name, mod in sys.modules.items():
-                path = os.path.splitext(getattr(mod, '__file__', ''))[0]
-                if path == mod_path:
-                    mod_name = mod.__name__
-                    break
+                try:
+                    path = os.path.splitext(getattr(mod, '__file__', ''))[0]
+                    if path == mod_path:
+                        mod_name = mod.__name__
+                        break
+                except:
+                    continue
 
         if mod_name is not None:
             self.warning(message, extra={'origin': mod_name})

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -147,6 +147,29 @@ def test_warning_logging_with_io_votable_warning():
     assert log_list[0].origin == 'astropy.tests.test_logger'
 
 
+def test_import_error_in_warning_logging():
+    """
+    Regression test for https://github.com/astropy/astropy/issues/2671
+
+    This test actually puts a goofy fake module into ``sys.modules`` to test
+    this problem.
+    """
+
+    class FakeModule(object):
+        def __getattr__(self, attr):
+            raise ImportError('_showwarning should ignore any exceptions '
+                              'here')
+
+    log.enable_warnings_logging()
+
+    sys.modules['<test fake module>'] = FakeModule()
+    try:
+        warnings.showwarning(AstropyWarning('Regression test for #2671'),
+                             AstropyWarning, '<this is only a test>', 1)
+    finally:
+        del sys.modules['<test fake module>']
+
+
 def test_exception_logging_disable_no_enable():
     with pytest.raises(LoggingError) as e:
         log.disable_exception_logging()


### PR DESCRIPTION
This is kind of obscure and might not be worth fixing

Some people using the Glue mac app (bundled with py2app, see mac.glueviz.org) were running into astropy errors when trying to read files that generate warning messages. I tracked it down to an ImportError being thrown at this line:

https://github.com/astropy/astropy/blob/master/astropy/logger.py#L203

Several email submodules install LazyImporters in sys.modules, that defer actual importing until the first time they are accessed (which happens inside this logger function).

``` python
In [11]: import sys, email
In [12]: sys.modules['email.MIMEBase']
Out[12]: <email.LazyImporter at 0x102046650>
```

Because of this (and because the email module isn't well-supported on py2app), the LazyImporter raises an ImportError on this line. 

I can workaround the issue on my end, but I thought I'd let you know that ImportErrors are technically possible when calling getattr on sys.modules entries. 
