### PR TITLE
Sporadic test failure with fast io.ascii reader

### DIFF
--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -86,7 +86,6 @@ cdef extern from "src/tokenizer.h":
     double fast_str_to_double(tokenizer_t *self, char *str)
     double str_to_double(tokenizer_t *self, char *str)
     void start_iteration(tokenizer_t *self, int col)
-    int finished_iteration(tokenizer_t *self)
     char *next_field(tokenizer_t *self, int *size)
     char *get_line(char *ptr, int *len, int map_len)
 

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -68,7 +68,7 @@ void resize_col(tokenizer_t *self, int index)
 {
     // Temporarily store the position in output_cols[index] to
     // which col_ptrs[index] points
-    int diff = self->col_ptrs[index] - self->output_cols[index];
+    long diff = self->col_ptrs[index] - self->output_cols[index];
 
     // Double the size of the column string
     self->output_cols[index] = (char *) realloc(self->output_cols[index], 2 *
@@ -120,7 +120,8 @@ static inline void push(tokenizer_t *self, char c, int col)
 
 static inline void end_field(tokenizer_t *self, int *col, int header)
 {
-    if (self->strip_whitespace_fields)
+    if (self->strip_whitespace_fields && self->col_ptrs[*col]
+	!= self->output_cols[*col])
     {
         --self->col_ptrs[*col];
         while (*self->col_ptrs[*col] == ' ' || *self->col_ptrs[*col] == '\t')
@@ -772,15 +773,6 @@ void start_iteration(tokenizer_t *self, int col)
     self->iter_col = col;
     // Start at the initial pointer position
     self->curr_pos = self->output_cols[col];
-}
-
-int finished_iteration(tokenizer_t *self)
-{
-    // Iteration is finished if we've exceeded the length of the column string
-    // or the pointer is at an empty byte
-    return (self->curr_pos - self->output_cols[self->iter_col] >=
-            self->output_len[self->iter_col] * sizeof(char)
-	    || *self->curr_pos == '\x00');
 }
 
 char *next_field(tokenizer_t *self, int *size)

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -80,7 +80,6 @@ double str_to_double(tokenizer_t *self, char *str);
 double xstrtod(const char *str, char **endptr, char decimal,
                char sci, char tsep, int skip_trailing);
 void start_iteration(tokenizer_t *self, int col);
-int finished_iteration(tokenizer_t *self);
 char *next_field(tokenizer_t *self, int *size);
 long file_len(FILE *fhandle);
 char *get_line(char *ptr, int *len, int map_len);


### PR DESCRIPTION
I'm seeing this test failure from time to time on the Mac Jenkins instance - it's not systematic, so maybe there is a race condition, or something to do with random numbers (haven't checked in detail):

```
def test_fill_include_exclude_names():
        """
        fill_include_names and fill_exclude_names should filter missing/empty value handling
        in the same way that include_names and exclude_names filter output columns.
        """
        text = """
    A, B, C
    , 1, 2
    3, , 4
    5, 5,
    """
        table = read_csv(text, fill_include_names=['A', 'B'])
        assert table['A'][0] is ma.masked
        assert table['B'][1] is ma.masked
        assert table['C'][2] is not ma.masked # C not in fill_include_names

>       table = read_csv(text, fill_exclude_names=['A', 'B'])

astropy/io/ascii/tests/test_c_reader.py:435: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

table = '\nA, B, C\n, 1, 2\n3, , 4\n5, 5,\n'
kwargs = {'fill_exclude_names': ['A', 'B']}

    def read_csv(table, **kwargs):
>       return _read(table, FastCsv, 'csv', **kwargs)

astropy/io/ascii/tests/test_c_reader.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

table = '\nA, B, C\n, 1, 2\n3, , 4\n5, 5,\n\n'
Reader = <class 'astropy.io.ascii.fastbasic.FastCsv'>, format = 'csv'
fail_parallel = False, kwargs = {'fill_exclude_names': ['A', 'B']}
reader = <astropy.io.ascii.fastbasic.FastCsv object at 0x10f9cbd90>
t1 = <Table rows=3 names=('A','B','C')>
masked_array(data = [('', '1', 2) ('3', '',...', 'N', 999999),
            dtype = [('A', 'S1'), ('B', 'S1'), ('C', '<i8')])

t2 = <Table rows=3 names=('A','B','C')>
masked_array(data = [('', '1', 2) ('3', '',...', 'N', 999999),
            dtype = [('A', 'S1'), ('B', 'S1'), ('C', '<i8')])

t3 = <Table rows=3 names=('A','B','C')>
masked_array(data = [('', '1', 2) ('3', '',...', 'N', 999999),
            dtype = [('A', 'S1'), ('B', 'S1'), ('C', '<i8')])

t4 = <Table rows=3 names=('A','B','C')>
masked_array(data = [(8070450532247928832, ..., 'N', 999999),
            dtype = [('A', '<i8'), ('B', 'S1'), ('C', '<i8')])

t5 = <Table rows=3 names=('A','B','C')>
masked_array(data = [('', '1', 2) ('3', '',...', 'N', 999999),
            dtype = [('A', 'S1'), ('B', 'S1'), ('C', '<i8')])


    def _read(table, Reader, format, fail_parallel=False, **kwargs):
        # make sure we have a newline so table can't be misinterpreted as a filename
        table += '\n'
        reader = Reader(**kwargs)
        t1 = reader.read(table)
        t2 = reader.read(StringIO(table))
        t3 = reader.read(table.splitlines())
        t4 = ascii.read(table, format=format, guess=False, **kwargs)
        t5 = ascii.read(table, format=format, guess=False, fast_reader=False, **kwargs)
        assert_table_equal(t1, t2)
        assert_table_equal(t2, t3)
>       assert_table_equal(t3, t4)

astropy/io/ascii/tests/test_c_reader.py:55: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

t1 = <Table rows=3 names=('A','B','C')>
masked_array(data = [('', '1', 2) ('3', '',...', 'N', 999999),
            dtype = [('A', 'S1'), ('B', 'S1'), ('C', '<i8')])

t2 = <Table rows=3 names=('A','B','C')>
masked_array(data = [(8070450532247928832, ..., 'N', 999999),
            dtype = [('A', '<i8'), ('B', 'S1'), ('C', '<i8')])


    def assert_table_equal(t1, t2):
        assert_equal(len(t1), len(t2))
        assert_equal(t1.colnames, t2.colnames)
        for name in t1.colnames:
            if len(t1) != 0:
>               assert_equal(t1[name].dtype.kind, t2[name].dtype.kind)

astropy/io/ascii/tests/test_c_reader.py:31: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = 'S', b = 'i'

    def assert_equal(a, b):
>       assert a == b
E       assert 'S' == 'i'
E         - S
E         + i

astropy/io/ascii/tests/common.py:41: AssertionError
```

cc @amras1 @taldcroft 
