### PR TITLE
SkyCoord array does not work with float32

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -308,6 +308,8 @@ Bug Fixes
   - The ``Distance`` class has been fixed to no longer rely on the deprecated
     cosmology functions. [#2991]
 
+  - Ensure ``float32`` values can be used in coordinate representations. [#2983]
+
 - ``astropy.cosmology``
 
   - The ``ztol`` keyword argument to z_at_value now works correctly [#2993].

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -140,7 +140,7 @@ class BaseRepresentation(object):
         """
         allcomp = np.array([getattr(self, component).value
                             for component in self.components])
-        dtype = np.dtype([(str(component), np.float)
+        dtype = np.dtype([(str(component), getattr(self, component).dtype)
                           for component in self.components])
         return (np.rollaxis(allcomp, 0, len(allcomp.shape))
                 .copy().view(dtype).squeeze())

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -91,6 +91,16 @@ class TestSphericalRepresentation(object):
         assert_allclose_quantity(lat, s1.lat)
         assert_allclose_quantity(distance, s1.distance)
 
+    def test_init_float32_array(self):
+        """Regression test against #2983"""
+        lon = Longitude(np.float32([1., 2.]), u.degree)
+        lat = Latitude(np.float32([3., 4.]), u.degree)
+        s1 = UnitSphericalRepresentation(lon=lon, lat=lat, copy=False)
+        assert s1.lon.dtype == np.float32
+        assert s1.lat.dtype == np.float32
+        assert s1._values['lon'].dtype == np.float32
+        assert s1._values['lat'].dtype == np.float32
+
     def test_reprobj(self):
 
         s1 = SphericalRepresentation(lon=8 * u.hourangle, lat=5 * u.deg, distance=10 * u.kpc)


### PR DESCRIPTION
If I have a numpy.float32 array I cannot initiate a SkyCoords array, but get an error. I have to manually cast it to numpy.float64 first (when loading arrays from fits you often get float32 arrays).
Example:

```
from astropy import units
from astropy.coordinates import SkyCoord
import numpy as np

coords = SkyCoord(ra=np.float32([1,2])*units.degree, dec=np.float32([3,4])*units.degree, frame='icrs')
print coords
```

results in: "ValueError: new type not compatible with array."
