### PR TITLE
Bugfix: utils.metadata.merge ignores the `metadata_conflicts` parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -676,6 +676,9 @@ Bug Fixes
   - Fixed an issue with the ``deprecated`` decorator on classes that invoke
     ``super()`` in their ``__init__`` method. [#3004]
 
+  - Fixed a bug which caused the ``metadata_conflicts`` parameter to be
+    ignored in the ``astropy.utils.metadata.merge`` function. [#3294]  
+
 - ``astropy.vo``
 
   - Fixed an issue with reconnecting to a SAMP Hub. [#2674]

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -76,7 +76,8 @@ def merge(left, right, merge_func=concat, metadata_conflicts='warn'):
 
         # There is a conflict that must be resolved
         if _both_isinstance(left[key], right[key], dict):
-            out[key] = merge(left[key], right[key], merge_func)
+            out[key] = merge(left[key], right[key], merge_func,
+                             metadata_conflicts=metadata_conflicts)
 
         else:
             try:

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -73,8 +73,12 @@ class TestMetaExampleData(MetaBaseTest):
     args = ()
 
 
-def test_metadata_conflicts_exception():
-    """Test the behaviour of merging metadata with metadata_conflicts='error'"""
+def test_metadata_merging_conflict_exception():
+    """Regression test for issue #3294.
+
+    Ensure that an exception is raised when a metadata conflict exists
+    and ``metadata_conflicts='error'`` has been set.
+    """
     from ..metadata import merge, MergeConflictError
     data1 = ExampleData()
     data2 = ExampleData()

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -1,6 +1,6 @@
 import abc
 
-from ..metadata import MetaData
+from ..metadata import MetaData, MergeConflictError, merge
 from ..compat.odict import OrderedDict
 from ...tests.helper import pytest
 from ...io import fits
@@ -71,3 +71,14 @@ class ExampleData(object):
 class TestMetaExampleData(MetaBaseTest):
     test_class = ExampleData
     args = ()
+
+
+def test_metadata_conflicts_exception():
+    """Test the behaviour of merging metadata with metadata_conflicts='error'"""
+    from ..metadata import merge, MergeConflictError
+    data1 = ExampleData()
+    data2 = ExampleData()
+    data1.meta['somekey'] = {'x': 1, 'y': 1}
+    data2.meta['somekey'] = {'x': 1, 'y': 999}
+    with pytest.raises(MergeConflictError):
+        merge(data1.meta, data2.meta, metadata_conflicts='error')


### PR DESCRIPTION
The `merge` function in `astropy.utils.metadata` makes use of recursion, but it does not pass the `metadata_conflicts` argument on in the recursive calls.  This leads to the following small bug: 

```Python
In [1]: from astropy import table
In [2]: t1, t2 = table.Table(), table.Table()
In [3]: t1.meta['somekey'] = {'x': 1, 'y': 1}
In [4]: t2.meta['somekey'] = {'x': 1, 'y': 999}
In [5]: table.vstack([t1, t2], metadata_conflicts='silent')
WARNING: MergeConflictWarning: Cannot merge meta key 'y' types <type 'int'> and <type 'int'>, choosing y=999 [astropy.utils.metadata]
Out[5]: 
<Table rows=0 names=()>
None
```
In the example above, the `MergeConflictWarning` should not have been raised because we asked for `metadata_conflicts='silent'`. Likewise, `metadata_conflicts='error'` will not raise the expected `MergeConflictException` in this situation.

This PR fixes the bug and adds a test.