### PR TITLE
Raise a CParserError if sem_open is not available

### DIFF
--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -389,7 +389,11 @@ cdef class CParser:
 
         cdef list line_comments = self._get_comments(self.tokenizer)
         cdef int N = self.parallel
-        queue = multiprocessing.Queue()
+        try:
+            queue = multiprocessing.Queue()
+        except ImportError:
+            self.raise_error("shared semaphore implementation required "
+                             "but not available")
         cdef int offset = self.tokenizer.source_pos
 
         if offset == source_len: # no data


### PR DESCRIPTION
closes #3416 as alternative to #3417 
On Hurd, there is still no implementation of sem_open available. This
causes multiprocessing.Queue() (in cparser.pyx) to fail with an
ImportError which is just translated into a CparserError.