### PR TITLE
Table item access with [], (), or np.array([]) returns no rows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -508,6 +508,9 @@ Bug Fixes
 
   - Fix a problem when doing nested iterators on a single table. [#3358]
 
+  - Fix an error when an empty list, tuple, or ndarray is used for item access
+    within a table.  This now returns the table with no rows. [#3442]
+
 - ``astropy.time``
 
   - When creating a Time object from a datetime object the time zone

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -842,8 +842,8 @@ class Table(object):
             return self.columns[item]
         elif isinstance(item, (int, np.integer)):
             return self.Row(self, item)
-        elif isinstance(item, (tuple, list)) and all(isinstance(x, six.string_types)
-                                                     for x in item):
+        elif (isinstance(item, (tuple, list)) and item and
+              all(isinstance(x, six.string_types) for x in item)):
             bad_names = [x for x in item if x not in self.colnames]
             if bad_names:
                 raise ValueError('Slice name(s) {0} not valid column name(s)'
@@ -852,6 +852,10 @@ class Table(object):
             out._groups = groups.TableGroups(out, indices=self.groups._indices,
                                              keys=self.groups._keys)
             return out
+        elif ((isinstance(item, np.ndarray) and len(item) == 0) or
+              (isinstance(item, (tuple, list)) and not item)):
+            # If item is an empty array/list/tuple then return the table with no rows
+            return self._new_from_slice([])
         elif (isinstance(item, slice) or
               isinstance(item, np.ndarray) or
               isinstance(item, list) or

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -131,6 +131,20 @@ class TestTableItems(BaseTestItems):
         assert self.t['a'][1] == 0
         assert self.t[1]['a'] == 0
 
+    def test_empty_iterable_item(self, table_data):
+        """
+        Table item access with [], (), or np.array([]) returns the same table
+        with no rows.
+        """
+        self.t = table_data.Table(table_data.COLS)
+        for item in [], (), np.array([]):
+            t2 = self.t[item]
+            assert not t2
+            assert len(t2) == 0
+            assert t2['a'].attrs_equal(table_data.COLS[0])
+            assert t2['b'].attrs_equal(table_data.COLS[1])
+            assert t2['c'].attrs_equal(table_data.COLS[2])
+
     def test_table_slice(self, table_data):
         """Table slice returns REFERENCE to data"""
         self.t = table_data.Table(table_data.COLS)

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -46,6 +46,7 @@ the data contained in that object relate to the original table data
   t[2:5]       # Table object with rows 2:5
   t[[1, 3, 4]]  # Table object with rows 1, 3, 4 (copy)
   t[np.array([1, 3, 4])]  # Table object with rows 1, 3, 4 (copy)
+  t[[]]        # Same table definition but with no rows of data
   t['a', 'c']  # Table with cols 'a', 'c' (copy)
   dat = np.array(t)  # Copy table data to numpy structured array object
   t['a'].quantity  # an astropy.units.Quantity for Column 'a'


### PR DESCRIPTION
Inspired by and closes #2856.
