### PR TITLE
Support for Abbreviated Data Types in IPAC Tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -446,6 +446,8 @@ Bug Fixes
     specify the output null values.  Previously the behavior was inconsistent
     or incorrect. [#3259]
 
+  - The IPAC table reader now correctly interprets abbreviated column types. [#3279]
+
 - ``astropy.io.fits``
 
   - Setting ``memmap=True`` in ``fits.open`` and related functions now raises a ValueError if opening a file in memory-mapped mode is impossible. [#2298]

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -70,6 +70,10 @@ class IpacHeaderSplitter(core.BaseSplitter):
 class IpacHeader(fixedwidth.FixedWidthHeader):
     """IPAC table header"""
     splitter_class = IpacHeaderSplitter
+
+    # Defined ordered list of possible types.  Ordering is needed to
+    # distinguish between "d" (double) and "da" (date) as defined by
+    # the IPAC standard for abbreviations.  This gets used in get_col_type().
     col_type_list = (('integer', core.IntType),
                      ('long', core.IntType),
                      ('double', core.FloatType),
@@ -151,7 +155,7 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
 
     def get_col_type(self, col):
         for (col_type_key, col_type) in self.col_type_list:
-            if col_type_key.startswith(col.raw_type):
+            if col_type_key.startswith(col.raw_type.lower()):
                 return col_type
         else:
             raise ValueError('Unknown data type ""%s"" for column "%s"' % (

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -70,20 +70,13 @@ class IpacHeaderSplitter(core.BaseSplitter):
 class IpacHeader(fixedwidth.FixedWidthHeader):
     """IPAC table header"""
     splitter_class = IpacHeaderSplitter
-    col_type_map = {'int': core.IntType,
-                    'integer': core.IntType,
-                    'long': core.IntType,
-                    'double': core.FloatType,
-                    'float': core.FloatType,
-                    'real': core.FloatType,
-                    'char': core.StrType,
-                    'date': core.StrType,
-                    'i': core.IntType,
-                    'l': core.IntType,
-                    'd': core.FloatType,
-                    'f': core.FloatType,
-                    'r': core.FloatType,
-                    'c': core.StrType}
+    col_type_list = (('integer', core.IntType),
+                     ('long', core.IntType),
+                     ('double', core.FloatType),
+                     ('float', core.FloatType),
+                     ('real', core.FloatType),
+                     ('char', core.StrType),
+                     ('date', core.StrType))
     definition='ignore'
     start_line = None
 
@@ -155,6 +148,14 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
                     val = line[2:].strip()
                     if val:
                         table_meta['comments'].append(val)
+
+    def get_col_type(self, col):
+        for (col_type_key, col_type) in self.col_type_list:
+            if col_type_key.startswith(col.raw_type):
+                return col_type
+        else:
+            raise ValueError('Unknown data type ""%s"" for column "%s"' % (
+                col.raw_type, col.name))
 
     def get_cols(self, lines):
         """Initialize the header Column objects from the table ``lines``.

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -901,3 +901,15 @@ def test_pformat_roundtrip():
     for c in dat.colnames:
         assert np.all(dat[c] == out[c])
 
+
+def test_ipac_abbrev():
+    lines = ['| c1 | c2 | c3   |   c4 | c5| c6 | c7  | c8 | c9|c10|c11|c12|',
+             '| r  | re | rea  | real | d | do | dou | f  | i | l | da| c |',
+             '  1    2    3       4     5   6    7     8    9   10  11  12 ']
+    dat = ascii.read(lines, format='ipac')
+    for name in dat.columns[0:8]:
+        assert dat[name].dtype.kind == 'f'
+    for name in dat.columns[8:10]:
+        assert dat[name].dtype.kind == 'i'
+    for name in dat.columns[10:12]:
+        assert dat[name].dtype.kind in ('U', 'S')

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -904,7 +904,7 @@ def test_pformat_roundtrip():
 
 def test_ipac_abbrev():
     lines = ['| c1 | c2 | c3   |   c4 | c5| c6 | c7  | c8 | c9|c10|c11|c12|',
-             '| r  | re | rea  | real | d | do | dou | f  | i | l | da| c |',
+             '| r  | rE | rea  | real | D | do | dou | f  | i | l | da| c |',
              '  1    2    3       4     5   6    7     8    9   10  11  12 ']
     dat = ascii.read(lines, format='ipac')
     for name in dat.columns[0:8]:


### PR DESCRIPTION
The IPAC table standard allows for abbreviation of data types to the point where they are unique[[0]](http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html). For example, "double" can be abbreviated as "doubl", "doub", ... all the way down to "do". "d" is not acceptable because then it can conflict with "date"

Astropy appears to currently accept the full form, but not the abbreviated form. This can be reproduced by taking the file:

    $cat test_table.tbl

    | test|
    |doubl|
    |     |
    | null|
      0.85

and running it through astropy, which yields:

    In [3]: Table.read("test_output.tbl", format="ascii.ipac", guess=False)
    ...
    ValueError: Unknown data type ""doubl"" for column "test"

This was run on a linux machine using astropy 0.4.1, numpy 1.8.1, and scipy 0.14.0 and python 2.7.6.

What it should do is recognize that "doubl" is an abbreviation of "double", and parse it accordingly, returning a table with one entry, and column name "test".

I've encountered this issue "in the wild" with some multi-object queries from IRSA where the column name is shorter than the data type. 

One possible workaround I found was to call the [STILTS](http://www.star.bris.ac.uk/~mbt/stilts/) program from python to read in, and write out the abbreviated IPAC file. From what I noticed, STILTS avoids abbreviating the data type, which makes it readable by Astropy.
