### PR TITLE
Fixes typo in two error messages

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -77,7 +77,7 @@ def _merge_col_meta(out, tables, col_name_map, idx_left=0, idx_right=1,
                                 'In merged column {0!r} the {1!r} attribute does not match '
                                 '({2} != {3})'.format(out_col.name, attr, left_attr, right_attr))
                         elif metadata_conflicts != 'silent':
-                            raise ValueError('metadata_conflict argument must be one of "silent",'
+                            raise ValueError('metadata_conflicts argument must be one of "silent",'
                                              ' "warn", or "error"')
                         merge_attr = right_attr
                     else:  # left_attr == right_attr

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -103,7 +103,7 @@ def merge(left, right, merge_func=concat, metadata_conflicts='warn'):
                         raise MergeConflictError('Cannot merge meta key {0!r} types {1!r} and {2!r}'
                                                  .format(key, type(left[key]), type(right[key])))
                     elif metadata_conflicts != 'silent':
-                        raise ValueError('metadata_conflict argument must be one of "silent", "warn", or "error"')
+                        raise ValueError('metadata_conflicts argument must be one of "silent", "warn", or "error"')
                     out[key] = right[key]
                 else:
                     out[key] = right[key]


### PR DESCRIPTION
Spotted this typo in error messages generated by `astropy.table` and `astropy.utils`.

Apologies for nitpicking!