### PR TITLE
Tests with TEST_UNICODE_LITERALS don't report errors correctly

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -597,7 +597,7 @@ class ModifiedModule(pytest.Module):
     def _importtestmodule(self):
         # We have to remove the __future__ statements *before* parsing
         # with compile, otherwise the flags are ignored.
-        content = re.sub(_RE_FUTURE_IMPORTS, b'', self.content)
+        content = re.sub(_RE_FUTURE_IMPORTS, b'\n', self.content)
 
         new_mod = types.ModuleType(self.mod_name)
         new_mod.__file__ = six.text_type(self.fspath)


### PR DESCRIPTION
I noticed this while working on #2981 but have seen it a couple other times.

For a test that uses the `#TEST_UNICODE_LITERALS` plugin to test with and without unicode literals, the py.test reporting doesn't work.  If `#TEST_UNICODE_LITERALS` is in, all errors yield this:

```
E       AssertionError: (assertion failed, but when it was re-run for printing intermediate values, it did not fail.  Suggestions: compute assert expression before the assert or use --assert=plain)
```

This is particularly annoying in situations like #2981 where it's not easy for me to get one of the travis environments going locally.

@mdboom, I think you wrote `TEST_UNICODE_LITERALS`, right?  Any idea what's going on here?
