### PR TITLE
Support numpy 1.10 (master) by adding support for np.cbrt [closes #2936]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -310,6 +310,9 @@ Other Changes and Additions
 
 - Ensure numpy 1.9 is supported. [#2917]
 
+- Ensure numpy master is supported, by making ``np.cbrt`` work with quantities.
+  [#2937] 
+
 0.4.1 (2014-08-08)
 ------------------
 

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from .core import UnitsError, dimensionless_unscaled
+from ..utils.compat.fractions import Fraction
 
 
 def _d(unit):
@@ -64,6 +65,11 @@ UFUNC_HELPERS[np.square] = lambda f, unit: ([1.], unit ** 2 if unit is not None
 UFUNC_HELPERS[np.reciprocal] = lambda f, unit: ([1.], unit ** -1
                                                 if unit is not None
                                                 else dimensionless_unscaled)
+# cbrt only was added in numpy 1.10
+if isinstance(getattr(np, 'cbrt', None), np.ufunc):
+    UFUNC_HELPERS[np.cbrt] = lambda f, unit: ([1.], unit ** Fraction(1, 3)
+                                              if unit is not None
+                                              else dimensionless_unscaled)
 # ones_like was not private in numpy <= 1.6
 if isinstance(getattr(np.core.umath, 'ones_like', None), np.ufunc):
     UFUNC_HELPERS[np.core.umath.ones_like] = (lambda f, unit:

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -264,6 +264,16 @@ class TestQuantityMathFuncs(object):
         assert np.all(np.reciprocal(np.array([1., 2., 4.]) * u.m)
                       == np.array([1., 0.5, 0.25]) / u.m)
 
+    # cbrt only introduced in numpy 1.10
+    @pytest.mark.skipif("not hasattr(np, 'cbrt')")
+    def test_cbrt_scalar(self):
+        assert np.cbrt(8. * u.m**3) == 2. * u.m
+
+    @pytest.mark.skipif("not hasattr(np, 'cbrt')")
+    def test_cbrt_array(self):
+        assert np.all(np.cbrt(np.array([1., 8., 64.]) * u.m**3)
+                      == np.array([1., 2., 4.]) * u.m)
+
     def test_power_scalar(self):
         assert np.power(4. * u.m, 2.) == 16. * u.m ** 2
         assert np.power(4., 200. * u.cm / u.m) == \


### PR DESCRIPTION
Add support for `np.cbrt` (cube root) to `Quantity`, so that astropy can work with numpy master (closing #2936).

@astrofrog: this passes with the numpy development version on my machine, but to test this on travis would need the PR you thought you could do to my branch for #2573. But then I guess we would have to remove it again before merging, since otherwise travis will always test against numpy master, which may not be what we want! Not quite sure how to handle this elegantly...
