### PR TITLE
Fix this docstring to not end the first line with '::'

### DIFF
--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -150,11 +150,16 @@ class XMLWriter:
     @contextlib.contextmanager
     def tag(self, tag, attrib={}, **extra):
         """
-        A convenience method for use with the ``with`` statement::
+        A convenience method for creating wrapper elements using the
+        ``with`` statement.
 
-            with writer.tag('foo'):
-                writer.element('bar')
-            # </foo> is implicitly closed here
+        Examples
+        --------
+
+        >>> with writer.tag('foo'):  # doctest: +SKIP
+        ...     writer.element('bar')
+        ... # </foo> is implicitly closed here
+        ...
 
         Parameters are the same as to `start`.
         """


### PR DESCRIPTION
Over in astropy/astropy-helpers#116 I'm trying to trackdown various issues related to the autosummary extension.  On of them I found is that the docstring for [astropy.utils.xml.writer.XMLWriter.tag](http://docs.astropy.org/en/stable/api/astropy.utils.xml.writer.XMLWriter.html#astropy.utils.xml.writer.XMLWriter), begin with a line ending with `::`, indicating that a literal block follows.  Astropy's current version of the autosummary extension seems to get around this by just including everything in the docstring up to the first period, but the results are still ugly and not really what was intended.  The new version I'm trying out just includes everything up to the `::`, but that results in a warning, and also doesn't look nice.

Eventually a workaround for this should be found, but in the meantime it's easiest to just fix this one docstring, as it seems to be the only offender in the whole of Astropy (affiliated packages will have to look out for this too).