### PR TITLE
Release the GIL in ERFA functions

### DIFF
--- a/astropy/_erfa/core.c.templ
+++ b/astropy/_erfa/core.c.templ
@@ -48,6 +48,8 @@ static PyObject *Py_{{ func.pyname }}(PyObject *self, PyObject *args, PyObject *
     char **dataptrarray = NpyIter_GetDataPtrArray(it);
     NpyIter_IterNextFunc *iternext = NpyIter_GetIterNext(it, NULL);
 
+    Py_BEGIN_ALLOW_THREADS
+
     do {
         {%- for arg in func.args_by_inout('in|inout|out') %}
         _{{ arg.name }} = (({{ arg.ctype }} *)(dataptrarray[{{ func.args.index(arg) }}])){%- if arg.ctype_ptr[-1] != '*' %}[0]{%- endif %};
@@ -65,6 +67,8 @@ static PyObject *Py_{{ func.pyname }}(PyObject *self, PyObject *args, PyObject *
         }
         {%- endfor %}
     } while (iternext(it));
+
+    Py_END_ALLOW_THREADS
 
     {%- if func.args_by_inout('stat')|length > 0 %}
     if (stat_ok) {


### PR DESCRIPTION
This releases the GIL inside of the main processing loop in the wrapped ERFA functions.

Don't know how much this helps multi-threaded programs, but it's standard to do this in Numpy inner loops, so it makes sense to do it here, too.