### PR TITLE
Docs clarifications for search_around_* and related functionality

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -219,6 +219,14 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
     if not distlimit.isscalar:
         raise ValueError('distlimit must be a scalar in search_around_3d')
 
+    if coords1.isscalar or coords2.isscalar:
+        raise ValueError('One of the inputs to search_around_3d is a scalar. '
+                         'search_around_3d is intended for use with array '
+                         'coordinates, not scalars.  Use the `separation_3d` '
+                         'method on coordinate objects along with '
+                         '`numpy.argmin` to find the closest match to a scalar'
+                         'coordinate.')
+
     kdt2 = _get_cartesian_kdtree(coords2, storekdtree)
     cunit = coords2.cartesian.x.unit
 
@@ -306,6 +314,14 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
 
     if not seplimit.isscalar:
         raise ValueError('seplimit must be a scalar in search_around_sky')
+
+    if coords1.isscalar or coords2.isscalar:
+        raise ValueError('One of the inputs to search_around_sky is a scalar. '
+                         'search_around_sky is intended for use with array '
+                         'coordinates, not scalars.  Use the `separation` '
+                         'method on coordinate objects along with '
+                         '`numpy.argmin` to find the closest match to a scalar'
+                         'coordinate.')
 
     # we convert coord1 to match coord2's frame.  We do it this way
     # so that if the conversion does happen, the KD tree of coord2 at least gets

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -222,10 +222,9 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
     if coords1.isscalar or coords2.isscalar:
         raise ValueError('One of the inputs to search_around_3d is a scalar. '
                          'search_around_3d is intended for use with array '
-                         'coordinates, not scalars.  Use the `separation_3d` '
-                         'method on coordinate objects along with '
-                         '`numpy.argmin` to find the closest match to a scalar'
-                         'coordinate.')
+                         'coordinates, not scalars.  Instead, use '
+                         '``coord1.separation_3d(coord2) < distlimit`` to find '
+                         'the coordinates near a scalar coordinate.')
 
     kdt2 = _get_cartesian_kdtree(coords2, storekdtree)
     cunit = coords2.cartesian.x.unit
@@ -318,10 +317,9 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
     if coords1.isscalar or coords2.isscalar:
         raise ValueError('One of the inputs to search_around_sky is a scalar. '
                          'search_around_sky is intended for use with array '
-                         'coordinates, not scalars.  Use the `separation` '
-                         'method on coordinate objects along with '
-                         '`numpy.argmin` to find the closest match to a scalar'
-                         'coordinate.')
+                         'coordinates, not scalars.  Instead, use '
+                         '``coord1.separation(coord2) < seplimit`` to find the '
+                         'coordinates near a scalar coordinate.')
 
     # we convert coord1 to match coord2's frame.  We do it this way
     # so that if the conversion does happen, the KD tree of coord2 at least gets

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -174,10 +174,10 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
     ----------
     coords1 : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
         The first set of coordinates, which will be searched for matches from
-        ``coords2`` within ``seplimit``.
+        ``coords2`` within ``seplimit``.  Cannot be a scalar coordinate.
     coords2 : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
         The second set of coordinates, which will be searched for matches from
-        ``coords1`` within ``seplimit``.
+        ``coords1`` within ``seplimit``.  Cannot be a scalar coordinate.
     distlimit : `~astropy.units.Quantity` with distance units
         The physical radius to search within.
     storekdtree : bool or str, optional
@@ -271,10 +271,10 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
     ----------
     coords1 : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
         The first set of coordinates, which will be searched for matches from
-        ``coords2`` within ``seplimit``.
+        ``coords2`` within ``seplimit``. Cannot be a scalar coordinate.
     coords2 : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
         The second set of coordinates, which will be searched for matches from
-        ``coords1`` within ``seplimit``.
+        ``coords1`` within ``seplimit``. Cannot be a scalar coordinate.
     seplimit : `~astropy.units.Quantity` with angle units
         The on-sky separation to search within.
     storekdtree : bool or str, optional

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -166,6 +166,10 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
     Searches for pairs of points that are at least as close as a specified
     distance in 3D space.
 
+    This is inteded for use on coordinate objects with arrays of coordinates,
+    not scalars.  For scalar coordinates, it is better to use the
+    ``separation_3d`` methods.
+
     Parameters
     ----------
     coords1 : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
@@ -251,6 +255,10 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
     """
     Searches for pairs of points that have an angular separation at least as
     close as a specified angle.
+
+    This is inteded for use on coordinate objects with arrays of coordinates,
+    not scalars.  For scalar coordinates, it is better to use the ``separation``
+    methods.
 
     Parameters
     ----------

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -166,7 +166,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
     Searches for pairs of points that are at least as close as a specified
     distance in 3D space.
 
-    This is inteded for use on coordinate objects with arrays of coordinates,
+    This is intended for use on coordinate objects with arrays of coordinates,
     not scalars.  For scalar coordinates, it is better to use the
     ``separation_3d`` methods.
 
@@ -264,7 +264,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
     Searches for pairs of points that have an angular separation at least as
     close as a specified angle.
 
-    This is inteded for use on coordinate objects with arrays of coordinates,
+    This is intended for use on coordinate objects with arrays of coordinates,
     not scalars.  For scalar coordinates, it is better to use the ``separation``
     methods.
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -755,11 +755,17 @@ class SkyCoord(object):
         Searches for all coordinates in this object around a supplied set of
         points within a given on-sky separation.
 
+        This is inteded for use on `~astropy.coordinates.SkyCoord` objects
+        with coordinate arrays, rather than a scalar coordinate.  For a scalar
+        coordinate, it is better to use
+        `~astropy.coordinates.SkyCoord.separation`.
+
         Parameters
         ----------
         searcharoundcoords : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseCoordinateFrame`
-            The coordinate(s) to search around to try to find matching points in
-            this `SkyCoord`.
+            The coordinates to search around to try to find matching points in
+            this `SkyCoord`. This should be an object with array coordinates,
+            not a scalar coordinate object.
         seplimit : `~astropy.units.Quantity` with angle units
             The on-sky separation to search within.
 
@@ -802,11 +808,17 @@ class SkyCoord(object):
         Searches for all coordinates in this object around a supplied set of
         points within a given 3D radius.
 
+        This is inteded for use on `~astropy.coordinates.SkyCoord` objects
+        with coordinate arrays, rather than a scalar coordinate.  For a scalar
+        coordinate, it is better to use
+        `~astropy.coordinates.SkyCoord.separation_3d`.
+
         Parameters
         ----------
         searcharoundcoords : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseCoordinateFrame`
-            The coordinate(s) to search around to try to find matching points in
-            this `SkyCoord`.
+            The coordinates to search around to try to find matching points in
+            this `SkyCoord`. This should be an object with array coordinates,
+            not a scalar coordinate object.
         distlimit : `~astropy.units.Quantity` with distance units
             The physical radius to search within.
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -673,6 +673,7 @@ class SkyCoord(object):
         See Also
         --------
         astropy.coordinates.match_coordinates_sky
+        SkyCoord.match_to_catalog_3d
         """
         from .matching import match_coordinates_sky
 
@@ -734,6 +735,7 @@ class SkyCoord(object):
         See Also
         --------
         astropy.coordinates.match_coordinates_3d
+        SkyCoord.match_to_catalog_sky
         """
         from .matching import match_coordinates_3d
 
@@ -798,6 +800,7 @@ class SkyCoord(object):
         See Also
         --------
         astropy.coordinates.search_around_sky
+        SkyCoord.search_around_3d
         """
         from .matching import search_around_sky
 
@@ -852,6 +855,7 @@ class SkyCoord(object):
         See Also
         --------
         astropy.coordinates.search_around_3d
+        SkyCoord.search_around_sky
         """
         from .matching import search_around_3d
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -548,6 +548,9 @@ class SkyCoord(object):
         """
         Computes on-sky separation between this coordinate and another.
 
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`/coordinates/matchsep`.
+
         Parameters
         ----------
         other : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseCoordinateFrame`
@@ -592,6 +595,9 @@ class SkyCoord(object):
         Computes three dimensional separation between this coordinate
         and another.
 
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`/coordinates/matchsep`.
+
         Parameters
         ----------
         other : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseCoordinateFrame`
@@ -635,6 +641,9 @@ class SkyCoord(object):
         """
         Finds the nearest on-sky matches of this coordinate in a set of
         catalog coordinates.
+
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -697,6 +706,9 @@ class SkyCoord(object):
         This finds the 3-dimensional closest neighbor, which is only different
         from the on-sky distance if ``distance`` is set in this object or the
         ``catalogcoord`` object.
+
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -762,6 +774,9 @@ class SkyCoord(object):
         coordinate, it is better to use
         `~astropy.coordinates.SkyCoord.separation`.
 
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`/coordinates/matchsep`.
+
         Parameters
         ----------
         searcharoundcoords : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseCoordinateFrame`
@@ -816,6 +831,9 @@ class SkyCoord(object):
         with coordinate arrays, rather than a scalar coordinate.  For a scalar
         coordinate, it is better to use
         `~astropy.coordinates.SkyCoord.separation_3d`.
+
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`/coordinates/matchsep`.
 
         Parameters
         ----------

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -772,11 +772,12 @@ class SkyCoord(object):
         Returns
         -------
         idxsearcharound : integer array
-            Indices into ``coords1`` that matches to the corresponding element of
+            Indices into ``self`` that matches to the corresponding element of
             ``idxself``. Shape matches ``idxself``.
         idxself : integer array
-            Indices into ``coords2`` that matches to the corresponding element of
-            ``idxsearcharound``. Shape matches ``idxsearcharound``.
+            Indices into ``searcharoundcoords`` that matches to the
+            corresponding element of ``idxsearcharound``. Shape matches
+            ``idxsearcharound``.
         sep2d : `~astropy.coordinates.Angle`
             The on-sky separation between the coordinates. Shape matches
             ``idxsearcharound`` and ``idxself``.
@@ -825,11 +826,12 @@ class SkyCoord(object):
         Returns
         -------
         idxsearcharound : integer array
-            Indices into ``coords1`` that matches to the corresponding element of
+            Indices into ``self`` that matches to the corresponding element of
             ``idxself``. Shape matches ``idxself``.
         idxself : integer array
-            Indices into ``coords2`` that matches to the corresponding element of
-            ``idxsearcharound``. Shape matches ``idxsearcharound``.
+            Indices into ``searcharoundcoords`` that matches to the
+            corresponding element of ``idxsearcharound``. Shape matches
+            ``idxsearcharound``.
         sep2d : `~astropy.coordinates.Angle`
             The on-sky separation between the coordinates. Shape matches
             ``idxsearcharound`` and ``idxself``.

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -146,3 +146,23 @@ def test_search_around():
     assert list(zip(idx1_1kpc, idx2_1kpc)) == [(0, 0), (0, 1), (0, 2), (1, 3)]
     assert list(zip(idx1_sm, idx2_sm)) == [(0, 1), (0, 2)]
     npt.assert_allclose(d2d_sm, [2, 1]*u.deg)
+
+
+@pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
+def test_search_around_scalar():
+    from astropy.coordinates import SkyCoord, Angle
+
+    cat = SkyCoord([1, 2, 3], [-30, 45, 8], unit="deg")
+    target = SkyCoord('1.1 -30.1', unit="deg")
+
+    with pytest.raises(ValueError) as excinfo:
+        cat.search_around_sky(target, Angle('2d'))
+
+    # make sure the error message is *specific* to search_around_sky rather than
+    # generic as reported in #3359
+    assert 'search_around_sky' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        cat.search_around_3d(target, Angle('2d'))
+    assert 'search_around_3d' in str(excinfo.value)

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -150,7 +150,7 @@ use the ``separation*`` methods::
    >>> d2d = scalarc.separation(catalog)  # doctest: +SKIP
    >>> catalogmsk = d2d < 1*u.deg  # doctest: +SKIP
    >>> d3d = scalarc.separation_3d(catalog)  # doctest: +SKIP
-   >>> catalog3dmsk = d3d < 1*u.deg < 1*u.kpc  # doctest: +SKIP
+   >>> catalog3dmsk = d3d < 1*u.kpc  # doctest: +SKIP
 
 The resulting ``catalogmsk`` or ``catalog3dmsk`` variables are boolean arrays
 rather than arrays of indicies, but in practice they usually can be used in

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -123,4 +123,34 @@ with an interface very similar to ``match_coordinates_*``::
 
 The key difference for these methods is that there can be multiple (or no)
 matches in ``catalog`` around any locations in ``c``.  Hence, indecies into both
-``c`` and ``catalog`` are returned instead of just indecies into ``catalog``.
+``c`` and ``catalog`` are returned instead of just indecies into ``catalog``. 
+These can then be indexed back into the two |skycoord| objects, or, for that
+matter, any array with the same order::
+
+   >>> np.all(c[idxc].separation(catalog[idxcatalog]) == d2d)  # doctest: +SKIP
+   True
+   >>> np.all(c[idxc].separation_3d(catalog[idxcatalog]) == d3d)  # doctest: +SKIP
+   True
+   >>> print catalog_objectnames[idxcatalog]  # doctest: +SKIP
+   ['NGC 1234' 'NGC 4567' ...]
+
+Note, though, that this dual-indexing means that ``search_around_*`` does not
+work well if one of the coordinates is a scalar, because the returned index 
+would not make sense for a scalar::
+
+   >>> scalarc = SkyCoord(1*u.deg, 2*u.deg)  # doctest: +SKIP
+   >>> idxscalarc, idxcatalog, d2d, d3d = catalog.search_around_sky(scalarc, 1*u.deg)  # THIS DOESN'T ACTUALLY WORK  # doctest: +SKIP
+   >>> scalarc[idxscalarc]  # doctest: +SKIP
+   IndexError: 0-d arrays can't be indexed
+
+As a result (and because the ``search_around_*`` algorithm is inefficient in 
+the scalar case, anyway), the best approach for this scenario is to instead
+use the ``separation*`` methods::
+
+   >>> d2d = scalarc.separation(catalog)  # doctest: +SKIP
+   >>> catalogmsk = d2d < 1*u.deg  # doctest: +SKIP
+   >>> d3d = scalarc.separation_3d(catalog)  # doctest: +SKIP
+   >>> catalog3dmsk = d3d < 1*u.deg < 1*u.kpc  # doctest: +SKIP
+
+The resulting ``catalogmsk`` or ``catalog3dmsk`` variables can then be used in
+mostly the same way as ``idxcatalog`` in the above examples.

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -123,7 +123,7 @@ with an interface very similar to ``match_coordinates_*``::
 
 The key difference for these methods is that there can be multiple (or no)
 matches in ``catalog`` around any locations in ``c``.  Hence, indecies into both
-``c`` and ``catalog`` are returned instead of just indecies into ``catalog``. 
+``c`` and ``catalog`` are returned instead of just indecies into ``catalog``.
 These can then be indexed back into the two |skycoord| objects, or, for that
 matter, any array with the same order::
 
@@ -135,7 +135,7 @@ matter, any array with the same order::
    ['NGC 1234' 'NGC 4567' ...]
 
 Note, though, that this dual-indexing means that ``search_around_*`` does not
-work well if one of the coordinates is a scalar, because the returned index 
+work well if one of the coordinates is a scalar, because the returned index
 would not make sense for a scalar::
 
    >>> scalarc = SkyCoord(1*u.deg, 2*u.deg)  # doctest: +SKIP
@@ -143,7 +143,7 @@ would not make sense for a scalar::
    >>> scalarc[idxscalarc]  # doctest: +SKIP
    IndexError: 0-d arrays can't be indexed
 
-As a result (and because the ``search_around_*`` algorithm is inefficient in 
+As a result (and because the ``search_around_*`` algorithm is inefficient in
 the scalar case, anyway), the best approach for this scenario is to instead
 use the ``separation*`` methods::
 
@@ -152,5 +152,10 @@ use the ``separation*`` methods::
    >>> d3d = scalarc.separation_3d(catalog)  # doctest: +SKIP
    >>> catalog3dmsk = d3d < 1*u.deg < 1*u.kpc  # doctest: +SKIP
 
-The resulting ``catalogmsk`` or ``catalog3dmsk`` variables can then be used in
-mostly the same way as ``idxcatalog`` in the above examples.
+The resulting ``catalogmsk`` or ``catalog3dmsk`` variables are boolean arrays
+rather than arrays of indicies, but in practice they usually can be used in
+the same way as ``idxcatalog`` from the above examples.  If you definitely do
+need indicies instead of boolean masks, you can do:
+
+   >>> idxcatalog = np.where(catalogmsk)[0]  # doctest: +SKIP
+   >>> idxcatalog3d = np.where(catalog3dmsk)[0]  # doctest: +SKIP

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -110,6 +110,11 @@ will work on either |skycoord| objects *or* the lower-level frame classes::
     >>> idx, d2d, d3d = match_coordinates_sky(c, catalog)  # doctest: +SKIP
     >>> idx, d2d, d3d = match_coordinates_sky(c.frame, catalog.frame)  # doctest: +SKIP
 
+.. _astropy-searching-coordinates:
+
+Searching Around Coordinates
+============================
+
 Closely-related functionality can be used to search for *all* coordinates within
 a certain distance (either 3D distance or on-sky) of another set of coordinates.
 The ``search_around_*`` methods (and functions) provide this functionality,

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -115,12 +115,12 @@ a certain distance (either 3D distance or on-sky) of another set of coordinates.
 The ``search_around_*`` methods (and functions) provide this functionality,
 with an interface very similar to ``match_coordinates_*``::
 
-   >>> idxc, idxcatalog, d2d, d3d = catalog.search_around_sky(c, 1*u.deg)  # doctest: +SKIP
-   >>> np.all(d2d < 1*u.deg)  # doctest: +SKIP
-   True
-   >>> idxc, idxcatalog, d2d, d3d = catalog.search_around_3d(c, 1*u.kpc)  # doctest: +SKIP
-   >>> np.all(d3d < 1*u.kpc)  # doctest: +SKIP
-   True
+    >>> idxc, idxcatalog, d2d, d3d = catalog.search_around_sky(c, 1*u.deg)  # doctest: +SKIP
+    >>> np.all(d2d < 1*u.deg)  # doctest: +SKIP
+    True
+    >>> idxc, idxcatalog, d2d, d3d = catalog.search_around_3d(c, 1*u.kpc)  # doctest: +SKIP
+    >>> np.all(d3d < 1*u.kpc)  # doctest: +SKIP
+    True
 
 The key difference for these methods is that there can be multiple (or no)
 matches in ``catalog`` around any locations in ``c``.  Hence, indecies into both
@@ -128,35 +128,35 @@ matches in ``catalog`` around any locations in ``c``.  Hence, indecies into both
 These can then be indexed back into the two |skycoord| objects, or, for that
 matter, any array with the same order::
 
-   >>> np.all(c[idxc].separation(catalog[idxcatalog]) == d2d)  # doctest: +SKIP
-   True
-   >>> np.all(c[idxc].separation_3d(catalog[idxcatalog]) == d3d)  # doctest: +SKIP
-   True
-   >>> print catalog_objectnames[idxcatalog]  # doctest: +SKIP
-   ['NGC 1234' 'NGC 4567' ...]
+    >>> np.all(c[idxc].separation(catalog[idxcatalog]) == d2d)  # doctest: +SKIP
+    True
+    >>> np.all(c[idxc].separation_3d(catalog[idxcatalog]) == d3d)  # doctest: +SKIP
+    True
+    >>> print catalog_objectnames[idxcatalog]  # doctest: +SKIP
+    ['NGC 1234' 'NGC 4567' ...]
 
 Note, though, that this dual-indexing means that ``search_around_*`` does not
 work well if one of the coordinates is a scalar, because the returned index
 would not make sense for a scalar::
 
-   >>> scalarc = SkyCoord(1*u.deg, 2*u.deg)  # doctest: +SKIP
-   >>> idxscalarc, idxcatalog, d2d, d3d = catalog.search_around_sky(scalarc, 1*u.deg)  # THIS DOESN'T ACTUALLY WORK  # doctest: +SKIP
-   >>> scalarc[idxscalarc]  # doctest: +SKIP
-   IndexError: 0-d arrays can't be indexed
+    >>> scalarc = SkyCoord(1*u.deg, 2*u.deg)  # doctest: +SKIP
+    >>> idxscalarc, idxcatalog, d2d, d3d = catalog.search_around_sky(scalarc, 1*u.deg)  # THIS DOESN'T ACTUALLY WORK  # doctest: +SKIP
+    >>> scalarc[idxscalarc]  # doctest: +SKIP
+    IndexError: 0-d arrays can't be indexed
 
 As a result (and because the ``search_around_*`` algorithm is inefficient in
 the scalar case, anyway), the best approach for this scenario is to instead
 use the ``separation*`` methods::
 
-   >>> d2d = scalarc.separation(catalog)  # doctest: +SKIP
-   >>> catalogmsk = d2d < 1*u.deg  # doctest: +SKIP
-   >>> d3d = scalarc.separation_3d(catalog)  # doctest: +SKIP
-   >>> catalog3dmsk = d3d < 1*u.kpc  # doctest: +SKIP
+    >>> d2d = scalarc.separation(catalog)  # doctest: +SKIP
+    >>> catalogmsk = d2d < 1*u.deg  # doctest: +SKIP
+    >>> d3d = scalarc.separation_3d(catalog)  # doctest: +SKIP
+    >>> catalog3dmsk = d3d < 1*u.kpc  # doctest: +SKIP
 
 The resulting ``catalogmsk`` or ``catalog3dmsk`` variables are boolean arrays
 rather than arrays of indicies, but in practice they usually can be used in
 the same way as ``idxcatalog`` from the above examples.  If you definitely do
 need indicies instead of boolean masks, you can do:
 
-   >>> idxcatalog = np.where(catalogmsk)[0]  # doctest: +SKIP
-   >>> idxcatalog3d = np.where(catalog3dmsk)[0]  # doctest: +SKIP
+    >>> idxcatalog = np.where(catalogmsk)[0]  # doctest: +SKIP
+    >>> idxcatalog3d = np.where(catalog3dmsk)[0]  # doctest: +SKIP

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -20,6 +20,7 @@ The on-sky separation is easily computed with the
 which computes the great-circle distance (*not* the small-angle
 approximation)::
 
+    >>> import numpy as np
     >>> from astropy import units as u
     >>> from astropy.coordinates import SkyCoord
     >>> c1 = SkyCoord('5h23m34.5s', '-69d45m22s', frame='icrs')


### PR DESCRIPTION
This is inspired by and closes #3359 .  In that, @cdeil and @collioud gave some good suggestions for how to improve the docs to make it easier to understand when `SkyCoord.search_around_*` vs. `separation` is appropriate, including a clearer error message when a scalar is given.

@collioud - I think I did everything you suggested, although with slight changes (particularly in the "parameters" section - I moved the array mention to the description instead of the type because to me it started getting a bit confusing when I made the type part more complicated).

@cdeil, I did not address your final suggestion in #3359 because in fact the methods and functions *do* support using coordinate frame objects, as long as they have data (frame objects can indeed store data, they just don't *have* to).

If you have other suggestions don't hesitate to suggest them or just issue a PR against my branch for this PR, @collioud or @cdeil.