### PR TITLE
Add TimeFormatMeta and TimeDeltaFormatMeta

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1267,6 +1267,24 @@ class TimeDelta(Time):
                           u.day).to(*args, **kwargs)
 
 
+class TimeFormatMeta(type):
+    """
+    Metaclass that adds `TimeFormat` and `TimeDeltaFormat` to the
+    `TIME_FORMATS` and `TIME_DELTA_FORMATS` registries, respectively.
+    """
+
+    _registry = TIME_FORMATS
+
+    def __new__(mcls, name, bases, members):
+        cls = super(TimeFormatMeta, mcls).__new__(mcls, name, bases, members)
+
+        if 'name' in members:
+            mcls._registry[cls.name] = cls
+
+        return cls
+
+
+@six.add_metaclass(TimeFormatMeta)
 class TimeFormat(object):
     """
     Base class for time representations.
@@ -1968,6 +1986,11 @@ class TimeJulianEpochString(TimeEpochDateString):
     epoch_prefix = 'J'
 
 
+class TimeDeltaFormatMeta(TimeFormatMeta):
+    _registry = TIME_DELTA_FORMATS
+
+
+@six.add_metaclass(TimeDeltaFormatMeta)
 class TimeDeltaFormat(TimeFormat):
     """Base class for time delta representations"""
 
@@ -2005,21 +2028,6 @@ class TimeDeltaJD(TimeDeltaFormat):
 
 class ScaleValueError(Exception):
     pass
-
-
-# Set module constant with names of all available time formats
-for name, val in list(six.iteritems(locals())):
-    try:
-        is_timeformat = issubclass(val, TimeFormat)
-        is_timedeltaformat = issubclass(val, TimeDeltaFormat)
-    except:
-        pass
-    else:
-        if hasattr(val, 'name'):
-            if is_timedeltaformat:
-                TIME_DELTA_FORMATS[val.name] = val
-            elif is_timeformat:
-                TIME_FORMATS[val.name] = val
 
 
 def _make_1d_array(val, copy=False):


### PR DESCRIPTION
 These automatically add `TimeFormat` classes to the `TIME_FORMAT` and `TIME_DELTA_FORMAT` dicts at class creation time instead of after the fact.  This should also reduce the effort required to define new formats external to Astropy.  This may understandably look overengineered, but it does have the advantage of fixing the annoyance mentioned here: https://github.com/astropy/astropy/pull/3095#issuecomment-65074252 by not doing any module-level hackery.
