### PR TITLE
Time constructor discards timezone information

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -467,6 +467,9 @@ Bug Fixes
 
 - ``astropy.time``
 
+  - When creating a Time object from a datetime object the time zone
+    info is now correctly used. [#3160]
+
 - ``astropy.units``
 
   - Added a ``latex_inline`` unit format that returns the units in LaTeX math

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1638,6 +1638,10 @@ class TimeDatetime(TimeUnique):
                              op_dtypes=[np.object] + 5*[np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
             dt = val.item()
+
+            if dt.tzinfo is not None:
+                dt = (dt - dt.utcoffset()).replace(tzinfo=None)
+
             iy[...] = dt.year
             im[...] = dt.month
             id[...] = dt.day

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -6,8 +6,7 @@ import copy
 import functools
 import sys
 
-from datetime import datetime
-import dateutil.parser
+from datetime import datetime, tzinfo, timedelta
 
 import numpy as np
 
@@ -757,7 +756,10 @@ def test_datetime_tzinfo():
     """
     Test #3160 that time zone info in datetime objects is respected.
     """
-    datestr = '2002-01-01 01:00:00-06'  # GMT - 6
-    d = dateutil.parser.parse(datestr)
+    class TZm6(tzinfo):
+        def utcoffset(self, dt):
+            return timedelta(hours=-6)
+
+    d = datetime(2002, 1, 2, 10, 3, 4, tzinfo=TZm6())
     t = Time(d)
-    assert t.value == datetime(2002, 1, 1, 7, 0, 0)
+    assert t.value == datetime(2002, 1, 2, 16, 3, 4)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -7,6 +7,7 @@ import functools
 import sys
 
 from datetime import datetime
+import dateutil.parser
 
 import numpy as np
 
@@ -750,3 +751,13 @@ def test_byteorder():
     time_little = Time(little_endian, format='mjd')
     assert np.all(time_big == time_mjd)
     assert np.all(time_little == time_mjd)
+
+
+def test_datetime_tzinfo():
+    """
+    Test #3160 that time zone info in datetime objects is respected.
+    """
+    datestr = '2002-01-01 01:00:00-06'  # GMT - 6
+    d = dateutil.parser.parse(datestr)
+    t = Time(d)
+    assert t.value == datetime(2002, 1, 1, 7, 0, 0)


### PR DESCRIPTION
Current behavior when creating a Time object from an "aware" datetime object is to discard timezone information and label the time as UTC. Correct behavior would be to calculate UTC time before creating object.

```python
from dateutil.parser import *
import astropy.time as time

datestr = '2002-05-01 15:45:00-06'

parse(datestr)
Out[44]: datetime.datetime(2002, 5, 1, 15, 45, tzinfo=tzoffset(None, -21600))

d = parse(datestr)

time.Time(d)
Out[48]: <Time object: scale='utc' format='datetime' value=2002-05-01 15:45:00>
```