### PR TITLE
Fix array Angle _repr_latex_ to make IPython notebooks look nicer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -468,6 +468,8 @@ Bug Fixes
   - Fixed support for subclasses of ``UnitSphericalRepresentation`` and
     ``SphericalRepresentation`` [#3354, #3366]
 
+  - Fixed latex display of array angles in IPython notebook. [#3480]
+
 - ``astropy.io.ascii``
 
   - In the ``CommentedHeader`` the ``data_start`` parameter now defaults to

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -17,6 +17,7 @@ from ..extern import six
 from . import angle_utilities as util
 from .. import units as u
 from ..utils import isiterable
+from ..utils.compat import NUMPY_LT_1_7
 
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
@@ -471,7 +472,18 @@ class Angle(u.Quantity):
         return str(self.to_string())
 
     def _repr_latex_(self):
-        return str(self.to_string(format='latex'))
+        if self.isscalar:
+            return self.to_string(format='latex')
+        else:
+            # need to do a magic incantation to convert to str.  Regular str
+            # or array2string causes all baslashes to get doubled
+            if NUMPY_LT_1_7:
+                #except that numpy 1.6 doesn't do formatter... so instead we
+                #just replace all double-backslashes with one
+                return str(self.to_string(format='latex')).replace('\\\\', '\\')
+            else:
+                return np.array2string(self.to_string(format='latex'),
+                                       formatter={'str_kind':lambda x:x})
 
 
 class Latitude(Angle):

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -475,15 +475,15 @@ class Angle(u.Quantity):
         if self.isscalar:
             return self.to_string(format='latex')
         else:
-            # need to do a magic incantation to convert to str.  Regular str
-            # or array2string causes all baslashes to get doubled
+            # Need to do a magic incantation to convert to str.  Regular str
+            # or array2string causes all backslashes to get doubled.
             if NUMPY_LT_1_7:
-                #except that numpy 1.6 doesn't do formatter... so instead we
-                #just replace all double-backslashes with one
+                # Except that numpy 1.6 doesn't do formatter... so instead we
+                # just replace all double-backslashes with one.
                 return str(self.to_string(format='latex')).replace('\\\\', '\\')
             else:
                 return np.array2string(self.to_string(format='latex'),
-                                       formatter={'str_kind':lambda x:x})
+                                       formatter={'str_kind': lambda x: x})
 
 
 class Latitude(Angle):

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -15,6 +15,7 @@ from ..angles import Longitude, Latitude, Angle
 from ...tests.helper import pytest
 from ... import units as u
 from ..errors import IllegalSecondError, IllegalMinuteError, IllegalHourError
+from ...utils.compat import NUMPY_LT_1_7
 
 
 def test_create_angles():
@@ -847,3 +848,31 @@ def test_wrap_at_without_new():
     l = np.concatenate([l1, l2])
     assert l._wrap_angle is not None
 
+
+def test_repr_latex():
+    """
+    Check the _repr_latex_ method, used primarily by IPython notebooks
+    """
+
+    # try with both scalar
+    scangle = Angle(2.1, u.deg)
+    rlscangle = scangle._repr_latex_()
+
+    # and array angles
+    arrangle = Angle([1, 2.1], u.deg)
+    rlarrangle = arrangle._repr_latex_()
+
+    if NUMPY_LT_1_7:
+        # numpy 1.6 gives weird latex output for unclear reasons.  We don't care
+        # that much though, so just xfail after making sure it isn't
+        # over-backslashing
+        assert '\\\\' not in rlscangle
+        assert '\\\\' not in rlarrangle
+        pytest.xfail('numpy 1.6 does not give correct to_string latex output')
+
+    assert rlscangle == '$2^\circ06{}^\prime00{}^{\prime\prime}$'
+    assert rlscangle.split('$')[1] in rlarrangle
+
+    # make sure the ... appears for large arrays
+    bigarrangle = Angle(np.ones(50000)/50000., u.deg)
+    assert '...' in bigarrangle._repr_latex_()


### PR DESCRIPTION
I've noticing for a while that array `coordinates.Angle` (and subclasses) don't render correctly in ipython notebooks.  Specifically, they look like this:
![before](https://cloud.githubusercontent.com/assets/346587/6139506/a3607e54-b15a-11e4-92e2-d47441952be9.png)

The problem seems to have been that the `Angle._repr_latex_` method (which is what IPython uses to get what it displays) was converting numpy arrays of strings into single strings in a way that makes ``\`` turn into ``\\``.  This PR fixes that, so that now this is what you see:
![after](https://cloud.githubusercontent.com/assets/346587/6139509/a9ddd5ce-b15a-11e4-90c2-f438d511ad2f.png)

I put this in the changelog for v1.0 because it's a bug, but it can be moved if this doesn't bet merged in time.

Note: this closes #3332