### PR TITLE
Bug in Angle.to_string with Numpy 1.6

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -370,7 +370,7 @@ class Angle(u.Quantity):
                 s = '${0}$'.format(s)
             return s
 
-        if NUMPY_LT_1_7 and not np.isscalar(values):
+        if NUMPY_LT_1_7 and not np.isscalar(values):  # pragma: no cover
             format_ufunc = np.vectorize(do_format, otypes=[np.object])
             # In Numpy 1.6, unicode output is broken.  vectorize always seems to
             # yieled U2 even if you tell it something else.  So we convert in

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -20,7 +20,6 @@ from ..utils import isiterable
 from ..utils.compat import NUMPY_LT_1_7
 
 
-
 __all__ = ['Angle', 'Latitude', 'Longitude']
 
 
@@ -373,14 +372,14 @@ class Angle(u.Quantity):
 
         if NUMPY_LT_1_7 and not np.isscalar(values):
             format_ufunc = np.vectorize(do_format, otypes=[np.object])
-            #In Numpy 1.6, unicode output is broken.  vectorize always seems to
+            # In Numpy 1.6, unicode output is broken.  vectorize always seems to
             # yieled U2 even if you tell it something else.  So we convert in
             # a second step with 60 chars, on the theory that you'll never want
             # better than what double-precision decimals give, which end up
             # around that many characters.
             result = format_ufunc(values).astype('U60')
         else:
-            #for newer numpy's, this just works as you would expect
+            #for newer Numpy versions, this just works as you would expect
             format_ufunc = np.vectorize(do_format, otypes=['U'])
             result = format_ufunc(values)
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -295,7 +295,6 @@ def test_angle_formatting():
     res = 'Angle as rad decimal: 0.0629763'
     assert "Angle as rad decimal: {0}".format(angle.to_string(unit=u.radian, decimal=True)) == res
 
-
     # check negative angles
 
     angle = Angle(-1.23456789, unit=u.degree)
@@ -306,6 +305,13 @@ def test_angle_formatting():
     assert angle.to_string(unit=u.hour) == '-0h04m56.2963s'
     assert angle2.to_string(unit=u.hour, pad=True) == '-01h14m04.4444s'
     assert angle.to_string(unit=u.radian, decimal=True) == '-0.0215473'
+
+
+def test_to_string_vector():
+    # Regression test for the fact that vectorize didn't work. This test works
+    # by comparing the result of ``to_string`` for a vector and a scalar angle.
+    assert Angle([1./7.], unit='deg').to_string() == Angle(1./7., unit='deg').to_string()
+
 
 def test_angle_format_roundtripping():
     """

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -308,9 +308,10 @@ def test_angle_formatting():
 
 
 def test_to_string_vector():
-    # Regression test for the fact that vectorize didn't work. This test works
-    # by comparing the result of ``to_string`` for a vector and a scalar angle.
-    assert Angle([1./7.], unit='deg').to_string() == Angle(1./7., unit='deg').to_string()
+    # Regression test for the fact that vectorize doesn't work with Numpy 1.6
+    assert Angle([1./7., 1./7.], unit='deg').to_string()[0] == "0d08m34.2857s"
+    assert Angle([1./7.], unit='deg').to_string()[0] == "0d08m34.2857s"
+    assert Angle(1./7., unit='deg').to_string() == "0d08m34.2857s"
 
 
 def test_angle_format_roundtripping():


### PR DESCRIPTION
Since we are still supporting Numpy 1.6, here is a bug that occurs with that version:

```
>>> from astropy.coordinates import Angle
>>> a = Angle(3.3333333, unit='deg')
>>> a.to_string()
u'3d19m59.9999s'
>>> a = Angle([3.3333333,3.3333333], unit='deg')
>>> a.to_string()
array([u'3d19m59.', u'3d19m59.'], 
      dtype='<U8')
```

Note that when the angle is an array, the strings get truncated to 8 characters. I think this is a bug in ``np.vectorize`` but we should work around it since we support that Numpy version.