### PR TITLE
Skip test for #3122 on Windows

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -947,12 +947,15 @@ class TestFileFunctions(FitsTestCase):
 
         self._test_write_string_bytes_io(io.BytesIO())
 
+    @pytest.mark.skipif(str('sys.platform.startswith("win32")'))
     def test_filename_with_colon(self):
         """
         Test reading and writing a file with a colon in the filename.
 
         Regression test for https://github.com/astropy/astropy/issues/3122
         """
+
+        # Skip on Windows since colons in filenames makes NTFS sad.
 
         filename = 'APEXHET.2014-04-01T15:18:01.000.fits'
         hdu = fits.PrimaryHDU(data=np.arange(10))


### PR DESCRIPTION
When I manually merged the fix for #3122 I failed to make sure it got tested on Windows, and now AppVeyor builds are broken.  This test should just be skipped on Windows, where a colon in a filename is not likely to happen (and even when it does it will be on a filesystem that supports that, and none of the code on our end cares what the underlying filesystem supports).