### PR TITLE
Add origin='lower' for imshow in documentation

### DIFF
--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -431,7 +431,7 @@ example:
     for idx, theta in enumerate((0, 45, 90)):
         g = RotatedGaussian(theta)
         plt.subplot(1, 3, idx + 1)
-        plt.imshow(g(x, y))
+        plt.imshow(g(x, y), origin='lower')
         plt.xticks([])
         plt.yticks([])
         plt.title('Rotated $ {0}^\circ $'.format(theta))

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -168,13 +168,15 @@ background in an image.
     # Plot the data with the best-fit model
     plt.figure(figsize=(8,2.5))
     plt.subplot(1,3,1)
-    plt.imshow(z, interpolation='nearest', vmin=-1e4, vmax=5e4)
+    plt.imshow(z, origin='lower', interpolation='nearest', vmin=-1e4, vmax=5e4)
     plt.title("Data")
     plt.subplot(1,3,2)
-    plt.imshow(p(x, y), interpolation='nearest', vmin=-1e4, vmax=5e4)
+    plt.imshow(p(x, y), origin='lower', interpolation='nearest', vmin=-1e4,
+               vmax=5e4)
     plt.title("Model")
     plt.subplot(1,3,3)
-    plt.imshow(z - p(x, y), interpolation='nearest', vmin=-1e4, vmax=5e4)
+    plt.imshow(z - p(x, y), origin='lower', interpolation='nearest', vmin=-1e4,
+               vmax=5e4)
     plt.title("Residual")
 
 A list of models is provided in the `Reference/API`_ section. The fitting

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -15,7 +15,7 @@ visualization. Two main types of transformations are provided:
 
 * *Stretching* of values in the [0:1] range to the [0:1] range using a linear
   or non-linear function:
-  
+
 .. math::
 
     z = f(y)
@@ -116,7 +116,7 @@ percentile value, followed by a square root stretch, you can do::
     >>> transform = SqrtStretch() + PercentileInterval(90.)
     >>> transform([1, 3, 4, 5, 6])
     array([ 0.        ,  0.60302269,  0.76870611,  0.90453403,  1.        ])
-    
+
 As before, the combined transformation can also accept a ``clip`` argument
 (which is `True` by default).
 
@@ -151,7 +151,7 @@ instance:
     # Make the figure
     fig = plt.figure()
     ax = fig.add_subplot(1,1,1)
-    im = ax.imshow(image, norm=norm)
+    im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
 
 As shown above, the colorbar ticks are automatically adjusted.


### PR DESCRIPTION
The default origin is 'upper', which is not the orientation most astronomers expect.
I first noticed this was missing because the middle panel of this plot
http://astropy.readthedocs.org/en/latest/modeling/compound-models-2.png
looks wrong for a 45 deg rotation, which is defined to be counterclockwise.