### PR TITLE
Remove precompiled wcslib version string

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -3450,10 +3450,6 @@ _setup_wcsprm_type(
   wcsprintf_set(NULL);
   wcserr_enable(1);
 
-  if (PyModule_AddStringConstant(m, "__version__", XSTRINGIFY(WCSLIB_VERSION))) {
-      return -1;
-  }
-
   return (
     PyModule_AddObject(m, "Wcsprm", (PyObject *)&PyWcsprmType) ||
     CONSTANT(WCSSUB_LONGITUDE) ||

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -785,18 +785,14 @@ def test_compare():
     assert w.compare(w2, tolerance=1e-6)
 
 
-@pytest.mark.xfail(
-    LooseVersion(_wcs.__version__) < LooseVersion("4.25"),
-    reason="wcslib < 4.25")
+@pytest.mark.xfail()
 def test_radesys_defaults():
     w = _wcs.Wcsprm()
     w.ctype = ['RA---TAN', 'DEC--TAN']
     w.set()
     assert w.radesys == "ICRS"
 
-@pytest.mark.xfail(
-    LooseVersion(_wcs.__version__) < LooseVersion("4.25"),
-    reason="wcslib < 4.25")
+@pytest.mark.xfail()
 def test_radesys_defaults_full():
 
     # As described in Section 3.1 of the FITS standard "Equatorial and ecliptic


### PR DESCRIPTION
This will fix #3400 
Up to of (at least) 4.25.1, the wcslib version cannot be determined at
runtime. Taking the version string from the header file will lead to
wrong results if the wcslib was upgraded after the astropy installation.
Therefore, it is better to remove the number at all unless we can query
the version number at runtime.