### PR TITLE
float decimal format not understood by astropy.io.fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -484,9 +484,19 @@ Bug Fixes
   - Fixed the problem in ``fits.open`` of some filenames with colon (``:``) in
     the name being recognized as URLs instead of file names. [#3122]
 
-  - Setting ``memmap=True`` in ``fits.open`` and related functions now raises a ValueError if opening a file in memory-mapped mode is impossible. [#2298]
+  - Setting ``memmap=True`` in ``fits.open`` and related functions now raises
+    a ValueError if opening a file in memory-mapped mode is impossible. [#2298]
 
-  - CONTINUE cards no longer end the value of the final card in the series with an ampersand, per the specification of the CONTINUE card convention. [#3282]
+  - CONTINUE cards no longer end the value of the final card in the series with
+    an ampersand, per the specification of the CONTINUE card convention. [#3282]
+
+  - Fixed a crash that occurred when reading an ASCII table containing
+    zero-precision floating point fields. [#3422]
+
+  - When a float field for an ASCII table has zero-precision a decimal point
+    (with no digits following it) is still written to the field as long as
+    there is space for it, as recommended by the FITS standard.  This makes it
+    less ambiguous that these columns should be interpreted as floats. [#3422]
 
 - ``astropy.logger``
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1077,6 +1077,12 @@ class FITS_rec(np.recarray):
         fmt = ''.join([_pc, format[1:], ASCII2STR[format[0]],
                        (' ' * trail)])
 
+        # Even if the format precision is 0, we should output a decimal point
+        # as long as there is space to do so--not including a decimal point in
+        # a float value is discouraged by the FITS Standard
+        trailing_decimal = (format.precision == 0 and
+                            format.format in ('F', 'E', 'D'))
+
         # not using numarray.strings's num2char because the
         # result is not allowed to expand (as C/Python does).
         for jdx, value in enumerate(input_field):
@@ -1085,6 +1091,11 @@ class FITS_rec(np.recarray):
                 raise ValueError(
                     "Value %r does not fit into the output's itemsize of "
                     "%s." % (value, spans[col_idx]))
+
+            if trailing_decimal and value[0] == ' ':
+                # We have some extra space in the field for the trailing
+                # decimal point
+                value = value[1:] + '.'
 
             output_field[jdx] = value
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -266,7 +266,8 @@ class FITS_rec(np.recarray):
                 if hasattr(obj, attr):
                     value = getattr(obj, attr, None)
                     if value is None:
-                        warnings.warn('Setting attribute %s as None' % attr, AstropyUserWarning)
+                        warnings.warn('Setting attribute %s as None' % attr,
+                                      AstropyUserWarning)
                     setattr(self, attr, value)
 
             if self._coldefs is None:
@@ -688,9 +689,9 @@ class FITS_rec(np.recarray):
         return dummy
 
     def _convert_ascii(self, indx, field):
-        """Special handling for ASCII table columns to convert columns
-        containing numeric types to actual numeric arrays from the string
-        representation.
+        """
+        Special handling for ASCII table columns to convert columns containing
+        numeric types to actual numeric arrays from the string representation.
         """
 
         format = self._coldefs.formats[indx]
@@ -988,57 +989,7 @@ class FITS_rec(np.recarray):
 
                 # ASCII table, convert numbers to strings
                 if isinstance(self._coldefs, _AsciiColDefs):
-                    starts = self._coldefs.starts[:]
-                    spans = self._coldefs.spans
-                    format = self._coldefs.formats[indx].strip()
-
-                    # The the index of the "end" column of the record, beyond
-                    # which we can't write
-                    end = super(FITS_rec, self).field(-1).itemsize
-                    starts.append(end + starts[-1])
-
-                    if indx > 0:
-                        lead = (starts[indx] - starts[indx - 1] -
-                                spans[indx - 1])
-                    else:
-                        lead = 0
-
-                    if lead < 0:
-                        warnings.warn(
-                            'Column %r starting point overlaps the '
-                            'previous column.' % (indx + 1))
-
-                    trail = starts[indx + 1] - starts[indx] - spans[indx]
-
-                    if trail < 0:
-                        warnings.warn(
-                            'Column %r ending point overlaps the next '
-                            'column.' % (indx + 1))
-
-                    # TODO: It would be nice if these string column formatting
-                    # details were left to a specialized class, as is the case
-                    # with FormatX and FormatP
-                    if 'A' in format:
-                        _pc = '%-'
-                    else:
-                        _pc = '%'
-
-                    fmt = ''.join([_pc, format[1:], ASCII2STR[format[0]],
-                                   (' ' * trail)])
-
-                    # not using numarray.strings's num2char because the
-                    # result is not allowed to expand (as C/Python does).
-                    for jdx in xrange(len(dummy)):
-                        x = fmt % dummy[jdx]
-                        if len(x) > starts[indx + 1] - starts[indx]:
-                            raise ValueError(
-                                "Value %r does not fit into the output's "
-                                "itemsize of %s." % (x, spans[indx]))
-                        else:
-                            field[jdx] = x
-                    # Replace exponent separator in floating point numbers
-                    if 'D' in format:
-                        field.replace(encode_ascii('E'), encode_ascii('D'))
+                    self._scale_back_ascii(indx, dummy, field)
                 # binary table
                 else:
                     if len(field) and isinstance(field[0], np.integer):
@@ -1081,3 +1032,62 @@ class FITS_rec(np.recarray):
 
         # Store the updated heapsize
         self._heapsize = heapsize
+
+    def _scale_back_ascii(self, col_idx, input_field, output_field):
+        """
+        Convert internal array values back to ASCII table representation.
+
+        The ``input_field`` is the internal representation of the values, and
+        the ``output_field`` is the character array representing the ASCII
+        output that will be written.
+        """
+
+        starts = self._coldefs.starts[:]
+        spans = self._coldefs.spans
+        format = self._coldefs.formats[col_idx]
+
+        # The the index of the "end" column of the record, beyond
+        # which we can't write
+        end = super(FITS_rec, self).field(-1).itemsize
+        starts.append(end + starts[-1])
+
+        if col_idx > 0:
+            lead = starts[col_idx] - starts[col_idx - 1] - spans[col_idx - 1]
+        else:
+            lead = 0
+
+        if lead < 0:
+            warnings.warn('Column %r starting point overlaps the previous '
+                          'column.' % (col_idx + 1))
+
+        trail = starts[col_idx + 1] - starts[col_idx] - spans[col_idx]
+
+        if trail < 0:
+            warnings.warn('Column %r ending point overlaps the next '
+                          'column.' % (col_idx + 1))
+
+        # TODO: It would be nice if these string column formatting
+        # details were left to a specialized class, as is the case
+        # with FormatX and FormatP
+        if 'A' in format:
+            _pc = '%-'
+        else:
+            _pc = '%'
+
+        fmt = ''.join([_pc, format[1:], ASCII2STR[format[0]],
+                       (' ' * trail)])
+
+        # not using numarray.strings's num2char because the
+        # result is not allowed to expand (as C/Python does).
+        for jdx, value in enumerate(input_field):
+            value = fmt % value
+            if len(value) > starts[col_idx + 1] - starts[col_idx]:
+                raise ValueError(
+                    "Value %r does not fit into the output's itemsize of "
+                    "%s." % (value, spans[col_idx]))
+
+            output_field[jdx] = value
+
+        # Replace exponent separator in floating point numbers
+        if 'D' in format:
+            output_field.replace(encode_ascii('E'), encode_ascii('D'))

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2428,6 +2428,25 @@ class TestColumnFunctions(FitsTestCase):
         c = fits.Column('TEST', 'D', ascii=True)
         assert c.format == 'D25.17'
 
+    def test_zero_precision_float_column(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/3422
+        """
+
+        c = fits.Column('TEST', 'F5.0', array=[1.1, 2.2, 3.3])
+        # The decimal places will be clipped
+        t = fits.TableHDU.from_columns([c])
+        t.writeto(self.temp('test.fits'))
+
+        with fits.open(self.temp('test.fits')) as hdul:
+            assert hdul[1].header['TFORM1'] == 'F5.0'
+            assert hdul[1].data['TEST'].dtype == np.dtype('float32')
+            assert np.all(hdul[1].data['TEST'] == [1.0, 2.0, 3.0])
+
+            # Check how the raw data looks
+            raw = np.rec.recarray.field(hdul[1].data, 'TEST')
+            assert raw.tostring() == b'   1.   2.   3.'
+
     def test_column_array_type_mismatch(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/218"""
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2383,6 +2383,23 @@ class TestColumnFunctions(FitsTestCase):
         assert c.format.width == 15
         assert c.format.precision == 8
 
+        # zero-precision should be allowed as well, for float types
+        # https://github.com/astropy/astropy/issues/3422
+        c = fits.Column('TEST', 'F10.0')
+        assert c.format.format == 'F'
+        assert c.format.width == 10
+        assert c.format.precision == 0
+
+        c = fits.Column('TEST', 'E10.0')
+        assert c.format.format == 'E'
+        assert c.format.width == 10
+        assert c.format.precision == 0
+
+        c = fits.Column('TEST', 'D10.0')
+        assert c.format.format == 'D'
+        assert c.format.width == 10
+        assert c.format.precision == 0
+
         # These are a couple cases where the format code is a valid binary
         # table format, and is not strictly a valid ASCII table format but
         # could be *interpreted* as one by appending a default width.  This


### PR DESCRIPTION
When trying to read data in a fits file I got the following error, while old good pyfits understood data types correctly.

    from astropy.io import fits
    f = fits.open('file.fits')
    f[0].data
    $> Format 'F9.0' is not valid--field width and decimal precision must be positive integers

Is there a fix or workaround? Many fits files uses this convention.