### PR TITLE
Fix issue with ImageNormalize not working with Matplotlib < 1.2 because Normalize used to be an old-style class

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -11,11 +11,11 @@ from numpy import ma
 
 try:
     import matplotlib
-    MATPLOTLIB_INSTALLED = True
+    HAS_MATPLOTLIB = True
     MATPLOTLIB_LT_12 = LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0")
     from matplotlib.colors import Normalize
 except ImportError:
-    MATPLOTLIB_INSTALLED = False
+    HAS_MATPLOTLIB = False
     class Normalize(object):
         def __init__(self, *args, **kwargs):
             raise ImportError("matplotlib is required in order to use this class")
@@ -39,7 +39,7 @@ class ImageNormalize(Normalize):
 
     def __init__(self, vmin=None, vmax=None, stretch=None, clip=False):
 
-        if MATPLOTLIB_INSTALLED and MATPLOTLIB_LT_12:
+        if HAS_MATPLOTLIB and MATPLOTLIB_LT_12:
             # Normalize is an old-style class
             Normalize.__init__(self, vmin=vmin, vmax=vmax, clip=clip)
         else:  # Normalize is a new-style class

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -11,9 +11,11 @@ from numpy import ma
 
 try:
     import matplotlib
+    MATPLOTLIB_INSTALLED = True
     MATPLOTLIB_LT_12 = LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0")
     from matplotlib.colors import Normalize
 except ImportError:
+    MATPLOTLIB_INSTALLED = False
     class Normalize(object):
         def __init__(self, *args, **kwargs):
             raise ImportError("matplotlib is required in order to use this class")
@@ -37,7 +39,8 @@ class ImageNormalize(Normalize):
 
     def __init__(self, vmin=None, vmax=None, stretch=None, clip=False):
 
-        if MATPLOTLIB_LT_12:  # Normalize is an old-style class
+        if MATPLOTLIB_INSTALLED and MATPLOTLIB_LT_12:
+            # Normalize is an old-style class
             Normalize.__init__(self, vmin=vmin, vmax=vmax, clip=clip)
         else:  # Normalize is a new-style class
             super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -4,10 +4,14 @@ Normalization class for Matplotlib that can be used to produce colorbars.
 
 from __future__ import division, print_function
 
+from distutils.version import LooseVersion
+
 import numpy as np
 from numpy import ma
 
 try:
+    import matplotlib
+    MATPLOTLIB_LT_12 = LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0")
     from matplotlib.colors import Normalize
 except ImportError:
     class Normalize(object):
@@ -33,7 +37,10 @@ class ImageNormalize(Normalize):
 
     def __init__(self, vmin=None, vmax=None, stretch=None, clip=False):
 
-        super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
+        if MATPLOTLIB_LT_12:  # Normalize is an old-style class
+            Normalize.__init__(self, vmin=vmin, vmax=vmax, clip=clip)
+        else:  # Normalize is a new-style class
+            super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
 
         self.vmin = vmin
         self.vmax = vmax


### PR DESCRIPTION
Will fix https://github.com/astropy/photutils/issues/247