### PR TITLE
Fix SkyCoord.to_string for multidimensional coordinate arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -457,6 +457,9 @@ Bug Fixes
 
   - ``Angle.to_string`` now outputs unicode arrays instead of object arrays [#2981]
 
+  - ``SkyCoord.to_string`` no longer gives an error when used with an array
+    coordinate with more than one dimension. [#3340]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -494,10 +494,12 @@ class SkyCoord(object):
                             sph_coord.lat.to_string(**latargs))
         else:
             coord_string = []
-            for lonangle, latangle in zip(sph_coord.lon, sph_coord.lat):
+            for lonangle, latangle in zip(sph_coord.lon.ravel(), sph_coord.lat.ravel()):
                 coord_string += [(lonangle.to_string(**lonargs)
                                  + " " +
                                  latangle.to_string(**latargs))]
+            if len(sph_coord.shape) > 1:
+                coord_string = np.array(coord_string).reshape(sph_coord.shape)
 
         return coord_string
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1067,3 +1067,9 @@ def test_skycoord_list_creation():
     assert np.all(scnew4.dec == sc.dec)
     assert scnew4.equinox == Time('J2010')
 
+
+def test_nd_skycoord_to_string():
+    c = SkyCoord(np.ones((2, 2)), 1, unit=('deg', 'deg'))
+    ts = c.to_string()
+    assert np.all(ts.shape == c.shape)
+    assert np.all(ts == u'1 1')


### PR DESCRIPTION
This closes #3322 by making coordinate arrays with more than one dimension output something sensible instead of erroring.

Note that there's a subtlety here in that now mutlidimensional coordinates output *arrrays* of strings instead of lists of strings like they do for 1d (or just strings for 0d/scalar).  But in practice I don't think that matters much, and it seems safer than changing 1d to arrays (which is technically a backwards-incompatible change).

cc @astrofrog