### PR TITLE
Unit test fail:  test_backend_parsers in test_html.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         # We also note the code coverage on Python 2.7.
         - python: 2.7
           env: SETUP_CMD='test --coverage'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
-        - python: 3.3
+        - python: 3.4
           env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
 
         # Try older numpy versions

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -9,6 +9,9 @@ must be installed to read HTML tables.
 """
 
 from __future__ import absolute_import, division, print_function
+
+import warnings
+
 from ...extern import six
 from ...extern.six.moves import zip as izip
 
@@ -78,7 +81,14 @@ class HTMLInputter(core.BaseInputter):
         """
 
         try:
-            from bs4 import BeautifulSoup
+            from bs4 import BeautifulSoup as _BeautifulSoup
+            # With Python 3.4, BeautifulSoup emits deprecation warnings over
+            # which we have no control so we wrap it.
+            class BeautifulSoup(_BeautifulSoup):
+                def __init__(self, *args, **kwargs):
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", DeprecationWarning)
+                        return super(BeautifulSoup, self).__init__(*args, **kwargs)
         except ImportError:
             raise core.OptionalTableImportError('BeautifulSoup must be '
                                         'installed to read HTML tables')


### PR DESCRIPTION
The `test_backend_parsers` unit test in `test_html.py` is failing with Python 3 and BeautifulSoup 4.3.2 on Mac.

Here's the full traceback: https://gist.github.com/cdeil/8130ee7b47a3f2a88c4b

This issue was first seen by @mwcraig on Windows and mentioned here:
https://github.com/astropy/astropy/pull/2755#issuecomment-52585216

@taldcroft Maybe simply skip this test for now on all platforms and deal with it later?