### PR TITLE
Adding links for exceptions in docstring

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -211,7 +211,7 @@ class ConfigItem(object):
 
     Raises
     ------
-    RuntimeError
+    RuntimeError : `~.exceptions.RuntimeError`
         If ``module`` is `None`, but the module this item is created from
         cannot be determined.
     """
@@ -288,7 +288,7 @@ class ConfigItem(object):
 
         Raises
         ------
-        TypeError
+        TypeError : `~.exceptions.TypeError`
             If the provided ``value`` is not valid for this `ConfigItem`.
         """
         try:
@@ -383,7 +383,7 @@ class ConfigItem(object):
 
         Raises
         ------
-        TypeError
+        TypeError : `~.exceptions.TypeError`
             If the configuration value as stored is not this item's type.
         """
         def section_name(section):
@@ -642,7 +642,7 @@ def get_config(packageormod=None, reload=False):
 
     Raises
     ------
-    RuntimeError
+    RuntimeError : `~.exceptions.RuntimeError`
         If ``packageormod`` is `None`, but the package this item is created
         from cannot be determined.
     """

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -20,7 +20,7 @@ def _find_home():
 
     Raises
     ------
-    OSError
+    OSError : `~.exceptions.OSError`
         If the home directory cannot be located - usually means you are running
         Astropy on some obscure platform that doesn't have standard home
         directories.

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -312,7 +312,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0, crop=True,
 
     Raises
     ------
-    ValueError:
+    ValueError : `~.exceptions.ValueError`
         If the array is bigger than 1 GB after padding, will raise this exception
         unless allow_huge is True
 

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -764,7 +764,7 @@ class Model1DKernel(Kernel1D):
 
     Raises
     ------
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If model is not an instance of `~astropy.modeling.Fittable1DModel`
 
     See also
@@ -830,7 +830,7 @@ class Model2DKernel(Kernel2D):
 
     Raises
     ------
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If model is not an instance of `~astropy.modeling.Fittable2DModel`
 
     See also
@@ -886,7 +886,7 @@ class CustomKernel(Kernel):
 
     Raises
     ------
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If array is not a list or array.
     KernelSizeError
         If array size is even.

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -77,7 +77,7 @@ class Angle(u.Quantity):
 
     Raises
     ------
-    `~astropy.units.UnitsError`
+    UnitsError : `~astropy.units.UnitsError`
         If a unit is not provided or it is not an angular unit.
     """
     _include_easy_conversion_members = True
@@ -516,9 +516,9 @@ class Latitude(Angle):
 
     Raises
     ------
-    `~astropy.units.UnitsError`
+    UnitsError : `~astropy.units.UnitsError`
         If a unit is not provided or it is not an angular unit.
-    `TypeError`
+    TypeError : `~.exceptions.TypeError`
         If the angle parameter is an instance of :class:`~astropy.coordinates.Longitude`.
     """
     def __new__(cls, angle, unit=None, **kwargs):
@@ -612,9 +612,9 @@ class Longitude(Angle):
 
     Raises
     ------
-    `~astropy.units.UnitsError`
+    UnitsError : `~astropy.units.UnitsError`
         If a unit is not provided or it is not an angular unit.
-    `TypeError`
+    TypeError : `~.exceptions.TypeError`
         If the angle parameter is an instance of :class:`~astropy.coordinates.Latitude`.
     """
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -176,7 +176,7 @@ class FrameAttribute(object):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If the input is not valid for this attribute.
         """
         return value, False
@@ -255,7 +255,7 @@ class TimeFrameAttribute(FrameAttribute):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If the input is not valid for this attribute.
         """
         from ..time import Time
@@ -626,7 +626,7 @@ class BaseCoordinateFrame(object):
 
         Raises
         ------
-        AttributeError
+        AttributeError : `~.exceptions.AttributeError`
             If this object had no `data`
 
         Examples
@@ -674,7 +674,7 @@ class BaseCoordinateFrame(object):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If there is no possible transformation route.
         """
         from .errors import ConvertError
@@ -902,7 +902,7 @@ class BaseCoordinateFrame(object):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If this or the other coordinate do not have distances.
         """
         from .distances import Distance

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -68,9 +68,9 @@ class Distance(u.Quantity):
 
     Raises
     ------
-    `~astropy.units.UnitsError`
+    UnitsError : `~astropy.units.UnitsError`
         If the ``unit`` is not a distance.
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If value specified is less than 0 and ``allow_negative=False``.
 
         If ``z`` is provided with a ``unit`` or ``cosmology`` is provided
@@ -229,12 +229,12 @@ class CartesianPoints(u.Quantity):
 
     Raises
     ------
-    UnitsError
+    UnitsError : `~astropy.units.UnitsError`
         If the units on ``x``, ``y``, and ``z`` do not match or an invalid
         unit is given.
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If ``y`` and ``z`` don't match ``x``'s shape or ``x`` is not length-3
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If incompatible array types are passed into ``x``, ``y``, or ``z``
 
     """

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -82,12 +82,12 @@ class EarthLocation(u.Quantity):
 
         Raises
         ------
-        astropy.units.UnitsError
+        UnitsError : `~astropy.units.UnitsError`
             If the units on ``x``, ``y``, and ``z`` do not match or an invalid
             unit is given.
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If the shapes of ``x``, ``y``, and ``z`` do not match.
-        TypeError
+        TypeError : `~.exceptions.TypeError`
             If ``x`` is not a `~astropy.units.Quantity` and no unit is given.
         """
         if unit is None:
@@ -137,10 +137,10 @@ class EarthLocation(u.Quantity):
 
         Raises
         ------
-        astropy.units.UnitsError
+        UnitsError : `~astropy.units.UnitsError`
             If the units on ``lon`` and ``lat`` are inconsistent with angular
             ones, or that on ``height`` with a length.
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If ``lon``, ``lat``, and ``height`` do not have the same shape, or
             if ``ellipsoid`` is not recognized as among the ones implemented.
 
@@ -199,7 +199,7 @@ class EarthLocation(u.Quantity):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             if ``ellipsoid`` is not recognized as among the ones implemented.
 
         Notes

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -268,7 +268,7 @@ class SkyCoord(object):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If there is no possible transformation route.
         """
         from astropy.coordinates.errors import ConvertError
@@ -510,7 +510,7 @@ class SkyCoord(object):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If this or the other coordinate do not have distances.
         """
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -97,7 +97,7 @@ class TransformGraph(object):
 
         Raises
         ------
-        TypeError
+        TypeError : `~.exceptions.TypeError`
             If ``fromsys`` or ``tosys`` are not classes or ``transform`` is
             not callable.
         """
@@ -624,7 +624,7 @@ class CoordinateTransform(object):
 
         Raises
         ------
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             If this is not currently in the transform graph.
         """
         graph.remove_transform(self.fromsys, self.tosys, self)
@@ -678,9 +678,9 @@ class FunctionTransform(CoordinateTransform):
 
     Raises
     ------
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If ``func`` is not callable.
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If ``func`` cannot accept two arguments.
 
 
@@ -740,7 +740,7 @@ class StaticMatrixTransform(CoordinateTransform):
 
     Raises
     ------
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If the matrix is not 3 x 3
 
     """
@@ -806,7 +806,7 @@ class DynamicMatrixTransform(CoordinateTransform):
 
     Raises
     ------
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If ``matrix_func`` is not callable
 
     """

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -35,7 +35,7 @@ def fnunpickle(fileorname, number=0, usecPickle=True):
 
     Raises
     ------
-    EOFError
+    EOFError : `~.exceptions.EOFError`
         If ``number`` is >0 and there are fewer than ``number`` objects in the
         pickled file.
 

--- a/astropy/io/votable/ucd.py
+++ b/astropy/io/votable/ucd.py
@@ -98,7 +98,8 @@ def parse_ucd(ucd, check_controlled_vocabulary=False, has_colon=False):
 
     Raises
     ------
-    ValueError : *ucd* is invalid
+    ValueError : `~.exceptions.ValueError`
+        ``ucd`` is invalid
     """
     global _ucd_singleton
     if _ucd_singleton is None:

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -79,7 +79,7 @@ class NDData(object):
 
     Raises
     ------
-    ValueError :
+    ValueError : `~.exceptions.ValueError`
         If the `uncertainty` or `mask` inputs cannot be broadcast (e.g., match
         shape) onto ``data``.
 
@@ -586,7 +586,7 @@ class NDData(object):
 
         Raises
         ------
-        UnitsError
+        UnitsError : `~astropy.units.UnitsError`
             If units are inconsistent.
 
         Notes

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -454,7 +454,7 @@ class BaseColumn(np.ndarray):
 
         Raises
         ------
-        astropy.units.UnitsError
+        UnitsError : `~astropy.units.UnitsError`
             If units are inconsistent
         """
         if self.unit is None:

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -74,7 +74,8 @@ def _normalize_equivalencies(equivalencies):
 
     Raises
     ------
-    ValueError if an equivalency cannot be interpreted
+    ValueError : `~.exceptions.ValueError`
+        If an equivalency cannot be interpreted
     """
     if equivalencies is None:
         return []
@@ -597,7 +598,8 @@ class UnitBase(object):
 
         Raises
         ------
-        ValueError if an equivalency cannot be interpreted
+        ValueError : `~.exceptions.ValueError`
+            if an equivalency cannot be interpreted
         """
         normalized = _normalize_equivalencies(equivalencies)
         if equivalencies is not None:
@@ -836,7 +838,7 @@ class UnitBase(object):
 
         Raises
         ------
-        UnitsError
+        UnitsError : `~astropy.units.UnitsError`
             If units are inconsistent
         """
         other = Unit(other)
@@ -906,7 +908,7 @@ class UnitBase(object):
 
         Raises
         ------
-        UnitsError
+        UnitsError : `~astropy.units.UnitsError`
             If units are inconsistent
         """
         return self.get_converter(other, equivalencies=equivalencies)(value)
@@ -1390,10 +1392,10 @@ class NamedUnit(UnitBase):
 
     Raises
     ------
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If any of the given unit names are already in the registry.
 
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If any of the given unit names are not valid Python tokens.
     """
     def __init__(self, st, register=None, doc=None, format=None,
@@ -1828,10 +1830,10 @@ class Unit(NamedUnit):
 
     Raises
     ------
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If any of the given unit names are already in the registry.
 
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If any of the given unit names are not valid Python tokens.
     """
 
@@ -2216,7 +2218,7 @@ def _condition_arg(value):
 
     Raises
     ------
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If value is not as expected
     """
     if isinstance(value, (float, six.integer_types, complex)):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -152,9 +152,9 @@ class Quantity(np.ndarray):
 
     Raises
     ------
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If the value provided is not a Python numeric type.
-    TypeError
+    TypeError : `~.exceptions.TypeError`
         If the unit provided is not either a :class:`~astropy.units.Unit`
         object or a parseable string unit.
     """

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -382,9 +382,9 @@ def get_pkg_data_fileobj(data_name, encoding=None, cache=True):
 
     Raises
     ------
-    urllib2.URLError, urllib.error.URLError
+    URLError : `~urllib2.URLError`, ``urllib.error.URLError``
         If a remote file cannot be found.
-    IOError
+    IOError : `~.exceptions.IOError`
         If problems occur writing or reading a local file.
 
     Examples
@@ -470,9 +470,9 @@ def get_pkg_data_filename(data_name, show_progress=True, remote_timeout=None):
 
     Raises
     ------
-    urllib2.URLError, urllib.error.URLError
+    URLError : `~urllib2.URLError`, ``urllib.error.URLError``
         If a remote file cannot be found.
-    IOError
+    IOError : `~.exceptions.IOError`
         If problems occur writing or reading a local file.
 
     Returns
@@ -595,9 +595,9 @@ def get_pkg_data_contents(data_name, encoding=None, cache=True):
 
     Raises
     ------
-    urllib2.URLError, urllib.error.URLError
+    URLError : `~urllib2.URLError`, ``urllib.error.URLError``
         If a remote file cannot be found.
-    IOError
+    IOError : `~.exceptions.IOError`
         If problems occur writing or reading a local file.
 
     See Also
@@ -860,7 +860,8 @@ def check_free_space_in_dir(path, size):
 
     Raises
     -------
-    IOError : There is not enough room on the filesystem
+    IOError :  : `~.exceptions.IOError`
+        There is not enough room on the filesystem
     """
     from ..utils.console import human_file_size
 
@@ -902,7 +903,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
     Raises
     ------
-    urllib2.URLError, urllib.error.URLError
+    URLError : `~urllib2.URLError`, ``urllib.error.URLError``
         Whenever there's a problem getting the remote file.
     """
 
@@ -1107,7 +1108,7 @@ def clear_download_cache(hashorurl=None):
 
     Raises
     ------
-    OSEerror
+    OSEerror : `~.exceptions.OSError`
         If the requested filename is not present in the data directory.
 
     """

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -74,7 +74,7 @@ def find_current_module(depth=1, finddiff=False):
 
     Raises
     ------
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If ``finddiff`` is a list with an invalid entry.
 
     Examples
@@ -934,7 +934,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
 
     Raises
     ------
-    ValueError
+    ValueError : `~.exceptions.ValueError`
         If the documentation can't be found
 
     """

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -247,7 +247,7 @@ class RunTimePredictor(object):
 
         Raises
         ------
-        AssertionError
+        AssertionError : `~.exceptions.AssertionError`
             Insufficient data points for fitting.
 
         ModelsError
@@ -296,7 +296,7 @@ class RunTimePredictor(object):
 
         Raises
         ------
-        AssertionError
+        AssertionError : `~.exceptions.AssertionError`
             No fitted data for prediction.
 
         """
@@ -327,7 +327,7 @@ class RunTimePredictor(object):
 
         Raises
         ------
-        AssertionError
+        AssertionError : `~.exceptions.AssertionError`
             Insufficient data for plotting.
 
         """

--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -165,10 +165,10 @@ def conesearch(center, radius, verb=1, **kwargs):
 
     Raises
     ------
-    ConeSearchError
+    ConeSearchError : `~astropy.vo.client.exceptions.ConeSearchError`
         When invalid inputs are passed into Cone Search.
 
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         If VO service request fails.
 
     """
@@ -259,7 +259,7 @@ def search_all(*args, **kwargs):
 
     Raises
     ------
-    ConeSearchError
+    ConeSearchError : `~astropy.vo.client.exceptions.ConeSearchError`
         When invalid inputs are passed into Cone Search.
 
     """
@@ -377,13 +377,13 @@ def predict_search(url, *args, **kwargs):
 
     Raises
     ------
-    AssertionError
+    AssertionError : `~.exceptions.AssertionError`
         If prediction fails.
 
-    ConeSearchError
+    ConeSearchError : `~astropy.vo.client.exceptions.ConeSearchError`
         If input parameters are invalid.
 
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         If VO service request fails.
 
     """

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -86,7 +86,7 @@ class VOSCatalog(VOSBase):
 
     Raises
     ------
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         Missing necessary key(s).
 
     """
@@ -116,10 +116,10 @@ class VOSCatalog(VOSBase):
 
         Raises
         ------
-        KeyError
+        KeyError : `~.exceptions.KeyError`
             Key not found.
 
-        VOSError
+        VOSError : `~astropy.vo.client.exceptions.VOSError`
             Key must exist in catalog, therefore cannot be deleted.
 
         """
@@ -151,7 +151,7 @@ class VOSCatalog(VOSBase):
 
         Raises
         ------
-        TypeError
+        TypeError : `~.exceptions.TypeError`
             Multiple values given for keyword argument.
 
         """
@@ -169,7 +169,7 @@ class VOSDatabase(VOSBase):
 
     Raises
     ------
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         If given ``tree`` does not have 'catalogs' key
         or catalog is invalid.
 
@@ -311,7 +311,7 @@ class VOSDatabase(VOSBase):
 
         Raises
         ------
-        VOSError
+        VOSError : `~astropy.vo.client.exceptions.VOSError`
             Invalid catalog.
 
         DuplicateCatalogName
@@ -405,7 +405,7 @@ class VOSDatabase(VOSBase):
 
         Raises
         ------
-        VOSError
+        VOSError : `~astropy.vo.client.exceptions.VOSError`
             Invalid database or incompatible version.
 
         """
@@ -436,7 +436,7 @@ class VOSDatabase(VOSBase):
 
         Raises
         ------
-        OSError
+        OSError : `~.exceptions.OSError`
             File exists.
 
         """
@@ -538,7 +538,7 @@ class VOSDatabase(VOSBase):
 
         Raises
         ------
-        VOSError
+        VOSError : `~astropy.vo.client.exceptions.VOSError`
             Invalid VO registry.
 
         """
@@ -658,7 +658,7 @@ def _get_catalogs(service_type, catalog_db, **kwargs):
 
     Raises
     ------
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         Invalid ``catalog_db``.
 
     """
@@ -727,10 +727,10 @@ def vo_tab_parse(tab, url, kwargs):
 
     Raises
     ------
-    IndexError
+    IndexError : `~.exceptions.IndexError`
         Table iterator fails.
 
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         Server returns error message or invalid table.
 
     """
@@ -838,7 +838,7 @@ def call_vo_service(service_type, catalog_db=None, pedantic=None,
 
     Raises
     ------
-    VOSError
+    VOSError : `~astropy.vo.client.exceptions.VOSError`
         If VO service request fails.
 
     """

--- a/astropy/vo/validator/validate.py
+++ b/astropy/vo/validator/validate.py
@@ -85,7 +85,7 @@ def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
 
     Raises
     ------
-    IOError
+    IOError : `~.exceptions.IOError`
         Invalid destination directory.
 
     timeout

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -55,28 +55,28 @@ world : double array[ncoord][nelem]
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-SingularMatrixError
+SingularMatrixError : `~astropy.wcs.SingularMatrixError`
     Linear transformation matrix is singular.
 
-InconsistentAxisTypesError
+InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
     Inconsistent or unrecognized coordinate axis types.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid parameter value.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid coordinate transformation parameters.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     x- and y-coordinate arrays are not the same size.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Invalid coordinate transformation.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Ill-conditioned coordinate transformation parameters.
 """.format(__.ORIGIN())
 
@@ -1086,28 +1086,28 @@ result : dict
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-SingularMatrixError
+SingularMatrixError : `~astropy.wcs.SingularMatrixError`
     Linear transformation matrix is singular.
 
-InconsistentAxisTypesError
+InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
     Inconsistent or unrecognized coordinate axis types.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid parameter value.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Invalid coordinate transformation parameters.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Ill-conditioned coordinate transformation parameters.
 
-InvalidCoordinateError
+InvalidCoordinateError : `~astropy.wcs.InvalidCoordinateError`
     Invalid world coordinate.
 
-NoSolutionError
+NoSolutionError : `~astropy.wcs.NoSolutionError`
     No solution found in the specified interval.
 
 See also
@@ -1281,25 +1281,25 @@ result : dict
 Raises
 ------
 
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-SingularMatrixError
+SingularMatrixError : `~astropy.wcs.SingularMatrixError`
     Linear transformation matrix is singular.
 
-InconsistentAxisTypesError
+InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
     Inconsistent or unrecognized coordinate axis types.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid parameter value.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     *x*- and *y*-coordinate arrays are not the same size.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Invalid coordinate transformation parameters.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Ill-conditioned coordinate transformation parameters.
 
 See also
@@ -1328,10 +1328,10 @@ foccrd : double array[ncoord][nelem]
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid coordinate transformation parameters.
 """.format(__.ORIGIN())
 
@@ -1396,10 +1396,10 @@ foccrd : double array[ncoord][nelem]
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid coordinate transformation parameters.
 """.format(__.ORIGIN())
 
@@ -1497,22 +1497,22 @@ result : dict
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-SingularMatrixError
+SingularMatrixError : `~astropy.wcs.SingularMatrixError`
     Linear transformation matrix is singular.
 
-InconsistentAxisTypesError
+InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
     Inconsistent or unrecognized coordinate axis types.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid parameter value.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
    Invalid coordinate transformation parameters.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Ill-conditioned coordinate transformation parameters.
 
 See also
@@ -1554,22 +1554,22 @@ etc.) but without changing the input header keywords.
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-SingularMatrixError
+SingularMatrixError : `~astropy.wcs.SingularMatrixError`
     Linear transformation matrix is singular.
 
-InconsistentAxisTypesError
+InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
     Inconsistent or unrecognized coordinate axis types.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid parameter value.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Invalid coordinate transformation parameters.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Ill-conditioned coordinate transformation parameters.
 """
 
@@ -1585,7 +1585,7 @@ by functions that need it.
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
 InvalidTabularParameters
@@ -1697,10 +1697,10 @@ pixcrd : double array[ncoord][nelem]
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid coordinate transformation parameters.
 """.format(__.ORIGIN())
 
@@ -1724,10 +1724,10 @@ foccrd : double array[ncoord][nelem]
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid coordinate transformation parameters.
 """.format(__.ORIGIN())
 
@@ -1783,25 +1783,25 @@ i : int
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-SingularMatrixError
+SingularMatrixError : `~astropy.wcs.SingularMatrixError`
     Linear transformation matrix is singular.
 
-InconsistentAxisTypesError
+InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
     Inconsistent or unrecognized coordinate axis types.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
     Invalid parameter value.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Invalid coordinate transformation parameters.
 
-InvalidTransformError
+InvalidTransformError : `~astropy.wcs.InvalidTransformError`
     Ill-conditioned coordinate transformation parameters.
 
-InvalidSubimageSpecificationError
+InvalidSubimageSpecificationError : `~astropy.wcs.InvalidSubimageSpecificationError`
     Invalid subimage specification (no spectral axis).
 """
 
@@ -1879,13 +1879,13 @@ new_wcs : `~astropy.wcs.WCS` object
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
     Memory allocation failed.
 
-InvalidSubimageSpecificationError
+InvalidSubimageSpecificationError : `~astropy.wcs.InvalidSubimageSpecificationError`
     Invalid subimage specification (no spectral axis).
 
-NonseparableSubimageCoordinateSystem
+NonseparableSubimageCoordinateSystemError : `~astropy.wcs.NonseparableSubimageCoordinateSystemError`
     Non-separable subimage coordinate system.
 
 Notes
@@ -2183,13 +2183,13 @@ colsel : sequence of int
 
 Raises
 ------
-MemoryError
+MemoryError : `~.exceptions.MemoryError`
      Memory allocation failed.
 
-ValueError
+ValueError : `~.exceptions.ValueError`
      Invalid key.
 
-KeyError
+KeyError : `~.exceptions.KeyError`
      Key not found in FITS header.
 """
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -279,16 +279,16 @@ class WCS(WCSBase):
 
     Raises
     ------
-    MemoryError
+    MemoryError : `~.exceptions.MemoryError`
          Memory allocation failed.
 
-    ValueError
+    ValueError : `~.exceptions.ValueError`
          Invalid key.
 
-    KeyError
+    KeyError : `~.exceptions.KeyError`
          Key not found in FITS header.
 
-    AssertionError
+    AssertionError : `~.exceptions.AssertionError`
          Lookup table distortion present in the header but *fobj* was
          not provided.
 
@@ -1183,28 +1183,28 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        SingularMatrixError
+        SingularMatrixError : `~astropy.wcs.SingularMatrixError`
             Linear transformation matrix is singular.
 
-        InconsistentAxisTypesError
+        InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
             Inconsistent or unrecognized coordinate axis types.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid parameter value.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             x- and y-coordinate arrays are not the same size.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Invalid coordinate transformation parameters.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Ill-conditioned coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('naxis', 8),
                    __.RA_DEC_ORDER(8),
@@ -1242,28 +1242,28 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        SingularMatrixError
+        SingularMatrixError : `~astropy.wcs.SingularMatrixError`
             Linear transformation matrix is singular.
 
-        InconsistentAxisTypesError
+        InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
             Inconsistent or unrecognized coordinate axis types.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid parameter value.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             x- and y-coordinate arrays are not the same size.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Invalid coordinate transformation parameters.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Ill-conditioned coordinate transformation parameters.
 
         Notes
@@ -1886,28 +1886,28 @@ naxis kwarg.
             See :py:class:``NoConvergence`` documentation for
             more details.
 
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        SingularMatrixError
+        SingularMatrixError : `~astropy.wcs.SingularMatrixError`
             Linear transformation matrix is singular.
 
-        InconsistentAxisTypesError
+        InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
             Inconsistent or unrecognized coordinate axis types.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid parameter value.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             x- and y-coordinate arrays are not the same size.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Invalid coordinate transformation parameters.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Ill-conditioned coordinate transformation parameters.
 
         Examples
@@ -2060,28 +2060,28 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        SingularMatrixError
+        SingularMatrixError : `~astropy.wcs.SingularMatrixError`
             Linear transformation matrix is singular.
 
-        InconsistentAxisTypesError
+        InconsistentAxisTypesError : `~astropy.wcs.InconsistentAxisTypesError`
             Inconsistent or unrecognized coordinate axis types.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid parameter value.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             x- and y-coordinate arrays are not the same size.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Invalid coordinate transformation parameters.
 
-        InvalidTransformError
+        InvalidTransformError : `~astropy.wcs.InvalidTransformError`
             Ill-conditioned coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('naxis', 8),
                    __.RA_DEC_ORDER(8),
@@ -2109,10 +2109,10 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('2', 8),
                    __.RETURNS('focal coordinates', 8))
@@ -2138,10 +2138,10 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('2', 8),
                    __.RETURNS('focal coordinates', 8))
@@ -2167,10 +2167,10 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('2', 8),
                    __.RETURNS('pixel coordinates', 8))
@@ -2208,10 +2208,10 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('2', 8),
                    __.RETURNS('focal coordinates', 8))
@@ -2245,10 +2245,10 @@ naxis kwarg.
 
         Raises
         ------
-        MemoryError
+        MemoryError : `~.exceptions.MemoryError`
             Memory allocation failed.
 
-        ValueError
+        ValueError : `~.exceptions.ValueError`
             Invalid coordinate transformation parameters.
         """.format(__.TWO_OR_MORE_ARGS('2', 8),
                    __.RETURNS('pixel coordinates', 8))


### PR DESCRIPTION
The docstring was a bit inconsistent whether giving links for the exceptions, or just listing them. However, even in cases when a link formatted text was given, the build didn't  format them as links but with boldface.

This PR adds links for all the exceptions with available API docs.
