### PR TITLE
New Sphinx with extra values to unpack

### DIFF
--- a/astropy/sphinx/ext/automodsumm.py
+++ b/astropy/sphinx/ext/automodsumm.py
@@ -421,6 +421,9 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
 
         try:
             name, obj, parent = import_by_name(name)
+        except ValueError:
+            # This exception is to accomodate v1.2.2 and v1.2.3 of Sphinx
+            name, obj, parent, module_name = import_by_name(name)
         except ImportError, e:
             warn('[automodsumm] failed to import %r: %s' % (name, e))
             continue


### PR DESCRIPTION
I doubt this will pass the tests with the current version of sphinx installed by conda (v1.2.2) but when the new version become available (which is already through pip), a `ValueError:  too many values to unpack` will be raised unless a new element is unpacked.   This PR add an extra variable to unpack all the elements properly.

In case you are interested, this was introduced in Sphinx by [this commit](https://bitbucket.org/birkenfeld/sphinx/commits/f4743ba9521feb16bedc98f29275868054f01d67)
