### PR TITLE
Update astropy.io.ascii docs to use Numpydoc format

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -235,16 +235,24 @@ class Csv(Basic):
     data_class = CsvData
 
     def inconsistent_handler(self, str_vals, ncols):
-        '''Adjust row if it is too short.
+        '''
+        Adjust row if it is too short.
 
         If a data row is shorter than the header, add empty values to make it the
         right length.
         Note that this will *not* be called if the row already matches the header.
 
-        :param str_vals: A list of value strings from the current row of the table.
-        :param ncols: The expected number of entries from the table header.
-        :returns:
-            list of strings to be parsed into data entries in the output table.
+        Parameters
+        ----------
+        str_vals : list
+            A list of value strings from the current row of the table.
+        ncols : int
+            The expected number of entries from the table header.
+
+        Returns
+        -------
+        str_vals : list
+            List of strings to be parsed into data entries in the output table.
         '''
         if len(str_vals) < ncols:
             str_vals.extend((ncols - len(str_vals)) * [''])

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -42,12 +42,17 @@ class CdsHeader(core.BaseHeader):
 
 
     def get_cols(self, lines):
-        """Initialize the header Column objects from the table ``lines`` for a CDS
+        """
+        Initialize the header Column objects from the table ``lines`` for a CDS
         header.
 
-        :param lines: list of table lines
-        :returns: list of table Columns
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
+
         # Read header block for the table ``self.data.table_name`` from the read
         # me file ``self.readme``.
         if self.readme and self.data.table_name:

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -153,22 +153,24 @@ class Column(object):
 
 class BaseInputter(object):
     """
-    Get the lines from the table input and return a list of lines.  The input
-    table can be one of:
+    Get the lines from the table input and return a list of lines.
 
-    * File name
-    * String (newline separated) with all header and data lines (must have at least 2 lines)
-    * File-like object with read() method
-    * List of strings
     """
     def get_lines(self, table):
         """
-        Get the lines from the ``table`` input.
+        Get the lines from the ``table`` input. The input table can be one of:
+
+        * File name
+        * String (newline separated) with all header and data lines (must have at least 2 lines)
+        * File-like object with read() method
+        * List of strings
 
         Parameters
         ----------
-        table : `~astropy.table.Table`
-            Table input
+        table : str, file_like, list
+            Can be either a file name, string (newline separated) with all header and data
+            lines (must have at least 2 lines), a file-like object with a ``read()`` method,
+            or a list of strings.
 
         Returns
         -------

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -512,7 +512,7 @@ class BaseHeader(object):
         strict_names : bool
             Whether to impose extra requirements on names
         guessing : bool
-            TODO: ?
+            True if this method is being called while guessing the table format
         """
         if strict_names:
             # Impose strict requirements on column names (normally used in guessing)
@@ -879,7 +879,7 @@ def _apply_include_exclude_names(table, names, include_names, exclude_names):
 
     Parameters
     ----------
-    table : `~astropy.io.ascii.BaseReader`, array_like
+    table : `~astropy.table.Table`
         Input table
     names : list
         List of names to override those in table (set to None to use existing names)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -162,10 +162,18 @@ class BaseInputter(object):
     * List of strings
     """
     def get_lines(self, table):
-        """Get the lines from the ``table`` input.
+        """
+        Get the lines from the ``table`` input.
 
-        :param table: table input
-        :returns: list of lines
+        Parameters
+        ----------
+        table : `~astropy.table.Table`
+            Table input
+
+        Returns
+        -------
+        lines : list
+            List of lines
         """
         try:
             if (hasattr(table, 'read') or
@@ -200,7 +208,8 @@ class BaseInputter(object):
 
 
 class BaseSplitter(object):
-    """Base splitter that uses python's split method to do the work.
+    """
+    Base splitter that uses python's split method to do the work.
 
     This does not handle quoted values.  A key feature is the formulation of
     __call__ as a generator that returns a list of the split line values at
@@ -216,6 +225,7 @@ class BaseSplitter(object):
       reader.header.splitter.process_val = lambda x: x.lstrip()
       reader.data.splitter.process_val = None
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param delimiter: one-character string used to separate fields
     """
     delimiter = None
@@ -259,6 +269,7 @@ class DefaultSplitter(BaseSplitter):
           for col_val in col_vals:
                ...
 
+    # TODO: not sure what to do here because these are optional, class-level attributes...
     :param delimiter: one-character string used to separate fields.
     :param doublequote:  control how instances of *quotechar* in a field are quoted
     :param escapechar: character to remove special meaning from following character
@@ -289,8 +300,15 @@ class DefaultSplitter(BaseSplitter):
         """Return an iterator over the table ``lines``, where each iterator output
         is a list of the split line values.
 
-        :param lines: list of table lines
-        :returns: iterator
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
+        Returns
+        -------
+        lines : iterator
+
         """
         if self.process_line:
             lines = [self.process_line(x) for x in lines]
@@ -378,6 +396,7 @@ def _get_line_index(line_or_func, lines):
 class BaseHeader(object):
     """Base table header reader
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param auto_format: format string for auto-generating column names
     :param start_line: None, int, or a function of ``lines`` that returns None or int
     :param comment: regular expression for comment lines
@@ -420,8 +439,11 @@ class BaseHeader(object):
         Based on the previously set Header attributes find or create the column names.
         Sets ``self.cols`` with the list of Columns.
 
-        :param lines: list of table lines
-        :returns: None
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
 
         start_line = _get_line_index(self.start_line, self.process_lines(lines))
@@ -486,15 +508,22 @@ class BaseHeader(object):
                 col.raw_type, col.name))
 
     def check_column_names(self, names, strict_names, guessing):
-        """Check column names.
+        """
+        Check column names.
 
         This must be done before applying the names transformation
-        so that guessing will fail appropriately if `names` is supplied.
+        so that guessing will fail appropriately if ``names`` is supplied.
         For instance if the basic reader is given a table with no column header
         row.
 
-        :param names: user-supplied list of column names
-        :param strict_names: whether to impose extra requirements on names
+        Parameters
+        ----------
+        names : list
+            User-supplied list of column names
+        strict_names : bool
+            Whether to impose extra requirements on names
+        guessing : bool
+            TODO: ?
         """
         if strict_names:
             # Impose strict requirements on column names (normally used in guessing)
@@ -518,6 +547,7 @@ class BaseHeader(object):
 class BaseData(object):
     """Base table data reader.
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param start_line: None, int, or a function of ``lines`` that returns None or int
     :param end_line: None, int, or a function of ``lines`` that returns None or int
     :param comment: Regular expression for comment lines
@@ -544,10 +574,19 @@ class BaseData(object):
         self.splitter = self.splitter_class()
 
     def process_lines(self, lines):
-        """Strip out comment lines and blank lines from list of ``lines``
+        """
+        Strip out comment lines and blank lines from list of ``lines``
 
-        :param lines: all lines in table
-        :returns: list of lines
+        Parameters
+        ----------
+        lines : list
+            All lines in table
+
+        Returns
+        -------
+        lines : list
+            List of lines
+
         """
         nonblank_lines = (x for x in lines if x.strip())
         if self.comment:
@@ -851,12 +890,20 @@ def _is_number(x):
     return False
 
 def _apply_include_exclude_names(table, names, include_names, exclude_names):
-    """Apply names, include_names and exclude_names to a table.
+    """
+    Apply names, include_names and exclude_names to a table.
 
-    :param table: input table (Reader object, NumPy struct array, list of lists, etc)
-    :param names: list of names to override those in table (default=None uses existing names)
-    :param include_names: list of names to include in output (default=None selects all names)
-    :param exclude_names: list of names to exclude from output (applied after ``include_names``)
+    Parameters
+    ----------
+    table : `~astropy.io.ascii.BaseReader`, array_like
+        Input table
+    names : list
+        List of names to override those in table (set to None to use existing names)
+    include_names : list
+        List of names to include in output
+    exclude_names: list
+        List of names to exclude from output (applied after ``include_names``)
+
     """
 
     if names is not None:
@@ -936,8 +983,16 @@ class BaseReader(object):
         * String (newline separated) with all header and data lines (must have at least 2 lines)
         * List of strings
 
-        :param table: table input
-        :returns: output table
+        Parameters
+        ----------
+        table : str, file_like, list
+            Input table.
+
+        Returns
+        -------
+        table : `~astropy.table.Table`
+            Output table
+
         """
         # If ``table`` is a file then store the name in the ``data``
         # attribute. The ``table`` is a "file" if it is a string
@@ -997,7 +1052,8 @@ class BaseReader(object):
         return table
 
     def inconsistent_handler(self, str_vals, ncols):
-        """Adjust or skip data entries if a row is inconsistent with the header.
+        """
+        Adjust or skip data entries if a row is inconsistent with the header.
 
         The default implementation does no adjustment, and hence will always trigger
         an exception in read() any time the number of data entries does not match
@@ -1005,10 +1061,17 @@ class BaseReader(object):
 
         Note that this will *not* be called if the row already matches the header.
 
-        :param str_vals: A list of value strings from the current row of the table.
-        :param ncols: The expected number of entries from the table header.
-        :returns:
-            list of strings to be parsed into data entries in the output table. If
+        Parameters
+        ----------
+        str_vals : list
+            A list of value strings from the current row of the table.
+        ncols : int
+            The expected number of entries from the table header.
+
+        Returns
+        -------
+        str_vals : list
+            List of strings to be parsed into data entries in the output table. If
             the length of this list does not match ``ncols``, an exception will be
             raised in read().  Can also be None, in which case the row will be
             skipped.
@@ -1033,10 +1096,19 @@ class BaseReader(object):
         self.header.write(lines)
 
     def write(self, table):
-        """Write ``table`` as list of strings.
+        """
+        Write ``table`` as list of strings.
 
-        :param table: input table data (astropy.table.Table object)
-        :returns: list of strings corresponding to ASCII table
+        Parameters
+        ----------
+        table : `~astropy.table.Table`
+            Input table data.
+
+        Returns
+        -------
+        lines : list
+            List of strings corresponding to ASCII table
+
         """
 
         # Check column names before altering

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -229,8 +229,8 @@ class BaseSplitter(object):
 
     """
 
-    #: one-character string used to separate fields
     delimiter = None
+    """ one-character string used to separate fields """
 
     def process_line(self, line):
         """Remove whitespace at the beginning or end of line.  This is especially useful for
@@ -272,12 +272,18 @@ class DefaultSplitter(BaseSplitter):
                ...
 
     """
-    delimiter = ' '  #: one-character string used to separate fields.
-    quotechar = '"'  #: control how instances of *quotechar* in a field are quoted
-    doublequote = True  #: character to remove special meaning from following character
-    escapechar = None  #: one-character stringto quote fields containing special characters
-    quoting = csv.QUOTE_MINIMAL  #: control when quotes are recognised by the reader
-    skipinitialspace = True  #: ignore whitespace immediately following the delimiter
+    delimiter = ' '
+    """ one-character string used to separate fields. """
+    quotechar = '"'
+    """ control how instances of *quotechar* in a field are quoted """
+    doublequote = True
+    """ character to remove special meaning from following character """
+    escapechar = None
+    """ one-character stringto quote fields containing special characters """
+    quoting = csv.QUOTE_MINIMAL
+    """ control when quotes are recognised by the reader """
+    skipinitialspace = True
+    """ ignore whitespace immediately following the delimiter """
     csv_writer = None
     csv_writer_out = StringIO()
 
@@ -392,11 +398,16 @@ class BaseHeader(object):
     """
     Base table header reader
     """
-    auto_format = 'col%d'  #: format string for auto-generating column names
-    start_line = None  #: None, int, or a function of ``lines`` that returns None or int
-    comment = None  #: regular expression for comment lines
-    splitter_class = DefaultSplitter  #: Splitter class for splitting data lines into columns
-    names = None  #: list of names corresponding to each data column
+    auto_format = 'col%d'
+    """ format string for auto-generating column names """
+    start_line = None
+    """ None, int, or a function of ``lines`` that returns None or int """
+    comment = None
+    """ regular expression for comment lines """
+    splitter_class = DefaultSplitter
+    """ Splitter class for splitting data lines into columns """
+    names = None
+    """ list of names corresponding to each data column """
     write_comment = False
     write_spacer_lines = ['ASCII_TABLE_WRITE_SPACER_LINE']
 
@@ -537,10 +548,14 @@ class BaseData(object):
     """
     Base table data reader.
     """
-    start_line = None  #: None, int, or a function of ``lines`` that returns None or int
-    end_line = None  #: None, int, or a function of ``lines`` that returns None or int
-    comment = None  #: Regular expression for comment lines
-    splitter_class = DefaultSplitter  #: Splitter class for splitting data lines into columns
+    start_line = None
+    """ None, int, or a function of ``lines`` that returns None or int """
+    end_line = None
+    """ None, int, or a function of ``lines`` that returns None or int """
+    comment = None
+    """ Regular expression for comment lines """
+    splitter_class = DefaultSplitter
+    """ Splitter class for splitting data lines into columns """
     write_spacer_lines = ['ASCII_TABLE_WRITE_SPACER_LINE']
     fill_include_names = None
     fill_exclude_names = None

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -227,9 +227,9 @@ class BaseSplitter(object):
       reader.header.splitter.process_val = lambda x: x.lstrip()
       reader.data.splitter.process_val = None
 
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param delimiter: one-character string used to separate fields
     """
+
+    #: one-character string used to separate fields
     delimiter = None
 
     def process_line(self, line):
@@ -271,20 +271,13 @@ class DefaultSplitter(BaseSplitter):
           for col_val in col_vals:
                ...
 
-    # TODO: not sure what to do here because these are optional, class-level attributes...
-    :param delimiter: one-character string used to separate fields.
-    :param doublequote:  control how instances of *quotechar* in a field are quoted
-    :param escapechar: character to remove special meaning from following character
-    :param quotechar: one-character stringto quote fields containing special characters
-    :param quoting: control when quotes are recognised by the reader
-    :param skipinitialspace: ignore whitespace immediately following the delimiter
     """
-    delimiter = ' '
-    quotechar = '"'
-    doublequote = True
-    escapechar = None
-    quoting = csv.QUOTE_MINIMAL
-    skipinitialspace = True
+    delimiter = ' '  #: one-character string used to separate fields.
+    quotechar = '"'  #: control how instances of *quotechar* in a field are quoted
+    doublequote = True  #: character to remove special meaning from following character
+    escapechar = None  #: one-character stringto quote fields containing special characters
+    quoting = csv.QUOTE_MINIMAL  #: control when quotes are recognised by the reader
+    skipinitialspace = True  #: ignore whitespace immediately following the delimiter
     csv_writer = None
     csv_writer_out = StringIO()
 
@@ -396,20 +389,14 @@ def _get_line_index(line_or_func, lines):
 
 
 class BaseHeader(object):
-    """Base table header reader
-
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param auto_format: format string for auto-generating column names
-    :param start_line: None, int, or a function of ``lines`` that returns None or int
-    :param comment: regular expression for comment lines
-    :param splitter_class: Splitter class for splitting data lines into columns
-    :param names: list of names corresponding to each data column
     """
-    auto_format = 'col%d'
-    start_line = None
-    comment = None
-    splitter_class = DefaultSplitter
-    names = None
+    Base table header reader
+    """
+    auto_format = 'col%d'  #: format string for auto-generating column names
+    start_line = None  #: None, int, or a function of ``lines`` that returns None or int
+    comment = None  #: regular expression for comment lines
+    splitter_class = DefaultSplitter  #: Splitter class for splitting data lines into columns
+    names = None  #: list of names corresponding to each data column
     write_comment = False
     write_spacer_lines = ['ASCII_TABLE_WRITE_SPACER_LINE']
 
@@ -547,18 +534,13 @@ class BaseHeader(object):
 
 
 class BaseData(object):
-    """Base table data reader.
-
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param start_line: None, int, or a function of ``lines`` that returns None or int
-    :param end_line: None, int, or a function of ``lines`` that returns None or int
-    :param comment: Regular expression for comment lines
-    :param splitter_class: Splitter class for splitting data lines into columns
     """
-    start_line = None
-    end_line = None
-    comment = None
-    splitter_class = DefaultSplitter
+    Base table data reader.
+    """
+    start_line = None  #: None, int, or a function of ``lines`` that returns None or int
+    end_line = None  #: None, int, or a function of ``lines`` that returns None or int
+    comment = None  #: Regular expression for comment lines
+    splitter_class = DefaultSplitter  #: Splitter class for splitting data lines into columns
     write_spacer_lines = ['ASCII_TABLE_WRITE_SPACER_LINE']
     fill_include_names = None
     fill_exclude_names = None

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -53,8 +53,11 @@ class DaophotHeader(core.BaseHeader):
         header.  The DAOphot header is specialized so that we just copy the entire BaseHeader
         get_cols routine and modify as needed.
 
-        :param lines: list of table lines
-        :returns: list of table Columns
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
 
         # Parse a series of column definition lines like below.  There may be several

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -314,10 +314,14 @@ class EcsvHeader(basic.BasicHeader):
         pass
 
     def get_cols(self, lines):
-        """Initialize the header Column objects from the table ``lines``.
+        """
+        Initialize the header Column objects from the table ``lines``.
 
-        :param lines: list of table lines
-        :returns: None (but sets self.cols)
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
         import textwrap
         try:

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -19,7 +19,8 @@ from . import basic
 
 
 class FixedWidthSplitter(core.BaseSplitter):
-    """Split line based on fixed start and end positions for each ``col`` in
+    """
+    Split line based on fixed start and end positions for each ``col`` in
     ``self.cols``.
 
     This class requires that the Header class will have defined ``col.start``
@@ -31,6 +32,7 @@ class FixedWidthSplitter(core.BaseSplitter):
     style so line[start:end] is the desired substring for a column.  This splitter
     class does not have a hook for ``process_lines`` since that is generally not
     useful for fixed-width input.
+
     """
     delimiter_pad = ''
     bookend = False
@@ -68,6 +70,7 @@ class FixedWidthHeader(basic.BasicHeader):
 
     The key settable class attributes are:
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param auto_format: format string for auto-generating column names
     :param start_line: None, int, or a function of ``lines`` that returns None or int
     :param comment: regular expression for comment lines
@@ -92,13 +95,17 @@ class FixedWidthHeader(basic.BasicHeader):
         return line
 
     def get_cols(self, lines):
-        """Initialize the header Column objects from the table ``lines``.
+        """
+        Initialize the header Column objects from the table ``lines``.
 
         Based on the previously set Header attributes find or create the column names.
         Sets ``self.cols`` with the list of Columns.
 
-        :param lines: list of table lines
-        :returns: None
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
 
         # See "else" clause below for explanation of start_line and position_line
@@ -162,15 +169,28 @@ class FixedWidthHeader(basic.BasicHeader):
             col.end = ends[i]
 
     def get_fixedwidth_params(self, line):
-        """Split ``line`` on the delimiter and determine column values and
+        """
+        Split ``line`` on the delimiter and determine column values and
         column start and end positions.  This might include null columns with
         zero length (e.g. for ``header row = "| col1 || col2 | col3 |"`` or
         ``header2_row = "----- ------- -----"``).  The null columns are
         stripped out.  Returns the values between delimiters and the
         corresponding start and end positions.
 
-        :param line: input line
-        :returns: (vals, starts, ends)
+        Parameters
+        ----------
+        line : str
+            Input line
+
+        Returns
+        -------
+        vals : list
+            List of values.
+        starts : list
+            List of starting indices.
+        ends : list
+            List of ending indices.
+
         """
 
         # If column positions are already specified then just use those, otherwise
@@ -206,8 +226,10 @@ class FixedWidthHeader(basic.BasicHeader):
 
 
 class FixedWidthData(basic.BasicData):
-    """Base table data reader.
+    """
+    Base table data reader.
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param start_line: None, int, or a function of ``lines`` that returns None or int
     :param end_line: None, int, or a function of ``lines`` that returns None or int
     :param comment: Regular expression for comment lines
@@ -247,7 +269,8 @@ class FixedWidthData(basic.BasicData):
 
 
 class FixedWidth(basic.Basic):
-    """Read or write a fixed width table with a single header line that defines column
+    """
+    Read or write a fixed width table with a single header line that defines column
     names and positions.  Examples::
 
       # Bar delimiter in header and data
@@ -270,6 +293,7 @@ class FixedWidth(basic.Basic):
 
     See the :ref:`fixed_width_gallery` for specific usage examples.
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param col_starts: list of start positions for each column (0-based counting)
     :param col_ends: list of end positions (inclusive) for each column
     :param delimiter_pad: padding around delimiter when writing (default = None)
@@ -301,7 +325,8 @@ class FixedWidthNoHeaderData(FixedWidthData):
 
 
 class FixedWidthNoHeader(FixedWidth):
-    """Read or write a fixed width table which has no header line.  Column
+    """
+    Read or write a fixed width table which has no header line.  Column
     names are either input (``names`` keyword) or auto-generated.  Column
     positions are determined either by input (``col_starts`` and ``col_stops``
     keywords) or by splitting the first data line.  In the latter case a
@@ -324,6 +349,7 @@ class FixedWidthNoHeader(FixedWidth):
 
     See the :ref:`fixed_width_gallery` for specific usage examples.
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param col_starts: list of start positions for each column (0-based counting)
     :param col_ends: list of end positions (inclusive) for each column
     :param delimiter_pad: padding around delimiter when writing (default = None)
@@ -361,7 +387,8 @@ class FixedWidthTwoLineData(FixedWidthData):
 
 
 class FixedWidthTwoLine(FixedWidth):
-    """Read or write a fixed width table which has two header lines.  The first
+    """
+    Read or write a fixed width table which has two header lines.  The first
     header line defines the column names and the second implicitly defines the
     column positions.  Examples::
 
@@ -383,6 +410,7 @@ class FixedWidthTwoLine(FixedWidth):
 
     See the :ref:`fixed_width_gallery` for specific usage examples.
 
+    # TODO: not sure what to do here because this is an optional, class-level attribute...
     :param position_line: row index of line that specifies position (default = 1)
     :param position_char: character used to write the position line (default = "-")
     :param delimiter_pad: padding around delimiter when writing (default = None)

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -69,10 +69,10 @@ class FixedWidthHeader(basic.BasicHeader):
     """
     Fixed width table header reader.
     """
-    #: Splitter class for splitting data lines into columns
     splitter_class = FixedWidthHeaderSplitter
-    #: row index of line that specifies position (default = 1)
+    """ Splitter class for splitting data lines into columns """
     position_line = None   # secondary header line position
+    """ row index of line that specifies position (default = 1) """
     set_of_position_line_characters = set(r'`~!#$%^&*-_+=\|":' + "'")
 
     def get_line(self, lines, index):
@@ -218,8 +218,8 @@ class FixedWidthData(basic.BasicData):
     """
     Base table data reader.
     """
-    #: Splitter class for splitting data lines into columns
     splitter_class = FixedWidthSplitter
+    """ Splitter class for splitting data lines into columns """
 
     def write(self, lines):
         vals_list = []

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -66,23 +66,12 @@ class FixedWidthHeaderSplitter(DefaultSplitter):
 
 
 class FixedWidthHeader(basic.BasicHeader):
-    """Fixed width table header reader.
-
-    The key settable class attributes are:
-
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param auto_format: format string for auto-generating column names
-    :param start_line: None, int, or a function of ``lines`` that returns None or int
-    :param comment: regular expression for comment lines
-    :param splitter_class: Splitter class for splitting data lines into columns
-    :param position_line: row index of line that specifies position (default = 1)
-    :param position_char: character used to write the position line (default = "-")
-    :param col_starts: list of start positions for each column (0-based counting)
-    :param col_ends: list of end positions (inclusive) for each column
-    :param delimiter_pad: padding around delimiter when writing (default = None)
-    :param bookend: put the delimiter at start and end of line when writing (default = False)
     """
+    Fixed width table header reader.
+    """
+    #: Splitter class for splitting data lines into columns
     splitter_class = FixedWidthHeaderSplitter
+    #: row index of line that specifies position (default = 1)
     position_line = None   # secondary header line position
     set_of_position_line_characters = set(r'`~!#$%^&*-_+=\|":' + "'")
 
@@ -228,14 +217,8 @@ class FixedWidthHeader(basic.BasicHeader):
 class FixedWidthData(basic.BasicData):
     """
     Base table data reader.
-
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param start_line: None, int, or a function of ``lines`` that returns None or int
-    :param end_line: None, int, or a function of ``lines`` that returns None or int
-    :param comment: Regular expression for comment lines
-    :param splitter_class: Splitter class for splitting data lines into columns
     """
-
+    #: Splitter class for splitting data lines into columns
     splitter_class = FixedWidthSplitter
 
     def write(self, lines):
@@ -293,11 +276,6 @@ class FixedWidth(basic.Basic):
 
     See the :ref:`fixed_width_gallery` for specific usage examples.
 
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param col_starts: list of start positions for each column (0-based counting)
-    :param col_ends: list of end positions (inclusive) for each column
-    :param delimiter_pad: padding around delimiter when writing (default = None)
-    :param bookend: put the delimiter at start and end of line when writing (default = False)
     """
     _format_name = 'fixed_width'
     _description = 'Fixed width'
@@ -349,11 +327,6 @@ class FixedWidthNoHeader(FixedWidth):
 
     See the :ref:`fixed_width_gallery` for specific usage examples.
 
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param col_starts: list of start positions for each column (0-based counting)
-    :param col_ends: list of end positions (inclusive) for each column
-    :param delimiter_pad: padding around delimiter when writing (default = None)
-    :param bookend: put the delimiter at start and end of line when writing (default = False)
     """
     _format_name = 'fixed_width_no_header'
     _description = 'Fixed width with no header'
@@ -410,11 +383,6 @@ class FixedWidthTwoLine(FixedWidth):
 
     See the :ref:`fixed_width_gallery` for specific usage examples.
 
-    # TODO: not sure what to do here because this is an optional, class-level attribute...
-    :param position_line: row index of line that specifies position (default = 1)
-    :param position_char: character used to write the position line (default = "-")
-    :param delimiter_pad: padding around delimiter when writing (default = None)
-    :param bookend: put the delimiter at start and end of line when writing (default = False)
     """
     _format_name = 'fixed_width_two_line'
     _description = 'Fixed width with second header line'

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -163,13 +163,17 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
                 col.raw_type, col.name))
 
     def get_cols(self, lines):
-        """Initialize the header Column objects from the table ``lines``.
+        """
+        Initialize the header Column objects from the table ``lines``.
 
         Based on the previously set Header attributes find or create the column names.
         Sets ``self.cols`` with the list of Columns.
 
-        :param lines: list of table lines
-        :returns: list of table Columns
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
         header_lines = self.process_lines(lines)  # generator returning valid header lines
         header_vals = [vals for vals in self.splitter(header_lines)]
@@ -433,10 +437,19 @@ class Ipac(basic.Basic):
         self.header.DBMS = DBMS
 
     def write(self, table):
-        """Write ``table`` as list of strings.
+        """
+        Write ``table`` as list of strings.
 
-        :param table: input table data (astropy.table.Table object)
-        :returns: list of strings corresponding to ASCII table
+        Parameters
+        ----------
+        table: `~astropy.table.Table`
+            Input table data
+
+        Returns
+        -------
+        lines : list
+            List of strings corresponding to ASCII table
+
         """
         # Set a default null value for all columns by adding at the end, which
         # is the position with the lowest priority.

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -33,11 +33,15 @@ latexdicts = {'AA':  {'tabletype': 'table',
 
 
 def add_dictval_to_list(adict, key, alist):
-    '''add a value from a dictionary to a list
+    '''
+    Add a value from a dictionary to a list
 
-    :param adict: dictionary
-    :param key: key of value
-    :param list: list where value should be added
+    Parameters
+    ----------
+    adict : dictionary
+    key : hashable
+    alist: list
+        List where value should be added
     '''
     if key in adict:
         if isinstance(adict[key], six.string_types):
@@ -47,11 +51,21 @@ def add_dictval_to_list(adict, key, alist):
 
 
 def find_latex_line(lines, latex):
-    '''Find the first line which matches a patters
+    '''
+    Find the first line which matches a patters
 
-    :param lines: list of strings
-    :param latex: search pattern
-    :returns: line number or None, if no match was found
+    Parameters
+    ----------
+    lines : list
+        List of strings
+    latex : str
+        Search pattern
+
+    Returns
+    -------
+    line_num : int, None
+        Line number. Returns None, if no match was found
+
     '''
     re_string = re.compile(latex.replace('\\', '\\\\'))
     for i, line in enumerate(lines):

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -19,12 +19,16 @@ class SExtractorHeader(core.BaseHeader):
     comment = r'^\s*#\s*\S\D.*'  # Find lines that don't have "# digit"
 
     def get_cols(self, lines):
-        """Initialize the header Column objects from the table ``lines`` for a SExtractor
+        """
+        Initialize the header Column objects from the table ``lines`` for a SExtractor
         header.  The SExtractor header is specialized so that we just copy the entire BaseHeader
         get_cols routine and modify as needed.
 
-        :param lines: list of table lines
-        :returns: list of table Columns
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
         """
 
         # This assumes that the columns are listed in order, one per line with a

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -41,36 +41,63 @@ _GUESS = True
 
 
 def set_guess(guess):
-    """Set the default value of the ``guess`` parameter for read()
+    """
+    Set the default value of the ``guess`` parameter for read()
 
-    :param guess: New default ``guess`` value (True|False)
+    Parameters
+    ----------
+    guess : bool
+        New default ``guess`` value (e.g., True or False)
+
     """
     global _GUESS
     _GUESS = guess
 
 
 def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
-    """Initialize a table reader allowing for common customizations.  Most of the
+    """
+    Initialize a table reader allowing for common customizations.  Most of the
     default behavior for various parameters is determined by the Reader class.
 
-    :param Reader: Reader class (DEPRECATED) (default= :class:`Basic`)
-    :param Inputter: Inputter class
-    :param Outputter: Outputter class
-    :param delimiter: column delimiter string
-    :param comment: regular expression defining a comment line in table
-    :param quotechar: one-character string to quote fields containing special characters
-    :param header_start: line index for the header line not counting comment lines
-    :param data_start: line index for the start of data not counting comment lines
-    :param data_end: line index for the end of data (can be negative to count from end)
-    :param converters: dict of converters
-    :param data_Splitter: Splitter class to split data columns
-    :param header_Splitter: Splitter class to split header columns
-    :param names: list of names corresponding to each data column
-    :param include_names: list of names to include in output (default= ``None`` selects all names)
-    :param exclude_names: list of names to exclude from output (applied after ``include_names``)
-    :param fill_values: specification of fill values for bad or missing table values
-    :param fill_include_names: list of names to include in fill_values (default= ``None`` selects all names)
-    :param fill_exclude_names: list of names to exclude from fill_values (applied after ``fill_include_names``)
+    Parameters
+    ----------
+    Reader : `~astropy.io.ascii.BaseReader`
+        Reader class (DEPRECATED) (default= :class:`Basic`)
+    Inputter : `~astropy.io.ascii.BaseInputter`
+        Inputter class
+    Outputter : `~astropy.io.ascii.BaseOutputter`
+        Outputter class
+    delimiter : str
+        Column delimiter string
+    comment : str
+        Regular expression defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    header_start : int
+        Line index for the header line not counting comment lines
+    data_start : int
+        Line index for the start of data not counting comment lines
+    data_end : int
+        Line index for the end of data (can be negative to count from end)
+    converters : dict
+        Dictionary of converters
+    data_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split data columns
+    header_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split header columns
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output (default= ``None`` selects all names)
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fill_values : dict
+        specification of fill values for bad or missing table values
+    fill_include_names : list
+        List of names to include in fill_values (default= ``None`` selects all names)
+    fill_exclude_names : list
+        List of names to exclude from fill_values (applied after ``fill_include_names``)
+
     """
     # This function is a light wrapper around core._get_reader to provide a public interface
     # with a default Reader.
@@ -94,32 +121,59 @@ def _get_format_class(format, ReaderWriter, label):
 
 
 def read(table, guess=None, **kwargs):
-    """Read the input ``table`` and return the table.  Most of
+    """
+    Read the input ``table`` and return the table.  Most of
     the default behavior for various parameters is determined by the Reader
     class.
 
-    :param table: input table (file name, file-like object, list of strings, or single newline-separated string)
-    :param guess: try to guess the table format (default= ``True``)
-    :param format: input table format
-    :param Inputter: Inputter class
-    :param Outputter: Outputter class (default= :class:`TableOutputter`)
-    :param delimiter: column delimiter string
-    :param comment: regular expression defining a comment line in table
-    :param quotechar: one-character string to quote fields containing special characters
-    :param header_start: line index for the header line not counting comment lines
-    :param data_start: line index for the start of data not counting comment lines
-    :param data_end: line index for the end of data (can be negative to count from end)
-    :param converters: dict of converters
-    :param data_Splitter: Splitter class to split data columns
-    :param header_Splitter: Splitter class to split header columns
-    :param names: list of names corresponding to each data column
-    :param include_names: list of names to include in output (default= ``None`` selects all names)
-    :param exclude_names: list of names to exclude from output (applied after ``include_names``)
-    :param fill_values: specification of fill values for bad or missing table values (default= ``('', '0')``)
-    :param fill_include_names: list of names to include in fill_values (default=None selects all names)
-    :param fill_exclude_names: list of names to exclude from fill_values (applied after ``fill_include_names``)
-    :param fast_reader: whether to use the C engine, can also be a dict with options which default to False (default= ``True``)
-    :param Reader: Reader class (DEPRECATED) (default= :class:`Basic`)
+    Parameters
+    ----------
+    table : str, file-like, list
+        Input table as a file name, file-like object, list of strings, or
+        single newline-separated string.
+    guess : bool
+        Try to guess the table format (default= ``True``)
+    format : str, `~astropy.io.ascii.BaseReader`
+        Input table format
+    Inputter : `~astropy.io.ascii.BaseInputter`
+        Inputter class
+    Outputter : `~astropy.io.ascii.BaseOutputter`
+        Outputter class
+    delimiter : str
+        Column delimiter string
+    comment : str
+        Regular expression defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    header_start : int
+        Line index for the header line not counting comment lines
+    data_start : int
+        Line index for the start of data not counting comment lines
+    data_end : int
+        Line index for the end of data (can be negative to count from end)
+    converters : dict
+        Dictionary of converters
+    data_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split data columns
+    header_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split header columns
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output (default= ``None`` selects all names)
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fill_values : dict
+        specification of fill values for bad or missing table values
+    fill_include_names : list
+        List of names to include in fill_values (default= ``None`` selects all names)
+    fill_exclude_names : list
+        List of names to exclude from fill_values (applied after ``fill_include_names``)
+    fast_reader : bool
+        Whether to use the C engine, can also be a dict with options which default to ``False``
+        (default= ``True``)
+    Reader : `~astropy.io.ascii.BaseReader`
+        Reader class (DEPRECATED) (default= :class:`Basic`).
     """
 
     if 'fill_values' not in kwargs:
@@ -305,19 +359,33 @@ extra_writer_pars = ('delimiter', 'comment', 'quotechar', 'formats',
 
 
 def get_writer(Writer=None, fast_writer=True, **kwargs):
-    """Initialize a table writer allowing for common customizations.  Most of the
+    """
+    Initialize a table writer allowing for common customizations.  Most of the
     default behavior for various parameters is determined by the Writer class.
 
-    :param Writer: Writer class (DEPRECATED) (default= :class:`Basic`)
-    :param delimiter: column delimiter string
-    :param write_comment: string defining a comment line in table
-    :param quotechar: one-character string to quote fields containing special characters
-    :param formats: dict of format specifiers or formatting functions
-    :param strip_whitespace: strip surrounding whitespace from column values (default= ``True``)
-    :param names: list of names corresponding to each data column
-    :param include_names: list of names to include in output (default= ``None`` selects all names)
-    :param exclude_names: list of names to exclude from output (applied after ``include_names``)
-    :param fast_writer: whether to use the fast Cython writer (default= ``True``)
+    Parameters
+    ----------
+    Writer : `~astropy.io.ascii.BaseWriter`
+        Writer class (DEPRECATED) (default= :class:`Basic`)
+    delimiter : str
+        Column delimiter string
+    write_comment : str
+        String defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    formats : dict
+        Dictionary of format specifiers or formatting functions
+    strip_whitespace : bool
+        Strip surrounding whitespace from column values (default= ``True``)
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output (default= ``None`` selects all names)
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fast_writer : bool
+        Whether to use the fast Cython writer (default= ``True``)
+
     """
     if Writer is None:
         Writer = basic.Basic
@@ -331,19 +399,35 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     """Write the input ``table`` to ``filename``.  Most of the default behavior
     for various parameters is determined by the Writer class.
 
-    :param table: input table (Reader object, NumPy struct array, list of lists, etc)
-    :param output: output [filename, file-like object] (default = ``sys.stdout``)
-    :param format: output format (default= ``basic``)
-    :param delimiter: column delimiter string
-    :param write_comment: string defining a comment line in table
-    :param quotechar: one-character string to quote fields containing special characters
-    :param formats: dict of format specifiers or formatting functions
-    :param strip_whitespace: strip surrounding whitespace from column values (default= ``True``)
-    :param names: list of names corresponding to each data column
-    :param include_names: list of names to include in output (default= ``None`` selects all names)
-    :param exclude_names: list of names to exclude from output (applied after ``include_names``)
-    :param fast_writer: whether to use the fast Cython writer (default= ``True``)
-    :param Writer: Writer class (DEPRECATED) (default= :class:`Basic`)
+    Parameters
+    ----------
+    table : `~astropy.io.ascii.BaseReader`, array_like, str, file_like, list
+        Input table as a Reader object, Numpy struct array, file name,
+        file-like object, list of strings, or single newline-separated string.
+    output : str, file_like
+        Output [filename, file-like object] (default = ``sys.stdout``)
+    format : str, `~astropy.io.ascii.BaseWriter`
+        Output table format (default= ``basic``)
+    delimiter : str
+        Column delimiter string
+    write_comment : str
+        String defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    formats : dict
+        Dictionary of format specifiers or formatting functions
+    strip_whitespace : bool
+        Strip surrounding whitespace from column values (default= ``True``)
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output (default= ``None`` selects all names)
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fast_writer : bool
+        Whether to use the fast Cython writer (default= ``True``)
+    Writer : `~astropy.io.ascii.BaseWriter`
+        Writer class (DEPRECATED) (default= :class:`Basic`)
     """
     if output is None:
         output = sys.stdout

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -365,7 +365,7 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
 
     Parameters
     ----------
-    Writer : `~astropy.io.ascii.BaseWriter`
+    Writer : ``Writer``
         Writer class (DEPRECATED) (default= :class:`Basic`)
     delimiter : str
         Column delimiter string
@@ -406,7 +406,7 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
         file-like object, list of strings, or single newline-separated string.
     output : str, file_like
         Output [filename, file-like object] (default = ``sys.stdout``)
-    format : str, `~astropy.io.ascii.BaseWriter`
+    format : str
         Output table format (default= ``basic``)
     delimiter : str
         Column delimiter string
@@ -426,7 +426,7 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
         List of names to exclude from output (applied after ``include_names``)
     fast_writer : bool
         Whether to use the fast Cython writer (default= ``True``)
-    Writer : `~astropy.io.ascii.BaseWriter`
+    Writer : ``Writer``
         Writer class (DEPRECATED) (default= :class:`Basic`)
     """
     if output is None:


### PR DESCRIPTION
This is my attempt at reformatting the existing documentation to use the Numpydoc format instead. In going through this, I've realized that the documentation itself needs __a lot__ of help, but that is outside the scope of this PR. I suggest we add a separate issue for someone to go through the documentation and make it clearer and more consistent. For example, all functions that take keyword arguments should better explain all of the various options, what arguments need to be set, what the defaults are, etc. This is done in some cases, but, e.g., statements like this are not useful:

    Inputter : `~astropy.io.ascii.BaseInputter`
        Inputter class

I added a bunch of `TODO`'s in the code in this PR because I wasn't sure what to do with some sections. For example, in a class with class-level attributes, they are currently documented like:

    class Derp(object):
        """ derp derp derp

        :param whatever: pancakes
        """

But what does this translate to in terms of a numpydoc docstring? These aren't really parameters, since they are attributes that require setting?

cc @astrofrog @embray @taldcroft @hamogu 