### PR TITLE
Add summary of changes

### DIFF
--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -27,6 +27,11 @@ objects containing arrays (see :ref:`whatsnew_table`).
 
 In addition to these major changes, Astropy 1.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
+By the numbers:
+
+* 679 issues have been closed since v0.4
+* 417 pull requests have been merged since v0.4
+* 122 distinct people have contributed code
 
 About Long-term support
 -----------------------

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -29,8 +29,8 @@ In addition to these major changes, Astropy 1.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
 By the numbers:
 
-* 679 issues have been closed since v0.4
-* 417 pull requests have been merged since v0.4
+* 681 issues have been closed since v0.4
+* 419 pull requests have been merged since v0.4
 * 122 distinct people have contributed code
 
 About Long-term support


### PR DESCRIPTION
As @astrofrog suggested in #3451, we should add something summarizing the number of bugs fixed in 1.0 (and possibly go back and do the same for 0.4).  I'll try to locate the script I did this with before and we can do it just before release to make sure we have the latest numbers.