### PR TITLE
Properly test defaults for RADESYS and EQUINOX

### DIFF
--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -784,3 +784,83 @@ def test_radesys_defaults():
     w.ctype = ['RA---TAN', 'DEC--TAN']
     w.set()
     assert w.radesys == "ICRS"
+
+@pytest.mark.xfail(
+    LooseVersion(_wcs.__version__) < LooseVersion("4.25"),
+    reason="wcslib < 4.25")
+def test_radesys_defaults_full():
+
+    # As described in Section 3.1 of the FITS standard "Equatorial and ecliptic
+    # coordinates", for those systems the RADESYS keyword can be used to
+    # indicate the equatorial/ecliptic frame to use. From the standard:
+
+    # "For RADESYSa values of FK4 and FK4-NO-E, any stated equinox is Besselian
+    # and, if neither EQUINOXa nor EPOCH are given, a default of 1950.0 is to
+    # be taken. For FK5, any stated equinox is Julian and, if neither keyword
+    # is given, it defaults to 2000.0.
+
+    # "If the EQUINOXa keyword is given it should always be accompanied by
+    # RADESYS a. However, if it should happen to ap- pear by itself then
+    # RADESYSa defaults to FK4 if EQUINOXa < 1984.0, or to FK5 if EQUINOXa
+    # 1984.0. Note that these defaults, while probably true of older files
+    # using the EPOCH keyword, are not required of them.
+
+    # By default RADESYS is empty
+    w = _wcs.Wcsprm(naxis=2)
+    assert w.radesys == ''
+    assert np.isnan(w.equinox)
+
+    # For non-ecliptic or equatorial systems it is still empty
+    w = _wcs.Wcsprm(naxis=2)
+    for ctype in [('GLON-CAR', 'GLAT-CAR'),
+                  ('SLON-SIN', 'SLAT-SIN')]:
+        w.ctype = ctype
+        w.set()
+        assert w.radesys == ''
+        assert np.isnan(w.equinox)
+
+    for ctype in [('RA---TAN', 'DEC--TAN'),
+                  ('ELON-TAN', 'ELAT-TAN'),
+                  ('DEC--TAN', 'RA---TAN'),
+                  ('ELAT-TAN', 'ELON-TAN')]:
+
+        # Check defaults for RADESYS
+        w = _wcs.Wcsprm(naxis=2)
+
+        w.ctype = ctype
+        w.set()
+        assert w.radesys == 'ICRS'
+
+        w.equinox = 1980
+        w.set()
+        assert w.radesys == 'FK4'
+
+        w.equinox = 1984
+        w.set()
+        assert w.radesys == 'FK5'
+
+        w.radesys = 'foo'
+        w.set()
+        assert w.radesys == 'foo'
+
+        # Check defaults for EQUINOX
+        w = _wcs.Wcsprm(naxis=2)
+        w.ctype = ctype
+        w.set()
+        assert np.isnan(w.equinox)  # frame is ICRS, no equinox
+
+        w.radesys = 'ICRS'
+        w.set()
+        assert np.isnan(w.equinox)
+
+        w.radesys = 'FK5'
+        w.set()
+        assert w.equinox == 2000.
+
+        w.radesys = 'FK4'
+        w.set()
+        assert w.equinox == 1950
+
+        w.radesys = 'FK4-NO-E'
+        w.set()
+        assert w.equinox == 1950

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -826,19 +826,21 @@ def test_radesys_defaults_full():
 
         # Check defaults for RADESYS
         w = _wcs.Wcsprm(naxis=2)
-
         w.ctype = ctype
         w.set()
         assert w.radesys == 'ICRS'
 
+        w = _wcs.Wcsprm(naxis=2)
         w.equinox = 1980
         w.set()
         assert w.radesys == 'FK4'
 
+        w = _wcs.Wcsprm(naxis=2)
         w.equinox = 1984
         w.set()
         assert w.radesys == 'FK5'
 
+        w = _wcs.Wcsprm(naxis=2)
         w.radesys = 'foo'
         w.set()
         assert w.radesys == 'foo'
@@ -849,18 +851,22 @@ def test_radesys_defaults_full():
         w.set()
         assert np.isnan(w.equinox)  # frame is ICRS, no equinox
 
+        w = _wcs.Wcsprm(naxis=2)
         w.radesys = 'ICRS'
         w.set()
         assert np.isnan(w.equinox)
 
+        w = _wcs.Wcsprm(naxis=2)
         w.radesys = 'FK5'
         w.set()
         assert w.equinox == 2000.
 
+        w = _wcs.Wcsprm(naxis=2)
         w.radesys = 'FK4'
         w.set()
         assert w.equinox == 1950
 
+        w = _wcs.Wcsprm(naxis=2)
         w.radesys = 'FK4-NO-E'
         w.set()
         assert w.equinox == 1950


### PR DESCRIPTION
@mdboom - this is based on the test I had added in https://github.com/astropy/astropy/pull/2729 - and just adds a test of the defaults for RADESYS and EQUINOX. As you can see there is a failure because according to the standard,

```
        w = _wcs.Wcsprm(naxis=2)
        w.equinox = 1980
        w.set()
        assert w.radesys == 'FK4'
```

should work but it currently still has ``radesys`` unset. Would you be able to look into this and see why this test is failing? Also, we can always combine the test here with ``test_radesys_defaults`` but I wasn't sure whether that would be the best approach so I'll leave it up to you to decide.


