### PR TITLE
0.4.1: source tar contains a lot of precompiled files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,7 +26,6 @@ recursive-include scripts *
 recursive-include static *
 recursive-include astropy/sphinx/themes *
 
-exclude *.pyc *.o
 prune docs/_build
 prune build
 
@@ -34,3 +33,4 @@ recursive-include astropy_helpers *
 exclude astropy_helpers/.git
 exclude astropy_helpers/.gitignore
 
+global-exclude *.pyc *.o


### PR DESCRIPTION
The [0.4.1 tarball](http://pypi.python.org/packages/source/a/astropy/astropy-0.4.1.tar.gz) contains a lot of .pyc files which create some formal difficulties for Debian: "lintian" complains f.e.

```
E: python-astropy source: source-is-missing astropy_helpers/astropy_helpers/__pycache__/__init__.cpython-32.pyc
E: python-astropy source: source-is-missing astropy_helpers/astropy_helpers/__pycache__/__init__.cpython-33.pyc
```

Especially the files in `__pycache__` seem to be there on accident only, right? Could they be dropped from the source distribution?
Optimal would be to drop all .pyc files.
