### PR TITLE
Implemented Quantity-aware wrapper for assert_allclose

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,10 @@ New Features
 
   - Add ``unique`` convenience method to table. [#3185]
 
+- ``astropy.tests``
+
+  - Added a new Quantity-aware ``assert_quantity_allclose``. [#3273]
+
 - ``astropy.time``
 
   - ``Time`` can now handle arbitrary array dimensions, with operations

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -606,7 +606,7 @@ def check_pickling_recovery(original, protocol):
                                     class_history)
 
 
-def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=0, err_msg='', verbose=True):
+def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, err_msg='', verbose=True):
     """
     Raise an assertion if two objects are not equal up to desired tolerance.
 
@@ -625,7 +625,8 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=0, err_msg='', ve
     except u.UnitsError:
         raise u.UnitsError("Units for 'desired' ({0}) and 'actual' ({1}) are not convertible".format(desired.unit, actual.unit))
 
-    if atol == 0:
+    if atol is None:
+        # by default, we assume an absolute tolerance of 0
         atol = u.Quantity(0)
     else:
         atol = u.Quantity(atol, subok=True, copy=False)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -604,3 +604,40 @@ def check_pickling_recovery(original, protocol):
     class_history = [original.__class__]
     generic_recursive_equality_test(original, unpickled,
                                     class_history)
+
+
+def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=0, err_msg='', verbose=True):
+    """
+    Raise an assertion if two objects are not equal up to desired tolerance.
+
+    This is a :class:`~astropy.units.Quantity`-aware version of
+    :func:`numpy.testing.assert_allclose`.
+    """
+
+    import numpy as np
+    from ..units import Quantity
+
+    if isinstance(actual, Quantity) and isinstance(desired, Quantity):
+
+        if atol != 0:
+            if not isinstance(atol, Quantity):
+                raise TypeError("If `actual` and `desired` are Quantities, `atol` parameter should also be a Quantity")
+            else:
+                atol = atol.to(actual.unit).value
+
+        np.testing.assert_allclose(actual.value, desired.to(actual.unit).value,
+                                   rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
+
+    elif isinstance(actual, Quantity):
+        raise TypeError("If `actual` is a Quantity, `desired` should also be a Quantity")
+
+    elif isinstance(desired, Quantity):
+        raise TypeError("If `desired` is a Quantity, `actual` should also be a Quantity")
+
+    else:
+
+        if isinstance(atol, Quantity):
+            raise TypeError("If `actual` and `desired` are not Quantities, `atol` parameter should also not be a Quantity")
+
+        np.testing.assert_allclose(actual, desired,
+                                   rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)

--- a/astropy/tests/tests/test_quantity_helpers.py
+++ b/astropy/tests/tests/test_quantity_helpers.py
@@ -17,19 +17,23 @@ def test_assert_quantity_allclose():
     with pytest.raises(AssertionError):
         assert_quantity_allclose([1,2] * u.m, [101,201] * u.cm, atol=0.5 * u.cm)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1,2] * u.m, [100,200])
-    assert exc.value.args[0] == "If `actual` is a Quantity, `desired` should also be a Quantity"
+    assert exc.value.args[0] == "Units for 'desired' () and 'actual' (m) are not convertible"
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1,2], [100,200] * u.cm)
-    assert exc.value.args[0] == "If `desired` is a Quantity, `actual` should also be a Quantity"
+    assert exc.value.args[0] == "Units for 'desired' (cm) and 'actual' () are not convertible"
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1,2] * u.m, [100,200] * u.cm, atol=0.3)
-    assert exc.value.args[0] == "If `actual` and `desired` are Quantities, `atol` parameter should also be a Quantity"
+    assert exc.value.args[0] == "Units for 'atol' () and 'actual' (m) are not convertible"
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1,2], [1, 2], atol=0.3 * u.m)
-    assert exc.value.args[0] == "If `actual` and `desired` are not Quantities, `atol` parameter should also not be a Quantity"
+    assert exc.value.args[0] == "Units for 'atol' (m) and 'actual' () are not convertible"
+
+    with pytest.raises(u.UnitsError) as exc:
+        assert_quantity_allclose([1,2], [1, 2], rtol=0.3 * u.m)
+    assert exc.value.args[0] == "`rtol` should be dimensionless"
 

--- a/astropy/tests/tests/test_quantity_helpers.py
+++ b/astropy/tests/tests/test_quantity_helpers.py
@@ -1,0 +1,35 @@
+from ... import units as u
+
+from ..helper import assert_quantity_allclose, pytest
+
+
+def test_assert_quantity_allclose():
+
+    assert_quantity_allclose([1,2], [1,2])
+
+    assert_quantity_allclose([1,2] * u.m, [100,200] * u.cm)
+
+    assert_quantity_allclose([1,2] * u.m, [101,201] * u.cm, atol=2 * u.cm)
+
+    with pytest.raises(AssertionError):
+        assert_quantity_allclose([1,2] * u.m, [90,200] * u.cm)
+
+    with pytest.raises(AssertionError):
+        assert_quantity_allclose([1,2] * u.m, [101,201] * u.cm, atol=0.5 * u.cm)
+
+    with pytest.raises(TypeError) as exc:
+        assert_quantity_allclose([1,2] * u.m, [100,200])
+    assert exc.value.args[0] == "If `actual` is a Quantity, `desired` should also be a Quantity"
+
+    with pytest.raises(TypeError) as exc:
+        assert_quantity_allclose([1,2], [100,200] * u.cm)
+    assert exc.value.args[0] == "If `desired` is a Quantity, `actual` should also be a Quantity"
+
+    with pytest.raises(TypeError) as exc:
+        assert_quantity_allclose([1,2] * u.m, [100,200] * u.cm, atol=0.3)
+    assert exc.value.args[0] == "If `actual` and `desired` are Quantities, `atol` parameter should also be a Quantity"
+
+    with pytest.raises(TypeError) as exc:
+        assert_quantity_allclose([1,2], [1, 2], atol=0.3 * u.m)
+    assert exc.value.args[0] == "If `actual` and `desired` are not Quantities, `atol` parameter should also not be a Quantity"
+


### PR DESCRIPTION
This is a replacement for #2402. It seems there is general resistance against having quantity-aware wrappers for many Numpy functions, but the one here is one that is needed in various packages so it makes sense to make it available as a helper.

Not a full feature, just part of the infrastructure, so I figured this would be ok for 1.0?