### PR TITLE
fix Mapping.inverse

### DIFF
--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -10,12 +10,16 @@ __all__ = ['Mapping', 'Identity']
 
 
 class Mapping(Model):
-    def __init__(self, mapping, **kwargs):
-        self._inputs = tuple('x' + str(idx)
-                             for idx in range(max(mapping) + 1))
+    def __init__(self, mapping, n_inputs=None):
+        if n_inputs is None:
+            self._inputs = tuple('x' + str(idx)
+                                 for idx in range(max(mapping) + 1))
+        else:
+            self._inputs = tuple('x' + str(idx)
+                                 for idx in range(n_inputs))
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
-        super(Mapping, self).__init__(**kwargs)
+        super(Mapping, self).__init__()
 
     @property
     def name(self):
@@ -62,13 +66,13 @@ class Mapping(Model):
 
 
 class Identity(Mapping):
-    def __init__(self, n_inputs):
-        mapping = tuple(range(n_inputs))
+    def __init__(self, n_outputs):
+        mapping = tuple(range(n_outputs))
         super(Identity, self).__init__(mapping)
 
     @property
     def name(self):
-        return 'Identity({0})'.format(self.n_inputs)
+        return 'Identity({0})'.format(self.n_outputs)
 
     @property
     def inverse(self):

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -10,16 +10,34 @@ __all__ = ['Mapping', 'Identity']
 
 
 class Mapping(Model):
-    def __init__(self, mapping):
+    """
+    Allows inputs to be reordered, duplicated or dropped.
+
+    Parameters
+    ----------
+    mapping : tuple
+        Integers representing indices of the inputs.
+
+    Raises
+    ------
+    TypeError
+        Raised when number of inputs is less that `max(mapping)`.
+
+    Examples
+    --------
+    >>> poly1 = Polynomial2D(1, c0_0=1, c1_0=2, c0_1=3)
+    >>> poly2 = Polynomial2D(1, c0_0=1, c1_0=2.4, c0_1=2.1)
+    >>> model = (Shift(1) & Shift(2)) | Mapping((0, 1, 0, 1)) | (poly1 & poly2)
+    >>> model(1, 2)
+    (17.0, 14.2)
+
+    """
+    def __init__(self, mapping, **kwargs):
         self._inputs = tuple('x' + str(idx)
                              for idx in range(max(mapping) + 1))
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
-        super(Mapping, self).__init__()
-
-    @property
-    def name(self):
-        return 'Mapping({0})'.format(self.mapping)
+        super(Mapping, self).__init__(**kwargs)
 
     @property
     def inputs(self):
@@ -55,17 +73,37 @@ class Mapping(Model):
                 "Mappings such as {0} that drop one or more of their inputs "
                 "are not invertible at this time.".format(self.mapping))
 
-        return self.__class__(mapping)
+        inv = self.__class__(mapping)
+        inv._inputs = self._outputs
+        inv._outputs = self._inputs
+        return inv
 
 
 class Identity(Mapping):
-    def __init__(self, n_inputs):
-        mapping = tuple(range(n_inputs))
-        super(Identity, self).__init__(mapping)
+    """
+    Returns inputs unchanged.
 
-    @property
-    def name(self):
-        return 'Identity({0})'.format(self.n_inputs)
+    This class is useful in compound models when some of the inputs must be
+    passed unchanged to the next model.
+
+    Parameters
+    ----------
+    n_inputs : int
+        Specifies how many of the inputs will be returned.
+
+    Examples
+    --------
+    # Transform (x, y) by a shift in x, followed by scaling the two inputs.
+    >>> model = (Shift(1) & Identity(1)) | Scale(1.2) & Scale(2)
+    >>> model(1,1)
+    (2.4, 2.0)
+    >>> model.inverse(2.4,2)
+    (1.0, 1.0)
+
+    """
+    def __init__(self, n_inputs, **kwargs):
+        mapping = tuple(range(n_inputs))
+        super(Identity, self).__init__(mapping, **kwargs)
 
     @property
     def inverse(self):

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -38,8 +38,8 @@ class Mapping(Model):
         return self._mapping
 
     def evaluate(self, *args):
-        if len(args) < self.n_inputs:
-            raise TypeError('{0} expects at most {1} inputs; got {2}'.format(
+        if len(args) != self.n_inputs:
+            raise TypeError('{0} expects {1} inputs; got {2}'.format(
                 self.name, self.n_inputs, len(args)))
 
         result = tuple(args[idx] for idx in self._mapping)
@@ -66,13 +66,13 @@ class Mapping(Model):
 
 
 class Identity(Mapping):
-    def __init__(self, n_outputs):
-        mapping = tuple(range(n_outputs))
-        super(Identity, self).__init__(mapping)
+    def __init__(self, n_inputs):
+        mapping = tuple(range(n_inputs))
+        super(Identity, self).__init__(mapping, n_inputs=n_inputs)
 
     @property
     def name(self):
-        return 'Identity({0})'.format(self.n_outputs)
+        return 'Identity({0})'.format(self.n_inputs)
 
     @property
     def inverse(self):

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -10,34 +10,16 @@ __all__ = ['Mapping', 'Identity']
 
 
 class Mapping(Model):
-    """
-    Allows inputs to be reordered, duplicated or dropped.
-
-    Parameters
-    ----------
-    mapping : tuple
-        Integers representing indices of the inputs.
-
-    Raises
-    ------
-    TypeError
-        Raised when number of inputs is less that `max(mapping)`.
-
-    Examples
-    --------
-    >>> poly1 = Polynomial2D(1, c0_0=1, c1_0=2, c0_1=3)
-    >>> poly2 = Polynomial2D(1, c0_0=1, c1_0=2.4, c0_1=2.1)
-    >>> model = (Shift(1) & Shift(2)) | Mapping((0, 1, 0, 1)) | (poly1 & poly2)
-    >>> model(1, 2)
-    (17.0, 14.2)
-
-    """
     def __init__(self, mapping, **kwargs):
         self._inputs = tuple('x' + str(idx)
                              for idx in range(max(mapping) + 1))
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
         super(Mapping, self).__init__(**kwargs)
+
+    @property
+    def name(self):
+        return 'Mapping({0})'.format(self.mapping)
 
     @property
     def inputs(self):
@@ -80,30 +62,13 @@ class Mapping(Model):
 
 
 class Identity(Mapping):
-    """
-    Returns inputs unchanged.
-
-    This class is useful in compound models when some of the inputs must be
-    passed unchanged to the next model.
-
-    Parameters
-    ----------
-    n_inputs : int
-        Specifies how many of the inputs will be returned.
-
-    Examples
-    --------
-    # Transform (x, y) by a shift in x, followed by scaling the two inputs.
-    >>> model = (Shift(1) & Identity(1)) | Scale(1.2) & Scale(2)
-    >>> model(1,1)
-    (2.4, 2.0)
-    >>> model.inverse(2.4,2)
-    (1.0, 1.0)
-
-    """
-    def __init__(self, n_inputs, **kwargs):
+    def __init__(self, n_inputs):
         mapping = tuple(range(n_inputs))
-        super(Identity, self).__init__(mapping, **kwargs)
+        super(Identity, self).__init__(mapping)
+
+    @property
+    def name(self):
+        return 'Identity({0})'.format(self.n_inputs)
 
     @property
     def inverse(self):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -187,9 +187,6 @@ class Rotation2D(Model):
         single coordinate pair.
         """
 
-        if x.shape != y.shape:
-            raise ValueError("Expected input arrays to have the same shape")
-
         # Note: If the original shape was () (an array scalar) convert to a
         # 1-element 1-D array on output for consistency with most other models
         orig_shape = x.shape or (1,)

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -41,6 +41,14 @@ def test_drop_axes_2():
         mapping.inverse
 
 
+def test_drop_axes_3():
+    mapping = Mapping((1,), n_inputs=2)
+    assert(mapping.n_inputs == 2)
+    rotation = Rotation2D(60)
+    model = rotation | mapping
+    assert_allclose(model(1, 2), 1.86602540378)
+
+
 def test_identity():
     ident1 = Identity(1)
     shift = Shift(1)
@@ -54,3 +62,4 @@ def test_identity():
                         np.array([[ 1.,  1.,  1.],
                                   [ 1.,  1.,  1.]])))
     assert_allclose(model.inverse(res_x, res_y), (x, y))
+

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -29,10 +29,8 @@ def test_duplicate_axes():
 
 
 def test_drop_axes_1():
-    mapping = Mapping((0, ))
+    mapping = Mapping((0, ), n_inputs=2)
     assert(mapping(1, 2) == (1.))
-    assert(mapping.inverse(1) == 1)
-
 
 def test_drop_axes_2():
     mapping = Mapping((1, ))

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -1,0 +1,56 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+from ...tests.helper import pytest
+from ..models import Shift, Rotation2D, Identity, Mapping
+import numpy as np
+from numpy.testing.utils import (assert_allclose, assert_array_equal)
+
+
+x = np.zeros((2, 3))
+y = np.ones((2, 3))
+
+
+def test_swap_axes():
+    mapping = Mapping((1, 0))
+    assert(mapping(1, 2) == (2.0, 1.0))
+    assert(mapping.inverse(2, 1) == (1, 2))
+    assert_array_equal(mapping(x, y), (y, x))
+    assert_array_equal(mapping.inverse(y, x), (x, y))
+
+
+def test_duplicate_axes():
+    mapping = Mapping((0, 1, 0, 1))
+    assert(mapping(1, 2) == (1.0, 2., 1., 2))
+    assert(mapping.inverse(1, 2, 1, 2) == (1, 2))
+    assert(mapping.inverse.n_inputs == 4)
+    assert(mapping.inverse.n_outputs == 2)
+
+
+def test_drop_axes_1():
+    mapping = Mapping((0, ))
+    assert(mapping(1, 2) == (1.))
+    assert(mapping.inverse(1) == 1)
+
+
+def test_drop_axes_2():
+    mapping = Mapping((1, ))
+    assert(mapping(1, 2) == (2.))
+    with pytest.raises(NotImplementedError):
+        mapping.inverse
+
+
+def test_identity():
+    ident1 = Identity(1)
+    shift = Shift(1)
+    rotation = Rotation2D(angle=60)
+    model = ident1 & shift | rotation
+    assert(model(1, 2) == (-2.098076211353316, 2.3660254037844393))
+    res_x, res_y = model(x, y)
+    assert_allclose((res_x, res_y),
+                       (np.array([[-1.73205081, -1.73205081, -1.73205081],
+                                  [-1.73205081, -1.73205081, -1.73205081]]),
+                        np.array([[ 1.,  1.,  1.],
+                                  [ 1.,  1.,  1.]])))
+    assert_allclose(model.inverse(res_x, res_y), (x, y))


### PR DESCRIPTION
`Mapping.inverse` is incorrect when duplicating inputs:

```
m = Mapping((0, 1, 0))
m.inverse.n_inputs
2
m.inverse.n_outputs
2
```
This causes the inverse of compound models to fail because the inputs don't match the outputs any more.

```
model = Shift(1) & Shift(2) | m | (Scale(1) & Scale(2) & Scale(3)
```

This PR provides a fix for this problem, although in somewhat kludgy way. The problem is that `Mapping` accepts arbitrary number of inputs. And there's no way to initialize a model by specifying how many inputs will be passed.

This PR also adds docstrings and changes the two models in such a way that now a `name` argument can be passed in when a model is initialized.

