### PR TITLE
Make NDDataArray equivalent to pre-1.0 NDData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,6 +192,9 @@ Bug fixes
 
 - ``astropy.nddata``
 
+  - Restore several properties to the compatibility class ``NDDataArray`` that
+    were inadvertently omitted [#3466].
+
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -6,7 +6,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from .. units import UnitsError
+from ..units import UnitsError, Unit
+from .. import log
 
 from .nddata import NDData
 from .nduncertainty import NDUncertainty
@@ -15,6 +16,8 @@ from .mixins.ndslicing import NDSlicingMixin
 from .mixins.ndarithmetic import NDArithmeticMixin
 from .mixins.ndio import NDIOMixin
 
+from .flag_collection import FlagCollection
+
 __all__ = ['NDDataArray']
 
 
@@ -22,9 +25,66 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
     """
     An ``NDData`` object with arithmetic. This class is functionally equivalent
     to ``NDData`` in astropy  versions prior to 1.0.
+
+    The key distinction from raw numpy arrays is the presence of
+    additional metadata such as uncertainties, a mask, units, flags,
+    and/or a coordinate system.
+
+    Parameters
+    -----------
+    data : `~numpy.ndarray` or `NDData`
+        The actual data contained in this `NDData` object. Not that this
+        will always be copies by *reference* , so you should make copy
+        the ``data`` before passing it in if that's the  desired behavior.
+
+    uncertainty : `~astropy.nddata.NDUncertainty`, optional
+        Uncertainties on the data.
+
+    mask : `~numpy.ndarray`-like, optional
+        Mask for the data, given as a boolean Numpy array or any object that
+        can be converted to a boolean Numpy array with a shape
+        matching that of the data. The values must be ``False`` where
+        the data is *valid* and ``True`` when it is not (like Numpy
+        masked arrays). If ``data`` is a numpy masked array, providing
+        ``mask`` here will causes the mask from the masked array to be
+        ignored.
+
+    flags : `~numpy.ndarray`-like or `~astropy.nddata.FlagCollection`, optional
+        Flags giving information about each pixel. These can be specified
+        either as a Numpy array of any type (or an object which can be converted
+        to a Numpy array) with a shape matching that of the
+        data, or as a `~astropy.nddata.FlagCollection` instance which has a
+        shape matching that of the data.
+
+    wcs : undefined, optional
+        WCS-object containing the world coordinate system for the data.
+
+        .. warning::
+            This is not yet defind because the discussion of how best to
+            represent this class's WCS system generically is still under
+            consideration. For now just leave it as None
+
+    meta : `dict`-like object, optional
+        Metadata for this object.  "Metadata" here means all information that
+        is included with this object but not part of any other attribute
+        of this particular object.  e.g., creation date, unique identifier,
+        simulation parameters, exposure time, telescope name, etc.
+
+    unit : `~astropy.units.UnitBase` instance or str, optional
+        The units of the data.
+
+
+    Raises
+    ------
+    ValueError :
+        If the `uncertainty` or `mask` inputs cannot be broadcast (e.g., match
+        shape) onto ``data``.
     """
 
     def __init__(self, *arg, **kwd):
+        # Remove the flag argument from input.
+        flag_argument = kwd.pop('flags', None)
+
         # Initialize with the parent...
         super(NDDataArray, self).__init__(*arg, **kwd)
 
@@ -33,8 +93,12 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         # set self._uncertainty to whatever uncertainty is passed in.
         self.uncertainty = self._uncertainty
 
-        # Same thing for mask...
+        # Same thing for mask.
         self.mask = self._mask
+
+        # Initial flags because it is no longer handled in NDData
+        # or NDDataBase.
+        self.flags = flag_argument
 
     # Implement uncertainty as NDUncertainty to support propagation of
     # uncertainties in arithmetic operations
@@ -68,6 +132,31 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         else:
             self._uncertainty = value
 
+    # Override unit so that we can add a setter.
+    @property
+    def unit(self):
+        return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        from . import conf
+
+        try:
+            if self._unit is not None and conf.warn_setting_unit_directly:
+                log.info('Setting the unit directly changes the unit without '
+                         'updating the data or uncertainty. Use the '
+                         '.convert_unit_to() method to change the unit and '
+                         'scale values appropriately.')
+        except AttributeError:
+            # raised if self._unit has not been set yet, in which case the
+            # warning is irrelevant
+            pass
+
+        if value is None:
+            self._unit = None
+        else:
+            self._unit = Unit(value)
+
     # Implement mask in a way that converts nicely to a numpy masked array
     @property
     def mask(self):
@@ -89,6 +178,55 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
             # internal representation should be one numpy understands
             self._mask = np.ma.nomask
 
+    @property
+    def shape(self):
+        """
+        shape tuple of this object's data.
+        """
+        return self.data.shape
+
+    @property
+    def size(self):
+        """
+        integer size of this object's data.
+        """
+        return self.data.size
+
+    @property
+    def dtype(self):
+        """
+        `numpy.dtype` of this object's data.
+        """
+        return self.data.dtype
+
+    @property
+    def ndim(self):
+        """
+        integer dimensions of this object's data
+        """
+        return self.data.ndim
+
+    @property
+    def flags(self):
+        return self._flags
+
+    @flags.setter
+    def flags(self, value):
+        if value is not None:
+            if isinstance(value, FlagCollection):
+                if value.shape != self.shape:
+                    raise ValueError("dimensions of FlagCollection does not match data")
+                else:
+                    self._flags = value
+            else:
+                flags = np.array(value, copy=False)
+                if flags.shape != self.shape:
+                    raise ValueError("dimensions of flags do not match data")
+                else:
+                    self._flags = flags
+        else:
+            self._flags = value
+
     def __array__(self):
         """
         This allows code that requests a Numpy array to use an NDData
@@ -107,3 +245,50 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
             return np.ma.masked_array(array, self.mask)
         else:
             return array
+
+    def convert_unit_to(self, unit, equivalencies=[]):
+        """
+        Returns a new `NDData` object whose values have been converted
+        to a new unit.
+
+        Parameters
+        ----------
+        unit : `astropy.units.UnitBase` instance or str
+            The unit to convert to.
+
+        equivalencies : list of equivalence pairs, optional
+           A list of equivalence pairs to try if the units are not
+           directly convertible.  See :ref:`unit_equivalencies`.
+
+        Returns
+        -------
+        result : `~astropy.nddata.NDData`
+            The resulting dataset
+
+        Raises
+        ------
+        UnitsError
+            If units are inconsistent.
+
+        """
+        if self.unit is None:
+            raise ValueError("No unit specified on source data")
+        data = self.unit.to(unit, self.data, equivalencies=equivalencies)
+        if self.uncertainty is not None:
+            uncertainty_values = self.unit.to(unit, self.uncertainty.array,
+                                              equivalencies=equivalencies)
+            # should work for any uncertainty class
+            uncertainty = self.uncertainty.__class__(uncertainty_values)
+        else:
+            uncertainty = None
+        if self.mask is not None:
+            new_mask = self.mask.copy()
+        else:
+            new_mask = None
+        # Call __class__ in case we are dealing with an inherited type
+        result = self.__class__(data, uncertainty=uncertainty,
+                                mask=new_mask,
+                                wcs=self.wcs,
+                                meta=self.meta, unit=unit)
+
+        return result

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -72,3 +72,25 @@ def test_convert_unit_to():
     assert d.mask[0, 0] != d1.mask[0, 0]
     d.flags = np.zeros_like(d.data)
     d1 = d.convert_unit_to('m')
+
+
+# check that subclasses can require wcs and/or unit to be present and use
+# _arithmetic and convert_unit_to
+class SubNDData(NDDataArray):
+    """
+    Subclass for test initialization of subclasses in NDData._arithmetic and
+    NDData.convert_unit_to
+    """
+    def __init__(self, *arg, **kwd):
+        super(SubNDData, self).__init__(*arg, **kwd)
+        if self.unit is None:
+            raise ValueError("Unit for subclass must be specified")
+        if self.wcs is None:
+            raise ValueError("WCS for subclass must be specified")
+
+
+def test_init_of_subclass_in_convert_unit_to():
+    data = np.ones([10, 10])
+    arr1 = SubNDData(data, unit='m', wcs=5)
+    result = arr1.convert_unit_to('km')
+    np.testing.assert_array_equal(arr1.data, 1000 * result.data)

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -1,0 +1,74 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# This module contains tests of a class equivalent to pre-1.0 NDData.
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from ...tests.helper import pytest
+from ..compat import NDDataArray
+from ..nduncertainty import StdDevUncertainty
+from ... import units as u
+
+
+NDDATA_ATTRIBUTES = ['mask', 'flags', 'uncertainty', 'unit', 'shape', 'size',
+                     'dtype', 'ndim', 'wcs', 'convert_unit_to']
+
+
+def test_nddataarray_has_attributes_of_old_nddata():
+    ndd = NDDataArray([1, 2, 3])
+    for attr in NDDATA_ATTRIBUTES:
+        assert hasattr(ndd, attr)
+
+
+def test_nddata_simple():
+    nd = NDDataArray(np.zeros((10, 10)))
+    assert nd.shape == (10, 10)
+    assert nd.size == 100
+    assert nd.dtype == np.dtype(float)
+
+
+def test_nddata_conversion():
+    nd = NDDataArray(np.array([[1, 2, 3], [4, 5, 6]]))
+    assert nd.size == 6
+    assert nd.dtype == np.dtype(int)
+
+
+@pytest.mark.parametrize('flags_in', [
+                         np.array([True, False]),
+                         np.array([1, 0]),
+                         [True, False],
+                         [1, 0],
+                         np.array(['a', 'b']),
+                         ['a', 'b']])
+def test_nddata_flags_init_without_np_array(flags_in):
+    ndd = NDDataArray([1, 1], flags=flags_in)
+    assert (ndd.flags == flags_in).all()
+
+
+@pytest.mark.parametrize(('shape'), [(10,), (5, 5), (3, 10, 10)])
+def test_nddata_flags_invalid_shape(shape):
+    with pytest.raises(ValueError) as exc:
+        NDDataArray(np.zeros((10, 10)), flags=np.ones(shape))
+    assert exc.value.args[0] == 'dimensions of flags do not match data'
+
+
+def test_convert_unit_to():
+    # convert_unit_to should return a copy of its input
+    d = NDDataArray(np.ones((5, 5)))
+    d.unit = 'km'
+    d.uncertainty = StdDevUncertainty(0.1 + np.zeros_like(d))
+    # workaround because zeros_like does not support dtype arg until v1.6
+    # and NDData accepts only bool ndarray as mask
+    tmp = np.zeros_like(d.data)
+    d.mask = np.array(tmp, dtype=np.bool)
+    d1 = d.convert_unit_to('m')
+    assert np.all(d1.data == np.array(1000.0))
+    assert np.all(d1.uncertainty.array == 1000.0 * d.uncertainty.array)
+    assert d1.unit == u.m
+    # changing the output mask should not change the original
+    d1.mask[0, 0] = True
+    assert d.mask[0, 0] != d1.mask[0, 0]
+    d.flags = np.zeros_like(d.data)
+    d1 = d.convert_unit_to('m')

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -266,18 +266,3 @@ from ...utils.tests.test_metadata import MetaBaseTest
 class TestMetaNDData(MetaBaseTest):
     test_class = NDData
     args = np.array([[1.]])
-
-
-# check that subclasses can require wcs and/or unit to be present and use
-# _arithmetic and convert_unit_to
-class SubNDData(NDData):
-    """
-    Subclass for test initialization of subclasses in NDData._arithmetic and
-    NDData.convert_unit_to
-    """
-    def __init__(self, *arg, **kwd):
-        super(SubNDData, self).__init__(*arg, **kwd)
-        if self.unit is None:
-            raise ValueError("Unit for subclass must be specified")
-        if self.wcs is None:
-            raise ValueError("WCS for subclass must be specified")

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -152,7 +152,9 @@ not need to be modified.
 
 Code that uses the arithemtic methods that used to be included in
 `~astropy.nddata.NDData` and relied on it to behave like a numpy array should
-instead subclass `~astropy.nddata.NDDataArray`.
+instead subclass `~astropy.nddata.NDDataArray`; that class is equivalent to
+the original `~astropy.nddata.NDData` class.
+
 
 Using ``nddata``
 ================


### PR DESCRIPTION
Closes #3466 -- see that issue for details.

Almost all of the code in this PR is copied (along with the relevant tests) from the old NDData.