### PR TITLE
Remove & from final CONTINUE card fix for #3282

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -478,6 +478,8 @@ Bug Fixes
 
   - Setting ``memmap=True`` in ``fits.open`` and related functions now raises a ValueError if opening a file in memory-mapped mode is impossible. [#2298]
 
+  - CONTINUE cards no longer end the value of the final card in the series with an ampersand, per the specification of the CONTINUE card convention. [#3282]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -1268,7 +1268,6 @@ class Card(_Verify):
         output = []
 
         # do the value string
-        value_format = "'%-s&'"
         value = self._value.replace("'", "''")
         words = _words_group(value, value_length)
         for idx, word in enumerate(words):
@@ -1276,15 +1275,29 @@ class Card(_Verify):
                 headstr = '%-*s= ' % (KEYWORD_LENGTH, self.keyword)
             else:
                 headstr = 'CONTINUE  '
+
+            # If this is the final CONTINUE remove the '&'
+            if not self.comment and idx == len(words) - 1:
+                value_format = "'%-s'"
+            else:
+                value_format = "'%-s&'"
+
             value = value_format % word
+
             output.append('%-80s' % (headstr + value))
 
         # do the comment string
         comment_format = "%-s"
         if self.comment:
             words = _words_group(self.comment, comment_length)
-            for word in words:
-                comment = "CONTINUE  '&' / " + comment_format % word
+            for idx, word in enumerate(words):
+                # If this is the final CONTINUE remove the '&'
+                if idx == len(words) - 1:
+                    headstr = "CONTINUE  '' / "
+                else:
+                    headstr = "CONTINUE  '&' / "
+
+                comment = headstr + comment_format % word
                 output.append('%-80s' % comment)
 
         return ''.join(output)

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -442,7 +442,7 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'string value long string value long string value &'                  "
             "CONTINUE  '&' / long comment long comment long comment long comment long        "
             "CONTINUE  '&' / comment long comment long comment long comment long comment     "
-            "CONTINUE  '&' / long comment                                                    ")
+            "CONTINUE  '' / long comment                                                     ")
 
     def test_long_unicode_string(self):
         """Regression test for
@@ -481,7 +481,7 @@ class TestHeaderFunctions(FitsTestCase):
              "CONTINUE  'string value long string value long string value &'                  ",
              "CONTINUE  '&' / long comment long comment long comment long comment long        ",
              "CONTINUE  '&' / comment long comment long comment long comment long comment     ",
-             "CONTINUE  '&' / long comment                                                    ",
+             "CONTINUE  '' / long comment                                                     ",
              str(fits.Card('TEST3', 'Regular value', 'Regular comment'))])
 
     def test_blank_keyword_long_value(self):
@@ -520,7 +520,7 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'string value long string value long string value &'                  "
             "CONTINUE  '&' / long comment long comment long comment long comment long        "
             "CONTINUE  '&' / comment long comment long comment long comment long comment     "
-            "CONTINUE  '&' / long comment                                                    ")
+            "CONTINUE  '' / long comment                                                     ")
 
     def test_word_in_long_string_too_long(self):
         # if a word in a long string is too long, it will be cut in the middle
@@ -530,7 +530,7 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'ingvaluelongstringvaluelongstringvaluelongstringvaluelongstringvalu&'"
             "CONTINUE  'elongstringvalue&'                                                   "
             "CONTINUE  '&' / longcommentlongcommentlongcommentlongcommentlongcommentlongcomme"
-            "CONTINUE  '&' / ntlongcommentlongcommentlongcommentlongcomment                  ")
+            "CONTINUE  '' / ntlongcommentlongcommentlongcommentlongcomment                   ")
 
     def test_long_string_value_via_fromstring(self, capsys):
         # long string value via fromstring() method
@@ -544,7 +544,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert (str(c) ==
                 "ABC     = 'longstring''s testing  continue with long string but without the &'  "
                  "CONTINUE  'ampersand at the endcontinue must have string value (with quotes)&'  "
-                 "CONTINUE  '&' / comments in line 1 comments with ''.                            ")
+                 "CONTINUE  '' / comments in line 1 comments with ''.                             ")
 
     def test_continue_card_with_equals_in_value(self):
         """
@@ -561,6 +561,28 @@ class TestHeaderFunctions(FitsTestCase):
                 '/grp/hst/cdbs//grid/pickles/dat_uvk/pickles_uk_10.fits '
                 '* 5.87359e-12 * MWAvg(Av=0.12)')
         assert c.comment == 'pysyn expression'
+
+    def test_final_continue_card_lacks_ampersand(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/3282
+        """
+
+        h = fits.Header()
+        h['SVALUE'] = 'A' * 69
+        assert repr(h).splitlines()[-1] == _pad("CONTINUE  'AA'")
+
+    def test_final_continue_card_ampersand_removal_on_long_comments(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/3282
+        """
+
+        c = fits.Card('TEST', 'long value' * 10, 'long comment &' * 10)
+        assert (str(c) ==
+            "TEST    = 'long valuelong valuelong valuelong valuelong valuelong valuelong &'  "
+            "CONTINUE  'valuelong valuelong valuelong value&'                                "
+            "CONTINUE  '&' / long comment &long comment &long comment &long comment &long    "
+            "CONTINUE  '&' / comment &long comment &long comment &long comment &long comment "
+            "CONTINUE  '' / &long comment &                                                  ")
 
     def test_hierarch_card_creation(self):
         # Test automatic upgrade to hierarch card


### PR DESCRIPTION
This is a fix for #3282. I am both unfamiliar with the code base and FITS but I believe the applied fix addresses the reported issue. In addition to the test I added, I had to update two tests that were failing due to expecting a Card with an '&' in the final CONTINUE card. Please let me know if you have any feedback or suggestings. 