### PR TITLE
Added kselect option to test runner

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -126,7 +126,7 @@ def _get_test_runner():
 def test(package=None, test_path=None, args=None, plugins=None,
          verbose=False, pastebin=None, remote_data=False, pep8=False,
          pdb=False, open_files=False, parallel=0, docs_path=None,
-         skip_docs=False):
+         skip_docs=False, kselect=None):
     """
     Run Astropy tests using py.test. A proper set of arguments is
     constructed and passed to `pytest.main`.
@@ -189,6 +189,9 @@ def test(package=None, test_path=None, args=None, plugins=None,
     skip_docs : bool, optional
         When `True`, skips running the doctests in the .rst files.
 
+    kselect : str, optional
+        Test selection, passed to py.test as "-k <kselect>".
+
     See Also
     --------
     pytest.main : py.test function wrapped by `run_tests`.
@@ -200,7 +203,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
         plugins=plugins, verbose=verbose, pastebin=pastebin,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         open_files=open_files, parallel=parallel, docs_path=docs_path,
-        skip_docs=skip_docs)
+        skip_docs=skip_docs, kselect=kselect)
 
 
 # if we are *not* in setup mode, import the logger and possibly populate the

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -110,7 +110,7 @@ class TestRunner(object):
     def run_tests(self, package=None, test_path=None, args=None, plugins=None,
                   verbose=False, pastebin=None, remote_data=False, pep8=False,
                   pdb=False, coverage=False, open_files=False, parallel=0,
-                  docs_path=None, skip_docs=False):
+                  docs_path=None, skip_docs=False, kselect=None):
         """
         The docstring for this method lives in astropy/__init__.py:test
         """
@@ -241,6 +241,14 @@ class TestRunner(object):
             if parallel < 0:
                 parallel = multiprocessing.cpu_count()
             all_args.extend(['-n', six.text_type(parallel)])
+
+        #add anything that was -k'ed
+        if kselect:
+            if '-k' in all_args:
+                raise ValueError('Cannot give two different -k arguments.')
+
+            all_args.append('-k')
+            all_args.append(kselect)
 
         if six.PY2:
             all_args = [x.encode('utf-8') for x in all_args]


### PR DESCRIPTION
I got tired of constantly doing `python setup.py test --args="-k <something>"` to select particular tests by name, so this adds a command to the astropy test runner that does this directly (without needing to go through `args`)
