### PR TITLE
Use slow fallback of io.ascii.read if sem_open is not available.

### DIFF
--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -156,7 +156,7 @@ def read(table, guess=None, **kwargs):
             fast_reader = get_reader(**new_kwargs)
             try:
                 return fast_reader.read(table)
-            except (core.ParameterError, cparser.CParserError) as e:
+            except (core.ParameterError, cparser.CParserError, ImportError) as e:
                 # special testing value to avoid falling back on the slow reader
                 if fast_reader_param == 'force':
                     raise e


### PR DESCRIPTION
A Fix for #3416 
On Hurd, there is still no implementation of sem_open available. This
causes multiprocessing.Queue() (in cparser.pyx) to fail with an
ImportError. In this case, we can just use the slow reader.