### PR TITLE
Define more parameter defaults for models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -328,6 +328,14 @@ API Changes
     signature, so these methods should only be overridden by ``Model``
     subclasses in order to provide new functionality. [#2835]
 
+  - Most models included in Astropy now have sensible default values for most
+    or all of their parameters.  Call ``help(ModelClass)`` on any model to
+    check what those defaults are.  Most of them time they should be
+    overridden, but some of them are useful (for example spatial offsets are
+    always set at the origin by default). Another rule of thumb is that, where
+    possible, default parameters are set so that the model is a no-op, or
+    close to it, by default. [#2932]
+
   - The ``Model.inverse`` method has been changed to a *property*, so that
     now accessing ``model.inverse`` on a model returns a new model that
     implements that model's inverse, and *calling* ``model.inverse(...)``` on

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -531,10 +531,19 @@ class Model(object):
     fittable = False
     linear = True
 
-    _custom_inverse = None
-
     meta = metadata.MetaData()
     """A dict-like object to store optional information."""
+
+    # By default models either use their own inverse property or have no
+    # inverse at all, but users my also assign a custom inverse to a model,
+    # optionally; in that case it is of course up to the user to determine
+    # whether their inverse is *actually* an inverse to the model they assign
+    # it to.
+    _custom_inverse = None
+
+    # Default n_models attribute, so that __len__ is still defined even when a
+    # model hasn't completed initialization yet
+    _n_models = 1
 
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -91,9 +91,9 @@ class Gaussian1D(Fittable1DModel):
     Gaussian2D, Box1D, Moffat1D, Lorentz1D
     """
 
-    amplitude = Parameter()
-    mean = Parameter()
-    stddev = Parameter()
+    amplitude = Parameter(default=1)
+    mean = Parameter(default=0)
+    stddev = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, mean, stddev):
@@ -139,9 +139,9 @@ class GaussianAbsorption1D(Fittable1DModel):
     Gaussian1D
     """
 
-    amplitude = Parameter()
-    mean = Parameter()
-    stddev = Parameter()
+    amplitude = Parameter(default=1)
+    mean = Parameter(default=0)
+    stddev = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, mean, stddev):
@@ -237,15 +237,17 @@ class Gaussian2D(Fittable2DModel):
     .. [1] http://en.wikipedia.org/wiki/Gaussian_function
     """
 
-    amplitude = Parameter()
-    x_mean = Parameter()
-    y_mean = Parameter()
-    x_stddev = Parameter()
-    y_stddev = Parameter()
-    theta = Parameter(default=0.0)
+    amplitude = Parameter(default=1)
+    x_mean = Parameter(default=0)
+    y_mean = Parameter(default=0)
+    x_stddev = Parameter(default=1)
+    y_stddev = Parameter(default=1)
+    theta = Parameter(default=0)
 
-    def __init__(self, amplitude, x_mean, y_mean, x_stddev=None, y_stddev=None,
-                 theta=theta.default, cov_matrix=None, **kwargs):
+
+    def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
+                 y_mean=y_mean.default, x_stddev=None, y_stddev=None,
+                 theta=0.0, cov_matrix=None, **kwargs):
         if y_stddev is None and cov_matrix is None:
             raise InputParameterError(
                 "Either x/y_stddev must be specified, or a "
@@ -261,9 +263,19 @@ class Gaussian2D(Fittable2DModel):
 
         # Compute principle coordinate system transformation
         elif cov_matrix is not None:
+            if (x_stddev is not None or y_stddev is not None):
+                raise InputParameterError(
+                    "Cannot specify both cov_matrix and x/y_stddev")
+            # Compute principle coordinate system transformation
             cov_matrix = np.array(cov_matrix)
+
             if cov_matrix.shape != (2, 2):
+                # TODO: Maybe it should be possible for the covariance matrix
+                # to be some (x, y, ..., z, 2, 2) array to be broadcast with
+                # other paramters of shape (x, y, ..., z)
+                # But that's maybe a special case to work out if/when needed
                 raise ValueError("Covariance matrix must be 2x2")
+
             eig_vals, eig_vecs = np.linalg.eig(cov_matrix)
             x_stddev, y_stddev = np.sqrt(eig_vals)
             y_vec = eig_vecs[:, 0]
@@ -351,7 +363,7 @@ class Shift(Model):
     inputs = ('x',)
     outputs = ('x',)
 
-    offset = Parameter()
+    offset = Parameter(default=0)
 
     @property
     def inverse(self):
@@ -377,7 +389,7 @@ class Scale(Model):
     inputs = ('x',)
     outputs = ('x',)
 
-    factor = Parameter()
+    factor = Parameter(default=1)
     linear = True
 
     @property
@@ -408,7 +420,7 @@ class Redshift(Fittable1DModel):
 
     """
 
-    z = Parameter(description='redshift')
+    z = Parameter(description='redshift', default=0)
 
     @staticmethod
     def evaluate(x, z):
@@ -454,8 +466,8 @@ class Sine1D(Fittable1DModel):
         .. math:: f(x) = A \\sin(2 \\pi f x)
     """
 
-    amplitude = Parameter()
-    frequency = Parameter()
+    amplitude = Parameter(default=1)
+    frequency = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, frequency):
@@ -496,8 +508,8 @@ class Linear1D(Fittable1DModel):
         .. math:: f(x) = a x + b
     """
 
-    slope = Parameter()
-    intercept = Parameter()
+    slope = Parameter(default=1)
+    intercept = Parameter(default=0)
     linear = True
 
     @staticmethod
@@ -541,9 +553,9 @@ class Lorentz1D(Fittable1DModel):
         f(x) = \\frac{A \\gamma^{2}}{\\gamma^{2} + \\left(x - x_{0}\\right)^{2}}
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    fwhm = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    fwhm = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, fwhm):
@@ -583,7 +595,7 @@ class Const1D(Fittable1DModel):
         .. math:: f(x) = A
     """
 
-    amplitude = Parameter()
+    amplitude = Parameter(default=1)
     linear = True
 
     @staticmethod
@@ -629,7 +641,7 @@ class Const2D(Fittable2DModel):
         .. math:: f(x, y) = A
     """
 
-    amplitude = Parameter()
+    amplitude = Parameter(default=1)
     linear = True
 
     @staticmethod
@@ -772,10 +784,10 @@ class Disk2D(Fittable2DModel):
                    \\right.
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    R_0 = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    R_0 = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0):
@@ -825,18 +837,22 @@ class Ring2D(Fittable2DModel):
     Where :math:`r_{out} = r_{in} + r_{width}`.
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    r_in = Parameter()
-    width = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    r_in = Parameter(default=1)
+    width = Parameter(default=1)
 
-    def __init__(self, amplitude, x_0, y_0, r_in, width=None, r_out=None,
-                 **kwargs):
+    def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
+                 y_0=y_0.default, r_in=r_in.default, width=width.default,
+                 r_out=None, **kwargs):
         if r_out is not None:
+            if width is not None:
+                raise InputParameterError(
+                    "Cannot specify both width and outer radius separately.")
             width = r_out - r_in
-        if r_out is None and width is None:
-            raise ModelDefinitionError("Either specify width or r_out.")
+        elif width is None:
+            width = self.width.default
 
         super(Ring2D, self).__init__(
             amplitude=amplitude, x_0=x_0, y_0=y_0, r_in=r_in, width=width,
@@ -896,9 +912,9 @@ class Box1D(Fittable1DModel):
                    \\right.
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    width = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    width = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, width):
@@ -955,11 +971,11 @@ class Box2D(Fittable2DModel):
 
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    x_width = Parameter()
-    y_width = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    x_width = Parameter(default=1)
+    y_width = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, x_width, y_width):
@@ -992,10 +1008,10 @@ class Trapezoid1D(Fittable1DModel):
     Box1D, Gaussian1D, Moffat1D
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    width = Parameter()
-    slope = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    width = Parameter(default=1)
+    slope = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, width, slope):
@@ -1040,11 +1056,11 @@ class TrapezoidDisk2D(Fittable2DModel):
     Disk2D, Box2D
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    R_0 = Parameter()
-    slope = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    R_0 = Parameter(default=1)
+    slope = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0, slope):
@@ -1086,9 +1102,9 @@ class MexicanHat1D(Fittable1DModel):
 
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    sigma = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    sigma = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, sigma):
@@ -1129,10 +1145,10 @@ class MexicanHat2D(Fittable2DModel):
         - \\left(y - y_{0}\\right)^{2}}{2 \\sigma^{2}}}
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    sigma = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    sigma = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, sigma):
@@ -1185,13 +1201,14 @@ class AiryDisk2D(Fittable2DModel):
     .. [1] http://en.wikipedia.org/wiki/Airy_disk
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    radius = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    radius = Parameter(default=1)
     _j1 = None
 
-    def __init__(self, amplitude, x_0, y_0, radius, **kwargs):
+    def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
+                 y_0=y_0.default, radius=radius.default, **kwargs):
         if self._j1 is None:
             try:
                 from scipy.special import j1, jn_zeros
@@ -1259,10 +1276,10 @@ class Moffat1D(Fittable1DModel):
         f(x) = A \\left(1 + \\frac{\\left(x - x_{0}\\right)^{2}}{\\gamma^{2}}\\right)^{- \\alpha}
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    gamma = Parameter()
-    alpha = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    gamma = Parameter(default=1)
+    alpha = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, gamma, alpha):
@@ -1314,11 +1331,11 @@ class Moffat2D(Fittable2DModel):
         \\left(y - y_{0}\\right)^{2}}{\\gamma^{2}}\\right)^{- \\alpha}
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    gamma = Parameter()
-    alpha = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    gamma = Parameter(default=1)
+    alpha = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, gamma, alpha):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -42,9 +42,9 @@ class PowerLaw1D(Fittable1DModel):
 
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    alpha = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=1)
+    alpha = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha):
@@ -100,10 +100,10 @@ class BrokenPowerLaw1D(Fittable1DModel):
                    \\right.
     """
 
-    amplitude = Parameter()
-    x_break = Parameter()
-    alpha_1 = Parameter()
-    alpha_2 = Parameter()
+    amplitude = Parameter(default=1)
+    x_break = Parameter(default=1)
+    alpha_1 = Parameter(default=1)
+    alpha_2 = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_break, alpha_1, alpha_2):
@@ -156,10 +156,10 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
 
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    alpha = Parameter()
-    x_cutoff = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=1)
+    alpha = Parameter(default=1)
+    x_cutoff = Parameter(default=1)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, x_cutoff):
@@ -210,10 +210,10 @@ class LogParabola1D(Fittable1DModel):
 
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    alpha = Parameter()
-    beta = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=1)
+    alpha = Parameter(default=1)
+    beta = Parameter(default=0)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, beta):

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -349,8 +349,8 @@ class Pix2Sky_CYP(Pix2SkyProjection, Cylindrical):
                     "CYP projection is not defined for mu=-lambda")
         return lam
 
-    mu = Parameter(setter=_validate_mu)
-    lam = Parameter(setter=_validate_lam)
+    mu = Parameter(default=0, setter=_validate_mu)
+    lam = Parameter(default=0, setter=_validate_lam)
 
     @property
     def inverse(self):
@@ -386,8 +386,8 @@ class Sky2Pix_CYP(Sky2PixProjection, Cylindrical):
                     "CYP projection is not defined for mu=-lambda")
         return lam
 
-    mu = Parameter(setter=_validate_mu)
-    lam = Parameter(setter=_validate_lam)
+    mu = Parameter(default=0, setter=_validate_mu)
+    lam = Parameter(default=0, setter=_validate_lam)
 
     @property
     def inverse(self):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -40,9 +40,9 @@ class EulerAngleRotation(Model):
         Euler angles in deg
     """
 
-    phi = Parameter(getter=np.rad2deg, setter=np.deg2rad)
-    theta = Parameter(getter=np.rad2deg, setter=np.deg2rad)
-    psi = Parameter(getter=np.rad2deg, setter=np.deg2rad)
+    phi = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
+    theta = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
+    psi = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
 
     @staticmethod
     def _rotate_zxz(phi_i, theta_i, phi, theta, psi):


### PR DESCRIPTION
Since at least 0.4 (and I think earlier) it has been possible to define defaults for the parameter values on any model.  But only a tiny handful of the built-in models currently take advantage of this (the polynomial models in particular set all coefficients to 0 by default, so that only the required coefficients need to be provided on instantiation).

However, I think that many if not most of the built-in models could have sensible defaults for at least some of their parameters (for example most of the models with an "amplitude" parameter could have it default to 1).

Having more parameter defaults could also be very helpful for compound models, where it becomes necessary to provide a large number of parameter values on instantiation.  If more of those parameters had defaults it would make instantiating those models simpler (it is still always possible to update a model's parameters after it has been instantiated, which may be clearer in some cases anyways).

Models that could use defaults for some or all of their parameters include:

* [x] [`Gaussian1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L31)
* [x] [`GaussianAbsorption1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L121)
* [x] [`Gaussian2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L171)
* [x] [`Shift`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L349)  (offsets=0?)
* [x] [`Scale`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L379) (factors=1?)
* [x] [`Redshift`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L405) (z=0?)
* [x] [`Sine1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L446)
* [x] [`Linear1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L492)
* [x] [`Lorentz1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L538)
* [x] [`Const1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L590)
* [x] [`Const2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L630)
* [x] [`Disk2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L663)
* [x] [`Ring2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L713)
* [ ] [`Delta1D/2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L779) (these need to be implemented, period--though how would these be useful outside integration?)
* [x] [`Box1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L793)
* [x] [`Box2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L850)
* [x] [`Trapezoid1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L909)
* [x] [`Trapezoid2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L959)
* [x] [`MexicanHat1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L1004)
* [x] [`MexicanHat2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L1048)
* [x] [`AiryDisk2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L1096)
* [x] [`Beta1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L1185)
* [x] [`Beta2D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/functional_models.py#L1241)
* [x] [`PowerLaw1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/powerlaws.py#L20)
* [x] [`BrokenPowerLaw1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/powerlaws.py#L73)
* [x] [`ExponentialCutoffPowerLaw1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/powerlaws.py#L141)
* [x] [`LogParabola1D`](https://github.com/astropy/astropy/blob/master/astropy/modeling/powerlaws.py#L200)
* [x] [`Pix2Sky_CYP`](https://github.com/astropy/astropy/blob/master/astropy/modeling/projections.py#L341)
* [x] [`Sky2Pix_CYP`](https://github.com/astropy/astropy/blob/master/astropy/modeling/projections.py#L381)
* [x] [`EulerAngleRotation`](https://github.com/astropy/astropy/blob/master/astropy/modeling/rotations.py#L33)

Above I've listed all models that have parameters without defaults.  I don't have experience with how all of these are used in practice so I don't know whether or not it makes sense to set defaults for all of them, or what those defaults would be.  There are others that I think are pretty obvious.

If you think it makes sense to, please add some defaults to the list either by editing this list or commenting below.

