### PR TITLE
Improved input validation for meta, names and dtype in Table.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -394,6 +394,9 @@ New Features
 
 - ``astropy.table``
 
+  - Added validation of meta, names and dtype parameters to only accept
+    the correct types. [#3511]
+
   - Changed the internal implementation of the ``Table`` class changed so that
     it no longer uses numpy structured arrays as the core table data container.
     [#2790, #3179]

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -6,6 +6,7 @@ from ..extern.six.moves import zip as izip
 from ..extern.six.moves import range as xrange
 
 import re
+import collections
 
 from copy import deepcopy
 
@@ -219,8 +220,23 @@ class Table(object):
         # Set up a placeholder empty table
         self._set_masked(masked)
         self.columns = self.TableColumns()
-        self.meta = meta
         self.formatter = self.TableFormatter()
+
+        # Validate input for meta
+        if meta is None or isinstance(meta, collections.Mapping):
+            self.meta = meta
+        else:
+            raise TypeError('Meta type {0} not allowed to init Table'
+                             .format(type(meta)))
+
+        # Validate input for names and dtype
+        if isinstance(names, six.string_types):
+            raise TypeError('Names type {0} not allowed to init Table'
+                             .format(type(names)))
+    
+        if isinstance(dtype, six.string_types):
+            raise TypeError('Dtype type {0} not allowed to init Table'
+                             .format(type(dtype)))
 
         # Must copy if dtype are changing
         if not copy and dtype is not None:

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -80,7 +80,7 @@ class BaseInitFrom():
     def test_names_cols_mismatch(self, table_type):
         self._setup(table_type)
         with pytest.raises(ValueError):
-            table_type(self.data, names=('a',), dtype=('i4'))
+            table_type(self.data, names=('a',), dtype=('i4',))
 
 @pytest.mark.usefixtures('table_type')
 class BaseInitFromListLike(BaseInitFrom):
@@ -459,3 +459,28 @@ def test_init_and_ref_from_multidim_ndarray(table_type):
         else:
             assert nd[str('a')][0] == -200
             assert nd[str('b')][1][1] == -100
+
+def test_init_names_and_dtype_type_exception():
+    """
+    Names and dtype parameters should raise an exception if a string is 
+    used in the constructor.
+    """
+    names = 'a'
+    with pytest.raises(TypeError) as exc:
+        t = table.Table(names=names)
+    assert exc.value.args[0] == 'Names type {0} not allowed to init Table'.format(type(names))
+
+    dtype = 'a'
+    with pytest.raises(TypeError) as exc:
+        t = table.Table(names=['a'], dtype=dtype)
+    assert exc.value.args[0] == 'Dtype type {0} not allowed to init Table'.format(type(dtype))
+
+def test_init_meta_type_exception():
+    """
+    Meta parameter should raise an exception if a dict-like object
+    is not used in the constructor.
+    """
+    meta = ['a']
+    with pytest.raises(TypeError) as exc:
+        t = table.Table(meta=meta)
+    assert exc.value.args[0] == 'Meta type {0} not allowed to init Table'.format(type(meta))


### PR DESCRIPTION
Addresses #3511. I have 4 failing tests locally but I do not believe them to be related to these changes. 