### PR TITLE
FITS: 'BLANK' keyword causes crash when reading data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -256,6 +256,11 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed a crash when reading data from an HDU whose header contained in
+    invalid value for the BLANK keyword (eg. a string value instead of an
+    integer as required by the FITS Standard). Invalid BLANK keywords are now
+    warned about, but are otherwise ignored. [#2711]
+
   - Fixed a crash when reading the header of a tile-compressed HDU if that
     header contained invalid duplicate keywords resulting in a ``KeyError``
     [#2750]


### PR DESCRIPTION
Hello,
I already notice since a while an issue while trying to read, e.g., data fits cube (so simply (x,y,z))  see below for the full error which originate from 'hdu/image.py'.
My dummy, quickest fix was to add, right before the offending 'if':
                `if blanks==False: blanks=np.array([False])`

I don't know if it is really appropriate, but it does the trick for me.

regards,
Gilles

```
In [120]: array=py.getdata(cube_file)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-120-5d145d1683de> in <module>()
----> 1 array=py.getdata(cube_file)

/usr/local/lib/python2.7/dist-packages/astropy-0.3.2-py2.7-linux-x86_64.egg/astropy/io/fits/convenience.pyc in getdata(filename, *args, **kwargs)
    186     hdulist, extidx = _getext(filename, mode, *args, **kwargs)
    187     hdu = hdulist[extidx]
--> 188     data = hdu.data
    189     if data is None and extidx == 0:
    190         try:

/usr/local/lib/python2.7/dist-packages/astropy-0.3.2-py2.7-linux-x86_64.egg/astropy/utils/misc.pyc in __get__(self, obj, owner)
    277         key = self._fget.__name__
    278         if key not in obj.__dict__:
--> 279             val = self._fget(obj)
    280             obj.__dict__[key] = val
    281             return val

/usr/local/lib/python2.7/dist-packages/astropy-0.3.2-py2.7-linux-x86_64.egg/astropy/io/fits/hdu/image.pyc in data(self)
    213             return
    214 
--> 215         data = self._get_scaled_image_data(self._data_offset, self.shape)
    216         self._update_header_scale_info(data.dtype)
    217 

/usr/local/lib/python2.7/dist-packages/astropy-0.3.2-py2.7-linux-x86_64.egg/astropy/io/fits/hdu/image.pyc in _get_scaled_image_data(self, offset, shape)
    582                 # So if the number of blank items is fewer than
    583                 # len(raw_data.flat) / 8, using np.where will use less memory
--> 584                 if blanks.sum() < len(blanks) / 8:
    585                     blanks = np.where(blanks)
    586 

AttributeError: 'bool' object has no attribute 'sum'
```
