### PR TITLE
.fz fits files KeyError: "Keyword 'ZSIMPLE' not found in 0.3.2 versus 0.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,6 +250,10 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed a crash when reading the header of a tile-compressed HDU if that
+    header contained invalid duplicate keywords resulting in a ``KeyError``
+    [#2750]
+
   - Fixed crash when reading gzip-compressed FITS tables through the Astropy
     ``Table`` interface. [#2783]
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1462,7 +1462,10 @@ class CompImageHDU(BinTableHDU):
         # the values of those cards that relate to the image from
         # their corresponding table cards.  These include
         # ZBITPIX -> BITPIX, ZNAXIS -> NAXIS, and ZNAXISn -> NAXISn.
-        for keyword in list(image_header):
+        # (Note: Used set here instead of list in case there are any duplicate
+        # keywords, which there may be in some pathological cases:
+        # https://github.com/astropy/astropy/issues/2750
+        for keyword in set(image_header):
             if CompImageHeader._is_reserved_keyword(keyword, warn=False):
                 del image_header[keyword]
 


### PR DESCRIPTION
I have some .fz fits files that are giving the error:

KeyError: "Keyword 'ZSIMPLE' not found."

when I use astropy 0.3.2 and also 0.4rc3.dev9443 but 0.3 reads the header OK

The header looks like
.
.
.
ZVAL2   =                    4 / bytes per pixel (1, 2, 4, or 8)  
EXTNAME = 'COMPRESSED_IMAGE'  
ZSIMPLE =                    T / file does conform to FITS standard  
ZBITPIX =                  -32 / number of bits per data pixel  
.
.
.
