### PR TITLE
units: Add a long name for Astronomical Unit

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -26,7 +26,7 @@ _ns = globals()
 ###########################################################################
 # LENGTH
 
-def_unit((['AU', 'au'], ['AstronomicalUnit']), _si.au.value * si.m, namespace=_ns, prefixes=True,
+def_unit((['AU', 'au'], ['astronomical_unit']), _si.au.value * si.m, namespace=_ns, prefixes=True,
          doc="astronomical unit: approximately the mean Earth--Sun "
          "distance.")
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -26,7 +26,7 @@ _ns = globals()
 ###########################################################################
 # LENGTH
 
-def_unit((['AU', 'au'], []), _si.au.value * si.m, namespace=_ns, prefixes=True,
+def_unit((['AU', 'au'], ['AstronomicalUnit']), _si.au.value * si.m, namespace=_ns, prefixes=True,
          doc="astronomical unit: approximately the mean Earth--Sun "
          "distance.")
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -308,14 +308,14 @@ def set_enabled_units(units):
     >>> u.m.find_equivalent_units()
       Primary name | Unit definition | Aliases
     [
-      AU           | 1.49598e+11 m   | au           ,
-      Angstrom     | 1e-10 m         | AA, angstrom ,
-      cm           | 0.01 m          | centimeter   ,
-      lyr          | 9.46073e+15 m   | lightyear    ,
-      m            | irreducible     | meter        ,
-      micron       | 1e-06 m         |              ,
-      pc           | 3.08568e+16 m   | parsec       ,
-      solRad       | 6.95508e+08 m   | R_sun, Rsun  ,
+      AU           | 1.49598e+11 m   | au, AstronomicalUnit ,
+      Angstrom     | 1e-10 m         | AA, angstrom         ,
+      cm           | 0.01 m          | centimeter           ,
+      lyr          | 9.46073e+15 m   | lightyear            ,
+      m            | irreducible     | meter                ,
+      micron       | 1e-06 m         |                      ,
+      pc           | 3.08568e+16 m   | parsec               ,
+      solRad       | 6.95508e+08 m   | R_sun, Rsun          ,
     ]
     """
     # get a context with a new registry, using equivalencies of the current one
@@ -355,19 +355,19 @@ def add_enabled_units(units):
     ...
       Primary name | Unit definition | Aliases
     [
-      AU           | 1.49598e+11 m   | au               ,
-      Angstrom     | 1e-10 m         | AA, angstrom     ,
-      cm           | 0.01 m          | centimeter       ,
-      ft           | 0.3048 m        | foot             ,
-      inch         | 0.0254 m        |                  ,
-      lyr          | 9.46073e+15 m   | lightyear        ,
-      m            | irreducible     | meter            ,
-      mi           | 1609.34 m       | mile             ,
-      micron       | 1e-06 m         |                  ,
-      nmi          | 1852 m          | nauticalmile, NM ,
-      pc           | 3.08568e+16 m   | parsec           ,
-      solRad       | 6.95508e+08 m   | R_sun, Rsun      ,
-      yd           | 0.9144 m        | yard             ,
+      AU           | 1.49598e+11 m   | au, AstronomicalUnit ,
+      Angstrom     | 1e-10 m         | AA, angstrom         ,
+      cm           | 0.01 m          | centimeter           ,
+      ft           | 0.3048 m        | foot                 ,
+      inch         | 0.0254 m        |                      ,
+      lyr          | 9.46073e+15 m   | lightyear            ,
+      m            | irreducible     | meter                ,
+      mi           | 1609.34 m       | mile                 ,
+      micron       | 1e-06 m         |                      ,
+      nmi          | 1852 m          | nauticalmile, NM     ,
+      pc           | 3.08568e+16 m   | parsec               ,
+      solRad       | 6.95508e+08 m   | R_sun, Rsun          ,
+      yd           | 0.9144 m        | yard                 ,
     ]
     """
     # get a context with a new registry, which is a copy of the current one

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -308,14 +308,14 @@ def set_enabled_units(units):
     >>> u.m.find_equivalent_units()
       Primary name | Unit definition | Aliases
     [
-      AU           | 1.49598e+11 m   | au, AstronomicalUnit ,
-      Angstrom     | 1e-10 m         | AA, angstrom         ,
-      cm           | 0.01 m          | centimeter           ,
-      lyr          | 9.46073e+15 m   | lightyear            ,
-      m            | irreducible     | meter                ,
-      micron       | 1e-06 m         |                      ,
-      pc           | 3.08568e+16 m   | parsec               ,
-      solRad       | 6.95508e+08 m   | R_sun, Rsun          ,
+      AU           | 1.49598e+11 m   | au, astronomical_unit ,
+      Angstrom     | 1e-10 m         | AA, angstrom          ,
+      cm           | 0.01 m          | centimeter            ,
+      lyr          | 9.46073e+15 m   | lightyear             ,
+      m            | irreducible     | meter                 ,
+      micron       | 1e-06 m         |                       ,
+      pc           | 3.08568e+16 m   | parsec                ,
+      solRad       | 6.95508e+08 m   | R_sun, Rsun           ,
     ]
     """
     # get a context with a new registry, using equivalencies of the current one
@@ -355,19 +355,19 @@ def add_enabled_units(units):
     ...
       Primary name | Unit definition | Aliases
     [
-      AU           | 1.49598e+11 m   | au, AstronomicalUnit ,
-      Angstrom     | 1e-10 m         | AA, angstrom         ,
-      cm           | 0.01 m          | centimeter           ,
-      ft           | 0.3048 m        | foot                 ,
-      inch         | 0.0254 m        |                      ,
-      lyr          | 9.46073e+15 m   | lightyear            ,
-      m            | irreducible     | meter                ,
-      mi           | 1609.34 m       | mile                 ,
-      micron       | 1e-06 m         |                      ,
-      nmi          | 1852 m          | nauticalmile, NM     ,
-      pc           | 3.08568e+16 m   | parsec               ,
-      solRad       | 6.95508e+08 m   | R_sun, Rsun          ,
-      yd           | 0.9144 m        | yard                 ,
+      AU           | 1.49598e+11 m   | au, astronomical_unit ,
+      Angstrom     | 1e-10 m         | AA, angstrom          ,
+      cm           | 0.01 m          | centimeter            ,
+      ft           | 0.3048 m        | foot                  ,
+      inch         | 0.0254 m        |                       ,
+      lyr          | 9.46073e+15 m   | lightyear             ,
+      m            | irreducible     | meter                 ,
+      mi           | 1609.34 m       | mile                  ,
+      micron       | 1e-06 m         |                       ,
+      nmi          | 1852 m          | nauticalmile, NM      ,
+      pc           | 3.08568e+16 m   | parsec                ,
+      solRad       | 6.95508e+08 m   | R_sun, Rsun           ,
+      yd           | 0.9144 m        | yard                  ,
     ]
     """
     # get a context with a new registry, which is a copy of the current one

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -185,7 +185,7 @@ requires the beam area and frequency as arguments.  Example::
 Temperature Energy Equivalency
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This equivalency allows conversion between temperature and its equivalent 
+This equivalency allows conversion between temperature and its equivalent
 in energy (i.e., the temperature multiplied by the Boltzmann constant),
 usually expressed in electronvolts. This is used frequently for
 observations at high-energy, be it for solar or X-ray astronomy. Example::
@@ -274,22 +274,22 @@ all kinds of things that ``Hz`` can be converted to::
   >>> u.Hz.find_equivalent_units(equivalencies=u.spectral())
     Primary name | Unit definition        | Aliases
   [
-    AU           | 1.49598e+11 m          | au             ,
-    Angstrom     | 1e-10 m                | AA, angstrom   ,
-    Bq           | 1 / s                  | becquerel      ,
-    Ci           | 2.7027e-11 / s         | curie          ,
-    Hz           | 1 / s                  | Hertz, hertz   ,
-    J            | kg m2 / s2             | Joule, joule   ,
-    Ry           | 2.17987e-18 kg m2 / s2 | rydberg        ,
-    cm           | 0.01 m                 | centimeter     ,
-    eV           | 1.60218e-19 kg m2 / s2 | electronvolt   ,
-    erg          | 1e-07 kg m2 / s2       |                ,
-    k            | 100 / m                | Kayser, kayser ,
-    lyr          | 9.46073e+15 m          | lightyear      ,
-    m            | irreducible            | meter          ,
-    micron       | 1e-06 m                |                ,
-    pc           | 3.08568e+16 m          | parsec         ,
-    solRad       | 6.95508e+08 m          | R_sun, Rsun    ,
+    AU           | 1.49598e+11 m          | au, astronomical_unit ,
+    Angstrom     | 1e-10 m                | AA, angstrom          ,
+    Bq           | 1 / s                  | becquerel             ,
+    Ci           | 2.7027e-11 / s         | curie                 ,
+    Hz           | 1 / s                  | Hertz, hertz          ,
+    J            | kg m2 / s2             | Joule, joule          ,
+    Ry           | 2.17987e-18 kg m2 / s2 | rydberg               ,
+    cm           | 0.01 m                 | centimeter            ,
+    eV           | 1.60218e-19 kg m2 / s2 | electronvolt          ,
+    erg          | 1e-07 kg m2 / s2       |                       ,
+    k            | 100 / m                | Kayser, kayser        ,
+    lyr          | 9.46073e+15 m          | lightyear             ,
+    m            | irreducible            | meter                 ,
+    micron       | 1e-06 m                |                       ,
+    pc           | 3.08568e+16 m          | parsec                ,
+    solRad       | 6.95508e+08 m          | R_sun, Rsun           ,
   ]
 
 .. _equivalency-context:


### PR DESCRIPTION
This is a trivial pull request, but I noticed there is no "long name" for `u.AU` in the units package. Others may have opinions on how exactly to format the long name, but right now it is included as `u.AstronomicalUnit`.

__Currently:__

    >>> import astropy.units as u
    >>> u.au.long_names
    []

__This PR:__

    >>> u.au.long_names
    [u'AstronomicalUnit']