### PR TITLE
Implement bit-byte unit equivalency and nibble unit

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -137,7 +137,7 @@ def_unit((['vox', 'voxel'], ['voxel']),
          namespace=_ns, prefixes=True)
 def_unit((['bit', 'b'], ['bit']), namespace=_ns,
          prefixes=si_prefixes + binary_prefixes)
-def_unit((['byte', 'B'], ['byte']), namespace=_ns,
+def_unit((['byte', 'B'], ['byte']), 8 * bit, namespace=_ns,
          format={'vounit': 'byte'},
          prefixes=si_prefixes + binary_prefixes,
          exclude_prefixes=['d'])

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -58,3 +58,8 @@ def test_photnu():
 @raises(ValueError)
 def test_redundant_physical_type():
     physical.def_physical_type(u.m, 'utter craziness')
+
+
+def test_data_quantity():
+    assert u.byte.physical_type == 'data quantity'
+    assert u.bit.physical_type == 'data quantity'

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -629,3 +629,7 @@ def test_composite_compose():
     # Issue #2382
     composite_unit = u.s.compose(units=[u.Unit("s")])[0]
     u.s.compose(units=[composite_unit])
+
+
+def test_data_quantities():
+    assert u.byte.is_equivalent(u.bit)


### PR DESCRIPTION
This is a feature request that was already mentioned here: https://github.com/astropy/astropy/issues/2897#issuecomment-55081397

It would be nice to implement bit-byle unit equivalency

``` python
>>> from astropy.units import Quantity
>>> Quantity(1, 'byte').to('bit') # currently gives an error
```

Also @astrofrog mentioned that it would be nice to have the [Nibble](http://en.wikipedia.org/wiki/Nibble) unit (= 4 bits) available.
