### PR TITLE
Use `absolute_import` for applicable setup_package modules

### DIFF
--- a/astropy/erfa/setup_package.py
+++ b/astropy/erfa/setup_package.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
 
 import os
 from distutils.extension import Extension

--- a/astropy/extern/setup_package.py
+++ b/astropy/extern/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
+from __future__ import absolute_import
 
 import os
 

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license
+from __future__ import absolute_import
 
 import os
 from distutils.extension import Extension

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
+from __future__ import absolute_import
 
 import os
 

--- a/astropy/io/votable/setup_package.py
+++ b/astropy/io/votable/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 from distutils.core import Extension
 from os.path import join
 

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 from distutils.extension import Extension
 

--- a/astropy/utils/setup_package.py
+++ b/astropy/utils/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 from distutils.core import Extension
 from os.path import dirname, join, relpath
 

--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 from distutils.core import Extension
 from os.path import join
 import sys

--- a/astropy/vo/samp/setup_package.py
+++ b/astropy/vo/samp/setup_package.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
 
 import os
 


### PR DESCRIPTION
Include `from __future__ absolute_import` for any `setup_package.py` module that uses the import system.  Motivated by https://github.com/astropy/astropy/pull/3206#issuecomment-67181883
