### PR TITLE
Make all astropy code compatible with Python 2 and 3 without requiring 2to3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -319,6 +319,8 @@ Other Changes and Additions
 
 - The version of ERFA included with Astropy is now v1.1.1 [#2971]
 
+- The code base is now fully Python 2 and 3 compatible and no longer requires
+  2to3. [#2033]
 
 0.4.3 (unreleased)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(name=NAME,
       ],
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
This is the same as #1219 but that has been merged with a smaller scope.  This should stay open until it is done.  By my reckoning these are the outstanding packages:
- [x] astropy.modeling
- [ ] <s>astropy.sphinx</s>
- [x] astropy.vo
- [x] astropy.io.misc
- [x] astropy.io.tests
- [x] astropy.modeling.tests
- [ ] <s>astropy.sphinx.ext</s>
- [x] astropy.vo.client
- [x] astropy.vo.validator
- [x] astropy.io.misc.tests
- [x] astropy.modeling.tests.data
- [ ] <s>astropy.sphinx.ext.tests</s>
- [x] astropy.vo.client.tests
- [x] astropy.vo.validator.tests

I generated this list using the `package_info` variable from `setup.py` as follows.  Not sure if this complete or correct, but it seems mostly there:

```
skip_2to3 = [re.sub(r'/', '.', x) for x in package_info['skip_2to3']
packages = package_info['packages']
p2to3 = [p for p in packages if not any(p.startswith(s) for s in skip_2to3)]
for p in p2to3:
    print '- [ ]', p
```

Optimistically milestoning for 0.4.  This would be good!
