### PR TITLE
Fix io.ascii test failures on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,21 @@ New Features
     also removes duplicate format guesses to improve performance. [#3418]
 
 
+1.0.1 (unreleased)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- ``astropy.io.ascii``
+
+  - Fixed support for reading inf and nan values with the fast reader in
+    Windows.  Also fixed in the case of using ``use_fast_converter=True``
+    with the fast reader. [#3525]
+
+  - Fixed use of mmap in the fast reader on Windows. [#3525]
+
+
 1.0 (2015-02-18)
 ----------------
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -124,7 +124,7 @@ cdef class FileString:
         self.fhandle = open(fname, 'r')
         if not self.fhandle:
             raise IOError('File "{0}" could not be opened'.format(fname))
-        self.mmap = mmap.mmap(self.fhandle.fileno(), 0, prot=mmap.PROT_READ)
+        self.mmap = mmap.mmap(self.fhandle.fileno(), 0, access=mmap.ACCESS_READ)
         cdef Py_ssize_t buf_len = len(self.mmap)
         if six.PY2:
             PyObject_AsReadBuffer(self.mmap, &self.mmap_ptr, &buf_len)

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -601,10 +601,15 @@ double str_to_double(tokenizer_t *self, char *str)
     {
         val = strtod(str, &tmp);
 
-        if (tmp == str || *tmp != 0)
+        if (tmp == str || *tmp != 0) {
+		    if (0 == strncmp(str, "nan", 3)) {
+				return NAN;
+		    }
             self->code = CONVERSION_ERROR;
-        else if (errno == ERANGE)
+		}
+        else if (errno == ERANGE) {
             self->code = OVERFLOW_ERROR;
+		}
     }
 
     return val;

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -40,6 +40,7 @@ tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar,
     return tokenizer;
 }
 
+
 void delete_data(tokenizer_t *tokenizer)
 {
     // Don't free tokenizer->source because it points to part of
@@ -60,6 +61,7 @@ void delete_data(tokenizer_t *tokenizer)
     tokenizer->output_len = 0;
 }
 
+
 void delete_tokenizer(tokenizer_t *tokenizer)
 {
     delete_data(tokenizer);
@@ -67,6 +69,7 @@ void delete_tokenizer(tokenizer_t *tokenizer)
     free(tokenizer->buf);
     free(tokenizer);
 }
+
 
 void resize_col(tokenizer_t *self, int index)
 {
@@ -88,6 +91,7 @@ void resize_col(tokenizer_t *self, int index)
     self->col_ptrs[index] = self->output_cols[index] + diff;
 }
 
+
 void resize_comments(tokenizer_t *self)
 {
     // Double the size of the comments string
@@ -104,7 +108,6 @@ void resize_comments(tokenizer_t *self)
   Resize the column string if necessary and then append c to the
   end of the column string, incrementing the column position pointer.
 */
-
 static inline void push(tokenizer_t *self, char c, int col)
 {
     if (self->col_ptrs[col] - self->output_cols[col] >=
@@ -116,37 +119,44 @@ static inline void push(tokenizer_t *self, char c, int col)
     *self->col_ptrs[col]++ = c;
 }
 
+
 /*
   Resize the comment string if necessary and then append c to the
   end of the comment string.
 */
-
 static inline void push_comment(tokenizer_t *self, char c)
 {
     if (self->comment_pos == self->comment_lines_len)
+    {
         resize_comments(self);
+    }
     self->comment_lines[self->comment_pos++] = c;
 }
+
 
 static inline void end_comment(tokenizer_t *self)
 {
     // Signal empty comment by inserting \x01
     if (self->comment_pos == 0 || self->comment_lines[self->comment_pos - 1] == '\x00')
+    {
         push_comment(self, '\x01');
+    }
     push_comment(self, '\x00');
 }
 
+
 #define PUSH(c) push(self, c, col)
+
 
 /* Set the state to START_FIELD and begin with the assumption that
    the field is entirely whitespace in order to handle the possibility
    that the comment character is found before any non-whitespace even
    if whitespace stripping is disabled.
 */
-
 #define BEGIN_FIELD()                           \
     self->state = START_FIELD;                  \
     whitespace = 1
+
 
 /*
   First, backtrack to eliminate trailing whitespace if strip_whitespace_fields
@@ -154,11 +164,10 @@ static inline void end_comment(tokenizer_t *self)
   Append a null byte to the end of the column string as a field delimiting marker.
   Increment the variable col if we are tokenizing data.
 */
-
 static inline void end_field(tokenizer_t *self, int *col, int header)
 {
-    if (self->strip_whitespace_fields && self->col_ptrs[*col]
-    != self->output_cols[*col])
+    if (self->strip_whitespace_fields &&
+            self->col_ptrs[*col] != self->output_cols[*col])
     {
         --self->col_ptrs[*col];
         while (*self->col_ptrs[*col] == ' ' || *self->col_ptrs[*col] == '\t')
@@ -168,24 +177,27 @@ static inline void end_field(tokenizer_t *self, int *col, int header)
         ++self->col_ptrs[*col];
     }
     if (self->col_ptrs[*col] == self->output_cols[*col] ||
-        self->col_ptrs[*col][-1] == '\x00')
+            self->col_ptrs[*col][-1] == '\x00')
     {
         push(self, '\x01', *col);
     }
     push(self, '\x00', *col);
-    if (!header)
+    if (!header) {
         ++*col;
+    }
 }
+
 
 #define END_FIELD() end_field(self, &col, header)
 
-// Set the error code to c for later retrieval and return c
 
+// Set the error code to c for later retrieval and return c
 #define RETURN(c)                                               \
     do {                                                        \
         self->code = c;                                         \
         return c;                                               \
     } while (0)
+
 
 /*
   If we are tokenizing the header, end after the first line.
@@ -194,36 +206,44 @@ static inline void end_field(tokenizer_t *self, int *col, int header)
   return an error. Increment our row count and possibly end if
   all the necessary rows have already been parsed.
 */
-
 static inline int end_line(tokenizer_t *self, int col, int header, int end,
-                    tokenizer_state *old_state)
+                           tokenizer_state *old_state)
 {
-    if (header)                                 
-    {                                           
-        ++self->source_pos;                     
-        RETURN(NO_ERROR);                       
-    }                                           
-    else if (self->fill_extra_cols)             
-    while (col < self->num_cols)            
-    {                                       
-            PUSH('\x01');                       
-        END_FIELD();                        
-    }                                       
-    else if (col < self->num_cols)              
-    RETURN(NOT_ENOUGH_COLS);                
-    ++self->num_rows;                           
-    *old_state = START_LINE;                     
-    if (end != -1 && self->num_rows == end)     
-    {                                           
-        ++self->source_pos;                     
-        RETURN(NO_ERROR);                       
+    if (header)
+    {
+        ++self->source_pos;
+        RETURN(NO_ERROR);
+    }
+    else if (self->fill_extra_cols)
+    {
+        while (col < self->num_cols)
+        {
+                PUSH('\x01');
+            END_FIELD();
+        }
+    }
+    else if (col < self->num_cols)
+    {
+        RETURN(NOT_ENOUGH_COLS);
+    }
+
+    ++self->num_rows;
+    *old_state = START_LINE;
+
+    if (end != -1 && self->num_rows == end)
+    {
+        ++self->source_pos;
+        RETURN(NO_ERROR);
     }
     return -1;
 }
 
+
 #define END_LINE() if (end_line(self, col, header, end, &old_state) != -1) return self->code
 
+
 #define HANDLE_CR() old_state = self->state; self->state = CARRIAGE_RETURN
+
 
 int skip_lines(tokenizer_t *self, int offset, int header)
 {
@@ -234,7 +254,7 @@ int skip_lines(tokenizer_t *self, int offset, int header)
 
     while (i < offset)
     {
-    if (self->source_pos >= self->source_len)
+        if (self->source_pos >= self->source_len)
         {
             if (header)
                 RETURN(INVALID_LINE); // header line is required
@@ -259,29 +279,30 @@ int skip_lines(tokenizer_t *self, int offset, int header)
             signif_chars = 0;
             comment = 0;
         }
+        else if ((c != ' ' && c != '\t') || !self->strip_whitespace_lines || header)
+        {
+                // comment line
+                if (!signif_chars && self->comment != 0 && c == self->comment)
+                    comment = 1;
+                else if (comment && !header)
+                    push_comment(self, c);
 
-    else if ((c != ' ' && c != '\t') || !self->strip_whitespace_lines || header)
-    {
-            // comment line
-            if (!signif_chars && self->comment != 0 && c == self->comment)
-                comment = 1;
-            else if (comment && !header)
-                push_comment(self, c);
-
-            // significant character encountered; during header
-            // tokenization, we count whitespace unlike data tokenization
-            // (see #2654)
-            ++signif_chars;
-    }
-
+                // significant character encountered; during header
+                // tokenization, we count whitespace unlike data tokenization
+                // (see #2654)
+                ++signif_chars;
+        }
         else if (comment && !header)
+        {
             push_comment(self, c);
+        }
 
-        ++self->source_pos;
+            ++self->source_pos;
     }
 
     RETURN(NO_ERROR);
 }
+
 
 int tokenize(tokenizer_t *self, int end, int header, int num_cols)
 {
@@ -570,8 +591,10 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
 
 
 // Lower-case a single C locale character
-static inline int ascii_tolower(int c) {
-    if (c >= 'A' || c <= 'Z') {
+static inline int ascii_tolower(int c)
+{
+    if (c >= 'A' || c <= 'Z')
+    {
         return c + ('a' - 'A');
     }
 
@@ -583,7 +606,8 @@ static int ascii_strncasecmp(const char *str1, const char *str2, size_t n)
 {
     int char1, char2;
 
-    do {
+    do
+    {
         char1 = tolower(*(str1++));
         char2 = tolower(*(str2++));
         n--;
@@ -608,6 +632,7 @@ long str_to_long(tokenizer_t *self, char *str)
     return ret;
 }
 
+
 double str_to_double(tokenizer_t *self, char *str)
 {
     char *tmp;
@@ -618,10 +643,12 @@ double str_to_double(tokenizer_t *self, char *str)
     {
         val = xstrtod(str, &tmp, '.', 'E', ',', 1);
 
-        if (*tmp) {
+        if (*tmp)
+        {
             goto conversion_error;
         }
-        else if (errno == ERANGE) {
+        else if (errno == ERANGE)
+        {
             self->code = OVERFLOW_ERROR;
         }
 
@@ -632,10 +659,12 @@ double str_to_double(tokenizer_t *self, char *str)
     {
         val = strtod(str, &tmp);
 
-        if (errno == EINVAL || tmp == str || *tmp != '\0') {
+        if (errno == EINVAL || tmp == str || *tmp != '\0')
+        {
             goto conversion_error;
         }
-        else if (errno == ERANGE) {
+        else if (errno == ERANGE)
+        {
             self->code = OVERFLOW_ERROR;
         }
 
@@ -648,28 +677,34 @@ conversion_error:
     val = 1.0;
     tmp = str;
 
-    if (*tmp == '+') {
+    if (*tmp == '+')
+    {
         tmp++;
     }
-    else if (*tmp == '-') {
+    else if (*tmp == '-')
+    {
         tmp++;
         val = -1.0;
     }
 
-    if (0 == ascii_strncasecmp(tmp, "nan", 3)) {
+    if (0 == ascii_strncasecmp(tmp, "nan", 3))
+    {
         // Handle optional nan type specifier; this is ignored
         tmp += 3;
         val = NAN;
     }
-    else if (0 == ascii_strncasecmp(tmp, "inf", 3)) {
+    else if (0 == ascii_strncasecmp(tmp, "inf", 3))
+    {
         tmp += 3;
-        if (0 == ascii_strncasecmp(tmp, "inity", 5)) {
+        if (0 == ascii_strncasecmp(tmp, "inity", 5))
+        {
             tmp += 5;
         }
         val *= INFINITY;
     }
 
-    if (tmp == str || *tmp != '\0') {
+    if (tmp == str || *tmp != '\0')
+    {
         self->code = CONVERSION_ERROR;
         val = 0;
     }
@@ -884,6 +919,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
     return number;
 }
 
+
 void start_iteration(tokenizer_t *self, int col)
 {
     // Begin looping over the column string with index col
@@ -891,6 +927,7 @@ void start_iteration(tokenizer_t *self, int col)
     // Start at the initial pointer position
     self->curr_pos = self->output_cols[col];
 }
+
 
 char *next_field(tokenizer_t *self, int *size)
 {
@@ -916,6 +953,7 @@ char *next_field(tokenizer_t *self, int *size)
         return tmp;
     }
 }
+
 
 char *get_line(char *ptr, int *len, int map_len)
 {
@@ -945,6 +983,7 @@ char *get_line(char *ptr, int *len, int map_len)
     // done with input
     return 0;
 }
+
 
 void reset_comments(tokenizer_t *self)
 {

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -568,6 +568,31 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
     RETURN(0);
 }
 
+
+// Lower-case a single C locale character
+static inline int ascii_tolower(int c) {
+    if (c >= 'A' || c <= 'Z') {
+        return c + ('a' - 'A');
+    }
+
+    return c;
+}
+
+
+static int ascii_strncasecmp(const char *str1, const char *str2, size_t n)
+{
+    int char1, char2;
+
+    do {
+        char1 = tolower(*(str1++));
+        char2 = tolower(*(str2++));
+        n--;
+    } while (n && char1 != '\0' && char1 == char2);
+
+    return (char1 - char2);
+}
+
+
 long str_to_long(tokenizer_t *self, char *str)
 {
     char *tmp;
@@ -631,14 +656,14 @@ conversion_error:
         val = -1.0;
     }
 
-    if (0 == strncasecmp(tmp, "nan", 3)) {
+    if (0 == ascii_strncasecmp(tmp, "nan", 3)) {
         // Handle optional nan type specifier; this is ignored
         tmp += 3;
         val = NAN;
     }
-    else if (0 == strncasecmp(tmp, "inf", 3)) {
+    else if (0 == ascii_strncasecmp(tmp, "inf", 3)) {
         tmp += 3;
-        if (0 == strncasecmp(tmp, "inity", 5)) {
+        if (0 == ascii_strncasecmp(tmp, "inity", 5)) {
             tmp += 5;
         }
         val *= INFINITY;

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -47,8 +47,8 @@ void delete_data(tokenizer_t *tokenizer)
     int i;
 
     if (tokenizer->output_cols)
-	for (i = 0; i < tokenizer->num_cols; ++i)
-	    free(tokenizer->output_cols[i]);
+    for (i = 0; i < tokenizer->num_cols; ++i)
+        free(tokenizer->output_cols[i]);
 
     free(tokenizer->output_cols);
     free(tokenizer->col_ptrs);
@@ -158,7 +158,7 @@ static inline void end_comment(tokenizer_t *self)
 static inline void end_field(tokenizer_t *self, int *col, int header)
 {
     if (self->strip_whitespace_fields && self->col_ptrs[*col]
-	!= self->output_cols[*col])
+    != self->output_cols[*col])
     {
         --self->col_ptrs[*col];
         while (*self->col_ptrs[*col] == ' ' || *self->col_ptrs[*col] == '\t')
@@ -204,13 +204,13 @@ static inline int end_line(tokenizer_t *self, int col, int header, int end,
         RETURN(NO_ERROR);                       
     }                                           
     else if (self->fill_extra_cols)             
-	while (col < self->num_cols)            
-	{                                       
+    while (col < self->num_cols)            
+    {                                       
             PUSH('\x01');                       
-	    END_FIELD();                        
-	}                                       
+        END_FIELD();                        
+    }                                       
     else if (col < self->num_cols)              
-	RETURN(NOT_ENOUGH_COLS);                
+    RETURN(NOT_ENOUGH_COLS);                
     ++self->num_rows;                           
     *old_state = START_LINE;                     
     if (end != -1 && self->num_rows == end)     
@@ -234,7 +234,7 @@ int skip_lines(tokenizer_t *self, int offset, int header)
 
     while (i < offset)
     {
-	if (self->source_pos >= self->source_len)
+    if (self->source_pos >= self->source_len)
         {
             if (header)
                 RETURN(INVALID_LINE); // header line is required
@@ -260,8 +260,8 @@ int skip_lines(tokenizer_t *self, int offset, int header)
             comment = 0;
         }
 
-	else if ((c != ' ' && c != '\t') || !self->strip_whitespace_lines || header)
-	{
+    else if ((c != ' ' && c != '\t') || !self->strip_whitespace_lines || header)
+    {
             // comment line
             if (!signif_chars && self->comment != 0 && c == self->comment)
                 comment = 1;
@@ -272,7 +272,7 @@ int skip_lines(tokenizer_t *self, int offset, int header)
             // tokenization, we count whitespace unlike data tokenization
             // (see #2654)
             ++signif_chars;
-	}
+    }
 
         else if (comment && !header)
             push_comment(self, c);
@@ -576,7 +576,7 @@ long str_to_long(tokenizer_t *self, char *str)
     ret = strtol(str, &tmp, 0);
 
     if (tmp == str || *tmp != '\0')
- 	self->code = CONVERSION_ERROR;
+     self->code = CONVERSION_ERROR;
     else if (errno == ERANGE)
         self->code = OVERFLOW_ERROR;
 
@@ -602,14 +602,14 @@ double str_to_double(tokenizer_t *self, char *str)
         val = strtod(str, &tmp);
 
         if (tmp == str || *tmp != 0) {
-		    if (0 == strncmp(str, "nan", 3)) {
-				return NAN;
-		    }
+            if (0 == strncmp(str, "nan", 3)) {
+                return NAN;
+            }
             self->code = CONVERSION_ERROR;
-		}
+        }
         else if (errno == ERANGE) {
             self->code = OVERFLOW_ERROR;
-		}
+        }
     }
 
     return val;
@@ -836,7 +836,7 @@ char *next_field(tokenizer_t *self, int *size)
 
     // pass through the entire field until reaching the delimiter
     while (*self->curr_pos != '\x00')
-	++self->curr_pos;
+    ++self->curr_pos;
 
     ++self->curr_pos; // next field begins after the delimiter
 

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -48,8 +48,12 @@ void delete_data(tokenizer_t *tokenizer)
     int i;
 
     if (tokenizer->output_cols)
-    for (i = 0; i < tokenizer->num_cols; ++i)
-        free(tokenizer->output_cols[i]);
+    {
+        for (i = 0; i < tokenizer->num_cols; ++i)
+        {
+            free(tokenizer->output_cols[i]);
+        }
+    }
 
     free(tokenizer->output_cols);
     free(tokenizer->col_ptrs);

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -17,6 +17,10 @@
         static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
         #define NAN (*(const float *) __nan)
     #endif
+    #ifndef INFINITY
+        static const unsigned long __infinity[2] = {0x7ff00000, 0x00000000};
+        #define INFINITY (*(const float *) __infinity)
+    #endif
 #endif
 
 typedef enum

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -13,6 +13,10 @@
 
 #ifdef _MSC_VER
 #define inline __inline
+    #ifndef NAN
+        static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
+        #define NAN (*(const float *) __nan)
+    #endif
 #endif
 
 typedef enum

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -15,11 +15,11 @@
 #define inline __inline
     #ifndef NAN
         static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
-        #define NAN (*(const float *) __nan)
+        #define NAN (*(const double *) __nan)
     #endif
     #ifndef INFINITY
-        static const unsigned long __infinity[2] = {0x7ff00000, 0x00000000};
-        #define INFINITY (*(const float *) __infinity)
+        static const unsigned long __infinity[2] = {0x00000000, 0x7ff00000};
+        #define INFINITY (*(const double *) __infinity)
     #endif
 #endif
 

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -554,8 +554,18 @@ def test_fast_reader():
         ascii.read(text, format='fast_basic', guess=False, comment='##')
 
     # Enable multiprocessing and the fast converter
-    ascii.read(text, format='basic', guess=False, fast_reader={'parallel': True,
-                                                    'use_fast_converter': True})
+    try:
+        ascii.read(text, format='basic', guess=False,
+                   fast_reader={'parallel': True, 'use_fast_converter': True})
+    except NotImplementedError:
+        # Might get this on Windows, try without parallel...
+        if os.name == 'nt':
+            ascii.read(text, format='basic', guess=False,
+                       fast_reader={'parallel': False,
+                                    'use_fast_converter': True})
+        else:
+            raise
+
     # Should raise an error if fast_reader has an invalid key
     with pytest.raises(FastOptionsError):
         ascii.read(text, format='fast_basic', guess=False, fast_reader={'foo': True})

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -5,8 +5,8 @@ try:
 except ImportError: # cStringIO doesn't exist in Python 3
     from io import BytesIO
     StringIO = lambda x: BytesIO(x.encode('ascii'))
-from tempfile import NamedTemporaryFile
 import os
+import functools
 
 import numpy as np
 from numpy import ma
@@ -44,8 +44,14 @@ def assert_table_equal(t1, t2, check_meta=False):
                 except (TypeError, NotImplementedError):
                     pass # ignore for now
 
-def _read(table, Reader, format, parallel=False, check_meta=False, **kwargs):
+# Use this counter to create a unique filename for each file created in a test
+# if this function is called more than once in a single test
+_filename_counter = 0
+
+def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=False, **kwargs):
     # make sure we have a newline so table can't be misinterpreted as a filename
+    global _filename_counter
+
     table += '\n'
     reader = Reader(**kwargs)
     t1 = reader.read(table)
@@ -67,45 +73,65 @@ def _read(table, Reader, format, parallel=False, check_meta=False, **kwargs):
             'parallel': True}, **kwargs)
         assert_table_equal(t1, t6, check_meta=check_meta)
 
-    with NamedTemporaryFile() as f:
+    filename = str(tmpdir.join('table{0}.txt'.format(_filename_counter)))
+    _filename_counter += 1
+
+    with open(filename, 'wb') as f:
         f.write(table.encode('ascii'))
         f.flush()
-        t7 = ascii.read(f.name, format=format, guess=False, **kwargs)
-        if parallel:
-            t8 = ascii.read(f.name, format=format, guess=False, fast_reader={
-                'parallel': True}, **kwargs)
+
+    t7 = ascii.read(filename, format=format, guess=False, **kwargs)
+    if parallel:
+        t8 = ascii.read(filename, format=format, guess=False, fast_reader={
+            'parallel': True}, **kwargs)
 
     assert_table_equal(t1, t7, check_meta=check_meta)
     if parallel:
         assert_table_equal(t1, t8, check_meta=check_meta)
     return t1
 
-def read_basic(table, **kwargs):
-    return _read(table, FastBasic, 'basic', **kwargs)
 
-def read_csv(table, **kwargs):
-    return _read(table, FastCsv, 'csv', **kwargs)
+@pytest.fixture(scope='function')
+def read_basic(tmpdir, request):
+    return functools.partial(_read, tmpdir, Reader=FastBasic, format='basic')
 
-def read_tab(table, **kwargs):
-    return _read(table, FastTab, 'tab', **kwargs)
 
-def read_commented_header(table, **kwargs):
-    return _read(table, FastCommentedHeader, 'commented_header', **kwargs)
+@pytest.fixture(scope='function')
+def read_csv(tmpdir, request):
+    return functools.partial(_read, tmpdir, Reader=FastCsv, format='csv')
 
-def read_rdb(table, **kwargs):
-    return _read(table, FastRdb, 'rdb', **kwargs)
 
-def read_no_header(table, **kwargs):
-    return _read(table, FastNoHeader, 'no_header', **kwargs)
+@pytest.fixture(scope='function')
+def read_tab(tmpdir, request):
+    return functools.partial(_read, tmpdir, Reader=FastTab, format='tab')
+
+
+@pytest.fixture(scope='function')
+def read_commented_header(tmpdir, request):
+    return functools.partial(_read, tmpdir, Reader=FastCommentedHeader,
+                             format='commented_header')
+
+
+@pytest.fixture(scope='function')
+def read_rdb(tmpdir, request):
+    return functools.partial(_read, tmpdir, Reader=FastRdb, format='rdb')
+
+
+@pytest.fixture(scope='function')
+def read_no_header(tmpdir, request):
+    return functools.partial(_read, tmpdir, Reader=FastNoHeader,
+                             format='no_header')
+
 
 @pytest.mark.parametrize("parallel", [True, False])
-def test_simple_data(parallel):
+def test_simple_data(parallel, read_basic):
     """
     Make sure the fast reader works with basic input data.
     """
     table = read_basic("A B C\n1 2 3\n4 5 6", parallel=parallel)
     expected = Table([[1, 4], [2, 5], [3, 6]], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
+
 
 def test_read_types():
     """
@@ -119,8 +145,9 @@ def test_read_types():
     assert_table_equal(t1, t2)
     assert_table_equal(t2, t3)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_supplied_names(parallel):
+def test_supplied_names(parallel, read_basic):
     """
     If passed as a parameter, names should replace any
     column names found in the header.
@@ -129,8 +156,9 @@ def test_supplied_names(parallel):
     expected = Table([[1, 4], [2, 5], [3, 6]], names=('X', 'Y', 'Z'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_no_header(parallel):
+def test_no_header(parallel, read_basic, read_no_header):
     """
     The header should not be read when header_start=None. Unless names is
     passed, the column names should be auto-generated.
@@ -141,8 +169,9 @@ def test_no_header(parallel):
     assert_table_equal(t1, expected)
     assert_table_equal(t2, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_no_header_supplied_names(parallel):
+def test_no_header_supplied_names(parallel, read_basic):
     """
     If header_start=None and names is passed as a parameter, header
     data should not be read and names should be used instead.
@@ -152,8 +181,9 @@ def test_no_header_supplied_names(parallel):
     expected = Table([['A', '1', '4'], ['B', '2', '5'], ['C', '3', '6']], names=('X', 'Y', 'Z'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_comment(parallel):
+def test_comment(parallel, read_basic):
     """
     Make sure that line comments are ignored by the C reader.
     """
@@ -161,8 +191,9 @@ def test_comment(parallel):
     expected = Table([[1, 4], [2, 5], [3, 6]], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_empty_lines(parallel):
+def test_empty_lines(parallel, read_basic):
     """
     Make sure that empty lines are ignored by the C reader.
     """
@@ -170,8 +201,9 @@ def test_empty_lines(parallel):
     expected = Table([[1, 4], [2, 5], [3, 6]], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_lstrip_whitespace(parallel):
+def test_lstrip_whitespace(parallel, read_basic):
     """
     Test to make sure the reader ignores whitespace at the beginning of fields.
     """
@@ -185,8 +217,9 @@ def test_lstrip_whitespace(parallel):
     expected = Table([['A', 'a'], ['B', 'b'], ['C', 'c']], names=('1', '2', '3'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_rstrip_whitespace(parallel):
+def test_rstrip_whitespace(parallel, read_basic):
     """
     Test to make sure the reader ignores whitespace at the end of fields.
     """
@@ -195,8 +228,9 @@ def test_rstrip_whitespace(parallel):
     expected = Table([['A', 'a'], ['B', 'b'], ['C', 'c']], names=('1', '2', '3'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_conversion(parallel):
+def test_conversion(parallel, read_basic):
     """
     The reader should try to convert each column to ints. If this fails, the
     reader should try to convert to floats. Failing this, it should fall back
@@ -215,8 +249,9 @@ A B C D E
     assert_equal(table['D'].dtype.kind, 'f')
     assert table['E'].dtype.kind in ('S', 'U')
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_delimiter(parallel):
+def test_delimiter(parallel, read_basic):
     """
     Make sure that different delimiters work as expected.
     """
@@ -231,8 +266,9 @@ COL1 COL2 COL3
         table = read_basic(text.replace(' ', sep), delimiter=sep, parallel=parallel)
         assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_include_names(parallel):
+def test_include_names(parallel, read_basic):
     """
     If include_names is not None, the parser should read only those columns in include_names.
     """
@@ -240,8 +276,9 @@ def test_include_names(parallel):
     expected = Table([[1, 5], [4, 8]], names=('A', 'D'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_exclude_names(parallel):
+def test_exclude_names(parallel, read_basic):
     """
     If exclude_names is not None, the parser should exclude the columns in exclude_names.
     """
@@ -249,8 +286,9 @@ def test_exclude_names(parallel):
     expected = Table([[2, 6], [3, 7]], names=('B', 'C'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_include_exclude_names(parallel):
+def test_include_exclude_names(parallel, read_basic):
     """
     Make sure that include_names is applied before exclude_names if both are specified.
     """
@@ -264,8 +302,9 @@ A B C D E F G H
     expected = Table([[1, 9], [4, 12], [8, 16]], names=('A', 'D', 'H'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_quoted_fields(parallel):
+def test_quoted_fields(parallel, read_basic):
     """
     The character quotechar (default '"') should denote the start of a field which can
     contain the field delimiter and newlines.
@@ -283,6 +322,7 @@ a b "   c
     assert_table_equal(table, expected)
     table = read_basic(text.replace('"', "'"), quotechar="'", parallel=parallel)
     assert_table_equal(table, expected)
+
 
 def test_invalid_parameters():
     """
@@ -317,6 +357,7 @@ def test_invalid_parameters():
         # Outputter cannot be specified in constructor
         table = FastBasic(Outputter=ascii.TableOutputter).read('1 2 3\n4 5 6')
 
+
 def test_too_many_cols():
     """
     If a row contains too many columns, the C reader should raise an error.
@@ -333,8 +374,9 @@ A B C
     assert 'CParserError: an error occurred while parsing table data: too many ' \
         'columns found in line 3 of data' in str(e)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_not_enough_cols(parallel):
+def test_not_enough_cols(parallel, read_csv):
     """
     If a row does not have enough columns, the FastCsv reader should add empty
     fields while the FastBasic reader should raise an error.
@@ -352,8 +394,9 @@ A,B,C
     with pytest.raises(CParserError) as e:
         table = FastBasic(delimiter=',').read(text)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_data_end(parallel):
+def test_data_end(parallel, read_basic, read_rdb):
     """
     The parameter data_end should specify where data reading ends.
     """
@@ -394,8 +437,9 @@ N\tN\tS
     expected = Table([[], [], []], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_fill_values(parallel):
+def test_fill_values(parallel, read_basic):
     """
     Make sure that the parameter fill_values works as intended. If fill_values
     is not specified, the default behavior should be to convert '' to 0.
@@ -441,8 +485,9 @@ nan, 5, -9999
     assert_almost_equal(table['C'].data.data[0], 999.0)
     assert_almost_equal(table['C'][1], -3.4) # column is still of type float
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_fill_include_exclude_names(parallel):
+def test_fill_include_exclude_names(parallel, read_csv):
     """
     fill_include_names and fill_exclude_names should filter missing/empty value handling
     in the same way that include_names and exclude_names filter output columns.
@@ -468,8 +513,9 @@ A, B, C
     assert table['B'][1] is not ma.masked # fill_exclude_names applies after fill_include_names
     assert table['C'][2] is not ma.masked
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_many_rows(parallel):
+def test_many_rows(parallel, read_basic):
     """
     Make sure memory reallocation works okay when the number of rows
     is large (so that each column string is longer than INITIAL_COL_SIZE).
@@ -483,8 +529,9 @@ def test_many_rows(parallel):
     expected = Table([[0] * 500, [1] * 500, [2] * 500], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_many_columns(parallel):
+def test_many_columns(parallel, read_basic):
     """
     Make sure memory reallocation works okay when the number of columns
     is large (so that each hedaer string is longer than INITIAL_HEADER_SIZE).
@@ -495,6 +542,7 @@ def test_many_columns(parallel):
     table = read_basic(text, parallel=parallel)
     expected = Table([[i, i] for i in range(500)], names=[str(i) for i in range(500)])
     assert_table_equal(table, expected)
+
 
 def test_fast_reader():
     """
@@ -517,8 +565,9 @@ def test_fast_reader():
     # Will try the slow reader afterwards by default
     ascii.read(text, format='basic', guess=False, comment='##')
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_read_tab(parallel):
+def test_read_tab(parallel, read_tab):
     """
     The fast reader for tab-separated values should not strip whitespace, unlike
     the basic reader.
@@ -533,8 +582,9 @@ def test_read_tab(parallel):
     assert_equal(table['2'][1], ' d e')  # preserve whitespace in quoted fields
     assert_equal(table['3'][1], '  ')    # preserve end-of-line whitespace
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_default_data_start(parallel):
+def test_default_data_start(parallel, read_basic):
     """
     If data_start is not explicitly passed to read(), data processing should
     beginning right after the header.
@@ -544,8 +594,9 @@ def test_default_data_start(parallel):
     expected = Table([[1, 4], [2, 5], [3, 6]], names=('a', 'b', 'c'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_commented_header(parallel):
+def test_commented_header(parallel, read_commented_header):
     """
     The FastCommentedHeader reader should mimic the behavior of the
     CommentedHeader by overriding the default header behavior of FastBasic.
@@ -573,8 +624,9 @@ def test_commented_header(parallel):
     with pytest.raises(ParameterError):
         read_commented_header(text, header_start=-1, data_start=-1, parallel=parallel) # data_start cannot be negative
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_rdb(parallel):
+def test_rdb(parallel, read_rdb):
     """
     Make sure the FastRdb reader works as expected.
     """
@@ -606,8 +658,9 @@ A\tB\tC
         read_rdb(text, parallel=parallel)
     assert 'type definitions do not all match [num](N|S)' in str(e)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_data_start(parallel):
+def test_data_start(parallel, read_basic):
     """
     Make sure that data parsing begins at data_start (ignoring empty and
     commented lines but not taking quoted values into account).
@@ -657,8 +710,9 @@ A B C
     expected = Table([[4, 7, 10], [5, 8, 11], [6, 9, 12]], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_quoted_empty_values(parallel):
+def test_quoted_empty_values(parallel, read_basic):
     """
     Quoted empty values spanning multiple lines should be treated correctly.
     """
@@ -668,8 +722,9 @@ def test_quoted_empty_values(parallel):
     table = read_basic(text, parallel=parallel)
     assert table['c'][0] is ma.masked # empty value masked by default
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_csv_comment_default(parallel):
+def test_csv_comment_default(parallel, read_csv):
     """
     Unless the comment parameter is specified, the CSV reader should
     not treat any lines as comments.
@@ -679,8 +734,9 @@ def test_csv_comment_default(parallel):
     expected = Table([['#1', '4'], [2, 5], [3, 6]], names=('a', 'b', 'c'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_whitespace_before_comment(parallel):
+def test_whitespace_before_comment(parallel, read_tab):
     """
     Readers that don't strip whitespace from data (Tab, RDB)
     should still treat lines with leading whitespace and then
@@ -691,8 +747,9 @@ def test_whitespace_before_comment(parallel):
     expected = Table([[1], [2], [3]], names=('a', 'b', 'c'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_strip_line_trailing_whitespace(parallel):
+def test_strip_line_trailing_whitespace(parallel, read_basic):
     """
     Readers that strip whitespace from lines should ignore
     trailing whitespace after the last data value of each
@@ -708,8 +765,9 @@ def test_strip_line_trailing_whitespace(parallel):
     expected = Table([[1, 4], [2, 5], [3, 6]], names=('a', 'b', 'c'))
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_no_data(parallel):
+def test_no_data(parallel, read_basic):
     """
     As long as column names are supplied, the C reader
     should return an empty table in the absence of data.
@@ -721,8 +779,9 @@ def test_no_data(parallel):
     table = read_basic('a b c\n1 2 3', data_start=2, parallel=parallel)
     assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_line_endings(parallel):
+def test_line_endings(parallel, read_basic, read_commented_header, read_rdb):
     """
     Make sure the fast reader accepts CR and CR+LF
     as newlines.
@@ -745,8 +804,9 @@ def test_line_endings(parallel):
         table = read_rdb(text.replace('\n', newline), parallel=parallel)
         assert_table_equal(table, expected)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
-def test_store_comments(parallel):
+def test_store_comments(parallel, read_basic):
     """
     Make sure that the output Table produced by the fast
     reader stores any comment lines in its meta attribute.
@@ -764,7 +824,7 @@ a b c
                  ['header comment', 'comment 2', 'comment 3'])
 
 @pytest.mark.parametrize("parallel", [True, False])
-def test_empty_quotes(parallel):
+def test_empty_quotes(parallel, read_basic):
     """
     Make sure the C reader doesn't segfault when the
     input data contains empty quotes. [#3407]

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -22,7 +22,6 @@ from ....tests.helper import pytest
 from ....extern import six
 
 TRAVIS = os.environ.get('TRAVIS', False)
-pytestmark = pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
 
 def assert_table_equal(t1, t2, check_meta=False):
     assert_equal(len(t1), len(t2))

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -2,7 +2,6 @@
 
 # TEST_UNICODE_LITERALS
 
-import os
 import re
 
 import numpy as np
@@ -96,7 +95,6 @@ def test_read_with_names_arg(fast_reader):
         dat = ascii.read(['c d', 'e f'], names=('a', ), guess=False, fast_reader=fast_reader)
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'), reason="fails on AppVeyor")
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_read_all_files(fast_reader):
     for testfile in get_testfiles():
@@ -118,7 +116,6 @@ def test_read_all_files(fast_reader):
                 assert_equal(len(table[colname]), testfile['nrows'])
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'), reason="fails on AppVeyor")
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_read_all_files_via_table(fast_reader):
     for testfile in get_testfiles():
@@ -205,7 +202,6 @@ def test_daophot_multiple_aperture():
     assert np.all(table['RAPERT5'] == 23.3)  # assert all the 5th apertures are same 23.3
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'), reason="fails on AppVeyor")
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_empty_table_no_header(fast_reader):
     with pytest.raises(ascii.InconsistentTableError):

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -44,17 +44,17 @@ XCENTER YCENTER
          ),
     dict(kwargs=dict(Writer=ascii.Rdb, exclude_names=['CHI']),
          out="""\
-ID	XCENTER	YCENTER	MAG	MERR	MSKY	NITER	SHARPNESS	PIER	PERROR
-N	N	N	N	N	N	N	N	N	S
-14	138.538	256.405	15.461	0.003	34.85955	4	-0.032	0	No_error
-18	18.114	280.170	22.329	0.206	30.12784	4	-2.544	0	No_error
+ID\tXCENTER\tYCENTER\tMAG\tMERR\tMSKY\tNITER\tSHARPNESS\tPIER\tPERROR
+N\tN\tN\tN\tN\tN\tN\tN\tN\tS
+14\t138.538\t256.405\t15.461\t0.003\t34.85955\t4\t-0.032\t0\tNo_error
+18\t18.114\t280.170\t22.329\t0.206\t30.12784\t4\t-2.544\t0\tNo_error
 """
          ),
     dict(kwargs=dict(Writer=ascii.Tab),
          out="""\
-ID	XCENTER	YCENTER	MAG	MERR	MSKY	NITER	SHARPNESS	CHI	PIER	PERROR
-14	138.538	256.405	15.461	0.003	34.85955	4	-0.032	0.802	0	No_error
-18	18.114	280.170	22.329	0.206	30.12784	4	-2.544	1.104	0	No_error
+ID\tXCENTER\tYCENTER\tMAG\tMERR\tMSKY\tNITER\tSHARPNESS\tCHI\tPIER\tPERROR
+14\t138.538\t256.405\t15.461\t0.003\t34.85955\t4\t-0.032\t0.802\t0\tNo_error
+18\t18.114\t280.170\t22.329\t0.206\t30.12784\t4\t-2.544\t1.104\t0\tNo_error
 """
          ),
     dict(kwargs=dict(Writer=ascii.Csv),

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -481,7 +481,6 @@ def test_strip_names(fast_writer):
     assert out.getvalue().splitlines()[0] == 'A,B,C'
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'), reason="fails on AppVeyor")
 def test_latex_units():
     """
     Check to make sure that Latex and AASTex writers attempt to fall

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -501,7 +501,8 @@ a & 1 \\\\
 b & 2 \\\\
 \\enddata
 \\end{table}
-'''
+'''.replace('\n', os.linesep)
+
     ascii.write(t, out, format='aastex', latexdict=latexdict)
     assert out.getvalue() == expected
     # use unit attribute instead


### PR DESCRIPTION
Fixes many tests for `io.ascii` that were failing for me on Windows.  Some of these were being skipped on appveyor due to not passing.  But I think there were some others that don't explicitly say they are skipped on appveyor, and yet it is a mystery to me how they could have been passing at all...

Once this passes the first round of testing I'll take off some of the "skip if appveyor" decorators and see how things go.