### PR TITLE
Quantity numpy ufunc additions: ufunc.at, reduce, reduceat, accumulate, outer

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -494,6 +494,18 @@ class Angle(u.Quantity):
                                        formatter={'str_kind': lambda x: x})
 
 
+def _no_angle_subclass(obj):
+    """Return any Angle subclass objects as an Angle objects.
+
+    This is used to ensure that Latitute and Longitude change to Angle
+    objects when they are used in calculations (such as lon/2.)
+    """
+    if isinstance(obj, tuple):
+        return tuple(_no_angle_subclass(_obj) for _obj in obj)
+
+    return obj.view(Angle) if isinstance(obj, Angle) else obj
+
+
 class Latitude(Angle):
     """
     Latitude-like angle(s) which must be in the range -90 to +90 deg.
@@ -575,11 +587,11 @@ class Latitude(Angle):
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
         obj = super(Angle, self).__array_wrap__(obj, context=context)
+        return _no_angle_subclass(obj)
 
-        if isinstance(obj, Angle):
-            return obj.view(Angle)
-
-        return obj
+    def __numpy_ufunc__(self, *args, **kwargs):
+        results = super(Latitude, self).__numpy_ufunc__(*args, **kwargs)
+        return _no_angle_subclass(results)
 
 
 class Longitude(Angle):
@@ -690,11 +702,12 @@ class Longitude(Angle):
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
         obj = super(Angle, self).__array_wrap__(obj, context=context)
+        return _no_angle_subclass(obj)
 
-        if isinstance(obj, Angle):
-            return obj.view(Angle)
+    def __numpy_ufunc__(self, *args, **kwargs):
+        results = super(Longitude, self).__numpy_ufunc__(*args, **kwargs)
+        return _no_angle_subclass(results)
 
-        return obj
 
 #<----------------------------------Rotations--------------------------------->
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -290,6 +290,21 @@ class EarthLocation(u.Quantity):
         else:
             return super(EarthLocation, self).__len__()
 
+    # Explicitly do __eq__, __ne__ to work around a bug in numpy 1.10-dev,
+    # where comparing two Quantities holding record arrays causes a segfault.
+    # See https://github.com/numpy/numpy/issues/4855
+    def __eq__(self, other):
+        if isinstance(other, EarthLocation):
+            return self.value == other.to(self.unit).value
+        else:
+            return False
+
+    def __ne__(self, other):
+        if isinstance(other, EarthLocation):
+            return self.value != other.to(self.unit).value
+        else:
+            return True
+
     def to(self, unit, equivalencies=[]):
         array_view = self.view(self._array_dtype, u.Quantity)
         converted = array_view.to(unit, equivalencies)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -21,19 +21,19 @@ from .core import (Unit, dimensionless_unscaled, UnitBase, UnitsError,
                    get_current_unit_registry)
 from .format.latex import Latex
 from ..utils import lazyproperty
-from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
+from ..utils.compat import (NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9,
+                            NUMPY_LT_1_10)
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from .utils import validate_power
 from .. import config as _config
-
+from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
+                              check_output)
 
 __all__ = ["Quantity"]
 
 
 # We don't want to run doctests in the docstrings we inherit from Numpy
 __doctest_skip__ = ['Quantity.*']
-
 
 _UNIT_NOT_INITIALISED = "(Unit not initialised)"
 
@@ -49,23 +49,6 @@ class Conf(_config.ConfigNamespace):
         'negative number means that the value will instead be whatever numpy '
         'gets from get_printoptions.')
 conf = Conf()
-
-
-def _can_have_arbitrary_unit(value):
-    """Test whether the items in value can have arbitrary units
-
-    Numbers whose value does not change upon a unit change, i.e.,
-    zero, infinity, or not-a-number
-
-    Parameters
-    ----------
-    value : number or array
-
-    Returns
-    -------
-    `True` if each member is either zero or not finite, `False` otherwise
-    """
-    return np.all(np.logical_or(np.equal(value, 0.), ~np.isfinite(value)))
 
 
 class QuantityIterator(object):
@@ -267,110 +250,39 @@ class Quantity(np.ndarray):
         # attributes to, etc. After this is called, then the ufunc is called
         # and the values in this empty array are set.
 
+        # In principle, this should not be needed any more in numpy >= 1.10,
+        # but it turns out it is still called if the output arguments to a
+        # ufunc is a quantity, given as a keyword, but the input arguments are
+        # not quantities.  See https://github.com/numpy/numpy/issues/4753
+
         # If no context is set, just return the input
         if context is None:
             return obj
 
         # Find out which ufunc is being used
         function = context[0]
-
-        from .quantity_helper import UNSUPPORTED_UFUNCS, UFUNC_HELPERS
-
-        # Check whether we even support this ufunc
-        if function in UNSUPPORTED_UFUNCS:
-            raise TypeError("Cannot use function '{0}' with quantities"
-                            .format(function.__name__))
-
-        # Now find out what arguments were passed to the ufunc, usually, this
-        # will include at least the present object, and another, which could
-        # be a Quantity, or a Numpy array, etc. when using two-argument ufuncs.
         args = context[1][:function.nin]
-        units = [getattr(arg, 'unit', None) for arg in args]
-
-        # If the ufunc is supported, then we call a helper function (defined
-        # in quantity_helper.py) which returns the scale by which the inputs
-        # should be multiplied before being passed to the ufunc, as well as
-        # the unit the output from the ufunc will have.
-        if function in UFUNC_HELPERS:
-            converters, result_unit = UFUNC_HELPERS[function](function, *units)
-        else:
-            raise TypeError("Unknown ufunc {0}.  Please raise issue on "
-                            "https://github.com/astropy/astropy"
-                            .format(function.__name__))
-
-        if any(converter is False for converter in converters):
-            # for two-argument ufuncs with a quantity and a non-quantity,
-            # the quantity normally needs to be dimensionless, *except*
-            # if the non-quantity can have arbitrary unit, i.e., when it
-            # is all zero, infinity or NaN.  In that case, the non-quantity
-            # can just have the unit of the quantity
-            # (this allows, e.g., `q > 0.` independent of unit)
-            maybe_arbitrary_arg = args[converters.index(False)]
-            try:
-                if _can_have_arbitrary_unit(maybe_arbitrary_arg):
-                    converters = [None, None]
-                else:
-                    raise UnitsError("Can only apply '{0}' function to "
-                                     "dimensionless quantities when other "
-                                     "argument is not a quantity (unless the "
-                                     "latter is all zero/infinity/nan)"
-                                     .format(function.__name__))
-            except TypeError:
-                # _can_have_arbitrary_unit failed: arg could not be compared
-                # with zero or checked to be finite.  Then, ufunc will fail too.
-                raise TypeError("Unsupported operand type(s) for ufunc {0}: "
-                                "'{1}' and '{2}'"
-                                .format(function.__name__,
-                                        args[0].__class__.__name__,
-                                        args[1].__class__.__name__))
-
-        # In the case of np.power, the unit itself needs to be modified by an
-        # amount that depends on one of the input values, so we need to treat
-        # this as a special case.
-        # TODO: find a better way to deal with this case
-        if function is np.power and result_unit is not dimensionless_unscaled:
-
-            if units[1] is None:
-                p = args[1]
-            else:
-                p = args[1].to(dimensionless_unscaled).value
-
-            result_unit = result_unit ** validate_power(p)
+        # determine required converter functions -- to bring the unit of the
+        # input to that expected (e.g., radian for np.sin), or to get
+        # consistent units between two inputs (e.g., in np.add) --
+        # and the unit of the result
+        converters, result_unit = converters_and_unit(function, '__call__',
+                                                      *args)
 
         # We now prepare the output object
-
         if self is obj:
-
             # this happens if the output object is self, which happens
             # for in-place operations such as q1 += q2
 
-            # In some cases, the result of a ufunc should be a plain Numpy
-            # array, which we can't do if we are doing an in-place operation.
-            if result_unit is None:
-                raise TypeError("Cannot store non-quantity output from {0} "
-                                "function in {1} instance"
-                                .format(function.__name__, type(self)))
-
-            if self.__quantity_subclass__(result_unit)[0] is not type(self):
-                raise TypeError(
-                    "Cannot store output with unit '{0}' from {1} function "
-                    "in {2} instance.  Use {3} instance instead."
-                    .format(result_unit, function.__name__, type(self),
-                            self.__quantity_subclass__(result_unit)[0]))
-
-            # If the Quantity has an integer dtype, in-place operations are
-            # dangerous because in some cases the quantity will be e.g.
-            # decomposed, which involves being scaled by a float, but since
-            # the array is an integer the output then gets converted to an int
-            # and truncated.
-            result_dtype = np.result_type(*(args + tuple(
+            # Check that we're not trying to store a plain Numpy array or a
+            # Quantity with an inconsistent unit (e.g., not angular for Angle),
+            # and that we can handle the type (e.g., that we are not int when
+            # float is required).
+            check_output(obj, result_unit, (args + tuple(
                 (float if converter and converter(1.) % 1. != 0. else int)
-                for converter in converters)))
-            if not np.can_cast(result_dtype, obj.dtype):
-                raise TypeError("Arguments cannot be cast safely to inplace "
-                                "output with dtype={0}".format(self.dtype))
-
-            result = self  # no view needed since we return the object itself
+                for converter in converters)),
+                         function=function)
+            result = obj  # no view needed since already a Quantity.
 
             # in principle, if self is also an argument, it could be rescaled
             # here, since it won't be needed anymore.  But maybe not change
@@ -380,8 +292,8 @@ class Quantity(np.ndarray):
 
             result = self._new_view(obj, result_unit)
 
-        # We now need to treat the case where the inputs have to be scaled -
-        # the issue is that we can't actually scale the inputs since that
+        # We now need to treat the case where the inputs have to be converter -
+        # the issue is that we can't actually convert the inputs since that
         # would be changing the objects passed to the ufunc, which would not
         # be expected by the user.
         if any(converters):
@@ -410,7 +322,7 @@ class Quantity(np.ndarray):
                 else:
                     result._contiguous = self.copy()
 
-            # ensure we remember the scales we need
+            # ensure we remember the converter functions we need
             result._converters = converters
 
         # unit output will get (setting _unit could prematurely change input
@@ -494,10 +406,79 @@ class Quantity(np.ndarray):
 
         return obj
 
-    def __deepcopy__(self, memo):
-        # If we don't define this, ``copy.deepcopy(quantity)`` will
-        # return a bare Numpy array.
-        return self.copy()
+    def __numpy_ufunc__(self, function, method, i, inputs, **kwargs):
+        """Wrap numpy ufunc and other functions, taking care of units.
+
+        Parameters
+        ----------
+        function : callable
+            ufunc or other function or method to wrap.
+        method : str
+            Callable attribute of ``function`` to use.  Should generally be
+            ``__call__``, but can also be ``at``, ``reduce``, etc., for ufuncs.
+        i : int
+            Position of ``self`` among the inputs.  Part of the standard
+            ``__numpy_ufunc__`` signature, but not used here.
+        inputs : tuple
+            Input arrays and other positional arguments.
+        kwargs : keyword arguments
+            As needed, but with the following treated specially:
+            ``unit`` : `~astropy.units.Unit`
+                Unit of the output result.  If not given (as for all ufunc's),
+                it will be inferred from the inputs and the ufunc.
+            ``out`` : `~astropy.units.Quantity`
+                A possible Quantity instance in which to store the output.
+
+        Returns
+        -------
+        out : `~astropy.units.Quantity`
+            Result of the function call, with the unit set properly.
+        """
+        # Ensure we don't loop back by turning any Quantity into array views.
+        arrays = tuple((i.value if isinstance(i, Quantity) else i)
+                       for i in inputs)
+
+        unit = kwargs.pop('unit', None)
+        if unit is None:  # This is a ufunc.
+            # If the unit is not given, we need to determine required conversion
+            # functions -- to bring the unit of the input to that expected
+            # (e.g., radian for np.sin), or to get consistent units between
+            # two inputs (e.g., in np.add) -- and the unit of the result.
+            converters, unit = converters_and_unit(function, method, *inputs)
+            # Convert inputs if required.
+            arrays = tuple((array if converter is None else converter(array))
+                           for array, converter in zip(arrays, converters))
+
+        out = kwargs.get('out', None)
+        if out is not None:
+            # If pre-allocated output is used, check it is suitable.
+            # This also returns array view, to ensure we don't loop back.
+            kwargs['out'] = check_output(out, unit, inputs, function=function)
+
+        result = getattr(function, method)(*arrays, **kwargs)
+        if unit is None or result is NotImplemented:
+            # result can be plain array, e.g., comparisons and np.frexp.
+            return result
+
+        if isinstance(result, tuple):
+            if not isinstance(out, tuple):
+                out = (out,) + (None,) * (len(result) - 1)
+            return tuple(self._result_as_quantity(_result, unit, _out)
+                         for (_result, _out) in zip(result, out))
+
+        return self._result_as_quantity(result, unit, out)
+
+    def _result_as_quantity(self, result, unit, out):
+        if out is None:
+            # View the result array as a Quantity with the proper unit.
+            return self._new_view(result, unit)
+        else:
+            # Result is an ndarray view of an output.  Usually a Quantity,
+            # except for, e.g., array += <dimensionless-quantity>.
+            if isinstance(out, Quantity):
+                out._unit = unit
+
+            return out
 
     def __quantity_subclass__(self, unit):
         """
@@ -525,7 +506,7 @@ class Quantity(np.ndarray):
         and with the unit passed on, or that of ``self``.  Subclasses can
         override the type of class used with ``__quantity_subclass__``, and
         can ensure other properties of ``self`` are copied using
-        `__array_finalize__`.
+        ``__array_finalize__``.
 
         Parameters
         ----------
@@ -562,6 +543,11 @@ class Quantity(np.ndarray):
         if unit is not None:
             view._unit = unit
         return view
+
+    def __deepcopy__(self, memo):
+        # If we don't define this, ``copy.deepcopy(quantity)`` will
+        # return a bare Numpy array.
+        return self.copy()
 
     def __reduce__(self):
         # patch to pickle Quantity objects (ndarray subclasses), see
@@ -759,7 +745,7 @@ class Quantity(np.ndarray):
         if isinstance(other, (UnitBase, six.string_types)):
             return self._new_view(self.copy(), other * self.unit)
 
-        return np.multiply(self, other)
+        return super(Quantity, self).__mul__(other)
 
     def __imul__(self, other):
         """In-place multiplication between `Quantity` objects and others."""
@@ -768,7 +754,7 @@ class Quantity(np.ndarray):
             self._unit = other * self.unit
             return self
 
-        return np.multiply(self, other, self)
+        return super(Quantity, self).__imul__(other)
 
     def __rmul__(self, other):
         """ Right Multiplication between `Quantity` objects and other
@@ -777,42 +763,42 @@ class Quantity(np.ndarray):
 
         return self.__mul__(other)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """ Division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
             return self._new_view(self.copy(), self.unit / other)
 
-        return np.true_divide(self, other)
+        return super(Quantity, self).__truediv__(other)
 
-    def __idiv__(self, other):
+    def __itruediv__(self, other):
         """Inplace division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
             self._unit = self.unit / other
             return self
 
-        return np.true_divide(self, other, self)
+        return super(Quantity, self).__itruediv__(other)
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         """ Right Division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
             return self._new_view(1. / self.value, other / self.unit)
 
-        return np.divide(other, self)
+        return super(Quantity, self).__rtruediv__(other)
 
-    def __truediv__(self, other):
+    def __div__(self, other):
         """ Division between `Quantity` objects. """
-        return self.__div__(other)
+        return self.__truediv__(other)
 
-    def __itruediv__(self, other):
+    def __idiv__(self, other):
         """ Division between `Quantity` objects. """
-        return self.__idiv__(other)
+        return self.__itruediv__(other)
 
-    def __rtruediv__(self, other):
+    def __rdiv__(self, other):
         """ Division between `Quantity` objects. """
-        return self.__rdiv__(other)
+        return self.__rtruediv__(other)
 
     def __divmod__(self, other):
         if isinstance(other, (six.string_types, UnitBase)):
@@ -1087,7 +1073,7 @@ class Quantity(np.ndarray):
             try:
                 _value = dimensionless_unscaled.to(self.unit, value)
             except UnitsError as exc:
-                if _can_have_arbitrary_unit(value):
+                if can_have_arbitrary_unit(value):
                     _value = value
                 else:
                     raise exc
@@ -1181,57 +1167,40 @@ class Quantity(np.ndarray):
     # We use the corresponding numpy functions to evaluate the results, since
     # the methods do not always allow calling with keyword arguments.
     # For instance, np.array([0.,2.]).clip(a_min=0., a_max=1.) gives
-    # TypeError: 'a_max' is an invalid keyword argument for this function
+    # TypeError: 'a_max' is an invalid keyword argument for this function.
     def _wrap_function(self, function, *args, **kwargs):
-        """Wrap a numpy function, returning a Quantity with the proper unit
+        """Wrap a numpy function that processes self, returning a Quantity.
 
         Parameters
         ----------
         function : callable
-            numpy function to wrap
+            Numpy function to wrap.
         args : positional arguments
-            any positional arguments to the function.
+            Any positional arguments to the function beyond the first argument
+            (which will be set to ``self``).
         kwargs : keyword arguments
             Keyword arguments to the function.
 
         If present, the following arguments are treated specially:
 
         unit : `~astropy.units.Unit` or `None`
-            unit of the output result.  If not given or `None` (default),
-            the unit of `self`.
+            Unit of the output result.  Defaults to the unit of ``self``.
         out : `~astropy.units.Quantity`
             A Quantity instance in which to store the output.
 
         Notes
         -----
-        Output should always be assigned via a keyword argument.
+        Output should always be assigned via a keyword argument, otherwise
+        no proper account of the unit is taken.
 
         Returns
         -------
         out : `~astropy.units.Quantity`
             Result of the function call, with the unit set properly.
         """
-
-        unit = kwargs.pop('unit', None)
-        out = kwargs.get('out', None)
-        if out is not None:
-            if unit is None:
-                unit = self.unit
-
-            if not (isinstance(out, Quantity) and
-                    out.__quantity_subclass__(unit)[0] is type(out)):
-                ok_class =  (out.__quantity_subclass__(out, unit)[0]
-                             if isinstance(out, Quantity) else Quantity)
-                raise TypeError("out cannot be assigned to a {0} instance; "
-                                "use a {1} instance instead.".format(
-                                    out.__class__, ok_class))
-
-        value = function(self.view(np.ndarray), *args, **kwargs)
-        if out is None:
-            return self._new_view(value, unit)
-        else:
-            out._unit = unit
-            return out
+        kwargs.setdefault('unit', self.unit)
+        return self.__numpy_ufunc__(function, '__call__', 0, (self,) + args,
+                                    **kwargs)
 
     def clip(self, a_min, a_max, out=None):
         return self._wrap_function(np.clip, self._to_own_unit(a_min),
@@ -1241,55 +1210,69 @@ class Quantity(np.ndarray):
         return self._wrap_function(np.trace, offset, axis1, axis2, dtype,
                                    out=out)
 
-    def var(self, axis=None, dtype=None, out=None, ddof=0):
-        return self._wrap_function(np.var, axis, dtype,
-                                   out=out, ddof=ddof, unit=self.unit**2)
+    if NUMPY_LT_1_10:
+        if NUMPY_LT_1_7:
+            # 'keepdims' was not yet available.
+            def max(self, axis=None, out=None):
+                return self._wrap_function(np.max, axis, out=out)
 
-    def std(self, axis=None, dtype=None, out=None, ddof=0):
-        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof)
+            def min(self, axis=None, out=None):
+                return self._wrap_function(np.min, axis, out=out)
 
-    def mean(self, axis=None, dtype=None, out=None):
-        return self._wrap_function(np.mean, axis, dtype, out=out)
+            def sum(self, axis=None, dtype=None, out=None):
+                return self._wrap_function(np.sum, axis, dtype, out=out)
 
-    def ptp(self, axis=None, out=None):
-        return self._wrap_function(np.ptp, axis, out=out)
+            # 'out' was not yet available.
+            def dot(self, b):
+                result_unit = self.unit * getattr(b, 'unit',
+                                                  dimensionless_unscaled)
+                return self._wrap_function(np.dot, b, unit=result_unit)
+
+        else:
+            def max(self, axis=None, out=None, keepdims=False):
+                return self._wrap_function(np.max, axis, out=out,
+                                           keepdims=keepdims)
+
+            def min(self, axis=None, out=None, keepdims=False):
+                return self._wrap_function(np.min, axis, out=out,
+                                           keepdims=keepdims)
+
+            def sum(self, axis=None, dtype=None, out=None, keepdims=False):
+                return self._wrap_function(np.sum, axis, dtype, out=out,
+                                           keepdims=keepdims)
+
+
+            def dot(self, b, out=None):
+                result_unit = self.unit * getattr(b, 'unit',
+                                                  dimensionless_unscaled)
+                return self._wrap_function(np.dot, b, out=out, unit=result_unit)
+
+        def var(self, axis=None, dtype=None, out=None, ddof=0):
+            return self._wrap_function(np.var, axis, dtype,
+                                       out=out, ddof=ddof, unit=self.unit**2)
+
+        def std(self, axis=None, dtype=None, out=None, ddof=0):
+            return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof)
+
+        def mean(self, axis=None, dtype=None, out=None):
+            return self._wrap_function(np.mean, axis, dtype, out=out)
+
+        def ptp(self, axis=None, out=None):
+            return self._wrap_function(np.ptp, axis, out=out)
+
+        def cumsum(self, axis=None, dtype=None, out=None):
+            return self._wrap_function(np.cumsum, axis, dtype, out=out)
 
     def round(self, decimals=0, out=None):
         return self._wrap_function(np.round, decimals, out=out)
 
     if NUMPY_LT_1_7:
-        # 'keepdims' was not yet available.
-        def max(self, axis=None, out=None):
-            return self._wrap_function(np.max, axis, out=out)
-
-        def min(self, axis=None, out=None):
-            return self._wrap_function(np.min, axis, out=out)
-
-        def sum(self, axis=None, dtype=None, out=None):
-            return self._wrap_function(np.sum, axis, dtype, out=out)
-
         def prod(self, axis=None, dtype=None, out=None):
             if not self.unit.is_unity():
                 raise ValueError("cannot use prod on scaled or "
                                  "non-dimensionless Quantity arrays")
             return self._wrap_function(np.prod, axis, dtype, out=out)
-
-        # 'out' was not yet available.
-        def dot(self, b):
-            result_unit = self.unit * getattr(b, 'unit', dimensionless_unscaled)
-            return self._wrap_function(np.dot, b, unit=result_unit)
-
     else:
-        def max(self, axis=None, out=None, keepdims=False):
-            return self._wrap_function(np.max, axis, out=out, keepdims=keepdims)
-
-        def min(self, axis=None, out=None, keepdims=False):
-            return self._wrap_function(np.min, axis, out=out, keepdims=keepdims)
-
-        def sum(self, axis=None, dtype=None, out=None, keepdims=False):
-            return self._wrap_function(np.sum, axis, dtype, out=out,
-                                       keepdims=keepdims)
-
         def prod(self, axis=None, dtype=None, out=None, keepdims=False):
             if not self.unit.is_unity():
                 raise ValueError("cannot use prod on scaled or "
@@ -1297,19 +1280,11 @@ class Quantity(np.ndarray):
             return self._wrap_function(np.prod, axis, dtype, out=out,
                                        keepdims=keepdims)
 
-        def dot(self, b, out=None):
-            result_unit = self.unit * getattr(b, 'unit', dimensionless_unscaled)
-            return self._wrap_function(np.dot, b, out=out, unit=result_unit)
-
-    def cumsum(self, axis=None, dtype=None, out=None):
-        return self._wrap_function(np.cumsum, axis, dtype, out=out)
-
     def cumprod(self, axis=None, dtype=None, out=None):
         if not self.unit.is_unity():
             raise ValueError("cannot use cumprod on scaled or "
                              "non-dimensionless Quantity arrays")
         return self._wrap_function(np.cumprod, axis, dtype, out=out)
-
 
     # Calculation: override methods that do not make sense.
 
@@ -1321,7 +1296,7 @@ class Quantity(np.ndarray):
         raise NotImplementedError("cannot evaluate truth value of quantities. "
                                   "Evaluate array with q.value.any(...)")
 
-    # Calculation --numpy functions that can be overridden with methods
+    # Calculation: numpy functions that can be overridden with methods.
 
     def diff(self, n=1, axis=-1):
         return self._wrap_function(np.diff, n, axis)

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -2,9 +2,12 @@
 # quantities (http://pythonhosted.org/quantities/) package.
 
 import numpy as np
+
 from .core import (UnitsError, dimensionless_unscaled,
                    get_current_unit_registry)
+from ..utils.compat import NUMPY_LT_1_10
 from ..utils.compat.fractions import Fraction
+from .utils import validate_power
 
 
 def _d(unit):
@@ -193,12 +196,18 @@ def helper_dimensionless_to_none(f, unit):
 
 UFUNC_HELPERS[np.frexp] = helper_dimensionless_to_none
 
+
 # TWO ARGUMENT UFUNCS
+def helper_multiplication(f, unit1, unit2):
+    return [None, None], _d(unit1) * _d(unit2)
 
-UFUNC_HELPERS[np.multiply] = lambda f, unit1, unit2: (
-    [None, None], _d(unit1) * _d(unit2))
+UFUNC_HELPERS[np.multiply] = helper_multiplication
+if not NUMPY_LT_1_10:
+    UFUNC_HELPERS[np.dot] = helper_multiplication
 
-helper_division = lambda f, unit1, unit2: ([None, None], _d(unit1) / _d(unit2))
+
+def helper_division(f, unit1, unit2):
+    return [None, None], _d(unit1) / _d(unit2)
 
 UFUNC_HELPERS[np.divide] = helper_division
 UFUNC_HELPERS[np.true_divide] = helper_division
@@ -324,3 +333,186 @@ UFUNC_HELPERS[np.arctan2] = helper_twoarg_invtrig
 # another private function in numpy; use getattr in case it disappears
 if isinstance(getattr(np.core.umath, '_arg', None), np.ufunc):
     UFUNC_HELPERS[np.core.umath._arg] = helper_twoarg_invtrig
+
+
+def can_have_arbitrary_unit(value):
+    """Test whether the items in value can have arbitrary units
+
+    Numbers whose value does not change upon a unit change, i.e.,
+    zero, infinity, or not-a-number
+
+    Parameters
+    ----------
+    value : number or array
+
+    Returns
+    -------
+    `True` if each member is either zero or not finite, `False` otherwise
+    """
+    return np.all(np.logical_or(np.equal(value, 0.), ~np.isfinite(value)))
+
+
+def converters_and_unit(function, method, *args):
+    """Determine the required converters and the unit of the ufunc result
+
+    Converters are functions required to convert to a ufunc's expected unit,
+    e.g., radian for np.sin; or to ensure units of two inputs are consistent,
+    e.g., for np.add.  In these examples, the unit of the result would be
+    dimensionless_unscaled for np.sin, and the same consistent unit for np.add.
+
+    Parameters
+    ----------
+    function : ~np.ufunc
+        Numpy universal function
+    method : str
+        Method with which the function is evaluated, e.g.,
+        '__call__', 'reduce', etc.
+    *args : Quantity or other ndarray subclass
+        Input arguments to the function
+
+    Raises
+    ------
+    TypeError : when the specified function cannot be used with Quantities
+        (e.g., np.logical_or), or when the routine does not know how to handle
+        the specified function (in which case an issue should be raised on
+        https://github.com/astropy/astropy).
+    UnitsError : when the conversion to the required (or consistent) units
+        is not possible.
+    """
+    # Check whether we even support this ufunc
+    if function in UNSUPPORTED_UFUNCS:
+        raise TypeError("Cannot use function '{0}' with quantities"
+                        .format(function.__name__))
+
+    if method == '__call__':
+        # Find out the units of the arguments passed to the ufunc; usually,
+        # at least one is a quantity, but for two-argument ufuncs, the second
+        # could also be a Numpy array, etc.  These are given unit=None.
+        units = [getattr(arg, 'unit', None) for arg in args]
+
+        # If the ufunc is supported, then we call a helper function (defined
+        # above) which returns a function that converts the inputs to the unit
+        # required for the ufunc, as well as the unit the output will have.
+        if function in UFUNC_HELPERS:
+            converters, result_unit = UFUNC_HELPERS[function](function, *units)
+        else:
+            raise TypeError("Unknown ufunc {0}.  Please raise issue on "
+                            "https://github.com/astropy/astropy"
+                            .format(function.__name__))
+
+        if any(converter is False for converter in converters):
+            # for two-argument ufuncs with a quantity and a non-quantity,
+            # the quantity normally needs to be dimensionless, *except*
+            # if the non-quantity can have arbitrary unit, i.e., when it
+            # is all zero, infinity or NaN.  In that case, the non-quantity
+            # can just have the unit of the quantity
+            # (this allows, e.g., `q > 0.` independent of unit)
+            maybe_arbitrary_arg = args[converters.index(False)]
+            try:
+                if can_have_arbitrary_unit(maybe_arbitrary_arg):
+                    converters = [None, None]
+                else:
+                    raise UnitsError("Can only apply '{0}' function to "
+                                     "dimensionless quantities when other "
+                                     "argument is not a quantity (unless the "
+                                     "latter is all zero/infinity/nan)"
+                                     .format(function.__name__))
+            except TypeError:
+                raise TypeError("Unsupported operand type(s) for ufunc {0}: "
+                                "'{1}' and '{2}'"
+                                .format(function.__name__,
+                                        args[0].__class__.__name__,
+                                        args[1].__class__.__name__))
+
+        # In the case of np.power, the unit itself needs to be modified by an
+        # amount that depends on one of the input values, so we need to treat
+        # this as a special case.
+        if function is np.power and result_unit is not dimensionless_unscaled:
+
+            if units[1] is None:
+                p = args[1]
+            else:
+                p = args[1].to(dimensionless_unscaled).value
+
+            result_unit = result_unit ** validate_power(p)
+
+    else:
+        # methods other than __call__, e.g., reduce, accumulate; these make
+        # sense only for two-argument functions that leave the unit intact.
+        if UFUNC_HELPERS[function] is helper_twoarg_invariant:
+            converters = [None]
+            result_unit = getattr(args[0], 'unit', None)
+        else:
+            raise TypeError("Unknown ufunc {0} for method {1}.  "
+                            "If this should work, please raise an issue on "
+                            "https://github.com/astropy/astropy"
+                            .format(function.__name__, method))
+
+    return converters, result_unit
+
+def check_output(output, unit, inputs, function=None):
+    """Check that function output can be stored in the output array given.
+
+    Parameters
+    ----------
+    output : array or `~astropy.units.Quantity` or tuple
+        Array that should hold the function output (or tuple of such arrays).
+    unit : `~astropy.units.Unit` or None
+        Unit that the output will have, or ``None`` for pure numbers.
+    inputs : tuple
+        Any input arguments.  These should be castable to the output.
+    function : callable
+        The function that will be producing the output.  If given, used to
+        give a more informative error message.
+
+    Returns
+    -------
+    arrays : ``ndarray`` view of ``output`` (or tuple of such views).
+
+    Raises
+    ------
+    TypeError : If ``unit`` is inconsistent with the class of ``output``,
+                or if the ``inputs`` cannot be cast safely to ``output``.
+    """
+    if isinstance(output, tuple):
+        if len(output) > 1:
+            return tuple(check_output(out, unit, inputs, function)
+                         for out in output)
+        else:
+            output = output[0]
+
+    # ``None`` indicates no actual array is needed.  This can happen, e.g.,
+    # with np.modf(a, out=(None, b)).
+    if output is None:
+        return None
+
+    if hasattr(output, '__quantity_subclass__'):
+        # Check that we're not trying to store a plain Numpy array or a
+        # Quantity with an inconsistent unit (e.g., not angular for Angle).
+        if unit is None:
+            raise TypeError("Cannot store non-quantity output in a "
+                            "{0} instance.".format(type(output)))
+
+        if output.__quantity_subclass__(unit)[0] is not type(output):
+            raise TypeError("Cannot store output with unit '{0}' in a "
+                            "{1} instance. Use a {2} instance instead."
+                            .format(unit, type(output),
+                                    output.__quantity_subclass__(unit)[0]))
+        # Turn into ndarray, so we do not loop into array_wrap/numpy_ufunc
+        # if the output is used to store results of a function.
+        output = output.view(np.ndarray)
+    else:
+        # output is not a Quantity, so cannot attain a unit.
+        if not (unit is None or unit is dimensionless_unscaled):
+            raise TypeError("Cannot store quantity with dimension "
+                            "{0}in a non-Quantity instance."
+                            .format("" if function is None else
+                                    "resulting from {0} function "
+                                    .format(function.__name__)))
+
+    # check we can handle the dtype (e.g., that we are not int
+    # when float is required)
+    if not np.can_cast(np.result_type(*inputs), output.dtype):
+        raise TypeError("Arguments cannot be cast safely to output "
+                        "with dtype={0}".format(output.dtype))
+    return output

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -511,8 +511,9 @@ def check_output(output, unit, inputs, function=None):
                                     .format(function.__name__)))
 
     # check we can handle the dtype (e.g., that we are not int
-    # when float is required)
-    if not np.can_cast(np.result_type(*inputs), output.dtype):
+    # when float is required); specifically exclude None for numpy <=1.7.
+    if not np.can_cast(np.result_type(*[i for i in inputs if i is not None]),
+                       output.dtype):
         raise TypeError("Arguments cannot be cast safely to output "
                         "with dtype={0}".format(output.dtype))
     return output

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -529,8 +529,8 @@ def test_temperature():
 def test_temperature_energy():
     x = 1000 * u.K
     y = (x * constants.k_B).to(u.keV)
-    assert_allclose(x.to(u.keV, u.temperature_energy()).value, y)
-    assert_allclose(y.to(u.K, u.temperature_energy()).value, x)
+    assert_allclose(x.to(u.keV, u.temperature_energy()).value, y.value)
+    assert_allclose(y.to(u.K, u.temperature_energy()).value, x.value)
 
 
 def test_compose_equivalencies():

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -563,7 +563,11 @@ class TestRecArray(object):
         qra = u.Quantity(self.ra, u.m)
         assert np.all(qra[:2].value == self.ra[:2])
 
+    # Pending resolution of https://github.com/numpy/numpy/issues/4855
+    # have to use explicity pytest.xfail, since this causes segmentation fault
     def test_equality(self):
         qra = u.Quantity(self.ra, u.m)
         qra[1] = qra[2]
+        if not NUMPY_LT_1_10:
+            pytest.xfail()
         assert qra[1] == qra[2]

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from ... import units as u
 from ...tests.helper import pytest
-from ...utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9_1
+from ...utils.compat import (NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9_1,
+                             NUMPY_LT_1_10)
 
 
 class TestQuantityArrayCopy(object):
@@ -231,7 +232,7 @@ class TestQuantityStatsFuncs(object):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
         assert np.ptp(q1) == 5. * u.m
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail("NUMPY_LT_1_10")
     def test_ptp_inplace(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
         qi = 1.5 * u.s
@@ -354,7 +355,7 @@ class TestQuantityStatsFuncs(object):
         assert np.all(q1.ediff1d() == np.array([1., 2., 6.]) * u.m)
         assert np.all(np.ediff1d(q1) == np.array([1., 2., 6.]) * u.m)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail("NUMPY_LT_1_10")
     def test_dot_func(self):
 
         q1 = np.array([1., 2., 4., 10.]) * u.m
@@ -554,10 +555,15 @@ class TestArrayConversion(object):
 class TestRecArray(object):
     """Record arrays are not specifically supported, but we should not
     prevent their use unnecessarily"""
-    def test_creation(self):
-        ra = (np.array(np.arange(12.).reshape(4,3))
+    def setup(self):
+        self.ra = (np.array(np.arange(12.).reshape(4,3))
               .view(dtype=('f8,f8,f8')).squeeze())
-        qra = u.Quantity(ra, u.m)
-        assert np.all(qra[:2].value == ra[:2])
+
+    def test_creation(self):
+        qra = u.Quantity(self.ra, u.m)
+        assert np.all(qra[:2].value == self.ra[:2])
+
+    def test_equality(self):
+        qra = u.Quantity(self.ra, u.m)
         qra[1] = qra[2]
         assert qra[1] == qra[2]

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing.utils import assert_allclose
+from ...utils.compat import NUMPY_LT_1_10
 
 from ... import units as u
 from ...tests.helper import pytest
@@ -23,3 +24,10 @@ class TestQuantityLinAlgFuncs(object):
         q2 = np.array([4, 5, 6]) / u.s
         o = np.inner(q1, q2)
         assert o == 32 * u.m / u.s
+
+    @pytest.mark.xfail("NUMPY_LT_1_10")
+    def test_dot(self):
+        q1 = np.array([1., 2., 3.]) * u.m
+        q2 = np.array([4., 5., 6.]) / u.s
+        o = np.dot(q1, q2)
+        assert o == 32. * u.m / u.s

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -646,3 +646,206 @@ class TestInplaceUfuncs(object):
         s2 += 1. * u.cm
         assert np.all(s[::2] > s_copy[::2])
         assert np.all(s[1::2] == s_copy[1::2])
+
+
+@pytest.mark.xfail("NUMPY_LT_1_10")
+class TestUfuncAt(object):
+    """Test that 'at' method for ufuncs (calculates in-place at given indices)
+
+    For Quantities, since calculations are in-place, it makes sense only
+    if the result is still a quantity, and if the unit does not have to change
+    """
+    def test_one_argument_ufunc_at(self):
+        q = np.arange(10.) * u.m
+        i = np.array([1, 2])
+        qv = q.value.copy()
+        np.negative.at(q, i)
+        np.negative.at(qv, i)
+        assert np.all(q.value == qv)
+        assert q.unit is u.m
+
+        # cannot change from quantity to bool array
+        with pytest.raises(TypeError):
+            np.isfinite.at(q, i)
+
+        # for selective in-place, cannot change the unit
+        with pytest.raises(u.UnitsError):
+            np.square.at(q, i)
+
+        # except if the unit does not change (i.e., dimensionless)
+        d = np.arange(10.) * u.dimensionless_unscaled
+        dv = d.value.copy()
+        np.square.at(d, i)
+        np.square.at(dv, i)
+        assert np.all(d.value == dv)
+        assert d.unit is u.dimensionless_unscaled
+
+        d = np.arange(10.) * u.dimensionless_unscaled
+        dv = d.value.copy()
+        np.log.at(d, i)
+        np.log.at(dv, i)
+        assert np.all(d.value == dv)
+        assert d.unit is u.dimensionless_unscaled
+
+        # also for sine it doesn't work, even if given an angle
+        a = np.arange(10.) * u.radian
+        with pytest.raises(u.UnitsError):
+            np.sin.at(a, i)
+
+        # except, for consistency, if we have made radian equivalent to
+        # dimensionless (though hopefully it will never be needed)
+        av = a.value.copy()
+        with u.add_enabled_equivalencies(u.dimensionless_angles()):
+            np.sin.at(a, i)
+            np.sin.at(av, i)
+            assert_allclose(a.value, av)
+
+            # but we won't do double conversion
+            ad = np.arange(10.) * u.degree
+            with pytest.raises(u.UnitsError):
+                np.sin.at(ad, i)
+
+    def test_two_argument_ufunc_at(self):
+        s = np.arange(10.) * u.m
+        i = np.array([1, 2])
+        check = s.value.copy()
+        np.add.at(s, i, 1.*u.km)
+        np.add.at(check, i, 1000.)
+        assert np.all(s.value == check)
+        assert s.unit is u.m
+
+        with pytest.raises(u.UnitsError):
+            np.add.at(s, i, 1.*u.s)
+
+        # also raise UnitsError if unit would have to be changed
+        with pytest.raises(u.UnitsError):
+            np.multiply.at(s, i, 1*u.s)
+
+        # but be fine if it does not
+        s = np.arange(10.) * u.m
+        check = s.value.copy()
+        np.multiply.at(s, i, 2.*u.dimensionless_unscaled)
+        np.multiply.at(check, i, 2)
+        assert np.all(s.value == check)
+        s = np.arange(10.) * u.m
+        np.multiply.at(s, i, 2.)
+        assert np.all(s.value == check)
+
+        # of course cannot change class of data either
+        with pytest.raises(TypeError):
+            np.greater.at(s, i, 1.*u.km)
+
+
+@pytest.mark.xfail("NUMPY_LT_1_10")
+class TestUfuncReduceReduceatAccumulate(object):
+    """Test 'reduce', 'reduceat' and 'accumulate' methods for ufuncs
+
+    For Quantities, it makes sense only if the unit does not have to change
+    """
+    def test_one_argument_ufunc_reduce_accumulate(self):
+        # one argument cannot be used
+        s = np.arange(10.) * u.radian
+        i = np.array([0, 5, 1, 6])
+        with pytest.raises(ValueError):
+            np.sin.reduce(s)
+        with pytest.raises(ValueError):
+            np.sin.accumulate(s)
+        with pytest.raises(ValueError):
+            np.sin.reduceat(s, i)
+
+    def test_two_argument_ufunc_reduce_accumulate(self):
+        s = np.arange(10.) * u.m
+        i = np.array([0, 5, 1, 6])
+        check = s.value.copy()
+        s_add_reduce = np.add.reduce(s)
+        check_add_reduce = np.add.reduce(check)
+        assert s_add_reduce.value == check_add_reduce
+        assert s_add_reduce.unit is u.m
+
+        s_add_accumulate = np.add.accumulate(s)
+        check_add_accumulate = np.add.accumulate(check)
+        assert np.all(s_add_accumulate.value == check_add_accumulate)
+        assert s_add_accumulate.unit is u.m
+
+        s_add_reduceat = np.add.reduceat(s, i)
+        check_add_reduceat = np.add.reduceat(check, i)
+        assert np.all(s_add_reduceat.value == check_add_reduceat)
+        assert s_add_reduceat.unit is u.m
+
+        # reduce(at) or accumulate on comparisons makes no sense,
+        # as intermediate result is not even a Quantity
+        with pytest.raises(TypeError):
+            np.greater.reduce(s)
+
+        with pytest.raises(TypeError):
+            np.greater.accumulate(s)
+
+        with pytest.raises(TypeError):
+            np.greater.reduceat(s, i)
+
+        # raise UnitsError if unit would have to be changed
+        with pytest.raises(u.UnitsError):
+            np.multiply.reduce(s)
+
+        with pytest.raises(u.UnitsError):
+            np.multiply.accumulate(s)
+
+        with pytest.raises(u.UnitsError):
+            np.multiply.reduceat(s)
+
+        # but be fine if it does not
+        s = np.arange(10.) * u.dimensionless_unscaled
+        check = s.value.copy()
+        s_multiply_reduce = np.multiply.reduce(s)
+        check_multiply_reduce = np.multiply.reduce(check)
+        assert s_multiply_reduce.value == check_multiply_reduce
+        assert s_multiply_reduce.unit is u.dimensionless_unscaled
+        s_multiply_accumulate = np.multiply.accumulate(s)
+        check_multiply_accumulate = np.multiply.accumulate(check)
+        assert np.all(s_multiply_accumulate.value == check_multiply_accumulate)
+        assert s_multiply_accumulate.unit is u.dimensionless_unscaled
+        s_multiply_reduceat = np.multiply.reduceat(s, i)
+        check_multiply_reduceat = np.multiply.reduceat(check, i)
+        assert np.all(s_multiply_reduceat.value == check_multiply_reduceat)
+        assert s_multiply_reduceat.unit is u.dimensionless_unscaled
+
+
+@pytest.mark.xfail("NUMPY_LT_1_10")
+class TestUfuncOuter(object):
+    """Test 'outer' methods for ufuncs
+
+    Just a few spot checks, since it uses the same code as the regular
+    ufunc call
+    """
+    def test_one_argument_ufunc_outer(self):
+        # one argument cannot be used
+        s = np.arange(10.) * u.radian
+        with pytest.raises(ValueError):
+            np.sin.outer(s)
+
+    def test_two_argument_ufunc_outer(self):
+        s1 = np.arange(10.) * u.m
+        s2 = np.arange(2.) * u.s
+        check1 = s1.value
+        check2 = s2.value
+        s12_multiply_outer = np.multiply.outer(s1, s2)
+        check12_multiply_outer = np.multiply.outer(check1, check2)
+        assert np.all(s12_multiply_outer.value == check12_multiply_outer)
+        assert s12_multiply_outer.unit == s1.unit * s2.unit
+
+        # raise UnitsError if appropriate
+        with pytest.raises(u.UnitsError):
+            np.add.outer(s1, s2)
+
+        # but be fine if it does not
+        s3 = np.arange(2.) * s1.unit
+        check3 = s3.value
+        s13_add_outer = np.add.outer(s1, s3)
+        check13_add_outer = np.add.outer(check1, check3)
+        assert np.all(s13_add_outer.value == check13_add_outer)
+        assert s13_add_outer.unit is s1.unit
+
+        s13_greater_outer = np.greater.outer(s1, s3)
+        check13_greater_outer = np.greater.outer(check1, check3)
+        assert type(s13_greater_outer) is np.ndarray
+        assert np.all(s13_greater_outer == check13_greater_outer)

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,7 @@ from ...utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_6_1', 'NUMPY_LT_1_7', 'NUMPY_LT_1_8', 'NUMPY_LT_1_9',
-           'NUMPY_LT_1_9_1']
+           'NUMPY_LT_1_9_1', 'NUMPY_LT_1_10']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -20,6 +20,7 @@ NUMPY_LT_1_7 = not minversion('numpy', '1.7.0')
 NUMPY_LT_1_8 = not minversion('numpy', '1.8.0')
 NUMPY_LT_1_9 = not minversion('numpy', '1.9.0')
 NUMPY_LT_1_9_1 = not minversion('numpy', '1.9.1')
+NUMPY_LT_1_10 = not minversion('numpy', '1.10.*')
 
 
 def _monkeypatch_unicode_mask_fill_values():

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -20,7 +20,7 @@ NUMPY_LT_1_7 = not minversion('numpy', '1.7.0')
 NUMPY_LT_1_8 = not minversion('numpy', '1.8.0')
 NUMPY_LT_1_9 = not minversion('numpy', '1.9.0')
 NUMPY_LT_1_9_1 = not minversion('numpy', '1.9.1')
-NUMPY_LT_1_10 = not minversion('numpy', '1.10.*')
+NUMPY_LT_1_10 = not minversion('numpy', '1.9.9999', inclusive=False)
 
 
 def _monkeypatch_unicode_mask_fill_values():


### PR DESCRIPTION
This follows on the introdoction of `__numpy_ufunc__` in #2583 (so only look at last commit), adding support to `Quantity` for ufunc methods [1]: `ufunc.at`, `reduce`, `reduceat`, `accumulate`, and `outer`. It think it will be useful, though one problem is that I do not know how to support this without `__numpy_ufunc__`; thus, it will only work in numpy >=1.10.

[1] http://docs.scipy.org/doc/numpy/reference/ufuncs.html#methods
