### PR TITLE
Catch also OSError in multiprocessing.Queue()

### DIFF
--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -391,7 +391,7 @@ cdef class CParser:
         cdef int N = self.parallel
         try:
             queue = multiprocessing.Queue()
-        except (ImportError, NotImplementedError, AttributeError):
+        except (ImportError, NotImplementedError, AttributeError, OSError):
             self.raise_error("shared semaphore implementation required "
                              "but not available")
         cdef int offset = self.tokenizer.source_pos


### PR DESCRIPTION
On older (k)FreeBSD systems, python raises an OSError if sem_open is
not implemented. We need to catch this as well.
Fixes #3416 