### PR TITLE
1.0rc1&2: test_identity fails on i386, arm64, powerpc, ppc64el, s390x

### DIFF
--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -61,4 +61,4 @@ def test_identity():
                                   [-1.73205081, -1.73205081, -1.73205081]]),
                         np.array([[ 1.,  1.,  1.],
                                   [ 1.,  1.,  1.]])))
-    assert_allclose(model.inverse(res_x, res_y), (x, y))
+    assert_allclose(model.inverse(res_x, res_y), (x, y), atol=1.e-10)


### PR DESCRIPTION
Since this is not fixed yet, I am separating it from #3380 (it is not 32-bitrelated). `test_identity` fails on i386, arm64, powerpc, pp64el, s390x. Looks like an accuracy problem:
```
    def test_identity():
[...]
        assert_allclose((res_x, res_y),
                           (np.array([[-1.73205081, -1.73205081, -1.73205081],
                                      [-1.73205081, -1.73205081, -1.73205081]]),
                            np.array([[ 1.,  1.,  1.],
                                      [ 1.,  1.,  1.]])))
>       assert_allclose(model.inverse(res_x, res_y), (x, y))

astropy/modeling/tests/test_mappings.py:64: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

actual = array([[[ -2.97613496e-17,  -2.97613496e-17,  -2.97613496e-17],
        [ -2.9...0000000e+00],
        [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00]]])
desired = array([[[ 0.,  0.,  0.],
        [ 0.,  0.,  0.]],

       [[ 1.,  1.,  1.],
        [ 1.,  1.,  1.]]])
rtol = 1e-07, atol = 0, err_msg = '', verbose = True

    def assert_allclose(actual, desired, rtol=1e-7, atol=0,
                        err_msg='', verbose=True):
        """[...]"""
        import numpy as np
        def compare(x, y):
            return np.allclose(x, y, rtol=rtol, atol=atol)
    
        actual, desired = np.asanyarray(actual), np.asanyarray(desired)
        header = 'Not equal to tolerance rtol=%g, atol=%g' % (rtol, atol)
        assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
>                            verbose=verbose, header=header)

/usr/lib/python2.7/dist-packages/numpy/testing/utils.py:1183: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

comparison = <function compare at 0xf17aebc4>
x = array([[[ -2.97613496e-17,  -2.97613496e-17,  -2.97613496e-17],
        [ -2.9...0000000e+00],
        [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00]]])
y = array([[[ 0.,  0.,  0.],
        [ 0.,  0.,  0.]],

       [[ 1.,  1.,  1.],
        [ 1.,  1.,  1.]]])
err_msg = '', verbose = True
header = 'Not equal to tolerance rtol=1e-07, atol=0'

    def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                             header=''):
[...]
                if not cond :
>                   raise AssertionError(msg)
E                   AssertionError: 
E                   Not equal to tolerance rtol=1e-07, atol=0
E                   
E                   (mismatch 100.0%)
E                    x: array([[[ -2.97613496e-17,  -2.97613496e-17,  -2.97613496e-17],
E                           [ -2.97613496e-17,  -2.97613496e-17,  -2.97613496e-17]],
E                   ...
E                    y: array([[[ 0.,  0.,  0.],
E                           [ 0.,  0.,  0.]],
E                   ...

/usr/lib/python2.7/dist-packages/numpy/testing/utils.py:644: AssertionError
```
