### PR TITLE
Ensure that quantity operations with incompatible types give a useful TypeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -280,6 +280,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Operations on quantities with incompatible types now raises a much
+    more informative ``TypeError``. [#2934]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -294,14 +294,23 @@ class Quantity(np.ndarray):
             # can just have the unit of the quantity
             # (this allows, e.g., `q > 0.` independent of unit)
             maybe_arbitrary_arg = args[scales.index(0.)]
-            if _can_have_arbitrary_unit(maybe_arbitrary_arg):
-                scales = [1., 1.]
-            else:
-                raise UnitsError("Can only apply '{0}' function to "
-                                 "dimensionless quantities when other "
-                                 "argument is not a quantity (unless the "
-                                 "latter is all zero/infinity/nan)"
-                                 .format(function.__name__))
+            try:
+                if _can_have_arbitrary_unit(maybe_arbitrary_arg):
+                    scales = [1., 1.]
+                else:
+                    raise UnitsError("Can only apply '{0}' function to "
+                                     "dimensionless quantities when other "
+                                     "argument is not a quantity (unless the "
+                                     "latter is all zero/infinity/nan)"
+                                     .format(function.__name__))
+            except TypeError:
+                # _can_have_arbitrary_unit failed: arg could not be compared
+                # with zero or checked to be finite.  Then, ufunc will fail too.
+                raise TypeError("Unsupported operand type(s) for ufunc {0}: "
+                                "'{1}' and '{2}'"
+                                .format(function.__name__,
+                                        args[0].__class__.__name__,
+                                        args[1].__class__.__name__))
 
         # In the case of np.power, the unit itself needs to be modified by an
         # amount that depends on one of the input values, so we need to treat

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -320,6 +320,17 @@ class TestQuantityOperations(object):
         with pytest.raises(u.UnitsError):
             new_q = q1 + q2
 
+    def test_non_number_type(self):
+        q1 = u.Quantity(11.412, unit=u.meter)
+        type_err_msg = ("Unsupported operand type(s) for ufunc add: "
+                        "'Quantity' and 'dict'")
+        with pytest.raises(TypeError) as exc:
+            q1 + {'a': 1}
+        assert exc.value.args[0] == type_err_msg
+
+        with pytest.raises(TypeError):
+            q1 + u.meter
+
     def test_dimensionless_operations(self):
         # test conversion to dimensionless
         dq = 3. * u.m / u.km


### PR DESCRIPTION
Currently, a rather uninformative `TypeError` is raised if one, e.g., adds a quantity to something that is not a number:

```
In [1]: import astropy.units as u, numpy as np

In [2]: np.add(np.arange(10.)*u.cm,  u.cm)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-63526e011ceb> in <module>()                                    
----> 1 np.add(np.arange(10.)*u.cm,  u.cm)                                      

/usr/lib/python3/dist-packages/astropy/units/quantity.py in __array_prepare__(self, obj, context)                                                               
    294             # (this allows, e.g., `q > 0.` independent of unit)         
    295             maybe_arbitrary_arg = args[scales.index(0.)]                
--> 296             if _can_have_arbitrary_unit(maybe_arbitrary_arg):           
    297                 scales = [1., 1.]                                       
    298             else:                                                       

/usr/lib/python3/dist-packages/astropy/units/quantity.py in _can_have_arbitrary_unit(value)
     57     `True` if each member is either zero or not finite, `False` otherwise
     58     """
---> 59     return np.all(np.logical_or(np.equal(value, 0.), ~np.isfinite(value)))
     60 
     61 

TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

With this PR, this becomes:

```
In [2]: np.add(np.arange(10.)*u.cm,  u.cm)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-63526e011ceb> in <module>()
----> 1 np.add(np.arange(10.)*u.cm,  u.cm)

/data/mhvk/venv/astropy-dev/lib/python3.4/site-packages/astropy-1.0.dev9886-py3.4-linux-x86_64.egg/astropy/units/quantity.py in __array_prepare__(self, obj, context)
    310                                 .format(function.__name__,
    311                                         args[0].__class__.__name__,
--> 312                                         args[1].__class__.__name__))
    313 
    314         # In the case of np.power, the unit itself needs to be modified by an

TypeError: Unsupported operand type(s) for add: 'Quantity' and 'Unit'
```
