### PR TITLE
This makes a single coordinate __repr__ like that of arrays of coordinates

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -810,11 +810,13 @@ class BaseCoordinateFrame(object):
         >>> from astropy.coordinates import SkyCoord, CartesianRepresentation
         >>> coord = SkyCoord(0*u.deg, 0*u.deg)
         >>> coord.represent_as(CartesianRepresentation)
-        <CartesianRepresentation x=1.0, y=0.0, z=0.0>
+        <CartesianRepresentation (x, y, z) in
+                (1.0, 0.0, 0.0)>
 
         >>> coord.representation = CartesianRepresentation
         >>> coord
-        <SkyCoord (ICRS): x=1.0, y=0.0, z=0.0>
+        <SkyCoord (ICRS): (x, y, z) in
+            (1.0, 0.0, 0.0)>
         """
         new_representation = _get_repr_cls(new_representation)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -165,19 +165,20 @@ class BaseRepresentation(object):
             v = self._values
 
         fstyle = lambda x: str(x)
-        if len(self._values.dtype.names) == 2:
+        names = self._values.dtype.names
+        if len(names) == 2:
             fmt = {'numpystr' : lambda x: "(" + \
-                                            np.array2string(x['lon'], style=fstyle) + \
+                                            np.array2string(x[names[0]], style=fstyle) + \
                                             ', ' + \
-                                            np.array2string(x['lat'], style=fstyle) + \
+                                            np.array2string(x[names[1]], style=fstyle) + \
                                             ")"}
         else:
             fmt = {'numpystr' : lambda x: "(" + \
-                                            np.array2string(x['lon'], style=fstyle) + \
+                                            np.array2string(x[names[0]], style=fstyle) + \
                                             ', ' + \
-                                            np.array2string(x['lat'], style=fstyle) + \
+                                            np.array2string(x[names[1]], style=fstyle) + \
                                             ', ' + \
-                                            np.array2string(x['distance'], style=fstyle) + \
+                                            np.array2string(x[names[2]], style=fstyle) + \
                                             ")"}
 
         arrstr = np.array2string(v, formatter=fmt,

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -153,29 +153,16 @@ class BaseRepresentation(object):
         return unitstr
 
     def __str__(self):
-        if self.isscalar and len(set(self._units.values())) > 1:
-            return '({0})'.format(', '.join(
-                ['{0}'.format(getattr(self, component))
-                 for component in self.components]))
-        else:
-            return '{0} {1:s}'.format(self._values, self._unitstr)
+        return '{0} {1:s}'.format(self._values, self._unitstr)
 
     def __repr__(self):
-        if self.isscalar:
-            return '<{0} {1}>'.format(
-                self.__class__.__name__,
-                ', '.join(['{0}={1}'.format(component,
-                                            getattr(self, component))
-                           for component in self.components]))
+        prefixstr = '    '
+        arrstr = np.array2string(self._values, separator=', ',
+                                 prefix=prefixstr)
 
-        else:
-            prefixstr = '    '
-            arrstr = np.array2string(self._values, separator=', ',
-                                     prefix=prefixstr)
-
-            return '<{0} ({1}) in {2:s}\n{3}{4}>'.format(
-                self.__class__.__name__, ', '.join(self.components),
-                self._unitstr, prefixstr, arrstr)
+        return '<{0} ({1}) in {2:s}\n{3}{4}>'.format(
+            self.__class__.__name__, ', '.join(self.components),
+            self._unitstr, prefixstr, arrstr)
 
 
 class CartesianRepresentation(BaseRepresentation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -157,8 +157,35 @@ class BaseRepresentation(object):
 
     def __repr__(self):
         prefixstr = '    '
-        arrstr = np.array2string(self._values, separator=', ',
+
+        if self._values.shape == ():
+            v = [tuple([self._values[nm] for nm in self._values.dtype.names])]
+            v = np.array(v, dtype=self._values.dtype)
+        else:
+            v = self._values
+
+        fstyle = lambda x: str(x)
+        if len(self._values.dtype.names) == 2:
+            fmt = {'numpystr' : lambda x: "(" + \
+                                            np.array2string(x['lon'], style=fstyle) + \
+                                            ', ' + \
+                                            np.array2string(x['lat'], style=fstyle) + \
+                                            ")"}
+        else:
+            fmt = {'numpystr' : lambda x: "(" + \
+                                            np.array2string(x['lon'], style=fstyle) + \
+                                            ', ' + \
+                                            np.array2string(x['lat'], style=fstyle) + \
+                                            ', ' + \
+                                            np.array2string(x['distance'], style=fstyle) + \
+                                            ")"}
+
+        arrstr = np.array2string(v, formatter=fmt,
+                                 separator=', ',
                                  prefix=prefixstr)
+
+        if self._values.shape == ():
+            arrstr = arrstr[1:-1]
 
         return '<{0} ({1}) in {2:s}\n{3}{4}>'.format(
             self.__class__.__name__, ', '.join(self.components),

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -22,11 +22,12 @@ __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
            "PhysicsSphericalRepresentation", "CylindricalRepresentation"]
 
+NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
+
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
 # get registered automatically.
 REPRESENTATION_CLASSES = {}
-
 
 class MetaBaseRepresentation(type):
     def __init__(cls, name, bases, dct):
@@ -42,6 +43,15 @@ class MetaBaseRepresentation(type):
 
         REPRESENTATION_CLASSES[cls.get_name()] = cls
 
+p_opt = np.get_printoptions()
+def _fstyle(x):
+    fmt_str = "{:." + str(p_opt['precision']) + "f}"
+    s = fmt_str.format(x)
+    s_trunc = s.rstrip("0")
+    if s_trunc.split(".")[1] == "":
+        return s_trunc + "0"
+    else:
+        return str(x)
 
 @six.add_metaclass(MetaBaseRepresentation)
 class BaseRepresentation(object):
@@ -164,26 +174,30 @@ class BaseRepresentation(object):
         else:
             v = self._values
 
-        fstyle = lambda x: str(x)
         names = self._values.dtype.names
         if len(names) == 2:
             fmt = {'numpystr' : lambda x: "(" + \
-                                            np.array2string(x[names[0]], style=fstyle) + \
+                                            np.array2string(x[names[0]], style=_fstyle) + \
                                             ', ' + \
-                                            np.array2string(x[names[1]], style=fstyle) + \
+                                            np.array2string(x[names[1]], style=_fstyle) + \
                                             ")"}
         else:
             fmt = {'numpystr' : lambda x: "(" + \
-                                            np.array2string(x[names[0]], style=fstyle) + \
+                                            np.array2string(x[names[0]], style=_fstyle) + \
                                             ', ' + \
-                                            np.array2string(x[names[1]], style=fstyle) + \
+                                            np.array2string(x[names[1]], style=_fstyle) + \
                                             ', ' + \
-                                            np.array2string(x[names[2]], style=fstyle) + \
+                                            np.array2string(x[names[2]], style=_fstyle) + \
                                             ")"}
 
-        arrstr = np.array2string(v, formatter=fmt,
-                                 separator=', ',
-                                 prefix=prefixstr)
+        if NUMPY_LT_1P7:
+            arrstr = np.array2string(v, separator=', ',
+                                     prefix=prefixstr)
+
+        else:
+            arrstr = np.array2string(v, formatter=fmt,
+                                     separator=', ',
+                                     prefix=prefixstr)
 
         if self._values.shape == ():
             arrstr = arrstr[1:-1]

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -45,7 +45,7 @@ class MetaBaseRepresentation(type):
 
 p_opt = np.get_printoptions()
 def _fstyle(x):
-    fmt_str = "{:." + str(p_opt['precision']) + "f}"
+    fmt_str = "{0:." + str(p_opt['precision']) + "f}"
     s = fmt_str.format(x)
     s_trunc = s.rstrip("0")
     if s_trunc.split(".")[1] == "":

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -358,9 +358,7 @@ def test_highlevel_api():
     #funny ways
     #assert repr(sc.frame) == '<ICRS Coordinate: ra=120.0 deg, dec=5.0 deg>'
     rscf = repr(sc.frame)
-    assert '<ICRS Coordinate: ra=' in rscf
-    assert 'deg, dec=' in rscf
-    assert 'deg>' in rscf
+    assert rscf.startswith('<ICRS Coordinate: (ra, dec) in deg')
 
     # and  the string representation will be inherited from the low-level class.
 
@@ -368,9 +366,7 @@ def test_highlevel_api():
     # versions may round the numbers differently
     #assert repr(sc) == '<SkyCoord (ICRS): ra=120.0 deg, dec=5.0 deg>'
     rsc = repr(sc)
-    assert '<SkyCoord (ICRS): ra=' in rsc
-    assert 'deg, dec=' in rsc
-    assert 'deg>' in rsc
+    assert rsc.startswith('<SkyCoord (ICRS): (ra, dec) in deg')
 
     # Supports a variety of possible complex string formats
     sc = coords.SkyCoord('8h00m00s +5d00m00.0s', frame='icrs')
@@ -413,7 +409,7 @@ def test_highlevel_api():
     # v0.2/0.3 coordinate objects.  This will *not* be in the low-level classes
     sc = coords.SkyCoord(ra=8 * u.hour, dec=5 * u.deg, frame='icrs')
     scgal = sc.galactic
-    assert str(scgal).startswith('<SkyCoord (Galactic): l=216.316')
+    assert str(scgal).startswith('<SkyCoord (Galactic): (l, b)')
 
     # the existing `from_name` and `match_to_catalog_*` methods will be moved to the
     # high-level class as convenience functionality.

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -11,6 +11,7 @@ from ... import units as u
 from ...tests.helper import pytest
 from .. import representation
 
+NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
 
 def test_frame_attribute_descriptor():
     """ Unit tests of the FrameAttribute descriptor """
@@ -155,19 +156,29 @@ def test_frame_repr():
     i2 = ICRS(ra=1*u.deg, dec=2*u.deg)
     i3 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.kpc)
 
-    assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
-                        '    (1.0, 2.0)>')
-    assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
-                        '    (1.0, 2.0, 3.0)>')
+    if NUMPY_LT_1P7:
+        assert repr(i2).startswith("<ICRS Coordinate: (ra, dec) in deg")
+        assert repr(i3).startswith("<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)")
+
+    else:
+        assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
+                            '    (1.0, 2.0)>')
+        assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
+                            '    (1.0, 2.0, 3.0)>')
 
     # try with arrays
     i2 = ICRS(ra=[1.1,2.1]*u.deg, dec=[2.1,3.1]*u.deg)
     i3 = ICRS(ra=[1.1,2.1]*u.deg, dec=[-15.6,17.1]*u.deg, distance=[11.,21.]*u.kpc)
 
-    assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
-                        '    [(1.1, 2.1), (2.1, 3.1)]>')
-    assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
-                        '    [(1.1, -15.6, 11.0), (2.1, 17.1, 21.0)]>')
+    if NUMPY_LT_1P7:
+        assert repr(i2).startswith("<ICRS Coordinate: (ra, dec) in deg")
+        assert repr(i3).startswith("<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)")
+
+    else:
+        assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
+                            '    [(1.1, 2.1), (2.1, 3.1)]>')
+        assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
+                            '    [(1.1, -15.6, 11.0), (2.1, 17.1, 21.0)]>')
 
 
 def test_converting_units():
@@ -192,12 +203,14 @@ def test_converting_units():
 
     ri2 = ''.join(rexrepr.split(repr(i2)))
     ri4 = ''.join(rexrepr.split(repr(i4)))
-    assert ri2 == ri4
+    if not NUMPY_LT_1P7:
+        assert ri2 == ri4
     assert i2.data.lon.unit != i4.data.lon.unit  # Internal repr changed
 
     ri2_many = ''.join(rexrepr.split(repr(i2_many)))
     ri4_many = ''.join(rexrepr.split(repr(i4_many)))
-    assert ri2_many == ri4_many
+    if not NUMPY_LT_1P7:
+        assert ri2_many == ri4_many
     assert i2_many.data.lon.unit != i4_many.data.lon.unit  # Internal repr changed
 
     #but that *shouldn't* hold if we turn off units for the representation

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -160,6 +160,15 @@ def test_frame_repr():
     assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
                         '    (1.0, 2.0, 3.0)>')
 
+    # try with arrays
+    i2 = ICRS(ra=[1.1,2.1]*u.deg, dec=[2.1,3.1]*u.deg)
+    i3 = ICRS(ra=[1.1,2.1]*u.deg, dec=[-15.6,17.1]*u.deg, distance=[11.,21.]*u.kpc)
+
+    assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
+                        '    [(1.1, 2.1), (2.1, 3.1)]>')
+    assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
+                        '    [(1.1, -15.6, 11.0), (2.1, 17.1, 21.0)]>')
+
 
 def test_converting_units():
     import re

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -155,9 +155,10 @@ def test_frame_repr():
     i2 = ICRS(ra=1*u.deg, dec=2*u.deg)
     i3 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.kpc)
 
-    assert repr(i2) == '<ICRS Coordinate: ra=1.0 deg, dec=2.0 deg>'
-    assert repr(i3) == ('<ICRS Coordinate: ra=1.0 deg, dec=2.0 deg, '
-                        'distance=3.0 kpc>')
+    assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
+                        '    (1.0, 2.0)>')
+    assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
+                        '    (1.0, 2.0, 3.0)>')
 
 
 def test_converting_units():
@@ -171,16 +172,24 @@ def test_converting_units():
     rexrepr = re.compile(r'(.*?=\d\.).*?( .*?=\d\.).*?( .*)')
 
     # Use values that aren't subject to rounding down to X.9999...
-    i2 = ICRS(ra=1.1*u.deg, dec=2.1*u.deg)
+    i2 = ICRS(ra=2.*u.deg, dec=2.*u.deg)
+    i2_many = ICRS(ra=[2.,4.]*u.deg, dec=[2.,-8.1]*u.deg)
 
     #converting from FK5 to ICRS and back changes the *internal* representation,
     # but it should still come out in the preferred form
 
     i4 = i2.transform_to(FK5).transform_to(ICRS)
+    i4_many = i2_many.transform_to(FK5).transform_to(ICRS)
+
     ri2 = ''.join(rexrepr.split(repr(i2)))
     ri4 = ''.join(rexrepr.split(repr(i4)))
     assert ri2 == ri4
     assert i2.data.lon.unit != i4.data.lon.unit  # Internal repr changed
+
+    ri2_many = ''.join(rexrepr.split(repr(i2_many)))
+    ri4_many = ''.join(rexrepr.split(repr(i4_many)))
+    assert ri2_many == ri4_many
+    assert i2_many.data.lon.unit != i4_many.data.lon.unit  # Internal repr changed
 
     #but that *shouldn't* hold if we turn off units for the representation
     class FakeICRS(ICRS):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -625,7 +625,8 @@ def test_representation_subclass():
 
     # A similar issue then happened in __repr__ with subclasses of
     # SphericalRepresentation.
-    assert repr(frame) == "<FK5 Coordinate (equinox=J2000.000): lon=32.0 deg, lat=20.0 deg>"
+    assert repr(frame) == ("<FK5 Coordinate (equinox=J2000.000): (lon, lat) in deg\n"
+                           "    (32.0, 20.0)>")
 
     # A more subtle issue is when specifying a custom
     # UnitSphericalRepresentation subclass for the data and

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -893,10 +893,12 @@ def test_unit_spherical_roundtrip():
 
 def test_representation_repr():
     r1 = SphericalRepresentation(lon=1 * u.deg, lat=2.5 * u.deg, distance=1 * u.kpc)
-    assert repr(r1) == '<SphericalRepresentation lon=1.0 deg, lat=2.5 deg, distance=1.0 kpc>'
+    assert repr(r1) == ('<SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)\n'
+                        '    (1.0, 2.5, 1.0)>')
 
     r2 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
-    assert repr(r2) == '<CartesianRepresentation x=1.0 kpc, y=2.0 kpc, z=3.0 kpc>'
+    assert repr(r2) == ('<CartesianRepresentation (x, y, z) in kpc\n'
+                        '    (1.0, 2.0, 3.0)>')
 
     r3 = CartesianRepresentation(x=[1, 2, 3] * u.kpc, y=4 * u.kpc, z=[9, 10, 11] * u.kpc)
     assert repr(r3) == ('<CartesianRepresentation (x, y, z) in kpc\n'
@@ -905,7 +907,7 @@ def test_representation_repr():
 
 def test_representation_str():
     r1 = SphericalRepresentation(lon=1 * u.deg, lat=2.5 * u.deg, distance=1 * u.kpc)
-    assert str(r1) == '(1.0 deg, 2.5 deg, 1.0 kpc)'
+    assert str(r1) == '(1.0, 2.5, 1.0) (deg, deg, kpc)'
 
     r2 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
     assert str(r2) == '(1.0, 2.0, 3.0) kpc'

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -476,15 +476,18 @@ def test_repr():
     sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame='icrs')
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
 
-    assert repr(sc1) == '<SkyCoord (ICRS): ra=0.0 deg, dec=1.0 deg>'
-    assert repr(sc2) == '<SkyCoord (ICRS): ra=1.0 deg, dec=1.0 deg, distance=1.0 kpc>'
+    assert repr(sc1) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
+                         '    (0.0, 1.0)>')
+    assert repr(sc2) == ('<SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)\n'
+                         '    (1.0, 1.0, 1.0)>')
 
     sc3 = SkyCoord(0.25 * u.deg, [1, 2.5] * u.deg, frame='icrs')
     assert repr(sc3) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
                          '    [(0.25, 1.0), (0.25, 2.5)]>')
 
     sc_default = SkyCoord(0 * u.deg, 1 * u.deg)
-    assert repr(sc_default) == '<SkyCoord (ICRS): ra=0.0 deg, dec=1.0 deg>'
+    assert repr(sc_default) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
+                                '    (0.0, 1.0)>')
 
 
 def test_ops():

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -107,7 +107,8 @@ Angles will also behave correctly for appropriate arithmetic operations::
 
     >>> from astropy.coordinates import ICRS
     >>> ICRS(Angle(1, u.radian), Angle(0.5, u.radian))
-    <ICRS Coordinate: ra=57.2957795131 deg, dec=28.6478897565 deg>
+    <ICRS Coordinate: (ra, dec) in deg
+        (57.2957795131, 28.6478897565)>
 
 
 Wrapping and bounds

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -106,7 +106,7 @@ Angles will also behave correctly for appropriate arithmetic operations::
 |Angle| objects can also be used for creating coordinate objects::
 
     >>> from astropy.coordinates import ICRS
-    >>> ICRS(Angle(1, u.radian), Angle(0.5, u.radian))
+    >>> ICRS(Angle(1, u.radian), Angle(0.5, u.radian)) # doctest: +FLOAT_CMP
     <ICRS Coordinate: (ra, dec) in deg
         (57.2957795131, 28.6478897565)>
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -70,9 +70,11 @@ equatorial systems)::
 
     >>> from astropy import units as u
     >>> ICRS(ra=1.1*u.deg, dec=2.2*u.deg)
-    <ICRS Coordinate: ra=1.1 deg, dec=2.2 deg>
+    <ICRS Coordinate: (ra, dec) in deg
+        (1.1, 2.2)>
     >>> FK5(ra=1.1*u.deg, dec=2.2*u.deg, equinox='J1975')
-    <FK5 Coordinate (equinox=J1975.000): ra=1.1 deg, dec=2.2 deg>
+    <FK5 Coordinate (equinox=J1975.000): (ra, dec) in deg
+        (1.1, 2.2)>
 
 These same attributes can be used to access the data in the frames, as
 |Angle| objects (or |Angle| subclasses)::
@@ -114,7 +116,8 @@ itself which represents a point in 3d space.
     >>> from astropy.coordinates import CartesianRepresentation
     >>> icrs.representation = CartesianRepresentation
     >>> icrs  # doctest: +FLOAT_CMP
-    <ICRS Coordinate: x=0.999238614955, y=0.0174417749028, z=0.0348994967025>
+    <ICRS Coordinate: (x, y, z) in
+        (0.999238614955, 0.0174417749028, 0.0348994967025)>
     >>> icrs.x  # doctest: +FLOAT_CMP
     <Quantity 0.9992386149554826>
 
@@ -123,7 +126,8 @@ and affects the set of keywords used to supply the coordinate data.  For
 example to create a coordinate with cartesian data do::
 
     >>> ICRS(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc, representation=CartesianRepresentation)
-    <ICRS Coordinate: x=1.0 kpc, y=2.0 kpc, z=3.0 kpc>
+    <ICRS Coordinate: (x, y, z) in kpc
+        (1.0, 2.0, 3.0)>
 
 For more information about the use of representations in coordinates see the
 :ref:`astropy-skycoord-representations` section, and for details about the
@@ -136,7 +140,8 @@ any  frame attributes required::
     >>> from astropy.coordinates import SphericalRepresentation
     >>> rep = SphericalRepresentation(lon=1.1*u.deg, lat=2.2*u.deg, distance=3.3*u.kpc)
     >>> FK5(rep, equinox='J1975')
-    <FK5 Coordinate (equinox=J1975.000): ra=1.1 deg, dec=2.2 deg, distance=3.3 kpc>
+    <FK5 Coordinate (equinox=J1975.000): (ra, dec, distance) in (deg, deg, kpc)
+        (1.1, 2.2, 3.3)>
 
 A final way is to create a frame object from an already existing frame
 (either one with or without data), using the ``realize_frame`` method. This
@@ -147,7 +152,8 @@ will yield a frame with the same attributes, but new data::
     <FK5 Frame (equinox=J1975.000)>
     >>> rep = SphericalRepresentation(lon=1.1*u.deg, lat=2.2*u.deg, distance=3.3*u.kpc)
     >>> f1.realize_frame(rep)
-    <FK5 Coordinate (equinox=J1975.000): ra=1.1 deg, dec=2.2 deg, distance=3.3 kpc>
+    <FK5 Coordinate (equinox=J1975.000): (ra, dec, distance) in (deg, deg, kpc)
+        (1.1, 2.2, 3.3)>
 
 You can check if a frame object has data using the ``has_data`` attribute, and
 if it is preset, it can be accessed from the ``data`` attribute::
@@ -158,7 +164,8 @@ if it is preset, it can be accessed from the ``data`` attribute::
     >>> cooi.has_data
     True
     >>> cooi.data
-    <UnitSphericalRepresentation lon=1.1 deg, lat=2.2 deg>
+    <UnitSphericalRepresentation (lon, lat) in deg
+        (1.1, 2.2)>
 
 All of the above methods can also accept array data (or other Python
 sequences) to create arrays of coordinates::
@@ -181,7 +188,8 @@ an ICRS coordinate::
     >>> from astropy.coordinates import CartesianRepresentation
     >>> cooi = ICRS(ra=0*u.deg, dec=45*u.deg, distance=10*u.pc)
     >>> cooi.represent_as(CartesianRepresentation)  # doctest: +FLOAT_CMP
-    <CartesianRepresentation x=7.07106781187 pc, y=0.0 pc, z=7.07106781187 pc>
+    <CartesianRepresentation (x, y, z) in pc
+        (7.07106781187, 0.0, 7.07106781187)>
 
 Transforming between Frames
 ===========================
@@ -194,9 +202,11 @@ data)::
 
     >>> cooi = ICRS(1.5*u.deg, 2.5*u.deg)
     >>> cooi.transform_to(FK5)  # doctest: +FLOAT_CMP
-    <FK5 Coordinate (equinox=J2000.000): ra=1.50000660527 deg, dec=2.50000238221 deg>
+    <FK5 Coordinate (equinox=J2000.000): (ra, dec) in deg
+        (1.50000660527, 2.50000238221)>
     >>> cooi.transform_to(FK5(equinox='J1975'))  # doctest: +FLOAT_CMP
-    <FK5 Coordinate (equinox=J1975.000): ra=1.17960348105 deg, dec=2.36085320826 deg>
+    <FK5 Coordinate (equinox=J1975.000): (ra, dec) in deg
+        (1.17960348105, 2.36085320826)>
 
 The :ref:`astropy-coordinates-api` includes a list of all of the frames built
 into `astropy.coordinates`, as well as the defined transformations between
@@ -247,7 +257,8 @@ the way you want.  As an example::
 
   >>> c = MyFrame(R=10*u.deg, D=20*u.deg)
   >>> c  # doctest: +FLOAT_CMP
-  <MyFrame Coordinate (location=None, equinox=B1950.000, obstime=B1950.000): R=0.174532925199 rad, D=0.349065850399 rad>
+  <MyFrame Coordinate (location=None, equinox=B1950.000, obstime=B1950.000): (R, D) in rad
+      (0.174532925199, 0.349065850399)>
   >>> c.equinox
   <Time object: scale='utc' format='byear_str' value=B1950.000>
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -39,7 +39,8 @@ equivalent::
     >>> c = SkyCoord('00 42 30 +41 12 00', frame='icrs', unit=(u.hourangle, u.deg))
     >>> c = SkyCoord('00:42.5 +41:12', frame='icrs', unit=(u.hourangle, u.deg))
     >>> c
-    <SkyCoord (ICRS): ra=10.625 deg, dec=41.2 deg>
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (10.625, 41.2)>
 
 The examples above illustrate a few simple rules to follow when creating a coordinate
 object:
@@ -104,21 +105,21 @@ are defined in::
     >>> c_icrs = SkyCoord(ra=10.68458*u.degree, dec=41.26917*u.degree, frame='icrs')
 
 Once you've defined the frame of your coordinates, you can transform from that
-frame to another frame.  You can do this a few different ways: if you just want
-the default version of that frame, you can use attribute-style access::
+frame to another frame.  You can do this a few different ways: For more control,
+you can use the `~astropy.coordinates.SkyCoord.transform_to` method, which
+accepts a frame name, frame class, or frame instance::
 
     >>> from astropy.coordinates import FK5
     >>> c_icrs.galactic  # doctest: +FLOAT_CMP
-    <SkyCoord (Galactic): l=121.174241811 deg, b=-21.5728855724 deg>
-
-For more control, you can use the `~astropy.coordinates.SkyCoord.transform_to`
-method, which accepts a frame name, frame class, or frame instance::
-
+    <SkyCoord (Galactic): (l, b) in deg
+        (121.174241811, -21.5728855724)>
     >>> c_fk5 = c_icrs.transform_to('fk5')  # c_icrs.fk5 does the same thing
     >>> c_fk5  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J2000.000): ra=10.6845915393 deg, dec=41.2691714591 deg>
+    <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+        (10.6845915393, 41.2691714591)>
     >>> c_fk5.transform_to(FK5(equinox='J1975'))  # precess to a different equinox  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J1975.000): ra=10.3420913461 deg, dec=41.1323211229 deg>
+    <SkyCoord (FK5: equinox=J1975.000): (ra, dec) in deg
+        (10.3420913461, 41.1323211229)>
 
 This form of `~astropy.coordinates.SkyCoord.transform_to` also makes it
 straightforward to convert from celestial coordinates to
@@ -149,13 +150,15 @@ coordinate objects::
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', frame='icrs', representation='cartesian')
     >>> c
-    <SkyCoord (ICRS): x=1.0 kpc, y=2.0 kpc, z=3.0 kpc>
+    <SkyCoord (ICRS): (x, y, z) in kpc
+        (1.0, 2.0, 3.0)>
     >>> c.x, c.y, c.z
     (<Quantity 1.0 kpc>, <Quantity 2.0 kpc>, <Quantity 3.0 kpc>)
 
     >>> c.representation = 'cylindrical'
     >>> c  # doctest: +FLOAT_CMP
-    <SkyCoord (ICRS): rho=2.2360679775 kpc, phi=63.4349488229 deg, z=3.0 kpc>
+    <SkyCoord (ICRS): (rho, phi, z) in (kpc, deg, kpc)
+        (2.2360679775, 63.4349488229, 3.0)>
     >>> c.phi
     <Angle 63.434948... deg>
     >>> c.phi.to(u.radian)
@@ -163,11 +166,13 @@ coordinate objects::
 
     >>> c.representation = 'spherical'
     >>> c  # doctest: +FLOAT_CMP
-    <SkyCoord (ICRS): ra=63.4349488229 deg, dec=53.3007747995 deg, distance=3.74165738677 kpc>
+    <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
+        (63.4349488229, 53.3007747995, 3.74165738677)>
 
     >>> c.representation = 'unitspherical'
     >>> c  # doctest: +FLOAT_CMP
-    <SkyCoord (ICRS): ra=63.4349488229 deg, dec=53.3007747995 deg>
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (63.4349488229, 53.3007747995)>
 
 |skycoord| defines a number of convenience methods as well, like on-sky
 separation between two coordinates and catalog matching (detailed in

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -45,7 +45,8 @@ objects::
     >>> from astropy.coordinates.representation import CartesianRepresentation
     >>> car = CartesianRepresentation(3 * u.kpc, 5 * u.kpc, 4 * u.kpc)
     >>> car
-    <CartesianRepresentation x=3.0 kpc, y=5.0 kpc, z=4.0 kpc>
+    <CartesianRepresentation (x, y, z) in kpc
+        (3.0, 5.0, 4.0)>
 
 Representations can be converted to other representations using the
 ``represent_as`` method::
@@ -53,10 +54,12 @@ Representations can be converted to other representations using the
     >>> from astropy.coordinates.representation import SphericalRepresentation, CylindricalRepresentation
     >>> sph = car.represent_as(SphericalRepresentation)
     >>> sph  # doctest: +FLOAT_CMP
-    <SphericalRepresentation lon=1.03037682652 rad, lat=0.601264216679 rad, distance=7.07106781187 kpc>
+    <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+        (1.03037682652, 0.601264216679, 7.07106781187)>
     >>> cyl = car.represent_as(CylindricalRepresentation)
     >>> cyl  # doctest: +FLOAT_CMP
-    <CylindricalRepresentation rho=5.83095189485 kpc, phi=1.03037682652 rad, z=4.0 kpc>
+    <CylindricalRepresentation (rho, phi, z) in (kpc, rad, kpc)
+        (5.83095189485, 1.03037682652, 4.0)>
 
 All representations can be converted to each other without loss of
 information, with the exception of
@@ -68,14 +71,16 @@ dimensionless sphere::
     >>> from astropy.coordinates.representation import UnitSphericalRepresentation
     >>> sph_unit = car.represent_as(UnitSphericalRepresentation)
     >>> sph_unit  # doctest: +FLOAT_CMP
-    <UnitSphericalRepresentation lon=1.03037682652 rad, lat=0.601264216679 rad>
+    <UnitSphericalRepresentation (lon, lat) in rad
+        (1.03037682652, 0.601264216679)>
 
 Converting back to cartesian, the absolute scaling information has been
 removed, and the points are still located on a unit sphere:
 
     >>> sph_unit = car.represent_as(UnitSphericalRepresentation)
-    >>> sph_unit.represent_as(CartesianRepresentation)
-    <CartesianRepresentation x=0.4242..., y=0.7071..., z=0.5656...>
+    >>> sph_unit.represent_as(CartesianRepresentation) # doctest: +FLOAT_CMP
+    <CartesianRepresentation (x, y, z) in
+        (0.424264068712, 0.707106781187, 0.565685424949)>
 
 Array values
 ^^^^^^^^^^^^

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -468,7 +468,7 @@ Transforming to a |SkyCoord| instance is an easy way of ensuring that two
 coordinates are in the exact same reference frame::
 
   >>> sc2 = SkyCoord(3, 4, frame='fk4', unit='deg', obstime='J1978.123', equinox='B1960.0')
-  >>> sc.transform_to(sc2)
+  >>> sc.transform_to(sc2) # doctest: +FLOAT_CMP
   <SkyCoord (FK4: equinox=B1960.000, obstime=J1978.123): (ra, dec) in deg
       (0.48726331438, 1.77731617297)>
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -71,7 +71,8 @@ positional and keyword arguments.  First we show positional arguments for
 RA and Dec::
 
   >>> SkyCoord(10, 20, unit='deg')  # Defaults to ICRS
-  <SkyCoord (ICRS): ra=10.0 deg, dec=20.0 deg>
+  <SkyCoord (ICRS): (ra, dec) in deg
+      (10.0, 20.0)>
 
   >>> SkyCoord([1, 2, 3], [-30, 45, 8], frame='icrs', unit='deg')
   <SkyCoord (ICRS): (ra, dec) in deg
@@ -349,7 +350,8 @@ new |SkyCoord| object in the requested frame::
 
   >>> sc_gal = sc.galactic
   >>> sc_gal  # doctest: +FLOAT_CMP
-  <SkyCoord (Galactic): l=99.6378552814 deg, b=-58.7096929334 deg>
+  <SkyCoord (Galactic): (l, b) in deg
+      (99.6378552814, -58.7096929334)>
 
 Other attributes you should recognize are ``distance``, ``equinox``,
 ``obstime``, ``shape``.
@@ -398,7 +400,8 @@ representation (spherical, cartesian, etc.), frame (aka low-level frame class),
 and |SkyCoord| (aka high-level class)::
 
   >>> sc.frame
-  <ICRS Coordinate: ra=1.0 deg, dec=2.0 deg>
+  <ICRS Coordinate: (ra, dec) in deg
+      (1.0, 2.0)>
 
   >>> sc.has_data is sc.frame.has_data
   True
@@ -430,7 +433,8 @@ The lowest layer in the stack is the abstract
 `~astropy.coordinates.UnitSphericalRepresentation` object:
 
   >>> sc_gal.frame.data  # doctest: +FLOAT_CMP
-  <UnitSphericalRepresentation lon=1.73900863429 rad, lat=-1.02467744452 rad>
+  <UnitSphericalRepresentation (lon, lat) in rad
+      (1.73900863429, -1.02467744452)>
 
 Transformations
 ^^^^^^^^^^^^^^^^^
@@ -449,20 +453,24 @@ name, frame class, frame instance, or |SkyCoord|::
   >>> from astropy.coordinates import FK5
   >>> sc = SkyCoord(1, 2, frame='icrs', unit='deg')
   >>> sc.galactic  # doctest: +FLOAT_CMP
-  <SkyCoord (Galactic): l=99.6378552814 deg, b=-58.7096929334 deg>
+  <SkyCoord (Galactic): (l, b) in deg
+      (99.6378552814, -58.7096929334)>
 
   >>> sc.transform_to('fk5')  # Same as sc.fk5 and sc.transform_to(FK5)  # doctest: +FLOAT_CMP
-  <SkyCoord (FK5: equinox=J2000.000): ra=1.00000655566 deg, dec=2.00000243092 deg>
+  <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+          (1.00000655566, 2.00000243092)>
 
   >>> sc.transform_to(FK5(equinox='J1975'))  # Transform to FK5 with a different equinox  # doctest: +FLOAT_CMP
-  <SkyCoord (FK5: equinox=J1975.000): ra=0.679672818323 deg, dec=1.86083014099 deg>
+  <SkyCoord (FK5: equinox=J1975.000): (ra, dec) in deg
+          (0.679672818323, 1.86083014099)>
 
 Transforming to a |SkyCoord| instance is an easy way of ensuring that two
 coordinates are in the exact same reference frame::
 
   >>> sc2 = SkyCoord(3, 4, frame='fk4', unit='deg', obstime='J1978.123', equinox='B1960.0')
   >>> sc.transform_to(sc2)
-  <SkyCoord (FK4: equinox=B1960.000, obstime=J1978.123): ra=0.48726331438 deg, dec=1.77731617297 deg>
+  <SkyCoord (FK4: equinox=B1960.000, obstime=J1978.123): (ra, dec) in deg
+      (0.48726331438, 1.77731617297)>
 
 .. _astropy-skycoord-representations:
 
@@ -487,23 +495,28 @@ supplying the corresponding components for that representation::
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
     >>> c
-    <SkyCoord (ICRS): x=1.0 kpc, y=2.0 kpc, z=3.0 kpc>
+    <SkyCoord (ICRS): (x, y, z) in kpc
+        (1.0, 2.0, 3.0)>
     >>> c.x, c.y, c.z
     (<Quantity 1.0 kpc>, <Quantity 2.0 kpc>, <Quantity 3.0 kpc>)
 
 Other variations include::
 
     >>> SkyCoord(1, 2*u.deg, 3, representation='cylindrical')
-    <SkyCoord (ICRS): rho=1.0, phi=2.0 deg, z=3.0>
+    <SkyCoord (ICRS): (rho, phi, z) in (, deg, )
+        (1.0, 2.0, 3.0)>
 
     >>> SkyCoord(rho=1*u.km, phi=2*u.deg, z=3*u.m, representation='cylindrical')
-    <SkyCoord (ICRS): rho=1.0 km, phi=2.0 deg, z=3.0 m>
+    <SkyCoord (ICRS): (rho, phi, z) in (km, deg, m)
+        (1.0, 2.0, 3.0)>
 
     >>> SkyCoord(rho=1, phi=2, z=3, unit=(u.km, u.deg, u.m), representation='cylindrical')
-    <SkyCoord (ICRS): rho=1.0 km, phi=2.0 deg, z=3.0 m>
+    <SkyCoord (ICRS): (rho, phi, z) in (km, deg, m)
+        (1.0, 2.0, 3.0)>
 
     >>> SkyCoord(1, 2, 3, unit=(None, u.deg, None), representation='cylindrical')
-    <SkyCoord (ICRS): rho=1.0, phi=2.0 deg, z=3.0>
+    <SkyCoord (ICRS): (rho, phi, z) in (, deg, )
+        (1.0, 2.0, 3.0)>
 
 In general terms, the allowed syntax is as follows::
 
@@ -647,11 +660,13 @@ in 3d space.
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
     >>> c
-    <SkyCoord (ICRS): x=1.0 kpc, y=2.0 kpc, z=3.0 kpc>
+    <SkyCoord (ICRS): (x, y, z) in kpc
+        (1.0, 2.0, 3.0)>
 
     >>> c.representation = 'cylindrical'
     >>> c  # doctest: +FLOAT_CMP
-    <SkyCoord (ICRS): rho=2.2360679775 kpc, phi=63.4349488229 deg, z=3.0 kpc>
+    <SkyCoord (ICRS): (rho, phi, z) in (kpc, deg, kpc)
+        (2.2360679775, 63.4349488229, 3.0)>
     >>> c.phi.to(u.deg)  # doctest: +FLOAT_CMP
     <Angle 63.43494882292201 deg>
     >>> c.x  # doctest: +SKIP
@@ -660,11 +675,13 @@ in 3d space.
 
     >>> c.representation = 'spherical'
     >>> c  # doctest: +FLOAT_CMP
-    <SkyCoord (ICRS): ra=63.4349488229 deg, dec=53.3007747995 deg, distance=3.74165738677 kpc>
+    <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
+        (63.4349488229, 53.3007747995, 3.74165738677)>
 
     >>> c.representation = 'unitspherical'
     >>> c  # doctest: +FLOAT_CMP
-    <SkyCoord (ICRS): ra=63.4349488229 deg, dec=53.3007747995 deg>
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (63.4349488229, 53.3007747995)>
 
 You can also use any representation class to set the representation::
 
@@ -678,7 +695,8 @@ state of the |SkyCoord| object, you should instead use the
     >>> c.representation = 'spherical'
     >>> cart = c.represent_as(CartesianRepresentation)
     >>> cart
-    <CartesianRepresentation x=1.0 kpc, y=2.0 kpc, z=3.0 kpc>
+    <CartesianRepresentation (x, y, z) in kpc
+        (1.0, 2.0, 3.0)>
     >>> c.representation
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
 

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -23,7 +23,8 @@ The simplest method of transformation is shown below::
     >>> from astropy.coordinates import SkyCoord
     >>> gc = SkyCoord(l=0*u.degree, b=45*u.degree, frame='galactic')
     >>> gc.fk5  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J2000.000): ra=229.272514629 deg, dec=-1.12844288043 deg>
+    <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+        (229.272514629, -1.12844288043)>
 
 While this appears to be simple attribute-style access, it is actually
 syntactic sugar for the more general
@@ -32,11 +33,14 @@ accept either a frame name, class or instance::
 
     >>> from astropy.coordinates import FK5
     >>> gc.transform_to('fk5')  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J2000.000): ra=229.272514629 deg, dec=-1.12844288043 deg>
+    <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+        (229.272514629, -1.12844288043)>
     >>> gc.transform_to(FK5)  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J2000.000): ra=229.272514629 deg, dec=-1.12844288043 deg>
+    <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+        (229.272514629, -1.12844288043)>
     >>> gc.transform_to(FK5(equinox='J1980.0'))  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J1980.000): ra=229.014693505 deg, dec=-1.05560349378 deg>
+    <SkyCoord (FK5: equinox=J1980.000): (ra, dec) in deg
+        (229.014693505, -1.05560349378)>
 
 As a convenience it is also possible to use a |SkyCoord| object as the frame in
 :meth:`~astropy.coordinates.SkyCoord.transform_to`.  This allows easily putting one
@@ -44,7 +48,8 @@ coordinate object into the frame of another::
 
     >>> sc = SkyCoord(ra=1.0, dec=2.0, unit='deg', frame=FK5, equinox='J1980.0')
     >>> gc.transform_to(sc)  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J1980.000): ra=229.014693505 deg, dec=-1.05560349378 deg>
+    <SkyCoord (FK5: equinox=J1980.000): (ra, dec) in deg
+        (229.014693505, -1.05560349378)>
 
 
 Additionally, some coordinate frames (including `~astropy.coordinates.FK5`,
@@ -59,10 +64,12 @@ frames use a default equinox if you don't specify one::
     >>> fk5c.equinox
     <Time object: scale='utc' format='jyear_str' value=J2000.000>
     >>> fk5c  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J2000.000): ra=37.9545416667 deg, dec=89.2641111111 deg>
+    <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+        (37.9545416667, 89.2641111111)>
     >>> fk5_2005 = FK5(equinox='J2005')  # String initializes an astropy.time.Time object
     >>> fk5c.transform_to(fk5_2005)  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=J2005.000): ra=39.3931763878 deg, dec=89.2858442155 deg>
+    <SkyCoord (FK5: equinox=J2005.000): (ra, dec) in deg
+        (39.3931763878, 89.2858442155)>
 
 You can also specify the equinox when you create a coordinate using an
 `~astropy.time.Time` object::
@@ -72,7 +79,8 @@ You can also specify the equinox when you create a coordinate using an
     ...            equinox=Time('J1970', scale='utc'))
     >>> fk5_2000 = FK5(equinox=Time(2000, format='jyear', scale='utc'))
     >>> fk5c.transform_to(fk5_2000)  # doctest: +FLOAT_CMP
-    <SkyCoord (FK5: equinox=2000.0): ra=48.0231710002 deg, dec=89.386724854 deg>
+    <SkyCoord (FK5: equinox=2000.0): (ra, dec) in deg
+        (48.0231710002, 89.386724854)>
 
 The same lower-level frame classes also have a
 :meth:`~astropy.coordinates.BaseCoordinateFrame.transform_to` method

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -30,7 +30,8 @@ specific sub-packages, for example::
     >>> from astropy import units as u
     >>> from astropy import coordinates as coord
     >>> coord.SkyCoord(ra=10.68458*u.deg, dec=41.26917*u.deg, frame='icrs')
-    <SkyCoord (ICRS): ra=10.68458 deg, dec=41.26917 deg>
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (10.68458, 41.26917)>
 
 Finally, in some cases, most of the required functionality is contained in a
 single class (or a few classes). In those cases, the class can be directly


### PR DESCRIPTION
This is a fix based on #3298 -- I had to add some subtle numpy `array2string()` hacks, so we may want to keep an eye on this if numpy/numpy#5463 gets replies.

The new behavior is:

    >>> coord.SkyCoord(ra=13.5135*u.hourangle, dec=-10.4124*u.degree)
    <SkyCoord (ICRS): (ra, dec) in deg
        (202.7025, -10.4124)>