### PR TITLE
Modeling documentation updates

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1307,8 +1307,10 @@ class FittableModel(Model):
     # derivative with respect to parameters
     fit_deriv = None
     """
-    Function (similar to the model's ``eval``) to compute the derivatives of
-    the model with respect to its parameters, for use by fitting algorithms.
+    Function (similar to the model's `~Model.evaluate`) to compute the
+    derivatives of the model with respect to its parameters, for use by fitting
+    algorithms.  In other words, this computes the Jacobian matrix with respect
+    to the model's parameters.
     """
     # Flag that indicates if the model derivatives with respect to parameters
     # are given in columns or rows

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -22,13 +22,14 @@ The goal is to eventually provide a rich toolset of models and fitters such
 that most users will not need to define new model classes, nor special purpose
 fitting routines (while making it reasonably easy to do when necessary).
 
-.. warning::
+.. note::
 
     `astropy.modeling` is currently a work-in-progress, and thus it is likely
-    there will still be API changes in later versions of Astropy, though
-    backwards compatibility support between versions will still be maintained
-    as much as possible. If you have specific ideas for how it might be
-    improved, feel free to let us know on the `astropy-dev mailing list`_ or at
+    there will still be API changes in later versions of Astropy.  Backwards
+    compatibility support between versions will still be maintained as much as
+    possible, but new features and enhancements are coming in future versions.
+    If you have specific ideas for how it might be improved, feel free to let
+    us know on the `astropy-dev mailing list`_ or at
     http://feedback.astropy.org
 
 

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -1,4 +1,5 @@
 .. include:: links.inc
+.. _modeling-instantiating:
 
 ***********************************
 Instantiating and Evaluating Models
@@ -63,6 +64,7 @@ error::
     with parameter 'stddev' of shape (3,).  All parameter arrays must have
     shapes that are mutually compatible according to the broadcasting rules.
 
+.. _modeling-model-sets:
 
 Model Sets
 ==========

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -229,6 +229,13 @@ Full example
 A full example of a LineModel
 -----------------------------
 
+This example demonstrates one other optional feature for model classes, which
+is an *inverse*.  An `~astropy.modeling.Model.inverse` implementation should be
+a `property` that returns a new model instance (not necessarily of the same
+class as the model being inverted) that computes the inverse of that model, so
+that for some model instance with an inverse, ``model.inverse(model(*input)) ==
+input``.
+
 .. code-block:: python
 
     from astropy.modeling import FittableModel, Parameter
@@ -248,6 +255,12 @@ A full example of a LineModel
             d_slope = x
             d_intercept = np.ones_like(x)
             return [d_slope, d_intercept]
+
+        @property
+        def inverse(self):
+            new_slope = self.slope ** -1
+            new_intercept = -self.intercept / self.slope
+            return LineModel(slope=new_slope, intercept=new_intercept)
 
 
 Defining New Fitter Classes

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -1,3 +1,5 @@
+.. _modeling-new-classes:
+
 Defining New Model Classes
 ==========================
 

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -149,7 +149,38 @@ For full details including extensive performance testing, see :ref:`fast_ascii_i
 New features in :ref:`astropy-modeling`
 ---------------------------------------
 
-.. Compound models and other changes
+New subclasses of `~astropy.modeling.Model` are now a bit easier to define,
+requiring less boilerplate code in general.  Now all that is necessary to
+define a new model class is an `~astropy.modeling.Model.evaluate` method that
+computes the model.  Optionally one can define :ref:`fittable parameters
+<modeling-parameters>`, a `~astropy.modeling.FittableModel.fit_deriv`, and/or
+an `~astropy.modeling.Model.inverse`.  The new, improved
+`~astropy.modeling.custom_model` decorator reduces to boilerplate needed for
+many models even more.  See :ref:`modeling-new-classes` for more details.
+
+Array broadcasting has also been improved, enabling a broader range of
+possibilities for the values of model parameters and inputs.  Support has also
+been improved for :ref:`modeling-model-sets` (previously referred to as
+parameter sets) which can be thought of like an array of models of the same
+class, each with different sets of parameters, which can be fitted
+simultaneously either to the same data, or to different data sets per model.
+See :ref:`modeling-instantiating` for more details.
+
+It is now possible to create *compound* models by combining existing models
+using the standard arithmetic operators such as ``+`` and ``*``, as well as
+functional composition using the ``|`` operator.  This provides a powerful
+and flexible new way to create more complex models without having to define
+any special classes or functions.  For example::
+
+    >>> from astropy.modeling.models import Gaussian1D
+    >>> gaussian1 = Gaussian1D(1, 0, 0.2)
+    >>> gaussian2 = Gaussian1D(2.5, 0.5, 0.1)
+    >>> sum_of_gaussians = gaussian1 + gaussian2
+
+The resulting model works like any other model, and also works with the
+fitting framework.  See the
+:ref:`introduction to compound models <compound-models-intro>` and full
+:ref:`compound models documentation <compound-models>` for more examples.
 
 Support for 'mixin' columns in :ref:`astropy-table`
 ---------------------------------------------------


### PR DESCRIPTION
Add's a "What's New" for the modeling package for 1.0, per #2935.  I feel like this could use more examples, but I didn't want it to drag on too long either--it already takes up about as much vertical space as the other sections on that page.

Also addresses #3336, and a few other things I found while working on this.