### PR TITLE
replace non-ASCII characters in header

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -391,7 +391,7 @@ class WCS(WCSBase):
                 header_string = header_string
             else:
                 header_bytes = header_string
-                header_string = header_string.decode('ascii')
+                header_string = header_string.decode('ascii', 'replace')
 
             try:
                 wcsprm = _wcs.Wcsprm(header=header_bytes, key=key,


### PR DESCRIPTION
Fixed problems with non-ASCII (e.g. UTF-8) characters in FITS header. This is a real issue with e.g. Astrometry.net, which puts into HISTORY local name of its build - and if the build was done on e.g. Czech locale, one will see UTF-8 characters in header (such as čt, which is for čtvrtek, Thursday). Such FITS headers open fine in Python and are probably valid, but due to header encoding does not work with wcs.
