### PR TITLE
Update doctests (update to #2735)

### DIFF
--- a/astropy/tests/output_checker.py
+++ b/astropy/tests/output_checker.py
@@ -45,7 +45,9 @@ class AstropyOutputChecker(doctest.OutputChecker):
         # NOTE OutputChecker is an old-style class with no __init__ method,
         # so we can't call the base class version of __init__ here
 
-        got_floats = r'(\d+\.\d*|\.\d+)(?:e[+-]?\d+)?'
+        exp = r'(?:e[+-]?\d+)'
+
+        got_floats = r'(\d+\.\d*%s?|\.\d+%s?|\d+%s)' % (exp, exp, exp)
 
         # floats in the 'want' string may contain ellipses
         want_floats = got_floats + r'(\.{3})?'

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -82,6 +82,7 @@ removed, and the points are still located on a unit sphere:
     <CartesianRepresentation (x, y, z) [dimensionless]
         (0.424264068712, 0.707106781187, 0.565685424949)>
 
+
 Array values
 ^^^^^^^^^^^^
 

--- a/docs/coordinates/sgr-example.rst
+++ b/docs/coordinates/sgr-example.rst
@@ -164,7 +164,7 @@ transform from ICRS coordinates to ``Sagittarius``, we simply::
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord
     >>> icrs = coord.ICRS(280.161732*u.degree, 11.91934*u.degree)
-    >>> icrs.transform_to(Sagittarius)  # doctest: +FLOAT_CMP
+    >>> icrs.transform_to(Sagittarius)  # doctest: +SKIP
     <Sagittarius Coordinate: (Lambda, Beta, distance) in (deg, deg, )
         (346.8182733552503, -39.28366798041541, 1.0)>
 

--- a/docs/coordinates/sgr-example.rst
+++ b/docs/coordinates/sgr-example.rst
@@ -164,9 +164,9 @@ transform from ICRS coordinates to ``Sagittarius``, we simply::
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord
     >>> icrs = coord.ICRS(280.161732*u.degree, 11.91934*u.degree)
-    >>> icrs.transform_to(Sagittarius)  # doctest: +SKIP
+    >>> icrs.transform_to(Sagittarius)  # doctest: +FLOAT_CMP
     <Sagittarius Coordinate: (Lambda, Beta, distance) in (deg, deg, )
-        (346.818273..., -39.283667..., 1.0)>
+        (346.8182733552503, -39.28366798041541, 1.0)>
 
 The complete code for the above example is included below for reference.
 

--- a/docs/modeling/parameters.rst
+++ b/docs/modeling/parameters.rst
@@ -52,14 +52,14 @@ Parameter examples
   when constructing an instance of that model::
 
       >>> g = models.Gaussian1D(1.0, 0.0, 0.1)
-      >>> g
-      <Gaussian1D(amplitude=1.0, mean=0.0, stddev=0.1...)>
+      >>> g  # doctest: +FLOAT_CMP
+      <Gaussian1D(amplitude=1.0, mean=0.0, stddev=0.1)>
 
   However, parameters may also be given as keyword arguments (in any order)::
 
       >>> g = models.Gaussian1D(mean=0.0, amplitude=2.0, stddev=0.2)
-      >>> g
-      <Gaussian1D(amplitude=2.0, mean=0.0, stddev=0.2...)>
+      >>> g  # doctest: +FLOAT_CMP
+      <Gaussian1D(amplitude=2.0, mean=0.0, stddev=0.2)>
 
   So all that really matters is knowing the names (and meanings) of the
   parameters that each model accepts.  More information about an individual

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -90,8 +90,8 @@ Finally, some further examples of what is possible.  For details, see
 the API documentation below.
 
   >>> dt = t[1] - t[0]
-  >>> dt
-  <TimeDelta object: scale='tai' format='jd' value=4018.0000217...>
+  >>> dt  # doctest: +FLOAT_CMP
+  <TimeDelta object: scale='tai' format='jd' value=4018.00002172>
 
 Here, note the conversion of the timescale to TAI.  Time differences
 can only have scales in which one day is always equal to 86400 seconds.
@@ -328,8 +328,8 @@ and ``jd2`` attributes::
   >>> t.jd1, t.jd2
   (2455197.5, 0.0)
   >>> t2 = t.tai
-  >>> t2.jd1, t2.jd2
-  (2455197.5, 0.00039351851851851...)
+  >>> t2.jd1, t2.jd2  # doctest: +FLOAT_CMP
+  (2455197.5, 0.0003935185185185185)
 
 Creating a Time object
 ----------------------
@@ -392,8 +392,8 @@ string-valued formats ignore ``val2`` and all numeric inputs effectively add
 the two values in a way that maintains the highest precision.  Example::
 
   >>> t = Time(100.0, 0.000001, format='mjd', scale='tt')
-  >>> t.jd, t.jd1, t.jd2  # doctest: +SKIP
-  (2400100.50000..., 2400100.5, 1e-06)
+  >>> t.jd, t.jd1, t.jd2  # doctest: +FLOAT_CMP
+  (2400100.500001, 2400100.5, 1e-06)
 
 format
 ^^^^^^
@@ -482,10 +482,10 @@ no explicit longitude is given.
 
   >>> t = Time('2001-03-22 00:01:44.732327132980', scale='utc',
   ...          location=('120d', '40d'))
-  >>> t.sidereal_time('apparent', 'greenwich')
-  <Longitude 12.00000000000... hourangle>
-  >>> t.sidereal_time('apparent')
-  <Longitude 20.00000000000... hourangle>
+  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP
+  <Longitude 12.00000000000001 hourangle>
+  >>> t.sidereal_time('apparent')  # doctest: +FLOAT_CMP
+  <Longitude 20.00000000000001 hourangle>
 
 .. note:: In future versions, we hope to add the possibility to add observatory
           objects and/or names.
@@ -654,16 +654,16 @@ transformations, ERFA C-library routines are used under the hood, which support
 calculations following different IAU resolutions.  Sample usage::
 
   >>> t = Time('2006-01-15 21:24:37.5', scale='utc', location=('120d', '45d'))
-  >>> t.sidereal_time('mean')
-  <Longitude 13.089521870640... hourangle>
-  >>> t.sidereal_time('apparent')
-  <Longitude 13.08950367508... hourangle>
-  >>> t.sidereal_time('apparent', 'greenwich')
-  <Longitude 5.08950367508... hourangle>
-  >>> t.sidereal_time('apparent', '-90d')
-  <Longitude 23.08950367508... hourangle>
-  >>> t.sidereal_time('apparent', '-90d', 'IAU1994')
-  <Longitude 23.08950365423... hourangle>
+  >>> t.sidereal_time('mean')  # doctest: +FLOAT_CMP
+  <Longitude 13.089521870640212 hourangle>
+  >>> t.sidereal_time('apparent')  # doctest: +FLOAT_CMP
+  <Longitude 13.089503675087027 hourangle>
+  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP
+  <Longitude 5.089503675087027 hourangle>
+  >>> t.sidereal_time('apparent', '-90d')  # doctest: +FLOAT_CMP
+  <Longitude 23.08950367508703 hourangle>
+  >>> t.sidereal_time('apparent', '-90d', 'IAU1994')  # doctest: +FLOAT_CMP
+  <Longitude 23.08950365423405 hourangle>
 
 Time Deltas
 -----------
@@ -754,8 +754,8 @@ object::
 i.e., scales for which it is not necessary to know the times that were
 differenced::
 
-  >>> dt.tt
-  <TimeDelta object: scale='tt' format='jd' value=364.99999974...>
+  >>> dt.tt  # doctest: +FLOAT_CMP
+  <TimeDelta object: scale='tt' format='jd' value=364.999999746>
   >>> dt.tdb
   Traceback (most recent call last):
     ...
@@ -803,8 +803,8 @@ of time.  Usage is most easily illustrated by examples::
   array([False,  True,  True], dtype=bool)
   >>> dt + 1.*u.hr                   # can also add/subtract such quantities
   <TimeDelta object: scale='None' format='jd' value=[ 10.04166667  20.04166667  30.04166667]>
-  >>> Time(50000., format='mjd', scale='utc') + 1.*u.hr
-  <Time object: scale='utc' format='mjd' value=50000.041666...>
+  >>> Time(50000., format='mjd', scale='utc') + 1.*u.hr  # doctest: +FLOAT_CMP
+  <Time object: scale='utc' format='mjd' value=value=50000.0416667>
   >>> dt * 10.*u.km/u.s              # for multiplication and division with a
   ...                                # Quantity, TimeDelta is converted
   <Quantity [ 100., 200., 300.] d km / s>

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -804,7 +804,7 @@ of time.  Usage is most easily illustrated by examples::
   >>> dt + 1.*u.hr                   # can also add/subtract such quantities
   <TimeDelta object: scale='None' format='jd' value=[ 10.04166667  20.04166667  30.04166667]>
   >>> Time(50000., format='mjd', scale='utc') + 1.*u.hr  # doctest: +FLOAT_CMP
-  <Time object: scale='utc' format='mjd' value=value=50000.0416667>
+  <Time object: scale='utc' format='mjd' value=50000.0416667>
   >>> dt * 10.*u.km/u.s              # for multiplication and division with a
   ...                                # Quantity, TimeDelta is converted
   <Quantity [ 100., 200., 300.] d km / s>

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -270,8 +270,8 @@ but this example is illustrative::
     >>> freq_to_vel = [(u.GHz, u.km/u.s,
     ... lambda x: (restfreq-x) / restfreq * si.c.to('km/s').value,
     ... lambda x: (1-x/si.c.to('km/s').value) * restfreq )]
-    >>> u.Hz.to(u.km / u.s, 116e9, equivalencies=freq_to_vel)
-    -1895.4321928669262  # doctest: +FLOAT_CMP
+    >>> u.Hz.to(u.km / u.s, 116e9, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
+    -1895.4321928669262
     >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)
     <Quantity -1895.4321928669262 km / s>
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -77,14 +77,14 @@ dimensionless).  For instance, normally the following raise exceptions::
 But when passing we pass the proper conversion function,
 :func:`~astropy.units.equivalencies.dimensionless_angles`, it works.
 
-  >>> u.deg.to('', equivalencies=u.dimensionless_angles())
-  0.01745329...
+  >>> u.deg.to('', equivalencies=u.dimensionless_angles())  # doctest: +FLOAT_CMP
+  0.017453292519943295
   >>> (0.5e38 * u.kg * u.m**2 * (u.cycle / u.s)**2).to(u.J,
-  ...                            equivalencies=u.dimensionless_angles())
-  <Quantity 1.97392...e+39 J>
+  ...                            equivalencies=u.dimensionless_angles())  # doctest: +FLOAT_CMP
+  <Quantity 1.9739208802178715e+39 J>
   >>> import numpy as np
-  >>> np.exp((1j*0.125*u.cycle).to('', equivalencies=u.dimensionless_angles()))
-  <Quantity (0.707106781186...+0.707106781186...j)>
+  >>> np.exp((1j*0.125*u.cycle).to('', equivalencies=u.dimensionless_angles()))  # doctest: +FLOAT_CMP
+  <Quantity (0.7071067811865476+0.7071067811865475j)>
 
 The example with complex numbers is also one may well be doing a fair
 number of similar calculations.  For such situations, there is the
@@ -105,15 +105,15 @@ energy can be converted.
 
   >>> ([1000, 2000] * u.nm).to(u.Hz, equivalencies=u.spectral())
   <Quantity [  2.99792458e+14,  1.49896229e+14] Hz>
-  >>> ([1000, 2000] * u.nm).to(u.eV, equivalencies=u.spectral())
-  <Quantity [ 1.239..., 0.619...] eV>
+  >>> ([1000, 2000] * u.nm).to(u.eV, equivalencies=u.spectral())  # doctest: +FLOAT_CMP
+  <Quantity [ 1.23984193, 0.61992096] eV>
 
 These equivalencies even work with non-base units::
 
   >>> # Inches to calories
   >>> from astropy.units import imperial
-  >>> imperial.inch.to(imperial.Cal, equivalencies=u.spectral())
-  1.8691807591...e-27
+  >>> imperial.inch.to(imperial.Cal, equivalencies=u.spectral())  # doctest: +FLOAT_CMP
+  1.869180759162485e-27
 
 Spectral (Doppler) equivalencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,8 +157,8 @@ location. For example::
     ...                 equivalencies=u.spectral_density(3500 * u.AA))
     <Quantity 1.5e-23 erg / (cm2 Hz s)>
     >>> (1.5 * u.Jy).to(u.erg / u.cm**2 / u.s / u.micron,
-    ...                 equivalencies=u.spectral_density(3500 * u.AA))
-    <Quantity 3.670928057142...e-08 erg / (cm2 micron s)>
+    ...                 equivalencies=u.spectral_density(3500 * u.AA))  # doctest: +FLOAT_CMP
+    <Quantity 3.670928057142856e-08 erg / (cm2 micron s)>
 
 Brightness Temperature / Flux Density Equivalency
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,12 +202,12 @@ example converts the FWHM to sigma::
 
     >>> import numpy as np
     >>> beam_fwhm = 50*u.arcsec
-    >>> fwhm_to_sigma = 1./(8*np.log(2))**0.5
-    >>> beam_sigma = beam_fwhm*fwhm_to_sigma
+    >>> fwhm_to_sigma = 1. / (8 * np.log(2))**0.5
+    >>> beam_sigma = beam_fwhm * fwhm_to_sigma
     >>> omega_B = 2 * np.pi * beam_sigma**2
     >>> freq = 5 * u.GHz
-    >>> u.Jy.to(u.K, equivalencies=u.brightness_temperature(omega_B, freq))
-    19.55392833...
+    >>> u.Jy.to(u.K, equivalencies=u.brightness_temperature(omega_B, freq))  # doctest: +FLOAT_CMP
+    19.553928332631582
 
 
 Temperature Energy Equivalency
@@ -220,8 +220,8 @@ observations at high-energy, be it for solar or X-ray astronomy. Example::
 
     >>> import astropy.units as u
     >>> t_k = 1e6 * u.K
-    >>> t_k.to(u.eV, equivalencies=u.temperature_energy())
-    <Quantity 86.17332384... eV>
+    >>> t_k.to(u.eV, equivalencies=u.temperature_energy())  # doctest: +FLOAT_CMP
+    <Quantity 86.17332384960955 eV>
 
 Writing new equivalencies
 -------------------------
@@ -249,13 +249,13 @@ for them::
 Note that the equivalency can be used with any other compatible units::
 
   >>> from astropy.units import imperial
-  >>> imperial.gallon.to(imperial.pound, 1, equivalencies=liters_water)
-  8.3454044633335...
+  >>> imperial.gallon.to(imperial.pound, 1, equivalencies=liters_water)  # doctest: +FLOAT_CMP
+  8.345404463333525
 
 And it also works in the other direction::
 
-  >>> imperial.lb.to(imperial.pint, 1, equivalencies=liters_water)
-  0.9586114172355...
+  >>> imperial.lb.to(imperial.pint, 1, equivalencies=liters_water)  # doctest: +FLOAT_CMP
+  0.9586114172355459
 
 A slightly more complicated example: Spectral Doppler Equivalencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,9 +271,9 @@ but this example is illustrative::
     ... lambda x: (restfreq-x) / restfreq * si.c.to('km/s').value,
     ... lambda x: (1-x/si.c.to('km/s').value) * restfreq )]
     >>> u.Hz.to(u.km / u.s, 116e9, equivalencies=freq_to_vel)
-    -1895.432192...
+    -1895.4321928669262  # doctest: +FLOAT_CMP
     >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)
-    <Quantity -1895.432192... km / s>
+    <Quantity -1895.4321928669262 km / s>
 
 Note that once this is defined for GHz and km/s, it will work for all other
 units of frequency and velocity.  ``x`` is converted from the input frequency
@@ -337,8 +337,8 @@ simply do:
   >>> import astropy.units as u
   >>> u.set_enabled_equivalencies(u.dimensionless_angles())
   <astropy.units.core._UnitContext object at ...>
-  >>> u.deg.to('')
-  0.01745329...
+  >>> u.deg.to('')  # doctest: +FLOAT_CMP
+  0.017453292519943295
 
 Here, any list of equivalencies could be used, or one could add, e.g.,
 :func:`~astropy.units.equivalencies.spectral` and
@@ -355,5 +355,5 @@ a context manager is provided:
   >>> with u.set_enabled_equivalencies(u.dimensionless_angles()):
   ...    phase = 0.5 * u.cycle
   ...    c = np.exp(1j*phase)
-  >>> c
-  <Quantity (-1+...j) >
+  >>> c  # doctest: +FLOAT_CMP
+  <Quantity (-1+1.2246063538223773e-16j) >

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -48,20 +48,20 @@ value members::
 From this simple building block, it's easy to start combining
 quantities with different units::
 
-    >>> 15.1 * u.meter / (32.0 * u.second)
-    <Quantity 0.47187... m / s>
-    >>> 3.0 * u.kilometer / (130.51 * u.meter / u.second)
-    <Quantity 0.0229867443... km s / m>
-    >>> (3.0 * u.kilometer / (130.51 * u.meter / u.second)).decompose()
-    <Quantity 22.9867443... s>
+    >>> 15.1 * u.meter / (32.0 * u.second)  # doctest: +FLOAT_CMP
+    <Quantity 0.471875 m / s>
+    >>> 3.0 * u.kilometer / (130.51 * u.meter / u.second)  # doctest: +FLOAT_CMP
+    <Quantity 0.022986744310780783 km s / m>
+    >>> (3.0 * u.kilometer / (130.51 * u.meter / u.second)).decompose()  # doctest: +FLOAT_CMP
+    <Quantity 22.986744310780782 s>
 
 Unit conversion is done using the
 :meth:`~astropy.units.quantity.Quantity.to` method, which returns a new
 |quantity| in the given unit::
 
     >>> x = 1.0 * u.parsec
-    >>> x.to(u.km)
-    <Quantity 30856775814671.9... km>
+    >>> x.to(u.km)  # doctest: +FLOAT_CMP
+    <Quantity 30856775814671.914 km>
 
 It is also possible to work directly with units at a lower level, for
 example, to create custom units::
@@ -74,8 +74,8 @@ example, to create custom units::
 
     >>> # And do some conversions
     >>> q = 42.0 * cms
-    >>> q.to(mph)
-    <Quantity 0.93951324266284... mi / h>
+    >>> q.to(mph)  # doctest: +FLOAT_CMP
+    <Quantity 0.939513242662849 mi / h>
 
 Units that "cancel out" become a special unit called the
 "dimensionless unit":
@@ -118,8 +118,8 @@ Format specifiers (like ``0.03f``) in new-style format
 strings will used to format the quantity value::
 
     >>> q = 15.1 * u.meter / (32.0 * u.second)
-    >>> q
-    <Quantity 0.47187... m / s>
+    >>> q  # doctest: +FLOAT_CMP
+    <Quantity 0.471875 m / s>
     >>> "{0:0.03f}".format(q)
     '0.472 m / s'
 
@@ -127,8 +127,8 @@ The value and unit can also be formatted separately. Format specifiers
 used on units can be used to choose the unit formatter::
 
     >>> q = 15.1 * u.meter / (32.0 * u.second)
-    >>> q
-    <Quantity 0.47187... m / s>
+    >>> q  # doctest: +FLOAT_CMP
+    <Quantity 0.471875 m / s>
     >>> "{0.value:0.03f} {0.unit:FITS}".format(q)
     '0.472 m s-1'
 

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -64,16 +64,16 @@ Converting to different units
 :meth:`~astropy.units.quantity.Quantity.to` method:
 
     >>> q = 2.3 * u.m / u.s
-    >>> q.to(u.km / u.h)
-    <Quantity 8.2... km / h>
+    >>> q.to(u.km / u.h) # doctest: +FLOAT_CMP
+    <Quantity 8.28 km / h>
 
 For convenience, the `~astropy.units.quantity.Quantity.si` and
 `~astropy.units.quantity.Quantity.cgs` attributes can be used to
 convert the |quantity| to base S.I. or c.g.s units:
 
     >>> q = 2.4 * u.m / u.s
-    >>> q.si
-    <Quantity 2... m / s>
+    >>> q.si # doctest: +FLOAT_CMP
+    <Quantity 2.4 m / s>
     >>> q.cgs
     <Quantity 240.0 cm / s>
 
@@ -97,12 +97,12 @@ resulting object **has units of the object on the left**:
 
     >>> 1100.1 * u.m + 13.5 * u.km
     <Quantity 14600.1 m>
-    >>> 13.5 * u.km + 1100.1 * u.m
-    <Quantity 14.600... km>
+    >>> 13.5 * u.km + 1100.1 * u.m # doctest: +FLOAT_CMP
+    <Quantity 14.6001 km>
     >>> 1100.1 * u.m - 13.5 * u.km
     <Quantity -12399.9 m>
-    >>> 13.5 * u.km - 1100.1 * u.m
-    <Quantity 12.399... km>
+    >>> 13.5 * u.km - 1100.1 * u.m # doctest: +FLOAT_CMP
+    <Quantity 12.3999 km>
 
 Addition and subtraction is not supported between |quantity| objects and basic
 numeric types:
@@ -123,36 +123,36 @@ Multiplication and division is supported between |quantity| objects with any
 units, and with numeric types. For these operations between objects with
 equivalent units, the **resulting object has composite units**:
 
-    >>> 1.1 * u.m * 140.3 * u.cm
-    <Quantity 154.33... cm m>
-    >>> 140.3 * u.cm * 1.1 * u.m
-    <Quantity 154.33... cm m>
-    >>> 1. * u.m / (20. * u.cm)
-    <Quantity 0.05... m / cm>
+    >>> 1.1 * u.m * 140.3 * u.cm # doctest: +FLOAT_CMP
+    <Quantity 154.33 cm m>
+    >>> 140.3 * u.cm * 1.1 * u.m # doctest: +FLOAT_CMP
+    <Quantity 154.33 cm m>
+    >>> 1. * u.m / (20. * u.cm) # doctest: +FLOAT_CMP
+    <Quantity 0.05 m / cm>
     >>> 20. * u.cm / (1. * u.m)
     <Quantity 20.0 cm / m>
 
 For multiplication, you can change how to represent the resulting object by
 using the :meth:`~astropy.units.quantity.Quantity.to` method:
 
-    >>> (1.1 * u.m * 140.3 * u.cm).to(u.m**2)
-    <Quantity 1.5433... m2>
-    >>> (1.1 * u.m * 140.3 * u.cm).to(u.cm**2)
-    <Quantity 15433.0... cm2>
+    >>> (1.1 * u.m * 140.3 * u.cm).to(u.m**2) # doctest: +FLOAT_CMP
+    <Quantity 1.5433000000000001 m2>
+    >>> (1.1 * u.m * 140.3 * u.cm).to(u.cm**2) # doctest: +FLOAT_CMP
+    <Quantity 15433.000000000002 cm2>
 
 For division, if the units are equivalent, you may want to make the resulting
 object dimensionless by reducing the units. To do this, use the
 :meth:`~astropy.units.quantity.Quantity.decompose()` method:
 
-    >>> (20. * u.cm / (1. * u.m)).decompose()
-    <Quantity 0.2...>
+    >>> (20. * u.cm / (1. * u.m)).decompose() # doctest: +FLOAT_CMP
+    <Quantity 0.2>
 
 This method is also useful for more complicated arithmetic:
 
-    >>> 15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)
-    <Quantity 0.341950972... cm kg m / (ms s)>
-    >>> (15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)).decompose()
-    <Quantity 3.41950972... kg m2 / s2>
+    >>> 15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms) # doctest: +FLOAT_CMP
+    <Quantity 0.3419509727792778 cm kg m / (ms s)>
+    >>> (15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)).decompose() # doctest: +FLOAT_CMP
+    <Quantity 3.4195097277927777 kg m2 / s2>
 
 
 Numpy functions
@@ -166,22 +166,22 @@ quantities:
     >>> q = np.array([1., 2., 3., 4.]) * u.m / u.s
     >>> np.mean(q)
     <Quantity 2.5 m / s>
-    >>> np.std(q)
-    <Quantity 1.118033... m / s>
+    >>> np.std(q) # doctest: +FLOAT_CMP
+    <Quantity 1.118033988749895 m / s>
 
 including functions that only accept specific units such as angles:
 
     >>> q = 30. * u.deg
-    >>> np.sin(q)
-    <Quantity 0.4999999...>
+    >>> np.sin(q) # doctest: +FLOAT_CMP
+    <Quantity 0.49999999999999994>
 
 or dimensionless quantities:
 
     >>> from astropy.constants import h, k_B
     >>> nu = 3 * u.GHz
     >>> T = 30 * u.K
-    >>> np.exp(-h * nu / (k_B * T))
-    <Quantity 0.99521225...>
+    >>> np.exp(-h * nu / (k_B * T)) # doctest: +FLOAT_CMP
+    <Quantity 0.995212254618668>
 
 (see `Dimensionless quantities`_ for more details).
 
@@ -194,8 +194,8 @@ or if they are passed to a Numpy function that takes dimensionless
 quantities, the units are simplified so that the quantity is
 dimensionless and scale-free. For example:
 
-    >>> 1. + 1. * u.m / u.km
-    <Quantity 1.00...>
+    >>> 1. + 1. * u.m / u.km # doctest: +FLOAT_CMP
+    <Quantity 1.001>
 
 which is different from:
 
@@ -219,15 +219,15 @@ dimensionless quantities:
 
     >>> nu = 3 * u.GHz
     >>> T = 30 * u.K
-    >>> np.exp(- h * nu / (k_B * T))
-    <Quantity 0.99521225...>
+    >>> np.exp(- h * nu / (k_B * T)) # doctest: +FLOAT_CMP
+    <Quantity 0.995212254618668>
 
 The result is independent from the units the different quantities were specified in:
 
     >>> nu = 3.e9 * u.Hz
     >>> T = 30 * u.K
-    >>> np.exp(- h * nu / (k_B * T))
-    <Quantity 0.99521225...>
+    >>> np.exp(- h * nu / (k_B * T)) # doctest: +FLOAT_CMP
+    <Quantity 0.995212254618668>
 
 Converting to plain Python scalars
 ----------------------------------

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -64,7 +64,7 @@ Converting to different units
 :meth:`~astropy.units.quantity.Quantity.to` method:
 
     >>> q = 2.3 * u.m / u.s
-    >>> q.to(u.km / u.h) # doctest: +FLOAT_CMP
+    >>> q.to(u.km / u.h)  # doctest: +FLOAT_CMP
     <Quantity 8.28 km / h>
 
 For convenience, the `~astropy.units.quantity.Quantity.si` and
@@ -72,7 +72,7 @@ For convenience, the `~astropy.units.quantity.Quantity.si` and
 convert the |quantity| to base S.I. or c.g.s units:
 
     >>> q = 2.4 * u.m / u.s
-    >>> q.si # doctest: +FLOAT_CMP
+    >>> q.si  # doctest: +FLOAT_CMP
     <Quantity 2.4 m / s>
     >>> q.cgs
     <Quantity 240.0 cm / s>
@@ -97,11 +97,11 @@ resulting object **has units of the object on the left**:
 
     >>> 1100.1 * u.m + 13.5 * u.km
     <Quantity 14600.1 m>
-    >>> 13.5 * u.km + 1100.1 * u.m # doctest: +FLOAT_CMP
+    >>> 13.5 * u.km + 1100.1 * u.m  # doctest: +FLOAT_CMP
     <Quantity 14.6001 km>
     >>> 1100.1 * u.m - 13.5 * u.km
     <Quantity -12399.9 m>
-    >>> 13.5 * u.km - 1100.1 * u.m # doctest: +FLOAT_CMP
+    >>> 13.5 * u.km - 1100.1 * u.m  # doctest: +FLOAT_CMP
     <Quantity 12.3999 km>
 
 Addition and subtraction is not supported between |quantity| objects and basic
@@ -123,11 +123,11 @@ Multiplication and division is supported between |quantity| objects with any
 units, and with numeric types. For these operations between objects with
 equivalent units, the **resulting object has composite units**:
 
-    >>> 1.1 * u.m * 140.3 * u.cm # doctest: +FLOAT_CMP
+    >>> 1.1 * u.m * 140.3 * u.cm  # doctest: +FLOAT_CMP
     <Quantity 154.33 cm m>
-    >>> 140.3 * u.cm * 1.1 * u.m # doctest: +FLOAT_CMP
+    >>> 140.3 * u.cm * 1.1 * u.m  # doctest: +FLOAT_CMP
     <Quantity 154.33 cm m>
-    >>> 1. * u.m / (20. * u.cm) # doctest: +FLOAT_CMP
+    >>> 1. * u.m / (20. * u.cm)  # doctest: +FLOAT_CMP
     <Quantity 0.05 m / cm>
     >>> 20. * u.cm / (1. * u.m)
     <Quantity 20.0 cm / m>
@@ -135,23 +135,23 @@ equivalent units, the **resulting object has composite units**:
 For multiplication, you can change how to represent the resulting object by
 using the :meth:`~astropy.units.quantity.Quantity.to` method:
 
-    >>> (1.1 * u.m * 140.3 * u.cm).to(u.m**2) # doctest: +FLOAT_CMP
+    >>> (1.1 * u.m * 140.3 * u.cm).to(u.m**2)  # doctest: +FLOAT_CMP
     <Quantity 1.5433000000000001 m2>
-    >>> (1.1 * u.m * 140.3 * u.cm).to(u.cm**2) # doctest: +FLOAT_CMP
+    >>> (1.1 * u.m * 140.3 * u.cm).to(u.cm**2)  # doctest: +FLOAT_CMP
     <Quantity 15433.000000000002 cm2>
 
 For division, if the units are equivalent, you may want to make the resulting
 object dimensionless by reducing the units. To do this, use the
 :meth:`~astropy.units.quantity.Quantity.decompose()` method:
 
-    >>> (20. * u.cm / (1. * u.m)).decompose() # doctest: +FLOAT_CMP
+    >>> (20. * u.cm / (1. * u.m)).decompose()  # doctest: +FLOAT_CMP
     <Quantity 0.2>
 
 This method is also useful for more complicated arithmetic:
 
-    >>> 15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms) # doctest: +FLOAT_CMP
+    >>> 15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)  # doctest: +FLOAT_CMP
     <Quantity 0.3419509727792778 cm kg m / (ms s)>
-    >>> (15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)).decompose() # doctest: +FLOAT_CMP
+    >>> (15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)).decompose()  # doctest: +FLOAT_CMP
     <Quantity 3.4195097277927777 kg m2 / s2>
 
 
@@ -166,13 +166,13 @@ quantities:
     >>> q = np.array([1., 2., 3., 4.]) * u.m / u.s
     >>> np.mean(q)
     <Quantity 2.5 m / s>
-    >>> np.std(q) # doctest: +FLOAT_CMP
+    >>> np.std(q)  # doctest: +FLOAT_CMP
     <Quantity 1.118033988749895 m / s>
 
 including functions that only accept specific units such as angles:
 
     >>> q = 30. * u.deg
-    >>> np.sin(q) # doctest: +FLOAT_CMP
+    >>> np.sin(q)  # doctest: +FLOAT_CMP
     <Quantity 0.49999999999999994>
 
 or dimensionless quantities:
@@ -180,7 +180,7 @@ or dimensionless quantities:
     >>> from astropy.constants import h, k_B
     >>> nu = 3 * u.GHz
     >>> T = 30 * u.K
-    >>> np.exp(-h * nu / (k_B * T)) # doctest: +FLOAT_CMP
+    >>> np.exp(-h * nu / (k_B * T))  # doctest: +FLOAT_CMP
     <Quantity 0.995212254618668>
 
 (see `Dimensionless quantities`_ for more details).
@@ -194,7 +194,7 @@ or if they are passed to a Numpy function that takes dimensionless
 quantities, the units are simplified so that the quantity is
 dimensionless and scale-free. For example:
 
-    >>> 1. + 1. * u.m / u.km # doctest: +FLOAT_CMP
+    >>> 1. + 1. * u.m / u.km  # doctest: +FLOAT_CMP
     <Quantity 1.001>
 
 which is different from:
@@ -219,14 +219,14 @@ dimensionless quantities:
 
     >>> nu = 3 * u.GHz
     >>> T = 30 * u.K
-    >>> np.exp(- h * nu / (k_B * T)) # doctest: +FLOAT_CMP
+    >>> np.exp(- h * nu / (k_B * T))  # doctest: +FLOAT_CMP
     <Quantity 0.995212254618668>
 
 The result is independent from the units the different quantities were specified in:
 
     >>> nu = 3.e9 * u.Hz
     >>> T = 30 * u.K
-    >>> np.exp(- h * nu / (k_B * T)) # doctest: +FLOAT_CMP
+    >>> np.exp(- h * nu / (k_B * T))  # doctest: +FLOAT_CMP
     <Quantity 0.995212254618668>
 
 Converting to plain Python scalars


### PR DESCRIPTION
I was reading through the `io.ascii` docs and saw a few slightly awkward doctest examples on [this page](http://docs.astropy.org/en/v0.4.3/io/ascii/fixed_width_gallery.html#fixedwidthtwoline) where, for example, "2.4" was written "2..." in the expected output.  Confused me quite a bit at first.

Then I remembered #2735 and that this was probably fixed in it, and so it was!  Turns out actually the fixes on that page are moot now that `Table.__repr__` has been updated to be nicer.  But there are still many other doctest fixes in that PR worth bringing over.

I've rebased it on master and added a fix to the float output checker to handle one case that was failing in the original PR.  Since this is very platform-sensitive stuff it's worth making a new PR so that Travis and AppVeyor will pick it up.  With apologies to @dklaes for taking so long to update his original PR!