### PR TITLE
Fix issue with logger due to iteration over sys.modules.items()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -483,6 +483,11 @@ Bug Fixes
 
 - ``astropy.io.votable``
 
+- ``astropy.logger``
+
+  - Fix a bug that occured when displaying warnings that produced an error
+    message ``dictionary changed size during iteration``. [#3353]
+
 - ``astropy.modeling``
 
 - ``astropy.nddata``

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -200,7 +200,7 @@ class AstropyLogger(Logger):
         mod_name = None
         if PY3:
             mod_path, ext = os.path.splitext(mod_path)
-            for name, mod in sys.modules.items():
+            for name, mod in list(sys.modules.items()):
                 try:
                     # Believe it or not this can fail in some cases:
                     # https://github.com/astropy/astropy/issues/2671
@@ -211,7 +211,7 @@ class AstropyLogger(Logger):
                     mod_name = mod.__name__
                     break
         else:  # pragma: py2
-            for name, mod in sys.modules.items():
+            for name, mod in list(sys.modules.items()):
                 try:
                     if getattr(mod, '__file__', '') == mod_path:
                         mod_name = mod.__name__


### PR DESCRIPTION
In rare cases the iteration over sys.modules.items() can fail with the error:

```
dictionary changed size during iteration
```

so we take a copy to avoid this. This is the same error as happened in this package:

https://bitbucket.org/cherrypy/cherrypy/issue/1280/autoreloader-throws-dictionary-changed

If there are no objections, I will merge by Monday to make sure it gets into 1.0.