### PR TITLE
Simplify, standardize, and reduce repetition of version checks

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -58,15 +58,12 @@ def _check_numpy():
     except ImportError:
         pass
     else:
-        major, minor, rest = numpy.__version__.split(".", 2)
-        rmajor, rminor, rest = __minimum_numpy_version__.split(".", 2)
-        requirement_met = ((int(major), int(minor)) >=
-                           (int(rmajor), int(rminor)))
+        from .utils import minversion
+        requirement_met = minversion(numpy, __minimum_numpy_version__)
 
     if not requirement_met:
-        msg = ("numpy version {0} or later must be installed to use "
-               "astropy".format(
-                   __minimum_numpy_version__))
+        msg = ("Numpy version {0} or later must be installed to use "
+               "Astropy".format(__minimum_numpy_version__))
         raise ImportError(msg)
 
     return numpy

--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -34,15 +34,15 @@ github repository for more about this.)
 from __future__ import absolute_import, division, print_function
 
 import warnings
-from distutils.version import LooseVersion
 
+from ..utils.compat import NUMPY_LT_1_8
 from ..utils.exceptions import AstropyUserWarning
 
 import numpy
 from . import _core
 
-NPYLT18 = LooseVersion(numpy.__version__) < LooseVersion('1.8')
-# TODO: remove the above variable and the code using it and make_outputs_scalar when numpy < 1.8 is no longer supported
+# TODO: remove the above variable and the code using it and make_outputs_scalar
+# when numpy < 1.8 is no longer supported
 
 __all__ = ['ErfaError', 'ErfaWarning',
            {{ funcs|map(attribute='pyname')|surround("'","'")|join(", ") }},
@@ -192,7 +192,7 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
 
     {%- if func.args_by_inout('in|inout') %}
     make_outputs_scalar = False
-    if NPYLT18:
+    if NUMPY_LT_1_8:
         # in numpy < 1.8, the iterator used below doesn't work with 0d/scalar arrays
         # so we replace all scalars with 1d arrays
         make_outputs_scalar = True

--- a/astropy/_erfa/core.pyx.templ
+++ b/astropy/_erfa/core.pyx.templ
@@ -17,7 +17,6 @@ For more about the module and how to use it, see the ``core.py`` docstrings.
 from __future__ import absolute_import, division, print_function
 
 import warnings
-from distutils.version import LooseVersion
 
 from ..utils.exceptions import AstropyUserWarning
 

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -9,20 +9,20 @@ from __future__ import (absolute_import, division, print_function,
 """Test initalization of angles not already covered by the API tests"""
 
 import functools
-from distutils import version
 import numpy as np
 
 from ..earth import EarthLocation, ELLIPSOIDS
 from ..angles import Longitude, Latitude
 from ...tests.helper import pytest
+from ...utils import minversion
 from ... import units as u
 
-NUMPY_VERSION = version.LooseVersion(np.__version__)
 
 allclose_m14 = functools.partial(np.allclose, rtol=1.e-14, atol=1.e-14)
 allclose_m8 = functools.partial(np.allclose, rtol=1.e-8, atol=1.e-8)
 
-if NUMPY_VERSION >= version.LooseVersion('1.7.0'):
+
+if minversion(np, '1.7.0'):
     isclose_m14 = functools.partial(np.isclose, rtol=1.e-14, atol=1.e-14)
     isclose_m8 = functools.partial(np.isclose, rtol=1.e-8, atol=1.e-8)
 else:

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -5,10 +5,10 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy import testing as npt
-from distutils import version
 from ...tests.helper import pytest
 
 from ... import units as u
+from ...utils import minversion
 
 
 """
@@ -23,7 +23,7 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-if HAS_SCIPY and version.LooseVersion(scipy.__version__) > version.LooseVersion('0.12.0'):
+if HAS_SCIPY and minversion(scipy, '0.12.0', inclusive=False):
     OLDER_SCIPY = False
 else:
     OLDER_SCIPY = True

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -14,7 +14,6 @@ import functools
 
 import numpy as np
 from numpy import testing as npt
-from distutils import version
 
 from ... import units as u
 from ...tests.helper import pytest, catch_warnings
@@ -24,6 +23,7 @@ from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             UnitSphericalRepresentation)
 from ...coordinates import Latitude, Longitude
 from ...time import Time
+from ...utils import minversion
 from ...utils.exceptions import AstropyDeprecationWarning
 
 RA = 1.0 * u.deg
@@ -40,7 +40,7 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-if HAS_SCIPY and version.LooseVersion(scipy.__version__) > version.LooseVersion('0.12.0'):
+if HAS_SCIPY and minversion(scipy, '0.12.0', inclusive=False):
     OLDER_SCIPY = False
 else:
     OLDER_SCIPY = True

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -601,7 +601,8 @@ def _array_from_file(infile, dtype, count, sep):
 
         global CHUNKED_FROMFILE
         if CHUNKED_FROMFILE is None:
-            if sys.platform == 'darwin' and LooseVersion(platform.mac_ver()[0]) < LooseVersion('10.9'):
+            if (sys.platform == 'darwin' and
+                    LooseVersion(platform.mac_ver()[0]) < LooseVersion('10.9')):
                 CHUNKED_FROMFILE = True
             else:
                 CHUNKED_FROMFILE = False

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -6,12 +6,12 @@ from ..extern import six
 import weakref
 
 from copy import deepcopy
-from distutils import version
 
 import numpy as np
 from numpy import ma
 
 from ..units import Unit, Quantity
+from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from . import groups
@@ -20,7 +20,6 @@ from .np_utils import fix_column_name
 
 from ..config import ConfigAlias
 
-NUMPY_VERSION = version.LooseVersion(np.__version__)
 
 AUTO_COLNAME = ConfigAlias(
     '0.4', 'AUTO_COLNAME', 'auto_colname',
@@ -992,8 +991,9 @@ class MaskedColumn(Column, ma.MaskedArray):
         3).  Here we change the string to a byte string so that in Python 3 the
         isinstance(val, basestring) part fails.
         """
-        if (NUMPY_VERSION < version.LooseVersion('1.8.0') and
-                isinstance(val, six.string_types) and (self.dtype.char not in 'SV')):
+
+        if (NUMPY_LT_1_8 and isinstance(val, six.string_types) and
+                (self.dtype.char not in 'SV')):
             val = val.encode()
         return val
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -12,6 +12,8 @@ import sys
 import numpy as np
 
 from .. import log
+# Note, in numpy <= 1.6, some classes do not properly represent themselves.
+from ..utils.compat import NUMPY_LT_1_6_1
 from ..utils.console import Getch, color_print, terminal_size, conf
 
 if six.PY3:
@@ -27,8 +29,7 @@ elif six.PY2:
 
 ### The first three functions are helpers for _auto_format_func
 
-# In numpy <= 1.6, some classes do not properly represent themselves.
-NUMPY_LE_1P6 = [int(x) for x in np.__version__.split('.')[:2]] <= [1, 6]
+
 def _use_val_tolist(format_func):
     """Wrap format function to work with values converted to python equivalents.
 
@@ -72,7 +73,7 @@ def _auto_format_func(format_, val):
     """
     if six.callable(format_):
         format_func = lambda format_, val: format_(val)
-        if NUMPY_LE_1P6:
+        if NUMPY_LT_1_6_1:
             format_func = _use_val_tolist(format_func)
         try:
             out = format_func(format_, val)
@@ -103,7 +104,7 @@ def _auto_format_func(format_, val):
             return str(val)
 
         for format_func in _possible_string_format_functions(format_):
-            if NUMPY_LE_1P6:
+            if NUMPY_LT_1_6_1:
                 format_func = _use_val_tolist(format_func)
 
             try:

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -4,13 +4,13 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import collections
-from distutils import version
 
 import numpy as np
 from numpy import ma
 
 from ..extern import six
 from ..utils import deprecated
+from ..utils.compat import NUMPY_LT_1_8
 
 class Row(object):
     """A class to represent one row of a Table object.
@@ -143,12 +143,14 @@ class Row(object):
                 # ValueError: Setting void-array with object members using buffer. [numpy.ma.core]
                 #
                 # All we do here is re-raise with a more informative message
-                if (six.text_type(err).startswith('Setting void-array with object members')
-                        and version.LooseVersion(np.__version__) < version.LooseVersion('1.8')):
-                    raise ValueError('Cannot convert masked table row with Object type columns '
-                                     'using as_void(), due to a bug in numpy {0}.  Please upgrade '
-                                     'to numpy 1.8 or newer.'
-                                     .format(np.__version__))
+                msg = six.text_type(err)
+                if ('Setting void-array with object members' in msg and
+                        NUMPY_LT_1_8):
+                    raise ValueError(
+                        'Cannot convert masked table row with Object type '
+                        'columns using as_void(), due to a bug in Numpy '
+                        '{0}.  Please upgrade to Numpy 1.8 or newer.'.format(
+                            np.__version__))
                 else:
                     raise
         else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -8,7 +8,6 @@ from ..extern.six.moves import range as xrange
 import re
 
 from copy import deepcopy
-from distutils import version
 
 import numpy as np
 from numpy import ma
@@ -16,7 +15,7 @@ from numpy import ma
 from .. import log
 from ..io import registry as io_registry
 from ..units import Quantity, Unit
-from ..utils import OrderedDict, isiterable, deprecated
+from ..utils import OrderedDict, isiterable, deprecated, minversion
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from . import groups
@@ -30,8 +29,7 @@ from .np_utils import fix_column_name, recarray_fromrecords
 # Prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
 # sorting of structured arrays containing Unicode columns to
 # silently fail.
-_NUMPY_VERSION = version.LooseVersion(np.__version__)
-_BROKEN_UNICODE_TABLE_SORT = _NUMPY_VERSION < version.LooseVersion('1.6.2')
+_BROKEN_UNICODE_TABLE_SORT = not minversion(np, '1.6.2')
 
 
 __doctest_skip__ = ['Table.read', 'Table.write',

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -10,8 +10,7 @@ from ...tests.helper import pytest, assert_follows_unicode_guidelines
 from ... import table
 from ... import units as u
 from ...extern import six
-
-NUMPY_LT_1P8 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 8]
+from ...utils.compat import NUMPY_LT_1_8
 
 
 class TestColumn():
@@ -463,7 +462,7 @@ def test_getitem_metadata_regression():
         assert subset.meta['c'] == 8
 
     # Metadata isn't copied for scalar values
-    if NUMPY_LT_1P8:
+    if NUMPY_LT_1_8:
         with pytest.raises(ValueError):
             c.take(0)
         with pytest.raises(ValueError):
@@ -483,7 +482,7 @@ def test_getitem_metadata_regression():
         assert subset.meta['c'] == 8
 
     # Metadata isn't copied for scalar values
-    if NUMPY_LT_1P8:
+    if NUMPY_LT_1_8:
         with pytest.raises(ValueError):
             c.take(0)
         with pytest.raises(ValueError):

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -4,16 +4,14 @@
 
 import sys
 
-from distutils import version
 import numpy as np
 
 from ...tests.helper import pytest, catch_warnings
 from ... import table
 from ...table import Row
+from ...utils.compat import NUMPY_LT_1_8
 from ...utils.exceptions import AstropyDeprecationWarning
 from .conftest import MaskedTable
-
-numpy_lt_1p8 = version.LooseVersion(np.__version__) < version.LooseVersion('1.8')
 
 
 def test_masked_row_with_object_col():
@@ -22,7 +20,7 @@ def test_masked_row_with_object_col():
     a column with object type.
     """
     t = table.Table([[1]], dtype=['O'], masked=True)
-    if numpy_lt_1p8:
+    if NUMPY_LT_1_8:
         with pytest.raises(ValueError):
             t['col0'].mask = False
             t[0].as_void()
@@ -192,7 +190,7 @@ class TestRow():
         t = table_types.Table([[{'a': 1}, {'b': 2}]], names=('a',))
         assert t[0][0] == {'a': 1}
         assert t[0]['a'] == {'a': 1}
-        if numpy_lt_1p8 and t.masked:
+        if NUMPY_LT_1_8 and t.masked:
             # With numpy < 1.8 there is a bug setting mvoid with
             # an object.
             with pytest.raises(ValueError):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -14,9 +14,6 @@ import re
 import numbers
 
 import numpy as np
-NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
-NUMPY_LT_1P8 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 8]
-NUMPY_LT_1P9 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 9]
 
 # AstroPy
 from ..extern import six
@@ -24,6 +21,7 @@ from .core import (Unit, dimensionless_unscaled, UnitBase, UnitsError,
                    get_current_unit_registry)
 from .format.latex import Latex
 from ..utils import lazyproperty
+from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
 from .utils import validate_power
@@ -725,7 +723,7 @@ class Quantity(np.ndarray):
         else:
             return value
 
-    if not NUMPY_LT_1P9:
+    if not NUMPY_LT_1_9:
         # Equality (return False if units do not match) needs to be handled
         # explicitly for numpy >=1.9, since it no longer traps errors.
         def __eq__(self, other):
@@ -955,7 +953,7 @@ class Quantity(np.ndarray):
         lstr
             A LaTeX string with the contents of this Quantity
         """
-        if NUMPY_LT_1P7:
+        if NUMPY_LT_1_7:
             if self.isscalar:
                 latex_value = Latex.format_exponential_notation(self.value)
             else:
@@ -1258,7 +1256,7 @@ class Quantity(np.ndarray):
     def round(self, decimals=0, out=None):
         return self._wrap_function(np.round, decimals, out=out)
 
-    if NUMPY_LT_1P7:
+    if NUMPY_LT_1_7:
         # 'keepdims' was not yet available.
         def max(self, axis=None, out=None):
             return self._wrap_function(np.max, axis, out=out)
@@ -1330,7 +1328,7 @@ class Quantity(np.ndarray):
     def ediff1d(self, to_end=None, to_begin=None):
         return self._wrap_function(np.ediff1d, to_end, to_begin)
 
-    if NUMPY_LT_1P8:
+    if NUMPY_LT_1_8:
         def nansum(self, axis=None):
             return self._wrap_function(np.nansum, axis)
     else:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -9,15 +9,14 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import copy
 import decimal
-from distutils import version
 
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_almost_equal)
-NUMPY_VERSION = version.LooseVersion(np.__version__)
+
 
 from ...tests.helper import raises, pytest
-from ...utils import isiterable
+from ...utils import isiterable, minversion
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
 from ...extern.six.moves import xrange
@@ -709,7 +708,7 @@ class TestQuantityDisplay(object):
         assert (q2scalar._repr_latex_() ==
                 '$1.5 \\times 10^{14} \\; \\mathrm{\\frac{m}{s}}$')
 
-        if NUMPY_VERSION < version.LooseVersion('1.7.0'):
+        if not minversion(np, '1.7.0'):
             with pytest.raises(NotImplementedError):
                 self.arrq._repr_latex_()
             return  # all arrays should fail
@@ -1132,7 +1131,7 @@ def test_insert():
     assert q2.unit is u.m
     assert q2.dtype.kind == 'f'
 
-    if NUMPY_VERSION >= version.LooseVersion('1.8.0'):
+    if minversion(np, '1.8.0'):
         q2 = q.insert(1, [1, 2] * u.km)
         assert np.all(q2.value == [1, 1000, 2000, 2])
         assert q2.unit is u.m

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -17,6 +17,7 @@ from numpy.testing import (assert_allclose, assert_array_equal,
 
 from ...tests.helper import raises, pytest
 from ...utils import isiterable, minversion
+from ...utils.compat import NUMPY_LT_1_7
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
 from ...extern.six.moves import xrange
@@ -708,7 +709,7 @@ class TestQuantityDisplay(object):
         assert (q2scalar._repr_latex_() ==
                 '$1.5 \\times 10^{14} \\; \\mathrm{\\frac{m}{s}}$')
 
-        if not minversion(np, '1.7.0'):
+        if NUMPY_LT_1_7:
             with pytest.raises(NotImplementedError):
                 self.arrq._repr_latex_()
             return  # all arrays should fail

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,10 +5,7 @@ import numpy as np
 
 from ... import units as u
 from ...tests.helper import pytest
-
-NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
-NUMPY_LT_1P8 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 8]
-NUMPY_LT_1P9P1 = [int(x) for x in np.__version__.split('.')[:3]] < [1, 9, 1]
+from ...utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9_1
 
 
 class TestQuantityArrayCopy(object):
@@ -147,12 +144,12 @@ class TestQuantityStatsFuncs(object):
 
     # For 1.7 <= Numpy < 1.9.1, inplace causes the variance to be stored instead
     # of the standard deviation; https://github.com/numpy/numpy/issues/5240
-    @pytest.mark.xfail("NUMPY_LT_1P9P1")
+    @pytest.mark.xfail("NUMPY_LT_1_9_1")
     def test_std_inplace(self):
 
         # For Numpy < 1.7, the test segfaults.  Hence, the xfail decorator does
         # not suffice: py.test will run the test anyway to see if it works.
-        if NUMPY_LT_1P7:
+        if NUMPY_LT_1_7:
             pytest.xfail()
 
         q1 = np.array([1., 2.]) * u.m
@@ -168,7 +165,7 @@ class TestQuantityStatsFuncs(object):
 
         # For Numpy < 1.7, the test segfaults.  Hence, we cannot use the xfail
         # decorator since py.test will run the test anyway to see if it works.
-        if NUMPY_LT_1P7:
+        if NUMPY_LT_1_7:
             pytest.xfail()
 
         q1 = np.array([1., 2.]) * u.m
@@ -301,7 +298,7 @@ class TestQuantityStatsFuncs(object):
         assert np.all(q2.nansum(0) == np.array([1., 5., 10.]) * u.s)
         assert np.all(np.nansum(q2, 0) == np.array([1., 5., 10.]) * u.s)
 
-    @pytest.mark.xfail("NUMPY_LT_1P8")
+    @pytest.mark.xfail("NUMPY_LT_1_8")
     def test_nansum_inplace(self):
 
         q1 = np.array([1., 2., np.nan]) * u.m

--- a/astropy/utils/__init__.py
+++ b/astropy/utils/__init__.py
@@ -13,7 +13,8 @@ from __future__ import (absolute_import, division, print_function,
 
 
 from .codegen import *
-from .compat.odict import OrderedDict
 from .decorators import *
 from .introspection import *
 from .misc import *
+
+from .compat.odict import OrderedDict

--- a/astropy/utils/compat/__init__.py
+++ b/astropy/utils/compat/__init__.py
@@ -11,4 +11,5 @@ imported here for easier access.
 from .misc import *
 
 if not _ASTROPY_SETUP_:
-    from . import numpycompat as _numpycompat
+    # Importing this module will also install monkey-patches defined in it
+    from .numpycompat import *

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -18,7 +18,6 @@ __all__ = ['NUMPY_LT_1_6_1', 'NUMPY_LT_1_7', 'NUMPY_LT_1_8', 'NUMPY_LT_1_9',
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
 NUMPY_LT_1_6_1 = not minversion(np, '1.6.1')
-NUMPY_LE_1_7 = not minversion(np, '1.7.0', inclusive=False)
 NUMPY_LT_1_7 = not minversion(np, '1.7.0')
 NUMPY_LT_1_8 = not minversion(np, '1.8.0')
 NUMPY_LT_1_9 = not minversion(np, '1.9.0')
@@ -27,13 +26,13 @@ NUMPY_LT_1_9_1 = not minversion(np, '1.9.1')
 
 def _monkeypatch_unicode_mask_fill_values():
     """
-    Numpy <= 1.7.0 on Python 2 does not support Unicode fill values, since
+    Numpy < 1.8.0 on Python 2 does not support Unicode fill values, since
     it assumes that all of the string dtypes are ``S`` and ``V`` (not ``U``).
 
     This monkey patches the function that validates and corrects a
     fill value to handle this case.
     """
-    if NUMPY_LE_1_7 and six.PY2:
+    if NUMPY_LT_1_8 and six.PY2:
         from numpy.ma import core as ma_core
         _check_fill_value_original = ma_core._check_fill_value
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -6,14 +6,22 @@ earlier versions of Numpy.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ...extern import six
+from ...utils import minversion
 
 import numpy as np
 
-# Note: We could have used distutils.version for this comparison,
-# but it seems like overkill to import distutils at runtime.
-numpy_major, numpy_minor, numpy_rest = np.__version__.split(".", 2)
-numpy_major = int(numpy_major)
-numpy_minor = int(numpy_minor)
+
+__all__ = ['NUMPY_LT_1_6_1', 'NUMPY_LT_1_7', 'NUMPY_LT_1_8', 'NUMPY_LT_1_9',
+           'NUMPY_LT_1_9_1']
+
+# TODO: It might also be nice to have aliases to these named for specific
+# features/bugs we're checking for (ex:
+# astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
+NUMPY_LT_1_6_1 = not minversion(np, '1.6.1')
+NUMPY_LT_1_7 = not minversion(np, '1.7.0')
+NUMPY_LT_1_8 = not minversion(np, '1.8.0')
+NUMPY_LT_1_9 = not minversion(np, '1.9.0')
+NUMPY_LT_1_9_1 = not minversion(np, '1.9.1')
 
 
 def _monkeypatch_unicode_mask_fill_values():
@@ -24,7 +32,7 @@ def _monkeypatch_unicode_mask_fill_values():
     This monkey patches the function that validates and corrects a
     fill value to handle this case.
     """
-    if numpy_major == 1 and numpy_minor <= 7 and six.PY2:
+    if NUMPY_LT_1_7 and six.PY2:
         from numpy.ma import core as ma_core
         _check_fill_value_original = ma_core._check_fill_value
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -18,6 +18,7 @@ __all__ = ['NUMPY_LT_1_6_1', 'NUMPY_LT_1_7', 'NUMPY_LT_1_8', 'NUMPY_LT_1_9',
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
 NUMPY_LT_1_6_1 = not minversion(np, '1.6.1')
+NUMPY_LE_1_7 = not minversion(np, '1.7.0', inclusive=False)
 NUMPY_LT_1_7 = not minversion(np, '1.7.0')
 NUMPY_LT_1_8 = not minversion(np, '1.8.0')
 NUMPY_LT_1_9 = not minversion(np, '1.9.0')
@@ -32,7 +33,7 @@ def _monkeypatch_unicode_mask_fill_values():
     This monkey patches the function that validates and corrects a
     fill value to handle this case.
     """
-    if NUMPY_LT_1_7 and six.PY2:
+    if NUMPY_LE_1_7 and six.PY2:
         from numpy.ma import core as ma_core
         _check_fill_value_original = ma_core._check_fill_value
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -4,21 +4,22 @@ Normalization class for Matplotlib that can be used to produce colorbars.
 
 from __future__ import division, print_function
 
-from distutils.version import LooseVersion
-
 import numpy as np
 from numpy import ma
 
 try:
     import matplotlib
-    HAS_MATPLOTLIB = True
-    MATPLOTLIB_LT_12 = LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0")
     from matplotlib.colors import Normalize
+
+    # On older versions of matplotlib Normalize is an old-style class
+    if not isinstance(Normalize, type):
+        class Normalize(Normalize, object):
+            pass
 except ImportError:
-    HAS_MATPLOTLIB = False
     class Normalize(object):
         def __init__(self, *args, **kwargs):
             raise ImportError("matplotlib is required in order to use this class")
+
 
 __all__ = ['ImageNormalize']
 
@@ -38,12 +39,7 @@ class ImageNormalize(Normalize):
     """
 
     def __init__(self, vmin=None, vmax=None, stretch=None, clip=False):
-
-        if HAS_MATPLOTLIB and MATPLOTLIB_LT_12:
-            # Normalize is an old-style class
-            Normalize.__init__(self, vmin=vmin, vmax=vmax, clip=clip)
-        else:  # Normalize is a new-style class
-            super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
+        super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
 
         self.vmin = vmin
         self.vmax = vmax

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from distutils.version import LooseVersion
 import gc
 import locale
 import re

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -37,13 +37,16 @@ py:obj n
 py:obj ndarray
 py:obj args
 
-# other classes that cannot be linked to
+# other classes and functions that cannot be linked to
 py:class numpy.ma.core.MaskedArray
 py:class numpy.core.records.recarray
 py:class xmlrpclib.Fault
 py:class xmlrpclib.Error
 py:class xmlrpc.client.Fault
 py:class xmlrpc.client.Error
+py:obj distutils.version.LooseVersion
+py:obj pkg_resources.parse_version
+
 
 # Pending on python docs links issue #11975
 py:class list


### PR DESCRIPTION
This adds a new utility `minversion` that can be used to check Python module version dependencies.  I also went through and used this where appropriate, but I also cut down on the number of Numpy version checks by putting several of them in the `numpycompat` module and just importing Numpy version checks from there where needed (in many cases).

I should also add, though it is unlikely to matter 99.99% of the time, `minversion` defaults to using `pkg_resources.parse_version` which, as of setuptools 8.0 uses PEP-440-compliant version comparison by default.  If for whatever reason that's unavailable we fall back on `distutils.verison.LooseVersion` which is still good enough for most cases.