### PR TITLE
Add mention of the license to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,3 +38,8 @@ Test Coverage Status
 
 .. image:: https://coveralls.io/repos/astropy/astropy/badge.png
     :target: https://coveralls.io/r/astropy/astropy
+
+License
+-------
+Astropy is licensed under a 3-clause BSD style license - see the
+``licenses/LICENSE.rst`` file.


### PR DESCRIPTION
This closes #2908 by adding a section to the readme pointing to the license file.
