### PR TITLE
Add block_reduce and block_replicate functions

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -30,7 +30,7 @@ $CONDA_INSTALL pytest Cython jinja2 psutil
 # OPTIONAL DEPENDENCIES
 if $OPTIONAL_DEPS
 then
-  $CONDA_INSTALL scipy h5py matplotlib pyyaml
+  $CONDA_INSTALL scipy h5py matplotlib pyyaml scikit-image
   pip install beautifulsoup4
 fi
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ New Features
   - Automatically use ``guess=False`` when reading if the file ``format`` is
     provided and the format parameters are uniquely specified.  This update
     also removes duplicate format guesses to improve performance. [#3418]
-    
+
   - Calls to ascii.read() for fixed-width tables may now omit one of the keyword
     arguments ``col_starts`` or ``col_ends``. Columns will be assumed to begin and
     end immediately adjacent to each other. [#3657]
@@ -45,6 +45,8 @@ New Features
 - ``astropy.modeling``
 
 - ``astropy.nddata``
+
+  - Added ``block_reduce`` and ``block_replicate`` functions. [#3453]
 
 - ``astropy.stats``
 
@@ -343,7 +345,7 @@ Bug Fixes
 
 - ``astropy.time``
 
-  - Ensure a ``Column`` without units is treated as an ``array``, not as an 
+  - Ensure a ``Column`` without units is treated as an ``array``, not as an
     dimensionless ``Quantity``. [#3648]
 
 - ``astropy.units``

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython scipy h5py beautiful-soup jinja2 pyyaml"
+    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython scipy h5py beautiful-soup jinja2 pyyaml scikit-image"
 
 # Not a .NET project, we build SunPy in the install step instead
 build: false

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -20,6 +20,7 @@ from .mixins.ndslicing import *
 from .mixins.ndio import *
 
 from .compat import *
+from .utils import *
 
 from .. import config as _config
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -5,7 +5,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from ...tests.helper import pytest
-from ..utils import extract_array, add_array, subpixel_indices
+from ..utils import (extract_array, add_array, subpixel_indices,
+                     block_reduce, block_replicate)
 
 test_positions = [(10.52, 3.12), (5.62, 12.97), (31.33, 31.77),
                   (0.46, 0.94), (20.45, 12.12), (42.24, 24.42)]
@@ -73,3 +74,106 @@ def test_subpixel_indices(position, subpixel_index):
     given test values.
     """
     assert np.all(subpixel_indices(position, subsampling) == subpixel_index)
+
+
+class TestBlockReduce(object):
+    def test_1d(self):
+        """Test 1D array."""
+        data = np.arange(4)
+        expected = np.array([1, 5])
+        result = block_reduce(data, 2)
+        assert np.all(result == expected)
+
+    def test_1d_mean(self):
+        """Test 1D array with func=np.mean."""
+        data = np.arange(4)
+        block_size = 2.
+        expected = block_reduce(data, block_size, func=np.sum) / block_size
+        result_mean = block_reduce(data, block_size, func=np.mean)
+        assert np.all(result_mean == expected)
+
+    def test_2d(self):
+        """Test 2D array."""
+        data = np.arange(4).reshape(2, 2)
+        expected = np.array([[6]])
+        result = block_reduce(data, 2)
+        assert np.all(result == expected)
+
+    def test_2d_mean(self):
+        """Test 2D array with func=np.mean."""
+        data = np.arange(4).reshape(2, 2)
+        block_size = 2.
+        expected = (block_reduce(data, block_size, func=np.sum) /
+                    block_size**2)
+        result = block_reduce(data, block_size, func=np.mean)
+        assert np.all(result == expected)
+
+    def test_2d_trim(self):
+        """
+        Test trimming of 2D array when size is not perfectly divisible
+        by block_size.
+        """
+
+        data1 = np.arange(15).reshape(5, 3)
+        result1 = block_reduce(data1, 2)
+        data2 = data1[0:4, 0:2]
+        result2 = block_reduce(data2, 2)
+        assert np.all(result1 == result2)
+
+    def test_block_size_broadcasting(self):
+        """Test scalar block_size broadcasting."""
+        data = np.arange(16).reshape(4, 4)
+        result1 = block_reduce(data, 2)
+        result2 = block_reduce(data, (2, 2))
+        assert np.all(result1 == result2)
+
+    def test_block_size_len(self):
+        """Test block_size length."""
+        data = np.ones((2, 2))
+        with pytest.raises(ValueError):
+            block_reduce(data, (2, 2, 2))
+
+
+class TestBlockReplicate(object):
+    def test_1d(self):
+        """Test 1D array."""
+        data = np.arange(2)
+        expected = np.array([0, 0, 0.5, 0.5])
+        result = block_replicate(data, 2)
+        assert np.all(result == expected)
+
+    def test_1d_conserve_sum(self):
+        """Test 1D array with conserve_sum=False."""
+        data = np.arange(2)
+        block_size = 2.
+        expected = block_replicate(data, block_size) * block_size
+        result = block_replicate(data, block_size, conserve_sum=False)
+        assert np.all(result == expected)
+
+    def test_2d(self):
+        """Test 2D array."""
+        data = np.arange(2).reshape(2, 1)
+        expected = np.array([[0, 0], [0, 0], [0.25, 0.25], [0.25, 0.25]])
+        result = block_replicate(data, 2)
+        assert np.all(result == expected)
+
+    def test_2d_conserve_sum(self):
+        """Test 2D array with conserve_sum=False."""
+        data = np.arange(6).reshape(2, 3)
+        block_size = 2.
+        expected = block_replicate(data, block_size) * block_size**2
+        result = block_replicate(data, block_size, conserve_sum=False)
+        assert np.all(result == expected)
+
+    def test_block_size_broadcasting(self):
+        """Test scalar block_size broadcasting."""
+        data = np.arange(4).reshape(2, 2)
+        result1 = block_replicate(data, 2)
+        result2 = block_replicate(data, (2, 2))
+        assert np.all(result1 == result2)
+
+    def test_block_size_len(self):
+        """Test block_size length."""
+        data = np.arange(5)
+        with pytest.raises(ValueError):
+            block_replicate(data, (2, 2))

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -8,6 +8,14 @@ from ...tests.helper import pytest
 from ..utils import (extract_array, add_array, subpixel_indices,
                      block_reduce, block_replicate)
 
+
+try:
+    import skimage
+    HAS_SKIMAGE = True
+except ImportError:
+    HAS_SKIMAGE = False
+
+
 test_positions = [(10.52, 3.12), (5.62, 12.97), (31.33, 31.77),
                   (0.46, 0.94), (20.45, 12.12), (42.24, 24.42)]
 
@@ -76,6 +84,7 @@ def test_subpixel_indices(position, subpixel_index):
     assert np.all(subpixel_indices(position, subsampling) == subpixel_index)
 
 
+@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestBlockReduce(object):
     def test_1d(self):
         """Test 1D array."""
@@ -134,6 +143,7 @@ class TestBlockReduce(object):
             block_reduce(data, (2, 2, 2))
 
 
+@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestBlockReplicate(object):
     def test_1d(self):
         """Test 1D array."""

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -209,10 +209,10 @@ def block_reduce(data, block_size, func=np.sum):
     data : array_like
         The data to be resampled.
 
-    block_size : array_like (int)
-        An array containing the integer downsampling factor along each
-        axis.  ``block_size`` must have the same length as
-        ``data.shape``.
+    block_size : int or array_like (int)
+        The integer block size along each axis.  If ``block_size`` is a
+        scalar and ``data`` has more than one dimension, then
+        ``block_size`` will be used for for every axis.
 
     function : callable
         The method to use to downsample the data.  Must be a callable
@@ -230,9 +230,14 @@ def block_reduce(data, block_size, func=np.sum):
     from skimage.measure import block_reduce
 
     data = np.asanyarray(data)
+
+    block_size = np.atleast_1d(block_size)
+    if data.ndim > 1 and len(block_size) == 1:
+        block_size = np.repeat(block_size, data.ndim)
+
     if len(block_size) != data.ndim:
-        raise ValueError('`block_size` must have the same length as '
-                         '`data.shape`')
+        raise ValueError('`block_size` must be a scalar or have the same '
+                         'length as `data.shape`')
 
     block_size = np.array([int(i) for i in block_size])
     size_resampled = np.array(data.shape) // block_size
@@ -254,11 +259,13 @@ def block_replicate(data, block_size, conserve_sum=True):
 
     Parameters
     ----------
-    data : array_like (1D, 2D, or 3D)
+    data : array_like
         The data to be block replicated.
 
-    block_size : array_like (int)
-        The integer block size (upsampling factor) along each axis.
+    block_size : int or array_like (int)
+        The integer block size along each axis.  If ``block_size`` is a
+        scalar and ``data`` has more than one dimension, then
+        ``block_size`` will be used for for every axis.
 
     conserve_sum : bool
         If `True` (the default) then the sum of the output
@@ -290,9 +297,12 @@ def block_replicate(data, block_size, conserve_sum=True):
     data = np.asanyarray(data)
 
     block_size = np.atleast_1d(block_size)
+    if data.ndim > 1 and len(block_size) == 1:
+        block_size = np.repeat(block_size, data.ndim)
+
     if len(block_size) != data.ndim:
-        raise ValueError('`block_size` must have the same length as '
-                         '`data.shape`')
+        raise ValueError('`block_size` must be a scalar or have the same '
+                         'length as `data.shape`')
 
     for i in range(data.ndim):
         data = np.repeat(data, block_size[i], axis=i)

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -4,8 +4,9 @@ This module includes helper functions for array operations.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
 import numpy as np
+from .decorators import support_nddata
+
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
            'overlap_slices', 'block_reduce', 'block_replicate']
@@ -196,6 +197,7 @@ def subpixel_indices(position, subsampling):
     return np.floor(fractions * subsampling)
 
 
+@support_nddata
 def block_reduce(data, block_size, func=np.sum):
     """
     Downsample a data array by applying a function to local blocks.
@@ -253,6 +255,7 @@ def block_reduce(data, block_size, func=np.sum):
     return block_reduce(data, tuple(block_size), func=func)
 
 
+@support_nddata
 def block_replicate(data, block_size, conserve_sum=True):
     """
     Upsample a data array by block replication.

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -233,11 +233,11 @@ def block_reduce(data, block_size, func=np.sum):
     >>> import numpy as np
     >>> from astropy.nddata.utils import block_reduce
     >>> data = np.arange(16).reshape(4, 4)
-    >>> block_reduce(data, 2)
+    >>> block_reduce(data, 2)    # doctest: +SKIP
     array([[10, 18],
            [42, 50]])
 
-    >>> block_reduce(data, 2, func=np.mean)
+    >>> block_reduce(data, 2, func=np.mean)    # doctest: +SKIP
     array([[  2.5,   4.5],
            [ 10.5,  12.5]])
     """

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -216,7 +216,7 @@ def block_reduce(data, block_size, func=np.sum):
         scalar and ``data`` has more than one dimension, then
         ``block_size`` will be used for for every axis.
 
-    function : callable
+    func : callable
         The method to use to downsample the data.  Must be a callable
         that takes in a `~numpy.ndarray` along with an ``axis`` keyword,
         which defines the axis along which the function is applied.  The
@@ -227,6 +227,19 @@ def block_reduce(data, block_size, func=np.sum):
     -------
     output : array-like
         The resampled data.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.nddata.utils import block_reduce
+    >>> data = np.arange(16).reshape(4, 4)
+    >>> block_reduce(data, 2)
+    array([[10, 18],
+           [42, 50]])
+
+    >>> block_reduce(data, 2, func=np.mean)
+    array([[  2.5,   4.5],
+           [ 10.5,  12.5]])
     """
 
     from skimage.measure import block_reduce
@@ -282,7 +295,7 @@ def block_replicate(data, block_size, conserve_sum=True):
     Examples
     --------
     >>> import numpy as np
-    >>> from imutils import block_replicate
+    >>> from astropy.nddata.utils import block_replicate
     >>> data = np.array([[0., 1.], [2., 3.]])
     >>> block_replicate(data, 2)
     array([[ 0.  ,  0.  ,  0.25,  0.25],

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
-           'overlap_slices', 'block_reduce']
+           'overlap_slices', 'block_reduce', 'block_replicate']
 
 
 def overlap_slices(large_array_shape, small_array_shape, position):
@@ -198,7 +198,7 @@ def subpixel_indices(position, subsampling):
 
 def block_reduce(data, block_size, func=np.sum):
     """
-    Downsample data by applying a function to local blocks.
+    Downsample a data array by applying a function to local blocks.
 
     If ``data`` is not perfectly divisible by ``block_size`` along a
     given axis then the data will be trimmed (from the end) along that
@@ -246,3 +246,58 @@ def block_reduce(data, block_size, func=np.sum):
             data = data.swapaxes(0, i)
 
     return block_reduce(data, tuple(block_size), func=func)
+
+
+def block_replicate(data, block_size, conserve_sum=True):
+    """
+    Upsample a data array by block replication.
+
+    Parameters
+    ----------
+    data : array_like (1D, 2D, or 3D)
+        The data to be block replicated.
+
+    block_size : array_like (int)
+        The integer block size (upsampling factor) along each axis.
+
+    conserve_sum : bool
+        If `True` (the default) then the sum of the output
+        block-replicated data will equal the sum of the input ``data``.
+
+    Returns
+    -------
+    output : array_like
+        The block-replicated data.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from imutils import block_replicate
+    >>> data = np.array([[0., 1.], [2., 3.]])
+    >>> block_replicate(data, 2)
+    array([[ 0.  ,  0.  ,  0.25,  0.25],
+           [ 0.  ,  0.  ,  0.25,  0.25],
+           [ 0.5 ,  0.5 ,  0.75,  0.75],
+           [ 0.5 ,  0.5 ,  0.75,  0.75]])
+
+    >>> block_replicate(data, 2, conserve_sum=False)
+    array([[ 0.,  0.,  1.,  1.],
+           [ 0.,  0.,  1.,  1.],
+           [ 2.,  2.,  3.,  3.],
+           [ 2.,  2.,  3.,  3.]])
+    """
+
+    data = np.asanyarray(data)
+
+    block_size = np.atleast_1d(block_size)
+    if len(block_size) != data.ndim:
+        raise ValueError('`block_size` must have the same length as '
+                         '`data.shape`')
+
+    for i in range(data.ndim):
+        data = np.repeat(data, block_size[i], axis=i)
+
+    if conserve_sum:
+        data /= float(np.prod(block_size))
+
+    return data

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -324,6 +324,6 @@ def block_replicate(data, block_size, conserve_sum=True):
         data = np.repeat(data, block_size[i], axis=i)
 
     if conserve_sum:
-        data /= float(np.prod(block_size))
+        data = data / float(np.prod(block_size))
 
     return data


### PR DESCRIPTION
The `downsample` and `upsample` (`Cython`) functions weren't merged as part of the large `imageutils` PR (https://github.com/astropy/astropy/pull/3201) because they could be accomplished using `ndarray` tricks (which are a bit slower than the `Cython`-based functions).  This PR implements `downsample` and `upsample` using the `ndarray` tricks, which are likely too obscure for most users.  Both functions can handle 1D or 2D data, and `downsample` will trim the input array if necessary.