### PR TITLE
Deprecate and privatize Unit.get_converter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -416,6 +416,10 @@ API Changes
       - Custom units can be defined "inline" by placing them between single
         quotes.
 
+  - ``Unit.get_converter`` has been deprecated.  It is not strictly
+    necessary for end users, and it was confusing due to lack of
+    support for ``Quantity`` objects. [#3456]
+
 - ``astropy.utils``
 
   - Some members of ``astropy.utils.misc`` were moved into new submodules.

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -33,7 +33,7 @@ def test_getting_started():
         speed_unit = u.cm / u.s
         x = speed_unit.to(imperial.mile / u.hour, 1)
         assert_allclose(x, 0.02236936292054402)
-        speed_converter = speed_unit.get_converter("mile hour^-1")
+        speed_converter = speed_unit._get_converter("mile hour^-1")
         x = speed_converter([1., 1000., 5000.])
         assert_allclose(x, [2.23693629e-02, 2.23693629e+01, 1.11846815e+02])
 
@@ -74,7 +74,7 @@ def test_invalid_compare():
 
 
 def test_convert():
-    assert u.h.get_converter(u.s)(1) == 3600
+    assert u.h._get_converter(u.s)(1) == 3600
 
 
 def test_convert_fail():
@@ -85,7 +85,7 @@ def test_convert_fail():
 
 
 def test_composite():
-    assert (u.cm / u.s * u.h).get_converter(u.m)(1) == 36
+    assert (u.cm / u.s * u.h)._get_converter(u.m)(1) == 36
     assert u.cm * u.cm == u.cm ** 2
 
     assert u.cm * u.cm * u.cm == u.cm ** 3
@@ -177,7 +177,7 @@ def test_unknown_unit3():
     assert not unit.is_equivalent(unit3)
 
     with pytest.raises(ValueError):
-        unit.get_converter(unit3)
+        unit._get_converter(unit3)
 
     x = unit.to_string('latex')
     y = unit2.to_string('cgs')

--- a/docs/units/conversion.rst
+++ b/docs/units/conversion.rst
@@ -25,30 +25,12 @@ Arrays are permitted as arguments.
   >>> u.h.to(u.s, [1, 2, 5, 10.1])
   array([  3600.,   7200.,  18000.,  36360.])
 
-Obtaining a Conversion Function
--------------------------------
-
-Finally, one may obtain a function that can be used to convert to the
-new unit. Normally this may seem like overkill when all one needs to
-do is multiply by a scale factor, but there are cases when the
-transformation between units may not be as simple as a single scale
-factor, for example when a custom equivalency table is in use.
-
-Conversion to different units involves obtaining a conversion function
-and then applying it to the value, or values to be converted.
-
-  >>> cms = u.cm / u.s
-  >>> cms_to_kmph = cms.get_converter(u.km / u.hour)
-  >>> cms_to_kmph(125.)
-  4.5
-  >>> cms_to_kmph([1000, 2000])
-  array([ 36.,  72.])
-
 Incompatible Conversions
 ------------------------
 
 If you attempt to convert to a incompatible unit, an exception will result:
 
+  >>> cms = u.cm / u.s
   >>> cms.to(u.km)
   Traceback (most recent call last):
     ...

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -17,12 +17,10 @@ define new equivalencies.
 
 Equivalencies are used by passing a list of equivalency pairs to the
 ``equivalencies`` keyword argument of :meth:`Quantity.to
-<astropy.units.quantity.Quantity.to>`, :meth:`Unit.to
-<astropy.units.core.UnitBase.to>` or :meth:`Unit.get_converter
-<astropy.units.core.UnitBase.get_converter>` methods.
-Alternatively, if a
-larger piece of code needs the same equivalencies, one can set them
-for a :ref:`given context <equivalency-context>`.
+<astropy.units.quantity.Quantity.to>` or :meth:`Unit.to
+<astropy.units.core.UnitBase.to>` methods.  Alternatively, if a larger
+piece of code needs the same equivalencies, one can set them for a
+:ref:`given context <equivalency-context>`.
 
 Built-in equivalencies
 ----------------------


### PR DESCRIPTION
In response to #3456: Rather than making get_converter work with Quantities, since it's not really necessary for the end user anyway, best to just privatize it.