### PR TITLE
Automatically recognize h5py Dataset objects in Table.read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,9 @@ Bug Fixes
 
 - ``astropy.io.misc``
 
+  - Fixed a bug that prevented h5py ``Dataset`` objects from being
+    automatically recognized by ``Table.read``. [#2831]
+
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -51,7 +51,7 @@ def is_hdf5(origin, filepath, fileobj, *args, **kwargs):
     except ImportError:
         return False
     else:
-        return isinstance(args[0], (h5py.highlevel.File, h5py.highlevel.Group))
+        return isinstance(args[0], (h5py.highlevel.File, h5py.highlevel.Group, h5py.highlevel.Dataset))
 
 
 def read_table_hdf5(input, path=None):

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -389,3 +389,27 @@ def test_skip_meta(tmpdir):
     assert len(w) == 1
     assert str(w[0].message).startswith(
         "Attribute `f` of type {0} cannot be written to HDF5 files - skipping".format(type(t1.meta['f'])))
+
+@pytest.mark.skipif('not HAS_H5PY')
+def test_read_h5py_objects(tmpdir):
+
+    # Regression test - ensure that Datasets are recognized automatically
+
+    test_file = str(tmpdir.join('test.hdf5'))
+
+    import h5py
+    with h5py.File(test_file, 'w') as output_file:
+        t1 = Table()
+        t1.add_column(Column(name='a', data=[1, 2, 3]))
+        t1.write(output_file, path='the_table')
+
+    f = h5py.File(test_file)
+
+    t2 = Table.read(f, path='the_table')
+    assert np.all(t2['a'] == [1, 2, 3])
+
+    t3 = Table.read(f['/'], path='the_table')
+    assert np.all(t3['a'] == [1, 2, 3])
+
+    t4 = Table.read(f['the_table'])
+    assert np.all(t4['a'] == [1, 2, 3])


### PR DESCRIPTION
This is a bug fix
