### PR TITLE
Added a new error message while slicing a table 

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -509,6 +509,8 @@ class Table(object):
         """Initialize table from a list of Column objects"""
 
         lengths = set(len(col) for col in cols)
+        if len(lengths) == 0:
+            raise ValueError('Cannot slice table with empty iterator')
         if len(lengths) != 1:
             raise ValueError('Inconsistent data column lengths: {0}'
                              .format(lengths))


### PR DESCRIPTION
Wrote more explicit error message while slicing a table with empty iterator. This fixes #2856.