### PR TITLE
Raise more informative exception in Table value formatting if type and format mismatch

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -291,7 +291,11 @@ class BaseColumn(np.ndarray):
         self._formatstring = format_string # set new format string
 
         try:
-            self.pformat(max_lines=-1) # test whether it formats without error for all entries
+            if type(self[0]) in ['numpy.object', 'numpy.object0', 'numpy.object_']:
+                self.pformat(max_lines=-1) # test whether it formats without error for all entries
+            else:
+                self.pformat(max_lines=1) # test whether it formats without error exemplarily
+
         except TypeError as err:
             self._formatstring = prev_format # revert to restore previous format if ther was one
             raise TypeError(err.args[0]) # propagate the error upwards

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -279,26 +279,26 @@ class BaseColumn(np.ndarray):
 
     @property
     def format(self):
-        return self._formatstring
+        return self._format
 
     @format.setter
     def format(self, format_string):
         try:
-            prev_format = self._formatstring # save current format string
-        except AttributeError: # nothing set at all yet
+            prev_format = self._format  # save current format string
+        except AttributeError:  # nothing set at all yet
             prev_format = None
 
-        self._formatstring = format_string # set new format string
+        self._format = format_string  # set new format string
 
         try:
             if type(self[0]) in ['numpy.object', 'numpy.object0', 'numpy.object_']:
-                self.pformat(max_lines=-1) # test whether it formats without error for all entries
+                self.pformat(max_lines=-1)  # test whether it formats without error for all entries
             else:
-                self.pformat(max_lines=1) # test whether it formats without error exemplarily
+                self.pformat(max_lines=1)  # test whether it formats without error exemplarily
 
         except TypeError as err:
-            self._formatstring = prev_format # revert to restore previous format if ther was one
-            raise TypeError(err.args[0]) # propagate the error upwards
+            self._format = prev_format  # revert to restore previous format if there was one
+            raise  # propagate the error upwards
 
 
     @property

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -291,7 +291,7 @@ class BaseColumn(np.ndarray):
         self._formatstring = format_string # set new format string
 
         try:
-            self.pformat() # test whether it formats without error
+            self.pformat(max_lines=-1) # test whether it formats without error for all entries
         except TypeError as err:
             self._formatstring = prev_format # revert to restore previous format if ther was one
             raise TypeError(err.args[0]) # propagate the error upwards

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -278,6 +278,26 @@ class BaseColumn(np.ndarray):
         self._name = val
 
     @property
+    def format(self):
+        return self._formatstring
+
+    @format.setter
+    def format(self, format_string):
+        try:
+            prev_format = self._formatstring # save current format string
+        except AttributeError: # nothing set at all yet
+            prev_format = None
+
+        self._formatstring = format_string # set new format string
+
+        try:
+            self.pformat() # test whether it formats without error
+        except TypeError as err:
+            self._formatstring = prev_format # revert to restore previous format if ther was one
+            raise TypeError(err.args[0]) # propagate the error upwards
+
+
+    @property
     def descr(self):
         """Array-interface compliant full description of the column.
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -289,18 +289,22 @@ class TableFormatter(object):
         # Add formatted values if within bounds allowed by max_lines
         for i in xrange(n_rows):
             if i < i0 or i > i1:
-                if multidims:
-                    # Prevents colums like Column(data=[[(1,)],[(2,)]], name='a')
-                    # with shape (n,1,...,1) from being printed as if there was
-                    # more than one element in a row
-                    if trivial_multidims:
-                        col_str = format_func(col.format, col[(i,) + multidim0])
+                try:
+                    if multidims:
+                        # Prevents colums like Column(data=[[(1,)],[(2,)]], name='a')
+                        # with shape (n,1,...,1) from being printed as if there was
+                        # more than one element in a row
+                        if trivial_multidims:
+                            col_str = format_func(col.format, col[(i,) + multidim0])
+                        else:
+                            col_str = (format_func(col.format, col[(i,) + multidim0]) +
+                                      ' .. ' +
+                                      format_func(col.format, col[(i,) + multidim1]))
                     else:
-                        col_str = (format_func(col.format, col[(i,) + multidim0]) +
-                                  ' .. ' +
-                                  format_func(col.format, col[(i,) + multidim1]))
-                else:
-                    col_str = format_func(col.format, col[i])
+                        col_str = format_func(col.format, col[i])
+                except TypeError:
+                    raise TypeError('Unable to parse format string {0} for entry {1} in column {2}'.format(col.format, col[i], col.name))
+
                 yield col_str
             elif i == i0:
                 yield '...'

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -117,7 +117,7 @@ def _auto_format_func(format_, val):
                 break
         else:
             # None of the possible string functions passed muster.
-            raise ValueError('Unable to parse format string {0}'
+            raise TypeError('Unable to parse format string {0} for its column'
                              .format(format_))
 
         # String-based format functions will fail on masked elements;

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -303,7 +303,8 @@ class TableFormatter(object):
                     else:
                         col_str = format_func(col.format, col[i])
                 except TypeError:
-                    raise TypeError('Unable to parse format string {0} for entry {1} in column {2}'.format(col.format, col[i], col.name))
+                    raise TypeError('Unable to parse format string "{0}" for entry "{1}" in column "{2}"'
+                            .format(col.format, col[i], col.name))
 
                 yield col_str
             elif i == i0:


### PR DESCRIPTION
Implementing Issue #2868:

Implementing raising TypeError upon nonworking format string instead of value error, handling it above the point where it was originally raised to include information about the exact point of failure.

Additionally getter and setter were implemented to raise the error as soon as it can be determined to not work (aka when setting it).

Format is checked for all existing entries in case of np.object-ish and for one entry for other types as this should be sufficient and more efficient for large tables.