### PR TITLE
What's New for ECSV format in io.ascii

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,7 @@ Astropy also depends on other packages for optional features:
 - `BeautifulSoup <http://www.crummy.com/software/BeautifulSoup/>`_: To read
   :class:`~astropy.table.table.Table` objects from HTML files
 
-- `PyYAML <http:://pyyaml.org>`_: To read/write
+- `PyYAML <http://pyyaml.org>`_: To read/write
   :class:`~astropy.table.Table` objects from/to the Enhanced CSV ASCII table format.
 
 - `scipy`_: To power a variety of features (currently

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -151,7 +151,7 @@ data table can be stored and read back as ASCII with no loss of information.
   >>> t.write(fh, format='ascii.ecsv')  # doctest: +SKIP
   >>> table_string = fh.getvalue()      # doctest: +SKIP
   >>> print(table_string)               # doctest: +SKIP
-  # %ECSV 1.0
+  # %ECSV 0.9
   # ---
   # columns:
   # - {name: x, unit: m, type: float32}
@@ -161,10 +161,13 @@ data table can be stored and read back as ASCII with no loss of information.
   2.0 True
 
   >>> Table.read(table_string, format='ascii')  # doctest: +SKIP
-  <Table rows=2 names=('x','y') units=('m',None)>
-  array([(1.0, False), (2.0, True)],
-        dtype=[('x', '<f4'), ('y', '?')])
-
+  <Table masked=False length=2>
+     x      y
+     m
+  float32  bool
+  ------- -----
+      1.0 False
+      2.0  True
 
 .. _supported_formats:
 

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -197,6 +197,8 @@ the automatically-detected ECSV we get::
       1.0 False
       2.0  True
 
+Note that using the ECSV reader requires the `PyYAML <http://pyyaml.org>`_
+package to be installed.
 
 New features in :ref:`astropy-modeling`
 ---------------------------------------

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -123,8 +123,11 @@ See :ref:`astropy_analytic_functions` for more details.
 In future versions of Astropy, the functions in this module might also be
 accessible as `~astropy.modeling.Model` classes.
 
+New features in :ref:`io-ascii`
+-------------------------------
+
 Fast readers/writers for ASCII files
-------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :mod:`astropy.io.ascii` module now includes a significantly faster Cython/C engine
 for reading and writing ASCII files.  This is available for the following
@@ -145,6 +148,55 @@ Certain features of the full read / write interface are not available in the
 fast version, in which case the pure-Python version will automatically be used.
 
 For full details including extensive performance testing, see :ref:`fast_ascii_io`.
+
+Enhanced CSV format
+^^^^^^^^^^^^^^^^^^^
+
+One of the problems when storing a table in an ASCII format is preserving table
+meta-data such as comments, keywords and column data types, units, and
+descriptions.  Using the newly defined `Enhanced Character Separated Values
+format <https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ it is
+now possible to write a table to an ASCII-format file and read it back with no
+loss of information.  The ECSV format has been designed to be both
+human-readable and compatible with most simple CSV readers.
+
+In the example below we show writing a table that has ``float32`` and ``bool``
+types.  This illustrates the simple look of the format which has a few header
+lines (starting with ``#``) in `YAML <http://www.yaml.org/>`_ format and then
+the data values in CSV format.
+::
+
+  >>> t = Table()
+  >>> t['x'] = Column([1.0, 2.0], unit='m', dtype='float32')
+  >>> t['y'] = Column([False, True], dtype='bool')
+
+  >>> from astropy.extern.six.moves import StringIO
+  >>> fh = StringIO()
+  >>> t.write(fh, format='ascii.ecsv')  # doctest: +SKIP
+  >>> table_string = fh.getvalue()      # doctest: +SKIP
+  >>> print(table_string)               # doctest: +SKIP
+  # %ECSV 0.9
+  # ---
+  # columns:
+  # - {name: x, unit: m, type: float32}
+  # - {name: y, type: bool}
+  x y
+  1.0 False
+  2.0 True
+
+Without the header this table would get read back with different types
+(``float64`` and ``string`` respectively) and no unit values.  Instead with
+the automatically-detected ECSV we get::
+
+  >>> Table.read(table_string, format='ascii')  # doctest: +SKIP
+  <Table masked=False length=2>
+     x      y
+     m
+  float32  bool
+  ------- -----
+      1.0 False
+      2.0  True
+
 
 New features in :ref:`astropy-modeling`
 ---------------------------------------


### PR DESCRIPTION
Note that this contains a slightly unrelated fix to the ECSV examples which I noticed along the way.  I decided to save some travis time this way, esp. since the doc examples in question are skipped.