### PR TITLE
Fix two problems in commented_header reader/writer

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -136,6 +136,21 @@ class CommentedHeader(Basic):
     header_class = CommentedHeaderHeader
     data_class = NoHeaderData
 
+
+    def read(self, table):
+        """
+        Read input data (file-like object, filename, list of strings, or
+        single string) into a Table and return the result.
+        """
+        out = super(CommentedHeader, self).read(table)
+
+        # Strip off first comment since this is the header line for
+        # commented_header format.
+        if 'comments' in out.meta:
+            out.meta['comments'] = out.meta['comments'][1:]
+
+        return out
+
     def write_header(self, lines, meta):
         """
         Write comment lines after, rather than before, the header.

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -148,6 +148,8 @@ class CommentedHeader(Basic):
         # commented_header format.
         if 'comments' in out.meta:
             out.meta['comments'] = out.meta['comments'][1:]
+            if not out.meta['comments']:
+                del out.meta['comments']
 
         return out
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -222,6 +222,8 @@ class FastCommentedHeader(FastBasic):
         # commented_header format.
         if 'comments' in out.meta:
             out.meta['comments'] = out.meta['comments'][1:]
+            if not out.meta['comments']:
+                del out.meta['comments']
 
         return out
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -5,6 +5,7 @@ from ...extern import six
 from ...table import Table
 from . import cparser
 from ...extern.six.moves import zip as izip
+from ...utils import OrderedDict
 import re
 
 @six.add_metaclass(core.MetaBaseReader)
@@ -96,7 +97,7 @@ class FastBasic(object):
             try_string = {}
 
         data, comments = self.engine.read(try_int, try_float, try_string)
-        meta = {}
+        meta = OrderedDict()
         if comments:
             meta['comments'] = comments
         return Table(data, names=list(self.engine.get_names()), meta=meta)
@@ -209,6 +210,20 @@ class FastCommentedHeader(FastBasic):
         # is relative to header_start if unspecified; see #2692
         if 'data_start' not in kwargs:
             self.data_start = 0
+
+    def read(self, table):
+        """
+        Read input data (file-like object, filename, list of strings, or
+        single string) into a Table and return the result.
+        """
+        out = super(FastCommentedHeader, self).read(table)
+
+        # Strip off first comment since this is the header line for
+        # commented_header format.
+        if 'comments' in out.meta:
+            out.meta['comments'] = out.meta['comments'][1:]
+
+        return out
 
     def _read_header(self):
         tmp = self.engine.source

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -6,6 +6,7 @@ import re
 
 import numpy as np
 
+from ....extern.six.moves import cStringIO as StringIO
 from ....utils import OrderedDict
 from ....tests.helper import pytest
 from ... import ascii
@@ -936,3 +937,23 @@ def test_almost_but_not_quite_daophot():
              "7 8 9"]
     dat = ascii.read(lines)
     assert len(dat) == 3
+
+
+@pytest.mark.parametrize('fast', [True, False])
+def test_commented_header_comments(fast):
+    """
+    Test that comments in commented_header are as expected and that the
+    table round-trips.
+    """
+    lines = ['# a b',
+             '# comment 1',
+             '# comment 2',
+             '1 2',
+             '3 4']
+    dat = ascii.read(lines, format='commented_header', fast_reader=fast)
+    assert dat.meta['comments'] == ['comment 1', 'comment 2']
+
+    out = StringIO()
+    ascii.write(dat, out, format='commented_header', fast_writer=fast)
+    assert out.getvalue().splitlines() == lines
+

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -957,3 +957,8 @@ def test_commented_header_comments(fast):
     ascii.write(dat, out, format='commented_header', fast_writer=fast)
     assert out.getvalue().splitlines() == lines
 
+    lines = ['# a b',
+             '1 2',
+             '3 4']
+    dat = ascii.read(lines, format='commented_header', fast_reader=fast)
+    assert 'comments' not in dat.meta

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -513,3 +513,22 @@ b & 2 \\\\
         'colhead{s}', 'colhead{$\mathrm{s}$}').replace(
         'colhead{ }', 'colhead{$\mathrm{yr}$}')
 
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_commented_header_comment(fast_writer):
+    """
+    Test the fix for #3562 with confusing exception using comment=False
+    for the commented_header writer.
+    """
+    t = table.Table([[1, 2]])
+    t.meta['comments'] = ['comment 1', 'comment 2']
+
+    out = StringIO()
+    ascii.write(t, out, format='commented_header', fast_writer=fast_writer)
+    assert '# comment 1' in out.getvalue()
+
+    with pytest.raises(ValueError) as err:
+        out = StringIO()
+        ascii.write(t, out, format='commented_header', comment=False,
+                    fast_writer=fast_writer)
+    assert "for the commented_header writer you must supply a string" in str(err.value)

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -5,11 +5,7 @@
 import os
 import copy
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-
+from ....extern.six.moves import cStringIO as StringIO
 from ... import ascii
 from .... import table
 from ....tests.helper import pytest
@@ -515,18 +511,12 @@ b & 2 \\\\
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])
-def test_commented_header_comment(fast_writer):
+def test_commented_header_comments(fast_writer):
     """
     Test the fix for #3562 with confusing exception using comment=False
     for the commented_header writer.
     """
     t = table.Table([[1, 2]])
-    t.meta['comments'] = ['comment 1', 'comment 2']
-
-    out = StringIO()
-    ascii.write(t, out, format='commented_header', fast_writer=fast_writer)
-    assert '# comment 1' in out.getvalue()
-
     with pytest.raises(ValueError) as err:
         out = StringIO()
         ascii.write(t, out, format='commented_header', comment=False,

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function
 import re
 import os
 import sys
-import six
+
 
 from . import core
 from . import basic
@@ -30,6 +30,7 @@ from . import fixedwidth
 
 from ...table import Table
 from ...utils.data import get_readable_fileobj
+from ...extern import six
 
 try:
     import yaml

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 import re
 import os
 import sys
+import six
 
 from . import core
 from . import basic
@@ -457,7 +458,7 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
         Writer class (DEPRECATED) (default= :class:`Basic`)
     delimiter : str
         Column delimiter string
-    write_comment : str
+    comment : str
         String defining a comment line in table
     quotechar : str
         One-character string to quote fields containing special characters
@@ -484,6 +485,19 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
     if 'strip_whitespace' not in kwargs:
         kwargs['strip_whitespace'] = True
     writer = core._get_writer(Writer, fast_writer, **kwargs)
+
+    # Handle the corner case of wanting to disable writing table comments for the
+    # commented_header format.  This format *requires* a string for `write_comment`
+    # because that is used for the header column row, so it is not possible to
+    # set the input `comment` to None.  Without adding a new keyword or assuming
+    # a default comment character, there is no other option but to tell user to
+    # simply remove the meta['comments'].
+    if (isinstance(writer, (basic.CommentedHeader, fastbasic.FastCommentedHeader))
+            and not isinstance(kwargs.get('comment', ''), six.string_types)):
+        raise ValueError("for the commented_header writer you must supply a string\n"
+                         "value for the `comment` keyword.  In order to disable writing\n"
+                         "table comments use `del t.meta['comments']` prior to writing.")
+
     return writer
 
 
@@ -502,7 +516,7 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
         Output table format (default= ``basic``)
     delimiter : str
         Column delimiter string
-    write_comment : str
+    comment : str
         String defining a comment line in table
     quotechar : str
         One-character string to quote fields containing special characters


### PR DESCRIPTION
This fixes two problems with the `io.ascii` `commented_header` format:

- The reader was leaving the initial comment line which defines the column names in the output `comments` list (in `t.meta['comments']`).  This line is part of the table definition and is not a comment line.  Leaving it there makes the table not round-trip back when written out.
- For the writer there is a problem when `comment=False` is supplied, because for this particular format a specification of the comment character is *required* in order to write the column names header line (#3562).  Fixing this in a fully general way would require a new parameter or else assuming a default for the comment character.  Instead this PR just issues an informative exception telling users to remove the `meta['comments']` in order to work around this.

Closes #3562.