### PR TITLE
Generate API docs for some missing sub-modules in astropy.utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,7 +109,7 @@ API Changes
   - Some members of ``astropy.utils.misc`` were moved into new submodules.
     Specifically:
 
-    - ``deprecated`, ``deprecated_attribute``, and ``lazyproperty`` ->
+    - ``deprecated``, ``deprecated_attribute``, and ``lazyproperty`` ->
       ``astropy.utils.decorators``
 
     - ``find_current_module``, ``find_mod_objs`` ->
@@ -2013,7 +2013,7 @@ API Changes
 - The ``--enable-legacy`` option for ``setup.py`` has been removed. [#1493]
 
 Bug Fixes
-^^^^^^^^^^
+^^^^^^^^^
 
 - ``astropy.io.ascii``
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -390,7 +390,7 @@ def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
           updated=functools.WRAPPER_UPDATES):
     """
     An alternative to `functools.wraps` which also preserves the original
-    function's call signature by way of `make_func_with_sig`.
+    function's call signature by way of `~astropy.utils.codegen.make_func_with_sig`.
 
     The documentation for the original `functools.wraps` follows:
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -37,6 +37,15 @@ Reference/API
 .. automodapi:: astropy.utils.misc
     :no-inheritance-diagram:
 
+.. automodapi:: astropy.utils.decorators
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.codegen
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.introspection
+    :no-inheritance-diagram:
+
 .. automodapi:: astropy.utils.exceptions
     :no-inheritance-diagram:
 


### PR DESCRIPTION
This PR adds some `automodapi` directives for `astropy.utils`.

I noticed in https://github.com/astropy/astropy/pull/2857#issuecomment-52617740 that e.g. `astropy.utils.lazyproperty` was missing from the online docs:
http://astropy.readthedocs.org/en/latest/search.html?q=lazyproperty

One issue with this approach is that with these separate `automodapi` directives, e.g. the `lazyproperty` function shows up at `astropy.utils.decorators.lazyproperty` instead of at `astropy.utils.lazyproperty` which is location users should import from.
Is this acceptable or if not, how exactly should it be structured instead (automodapi for `astropy.utils` or manual listing to get nicely sorted functions by topic)?

cc @embray @astrofrog
