### PR TITLE
Allow to print affiliated package version number in test header

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -478,11 +478,11 @@ def pytest_report_header(config):
         args = config.args
 
     # TESTED_VERSIONS can contain the affiliated package version, too
-    if len(TESTED_VERSIONS.keys()) > 1:
-        for pkg in TESTED_VERSIONS.keys():
+    if len(TESTED_VERSIONS) > 1:
+        for pkg, version in TESTED_VERSIONS.items():
             if pkg != 'Astropy':
                 s = "\nRunning tests with {0} version {1}.\n".format(
-                    pkg, TESTED_VERSIONS[pkg], " ".join(args))
+                    pkg, version)
     else:
         s = "\nRunning tests with Astropy version {0}.\n".format(
             TESTED_VERSIONS['Astropy'])

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -462,17 +462,31 @@ PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
                                      ('Matplotlib', 'matplotlib'),
                                      ('h5py', 'h5py')])
 
+# This always returns with Astropy's version
+from .. import __version__
+
+TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
+
 
 def pytest_report_header(config):
-    from .. import __version__
 
     stdoutencoding = getattr(sys.stdout, 'encoding') or 'ascii'
 
-    s = "\nRunning tests with Astropy version {0}.\n".format(__version__)
     if six.PY2:
         args = [x.decode('utf-8') for x in config.args]
     elif six.PY3:
         args = config.args
+
+    # TESTED_VERSIONS can contain the affiliated package version, too
+    if len(TESTED_VERSIONS.keys()) > 1:
+        for pkg in TESTED_VERSIONS.keys():
+            if pkg != 'Astropy':
+                s = "\nRunning tests with {0} version {1}.\n".format(
+                    pkg, TESTED_VERSIONS[pkg], " ".join(args))
+    else:
+        s = "\nRunning tests with Astropy version {0}.\n".format(
+            TESTED_VERSIONS['Astropy'])
+
     s += "Running tests in {0}.\n\n".format(" ".join(args))
 
     from platform import platform


### PR DESCRIPTION
When running tests for affiliated packages it's still the astropy's version number that gets printed in the header. This PR allows affiliated packages a bit of customization and print their version number instead (that is missing altogether at the moment).

Astropy's version number can be listed with the other moduls as part of the ``PYTEST_HEADER_MODULES`` dict.