### PR TITLE
Adding new nitpick exceptions

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -42,6 +42,8 @@ py:class numpy.ma.core.MaskedArray
 py:class numpy.core.records.recarray
 py:class xmlrpclib.Fault
 py:class xmlrpclib.Error
+py:class xmlrpc.client.Fault
+py:class xmlrpc.client.Error
 
 # Pending on python docs links issue #11975
 py:class list

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -16,7 +16,7 @@ methods::
   Unit("2.17987e-18 kg m2 / s2")
 
 You can limit the selection of units that you want to decompose to
-using the `bases` keyword argument::
+using the ``bases`` keyword argument::
 
   >>> u.Ry.decompose(bases=[u.m, u.N])
   Unit("2.17987e-18 m N")


### PR DESCRIPTION
Adding new nitpick exceptions (they are needed when ``build_sphinx`` is run with python3) and fixing a broken link, that should be linked.