### PR TITLE
Change Csv comment character to None to fix regression from #2812

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -184,12 +184,16 @@ class CsvSplitter(core.DefaultSplitter):
 class CsvHeader(BasicHeader):
     '''Header that uses the :class:`astropy.io.ascii.basic.CsvSplitter`'''
     splitter_class = CsvSplitter
+    comment = None
+    write_comment = None
 
 
 class CsvData(BasicData):
     '''Data that uses the :class:`astropy.io.ascii.basic.CsvSplitter`'''
     splitter_class = CsvSplitter
     fill_values = [(core.masked, '')]
+    comment = None
+    write_comment = None
 
 
 class Csv(Basic):

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -813,3 +813,13 @@ def test_list_with_newlines():
     assert len(t) == 2
     assert t[0][0] == 123
     assert t[1][0] == 456
+
+def test_commented_csv():
+    """
+    Check that Csv reader does not have ignore lines with the # comment
+    character which is defined for most Basic readers.
+    """
+    t = ascii.read(['#a,b', '1,2', '#3,4'], format='csv')
+    assert t.colnames == ['#a', 'b']
+    assert len(t) == 2
+    assert t['#a'][1] == '#3'


### PR DESCRIPTION
As @amras1 noted in #2716:

"Looks like the rebase on #2812 introduced a test error resulting from the fact that legacy CSV functionality has now changed so that '#' is the default comment character (previously there had been no default comment character for CSV). Is this an unintended consequence of the restructuring in #2812?"

This PR reverts the comment characters for the `Csv` reader back to `None`.

@hamogu @amras1 - does this look reasonable?  No CHANGES.rst update since this regression never got released.
