### PR TITLE
Better handling of inputs to Mapping models

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2155,7 +2155,6 @@ def _prepare_inputs_single_model(model, params, inputs, **kwargs):
     broadcasts = []
 
     for idx, _input in enumerate(inputs):
-        _input = np.asanyarray(_input, dtype=np.float)
         input_shape = _input.shape
 
         if not params:
@@ -2233,8 +2232,6 @@ def _prepare_inputs_model_set(model, params, inputs, n_models, model_set_axis,
     pivots = []
 
     for idx, _input in enumerate(inputs):
-        _input = np.asanyarray(_input, dtype=np.float)
-
         max_param_shape = ()
 
         if n_models > 1 and model_set_axis is not False:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -768,16 +768,6 @@ class Model(object):
         params = [getattr(self, name) for name in self.param_names]
         inputs = [np.asanyarray(_input, dtype=float) for _input in inputs]
 
-        scalar_params = all(not param.shape for param in params)
-        scalar_inputs = all(not np.shape(_input) for _input in inputs)
-
-        if n_models == 1 and scalar_params and scalar_inputs:
-            # Simplest case is either a parameterless models (currently I don't
-            # think we have any but they could exist in principle) or a single
-            # model (not a model set) with all scalar parameters and all scalar
-            # inputs
-            return inputs, ()
-
         _validate_input_shapes(inputs, self.inputs, n_models,
                                model_set_axis, self.standard_broadcasting)
 
@@ -2157,6 +2147,12 @@ def _prepare_inputs_single_model(model, params, inputs, **kwargs):
     for idx, _input in enumerate(inputs):
         input_shape = _input.shape
 
+        # Ensure that array scalars are always upgrade to 1-D arrays for the
+        # sake of consistency with how parameters work.  They will be cast back
+        # to scalars at the end
+        if not input_shape:
+            inputs[idx] = _input.reshape((1,))
+
         if not params:
             max_broadcast = input_shape
         else:
@@ -2200,13 +2196,6 @@ def _prepare_inputs_single_model(model, params, inputs, **kwargs):
 
 
 def _prepare_outputs_single_model(model, outputs, format_info):
-    if not format_info:
-        # This is the shortcut for models with all scalar inputs/parameters
-        if model.n_outputs == 1:
-            return np.asscalar(outputs[0])
-        else:
-            return tuple(np.asscalar(output) for output in outputs)
-
     broadcasts = format_info[0]
 
     outputs = list(outputs)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -530,6 +530,27 @@ def test_mapping_inverse():
     assert_allclose((0, 1, 2), m.inverse(*m(0, 1, 2)), atol=1e-08)
 
 
+def test_identity_input():
+    """
+    Test a case where an Identity (or Mapping) model is the first in a chain
+    of composite models and thus is responsible for handling input broadcasting
+    properly.
+
+    Regression test for https://github.com/astropy/astropy/pull/3362
+    """
+
+    ident1 = Identity(1)
+    shift = Shift(1)
+    rotation = Rotation2D(angle=90)
+    model = ident1 & shift | rotation
+    assert_allclose(model(1, 2), [-3.0, 1.0])
+
+    # Same test case but using class composition
+    TestModel = ident1 & Shift | Rotation2D
+    model = TestModel(offset_1=1, angle_2=90)
+    assert_allclose(model(1, 2), [-3.0, 1.0])
+
+
 def test_slicing_on_instances_2():
     """
     More slicing tests.


### PR DESCRIPTION
This introduces a workaround to the issue raised by @nden in [this comment](https://github.com/astropy/astropy/pull/3297#issuecomment-70105705)

I'm not super happy about it since it introduces a (very slight, on the order of a few milliseconds) performance regression on evaluated models with a scalar input.  This isn't that critical since it's not something that scales with the size of the input.

What bothers me more is that this fix is for compatibility with an undocumented, sort of unintentional assumption that all `Model.evaluate()` implementations will return one or more array of at least 1 dimension, even for simple arithmetic expressions involving all scalars (this is because the framework already promotes all scalar parameters to 1-D arrays before passing them to `evaluate`).  I think the current assumptions are fairly reasonable, but they're not universal (clearly, as the `Mapping` class broke this assumption), and it's all still a little confusing.  This explanation probably doesn't even make sense to anyone but me, which is cause for concern in of itself.