### PR TITLE
update README to mention dashboard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,15 +26,21 @@ For system packagers: Please install Astropy with the command::
 This will prevent the astropy_helpers bootstrap script from attempting to
 reach out to PyPI.
 
+Project Status
+--------------
 
-Travis Build Status
--------------------
+For an overview of the testing and build status of all packages associated 
+with the Astropy Project, see http://dashboard.astropy.org.
+
+Core Package Travis Build Status
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. image:: https://travis-ci.org/astropy/astropy.png
     :target: https://travis-ci.org/astropy/astropy
 
 
-Test Coverage Status
---------------------
+
+Core Package Test Coverage Status
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. image:: https://coveralls.io/repos/astropy/astropy/badge.png
     :target: https://coveralls.io/r/astropy/astropy


### PR DESCRIPTION
This updates the README to mention the existence of the astropy dashboard and slightly re-word some of the status badges.  See https://github.com/eteq/astropy/tree/add-dashboard for how it will look on the github page

cc @astrofrog @cdeil
