### PR TITLE
Bugfix: stacking a single table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -489,6 +489,9 @@ Bug Fixes
   - Fix a problem where ``table.hstack`` fails to stack multiple references to
     the same table, e.g. ``table.hstack([t, t])``. [#2995]
 
+  - Fixed a problem where ``table.vstack`` and ``table.hstack`` failed to stack
+    a single table, e.g. ``table.vstack([t])``. [#3313]
+
 - ``astropy.time``
 
   - When creating a Time object from a datetime object the time zone

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -105,7 +105,7 @@ def _get_list_of_tables(tables):
         tables = [tables]
 
     # Make sure each thing is a Table or Row
-    if any(not isinstance(x, (Table, Row)) for x in tables):
+    if any(not isinstance(x, (Table, Row)) for x in tables) or len(tables) == 0:
         raise TypeError('`tables` arg must be a Table or sequence of Tables or Rows')
 
     # Convert any Rows to Tables

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -222,6 +222,8 @@ def vstack(tables, join_type='outer', metadata_conflicts='warn'):
         6   8
     """
     tables = _get_list_of_tables(tables)  # validates input
+    if len(tables) == 1:
+        return tables[0]  # no point in stacking a single table
     col_name_map = OrderedDict()
 
     out = _vstack(tables, join_type, col_name_map)
@@ -257,9 +259,6 @@ def hstack(tables, join_type='outer',
     table_names : list of str or None
         Two-element list of table names used when generating unique output
         column names.  The default is ['1', '2', ..].
-    col_name_map : empty dict or None
-        If passed as a dict then it will be updated in-place with the
-        mapping of output to input column names.
     metadata_conflicts : str
         How to proceed with metadata conflicts. This should be one of:
             * ``'silent'``: silently pick the last conflicting meta-data value
@@ -295,6 +294,8 @@ def hstack(tables, join_type='outer',
         2   4   6   8
     """
     tables = _get_list_of_tables(tables)  # validates input
+    if len(tables) == 1:
+        return tables[0]  # no point in stacking a single table
     col_name_map = OrderedDict()
 
     out = _hstack(tables, join_type, uniq_col_name, table_names,

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -445,6 +445,8 @@ class TestVStack():
 
     def test_bad_input_type(self):
         with pytest.raises(TypeError):
+            table.vstack([])
+        with pytest.raises(TypeError):
             table.vstack(1)
         with pytest.raises(TypeError):
             table.vstack([self.t2, 1])
@@ -656,6 +658,8 @@ class TestHStack():
             out = table.hstack([self.t1, self.t5], join_type='inner', metadata_conflicts='nonsense')
 
     def test_bad_input_type(self):
+        with pytest.raises(TypeError):
+            table.hstack([])
         with pytest.raises(TypeError):
             table.hstack(1)
         with pytest.raises(TypeError):

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -571,6 +571,10 @@ class TestVStack():
             assert ("In merged column 'a' the 'unit' attribute does not match (m != km)"
                     in str(warning_lines[1].message))
 
+    def test_vstack_one_table(self):
+        assert (self.t1 == table.vstack(self.t1)).all()
+        assert (self.t1 == table.vstack([self.t1])).all()
+
 
 class TestHStack():
 
@@ -749,6 +753,10 @@ class TestHStack():
             # Make sure we got a copy of meta, not ref
             t1['b'].meta['b'] = None
             assert out['b'].meta['b'] == [1, 2]
+
+    def test_hstack_one_table(self):
+        assert (self.t1 == table.hstack(self.t1)).all()
+        assert (self.t1 == table.hstack([self.t1])).all()
 
 
 def test_unique():

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -574,6 +574,7 @@ class TestVStack():
                     in str(warning_lines[1].message))
 
     def test_vstack_one_table(self):
+        """Regression test for issue #3313"""
         assert (self.t1 == table.vstack(self.t1)).all()
         assert (self.t1 == table.vstack([self.t1])).all()
 
@@ -759,6 +760,7 @@ class TestHStack():
             assert out['b'].meta['b'] == [1, 2]
 
     def test_hstack_one_table(self):
+        """Regression test for issue #3313"""
         assert (self.t1 == table.hstack(self.t1)).all()
         assert (self.t1 == table.hstack([self.t1])).all()
 


### PR DESCRIPTION
The `vstack` and `hstack` operations in `astropy.table` fail when called on a single table, i.e. `vstack([table])` raises a confusing exception rather than returning `table` as one might expect.  It is of course silly to stack a single table, but it is a situation that may well occur in a generic piece of code.

For example:

```Python
In [1]: from astropy.table import Table, vstack, hstack
In [2]: t = Table({'col1': [1, 2, 3]})
In [3]: hstack([t])
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-42e885d3c8bc> in <module>()
----> 1 hstack(t)

/home/gb/dev/astropy/astropy/table/operations.py in hstack(tables, join_type, uniq_col_name, table_names, metadata_conflicts)
    301                   col_name_map)
    302 
--> 303     _merge_col_meta(out, tables, col_name_map, metadata_conflicts=metadata_conflicts)
    304     _merge_table_meta(out, tables, metadata_conflicts=metadata_conflicts)
    305 

/home/gb/dev/astropy/astropy/table/operations.py in _merge_col_meta(out, tables, col_name_map, idx_left, idx_right, metadata_conflicts)
     44         for idx_table, table in enumerate(tables):
     45             left_col = out_col
---> 46             right_name = col_name_map[out_col.name][idx_table]
     47 
     48             if right_name:

KeyError: 'col1'
```

the error is identical for `vstack([t])`.

On a related note, stacking an empty list does not raise a user-friendly exception, but instead triggers this:
```Python
In [2]: vstack([])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-d01c7f711ce7> in <module>()
----> 1 vstack([])

/home/gb/dev/astropy/astropy/table/operations.py in vstack(tables, join_type, metadata_conflicts)
    225     col_name_map = OrderedDict()
    226 
--> 227     out = _vstack(tables, join_type, col_name_map)
    228 
    229     # Merge column and table metadata

/home/gb/dev/astropy/astropy/table/operations.py in _vstack(arrays, join_type, col_name_map)
    712         _col_name_map.update(col_name_map)
    713 
--> 714     out = Table(out, names=names, masked=masked)
    715 
    716     return out

/home/gb/dev/astropy/astropy/table/table.pyc in __init__(self, data, masked, names, dtype, meta, copy, rows)
    286 
    287         # Finally do the real initialization
--> 288         init_func(data, names, dtype, n_cols, copy)
    289 
    290         # Whatever happens above, the masked property should be set to a boolean

/home/gb/dev/astropy/astropy/table/table.pyc in _init_from_dict(self, data, names, dtype, n_cols, copy)
    458 
    459         data_list = [data[name] for name in names]
--> 460         self._init_from_list(data_list, names, dtype, n_cols, copy)
    461 
    462     def _init_from_table(self, data, names, dtype, n_cols, copy):

/home/gb/dev/astropy/astropy/table/table.pyc in _init_from_list(self, data, names, dtype, n_cols, copy)
    424             cols.append(col)
    425 
--> 426         self._init_from_cols(cols)
    427 
    428     def _init_from_ndarray(self, data, names, dtype, n_cols, copy):

/home/gb/dev/astropy/astropy/table/table.pyc in _init_from_cols(self, cols)
    495         if len(lengths) != 1:
    496             raise ValueError('Inconsistent data column lengths: {0}'
--> 497                              .format(lengths))
    498 
    499         # Set the table masking

ValueError: Inconsistent data column lengths: set([])
```

This PR enables `hstack([t])` and `vstack([t])` to return `t`, and ensures that a nice exception is raised for `hstack([])` and `vstack([])`.  Regression tests are included.

(The PR also removes the non-existent parameter `col_name_map` from the docstring of `hstack`.)