### PR TITLE
FITS objects created with `fromstring` have problems?

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -260,6 +260,10 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed a crash when reading scaled float data out of a FITS file that was
+    loaded from a string (using ``HDUList.fromfile``) rather than from a file.
+    [#2710]
+
   - Fixed a crash when reading data from an HDU whose header contained in
     invalid value for the BLANK keyword (eg. a string value instead of an
     integer as required by the FITS Standard). Invalid BLANK keywords are now

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -616,7 +616,10 @@ class _ImageBaseHDU(_ValidHDU):
             if new_dtype is not None:
                 data = np.array(raw_data, dtype=new_dtype)
             else:  # floating point cases
-                if self._file.memmap:
+                if self._file is not None and self._file.memmap:
+                    data = raw_data.copy()
+                elif not raw_data.flags.writeable:
+                    # create a writeable copy if needed
                     data = raw_data.copy()
                 # if not memmap, use the space already in memory
                 else:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -809,6 +809,24 @@ class TestImageFunctions(FitsTestCase):
         msg = "Invalid 'BLANK' keyword"
         assert msg in str(w[1].message)
 
+    def test_scaled_image_fromfile(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/2710
+        """
+
+        # Make some sample data
+        a = np.arange(100, dtype=np.float32)
+
+        hdu = fits.PrimaryHDU(data=a.copy())
+        hdu.scale(bscale=1.1)
+        hdu.writeto(self.temp('test.fits'))
+
+        with open(self.temp('test.fits'), 'rb') as f:
+            file_data = f.read()
+
+        hdul = fits.HDUList.fromstring(file_data)
+        assert np.allclose(hdul[0].data, a)
+
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):


### PR DESCRIPTION
I have some FITS objects being created from strings.  I can't access their `data` attribute.  I think it has to do with `_orig_bitpix` being negative, possibly, but I'm not sure.  @embray any thoughts?  I can provide an example if needed.

```
In [32]: blah._orig_bitpix
Out[32]: -32

In [33]: blah.data
Traceback (most recent call last):
  File "<ipython-input-33-dd8ff7218a27>", line 1, in <module>
    blah.data
  File "/Users/adam/repos/astropy/astropy/utils/misc.py", line 286, in __get__
    val = self._fget(obj)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/image.py", line 218, in data
    data = self._get_scaled_image_data(self._data_offset, self.shape)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/image.py", line 594, in _get_scaled_image_data
    if self._file.memmap:
AttributeError: 'NoneType' object has no attribute 'memmap'

> /Users/adam/repos/astropy/astropy/io/fits/hdu/image.py(594)_get_scaled_image_data()
    593             else:  # floating point cases
--> 594                 if self._file.memmap:
    595                     data = raw_data.copy()
```
