### PR TITLE
test --test-path allows directories as well as files

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -146,24 +146,34 @@ class TestRunner(object):
 
         if test_path:
             base, ext = os.path.splitext(test_path)
-            if ext == '.py':
-                test_path = os.path.abspath(test_path)
-                all_args.append(test_path)
-            elif ext == '.rst':
+
+            if ext in ('.rst', ''):
                 if docs_path is None:
                     # This shouldn't happen from "python setup.py test"
                     raise ValueError(
-                        "Can not test .rst files without a docs_path specified.")
-                else:
+                        "Can not test .rst files without a docs_path "
+                        "specified.")
+
+                abs_docs_path = os.path.abspath(docs_path)
+                abs_test_path = os.path.abspath(
+                    os.path.join(abs_docs_path, os.pardir, test_path))
+
+                common = os.path.commonprefix((abs_docs_path, abs_test_path))
+
+                if os.path.exists(abs_test_path) and common == abs_docs_path:
                     # Since we aren't testing any Python files within
                     # the astropy tree, we need to forcibly load the
                     # astropy py.test plugins, and then turn on the
                     # doctest_rst plugin.
-                    all_args.extend(['-p', 'astropy.tests.pytest_plugins', '--doctest-rst'])
-                    test_path = os.path.join(docs_path, '..', test_path)
-                    all_args.append(test_path)
-            else:
-                raise ValueError("Test file path must be to a .py or .rst file")
+                    all_args.extend(['-p', 'astropy.tests.pytest_plugins',
+                                     '--doctest-rst'])
+                    test_path = abs_test_path
+
+            if not (os.path.isdir(test_path) or ext in ('.py', '.rst')):
+                raise ValueError("Test path must be a directory or a path to "
+                                 "a .py or .rst file")
+
+            all_args.append(test_path)
         else:
             all_args.append(package_path)
             if docs_path is not None and not skip_docs:


### PR DESCRIPTION
This enhances the `test_path` option to `TestRunner` (and by extension the `./setup.py test --test-path` option to allow directories as well as files.

The logic is mostly the same as before.  If a file it must be a `.py` or `.rst` file.  However it may now also be a directory which might or might not contain tests of either type. 

This also allows something like `./setup.py test --test-path docs/` which allows running the doctests only.  This could be useful for a separate PR I have coming up in a bit.

Note: This might also necessitate a change to the documentation to `--test-path` in astropy-helpers, which is unfortunate.  I have plans to fix that situation later.
