### PR TITLE
hstack fails with duplicate column names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -237,6 +237,9 @@ Bug Fixes
 
 - ``astropy.table``
 
+  - Fix a problem where ``table.hstack`` fails to stack multiple references to
+    the same table, e.g. ``table.hstack([t, t])``. [#2995]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -74,7 +74,8 @@ def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name
             else:
                 # If name is not one of the common column outputs, and it collides
                 # with the names in one of the other arrays, then rename
-                others = (x for x in arrays if x is not array)
+                others = list(arrays)
+                others.pop(idx)
                 if any(name in other.dtype.names for other in others):
                     out_name = uniq_col_name.format(table_name=table_name, col_name=name)
                 col_name_list.append(out_name)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -608,6 +608,17 @@ class TestHStack():
                                        ('a', 1),
                                        ('e', 1)])
 
+    def test_stack_same_table(self):
+        """
+        From #2995, test that hstack'ing references to the same table has the
+        expected output.
+        """
+        out = table.hstack([self.t1, self.t1])
+        assert out.pformat() == ['a_1 b_1 a_2 b_2',
+                                 '--- --- --- ---',
+                                 '  0 foo   0 foo',
+                                 '  1 bar   1 bar']
+
     def test_stack_rows(self):
         out = table.hstack([self.t1[0], self.t2[1]])
         assert out.pformat() == ['a_1 b_1 a_2 b_2  c ',


### PR DESCRIPTION
Haven't had a chance to look in detail yet, but the following example should not fail:

```
In [14]: t = Table()

In [15]: t['a'] = [1,2,3]

In [16]: hstack([t,t], table_names=['1', '2'])
...
TableMergeError: Merging column names resulted in duplicates: ['a'].  Change uniq_col_name or table_names args to fix this.
```

because in principle, the columns should get renamed (according to the docstring).

cc @taldcroft 
