### PR TITLE
Support creation of BinTableHDUs with zero rows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -217,6 +217,9 @@ Bug Fixes
   - Fixed crash when reading gzip-compressed FITS tables through the Astropy
     ``Table`` interface. [#2783]
 
+  - It is now possible to create ``astropy.io.fits.BinTableHDU``
+    objects with a table with zero rows. [#2916]
+
 - ``astropy.io.misc``
 
   - Fixed a bug that prevented h5py ``Dataset`` objects from being

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -758,11 +758,11 @@ class FITS_rec(np.recarray):
             # See if the dimensions already match, if not, make sure the
             # number items will fit in the specified dimensions
             if field.ndim > 1:
-                actual_shape = field[0].shape
+                actual_shape = field.shape[1:]
                 if _str:
-                    actual_shape = (field[0].itemsize,) + actual_shape
+                    actual_shape = (field.itemsize,) + actual_shape
             else:
-                actual_shape = len(field[0])
+                actual_shape = field.shape[0]
 
             if dim == actual_shape:
                 # The array already has the correct dimensions, so we

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2136,6 +2136,19 @@ class TestTableFunctions(FitsTestCase):
                 zwc_pl = pickle.loads(zwc_pd)
                 assert comparerecords(zwc_pl, zwc[2].data)
 
+    def test_zero_length_table(self):
+        array = np.array([], dtype=[
+            ('a', 'i8'),
+            ('b', 'S64'),
+            ('c', ('i4', (3, 2)))])
+        hdu = fits.BinTableHDU(array)
+        assert hdu.header['NAXIS1'] == 96
+        assert hdu.header['NAXIS2'] == 0
+        assert hdu.header['TDIM3'] == '(2,3)'
+
+        field = hdu.data.field(1)
+        assert field.shape == (0,)
+
 
 class TestVLATables(FitsTestCase):
     """Tests specific to tables containing variable-length arrays."""


### PR DESCRIPTION
This is a problem we've run into with `jwst_lib.models`.  It doesn't seem to be possible to create a BinTableHDU from a numpy structured array with 0 rows.  This fixes that by determining the shape from shape of the field, not the shape of the first row of the field (which may not always exist).

@embray 
