### PR TITLE
wcs example clean-up

### DIFF
--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -71,9 +71,9 @@ The basic workflow is as follows:
 
 For example, to convert pixel coordinates to world coordinates::
 
-    >>> from astropy import wcs
-    >>> WCS = wcs.WCS('image.fits')
-    >>> lon, lat = WCS.all_pix2world(30, 40, 0)
+    >>> from astropy.wcs import WCS
+    >>> w = WCS('image.fits')
+    >>> lon, lat = w.all_pix2world(30, 40, 0)
     >>> print(lon, lat)
 
 


### PR DESCRIPTION
I used astropy.wcs for the first time today, and experienced some confusion due to the fact that the "wcs" variable in the example provided represents the module in the first line, but is overwritten to hold an object in the second line. So I edited the example to make the module always lower-case "wcs" and the object always uppercase "WCS". Thanks for the work you do maintaining AstroPy!
