### PR TITLE
Support Table mixin columns

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -129,6 +129,10 @@ class SkyCoord(object):
             Cartesian coordinates values for the Galactic frame.
     """
 
+
+    # Declare that SkyCoord can be used as a Table columm
+    _astropy_table_compatible = True
+
     def __init__(self, *args, **kwargs):
 
         # Parse the args and kwargs to assemble a sanitized and validated

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -130,8 +130,9 @@ class SkyCoord(object):
     """
 
 
-    # Declare that SkyCoord can be used as a Table mixin columm
-    _astropy_mixin_column = True
+    # Declare that SkyCoord can be used as a Table column by defining the
+    # attribute where column attributes will be stored.
+    _astropy_column_attrs = None
 
     def __init__(self, *args, **kwargs):
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -130,8 +130,8 @@ class SkyCoord(object):
     """
 
 
-    # Declare that SkyCoord can be used as a Table columm
-    _astropy_table_compatible = True
+    # Declare that SkyCoord can be used as a Table mixin columm
+    _astropy_mixin_column = True
 
     def __init__(self, *args, **kwargs):
 

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -16,6 +16,7 @@ import re
 import numpy as np
 
 from . import core
+from ...table import col_getattr
 
 class BasicHeader(core.BaseHeader):
     '''Basic table Header Reader
@@ -297,7 +298,7 @@ class RdbHeader(TabHeader):
         rdb_types = []
         for col in self.cols:
             # Check if dtype.kind is string or unicode.  See help(np.core.numerictypes)
-            rdb_type = 'S' if col.dtype.kind in ('S', 'U') else 'N'
+            rdb_type = 'S' if col_getattr(col, 'dtype').kind in ('S', 'U') else 'N'
             rdb_types.append(rdb_type)
 
         lines.append(self.splitter.join(rdb_types))

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -16,7 +16,7 @@ import re
 import numpy as np
 
 from . import core
-from ...table import col_getattr
+from ...table.column import col_getattr
 
 class BasicHeader(core.BaseHeader):
     '''Basic table Header Reader

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -57,12 +57,12 @@ def _get_connectors_table():
 
         io_format = 'ascii.' + cls._format_name
         description = getattr(cls, '_description', '')
-        class_link = ':class:`~{}.{}`'.format(cls.__module__, cls.__name__)
+        class_link = ':class:`~{0}.{1}`'.format(cls.__module__, cls.__name__)
         suffix = getattr(cls, '_io_registry_suffix', '')
         can_write = 'Yes' if getattr(cls, '_io_registry_can_write', True) else ''
 
         rows.append((io_format, suffix, can_write,
-                     '{}: {}'.format(class_link, description)))
+                     '{0}: {1}'.format(class_link, description)))
     out = Table(list(zip(*rows)), names=('Format', 'Suffix', 'Write', 'Description'))
     for colname in ('Format', 'Description'):
         width = max(len(x) for x in out[colname])

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -66,7 +66,7 @@ def _get_connectors_table():
     out = Table(list(zip(*rows)), names=('Format', 'Suffix', 'Write', 'Description'))
     for colname in ('Format', 'Description'):
         width = max(len(x) for x in out[colname])
-        out[colname].format = '%-{}s'.format(width)
+        out[colname].format = '%-{0}s'.format(width)
 
     return out
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -647,7 +647,7 @@ class BaseData(object):
         self._set_fill_values(self.cols)
         self._set_col_formats()
         for col in self.cols:
-            col.str_vals = list(col_iter_str_vals())
+            col.str_vals = list(col_iter_str_vals(col))
         self._replace_vals(self.cols)
         return [col.str_vals for col in self.cols]
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -24,7 +24,8 @@ from ...extern.six.moves import zip
 from ...extern.six.moves import cStringIO as StringIO
 from ...utils.exceptions import AstropyWarning
 
-from ...table import Table, col_getattr, col_setattr, col_iter_str_vals
+from ...table import Table
+from ...table.column import col_getattr, col_setattr, col_iter_str_vals
 from ...utils.compat import ignored
 from ...utils.data import get_readable_fileobj
 from ...utils import OrderedDict

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -24,7 +24,7 @@ from ...extern.six.moves import zip
 from ...extern.six.moves import cStringIO as StringIO
 from ...utils.exceptions import AstropyWarning
 
-from ...table import Table
+from ...table import Table, col_getattr, col_setattr, col_iter_str_vals
 from ...utils.compat import ignored
 from ...utils.data import get_readable_fileobj
 from ...utils import OrderedDict
@@ -457,12 +457,13 @@ class BaseHeader(object):
             for i, spacer_line in zip(range(self.start_line),
                                       itertools.cycle(self.write_spacer_lines)):
                 lines.append(spacer_line)
-            lines.append(self.splitter.join([x.name for x in self.cols]))
+            lines.append(self.splitter.join([col_getattr(x, 'name') for x in self.cols]))
 
     @property
     def colnames(self):
         """Return the column names of the table"""
-        return tuple(col.name for col in self.cols)
+        return tuple(col.name if isinstance(col, Column) else col_getattr(col, 'name')
+                     for col in self.cols)
 
     def get_type_map_key(self, col):
         return col.raw_type
@@ -645,7 +646,7 @@ class BaseData(object):
         self._set_fill_values(self.cols)
         self._set_col_formats()
         for col in self.cols:
-            col.str_vals = list(col.iter_str_vals())
+            col.str_vals = list(col_iter_str_vals())
         self._replace_vals(self.cols)
         return [col.str_vals for col in self.cols]
 
@@ -666,8 +667,8 @@ class BaseData(object):
         """
         """
         for col in self.cols:
-            if col.name in self.formats:
-                col.format = self.formats[col.name]
+            if col_getattr(col, 'name') in self.formats:
+                col_setattr(col, 'format', self.formats[col.name])
 
 
 def convert_numpy(numpy_type):

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -11,7 +11,7 @@ fixedwidth.py:
 from __future__ import absolute_import, division, print_function
 
 from ...extern.six.moves import zip
-from ...table import col_iter_str_vals, col_getattr
+from ...table.column import col_iter_str_vals, col_getattr
 
 from . import core
 from .core import InconsistentTableError, DefaultSplitter

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -11,6 +11,7 @@ fixedwidth.py:
 from __future__ import absolute_import, division, print_function
 
 from ...extern.six.moves import zip
+from ...table import col_iter_str_vals, col_getattr
 
 from . import core
 from .core import InconsistentTableError, DefaultSplitter
@@ -224,12 +225,13 @@ class FixedWidthData(basic.BasicData):
         for i, col in enumerate(self.cols):
             col.width = max([len(vals[i]) for vals in vals_list])
             if self.header.start_line is not None:
-                col.width = max(col.width, len(col.name))
+                col.width = max(col.width, len(col_getattr(col, 'name')))
 
         widths = [col.width for col in self.cols]
 
         if self.header.start_line is not None:
-            lines.append(self.splitter.join([col.name for col in self.cols], widths))
+            lines.append(self.splitter.join([col_getattr(col, 'name') for col in self.cols],
+                                            widths))
 
         if self.header.position_line is not None:
             char = self.header.position_char

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -13,7 +13,7 @@ from ...extern import six
 from ...extern.six.moves import zip as izip
 
 from . import core
-from ...table import Column, col_iter_str_vals
+from ...table import Column, col_iter_str_vals, col_getattr
 from ...utils.xml import writer
 
 from copy import deepcopy
@@ -357,7 +357,7 @@ class HTML(core.BaseReader):
                                     w.start('th', colspan=col.shape[1])
                                 else:
                                     w.start('th')
-                                w.data(col.name.strip())
+                                w.data(col_getattr(col, 'name').strip())
                                 w.end(indent=False)
                         col_str_iters = []
                         for col in cols:

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -13,7 +13,7 @@ from ...extern import six
 from ...extern.six.moves import zip as izip
 
 from . import core
-from ...table import Column
+from ...table import Column, col_iter_str_vals
 from ...utils.xml import writer
 
 from copy import deepcopy
@@ -366,9 +366,9 @@ class HTML(core.BaseReader):
                                 for i in range(span):
                                     # Split up multicolumns into separate columns
                                     new_col = Column([el[i] for el in col])
-                                    col_str_iters.append(new_col.iter_str_vals())
+                                    col_str_iters.append(col_iter_str_vals(new_col))
                             else:
-                                col_str_iters.append(col.iter_str_vals())
+                                col_str_iters.append(col_iter_str_vals(col))
 
                     for row in izip(*col_str_iters):
                         with w.tag('tr'):

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -13,7 +13,8 @@ from ...extern import six
 from ...extern.six.moves import zip as izip
 
 from . import core
-from ...table import Column, col_iter_str_vals, col_getattr
+from ...table import Column
+from ...table.column import col_iter_str_vals, col_getattr
 from ...utils.xml import writer
 
 from copy import deepcopy

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -24,6 +24,7 @@ from . import basic
 from ...utils import OrderedDict
 from ...utils.exceptions import AstropyUserWarning
 from ...table.pprint import _format_funcs, _auto_format_func
+from ...table import col_iter_str_vals
 
 
 class IpacFormatErrorDBMS(Exception):

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -24,7 +24,7 @@ from . import basic
 from ...utils import OrderedDict
 from ...utils.exceptions import AstropyUserWarning
 from ...table.pprint import _format_funcs, _auto_format_func
-from ...table import col_iter_str_vals, col_getattr
+from ...table.column import col_iter_str_vals, col_getattr
 
 
 class IpacFormatErrorDBMS(Exception):

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -24,7 +24,7 @@ from . import basic
 from ...utils import OrderedDict
 from ...utils.exceptions import AstropyUserWarning
 from ...table.pprint import _format_funcs, _auto_format_func
-from ...table import col_iter_str_vals
+from ...table import col_iter_str_vals, col_getattr
 
 
 class IpacFormatErrorDBMS(Exception):
@@ -223,11 +223,11 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
         else:
             IpacFormatE = IpacFormatError
 
-        namelist = [col.name for col in self.cols]
+        namelist = self.colnames
         if self.DBMS:
             countnamelist = defaultdict(int)
-            for col in self.cols:
-                countnamelist[col.name.lower()] += 1
+            for name in self.colnames:
+                countnamelist[name.lower()] += 1
             doublenames = [x for x in countnamelist if countnamelist[x] > 1]
             if doublenames != []:
                 raise IpacFormatE('IPAC DBMS tables are not case sensitive. '
@@ -256,20 +256,26 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
         unitlist = []
         nullist = []
         for col in self.cols:
-            if col.dtype.kind in ['i', 'u']:
+            col_dtype = col_getattr(col, 'dtype')
+            col_unit = col_getattr(col, 'unit')
+            col_format = col_getattr(col, 'format')
+
+            if col_dtype.kind in ['i', 'u']:
                 dtypelist.append('long')
-            elif col.dtype.kind == 'f':
+            elif col_dtype.kind == 'f':
                 dtypelist.append('double')
             else:
                 dtypelist.append('char')
-            if col.unit is None:
+
+            if col_unit is None:
                 unitlist.append('')
             else:
                 unitlist.append(str(col.unit))
+            # This may be incompatible with mixin columns
             null = col.fill_values[core.masked]
             try:
-                format_func = _format_funcs.get(col.format, _auto_format_func)
-                nullist.append((format_func(col.format, null)).strip())
+                format_func = _format_funcs.get(col_format, _auto_format_func)
+                nullist.append((format_func(col_format, null)).strip())
             except:
                 # It is possible that null and the column values have different
                 # data types (e.g. number und null = 'null' (i.e. a string).

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -14,7 +14,7 @@ import re
 
 from ...extern import six
 from . import core
-from ...table import col_getattr
+from ...table.column import col_getattr
 
 latexdicts = {'AA':  {'tabletype': 'table',
                       'header_start': r'\hline \hline', 'header_end': r'\hline',

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -14,6 +14,7 @@ import re
 
 from ...extern import six
 from . import core
+from ...table import col_getattr
 
 latexdicts = {'AA':  {'tabletype': 'table',
                       'header_start': r'\hline \hline', 'header_end': r'\hline',
@@ -114,12 +115,14 @@ class LatexHeader(core.BaseHeader):
             lines.append(r'\caption{' + self.latex['caption'] + '}')
         lines.append(self.header_start + r'{' + self.latex['col_align'] + r'}')
         add_dictval_to_list(self.latex, 'header_start', lines)
-        lines.append(self.splitter.join([x.name for x in self.cols]))
-        units = dict((x.name, x.unit.to_string(format='latex_inline')) for x in self.cols if x.unit)
+        col_units = [col_getattr(col, 'unit') for col in self.cols]
+        lines.append(self.splitter.join(self.colnames))
+        units = dict((name, unit.to_string(format='latex_inline'))
+                     for name, unit in zip(self.colnames, col_units) if unit)
         if 'units' in self.latex:
             units.update(self.latex['units'])
         if units:
-            lines.append(self.splitter.join([units.get(x.name, ' ') for x in self.cols]))
+            lines.append(self.splitter.join([units.get(name, ' ') for name in self.colnames]))
         add_dictval_to_list(self.latex, 'header_end', lines)
 
 
@@ -338,12 +341,15 @@ class AASTexHeader(LatexHeader):
         add_dictval_to_list(self.latex, 'preamble', lines)
         if 'caption' in self.latex:
             lines.append(r'\tablecaption{' + self.latex['caption'] + '}')
-        tablehead = ' & '.join([r'\colhead{' + x.name + '}' for x in self.cols])
-        units = dict((x.name, x.unit.to_string(format='latex_inline')) for x in self.cols if x.unit)
+        tablehead = ' & '.join([r'\colhead{' + name + '}' for name in self.colnames])
+        col_units = [col_getattr(col, 'unit') for col in self.cols]
+        units = dict((name, unit.to_string(format='latex_inline'))
+                     for name, unit in zip(self.colnames, col_units) if unit)
         if 'units' in self.latex:
             units.update(self.latex['units'])
         if units:
-            tablehead += r'\\ ' + self.splitter.join([units.get(x.name, ' ') for x in self.cols])
+            tablehead += r'\\ ' + self.splitter.join([units.get(name, ' ')
+                                                      for name in self.colnames])
         lines.append(r'\tablehead{' + tablehead + '}')
 
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -336,6 +336,9 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
 
     table = Table(table, names=kwargs.get('names'))
 
+    if table._has_mixin_columns:
+        fast_writer = False
+
     Writer = _get_format_class(format, Writer, 'Writer')
     writer = get_writer(Writer=Writer, fast_writer=fast_writer, **kwargs)
     if writer._format_name in core.FAST_CLASSES:

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -336,7 +336,7 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
 
     table = Table(table, names=kwargs.get('names'))
 
-    if table._has_mixin_columns:
+    if table.has_mixin_columns:
         fast_writer = False
 
     Writer = _get_format_class(format, Writer, 'Writer')

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -210,6 +210,13 @@ def write_table_fits(input, output, overwrite=False):
         Whether to overwrite any existing file without warning.
     """
 
+    # Tables with mixin columns are not supported
+    if input.has_mixin_columns:
+        mixin_names = [name for name, col in input.columns.items()
+                       if not isinstance(col, input.ColumnClass)]
+        raise ValueError('cannot write table with mixin column(s) {0} to FITS'
+                         .format(mixin_names))
+
     # Check if output file already exists
     if isinstance(output, string_types) and os.path.exists(output):
         if overwrite:

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -179,6 +179,13 @@ def write_table_hdf5(table, output, path=None, compression=False,
     except ImportError:
         raise Exception("h5py is required to read and write HDF5 files")
 
+    # Tables with mixin columns are not supported
+    if table.has_mixin_columns:
+        mixin_names = [name for name, col in table.columns.items()
+                       if not isinstance(col, table.ColumnClass)]
+        raise ValueError('cannot write table with mixin column(s) {0} to HDF5'
+                         .format(mixin_names))
+
     if path is None:
         raise ValueError("table path should be set via the path= argument")
     elif path.endswith('/'):

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -139,6 +139,13 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
         ``tabledata``.  See :ref:`votable-serialization`.
     """
 
+    # Tables with mixin columns are not supported
+    if input.has_mixin_columns:
+        mixin_names = [name for name, col in input.columns.items()
+                       if not isinstance(col, input.ColumnClass)]
+        raise ValueError('cannot write table with mixin column(s) {0} to VOTable'
+                         .format(mixin_names))
+
     # Check if output file already exists
     if isinstance(output, six.string_types) and os.path.exists(output):
         if overwrite:

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -19,7 +19,6 @@ conf = Conf()
 
 
 from .column import Column, MaskedColumn
-from .column import col_getattr, col_setattr, col_iter_str_vals, col_copy
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn
+from .column import Column, MaskedColumn, col_getattr, col_setattr
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,8 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn, col_getattr, col_setattr, col_iter_str_vals
+from .column import Column, MaskedColumn
+from .column import col_getattr, col_setattr, col_iter_str_vals, col_copy
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn, col_getattr, col_setattr
+from .column import Column, MaskedColumn, col_getattr, col_setattr, col_iter_str_vals
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -20,7 +20,7 @@ conf = Conf()
 
 from .column import Column, MaskedColumn
 from .groups import TableGroups, ColumnGroups
-from .table import Table, TableColumns, Row, TableFormatter
+from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError
 
 # Import routines that connect readers/writers to astropy.table

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -788,6 +788,9 @@ class Column(BaseColumn):
             data = np.insert(self, obj, None, axis=0)
             data[obj] = values
         else:
+            # Explicitly convert to dtype of this column.  Needed because numpy 1.7
+            # enforces safe casting by default, so .  This isn't the case for 1.6 or 1.8+.
+            values = np.asarray(values, dtype=self.dtype)
             data = np.insert(self, obj, values, axis=0)
         out = data.view(self.__class__)
         out.__array_finalize__(self)
@@ -1018,8 +1021,16 @@ class MaskedColumn(Column, ma.MaskedArray):
             new_data = np.insert(self_ma.data, obj, None, axis=0)
             new_data[obj] = values
         else:
+            # Explicitly convert to dtype of this column.  Needed because numpy 1.7
+            # enforces safe casting by default, so .  This isn't the case for 1.6 or 1.8+.
+            values = np.asarray(values, dtype=self.dtype)
             new_data = np.insert(self_ma.data, obj, values, axis=0)
 
+        if mask is None:
+            if self.dtype.kind == 'O':
+                mask = False
+            else:
+                mask = np.zeros(values.shape, dtype=np.bool)
         new_mask = np.insert(self_ma.mask, obj, mask, axis=0)
         new_ma = np.ma.array(new_data, mask=new_mask, copy=False)
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -66,7 +66,7 @@ def col_setattr(col, attr, value):
         if getattr(col, '_astropy_column_attrs', None) is None:
             col._astropy_column_attrs = {}
         if attr == 'parent_table':
-            value = weakref.ref(value)
+            value = None if value is None else weakref.ref(value)
         col._astropy_column_attrs[attr] = value
 
 def col_getattr(col, attr, default=None):
@@ -135,6 +135,7 @@ def col_copy(col):
     if isinstance(col, BaseColumn):
         return col.copy()
 
+    col_setattr(col, 'parent_table', None)  # Don't copy weakref to parent table
     newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
 
     # Copy old attributes.  Even deepcopy above may not get this (e.g. pandas).

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -101,17 +101,17 @@ def col_getattr(col, attr, default=None):
 
     return value
 
-def _col_update_attrs_from(newcol, col):
+def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
     """
     Update _astropy_column_attrs from mixin `col` to `newcol`.  Does nothing
     for BaseColumn cols
 
     Warning: this function is subject to change or removal.
     """
-    if isinstance(col, BaseColumn):
+    if isinstance(newcol, BaseColumn):
         return
 
-    attrs = COLUMN_ATTRS - set(['name', 'parent_table'])
+    attrs = COLUMN_ATTRS - set(exclude_attrs)
     for attr in attrs:
         val = col_getattr(col, attr)
         if val is not None:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -961,8 +961,6 @@ class MaskedColumn(Column, ma.MaskedArray):
         else:
             new_data = np.insert(self_ma.data, obj, values, axis=0)
 
-        if mask is None:
-            mask = np.zeros(np.asarray(values).shape, dtype=bool)
         new_mask = np.insert(self_ma.mask, obj, mask, axis=0)
         new_ma = np.ma.array(new_data, mask=new_mask, copy=False)
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -57,13 +57,14 @@ def col_setattr(col, attr, value):
         raise AttributeError("attribute must be one of {}".format(COLUMN_ATTRS))
 
     # The unit and dtype attributes are considered univeral and do NOT get
-    # stored in _column_attrs.  For BaseColumn instances use the usual setattr.
+    # stored in _astropy_column_attrs.  For BaseColumn instances use the usual setattr.
     if isinstance(col, BaseColumn) or attr in ('unit', 'dtype'):
         setattr(col, attr, value)
     else:
-        if not hasattr(col, '_column_attrs'):
-            col._column_attrs = {}
-        col._column_attrs[attr] = value
+        # If no _astropy_column_attrs or it is None then convert to dict
+        if getattr(col, '_astropy_column_attrs', None) is None:
+            col._astropy_column_attrs = {}
+        col._astropy_column_attrs[attr] = value
 
 def col_getattr(col, attr, default=None):
     """
@@ -75,14 +76,17 @@ def col_getattr(col, attr, default=None):
         raise AttributeError("attribute must be one of {}".format(COLUMN_ATTRS))
 
     # The unit and dtype attributes are considered univeral and do NOT get
-    # stored in _column_attrs.  For BaseColumn instances use the usual setattr.
+    # stored in _astropy_column_attrs.  For BaseColumn instances use the usual setattr.
     if isinstance(col, BaseColumn) or attr in ('unit', 'dtype'):
         value = getattr(col, attr, default)
     else:
-        if hasattr(col, '_column_attrs'):
-            value = col._column_attrs.get(attr, default)
-        else:
+        # If col does not have _astropy_column_attrs or it is None (meaning
+        # nothing has been set yet) then return default, otherwise look for
+        # the attribute in the astropy_column_attrs dict.
+        if getattr(col, '_astropy_column_attrs', None) is None:
             value = default
+        else:
+            value = col._astropy_column_attrs.get(attr, default)
 
     return value
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -54,7 +54,7 @@ def col_setattr(col, attr, value):
     TODO: full docstring
     """
     if attr not in COLUMN_ATTRS:
-        raise AttributeError("attribute must be one of {}".format(COLUMN_ATTRS))
+        raise AttributeError("attribute must be one of {0}".format(COLUMN_ATTRS))
 
     # The unit and dtype attributes are considered univeral and do NOT get
     # stored in _astropy_column_attrs.  For BaseColumn instances use the usual setattr.
@@ -76,7 +76,7 @@ def col_getattr(col, attr, default=None):
     TODO: full docstring
     """
     if attr not in COLUMN_ATTRS:
-        raise AttributeError("attribute must be one of {}".format(COLUMN_ATTRS))
+        raise AttributeError("attribute must be one of {0}".format(COLUMN_ATTRS))
 
     # The unit and dtype attributes are considered univeral and do NOT get
     # stored in _astropy_column_attrs.  For BaseColumn instances use the usual setattr.

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -198,6 +198,13 @@ class BaseColumn(np.ndarray):
                 unit = data.unit
             else:
                 self_data = np.array(data.to(unit), dtype=dtype, copy=copy)
+            if description is None:
+                description = col_getattr(data, 'description')
+            if format is None:
+                format = col_getattr(data, 'format')
+            if meta is None:
+                meta = deepcopy(col_getattr(data, 'meta'))
+
         else:
             self_data = np.array(data, dtype=dtype, copy=copy)
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -91,8 +91,14 @@ def col_getattr(col, attr, default=None):
             value = default
         else:
             value = col._astropy_column_attrs.get(attr, default)
-            if attr == 'parent_table' and callable(value):
-                value = value()
+
+        # Weak ref for parent table
+        if attr == 'parent_table' and callable(value):
+            value = value()
+
+        # Mixins have a default dtype of Object if nothing else was set
+        if attr == 'dtype' and value is None:
+            value = np.dtype('O')
 
     return value
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -49,9 +49,9 @@ COLUMN_ATTRS = ('name', 'unit', 'dtype', 'format', 'description', 'meta', 'paren
 
 def col_setattr(col, attr, value):
     """
-    Set one of the column attributes
+    Set one of the column attributes.
 
-    TODO: full docstring
+    Warning: this function is subject to change or removal.
     """
     if attr not in COLUMN_ATTRS:
         raise AttributeError("attribute must be one of {0}".format(COLUMN_ATTRS))
@@ -72,7 +72,7 @@ def col_getattr(col, attr, default=None):
     """
     Get one of the column attributes
 
-    TODO: full docstring
+    Warning: this function is subject to change or removal.
     """
     if attr not in COLUMN_ATTRS:
         raise AttributeError("attribute must be one of {0}".format(COLUMN_ATTRS))
@@ -105,6 +105,8 @@ def _col_update_attrs_from(newcol, col):
     """
     Update _astropy_column_attrs from mixin `col` to `newcol`.  Does nothing
     for BaseColumn cols
+
+    Warning: this function is subject to change or removal.
     """
     if isinstance(col, BaseColumn):
         return
@@ -117,8 +119,9 @@ def _col_update_attrs_from(newcol, col):
 
 def col_iter_str_vals(col):
     """
-    TODO: docstring
     This is a mixin-safe version of Column.iter_str_vals.
+
+    Warning: this function is subject to change or removal.
     """
     parent_table = col_getattr(col, 'parent_table')
     formatter = FORMATTER if parent_table is None else parent_table.formatter
@@ -128,8 +131,9 @@ def col_iter_str_vals(col):
 
 def col_copy(col):
     """
-    TODO: docstring
     This is a mixin-safe version of Column.copy() (with copy_data=True).
+
+    Warning: this function is subject to change or removal.
     """
     if isinstance(col, BaseColumn):
         return col.copy()

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -135,7 +135,8 @@ def col_copy(col):
     if isinstance(col, BaseColumn):
         return col.copy()
 
-    col_setattr(col, 'parent_table', None)  # Don't copy weakref to parent table
+    if hasattr(col, '_astropy_column_attrs'):
+        col_setattr(col, 'parent_table', None)  # Don't copy weakref to parent table
     newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
 
     # Copy old attributes.  Even deepcopy above may not get this (e.g. pandas).

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -102,6 +102,20 @@ def col_getattr(col, attr, default=None):
 
     return value
 
+def _col_update_attrs_from(newcol, col):
+    """
+    Update _astropy_column_attrs from mixin `col` to `newcol`.  Does nothing
+    for BaseColumn cols
+    """
+    if isinstance(col, BaseColumn):
+        return
+
+    attrs = set(COLUMN_ATTRS) - set(['name', 'parent_table'])
+    for attr in attrs:
+        val = col_getattr(col, attr)
+        if val is not None:
+            col_setattr(newcol, attr, deepcopy(val))
+
 def col_iter_str_vals(col):
     """
     TODO: docstring

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -45,7 +45,7 @@ _comparison_functions = set(
      np.isfinite, np.isinf, np.isnan, np.sign, np.signbit])
 
 
-COLUMN_ATTRS = ('name', 'unit', 'dtype', 'format', 'description', 'meta', 'parent_table')
+COLUMN_ATTRS = set(['name', 'unit', 'dtype', 'format', 'description', 'meta', 'parent_table'])
 
 def col_setattr(col, attr, value):
     """
@@ -111,7 +111,7 @@ def _col_update_attrs_from(newcol, col):
     if isinstance(col, BaseColumn):
         return
 
-    attrs = set(COLUMN_ATTRS) - set(['name', 'parent_table'])
+    attrs = COLUMN_ATTRS - set(['name', 'parent_table'])
     for attr in attrs:
         val = col_getattr(col, attr)
         if val is not None:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -58,8 +58,7 @@ def col_setattr(col, attr, value):
 
     # The unit and dtype attributes are considered univeral and do NOT get
     # stored in _astropy_column_attrs.  For BaseColumn instances use the usual setattr.
-    if (isinstance(col, BaseColumn) or
-            (isinstance(col, Quantity) and attr in ('dtype', 'unit'))):
+    if isinstance(col, BaseColumn):
         setattr(col, attr, value)
     else:
         # If no _astropy_column_attrs or it is None then convert to dict

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -45,6 +45,47 @@ _comparison_functions = set(
      np.isfinite, np.isinf, np.isnan, np.sign, np.signbit])
 
 
+COLUMN_ATTRS = ('name', 'unit', 'dtype', 'format', 'description', 'meta')
+
+def col_setattr(col, attr, value):
+    """
+    Set one of the column attributes
+
+    TODO: full docstring
+    """
+    if attr not in COLUMN_ATTRS:
+        raise AttributeError("attribute must be one of {}".format(COLUMN_ATTRS))
+
+    # The unit and dtype attributes are considered univeral and do NOT get
+    # stored in _column_attrs.  For BaseColumn instances use the usual setattr.
+    if isinstance(col, BaseColumn) or attr in ('unit', 'dtype'):
+        setattr(col, attr, value)
+    else:
+        if not hasattr(col, '_column_attrs'):
+            col._column_attrs = {}
+        col._column_attrs[attr] = value
+
+def col_getattr(col, attr, default=None):
+    """
+    Get one of the column attributes
+
+    TODO: full docstring
+    """
+    if attr not in COLUMN_ATTRS:
+        raise AttributeError("attribute must be one of {}".format(COLUMN_ATTRS))
+
+    # The unit and dtype attributes are considered univeral and do NOT get
+    # stored in _column_attrs.  For BaseColumn instances use the usual setattr.
+    if isinstance(col, BaseColumn) or attr in ('unit', 'dtype'):
+        value = getattr(col, attr, default)
+    else:
+        if hasattr(col, '_column_attrs'):
+            value = col._column_attrs.get(attr, default)
+        else:
+            value = default
+
+    return value
+
 class FalseArray(np.ndarray):
     def __new__(cls, shape):
         obj = np.zeros(shape, dtype=np.bool).view(cls)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -96,6 +96,17 @@ def col_getattr(col, attr, default=None):
 
     return value
 
+def col_iter_str_vals(col):
+    """
+    TODO: docstring
+    This is a mixin-safe version of Column.iter_str_vals.
+    """
+    parent_table = col_getattr(col, 'parent_table')
+    formatter = FORMATTER if parent_table is None else parent_table.formatter
+    _pformat_col_iter = formatter._pformat_col_iter
+    for str_val in _pformat_col_iter(col, -1, False, False, {}):
+        yield str_val
+
 class FalseArray(np.ndarray):
     def __new__(cls, shape):
         obj = np.zeros(shape, dtype=np.bool).view(cls)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -45,6 +45,24 @@ _comparison_functions = set(
      np.isfinite, np.isinf, np.isnan, np.sign, np.signbit])
 
 
+class FalseArray(np.ndarray):
+    def __new__(cls, shape):
+        obj = np.zeros(shape, dtype=np.bool).view(cls)
+        return obj
+
+    def __setitem__(self, item, val):
+        val = np.asarray(val)
+        if np.any(val):
+            raise ValueError('Cannot set any element of {0} class to True'
+                             .format(self.__class__.__name__))
+
+    def __setslice__(self, start, stop, val):
+        val = np.asarray(val)
+        if np.any(val):
+            raise ValueError('Cannot set any element of {0} class to True'
+                             .format(self.__class__.__name__))
+
+
 class BaseColumn(np.ndarray):
 
     meta = MetaData()

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -113,6 +113,25 @@ def col_iter_str_vals(col):
     for str_val in _pformat_col_iter(col, -1, False, False, {}):
         yield str_val
 
+def col_copy(col):
+    """
+    TODO: docstring
+    This is a mixin-safe version of Column.copy() (with copy_data=True).
+    """
+    if isinstance(col, BaseColumn):
+        return col.copy()
+
+    newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
+
+    # Copy old attributes.  Even deepcopy above may not get this (e.g. pandas).
+    if (not hasattr(newcol, '_astropy_column_attrs') or
+            newcol._astropy_column_attrs is None):
+        _column_attrs = deepcopy(getattr(col, '_astropy_column_attrs', {}))
+        newcol._astropy_column_attrs = _column_attrs
+
+    return newcol
+
+
 class FalseArray(np.ndarray):
     def __new__(cls, shape):
         obj = np.zeros(shape, dtype=np.bool).view(cls)

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -47,7 +47,8 @@ def _merge_col_meta(out, tables, col_name_map, idx_left=0, idx_right=1,
 
             if right_name:
                 right_col = table[right_name]
-                out_col.meta = metadata.merge(left_col.meta, right_col.meta,
+                out_col.meta = metadata.merge(getattr(left_col, 'meta', {}),
+                                              getattr(right_col, 'meta', {}),
                                               metadata_conflicts=metadata_conflicts)
                 for attr in attrs:
 
@@ -56,8 +57,8 @@ def _merge_col_meta(out, tables, col_name_map, idx_left=0, idx_right=1,
                     # and if they are different, there is a conflict and we
                     # pick the one on the right (or raise an error).
 
-                    left_attr = getattr(left_col, attr)
-                    right_attr = getattr(right_col, attr)
+                    left_attr = getattr(left_col, attr, None)
+                    right_attr = getattr(right_col, attr, None)
 
                     if left_attr is None:
                         # This may not seem necessary since merge_attr gets set
@@ -83,7 +84,12 @@ def _merge_col_meta(out, tables, col_name_map, idx_left=0, idx_right=1,
                     else:  # left_attr == right_attr
                         merge_attr = right_attr
 
-                    setattr(out_col, attr, merge_attr)
+                    try:
+                        # It may not be allowed to set attributes, for instance `unit`
+                        # in a Quantity column.
+                        setattr(out_col, attr, merge_attr)
+                    except AttributeError:
+                        pass
 
 
 def _merge_table_meta(out, tables, metadata_conflicts='warn'):
@@ -112,6 +118,21 @@ def _get_list_of_tables(tables):
     tables = [(x if isinstance(x, Table) else Table(x)) for x in tables]
 
     return tables
+
+
+def _get_out_class(tables):
+    """
+    From a list of table instances get the merged output table class.
+    This is just taken as the deepest subclass.  It is assumed that
+    `tables` is a list of at least one element and that they are all
+    Table (subclass) instances.  This doesn't handle complicated
+    inheritance schemes.
+    """
+    out_class = tables[0].__class__
+    for t in tables[1:]:
+        if issubclass(t.__class__, out_class):
+            out_class = t.__class__
+    return out_class
 
 
 def join(left, right, keys=None, join_type='inner',
@@ -522,8 +543,6 @@ def _join(left, right, keys=None, join_type='inner',
     joined_table : `~astropy.table.Table` object
         New table containing the result of the join operation.
     """
-    from .table import Table
-
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
 
@@ -549,6 +568,8 @@ def _join(left, right, keys=None, join_type='inner',
             if hasattr(arr[name], 'mask') and np.any(arr[name].mask):
                 raise TableMergeError('{0} key column {1!r} has missing values'
                                       .format(arr_label, name))
+            if arr._is_mixin_column(name):
+                raise ValueError("mixin column '{0}' not allowed as a key column")
 
     len_left, len_right = len(left), len(right)
 
@@ -585,13 +606,13 @@ def _join(left, right, keys=None, join_type='inner',
         masked = True
     masked = bool(masked)
 
-    out = Table(masked=masked)
+    out = _get_out_class([left, right])(masked=masked)
 
     for out_name, dtype, shape in out_descrs:
-        out[out_name] = out.ColumnClass(length=n_out, name=out_name, dtype=dtype, shape=shape)
 
         left_name, right_name = col_name_map[out_name]
         if left_name and right_name:  # this is a key which comes from left and right
+            out[out_name] = out.ColumnClass(length=n_out, name=out_name, dtype=dtype, shape=shape)
             out[out_name] = np.where(right_mask,
                                      left[left_name].take(left_out),
                                      right[right_name].take(right_out))
@@ -603,11 +624,26 @@ def _join(left, right, keys=None, join_type='inner',
         else:
             raise TableMergeError('Unexpected column names (maybe one is ""?)')
 
+        # Finally add the joined column to the output table.
         out[out_name] = array[name].take(array_out, axis=0)
+
+        # If the output table is masked then set the output column masking
+        # accordingly.  Check for columns that don't support a mask attribute.
         if masked:
-            if array.masked:
+            # If input column has mask then OR that mask with the mask from
+            # join process.
+            if hasattr(array[name], 'mask'):
                 array_mask = array_mask | array[name].mask.take(array_out)
-            out[out_name].mask = array_mask
+
+            # If the output column has a mask attribute then set to array_mask.
+            # If no mask then check if any elements are actually masked, and if
+            # so raise an error.  This is probably a mixin column.
+            if hasattr(out[out_name], 'mask'):
+                out[out_name].mask = array_mask
+            elif np.any(array_mask):
+                raise ValueError("cannot mask elements of '{0}' column since "
+                                 "{1} type does not support masking"
+                                 .format(name, array[name].__class__.__name__))
 
     # If col_name_map supplied as a dict input, then update.
     if isinstance(_col_name_map, collections.Mapping):
@@ -642,8 +678,6 @@ def _vstack(arrays, join_type='inner', col_name_map=None):
     stacked_table : `~astropy.table.Table` object
         New table containing the stacked data from the input tables.
     """
-    from .table import Table
-
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
 
@@ -687,9 +721,8 @@ def _vstack(arrays, join_type='inner', col_name_map=None):
 
     lens = [len(arr) for arr in arrays]
     n_rows = sum(lens)
-    out = {}
+    out = _get_out_class(arrays)(masked=masked)
     out_descrs = get_descrs(arrays, col_name_map)
-    names = list(col_name_map.keys())
     for out_descr in out_descrs:
         name = out_descr[0]
         dtype = out_descr[1:]
@@ -710,8 +743,6 @@ def _vstack(arrays, join_type='inner', col_name_map=None):
     # If col_name_map supplied as a dict input, then update.
     if isinstance(_col_name_map, collections.Mapping):
         _col_name_map.update(col_name_map)
-
-    out = Table(out, names=names, masked=masked)
 
     return out
 
@@ -787,9 +818,8 @@ def _hstack(arrays, join_type='exact', uniq_col_name='{col_name}_{table_name}',
     masked = any(getattr(arr, 'masked', False) for arr in arrays) or len(set(arr_lens)) > 1
 
     n_rows = max(arr_lens)
-    out = {}
+    out = _get_out_class(arrays)(masked=masked)
     out_descrs = get_descrs(arrays, col_name_map)
-    names = list(col_name_map.keys())
 
     for out_descr in out_descrs:
         name = out_descr[0]
@@ -811,7 +841,5 @@ def _hstack(arrays, join_type='exact', uniq_col_name='{col_name}_{table_name}',
     # If col_name_map supplied as a dict input, then update.
     if isinstance(_col_name_map, collections.Mapping):
         _col_name_map.update(col_name_map)
-
-    out = Table(out, names=names, masked=masked)
 
     return out

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -575,8 +575,8 @@ def _join(left, right, keys=None, join_type='inner',
             if hasattr(arr[name], 'mask') and np.any(arr[name].mask):
                 raise TableMergeError('{0} key column {1!r} has missing values'
                                       .format(arr_label, name))
-            if arr._is_mixin_column(name):
-                raise ValueError("mixin column '{0}' not allowed as a key column")
+            if not isinstance(arr[name], np.ndarray):
+                raise ValueError("non-ndarray column '{0}' not allowed as a key column")
 
     len_left, len_right = len(left), len(right)
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -633,6 +633,7 @@ def _join(left, right, keys=None, join_type='inner',
 
         # Finally add the joined column to the output table.
         out[out_name] = array[name][array_out]
+        _col_update_attrs_from(out[out_name], array[name])
 
         # If the output table is masked then set the output column masking
         # accordingly.  Check for columns that don't support a mask attribute.

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -690,6 +690,10 @@ def _vstack(arrays, join_type='inner', col_name_map=None):
     if len(arrays) == 1:
         return arrays[0]
 
+    for arr in arrays:
+        if arr.has_mixin_columns:
+            raise NotImplementedError('vstack not available for tables with mixin columns')
+
     # Start by assuming an outer match where all names go to output
     names = set(itertools.chain(*[arr.colnames for arr in arrays]))
     col_name_map = get_col_name_map(arrays, names)

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -295,6 +295,7 @@ class TableFormatter(object):
             Must be a dict which is used to pass back additional values
             defined within the iterator.
         """
+        from .column import col_getattr
         max_lines, _ = self._get_pprint_size(max_lines, -1)
 
         multidims = getattr(col, 'shape', [0])[1:]
@@ -309,7 +310,7 @@ class TableFormatter(object):
         if show_name:
             i_centers.append(n_header)
             # Get column name (or 'None' if not set)
-            col_name = six.text_type(col.name)
+            col_name = six.text_type(col_getattr(col, 'name'))
             if multidims:
                 col_name += ' [{0}]'.format(
                     ','.join(six.text_type(n) for n in multidims))

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -336,7 +336,8 @@ class TableFormatter(object):
         n_print2 = max_lines // 2
         n_rows = len(col)
 
-        col_format = getattr(col, 'format', None)
+        col_format = (col._table_format if hasattr(col, '_table_format')
+                      else getattr(col, 'format', None))
         format_func = _format_funcs.get(col_format, _auto_format_func)
         if len(col) > max_lines:
             if show_length is None:

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -337,8 +337,7 @@ class TableFormatter(object):
         n_print2 = max_lines // 2
         n_rows = len(col)
 
-        col_format = (col._table_format if hasattr(col, '_table_format')
-                      else getattr(col, 'format', None))
+        col_format = col_getattr(col, 'format')
         format_func = _format_funcs.get(col_format, _auto_format_func)
         if len(col) > max_lines:
             if show_length is None:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1580,6 +1580,9 @@ class Table(object):
         if name not in self.keys():
             raise KeyError("Column {0} does not exist".format(name))
 
+        if not isinstance(self.columns[name], BaseColumn):
+            raise NotImplementedError('cannot rename a mixin column')
+
         col_setattr(self.columns[name], 'name', new_name)
 
     def add_row(self, vals=None, mask=None):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -436,8 +436,6 @@ class Table(object):
                     col = col_copy(col)
 
                 col_setattr(col, 'name', name or col_getattr(col, 'name') or def_name)
-
-                # TODO: What about dtype?
             elif isinstance(col, np.ndarray) or isiterable(col):
                 col = self.ColumnClass(name=(name or def_name), data=col, dtype=dtype,
                                        copy=copy)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -8,6 +8,7 @@ from ..extern.six.moves import range as xrange
 import re
 
 from copy import deepcopy
+from copy import copy as copy_stdlib
 from distutils import version
 
 import numpy as np
@@ -440,12 +441,12 @@ class Table(object):
                 col = self.ColumnClass(name=(name or col.name), data=col, dtype=dtype,
                                        copy=copy)
             elif self._is_table_compatible(col):
+                name = getattr(col, 'name', name)
                 if copy:
                     if hasattr(col, 'copy'):
                         col = col.copy()
                     else:
-                        from copy import copy as copy_function
-                        col = copy_function(col)
+                        col = copy_stdlib(col)
                 col.name = name
                 # TODO: What about dtype?
             elif isinstance(col, np.ndarray) or isiterable(col):
@@ -1188,7 +1189,7 @@ class Table(object):
             # Copy new columns, being aware that copy() method might not copy
             # the name.
             names = [col.name for col in cols]
-            cols = [col.copy() for col in cols]
+            cols = [(col.copy() if hasattr(col, 'copy') else copy_stdlib(col)) for col in cols]
             for name, col in zip(names, cols):
                 col.name = name
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -544,6 +544,7 @@ class Table(object):
         # for item/slicing operations.  Do this here in table.
         for name, col, newcol in zip(names, cols, newcols):
             if hasattr(col, '_astropy_column_attrs'):
+                col_setattr(col, 'parent_table', None)  # Don't copy weakref
                 newcol._astropy_column_attrs = deepcopy(col._astropy_column_attrs)
 
         self._update_table_from_cols(table, newcols)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1201,13 +1201,15 @@ class Table(object):
         elif len(indexes) != len(cols):
             raise ValueError('Number of indexes must match number of cols')
 
-        if copy:
-            # Copy new columns, being aware that copy() method might not copy
-            # the name.
-            names = [col_getattr(col, 'name') for col in cols]
-            cols = [(col.copy() if hasattr(col, 'copy') else deepcopy(col)) for col in cols]
-            for name, col in zip(names, cols):
-                col_setattr(col, 'name', name)
+        for i, col in enumerate(cols):
+            if copy:
+                if hasattr(col, 'copy'):
+                    newcol = col.copy()
+                    if hasattr(col, '_astropy_column_attrs'):
+                        newcol._astropy_column_attrs = deepcopy(col._astropy_column_attrs)
+                else:
+                    newcol = deepcopy(col)
+                cols[i] = newcol
 
         if len(self.columns) == 0:
             # No existing table data, init from cols

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -490,41 +490,14 @@ class Table(object):
         """Initialize table from an existing Table object """
 
         table = data  # data is really a Table, rename for clarity
-        data_names = table.colnames
         self.meta.clear()
         self.meta.update(deepcopy(table.meta))
         # If not use_quantity not explicitly set then inherit from table
         if not hasattr(self, '_use_quantity'):
             self.use_quantity = table.use_quantity
-        cols = list(six.itervalues(table.columns))
+        cols = list(table.columns.values())
 
-        # Set self.masked appropriately from cols
-        self._set_masked_from_cols(cols)
-
-        if copy:
-            self._init_from_list(cols, names, dtype, n_cols, copy)
-        else:
-            # Make new columns with possibly new names, but with references to the
-            # original data values.
-            names = [vals[0] or vals[1] for vals in zip(names, data_names)]
-            newcols = []
-            for name, col in zip(names, cols):
-                if isinstance(col, (self.Column, self.MaskedColumn)):
-                    col = self.ColumnClass(col, name=name, copy=copy)
-                elif self._is_table_compatible(col):
-                    # Non-Column objects that are compatible with Table
-                    try:
-                        col = col.__class__(col, copy=copy)
-                    except:
-                        col = col.__class__(col)
-                    col.name = name
-                    # TODO: What about dtype?
-                else:
-                    raise ValueError('Elements in Table initialization must be '
-                                     'either Column or Table compatible')
-                newcols.append(col)
-
-            self._update_table_from_cols(self, newcols)
+        self._init_from_list(cols, names, dtype, n_cols, copy)
 
     def _init_from_cols(self, cols):
         """Initialize table from a list of Column objects"""

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -632,7 +632,7 @@ class Table(object):
         elif isinstance(col, Quantity):
             is_mixin = isinstance(self, QTable)
         else:
-            is_mixin = getattr(col, '_astropy_mixin_column', False)
+            is_mixin = hasattr(col, '_astropy_column_attrs')
 
         return is_mixin
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -405,7 +405,7 @@ class Table(object):
 
     def _init_from_list(self, data, names, dtype, n_cols, copy):
         """Initialize table from a list of columns.  A column can be a
-        Column object, np.ndarray, or any other iterable object.
+        Column object, np.ndarray, mixin, or any other iterable object.
         """
         if data and all(isinstance(row, dict) for row in data):
             self._init_from_list_of_dicts(data, names, dtype, n_cols, copy)
@@ -419,7 +419,7 @@ class Table(object):
 
         for col, name, def_name, dtype in zip(data, names, def_names, dtype):
             if isinstance(col, (Column, MaskedColumn)):
-                col = self.ColumnClass(name=(name or col.name), data=col, dtype=dtype,
+                col = self.ColumnClass(name=(name or col.name or def_name), data=col, dtype=dtype,
                                        copy=copy)
             elif self._is_mixin_column(col):
                 if copy:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -522,11 +522,10 @@ class Table(object):
             # Convert any Columns with units to Quantity for a QTable
             if (isinstance(self, QTable) and isinstance(col, Column)
                     and getattr(col, 'unit', None) is not None):
+
                 qcol = Quantity(col, unit=col.unit, copy=False)
-                col_setattr(qcol, 'name', col.name)
-                col_setattr(qcol, 'description', col.description)
-                col_setattr(qcol, 'format', col.format)
-                col_setattr(qcol, 'meta', deepcopy(col.meta))
+                _col_update_attrs_from(qcol, col, exclude_attrs=['unit', 'dtype', 'parent_table'])
+
                 newcols.append(qcol)
                 continue
 
@@ -550,8 +549,7 @@ class Table(object):
         # for item/slicing operations.  Do this here in table.
         for name, col, newcol in zip(names, cols, newcols):
             if is_mixin_class(col):
-                newcol._astropy_column_attrs = deepcopy(col._astropy_column_attrs)
-                col_setattr(newcol, 'parent_table', None)  # Clear ref to parent table
+                _col_update_attrs_from(newcol, col, exclude_attrs=['parent_table'])
 
         self._update_table_from_cols(table, newcols)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -22,7 +22,7 @@ from ..utils.metadata import MetaData
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
-                     col_getattr, col_setattr, col_copy)
+                     col_getattr, col_setattr, col_copy, _col_update_attrs_from)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 
@@ -1745,8 +1745,11 @@ class Table(object):
                 if isinstance(col, Column) and not isinstance(col, self.ColumnClass):
                     col = self.ColumnClass(col, copy=False)
 
-
                 newcol = col.insert(index, val)
+                if not isinstance(newcol, BaseColumn):
+                    _col_update_attrs_from(newcol, col)
+                    col_setattr(newcol, 'name', name)
+
                 if len(newcol) != N + 1:
                     raise ValueError('Incorrect length for column {0} after inserting {1}'
                                      ' (expected {2}, got {3})'

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -8,7 +8,6 @@ from ..extern.six.moves import range as xrange
 import re
 
 from copy import deepcopy
-from copy import copy as copy_stdlib
 from distutils import version
 
 import numpy as np
@@ -437,7 +436,7 @@ class Table(object):
                     if hasattr(col, 'copy'):
                         newcol = col.copy()
                     else:
-                        newcol = copy_stdlib(col)
+                        newcol = deepcopy(col)
                     if not hasattr(newcol, '_astropy_column_attrs'):
                         _column_attrs = deepcopy(getattr(col, '_astropy_column_attrs', {}))
                         newcol._astropy_column_attrs = _column_attrs
@@ -483,6 +482,7 @@ class Table(object):
     def _init_from_dict(self, data, names, dtype, n_cols, copy):
         """Initialize table from a dictionary of columns"""
 
+        # TODO: is this restriction still needed with no ndarray?
         if not copy:
             raise ValueError('Cannot use copy=False with a dict data input')
 
@@ -1202,7 +1202,7 @@ class Table(object):
             # Copy new columns, being aware that copy() method might not copy
             # the name.
             names = [col_getattr(col, 'name') for col in cols]
-            cols = [(col.copy() if hasattr(col, 'copy') else copy_stdlib(col)) for col in cols]
+            cols = [(col.copy() if hasattr(col, 'copy') else deepcopy(col)) for col in cols]
             for name, col in zip(names, cols):
                 col_setattr(col, 'name', name)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -39,6 +39,15 @@ __doctest_skip__ = ['Table.read', 'Table.write',
                     ]
 
 
+def is_table_compatible(obj):
+    """
+    Determine if `obj` meets the protocol for a Table column.
+    """
+    # Temporary but minimal test
+    ok = getattr(obj, '_astropy_table_compatible', False)
+    return ok
+
+
 def descr(col):
     """Array-interface compliant full description of a column.
 
@@ -414,6 +423,15 @@ class Table(object):
             if isinstance(col, (Column, MaskedColumn)):
                 col = self.ColumnClass(name=(name or col.name), data=col, dtype=dtype,
                                        copy=copy)
+            elif is_table_compatible(col):
+                if copy:
+                    if hasattr(col, 'copy'):
+                        col = col.copy()
+                    else:
+                        from copy import copy as copy_function
+                        col = copy_function(col)
+                col.name = name
+                # TODO: What about dtype?
             elif isinstance(col, np.ndarray) or isiterable(col):
                 col = self.ColumnClass(name=(name or def_name), data=col, dtype=dtype,
                                        copy=copy)
@@ -481,6 +499,14 @@ class Table(object):
             for name, col in zip(names, cols):
                 if isinstance(col, (self.Column, self.MaskedColumn)):
                     col = self.ColumnClass(col, name=name, copy=copy)
+                elif is_table_compatible(col):
+                    # Non-Column objects that are compatible with Table
+                    try:
+                        col = col.__class__(col, copy=copy)
+                    except:
+                        col = col.__class__(col)
+                    col.name = name
+                    # TODO: What about dtype?
                 else:
                     raise ValueError('Elements in Table initialization must be '
                                      'either Column or Table compatible')
@@ -831,6 +857,9 @@ class Table(object):
             name = item
             if isinstance(value, BaseColumn):
                 new_column = value.copy(copy_data=False)
+                new_column.name = name
+            elif is_table_compatible(value):
+                new_column = value
                 new_column.name = name
             elif len(self) == 0:
                 new_column = NewColumn(value, name=name)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -884,11 +884,8 @@ class Table(object):
             # set it from value.  This allows for broadcasting, e.g. t['a']
             # = 1.
             name = item
-            if isinstance(value, BaseColumn):
-                new_column = value.copy(copy_data=False)
-                col_setattr(new_column, 'name', name)
-            elif self._is_mixin_column(value):
-                new_column = value
+            if isinstance(value, BaseColumn) or self._is_mixin_column(value):
+                new_column = col_copy(value)
                 col_setattr(new_column, 'name', name)
             elif len(self) == 0:
                 new_column = NewColumn(value, name=name)
@@ -901,7 +898,7 @@ class Table(object):
                     new_column.unit = value.unit
 
             # Now add new column to the table
-            self.add_column(new_column)
+            self.add_columns([new_column], copy=False)
 
         else:
             n_cols = len(self.columns)
@@ -1198,9 +1195,8 @@ class Table(object):
         elif len(indexes) != len(cols):
             raise ValueError('Number of indexes must match number of cols')
 
-        for i, col in enumerate(cols):
-            if copy:
-                cols[i] = col_copy(col)
+        if copy:
+            cols = [col_copy(col) for col in cols]
 
         if len(self.columns) == 0:
             # No existing table data, init from cols

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1608,31 +1608,56 @@ class Table(object):
              2   5   8
              3   6   9
         """
+        self.insert_row(len(self), vals, mask)
 
-        non_basecolumn_types = set(col.__class__.__name__ for col in self.columns.values()
-                               if not isinstance(col, BaseColumn))
-        if non_basecolumn_types:
-            raise NotImplementedError('Cannot add a row in table with column types {}'
-                                      .format(sorted(non_basecolumn_types)))
+    def insert_row(self, index, vals=None, mask=None):
+        """Add a new row before the given ``index`` position in the table.
+
+        The ``vals`` argument can be:
+
+        sequence (e.g. tuple or list)
+            Column values in the same order as table columns.
+        mapping (e.g. dict)
+            Keys corresponding to column names.  Missing values will be
+            filled with np.zeros for the column dtype.
+        `None`
+            All values filled with np.zeros for the column dtype.
+
+        The ``mask`` attribute should give (if desired) the mask for the
+        values. The type of the mask should match that of the values, i.e. if
+        ``vals`` is an iterable, then ``mask`` should also be an iterable
+        with the same length, and if ``vals`` is a mapping, then ``mask``
+        should be a dictionary.
+
+        Parameters
+        ----------
+        vals : tuple, list, dict or `None`
+            Use the specified values in the new row
+        mask : tuple, list, dict or `None`
+            Use the specified mask values in the new row
+        """
+        colnames = self.colnames
+
+        N = len(self)
+        if index < -N or index > N:
+            raise IndexError("Index {0} is out of bounds for table with length {1}"
+                             .format(index, N))
+        if index < 0:
+            index += N
 
         def _is_mapping(obj):
             """Minimal checker for mapping (dict-like) interface for obj"""
             attrs = ('__getitem__', '__len__', '__iter__', 'keys', 'values', 'items')
             return all(hasattr(obj, attr) for attr in attrs)
 
-        newlen = len(self) + 1
-
-        if vals is None:
-            vals = np.zeros(1, dtype=self.dtype)[0]
-
         if mask is not None and not self.masked:
+            # Possibly issue upgrade warning and update self.ColumnClass.  This
+            # does not change the existing columns.
             self._set_masked(True)
 
-        # Create a table with one row to test the operation on
-        test_data = (ma.zeros if self.masked else np.zeros)(1, dtype=self.dtype)
-
-        if _is_mapping(vals):
-
+        if _is_mapping(vals) or vals is None:
+            # From the vals and/or mask mappings create the corresponding lists
+            # that have entries for each table column.
             if mask is not None and not _is_mapping(mask):
                 raise TypeError("Mismatch between type of vals and mask")
 
@@ -1641,69 +1666,82 @@ class Table(object):
             if mask is not None and set(vals.keys()) != set(mask.keys()):
                 raise ValueError('keys in mask should match keys in vals')
 
-            if self.masked:
-                # We set the mask to True regardless of whether a mask value
-                # is specified or not - that is, any cell where a new row
-                # value is not specified should be treated as missing.
-                test_data.mask[-1] = (True,) * len(test_data.dtype)
+            if vals and any(name not in colnames for name in vals):
+                raise ValueError('Keys in vals must all be valid column names')
 
-            # First we copy the values
-            for name, val in six.iteritems(vals):
-                try:
-                    test_data[name][-1] = val
-                except IndexError:
-                    raise ValueError("No column {0} in table".format(name))
-                if mask:
-                    test_data[name].mask[-1] = mask[name]
+            vals_list = []
+            mask_list = []
 
-        elif isiterable(vals):
+            for name in colnames:
+                if vals and name in vals:
+                    vals_list.append(vals[name])
+                    mask_list.append(False if mask is None else mask[name])
+                else:
+                    col = self[name]
+                    if hasattr(col, 'dtype'):
+                        # Make a placeholder zero element of the right type which is masked.
+                        # This assumes the appropriate insert() method will broadcast a
+                        # numpy scalar to the right shape.
+                        vals_list.append(np.zeros(shape=(), dtype=col.dtype))
 
+                        # For masked table any unsupplied values are masked by default.
+                        mask_list.append(self.masked and vals is not None)
+                    else:
+                        raise ValueError("Value must be supplied for column '{0}'".format(name))
+
+            vals = vals_list
+            mask = mask_list
+
+        if isiterable(vals):
             if mask is not None and (not isiterable(mask) or _is_mapping(mask)):
                 raise TypeError("Mismatch between type of vals and mask")
 
             if len(self.columns) != len(vals):
                 raise ValueError('Mismatch between number of vals and columns')
 
-            if not isinstance(vals, tuple):
-                vals = tuple(vals)
-
-            test_data[-1] = vals
-
             if mask is not None:
-
                 if len(self.columns) != len(mask):
                     raise ValueError('Mismatch between number of masks and columns')
-
-                if not isinstance(mask, tuple):
-                    mask = tuple(mask)
-
-                test_data.mask[-1] = mask
+            else:
+                mask = [False] * len(self.columns)
 
         else:
             raise TypeError('Vals must be an iterable or mapping or None')
 
-        # import pdb; pdb.set_trace()
-        # If no errors have been raised, then the table can be resized
         columns = self.TableColumns()
-        for name, col in self.columns.items():
-            newcol = self.ColumnClass(length=newlen, dtype=col.dtype, shape=col.shape[1:], name=name,
-                                      description=col.description, unit=col.unit,
-                                      format=col.format, meta=deepcopy(col.meta))
+        try:
+            # Insert val at index for each column
+            for name, col, val, mask_ in izip(colnames, self.columns.values(), vals, mask):
+                # If the new row caused a change in self.ColumnClass then
+                # Column-based classes need to be converted first.  This is
+                # typical for adding a row with mask values to an unmasked table.
+                if isinstance(col, Column) and not isinstance(col, self.ColumnClass):
+                    col = self.ColumnClass(col, copy=False)
 
-            if newlen > 1:
-                newcol[:-1] = col
 
-            # Assign the new row
-            newcol[-1:] = test_data[name]
+                newcol = col.insert(index, val)
+                if len(newcol) != N + 1:
+                    raise ValueError('Incorrect length for column {0} after inserting {1}'
+                                     ' (expected {2}, got {3})'
+                                     .format(name, val, len(newcol), N + 1))
+                newcol.parent_table = self
 
-            columns[name] = newcol
-            newcol.parent_table = self
+                # Inserting always defaults to mask=False, so only actually set for True.
+                # This allows for mixin columns that don't have a mask attribute.
+                if self.masked and mask_:
+                    newcol.mask[index] = mask_
 
-        self.columns = columns
+                columns[name] = newcol
 
-        # Revert groups to default (ungrouped) state
-        if hasattr(self, '_groups'):
-            del self._groups
+        except Exception as err:
+            raise ValueError("Unable to insert row because of exception in column '{0}':\n{1}"
+                             .format(name, err))
+        else:
+            self.columns = columns
+
+            # Revert groups to default (ungrouped) state
+            if hasattr(self, '_groups'):
+                del self._groups
 
     def argsort(self, keys=None, kind=None):
         """

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -611,10 +611,10 @@ class Table(object):
         __str__ = __bytes__
 
     @property
-    def _has_mixin_columns(self):
+    def has_mixin_columns(self):
         """
-        Determine if table has any columns that are mixins (are not
-        Column subclasses)
+        True if table has any mixin columns (defined as columns that are not Column
+        subclasses)
         """
         return any(not isinstance(col, BaseColumn) for col in self.columns.values())
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -22,7 +22,7 @@ from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from . import groups
 from .pprint import TableFormatter
-from .column import BaseColumn, Column, MaskedColumn, _auto_names
+from .column import BaseColumn, Column, MaskedColumn, _auto_names, FalseArray
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 
@@ -499,7 +499,7 @@ class Table(object):
         # Make sure that all Column-based objects have class self.ColumnClass
         newcols = []
         for col in cols:
-            if (not self.masked and isinstance(self, QTable)
+            if (isinstance(self, QTable)
                     and isinstance(col, Column) and hasattr(col, 'unit')
                     and col.unit is not None):
                 try:
@@ -552,6 +552,8 @@ class Table(object):
 
         for col in cols:
             col.parent_table = table
+            if table.masked and not hasattr(col, 'mask'):
+                col.mask = FalseArray(col.shape)
 
         table.columns = columns
 
@@ -857,7 +859,7 @@ class Table(object):
             NewColumn = self.MaskedColumn if self.masked else self.Column
 
             # Make sure value has a dtype.  If not make it into a numpy array
-            if not hasattr(value, 'dtype'):
+            if not hasattr(value, 'dtype') and not self._is_mixin_column(value):
                 value = np.asarray(value)
 
             # Make new column and assign the value.  If the table currently

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -22,7 +22,7 @@ from ..utils.metadata import MetaData
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
-                     col_getattr, col_setattr)
+                     col_getattr, col_setattr, col_copy)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 
@@ -433,14 +433,10 @@ class Table(object):
                 # Copy the mixin column attributes if they exist since the copy below
                 # may not get this attribute.
                 if copy:
-                    if hasattr(col, 'copy'):
-                        newcol = col.copy()
-                        _column_attrs = deepcopy(getattr(col, '_astropy_column_attrs', {}))
-                        newcol._astropy_column_attrs = _column_attrs
-                    else:
-                        newcol = deepcopy(col)
-                    col = newcol
+                    col = col_copy(col)
+
                 col_setattr(col, 'name', name or col_getattr(col, 'name') or def_name)
+
                 # TODO: What about dtype?
             elif isinstance(col, np.ndarray) or isiterable(col):
                 col = self.ColumnClass(name=(name or def_name), data=col, dtype=dtype,
@@ -1203,13 +1199,7 @@ class Table(object):
 
         for i, col in enumerate(cols):
             if copy:
-                if hasattr(col, 'copy'):
-                    newcol = col.copy()
-                    if hasattr(col, '_astropy_column_attrs'):
-                        newcol._astropy_column_attrs = deepcopy(col._astropy_column_attrs)
-                else:
-                    newcol = deepcopy(col)
-                cols[i] = newcol
+                cols[i] = col_copy(col)
 
         if len(self.columns) == 0:
             # No existing table data, init from cols

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -314,7 +314,9 @@ class Table(object):
 
     @property
     def _mask(self):
-        """This is needed due to intricacies in numpy.ma, don't remove it."""
+        """This is needed so that comparison of a masked Table and a
+        MaskedArray works.  The requirement comes from numpy.ma.core
+        so don't remove this property."""
         return self.as_array().mask
 
     def filled(self, fill_value=None):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2028,6 +2028,9 @@ class Table(object):
         out : `Table`
             New table with groups set
         """
+        if self.has_mixin_columns:
+            raise NotImplementedError('group_by not available for tables with mixin columns')
+
         return groups.table_group_by(self, keys)
 
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -422,13 +422,12 @@ class Table(object):
                 col = self.ColumnClass(name=(name or col.name), data=col, dtype=dtype,
                                        copy=copy)
             elif self._is_mixin_column(col):
-                name = getattr(col, 'name', name)
                 if copy:
                     if hasattr(col, 'copy'):
                         col = col.copy()
                     else:
                         col = copy_stdlib(col)
-                col.name = name
+                col.name = getattr(col, 'name', name or def_name)
                 # TODO: What about dtype?
             elif isinstance(col, np.ndarray) or isiterable(col):
                 col = self.ColumnClass(name=(name or def_name), data=col, dtype=dtype,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1756,6 +1756,8 @@ class Table(object):
                 if not isinstance(newcol, BaseColumn):
                     _col_update_attrs_from(newcol, col)
                     col_setattr(newcol, 'name', name)
+                    if self.masked:
+                        newcol.mask = FalseArray(newcol.shape)
 
                 if len(newcol) != N + 1:
                     raise ValueError('Incorrect length for column {0} after inserting {1}'
@@ -1763,9 +1765,8 @@ class Table(object):
                                      .format(name, val, len(newcol), N + 1))
                 col_setattr(newcol, 'parent_table', self)
 
-                # Inserting always defaults to mask=False, so only actually set for True.
-                # This allows for mixin columns that don't have a mask attribute.
-                if self.masked and mask_:
+                # Set mask if needed
+                if self.masked:
                     newcol.mask[index] = mask_
 
                 columns[name] = newcol

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -46,7 +46,7 @@ def descr(col):
     This returns a 3-tuple (name, type, shape) that can always be
     used in a structured array dtype definition.
     """
-    col_dtype_str = col.dtype.str if isinstance(col, BaseColumn) else 'O'
+    col_dtype_str = col.dtype.str if hasattr(col, 'dtype') else 'O'
     col_shape = col.shape[1:] if hasattr(col, 'shape') else ()
     return (col_getattr(col, 'name'), col_dtype_str, col_shape)
 

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -148,7 +148,11 @@ class ArrayWrapper(object):
         col_setattr(self, 'dtype', self.data.dtype)
 
     def __getitem__(self, item):
-        return self.data[item]
+        if isinstance(item, (int, np.integer)):
+            out = self.data[item]
+        else:
+            out = self.__class__(self.data[item])
+        return out
 
     def __setitem__(self, item, value):
         self.data[item] = value

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -12,7 +12,7 @@ from itertools import cycle
 import string
 import numpy as np
 
-from .table import Table, Column
+from .table import Table, Column, col_setattr, col_getattr
 from ..extern.six.moves import zip, range
 
 class TimingTables(object):
@@ -136,3 +136,30 @@ def complex_table():
     table = first_table.to_table()
 
     return table
+
+class ArrayWrapper(object):
+    """
+    Minimal mixin using a simple wrapper around a numpy array
+    """
+    _astropy_column_attrs = None
+
+    def __init__(self, data):
+        self.data = np.array(data)
+        col_setattr(self, 'dtype', self.data.dtype)
+
+    def __getitem__(self, item):
+        return self.data[item]
+
+    def __setitem__(self, item, value):
+        self.data[item] = value
+
+    def __len__(self):
+        return len(self.data)
+
+    @property
+    def shape(self):
+        return self.data.shape
+
+    def __repr__(self):
+        return ("<{0} name='{1}' data={2}>"
+                .format(self.__class__.__name__, col_getattr(self, 'name'), self.data))

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -17,7 +17,11 @@ between modules.
 
 from ...tests.helper import pytest
 from ... import table
+from ... import time
+from ... import units as u
+from ... import coordinates
 from .. import pprint
+from ...utils import OrderedDict
 
 
 @pytest.fixture(params=[table.Column, table.MaskedColumn])
@@ -124,3 +128,24 @@ def table_type(request):
         return MaskedTable
     except AttributeError:
         return table.Table
+
+
+@pytest.fixture(params=['quantity', 'time', 'skycoord'])
+def mixin_cols(request):
+    """
+    Fixture to return a set of columns for mixin testing which includes
+    an index column 'i', two string cols 'a', 'b' (for joins etc), and
+    one of the available mixin column types.
+    """
+    mixins = {'quantity': [0, 1, 2, 3] * u.m,
+              'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
+              'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
+                                               dec=[0, 1, 2, 3] * u.deg)
+              }
+    cols = OrderedDict()
+    cols['i'] = table.Column([0, 1, 2, 3])
+    cols['a'] = table.Column(['a', 'b', 'b', 'c'])
+    cols['b'] = table.Column(['b', 'c', 'a', 'd'])
+    cols['m'] = mixins[request.param]
+
+    return cols

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -14,6 +14,7 @@ place to put fixtures that are shared between modules.  These fixtures
 can not be defined in a module by a different name and still be shared
 between modules.
 """
+from copy import deepcopy
 
 from ...tests.helper import pytest
 from ... import table
@@ -23,6 +24,12 @@ from ... import coordinates
 from .. import pprint
 from ...utils import OrderedDict
 
+
+MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
+              'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
+              'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
+                                               dec=[0, 1, 2, 3] * u.deg)
+              }
 
 @pytest.fixture(params=[table.Column, table.MaskedColumn])
 def Column(request):
@@ -130,22 +137,18 @@ def table_type(request):
         return table.Table
 
 
-@pytest.fixture(params=['quantity', 'time', 'skycoord'])
+@pytest.fixture(params=sorted(MIXIN_COLS))
 def mixin_cols(request):
     """
     Fixture to return a set of columns for mixin testing which includes
     an index column 'i', two string cols 'a', 'b' (for joins etc), and
     one of the available mixin column types.
     """
-    mixins = {'quantity': [0, 1, 2, 3] * u.m,
-              'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
-              'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
-                                               dec=[0, 1, 2, 3] * u.deg)
-              }
     cols = OrderedDict()
+    mixin_cols = deepcopy(MIXIN_COLS)
     cols['i'] = table.Column([0, 1, 2, 3], name='i')
     cols['a'] = table.Column(['a', 'b', 'b', 'c'], name='a')
     cols['b'] = table.Column(['b', 'c', 'a', 'd'], name='b')
-    cols['m'] = mixins[request.param]
+    cols['m'] = mixin_cols[request.param]
 
     return cols

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -18,18 +18,13 @@ from copy import deepcopy
 
 from ...tests.helper import pytest
 from ... import table
+from ...table import table_helpers
 from ... import time
 from ... import units as u
 from ... import coordinates
 from .. import pprint
 from ...utils import OrderedDict
 
-
-MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
-              'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
-              'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
-                                               dec=[0, 1, 2, 3] * u.deg)
-              }
 
 @pytest.fixture(params=[table.Column, table.MaskedColumn])
 def Column(request):
@@ -136,6 +131,15 @@ def table_type(request):
     except AttributeError:
         return table.Table
 
+
+# Stuff for testing mixin columns
+
+MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
+              'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
+              'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
+                                               dec=[0, 1, 2, 3] * u.deg),
+              'ndwrap': table_helpers.ArrayWrapper([0, 1, 2, 3])
+              }
 
 @pytest.fixture(params=sorted(MIXIN_COLS))
 def mixin_cols(request):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -138,7 +138,7 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
               'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
                                                dec=[0, 1, 2, 3] * u.deg),
-              'ndwrap': table_helpers.ArrayWrapper([0, 1, 2, 3])
+              'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3])
               }
 
 @pytest.fixture(params=sorted(MIXIN_COLS))

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -143,9 +143,9 @@ def mixin_cols(request):
                                                dec=[0, 1, 2, 3] * u.deg)
               }
     cols = OrderedDict()
-    cols['i'] = table.Column([0, 1, 2, 3])
-    cols['a'] = table.Column(['a', 'b', 'b', 'c'])
-    cols['b'] = table.Column(['b', 'c', 'a', 'd'])
+    cols['i'] = table.Column([0, 1, 2, 3], name='i')
+    cols['a'] = table.Column(['a', 'b', 'b', 'c'], name='a')
+    cols['b'] = table.Column(['b', 'c', 'a', 'd'], name='b')
     cols['m'] = mixins[request.param]
 
     return cols

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -16,6 +16,13 @@ between modules.
 """
 from copy import deepcopy
 
+try:
+    import pandas
+except ImportError:
+    HAS_PANDAS = False
+else:
+    HAS_PANDAS = True
+
 from ...tests.helper import pytest
 from ... import table
 from ...table import table_helpers
@@ -140,6 +147,8 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
                                                dec=[0, 1, 2, 3] * u.deg),
               'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3])
               }
+if HAS_PANDAS:
+    MIXIN_COLS['pandas'] = pandas.Series([0, 1, 2, 3])
 
 @pytest.fixture(params=sorted(MIXIN_COLS))
 def mixin_cols(request):
@@ -150,6 +159,8 @@ def mixin_cols(request):
     """
     cols = OrderedDict()
     mixin_cols = deepcopy(MIXIN_COLS)
+    if HAS_PANDAS:
+        mixin_cols['pandas']._astropy_column_attrs = None
     cols['i'] = table.Column([0, 1, 2, 3], name='i')
     cols['a'] = table.Column(['a', 'b', 'b', 'c'], name='a')
     cols['b'] = table.Column(['b', 'c', 'a', 'd'], name='b')

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -256,6 +256,84 @@ class TestColumn():
             assert isinstance(c01, Column)
             assert c01.shape == (1,)
 
+    def test_insert_basic(self, Column):
+        c = Column([0, 1, 2], name='a', dtype=int, unit='mJy', format='%i',
+                   description='test column', meta={'c': 8, 'd': 12})
+
+        # Basic insert
+        c1 = c.insert(1, 100)
+        assert np.all(c1 == [0, 100, 1, 2])
+        assert c1.attrs_equal(c)
+        assert type(c) is type(c1)
+
+        c1 = c.insert(-1, 100)
+        assert np.all(c1 == [0, 1, 100, 2])
+
+        c1 = c.insert(3, 100)
+        assert np.all(c1 == [0, 1, 2, 100])
+
+        c1 = c.insert(-3, 100)
+        assert np.all(c1 == [100, 0, 1, 2])
+
+        # Out of bounds index
+        with pytest.raises(IndexError):
+            c1 = c.insert(-4, 100)
+        with pytest.raises(IndexError):
+            c1 = c.insert(4, 100)
+
+    def test_insert_multidim(self, Column):
+        c = Column([[1, 2],
+                    [3, 4]], name='a', dtype=int)
+
+        # Basic insert
+        c1 = c.insert(1, [100, 200])
+        assert np.all(c1 == [[1, 2], [100, 200], [3, 4]])
+
+        # Broadcast
+        c1 = c.insert(1, 100)
+        assert np.all(c1 == [[1, 2], [100, 100], [3, 4]])
+
+        # Wrong shape
+        with pytest.raises(ValueError):
+            c1 = c.insert(1, [100, 200, 300])
+
+    def test_insert_object(self, Column):
+        c = Column(['a', 1, None], name='a', dtype=object)
+
+        # Basic insert
+        c1 = c.insert(1, [100, 200])
+        assert np.all(c1 == ['a', [100, 200], 1, None])
+
+    def test_insert_masked(self):
+        c = table.MaskedColumn([0, 1, 2], name='a', mask=[False, True, False])
+
+        # Basic insert
+        c1 = c.insert(1, 100)
+        assert np.all(c1.data.data == [0, 100, 1, 2])
+        assert np.all(c1.data.mask == [False, False, True, False])
+        assert type(c) is type(c1)
+
+        for mask in (False, True):
+            c1 = c.insert(1, 100, mask=mask)
+            assert np.all(c1.data.data == [0, 100, 1, 2])
+            assert np.all(c1.data.mask == [False, mask, True, False])
+
+    def test_insert_masked_multidim(self):
+        c = table.MaskedColumn([[1, 2],
+                                [3, 4]], name='a', dtype=int)
+
+        c1 = c.insert(1, [100, 200], mask=True)
+        assert np.all(c1.data.data == [[1, 2], [100, 200], [3, 4]])
+        assert np.all(c1.data.mask == [[False, False], [True, True], [False, False]])
+
+        c1 = c.insert(1, [100, 200], mask=[True, False])
+        assert np.all(c1.data.data == [[1, 2], [100, 200], [3, 4]])
+        assert np.all(c1.data.mask == [[False, False], [True, False], [False, False]])
+
+        with pytest.raises(ValueError):
+            c1 = c.insert(1, [100, 200], mask=[True, False, True])
+
+
 class TestAttrEqual():
     """Bunch of tests originally from ATpy that test the attrs_equal method."""
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -265,6 +265,8 @@ class TestColumn():
         assert np.all(c1 == [0, 100, 1, 2])
         assert c1.attrs_equal(c)
         assert type(c) is type(c1)
+        if hasattr(c1, 'mask'):
+            assert c1.data.shape == c1.mask.shape
 
         c1 = c.insert(-1, 100)
         assert np.all(c1 == [0, 1, 100, 2])
@@ -275,10 +277,14 @@ class TestColumn():
         c1 = c.insert(-3, 100)
         assert np.all(c1 == [100, 0, 1, 2])
 
+        c1 = c.insert(1, [100, 200, 300])
+        if hasattr(c1, 'mask'):
+            assert c1.data.shape == c1.mask.shape
+
         # Out of bounds index
-        with pytest.raises(IndexError):
+        with pytest.raises((ValueError, IndexError)):
             c1 = c.insert(-4, 100)
-        with pytest.raises(IndexError):
+        with pytest.raises((ValueError,IndexError)):
             c1 = c.insert(4, 100)
 
     def test_insert_multidim(self, Column):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -20,11 +20,9 @@ from .. import table_helpers
 from .conftest import MIXIN_COLS
 
 # ISSUES / TODO
-# - Test vstack, groups
+# - Test groups
 # - Check attributes in join outputs
-# - Test adding a row
 # - Test convert QTable <=> Table
-# - Conversion to numpy array and dtype
 # - Assignment
 # - Copy
 # - Array subsetting
@@ -270,3 +268,14 @@ def test_insert_row(mixin_cols):
         with pytest.raises(ValueError) as exc:
             t.insert_row(1, t[-1])
         assert "Unable to insert row" in str(exc.value)
+
+def test_convert_np_array(mixin_cols):
+    """
+    Test that converting to numpy array creates an object dtype and that
+    each instance in the array has the expected type.
+    """
+    t = QTable(mixin_cols)
+    ta = t.as_array()
+    m = mixin_cols['m']
+    dtype_kind = m.dtype.kind if hasattr(m, 'dtype') else 'O'
+    assert ta['m'].dtype.kind == dtype_kind

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -1,0 +1,45 @@
+from ..table import QTable
+from ... import units as u
+
+# ISSUES
+# - Overlap with SkyCoord.name => SkyCoord.frame.name => 'icrs' by default.
+#   This gets clobbered by directly setting `frame` attribute.
+
+def test_attributes(mixin_cols):
+    """
+    Required attributes for a column can be set.
+    """
+    m = mixin_cols['m']
+    m.name = 'a'
+    assert m.name == 'a'
+
+    m.description = 'a'
+    assert m.description == 'a'
+
+    if not isinstance(m, u.Quantity):
+        m.unit = u.m
+    assert m.unit is u.m
+
+    if hasattr(m, '_table_format'):
+        m._table_format = 'a'
+        assert m._table_format == 'a'
+    else:
+        m.format = 'a'
+        assert m.format == 'a'
+
+    m.meta = {'a': 1}
+    assert m.meta == {'a': 1}
+
+
+def test_make_table(table_types, mixin_cols):
+    """
+    Make a table with the columns in mixin_cols, which is an ordered dict of
+    three cols: 'a' and 'b' are table_types.Column type, and 'm' is a mixin.
+    """
+    t = table_types.Table(mixin_cols)
+    m = mixin_cols['m']
+    tm = t['m']
+    if isinstance(m, u.Quantity) and type(t) is not QTable:
+        assert type(tm) is table_types.Column
+    else:
+        assert type(tm) is type(m)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -255,3 +255,18 @@ def test_vstack():
     t2 = QTable(MIXIN_COLS)
     with pytest.raises(NotImplementedError):
         vstack([t1, t2])
+
+def test_insert_row(mixin_cols):
+    """
+    Test inserting a row, which only works for BaseColumn and Quantity
+    """
+    t = QTable(mixin_cols)
+    col_setattr(t['m'], 'description', 'd')
+    if isinstance(t['m'], u.Quantity):
+        t.insert_row(1, t[-1])
+        assert t[1] == t[-1]
+        assert col_getattr(t['m'], 'description') == 'd'
+    else:
+        with pytest.raises(ValueError) as exc:
+            t.insert_row(1, t[-1])
+        assert "Unable to insert row" in str(exc.value)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -144,6 +144,10 @@ def test_join(table_types):
         t12 = join(t1, t2, keys=['a', 'skycoord'])
     assert 'not allowed as a key column' in str(exc.value)
 
+    # Join does work for a mixin which is a subclass of np.ndarray
+    t12 = join(t1, t2, keys=['quantity'])
+    assert np.all(t12['a_1'] == t1['a'])
+
 def test_hstack(table_types):
     """
     Hstack tables with mixin cols.  Use column "i" as proxy for what the

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -3,6 +3,13 @@ try:
 except ImportError:
     from io import StringIO
 
+try:
+    import h5py
+except ImportError:
+    HAS_H5PY = False
+else:
+    HAS_H5PY = True
+
 from ...tests.helper import pytest
 from ...table import QTable, col_setattr, col_getattr
 from ... import units as u
@@ -85,6 +92,8 @@ def test_io_write_fail(mixin_cols):
     """
     t = QTable(mixin_cols)
     for fmt in ('fits', 'votable', 'hdf5'):
+        if fmt == 'hdf5' and not HAS_H5PY:
+            continue
         out = StringIO()
         with pytest.raises(ValueError) as err:
             t.write(out, format=fmt)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -1,5 +1,10 @@
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from ...tests.helper import pytest
-from ..table import QTable, col_setattr, col_getattr
+from ...table import QTable, col_setattr, col_getattr
 from ... import units as u
 
 # ISSUES
@@ -55,3 +60,17 @@ def test_make_table(table_types, mixin_cols):
 
     t = table_types.Table(cols)
     check_mixin_type(t, t['col3'], mixin_cols['m'])
+
+
+def test_io_ascii_write(mixin_cols):
+    """
+    Test that table with mixin column can be written by io.ascii for
+    every pure Python writer.  No validation of the output is done,
+    this just confirms no exceptions.
+    """
+    from ...io.ascii.connect import _get_connectors_table
+    t = QTable(mixin_cols)
+    for fmt in _get_connectors_table():
+        if fmt['Write'] and '.fast_' not in fmt['Format']:
+            out = StringIO()
+            t.write(out, format=fmt['Format'])

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -1,4 +1,5 @@
-from ..table import QTable
+from ...tests.helper import pytest
+from ..table import QTable, col_setattr, col_getattr
 from ... import units as u
 
 # ISSUES
@@ -10,25 +11,27 @@ def test_attributes(mixin_cols):
     Required attributes for a column can be set.
     """
     m = mixin_cols['m']
-    m.name = 'a'
-    assert m.name == 'a'
+    col_setattr(m, 'name', 'a')
+    assert col_getattr(m, 'name') == 'a'
 
-    m.description = 'a'
-    assert m.description == 'a'
+    col_setattr(m, 'description', 'a')
+    assert col_getattr(m, 'description') == 'a'
 
     if not isinstance(m, u.Quantity):
-        m.unit = u.m
-    assert m.unit is u.m
+        col_setattr(m, 'unit', u.m)
+    assert col_getattr(m, 'unit') is u.m
 
-    if hasattr(m, '_table_format'):
-        m._table_format = 'a'
-        assert m._table_format == 'a'
-    else:
-        m.format = 'a'
-        assert m.format == 'a'
+    col_setattr(m, 'format', 'a')
+    assert col_getattr(m, 'format') == 'a'
 
-    m.meta = {'a': 1}
-    assert m.meta == {'a': 1}
+    col_setattr(m, 'meta', {'a': 1})
+    assert col_getattr(m, 'meta') == {'a': 1}
+
+    with pytest.raises(AttributeError):
+        col_setattr(m, 'bad_attr', 1)
+
+    with pytest.raises(AttributeError):
+        col_getattr(m, 'bad_attr')
 
 
 def check_mixin_type(table, table_col, in_col):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -279,3 +279,13 @@ def test_convert_np_array(mixin_cols):
     m = mixin_cols['m']
     dtype_kind = m.dtype.kind if hasattr(m, 'dtype') else 'O'
     assert ta['m'].dtype.kind == dtype_kind
+
+def test_assignment():
+    for name in ('quantity', 'arraywrap'):
+        m = MIXIN_COLS[name]
+        t = QTable([m], names=['m'])
+        t['m'][0:2] = m[1:3]
+        if name == 'arraywrap':
+            assert np.all(t['m'].data[0:2] == m.data[1:3])
+        else:
+            assert np.all(t['m'][0:2] == m[1:3])

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -269,6 +269,15 @@ def test_insert_row(mixin_cols):
             t.insert_row(1, t[-1])
         assert "Unable to insert row" in str(exc.value)
 
+def test_insert_row_bad_unit():
+    """
+    Insert a row into a QTable with the wrong unit
+    """
+    t = QTable([[1] * u.m])
+    with pytest.raises(ValueError) as exc:
+        t.insert_row(0, (2 * u.m / u.s,))
+    assert "'m / s' (speed) and 'm' (length) are not convertible" in str(exc.value)
+
 def test_convert_np_array(mixin_cols):
     """
     Test that converting to numpy array creates an object dtype and that

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -20,8 +20,6 @@ from ... import coordinates
 from .. import table_helpers
 from .conftest import MIXIN_COLS
 
-# ISSUES / TODO
-# - Check attributes in join outputs
 
 def test_attributes(mixin_cols):
     """

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -13,7 +13,8 @@ else:
 import numpy as np
 
 from ...tests.helper import pytest
-from ...table import Table, QTable, col_setattr, col_getattr, join, hstack, vstack
+from ...table import Table, QTable, join, hstack, vstack
+from ..column import col_setattr, col_getattr
 from ... import units as u
 from ... import coordinates
 from .. import table_helpers

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -66,7 +66,6 @@ def check_mixin_type(table, table_col, in_col):
     # Make sure in_col got copied and creating table did not touch it
     assert col_getattr(in_col, 'name') is None
 
-
 def test_make_table(table_types, mixin_cols):
     """
     Make a table with the columns in mixin_cols, which is an ordered dict of
@@ -221,6 +220,15 @@ def test_add_column(mixin_cols):
     """
     attrs = ('name', 'unit', 'dtype', 'format', 'description', 'meta')
     m = mixin_cols['m']
+    assert col_getattr(m, 'name') is None
+
+    # Make sure adding column in various ways doesn't touch
+    t = QTable([m], names=['a'])
+    assert col_getattr(m, 'name') is None
+
+    t['new'] = m
+    assert col_getattr(m, 'name') is None
+
     col_setattr(m, 'name', 'm')
     col_setattr(m, 'format', '{0}')
     col_setattr(m, 'description', 'd')

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -21,6 +21,12 @@ from .conftest import MIXIN_COLS
 
 # ISSUES / TODO
 # - Test hstack, vstack, groups
+# - Test adding a row
+# - Test convert QTable <=> Table
+# - Conversion to numpy array and dtype
+# - Assignment
+# - Copy
+# - Array subsetting
 
 def test_attributes(mixin_cols):
     """

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -13,14 +13,15 @@ else:
 import numpy as np
 
 from ...tests.helper import pytest
-from ...table import QTable, col_setattr, col_getattr, join, hstack
+from ...table import QTable, col_setattr, col_getattr, join, hstack, vstack
 from ... import units as u
 from ... import coordinates
 from .. import table_helpers
 from .conftest import MIXIN_COLS
 
 # ISSUES / TODO
-# - Test hstack, vstack, groups
+# - Test vstack, groups
+# - Check attributes in join outputs
 # - Test adding a row
 # - Test convert QTable <=> Table
 # - Conversion to numpy array and dtype
@@ -237,3 +238,12 @@ def test_add_column(mixin_cols):
         for attr in attrs:
             if attr != 'name':
                 assert col_getattr(t['m'], attr) == col_getattr(t[name], attr)
+
+def test_vstack():
+    """
+    Vstack tables with mixin cols.
+    """
+    t1 = QTable(MIXIN_COLS)
+    t2 = QTable(MIXIN_COLS)
+    with pytest.raises(NotImplementedError):
+        vstack([t1, t2])

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -74,3 +74,18 @@ def test_io_ascii_write(mixin_cols):
         if fmt['Write'] and '.fast_' not in fmt['Format']:
             out = StringIO()
             t.write(out, format=fmt['Format'])
+
+
+def test_io_write_fail(mixin_cols):
+    """
+    Test that table with mixin column cannot be written by io.votable,
+    io.fits, and io.misc.hdf5
+    every pure Python writer.  No validation of the output is done,
+    this just confirms no exceptions.
+    """
+    t = QTable(mixin_cols)
+    for fmt in ('fits', 'votable', 'hdf5'):
+        out = StringIO()
+        with pytest.raises(ValueError) as err:
+            t.write(out, format=fmt)
+        assert 'cannot write table with mixin column(s)' in str(err.value)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -33,7 +33,7 @@ def test_attributes(mixin_cols):
 
 def check_mixin_type(table, table_col, in_col):
     if isinstance(in_col, u.Quantity) and type(table) is not QTable:
-        assert type(table_col) is table.Column
+        assert type(table_col) is table.ColumnClass
     else:
         assert type(table_col) is type(in_col)
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -334,3 +334,11 @@ def test_conversion_qtable_table():
     for name in names:
         assert col_getattr(qt2[name], 'description') == name
         assert_table_name_col_equal(qt2, name, qt[name])
+
+@pytest.mark.xfail
+def test_column_rename():
+    qt = QTable(MIXIN_COLS)
+    names = qt.colnames
+    for name in names:
+        qt.rename_column(name, name + '2')
+    assert qt.colnames == [name + '2' for name in names]

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -17,9 +17,10 @@ from ...table import QTable, col_setattr, col_getattr, join
 from ... import units as u
 from .conftest import MIXIN_COLS
 
-# ISSUES
-# - Overlap with SkyCoord.name => SkyCoord.frame.name => 'icrs' by default.
-#   This gets clobbered by directly setting `frame` attribute.
+# ISSUES / TODO
+# - Test that slicing / indexing table gives right values and col attrs inherit
+# - Test hstack, vstack, groups
+# - Add column to table => makes copy and copies col attrs if existent
 
 def test_attributes(mixin_cols):
     """
@@ -54,6 +55,9 @@ def check_mixin_type(table, table_col, in_col):
         assert type(table_col) is table.ColumnClass
     else:
         assert type(table_col) is type(in_col)
+
+    # Make sure in_col got copied and creating table did not touch it
+    assert col_getattr(in_col, 'name') is None
 
 
 def test_make_table(table_types, mixin_cols):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -31,15 +31,24 @@ def test_attributes(mixin_cols):
     assert m.meta == {'a': 1}
 
 
+def check_mixin_type(table, table_col, in_col):
+    if isinstance(in_col, u.Quantity) and type(table) is not QTable:
+        assert type(table_col) is table.Column
+    else:
+        assert type(table_col) is type(in_col)
+
+
 def test_make_table(table_types, mixin_cols):
     """
     Make a table with the columns in mixin_cols, which is an ordered dict of
     three cols: 'a' and 'b' are table_types.Column type, and 'm' is a mixin.
     """
     t = table_types.Table(mixin_cols)
-    m = mixin_cols['m']
-    tm = t['m']
-    if isinstance(m, u.Quantity) and type(t) is not QTable:
-        assert type(tm) is table_types.Column
-    else:
-        assert type(tm) is type(m)
+    check_mixin_type(t, t['m'], mixin_cols['m'])
+
+    cols = list(mixin_cols.values())
+    t = table_types.Table(cols, names=('a', 'b', 'c', 'm'))
+    check_mixin_type(t, t['m'], mixin_cols['m'])
+
+    t = table_types.Table(cols)
+    check_mixin_type(t, t['col3'], mixin_cols['m'])

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -243,7 +243,7 @@ class TestPprint():
     def test_clip4(self, table_type):
         """Test a range of max_lines"""
         self._setup(table_type)
-        for max_lines in range(130):
+        for max_lines in (0, 1, 4, 5, 6, 7, 8, 100, 101, 102, 103, 104, 130):
             lines = self.tb.pformat(max_lines=max_lines, show_unit=False)
             assert len(lines) == max(8, min(102, max_lines))
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -643,6 +643,32 @@ class TestAddRow(SetupData):
         assert len(t) == 3
         assert np.all(t.as_array() == t_copy.as_array())
 
+    def test_insert_table_row(self, table_types):
+        """
+        Light testing of Table.insert_row() method.  The deep testing is done via
+        the add_row() tests which calls insert_row(index=len(self), ...), so
+        here just test that the added index parameter is handled correctly.
+        """
+        self._setup(table_types)
+        row = (10, 40.0, 'x', [10, 20])
+        for index in xrange(-3, 4):
+            indices = np.insert(np.arange(3), index, 3)
+            t = table_types.Table([self.a, self.b, self.c, self.d])
+            t2 = t.copy()
+            t.add_row(row)  # By now we know this works
+            t2.insert_row(index, row)
+            for name in t.colnames:
+                if t[name].dtype.kind == 'f':
+                    assert np.allclose(t[name][indices], t2[name])
+                else:
+                    assert np.all(t[name][indices] == t2[name])
+
+        for index in (-4, 4):
+            t = table_types.Table([self.a, self.b, self.c, self.d])
+            with pytest.raises(IndexError):
+                t.insert_row(index, row)
+
+
 @pytest.mark.usefixtures('table_types')
 class TestTableColumn(SetupData):
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -651,7 +651,7 @@ class TestAddRow(SetupData):
         """
         self._setup(table_types)
         row = (10, 40.0, 'x', [10, 20])
-        for index in xrange(-3, 4):
+        for index in range(-3, 4):
             indices = np.insert(np.arange(3), index, 3)
             t = table_types.Table([self.a, self.b, self.c, self.d])
             t2 = t.copy()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -867,6 +867,10 @@ class Time(object):
     def __len__(self):
         return len(self.jd1)
 
+    @property
+    def shape(self):
+        return self.jd1.shape
+
     def __sub__(self, other):
         if not isinstance(other, Time):
             try:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -867,10 +867,6 @@ class Time(object):
     def __len__(self):
         return len(self.jd1)
 
-    @property
-    def shape(self):
-        return self.jd1.shape
-
     def __sub__(self, other):
         if not isinstance(other, Time):
             try:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -153,6 +153,10 @@ class Time(object):
     # gets called over the __mul__ of Numpy arrays.
     __array_priority__ = 20000
 
+    # Declare that SkyCoord can be used as a Table columm
+    _astropy_table_compatible = True
+    _table_format = None
+
     def __new__(cls, val, val2=None, format=None, scale=None,
                 precision=None, in_subfmt=None, out_subfmt=None,
                 location=None, copy=False):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -154,7 +154,7 @@ class Time(object):
     __array_priority__ = 20000
 
     # Declare that SkyCoord can be used as a Table columm
-    _astropy_table_compatible = True
+    _astropy_mixin_column = True
     _table_format = None
 
     def __new__(cls, val, val2=None, format=None, scale=None,

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -153,9 +153,9 @@ class Time(object):
     # gets called over the __mul__ of Numpy arrays.
     __array_priority__ = 20000
 
-    # Declare that SkyCoord can be used as a Table columm
-    _astropy_mixin_column = True
-    _table_format = None
+    # Declare that Time can be used as a Table column by defining the
+    # attribute where column attributes will be stored.
+    _astropy_column_attrs = None
 
     def __new__(cls, val, val2=None, format=None, scale=None,
                 precision=None, in_subfmt=None, out_subfmt=None,

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -175,9 +175,6 @@ class Quantity(np.ndarray):
 
     __array_priority__ = 10000
 
-    # Declare that SkyCoord can be used as a Table columm
-    _astropy_table_compatible = True
-
     def __new__(cls, value, unit=None, dtype=None, copy=True, order=None,
                 subok=False, ndmin=0):
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -175,6 +175,9 @@ class Quantity(np.ndarray):
 
     __array_priority__ = 10000
 
+    # Declare that SkyCoord can be used as a Table columm
+    _astropy_table_compatible = True
+
     def __new__(cls, value, unit=None, dtype=None, copy=True, order=None,
                 subok=False, ndmin=0):
 

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -284,6 +284,14 @@ I/O with tables
 
    io.rst
 
+Mixin columns
+----------------
+
+.. toctree::
+   :maxdepth: 2
+
+   mixin_columns.rst
+
 Implementation
 ----------------
 

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -212,6 +212,12 @@ which can be used as a mixin column.  A `pandas.Series
 <http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.html>`_
 object can function as a mixin column as well. 
 
+Other interesting possibilities for mixin columns include:
+
+- Columns which are dynamically computed as a function of other columns (AKA
+  spreadsheet)
+- Columns which are themselves a |Table|, i.e. nested tables
+
 .. _arraywrapper_example:
 
 Example: ArrayWrapper

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -1,0 +1,256 @@
+.. include:: references.txt
+.. |join| replace:: :func:`~astropy.table.join`
+.. |Quantity| replace:: :class:`~astropy.units.Quantity`
+.. |Time| replace:: :class:`~astropy.time.Time`
+.. |SkyCoord| replace:: :class:`~astropy.coordinates.SkyCoord`
+
+.. _mixin_columns:
+
+Mixin columns
+---------------
+
+Version 1.0 of astropy introduces a new concept of the "Mixin
+Column" in tables which allows integration of appropriate non-|Column| based
+class objects within a |Table| object.  These mixin column objects are not
+converted in any way but are used natively.
+
+The available built-in mixin column classes are:
+
+- |Quantity|
+- |SkyCoord|
+- |Time|
+
+.. Warning:: 
+
+   The interface for using mixin columns is experimental at this point and it
+   is not recommended to use this feature in production code.  There are known
+   limitations and some table functionality which is not yet implemented for
+   mixin columns.  API changes are likely and since the code is all new there
+   may be some bugs.
+   
+As a first example we can create a table and add a time column::
+
+  >>> from astropy.table import Table
+  >>> from astropy.time import Time
+  >>> t = Table()
+  >>> t['index'] = [1, 2]
+  >>> t['time'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+  >>> print(t)
+  index           time         
+  ----- -----------------------
+      1 2001-01-02T12:34:56.000
+      2 2001-02-03T00:01:02.000
+
+The important point here is that the ``time`` column is a bona fide |Time| object::
+
+  >>> t['time']
+  <Time object: scale='utc' format='isot' value=['2001-01-02T12:34:56.000' '2001-02-03T00:01:02.000']>
+  >>> t['time'].mjd
+  array([ 51911.52425926,  51943.00071759])
+
+.. _quantity_and_qtable:
+
+Quantity and QTable
+^^^^^^^^^^^^^^^^^^^
+
+The ability to natively handle |Quantity| objects within a table makes it
+easier to manipulate tabular data with units in a natural and robust way.
+However, this feature introduces an ambiguity because data with a unit
+(e.g. from a FITS binary table) can be represented as either a |Column| with a
+``unit`` attribute or as a |Quantity| object. In order to retain complete
+backward compatibility with astropy versions prior to 1.0, a minor variant of
+the |Table| class called |QTable| is available.  |QTable| is exactly the same
+as |Table| except that |Quantity| is the default for any data column with a
+defined unit.
+
+To illustrate we first create a standard |Table| where we supply as input a
+|Time| object and a |Quantity| object with units of ``m / s``.  In this case
+the quantity is converted to a |Column| (which has a ``unit`` attribute but
+does not have all the features of a |Quantity|)::
+
+  >>> import astropy.units as u
+  >>> t = Table()
+  >>> t['index'] = [1, 2]
+  >>> t['time'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+  >>> t['velocity'] = [3, 4] * u.m / u.s
+
+  >>> print(t)
+  index           time          velocity
+                                 m / s  
+  ----- ----------------------- --------
+      1 2001-01-02T12:34:56.000      3.0
+      2 2001-02-03T00:01:02.000      4.0
+
+  >>> type(t['velocity'])
+  <class 'astropy.table.column.Column'>
+
+  >>> t['velocity'].unit
+  Unit("m / s")
+
+  >>> (t['velocity'] ** 2).unit  # WRONG because Column is not smart about unit
+  Unit("m / s")
+
+So instead let's do the same thing using a quantity table |QTable|::
+
+  >>> from astropy.table import QTable
+
+  >>> qt = QTable()
+  >>> qt['index'] = [1, 2]
+  >>> qt['time'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+  >>> qt['velocity'] = [3, 4] * u.m / u.s
+
+Now we print the table again but this time notice that the individual values
+all have units because this is how |Quantity| prints a single array element::
+
+  >>> print(qt)
+  index           time           velocity
+                                  m / s  
+  ----- ----------------------- ---------
+      1 2001-01-02T12:34:56.000 3.0 m / s
+      2 2001-02-03T00:01:02.000 4.0 m / s
+
+The ``velocity`` column is now a |Quantity| and behaves accordingly::
+
+  >>> type(qt['velocity'])
+  <class 'astropy.units.quantity.Quantity'>
+
+  >>> qt['velocity'].unit
+  Unit("m / s")
+
+  >>> (qt['velocity'] ** 2).unit  # GOOD!
+  Unit("m2 / s2")
+
+You can easily convert |Table| to |QTable| and vice-versa::
+
+  >>> qt2 = QTable(t)
+  >>> type(qt2['velocity'])
+  <class 'astropy.units.quantity.Quantity'>
+
+  >>> t2 = Table(qt2)
+  >>> type(t2['velocity'])
+  <class 'astropy.table.column.Column'>
+
+Details and caveats
+^^^^^^^^^^^^^^^^^^^
+
+Most common table operations behave as expected when mixin columns are part of
+the table.  However, there are limitations in the current implementation.
+
+**Adding or inserting a row**
+
+Adding or inserting a row works as expected only for mixin classes that are
+mutable (data can changed internally) and that have an ``insert()`` method.
+|Quantity| supports ``insert()`` but |Time| and |SkyCoord| do not.  If we try to
+insert a row into the previously defined table an exception occurs::
+
+  >>> qt.add_row((1, '2001-02-03T00:01:02', 5 * u.m / u.s))  # doctest: +SKIP
+  ...
+  ValueError: Unable to insert row because of exception in column 'time':
+  'Time' object has no attribute 'insert'
+
+**Masking**
+
+Mixin columns do not support masking, but there is limited support for use of
+mixins within a masked table.  In this case a ``mask`` attribute is assigned to
+the mixin column object.  This ``mask`` is a special object that is a boolean
+array of ``False`` corresponding to the mixin data shape.  The ``mask`` looks
+like a normal numpy array but an exception will be raised if ``True`` is assigned
+to any element.  The consequences of the limitation are most obvious in the
+high-level table operations.
+
+**High-level table operations**
+
+The table below gives a summary of support for high-level operations on tables
+that contain mixin columns:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Operation
+     - Support
+   * - :ref:`grouped-operations`
+     - Not implemented yet, but no fundamental limitation
+   * - :ref:`stack-vertically`
+     - Not implemented yet, pending definition of generic concatenation protocol
+   * - :ref:`stack-horizontally`
+     - Works if output mixin columns do not require masking
+   * - :ref:`table-join`
+     - Works if output mixin columns do not require masking; no mixin key
+       columns allowed
+   * - :ref:`unique-rows`
+     - Not implemented yet, uses grouped operations
+
+**Mixin column attributes**
+
+For mixin columns the column attributes ``name``, ``unit``, ``dtype``,
+``format``, ``description`` and ``meta`` are currently stored in a simple
+dictionary called `_astropy_column_attrs`.  These attributes can be manipulated
+with the functions ``col_getattr`` and ``col_setattr`` which are available in
+the ``astropy.table.column`` module.  These methods are not formally part of
+the astropy public API and may change in the future.
+
+
+Mixin protocol
+^^^^^^^^^^^^^^
+
+A key idea behind mixin columns is that any class which satisfies a specified
+protocol can be used.  That means many user-defined class objects which handle
+array-like data can be used natively within a |Table|.  The protocol is
+relatively simple and requires that a class behave like a minimal numpy array
+with the following properties:
+
+- Contains array-like data
+- Supports getting data as a single item, slicing, or index array access
+- Has a ``shape`` attribute
+- Has a ``__len__`` method for length
+- Has a ``_astropy_column_attrs`` attribute, which tells the |Table| class to
+  use the object natively instead of converting to a |Column|
+
+The `Example: ArrayWrapper`_ section shows a working minimal example of a class
+which can be used as a mixin column.  A `pandas.Series
+<http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.html>`_
+object can function as a mixin column as well. 
+
+.. _arraywrapper_example:
+
+Example: ArrayWrapper
+^^^^^^^^^^^^^^^^^^^^^
+
+The code listing below shows a example of a data container class which acts as
+a mixin column class.  This class is a simple wrapper around a numpy array.  It
+is used in the astropy mixin test suite and is fully compliant as a mixin
+column.
+
+::
+
+  class ArrayWrapper(object):
+      """
+      Minimal mixin using a simple wrapper around a numpy array
+      """
+      _astropy_column_attrs = None
+
+      def __init__(self, data):
+          self.data = np.array(data)
+          col_setattr(self, 'dtype', self.data.dtype)
+
+      def __getitem__(self, item):
+          if isinstance(item, (int, np.integer)):
+              out = self.data[item]
+          else:
+              out = self.__class__(self.data[item])
+          return out
+
+      def __setitem__(self, item, value):
+          self.data[item] = value
+
+      def __len__(self):
+          return len(self.data)
+
+      @property
+      def shape(self):
+          return self.data.shape
+
+      def __repr__(self):
+          return ("<{0} name='{1}' data={2}>"
+                  .format(self.__class__.__name__, col_getattr(self, 'name'), self.data))

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -143,8 +143,9 @@ mutable (data can changed internally) and that have an ``insert()`` method.
 |Quantity| supports ``insert()`` but |Time| and |SkyCoord| do not.  If we try to
 insert a row into the previously defined table an exception occurs::
 
-  >>> qt.add_row((1, '2001-02-03T00:01:02', 5 * u.m / u.s))  # doctest: +SKIP
-  ...
+  >>> qt.add_row((1, '2001-02-03T00:01:02', 5 * u.m / u.s))
+  Traceback (most recent call last):
+    ...
   ValueError: Unable to insert row because of exception in column 'time':
   'Time' object has no attribute 'insert'
 
@@ -187,8 +188,8 @@ For mixin columns the column attributes ``name``, ``unit``, ``dtype``,
 ``format``, ``description`` and ``meta`` are currently stored in a simple
 dictionary called `_astropy_column_attrs`.  These attributes can be manipulated
 with the functions ``col_getattr`` and ``col_setattr`` which are available in
-the ``astropy.table.column`` module.  These methods are not formally part of
-the astropy public API and may change in the future.
+the ``astropy.table.column`` module.  These methods are not part of
+the astropy public API and are likely to change in the future.
 
 
 Mixin protocol

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -20,14 +20,14 @@ The available built-in mixin column classes are:
 - |SkyCoord|
 - |Time|
 
-.. Warning:: 
+.. Warning::
 
    The interface for using mixin columns is experimental at this point and it
    is not recommended to use this feature in production code.  There are known
    limitations and some table functionality which is not yet implemented for
    mixin columns.  API changes are likely and since the code is all new there
    may be some bugs.
-   
+
 As a first example we can create a table and add a time column::
 
   >>> from astropy.table import Table
@@ -36,7 +36,7 @@ As a first example we can create a table and add a time column::
   >>> t['index'] = [1, 2]
   >>> t['time'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
   >>> print(t)
-  index           time         
+  index           time
   ----- -----------------------
       1 2001-01-02T12:34:56.000
       2 2001-02-03T00:01:02.000
@@ -63,7 +63,12 @@ the |Table| class called |QTable| is available.  |QTable| is exactly the same
 as |Table| except that |Quantity| is the default for any data column with a
 defined unit.
 
-To illustrate we first create a standard |Table| where we supply as input a
+If you take advantage of the |Quantity| infrastructure in your analysis then
+|QTable| is the preferred way to create tables with units.  If instead you use
+table column units more as a descriptive label then the plain |Table| class is
+probably the best class to use.
+
+To illustrate these concepts we first create a standard |Table| where we supply as input a
 |Time| object and a |Quantity| object with units of ``m / s``.  In this case
 the quantity is converted to a |Column| (which has a ``unit`` attribute but
 does not have all the features of a |Quantity|)::
@@ -76,7 +81,7 @@ does not have all the features of a |Quantity|)::
 
   >>> print(t)
   index           time          velocity
-                                 m / s  
+                                 m / s
   ----- ----------------------- --------
       1 2001-01-02T12:34:56.000      3.0
       2 2001-02-03T00:01:02.000      4.0
@@ -104,7 +109,7 @@ all have units because this is how |Quantity| prints a single array element::
 
   >>> print(qt)
   index           time           velocity
-                                  m / s  
+                                  m / s
   ----- ----------------------- ---------
       1 2001-01-02T12:34:56.000 3.0 m / s
       2 2001-02-03T00:01:02.000 4.0 m / s
@@ -191,6 +196,12 @@ with the functions ``col_getattr`` and ``col_setattr`` which are available in
 the ``astropy.table.column`` module.  These methods are not part of
 the astropy public API and are likely to change in the future.
 
+**ASCII table writing**
+
+Mixin columns can be written out to file using the `astropy.io.ascii` module,
+but the fast C-based writers are not available.  Instead the legacy pure-Python
+writers will be used.
+
 
 Mixin protocol
 ^^^^^^^^^^^^^^
@@ -211,7 +222,7 @@ with the following properties:
 The `Example: ArrayWrapper`_ section shows a working minimal example of a class
 which can be used as a mixin column.  A `pandas.Series
 <http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.html>`_
-object can function as a mixin column as well. 
+object can function as a mixin column as well.
 
 Other interesting possibilities for mixin columns include:
 

--- a/docs/table/references.txt
+++ b/docs/table/references.txt
@@ -1,5 +1,6 @@
 .. |Row| replace:: :class:`~astropy.table.Row`
 .. |Table| replace:: :class:`~astropy.table.Table`
+.. |QTable| replace:: :class:`~astropy.table.QTable`
 .. |Column| replace:: :class:`~astropy.table.Column`
 .. |MaskedColumn| replace:: :class:`~astropy.table.MaskedColumn`
 .. |TableColumns| replace:: :class:`~astropy.table.TableColumns`


### PR DESCRIPTION
This is essentially the same as #1833, #1835, #1839 but will be done in the framework of #2790 as a follow-on once that is merged.

The starting point here will be fed00dc5f6d6d9529ed8f073c95346eb176fdfa6, which *removed* the proof-of-concept changes showing that mixin columns would be straightforward in the new column-based Table structure.   In this issue (and eventual PR) we can define the right way to support mixin columns like Quantity, Time, and SkyCoord.  The original proof-of-concept used a some simple class / instance variables, but @mhvk has proposed using an abstract base class.

Closes #1833
Closes #1835
Closes #1839