### PR TITLE
UnboundLocalError from Table repr

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -429,11 +429,11 @@ class TableFormatter(object):
                 lines = lines[:-1]
             cols.append(lines)
 
+        if not cols:
+            return ['<No columns>'], {'show_length': False}
+
         # Use the values for the last column since they are all the same
         n_header = outs['n_header']
-
-        if not cols:
-            return []
 
         n_rows = len(cols[0])
         outwidth = lambda cols: sum(len(c[0]) for c in cols) + len(cols) - 1

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -117,6 +117,14 @@ class TestPprint():
         self.tb['col19'].unit = 'kg s m**-2'
         self.ts = table_type(SMALL_ARR)
 
+    def test_empty_table(self, table_type):
+        t = table_type()
+        lines = t.pformat()
+        assert lines == ['<No columns>']
+        c = repr(t)
+        assert c.splitlines() == ['<{0} masked={1} length=0>'.format(table_type.__name__, t.masked),
+                                  '<No columns>']
+
     def test_format0(self, table_type):
         """Try getting screen size but fail to defaults because testing doesn't
         have access to screen (fcntl.ioctl fails).


### PR DESCRIPTION
@taldcroft I'm getting this error ... I think this is a recently introduced bug?
```python
>>> from astropy.table import Table
>>> Table()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11738-py3.4-macosx-10.10-x86_64.egg/astropy/table/table.py", line 605, in __repr__
    return self._base_repr_(html=False)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11738-py3.4-macosx-10.10-x86_64.egg/astropy/table/table.py", line 593, in _base_repr_
    show_name=True, show_unit=None, show_dtype=True)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev11738-py3.4-macosx-10.10-x86_64.egg/astropy/table/pprint.py", line 433, in _pformat_table
    n_header = outs['n_header']
UnboundLocalError: local variable 'outs' referenced before assignment
```