### PR TITLE
Use union merge for changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.fits    -text
 astropy.0.3.windows.cfg eol=crlf
+CHANGES.rst merge=union


### PR DESCRIPTION
Thanks to @Cadair for pointing this out to me - this should allow us to avoid merge conflicts in the changelog in future, if GitHub takes it into account (it should?)

cc @embray
