### PR TITLE
Updates to sigma_clipped_stats

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -452,7 +452,7 @@ def median_absolute_deviation(a, axis=None):
 
     Parameters
     ----------
-    a : array_like
+    a : array-like
         Input array or object that can be converted to an array.
     axis : int, optional
         Axis along which the medians are computed. The default (axis=None)
@@ -521,7 +521,7 @@ def biweight_location(a, c=6.0, M=None):
 
     Parameters
     ----------
-    a : array_like
+    a : array-like
         Input array or object that can be converted to an array.
     c : float
         Tuning constant for the biweight estimator.  Default value is 6.0.
@@ -606,7 +606,7 @@ def biweight_midvariance(a, c=9.0, M=None):
 
     Parameters
     ----------
-    a : array_like
+    a : array-like
         Input array or object that can be converted to an array.
     c : float
         Tuning constant for the biweight estimator.  Default value is 9.0.

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -161,8 +161,8 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
 
     mask_val : float, optional
         An image data value (e.g., ``0.0``) that is ignored when
-        computing the image statistics.  ``mask_val`` will be ignored if
-        ``mask`` is input.
+        computing the image statistics.  ``mask_val`` will be masked in
+        addition to any input ``mask``.
 
     sigma : float, optional
         The number of standard deviations to use as the clipping limit.
@@ -180,14 +180,10 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
         image.
     """
 
-    data = np.asanyarray(data)
     if mask is not None:
-        if mask.dtype != np.bool:
-            raise TypeError('mask must be a boolean ndarray')
-        data = data[~mask]
-    if mask_val is not None and mask is None:
-        idx = (data != mask_val).nonzero()
-        data = data[idx]
+        data = np.ma.MaskedArray(data, mask)
+    if mask_val is not None:
+        data = np.ma.masked_values(data, mask_val)
     data_clip = sigma_clip(data, sig=sigma, iters=iters)
     goodvals = data_clip.data[~data_clip.mask]
     return np.mean(goodvals), np.median(goodvals), np.std(goodvals)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -180,6 +180,7 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
         image.
     """
 
+    data = np.asanyarray(data)
     if mask is not None:
         if mask.dtype != np.bool:
             raise TypeError('mask must be a boolean ndarray')

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -151,7 +151,7 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
 
     Parameters
     ----------
-    data : array_like
+    data : array-like
         Data array or object that can be converted to an array.
 
     mask : `numpy.ndarray` (bool), optional

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -144,7 +144,7 @@ def sigma_clip(data, sig=3, iters=1, cenfunc=np.ma.median, varfunc=np.var,
 
 def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
     """
-    Calculate sigma-clipped statistics of an image.
+    Calculate sigma-clipped statistics from data.
 
     For example, sigma-clipped statistics can be used to estimate the
     background and background noise in an image.
@@ -152,7 +152,7 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
     Parameters
     ----------
     data : array_like
-        The 2D array of the image.
+        Data array or object that can be converted to an array.
 
     mask : `numpy.ndarray` (bool), optional
         A boolean mask with the same shape as ``data``, where a `True`

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -79,3 +79,20 @@ def test_compare_to_scipy_sigmaclip():
 
         assert astropyres.count() == len(scipyres)
         assert_equal(astropyres[~astropyres.mask].data, scipyres)
+
+
+def test_sigma_clipped_stats():
+    """Test list data with input mask or mask_val (#3268)."""
+    # test list data with mask
+    data = [0, 1]
+    mask = np.array([True, False])
+    result = sigma_clipped_stats(data, mask=mask)
+    assert result[0] == 1.
+    assert result[1] == 1.
+    assert result[2] == 0.
+
+    # test list data with mask_val
+    result2 = sigma_clipped_stats(data, mask_val=0.)
+    assert result2[0] == 1.
+    assert result2[1] == 1.
+    assert result2[2] == 0.


### PR DESCRIPTION
The input `data` array in `sigma_clipped_stats` doesn't need to be an image.  This PR also applies `np.asanyarray()` to allow the input `data` to be "array-like".