### PR TITLE
Fixed typo in Fittable2DModel docstring

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1324,7 +1324,7 @@ class Fittable1DModel(FittableModel):
 
 class Fittable2DModel(FittableModel):
     """
-    Base class for one-dimensional fittable models.
+    Base class for two-dimensional fittable models.
 
     This class provides an easier interface to defining new models.
     Examples can be found in `astropy.modeling.functional_models`.


### PR DESCRIPTION
s/one/two: in docstring.

I've tried to generate the docs to check that [this section](http://astropy.readthedocs.org/en/latest/modeling/index.html#classes) gets correctly updated but I get the following error:

    File "/data01/montefra/Gitrepos/astropy/build/lib.linux-x86_64-2.7/astropy/time/core.py", line 278, in _get_time_fmt
    raise ValueError('Input values did not match {0}'.format(err_msg))
    ValueError: Input values did not match any of the formats where the format keyword is optional [u'astropy_time', u'datetime', u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']

a question: do I have to add in `CHANGES.rst` this little fix?