### PR TITLE
Remove xfail from Quantity test_std_inplace since upstream fix is in

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -8,6 +8,7 @@ from ...tests.helper import pytest
 
 NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
 NUMPY_LT_1P8 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 8]
+NUMPY_LT_1P9P1 = [int(x) for x in np.__version__.split('.')[:3]] < [1, 9, 1]
 
 
 class TestQuantityArrayCopy(object):
@@ -144,14 +145,15 @@ class TestQuantityStatsFuncs(object):
         q1 = np.array([1., 2.]) * u.m
         assert np.std(q1) == 0.5 * u.m
 
+    # For 1.7 <= Numpy < 1.9.1, inplace causes the variance to be stored instead
+    # of the standard deviation; https://github.com/numpy/numpy/issues/5240
+    @pytest.mark.xfail("NUMPY_LT_1P9P1")
     def test_std_inplace(self):
 
-        # For Numpy >= 1.7, inplace causes the variance to be stored instead
-        # of the standard deviation.
-        # see https://github.com/numpy/numpy/issues/5240
-        # For Numpy < 1.7, the test segfaults.  Hence, we cannot use the xfail
-        # decorator since py.test will run the test anyway to see if it works.
-        pytest.xfail()
+        # For Numpy < 1.7, the test segfaults.  Hence, the xfail decorator does
+        # not suffice: py.test will run the test anyway to see if it works.
+        if NUMPY_LT_1P7:
+            pytest.xfail()
 
         q1 = np.array([1., 2.]) * u.m
         qi = 1.5 * u.s


### PR DESCRIPTION
Inplace calculations of `std` used to store the variance. This was a `numpy` bug, raised in https://github.com/numpy/numpy/issues/5240 and solved by https://github.com/numpy/numpy/pull/5242. That implies that for numpy >=1.9.1, the test we already had will no longer fail. This PR ensures we will notice if we do something wrong on our side.
