### PR TITLE
Message about unclosed files in affiliated packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -537,6 +537,9 @@ Bug Fixes
   - Astropy will now work if your Python interpreter does not have the
     ``bz2`` module installed. [#3104]
 
+  - Fixed ``ResourceWarning`` for ``astropy/extern/bundled/six.py`` that could
+    occur sometimes after using Astropy in Python 3.4. [#3156]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/extern/six.py
+++ b/astropy/extern/six.py
@@ -32,25 +32,29 @@ def _find_module(name, path=None):
     return fh, path, descr
 
 
-for mod_name in _SIX_SEARCH_PATH:
-    try:
-        mod_info = _find_module(mod_name)
-    except ImportError:
-        continue
+def _import_six(search_path=_SIX_SEARCH_PATH):
+    for mod_name in search_path:
+        try:
+            mod_info = _find_module(mod_name)
+        except ImportError:
+            continue
 
-    mod = imp.load_module(__name__, *mod_info)
+        mod = imp.load_module(__name__, *mod_info)
 
-    try:
-        if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:
-            break
-    except (AttributeError, ValueError):
-        # Attribute error if the six module isn't what it should be and doesn't
-        # have a .__version__; ValueError if the version string exists but is
-        # somehow bogus/unparseable
-        continue
-else:
-    raise ImportError(
-        "Astropy requires the 'six' module of minimum version {0}; "
-        "normally this is bundled with the astropy package so if you get "
-        "this warning consult the packager of your Astropy "
-        "distribution.".format(_SIX_MIN_VERSION))
+        try:
+            if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:
+                break
+        except (AttributeError, ValueError):
+            # Attribute error if the six module isn't what it should be and
+            # doesn't have a .__version__; ValueError if the version string
+            # exists but is somehow bogus/unparseable
+            continue
+    else:
+        raise ImportError(
+            "Astropy requires the 'six' module of minimum version {0}; "
+            "normally this is bundled with the astropy package so if you get "
+            "this warning consult the packager of your Astropy "
+            "distribution.".format(_SIX_MIN_VERSION))
+
+
+_import_six()


### PR DESCRIPTION
For a number of affiliated packages, I see the following when running `python setup.py test` with Python 3.4:

```
sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Volumes/Raptor/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev10555-py3.4-macosx-10.8-x86_64.egg/astropy/extern/bundled/six.py' mode='r' encoding='utf-8'>
```

This occurs after the tests have run. @cdeil also reported a similar issue in the past.

To reproduce:

```
git clone git@github.com:astrofrog/wcsaxes.git
cd wcsaxes
python setup.py test  # with Python 3.4
```

Output:

```
...
=============== 4 failed, 113 passed, 1 skipped in 8.23 seconds ================
sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Volumes/Raptor/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev10555-py3.4-macosx-10.8-x86_64.egg/astropy/extern/bundled/six.py' mode='r' encoding='utf-8'>
/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/importlib/_bootstrap.py:2150: ImportWarning: sys.meta_path is empty
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=10>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=12>
```

I'm opening this here because I wonder if it's to do with the way we import the six module?
