### PR TITLE
Fixes issue #3122 of filenames being taken as URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,6 +313,8 @@ Bug Fixes
 
   - Setting ``memmap=True`` in ``fits.open`` and related functions now raises a ValueError if opening a file in memory-mapped mode is impossible. [#2298]
 
+  - Fixes the problem in ``fits.open`` of some filenames with colon (:) in the name being taken as URL instead of file. [#3122]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -112,9 +112,11 @@ class _File(object):
         if mode not in PYFITS_MODES:
             raise ValueError("Mode '%s' not recognized" % mode)
 
+        protocols = ['http' , 'https', 'ftp', 'sftp', 'ftps'] # Used for verifying fileobj as URL
+
         if (isinstance(fileobj, string_types) and
             mode not in ('ostream', 'append') and
-            str(urllib.parse.urlparse(fileobj).scheme) in ['http' , 'https', 'ftp']):
+            str(urllib.parse.urlparse(fileobj).scheme) in protocols):
             #The above verifies the given file is an URL by matching the scheme to HTTP(S) and FTP protocols
                 self.name, _ = urllib.request.urlretrieve(fileobj)
         else:

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -114,7 +114,6 @@ class _File(object):
 
         if (isinstance(fileobj, string_types) and
             mode not in ('ostream', 'append') and
-            len(urllib.parse.urlparse(fileobj).scheme) in [3,4,5] and
             str(urllib.parse.urlparse(fileobj).scheme) in ['http' , 'https', 'ftp']):
             #The above verifies the given file is an URL by matching the scheme to HTTP(S) and FTP protocols
                 self.name, _ = urllib.request.urlretrieve(fileobj)

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -114,7 +114,9 @@ class _File(object):
 
         if (isinstance(fileobj, string_types) and
             mode not in ('ostream', 'append') and
-            len(urllib.parse.urlparse(fileobj).scheme) > 1): # This is an URL.
+            len(urllib.parse.urlparse(fileobj).scheme) in [3,4,5] and
+            str(urllib.parse.urlparse(fileobj).scheme) in ['http' , 'https', 'ftp']):
+            #The above verifies the given file is an URL by matching the scheme to HTTP(S) and FTP protocols
                 self.name, _ = urllib.request.urlretrieve(fileobj)
         else:
             self.name = fileobj_name(fileobj)


### PR DESCRIPTION
I have added more checks to verify that given fileobj is an url by checking the scheme. The scheme is returned by urllib.parse.urlparse(urlfile).scheme - which contains the protocol for urlfile. For a valid URL, the scheme could be HTTP, HTTPS or FTP, hence anything else returned apart from this should not be treated as URL and should be treated as File.  Fixes #3122 