### PR TITLE
Remove float128 from DTYPES in 32-bit architecture

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -8,6 +8,7 @@ Requires `pyyaml <http://pyyaml.org/>`_ to be installed.
 """
 import os
 import copy
+import sys
 
 import numpy as np
 
@@ -28,7 +29,7 @@ except ImportError:
 DTYPES = ['bool', 'int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32',
           'uint64', 'float16', 'float32', 'float64', 'float128',
           'str']
-if os.name == 'nt':
+if os.name == 'nt' or sys.maxsize <= 2**32:
     DTYPES.remove('float128')
 
 T_DTYPES = Table()


### PR DESCRIPTION
Remove `float128` from DTYPES list on 32-bit machines to fix an error in an `io.ascii` test reported in  #3380..
