### PR TITLE
Correct determination of scaling in NDUncertainty.uncertainty.setter

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -242,7 +242,7 @@ class NDData(object):
                 class_name = self.__class__.__name__
                 if self.unit and value._unit:
                     try:
-                        scaling = (1 * value._unit).to(self.unit)
+                        scaling = value._unit.to(self.unit)
                     except UnitsError:
                         raise UnitsError('Cannot convert unit of uncertainty '
                                          'to unit of '


### PR DESCRIPTION
In the setter, a scaling is determined that still carries a unit, which is subsequently used for in-place multiplication. In the current implementation of `Quantity`, this works, but it stops working with my stricter `__numpy_ufunc__` implementation (#2583). This PR solves the bug in `NDUncertainty`.
