### PR TITLE
Fix #3490: Fix faulty warning about changed config file

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -727,7 +727,7 @@ def reload_config(packageormod=None):
     sec.reload()
 
 
-def is_unedited_config_file(filename, template_content=None):
+def is_unedited_config_file(content, template_content=None):
     """
     Determines if a config file can be safely replaced because it doesn't
     actually contain any meaningful content.
@@ -739,19 +739,10 @@ def is_unedited_config_file(filename, template_content=None):
     - An exact match to a "legacy" version of the config file prior to
       Astropy 0.4, when APE3 was implemented and the config file
       contained commented-out values by default.
-
-    If the config file is already identical to the template config
-    file, `False` is returned so it is not needlessly overwritten.
     """
     # We want to calculate the md5sum using universal line endings, so
     # that even if the files had their line endings converted to \r\n
     # on Windows, this will still work.
-
-    with io.open(filename, 'rt', encoding='latin-1') as fd:
-        content = fd.read()
-
-    if content == template_content:
-        return False
 
     content = content.encode('latin-1')
 
@@ -836,9 +827,17 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     doupdate = False
     if cfgfn is not None:
         if path.exists(cfgfn):
-            doupdate = is_unedited_config_file(cfgfn, template_content)
+            with io.open(cfgfn, 'rt', encoding='latin-1') as fd:
+                content = fd.read()
+
+            identical = (content == template_content)
+
+            if not identical:
+                doupdate = is_unedited_config_file(
+                    content, template_content)
         elif path.exists(path.dirname(cfgfn)):
             doupdate = True
+            identical = False
 
     if version is None:
         mod = __import__(pkg)
@@ -860,7 +859,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
             # If we just installed a new template file and we can't
             # update the main configuration file because it has user
             # changes, display a warning.
-            if not doupdate:
+            if not identical and not doupdate:
                 warn(
                     "The configuration options in {0} {1} may have changed, "
                     "your configuration file was not updated in order to "
@@ -869,7 +868,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
                         pkg, version, template_path),
                     ConfigurationChangedWarning)
 
-        if doupdate:
+        if doupdate and not identical:
             with io.open(cfgfn, 'wt', encoding='latin-1') as fw:
                 fw.write(template_content)
             return True

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -178,17 +178,21 @@ def test_configitem_setters():
 def test_empty_config_file():
     from ..configuration import is_unedited_config_file
 
-    fn = get_pkg_data_filename('data/empty.cfg')
-    assert is_unedited_config_file(fn)
+    def get_content(fn):
+        with io.open(get_pkg_data_filename(fn), 'rt', encoding='latin-1') as fd:
+            return fd.read()
 
-    fn = get_pkg_data_filename('data/not_empty.cfg')
-    assert not is_unedited_config_file(fn)
+    content = get_content('data/empty.cfg')
+    assert is_unedited_config_file(content)
 
-    fn = get_pkg_data_filename('data/astropy.0.3.cfg')
-    assert is_unedited_config_file(fn)
+    content = get_content('data/not_empty.cfg')
+    assert not is_unedited_config_file(content)
 
-    fn = get_pkg_data_filename('data/astropy.0.3.windows.cfg')
-    assert is_unedited_config_file(fn)
+    content = get_content('data/astropy.0.3.cfg')
+    assert is_unedited_config_file(content)
+
+    content = get_content('data/astropy.0.3.windows.cfg')
+    assert is_unedited_config_file(content)
 
 
 def test_alias():


### PR DESCRIPTION
This bug was introduced in d6b11fcd0cac16781940c0c4d08e0f09c733ce95 in an attempt to reduce unnecessarily overwriting the config file.