### PR TITLE
str(SkyCoord) should not return repr-style output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,7 @@ New Features
 
   - ``SkyCoord`` now accepts more formats of the coordinate string when the
     representation has ``ra`` and ``dec`` attributes. [#2920]
+
   - ``SkyCoord`` can now accept lists of ``SkyCoord`` objects, frame objects,
     or representation objects and will combine them into a single object.
     [#3285]
@@ -295,9 +296,8 @@ API Changes
     class has now been deprecated, except in the case where a frame with data
     is passed as the sole positional argument. [#3152]
 
-  - ``str(SkyCoord(...))`` now returns the same as ``SkyCoord.to_string`` for
-    scalar values and gives an error for vector coordinates (and refers the
-    user to ``SkyCoord.to_string``). [#3315]
+  - ``str(SkyCoord(...))`` now returns the same as ``str(SkyCoord.to_string)``.
+    [#3315]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -295,6 +295,10 @@ API Changes
     class has now been deprecated, except in the case where a frame with data
     is passed as the sole positional argument. [#3152]
 
+  - ``str(SkyCoord(...))`` now returns the same as ``SkyCoord.to_string`` for
+    scalar values and gives an error for vector coordinates (and refers the
+    user to ``SkyCoord.to_string``). [#3315]
+
 - ``astropy.cosmology``
 
   - The functional interface to the cosmological routines as well as

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -426,6 +426,12 @@ class SkyCoord(object):
 
         return dir_values
 
+    def __str__(self):
+        if self.isscalar:
+            return self.to_string()
+        else:
+            raise TypeError("str() can only be used with scalar coordinates - use to_string() instead")
+
     def __repr__(self):
         clsnm = self.__class__.__name__
         coonm = self.frame.__class__.__name__

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -427,10 +427,7 @@ class SkyCoord(object):
         return dir_values
 
     def __str__(self):
-        if self.isscalar:
-            return self.to_string()
-        else:
-            raise TypeError("str() can only be used with scalar coordinates - use to_string() instead")
+        return str(self.to_string())
 
     def __repr__(self):
         clsnm = self.__class__.__name__

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -413,7 +413,7 @@ def test_highlevel_api():
     # v0.2/0.3 coordinate objects.  This will *not* be in the low-level classes
     sc = coords.SkyCoord(ra=8 * u.hour, dec=5 * u.deg, frame='icrs')
     scgal = sc.galactic
-    assert str(scgal).startswith('<SkyCoord (Galactic): l=216.316')
+    assert repr(scgal).startswith('<SkyCoord (Galactic): l=216.316')
 
     # the existing `from_name` and `match_to_catalog_*` methods will be moved to the
     # high-level class as convenience functionality.

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -57,13 +57,13 @@ rt_sets = []
 rt_frames = [ICRS, FK4, FK5, Galactic]
 for rt_frame0 in rt_frames:
     for rt_frame1 in rt_frames:
-            for equinox0 in (None, 'J1975.0'):
-                for obstime0 in (None, 'J1980.0'):
-                    for equinox1 in (None, 'J1975.0'):
-                        for obstime1 in (None, 'J1980.0'):
-                            rt_sets.append([rt_frame0, rt_frame1,
-                                            equinox0, equinox1,
-                                            obstime0, obstime1])
+        for equinox0 in (None, 'J1975.0'):
+            for obstime0 in (None, 'J1980.0'):
+                for equinox1 in (None, 'J1975.0'):
+                    for obstime1 in (None, 'J1980.0'):
+                        rt_sets.append([rt_frame0, rt_frame1,
+                                        equinox0, equinox1,
+                                        obstime0, obstime1])
 rt_args = 'frame0,frame1,equinox0,equinox1,obstime0,obstime1'
 
 
@@ -485,6 +485,22 @@ def test_repr():
 
     sc_default = SkyCoord(0 * u.deg, 1 * u.deg)
     assert repr(sc_default) == '<SkyCoord (ICRS): ra=0.0 deg, dec=1.0 deg>'
+
+
+def test_str():
+
+    # Repr tests must use exact floating point vals because Python 2.6
+    # outputs values like 0.1 as 0.1000000000001.  No workaround found.
+    sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame='icrs')
+    sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
+
+    assert str(sc1) == '0 1'
+    assert str(sc2) == '1 1'
+
+    sc3 = SkyCoord(0.25 * u.deg, [1, 2.5] * u.deg, frame='icrs')
+    with pytest.raises(TypeError) as exc:
+        str(sc3)
+    assert exc.value.args[0] == "str() can only be used with scalar coordinates - use to_string() instead"
 
 
 def test_ops():
@@ -1066,4 +1082,3 @@ def test_skycoord_list_creation():
     assert np.all(scnew4.ra == sc.ra)
     assert np.all(scnew4.dec == sc.dec)
     assert scnew4.equinox == Time('J2010')
-

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -489,8 +489,6 @@ def test_repr():
 
 def test_str():
 
-    # Repr tests must use exact floating point vals because Python 2.6
-    # outputs values like 0.1 as 0.1000000000001.  No workaround found.
     sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame='icrs')
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
 
@@ -498,9 +496,7 @@ def test_str():
     assert str(sc2) == '1 1'
 
     sc3 = SkyCoord(0.25 * u.deg, [1, 2.5] * u.deg, frame='icrs')
-    with pytest.raises(TypeError) as exc:
-        str(sc3)
-    assert exc.value.args[0] == "str() can only be used with scalar coordinates - use to_string() instead"
+    assert str(sc3) == "['0.25 1', '0.25 2.5']"
 
 
 def test_ops():


### PR DESCRIPTION
At the moment `str(SkyCoord)` returns a repr-style output:

```
In [20]: str(c)
Out[20]: '<SkyCoord (ICRS): ra=10.68470833 deg, dec=41.26875 deg>'
```

On the other hand, `Time` returns a nicely formatted time:

```
In [21]: str(t)
Out[21]: '2015-01-20 12:46:46.735742'
```

I think the second is correct, and `str(c)` should return 'nice' output. I would suggest that `str` should return the same output as `c.to_string()`.

Furthermore, `to_string` at the moment could return a better default:

```
In [22]: c
Out[22]: <SkyCoord (ICRS): ra=10.68470833 deg, dec=41.26875 deg>

In [23]: c.to_string()
Out[23]: '10.6847 41.2687'
```

For equatorial systems the default really should be `hmsdms`:

```
In [18]: c.to_string(style='hmsdms')
Out[18]: '00h42m44.33s +41d16m07.5s'
```

So there are two requests here:
- Tie `str(SkyCoord)` to `SkyCoord.to_string`
- Have frames define a default syle for `to_string`

Both of these are trivial so I'm happy to implement them if @eteq and @taldcroft agree.

By the way, this will result in more 'normal' output for `SkyCoord` in tables following #3011 
