### PR TITLE
Add support for specifying the axis when obtaining a wcs pixel scale

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -261,6 +261,14 @@ def test_pixscale_cd():
     mywcs.wcs.cd = [[-0.1,0],[0,0.1]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
     assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lon').to(u.deg)
+                        .value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lat').to(u.deg)
+                        .value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='both')[0].to(u.deg)
+                        .value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='both')[1].to(u.deg)
+                        .value, 0.1)
 
 def test_pixscale_warning(recwarn):
     mywcs = WCS(naxis=2)
@@ -283,6 +291,13 @@ def test_pixscale_asymmetric():
         celestial_pixel_scale(mywcs)
     assert exc.value.args[0] == "Pixels are not square: 'pixel scale' is ambiguous"
 
+    assert_almost_equal(celestial_pixel_scale(mywcs, allow_nonsquare=True)
+                        .to(u.deg).value, np.sqrt(0.2*0.1))
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lon')
+                        .to(u.deg).value, 0.2)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lat')
+                        .to(u.deg).value, 0.1)
+
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
 def test_pixscale_cd_rotated(angle):
@@ -293,6 +308,10 @@ def test_pixscale_cd_rotated(angle):
                     [scale*np.sin(rho), scale*np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
     assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lon')
+                        .to(u.deg).value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lat')
+                        .to(u.deg).value, 0.1)
 
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
@@ -305,6 +324,10 @@ def test_pixscale_pc_rotated(angle):
                     [np.sin(rho), np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
     assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lon')
+                        .to(u.deg).value, 0.1)
+    assert_almost_equal(celestial_pixel_scale(mywcs, which='lat')
+                        .to(u.deg).value, 0.1)
 
 @pytest.mark.parametrize(('cdelt','pc','pccd'),
                          (([0.1,0.2], np.eye(2), np.diag([0.1,0.2])),

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -151,28 +151,28 @@ def wcs_to_celestial_frame(wcs):
 
 def celestial_pixel_scale(inwcs, which='combine', allow_nonsquare=False):
     """
-    For a WCS, return the pixel scale in the spatial dimensions
+    For a WCS, return the pixel scale in the spatial dimensions.
 
     Parameters
     ----------
-    inwcs: `astropy.wcs.WCS`
+    inwcs : `~astropy.wcs.WCS`
         The world coordinate system object
-    which: one of 'combine', 'lon', 'lat', or 'both'
+    which : one of 'combine', 'lon', 'lat', or 'both'
         The dimension to calculate the pixel scale along. If 'both', a tuple
         will be returned. If 'combine' with nonsquare pixels, a geometric mean
-        is taken unless `allow_nonsquare=False`
+        is taken unless ``allow_nonsquare=False``
     allow_nonsquare : bool
         Return the geometric average of the X and Y scales if True
 
     Returns
     -------
-    scale : `Quantity` or tuple of `Quantity`
+    scale : `~astropy.units.Quantity` or tuple of `~astropy.units.Quantity`
         The pixel scale
 
     Raises
     ------
     ValueError if the pixels are nonsquare, which='combine', and
-    ``allow_nonsquare==False``
+    allow_nonsquare is not set.
     """
     cwcs = inwcs.celestial
     if cwcs.wcs.ctype[0][-3:] != 'CAR':
@@ -199,8 +199,8 @@ def celestial_pixel_scale(inwcs, which='combine', allow_nonsquare=False):
 
 def non_celestial_pixel_scales(inwcs):
     """
-    For a non-celestial WCS, e.g. one with mixed spectral and spatial axes, it
-    is still sometimes possible to define a pixel scale.
+    For a non-celestial WCS, such as one with mixed spectral and spatial axes,
+    it is still sometimes possible to define a pixel scale.
 
     Parameters
     ----------


### PR DESCRIPTION
Simple change. There didn't seem to be any disagreement to @mcara's suggestion in #3113 to use the geometric mean. This PR does that and adds a `which=` kwarg for obtaining a the pixel scale in a specific diminsion, and @nden's suggestion of exposing the pixel scale for each diminsion.