### PR TITLE
Bug in u.quantity_decorator when using **kwargs

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -28,6 +28,12 @@ class QuantityInput(object):
         Where an equivalency is specified in the decorator, the function will be
         executed with that equivalency in force.
 
+        Notes
+        -----
+
+        The checking of arguments inside variable arguments to a function is not
+        supported (i.e. \*arg or \**kwargs).
+
         Examples
         --------
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -76,6 +76,10 @@ class QuantityInput(object):
 
             # Iterate through the parameters of the original signature
             for param in wrapped_signature.parameters.values():
+                # We do not support variable arguments (*args, **kwargs)
+                if param.kind in (funcsigs.Parameter.VAR_KEYWORD,
+                                  funcsigs.Parameter.VAR_POSITIONAL):
+                    continue
                 # Catch the (never triggered) case where bind relied on a default value.
                 if param.name not in bound_args.arguments and param.default is not param.empty:
                     bound_args.arguments[param.name] = param.default

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -83,7 +83,7 @@ class QuantityInput(object):
                 # Get the value of this parameter (argument to new function)
                 arg = bound_args.arguments[param.name]
 
-                # Get target unit, either from decotrator kwargs or annotations
+                # Get target unit, either from decorator kwargs or annotations
                 if param.name in self.decorator_kwargs:
                     target_unit = self.decorator_kwargs[param.name]
                 else:

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -168,19 +168,6 @@ def test_no_equivalent():
 
         assert str(e.value) == "Argument 'solarx' to function has 'myfunc_args' a 'unit' attribute without an 'is_equivalent' method. You may want to pass in an astropy Quantity instead."
 
-def test_kwargs_dict():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
-    def myfunc_args(**kwargs):
-        return kwargs['solarx'], kwargs['solary']
-
-    solarx, solary = myfunc_args(solary=10*u.deg, solarx=1*u.arcsec)
-
-    assert isinstance(solarx, u.Quantity)
-    assert isinstance(solary, u.Quantity)
-
-    assert solarx.unit == u.arcsec
-    assert solary.unit == u.deg
-
 def test_kwargs_input():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)
     def myfunc_args(solarx=1*u.arcsec, solary=1*u.deg):
@@ -200,7 +187,7 @@ def test_kwargs_extra():
     def myfunc_args(solarx, **kwargs):
         return solarx
 
-    solarx, solary = myfunc_args(1*u.deg)
+    solarx = myfunc_args(1*u.deg)
 
     assert isinstance(solarx, u.Quantity)
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -167,3 +167,42 @@ def test_no_equivalent():
         solarx, solary = myfunc_args(test_quantity())
 
         assert str(e.value) == "Argument 'solarx' to function has 'myfunc_args' a 'unit' attribute without an 'is_equivalent' method. You may want to pass in an astropy Quantity instead."
+
+def test_kwargs_dict():
+    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+    def myfunc_args(**kwargs):
+        return kwargs['solarx'], kwargs['solary']
+
+    solarx, solary = myfunc_args(solary=10*u.deg, solarx=1*u.arcsec)
+
+    assert isinstance(solarx, u.Quantity)
+    assert isinstance(solary, u.Quantity)
+
+    assert solarx.unit == u.arcsec
+    assert solary.unit == u.deg
+
+def test_kwargs_input():
+    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+    def myfunc_args(solarx=1*u.arcsec, solary=1*u.deg):
+        return solarx, solary
+
+    kwargs = {'solarx':10*u.arcsec, 'solary':10*u.deg}
+    solarx, solary = myfunc_args(**kwargs)
+
+    assert isinstance(solarx, u.Quantity)
+    assert isinstance(solary, u.Quantity)
+
+    assert solarx.unit == u.arcsec
+    assert solary.unit == u.deg
+
+def test_kwargs_extra():
+    @u.quantity_input(solary=u.deg)
+    def myfunc_args(solarx, **kwargs):
+        return solarx
+
+    solarx, solary = myfunc_args(1*u.deg)
+
+    assert isinstance(solarx, u.Quantity)
+
+    assert solarx.unit == u.deg
+


### PR DESCRIPTION
So the following code breaks the `u.quantity_decorator`:

```python
In [2]: import astropy.units as u

In [4]: @u.quantity_input(a=u.deg)
   ...: def funct(a, **kwargs):
   ...:     pass
   ...: 

In [5]: funct(1 * u.deg)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-5-5fb4e89adcc1> in <module>()
----> 1 funct(1 * u.deg)

/Users/ireland/sunpy/sunpy/util/unit_decorators.pyc in wrapper(*func_args, **func_kwargs)
     81 
     82                 # Get the value of this parameter (argument to new function)
---> 83                 arg = bound_args.arguments[param.name]
     84 
     85                 # Get target unit, either from decotrator kwargs or annotations

KeyError: 'kwargs'
```

I have written a test which demos this bug, but as yet have not yet come up with a fix.

ping @embray @mhvk @astrofrog 