### PR TITLE
Minor typo in the io.fits docs

### DIFF
--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -94,7 +94,7 @@ because by that point you're likely to run out of physical memory anyways), but
 	that were built with the assumption that the .data attribute has all the data in-memory.
 	
 	In order to force the mmap to close either wait for the containing ``HDUList`` object to go 
-	out of scope, or manually call del ``hdul[0].data`` (this works so long as there are no other
+	out of scope, or manually call ``del hdul[0].data`` (this works so long as there are no other
 	references held to the data array).
 
 Working with FITS Headers


### PR DESCRIPTION
Fixes the placement of two backticks.