### PR TITLE
Make InheritDocstrings work for __call__

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -492,9 +492,15 @@ class InheritDocstrings(type):
         u'Wiggle the thingamajig'
     """
     def __init__(cls, name, bases, dct):
+        def is_public_member(key):
+            return (
+                (key.startswith('__') and key.endswith('__')
+                 and len(key) > 4) or
+                not key.startswith('_'))
+
         for key, val in six.iteritems(dct):
             if (inspect.isfunction(val) and
-                not key.startswith('_') and
+                is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:
                     super_method = getattr(base, key, None)

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from .. import data, misc
 from ...tests.helper import remote_data
+from ...extern import six
 
 
 def test_isiterable():
@@ -51,3 +52,17 @@ def test_JsonCustomEncoder():
                       cls=misc.JsonCustomEncoder) == '"hello world \\u00c5"'
     assert json.dumps({1: 2},
                       cls=misc.JsonCustomEncoder) == '{"1": 2}'  # default
+
+
+def test_inherit_docstrings():
+    @six.add_metaclass(misc.InheritDocstrings)
+    class Base(object):
+        def __call__(self, *args):
+            "FOO"
+            pass
+
+    class Subclass(Base):
+        def __call__(self, *args):
+            pass
+
+    assert Subclass.__call__.__doc__ == "FOO"


### PR DESCRIPTION
At the moment, InheritDocstrings ignores any hidden method:

https://github.com/astropy/astropy/blob/master/astropy/utils/misc.py#L497

which means `__call__`, but it would be nice for that to work since `__call__` can appear in API documentation. Can we add an exception for `__call__`?
