### PR TITLE
A few speedups related to SkyCoord.__getitem__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -590,7 +590,7 @@ API Changes
 - ``astropy.vo.samp``
 
   - The default SSL protocol used is now determined from the default
-    used in the Python `ssl` standard library.  This default may be
+    used in the Python ``ssl`` standard library.  This default may be
     different depending on the exact version of Python you are using.
     [#3308]
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -94,7 +94,7 @@ class Angle(u.Quantity):
             # This includes Angle subclasses as well
             if unit is not None:
                 angle = angle.to(unit).value
-            else:
+            elif not isinstance(angle, Angle):
                 unit = angle.unit
                 unit = cls._convert_unit_to_angle_unit(unit)
                 if not unit.is_equivalent(u.radian):
@@ -125,14 +125,19 @@ class Angle(u.Quantity):
         self = super(Angle, cls).__new__(cls, angle, unit, dtype=dtype,
                                          copy=copy)
 
-        if self.unit is u.dimensionless_unscaled:
-            raise u.UnitsError("No unit was given - must be some kind of angle")
-        elif not self.unit.is_equivalent(u.radian):
-            raise u.UnitsError("Unit {0} is not an angle".format(self.unit))
+        if not isinstance(angle, Angle):
+            # These checks are unnecessary if we're just copying an existing
+            # Angle
+            if self.unit is u.dimensionless_unscaled:
+                raise u.UnitsError(
+                    "No unit was given - must be some kind of angle")
+            elif not self.unit.is_equivalent(u.radian):
+                raise u.UnitsError(
+                    "Unit {0} is not an angle".format(self.unit))
 
-        if self.dtype.kind not in 'iuf':
-                raise TypeError("Unsupported dtype for "
-                                "Angle:'{0}'".format(angle.dtype))
+            if self.dtype.kind not in 'iuf':
+                raise TypeError(
+                    "Unsupported dtype for Angle:'{0}'".format(angle.dtype))
 
         return self
 
@@ -674,12 +679,7 @@ class Longitude(Angle):
 
     @wrap_angle.setter
     def wrap_angle(self, value):
-        if not isinstance(value, Angle):
-            # TODO: Might be nice if Angle() had a better built-in pass-through
-            # for this case
-            # TODO: If the given angle *was* already an Angle, should we copy
-            # it?
-            value = Angle(value)
+        value = Angle(value)
 
         self._wrap_angle = value
         self._wrap_internal()

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -85,59 +85,43 @@ class Angle(u.Quantity):
     _include_easy_conversion_members = True
 
     def __new__(cls, angle, unit=None, dtype=None, copy=True):
-        unit = cls._convert_unit_to_angle_unit(unit)
-        if (unit is not None and not unit.is_equivalent(u.radian)):
-            raise u.UnitsError("Requested unit {0} is not convertible to an "
-                               "angle".format(unit))
 
-        if isinstance(angle, u.Quantity):
-            # This includes Angle subclasses as well
+        if not isinstance(angle, u.Quantity):
             if unit is not None:
-                angle = angle.to(unit).value
-            elif not isinstance(angle, Angle):
-                unit = angle.unit
                 unit = cls._convert_unit_to_angle_unit(unit)
-                if not unit.is_equivalent(u.radian):
-                    raise u.UnitsError(
-                        "Given quantity {0} is not convertible to an "
-                        "angle".format(angle))
 
-                angle = angle.value
-        else:
-            # this does nothing if it's not a tuple
-            angle = cls._tuple_to_float(angle, unit)
-
-            if isinstance(angle, six.string_types):
-                angle, new_unit = util.parse_angle(angle, unit)
-                if new_unit is not None and unit is None:
-                    unit = new_unit
+            if isinstance(angle, tuple):
                 angle = cls._tuple_to_float(angle, unit)
-                if new_unit is not None and unit is not None and new_unit != unit:
-                    angle = new_unit.to(unit, angle)
+
+            elif isinstance(angle, six.string_types):
+                angle, angle_unit = util.parse_angle(angle, unit)
+                if angle_unit is None:
+                    angle_unit = unit
+
+                if isinstance(angle, tuple):
+                    angle = cls._tuple_to_float(angle, angle_unit or unit)
+
+                if angle_unit is not unit:
+                    # Possible conversion to `unit` will be done below.
+                    angle = u.Quantity(angle, angle_unit, copy=False)
+
             elif (isiterable(angle) and
                   not (isinstance(angle, np.ndarray) and
                        angle.dtype.kind not in 'SUVO')):
                 angle = [Angle(x, unit) for x in angle]
-                if unit is None:
-                    unit = angle[0].unit
-                angle = [x.to(unit) for x in angle]
 
         self = super(Angle, cls).__new__(cls, angle, unit, dtype=dtype,
                                          copy=copy)
 
         if not isinstance(angle, Angle):
-            # These checks are unnecessary if we're just copying an existing
-            # Angle
             if self.unit is u.dimensionless_unscaled:
-                raise u.UnitsError(
-                    "No unit was given - must be some kind of angle")
-            elif not self.unit.is_equivalent(u.radian):
-                raise u.UnitsError(
-                    "Unit {0} is not an angle".format(self.unit))
+                raise u.UnitsError("No unit was given - "
+                                   "must be some kind of angle")
 
-            if self.dtype.kind not in 'iuf':
-                raise TypeError(
-                    "Unsupported dtype for Angle:'{0}'".format(angle.dtype))
+            self._unit = cls._convert_unit_to_angle_unit(self.unit)
+            if not self.unit.is_equivalent(u.radian):
+                raise u.UnitsError("Unit {0} is not an angle"
+                                   .format(self.unit))
 
         return self
 
@@ -147,26 +131,18 @@ class Angle(u.Quantity):
         Converts an angle represented as a 3-tuple or 2-tuple into a floating
         point number in the given unit.
         """
-        if isinstance(angle, tuple):
-            # TODO: Numpy array of tuples?
-            if unit is u.hourangle:
-                angle = util.hms_to_hours(*angle)
-            elif unit is u.degree:
-                angle = util.dms_to_degrees(*angle)
-            else:
-                raise u.UnitsError(
-                    "Can not parse '{0}' as unit '{1}'".format(
-                        angle, unit))
-        return angle
+        # TODO: Numpy array of tuples?
+        if unit == u.hourangle:
+            return util.hms_to_hours(*angle)
+        elif unit == u.degree:
+            return util.dms_to_degrees(*angle)
+        else:
+            raise u.UnitsError("Can not parse '{0}' as unit '{1}'"
+                               .format(angle, unit))
 
     @staticmethod
     def _convert_unit_to_angle_unit(unit):
-        if unit is not None:
-            unit = u.Unit(unit)
-
-            if unit is u.hour:
-                unit = u.hourangle
-        return unit
+        return u.hourangle if unit is u.hour else unit
 
     def __quantity_subclass__(self, unit):
         unit = self._convert_unit_to_angle_unit(unit)
@@ -281,6 +257,8 @@ class Angle(u.Quantity):
         """
         if unit is None:
             unit = self.unit
+        else:
+            unit = u.Unit(unit)
         unit = self._convert_unit_to_angle_unit(unit)
 
         separators = {
@@ -628,7 +606,8 @@ class Longitude(Angle):
     def __new__(cls, angle, unit=None, wrap_angle=None, **kwargs):
         # Forbid creating a Long from a Lat.
         if isinstance(angle, Latitude):
-            raise TypeError("A Longitude angle cannot be created from a Latitude angle")
+            raise TypeError("A Longitude angle cannot be created from "
+                            "a Latitude angle.")
         self = super(Longitude, cls).__new__(cls, angle, unit=unit, **kwargs)
 
         if wrap_angle is None:
@@ -679,14 +658,13 @@ class Longitude(Angle):
 
     @wrap_angle.setter
     def wrap_angle(self, value):
-        value = Angle(value)
-
-        self._wrap_angle = value
+        self._wrap_angle = Angle(value)
         self._wrap_internal()
 
     def __array_finalize__(self, obj):
         super(Longitude, self).__array_finalize__(obj)
-        self._wrap_angle = getattr(obj, '_wrap_angle', 360 * u.deg)
+        self._wrap_angle = getattr(obj, '_wrap_angle',
+                                   self._default_wrap_angle)
 
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -30,15 +30,10 @@ J_PREFIXED_RA_DEC_RE = re.compile(
     """, re.VERBOSE)
 
 
-# Define a convenience mapping.  This is used like a module constants
-# but is actually dynamically evaluated.
 def FRAME_ATTR_NAMES_SET():
     """Set of all possible frame-specific attributes"""
-    out = set()
-    for frame_cls in frame_transform_graph.frame_set:
-        for attr in frame_cls.get_frame_attr_names().keys():
-            out.add(attr)
-    return out
+
+    return frame_transform_graph.frame_attr_names
 
 
 class SkyCoord(object):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1193,7 +1193,6 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
     frame_attr_names = frame.representation_component_names.keys()
     repr_attr_names = frame.representation_component_names.values()
     repr_attr_classes = frame.representation.attr_classes.values()
-    n_attr_names = len(repr_attr_names)
 
     # Turn a single string into a list of strings for convenience
     if isinstance(coords, six.string_types):
@@ -1210,10 +1209,10 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
         data = coords.data.represent_as(frame.representation)
 
         values = []  # List of values corresponding to representation attrs
+        is_spherical = isinstance(coords.data, UnitSphericalRepresentation)
         for repr_attr_name in repr_attr_names:
             # If coords did not have an explicit distance then don't include in initializers.
-            if (isinstance(coords.data, UnitSphericalRepresentation) and
-                    repr_attr_name == 'distance'):
+            if is_spherical and repr_attr_name == 'distance':
                 continue
 
             # Get the value from `data` in the eventual representation
@@ -1301,10 +1300,12 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             n_coords = n_coords[0]
 
             # Must have no more coord inputs than representation attributes
-            if n_coords > n_attr_names:
-                raise ValueError('Input coordinates have {0} values but '
-                                 'representation {1} only accepts {2}'
-                                 .format(n_coords, frame.representation.get_name(), n_attr_names))
+            if n_coords > len(repr_attr_names):
+                raise ValueError(
+                    'Input coordinates have {0} values but representation '
+                    '{1} only accepts {2}'.format(
+                        n_coords, frame.representation.get_name(),
+                        len(repr_attr_names)))
 
             # Now transpose vals to get [(v1_0 .. v1_N), (v2_0 .. v2_N), (v3_0 .. v3_N)]
             # (ok since we know it is exactly rectangular).  (Note: can't just use zip(*values)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -868,13 +868,22 @@ class UnitBase(object):
         UnitsError
             If units are inconsistent
         """
-        other = Unit(other)
 
-        try:
-            scale = self._to(other)
-        except UnitsError:
-            return self._apply_equivalences(
-                self, other, self._normalize_equivalencies(equivalencies))
+        if self is other:
+            # Shortcut
+            # TODO: Should this even bother with the conversion or just pass
+            # the value straight through?  Should it still be run through
+            # _condition_arg at least?
+            scale = 1.0
+        else:
+            other = Unit(other)
+
+            try:
+                scale = self._to(other)
+            except UnitsError:
+                return self._apply_equivalences(
+                    self, other, self._normalize_equivalencies(equivalencies))
+
         return lambda val: scale * _condition_arg(val)
 
     def _to(self, other):


### PR DESCRIPTION
Here's a small collection of speedups aimed at the test case from #3323.  These are very specifically aimed at that one case, but may help in other cases as well:

```
In [1]: import numpy as np
In [2]: from astropy import units as u
In [3]: from astropy.coordinates import SkyCoord
In [4]: ra = np.random.uniform(0, 360, size=1000) * u.deg
In [5]: dec = np.random.uniform(-90, 90, size=1000) * u.deg
In [6]: crd = SkyCoord(ra, dec)
In [7]: %timeit [c for c in crd]
1 loops, best of 3: 19.3 s per loop
```

with the speedups in this branch I now get:

```
In [3]: %timeit [c for c in crd]
1 loops, best of 3: 2.47 s per loop
```

so improvement by an order of magnitude.  There are plenty other things that could be done, but I shouldn't spend any more time on it _right now_ (I may come back to it later).  There are also a few open questions I left in the code as `# TODO` comments that might be worth a look.

One of them in particular is that this obviates the need for the [`FRAME_ATTR_NAMES_SET`](https://github.com/embray/astropy/compare/astropy:master...embray:coordinates/minor-speedups?expand=1#diff-443cf9a7fca154e62d35de00f15d5c44R33) function, which I think could either be removed outright (since it isn't documented), or at least deprecated.
