### PR TITLE
Add APE-6 references to io.ascii docs

### DIFF
--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -403,7 +403,10 @@ class Ecsv(basic.Basic):
     """
     Read a file which conforms to the ECSV (Enhanced Character Separated
     Values) format.  This format allows for specification of key table
-    and column meta-data, in particular the data type and unit.  For example::
+    and column meta-data, in particular the data type and unit.  For details
+    see: https://github.com/astropy/astropy-APEs/blob/master/APE6.rst.
+
+    For example::
 
       # %ECSV 0.9
       # ---

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -20,7 +20,7 @@ The following shows a few of the ASCII formats that are available, while the sec
 * :class:`~astropy.io.ascii.Basic`: basic table with customizable delimiters and header configurations
 * :class:`~astropy.io.ascii.Cds`: `CDS format table <http://vizier.u-strasbg.fr/doc/catstd.htx>`_ (also Vizier and ApJ machine readable tables)
 * :class:`~astropy.io.ascii.Daophot`: table from the IRAF DAOphot package
-* :class:`~astropy.io.ascii.Ecsv`: Enhanced CSV format
+* :class:`~astropy.io.ascii.Ecsv`: `Enhanced CSV format <https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_
 * :class:`~astropy.io.ascii.FixedWidth`: table with fixed-width columns (see also :ref:`fixed_width_gallery`)
 * :class:`~astropy.io.ascii.Ipac`: `IPAC format table <http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html>`_
 * :class:`~astropy.io.ascii.HTML`: HTML format table contained in a <table> tag
@@ -137,9 +137,10 @@ To disable this engine, use the parameter ``fast_writer``::
 
    >>> ascii.write(data, 'values.csv', format='csv', fast_writer=False)  # doctest: +SKIP
 
-Finally, one can write data in the ECSV table format which allows preserving
-table meta-data such as column data types and units.  In this way a data table
-can be stored and read back as ASCII with no loss of information.
+Finally, one can write data in the `ECSV table format
+<https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ which allows
+preserving table meta-data such as column data types and units.  In this way a
+data table can be stored and read back as ASCII with no loss of information.
 
   >>> t = Table()
   >>> t['x'] = Column([1.0, 2.0], unit='m', dtype='float32')


### PR DESCRIPTION
As a quick follow-on to #2319 this puts in a few links to the accepted APE-6 document.