### PR TITLE
Add table info() method along with test and doc updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -260,6 +260,10 @@ New Features
 - ``astropy.stats``
 
 - ``astropy.sphinx``
+- ``astropy.table``
+
+  - Add ``info`` method that outputs a summary description of the
+    table columns.  [#3455]
 
 - ``astropy.table``
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -16,6 +16,7 @@ from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from . import groups
 from . import pprint
+from . import info
 from .np_utils import fix_column_name
 
 from ..config import ConfigAlias
@@ -695,6 +696,9 @@ class BaseColumn(np.ndarray):
             val = getattr(obj, attr, None)
             setattr(self, attr, val)
         self.meta = deepcopy(getattr(obj, 'meta', {}))
+
+    info = info.column_info
+    info.__name__ = str('info')
 
 
 class Column(BaseColumn):

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -1,0 +1,234 @@
+"""
+Table method and functions related to providing information about
+columns and tables.
+"""
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import sys
+import os
+
+import numpy as np
+
+from ..extern import six
+from ..utils import OrderedDict
+
+__all__ = ['column_info_factory']
+
+OPTIONS = ('meta', 'stats')
+
+def column_info_factory(names, funcs):
+    """
+    Factory to create a function that can be used as an ``option``
+    for outputting table or column summary information.
+
+    Examples
+    --------
+    >>> from astropy.table.info import column_info_factory
+    >>> from astropy.table import Column
+    >>> c = Column([4., 3., 2., 1.])
+    >>> mystats = column_info_factory(names=['min', 'median', 'max'],
+    ...                               funcs=[np.min, np.median, np.max])
+    >>> c.info(option=mystats)
+    min = 1.0
+    median = 2.5
+    max = 4.0
+
+    Parameters
+    ----------
+    names: list
+        List of information attribute names
+    funcs: list
+        List of functions that compute the corresponding information attribute
+
+    Returns
+    -------
+    func: function
+        Function that can be used as a table or column info option
+    """
+    def func(col):
+        outs = []
+        for name, func in zip(names, funcs):
+            try:
+                out = func(col)
+            except:
+                outs.append('--')
+            else:
+                outs.append(str(out))
+
+        return OrderedDict(zip(names, outs))
+    return func
+
+
+def meta(col):
+    """
+    Info function that returns basic metadata.
+    """
+    from .column import BaseColumn, col_getattr
+
+    attrs = ('dtype', 'unit', 'format', 'description', 'class')
+    info = OrderedDict()
+    for attr in attrs:
+        if attr == 'class':
+            val = '' if isinstance(col, BaseColumn) else col.__class__.__name__
+        elif attr == 'dtype':
+            val = col_getattr(col, attr).name
+        else:
+            val = col_getattr(col, attr)
+        if val is None:
+            val = ''
+        info[attr] = str(val)
+
+    return info
+
+
+stats = column_info_factory(names=['min', 'mean', 'max'],
+                            funcs=[np.min, np.mean, np.max])
+
+def column_info(self, option='meta', out=''):
+    """
+    Write summary information about column to the ``out`` filehandle.
+    By default this prints to standard output via sys.stdout.
+
+    The ``option` argument specifies what type of information
+    to include.  This can be a string, a function, or a list of
+    strings or functions.  Built-in options are:
+
+    - ``meta``: basic column meta data like ``dtype`` or ``format``
+    - ``stats``: basic statistics: minimum, mean, and maximum
+
+    If a function is specified then that function will be called with the
+    column as its single argument.  The function must return an OrderedDict
+    containing the information attributes.
+
+    If a list is provided then the information attributes will be
+    appended for each of the options, in order.
+
+    Examples
+    --------
+
+    >>> from astropy.table import Column
+    >>> c = Column([1, 2, 3], unit='m', dtype='int32')
+    >>> c.info()
+    dtype = int64
+    unit = m
+    >>> c.info(['meta', 'stats'])
+    dtype = int32
+    unit = m
+    min = 1
+    mean = 2.0
+    max = 3
+
+    Parameters
+    ----------
+    option: str, function, list of (str or function)
+        Info option (default='meta')
+    out: file-like object, None
+        Output destination (default=sys.stdout).  If None then the
+        OrderedDict with information attributes is returned
+
+    Returns
+    -------
+    info: OrderedDict if out==None else None
+    """
+    from .column import col_getattr
+
+    if out == '':
+        out = sys.stdout
+
+    info = OrderedDict()
+    name=col_getattr(self, 'name')
+    if name is not None:
+        info['name'] = name
+
+    options = option if isinstance(option, (list, tuple)) else [option]
+    for option in options:
+        if isinstance(option, six.string_types):
+            if option in OPTIONS:
+                option = globals()[option]
+            else:
+                raise ValueError('option={0} is not in allowed values for option: {1}',
+                                 option, ', '.join(OPTIONS))
+        info.update(option(self))
+
+    if out is None:
+        return info
+
+    for key, val in info.items():
+        if val != '':
+            out.write('{0} = {1}\n'.format(key, val))
+
+
+def table_info(self, option='meta', out=''):
+    """
+    Write summary information about column to the ``out`` filehandle.
+    By default this prints to standard output via sys.stdout.
+
+    The ``option` argument specifies what type of information
+    to include.  This can be a string, a function, or a list of
+    strings or functions.  Built-in options are:
+
+    - ``meta``: basic column meta data like ``dtype`` or ``format``
+    - ``stats``: basic statistics: minimum, mean, and maximum
+
+    If a function is specified then that function will be called with the
+    column as its single argument.  The function must return an OrderedDict
+    containing the information attributes.
+
+    If a list is provided then the information attributes will be
+    appended for each of the options, in order.
+
+    Examples
+    --------
+    >>> from astropy.table.table_helpers import simple_table
+    >>> t = simple_table()
+    >>> t['a'].unit = 'm'
+    >>> t.info()
+    <Table length=3>
+    name  dtype  unit
+    ---- ------- ----
+       a   int32    m
+       b float32
+       c string8
+
+    >>> t.info('stats')
+    <Table length=3>
+    name min mean max
+    ---- --- ---- ---
+       a   1  2.0   3
+       b 1.0  2.0 3.0
+       c  --   --  --
+
+    Parameters
+    ----------
+    option: str, function, list of (str or function)
+        Info option (default='meta')
+    out: file-like object, None
+        Output destination (default=sys.stdout).  If None then the
+        OrderedDict with information attributes is returned
+    """
+    from .table import Table
+
+    if out == '':
+        out = sys.stdout
+
+    descr_vals = [self.__class__.__name__]
+    if self.masked:
+        descr_vals.append('masked=True')
+    descr_vals.append('length={0}'.format(len(self)))
+
+    outlines = ['<' + ' '.join(descr_vals) + '>']
+
+    infos = []
+    for col in self.columns.values():
+        # SHOULD BE as follows after #3731
+        # infos.append(col.info(option, out='object'))
+        infos.append(column_info(col, option, out=None))
+
+    info = Table(infos, names=list(infos[0].keys()))
+    for name in info.colnames:
+        if np.all(info[name] == ''):
+            del info[name]
+
+    outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))
+    out.writelines(outline + os.linesep for outline in outlines)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -5,10 +5,7 @@ from ..extern import six
 from ..extern.six.moves import zip as izip
 from ..extern.six.moves import range as xrange
 
-import sys
-import os
 import re
-import collections
 
 from copy import deepcopy
 
@@ -27,7 +24,7 @@ from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      col_getattr, col_setattr, col_copy, _col_update_attrs_from)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
-
+from . import info
 
 # Prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
 # sorting of structured arrays containing Unicode columns to
@@ -2178,47 +2175,9 @@ class Table(object):
         return cls(out)
 
 
-    def info(self, out=None):
-        """
-        Write summary information about table to the ``out`` filehandle.
-        By default this prints to standard output via sys.stdout.
 
-        Parameters
-        ----------
-        out: file-like object
-            Output destination (default=sys.stdout)
-        """
-        if out is None:
-            out = sys.stdout
-
-        descr_vals = [self.__class__.__name__]
-        if self.masked:
-            descr_vals.append('masked=True')
-        descr_vals.append('length={0}'.format(len(self)))
-
-        outlines = ['<' + ' '.join(descr_vals) + '>']
-
-        info = collections.defaultdict(list)
-        attrs = ('name', 'dtype', 'unit', 'format', 'description', 'class')
-        for attr in attrs:
-            for col in self.columns.values():
-                if attr == 'class':
-                    val = '' if isinstance(col, BaseColumn) else col.__class__.__name__
-                elif attr == 'dtype':
-                    val = col_getattr(col, attr).name
-                else:
-                    val = col_getattr(col, attr)
-                if val is None:
-                    val = ''
-                info[attr].append(str(val))
-
-        info = Table(info, names=attrs)
-        for attr in attrs:
-            if np.all(info[attr] == ''):
-                del info[attr]
-
-        outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))
-        out.writelines(outline + os.linesep for outline in outlines)
+    info = info.table_info
+    info.__name__ == str('info')
 
 
 class QTable(Table):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -13,6 +13,7 @@ from ...extern import six
 from ...tests.helper import pytest, assert_follows_unicode_guidelines
 from ... import table
 from ... import units as u
+from ... import time
 from .conftest import MaskedTable
 
 try:
@@ -1514,3 +1515,42 @@ class TestPandas(object):
                     assert column.dtype == t2[name].dtype
                 else:
                     assert column.byteswap().newbyteorder().dtype == t2[name].dtype
+
+
+def test_info(table_types):
+    """
+    Test the info() method of printing a table summary
+    """
+    a = np.array([1, 2, 3], dtype='int32')
+    b = np.array([1, 2, 3], dtype='float32')
+    c = np.array(['a', 'c', 'e'], dtype='|S1')
+    t = table_types.Table([a, b, c], names=['a', 'b', 'c'])
+    masked = 'masked=True ' if t.masked else ''
+    string8 = 'string8' if six.PY2 else ' bytes8'
+
+    # Minimal output for a typical table
+    out = six.moves.cStringIO()
+    t.info(out)
+    assert out.getvalue().splitlines() == ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
+                                           'name  dtype ',
+                                           '---- -------',
+                                           '   a   int32',
+                                           '   b float32',
+                                           '   c {0}'.format(string8)]
+
+    # All output fields including a mixin column
+    t['d'] = [1,2,3] * u.m
+    t['d'].description = 'description'
+    t['a'].format = '%02d'
+    t['e'] = time.Time([1,2,3], format='cxcsec')
+    out = six.moves.cStringIO()
+    t.info(out)
+    assert out.getvalue().splitlines() == ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
+                                           'name  dtype  unit format description class',
+                                           '---- ------- ---- ------ ----------- -----',
+                                           '   a   int32        %02d                  ',
+                                           '   b float32                              ',
+                                           '   c {0}                              '.format(string8),
+                                           '   d float64    m        description      ',
+                                           '   e  object                          Time']
+

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1530,7 +1530,7 @@ def test_info(table_types):
 
     # Minimal output for a typical table
     out = six.moves.cStringIO()
-    t.info(out)
+    t.info(out=out)
     assert out.getvalue().splitlines() == ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
                                            'name  dtype ',
                                            '---- -------',
@@ -1544,7 +1544,7 @@ def test_info(table_types):
     t['a'].format = '%02d'
     t['e'] = time.Time([1,2,3], format='cxcsec')
     out = six.moves.cStringIO()
-    t.info(out)
+    t.info(out=out)
     assert out.getvalue().splitlines() == ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
                                            'name  dtype  unit format description class',
                                            '---- ------- ---- ------ ----------- -----',

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -100,6 +100,19 @@ For all the following examples it is assumed that the table has been created as 
        9.000  10  11
       12.000  13  14
 
+Summary information
+"""""""""""""""""""
+
+You can get summary information about the table as follows::
+
+  >>> t.info()
+  <Table length=5>
+  name dtype   unit   format       description
+  ---- ----- -------- ------ ------------------------
+     a int32 m sec^-1  %6.3f unladen swallow velocity
+     b int32
+     c int32
+
 Accessing properties
 """"""""""""""""""""
 

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -94,6 +94,16 @@ assigned, all units would be shown as follows::
       4     5.0       y
       5     8.2       z
 
+Finally, you can get a summary information about the table as follows::
+
+  >>> t.info()
+  <Table length=3>
+  name  dtype  unit
+  ---- ------- ----
+     a   int32
+     b float64    s
+     c string8
+
 A column with a unit works with and can be easily converted to an
 `~astropy.units.Quantity` object::
 


### PR DESCRIPTION
I was looking at ATpy docs last night and seeing the awesome `describe()` method reminded me about #2999.

This is a partial implementation of the idea in #2999.  It just does the basic table information output with no option to select different things like table statistics etc.  For 1.1 we can add some sort of `option` keyword and make `describe()` more useful, but it would be really sweet to get at least this into 1.0.  :smile:

@astrofrog @mhvk