### PR TITLE
Return False on update if there is no default configuration file.

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -812,7 +812,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
 
     Raises
     ------
-    ConfigurationDefaultMissingError
+    AttributeError
         If the version number of the package could not determined.
 
     """
@@ -842,9 +842,6 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
 
     if version is None:
         mod = __import__(pkg)
-        if not hasattr(mod, '__version__'):
-            raise ConfigurationDefaultMissingError(
-                'Could not determine version of package {0}'.format(pkg))
         version = mod.__version__
 
     # Don't install template files for dev versions, or we'll end up

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -813,7 +813,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     Raises
     ------
     ConfigurationDefaultMissingError
-        If the default configuration could not be found.
+        If the version number of the package could not determined.
 
     """
 
@@ -826,7 +826,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
         # There is no template configuration file, which basically
         # means the affiliated package is not using the configuration
         # system, so just return.
-        return
+        return False
 
     cfgfn = get_config(pkg).filename
 


### PR DESCRIPTION
Closes #2841 (seems to be forgotten?)

If there is no default configuration file, the update function should do nothing, which means it should return `False` (and not `None`).

However, for me this still looks not perfect: formally, the patch fixes the problem and the function behaves as described in its doc. But we have now three cases:

* default config available, first call --> update and return `True`
* default config available, subsequent calls --> no update **but write an alternative file** and return `False`
* no default config available --> no update, just return `False`

So, if the return value is really used as indicator whether something was updated, then it is fine.
But when it factically is used to determine whether there is an alternative file, the it will fail:
```
if assert configuration.update_default_config('astropy', config_dir) == False:
  # force updating
  os.rename('astropy.{1}.cfg'.format(astropy.__version__, 'astropy.cfg')
```
it will fail if the default file does not exist. I, however, do not understand why the error is not raised here anymore -- updating the configuration of a package that has no template is IMO nothing that should just pass through.

I also fixed the documentation (since the missing default does not raise the `ConfigurationDefaultMissingError` anymore); however it now becomes clear that the choice of this error class for the remaining case (missing version number of the package) is not really fortunate...