### PR TITLE
Fixes some SphericalRepresentation handling to allow subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,8 @@ New Features
 
 - ``astropy.units``
 
+  - Support for subclasses of UnitSphericalRepresentation has been improved [#3354]
+
   - Support for VOUnit has been updated to be compliant with version
     1.0 of the standard. [#2901]
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -589,7 +589,7 @@ class BaseCoordinateFrame(object):
             if repr_kwargs:
                 if repr_kwargs.get('distance', True) is None:
                     del repr_kwargs['distance']
-                if (self.representation == SphericalRepresentation and
+                if (issubclass(self.representation, SphericalRepresentation) and
                         'distance' not in repr_kwargs):
                     representation_data = UnitSphericalRepresentation(**repr_kwargs)
                 else:
@@ -985,9 +985,9 @@ class BaseCoordinateFrame(object):
 
         if self.has_data:
             if self.representation:
-                if (self.representation == SphericalRepresentation and
-                        isinstance(self.data, UnitSphericalRepresentation)):
-                    data = self.represent_as(UnitSphericalRepresentation,
+                if (issubclass(self.representation, SphericalRepresentation) and
+                    isinstance(self.data, UnitSphericalRepresentation)):
+                    data = self.represent_as(self.data.__class__,
                                              in_frame_units=True)
                 else:
                     data = self.represent_as(self.representation,


### PR DESCRIPTION
This allows subclasses of `SphericalRepresentation` to be detected as such and handled correctly. There may be other instances of this, these are just the ones that were causing me issues.