### PR TITLE
Auto-build extension modules when importing astropy from source checkout

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -216,8 +216,9 @@ def _initialize_astropy():
 
     # If this __init__.py file is in ./astropy/ then import is within a source dir
     source_dir = os.path.abspath(os.path.dirname(__file__))
-    is_astropy_source_dir = os.path.exists(
-            os.path.join(source_dir, os.pardir, 'static', '.astropy-root'))
+    is_astropy_source_dir = (
+            os.path.exists(os.path.join(source_dir, os.pardir, '.git')) and
+            os.path.isfile(os.path.join(source_dir, os.pardir, 'setup.py')))
 
     def _rollback_import(message):
         log.error(message)
@@ -272,7 +273,9 @@ def _rebuild_extensions():
     import subprocess
     import sys
     import time
+
     from .utils.console import Spinner
+    from .extern.six import next
 
     devnull = open(os.devnull, 'w')
     old_cwd = os.getcwd()
@@ -283,7 +286,7 @@ def _rebuild_extensions():
                                stderr=devnull)
         with Spinner('Rebuilding extension modules') as spinner:
             while sp.poll() is None:
-                spinner.next()
+                next(spinner)
                 time.sleep(0.05)
     finally:
         os.chdir(old_cwd)

--- a/static/.astropy-root
+++ b/static/.astropy-root
@@ -1,3 +1,0 @@
-This is a special placeholder file used to determine whether we are in
-an Astropy source checkout.  It should never appear be installed, but
-please do not delete it either.


### PR DESCRIPTION
This is a somewhat minor enhancement developer convenience, but something that affects me frequently.
If either importing astropy when your CWD is  in the Astropy source checkout, or when using `./setup.py develop`, there was already an error message displayed if the C extension modules need to be built.

But this necessitated exiting the Python interpreter (or at least opening a separate terminal) and manually running `./setup.py build_ext --inplace` in order to make it work.  This now just does that automatically without ever having to leave the Python prompt.

The one shortcoming I see, which is not unique to this PR is that the heuristic used is just that the `utils._compiler` module can't be imported.  Ideally we'd check for any extension modules that need to be rebuilt, but that's a little trickier without some explicit list of extension modules somewhere.  I think that can be addressed as a separate issue though.
