### PR TITLE
Minor fix to pytest header modules version check

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -502,7 +502,11 @@ def pytest_report_header(config):
         except ImportError:
             s += "{0}: not available\n".format(module_display)
         else:
-            s += "{0}: {1}\n".format(module_display, module.__version__)
+            try:
+                version = module.__version__
+            except AttributeError:
+                version = 'unknown (no __version__ attribute)'
+            s += "{0}: {1}\n".format(module_display, version)
 
     special_opts = ["remote_data", "pep8"]
     opts = []


### PR DESCRIPTION
This is a minor fix to the pytest header module version check that @astrofrog and I already discussed here: https://github.com/astropy/astropy/pull/3157#issuecomment-64958270
