### PR TITLE
Let Python choose the default SSL protocol for us.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -562,6 +562,29 @@ Other Changes and Additions
   source code from the git repository, in order to allow the ERFA wrappers to
   be generated. [#3166]
 
+0.4.4 (unreleased)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- ``astropy.vo.samp``
+
+  - ``astropy.vo.samp`` is now usable on Python builds that do not
+    support the SSLv3 protocol (which depends both on the version of
+    Python and the version of OpenSSL or LibreSSL that it is built
+    against.) [#3308]
+
+API Changes
+^^^^^^^^^^^
+
+- ``astropy.vo.samp``
+
+  - The default SSL protocol used is now determined from the default
+    used in the Python `ssl` standard library.  This default may be
+    different depending on the exact version of Python you are using.
+    [#3308]
+
 0.4.3 (2015-01-15)
 ------------------
 

--- a/astropy/vo/samp/client.py
+++ b/astropy/vo/samp/client.py
@@ -85,13 +85,13 @@ class SAMPClient(object):
         passed from the Hub end of the connection.
 
     ssl_version : int, optional
-        Which version of the SSL protocol to use. Typically, the server
-        chooses a particular protocol version, and the client must adapt to
-        the server's choice. Most of the versions are not interoperable with
-        the other versions. If not specified the default SSL version is
-        `ssl.PROTOCOL_SSLv23`. This version provides the most compatibility
-        with other versions Hub side. Other SSL protocol versions are:
-        `ssl.PROTOCOL_SSLv2`, `ssl.PROTOCOL_SSLv3` and `ssl.PROTOCOL_TLSv1`.
+        Which version of the SSL protocol to use. Typically, the
+        server chooses a particular protocol version, and the client
+        must adapt to the server's choice. Most of the versions are
+        not interoperable with the other versions. If not specified,
+        the default SSL version is taken from the default in the
+        installed version of the Python standard `ssl` library.  See
+        the `ssl` documentation for more information.
 
     callable : bool, optional
         Whether the client can receive calls and notifications. If set to
@@ -117,9 +117,6 @@ class SAMPClient(object):
 
         if description is not None:
             metadata["samp.description.text"] = description
-
-        if SSL_SUPPORT and ssl_version is None:
-            ssl_version = ssl.PROTOCOL_SSLv23
 
         self._metadata = metadata
 

--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -114,14 +114,14 @@ class SAMPHubServer(object):
         passed from the Hub end of the connection.
 
     ssl_version : int, optional
-        The ``ssl_version`` option specifies which version of the SSL protocol
-        to use. Typically, the server chooses a particular protocol version,
-        and the client must adapt to the server's choice. Most of the versions
-        are not interoperable with the other versions. If not specified the
-        default SSL version is `ssl.PROTOCOL_SSLv23`. This version provides
-        the most compatibility with other versions client side. Other SSL
-        protocol versions are: `ssl.PROTOCOL_SSLv2`, `ssl.PROTOCOL_SSLv3` and
-        `ssl.PROTOCOL_TLSv1`.
+        The ``ssl_version`` option specifies which version of the SSL
+        protocol to use. Typically, the server chooses a particular
+        protocol version, and the client must adapt to the server's
+        choice. Most of the versions are not interoperable with the
+        other versions. If not specified, the default SSL version is
+        taken from the default in the installed version of the Python
+        standard `ssl` library.  See the `ssl` documentation for more
+        information.
 
     web_profile : bool, optional
         Enables or disables the Web Profile support.
@@ -164,9 +164,6 @@ class SAMPHubServer(object):
         self._timeout = timeout
         self._client_timeout = client_timeout
         self._pool_size = pool_size
-
-        if SSL_SUPPORT and ssl_version is None:
-            ssl_version = ssl.PROTOCOL_SSLv23
 
         self._web_profile = web_profile
         self._web_profile_server = None

--- a/astropy/vo/samp/hub_proxy.py
+++ b/astropy/vo/samp/hub_proxy.py
@@ -78,14 +78,14 @@ class SAMPHubProxy(object):
             certificate passed from the Hub end of the connection.
 
         ssl_version : int, optional
-            Which version of the SSL protocol to use. Typically, the server
-            chooses a particular protocol version, and the client must adapt
-            to the server's choice. Most of the versions are not interoperable
-            with the other versions. If not specified the default SSL version
-            is `ssl.PROTOCOL_SSLv3`. This version provides the most
-            compatibility with other versions server side. Other SSL protocol
-            versions are: `ssl.PROTOCOL_SSLv2`, `ssl.PROTOCOL_SSLv3` and
-            `ssl.PROTOCOL_TLSv1`.
+            Which version of the SSL protocol to use. Typically, the
+            server chooses a particular protocol version, and the
+            client must adapt to the server's choice. Most of the
+            versions are not interoperable with the other versions. If
+            not specified, the default SSL version is taken from the
+            default in the installed version of the Python standard
+            `ssl` library.  See the `ssl` documentation for more
+            information.
 
         pool_size : int, optional
             The number of socket connections opened to communicate with the
@@ -94,9 +94,6 @@ class SAMPHubProxy(object):
 
         self._connected = False
         self.lockfile = {}
-
-        if SSL_SUPPORT and ssl_version is None:
-            ssl_version = ssl.PROTOCOL_SSLv3
 
         if hub is not None and hub_params is not None:
             raise ValueError("Cannot specify both hub and hub_params")

--- a/astropy/vo/samp/integrated_client.py
+++ b/astropy/vo/samp/integrated_client.py
@@ -68,13 +68,13 @@ class SAMPIntegratedClient(object):
         passed from the Hub end of the connection.
 
     ssl_version : int, optional
-        Which version of the SSL protocol to use. Typically, the server chooses
-        a particular protocol version, and the client must adapt to the
-        server's choice. Most of the versions are not interoperable with the
-        other versions. If not specified the default SSL version is
-        `ssl.PROTOCOL_SSLv23`. This version provides the most compatibility
-        with other versions Hub side. Other SSL protocol versions are:
-        `ssl.PROTOCOL_SSLv2`, `ssl.PROTOCOL_SSLv3` and `ssl.PROTOCOL_TLSv1`.
+        Which version of the SSL protocol to use. Typically, the
+        server chooses a particular protocol version, and the client
+        must adapt to the server's choice. Most of the versions are
+        not interoperable with the other versions. If not specified,
+        the default SSL version is taken from the default in the
+        installed version of the Python standard `ssl` library.  See
+        the `ssl` documentation for more information.
 
     callable : bool, optional
         Whether the client can receive calls and notifications. If set to
@@ -167,14 +167,14 @@ class SAMPIntegratedClient(object):
             certificate passed from the Hub end of the connection.
 
         ssl_version : int, optional
-            Which version of the SSL protocol to use. Typically, the server
-            chooses a particular protocol version, and the client must adapt
-            to the server's choice. Most of the versions are not interoperable
-            with the other versions. If not specified the default SSL version
-            is `ssl.PROTOCOL_SSLv3`. This version provides the most
-            compatibility with other versions server side. Other SSL protocol
-            versions are: `ssl.PROTOCOL_SSLv2`, `ssl.PROTOCOL_SSLv3` and
-            `ssl.PROTOCOL_TLSv1`.
+            Which version of the SSL protocol to use. Typically, the
+            server chooses a particular protocol version, and the
+            client must adapt to the server's choice. Most of the
+            versions are not interoperable with the other versions. If
+            not specified, the default SSL version is taken from the
+            default in the installed version of the Python standard
+            `ssl` library.  See the `ssl` documentation for more
+            information.
 
         pool_size : int, optional
             The number of socket connections opened to communicate with the


### PR DESCRIPTION
This is a possible fix for #3306.

To summarize: SSLv2 and SSLv3 have been determined to be [unsafe](https://www.openssl.org/~bodo/ssl-poodle.pdf), and so it has been removed from recent versions of OpenSSL (not sure if that's upstream or just as-distributed in many places).  Therefore, recent bugfix release versions of Python have been updated to not provide these protocols when the underlying library does not.  The versions affected are 2.7.9 and 3.4.3.  See Python [22935](http://bugs.python.org/issue22935).  It's not clear if other Python major versions will be updated, since they will shortly stop compiling against OpenSSL.

I thought it best to just move the responsibility of choosing a default SSL protocol to the Python stdlib, rather than maintaining it ourselves.  The defaults may change again in the future if other vulnerabilities are discovered, and I think Python as a whole has a better chance of staying on top of that than we do.  It does mean the protocol used by default depends on the version of Python, and which version of OpenSSL it is linked against.  But the protocols that are even available depends on that, so I don't see much else that we can do.

@embray: If there's going to be another 0.4.x, this is certainly a good candidate for a backport, since the bug is a rather severe "can't import `astropy.vo.samp`" on one of these new Pythons.