### PR TITLE
Prevent logger from logging twice in IPython notebooks

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -74,6 +74,10 @@ class Conf(_config.ConfigNamespace):
         "%(asctime)r, "
         "%(origin)r, %(levelname)r, %(message)r",
         "Format for log file entries.")
+    propagate_log = _config.ConfigItem(
+        False,
+        "Whether messages logged to the Astropy logger "
+        "should be propagated to the root logger handler.")
 conf = Conf()
 
 
@@ -104,8 +108,8 @@ def _init_log():
     finally:
         logging.setLoggerClass(orig_logger_cls)
 
-    log.propagate = False
-
+    log.propagate = conf.propagate_log
+    
     return log
 
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -109,7 +109,7 @@ def _init_log():
         logging.setLoggerClass(orig_logger_cls)
 
     log.propagate = conf.propagate_log
-    
+
     return log
 
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -104,6 +104,8 @@ def _init_log():
     finally:
         logging.setLoggerClass(orig_logger_cls)
 
+    log.propagate = False
+    
     return log
 
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -105,7 +105,7 @@ def _init_log():
         logging.setLoggerClass(orig_logger_cls)
 
     log.propagate = False
-    
+
     return log
 
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -142,6 +142,9 @@ of the Astropy configuration file::
     # Format for log file entries
     log_file_format = '%(asctime)s, %(origin)s, %(levelname)s, %(message)s'
 
+    # Whether messages logged to the Astropy logger 
+    # should be propagated to the root logger handler.
+    propagate_log = False
 
 Reference/API
 =============


### PR DESCRIPTION
The astropy logger will log twice in IPython notebooks due to the fact that the logger is being propagated to the IPython logger. This results in things like this:

http://nbviewer.ipython.org/gist/jzuhone/4d4d315dceecf658eb57

where the IPython logger is highlighted in pink/red/something like that.

The small change below resolves this behavior, which results in this:

http://nbviewer.ipython.org/gist/jzuhone/8d387639a530418594df

which is behavior consistent with the console. 
