### PR TITLE
Clarify current state of NDDataArray in the documentation

### DIFF
--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -152,9 +152,7 @@ not need to be modified.
 
 Code that uses the arithemtic methods that used to be included in
 `~astropy.nddata.NDData` and relied on it to behave like a numpy array should
-instead subclass `~astropy.nddata.NDDataArray`; that class is equivalent to
-the original `~astropy.nddata.NDData` class.
-
+instead subclass `~astropy.nddata.NDDataArray`.
 
 Using ``nddata``
 ================


### PR DESCRIPTION
This is a temporary substitute for #3467 to allow more time to incorporate the changes in that PR.

@eteq @astrofrog -- this is a bit more minimal edit than suggested in #3467. It is really only the last bit, about being equivalent to `NDData`, that is the issue. `NDDataArray` a currently in 1.0 does have slicing, arithmetic,  an ``__array__`` method, etc. It's just missing a handful of properties.