### PR TITLE
Ensure Quantity.squeeze() returns a Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -404,6 +404,9 @@ Bug Fixes
   - ``Quantity.round`` now always returns a ``Quantity`` (previously it
     returned an ``ndarray`` for ``decimals>0``). [#3062]
 
+  - Ensured ``np.squeeze`` always returns a ``Quantity`` (it only worked if
+    no dimensions were removed). [#3045]
+
 - ``astropy.utils``
 
   - Fixed an issue with the ``deprecated`` decorator on classes that invoke

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -407,8 +407,13 @@ class Quantity(np.ndarray):
         return result
 
     def __array_wrap__(self, obj, context=None):
-        if context is not None:
+        if context is None:
+            # Methods like .squeeze() created a new `ndarray` and then call
+            # __array_wrap__ to turn the array into self's subclass.
+            return self._new_view(obj)
 
+        else:
+            # with context defined, we are continuing after a ufunc evaluation.
             if hasattr(obj, '_result_unit'):
                 result_unit = obj._result_unit
                 del obj._result_unit

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -76,6 +76,54 @@ class TestQuantityArrayCopy(object):
         assert q[2,2] == -1. * u.km / u.s
 
 
+class TestQuantityReshapeFuncs(object):
+    """Test different ndarray methods that alter the array shape
+
+    tests: reshape, squeeze, ravel, flatten, transpose, swapaxes
+    """
+    def test_reshape(self):
+        q = np.arange(6.) * u.m
+        q_reshape = q.reshape(3, 2)
+        assert isinstance(q_reshape, u.Quantity)
+        assert q_reshape.unit == q.unit
+        assert np.all(q_reshape.value == q.value.reshape(3, 2))
+
+    def test_squeeze(self):
+        q = np.arange(6.).reshape(6, 1) * u.m
+        q_squeeze = q.squeeze()
+        assert isinstance(q_squeeze, u.Quantity)
+        assert q_squeeze.unit == q.unit
+        assert np.all(q_squeeze.value == q.value.squeeze())
+
+    def test_ravel(self):
+        q = np.arange(6.).reshape(3, 2) * u.m
+        q_ravel = q.ravel()
+        assert isinstance(q_ravel, u.Quantity)
+        assert q_ravel.unit == q.unit
+        assert np.all(q_ravel.value == q.value.ravel())
+
+    def test_flatten(self):
+        q = np.arange(6.).reshape(3, 2) * u.m
+        q_flatten = q.flatten()
+        assert isinstance(q_flatten, u.Quantity)
+        assert q_flatten.unit == q.unit
+        assert np.all(q_flatten.value == q.value.flatten())
+
+    def test_transpose(self):
+        q = np.arange(6.).reshape(3, 2) * u.m
+        q_transpose = q.transpose()
+        assert isinstance(q_transpose, u.Quantity)
+        assert q_transpose.unit == q.unit
+        assert np.all(q_transpose.value == q.value.transpose())
+
+    def test_swapaxes(self):
+        q = np.arange(6.).reshape(3, 1, 2) * u.m
+        q_swapaxes = q.swapaxes(0, 2)
+        assert isinstance(q_swapaxes, u.Quantity)
+        assert q_swapaxes.unit == q.unit
+        assert np.all(q_swapaxes.value == q.value.swapaxes(0, 2))
+
+
 class TestQuantityStatsFuncs(object):
     """
     Test statistical functions


### PR DESCRIPTION
In #3038, it was noted that `np.squeeze` does not return a `Quantity`. This seemed surprising since in the quantity source file I had noted [1] that all shape manipulation worked fine -- but clearly had omitted to actually test this properly. It turns out that internally, `ndarray.squeeze` calls `__array_wrap__` for subclasses, with `context=None` (unlike ufuncs, which set the context). So, this PR changes `Quantity..__array_wrap__` so that if context is None, it returns `self._new_view(obj)`, i.e., a Quantity view with the unit set to that of `self`.

It is possible that this has side-benefits... (or introduces problems, though all tests pass locally).

It also suggests that part of the functionaility of `_new_view` could be taken up by `__array_wrap__` -- this may need some thought, but should not really matter for this PR.

[1] https://github.com/astropy/astropy/blob/master/astropy/units/quantity.py#L1104
