### PR TITLE
Simplified celestial_pixel_scale (now re-named to proj_plane_pixel_scale) and new proj_plane_pixel_area

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -241,26 +241,26 @@ def test_pixscale_nodrop():
     mywcs = WCS(naxis=2)
     mywcs.wcs.cdelt = [0.1,0.1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1]
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
 def test_pixscale_withdrop():
     mywcs = WCS(naxis=3)
     mywcs.wcs.cdelt = [0.1,0.1,1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN','VOPT']
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1,1]
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
 
 def test_pixscale_cd():
     mywcs = WCS(naxis=2)
     mywcs.wcs.cd = [[-0.1,0],[0,0.1]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
 
 @pytest.mark.parametrize('angle',
@@ -272,7 +272,7 @@ def test_pixscale_cd_rotated(angle):
     mywcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
                     [scale*np.sin(rho), scale*np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
@@ -284,7 +284,7 @@ def test_pixscale_pc_rotated(angle):
     mywcs.wcs.pc = [[np.cos(rho), -np.sin(rho)],
                     [np.sin(rho), np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
 
 @pytest.mark.parametrize(('cdelt','pc','pccd'),
                          (([0.1,0.2], np.eye(2), np.diag([0.1,0.2])),

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -239,28 +239,28 @@ def test_wcs_to_celestial_frame_extend():
 
 def test_pixscale_nodrop():
     mywcs = WCS(naxis=2)
-    mywcs.wcs.cdelt = [0.1,0.1]
+    mywcs.wcs.cdelt = [0.1,0.2]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(proj_plane_pixel_scales(mywcs), (0.1, 0.2))
 
-    mywcs.wcs.cdelt = [-0.1,0.1]
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    mywcs.wcs.cdelt = [-0.1,0.2]
+    assert_almost_equal(proj_plane_pixel_scales(mywcs), (0.1, 0.2))
 
 def test_pixscale_withdrop():
     mywcs = WCS(naxis=3)
-    mywcs.wcs.cdelt = [0.1,0.1,1]
+    mywcs.wcs.cdelt = [0.1,0.2,1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN','VOPT']
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs.celestial))/2.0, 0.1)
+    assert_almost_equal(proj_plane_pixel_scales(mywcs.celestial), (0.1, 0.2))
 
-    mywcs.wcs.cdelt = [-0.1,0.1,1]
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs.celestial))/2.0, 0.1)
+    mywcs.wcs.cdelt = [-0.1,0.2,1]
+    assert_almost_equal(proj_plane_pixel_scales(mywcs.celestial), (0.1, 0.2))
 
 
 def test_pixscale_cd():
     mywcs = WCS(naxis=2)
-    mywcs.wcs.cd = [[-0.1,0],[0,0.1]]
+    mywcs.wcs.cd = [[-0.1,0],[0,0.2]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(proj_plane_pixel_scales(mywcs), (0.1, 0.2))
 
 
 @pytest.mark.parametrize('angle',
@@ -272,7 +272,7 @@ def test_pixscale_cd_rotated(angle):
     mywcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
                     [scale*np.sin(rho), scale*np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(proj_plane_pixel_scales(mywcs), (0.1, 0.1))
 
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
@@ -284,7 +284,7 @@ def test_pixscale_pc_rotated(angle):
     mywcs.wcs.pc = [[np.cos(rho), -np.sin(rho)],
                     [np.sin(rho), np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(proj_plane_pixel_scales(mywcs), (0.1, 0.1))
 
 @pytest.mark.parametrize(('cdelt','pc','pccd'),
                          (([0.1,0.2], np.eye(2), np.diag([0.1,0.2])),

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -250,10 +250,10 @@ def test_pixscale_withdrop():
     mywcs = WCS(naxis=3)
     mywcs.wcs.cdelt = [0.1,0.1,1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN','VOPT']
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs.celestial))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1,1]
-    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs.celestial))/2.0, 0.1)
 
 
 def test_pixscale_cd():

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from ...utils.data import get_pkg_data_contents, get_pkg_data_filename
 from ...wcs import WCS
 from .. import utils
-from ..utils import celestial_pixel_scales, non_celestial_pixel_scales
+from ..utils import proj_plane_pixel_scales, non_celestial_pixel_scales
 from ...tests.helper import pytest, catch_warnings
 from ...utils.exceptions import AstropyUserWarning
 from ... import units as u
@@ -241,26 +241,26 @@ def test_pixscale_nodrop():
     mywcs = WCS(naxis=2)
     mywcs.wcs.cdelt = [0.1,0.1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1]
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
 def test_pixscale_withdrop():
     mywcs = WCS(naxis=3)
     mywcs.wcs.cdelt = [0.1,0.1,1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN','VOPT']
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1,1]
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
 
 def test_pixscale_cd():
     mywcs = WCS(naxis=2)
     mywcs.wcs.cd = [[-0.1,0],[0,0.1]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
 
 @pytest.mark.parametrize('angle',
@@ -272,7 +272,7 @@ def test_pixscale_cd_rotated(angle):
     mywcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
                     [scale*np.sin(rho), scale*np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
@@ -284,7 +284,7 @@ def test_pixscale_pc_rotated(angle):
     mywcs.wcs.pc = [[np.cos(rho), -np.sin(rho)],
                     [np.sin(rho), np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(sum(celestial_pixel_scales(mywcs))/2.0, 0.1)
+    assert_almost_equal(sum(proj_plane_pixel_scales(mywcs))/2.0, 0.1)
 
 @pytest.mark.parametrize(('cdelt','pc','pccd'),
                          (([0.1,0.2], np.eye(2), np.diag([0.1,0.2])),

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from ...utils.data import get_pkg_data_contents, get_pkg_data_filename
 from ...wcs import WCS
 from .. import utils
-from ..utils import celestial_pixel_scale, non_celestial_pixel_scales
+from ..utils import celestial_pixel_scales, non_celestial_pixel_scales
 from ...tests.helper import pytest, catch_warnings
 from ...utils.exceptions import AstropyUserWarning
 from ... import units as u
@@ -241,47 +241,27 @@ def test_pixscale_nodrop():
     mywcs = WCS(naxis=2)
     mywcs.wcs.cdelt = [0.1,0.1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1]
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
 def test_pixscale_withdrop():
     mywcs = WCS(naxis=3)
     mywcs.wcs.cdelt = [0.1,0.1,1]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN','VOPT']
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
     mywcs.wcs.cdelt = [-0.1,0.1,1]
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
 
 def test_pixscale_cd():
     mywcs = WCS(naxis=2)
     mywcs.wcs.cd = [[-0.1,0],[0,0.1]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
-def test_pixscale_warning(recwarn):
-    mywcs = WCS(naxis=2)
-    mywcs.wcs.cd = [[-0.1,0],[0,0.1]]
-    mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-
-    with catch_warnings(AstropyUserWarning) as warning_lines:
-
-        celestial_pixel_scale(mywcs)
-        assert ("Pixel sizes may very over the image for "
-                "projection class TAN"
-                in str(warning_lines[0].message))
-
-def test_pixscale_asymmetric():
-    mywcs = WCS(naxis=2)
-    mywcs.wcs.cd = [[-0.2,0],[0,0.1]]
-    mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-
-    with pytest.raises(ValueError) as exc:
-        celestial_pixel_scale(mywcs)
-    assert exc.value.args[0] == "Pixels are not square: 'pixel scale' is ambiguous"
 
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
@@ -292,7 +272,7 @@ def test_pixscale_cd_rotated(angle):
     mywcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
                     [scale*np.sin(rho), scale*np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
 @pytest.mark.parametrize('angle',
                          (30,45,60,75))
@@ -304,7 +284,7 @@ def test_pixscale_pc_rotated(angle):
     mywcs.wcs.pc = [[np.cos(rho), -np.sin(rho)],
                     [np.sin(rho), np.cos(rho)]]
     mywcs.wcs.ctype = ['RA---TAN','DEC--TAN']
-    assert_almost_equal(celestial_pixel_scale(mywcs).to(u.deg).value, 0.1)
+    assert_almost_equal(sum(celestial_pixel_scale(mywcs))/2.0, 0.1)
 
 @pytest.mark.parametrize(('cdelt','pc','pccd'),
                          (([0.1,0.2], np.eye(2), np.diag([0.1,0.2])),

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -152,10 +152,10 @@ def wcs_to_celestial_frame(wcs):
 
 def proj_plane_pixel_scales(wcs):
     """
-    For a WCS returns pixel scales along each axis of the image pixel at the
-    ``CRPIX`` location once it is projected onto the
+    For a WCS returns pixel scales along each axis of the image pixel at
+    the ``CRPIX`` location once it is projected onto the
     "plane of intermediate world coordinates" as defined in
-    `Greisen, E. W. & Calabretta, M. R. 2002, A&A, 395, 1061 <http://adsabs.harvard.edu/abs/2002A%26A...395.1061G>`_.
+    `Greisen & Calabretta 2002, A&A, 395, 1061 <http://adsabs.harvard.edu/abs/2002A%26A...395.1061G>`_.
 
     .. note::
         This function is concerned **only** about the transformation
@@ -199,7 +199,7 @@ def proj_plane_pixel_area(wcs):
     For a **celestial** WCS (see `astropy.wcs.WCS.celestial`) returns pixel
     area of the image pixel at the ``CRPIX`` location once it is projected
     onto the "plane of intermediate world coordinates" as defined in
-    `Greisen, E. W. & Calabretta, M. R. 2002, A&A, 395, 1061 <http://adsabs.harvard.edu/abs/2002A%26A...395.1061G>`_.
+    `Greisen & Calabretta 2002, A&A, 395, 1061 <http://adsabs.harvard.edu/abs/2002A%26A...395.1061G>`_.
 
     .. note::
         This function is concerned **only** about the transformation

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -177,21 +177,21 @@ def proj_plane_pixel_scales(wcs):
 
     Returns
     -------
-    scale : tuple of float
-        A tuple of projection plane increments corresponding to each
-        pixel side (axis). The units of the returned results are the same as
-        the units of `~astropy.wcs.Wcsprm.cdelt`, `~astropy.wcs.Wcsprm.crval`,
-        and `~astropy.wcs.Wcsprm.cd` for the celestial WCS and can be
-        obtained by inquiring the value of `~astropy.wcs.Wcsprm.cunit`
-        property of the input `~astropy.wcs.WCS` WCS object.
+    scale : `~numpy.ndarray`
+        A vector (`~numpy.ndarray`) of projection plane increments
+        corresponding to each pixel side (axis). The units of the returned
+        results are the same as the units of `~astropy.wcs.Wcsprm.cdelt`,
+        `~astropy.wcs.Wcsprm.crval`, and `~astropy.wcs.Wcsprm.cd` for
+        the celestial WCS and can be obtained by inquiring the value
+        of `~astropy.wcs.Wcsprm.cunit` property of the input
+        `~astropy.wcs.WCS` WCS object.
 
     See Also
     --------
     astropy.wcs.utils.proj_plane_pixel_area
 
     """
-    scale = np.sqrt((wcs.pixel_scale_matrix**2).sum(axis=0))
-    return tuple(map(float, scale))
+    return np.sqrt((wcs.pixel_scale_matrix**2).sum(axis=0, dtype=np.float))
 
 
 def proj_plane_pixel_area(wcs):
@@ -252,7 +252,7 @@ def proj_plane_pixel_area(wcs):
     psm = wcs.celestial.pixel_scale_matrix
     if psm.shape != (2, 2):
         raise ValueError("Pixel area is defined only for 2D pixels.")
-    return float(np.abs(np.linalg.det(psm)))
+    return np.abs(np.linalg.det(psm))
 
 
 def non_celestial_pixel_scales(inwcs):

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -211,7 +211,7 @@ def proj_plane_pixel_area(wcs):
     .. note::
         In order to compute the area of pixels corresponding to celestial
         axes only, this function uses the `~astropy.wcs.WCS.celestial` WCS
-        object of the input `wcs`.  This is different from the
+        object of the input ``wcs``.  This is different from the
         `~astropy.wcs.utils.proj_plane_pixel_scales` function
         that computes the scales for the axes of the input WCS itself.
 

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -182,7 +182,7 @@ included.
 The pixel scales of a celestial image or the pixel dimensions of a non-celestial
 image can be extracted with the utility functions
 `~astropy.wcs.utils.proj_plane_pixel_scales` and
-`~astropy.wcs.utils.non_celestial_pixel_scales`. Likewise, pixel
+`~astropy.wcs.utils.non_celestial_pixel_scales`. Likewise, celestial pixel
 area can be extracted with the utility function
 `~astropy.wcs.utils.proj_plane_pixel_area`.
 

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -181,10 +181,10 @@ included.
 
 The pixel scales of a celestial image or the pixel dimensions of a non-celestial
 image can be extracted with the utility functions
-`~astropy.wcs.utils.celestial_pixel_scales` and
+`~astropy.wcs.utils.proj_plane_pixel_scales` and
 `~astropy.wcs.utils.non_celestial_pixel_scales`. Likewise, celestial pixel
 area can be extracted with the utility function
-`~astropy.wcs.utils.celestial_pixel_area`.
+`~astropy.wcs.utils.proj_plane_pixel_area`.
 
 Matplotlib plots with correct WCS projection
 ============================================

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -182,7 +182,7 @@ included.
 The pixel scales of a celestial image or the pixel dimensions of a non-celestial
 image can be extracted with the utility functions
 `~astropy.wcs.utils.proj_plane_pixel_scales` and
-`~astropy.wcs.utils.non_celestial_pixel_scales`. Likewise, celestial pixel
+`~astropy.wcs.utils.non_celestial_pixel_scales`. Likewise, pixel
 area can be extracted with the utility function
 `~astropy.wcs.utils.proj_plane_pixel_area`.
 

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -179,10 +179,12 @@ WCS objects can be broken apart into their constituent axes using the
 convenience function that will return a WCS object with only the celestial axes
 included.
 
-The pixel scale of a celestial image or the pixel dimensions of a non-celestial
+The pixel scales of a celestial image or the pixel dimensions of a non-celestial
 image can be extracted with the utility functions
-`~astropy.wcs.utils.celestial_pixel_scale` and
-`~astropy.wcs.utils.non_celestial_pixel_scales`.
+`~astropy.wcs.utils.celestial_pixel_scales` and
+`~astropy.wcs.utils.non_celestial_pixel_scales`. Likewise, celestial pixel
+area can be extracted with the utility function
+`~astropy.wcs.utils.celestial_pixel_area`.
 
 Matplotlib plots with correct WCS projection
 ============================================


### PR DESCRIPTION
This PR addresses issues raised in #3113 and #3230 related to `celestial_pixel_scale`.

I propose a simplified version of the `celestial_pixel_scale` that now will be called `celestial_pixel_scales` and will return a tuple of pixel scales for each axis. It is left to the user to decide how to use these scales. This function does not give any warnings about "non-square" pixels (the old function was really testing for the **non-equilateral** pixels). It is left to the user to test if pixels are "non-square", "non-equilateral", etc. (but see note below).

I also introduce a new function ``celestial_pixel_area`` that will compute pixel area. Square root of this area can be used to compute the pixel scale of an equivalent square pixel that has the same area as the area of the (generally non-square) pixel of the input WCS. This kind of quantity is better suitable for conversion of images from flux units to brightness than the arithmetic mean returned by the old `celestial_pixel_scale` as discussed in #3113.

NOTE: I plan to create a new PR with a function that can correctly test if a pixel is non-square.

NOTE: I have also removed the "Pixel sizes may very over the image..." warning as this is true for **all** projections except Cartesian (and that only when no distortions are present). Assuming in the future we will add (x,y) parameters to these two functions to compute pixel scales at various locations, this kind of warning may incur a severe (and unnecessary) performance penalty.