### PR TITLE
Resize masked array in a way that's compatible with Numpy-dev

### DIFF
--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -67,9 +67,15 @@ def _resize(masked, new_size):
     """
     new_array = ma.zeros((new_size,), dtype=masked.dtype)
     length = min(len(masked), new_size)
-    new_array.data[:length] = masked.data[:length]
-    if length != 0:
-        new_array.mask[:length] = masked.mask[:length]
+    try:
+        # Pre Numpy 1.10 way
+        new_array.data[:length] = masked.data[:length]
+    except TypeError:
+        # Numpy 1.10 and later
+        new_array[:length] = masked[:length]
+    else:
+        if length != 0:
+            new_array.mask[:length] = masked.mask[:length]
     return new_array
 
 


### PR DESCRIPTION
Fix #3420.

@embray: This affects 0.4.x on Numpy-dev and Python 3.x as well.  I guess that means it should be backported, but I leave that to your discretion (since it's Numpy-dev only).