### PR TITLE
0.4rc1: test_Rotation2D_inverse failure on powerpc and s390x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -352,6 +352,8 @@ Bug Fixes
 
 - ``astropy.modeling``
 
+  - Fixed a test failure on Debian/PowerPC and Debian/s390x. [#2708]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -50,4 +50,4 @@ def test_Rotation2D():
 def test_Rotation2D_inverse():
     model = models.Rotation2D(angle=234.23494)
     x, y = model.inverse(*model(1, 0))
-    utils.assert_allclose([x, y], [1, 0])
+    utils.assert_allclose([x, y], [1, 0], atol=1e-10)


### PR DESCRIPTION
On Debian/Powerpc and Debian/s390x, the 0.4rc1 version fails with

```
    def test_Rotation2D_inverse():
        model = models.Rotation2D(angle=234.23494)
        inverse = model.inverse()
        x, y = inverse(*model(1, 0))
>       utils.assert_allclose([x, y], [1, 0])

astropy/modeling/tests/test_rotations.py:54: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

actual = array([  1.00000000e+00,   3.41493897e-19]), desired = array([1, 0])
rtol = 1e-07, atol = 0, err_msg = '', verbose = True
[...]
```
- [powerpc build log](https://buildd.debian.org/status/fetch.php?pkg=python-astropy&arch=powerpc&ver=0.4~rc1-1&stamp=1404749162)
- [s390x build log](https://buildd.debian.org/status/fetch.php?pkg=python-astropy&arch=s390x&ver=0.4~rc1-1&stamp=1404755898)
