### PR TITLE
Speed up wcs test

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -193,6 +193,11 @@ def test_pix2world():
     assert  np.all(np.abs(result-answer) < close_enough)
 
 
+def test_load_fits_path():
+    fits_name = get_pkg_data_filename('data/sip.fits')
+    w = wcs.WCS(fits_name)
+
+
 def test_dict_init():
     """
     Test that WCS can be initialized with a dict-like object


### PR DESCRIPTION
One of the wcs tests were rather slow and ate up a significant amount of memory, too.

With this PR, running tests is faster by 4-5 mins on my laptop. I couldn't see the point why a 4000x2000 pixel image cannot be cut for the test purposes, please advise if it was essential.

Unnecessary imports and function(parts) were also removed (unless there were extra notes). I think `test_all_world2pix()` could be clean up further to better fit into the rest of the file (by removing the arguments and print statements, etc), but it doesn't cost any runtime so I left it untouched.

cc: @mdboom 
