### PR TITLE
Move badges in README to top of page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,6 @@ Astropy
 .. image:: https://pypip.in/d/astropy/badge.png
     :target: https://pypi.python.org/pypi/astropy
 
-.. image:: https://travis-ci.org/astropy/astropy.png
-    :target: https://travis-ci.org/astropy/astropy
-
-.. image:: https://coveralls.io/repos/astropy/astropy/badge.png
-    :target: https://coveralls.io/r/astropy/astropy
-
 Astropy (http://astropy.org/) is a package intended to contain much of
 the core functionality and some common tools needed for performing
 astronomy and astrophysics with Python.
@@ -34,6 +28,12 @@ reach out to PyPI.
 
 Project Status
 --------------
+
+.. image:: https://travis-ci.org/astropy/astropy.png
+    :target: https://travis-ci.org/astropy/astropy
+
+.. image:: https://coveralls.io/repos/astropy/astropy/badge.png
+    :target: https://coveralls.io/r/astropy/astropy
 
 For an overview of the testing and build status of all packages associated 
 with the Astropy Project, see http://dashboard.astropy.org.


### PR DESCRIPTION
This builds on #3068 to take things a bit further and move all the existing project badges to the top of the README.  You can see what it looks like at
https://github.com/eteq/astropy/tree/move-badges

I did this separately from #3068 because this is a bigger change to what people see on the github page...

Note that #3068 should be merged before this.

cc @astrofrog @cdeil @embray @mdboom 
