### PR TITLE
Catch also NotImplementedError and AttributeError in multiprocessing.Queue()

### DIFF
--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -391,7 +391,7 @@ cdef class CParser:
         cdef int N = self.parallel
         try:
             queue = multiprocessing.Queue()
-        except ImportError:
+        except (ImportError, NotImplementedError, AttributeError):
             self.raise_error("shared semaphore implementation required "
                              "but not available")
         cdef int offset = self.tokenizer.source_pos


### PR DESCRIPTION
Fixes #3416 for Python 3.4

While Python 2.7 raises an `ImportError`, Python 3.4 raises an `AttributeError`. To me, it seems that the correct error would be a `NotImplementedError`; that's why I added it as well. This behaviour is not documented in the Python doc.
This is tested to work with current Debian unstable, python version 2.7.9 and 3.4.2.