### PR TITLE
Skycoord to accept more formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ New Features
 
   - ``astropy.coordinates`` now has a ``Galactocentric`` frame, a coordinate
     frame centered on a (user specified) center of the Milky Way. [#2761, #3286]
+  - ``SkyCoord`` now accepts more formats of the coordinate string when the
+    representation has ``ra`` and ``dec`` attributes.
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,8 +46,9 @@ New Features
 
   - ``astropy.coordinates`` now has a ``Galactocentric`` frame, a coordinate
     frame centered on a (user specified) center of the Milky Way. [#2761, #3286]
+
   - ``SkyCoord`` now accepts more formats of the coordinate string when the
-    representation has ``ra`` and ``dec`` attributes.
+    representation has ``ra`` and ``dec`` attributes. [#2920]
 
 - ``astropy.cosmology``
 
@@ -86,7 +87,7 @@ New Features
     in ``read`` and ``fast_writer`` in ``write``. [#2716]
 
   - Make Latex/AASTex tables use unit attribute of Column for output. [#3064]
-  
+
   - Store comment lines encountered during reading in metadata of the
     output table via ``meta['comment_lines']``. [#3222]
 
@@ -197,7 +198,7 @@ New Features
   - When viewed in IPython, ``Quantity`` objects with array values now render
     using LaTeX and scientific notation. [#2271]
 
-  - Added units.quantity_input decorator to validate quantity inputs to a 
+  - Added units.quantity_input decorator to validate quantity inputs to a
     function for unit compatibility. [#3072]
 
 - ``astropy.utils``
@@ -686,7 +687,7 @@ Bug Fixes
     ``super()`` in their ``__init__`` method. [#3004]
 
   - Fixed a bug which caused the ``metadata_conflicts`` parameter to be
-    ignored in the ``astropy.utils.metadata.merge`` function. [#3294]  
+    ignored in the ``astropy.utils.metadata.merge`` function. [#3294]
 
 - ``astropy.vo``
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -5,6 +5,7 @@ import collections
 import warnings
 
 import numpy as np
+import re
 
 from ..utils.compat.misc import override__dir__
 from ..extern import six
@@ -1213,8 +1214,12 @@ def _parse_coordinate_arg(coords, frame, units):
             if isinstance(coord, six.string_types):
                 coord1 = coord.split()
                 if len(coord1) == 6:
-                    coord1 = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
-                coord = coord1
+                    coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
+                elif len(coord1) > 2:
+                    coord = re.split('(\+|\-)', coord)
+                    coord = (coord[0], ' '.join(coord[1:]))
+                else:
+                    coord = coord1
 
             vals.append(coord)  # This assumes coord is a sequence at this point
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1218,7 +1218,7 @@ def _parse_coordinate_arg(coords, frame, units):
                 coord1 = coord.split()
                 if len(coord1) == 6:
                     coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
-                elif frame.name == 'icrs':  # radec
+                elif 'ra' in frame.representation_component_names:
                     coord = parse_ra_dec(coord)
                 else:
                     coord = coord1
@@ -1262,8 +1262,8 @@ def _parse_coordinate_arg(coords, frame, units):
                 frame_attr_names, repr_attr_classes, values, units):
             valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
     except Exception as err:
-        raise ValueError('Cannot parse longitude and latitude from first argument: {0}'
-                         .format(err))
+        raise ValueError('Cannot parse longitude and latitude from first argument '
+                         'for the specified frame: {0}'.format(err))
 
     return valid_kwargs
 
@@ -1299,14 +1299,12 @@ def parse_ra_dec(coord_str):
 
     Parameters
     ----------
-
     coord_str : str or list of str
         Coordinate string to parse.
 
     Returns
     -------
-
-    coord : str
+    coord : str or list of str
         Parsed coordinate values.
     """
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -23,6 +23,8 @@ from .representation import (BaseRepresentation, SphericalRepresentation,
 
 __all__ = ['SkyCoord']
 
+PMRE = re.compile('(\+|\-)')
+
 
 # Define a convenience mapping.  This is used like a module constants
 # but is actually dynamically evaluated.
@@ -1216,7 +1218,7 @@ def _parse_coordinate_arg(coords, frame, units):
                 if len(coord1) == 6:
                     coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
                 elif len(coord1) > 2:
-                    coord = re.split('(\+|\-)', coord)
+                    coord = PMRE.split(coord)
                     coord = (coord[0], ' '.join(coord[1:]))
                 else:
                     coord = coord1

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1218,21 +1218,10 @@ def _parse_coordinate_arg(coords, frame, units):
                 coord1 = coord.split()
                 if len(coord1) == 6:
                     coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
-                elif len(coord1) > 2:
-                    coord = PMRE.split(coord)
-                    coord = (coord[0], ' '.join(coord[1:]))
-                elif len(coord1) == 1:
-                        try:
-                            coord = JPMRE.match(coord).groups()
-                            coord = ('{0} {1} {2}'.
-                                     format(coord[0][0:2], coord[0][2:4], coord[0][4:]),
-                                     '{0} {1} {2}'.
-                                     format(coord[1][0:3], coord[1][3:5], coord[1][5:]))
-                        except:
-                            coord = coord1
+                elif frame.name == 'icrs':  # radec
+                    coord = parse_ra_dec(coord)
                 else:
                     coord = coord1
-
             vals.append(coord)  # This assumes coord is a sequence at this point
 
         # Do some basic validation of the list elements: all have a length and all
@@ -1299,3 +1288,48 @@ def _get_representation_attrs(frame, units, kwargs):
             valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
 
     return valid_kwargs
+
+
+def parse_ra_dec(coord_str):
+    """
+    Parsing RA--Dec input pairs. Currently the following formats are supported:
+
+     * space separated <6 value format
+     * JHHMMSS.ss+DDMMSS.s format
+
+    Parameters
+    ----------
+
+    coord_str : str or list of str
+        Coordinate string to parse.
+
+    Returns
+    -------
+
+    coord : str
+        Parsed coordinate values.
+    """
+
+    if isinstance(coord_str, six.string_types):
+        coord1 = coord_str.split()
+    else:
+        coord1 = coord_str
+
+    if len(coord1) == 6:
+        coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
+    elif len(coord1) > 2:
+        coord = PMRE.split(coord_str)
+        coord = (coord[0], ' '.join(coord[1:]))
+    elif len(coord1) == 1:
+        try:
+            coord = JPMRE.match(coord_str).groups()
+            coord = ('{0} {1} {2}'.
+                     format(coord[0][0:2], coord[0][2:4], coord[0][4:]),
+                     '{0} {1} {2}'.
+                     format(coord[1][0:3], coord[1][3:5], coord[1][5:]))
+        except:
+            coord = coord1
+    else:
+        coord = coord1
+
+    return coord

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -5,7 +5,6 @@ import collections
 import warnings
 
 import numpy as np
-import re
 
 from ..utils.compat.misc import override__dir__
 from ..extern import six
@@ -21,7 +20,7 @@ from .builtin_frames import ICRS
 from .representation import (BaseRepresentation, SphericalRepresentation,
                              UnitSphericalRepresentation)
 
-__all__ = ['SkyCoord']
+__all__ = ['SkyCoord', 'parse_ra_dec']
 
 PMRE = re.compile(r'(\+|\-)')
 JPMRE = re.compile(r'J([0-9]{6}\.?[0-9]{0,2})([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$')

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -23,9 +23,11 @@ from .representation import (BaseRepresentation, SphericalRepresentation,
 __all__ = ['SkyCoord']
 
 PLUS_MINUS_RE = re.compile(r'(\+|\-)')
-J_PREFIXED_RA_DEC_RE = re.compile(r"""J([0-9]{6})\.?[0-9]{0,2}    # RA with up to two optional decimal digits                                                                    
-                                  ([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$    # DEC with up to two optional decimal digits                                                                
-                                  """, re.VERBOSE) 
+J_PREFIXED_RA_DEC_RE = re.compile(
+    r"""J                              # J prefix
+    ([0-9]{6})\.?[0-9]{0,2}            # RA as HHMMSS.ss, optional decimal digits
+    ([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$  # Dec as DDMMSS.ss, optional decimal digits
+    """, re.VERBOSE)
 
 
 # Define a convenience mapping.  This is used like a module constants
@@ -1214,7 +1216,7 @@ def _parse_coordinate_arg(coords, frame, units):
 
         # First turn into a list of lists like [[v1_0, v2_0, v3_0], ... [v1_N, v2_N, v3_N]]
         vals = []
-        
+
         is_ra_dec_representation = ('ra' in frame.representation_component_names and
                                     'dec' in frame.representation_component_names)
 
@@ -1297,10 +1299,12 @@ def _get_representation_attrs(frame, units, kwargs):
 
 def _parse_ra_dec(coord_str):
     """
-    Parse RA and Dec values from a coordinate string. Currently the following formats are supported:
+    Parse RA and Dec values from a coordinate string. Currently the
+    following formats are supported:
 
      * space separated 6-value format
-     * space separated <6-value format, this requires a plus or minus sign separation between RA and Dec
+     * space separated <6-value format, this requires a plus or minus sign
+       separation between RA and Dec
      * JHHMMSS.ss+DDMMSS.ss format, with up to two optional decimal digits
 
     Parameters
@@ -1317,7 +1321,7 @@ def _parse_ra_dec(coord_str):
     if isinstance(coord_str, six.string_types):
         coord1 = coord_str.split()
     else:
-        # This exception should never be raised from SkyCoord                                                  
+        # This exception should never be raised from SkyCoord
         raise TypeError('coord_str must be a single str')
 
     if len(coord1) == 6:
@@ -1328,7 +1332,7 @@ def _parse_ra_dec(coord_str):
     elif len(coord1) == 1:
         match = J_PREFIXED_RA_DEC_RE.match(coord_str)
         if match:
-            coord = match.groups()                 
+            coord = match.groups()
             coord = ('{0} {1} {2}'.
                      format(coord[0][0:2], coord[0][2:4], coord[0][4:]),
                      '{0} {1} {2}'.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -23,7 +23,8 @@ from .representation import (BaseRepresentation, SphericalRepresentation,
 
 __all__ = ['SkyCoord']
 
-PMRE = re.compile('(\+|\-)')
+PMRE = re.compile(r'(\+|\-)')
+JPMRE = re.compile(r'J([0-9]{6}\.?[0-9]{0,2})([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$')
 
 
 # Define a convenience mapping.  This is used like a module constants
@@ -1220,6 +1221,15 @@ def _parse_coordinate_arg(coords, frame, units):
                 elif len(coord1) > 2:
                     coord = PMRE.split(coord)
                     coord = (coord[0], ' '.join(coord[1:]))
+                elif len(coord1) == 1:
+                        try:
+                            coord = JPMRE.match(coord).groups()
+                            coord = ('{0} {1} {2}'.
+                                     format(coord[0][0:2], coord[0][2:4], coord[0][4:]),
+                                     '{0} {1} {2}'.
+                                     format(coord[1][0:3], coord[1][3:5], coord[1][5:]))
+                        except:
+                            coord = coord1
                 else:
                     coord = coord1
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -160,6 +160,14 @@ def test_coord_init_string():
     assert allclose(sc5.ra, Angle(120.15 * u.deg))
     assert allclose(sc5.dec, Angle(-5.01 * u.deg))
 
+    sc6 = SkyCoord('8h00.6m -5d00.6m', unit=(u.hour, u.deg), frame='fk4')
+    assert isinstance(sc6, SkyCoord)
+    assert allclose(sc6.ra, Angle(120.15 * u.deg))
+    assert allclose(sc6.dec, Angle(-5.01 * u.deg))
+
+    with pytest.raises(ValueError):
+        SkyCoord('8 00 -5 00.6', unit=(u.deg, u.deg), frame='galactic')
+
 
 def test_coord_init_unit():
     """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -140,6 +140,11 @@ def test_coord_init_string():
     assert allclose(sc1.ra, Angle(120 * u.deg))
     assert allclose(sc1.dec, Angle(5 * u.deg))
 
+    sc11 = SkyCoord('8h00m00s+5d00m00.0s', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc11, SkyCoord)
+    assert allclose(sc1.ra, Angle(120 * u.deg))
+    assert allclose(sc1.dec, Angle(5 * u.deg))
+
     sc2 = SkyCoord('8 00 -5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc2, SkyCoord)
     assert allclose(sc2.ra, Angle(120 * u.deg))
@@ -169,6 +174,21 @@ def test_coord_init_string():
     assert isinstance(sc6, SkyCoord)
     assert allclose(sc6.ra, Angle(120.15 * u.deg))
     assert allclose(sc6.dec, Angle(-5.01 * u.deg))
+
+    sc61 = SkyCoord('8h00.6m-5d00.6m', unit=(u.hour, u.deg), frame='fk4')
+    assert isinstance(sc61, SkyCoord)
+    assert allclose(sc6.ra, Angle(120.15 * u.deg))
+    assert allclose(sc6.dec, Angle(-5.01 * u.deg))
+
+    sc61 = SkyCoord('8h00.6-5d00.6', unit=(u.hour, u.deg), frame='fk4')
+    assert isinstance(sc61, SkyCoord)
+    assert allclose(sc6.ra, Angle(120.15 * u.deg))
+    assert allclose(sc6.dec, Angle(-5.01 * u.deg))
+
+    sc7 = SkyCoord("J1874221.60+122421.6", unit=u.deg)
+    assert isinstance(sc7, SkyCoord)
+    assert allclose(sc7.ra, Angle(187.706 * u.deg))
+    assert allclose(sc7.dec, Angle(12.406 * u.deg))
 
     with pytest.raises(ValueError):
         SkyCoord('8 00 -5 00.6', unit=(u.deg, u.deg), frame='galactic')

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -150,6 +150,11 @@ def test_coord_init_string():
     assert allclose(sc3.ra, Angle(120 * u.deg))
     assert allclose(sc3.dec, Angle(-5.01 * u.deg))
 
+    sc4 = SkyCoord('J080000.0-050036.0', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc4, SkyCoord)
+    assert allclose(sc4.ra, Angle(120 * u.deg))
+    assert allclose(sc4.dec, Angle(-5.01 * u.deg))
+
     sc5 = SkyCoord('8h00.6m -5d00.6m', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc5, SkyCoord)
     assert allclose(sc5.ra, Angle(120.15 * u.deg))

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -140,9 +140,10 @@ def test_coord_init_string():
     assert allclose(sc1.ra, Angle(120 * u.deg))
     assert allclose(sc1.dec, Angle(5 * u.deg))
 
-    with pytest.raises(ValueError) as err:
-        SkyCoord('8 00 -5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
-    assert 'coordinates have 5 values but spherical representation only accepts 3' in str(err)
+    sc2 = SkyCoord('8 00 -5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc2, SkyCoord)
+    assert allclose(sc2.ra, Angle(120 * u.deg))
+    assert allclose(sc2.dec, Angle(-5 * u.deg))
 
     sc5 = SkyCoord('8h00.6m -5d00.6m', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc5, SkyCoord)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -150,10 +150,15 @@ def test_coord_init_string():
     assert allclose(sc3.ra, Angle(120 * u.deg))
     assert allclose(sc3.dec, Angle(-5.01 * u.deg))
 
-    sc4 = SkyCoord('J080000.0-050036.0', unit=(u.hour, u.deg), frame='icrs')
+    sc4 = SkyCoord('J080000.00-050036.00', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc4, SkyCoord)
     assert allclose(sc4.ra, Angle(120 * u.deg))
     assert allclose(sc4.dec, Angle(-5.01 * u.deg))
+
+    sc41 = SkyCoord('J080000+050036', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc41, SkyCoord)
+    assert allclose(sc41.ra, Angle(120 * u.deg))
+    assert allclose(sc41.dec, Angle(+5.01 * u.deg))
 
     sc5 = SkyCoord('8h00.6m -5d00.6m', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc5, SkyCoord)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -145,6 +145,11 @@ def test_coord_init_string():
     assert allclose(sc2.ra, Angle(120 * u.deg))
     assert allclose(sc2.dec, Angle(-5 * u.deg))
 
+    sc3 = SkyCoord('8 00 -5 00.6', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc3, SkyCoord)
+    assert allclose(sc3.ra, Angle(120 * u.deg))
+    assert allclose(sc3.dec, Angle(-5.01 * u.deg))
+
     sc5 = SkyCoord('8h00.6m -5d00.6m', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc5, SkyCoord)
     assert allclose(sc5.ra, Angle(120.15 * u.deg))

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -97,10 +97,20 @@ e.g. ``"fk4"``::
   >>> sc = SkyCoord("1h12m43.2s", "+1d12m43s", frame=Galactic)  # Units from strings
   >>> sc = SkyCoord("1h12m43.2s +1d12m43s", frame=Galactic)  # Units from string
   >>> sc = SkyCoord(l="1h12m43.2s", b="+1d12m43s", frame='galactic')
+  >>> sc = SkyCoord("1h12.72m +1d12.71m", frame='galactic')
 
 Note that frame instances with data and `~astropy.coordinates.SkyCoord` instances
 can only be passed as frames using the ``frame=`` keyword argument and not as
 positional arguments.
+
+For representations that have ``ra`` and ``dec`` attributes one can supply a coordinate
+string in a number of other common formats.  Examples include::
+
+  >>> sc = SkyCoord("15h17+89d15")
+  >>> sc = SkyCoord("275d11m15.6954s+17d59m59.876s")
+  >>> sc = SkyCoord("8 00 -5 00.6", unit=(u.hour, u.deg))
+  >>> sc = SkyCoord("J080000.00-050036.00", unit=(u.hour, u.deg))
+  >>> sc = SkyCoord("J1874221.31+122328.03", unit=u.deg)
 
 Astropy `~astropy.units.Quantity`-type objects are acceptable and encouraged
 as a form of input::
@@ -676,12 +686,12 @@ state of the |SkyCoord| object, you should instead use the
 Example 1: Plotting random data in Aitoff projection
 ====================================================
 
-This is an example how to make a plot in the Aitoff projection using data 
+This is an example how to make a plot in the Aitoff projection using data
 in a |SkyCoord| object. Here a randomly generated data set will be used.
 
-First we need to import the required packages. We use 
+First we need to import the required packages. We use
 `matplotlib <http://www.matplotlib.org/>`_ here for
-plotting and `numpy <http://www.numpy.org/>`_  to get the value of pi and to 
+plotting and `numpy <http://www.numpy.org/>`_  to get the value of pi and to
 generate our random data.
 
     >>> from astropy import units as u
@@ -690,7 +700,7 @@ generate our random data.
 
 We now generate random data for visualisation. For RA this is done in the range
 of 0 and 360 degrees (``ra_random``), for DEC between -90 and +90 degrees
-(``dec_random``). Finally, we multiply these values by degrees to get an 
+(``dec_random``). Finally, we multiply these values by degrees to get an
 `~astropy.units.Quantity` with units of degrees.
 
 
@@ -704,7 +714,7 @@ As next step, those coordinates are transformed into an astropy.coordinates
     >>> c = SkyCoord(ra=ra_random, dec=dec_random, frame='icrs')
 
 Because matplotlib needs the coordinates in radians and between :math:`-\pi`
-and :math:`\pi`, not 0 and :math:`2\pi`, we have to convert them. 
+and :math:`\pi`, not 0 and :math:`2\pi`, we have to convert them.
 For this purpose the `astropy.coordinates.Angle` object provides a special method,
 which we use here to wrap at 180:
 
@@ -714,8 +724,8 @@ which we use here to wrap at 180:
 
 As last step we set up the plotting environment with matplotlib using the
 Aitoff projection with a specific title, a grid, filled circles as markers with
-a markersize of 2 and an alpha value of 0.3. We use a figure with an x-y ratio 
-that is well suited for such a projection and we move the title upwards from 
+a markersize of 2 and an alpha value of 0.3. We use a figure with an x-y ratio
+that is well suited for such a projection and we move the title upwards from
 its usual position to avoid overlap with the axis labels.
 
 .. doctest-skip::
@@ -726,19 +736,19 @@ its usual position to avoid overlap with the axis labels.
     >>> plt.title("Aitoff projection of our random data")
     >>> plt.grid(True)
     >>> plt.plot(ra_rad, dec_rad, 'o', markersize=2, alpha=0.3)
-    >>> plt.subplots_adjust(top=0.95,bottom=0.0) 
+    >>> plt.subplots_adjust(top=0.95,bottom=0.0)
     >>> plt.show()
 
 
 .. plot::
 
-    # This is an example how to make a plot in the Aitoff projection using data 
+    # This is an example how to make a plot in the Aitoff projection using data
     # in a SkyCoord object. Here a randomly generated data set will be used. The
     # final script can be found below.
 
-    # First we need to import the required packages. We use 
+    # First we need to import the required packages. We use
     # `matplotlib <http://www.matplotlib.org/>`_ here for
-    # plotting and `numpy <http://www.numpy.org/>`_  to get the value of pi and to 
+    # plotting and `numpy <http://www.numpy.org/>`_  to get the value of pi and to
     # generate our random data.
     from astropy import units as u
     from astropy.coordinates import SkyCoord
@@ -747,7 +757,7 @@ its usual position to avoid overlap with the axis labels.
 
     # We now generate random data for visualisation. For RA this is done in the range
     # of 0 and 360 degrees (``ra_random``), for DEC between -90 and +90 degrees
-    # (``dec_random``). Finally, we multiply these values by degrees to get an 
+    # (``dec_random``). Finally, we multiply these values by degrees to get an
     # `~astropy.units.Quantity` with units of degrees.
     ra_random = np.random.rand(100)*360.0 * u.degree
     dec_random = (np.random.rand(100)*180.0-90.0) * u.degree
@@ -757,7 +767,7 @@ its usual position to avoid overlap with the axis labels.
     c = SkyCoord(ra=ra_random, dec=dec_random, frame='icrs')
 
     # Because matplotlib needs the coordinates in radians and between :math:`-\pi`
-    # and :math:`\pi`, not 0 and :math:`2\pi`, we have to convert them. 
+    # and :math:`\pi`, not 0 and :math:`2\pi`, we have to convert them.
     # For this purpose the `astropy.coordinates.Angle` object provides a special method,
     # which we use here to wrap at 180:
     ra_rad = c.ra.wrap_at(180 * u.deg).radian
@@ -771,7 +781,7 @@ its usual position to avoid overlap with the axis labels.
     plt.title("Aitoff projection of our random data", y=1.08)
     plt.grid(True)
     plt.plot(ra_rad, dec_rad, 'o', markersize=2, alpha=0.3)
-    plt.subplots_adjust(top=0.95,bottom=0.0) 
+    plt.subplots_adjust(top=0.95,bottom=0.0)
     plt.show()
 
 
@@ -783,7 +793,7 @@ This is more realitic example how to make a plot in the Aitoff projection
 using data in a |SkyCoord| object.
 Here a randomly generated data set (multivariante
 normal distribution) for both stars in the bulge and in the disk of a galaxy
-will be used. Both types will be plotted with different number counts. 
+will be used. Both types will be plotted with different number counts.
 
 As in the last example, we first import the required packages.
 
@@ -804,7 +814,7 @@ As next step, those coordinates are transformed into an astropy.coordinates
     >>> c_gal = SkyCoord(galaxy, representation='cartesian', frame='galactic')
     >>> c_gal_icrs = c_gal.icrs
 
-Again, as in the last example, we need to convert the coordinates in radians 
+Again, as in the last example, we need to convert the coordinates in radians
 and make sure they are between :math:`-\pi` and :math:`\pi`:
 
     >>> ra_rad = c_gal_icrs.ra.wrap_at(180 * u.deg).radian
@@ -820,7 +830,7 @@ We use the same plotting setup as in the last example:
     >>> plt.title("Aitoff projection of our random data")
     >>> plt.grid(True)
     >>> plt.plot(ra_rad, dec_rad, 'o', markersize=2, alpha=0.3)
-    >>> plt.subplots_adjust(top=0.95,bottom=0.0) 
+    >>> plt.subplots_adjust(top=0.95,bottom=0.0)
     >>> plt.show()
 
 
@@ -828,7 +838,7 @@ We use the same plotting setup as in the last example:
 
     # This is more realitic example how to make a plot in the Aitoff projection
     # using data in a SkyCoord object.
-    # Here a randomly generated data set (multivariante normal distribution) 
+    # Here a randomly generated data set (multivariante normal distribution)
     # for both stars in the bulge and in the disk of a galaxy
     # will be used. Both types will be plotted with different number counts. The
     # final script can be found below.
@@ -839,7 +849,7 @@ We use the same plotting setup as in the last example:
     import matplotlib.pyplot as plt
     import numpy as np
 
-    # We now generate random data for visualisation with 
+    # We now generate random data for visualisation with
     # np.random.multivariate_normal.
     disk = np.random.multivariate_normal(mean=[0,0,0], cov=np.diag([1,1,0.5]), size=5000)
     bulge = np.random.multivariate_normal(mean=[0,0,0], cov=np.diag([1,1,1]), size=500)
@@ -850,7 +860,7 @@ We use the same plotting setup as in the last example:
     c_gal = SkyCoord(galaxy, representation='cartesian', frame='galactic')
     c_gal_icrs = c_gal.icrs
 
-    # Again, as in the last example, we need to convert the coordinates in radians 
+    # Again, as in the last example, we need to convert the coordinates in radians
     # and make sure they are between :math:`-\pi` and :math:`\pi`:
     ra_rad = c_gal_icrs.ra.wrap_at(180 * u.deg).radian
     dec_rad = c_gal_icrs.dec.radian
@@ -861,7 +871,7 @@ We use the same plotting setup as in the last example:
     plt.title("Aitoff projection of our random data", y=1.08)
     plt.grid(True)
     plt.plot(ra_rad, dec_rad, 'o', markersize=2, alpha=0.3)
-    plt.subplots_adjust(top=0.95,bottom=0.0) 
+    plt.subplots_adjust(top=0.95,bottom=0.0)
     plt.show()
 
 


### PR DESCRIPTION
This is just a dump of the skycoord related commits removed from #2846. This should not be merged as is. First the right place/function need to be found for it as it's representation specific.  Added features:

* acceptance of space separated <6 value format
* support for JHHMMSS.ss+DDMMSS.s format