### PR TITLE
New jsviewer css

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ New Features
     columns that allow the column values to be easily converted to
     ``astropy.units.Quantity`` objects. [#2950]
 
+  - New CSS for jsviewer table [#2917]
+  
 - ``astropy.time``
 
 - ``astropy.units``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,11 +74,7 @@ New Features
     browsing capabilities. To write out to this format, use
     ``Table.write('filename.html', format='jsviewer')``. [#2875]
 
-  - A ``quantity`` property and ``to`` method were added to ``Table``
-    columns that allow the column values to be easily converted to
-    ``astropy.units.Quantity`` objects. [#2950]
-
-  - New CSS for jsviewer table [#2917]
+  - New CSS for jsviewer table [#2917, #2982]
   
 - ``astropy.time``
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -352,7 +352,10 @@ class HTML(core.BaseReader):
                     html_table_id = None
                 if 'table_class' in self.html:
                     html_table_class = self.html['table_class']
-                with w.tag('table', id=html_table_id, attrib={"class":html_table_class}):
+                    attrib={"class":html_table_class}
+                else:
+                    attrib={}
+                with w.tag('table', id=html_table_id, attrib=attrib):
                     with w.tag('thead'):
                         with w.tag('tr'):
                             for col in cols:

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -279,7 +279,7 @@ class HTML(core.BaseReader):
         * cssfiles : list of css files to include when writing table.
 
         * js : js script to include in the body when writing table.
-        
+
         * table_class : css class for the table
     """
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -279,6 +279,8 @@ class HTML(core.BaseReader):
         * cssfiles : list of css files to include when writing table.
 
         * js : js script to include in the body when writing table.
+        
+        * table_class : css class for the table
     """
 
     _format_name = 'html'
@@ -348,7 +350,9 @@ class HTML(core.BaseReader):
                     html_table_id = self.html['table_id']
                 else:
                     html_table_id = None
-                with w.tag('table', id=html_table_id):
+                if 'table_class' in self.html:
+                    html_table_class = self.html['table_class']
+                with w.tag('table', id=html_table_id, attrib={"class":html_table_class}):
                     with w.tag('thead'):
                         with w.tag('tr'):
                             for col in cols:

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -26,7 +26,7 @@ class Conf(_config.ConfigNamespace):
         'The URL to the jquery datatables library.')
 
     css_urls = _config.ConfigItem(
-        ['https://code.jquery.com/ui/1.11.1/themes/overcast/jquery-ui.css'],
+        ['https://cdn.datatables.net/1.10.2/css/jquery.dataTables.css'],
         'The URLs to the css file(s) to include.', cfgtype='list')
 
 
@@ -70,8 +70,7 @@ IPYNB_JS_SCRIPT = """
         $('#{tid}').dataTable({{
              "iDisplayLength": {display_length},
              "aLengthMenu": {display_length_menu},
-             "bJQueryUI": true,
-             "sPaginationType": "full_numbers"
+             "pagingType": "full_numbers"
         }});
     }}
     function replace_table() {{
@@ -88,8 +87,7 @@ $(document).ready(function() {{
     $('#{tid}').dataTable({{
      "iDisplayLength": {display_length},
      "aLengthMenu": {display_length_menu},
-     "bJQueryUI": true,
-     "sPaginationType": "full_numbers"
+     "pagingType": "full_numbers"
     }});
 }} );
 """
@@ -162,10 +160,13 @@ def write_table_jsviewer(table, filename, table_id=None,
     if table_id is None:
         table_id = 'table{id}'.format(id=id(table))
 
+    table_class = "cell-border compact strip hover order-column" #Nice defaults
+
     jsv = JSViewer(**jskwargs)
 
     htmldict = {}
     htmldict['table_id'] = table_id
+    htmldict['table_class'] = table_class
     htmldict['css'] = css
     htmldict['cssfiles'] = jsv.css_urls
     htmldict['jsfiles'] = jsv.jquery_urls

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -153,7 +153,7 @@ class JSViewer(object):
 
 
 def write_table_jsviewer(table, filename, table_id=None,
-                         css="table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}",
+                         css="table,th,td,tr,tbody {}",
                          max_lines=5000,
                          jskwargs={}):
 

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -153,7 +153,7 @@ class JSViewer(object):
 
 
 def write_table_jsviewer(table, filename, table_id=None,
-                         css="table,th,td,tr,tbody {}",
+                         css="table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}",
                          max_lines=5000,
                          jskwargs={}):
 

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -7,7 +7,7 @@ REFERENCE = """
   <meta content="text/html;charset=UTF-8" http-equiv="Content-type"/>
   <style>
 table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}  </style>
-  <link href="https://code.jquery.com/ui/1.11.1/themes/overcast/jquery-ui.css" rel="stylesheet" type="text/css"/>
+  <link href="https://cdn.datatables.net/1.10.2/css/jquery.dataTables.css" rel="stylesheet" type="text/css"/>
   <script src="http://code.jquery.com/jquery-1.11.1.min.js">
   </script>
   <script src="http://cdn.datatables.net/1.10.2/js/jquery.dataTables.min.js">
@@ -19,11 +19,10 @@ $(document).ready(function() {
     $('#test').dataTable({
      "iDisplayLength": 50,
      "aLengthMenu": [[10, 25, 50, 100, 500, 1000, -1], [10, 25, 50, 100, 500, 1000, 'All']],
-     "bJQueryUI": true,
-     "sPaginationType": "full_numbers"
+     "pagingType": "full_numbers"
     });
 } );  </script>
-  <table id="test">
+  <table class="cell-border compact strip hover order-column" id="test">
    <thead>
     <tr>
      <th>a</th>


### PR DESCRIPTION
In response to #2917, I have swapped in a lighter-weight CSS for the jsviewer table output. This also has some features like subtle row-highlighting (based on mouse-over) and column-highlighting (based on sort). Here's a short example (sorted on nobs and hovering over the 5th row).

![example-new-table](https://cloud.githubusercontent.com/assets/3639698/4412535/f4730b7c-44f9-11e4-86e2-76e9b3a35021.png)

The only problem is that I had to remove the in-line table styling https://github.com/jfoster17/astropy/commit/c1ea7b79fda2956d61019d42721b731185dcffd6
in order to make this table style look nice, which means that if the CSS doesn't load from the remote server, the fallback styling is normally pretty bad (this is browser/configuration dependent).  Perhaps someone else knows how to fix this?