### PR TITLE
Documentation bug for Fits tables

### DIFF
--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -508,7 +508,7 @@ variables for the individual columns and without manually creating a
 
 Now you may write this new table HDU directly to a FITS file like so::
 
-    >>> hdu = fits.PrimaryHDU(n)
+    >>> tbhdu.writeto('table.fits')
 
 This shortcut will automatically create a minimal primary HDU with no data and
 prepend it to the table HDU to create a valid FITS file.  If you require


### PR DESCRIPTION
The 'creating a new table file' sphinx documentation for astropy.io.fits seems to have some errors related to appending a primary HDU.

First, the description of appending a primary HDU:

```
  hdu = fits.PrimaryHDU(n)
```

uses an undefined variable (n).  Actually, it works in the doctest because n is defined in an earlier section unrelated to making tables, but it shouldn't be there.

Fixing that would be trivial, but the bigger issue is that - as far as I can tell - this command does not do what the docs say, which is to automatically append an empty primary HDU to the table HDU (a good thing, since you haven't specified any connection to the table).

Maybe what was intended was

```
 tbhdu.writeto(filename)
```

but I'm not sure enough of that to just submit a pull to fix it.
