### PR TITLE
Incorrect dtype format used for string columns when initializing Table from rows on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -357,6 +357,9 @@ Bug Fixes
   - Fix a bug that prevented initializing a table from a structured array
     with multi-dimensional columns with copy=True. [#3034]
 
+  - Fixed unnecessarily large unicode columns when instantiating a table from
+    row data on Python 3. [#3052]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -579,3 +579,26 @@ def fix_column_name(val):
             raise
 
     return val
+
+
+def recarray_fromrecords(rec_list):
+    """
+    Partial replacement for `~numpy.core.records.fromrecords` which includes
+    a workaround for the bug with unicode arrays described at:
+    https://github.com/astropy/astropy/issues/3052
+
+    This should not serve as a full replacement for the original function;
+    this only does enough to fulfill the needs of the table module.
+    """
+
+    # Note: This is just copying what Numpy does for converting arbitrary rows
+    # to column arrays in the recarray module; it could be there is a better
+    # way
+    nfields = len(rec_list[0])
+    obj = np.array(rec_list, dtype=object)
+    array_list = [np.array(obj[..., i].tolist()) for i in range(nfields)]
+    formats = []
+    for obj in array_list:
+        formats.append(obj.dtype.str)
+    formats = ','.join(formats)
+    return np.rec.fromarrays(array_list, formats=formats)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -25,7 +25,7 @@ from . import groups
 from .pprint import TableFormatter
 from .column import BaseColumn, Column, MaskedColumn, _auto_names
 from .row import Row
-from .np_utils import fix_column_name
+from .np_utils import fix_column_name, recarray_fromrecords
 
 
 # Prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
@@ -178,7 +178,7 @@ class Table(object):
             elif isinstance(rows, self.Row):
                 data = rows
             else:
-                rec_data = np.rec.fromrecords(rows)
+                rec_data = recarray_fromrecords(rows)
                 data = [rec_data[name] for name in rec_data.dtype.names]
 
         # Infer the type of the input data and set up the initialization

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -418,6 +418,9 @@ class TestInitFromRows():
             assert t.colnames == ['a', 'b']
             assert t['a'].dtype.kind == 'i'
             assert t['b'].dtype.kind in ('S', 'U')
+            # Regression test for
+            # https://github.com/astropy/astropy/issues/3052
+            assert t['b'].dtype.str.endswith('1')
 
         rows = np.arange(6).reshape(2, 3)
         t = table_type(rows=rows, names=('a', 'b', 'c'), dtype=['f8', 'f4', 'i8'])


### PR DESCRIPTION
I noticed this while testing the doctests on Python 3, in this example:

``` python
>>> data_rows = [(1, 2.0, 'x'),
...              (4, 5.0, 'y'),
...              (5, 8.2, 'z')]
>>> t = Table(rows=data_rows, names=('a', 'b', 'c'), meta={'name': 'first table'})
>>> t
array([(1, 2.0, 'x'), (4, 5.0, 'y'), (5, 8..., 'z')],
      dtype=[('a', '<i8'), ('b', '<f8'), ('c', 'S1')])
```

On Python 3 the output of this example is:

``` python
array([(1, 2.0, 'x'), (4, 5.0, 'y'), (5, 8..., 'z')],
      dtype=[('a', '<i8'), ('b', '<f8'), ('c', '<U4')])
```

The difference is in the dtype of column 'c'.  The change from 'S' to 'U' is expected.  However, this should be 'U1' not 'U4'.  The result is that it's using 16 bytes per column to represent a single-character column, instead of just 4 bytes.

This is due to a bug in `np.rec.fromrecords` which we call call [here](https://github.com/astropy/astropy/blob/e573eb7cfe659697d720d1df22fcd9111f52e239/astropy/table/table.py#L181).  The bug is on this line:  https://github.com/numpy/numpy/blob/master/numpy/core/records.py#L536

It checks if the type of the objects in some column are a subtype of the `flexible` type (which the Numpy unicode type _is_).  For other `flexible` subtypes, such as `void`, the format code should include the `itemsize` for the dtype.  However, for the unicode type it should include the number of characters (i.e. `itemsize / 4`).

We can easily fix this on our end by partially reimplementing `np.rec.fromrecords`.  I will also submit an upstream patch.
