### PR TITLE
Changed inline to __inline when building with MSVC

### DIFF
--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -11,6 +11,10 @@
 #include <float.h>
 #include <ctype.h>
 
+#ifdef _MSC_VER
+#define inline __inline
+#endif
+
 typedef enum
 {
     START_LINE = 0,


### PR DESCRIPTION
See #3193.
