### PR TITLE
``has_distortion`` needs to be clearly documented

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,10 +120,9 @@ New Features
     and ``non_celestial_pixel_scales`` utility functions for retrieving WCS
     pixel scale information [#2832]
 
-  - Added two functions ``pixel_to_skycoord`` and ``skycoord_to_pixel`` that
-    make it easy to convert between SkyCoord objects and pixel coordinates, as
-    well as a ``has_distortion`` property on the ``WCS`` class that indicates
-    whether any distortions are present. [#2885]
+  - Added two functions ``pixel_to_skycoord`` and
+    ``skycoord_to_pixel`` that make it easy to convert between
+    SkyCoord objects and pixel coordinates. [#2885]
 
 API Changes
 ^^^^^^^^^^^

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -670,17 +670,6 @@ def test_printwcs():
     w.printwcs()
 
 
-def test_has_distorion():
-
-    header = get_pkg_data_contents('maps/1904-66_TAN.hdr', encoding='binary')
-    w = wcs.WCS(header)
-    assert not w.has_distortion
-
-    header = get_pkg_data_filename('data/sip.fits')
-    w = wcs.WCS(header)
-    assert w.has_distortion
-
-
 def test_invalid_spherical():
     header = six.text_type("""
 SIMPLE  =                    T / conforms to FITS standard

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -212,6 +212,15 @@ def non_celestial_pixel_scales(inwcs):
     else:
         raise ValueError("WCS is rotated, cannot determine consistent pixel scales")
 
+
+def _has_distortion(wcs):
+    """
+    `True` if contains any SIP or image distortion components.
+    """
+    return any(getattr(wcs, dist_attr) is not None
+               for dist_attr in ['cpdis1', 'cpdis2', 'det2im1', 'det2im2', 'sip'])
+
+
 # TODO: in future, we should think about how the following two functions can be
 # integrated better into the WCS class.
 
@@ -244,7 +253,7 @@ def skycoord_to_pixel(coords, wcs, origin=0, mode='all'):
     from .. import units as u
     from . import WCSSUB_CELESTIAL
 
-    if wcs.has_distortion and wcs.naxis != 2:
+    if _has_distortion(wcs) and wcs.naxis != 2:
         raise ValueError("Can only handle WCS with distortions for 2-dimensional WCS")
 
     # Keep only the celestial part of the axes, also re-orders lon/lat
@@ -327,7 +336,7 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
     if cls is None:
         cls = SkyCoord
 
-    if wcs.has_distortion and wcs.naxis != 2:
+    if _has_distortion(wcs) and wcs.naxis != 2:
         raise ValueError("Can only handle WCS with distortions for 2-dimensional WCS")
 
     # Keep only the celestial part of the axes, also re-orders lon/lat

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2766,14 +2766,6 @@ naxis kwarg.
 
         return pccd
 
-    @property
-    def has_distortion(self):
-        """
-        `True` if contains any SIP or image distortion components.
-        """
-        return any(getattr(self, dist_attr) is not None
-                   for dist_attr in ['cpdis1', 'cpdis2', 'det2im1', 'det2im2', 'sip'])
-
 
 def __WCS_unpickle__(cls, dct, fits_data):
     """


### PR DESCRIPTION
@astrofrog @mdboom 

`has_distortion` property is not documented. Based on the log entry for issue #2885 : _"... as well as a `has_distortion` property on the `WCS` class that indicates whether any distortions are present."_ It must be clarified what does _"any distortions are present"_ means. Based on the code, I understand that this is a convenience method that replaces multiple checks of `sip is None`, `cpdis1 is None`, etc. with a single call to `has_distortion`. However, `has_distortion==False` does not mean that the image is not distorted. Therefore, I believe, this must be made clear in the documentation.
