### PR TITLE
Change link to Full Changelog so it goes directly there

### DIFF
--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -26,7 +26,7 @@ include :class:`~astropy.coordinates.SkyCoord` and :class:`~astropy.time.Time`
 objects containing arrays (see :ref:`whatsnew_table`).
 
 In addition to these major changes, Astropy 1.0 includes a large number of
-smaller improvements and bug fixes, which are described in the `Full change log`_
+smaller improvements and bug fixes, which are described in the :ref:`changelog`.
 
 About Long-term support
 -----------------------


### PR DESCRIPTION
The top section of What's New ends with a link to the "Full Changelog", but that is actually a link to the final section in What's New.  But it is really confusing because that section is short and at the very end, so what you  focus on is some random material at the top of the page.   This change just makes the summary section link go straight to the actual Full Changelog page.