### PR TITLE
Removed a few spectral density equivalencies which do not make sense.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -513,6 +513,9 @@ Bug Fixes
   - Units with fractional powers are now correctly multiplied together
     by using rational arithmetic.  [#3121]
 
+  - Removed a few entries from spectral density equivalencies which did not
+    make sense. [#3153]
+
 - ``astropy.utils``
 
   - Fixed an issue with the ``deprecated`` decorator on classes that invoke

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -167,10 +167,7 @@ def spectral_density(wav, factor=None):
         return x * wav.to(si.AA, spectral()).value ** 3 / (hc * c_Aps)
 
     return [
-        (si.AA, fnu, converter, iconverter),
         (fla, fnu, converter, iconverter),
-        (si.AA, si.Hz, converter, iconverter),
-        (fla, si.Hz, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
         (fla, lafla, converter_fla_lafla, iconverter_fla_lafla),
         (photlam, fla, converter_photlam_fla, iconverter_photlam_fla),

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -283,20 +283,6 @@ def test_spectral4(in_val, in_unit):
         assert_allclose(b, in_val)
 
 
-def test_spectraldensity():
-    a = u.AA.to(u.Jy, 1, u.spectral_density(u.eV, 2.2))
-    assert_allclose(a, 1059416252057.8357, rtol=1e-4)
-
-    b = u.Jy.to(u.AA, a, u.spectral_density(u.eV, 2.2))
-    assert_allclose(b, 1)
-
-    c = u.AA.to(u.Jy, 1, u.spectral_density(2.2 * u.eV))
-    assert_allclose(c, 1059416252057.8357, rtol=1e-4)
-
-    d = u.Jy.to(u.AA, c, u.spectral_density(2.2 * u.eV))
-    assert_allclose(d, 1)
-
-
 def test_spectraldensity2():
     flambda = u.erg / u.angstrom / u.cm ** 2 / u.s
     fnu = u.erg / u.Hz / u.cm ** 2 / u.s


### PR DESCRIPTION
I don't think the equivalencies removed here make sense for spectral density.

@mdboom - since you originally added these, can you comment on this?

cc @pllim @mhvk 

(originally discussed in https://github.com/astropy/astropy/pull/692)
