### PR TITLE
Converting a constant to a Quantity breaks __repr__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -172,6 +172,8 @@ Bug fixes
 
 - ``astropy.constants``
 
+  - Ensure constants can be turned into ``Quantity`` safely. [#3537, #3538]
+  
 - ``astropy.convolution``
 
 - ``astropy.coordinates``

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -41,11 +41,11 @@ for _nm, _c in itertools.chain(sorted(vars(si).items()),
                                sorted(vars(cgs).items())):
     if isinstance(_c, Constant) and _c.abbrev not in locals():
         locals()[_c.abbrev] = _c.__class__(_c.abbrev, _c.name, _c.value,
-                                           _c._unit, _c.uncertainty,
+                                           _c._unit_string, _c.uncertainty,
                                            _c.reference)
 
         _lines.append('{0:^10} {1:^14.9g} {2:^16} {3}'.format(
-            _c.abbrev, _c.value, _c._unit, _c.name))
+            _c.abbrev, _c.value, _c._unit_string, _c.name))
 
 _lines.append(_lines[1])
 

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -6,6 +6,7 @@ from ..extern import six
 import functools
 import types
 import warnings
+import numpy as np
 
 from ..units.core import Unit, UnitsError
 from ..units.quantity import Quantity
@@ -91,9 +92,11 @@ class Constant(Quantity):
         instances = Constant._registry.setdefault(name_lower, {})
         if system in instances:
             warnings.warn('Constant {0!r} is already has a definition in the '
-                          '{1!r} system'.format(name, system), AstropyUserWarning)
-
-        inst = super(Constant, cls).__new__(cls, value)
+                          '{1!r} system'.format(name, system),
+                          AstropyUserWarning)
+        # By-pass Quantity initialization, since units may not yet be
+        # initialized here, and we store the unit in string form.
+        inst = np.array(value).view(cls)
 
         for c in six.itervalues(instances):
             if system is not None and not hasattr(c.__class__, system):
@@ -103,19 +106,16 @@ class Constant(Quantity):
 
         instances[system] = inst
 
+        inst._abbrev = abbrev
+        inst._name = name
+        inst._value = value
+        inst._unit_string = unit
+        inst._uncertainty = uncertainty
+        inst._reference = reference
+        inst._system = system
+
+        inst._checked_units = False
         return inst
-
-    def __init__(self, abbrev, name, value, unit, uncertainty, reference,
-                 system=None):
-        self._abbrev = abbrev
-        self._name = name
-        self._value = value
-        self._unit = unit
-        self._uncertainty = uncertainty
-        self._reference = reference
-        self._system = system
-
-        self._checked_units = False
 
     def __repr__(self):
         return ('<Constant name={0!r} value={1} error={2} units={3!r} '
@@ -159,10 +159,10 @@ class Constant(Quantity):
         return self._name
 
     @lazyproperty
-    def unit(self):
+    def _unit(self):
         """The unit(s) in which this constant is defined."""
 
-        return Unit(self._unit)
+        return Unit(self._unit_string)
 
     @property
     def uncertainty(self):
@@ -202,6 +202,13 @@ class Constant(Quantity):
 
         instances = Constant._registry[self.name.lower()]
         return instances.get('cgs') or super(Constant, self).cgs
+
+    def __array_finalize__(self, obj):
+        for attr in ('_abbrev', '_name', '_value', '_unit_string',
+                      '_uncertainty', '_reference', '_system'):
+            setattr(self, attr, getattr(obj, attr, None))
+
+        self._checked_units = getattr(obj, '_checked_units', False)
 
 
 class EMConstant(Constant):

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -125,3 +125,40 @@ def test_copy():
 
     cc = copy.copy(const.c)
     assert cc == const.c
+
+
+def test_view():
+    """Check that Constant and Quantity views can be taken."""
+    from .. import c
+    c2 = c.view(Constant)
+    assert c2 == c
+    assert c2.value == c.value
+    # make sure it has the necessary attributes and they're not blank
+    assert c2.uncertainty == 0  # c is a *defined* quantity
+    assert c2.name == c.name
+    assert c2.reference == c.reference
+    assert c2.unit == c.unit
+
+    q1 = c.view(Q)
+    assert q1 == c
+    assert q1.value == c.value
+    assert type(q1) is Q
+    assert not hasattr(q1, 'reference')
+
+    q2 = Q(c)
+    assert q2 == c
+    assert q2.value == c.value
+    assert type(q2) is Q
+    assert not hasattr(q2, 'reference')
+
+    c3 = Q(c, subok=True)
+    assert c3 == c
+    assert c3.value == c.value
+    # make sure it has the necessary attributes and they're not blank
+    assert c3.uncertainty == 0  # c is a *defined* quantity
+    assert c3.name == c.name
+    assert c3.reference == c.reference
+    assert c3.unit == c.unit
+
+    c4 = Q(c, subok=True, copy=False)
+    assert c4 is c

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -128,7 +128,7 @@ def test_copy():
 
 
 def test_view():
-    """Check that Constant and Quantity views can be taken."""
+    """Check that Constant and Quantity views can be taken (#3537, #3538)."""
     from .. import c
     c2 = c.view(Constant)
     assert c2 == c


### PR DESCRIPTION
```python
import astropy.units as u

import astropy.constants

u.Quantity(astropy.constants.c)
/usr/lib/python2.7/site-packages/IPython/core/formatters.py:239: FormatterWarning: Exception in text/latex formatter: 'unicode' object has no attribute '_repr_latex_'
  FormatterWarning,
Out[3]: <repr(<astropy.units.quantity.Quantity at 0x7fba9bb288c0>) failed: AttributeError: 'Quantity' object has no '_unitstr' member>
```