### PR TITLE
Doctest failures in skycoord.rst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,13 @@ before_install:
     # DOCUMENTATION DEPENDENCIES
     - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
+    # Make sure that interactive matplotlib backends work
+    - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start
+
+    # Make sure matplotlib uses PyQT not PySide (if using Qt)
+    - export QT_API=pyqt
+
 install:
 
     # CONDA


### PR DESCRIPTION
On a Linux server I'm getting this Astropy test failure:

```
____________________________________________________________________ [doctest] skycoord.rst ____________________________________________________________________
720 
721 As last step we set up the plotting environment with matplotlib using the
722 Aitoff projection with a specific title, a grid, filled circles as markers with
723 a markersize of 2 and an alpha value of 0.3. We use a figure with an x-y ratio 
724 that is well suited for such a projection and we move the title upwards from 
725 its usual position to avoid overlap with the axis labels.
726 
727 .. doctest-requires:: matplotlib
728 
729     >>> plt.figure(figsize=(8,4.2))
UNEXPECTED EXCEPTION: TclError('couldn\'t connect to display "localhost:10.0"',)
Traceback (most recent call last):

  File "/usr/lib/python2.7/doctest.py", line 1315, in __run
    compileflags, 1) in test.globs

  File "<doctest skycoord.rst[91]>", line 1, in <module>

  File "/usr/lib/pymodules/python2.7/matplotlib/pyplot.py", line 423, in figure
    **kwargs)

  File "/usr/lib/pymodules/python2.7/matplotlib/backends/backend_tkagg.py", line 79, in new_figure_manager
    return new_figure_manager_given_figure(num, figure)

  File "/usr/lib/pymodules/python2.7/matplotlib/backends/backend_tkagg.py", line 87, in new_figure_manager_given_figure
    window = Tk.Tk()

  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1767, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)

TclError: couldn't connect to display "localhost:10.0"

/home/hfm/deil/astropy/docs/coordinates/skycoord.rst:729: UnexpectedException
```

What needs to be done to avoid this fail?

It looks like no plot is produced for the online docs for the `skycoord.rst` page ... does this need fixing also?
http://astropy.readthedocs.org/en/latest/coordinates/skycoord.html#example-1-plotting-random-data-in-aitoff-projection
