### PR TITLE
Support importing is_distutils_display_option from its old location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ builtins._ASTROPY_SETUP_ = True
 import astropy
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_package_info, get_debug_option)
-from astropy_helpers.distutils_helpers import is_distutils_display_option
+try:
+    from astropy_helpers.distutils_helpers import is_distutils_display_option
+except:
+    # For astropy-helpers v0.4.x
+    from astropy_helpers.setup_helpers import is_distutils_display_option
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 


### PR DESCRIPTION
I discussed this with a few people over the last couple days, but it still needs to be done.

This will will cut down on the number of `ImportError: is_distutils_display_option` reports for users that, for whatever reason, are somehow building with astropy-helpers v0.4.x instead of the 1.0.dev version that's bundled with astropy 1.0rc1 (and ultimately 1.0 final which will include astropy-helpers 1.0).

For what it's worth, I *think* Astropy v1.0 will build correctly, at least from a source tarball, with astropy-helpers v0.4.x.  It won't build correctly from a source checkout because it needs the new command-hook support to build the erfa sources.

I made it a try/except as a reminder to remove support for the old import path later, but it can stay for now if it cuts down on problems.  