### PR TITLE
Ignore BeautifulSoup4 DeprecationWarnings on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         # We also note the code coverage on Python 2.7.
         - python: 2.7
           env: SETUP_CMD='test --coverage'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
-        - python: 3.3
+        - python: 3.4
           env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii
 
         # Try older numpy versions

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -456,6 +456,18 @@ def treat_deprecations_as_exceptions():
             r"'U' mode is deprecated",
             DeprecationWarning)
 
+        # BeautifulSoup4 triggers a DeprecationWarning in stdlib's
+        # html module.x
+        warnings.filterwarnings(
+            "always",
+            "The strict argument and mode are deprecated.",
+            DeprecationWarning)
+        warnings.filterwarnings(
+            "always",
+            "The value of convert_charrefs will become True in 3.5. "
+            "You are encouraged to set the value explicitly.",
+            DeprecationWarning)
+
 
 class catch_warnings(warnings.catch_warnings):
     """


### PR DESCRIPTION
Partial fix for #3405, along with #3406.

BeautifulSoup4 uses some deprecated kwargs to the stdlib html module.  There's not much we can do to work around them until BeautifulSoup updates itself, so we just add these to the list of warnings to ignore.

This was missed because we only test optional dependencies on Travis on Python 3.3, not 3.4.  This also update `.travis.yml` to use Python 3.4 instead.  @astrofrog, @embray: is that good enough, or should we do optional dependencies on both 3.3 and 3.4?