### PR TITLE
Coordinates PEP-8

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -880,8 +880,9 @@ class BaseCoordinateFrame(object):
 
         # attr == '_representation' is likely from the hasattr() test in the
         # representation property which is used for
-        # self.representation_component_names.  Prevent infinite recursion
-        # here.
+        # self.representation_component_names.
+        #
+        # Prevent infinite recursion here.
         if (attr == '_representation' or
                 attr not in self.representation_component_names):
             raise AttributeError("'{0}' object has no attribute '{1}'"


### PR DESCRIPTION
With apologies in advance, a little bit of what I would consider "cleanup" of the baseframe module, much of which I found hard to read.  I apologize because a lot of this is highly subjective any if there's anything the original authors of that module object to I'm happy to reverse the change.

Mostly this is just shortening some of the lines (not even all of them--just some that I found hard to read personally.  I think some of these changes make the code more stylistically consistent with most of the other modules in Astropy.

I wanted to do this before working on #2845, though I'll keep the PR for that issue independent of these changes.
