### PR TITLE
add is_equivalent_frame to coordinate objects

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -945,6 +945,32 @@ class BaseCoordinateFrame(object):
         """
         return attrnm in self._attr_names_with_defaults
 
+    def is_equivalent_frame(self, other):
+        """
+        Checks if this object is the same frame as the ``other`` object.
+
+        To be the same frame, two objects must be the same frame class and have
+        the same frame attributes.  Note that it does *not* matter what, if any,
+        data either object has.
+
+        Parameters
+        ----------
+        other : BaseCoordinateFrame
+            the other frame to check
+
+        Returns
+        -------
+        isequiv : bool
+            True if the frames are the same, False if not.
+        """
+        if self.__class__ == other.__class__:
+            for frame_attr_name in self.get_frame_attr_names():
+                if getattr(self, frame_attr_name) != getattr(other, frame_attr_name):
+                    return False
+            return True
+        else:
+            return False
+
     def __repr__(self):
         frameattrs = ', '.join([attrnm + '=' + str(getattr(self, attrnm))
                                 for attrnm in self.get_frame_attr_names()])

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -962,12 +962,20 @@ class BaseCoordinateFrame(object):
         -------
         isequiv : bool
             True if the frames are the same, False if not.
+
+        Raises
+        ------
+        TypeError
+            If ``other`` isn't a `BaseCoordinateFrame` or subclass.
         """
         if self.__class__ == other.__class__:
             for frame_attr_name in self.get_frame_attr_names():
                 if getattr(self, frame_attr_name) != getattr(other, frame_attr_name):
                     return False
             return True
+        elif not isinstance(other, BaseCoordinateFrame):
+            raise TypeError("Tried to do is_equivalent_frame on something that "
+                            "isn't a frame")
         else:
             return False
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -530,8 +530,7 @@ class SkyCoord(object):
         """
         if isinstance(other, BaseCoordinateFrame):
             return self.frame.is_equivalent_frame(other)
-        elif hasattr(other, 'frame'):
-            # assume it's a SkyCoord-ish thing
+        elif isinstance(other, SkyCoord):
             if other.frame.name != self.frame.name:
                 return False
 
@@ -540,7 +539,7 @@ class SkyCoord(object):
                     return False
             return True
         else:
-            #not a BaseCoordinateFrame nor a SkyCoord-ish object
+            #not a BaseCoordinateFrame nor a SkyCoord object
             raise TypeError("Tried to do is_equivalent_frame on something that "
                             "isn't frame-like")
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -503,6 +503,41 @@ class SkyCoord(object):
 
         return coord_string
 
+    def is_equivalent_frame(self, other):
+        """
+        Checks if this object's frame as the same as that of the ``other``
+        object.
+
+        To be the same frame, two objects must be the same frame class and have
+        the same frame attributes. For two `SkyCoord` objects, *all* of the
+        frame attributes have to match, not just those relevant for the object's
+        frame.
+
+        Parameters
+        ----------
+        other : SkyCoord or BaseCoordinateFrame
+            The other object to check.
+
+        Returns
+        -------
+        isequiv : bool
+            True if the frames are the same, False if not.
+        """
+        if isinstance(other, BaseCoordinateFrame):
+            return self.frame.is_equivalent_frame(other)
+        elif hasattr(other, 'frame'):
+            # assume it's a SkyCoord-ish thing
+            if other.frame.name != self.frame.name:
+                return False
+
+            for fattrnm in FRAME_ATTR_NAMES_SET():
+                if getattr(self, fattrnm) != getattr(other, fattrnm):
+                    return False
+            return True
+        else:
+            #not a BaseCoordinateFrame nor a SkyCoord-ish object
+            return False
+
     # High-level convinience methods
     def separation(self, other):
         """
@@ -1241,6 +1276,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # now check that they're all self-consistent in their frame attributes
             # and frame name
+
             frames_to_check = [sc.frame.name for sc in scs]
             if len(set(frames_to_check)) > 1:
                 raise ValueError("List of inputs have different frames: {0}".format(frames_to_check))

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1274,19 +1274,15 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # SkyCoords from the list elements and then combine them.
             scs = [SkyCoord(coord, **init_kwargs) for coord in coords]
 
-            # now check that they're all self-consistent in their frame attributes
-            # and frame name
+            # now check that they're all self-consistent in their frames
+            for sc in scs[1:]:
+                if not sc.is_equivalent_frame(scs[0]):
+                        raise ValueError("List of inputs don't have equivalent "
+                                         "frames: {0} != {1}".format(sc, scs[0]))
 
-            frames_to_check = [sc.frame.name for sc in scs]
-            if len(set(frames_to_check)) > 1:
-                raise ValueError("List of inputs have different frames: {0}".format(frames_to_check))
+            # get the frame attributes from the first one, because from above we
+            # know it matches all the others
             for fattrnm in FRAME_ATTR_NAMES_SET():
-                vals = [getattr(sc, fattrnm) for sc in scs]
-                for val in vals[1:]:
-                    if val != vals[0]:
-                        raise ValueError("List of inputs don't give consistent "
-                                         "frame attribute {0}: {1}".format(fattrnm, vals))
-
                 valid_kwargs[fattrnm] = getattr(scs[0], fattrnm)
 
             # Now combine the values, to be used below

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -522,6 +522,11 @@ class SkyCoord(object):
         -------
         isequiv : bool
             True if the frames are the same, False if not.
+
+        Raises
+        ------
+        TypeError
+            If ``other`` isn't a `SkyCoord` or a `BaseCoordinateFrame` or subclass.
         """
         if isinstance(other, BaseCoordinateFrame):
             return self.frame.is_equivalent_frame(other)
@@ -536,7 +541,8 @@ class SkyCoord(object):
             return True
         else:
             #not a BaseCoordinateFrame nor a SkyCoord-ish object
-            return False
+            raise TypeError("Tried to do is_equivalent_frame on something that "
+                            "isn't frame-like")
 
     # High-level convinience methods
     def separation(self, other):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -536,3 +536,30 @@ def test_eloc_attributes():
     assert el3.latitude != gc.dec
     assert el3.longitude != gc.ra
     assert np.abs(el3.height) < 500*u.km
+
+
+def test_equivalent_frames():
+    from ..builtin_frames import ICRS, FK4, FK5, AltAz
+
+    i = ICRS()
+    i2 = ICRS(1*u.deg, 2*u.deg)
+    assert i.is_equivalent_frame(i)
+    assert i.is_equivalent_frame(i2)
+
+    f1 = FK5()
+    f2 = FK5(1*u.deg, 2*u.deg, equinox='J2000')
+    f3 = FK5(equinox='J2010')
+    f4 = FK4(equinox='J2010')
+
+    assert f1.is_equivalent_frame(f1)
+    assert not i.is_equivalent_frame(f1)
+    assert f1.is_equivalent_frame(f2)
+    assert not f1.is_equivalent_frame(f3)
+    assert not f3.is_equivalent_frame(f4)
+
+    aa1 = AltAz()
+    aa2 = AltAz(obstime='J2010')
+
+    assert aa2.is_equivalent_frame(aa2)
+    assert not aa1.is_equivalent_frame(i)
+    assert not aa1.is_equivalent_frame(aa2)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -539,12 +539,17 @@ def test_eloc_attributes():
 
 
 def test_equivalent_frames():
+    from .. import SkyCoord
     from ..builtin_frames import ICRS, FK4, FK5, AltAz
 
     i = ICRS()
     i2 = ICRS(1*u.deg, 2*u.deg)
     assert i.is_equivalent_frame(i)
     assert i.is_equivalent_frame(i2)
+    with pytest.raises(TypeError):
+        assert i.is_equivalent_frame(10)
+    with pytest.raises(TypeError):
+        assert i2.is_equivalent_frame(SkyCoord(i2))
 
     f1 = FK5()
     f2 = FK5(1*u.deg, 2*u.deg, equinox='J2000')

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1083,7 +1083,8 @@ def test_equiv_skycoord():
 
     assert sci1.is_equivalent_frame(ICRS())
     assert not sci1.is_equivalent_frame(FK5())
-    assert not sci1.is_equivalent_frame(10)
+    with pytest.raises(TypeError):
+        sci1.is_equivalent_frame(10)
 
     scf1 = SkyCoord(1*u.deg, 2*u.deg, frame='fk5')
     scf2 = SkyCoord(1*u.deg, 2*u.deg, frame='fk5', equinox='J2005')

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1073,3 +1073,29 @@ def test_nd_skycoord_to_string():
     ts = c.to_string()
     assert np.all(ts.shape == c.shape)
     assert np.all(ts == u'1 1')
+
+
+def test_equiv_skycoord():
+    sci1 = SkyCoord(1*u.deg, 2*u.deg, frame='icrs')
+    sci2 = SkyCoord(1*u.deg, 3*u.deg, frame='icrs')
+    assert sci1.is_equivalent_frame(sci1)
+    assert sci1.is_equivalent_frame(sci2)
+
+    assert sci1.is_equivalent_frame(ICRS())
+    assert not sci1.is_equivalent_frame(FK5())
+    assert not sci1.is_equivalent_frame(10)
+
+    scf1 = SkyCoord(1*u.deg, 2*u.deg, frame='fk5')
+    scf2 = SkyCoord(1*u.deg, 2*u.deg, frame='fk5', equinox='J2005')
+    #obstime is *not* an FK5 attribute, but we still want scf1 and scf3 to come
+    #to come out different because they're part of SkyCoord
+    scf3 = SkyCoord(1*u.deg, 2*u.deg, frame='fk5', obstime='J2005')
+
+    assert scf1.is_equivalent_frame(scf1)
+    assert not scf1.is_equivalent_frame(sci1)
+    assert scf1.is_equivalent_frame(FK5())
+
+    assert not scf1.is_equivalent_frame(scf2)
+    assert scf2.is_equivalent_frame(FK5(equinox='J2005'))
+    assert not scf3.is_equivalent_frame(scf1)
+    assert not scf3.is_equivalent_frame(FK5(equinox='J2005'))


### PR DESCRIPTION
As suggested by @astrofrog in an inline comment of #3285, this PR implements a method on frames and `SkyCoord` to check if they are the same frame.

It turns out there's a subtlety here: for frames (subclasses of `BaseCoordinateFrame`), it's unambiguous that an "equivalent" frame is one of the same type with the same frame attributes.  But for `SkyCoord`, there's two possible interpretations: 1) it could just be the same as for the frame, or it could mean 2) that *all* frame attributes have to match, even if they're not relevant for the current frame (`SkyCoord` can store frame attributes that it then carries over to new frames that are created via `transform_to`, but frame objects don't do this).

The approach I've taken here is 2.  Mainly I chose this because the user can still get 1 by doing ``sc.frame.is_equivalent_frame(sc2.frame)``, so this allows either option to be used fairly easily from a SkyCoord.

This is not critical, so as usual I'll leave it to @astrofrog to decide if it should be in 1.0

cc @taldcroft