### PR TITLE
Reworked fits.open() - Fixes #3041

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,6 +192,10 @@ API Changes
 
 - ``astropy.io.fits``
 
+  - A new optional argument ``cached`` has been added to  ``astropy.io.fits.fits_open()``.
+    ``cached`` is a boolean field which by default is ``True`` and is used
+    to cache the downloaded fits file on local machine. [#3041]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -310,6 +314,9 @@ Bug Fixes
     ``0``, which is the first uncommented line. Discussed in #2692. [#3054]
 
 - ``astropy.io.fits``
+
+  - Fixes the problem in ``fits.open`` of some filenames with colon (:) in the name
+    being taken as URL instead of file. [#3122]
 
   - Setting ``memmap=True`` in ``fits.open`` and related functions now raises a ValueError if opening a file in memory-mapped mode is impossible. [#2298]
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -3,7 +3,7 @@
 from __future__ import division, with_statement
 
 from ...utils.compat import gzip as _astropy_gzip
-from ...utils.data import download_file
+from ...utils.data import download_file, _is_url
 import gzip as _system_gzip
 import mmap
 import os
@@ -82,7 +82,7 @@ class _File(object):
     # See self._test_mmap
     _mmap_available = None
 
-    def __init__(self, fileobj=None, mode=None, memmap=None, clobber=False):
+    def __init__(self, fileobj=None, mode=None, memmap=None, clobber=False, cached=True):
 
         self.strict_memmap = bool(memmap)
         memmap = True if memmap is None else memmap
@@ -115,8 +115,8 @@ class _File(object):
 
         if (isinstance(fileobj, string_types) and
             mode not in ('ostream', 'append') and
-            self.is_url(fileobj)): # This is an URL.
-                self.name = download_file(fileobj,cache=True)
+            _is_url(fileobj)): # This is an URL.
+                self.name = download_file(fileobj,cache=cached)
         else:
             self.name = fileobj_name(fileobj)
 
@@ -180,22 +180,6 @@ class _File(object):
     def __repr__(self):
         return '<%s.%s %s>' % (self.__module__, self.__class__.__name__,
                                self.__file)
-
-    def is_url(self,url):
-        """
-        Test whether a string is a valid URL
-
-        Parameters
-        ----------
-        string : url
-        The string to test
-        """
-        url_retrieved = urllib.parse.urlparse(url)
-        # url[0]==url.scheme, but url[0] is py 2.6-compat
-        # we can't just check that url[0] is not an empty string, because
-        # file paths in windows would return a non-empty scheme (e.g. e:\\
-        # returns 'e').
-        return url_retrieved[0].lower() in ['http', 'https', 'ftp', 'sftp', 'ssh']
 
     # Support the 'with' statement
     def __enter__(self):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -22,7 +22,7 @@ from ....utils import indent
 from ....utils.exceptions import AstropyUserWarning
 
 
-def fitsopen(name, mode='readonly', memmap=None, save_backup=False, **kwargs):
+def fitsopen(name, mode='readonly', memmap=None, save_backup=False, cached=True, **kwargs):
     """Factory function to open a FITS file and return an `HDUList` object.
 
     Parameters
@@ -120,7 +120,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False, **kwargs):
     if not name:
         raise ValueError('Empty filename: %s' % repr(name))
 
-    return HDUList.fromfile(name, mode, memmap, save_backup, **kwargs)
+    return HDUList.fromfile(name, mode, memmap, save_backup, cached, **kwargs)
 
 
 class HDUList(list, _Verify):
@@ -242,7 +242,7 @@ class HDUList(list, _Verify):
 
     @classmethod
     def fromfile(cls, fileobj, mode=None, memmap=None,
-                 save_backup=False, **kwargs):
+                 save_backup=False, cached=True, **kwargs):
         """
         Creates an `HDUList` instance from a file-like object.
 
@@ -252,7 +252,7 @@ class HDUList(list, _Verify):
         """
 
         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,
-                             save_backup=save_backup, **kwargs)
+                             save_backup=save_backup, cached=cached, **kwargs)
 
     @classmethod
     def fromstring(cls, data, **kwargs):
@@ -759,7 +759,7 @@ class HDUList(list, _Verify):
 
     @classmethod
     def _readfrom(cls, fileobj=None, data=None, mode=None,
-                  memmap=None, save_backup=False, **kwargs):
+                  memmap=None, save_backup=False, cached=True, **kwargs):
         """
         Provides the implementations from HDUList.fromfile and
         HDUList.fromstring, both of which wrap this method, as their
@@ -769,7 +769,7 @@ class HDUList(list, _Verify):
         if fileobj is not None:
             if not isinstance(fileobj, _File):
                 # instantiate a FITS file object (ffo)
-                ffo = _File(fileobj, mode=mode, memmap=memmap)
+                ffo = _File(fileobj, mode=mode, memmap=memmap, cached=cached)
             else:
                 ffo = fileobj
             # The pyfits mode is determined by the _File initializer if the


### PR DESCRIPTION
Following the discussions on #3041 - The following changes are made:

1. ```urlretrieve``` was previously used for downloading files from remote machines, this has been replaced by using ```astropy.utils.data``` package which provides a good caching mechanism and better way to deal with downloading files.
2. ```fits.open(url,cached=False)``` can be used to disable caching when downloading from remote machines, and by default the caching mechanism is enabled.

This PR also fixes #3122 - as an already existing method is now used from ```astropy.utils.data``` to check if given filename is url or not.