### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/development/building.rst
+++ b/docs/development/building.rst
@@ -106,7 +106,7 @@ process:
     This function declares whether the package requires processing
     through the `2to3`_ tool to run on Python 3.  If not included, it
     defaults to `True`.  The use of `2to3`_ is phased out in astropy
-    and is retained for use in affliate packages which have not switched
+    and is retained for use in affiliate packages which have not switched
     to using `six`_ instead.  See :ref:`dev-portable` for more information.
 
 The ``astropy_helpers.setup_helpers`` modules includes an

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -120,7 +120,7 @@ followed by IPython:
 
   * Duplicate of an existing issue
 
-  * A pull request superceded by a new pull request providing an alternate implementation
+  * A pull request superseded by a new pull request providing an alternate implementation
 
 * Open issues should only lack a milestone if:
 
@@ -136,7 +136,7 @@ followed by IPython:
   * The next bug fix releases for any still-supported version lines; for example if 0.4 is in development and
     0.2.x and 0.3.x are still supported there should be milestones for the next 0.2.x and 0.3.x releases.
 
-  * The next X.Y release, ie. the next minor release; this is generally the next release that all development in
+  * The next X.Y release, i.e. the next minor release; this is generally the next release that all development in
     master is aimed toward.
 
   * The next X.Y release +1; for example if 0.3 is the next release, there should also be a milestone for 0.4 for

--- a/docs/io/fits/appendix/history.rst
+++ b/docs/io/fits/appendix/history.rst
@@ -165,7 +165,7 @@ Bug Fixes
   (spacetelescope/PyFITS#53)
 
 - Improved behavior when writing large compressed images on OSX by removing an
-  unncessary check for platform architecture. (spacetelescope/PyFITS#57)
+  unnecessary check for platform architecture. (spacetelescope/PyFITS#57)
 
 - Allow reading FITS files from file-like objects that do not have a
   ``.closed`` attribute (and as such may not even have an "open" vs. "closed"
@@ -194,7 +194,7 @@ Bug Fixes
   (Backported from 3.2.3)
 
 - Improved behavior when writing large compressed images on OSX by removing an
-  unncessary check for platform architecture. (Backported from 3.2.3)
+  unnecessary check for platform architecture. (Backported from 3.2.3)
 
 - Allow reading FITS files from file-like objects that do not have a
   ``.closed`` attribute (and as such may not even have an "open" vs. "closed"
@@ -230,7 +230,7 @@ Bug Fixes
   accepting an integer index as the first argument, it also supports supplying
   a keyword name as the first argument for insertion relative to a specific
   keyword.  It also now supports an optional ``after`` argument.  If
-  ``after=True`` the the insertion is made below the insertion point instead
+  ``after=True`` the insertion is made below the insertion point instead
   of above it. (spacetelescope/PyFITS#12)
 
 - Fixed support for broadcasting of values assigned to table columns.
@@ -304,7 +304,7 @@ Bug Fixes
   accepting an integer index as the first argument, it also supports supplying
   a keyword name as the first argument for insertion relative to a specific
   keyword.  It also now supports an optional ``after`` argument.  If
-  ``after=True`` the the insertion is made below the insertion point instead
+  ``after=True`` the insertion is made below the insertion point instead
   of above it. (Backported from 3.2.1)
 
 - A grab bag of minor performance improvements in headers.
@@ -2903,7 +2903,7 @@ Minor changes since v0.9.6:
 
 - Add output verification in methods flush() and close().
 
-- Modify the the design of the open() function to remove the output_verify
+- Modify the design of the open() function to remove the output_verify
   argument.
 
 - Remove the groups argument in GroupsHDU's constructor.
@@ -3079,7 +3079,7 @@ Changes since 0.7.5:
   in order for pyfits to run under numarray 0.4.
 
 - edit _readblock to add the (optional) firstblock argument and raise IOError
-  if the the first 8 characters in the first block is not 'SIMPLE  ' or
+  if the first 8 characters in the first block is not 'SIMPLE  ' or
   'XTENSION'.  Edit the function open to check for IOError to skip the last
   null filled block(s).  Edit readHDU to add the firstblock argument.
 


### PR DESCRIPTION
Some typo corrections in development docs and `io.fits`

[ci skip]