### PR TITLE
Euler angle rotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,10 @@ API changes
 
 - ``astropy.modeling``
 
+  - Renamed the parameters of ``RotateNative2Celestial`` and 
+    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to 
+    ``lon``, ``lat`` and ``lon_pole``. [#3578]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -33,12 +33,16 @@ __all__ = ['RotateCelestial2Native', 'RotateNative2Celestial', 'Rotation2D',
 
 class EulerAngleRotation(Model):
     """
-    Implements Euler angle rotation.
+    Implements Euler angle intrinsic rotations.
+
+    Rotates one coordinate system into another (fixed) coordinate system.
+    All coordinate systems are right-handed. All intrinsic rotations are
+    performed clockwise.
 
     Parameters
     ----------
     phi, theta, psi : float
-        Euler angles in deg
+        "proper" Euler angles in deg
     order : str
         A 3 character string, a combination of 'x', 'y' and 'z',
         where each character denotes an axis in 3D space.
@@ -52,9 +56,9 @@ class EulerAngleRotation(Model):
     psi = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, phi, theta, psi, order):
-        if len(order) >3 or len(order) < 2:
+        if len(order) != 3:
             raise TypeError(
-                "Expected order to be a character sequence of 2 or 3, got {0}".format(order))
+                "Expected order to be a character sequence of length 3, got {0}".format(order))
         for i in order:
             if i not in ['x', 'y', 'z']:
                 raise ValueError("Expected order to be a combination of characters"
@@ -114,7 +118,7 @@ class EulerAngleRotation(Model):
 
 class _SkyRotation(Model):
     """
-    Base class for Euler angle rotations.
+    Base class for FITS WCS sky rotations.
 
     Parameters
     ----------
@@ -157,9 +161,7 @@ class _SkyRotation(Model):
 
 class RotateNative2Celestial(_SkyRotation):
     """
-    Transformation from Native to Celestial Spherical Coordinates.
-
-    Defines a ZXZ rotation.
+    Transform from Native to Celestial Spherical Coordinates.
 
     Parameters
     ----------
@@ -181,7 +183,7 @@ class RotateNative2Celestial(_SkyRotation):
     @classmethod
     def evaluate(cls, phi_N, theta_N, lon, lat, lon_pole):
         """
-        Evaluate ZXZ rotation into celestial coordinates.
+        Rotate native spherical coordinates into celestial coordinates.
         """
 
         phi_N = np.deg2rad(phi_N)
@@ -203,9 +205,7 @@ class RotateNative2Celestial(_SkyRotation):
 
 class RotateCelestial2Native(_SkyRotation):
     """
-    Transformation from Celestial to Native to Spherical Coordinates.
-
-    Defines a ZXZ rotation.
+    Transform from Celestial to Native to Spherical Coordinates.
 
     Parameters
     ----------
@@ -227,10 +227,9 @@ class RotateCelestial2Native(_SkyRotation):
     @classmethod
     def evaluate(cls, alpha_C, delta_C, lon, lat, lon_pole):
         """
-        Evaluate ZXZ rotation into native coordinates.
+        Rotate celestial coordinates into native spherical coordinates.
 
-        This is like RotateNative2Celestial.evaluate except phi and psi are
-        swapped in ZXZ rotation.
+        This is the inverse transformation of RotateNative2Celestial.
         """
 
         alpha_C = np.deg2rad(alpha_C)

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -36,8 +36,8 @@ class EulerAngleRotation(Model):
     Implements Euler angle intrinsic rotations.
 
     Rotates one coordinate system into another (fixed) coordinate system.
-    All coordinate systems are right-handed. All intrinsic rotations are
-    performed clockwise.
+    All coordinate systems are right-handed. The sign of the angles is 
+    determined by the right-hand rule..
 
     Parameters
     ----------

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -98,6 +98,12 @@ class EulerAngleRotation(Model):
                   np.sin(np.deg2rad(delta)))
         return np.array([result]).T
 
+    def inverse(self):
+        return self.__class__(phi=-self.psi,
+                              theta=-self.theta,
+                              psi=-self.phi,
+                              order=self.order[::-1])
+
     def evaluate(self, alpha, delta, phi, theta, psi):
         input = self.directional_cosine(alpha, delta)
         matrix = self._create_matrix(phi, theta, psi, self.order)
@@ -187,7 +193,7 @@ class RotateNative2Celestial(_SkyRotation):
         return alpha_C, delta_C
 
 
-class RotateCelestial2Native(EulerAngleRotation):
+class RotateCelestial2Native(_SkyRotation):
     """
     Transformation from Celestial to Native to Spherical Coordinates.
 

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -9,20 +9,20 @@ from ...tests.helper import pytest
 
 
 def test_RotateNative2Celestial():
-    phi, theta, psi = 42, 43, 44
-    model = models.RotateNative2Celestial(phi, theta, psi)
-    model.phi = model.phi + 1
-    model.psi = model.psi + 1
-    model.theta = model.theta + 1
-    assert model.phi == phi + 1
-    assert model.theta == theta + 1
-    assert model.psi == psi + 1
+    lon, lat, lon_pole = 42, 43, 44
+    model = models.RotateNative2Celestial(lon, lat, lon_pole)
+    model.lon = model.lon + 1
+    model.lon_pole = model.lon_pole + 1
+    model.lat = model.lat + 1
+    assert model.lon == lon + 1
+    assert model.lat == lat + 1
+    assert model.lon_pole == lon_pole + 1
 
 
 def test_native_celestial_native():
-    phi, theta, psi = 42, 43, 44
-    n2c = models.RotateNative2Celestial(phi, theta, psi)
-    c2n = models.RotateCelestial2Native(phi, theta, psi)
+    lon, lat, lon_pole = 42, 43, 44
+    n2c = models.RotateNative2Celestial(lon, lat, lon_pole)
+    c2n = models.RotateCelestial2Native(lon, lat, lon_pole)
 
     nnphi, ntheta = 33, 44
     calpha, cdelta = n2c(nnphi, ntheta)
@@ -34,7 +34,7 @@ def test_native_celestial_native():
     assert c2n.inverse(nnphi, ntheta) == n2c(nnphi, ntheta)
 
 
-def test_native_celestial_theta90():
+def test_native_celestial_lat90():
     n2c = models.RotateNative2Celestial(1, 90, 0)
     alpha, delta = n2c(1, 1)
     utils.assert_allclose( delta, 1)

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -102,3 +102,49 @@ def test_euler_against_sky():
         ra += 360
     utils.assert_allclose((ra, dec), n2c(1, 23.1))
 
+
+
+euler_axes_order = ['zxz', 'zyz', 'yzy', 'yxy', 'xyx', 'xzx']
+
+@pytest.mark.parametrize(('axes_order'), euler_axes_order)
+def test_euler_angles(axes_order):
+    """
+    Tests against all Euler sequences.
+    The rotation matrices definitions come from Wikipedia.
+    """
+    phi = np.deg2rad(23.4)
+    theta = np.deg2rad(12.2)
+    psi = np.deg2rad(34)
+    c1 =cos(phi)
+    c2 = cos(theta)
+    c3 = cos(psi)
+    s1 = sin(phi)
+    s2 = sin(theta)
+    s3 = sin(psi)
+
+    matrices = {'zxz': np.array([[(c1*c3 - c2*s1*s3), (-c1*s3 - c2*c3*s1), (s1*s2)],
+                        [(c3*s1 + c1*c2*s3), (c1*c2*c3 - s1*s3), (-c1*s2)],
+                        [(s2*s3),             (c3*s2),            (c2)   ]]),
+                'zyz': np.array([[(c1*c2*c3 -s1*s3), (-c3*s1 - c1*c2*s3), (c1*s2)],
+                        [(c1*s3 +c2*c3*s1), (c1*c3 - c2*s1*s3),  (s1*s2)],
+                        [(-c3*s2),           (s2*s3),             (c2)]]),
+                'yzy': np.array([[(c1*c2*c3 - s1*s3), (-c1*s2), (c3*s1+c1*c2*s3)],
+                                  [(c3*s2), (c2), (s2*s3)],
+                                  [(-c1*s3 - c2*c3*s1), (s1*s2), (c1*c3-c2*s1*s3)]]),
+                'yxy': np.array([[(c1*c3 - c2*s1*s3), (s1*s2), (c1*s3+c2*c3*s1)],
+                                 [(s2*s3), (c2), (-c3*s2)],
+                                 [(-c3*s1 - c1*c2*s3), (c1*s2), (c1*c2*c3 - s1*s3)]]),
+                'xyx': np.array([[(c2), (s2*s3), (c3*s2)],
+                                 [(s1*s2), (c1*c3 - c2*s1*s3), (-c1*s3 - c2*c3*s1)],
+                                 [(-c1*s2), (c3*s1 + c1*c2*s3), (c1*c2*c3 - s1*s3)]]),
+                'xzx': np.array([[(c2), (-c3*s2), (s2*s3)],
+                                 [(c1*s2), (c1*c2*c3 - s1*s3), (-c3*s1 - c1*c2*s3)],
+                                 [(s1*s2), (c1*s3 + c2*c3*s1), (c1*c3 - c2*s1*s3)]])
+
+                }
+    model = models.EulerAngleRotation(23.4, 12.2, 34, axes_order)
+    mat = model._create_matrix(phi, theta, psi, axes_order)
+
+
+    utils.assert_allclose(mat.T, matrices[axes_order])#get_rotation_matrix(axes_order))
+


### PR DESCRIPTION
There are a couple of classes in `modeling` (`RotateNative2Celestial` and `RotateCelestial2Native`) which essentially perform rotation on the sky using 3 Euler angles. The angles they use are the  FITS WCS angles CRVALs and LONPOLE. However, the true Euler angles are (right ascension+90), (90-declination) and (lonpole-90). While this is a 'zxz' Euler rotation, the computational formula used in the current `EulerAngleRotation` does not compute correctly a 'zxz' rotation but is a simplified formula using the fact that the Euler angles are sums of the WCS angles and +/-90.

This PR implements a rotation by 3 Euler angles. There are many conventions for Euler angles and the transformations can easily become confusing unless the convention is well specified. The following convention is used here:

- These are the so called "proper" Euler angles which perform intrinsic rotations
- This transformation rotates one coordinate system into another (fixed) coordinate system (as opposed to rotating vectors in coordinate system1 to vectors in coordinate system 2 which mathematically is the inverse operation)
- All coordinate systems are right-handed.
- All individual rotations are in the clockwise direction.

While the `RotateNative2Celestial` and `RotateCelestial2Native` can be written as subclasses of `EulerAngleRotation`, I think we should keep the current implementation because the performance on large inputs is much better than the matrix operations implemented in `EulerAngleRotation`.
So the current `EulerAngleRotation` is renamed to `_SkyRotation`. I know it's a change of name but the current `EulerAngleRotation` was never publicky exposed in `modeling.models`.

I'd like to hear what others think about this approach before finishing the PR.

update: I also changed the names of the parameters of the sky rotation classes from the generic `phi`, `theta`, `psi`  to the slightly less generic `lon`, `lat`, `lon_pole` as this seems to clarify what is expected as input.