### PR TITLE
Allow lists of SkyCoord/frames/representations in SkyCoord init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ New Features
 
   - ``SkyCoord`` now accepts more formats of the coordinate string when the
     representation has ``ra`` and ``dec`` attributes. [#2920]
+  - ``SkyCoord`` can now accept lists of ``SkyCoord`` objects, frame objects,
+    or representation objects and will combine them into a single object. [#xxxx]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,8 @@ New Features
   - ``SkyCoord`` now accepts more formats of the coordinate string when the
     representation has ``ra`` and ``dec`` attributes. [#2920]
   - ``SkyCoord`` can now accept lists of ``SkyCoord`` objects, frame objects,
-    or representation objects and will combine them into a single object. [#xxxx]
+    or representation objects and will combine them into a single object.
+    [#3285]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -665,7 +665,7 @@ class Longitude(Angle):
 
     def __array_finalize__(self, obj):
         super(Longitude, self).__array_finalize__(obj)
-        self._wrap_angle = getattr(obj, '_wrap_angle', None)
+        self._wrap_angle = getattr(obj, '_wrap_angle', 360 * u.deg)
 
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -161,7 +161,7 @@ def concatenate(coords):
     `~astropy.coordinates.SkyCoord`.
 
     "Coordinate objects" here mean frame objects with data,
-    `~astropy.coordinates.SkyCoord`s, or representation objects.  Currently,
+    `~astropy.coordinates.SkyCoord`, or representation objects.  Currently,
     they must all be in the same frame, but in a future version this may be
     relaxed to allow inhomogenous sequences of objects.
 

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -12,8 +12,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .. import units as u
+from ..utils import isiterable
 
-__all__ = ['cartesian_to_spherical', 'spherical_to_cartesian', 'get_sun']
+__all__ = ['cartesian_to_spherical', 'spherical_to_cartesian', 'get_sun', 'concatenate']
 
 
 def cartesian_to_spherical(x, y, z):
@@ -153,3 +154,30 @@ def get_sun(time):
     z = -earth_pv_helio[..., 0, 2] * u.AU
     cartrep = CartesianRepresentation(x=x, y=y, z=z)
     return SkyCoord(cartrep, frame=GCRS)
+
+def concatenate(coords):
+    """
+    Combine multiple coordinate objects into a single
+    `~astropy.coordinates.SkyCoord`.
+
+    "Coordinate objects" here mean frame objects with data,
+    `~astropy.coordinates.SkyCoord`s, or representation objects.  Currently,
+    they must all be in the same frame, but in a future version this may be
+    relaxed to allow inhomogenous sequences of objects.
+
+    Parameters
+    ----------
+    coords : sequence of coordinate objects
+        The objects to concatenate
+
+    Returns
+    -------
+    cskycoord : SkyCoord
+        A single sky coordinate with its data set to the concatenation of all
+        the elements in ``coords``
+    """
+    from .sky_coordinate import SkyCoord
+
+    if getattr(coords, 'isscalar', False) or not isiterable(coords):
+        raise TypeError('The argument to concatenate must be iterable')
+    return SkyCoord(coords)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1253,9 +1253,9 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # now check that they're all self-consistent in their frame attributes
             # and frame name
-            if len(set((sc.frame.name for sc in scs))) > 1:
-                frames = [sc.frame.name for sc in scs]
-                raise ValueError("List of inputs have different frames: {0}".format(frames))
+            frames_to_check = [sc.frame.name for sc in scs]
+            if len(set(frames_to_check)) > 1:
+                raise ValueError("List of inputs have different frames: {0}".format(frames_to_check))
             for fattrnm in FRAME_ATTR_NAMES_SET():
                 vals = [getattr(sc, fattrnm) for sc in scs]
                 for val in vals[1:]:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1157,7 +1157,7 @@ def _get_units(args, kwargs):
     return units
 
 
-def _parse_coordinate_arg(coords, frame, units, scinit_kwargs):
+def _parse_coordinate_arg(coords, frame, units, init_kwargs):
     """
     Single unnamed arg supplied.  This must be:
     - Coordinate frame with data
@@ -1249,7 +1249,7 @@ def _parse_coordinate_arg(coords, frame, units, scinit_kwargs):
             # this parsing path is used when there are coordinate-like objects
             # in the list - instead of creating lists of values, we create
             # SkyCoords from the list elements and then combine them.
-            scs = [SkyCoord(coord, **scinit_kwargs) for coord in coords]
+            scs = [SkyCoord(coord, **init_kwargs) for coord in coords]
 
             # now check that they're all self-consistent in their frame attributes
             # and frame name

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1301,8 +1301,8 @@ def _parse_coordinate_arg(coords, frame, units, scinit_kwargs):
 
             if is_scalar:
                 values = [x[0] for x in values]
-            else:
-                raise ValueError('Cannot parse coordinates from first argument')
+    else:
+        raise ValueError('Cannot parse coordinates from first argument')
 
     # Finally we have a list of values from which to create the keyword args
     # for the frame initialization.  Validate by running through the appropriate

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1289,8 +1289,8 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # Must have no more coord inputs than representation attributes
             if n_coords > n_attr_names:
-                raise ValueError('Input coordinates have {0} values but {1} representation '
-                                 'only accepts {2}'
+                raise ValueError('Input coordinates have {0} values but '
+                                 'representation {1} only accepts {2}'
                                  .format(n_coords, frame.representation.get_name(), n_attr_names))
 
             # Now transpose vals to get [(v1_0 .. v1_N), (v2_0 .. v2_N), (v3_0 .. v3_N)]
@@ -1312,8 +1312,8 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                 frame_attr_names, repr_attr_classes, values, units):
             valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
     except Exception as err:
-        raise ValueError('Cannot parse coordinate data "{0}" from first argument: {1}'
-                         .format(value, err))
+        raise ValueError('Cannot parse first argument data "{0}" for attribute '
+                         '{1}'.format(value, frame_attr_name), err)
     return valid_kwargs
 
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1267,13 +1267,16 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # Now combine the values, to be used below
             values = []
-            for aname in frame_attr_names:
-                values.append([])
+            for data_attr_name in frame_attr_names:
+                data_vals = []
                 for sc in scs:
-                    if sc.isscalar:
-                        values[-1].append(getattr(sc, aname))
-                    else:
-                        values[-1].extend(getattr(sc, aname))
+                    data_val = getattr(sc, data_attr_name)
+                    data_vals.append(data_val.reshape(1,) if sc.isscalar else data_val)
+                concat_vals = np.concatenate(data_vals)
+                # Hack because np.concatenate doesn't fully work with Quantity
+                if isinstance(concat_vals, u.Quantity):
+                    concat_vals._unit = data_val.unit
+                values.append(concat_vals)
         else:
             # Do some basic validation of the list elements: all have a length and all
             # lengths the same

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1220,7 +1220,7 @@ def _parse_coordinate_arg(coords, frame, units):
         is_ra_dec_representation = ('ra' in frame.representation_component_names and
                                     'dec' in frame.representation_component_names)
 
-        for ii, coord in enumerate(coords):
+        for coord in coords:
             if isinstance(coord, six.string_types):
                 coord1 = coord.split()
                 if len(coord1) == 6:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1253,8 +1253,8 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # now check that they're all self-consistent in their frame attributes
             # and frame name
-            if len(set((sc.frame.name for sc in scs if hasattr(sc, 'frame')))) > 1:
-                frames = [sc.frame.name if hasattr(sc, 'frame') else None for sc in scs]
+            if len(set((sc.frame.name for sc in scs))) > 1:
+                frames = [sc.frame.name for sc in scs]
                 raise ValueError("List of inputs have different frames: {0}".format(frames))
             for fattrnm in FRAME_ATTR_NAMES_SET():
                 vals = [getattr(sc, fattrnm) for sc in scs]

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -45,11 +45,12 @@ class SkyCoord(object):
     """High-level object providing a flexible interface for celestial coordinate
     representation, manipulation, and transformation between systems.
 
-    The `SkyCoord` class accepts a wide variety of inputs for initialization.
-    At a minimum these must provide one or more celestial coordinate values
-    with unambiguous units.  Typically one also specifies the coordinate
-    frame, though this is not required.  The general pattern is for spherical
-    representations is::
+    The `SkyCoord` class accepts a wide variety of inputs for initialization. At
+    a minimum these must provide one or more celestial coordinate values with
+    unambiguous units.  Inputs may be scalars or lists/tuples/arrays, yielding
+    scalar or array coordinates (can be checked via ``SkyCoord.isscalar``).
+    Typically one also specifies the coordinate frame, though this is not
+    required. The general pattern for spherical representations is::
 
       SkyCoord(COORD, [FRAME], keyword_args ...)
       SkyCoord(LON, LAT, [FRAME], keyword_args ...)
@@ -93,6 +94,8 @@ class SkyCoord(object):
       >>> c = SkyCoord(c, obstime='J2010.11', equinox='B1965')  # Override defaults
 
       >>> c = SkyCoord(w=0, u=1, v=2, unit='kpc', frame='galactic', representation='cartesian')
+
+      >>> c = SkyCoord([ICRS(ra=1*u.deg, dec=2*u.deg), ICRS(ra=3*u.deg, dec=4*u.deg)])
 
     As shown, the frame can be a `~astropy.coordinates.BaseCoordinateFrame`
     class or the corresponding string alias.  The frame classes that are built in

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -833,3 +833,17 @@ def test_array_angle_tostring():
     aobj = Angle([1, 2], u.deg)
     assert aobj.to_string().dtype.kind == 'U'
     assert np.all(aobj.to_string() == ['1d00m00s', '2d00m00s'])
+
+def test_wrap_at_without_new():
+    """
+    Regression test for subtle bugs from situations where an Angle is
+    created via numpy channels that don't do the standard __new__ but instead
+    depend on array_finalize to set state.  Longitude is used because the
+    bug was in its _wrap_angle not getting initialized correctly
+    """
+    l1 = Longitude([1]*u.deg)
+    l2 = Longitude([2]*u.deg)
+
+    l = np.concatenate([l1, l2])
+    assert l._wrap_angle is not None
+

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -10,6 +10,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
+from ...tests.helper import pytest
+
 from ... import units as u
 from ...time import Time
 
@@ -30,3 +32,20 @@ def test_sun():
 
     gcrs2 = get_sun(Time([northern_summer_solstice, equinox_2, northern_winter_solstice]))
     assert np.all(np.abs(gcrs2.dec - [23.5, 0, -23.5]*u.deg) < 1*u.deg)
+
+def test_concatenate():
+    from .. import FK5, SkyCoord
+    from ..funcs import concatenate
+
+    fk5 = FK5(1*u.deg, 2*u.deg)
+    sc = SkyCoord(3*u.deg, 4*u.deg, frame='fk5')
+
+    res = concatenate([fk5, sc])
+    np.testing.assert_allclose(res.ra, [1, 3]*u.deg)
+    np.testing.assert_allclose(res.dec, [2, 4]*u.deg)
+
+    with pytest.raises(TypeError):
+        concatenate(fk5)
+
+    with pytest.raises(TypeError):
+        concatenate(1*u.deg)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -134,7 +134,7 @@ def test_coord_init_string():
 
     with pytest.raises(ValueError) as err:
         SkyCoord('1d 2d 3d')
-    assert "Cannot parse coordinate data" in str(err)
+    assert "Cannot parse first argument data" in str(err)
 
     sc1 = SkyCoord('8 00 00 +5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc1, SkyCoord)
@@ -240,11 +240,11 @@ def test_coord_init_list():
 
     with pytest.raises(ValueError) as err:
         SkyCoord(['1d 2d 3d'])
-    assert "Cannot parse coordinate data" in str(err)
+    assert "Cannot parse first argument data" in str(err)
 
     with pytest.raises(ValueError) as err:
         SkyCoord([('1d', '2d', '3d')])
-    assert "Cannot parse coordinate data" in str(err)
+    assert "Cannot parse first argument data" in str(err)
 
     sc = SkyCoord([1 * u.deg, 1 * u.deg], [2 * u.deg, 2 * u.deg])
     assert allclose(sc.ra, Angle('1d'))

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -134,7 +134,7 @@ def test_coord_init_string():
 
     with pytest.raises(ValueError) as err:
         SkyCoord('1d 2d 3d')
-    assert "Cannot parse longitude and latitude" in str(err)
+    assert "Cannot parse coordinate data" in str(err)
 
     sc1 = SkyCoord('8 00 00 +5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc1, SkyCoord)
@@ -240,11 +240,11 @@ def test_coord_init_list():
 
     with pytest.raises(ValueError) as err:
         SkyCoord(['1d 2d 3d'])
-    assert "Cannot parse longitude and latitude" in str(err)
+    assert "Cannot parse coordinate data" in str(err)
 
     with pytest.raises(ValueError) as err:
         SkyCoord([('1d', '2d', '3d')])
-    assert "Cannot parse longitude and latitude" in str(err)
+    assert "Cannot parse coordinate data" in str(err)
 
     sc = SkyCoord([1 * u.deg, 1 * u.deg], [2 * u.deg, 2 * u.deg])
     assert allclose(sc.ra, Angle('1d'))

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -19,7 +19,8 @@ from ... import units as u
 from ...tests.helper import pytest, catch_warnings
 from ..representation import REPRESENTATION_CLASSES
 from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
-                            SphericalRepresentation, CartesianRepresentation)
+                            SphericalRepresentation, CartesianRepresentation,
+                            UnitSphericalRepresentation)
 from ...coordinates import Latitude, Longitude
 from ...time import Time
 from ...utils.exceptions import AstropyDeprecationWarning
@@ -1022,3 +1023,47 @@ def test_guess_from_table():
     tabgal['gal_l'].name = 'central'
     with pytest.raises(ValueError):
         SkyCoord.guess_from_table(tabgal, frame='galactic')
+
+
+def test_skycoord_list_creation():
+    """
+    Test that SkyCoord can be created in a reasonable way with lists of SkyCoords
+    (regression for #2702)
+    """
+    sc = SkyCoord(ra=[1, 2, 3]*u.deg, dec=[4, 5, 6]*u.deg)
+    sc0 = sc[0]
+    sc2 = sc[2]
+    scnew = SkyCoord([sc0, sc2])
+    assert np.all(scnew.ra == [1, 3]*u.deg)
+    assert np.all(scnew.dec == [4, 6]*u.deg)
+
+    #also check ranges
+    sc01 = sc[:2]
+    scnew2 = SkyCoord([sc01, sc2])
+    assert np.all(scnew2.ra == sc.ra)
+    assert np.all(scnew2.dec == sc.dec)
+
+    #now try with a mix of skycoord, frame, and repr objects
+    frobj = ICRS(2*u.deg, 5*u.deg)
+    reprobj = UnitSphericalRepresentation(3*u.deg, 6*u.deg)
+    scnew3 = SkyCoord([sc0, frobj, reprobj])
+    assert np.all(scnew3.ra == sc.ra)
+    assert np.all(scnew3.dec == sc.dec)
+
+    #should *fail* if different frame attributes or types are passed in
+    scfk5_j2000 = SkyCoord(1*u.deg, 4*u.deg, frame='fk5')
+    with pytest.raises(ValueError):
+        SkyCoord([sc0, scfk5_j2000])
+    scfk5_j2010 = SkyCoord(1*u.deg, 4*u.deg, frame='fk5', equinox='J2010')
+    with pytest.raises(ValueError):
+        SkyCoord([scfk5_j2000, scfk5_j2010])
+
+    # but they should inherit if they're all consistent
+    scfk5_2_j2010 = SkyCoord(2*u.deg, 5*u.deg, frame='fk5', equinox='J2010')
+    scfk5_3_j2010 = SkyCoord(3*u.deg, 6*u.deg, frame='fk5', equinox='J2010')
+
+    scnew4 = SkyCoord([scfk5_j2010, scfk5_2_j2010, scfk5_3_j2010])
+    assert np.all(scnew4.ra == sc.ra)
+    assert np.all(scnew4.dec == sc.dec)
+    assert scnew4.equinox == Time('J2010')
+


### PR DESCRIPTION
This PR is a different take on #2702 (which it replaces, and has been in limbo since just before 0.4).  It does the main point of that, allowing usage like:
```
>>> sc = SkyCoord(ra=[1,2,3]*u.deg,dec=[4,5,6]*u.deg)
>>> sc0 = sc[0]
>>> sc2 = sc[2]
>>> SkyCoord([sc0, sc2])
```
However, it's more restricted than #2702, which allowed various mixes of types of frames and converted as needed to match the first one.  Based on @taldcroft's last comments in #2702, it no longer does that, and always raises an error if the input frames are not all consistent.

This is also different from #2702 in that it is a no-op if the input list does not include SkyCoords, frame objects, or representations.  So unlike #2702, it should have no effects outside that case, which previously was not allowed.  (The big block of changes in the diff is mostly just indenting in an else statement - all of that is unchanged aside from the indednt)  

I'll leave it to @astrofrog to decide if this should be aimed for v1.0, 1.0.1, or 1.1 .