### PR TITLE
Bring stability up-to-date for 1.0

### DIFF
--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -48,7 +48,14 @@ The current planned and existing sub-packages are:
 
 .. raw:: html
 
-    <table border="1" class="docutils" align='center'>
+    <style>
+    .stability img {
+        max-width: none;
+        margin: 0px;
+    } 
+    </style>
+
+    <table border="1" class="docutils stability" align='center'>
         <tr>
             <th class="head">
                 Sub-Package

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -83,10 +83,10 @@ The current planned and existing sub-packages are:
                 astropy.constants
             </td>
             <td align='center'>
-                <img alt="dev" src="_images/dev.png">
+                <img alt="stable" src="_images/stable.png">
             </td>
             <td>
-                Constants have been changed to <tt class="docutils literal"><span class="pre">Quantity</span></tt> objects in v0.2.
+                Constants were changed to <tt class="docutils literal"><span class="pre">Quantity</span></tt> objects in v0.2. Since then on, the package has been stable, with occasional additions of new constants.
             </td>
         </tr>
         <tr>
@@ -94,12 +94,12 @@ The current planned and existing sub-packages are:
                 astropy.convolution
             </td>
             <td align='center'>
-                <img alt="dev" src="_images/dev.png">
+                <img alt="stable" src="_images/stable.png">
             </td>
             <td>
                 New top-level package in v0.3 (was previously part of
                 <tt class="docutils literal"><span class="pre">astropy.nddata</span></tt>).
-                No major changes in v0.4.
+                No major changes since, likely will maintain backwards compatibility but possible future additions or improvements.
             </td>
         </tr>
         <tr>
@@ -107,11 +107,11 @@ The current planned and existing sub-packages are:
                 astropy.coordinates
             </td>
             <td align='center'>
-                <img alt="dev" src="_images/stable.png">
+                <img alt="stable" src="_images/stable.png">
             </td>
             <td>
                 New in v0.2, major changes in v0.4.  Subsequent versions should
-                maintain a stable/backwards-compatible API.
+                maintain a stable/backwards-compatible API, following the plan of <a href="https://github.com/astropy/astropy-APEs/blob/master/APE5.rst">APE 5</a>.  Further major additions/enhancements likely, but with basic framework unchanged.
             </td>
         </tr>
         <tr>
@@ -178,7 +178,7 @@ The current planned and existing sub-packages are:
                 <img alt="dev" src="_images/dev.png">
             </td>
             <td>
-                New in v0.3
+                New in v0.3.  Major changes in v1.0, signficant additions planned.  Backwards-compatibility likely to be maintained, but not guaranteed.
             </td>
         </tr>
         <tr>
@@ -189,7 +189,7 @@ The current planned and existing sub-packages are:
                 <img alt="dev" src="_images/dev.png">
             </td>
             <td>
-                In development, and does not yet contain much functionality apart from a base class for N-dimensional datasets.
+                Significant changes in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/master/APE7.rst">APE 7</a>. 
             </td>
         </tr>
         <tr>
@@ -211,7 +211,7 @@ The current planned and existing sub-packages are:
                 <img alt="dev" src="_images/dev.png">
             </td>
             <td>
-                Still in development, and does not yet contain much functionality.
+                Likely to maintain backwards-compatibility, but functionality continually being expanded, so significant additions likely in the future.
             </td>
         </tr>
         <tr>
@@ -244,7 +244,7 @@ The current planned and existing sub-packages are:
                 <img alt="stable" src="_images/stable.png">
             </td>
             <td>
-                New in v0.2. Adapted from <tt class="docutils literal"><span class="pre">pnbody</span></tt> and integrated into Astropy.
+                New in v0.2. Adapted from <tt class="docutils literal"><span class="pre">pnbody</span></tt> and integrated into Astropy. Current functionality stable with intent to maintain backwards compatibility. Significant new functionality is likely to be added in future versions.
             </td>
         </tr>
         <tr>
@@ -255,7 +255,7 @@ The current planned and existing sub-packages are:
                 <img alt="dev" src="_images/dev.png">
             </td>
             <td>
-                This sub-package contains mostly utilities destined for use in other parts of Astropy, and is not yet stable.
+                Contains mostly utilities destined for internal use with other parts of Astropy.  Existing functionality generally stable, but reglar additions and occasional changes.
             </td>
         </tr>
         <tr>

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -8,11 +8,6 @@ sub-packages. This document summarizes the current status of the Astropy
 sub-packages, so that users understand where they might expect changes in
 future, and which sub-packages they can safely use for production code.
 
-Note that until version 1.0, even sub-packages considered *Mature* could
-undergo some user interface changes as we work to integrate the packages
-better. Thus, we cannot guarantee complete backward-compatibility between
-versions at this stage.
-
 .. |planned| image:: _static/planned.png
 
 .. |dev| image:: _static/dev.png
@@ -32,15 +27,15 @@ The classification is as follows:
       </tr>
       <tr>
         <td align='center'><img src='_images/dev.png'></td>
-        <td>Actively developed, be prepared for possible significant changes</td>
+        <td>Actively developed, be prepared for possible significant changes.</td>
       </tr>
       <tr>
         <td align='center'><img src='_images/stable.png'></td>
-        <td>Reasonably stable, no major changes likely</td>
+        <td>Reasonably stable, any significant changes/additions will generally include backwards-compatiblity.</td>
       </tr>
       <tr>
         <td align='center'><img src='_images/mature.png'></td>
-        <td>Mature</td>
+        <td>Mature.  Additions/improvements possible, but no major changes planned. </td>
       </tr>
     </table>
 

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -189,7 +189,7 @@ The current planned and existing sub-packages are:
                 <img alt="dev" src="_images/dev.png">
             </td>
             <td>
-                Significant changes in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/master/APE7.rst">APE 7</a>.
+                Significantly revised in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/master/APE7.rst">APE 7</a>. Major changes in the API are not anticipated, broader use may reveal flaws that require API changes.
             </td>
         </tr>
         <tr>

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -270,7 +270,7 @@ The current planned and existing sub-packages are:
                 astropy.vo
             </td>
             <td align='center'>
-                <img alt="dev" src="_images/dev.png">
+                <img alt="stable" src="_images/stable.png">
             </td>
             <td>
                 Virtual Observatory service access and validation. Currently, only Simple Cone Search and SAMP are supported.

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -52,7 +52,7 @@ The current planned and existing sub-packages are:
     .stability img {
         max-width: none;
         margin: 0px;
-    } 
+    }
     </style>
 
     <table border="1" class="docutils stability" align='center'>
@@ -189,7 +189,7 @@ The current planned and existing sub-packages are:
                 <img alt="dev" src="_images/dev.png">
             </td>
             <td>
-                Significant changes in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/master/APE7.rst">APE 7</a>. 
+                Significant changes in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/master/APE7.rst">APE 7</a>.
             </td>
         </tr>
         <tr>
@@ -230,10 +230,11 @@ The current planned and existing sub-packages are:
                 astropy.time
             </td>
             <td align='center'>
-                <img alt="stable" src="_images/stable.png">
+                <img alt="mature" src="_images/mature.png">
             </td>
             <td>
-                Incremental improvements since v0.1, but mostly stable API.
+                Incremental improvements since v0.1, API likely to remain stable
+                for the foreseeable future.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Prompted by @astrofrog's question in #2758, this does three things with the stability document:

1. Fixes the rendered stability document so that the bullet points come out the correct size (see http://eteq.github.io/astropy/stability.html vs. http://devdocs.astropy.org/stability.html).  This is accomplished in a way that technically violates the HTML spec (CSS ``<style>`` tags inside the ``<body>``), but the internet suggests that basically all web browsers in the last 5-10 years support this anyway.
2. Changes `constants` and `convolution` to blue/stable from yellow/dev
3. A variety of updated descriptions


Two changes I thought about but wasn't sure if I should actually do:  
1. Should `time` be upgraded to green?  It hasn't seen major changes for a while, and I imagine it won't?  @taldcroft and @mhvk, what do you think?
2. Should `nddata` be upgraded to blue?  With APE7 it now has a firm basis so we don't expect to break backwards compatibility now, right?  @astrofrog @mwcraig?