### PR TITLE
Fixed a bug which meant that Python thought that WCS instances were iterable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -395,6 +395,9 @@ Bug Fixes
     now be correctly identified and returned as ``nan``
     values. [#2965]
 
+  - Fixed an issue which meant that Python thought ``WCS`` objects were
+    iterable. [#3066]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -711,3 +711,23 @@ IMAGEH  =                 2832 / Image height, in pixels.
     w = wcs.WCS(header)
     x, y = w.wcs_world2pix(211, -26, 0)
     assert np.isnan(x) and np.isnan(y)
+
+
+def test_no_iteration():
+
+    # Regression test for #3066
+
+    w = wcs.WCS(naxis=2)
+
+    with pytest.raises(TypeError) as exc:
+        iter(w)
+    assert exc.value.args[0] == "'WCS' object is not iterable"
+
+    class NewWCS(wcs.WCS):
+        pass
+
+    w = NewWCS(naxis=2)
+
+    with pytest.raises(TypeError) as exc:
+        iter(w)
+    assert exc.value.args[0] == "'NewWCS' object is not iterable"

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2703,6 +2703,12 @@ naxis kwarg.
         # (wcs[i] -> wcs.sub([i+1])
         return self.slice(item)
 
+    def __iter__(self):
+        # Having __getitem__ makes Python think WCS is iterable. However,
+        # Python first checks whether __iter__ is present, so we can raise an
+        # exception here.
+        raise TypeError("'{0}' object is not iterable".format(self.__class__.__name__))
+
     @property
     def axis_type_names(self):
         """


### PR DESCRIPTION
cc @keflavich @mdboom
