### PR TITLE
Check for specific exception raised in FlagCollection instead of string content of exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -482,8 +482,6 @@ Bug Fixes
 
 - ``astropy.nddata``
 
-  - Fix ``FlagCollection`` test that fails on 64-bit Windows. [#2861]
-
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -482,6 +482,8 @@ Bug Fixes
 
 - ``astropy.nddata``
 
+  - Fix ``FlagCollection`` test that fails on 64-bit Windows. [#2861]
+
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -52,3 +52,5 @@ def test_setitem_invalid_shape():
     f = FlagCollection(shape=(1, 2, 3))
     with pytest.raises(ValueError) as exc:
         f['a'] = np.ones((3, 2, 1))
+    assert exc.value.args[0].startswith('flags array shape')
+    assert exc.value.args[0].endswith('does not match data shape (1, 2, 3)')

--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -50,7 +50,5 @@ def test_setitem_invalid_type(value):
 @pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
 def test_setitem_invalid_shape():
     f = FlagCollection(shape=(1, 2, 3))
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(ValueError) as exc:
         f['a'] = np.ones((3, 2, 1))
-    assert exc.value.args[0] == ('flags array shape (3, 2, 1) does not match '
-                                 'data shape (1, 2, 3)')


### PR DESCRIPTION
This closes one of the windows 64-bit test failures on appveyor seen in #2755