### PR TITLE
Set matplotlib to Agg backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,13 +70,6 @@ before_install:
     # DOCUMENTATION DEPENDENCIES
     - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
-    # Make sure that interactive matplotlib backends work
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
-
-    # Make sure matplotlib uses PyQT not PySide
-    - export QT_API=pyqt
-
 install:
 
     # CONDA

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -4,4 +4,11 @@
 
 from .tests.pytest_plugins import *
 
+try:
+    import matplotlib
+except ImportError:
+    pass
+else:
+    matplotlib.use('Agg')
+
 enable_deprecations_as_exceptions(include_astropy_deprecations=False)


### PR DESCRIPTION
This is an alternative to f2744344 that uses the Agg backend rather than setting up Travis to use X11, which seems like overkill.
