### PR TITLE
Fix #3356: Accept unicode strings to wcs.sub on Python 2.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -546,6 +546,8 @@ Bug Fixes
 
 - ``astropy.wcs``
 
+  - ``astropy.wcs.WCS.sub`` now accepts unicode strings as input on
+    Python 2.x [#3356]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1733,9 +1733,7 @@ PyWcsprm_sub(
   PyObject*  py_axes        = NULL;
   PyWcsprm*  py_dest_wcs    = NULL;
   PyObject*  element        = NULL;
-  #if PY3K
   PyObject*  element_utf8   = NULL;
-  #endif
   char*      element_str    = NULL;
   int        element_val    = 0;
   int        nsub           = 0;
@@ -1770,19 +1768,19 @@ PyWcsprm_sub(
         goto exit;
       }
 
-      #if PY3K
-      if (PyUnicode_Check(element)) {
-        element_utf8 = PyUnicode_AsUTF8String(element);
-        if (element_utf8 == NULL) {
-          goto exit;
+      if (PyUnicode_Check(element) || PyBytes_Check(element)) {
+        if (PyUnicode_Check(element)) {
+          element_utf8 = PyUnicode_AsUTF8String(element);
+          if (element_utf8 == NULL) {
+            goto exit;
+          }
+
+          element_str = PyBytes_AsString(element_utf8);
+          Py_DECREF(element_utf8); element_utf8 = NULL;
+        } else if (PyBytes_Check(element)) {
+          element_str = PyBytes_AsString(element);
         }
-        element_str = PyBytes_AsString(element_utf8);
-        Py_DECREF(element_utf8); element_utf8 = NULL;
-      #else
-      if (PyString_Check(element)) {
-        /* Doesn't return NULL, because we already known it's a string */
-        element_str = PyString_AsString(element);
-      #endif
+
         if (strncmp(element_str, "longitude", 10) == 0) {
           element_val = WCSSUB_LONGITUDE;
         } else if (strncmp(element_str, "latitude", 9) == 0) {

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -753,6 +753,15 @@ def test_wcs_sub_error_message():
     assert str(e).endswith("axes must None, a sequence or an integer")
 
 
+def test_wcs_sub():
+    # Issue #3356
+    w = _wcs.Wcsprm()
+    w.sub(['latitude'])
+
+    w = _wcs.Wcsprm()
+    w.sub([b'latitude'])
+
+
 def test_compare():
     header = get_pkg_data_contents('data/3d_cd.hdr', encoding='binary')
     w = _wcs.Wcsprm(header)


### PR DESCRIPTION
Fixes #3356 