### PR TITLE
Alias the 3-letter FITS WCS names for projections with longer names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,8 +156,6 @@ API changes
 
 - ``astropy.constants``
 
-  - Ensure constants can be turned into ``Quantity`` safely. [#3537, #3538]
-
 - ``astropy.convolution``
 
 - ``astropy.coordinates``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,11 @@ New Features
 
 - ``astropy.modeling``
 
+  - The projection classes that are named based on the 3-letter FITS
+    WCS projections (e.g. ``Pix2Sky_TAN``) now have aliases using
+    longer, more descriptive names (e.g. ``Pix2Sky_Gnomonic``).
+    [#3583]
+
 - ``astropy.nddata``
 
   - Added ``block_reduce`` and ``block_replicate`` functions. [#3453]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,6 +156,8 @@ API changes
 
 - ``astropy.constants``
 
+  - Ensure constants can be turned into ``Quantity`` safely. [#3537, #3538]
+
 - ``astropy.convolution``
 
 - ``astropy.coordinates``
@@ -255,6 +257,10 @@ Bug fixes
 - ``astropy.logger.py``
 
 - ``astropy.modeling``
+
+  - The projection classes that are named based on the 3-letter FITS
+    WCS projections (e.g. ``Pix2Sky_TAN``) are deprecated in favor of
+    longer class names (e.g. ``Pix2Sky_Gnomonic``).  [#3583]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -24,6 +24,7 @@ from .core import Model
 from .parameters import Parameter, InputParameterError
 
 from ..utils.compat import ignored
+from ..utils.decorators import deprecated
 
 
 projcodes = ['TAN', 'AZP', 'SZP', 'STG', 'SIN', 'ARC', 'ZPN', 'ZEA', 'AIR',
@@ -32,12 +33,23 @@ projcodes = ['TAN', 'AZP', 'SZP', 'STG', 'SIN', 'ARC', 'ZPN', 'ZEA', 'AIR',
 
 __all__ = ['Projection', 'Pix2SkyProjection', 'Sky2PixProjection',
            'Zenithal', 'Cylindrical',
+           'AffineTransformation2D',
+
+           'Pix2Sky_ZenithalPerspective', 'Sky2Pix_ZenithalPerspective',
+           'Pix2Sky_Gnomonic', 'Sky2Pix_Gnomonic',
+           'Pix2Sky_Stereographic', 'Sky2Pix_Stereographic',
+           'Pix2Sky_SlantOrthographic', 'Sky2Pix_SlantOrthographic',
+           'Pix2Sky_CylindricalPerspective', 'Sky2Pix_CylindricalPerspective',
+           'Pix2Sky_CylindricalEqualArea', 'Sky2Pix_CylindricalEqualArea',
+           'Pix2Sky_PlateCarree', 'Sky2Pix_PlateCarree',
+           'Pix2Sky_Mercator', 'Sky2Pix_Mercator',
+
+           # The following were @deprecated in 1.1
            'Pix2Sky_AZP', 'Sky2Pix_AZP', 'Pix2Sky_CAR', 'Sky2Pix_CAR',
            'Pix2Sky_CEA', 'Sky2Pix_CEA', 'Pix2Sky_CYP', 'Sky2Pix_CYP',
            'Pix2Sky_MER', 'Sky2Pix_MER',
            'Pix2Sky_SIN', 'Sky2Pix_SIN', 'Pix2Sky_STG', 'Sky2Pix_STG',
-           'Pix2Sky_TAN', 'Sky2Pix_TAN',
-           'AffineTransformation2D']
+           'Pix2Sky_TAN', 'Sky2Pix_TAN']
 
 
 class Projection(Model):
@@ -88,9 +100,11 @@ class Zenithal(Projection):
     """
 
 
-class Pix2Sky_AZP(Pix2SkyProjection, Zenithal):
+class Pix2Sky_ZenithalPerspective(Pix2SkyProjection, Zenithal):
     r"""
-    AZP : Zenithal perspective projection - pixel to sky.
+    Zenithal perspective projection - pixel to sky.
+
+    Corresponds to the ``AZP`` projection in FITS WCS.
 
     .. math::
         \phi &= \arg(-y \cos \gamma, x) \\
@@ -116,7 +130,8 @@ class Pix2Sky_AZP(Pix2SkyProjection, Zenithal):
 
     def _validate_mu(mu):
         if np.asarray(mu == -1).any():
-            raise ValueError("AZP projection is not defined for mu=-1")
+            raise ValueError(
+                "Zenithal perspective projection is not defined for mu=-1")
         return mu
 
     mu = Parameter(default=0.0, setter=_validate_mu)
@@ -126,15 +141,16 @@ class Pix2Sky_AZP(Pix2SkyProjection, Zenithal):
         self.check_mu(mu)
         # units : mu - in spherical radii, gamma - in deg
         # TODO: Support quantity objects here and in similar contexts
-        super(Pix2Sky_AZP, self).__init__(mu, gamma, **kwargs)
+        super(Pix2Sky_ZenithalPerspective, self).__init__(mu, gamma, **kwargs)
 
     def check_mu(self, val):
         if np.asarray(val == -1).any():
-            raise ValueError("AZP projection is not defined for mu=-1")
+            raise ValueError(
+                "Zenithal perspective projection is not defined for mu=-1")
 
     @property
     def inverse(self):
-        return Sky2Pix_AZP(self.mu.value, self.gamma.value)
+        return Sky2Pix_ZenithalPerspective(self.mu.value, self.gamma.value)
 
     @classmethod
     def evaluate(cls, x, y, mu, gamma):
@@ -168,9 +184,16 @@ class Pix2Sky_AZP(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2 * (np.cos(gamma)) ** 2)
 
 
-class Sky2Pix_AZP(Sky2PixProjection, Zenithal):
+@deprecated('1.1', alternative="Pix2Sky_ZenithalPerspective")
+class Pix2Sky_AZP(Pix2Sky_ZenithalPerspective):
+    pass
+
+
+class Sky2Pix_ZenithalPerspective(Sky2PixProjection, Zenithal):
     r"""
-    AZP : Zenithal perspective projection - sky to pixel.
+    Zenithal perspective projection - sky to pixel.
+
+    Corresponds to the ``AZP`` projection in FITS WCS.
 
     .. math::
         x &= R \sin \phi \\
@@ -193,7 +216,7 @@ class Sky2Pix_AZP(Sky2PixProjection, Zenithal):
 
     def _validate_mu(mu):
         if np.asarray(mu == -1).any():
-            raise ValueError("AZP projection is not defined for mu=-1")
+            raise ValueError("Zenithal perspective projection is not defined for mu=-1")
         return mu
 
     mu = Parameter(default=0.0, setter=_validate_mu)
@@ -201,7 +224,7 @@ class Sky2Pix_AZP(Sky2PixProjection, Zenithal):
 
     def check_mu(self, val):
         if np.asarray(val == -1).any():
-            raise ValueError("AZP projection is not defined for mu=-1")
+            raise ValueError("Zenithal perspective projection is not defined for mu=-1")
 
     @property
     def inverse(self):
@@ -225,9 +248,16 @@ class Sky2Pix_AZP(Sky2PixProjection, Zenithal):
                  np.cos(theta) * np.cos(phi) * np.tan(gamma)))
 
 
-class Pix2Sky_TAN(Pix2SkyProjection, Zenithal):
+@deprecated('1.1', alternative='Sky2Pix_ZenithalPerspective')
+class Sky2Pix_AZP(Sky2Pix_ZenithalPerspective):
+    pass
+
+
+class Pix2Sky_Gnomonic(Pix2SkyProjection, Zenithal):
     r"""
-    TAN : Gnomonic projection - pixel to sky.
+    Gnomonic projection - pixel to sky.
+
+    Corresponds to the ``TAN`` projection in FITS WCS.
 
     See `Zenithal` for a definition of the full transformation.
 
@@ -237,7 +267,7 @@ class Pix2Sky_TAN(Pix2SkyProjection, Zenithal):
 
     @property
     def inverse(self):
-        return Sky2Pix_TAN()
+        return Sky2Pix_Gnomonic()
 
     @classmethod
     def evaluate(cls, x, y):
@@ -252,9 +282,16 @@ class Pix2Sky_TAN(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2)
 
 
-class Sky2Pix_TAN(Sky2PixProjection, Zenithal):
+@deprecated('1.1', alternative='Pix2Sky_Gnomonic')
+class Pix2Sky_TAN(Pix2Sky_Gnomonic):
+    pass
+
+
+class Sky2Pix_Gnomonic(Sky2PixProjection, Zenithal):
     r"""
-    TAN : Gnomonic Projection - sky to pixel.
+    Gnomonic Projection - sky to pixel.
+
+    Corresponds to the ``TAN`` projection in FITS WCS.
 
     See `Zenithal` for a definition of the full transformation.
 
@@ -264,7 +301,7 @@ class Sky2Pix_TAN(Sky2PixProjection, Zenithal):
 
     @property
     def inverse(self):
-        return Pix2Sky_TAN()
+        return Pix2Sky_Gnomonic()
 
     @classmethod
     def evaluate(cls, phi, theta):
@@ -282,9 +319,16 @@ class Sky2Pix_TAN(Sky2PixProjection, Zenithal):
         return 1 / np.tan(theta)
 
 
-class Pix2Sky_STG(Pix2SkyProjection, Zenithal):
+@deprecated('1.1', alternative='Sky2Pix_Gnomonic')
+class Sky2Pix_TAN(Sky2Pix_Gnomonic):
+    pass
+
+
+class Pix2Sky_Stereographic(Pix2SkyProjection, Zenithal):
     r"""
-    STG : Stereographic Projection - pixel to sky.
+    Stereographic Projection - pixel to sky.
+
+    Corresponds to the ``STG`` projection in FITS WCS.
 
     See `Zenithal` for a definition of the full transformation.
 
@@ -294,7 +338,7 @@ class Pix2Sky_STG(Pix2SkyProjection, Zenithal):
 
     @property
     def inverse(self):
-        return Sky2Pix_STG()
+        return Sky2Pix_Stereographic()
 
     @classmethod
     def evaluate(cls, x, y):
@@ -309,9 +353,16 @@ class Pix2Sky_STG(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2)
 
 
-class Sky2Pix_STG(Sky2PixProjection, Zenithal):
+@deprecated('1.1', alternative='Pix2Sky_Stereographic')
+class Pix2Sky_STG(Pix2Sky_Stereographic):
+    pass
+
+
+class Sky2Pix_Stereographic(Sky2PixProjection, Zenithal):
     r"""
-    STG : Stereographic Projection - sky to pixel.
+    Stereographic Projection - sky to pixel.
+
+    Corresponds to the ``STG`` projection in FITS WCS.
 
     See `Zenithal` for a definition of the full transformation.
 
@@ -321,7 +372,7 @@ class Sky2Pix_STG(Sky2PixProjection, Zenithal):
 
     @property
     def inverse(self):
-        return Pix2Sky_STG()
+        return Pix2Sky_Stereographic()
 
     @classmethod
     def evaluate(cls, phi, theta):
@@ -339,9 +390,16 @@ class Sky2Pix_STG(Sky2PixProjection, Zenithal):
         return (cls.r0 * 2 * np.cos(theta)) / (1 + np.sin(theta))
 
 
-class Pix2Sky_SIN(Pix2SkyProjection, Zenithal):
+@deprecated('1.1', alternative='Sky2Pix_Stereographic')
+class Sky2Pix_STG(Sky2Pix_Stereographic):
+    pass
+
+
+class Pix2Sky_SlantOrthographic(Pix2SkyProjection, Zenithal):
     r"""
-    SIN : Slant orthographic projection - pixel to sky.
+    Slant orthographic projection - pixel to sky.
+
+    Corresponds to the ``SIN`` projection in FITS WCS.
 
     See `Zenithal` for a definition of the full transformation.
 
@@ -351,7 +409,7 @@ class Pix2Sky_SIN(Pix2SkyProjection, Zenithal):
 
     @property
     def inverse(self):
-        return Sky2Pix_SIN()
+        return Sky2Pix_SlantOrthographic()
 
     @classmethod
     def evaluate(cls, x, y):
@@ -366,9 +424,16 @@ class Pix2Sky_SIN(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2)
 
 
-class Sky2Pix_SIN(Sky2PixProjection, Zenithal):
+@deprecated('1.1', alternative='Pix2Sky_SlantOrthographic')
+class Pix2Sky_SIN(Pix2Sky_SlantOrthographic):
+    pass
+
+
+class Sky2Pix_SlantOrthographic(Sky2PixProjection, Zenithal):
     r"""
-    SIN : Slant orthographic projection - sky to pixel.
+    Slant orthographic projection - sky to pixel.
+
+    Corresponds to the ``SIN`` projection in FITS WCS.
 
     See `Zenithal` for a definition of the full transformation.
 
@@ -378,7 +443,7 @@ class Sky2Pix_SIN(Sky2PixProjection, Zenithal):
 
     @property
     def inverse(self):
-        return Pix2Sky_SIN()
+        return Pix2Sky_SlantOrthographic()
 
     @classmethod
     def evaluate(cls, phi, theta):
@@ -395,6 +460,11 @@ class Sky2Pix_SIN(Sky2PixProjection, Zenithal):
         return cls.r0 * np.cos(theta)
 
 
+@deprecated('1.1', alternative='Sky2Pix_SlantOrthographic')
+class Sky2Pix_SIN(Sky2Pix_SlantOrthographic):
+    pass
+
+
 class Cylindrical(Projection):
     r"""Base class for Cylindrical projections.
 
@@ -403,9 +473,11 @@ class Cylindrical(Projection):
     """
 
 
-class Pix2Sky_CYP(Pix2SkyProjection, Cylindrical):
+class Pix2Sky_CylindricalPerspective(Pix2SkyProjection, Cylindrical):
     r"""
-    CYP : Cylindrical perspective - pixel to sky.
+    Cylindrical perspective - pixel to sky.
+
+    Corresponds to the ``CYP`` projection in FITS WCS.
 
     .. math::
         \phi &= \frac{x}{\lambda} \\
@@ -447,7 +519,7 @@ class Pix2Sky_CYP(Pix2SkyProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Sky2Pix_CYP(self.mu.value, self.lam.value)
+        return Sky2Pix_CylindricalPerspective(self.mu.value, self.lam.value)
 
     @classmethod
     def evaluate(cls, x, y, mu, lam):
@@ -459,9 +531,16 @@ class Pix2Sky_CYP(Pix2SkyProjection, Cylindrical):
         return phi, np.rad2deg(theta)
 
 
-class Sky2Pix_CYP(Sky2PixProjection, Cylindrical):
+@deprecated('1.1', alternative='Pix2Sky_CylindricalPerspective')
+class Pix2Sky_CYP(Pix2Sky_CylindricalPerspective):
+    pass
+
+
+class Sky2Pix_CylindricalPerspective(Sky2PixProjection, Cylindrical):
     r"""
-    CYP : Cylindrical Perspective - sky to pixel.
+    Cylindrical Perspective - sky to pixel.
+
+    Corresponds to the ``CYP`` projection in FITS WCS.
 
     .. math::
         x &= \lambda \phi \\
@@ -497,7 +576,7 @@ class Sky2Pix_CYP(Sky2PixProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Pix2Sky_CYP(self.mu, self.lam)
+        return Pix2Sky_CylindricalPerspective(self.mu, self.lam)
 
     @classmethod
     def evaluate(cls, phi, theta, mu, lam):
@@ -508,9 +587,16 @@ class Sky2Pix_CYP(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-class Pix2Sky_CEA(Pix2SkyProjection, Cylindrical):
+@deprecated('1.1', alternative='Sky2Pix_CylindricalPerspective')
+class Sky2Pix_CYP(Sky2Pix_CylindricalPerspective):
+    pass
+
+
+class Pix2Sky_CylindricalEqualArea(Pix2SkyProjection, Cylindrical):
     r"""
-    CEA : Cylindrical equal area projection - pixel to sky.
+    Cylindrical equal area projection - pixel to sky.
+
+    Corresponds to the ``CEA`` projection in FITS WCS.
 
     .. math::
         \phi &= x \\
@@ -526,7 +612,7 @@ class Pix2Sky_CEA(Pix2SkyProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Sky2Pix_CEA(self.lam)
+        return Sky2Pix_CylindricalEqualArea(self.lam)
 
     @classmethod
     def evaluate(cls, x, y, lam):
@@ -536,9 +622,16 @@ class Pix2Sky_CEA(Pix2SkyProjection, Cylindrical):
         return phi, theta
 
 
-class Sky2Pix_CEA(Sky2PixProjection, Cylindrical):
+@deprecated('1.1', alternative='Pix2Sky_CylindricalEqualArea')
+class Pix2Sky_CEA(Pix2Sky_CylindricalEqualArea):
+    pass
+
+
+class Sky2Pix_CylindricalEqualArea(Sky2PixProjection, Cylindrical):
     r"""
-    CEA: Cylindrical equal area projection - sky to pixel.
+    Cylindrical equal area projection - sky to pixel.
+
+    Corresponds to the ``CEA`` projection in FITS WCS.
 
     .. math::
         x &= \phi \\
@@ -554,7 +647,7 @@ class Sky2Pix_CEA(Sky2PixProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Pix2Sky_CEA(self.lam)
+        return Pix2Sky_CylindricalEqualArea(self.lam)
 
     @classmethod
     def evaluate(cls, phi, theta, lam):
@@ -565,9 +658,16 @@ class Sky2Pix_CEA(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-class Pix2Sky_CAR(Pix2SkyProjection, Cylindrical):
+@deprecated('1.1', alternative='Sky2Pix_CylindricalEqualArea')
+class Sky2Pix_CEA(Sky2Pix_CylindricalEqualArea):
+    pass
+
+
+class Pix2Sky_PlateCarree(Pix2SkyProjection, Cylindrical):
     r"""
-    CAR: Plate carrée projection - pixel to sky.
+    Plate carrée projection - pixel to sky.
+
+    Corresponds to the ``CAR`` projection in FITS WCS.
 
     .. math::
         \phi &= x \\
@@ -576,7 +676,7 @@ class Pix2Sky_CAR(Pix2SkyProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Sky2Pix_CAR()
+        return Sky2Pix_PlateCarree()
 
     @staticmethod
     def evaluate(x, y):
@@ -587,9 +687,16 @@ class Pix2Sky_CAR(Pix2SkyProjection, Cylindrical):
         return phi, theta
 
 
-class Sky2Pix_CAR(Sky2PixProjection, Cylindrical):
+@deprecated('1.1', alternative='Pix2Sky_PlateCarree')
+class Pix2Sky_CAR(Pix2Sky_PlateCarree):
+    pass
+
+
+class Sky2Pix_PlateCarree(Sky2PixProjection, Cylindrical):
     r"""
-    CAR: Plate carrée projection - sky to pixel.
+    Plate carrée projection - sky to pixel.
+
+    Corresponds to the ``CAR`` projection in FITS WCS.
 
     .. math::
         x &= \phi \\
@@ -598,7 +705,7 @@ class Sky2Pix_CAR(Sky2PixProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Pix2Sky_CAR()
+        return Pix2Sky_PlateCarree()
 
     @staticmethod
     def evaluate(phi, theta):
@@ -609,9 +716,16 @@ class Sky2Pix_CAR(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-class Pix2Sky_MER(Pix2SkyProjection, Cylindrical):
+@deprecated('1.1', alternative='Sky2Pix_PlateCarree')
+class Sky2Pix_CAR(Sky2Pix_PlateCarree):
+    pass
+
+
+class Pix2Sky_Mercator(Pix2SkyProjection, Cylindrical):
     r"""
-    MER: Mercator - pixel to sky.
+    Mercator - pixel to sky.
+
+    Corresponds to the ``MER`` projection in FITS WCS.
 
     .. math::
         \phi &= x \\
@@ -620,7 +734,7 @@ class Pix2Sky_MER(Pix2SkyProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Sky2Pix_MER()
+        return Sky2Pix_Mercator()
 
     @classmethod
     def evaluate(cls, x, y):
@@ -630,9 +744,16 @@ class Pix2Sky_MER(Pix2SkyProjection, Cylindrical):
         return phi, theta
 
 
-class Sky2Pix_MER(Sky2PixProjection, Cylindrical):
+@deprecated('1.1', alternative='Pix2Sky_Mercator')
+class Pix2Sky_MER(Pix2Sky_Mercator):
+    pass
+
+
+class Sky2Pix_Mercator(Sky2PixProjection, Cylindrical):
     r"""
-    MER: Mercator - sky to pixel.
+    Mercator - sky to pixel.
+
+    Corresponds to the ``MER`` projection in FITS WCS.
 
     .. math::
         x &= \phi \\
@@ -641,7 +762,7 @@ class Sky2Pix_MER(Sky2PixProjection, Cylindrical):
 
     @property
     def inverse(self):
-        return Pix2Sky_MER()
+        return Pix2Sky_Mercator()
 
     @classmethod
     def evaluate(cls, phi, theta):
@@ -650,6 +771,11 @@ class Sky2Pix_MER(Sky2PixProjection, Cylindrical):
         y = cls.r0 * np.log(np.tan((np.pi / 2 + theta) / 2))
 
         return x, y
+
+
+@deprecated('1.1', alternative='Sky2Pix_Mercator')
+class Sky2Pix_MER(Sky2Pix_Mercator):
+    pass
 
 
 class AffineTransformation2D(Model):

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -27,8 +27,7 @@ from ..utils.compat import ignored
 from ..utils.decorators import deprecated
 
 
-projcodes = ['TAN', 'AZP', 'SZP', 'STG', 'SIN', 'ARC', 'ZPN', 'ZEA', 'AIR',
-             'CYP', 'CEA', 'MER']
+projcodes = ['TAN', 'AZP', 'STG', 'SIN', 'CYP', 'CEA', 'MER']
 
 
 __all__ = ['Projection', 'Pix2SkyProjection', 'Sky2PixProjection',
@@ -43,6 +42,7 @@ __all__ = ['Projection', 'Pix2SkyProjection', 'Sky2PixProjection',
            'Pix2Sky_CylindricalEqualArea', 'Sky2Pix_CylindricalEqualArea',
            'Pix2Sky_PlateCarree', 'Sky2Pix_PlateCarree',
            'Pix2Sky_Mercator', 'Sky2Pix_Mercator',
+           'projcodes', 'get_projection_from_wcs_code',
 
            # The following were @deprecated in 1.1
            'Pix2Sky_AZP', 'Sky2Pix_AZP', 'Pix2Sky_CAR', 'Sky2Pix_CAR',
@@ -892,3 +892,46 @@ class AffineTransformation2D(Model):
         augmented_matrix[0:2, 2:].flat = translation
         augmented_matrix[2] = [0, 0, 1]
         return augmented_matrix
+
+
+def get_projection_from_wcs_code(direction, code):
+    """
+    Get a projection class from a 3-letter FITS WCS projection code.
+
+    Parameters
+    ----------
+    direction : string
+       Must be ``pix2sky`` or ``sky2pix``.
+
+    code : string
+       Must be a 3-letter FITS WCS projection code, such as ``TAN``.
+
+    Returns
+    -------
+    projection : Model subclass
+    """
+    direction_mapping = {
+        'pix2sky': 'Pix2Sky',
+        'sky2pix': 'Sky2Pix'
+    }
+
+    direction = direction_mapping.get(direction.lower(), None)
+    if direction is None:
+        raise ValueError("direction must be 'pix2sky' or 'sky2pix'")
+
+    code_mapping = {
+        'TAN': 'Gnomonic',
+        'AZP': 'ZenithalPerspective',
+        'STG': 'Stereographic',
+        'SIN': 'SlantedOrthographic',
+        'CYP': 'CylindricalPerspective',
+        'CEA': 'CylindricalEqualArea',
+        'CAR': 'PlateCarree',
+        'MER': 'Mercator'
+    }
+
+    code = code_mapping.get(code.upper(), None)
+    if code is None:
+        raise ValueError("Unknown code '{0}'".format(code))
+
+    return globals().get('{0}_{1}'.format(direction, code))

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -24,7 +24,6 @@ from .core import Model
 from .parameters import Parameter, InputParameterError
 
 from ..utils.compat import ignored
-from ..utils.decorators import deprecated
 
 
 projcodes = ['TAN', 'AZP', 'STG', 'SIN', 'CYP', 'CEA', 'MER']
@@ -42,9 +41,9 @@ __all__ = ['Projection', 'Pix2SkyProjection', 'Sky2PixProjection',
            'Pix2Sky_CylindricalEqualArea', 'Sky2Pix_CylindricalEqualArea',
            'Pix2Sky_PlateCarree', 'Sky2Pix_PlateCarree',
            'Pix2Sky_Mercator', 'Sky2Pix_Mercator',
-           'projcodes', 'get_projection_from_wcs_code',
+           'projcodes',
 
-           # The following were @deprecated in 1.1
+           # The following are short FITS WCS aliases
            'Pix2Sky_AZP', 'Sky2Pix_AZP', 'Pix2Sky_CAR', 'Sky2Pix_CAR',
            'Pix2Sky_CEA', 'Sky2Pix_CEA', 'Pix2Sky_CYP', 'Sky2Pix_CYP',
            'Pix2Sky_MER', 'Sky2Pix_MER',
@@ -184,9 +183,7 @@ class Pix2Sky_ZenithalPerspective(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2 * (np.cos(gamma)) ** 2)
 
 
-@deprecated('1.1', alternative="Pix2Sky_ZenithalPerspective")
-class Pix2Sky_AZP(Pix2Sky_ZenithalPerspective):
-    pass
+Pix2Sky_AZP = Pix2Sky_ZenithalPerspective
 
 
 class Sky2Pix_ZenithalPerspective(Sky2PixProjection, Zenithal):
@@ -248,9 +245,7 @@ class Sky2Pix_ZenithalPerspective(Sky2PixProjection, Zenithal):
                  np.cos(theta) * np.cos(phi) * np.tan(gamma)))
 
 
-@deprecated('1.1', alternative='Sky2Pix_ZenithalPerspective')
-class Sky2Pix_AZP(Sky2Pix_ZenithalPerspective):
-    pass
+Sky2Pix_AZP = Sky2Pix_ZenithalPerspective
 
 
 class Pix2Sky_Gnomonic(Pix2SkyProjection, Zenithal):
@@ -282,9 +277,7 @@ class Pix2Sky_Gnomonic(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2)
 
 
-@deprecated('1.1', alternative='Pix2Sky_Gnomonic')
-class Pix2Sky_TAN(Pix2Sky_Gnomonic):
-    pass
+Pix2Sky_TAN = Pix2Sky_Gnomonic
 
 
 class Sky2Pix_Gnomonic(Sky2PixProjection, Zenithal):
@@ -319,9 +312,7 @@ class Sky2Pix_Gnomonic(Sky2PixProjection, Zenithal):
         return 1 / np.tan(theta)
 
 
-@deprecated('1.1', alternative='Sky2Pix_Gnomonic')
-class Sky2Pix_TAN(Sky2Pix_Gnomonic):
-    pass
+Sky2Pix_TAN = Sky2Pix_Gnomonic
 
 
 class Pix2Sky_Stereographic(Pix2SkyProjection, Zenithal):
@@ -353,9 +344,7 @@ class Pix2Sky_Stereographic(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2)
 
 
-@deprecated('1.1', alternative='Pix2Sky_Stereographic')
-class Pix2Sky_STG(Pix2Sky_Stereographic):
-    pass
+Pix2Sky_STG = Pix2Sky_Stereographic
 
 
 class Sky2Pix_Stereographic(Sky2PixProjection, Zenithal):
@@ -390,9 +379,7 @@ class Sky2Pix_Stereographic(Sky2PixProjection, Zenithal):
         return (cls.r0 * 2 * np.cos(theta)) / (1 + np.sin(theta))
 
 
-@deprecated('1.1', alternative='Sky2Pix_Stereographic')
-class Sky2Pix_STG(Sky2Pix_Stereographic):
-    pass
+Sky2Pix_STG = Sky2Pix_Stereographic
 
 
 class Pix2Sky_SlantOrthographic(Pix2SkyProjection, Zenithal):
@@ -424,9 +411,7 @@ class Pix2Sky_SlantOrthographic(Pix2SkyProjection, Zenithal):
         return np.sqrt(x ** 2 + y ** 2)
 
 
-@deprecated('1.1', alternative='Pix2Sky_SlantOrthographic')
-class Pix2Sky_SIN(Pix2Sky_SlantOrthographic):
-    pass
+Pix2Sky_SIN = Pix2Sky_SlantOrthographic
 
 
 class Sky2Pix_SlantOrthographic(Sky2PixProjection, Zenithal):
@@ -460,9 +445,7 @@ class Sky2Pix_SlantOrthographic(Sky2PixProjection, Zenithal):
         return cls.r0 * np.cos(theta)
 
 
-@deprecated('1.1', alternative='Sky2Pix_SlantOrthographic')
-class Sky2Pix_SIN(Sky2Pix_SlantOrthographic):
-    pass
+Sky2Pix_SIN = Sky2Pix_SlantOrthographic
 
 
 class Cylindrical(Projection):
@@ -531,9 +514,7 @@ class Pix2Sky_CylindricalPerspective(Pix2SkyProjection, Cylindrical):
         return phi, np.rad2deg(theta)
 
 
-@deprecated('1.1', alternative='Pix2Sky_CylindricalPerspective')
-class Pix2Sky_CYP(Pix2Sky_CylindricalPerspective):
-    pass
+Pix2Sky_CYP = Pix2Sky_CylindricalPerspective
 
 
 class Sky2Pix_CylindricalPerspective(Sky2PixProjection, Cylindrical):
@@ -587,9 +568,7 @@ class Sky2Pix_CylindricalPerspective(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-@deprecated('1.1', alternative='Sky2Pix_CylindricalPerspective')
-class Sky2Pix_CYP(Sky2Pix_CylindricalPerspective):
-    pass
+Sky2Pix_CYP = Sky2Pix_CylindricalPerspective
 
 
 class Pix2Sky_CylindricalEqualArea(Pix2SkyProjection, Cylindrical):
@@ -622,9 +601,7 @@ class Pix2Sky_CylindricalEqualArea(Pix2SkyProjection, Cylindrical):
         return phi, theta
 
 
-@deprecated('1.1', alternative='Pix2Sky_CylindricalEqualArea')
-class Pix2Sky_CEA(Pix2Sky_CylindricalEqualArea):
-    pass
+Pix2Sky_CEA = Pix2Sky_CylindricalEqualArea
 
 
 class Sky2Pix_CylindricalEqualArea(Sky2PixProjection, Cylindrical):
@@ -658,9 +635,7 @@ class Sky2Pix_CylindricalEqualArea(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-@deprecated('1.1', alternative='Sky2Pix_CylindricalEqualArea')
-class Sky2Pix_CEA(Sky2Pix_CylindricalEqualArea):
-    pass
+Sky2Pix_CEA = Sky2Pix_CylindricalEqualArea
 
 
 class Pix2Sky_PlateCarree(Pix2SkyProjection, Cylindrical):
@@ -687,9 +662,7 @@ class Pix2Sky_PlateCarree(Pix2SkyProjection, Cylindrical):
         return phi, theta
 
 
-@deprecated('1.1', alternative='Pix2Sky_PlateCarree')
-class Pix2Sky_CAR(Pix2Sky_PlateCarree):
-    pass
+Pix2Sky_CAR = Pix2Sky_PlateCarree
 
 
 class Sky2Pix_PlateCarree(Sky2PixProjection, Cylindrical):
@@ -716,9 +689,7 @@ class Sky2Pix_PlateCarree(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-@deprecated('1.1', alternative='Sky2Pix_PlateCarree')
-class Sky2Pix_CAR(Sky2Pix_PlateCarree):
-    pass
+Sky2Pix_CAR = Sky2Pix_PlateCarree
 
 
 class Pix2Sky_Mercator(Pix2SkyProjection, Cylindrical):
@@ -744,9 +715,7 @@ class Pix2Sky_Mercator(Pix2SkyProjection, Cylindrical):
         return phi, theta
 
 
-@deprecated('1.1', alternative='Pix2Sky_Mercator')
-class Pix2Sky_MER(Pix2Sky_Mercator):
-    pass
+Pix2Sky_MER = Pix2Sky_Mercator
 
 
 class Sky2Pix_Mercator(Sky2PixProjection, Cylindrical):
@@ -773,9 +742,7 @@ class Sky2Pix_Mercator(Sky2PixProjection, Cylindrical):
         return x, y
 
 
-@deprecated('1.1', alternative='Sky2Pix_Mercator')
-class Sky2Pix_MER(Sky2Pix_Mercator):
-    pass
+Sky2Pix_MER = Sky2Pix_Mercator
 
 
 class AffineTransformation2D(Model):
@@ -892,46 +859,3 @@ class AffineTransformation2D(Model):
         augmented_matrix[0:2, 2:].flat = translation
         augmented_matrix[2] = [0, 0, 1]
         return augmented_matrix
-
-
-def get_projection_from_wcs_code(direction, code):
-    """
-    Get a projection class from a 3-letter FITS WCS projection code.
-
-    Parameters
-    ----------
-    direction : string
-       Must be ``pix2sky`` or ``sky2pix``.
-
-    code : string
-       Must be a 3-letter FITS WCS projection code, such as ``TAN``.
-
-    Returns
-    -------
-    projection : Model subclass
-    """
-    direction_mapping = {
-        'pix2sky': 'Pix2Sky',
-        'sky2pix': 'Sky2Pix'
-    }
-
-    direction = direction_mapping.get(direction.lower(), None)
-    if direction is None:
-        raise ValueError("direction must be 'pix2sky' or 'sky2pix'")
-
-    code_mapping = {
-        'TAN': 'Gnomonic',
-        'AZP': 'ZenithalPerspective',
-        'STG': 'Stereographic',
-        'SIN': 'SlantedOrthographic',
-        'CYP': 'CylindricalPerspective',
-        'CEA': 'CylindricalEqualArea',
-        'CAR': 'PlateCarree',
-        'MER': 'Mercator'
-    }
-
-    code = code_mapping.get(code.upper(), None)
-    if code is None:
-        raise ValueError("Unknown code '{0}'".format(code))
-
-    return globals().get('{0}_{1}'.format(direction, code))

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -17,7 +17,7 @@ from ...tests.helper import pytest
 
 
 def test_Projection_properties():
-    projection = projections.Sky2Pix_CAR()
+    projection = projections.Sky2Pix_PlateCarree()
     assert projection.n_inputs == 2
     assert projection.n_outputs == 2
 
@@ -26,12 +26,12 @@ PIX_COORDINATES = [-10, 30]
 
 
 pars = [
-    ('TAN', projections.Sky2Pix_TAN, {}),
-    ('STG', projections.Sky2Pix_STG, {}),
-    ('SIN', projections.Sky2Pix_SIN, {}),
-    ('CEA', projections.Sky2Pix_CEA, {}),
-    ('CAR', projections.Sky2Pix_CAR, {}),
-    ('MER', projections.Sky2Pix_MER, {})
+    ('TAN', projections.Sky2Pix_Gnomonic, {}),
+    ('STG', projections.Sky2Pix_Stereographic, {}),
+    ('SIN', projections.Sky2Pix_SlantOrthographic, {}),
+    ('CEA', projections.Sky2Pix_CylindricalEqualArea, {}),
+    ('CAR', projections.Sky2Pix_PlateCarree, {}),
+    ('MER', projections.Sky2Pix_Mercator, {})
 ]
 
 
@@ -55,12 +55,12 @@ def test_Sky2Pix(ID, model, args):
     utils.assert_almost_equal(np.asarray(y), wcs_pix[:, 1])
 
 pars = [
-    ('TAN', projections.Pix2Sky_TAN, {}),
-    ('STG', projections.Pix2Sky_STG, {}),
-    ('SIN', projections.Pix2Sky_SIN, {}),
-    ('CEA', projections.Pix2Sky_CEA, {}),
-    ('CAR', projections.Pix2Sky_CAR, {}),
-    ('MER', projections.Pix2Sky_MER, {}),
+    ('TAN', projections.Pix2Sky_Gnomonic, {}),
+    ('STG', projections.Pix2Sky_Stereographic, {}),
+    ('SIN', projections.Pix2Sky_SlantOrthographic, {}),
+    ('CEA', projections.Pix2Sky_CylindricalEqualArea, {}),
+    ('CAR', projections.Pix2Sky_PlateCarree, {}),
+    ('MER', projections.Pix2Sky_Mercator, {}),
 ]
 
 
@@ -85,8 +85,8 @@ def test_Pix2Sky(ID, model, args):
     utils.assert_almost_equal(np.asarray(theta), wcs_theta)
 
 
-class TestAZP(object):
-    """Test AZP projection"""
+class TestZenithalPerspective(object):
+    """Test Zenithal Perspective projection"""
 
     def setup_class(self):
         ID = 'AZP'
@@ -99,8 +99,7 @@ class TestAZP(object):
         self.wazp.wcs.crval = np.array([0., 0.])
         self.wazp.wcs.cdelt = np.array([1., 1.])
         self.pv_kw = [kw[2] for kw in self.wazp.wcs.get_pv()]
-        proj = projections.__getattribute__("Pix2Sky_{0}".format(ID))
-        self.azp = proj(*self.pv_kw)
+        self.azp = projections.Pix2Sky_ZenithalPerspective(*self.pv_kw)
 
     def test_AZP_p2s(self):
         wcslibout = self.wazp.wcs.p2s([[-10, 30]], 1)
@@ -118,8 +117,8 @@ class TestAZP(object):
         utils.assert_almost_equal(np.asarray(y), wcs_pix[:, 1])
 
 
-class TestCYP(object):
-    """Test CYP projection"""
+class TestCylindricalPerspective(object):
+    """Test cylindrical perspective projection"""
 
     def setup_class(self):
         ID = "CYP"
@@ -132,8 +131,7 @@ class TestCYP(object):
         self.wazp.wcs.crval = np.array([0., 0.])
         self.wazp.wcs.cdelt = np.array([1., 1.])
         self.pv_kw = [kw[2] for kw in self.wazp.wcs.get_pv()]
-        proj = projections.__getattribute__("Pix2Sky_{0}".format(ID))
-        self.azp = proj(*self.pv_kw)
+        self.azp = projections.Pix2Sky_CylindricalPerspective(*self.pv_kw)
 
     def test_CYP_p2s(self):
         wcslibout = self.wazp.wcs.p2s([[-10, 30]], 1)


### PR DESCRIPTION
This is on top of #3581, which can go into a point release, but this can't (because it's deprecating a public API).