### PR TITLE
Unexpected iterating behaviour from Tables in loops within loops

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -538,6 +538,8 @@ Bug Fixes
   - Fixed a problem where ``table.vstack`` and ``table.hstack`` failed to stack
     a single table, e.g. ``table.vstack([t])``. [#3313]
 
+  - Fix a problem when doing nested iterators on a single table. [#3358]
+
 - ``astropy.time``
 
   - When creating a Time object from a datetime object the time zone

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -36,6 +36,11 @@ class Row(object):
         self._table = table
         self._index = index
 
+        n = len(table)
+        if index < -n or index >= n:
+            raise IndexError('index {0} out of range for table with length {1}'
+                             .format(index, len(table)))
+
     def __getitem__(self, item):
         return self._table.columns[item][self._index]
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -953,23 +953,6 @@ class Table(object):
         elif isinstance(item, tuple):
             self.remove_columns(item)
 
-    def __iter__(self):
-        self._iter_index = 0
-        self._len = len(self)
-        return self
-
-    def __next__(self):
-        """Python 3 iterator"""
-        if self._iter_index < self._len:
-            val = self.Row(self, self._iter_index)
-            self._iter_index += 1
-            return val
-        else:
-            raise StopIteration
-
-    if six.PY2:
-        next = __next__
-
     def field(self, item):
         """Return column[item] for recarray compatibility."""
         return self.columns[item]

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -200,3 +200,10 @@ class TestRow():
         else:
             assert t[0].as_void()[0] == {'a': 1}
             assert t[0].as_void()['a'] == {'a': 1}
+
+    def test_bounds_checking(self, table_types):
+        """Row gives index error upon creation for out-of-bounds index"""
+        self._setup(table_types)
+        for ibad in (-5, -4, 3, 4):
+            with pytest.raises(IndexError):
+                self.t[ibad]

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1353,3 +1353,14 @@ def test_table_deletion():
     gc.collect()
 
     assert the_id in deleted
+
+def test_nested_iteration():
+    """
+    Regression test for issue 3358 where nested iteration over a single table fails.
+    """
+    t = table.Table([[0, 1]], names=['a'])
+    out = []
+    for r1 in t:
+        for r2 in t:
+            out.append((r1['a'], r2['a']))
+    assert out == [(0, 0), (0, 1), (1, 0), (1, 1)]


### PR DESCRIPTION
Hi,

I am not sure if this is a bug, but it seemed counter-intuitive to me. When I iterate over the rows in an `astropy.table.Table` in a sub-loop, the outer loop breaks after just a single iteration. If I create a copy of the table in the sub-loop, then the outer loop does not break and the code works as expected. I do not observe this behaviour if the same data is in a numpy array.

Here is example code that replicates the behaviour. The output is below.

````
import numpy as np
from astropy.table import Table

stars_as_table = Table(np.arange(60).reshape(3, 20))
stars_as_array = np.arange(60).reshape(3, 20)

stars_in_different_formats = (stars_as_table, stars_as_array)
descriptions = ("astropy.table.Table", "numpy array")
for stars, description in zip(stars_in_different_formats, descriptions):

    # Unexpected behaviour with astropy.table.Table:
    for i, star_i in enumerate(stars):
        for j, star_j in enumerate(stars):
            #print("in i, j = {0}, {1}".format(i, j))
            continue

    print("Using {0} (no copy), i looped to {1}".format(description, i))

    # Works with both astropy.table.Table and numpy array:
    for i, star_i in enumerate(stars):
        for j, star_j in enumerate(stars.copy()):
            #print("in i, j = {0}, {1}".format(i, j))
            continue

    print("Using {0} (with sub-copy), i looped to {1}".format(description, i))
```

On my OSX 10.10.1 with Python 2.7.6 (64bit; IPython 2.3.1), numpy 1.9.0, and Astropy 0.4.1 this yields:
```
Using astropy.table.Table (no copy), i looped to 0
Using astropy.table.Table (with sub-copy), i looped to 2
Using numpy array (no copy), i looped to 2
Using numpy array (with sub-copy), i looped to 2
````

Note that when an `astropy.table.Table` is used and no ``.copy()`` is made , the sub-loop is run once, and then the outer loop breaks. Is this a bug?

Cheers,
Andy