### PR TITLE
Enable importing Astropy from a source checkout on Python 3

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -230,13 +230,6 @@ def _initialize_astropy():
                 del sys.modules[key]
         raise ImportError('astropy')
 
-    if sys.version_info[0] >= 3 and is_astropy_source_dir:
-        _rollback_import(
-            "You appear to be trying to import astropy from within a source "
-            "checkout. This is currently not possible using Python 3 due to "
-            "the reliance of 2to3 to convert some of Astropy's subpackages "
-            "for Python 3 compatibility.")
-
     try:
         from .utils import _compiler
     except ImportError:

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -187,7 +187,7 @@ class AstropyLogger(Logger):
         if type(warning) not in (AstropyWarning, AstropyUserWarning):
             message = '{0}: {1}'.format(warning.__class__.__name__, args[0])
         else:
-            message = unicode(args[0])
+            message = str(args[0])
 
         mod_path = args[2]
         # Now that we have the module's path, we look through

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -8,6 +8,22 @@ import os
 import types
 
 
+# Compatibility subpackages that should only be used on Python 2
+_py2_packages = set([
+    'astropy.extern.configobj_py2',
+    'astropy.utils.compat._fractions_py2',
+    'astropy.utils.compat._gzip_py2',
+    'astropy.utils.compat._odict_py2',
+    'astropy.utils.compat._subprocess_py2'
+])
+
+# Same but for Python 3
+_py3_packages = set([
+    'astropy.extern.configobj_py3',
+    'astropy.utils.compat._gzip_py3'
+])
+
+
 def test_imports():
     """
     This just imports all modules in astropy, making sure they don't have any
@@ -35,8 +51,20 @@ def test_imports():
         raise AttributeError('package to generate config items for does not '
                              'have __file__ or __path__')
 
+    if six.PY3:
+        excludes = _py2_packages
+    else:
+        excludes = _py3_packages
+
     prefix = package.__name__ + '.'
-    for imper, nm, ispkg in pkgutil.walk_packages(pkgpath, prefix):
+
+    def onerror(name):
+        if not any(name.startswith(excl) for excl in excludes):
+            # A legitimate error occurred in a module that wasn't excluded
+            raise
+
+    for imper, nm, ispkg in pkgutil.walk_packages(pkgpath, prefix,
+                                                  onerror=onerror):
         imper.find_module(nm)
 
 


### PR DESCRIPTION
I could have sworn I already had a PR for this but apparently not...

This removes a check in `astropy.__init__` which prevented importing astropy from a git repository when using Python 3.  Previously this was necessary because astropy only worked on Python 3 using 2to3.  But now (with a few small tweaks in this PR) all modules in Astropy work in Python 3 without translation through 2to3.

I don't think Travis-CI will test this, but I confirmed that with this PR I could run

```
$ python3.x setup.py build_ext --inplace
$ python3.x -c 'import astropy; astropy.test()'
```

and that the tests would use the astropy in the source checkout and pass.  I did this with python 3.3 and 3.4.
