### PR TITLE
Rename parameters for Shift and Scale models

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -344,26 +344,24 @@ class Shift(Model):
 
     Parameters
     ----------
-    offsets : float or a list of floats
-        offsets to be applied to a coordinate
-        if a list - each value in the list is an offset to be applied to a
-        column in the input coordinate array
+    offset : float
+        Offset to add to a coordinate.
     """
 
     inputs = ('x',)
     outputs = ('x',)
 
-    offsets = Parameter()
+    offset = Parameter()
 
     @property
     def inverse(self):
         inv = self.copy()
-        inv.offsets *= -1
+        inv.offset *= -1
         return inv
 
     @staticmethod
-    def evaluate(x, offsets):
-        return x + offsets
+    def evaluate(x, offset):
+        return x + offset
 
 
 class Scale(Model):
@@ -372,25 +370,25 @@ class Scale(Model):
 
     Parameters
     ----------
-    factors : float or a list of floats
-        scale for a coordinate
+    factor : float
+        Factor by which to scale a coordinate.
     """
 
     inputs = ('x',)
     outputs = ('x',)
 
-    factors = Parameter()
+    factor = Parameter()
     linear = True
 
     @property
     def inverse(self):
         inv = self.copy()
-        inv.factors = 1 / self.factors
+        inv.factor = 1 / self.factor
         return inv
 
     @staticmethod
-    def evaluate(x, factors):
-        return factors * x
+    def evaluate(x, factor):
+        return factor * x
 
 
 class Redshift(Fittable1DModel):

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -124,3 +124,13 @@ def test_Ellipse2D():
     e1 = models.Ellipse2D(amplitude, x0, y0, 7, 3, theta=0.)
     e2 = models.Ellipse2D(amplitude, x0, y0, 7, 3, theta=theta.radian)
     assert e1(*point1) == e2(*point2)
+
+
+def test_Scale_inverse():
+    m = models.Scale(1.2345)
+    assert_allclose(m.inverse(m(6.789)), 6.789)
+
+
+def test_Shift_inverse():
+    m = models.Shift(1.2345)
+    assert_allclose(m.inverse(m(6.789)), 6.789)

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -279,20 +279,22 @@ class TestParameters(object):
         utils.assert_equal(p2.parameters, [2, 3, 1, 2, 4, 5,
                                            1, 1, 2, 2, 5, 5])
 
-    def test_non_fittable_model_parameters1d(self):
+    def test_shift_model_parameters1d(self):
         sh1 = models.Shift(2)
-        sh1.offsets = 3
-        assert(sh1.offsets == 3)
+        sh1.offset = 3
+        assert sh1.offset == 3
+        assert sh1.offset.value == 3
 
-    def test_non_fittable_model_parametersnd(self):
+    def test_scale_model_parametersnd(self):
         sc1 = models.Scale([2, 2])
-        sc1.factors = [3, 3]
-        assert(sc1.factors == [3, 3])
+        sc1.factor = [3, 3]
+        assert sc1.factor == [3, 3]
+        utils.assert_array_equal(sc1.factor.value, [3, 3])
 
-    def test_non_fittable_model_parameters_wrong_shape(self):
+    def test_parameters_wrong_shape(self):
         sh1 = models.Shift(2)
         with pytest.raises(InputParameterError):
-            sh1.offsets = [3, 3]
+            sh1.offset = [3, 3]
 
 
 class TestMultipleParameterSets(object):


### PR DESCRIPTION
The (very basic) [`Shift`](http://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Shift.html#astropy.modeling.functional_models.Shift) model takes one parameter called `offsets`.  The plural name was to indicate that it could take a list of offsets, and that calling the shift model on an array-like input could shift each element in the array by a different offset.  For example:

``` python
>>> s = Shift([1, 2, 3])
>>> s([4, 5, 6])
array([ 5.,  7.,  9.])
```

Previously this capability was a feature only supported in some "special" cases like the `Shift` and `Scale` models.  But since #2634 that sort of capability was generalized to all models in the framework.  So it doesn't make sense to single out these two models, or to pluralize the names of their parameters (since none of the other models use plurals).

I can add backward-compatibility for the old names if needed, but I don't know how much code is relying on this yet.

Also added a couple fairly trivial tests for code in these models that wasn't tested directly.
