### PR TITLE
Update access_table.rst

### DIFF
--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -57,12 +57,6 @@ the data contained in that object relate to the original table data
    object gets created) versus ``t['a'][1]`` (faster).  Always use the latter
    when possible.
 
-.. Note::
-   Although they appear nearly equivalent, there is a factor of two performance
-   difference between ``t[1]['a']`` (slower, because an intermediate |Row|
-   object gets created) versus ``t['a'][1]`` (faster).  Always use the latter
-   when possible.
-
 **Print table or column**
 ::
 


### PR DESCRIPTION
These lines must have been copied accidentally so that the note appeared  twice.

[skip ci]