### PR TITLE
Slight improvement to memory usage for guess

### DIFF
--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -175,7 +175,9 @@ def _guess(table, read_kwargs):
 
             # When guessing require at least two columns
             if len(dat.colnames) <= 1:
+                del dat
                 raise ValueError
+
             return dat
 
         except (core.InconsistentTableError, ValueError, TypeError,


### PR DESCRIPTION
When a reader results in a `Table` object (that is nonetheless invalid) delete the local reference to that `Table` as soon as we don't need it anymore.  That will immediately allow memory to be freed up for the next reader(s) to do their parsing.

This came up in #2877, and while it does not solve #2877 it will lessen the impact.
