### PR TITLE
Disable conda update since latest version breaks SSL certificate checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,22 +72,27 @@ before_install:
 
 install:
 
+    # Certificate checking is not working with Python 2.7.9 (due to PEP 476)
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export TRAVIS_PYTHON_VERSION=2.7.8; fi
+
     # CONDA
     - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
     - source activate test
 
+    - export CONDA_INSTALL="conda install -c astropy-ci-extras --yes python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION"
+
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then conda install -c astropy-ci-extras --yes numpy=$NUMPY_VERSION pytest pip Cython psutil; fi
+    - if [[ $SETUP_CMD == test* || $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL pytest pip Cython psutil; fi
 
     # OPTIONAL DEPENDENCIES
-    - if $OPTIONAL_DEPS; then conda install --yes numpy=$NUMPY_VERSION scipy h5py; fi
+    - if $OPTIONAL_DEPS; then $CONDA_INSTALL scipy h5py; fi
     - if $OPTIONAL_DEPS; then pip install beautifulsoup4; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then conda install --yes numpy=$NUMPY_VERSION Sphinx=1.2.2 Pygments matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage coveralls; fi


### PR DESCRIPTION
This is a fix for the Sphinx failures on Travis:

```
urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)>
```

In fact, one could argue we should not update to avoid precisely this kind of issue. Without the update, we are always using the same version of Miniconda.
