### PR TITLE
Add furlong, attempt 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ New Features
     provided and the format parameters are uniquely specified.  This update
     also removes duplicate format guesses to improve performance. [#3418]
 
+- ``astropy.units``
+
+  - Added furlong to imperial units.
+
 
 1.0 (2015-02-18)
 ----------------

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -359,7 +359,7 @@ def add_enabled_units(units):
       Angstrom     | 1e-10 m         | AA, angstrom          ,
       cm           | 0.01 m          | centimeter            ,
       ft           | 0.3048 m        | foot                  ,
-      furlong      | 201.168 m       | furlong               ,
+      fur          | 201.168 m       | furlong               ,
       inch         | 0.0254 m        |                       ,
       lyr          | 9.46073e+15 m   | lightyear             ,
       m            | irreducible     | meter                 ,

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -359,6 +359,7 @@ def add_enabled_units(units):
       Angstrom     | 1e-10 m         | AA, angstrom          ,
       cm           | 0.01 m          | centimeter            ,
       ft           | 0.3048 m        | foot                  ,
+      furlong      | 201.168 m       | furlong               ,
       inch         | 0.0254 m        |                       ,
       lyr          | 9.46073e+15 m   | lightyear             ,
       m            | irreducible     | meter                 ,

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -30,6 +30,8 @@ def_unit(['mi', 'mile'], 5280 * ft, namespace=_ns,
          doc="International mile")
 def_unit(['nmi', 'nauticalmile', 'NM'], 1852 * si.m, namespace=_ns,
          doc="Nautical mile")
+def_unit(['fur', 'furlong'], 660 * ft, namespace=_ns,
+         doc="Furlong")
 
 
 ###########################################################################

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -399,7 +399,7 @@ def test_equivalent_units2():
         units = set(u.Hz.find_equivalent_units(u.spectral()))
         match = set(
             [u.AU, u.Angstrom, imperial.BTU, u.Hz, u.J, u.Ry,
-             imperial.cal, u.cm, u.eV, u.erg, imperial.ft,
+             imperial.cal, u.cm, u.eV, u.erg, imperial.ft, imperial.fur,
              imperial.inch, imperial.kcal, u.lyr, u.m, imperial.mi,
              u.micron, u.pc, u.solRad, imperial.yd, u.Bq, u.Ci,
              imperial.nmi, u.k])

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -119,6 +119,7 @@ For example, to enable Imperial units, simply do::
       Angstrom     | 1e-10 m         | AA, angstrom     ,
       cm           | 0.01 m          | centimeter       ,
       ft           | 0.3048 m        | foot             ,
+      fur          | 201.168 m       | furlong          ,
       inch         | 0.0254 m        |                  ,
       lyr          | 9.46073e+15 m   | lightyear        ,
       m            | irreducible     | meter            ,


### PR DESCRIPTION
From the "turn it off and turn it on again" school of bug fixes: a second attempt at adding furlongs to units, this time without touching `astropy_helpers` (except that I did do `git submodule update` and `git fetch astropy` before making a new branch off master).