### PR TITLE
v1.0rc2: test failure due to a DeprecationWarning over log.warn()

### DIFF
--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -188,9 +188,9 @@ class SAMPHubServer(object):
                 self._web_profile_server.register_introspection_functions()
                 log.info("Hub set to run with Web Profile support enabled.")
             except socket.error:
-                log.warn("Port {0} already in use. Impossible to run the "
-                         "Hub with Web Profile support.".format(self._web_port),
-                         SAMPWarning)
+                log.warning("Port {0} already in use. Impossible to run the "
+                            "Hub with Web Profile support.".format(self._web_port),
+                            SAMPWarning)
                 self._web_profile = web_profile = False
 
         # SSL general settings


### PR DESCRIPTION
Running `import astropy; astropy.test()` using a pip-installed version of AstroPy v1.0rc2 with Python 3.3.5 on Scientific Linux 7, I got the error below.  The attached PR is the trivial fix.

I found other places where `log.warn` instead of `log.warning` is used, but they don't trigger a test failure so I'll open a separate issue for them.

```
=========================================================================================== ERRORS ===========================================================================================
______________________________________________________________________________ ERROR at setup of test_reconnect ______________________________________________________________________________

request = <SubRequest 'samp_hub' for <Function 'test_reconnect'>>

    @pytest.fixture
    def samp_hub(request):
        """A fixture that can be used by client tests that require a HUB."""
>       my_hub = SAMPHubServer()

/home/gb/bin/anaconda/envs/p3/lib/python3.3/site-packages/astropy/vo/samp/tests/test_client.py:36: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.vo.samp.hub.SAMPHubServer object at 0x7ff5f2c36c50>, secret = None, addr = None, port = 0, lockfile = None, timeout = 0, client_timeout = 0, mode = 'single', label = ''
https = False, key_file = None, cert_file = None, cert_reqs = 0, ca_certs = None, ssl_version = None, web_profile = True, web_profile_dialog = None, web_port = 21012, pool_size = 20

    def __init__(self, secret=None, addr=None, port=0, lockfile=None,
                 timeout=0, client_timeout=0, mode='single', label="",
                 https=False, key_file=None, cert_file=None, cert_reqs=0,
                 ca_certs=None, ssl_version=None, web_profile=True,
                 web_profile_dialog=None, web_port=21012, pool_size=20):
    
        # Generate random ID for the hub
        self._id = str(uuid.uuid1())
    
        # General settings
        self._is_running = False
        self._customlockfilename = lockfile
        self._lockfile = None
        self._addr = addr
        self._port = port
        self._mode = mode
        self._label = label
        self._timeout = timeout
        self._client_timeout = client_timeout
        self._pool_size = pool_size
    
        self._web_profile = web_profile
        self._web_profile_server = None
        self._web_profile_callbacks = {}
        self._web_profile_requests_queue = queue.Queue(1)
        self._web_profile_requests_result = queue.Queue(1)
        self._web_profile_requests_semaphore = queue.Queue(1)
    
        self._web_profile_dialog = web_profile_dialog
        if self._web_profile_dialog is not None:
            # TODO: Some sort of duck-typing on the web_profile_dialog object
            self._web_profile_dialog.queue_request = self._web_profile_requests_queue
            self._web_profile_dialog.queue_result = self._web_profile_requests_result
        self._web_port = web_port
    
        if web_profile:
            try:
                self._web_profile_server = WebProfileXMLRPCServer(('localhost', self._web_port), log,
                                                                  logRequests=False,
                                                                  allow_none=True)
                self._web_port = self._web_profile_server.socket.getsockname()[1]
                self._web_profile_server.register_introspection_functions()
                log.info("Hub set to run with Web Profile support enabled.")
            except socket.error:
                log.warn("Port {0} already in use. Impossible to run the "
                         "Hub with Web Profile support.".format(self._web_port),
>                        SAMPWarning)

/home/gb/bin/anaconda/envs/p3/lib/python3.3/site-packages/astropy/vo/samp/hub.py:193: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <astropy.logger.AstropyLogger object at 0x7ff61577ea10>, msg = 'Port 21012 already in use. Impossible to run the Hub with Web Profile support.'
args = (<class 'astropy.vo.samp.errors.SAMPWarning'>,), kwargs = {}

    def warn(self, msg, *args, **kwargs):
        warnings.warn("The 'warn' method is deprecated, "
>           "use 'warning' instead", DeprecationWarning, 2)
E       DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead

/home/gb/bin/anaconda/envs/p3/lib/python3.3/logging/__init__.py:1253: DeprecationWarning
========================================================= 5857 passed, 104 skipped, 42 xfailed, 3 xpassed, 1 error in 161.39 seconds =========================================================
1
>>> 
```