### PR TITLE
Remove width/height style of banner logo

### DIFF
--- a/docs/_static/astropy.css
+++ b/docs/_static/astropy.css
@@ -1,0 +1,6 @@
+
+@import url("bootstrap-astropy.css");
+
+body, .topbar, .related {
+  min-width: 645px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,6 +149,9 @@ html_title = '{0} v{1}'.format(project, release)
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'
 
+# Static files to copy after template files
+html_static_path = ['_static']
+html_style = 'astropy.css'
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,6 @@ Astropy Core Package Documentation
 ##################################
 
 .. image:: astropy_banner_96.png
-    :width: 485px
-    :height: 96px
     :target: http://www.astropy.org/
 
 Welcome to the Astropy documentation! Astropy is a community-driven


### PR DESCRIPTION
This will prevent it from being squished horizontally (non-proportionally) in small windows.  This addresses part of #3171.