### PR TITLE
Skip a handful of doctests that

### DIFF
--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -246,7 +246,7 @@ the way you want.  As an example::
   ...      obstime = TimeFrameAttribute(default=None, secondary_attribute='equinox')
 
   >>> c = MyFrame(R=10*u.deg, D=20*u.deg)
-  >>> c
+  >>> c  # doctest: +SKIP
   <MyFrame Coordinate: equinox=B1950.000, location=None, obstime=B1950.000, R=0.174532... rad, D=0.349065... rad>
   >>> c.equinox
   <Time object: scale='utc' format='byear_str' value=B1950.000>

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -364,7 +364,7 @@ Another important attribute is ``frame_attr_names``, which defines the
 additional attributes that are required to fully define the frame::
 
   >>> sc_fk4 = SkyCoord(1, 2, 'fk4', unit='deg')
-  >>> sc_fk4.get_frame_attr_names()
+  >>> sc_fk4.get_frame_attr_names()  # doctest: +SKIP
   {u'equinox': <Time object: scale='tai' format='byear_str' value=B1950.000>,
    u'obstime': None}
 

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -116,7 +116,7 @@ A dictionary of column data can be used to initialize a |Table|.
   ...        'b': [2.0, 5.0],
   ...        'c': ['x', 'y']}
   >>>
-  >>> Table(arr)
+  >>> Table(arr)  # doctest: +SKIP
   <Table rows=2 names=('a','c','b')>
   array([(1, 'x', 2.0), (4, 'y', 5.0)],
         dtype=[('a', '<i8'), ('c', 'S1'), ('b', '<f8')])
@@ -784,7 +784,7 @@ First make a table and add a couple of rows::
   >>> t = ParamsTable(names=['a', 'b', 'params'], dtype=['i', 'f', 'O'])
   >>> t.add_row((1, 2.0, {'x': 1.5, 'y': 2.5}))
   >>> t.add_row((2, 3.0, {'z': 'hello', 'id': 123123}))
-  >>> print(t)
+  >>> print(t)  # doctest: +SKIP
    a   b             params
   --- --- ----------------------------
     1 2.0         {'y': 2.5, 'x': 1.5}

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -416,7 +416,7 @@ One can explicitly specify ``in_subfmt`` in order to strictly require a
 certain subformat::
 
   >>> t = Time('2000:002:03:04', in_subfmt='date_hm')
-  >>> t = Time('2000:002', in_subfmt='date_hm')
+  >>> t = Time('2000:002', in_subfmt='date_hm')  # doctest: +SKIP
   Traceback (most recent call last):
     ...
   ValueError: Input values did not match any of the formats where the


### PR DESCRIPTION
These tests tended to  tended to fail pseudo-nondeterministically for me in some cases.  In particular it would happen when running the tests through tox.  Not sure why that was, but clearly these could in principle fail in other contexts too.

It's worth nothing that some of the failures seem to be due to the fact that coordinate frames' `__repr__` does not display the coordinate attributes in a deterministic order, so maybe that should be fixed separately..
