### PR TITLE
Time(np.nan) should raise a ValueError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -510,6 +510,8 @@ Bug Fixes
   - When creating a Time object from a datetime object the time zone
     info is now correctly used. [#3160]
 
+  - For Time objects, it is now checked that numerical input is finite. [#3396]
+    
 - ``astropy.units``
 
   - Added a ``latex_inline`` unit format that returns the units in LaTeX math

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1313,11 +1313,9 @@ class TimeFormat(object):
 
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
-        try:
-            assert (val1.dtype == np.double and np.all(np.isfinite(val1)) and
-                    (val2 is None or
-                     val2.dtype == np.double and np.all(np.isfinite(val2))))
-        except:
+        if not (val1.dtype == np.double and np.all(np.isfinite(val1)) and
+                (val2 is None or
+                 val2.dtype == np.double and np.all(np.isfinite(val2)))):
             raise TypeError('Input values for {0} class must be finite doubles'
                             .format(self.name))
 
@@ -1692,9 +1690,7 @@ class TimeDatetime(TimeUnique):
 
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class
-        try:
-            assert all(isinstance(val, datetime) for val in val1.flat)
-        except:
+        if not all(isinstance(val, datetime) for val in val1.flat):
             raise TypeError('Input values for {0} class must be '
                             'datetime objects'.format(self.name))
         return val1, None
@@ -1751,9 +1747,7 @@ class TimeString(TimeUnique):
     """
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for these classes
-        try:
-            assert val1.dtype.kind in ('S', 'U')
-        except:
+        if val1.dtype.kind not in ('S', 'U'):
             raise TypeError('Input values for {0} class must be strings'
                             .format(self.name))
         return val1, None

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1314,8 +1314,9 @@ class TimeFormat(object):
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
         try:
-            assert (val1.dtype == np.double and
-                    (val2 is None or val2.dtype == np.double))
+            assert (val1.dtype == np.double and np.all(np.isfinite(val1)) and
+                    (val2 is None or
+                     val2.dtype == np.double and np.all(np.isfinite(val2))))
         except:
             raise TypeError('Input values for {0} class must be doubles'
                             .format(self.name))

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1318,7 +1318,7 @@ class TimeFormat(object):
                     (val2 is None or
                      val2.dtype == np.double and np.all(np.isfinite(val2))))
         except:
-            raise TypeError('Input values for {0} class must be doubles'
+            raise TypeError('Input values for {0} class must be finite doubles'
                             .format(self.name))
 
         if hasattr(val1, 'to'):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -382,6 +382,9 @@ class TestBasic():
             Time(50000.0, 'bad', format='mjd', scale='tai')
         with pytest.raises(ValueError):
             Time('2005-08-04T00:01:02.000Z', scale='tai')
+        # regression test against #3396
+        with pytest.raises(ValueError):
+            Time(np.nan, format='jd', scale='utc')
 
     def test_utc_leap_sec(self):
         """Time behaves properly near or in UTC leap second.  This


### PR DESCRIPTION
Don't ask how I stumbled upon this, but I think the third line in this snippet of code should have raised a `ValueError`, instead of the dubious things that ensue:

```Python
In [1]: import numpy as np
In [2]: from astropy.time import Time
In [3]: t = Time(np.nan, format='jd')
In [4]: t.iso
WARNING: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)" [astropy._erfa.core]
Out[4]: '-4713-11-25 -2147483648:-2147483648:-2147483648.-2147483648'
```