### PR TITLE
Define TimeFITS format class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ New Features
 
 - ``astropy.time``
 
+  - Add support for FITS standard time strings. [#3547]
+  
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2027,22 +2027,18 @@ class TimeFITS(TimeString):
     name = 'fits'
     subfmts = (
         ('date_hms',
-         '%Y-%m-%dT%H:%M:%S',
+         (r'(?P<year>\d{4})-(?P<mon>\d{1,2})-(?P<mday>\d{1,2})T'
+          r'(?P<hour>\d{1,2}):(?P<min>\d{1,2}):(?P<sec>\d{1,2})'),
          '{year:04d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}'),
-        ('date_hm',
-         '%Y-%m-%dT%H:%M',
-         '{year:04d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}'),
         ('date',
-         '%Y-%m-%d',
+         r'(?P<year>\d{4})-(?P<mon>\d{1,2})-(?P<mday>\d{1,2})',
          '{year:04d}-{mon:02d}-{day:02d}'),
         ('longdate_hms',
-         r'(?P<year>[+-]\d{1,5})-%m-%dT%H:%M:%S',
+         (r'(?P<year>[+-]\d{1,5})-(?P<mon>\d{1,2})-(?P<mday>\d{1,2})T'
+          r'(?P<hour>\d{1,2}):(?P<min>\d{1,2}):(?P<sec>\d{1,2})'),
          '{year:+06d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}'),
-        ('longdate_hm',
-         r'(?P<year>[+-]\d{1,5})-%m-%dT%H:%M',
-         '{year:+06d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}'),
         ('longdate',
-         r'(?P<year>[+-]\d{1,5})-%m-%d',
+         r'(?P<year>[+-]\d{1,5})-(?P<mon>\d{1,2})-(?P<mday>\d{1,2})',
          '{year:+06d}-{mon:02d}-{day:02d}'))
     _fits_scale = None
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1828,16 +1828,20 @@ class TimeString(TimeUnique):
                 except ValueError:
                     continue
                 else:
-                    return [getattr(tm, 'tm_' + component)
-                            for component in components] + [fracsec]
+                    vals = [getattr(tm, 'tm_' + component)
+                            for component in components]
 
             else:
                 tm = re.match(strptime_fmt_or_regex, timestr)
                 if tm is None:
                     continue
                 tm = tm.groupdict()
-                return [int(tm.get(component, default)) for component, default
-                        in six.moves.zip(components, defaults)] + [fracsec]
+                vals = [int(tm.get(component, default)) for component, default
+                        in six.moves.zip(components, defaults)]
+
+            # Add fractional seconds
+            vals[-1] = vals[-1] + fracsec
+            return vals
         else:
             raise ValueError('Time {0} does not match {1} format'
                              .format(timestr, self.name))
@@ -1852,9 +1856,8 @@ class TimeString(TimeUnique):
 
 
         for val, iy, im, id, ihr, imin, dsec in iterator:
-            iy[...], im[...], id[...], ihr[...], imin[...], sec, fracsec = (
+            iy[...], im[...], id[...], ihr[...], imin[...], dsec[...] = (
                 self.parse_string(val.item(), subfmts))
-            dsec[...] = sec + fracsec
 
         self.jd1, self.jd2 = erfa_time.dtf_jd(
             self.scale.upper().encode('utf8'), *iterator.operands[1:])

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2024,12 +2024,13 @@ class TimeFITS(TimeString):
     FITS format: "[±Y]YYYY-MM-DD[THH:MM:SS[.sss]][(SCALE[(REALIZATION)])]".
 
     ISOT with two extensions:
-    - Signed five-digit year (mostly for negative years);
+    - Can give signed five-digit year (mostly for negative years);
     - A possible time scale (and realization) appended in parentheses.
-      Note: FITS supports some deprecated names for timescales; these are
-      translated to the formal names upon initialization.  Furthermore, any
-      specific realization information is stored only as long as the time scale
-      is not changed.
+
+    Note: FITS supports some deprecated names for timescales; these are
+    translated to the formal names upon initialization.  Furthermore, any
+    specific realization information is stored only as long as the time scale
+    is not changed.
 
     The allowed subformats are:
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from .. import units as u
 from .. import _erfa as erfa
+from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
 from ..extern import six
 
@@ -45,9 +46,11 @@ except ImportError:
     if not _ASTROPY_SETUP_:
         raise
 
-# These both get filled in at end after TimeFormat subclasses defined
-TIME_FORMATS = {}
-TIME_DELTA_FORMATS = {}
+# These both get filled in at end after TimeFormat subclasses defined.
+# Use an OrderedDict to fix the order in which formats are tried.
+# This ensures, e.g., that 'isot' gets tried before 'fits'.
+TIME_FORMATS = OrderedDict()
+TIME_DELTA_FORMATS = OrderedDict()
 
 TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
 MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -553,6 +553,12 @@ class TestSubFormat():
         assert np.all(t3.fits == np.array(['+02000-01-01T00:00:00.000(TAI)',
                                            '+02000-01-01T01:01:01.000(TAI)',
                                            '-00594-01-01T00:00:00.000(TAI)']))
+        # Implicit long format for output, because of large positive year.
+        times[2] = '+10594-01-01'
+        t4 = Time(times, format='fits', scale='tai')
+        assert np.all(t4.fits == np.array(['+02000-01-01T00:00:00.000(TAI)',
+                                           '+02000-01-01T01:01:01.000(TAI)',
+                                           '+10594-01-01T00:00:00.000(TAI)']))
 
     def test_yday_format(self):
         """Year:Day_of_year format"""
@@ -799,6 +805,15 @@ def test_fits_year0():
     assert t.fits == '+00000-01-01T00:00:00.000(UTC)'
     t = Time(1721425.5 - 366. - 365., format='jd')
     assert t.fits == '-00001-01-01T00:00:00.000(UTC)'
+
+
+def test_fits_year10000():
+    t = Time(5373484.5, format='jd', scale='tai')
+    assert t.fits == '+10000-01-01T00:00:00.000(TAI)'
+    t = Time(5373484.5 - 365., format='jd', scale='tai')
+    assert t.fits == '9999-01-01T00:00:00.000(TAI)'
+    t = Time(5373484.5, -1./24./3600., format='jd', scale='tai')
+    assert t.fits == '9999-12-31T23:59:59.000(TAI)'
 
 
 def test_dir():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -537,24 +537,20 @@ class TestSubFormat():
     def test_fits_format(self):
         """FITS format includes bigger years."""
         # Heterogeneous input formats with in_subfmt='*' (default)
-        times = ['2000-01-01', '2000-01-01T01:01',
-                 '2000-01-01T01:01:01', '2000-01-01T01:01:01.123']
+        times = ['2000-01-01', '2000-01-01T01:01:01', '2000-01-01T01:01:01.123']
         t = Time(times, format='fits', scale='tai')
         assert np.all(t.fits == np.array(['2000-01-01T00:00:00.000(TAI)',
-                                          '2000-01-01T01:01:00.000(TAI)',
                                           '2000-01-01T01:01:01.000(TAI)',
                                           '2000-01-01T01:01:01.123(TAI)']))
         # Explicit long format for output, default scale is UTC.
         t2 = Time(times, format='fits', out_subfmt='long*')
         assert np.all(t2.fits == np.array(['+02000-01-01T00:00:00.000(UTC)',
-                                           '+02000-01-01T01:01:00.000(UTC)',
                                            '+02000-01-01T01:01:01.000(UTC)',
                                            '+02000-01-01T01:01:01.123(UTC)']))
         # Implicit long format for output, because of negative year.
-        times[3] = '-00594-01-01'
+        times[2] = '-00594-01-01'
         t3 = Time(times, format='fits', scale='tai')
         assert np.all(t3.fits == np.array(['+02000-01-01T00:00:00.000(TAI)',
-                                           '+02000-01-01T01:01:00.000(TAI)',
                                            '+02000-01-01T01:01:01.000(TAI)',
                                            '-00594-01-01T00:00:00.000(TAI)']))
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -167,14 +167,14 @@ class TestBasic():
         """Use properties to convert scales and formats.  Note that the UT1 to
         UTC transformation requires a supplementary value (``delta_ut1_utc``)
         that can be obtained by interpolating from a table supplied by IERS.
-        This will be included in the package later."""
+        This is tested separately."""
 
         t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
         t.delta_ut1_utc = 0.3341  # Explicitly set one part of the xform
         assert allclose_jd(t.jd, 2455197.5)
         assert t.iso == '2010-01-01 00:00:00.000'
         assert t.tt.iso == '2010-01-01 00:01:06.184'
-        assert t.tai.iso == '2010-01-01 00:00:34.000'
+        assert t.tai.fits == '2010-01-01T00:00:34.000(TAI)'
         assert allclose_jd(t.utc.jd, 2455197.5)
         assert allclose_jd(t.ut1.jd, 2455197.500003867)
         assert t.tcg.isot == '2010-01-01T00:01:06.910'
@@ -317,6 +317,9 @@ class TestBasic():
         Time('2000-01-01 12:23:34.0Z', format='iso', scale='utc')
         Time('2000-01-01T12:23:34.0', format='isot', scale='tai')
         Time('2000-01-01T12:23:34.0Z', format='isot', scale='utc')
+        Time('2000-01-01T12:23:34.0', format='fits')
+        Time('2000-01-01T12:23:34.0', format='fits', scale='tdb')
+        Time('2000-01-01T12:23:34.0(TDB)', format='fits')
         Time(2400000.5, 51544.0333981, format='jd', scale='tai')
         Time(0.0, 51544.0333981, format='mjd', scale='tai')
         Time('2000:001:12:23:34.0', format='yday', scale='tai')
@@ -389,6 +392,12 @@ class TestBasic():
         # regression test against #3396
         with pytest.raises(ValueError):
             Time(np.nan, format='jd', scale='utc')
+        with pytest.raises(ValueError):
+            Time('2000-01-02T03:04:05(TAI)', scale='utc')
+        with pytest.raises(ValueError):
+            Time('2000-01-02T03:04:05(TAI')
+        with pytest.raises(ValueError):
+            Time('2000-01-02T03:04:05(UT(NIST)')
 
     def test_utc_leap_sec(self):
         """Time behaves properly near or in UTC leap second.  This
@@ -525,6 +534,30 @@ class TestSubFormat():
                                          '2000-01-01 01:01',
                                          '2000-01-01 01:01']))
 
+    def test_fits_format(self):
+        """FITS format includes bigger years."""
+        # Heterogeneous input formats with in_subfmt='*' (default)
+        times = ['2000-01-01', '2000-01-01T01:01',
+                 '2000-01-01T01:01:01', '2000-01-01T01:01:01.123']
+        t = Time(times, format='fits', scale='tai')
+        assert np.all(t.fits == np.array(['2000-01-01T00:00:00.000(TAI)',
+                                          '2000-01-01T01:01:00.000(TAI)',
+                                          '2000-01-01T01:01:01.000(TAI)',
+                                          '2000-01-01T01:01:01.123(TAI)']))
+        # Explicit long format for output, default scale is UTC.
+        t2 = Time(times, format='fits', out_subfmt='long*')
+        assert np.all(t2.fits == np.array(['+02000-01-01T00:00:00.000(UTC)',
+                                           '+02000-01-01T01:01:00.000(UTC)',
+                                           '+02000-01-01T01:01:01.000(UTC)',
+                                           '+02000-01-01T01:01:01.123(UTC)']))
+        # Implicit long format for output, because of negative year.
+        times[3] = '-00594-01-01'
+        t3 = Time(times, format='fits', scale='tai')
+        assert np.all(t3.fits == np.array(['+02000-01-01T00:00:00.000(TAI)',
+                                           '+02000-01-01T01:01:00.000(TAI)',
+                                           '+02000-01-01T01:01:01.000(TAI)',
+                                           '-00594-01-01T00:00:00.000(TAI)']))
+
     def test_yday_format(self):
         """Year:Day_of_year format"""
         # Heterogeneous input formats with in_subfmt='*' (default)
@@ -555,6 +588,24 @@ class TestSubFormat():
         # Check that bad scale is caught when format is auto-determined
         with pytest.raises(ScaleValueError):
             Time('2000:001:00:00:00', scale='bad scale')
+
+    def test_fits_scale(self):
+        """Test that scale gets interpreted correctly for FITS strings."""
+        t = Time('2000-01-02(TAI)')
+        assert t.scale == 'tai'
+        # Test deprecated scale.
+        t = Time('2000-01-02(IAT)')
+        assert t.scale == 'tai'
+        # Check that inconsistent scales lead to errors.
+        with pytest.raises(ValueError):
+            Time('2000-01-02(TAI)', scale='utc')
+        with pytest.raises(ValueError):
+            Time(['2000-01-02(TAI)', '2001-02-03(UTC)'])
+
+    def test_fits_scale_representation(self):
+        t = Time('1960-01-02T03:04:05.678(ET(NIST))')
+        assert t.scale == 'tt'
+        assert t.value == '1960-01-02T03:04:05.678(ET(NIST))'
 
     def test_scale_default(self):
         """Test behavior when no scale is provided"""
@@ -743,6 +794,15 @@ def test_decimalyear():
     d_jd = jd1 - jd0
     assert np.all(t.jd == [jd0 + 0.5 * d_jd,
                            jd0 + 0.75 * d_jd])
+
+
+def test_fits_year0():
+    t = Time(1721425.5, format='jd')
+    assert t.fits == '0001-01-01T00:00:00.000(UTC)'
+    t = Time(1721425.5 - 366., format='jd')
+    assert t.fits == '+00000-01-01T00:00:00.000(UTC)'
+    t = Time(1721425.5 - 366. - 365., format='jd')
+    assert t.fits == '-00001-01-01T00:00:00.000(UTC)'
 
 
 def test_dir():

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -78,8 +78,14 @@ TT.  This uses the same attribute mechanism as above but now returns a new
   array([ 2451179.5007443 ,  2455197.50076602])
 
 Note that both the ISO (ISOT) and JD representations of ``t2`` are different
-than for ``t`` because they are expressed relative to the TT time scale.
+than for ``t`` because they are expressed relative to the TT time scale.  Of
+course, from the numbers or strings one could not tell; one format in which
+this information is kept is the ``fits`` format::
 
+  >>> t2.fits
+  array(['1999-01-01T00:01:04.307(TT)', '2010-01-01T00:01:06.184(TT)'],
+        dtype='|S27')
+  
 Finally, some further examples of what is possible.  For details, see
 the API documentation below.
 
@@ -141,6 +147,7 @@ byear_str    :class:`~astropy.time.TimeBesselianEpochString`    'B1950.0'
 cxcsec       :class:`~astropy.time.TimeCxcSec`                  63072064.184
 datetime     :class:`~astropy.time.TimeDatetime`                datetime(2000, 1, 2, 12, 0, 0)
 decimalyear  :class:`~astropy.time.TimeDecimalYear`             2000.45
+fits         :class:`~astropy.time.TimeFITS`                    '2000-01-01T00:00:00.000(TAI)'
 gps          :class:`~astropy.time.TimeGPS`                     630720013.0
 iso          :class:`~astropy.time.TimeISO`                     '2000-01-01 00:00:00.000'
 isot         :class:`~astropy.time.TimeISOT`                    '2000-01-01T00:00:00.000'
@@ -153,28 +160,43 @@ unix         :class:`~astropy.time.TimeUnix`                    946684800.0
 yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:00.000
 ===========  =================================================  ==============================
 
+.. note:: The :class:`~astropy.time.TimeFITS` format allows for most
+   but not all of the the FITS standard [#]_. Not implemented (yet) is
+   support for a ``LOCAL`` timescale. Furthermore, FITS supports some deprecated
+   names for timescales; these are translated to the formal names upon
+   initialization.  Furthermore, any specific realization information,
+   such as ``UT(NIST)`` is stored only as long as the time scale is not changed.
+.. [#] `Rots et al. 2015, A&A 574:A36 <http://adsabs.harvard.edu/abs/2015A%26A...574A..36R>`_
+	  
 Subformat
 """""""""
 
 The time format classes :class:`~astropy.time.TimeISO`,
-:class:`~astropy.time.TimeISOT`, and
+:class:`~astropy.time.TimeISOT`, :class:`~astropy.time.TimeFITS`, and
 :class:`~astropy.time.TimeYearDayTime` support the concept of
 subformats.  This allows for variations on the basic theme of a format in both
 the input string parsing and the output.
 
-The supported subformats are ``date_hms``, ``date_hm``, and ``date``.  The
-table below illustrates these subformats for ``iso`` and ``yday`` formats:
+The supported subformats are ``date_hms``, ``date_hm``, and ``date``
+for all but the :class:`~astropy.time.TimeFITS` format; the latter
+does not support ``data_hm`` but does support ``longdate_hms`` and
+``longdate`` for years before the year 0 and after the year 10000.  The
+table below illustrates these subformats for ``iso``, ``fits``, ``yday``
+formats:
 
-=========  ========== ===========================
-Format     Subformat  Input / output
-=========  ========== ===========================
-``iso``    date_hms   2001-01-02 03:04:05.678
-``iso``    date_hm    2001-01-02 03:04
-``iso``    date       2001-01-02
-``yday``   date_hms   2001:032:03:04:05.678
-``yday``   date_hm    2001:032:03:04
-``yday``   date       2001:032
-=========  ========== ===========================
+========  ============ ==============================
+Format    Subformat    Input / output
+========  ============ ==============================
+``iso``   date_hms     2001-01-02 03:04:05.678
+``iso``   date_hm      2001-01-02 03:04
+``iso``   date         2001-01-02
+``fits``  date_hms     2001-01-02T03:04:05.678(UTC)
+``fits``  longdate_hms +02001-01-02T03:04:05.678(UTC)
+``fits``  longdate     +02001-01-02(UTC)
+``yday``  date_hms     2001:032:03:04:05.678
+``yday``  date_hm      2001:032:03:04
+``yday``  date         2001:032
+========  ============ ==============================
 
 Time from epoch formats
 """""""""""""""""""""""


### PR DESCRIPTION
This is a first step to addressing #3000, defining a new `fits` format for `Time`.  E.g.,
```
from astropy.time import Time
Time('2000-01-02T03:04:05(TDB)')
# <Time object: scale='tdb' format='fits' value=2000-01-02T03:04:05.000(TDB)>
Time(1721425.5, format='jd', scale='tai').fits
# '0001-01-01T00:00:00.000(TAI)'
Time(1721425.5 - 366., format='jd', scale='tai').fits
# '+00000-01-01T00:00:00.000(TAI)'
```

Some things are still partial/missing: input scales that include a realisation (e.g., `ET(NIST)` will keep this realisation only as long as the `Time` object is not converted to anything else. Also, the `LOCAL` scale is not yet defined. 

See http://arxiv.org/abs/1409.7583 for what we would need to support...