### PR TITLE
Checking scipy version for coordinates module

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -198,8 +198,8 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
 
     Notes
     -----
-    This function requires `SciPy <http://www.scipy.org>`_ to be installed
-    or it will fail.
+    This function requires `SciPy <http://www.scipy.org>`_ (>=0.12.0)
+    to be installed or it will fail.
 
     If you are using this function to search in a catalog for matches around
     specific points, the convention is for ``coords2`` to be the catalog, and
@@ -286,8 +286,8 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
 
     Notes
     -----
-    This function requires `SciPy <http://www.scipy.org>`_ to be installed
-    or it will fail.
+    This function requires `SciPy <http://www.scipy.org>`_ (>=0.12.0)
+    to be installed or it will fail.
 
     In the current implementation, the return values are always sorted in the
     same order as the ``coords1`` (so ``idx1`` is in ascending order).  This is

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -780,7 +780,7 @@ class SkyCoord(object):
 
         Notes
         -----
-        This method requires `SciPy <http://www.scipy.org>`_ to be
+        This method requires `SciPy <http://www.scipy.org>`_ (>=0.12.0) to be
         installed or it will fail.
 
         In the current implementation, the return values are always sorted in
@@ -827,7 +827,7 @@ class SkyCoord(object):
 
         Notes
         -----
-        This method requires `SciPy <http://www.scipy.org>`_ to be
+        This method requires `SciPy <http://www.scipy.org>`_ (>=0.12.0) to be
         installed or it will fail.
 
         In the current implementation, the return values are always sorted in

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy import testing as npt
+from distutils import version
 from ...tests.helper import pytest
 
 from ... import units as u
@@ -21,6 +22,12 @@ try:
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
+
+if HAS_SCIPY and version.LooseVersion(scipy.__version__) > version.LooseVersion('0.12.0'):
+    OLDER_SCIPY = False
+else:
+    OLDER_SCIPY = True
+
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching_function():
@@ -116,6 +123,7 @@ def test_matching_method():
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
 def test_search_around():
     from .. import ICRS
     from ..matching import search_around_sky, search_around_3d

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -885,7 +885,7 @@ def test_immutable():
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
-@pytest.mark.skipif(str('OLD_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
 def test_search_around():
     """
     Test the search_around_* methods

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -14,6 +14,7 @@ import functools
 
 import numpy as np
 from numpy import testing as npt
+from distutils import version
 
 from ... import units as u
 from ...tests.helper import pytest, catch_warnings
@@ -38,6 +39,11 @@ try:
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
+
+if HAS_SCIPY and version.LooseVersion(scipy.__version__) > version.LooseVersion('0.12.0'):
+    OLDER_SCIPY = False
+else:
+    OLDER_SCIPY = True
 
 
 def test_transform_to():
@@ -879,6 +885,7 @@ def test_immutable():
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLD_SCIPY'))
 def test_search_around():
     """
     Test the search_around_* methods


### PR DESCRIPTION
This PR adds a note about the required version for some of the coordinate functions, and checks for it the affected tests.
``scipy.spatial.ckdtree.cKDTree.query_ball_tree`` is used from scipy in a few places, but it appeared only in 0.12.0. Earlier version (tested with 0.10.0) is OK for all the other part of astropy.

Related to some of the test failures reported in #3380.