### PR TITLE
Inheriting `bounds`, `fixed`, and `tied` properties for compound models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -198,6 +198,11 @@ Bug fixes
 
 - ``astropy.modeling``
 
+  - Fixed propagation of parameter constraints ('fixed', 'bounds', 'tied')
+    between compound models and their components.  There is may still be some
+    difficulty defining 'tied' constraints properly for use with compound
+    models, however. [#3481]
+
 - ``astropy.nddata``
 
   - Restore several properties to the compatibility class ``NDDataArray`` that

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1736,8 +1736,8 @@ class _CompoundModelMeta(_ModelMeta):
                     default = orig_param.default
 
                 # Copy constraints
-                constraints = {key: getattr(orig_param, key)
-                               for key in Model.parameter_constraints}
+                constraints = dict((key, getattr(orig_param, key))
+                                   for key in Model.parameter_constraints)
 
                 # Note: Parameter.copy() returns a new unbound Parameter, never
                 # a bound Parameter even if submodel is a Model instance (as

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -494,7 +494,7 @@ class Model(object):
     True
     """
 
-    parameter_constraints = ('fixed', 'tied', 'bounds')
+    parameter_constraints = Parameter.constraints
     """
     Primarily for informational purposes, these are the types of constraints
     that can be set on a model's parameters.

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -10,7 +10,6 @@ define their own models.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-import collections
 import inspect
 import functools
 import numbers
@@ -53,20 +52,6 @@ def _tofloat(value):
             "Don't know how to convert parameter of {0} to "
             "float".format(type(value)))
     return value
-
-
-class _Bounds(collections.namedtuple('_Bounds', ('min', 'max'))):
-    """
-    A two-tuple representing min and max bounds.
-
-    Currently this is used stricly internally for convenience.
-    TODO: Consider exposing this for Astropy v1.1.
-    """
-
-    def __nonzero__(self):
-        return self.min is not None and self.max is not None
-
-    __bool__ = __nonzero__
 
 
 class Parameter(object):
@@ -154,9 +139,8 @@ class Parameter(object):
                 raise ValueError(
                     'bounds may not be specified simulatenously with min or '
                     'or max when instantiating Parameter {0}'.format(name))
-            bounds = _Bounds(*bounds)
         else:
-            bounds = _Bounds(min, max)
+            bounds = (min, max)
 
         self._fixed = fixed
         self._tied = tied
@@ -257,7 +241,7 @@ class Parameter(object):
 
         for cons in self.constraints:
             val = getattr(self, cons)
-            if val:
+            if val not in (None, False, (None, None)):
                 # Maybe non-obvious, but False is the default for the fixed and
                 # tied constraints
                 args += ', {0}={1}'.format(cons, val)

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -124,7 +124,7 @@ class Parameter(object):
         creating bound Parameters
     """
 
-    constraints = ['fixed', 'tied', 'bounds']
+    constraints = ('fixed', 'tied', 'bounds')
     """
     Types of constraints a parameter can have.  Excludes 'min' and 'max'
     which are just aliases for the first and second elements of the 'bounds'

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -10,6 +10,7 @@ define their own models.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
+import collections
 import inspect
 import functools
 import numbers
@@ -52,6 +53,20 @@ def _tofloat(value):
             "Don't know how to convert parameter of {0} to "
             "float".format(type(value)))
     return value
+
+
+class _Bounds(collections.namedtuple('_Bounds', ('min', 'max'))):
+    """
+    A two-tuple representing min and max bounds.
+
+    Currently this is used stricly internally for convenience.
+    TODO: Consider exposing this for Astropy v1.1.
+    """
+
+    def __nonzero__(self):
+        return self.min is not None and self.max is not None
+
+    __bool__ = __nonzero__
 
 
 class Parameter(object):
@@ -101,9 +116,19 @@ class Parameter(object):
         the lower bound of a parameter
     max : float
         the upper bound of a parameter
+    bounds : tuple
+        specify min and max as a single tuple--bounds may not be specified
+        simultaneously with min or max
     model : object
         an instance of a Model class; this should only be used internally for
         creating bound Parameters
+    """
+
+    constraints = ['fixed', 'tied', 'bounds']
+    """
+    Types of constraints a parameter can have.  Excludes 'min' and 'max'
+    which are just aliases for the first and second elements of the 'bounds'
+    constraint (which is represented as a 2-tuple).
     """
 
     # See the _nextid classmethod
@@ -111,7 +136,7 @@ class Parameter(object):
 
     def __init__(self, name='', description='', default=None, getter=None,
                  setter=None, fixed=False, tied=False, min=None, max=None,
-                 model=None):
+                 bounds=None, model=None):
         super(Parameter, self).__init__()
 
         if model is not None and not name:
@@ -124,10 +149,18 @@ class Parameter(object):
         # NOTE: These are *default* constraints--on model instances constraints
         # are taken from the model if set, otherwise the defaults set here are
         # used
+        if bounds is not None:
+            if min is not None or max is not None:
+                raise ValueError(
+                    'bounds may not be specified simulatenously with min or '
+                    'or max when instantiating Parameter {0}'.format(name))
+            bounds = _Bounds(*bounds)
+        else:
+            bounds = _Bounds(min, max)
+
         self._fixed = fixed
         self._tied = tied
-        self._min = min
-        self._max = max
+        self._bounds = bounds
 
         self._order = None
         self._shape = None
@@ -163,9 +196,8 @@ class Parameter(object):
 
         return self.__class__(self._name, default=self._default,
                               getter=self._getter, setter=self._setter,
-                              fixed=self._fixed,
-                              tied=self._tied, min=self._min,
-                              max=self._max, model=obj)
+                              fixed=self._fixed, tied=self._tied,
+                              bounds=self._bounds, model=obj)
 
     def __set__(self, obj, value):
         value, shape = self._validate_value(obj, value)
@@ -222,6 +254,14 @@ class Parameter(object):
                 args += ', default={0}'.format(self._default)
         else:
             args += ', value={0}'.format(self.value)
+
+        for cons in self.constraints:
+            val = getattr(self, cons)
+            if val:
+                # Maybe non-obvious, but False is the default for the fixed and
+                # tied constraints
+                args += ', {0}={1}'.format(cons, val)
+
         return "Parameter({0})".format(args)
 
     @property
@@ -350,10 +390,9 @@ class Parameter(object):
 
         if self._model is not None:
             bounds = self._model._constraints['bounds']
-            default_bounds = (self._min, self._max)
-            return bounds.get(self._name, default_bounds)
+            return bounds.get(self._name, self._bounds)
         else:
-            return (self._min, self._max)
+            return self._bounds
 
     @bounds.setter
     def bounds(self, value):
@@ -410,7 +449,8 @@ class Parameter(object):
                                  "definition")
 
     def copy(self, name=None, description=None, default=None, getter=None,
-             setter=None, fixed=False, tied=False, min=None, max=None):
+             setter=None, fixed=False, tied=False, min=None, max=None,
+             bounds=None):
         """
         Make a copy of this `Parameter`, overriding any of its core attributes
         in the process (or an exact copy).
@@ -430,7 +470,16 @@ class Parameter(object):
 
         for key, value in six.iteritems(kwargs):
             if value is None:
-                kwargs[key] = getattr(self, '_' + key)
+                # Annoying special cases for min/max where are just aliases for
+                # the components of bounds
+                if key in ('min', 'max'):
+                    continue
+                else:
+                    if hasattr(self, key):
+                        value = getattr(self, key)
+                    elif hasattr(self, '_' + key):
+                        value = getattr(self, '_' + key)
+                kwargs[key] = value
 
         return self.__class__(**kwargs)
 


### PR DESCRIPTION
Hi,

I tried to find a discussion related to this previously, but I could not find one. Apologies if this has already been brought up before. This relates to the `modeling` package on `1.0rc1`.

I am wondering if the `bounds`, `fixed`, and `tied` properties should be inherited from their parent models when a compound model is created. The parameter names get compiled together in a sensible way, but the `bounds`, `fixed`, and `tied` properties do not get passed on to the child.

When I run this code on 1.0rc1:
````
from astropy.modeling import models

a = models.Gaussian1D(mean=1, stddev=0.2)
a.bounds["stddev"] = (0, 0.3)
a.fixed["mean"] = True

b = models.Gaussian1D(mean=2, stddev=0.5)
b.fixed["mean"] = True

combined = a * b

print("Before combination")
print(a.bounds["stddev"])
print(b.fixed["mean"])

print("After combination")
print(combined.bounds["stddev_0"])
print(combined.fixed["mean_1"])

print("Making sure they are not hiding..")
print(combined.bounds)
print(combined.fixed)
````

I observe the following behaviour (spaced for clarity):
````
Before combination
(0, 0.3)
True

After combination
(None, None)
False

Making sure they are not hiding..
{u'mean_0': (None, None), u'amplitude_0': (None, None), u'stddev_1': (None, None), u'stddev_0': (None, None), u'amplitude_1': (None, None), u'mean_1': (None, None)}
{u'mean_0': False, u'amplitude_0': False, u'stddev_1': False, u'stddev_0': False, u'amplitude_1': False, u'mean_1': False}
````

Is this behaviour intentional for some deep, deep reason, or is it an oversight? At the moment my work-around is to re-apply the `bounds`, `fixed`, and `tied` behaviour to each compound model (which is frequent).

Thanks,
Andy