### PR TITLE
io.ascii: improve guessing when format is specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,14 @@
 1.1 (unreleased)
 ----------------
 
+New Features
+^^^^^^^^^^^^
+
 - ``astropy.io.ascii``
 
   - Automatically use ``guess=False`` when reading if the file ``format`` is
-    provided and the format parameters are uniquely specified. [#3418]
+    provided and the format parameters are uniquely specified.  This update
+    also removes duplicate format guesses to improve performance. [#3418]
 
 
 1.0rc1 (2015-01-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- ``astropy.io.ascii``
+
+  - Automatically use ``guess=False`` when reading if the file ``format`` is
+    provided and the format parameters are uniquely specified. [#3418]
 
 
 1.0rc1 (2015-01-27)

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -199,8 +199,23 @@ def read(table, guess=None, **kwargs):
 
     if guess is None:
         guess = _GUESS
+
     if guess:
+        # If `table` is a filename or readable file object then read in the
+        # file now.  This prevents problems in Python 3 with the file object
+        # getting closed or left at the file end.  See #3132, #3013, #3109,
+        # #2001.  If a `readme` arg was passed that implies CDS format, in
+        # which case the original `table` as the data filename must be left
+        # intact.
+        if 'readme' not in new_kwargs:
+            try:
+                with get_readable_fileobj(table) as fileobj:
+                    table = fileobj.read()
+            except:
+                pass
+
         dat, guess = _guess(table, new_kwargs, format, fast_reader_param)
+
     if not guess:
         reader = get_reader(**new_kwargs)
         # Try the fast reader first if applicable
@@ -228,18 +243,6 @@ def _guess(table, read_kwargs, format, fast_reader):
     keyword args. For each key/val pair specified explicitly in the read()
     call make sure that if there is a corresponding definition in the guess
     then it must have the same val.  If not then skip this guess."""
-
-    # If `table` is a readable file object then read in the file now.  This
-    # prevents problems in Python 3 with the file object getting closed or
-    # left at the file end.  See #3132, #3013, #3109, #2001.  If a `readme`
-    # arg was passed that implies CDS format, in which case the original
-    # `table` as the data filename must be left intact.
-    if 'readme' not in read_kwargs:
-        try:
-            with get_readable_fileobj(table) as fileobj:
-                table = fileobj.read()
-        except:
-            pass
 
     # Keep a trace of all failed guesses kwarg
     failed_kwargs = []

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -98,6 +98,10 @@ def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
     fill_exclude_names : list
         List of names to exclude from fill_values (applied after ``fill_include_names``)
 
+    Returns
+    -------
+    reader : `~astropy.io.ascii.BaseReader` subclass
+        ASCII format reader instance
     """
     # This function is a light wrapper around core._get_reader to provide a public interface
     # with a default Reader.
@@ -174,6 +178,11 @@ def read(table, guess=None, **kwargs):
         (default= ``True``)
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
+
+    Returns
+    -------
+    dat : `~astropy.table.Table`
+        Output table
     """
 
     if 'fill_values' not in kwargs:
@@ -247,7 +256,8 @@ def _guess(table, read_kwargs, format, fast_reader):
     """
     Try to read the table using various sets of keyword args.  Start with the
     standard guess list and filter to make it unique and consistent with
-    user-suppled read keyword args.
+    user-suppled read keyword args.  Finally, if none of those work then
+    try the original user-supplied keyword args.
 
     Parameters
     ----------
@@ -261,6 +271,11 @@ def _guess(table, read_kwargs, format, fast_reader):
     fast_reader : bool
         Whether to use the C engine, can also be a dict with options which
         default to ``False`` (default= ``True``)
+
+    Returns
+    -------
+    dat : `~astropy.table.Table` or None
+        Output table or None if only one guess format was available
     """
 
     # Keep a trace of all failed guesses kwarg
@@ -377,6 +392,11 @@ def _get_guess_kwargs_list(read_kwargs):
     ----------
     read_kwargs : dict
        User-supplied read keyword args
+
+    Returns
+    -------
+    guess_kwargs_list : list
+        List of read format keyword arg dicts
     """
     guess_kwargs_list = []
 
@@ -454,6 +474,10 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
     fast_writer : bool
         Whether to use the fast Cython writer (default= ``True``)
 
+    Returns
+    -------
+    writer : `~astropy.io.ascii.BaseReader` subclass
+        ASCII format writer instance
     """
     if Writer is None:
         Writer = basic.Basic


### PR DESCRIPTION
When trying to read a large table yesterday I noticed that if I did:

```python
t = Table.read('sometable.tbl', format='ascii.ipac')
```

``io.ascii`` was still trying to guess the format and I had to use

```python
t = Table.read('sometable.tbl', format='ascii.ipac', guess=False)
```

to prevent the guessing. Should specifying the format not disable guessing?
