### PR TITLE
make ROLL0 visible as a class method on Galactocentric

### DIFF
--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -139,7 +139,7 @@ class Galactocentric(BaseCoordinateFrame):
         frame attribute to  -this method's return value removes this rotation,
         allowing the use of the `Galactocentric` frame in more general contexts.
         """
-        # not that the actual value is defined at the module level.  We make at
+        # note that the actual value is defined at the module level.  We make at
         # a property here because this module isn't actually part of the public
         # API, so it's better for it to be accessable from Galactocentric
         return _ROLL0


### PR DESCRIPTION
This is a minor adjustment to the `Galactocentric` frame adding a `get_roll0` class method in place of the `ROLL0` module-level variable.  The reasoning behind this is that this now creates a public way to get the value of roll0.  That's important for anyone who wants to use Galactocentric to move to frames *other* than the Milky Way centrer. (For example, the Galactocentric frame can quite reasonably be used as an "M31-centric" system, but the orientation is much easier to work out if you start from ``-ROLL0``.)

cc @adrn

I'm marking this as v1.0 because `Galactocentric` is new there, and this just exposes something that users may want from that. (and this should be a pretty trivial change)