### PR TITLE
WIP Store table and column meta as JSON in Table HDF5 interface

### DIFF
--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -90,20 +90,9 @@ def _get_col_attributes(col):
     Extract information from a column (apart from the values) that is required
     to fully serialize the column.
     """
-    if len(getattr(col, 'shape', ())) > 1:
-        raise ValueError("ECSV format does not support multidimensional column '{0}'"
-                         .format(col_getattr(col, 'name')))
-
     # attrs = ColumnDict()
     attrs = dict()
     attrs['name'] = col_getattr(col, 'name')
-
-    type_name = col_getattr(col, 'dtype').type.__name__
-    if six.PY3 and (type_name.startswith('bytes') or type_name.startswith('str')):
-        type_name = 'string'
-    if type_name.endswith('_'):
-        type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
-    attrs['datatype'] = type_name
 
     # Set the output attributes
     for attr, nontrivial, xform in (('unit', lambda x: x is not None, str),


### PR DESCRIPTION
Inspired by #3567 and stealing code and ideas from the original JSON version of the ECSV format (#2319), this serializes table meta and column attributes as compact JSON and stores this in a single HDF5 dataset attribute.  This (should) allow round-tripping of all column attributes (including units of course) as well as any table meta that is serializable as JSON.

The existing astropy 1.0 implementation only allows storage of meta values that correspond to atomic datatypes in HDF5.

Just throwing this out as an idea.  Using this capability requires setting the `serialize_meta` keyword to `True` when writing, but it is automatic when reading if the correct dataset attribute is found.