### PR TITLE
1.0rc1 Unicode problems with Python3.4 (test failures)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
         # Now try do scipy on 2.7 and an appropriate 3.x build (with latest numpy)
         # We also note the code coverage on Python 2.7.
         - python: 2.7
-          env: SETUP_CMD='test --coverage'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
+          env: SETUP_CMD='test --coverage'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
         - python: 3.4
-          env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
+          env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
 
         # Try older numpy versions
         - python: 2.7


### PR DESCRIPTION
With Python 3.4, I get quite a number of test failures:

1. some doctests in `astropy/coordinates/angles.py` fail:  `Angle.is_within_bounds()` and `Angle.wrap_at()` just fail without additional info (they stop the tests)

2. I get the error (twice)
```
_____________ ERROR collecting astropy/time/tests/test_sidereal.py _____________
astropy/time/tests/test_sidereal.py:68: in <module>
>   class TestST():
astropy/time/tests/test_sidereal.py:76: in TestST
>       t2 = Time(t1, location=('120d', '10d'))
astropy/time/core.py:183: in __init__
>               self.location = EarthLocation(*location)
astropy/coordinates/earth.py:73: in __new__
>                               .format(exc_geocentric, exc_geodetic))
E               TypeError: Coordinates could not be parsed as either geocentric or geodetic, with respective exceptions "from_geocentric() missing 1 requ
ired positional argument: 'z'" and "'ascii' codec can't decode byte 0xc2 in position 819: ordinal not in range(128)"
```
There are many more failures due to ascii codec, like:
```
____________ [doctest] astropy.coordinates.sky_coordinate.SkyCoord _____________
074       >>> import astropy.units as u
075 
076     The coordinate values and frame specification can now be provided using
077     positional and keyword arguments::
078 
079       >>> c = SkyCoord(10, 20, unit="deg")  # defaults to ICRS frame
080       >>> c = SkyCoord([1, 2, 3], [-30, 45, 8], "icrs", unit="deg")  # 3 coords
081 
082       >>> coords = ["1:12:43.2 +1:12:43", "1 12 43.2 +1 12 43"]
083       >>> c = SkyCoord(coords, FK4, unit=(u.deg, u.hourangle), obstime="J1992.21")
UNEXPECTED EXCEPTION: ValueError('Cannot parse first argument data [...] ')
Traceback (most recent call last):
 [...]
  File "/tmp/astropy-test-9zl5a2gi/lib.linux-x86_64-3.4/astropy/extern/ply/yacc.py", line 2837, in validate_files
    lines = f.readlines()

  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 819: ordinal not in range(128)

During handling of the above exception, another exception occurred: [...]
```
They all seem to be caused by the UnicodeDecodeError. Full build log ist [here](http://ole.ath.cx/python-astropy_1.0~rc1-1_amd64.build)