### PR TITLE
Numpy/scipy intersphinx workaround: use a mirror

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ numpy_intersphinx_urls = ['http://docs.scipy.org/doc/numpy/objects.inv',
                           'http://jiffyclub.github.io/numpy/',]
 intersphinx_mapping['numpy'] = (get_working_intersphinx(numpy_intersphinx_urls), None)
 scipy_intersphinx_urls = ['http://docs.scipy.org/doc/scipy/objects.inv',
-                          'http://scipy.org/docs/scipy/',
+                          'http://scipy.org/docs/scipy/reference/',
                           'http://jiffyclub.github.io/scipy/',]
 intersphinx_mapping['scipy'] = (get_working_intersphinx(scipy_intersphinx_urls), None)
 


### PR DESCRIPTION
This is a workaround for the failure of the numpy/scipy servers.  We can add any list of mirrors to this.  Does this seem like a reasonable workaround?

related: https://github.com/astropy/astropy/issues/2863
