### PR TITLE
Enabling ipython testing for affiliated packages

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -115,8 +115,9 @@ class TestRunner(object):
         except NameError:
             pass
         else:
-            raise RuntimeError(
-                "Running astropy tests inside of IPython is not supported.")
+            if self.base_path == 'astropy':
+                raise RuntimeError(
+                    "Running astropy tests inside of IPython is not supported.")
 
         if coverage:
             warnings.warn(


### PR DESCRIPTION
This is a working solution (or just a simple workaround) for #3184, that enables ipython testing for non-core astropy packages. 

I needed this for some investigation in ``photutils`` where normal local testing raises some weird errors (but at least runs in ipython with the change in this PR).