### PR TITLE
add a test to see if pixels in the projected plane are non-square (distorted)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -269,6 +269,9 @@ New Features
   - Add ability to use ``WCS`` object to define projections in Matplotlib,
     using the ``WCSAxes`` package. [#3183]
 
+  - Added ``is_proj_plane_distorted`` for testing if pixels are
+    distorted. [#3329]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from ...utils.data import get_pkg_data_contents, get_pkg_data_filename
 from ...wcs import WCS
 from .. import utils
-from ..utils import proj_plane_pixel_scales, non_celestial_pixel_scales
+from ..utils import proj_plane_pixel_scales, is_proj_plane_distorted, non_celestial_pixel_scales
 from ...tests.helper import pytest, catch_warnings
 from ...utils.exceptions import AstropyUserWarning
 from ... import units as u
@@ -370,6 +370,23 @@ def test_skycoord_to_pixel(mode):
     assert new2.__class__ is SkyCoord2
     assert_allclose(new2.ra.degree, ref.ra.degree)
     assert_allclose(new2.dec.degree, ref.dec.degree)
+
+
+def test_is_proj_plane_distorted():
+    # non-orthogonal CD:
+    wcs = WCS(naxis=2)
+    wcs.wcs.cd = [[-0.1,0],[0,0.2]]
+    wcs.wcs.ctype = ['RA---TAN','DEC--TAN']
+    assert(is_proj_plane_distorted(wcs))
+
+    # almost orthogonal CD:
+    wcs.wcs.cd = [[0.1+2.0e-7,1.7e-7],[1.2e-7,0.1-1.3e-7]]
+    assert(not is_proj_plane_distorted(wcs))
+
+    # real case:
+    header = get_pkg_data_filename('data/sip.fits')
+    wcs = WCS(header)
+    assert(is_proj_plane_distorted(wcs))
 
 
 @pytest.mark.parametrize('mode', ['all', 'wcs'])

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -255,7 +255,7 @@ def proj_plane_pixel_area(wcs):
     return np.abs(np.linalg.det(psm))
 
 
-def is_proj_plane_distorted(wcs, maxerr=5.0e-6):
+def is_proj_plane_distorted(wcs, maxerr=1.0e-5):
     """
     For a WCS returns `False` if square image (detector) pixels stay square
     when projected onto the "plane of intermediate world coordinates"
@@ -287,7 +287,7 @@ def is_proj_plane_distorted(wcs, maxerr=5.0e-6):
     wcs : `~astropy.wcs.WCS`
         World coordinate system object
 
-    maxerr : float
+    maxerr : float, optional
         Accuracy to which the CD matrix, **normalized** such
         that :math:`|det(CD)|=1`, should be close to being an
         orthogonal matrix as described in the above equation
@@ -301,12 +301,11 @@ def is_proj_plane_distorted(wcs, maxerr=5.0e-6):
 
     """
     cwcs = wcs.celestial
-    return (not _is_cd_orthogonal(cwcs, maxerr) or _has_distortion(cwcs))
+    return (not _is_cd_orthogonal(cwcs.pixel_scale_matrix, maxerr) or
+            _has_distortion(cwcs))
 
 
-def _is_cd_orthogonal(wcs, maxerr):
-    cd = wcs.pixel_scale_matrix
-
+def _is_cd_orthogonal(cd, maxerr):
     shape = cd.shape
     if not (len(shape) == 2 and shape[0] == shape[1]):
         raise ValueError("CD (or PC) matrix must be a 2D square matrix.")

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -273,7 +273,7 @@ def is_proj_plane_distorted(wcs, maxerr=5.0e-6):
         of most projections.
 
     Let's denote by *C* either the original or the reconstructed
-    (from ``PC`` and ``CDELT``) CD matrix. `is_projection_plane_distorted`
+    (from ``PC`` and ``CDELT``) CD matrix. `is_proj_plane_distorted`
     verifies that the transformation from image (detector) coordinates
     to the focal plane coordinates is orthogonal using the following
     check:


### PR DESCRIPTION
Add a function that tests a WCS to see if pixels, when projected to the projection plane, remain square or if they become non-square (distorted).

Simply checking for the presence of distortion properties (`sip`, `det2im1`, etc.) is not enough to conclude whether or not pixels will look square in the projection plane - see #3112. In addition, having equal pixel scales (see, e.g., #3230) does not guarantee that pixels will be square.

This function considers that pixels will be "square" on the projection plane if:

1. All distortion properties of the WCS object (`sip`, `det2im1`, etc.) are `None`; **and**

2. The CD matrix corresponding to the celestial axes is orthogonal (or unitary for complex-valued CD matrices - not supported at present).

If one of the above conditions is not satisfied then pixels will be non-square.