### PR TITLE
Compound model fitting example not too impressive 

### DIFF
--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -288,7 +288,7 @@ These new compound models can also be fitted to data, like most other models:
     from astropy.modeling import models, fitting
 
     # Generate fake data
-    np.random.seed(0)
+    np.random.seed(42)
     g1 = models.Gaussian1D(1, 0, 0.2)
     g2 = models.Gaussian1D(2.5, 0.5, 0.1)
     x = np.linspace(-1, 1, 200)

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -296,7 +296,7 @@ These new compound models can also be fitted to data, like most other models:
 
     # Now to fit the data create a new superposition with initial
     # guesses for the parameters:
-    gg_init = models.Gaussian1D(1, 0, 0.1) + models.Gaussian1D(1, 0, 0.1)
+    gg_init = models.Gaussian1D(1, 0, 0.1) + models.Gaussian1D(2, 0.5, 0.1)
     fitter = fitting.SLSQPLSQFitter()
     gg_fit = fitter(gg_init, x, y)
 


### PR DESCRIPTION
In the intro to the modeling docs there is a new section introducing the compound model feature:

http://docs.astropy.org/en/latest/modeling/index.html#compound-models

It includes an example of fitting a compound model, but the plot of the fit does not demonstrate such a great fit. This is weird, because when I run that example locally (including when building the docs) the fit looks pretty great. So I'm not sure what the difference is here. It could have something to do with the SciPy  version, or possibly just the random seed used. In any case, it would be nice to try to figure out where it's going wrong and to tweak the example. 