### PR TITLE
Fix #3117: Convert some time errors into warnings

### DIFF
--- a/astropy/erfa/core.py.templ
+++ b/astropy/erfa/core.py.templ
@@ -76,11 +76,8 @@ STATUS_CODES_REMAP = {
 def check_errwarn(statcodes, func_name):
     # Remap any errors into warnings in the STATUS_CODES_REMAP dict.
     if func_name in STATUS_CODES_REMAP:
-        mapping = STATUS_CODES_REMAP[func_name]
-        for i in range(len(statcodes)):
-            if statcodes[i] in mapping:
-                statcodes[i] = mapping[statcodes[i]]
-        for before, after in mapping.items():
+        for before, after in STATUS_CODES_REMAP[func_name].items():
+            statcodes = numpy.where(statcodes == before, after, statcodes)
             STATUS_CODES[func_name][after] = STATUS_CODES[func_name][before]
 
     if numpy.any(statcodes<0):

--- a/astropy/erfa/core.py.templ
+++ b/astropy/erfa/core.py.templ
@@ -66,7 +66,23 @@ class ErfaWarning(AstropyUserWarning):
 
 STATUS_CODES = {}  # populated below before each function that returns an int
 
+# This is a hard-coded list of status codes that need to be remapped,
+# such as to turn errors into warnings.
+STATUS_CODES_REMAP = {
+    'cal2jd': {-3: 3}
+}
+
+
 def check_errwarn(statcodes, func_name):
+    # Remap any errors into warnings in the STATUS_CODES_REMAP dict.
+    if func_name in STATUS_CODES_REMAP:
+        mapping = STATUS_CODES_REMAP[func_name]
+        for i in range(len(statcodes)):
+            if statcodes[i] in mapping:
+                statcodes[i] = mapping[statcodes[i]]
+        for before, after in mapping.items():
+            STATUS_CODES[func_name][after] = STATUS_CODES[func_name][before]
+
     if numpy.any(statcodes<0):
         # errors present - only report the errors.
         if statcodes.shape:

--- a/astropy/erfa/core.py.templ
+++ b/astropy/erfa/core.py.templ
@@ -77,7 +77,7 @@ def check_errwarn(statcodes, func_name):
     # Remap any errors into warnings in the STATUS_CODES_REMAP dict.
     if func_name in STATUS_CODES_REMAP:
         for before, after in STATUS_CODES_REMAP[func_name].items():
-            statcodes = numpy.where(statcodes == before, after, statcodes)
+            statcodes[statcodes == before] = after
             STATUS_CODES[func_name][after] = STATUS_CODES[func_name][before]
 
     if numpy.any(statcodes<0):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -602,10 +602,7 @@ class TestSubFormat():
         t = Time('2004-09-16T23:59:59', scale='utc')
         assert allclose_sec(t.unix, 1095379199.0)
 
-# this test fails because it uses the  erfa_time.pyx cal2jd, which doesn't raise
-# an error on a "bad day".  Can just eliminate the test if we don't care about
-# this anymore
-@pytest.mark.xfail
+
 class TestSofaErrors():
     """Test that erfa_time.pyx handles erfa status return values correctly"""
 
@@ -616,7 +613,7 @@ class TestSofaErrors():
         djm0 = np.array([0], dtype=np.double)
         djm = np.array([0], dtype=np.double)
         with pytest.raises(ValueError):  # bad month, fatal error
-            djm0, djm= erfa_time.cal2jd(iy, im, id)
+            djm0, djm = erfa_time.cal2jd(iy, im, id)
 
         # Set month to a good value so now the bad day just gives a warning
         im[0] = 2

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -605,7 +605,7 @@ class TestSubFormat():
 
 
 class TestSofaErrors():
-    """Test that erfa_time.pyx handles erfa status return values correctly"""
+    """Test that erfa status return values are handled correctly"""
 
     def test_bad_time(self):
         iy = np.array([2000], dtype=np.intc)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -614,8 +614,12 @@ class TestSofaErrors():
         with pytest.raises(ValueError):  # bad month, fatal error
             djm0, djm = erfa_time.cal2jd(iy, im, id)
 
-        # Set month to a good value so now the bad day just gives a warning
+        iy[0] = -5000
         im[0] = 2
+        with pytest.raises(ValueError):  # bad year, fatal error
+            djm0, djm = erfa_time.cal2jd(iy, im, id)
+
+        iy[0] = 2000
         with catch_warnings() as w:
             djm0, djm = erfa_time.cal2jd(iy, im, id)
         assert len(w) == 1
@@ -623,9 +627,6 @@ class TestSofaErrors():
 
         assert allclose_jd(djm0, [2400000.5])
         assert allclose_jd(djm, [53574.])
-
-        # How do you test for warnings in pytest?  Test that dubious year for
-        # UTC works.
 
 
 class TestCopyReplicate():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -610,8 +610,6 @@ class TestSofaErrors():
         iy = np.array([2000], dtype=np.intc)
         im = np.array([2000], dtype=np.intc)  # bad month
         id = np.array([2000], dtype=np.intc)  # bad day
-        djm0 = np.array([0], dtype=np.double)
-        djm = np.array([0], dtype=np.double)
         with pytest.raises(ValueError):  # bad month, fatal error
             djm0, djm = erfa_time.cal2jd(iy, im, id)
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -10,7 +10,8 @@ from datetime import datetime, tzinfo, timedelta
 
 import numpy as np
 
-from ...tests.helper import pytest
+from ...tests.helper import pytest, catch_warnings
+from ...extern import six
 from .. import Time, ScaleValueError, erfa_time, TIME_SCALES
 from ...coordinates import EarthLocation
 
@@ -615,7 +616,11 @@ class TestSofaErrors():
 
         # Set month to a good value so now the bad day just gives a warning
         im[0] = 2
-        djm0, djm = erfa_time.cal2jd(iy, im, id)
+        with catch_warnings() as w:
+            djm0, djm = erfa_time.cal2jd(iy, im, id)
+        assert len(w) == 1
+        assert 'bad day    (JD computed)' in six.text_type(w[0].message)
+
         assert allclose_jd(djm0, [2400000.5])
         assert allclose_jd(djm, [53574.])
 


### PR DESCRIPTION
This should resolve #3117.  It doesn't take the suggested solution there (to add a wrapper to convert the exception into a warning), since one an exception is thrown, the value is lost.  We need to go deeper and prevent the exception from being thrown at all.