### PR TITLE
Allow a memory error when allocating large array

### DIFF
--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -462,7 +462,7 @@ class TestConvolve2D(object):
     def test_big_fail(self):
         """ Test that convolve_fft raises an exception if a too-large array is passed in """
 
-        with pytest.raises(ValueError) as ex:
+        with pytest.raises((ValueError, MemoryError)) as ex:
             # while a good idea, this approach did not work; it actually writes to disk
             #arr = np.memmap('file.np', mode='w+', shape=(512, 512, 512), dtype=np.complex)
             # this just allocates the memory but never touches it; it's better:


### PR DESCRIPTION
A fix for one of the failures mentioned in #3405.

One of the convolve tests allocates a large array, and then passes it to convolve expecting a ValueError to be raised because it is so large.  On @migueldvb's machine at least, the allocation of the large array itself fails with a MemoryError.  How much RAM does that machine have @migueldvb?  Do you think that's a false positive?  If in fact memory is tight, than this is reasonable behavior all around and the test should probably pass.

Cc: @keflavich as the last to touch this file.