### PR TITLE
Add linkchecker to build_sphinx test on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ install:
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
     - if [[ $SETUP_CMD == build_sphinx* ]]; then conda install --yes numpy=$NUMPY_VERSION Sphinx=1.2.2 Pygments matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then pip install linkchecker; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage coveralls; fi
@@ -99,6 +100,7 @@ install:
 
 script:
     - $MAIN_CMD $SETUP_CMD
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then linkchecker docs/_build/html --ignore-url astropy/wcs/_wcs.html; fi
 
 after_success:
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='astropy/tests/coveragerc'; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1261,7 +1261,7 @@ Bug Fixes
     to install ``wcslib`` headers under ``astropy/wcs/include``. [#2536]
 
   - Fixes an unresolved external symbol error in the
-    `astropy.wcs._wcs` C extension on Microsoft Windows when built
+    ``astropy.wcs._wcs`` C extension on Microsoft Windows when built
     with a Microsoft compiler. [#2478]
 
 - Misc

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -271,7 +271,7 @@ reproducible results. Before you try out a new feature or think you have found
 a bug make sure the tests run properly on your system.
 
 If the test *don't* complete successfully, that is itself a bug--please
-`report it <http://github.com/astropy/astropy/issues>`_.
+report it on the `astropy issues page`_.
 
 To run the tests, navigate back to the directory your copy of astropy is in on
 your computer, then, at the shell prompt, type::
@@ -285,7 +285,7 @@ this::
     4741 passed, 85 skipped, 11 xfailed
 
 Skips and xfails are fine, but if there are errors or failures please
-`report them <http://github.com/astropy/astropy/issues>`_.
+report them on the `astropy issues page`_.
 
 .. _try_devel:
 


### PR DESCRIPTION
Sphinx doesn't warn on a few cases with broken HTML internal links in the docs (not sure why).

These are fixed here and `linkchecker` is run on travis-ci (as e.g. [matplotlib does as well](https://github.com/matplotlib/matplotlib/blob/master/.travis.yml)), for internal links only so that will _not_ cause any test failures if external webpages are down.
