### PR TITLE
Correct Quantity.list to .tolist, overriding the correct ndarray method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -367,6 +367,9 @@ Bug Fixes
   - Operations on quantities with incompatible types now raises a much
     more informative ``TypeError``. [#2934]
 
+  - ``Quantity.tolist`` now overrides the ``ndarray`` method to give a 
+    ``NotImplementedError`` (by renaming the previous ``list`` method). [#3050]
+
 - ``astropy.utils``
 
   - Fixed an issue with the ``deprecated`` decorator on classes that invoke

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1044,7 +1044,7 @@ class Quantity(np.ndarray):
         # item returns python built-ins, so use initializer, not _new_view
         return self.__class__(super(Quantity, self).item(*args), self.unit)
 
-    def list(self):
+    def tolist(self):
         raise NotImplementedError("cannot make a list of Quantities.  Get "
                                   "list of values with q.value.list()")
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -464,7 +464,7 @@ class TestArrayConversion(object):
             q1.choose([0, 0, 1])
 
         with pytest.raises(NotImplementedError):
-            q1.list()
+            q1.tolist()
         with pytest.raises(NotImplementedError):
             q1.tostring()
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
While testing `ndarray` methods, I noticed `Quantity` does not override `tolist`, but instead mistakenly has a `list` method. This PR corrects this mistake. Strictly, this is a bug, but since `.list` only gives a `NotImplementedError` it is probably not worth backporting.
