### PR TITLE
Fix a small syntactic typo in tokenizer.c

### DIFF
--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -680,7 +680,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
             ++exponent;
 
         p++;
-        p += (tsep != '\0' & *p == tsep);
+        p += (tsep != '\0' && *p == tsep);
     }
 
     // Process decimal part


### PR DESCRIPTION
This fix should be logically equivalent, but I don't think "bitwise and"
was really intended here, and gcc 4.8.3 warns about it:

```
astropy/io/ascii/src/tokenizer.c:683:20: warning: suggest parentheses around comparison in operand of ‘&’ [-Wparentheses]
     p += (tsep != '\0' & *p == tsep);
```
