### PR TITLE
Change spherical<->cartesian conversions to a representation-based implementation

### DIFF
--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -19,5 +19,6 @@ from .name_resolve import *
 from .matching import *
 from .representation import *
 from .sky_coordinate import *
+from .funcs import *
 
 __doc__ += builtin_frames._transform_graph_docs

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -4,18 +4,14 @@
 This module contains the classes and utility functions for distance and
 cartesian coordinates.
 """
-
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
-import math
 
 import numpy as np
 
 from .. import units as u
-from ..utils import deprecated
 
-__all__ = ['Distance', 'cartesian_to_spherical', 'spherical_to_cartesian']
+__all__ = ['Distance']
 
 
 __doctest_requires__ = {'*': ['scipy.integrate']}
@@ -218,103 +214,3 @@ def _convert_to_and_validate_length_unit(unit, allow_dimensionless=False):
 
     return unit
 
-#<------------transformation-related utility functions----------------->
-
-
-def cartesian_to_spherical(x, y, z):
-    """
-    Converts 3D rectangular cartesian coordinates to spherical polar
-    coordinates.
-
-    Note that the resulting angles are latitude/longitude or
-    elevation/azimuthal form.  I.e., the origin is along the equator
-    rather than at the north pole.
-
-    .. note::
-        This is a low-level function used internally in
-        `astropy.coordinates`.  It is provided for users if they really
-        want to use it, but it is recommended that you use the
-        `astropy.coordinates` coordinate systems.
-
-    Parameters
-    ----------
-    x : scalar or array-like
-        The first cartesian coordinate.
-    y : scalar or array-like
-        The second cartesian coordinate.
-    z : scalar or array-like
-        The third cartesian coordinate.
-
-    Returns
-    -------
-    r : float or array
-        The radial coordinate (in the same units as the inputs).
-    lat : float or array
-        The latitude in radians
-    lon : float or array
-        The longitude in radians
-    """
-
-    xsq = x ** 2
-    ysq = y ** 2
-    zsq = z ** 2
-
-    r = (xsq + ysq + zsq) ** 0.5
-    s = (xsq + ysq) ** 0.5
-
-    if np.isscalar(x) and np.isscalar(y) and np.isscalar(z):
-        lon = math.atan2(y, x)
-        lat = math.atan2(z, s)
-    else:
-        lon = np.arctan2(y, x)
-        lat = np.arctan2(z, s)
-
-    return r, lat, lon
-
-
-def spherical_to_cartesian(r, lat, lon):
-    """
-    Converts spherical polar coordinates to rectangular cartesian
-    coordinates.
-
-    Note that the input angles should be in latitude/longitude or
-    elevation/azimuthal form.  I.e., the origin is along the equator
-    rather than at the north pole.
-
-    .. note::
-        This is a low-level function used internally in
-        `astropy.coordinates`.  It is provided for users if they really
-        want to use it, but it is recommended that you use the
-        `astropy.coordinates` coordinate systems.
-
-    Parameters
-    ----------
-    r : scalar or array-like
-        The radial coordinate (in the same units as the inputs).
-    lat : scalar or array-like
-        The latitude in radians
-    lon : scalar or array-like
-        The longitude in radians
-
-    Returns
-    -------
-    x : float or array
-        The first cartesian coordinate.
-    y : float or array
-        The second cartesian coordinate.
-    z : float or array
-        The third cartesian coordinate.
-
-
-    """
-
-    if np.isscalar(r) and np.isscalar(lat) and np.isscalar(lon):
-        x = r * math.cos(lat) * math.cos(lon)
-        y = r * math.cos(lat) * math.sin(lon)
-        z = r * math.sin(lat)
-    else:
-        x = r * np.cos(lat) * np.cos(lon)
-        y = r * np.cos(lat) * np.sin(lon)
-        z = r * np.sin(lat)
-
-    return x, y, z

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -1,0 +1,118 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+This module contains convinience functions for coordinate-related functionality.
+
+This is generally just wrapping around the object-oriented coordinates
+framework, but it is useful for some users who are used to more functional
+interfaces.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from .. import units as u
+
+__all__ = ['cartesian_to_spherical', 'spherical_to_cartesian']
+
+
+def cartesian_to_spherical(x, y, z):
+    """
+    Converts 3D rectangular cartesian coordinates to spherical polar
+    coordinates.
+
+    Note that the resulting angles are latitude/longitude or
+    elevation/azimuthal form.  I.e., the origin is along the equator
+    rather than at the north pole.
+
+    .. note::
+        This function simply wraps functionality provided by the
+        `~astropy.coordinates.CartesianRepresentation` and
+        `~astropy.coordinates.SphericalRepresentation` classes.  In general,
+        for both performance and readability, we suggest using these classes
+        directly.  But for situations where a quick one-off conversion makes
+        sense, this function is provided.
+
+    Parameters
+    ----------
+    x : scalar, array-like, or `~astropy.units.Quantity`
+        The first cartesian coordinate.
+    y : scalar, array-like, or `~astropy.units.Quantity`
+        The second cartesian coordinate.
+    z : scalar, array-like, or `~astropy.units.Quantity`
+        The third cartesian coordinate.
+
+    Returns
+    -------
+    r : `~astropy.units.Quantity`
+        The radial coordinate (in the same units as the inputs).
+    lat : `~astropy.units.Quantity`
+        The latitude in radians
+    lon : `~astropy.units.Quantity`
+        The longitude in radians
+    """
+    from .representation import SphericalRepresentation, CartesianRepresentation
+
+    if not hasattr(x, 'unit'):
+        x = x * u.dimensionless_unscaled
+    if not hasattr(y, 'unit'):
+        y = y * u.dimensionless_unscaled
+    if not hasattr(z, 'unit'):
+        z = z * u.dimensionless_unscaled
+
+    cart = CartesianRepresentation(x, y, z)
+    sph = cart.represent_as(SphericalRepresentation)
+
+    return sph.distance, sph.lat, sph.lon
+
+
+def spherical_to_cartesian(r, lat, lon):
+    """
+    Converts spherical polar coordinates to rectangular cartesian
+    coordinates.
+
+    Note that the input angles should be in latitude/longitude or
+    elevation/azimuthal form.  I.e., the origin is along the equator
+    rather than at the north pole.
+
+    .. note::
+        This is a low-level function used internally in
+        `astropy.coordinates`.  It is provided for users if they really
+        want to use it, but it is recommended that you use the
+        `astropy.coordinates` coordinate systems.
+
+    Parameters
+    ----------
+    r : scalar, array-like, or `~astropy.units.Quantity`
+        The radial coordinate (in the same units as the inputs).
+    lat : scalar, array-like, or `~astropy.units.Quantity`
+        The latitude (in radians if array or scalar)
+    lon : scalar, array-like, or `~astropy.units.Quantity`
+        The longitude (in radians if array or scalar)
+
+    Returns
+    -------
+    x : float or array
+        The first cartesian coordinate.
+    y : float or array
+        The second cartesian coordinate.
+    z : float or array
+        The third cartesian coordinate.
+
+
+    """
+    from .representation import SphericalRepresentation, CartesianRepresentation
+
+    if not hasattr(r, 'unit'):
+        r = r * u.dimensionless_unscaled
+    if not hasattr(lat, 'unit'):
+        lat = lat * u.radian
+    if not hasattr(lon, 'unit'):
+        lon = lon * u.radian
+
+    sph = SphericalRepresentation(distance=r, lat=lat, lon=lon)
+    cart = sph.represent_as(CartesianRepresentation)
+
+    return cart.x, cart.y, cart.z

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -140,8 +140,7 @@ def test_sphere_cart():
     """
     from numpy.testing.utils import assert_allclose
     from ...utils import NumpyRNGContext
-    from ..distances import spherical_to_cartesian, cartesian_to_spherical
-
+    from .. import spherical_to_cartesian, cartesian_to_spherical
 
     x, y, z = spherical_to_cartesian(1, 0, 0)
     npt.assert_allclose(x, 1)


### PR DESCRIPTION
This is a a way to close #2988 by making the `spherical_to_cartesian` and `cartesian_to_spherical` long-lived "convinience functions" instead of deprecating them.  In the process it also changes them to use the representation classes as the implementation.  See the discussion in #2988 for more on this.
