### PR TITLE
Add Jinja2 to setup_requires since it is in fact required

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ entry_points['console_scripts'] = [
     'wcslint = astropy.wcs.wcslint:main',
 ]
 
-setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__, 'Jinja2']
+setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__, 'Jinja2',
+                  'Cython']
 install_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
 # Avoid installing setup_requires dependencies if the user just
 # queries for information

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ entry_points['console_scripts'] = [
     'wcslint = astropy.wcs.wcslint:main',
 ]
 
-setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
+setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__, 'Jinja2']
 install_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
 # Avoid installing setup_requires dependencies if the user just
 # queries for information


### PR DESCRIPTION
We might also want to specify a minimum version?  I don't know if it much matters though since we're not requiring anything particularly fancy from Jinja2--any version from within the last several years probably ought to be good enough...
