### PR TITLE
Check if outfile is an instance of io.TextIOWrapper

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -649,7 +649,10 @@ def _array_to_file(arr, outfile):
     """
 
 
-    if isfile(outfile):
+    if isinstance(outfile, io.TextIOWrapper):
+        outfile = outfile.buffer
+        write = _array_to_file_like
+    elif isfile(outfile):
         write = lambda a, f: a.tofile(f)
     else:
         write = _array_to_file_like


### PR DESCRIPTION
Added a condition to check if the file like object is an instance of io.TextIOWrapper
