### PR TITLE
Define Time.__bool__ and add tests (closes #3520)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -761,6 +761,8 @@ Bug Fixes
 
   - For Time objects, it is now checked that numerical input is finite. [#3396]
 
+  - Time objects now always evalutate to ``True``, except when empty. [#3530]
+
 - ``astropy.units``
 
   - Added a ``latex_inline`` unit format that returns the units in LaTeX math

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,6 +200,8 @@ Bug fixes
 
 - ``astropy.time``
 
+  - Time objects now always evalutate to ``True``, except when empty. [#3530]
+
 - ``astropy.units``
 
 - ``astropy.utils``
@@ -760,8 +762,6 @@ Bug Fixes
     info is now correctly used. [#3160]
 
   - For Time objects, it is now checked that numerical input is finite. [#3396]
-
-  - Time objects now always evalutate to ``True``, except when empty. [#3530]
 
 - ``astropy.units``
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -416,6 +416,10 @@ class Time(object):
     def size(self):
         return self._time.jd1.size
 
+    def __bool__(self):
+        """Any time should evaulate to True, but an empty object is False."""
+        return self.size > 0
+
     @property
     def isscalar(self):
         return self.shape == ()
@@ -451,7 +455,7 @@ class Time(object):
             ``'mean'`` or ``'apparent'``, i.e., accounting for precession
             only, or also for nutation.
         longitude : `~astropy.units.Quantity`, `str`, or `None`; optional
-           The longitude on the Earth at which to compute the sidereal time.
+            The longitude on the Earth at which to compute the sidereal time.
             Can be given as a `~astropy.units.Quantity` with angular units
             (or an `~astropy.coordinates.Angle` or
             `~astropy.coordinates.Longitude`), or as a name of an

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -417,8 +417,11 @@ class Time(object):
         return self._time.jd1.size
 
     def __bool__(self):
-        """Any time should evaulate to True, but an empty object is False."""
+        """Any time should evaluate to True, except when it is empty."""
         return self.size > 0
+
+    # In python2, __bool__ is not defined.
+    __nonzero__ = __bool__
 
     @property
     def isscalar(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -869,6 +869,9 @@ class Time(object):
     """TDB - TT time scale offset"""
 
     def __len__(self):
+        if self.isscalar:
+            raise TypeError("Scalar {0} object has no len()"
+                            .format(self.__class__.__name__))
         return len(self.jd1)
 
     def __sub__(self, other):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -157,7 +157,11 @@ class TestBasic():
         assert np.all(t7[:, 2]._time.jd2 == t7._time.jd2[:, 2])
         assert np.all(t7[:, 0]._time.jd1 == t._time.jd1)
         assert np.all(t7[:, 0]._time.jd2 == t._time.jd2)
-
+        # Finally check empty array.
+        t8 = t[:0]
+        assert t8.isscalar is False
+        assert t8.shape == (0,)
+        assert t8.size == 0
 
     def test_properties(self):
         """Use properties to convert scales and formats.  Note that the UT1 to
@@ -744,6 +748,31 @@ def test_decimalyear():
 def test_dir():
     t = Time('2000:001', format='yday', scale='tai')
     assert 'utc' in dir(t)
+
+
+def test_bool():
+    """Any Time object should evaluate to True unless it is empty [#3520]."""
+    t = Time(np.arange(50000, 50010), format='mjd', scale='utc')
+    assert bool(t) is True
+    assert bool(t[0]) is True
+    assert bool(t[:0]) is False
+
+
+def test_len_size():
+    """Check length of Time objects and that scalar ones do not have one."""
+    t = Time(np.arange(50000, 50010), format='mjd', scale='utc')
+    assert len(t) == 10 and t.size == 10
+    t1 = Time(np.arange(50000, 50010).reshape(2, 5), format='mjd', scale='utc')
+    assert len(t1) == 2 and t1.size == 10
+    # Can have length 1 or length 0 arrays.
+    t2 = t[:1]
+    assert len(t2) == 1 and t2.size == 1
+    t3 = t[:0]
+    assert len(t3) == 0 and t3.size == 0
+    # But cannot get length from scalar.
+    t4 = t[0]
+    with pytest.raises(TypeError):
+        len(t4)
 
 
 def test_TimeFormat_scale():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -771,8 +771,11 @@ def test_len_size():
     assert len(t3) == 0 and t3.size == 0
     # But cannot get length from scalar.
     t4 = t[0]
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as err:
         len(t4)
+    # Ensure we're not just getting the old error of
+    # "object of type 'float' has no len()".
+    assert 'Time' in str(err)
 
 
 def test_TimeFormat_scale():


### PR DESCRIPTION
This ensures any time object evaluates to `True` unless it is empty (see #3520). Also adds tests for both `__bool__` and `__len__`.