### PR TITLE
Invalid KeyError when adding a column to Table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -626,12 +626,7 @@ class Table(object):
         """
         Determine if ``col`` meets the protocol for a mixin Table column for
         this table.  By definition a BaseColumn instance is not a mixin.
-
-        If ``col`` is a string then it refers to a column name in this table.
         """
-        if isinstance(col, six.string_types):
-            col = self[col]
-
         if isinstance(col, BaseColumn):
             is_mixin = False
         elif isinstance(col, Quantity):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -355,3 +355,14 @@ def test_column_rename():
     for name in names:
         qt.rename_column(name, name + '2')
     assert qt.colnames == [name + '2' for name in names]
+
+
+def test_setitem_as_column_name():
+    """
+    Test for mixin-related regression described in #3321.
+    """
+    t = Table()
+    t['a'] = ['x', 'y']
+    t['b'] = 'b'  # Previously was failing with KeyError
+    assert np.all(t['a'] == ['x', 'y'])
+    assert np.all(t['b'] == ['b', 'b'])


### PR DESCRIPTION
@taldcroft - I think #3011 introduced a bug ... I noticed that it broke my code here:
https://travis-ci.org/astropy/coordinates-benchmark/builds/47758457#L4223

Here's a self-contained example ... it fails with the same error on Python 2 and 3:
```python
>>> from astropy.table import Table
>>> table = Table()
>>> table['first_col'] = ['a', 'b']
>>> table['second_col'] = 'c'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11571-py3.4-macosx-10.10-x86_64.egg/astropy/table/table.py", line 880, in __setitem__
    if not hasattr(value, 'dtype') and not self._is_mixin_column(value):
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11571-py3.4-macosx-10.10-x86_64.egg/astropy/table/table.py", line 633, in _is_mixin_column
    col = self[col]
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11571-py3.4-macosx-10.10-x86_64.egg/astropy/table/table.py", line 847, in __getitem__
    return self.columns[item]
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11571-py3.4-macosx-10.10-x86_64.egg/astropy/table/table.py", line 109, in __getitem__
    return OrderedDict.__getitem__(self, item)
KeyError: 'c'
```

I think this should work, no? (it did before #3011)