### PR TITLE
New RedshiftSpectrum Model

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -19,7 +19,7 @@ __all__ = sorted([
     'AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
     'Const2D', 'Ellipse2D', 'Disk2D', 'Gaussian1D',
     'GaussianAbsorption1D', 'Gaussian2D', 'Linear1D', 'Lorentz1D',
-    'MexicanHat1D', 'MexicanHat2D', 'Scale', 'Redshift',
+    'MexicanHat1D', 'MexicanHat2D', 'Scale', 'RedshiftWavelength',
     'RedshiftSpectrum', 'Shift', 'Sine1D', 'Trapezoid1D',
     'TrapezoidDisk2D', 'Ring2D', 'custom_model_1d'
 ])
@@ -400,7 +400,7 @@ class Scale(Model):
         return factor * x
 
 
-class Redshift(Fittable1DModel):
+class RedshiftWavelength(Fittable1DModel):
     """
     One dimensional redshift model.
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -16,12 +16,12 @@ from ..utils import deprecated
 from ..extern import six
 
 __all__ = sorted([
-    'AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D',
-    'Box2D', 'Const1D', 'Const2D', 'Ellipse2D', 'Disk2D',
-    'Gaussian1D', 'GaussianAbsorption1D', 'Gaussian2D', 'Linear1D',
-    'Lorentz1D', 'MexicanHat1D', 'MexicanHat2D', 'Scale', 'Redshift', 'Shift',
-    'Sine1D', 'Trapezoid1D', 'TrapezoidDisk2D', 'Ring2D',
-    'custom_model_1d'
+    'AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
+    'Const2D', 'Ellipse2D', 'Disk2D', 'Gaussian1D',
+    'GaussianAbsorption1D', 'Gaussian2D', 'Linear1D', 'Lorentz1D',
+    'MexicanHat1D', 'MexicanHat2D', 'Scale', 'Redshift',
+    'RedshiftSpectrum', 'Shift', 'Sine1D', 'Trapezoid1D',
+    'TrapezoidDisk2D', 'Ring2D', 'custom_model_1d'
 ])
 
 
@@ -440,6 +440,41 @@ class Redshift(Fittable1DModel):
         inv = self.copy()
         inv.z = 1.0 / (1.0 + self.z) - 1.0
         return inv
+
+
+class RedshiftSpectrum(Model):
+    """
+    One dimensional redshift model.
+
+    Parameters
+    ----------
+    z : int or float
+        Redshift value of the output spectrum.
+
+    z_in : int or float
+        Redshift value of the input spectrum.
+
+    Notes
+    -----
+    Model formula:
+
+    .. math::
+        \\lambda_{out} = \\frac{(1 + z)}{(1 + z_{in})} \\lambda_{in}
+
+        F_{out} = \\frac{(1 + z_{in})}{(1 + z)} F_{in}
+    """
+
+    inputs = ('wavelength', 'flux')
+    outputs = ('redshifted_wavelength', 'redshifted_flux')
+
+    z = Parameter(description='Redshift of output spectrum', default=0)
+    z_in = Parameter(description='Redshift of input spectrum', default=0)
+
+    @staticmethod
+    def evaluate(wavelength, flux, z, z_in):
+        """RedshiftSpectrum model function."""
+        factor = (1. + z) / (1. + z_in)
+        return (wavelength * factor), (flux / factor)
 
 
 class Sine1D(Fittable1DModel):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -404,9 +404,11 @@ class Redshift(Fittable1DModel):
     """
     One dimensional redshift model.
 
+    Redshifts a wavelength array from rest (z=0) to the input redshift.
+
     Parameters
     ----------
-    z : float or a list of floats
+    z : int or float
         Redshift value(s).
 
     Notes
@@ -414,20 +416,20 @@ class Redshift(Fittable1DModel):
     Model formula:
 
         .. math:: \\lambda_{obs} = (1 + z) \\lambda_{rest}
-
     """
 
     z = Parameter(description='redshift', default=0)
 
     @staticmethod
     def evaluate(x, z):
-        """One dimensional Redshift model function"""
+        """One dimensional Redshift model function."""
 
         return (1 + z) * x
 
     @staticmethod
     def fit_deriv(x, z):
-        """One dimensional Redshift model derivative"""
+        """One dimensional Redshift model derivative."""
+
         d_z = x
         return [d_z]
 

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -87,18 +87,18 @@ def test_Gaussian2DRotation():
     assert_allclose(value1, value2)
 
 
-def test_Redshift():
+def test_RedshiftWavelength():
     """Like ``test_ScaleModel()``."""
 
     # Scale by a scalar
-    m = models.Redshift(0.4)
+    m = models.RedshiftWavelength(0.4)
     assert m(0) == 0
     assert_array_equal(m([1, 2]), [1.4, 2.8])
 
     assert_allclose(m.inverse(m([1, 2])), [1, 2])
 
     # Scale by a list
-    m = models.Redshift([-0.5, 0, 0.5], model_set_axis=0)
+    m = models.RedshiftWavelength([-0.5, 0, 0.5], model_set_axis=0)
     assert_array_equal(m(0), 0)
     assert_array_equal(m([1, 2], model_set_axis=False),
                        [[0.5, 1], [1, 2], [1.5, 3]])


### PR DESCRIPTION
This PR adds a new `RedshiftSpectrum` model.  This model applies the redshift factor to both the wavelength and flux arrays to conserve total flux.  It is not limited to redshifting a spectrum at rest (`z=0`) to higher redshift.  Using the `z_in` parameter, it can change the redshift of a spectrum at any redshift (`z_in`) to any other redshift (`z`).

This PR also renames the `Redshift` model to `RedshiftWavelength` to be more specific.  To be completely specific, the `Redshift` model should be called `RedshiftWavelengthFromRest`, but that may be too long of a name. :smile:

I still need to add tests for `RedshiftSpectrum`.  Here's a quick example of usage:

```
from astropy.modeling.models import RedshiftSpectrum, Gaussian1D
wave = np.arange(4000, 6000)
g = Gaussian1D(100, 5000, 50.)
flux = g(wave)
z0_to_z1 = RedshiftSpectrum(1.)
wave1, flux1 = z0_to_z1(wave, flux)
z5_to_z3 = RedshiftSpectrum(3, z_in=5)
wave2, flux2 = z5_to_z3(wave, flux)
```