### PR TITLE
Fix ColDefs.change_ methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -291,6 +291,13 @@ Bug Fixes
     copying data from an existing FITS file to a new FITS table with a
     TDIMn keyword for that column. [#3561]
 
+  - The ``ColDefs.change_attrib``, ``ColDefs.change_name``, and
+    ``ColDefs.change_unit`` methods now work as advertised.  It is also
+    possible (and preferable) to update attributes directly on ``Column``
+    objects (for example setting ``column.name``), and the change will be
+    accurately reflected in any associated table data and its FITS header.
+    [#3283, #1539, #2618]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1141,8 +1141,6 @@ class ColDefs(NotifierMixin):
     def _init_from_table(self, table):
         hdr = table._header
         nfields = hdr['TFIELDS']
-        self._width = hdr['NAXIS1']
-        self._shape = hdr['NAXIS2']
 
         # go through header keywords to pick out column definition keywords
         # definition dictionaries for each field

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -368,7 +368,7 @@ class Column(object):
         name : str, optional
             column name, corresponding to ``TTYPE`` keyword
 
-        format : str, optional
+        format : str
             column format, corresponding to ``TFORM`` keyword
 
         unit : str, optional

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -12,12 +12,13 @@ from functools import reduce
 import numpy as np
 from numpy import char as chararray
 
-from .card import Card
-from .util import pairwise, _is_int, _convert_array, encode_ascii, cmp
+from .card import Card, CARD_LENGTH
+from .util import (pairwise, _is_int, _convert_array, encode_ascii, cmp,
+                   NotifierMixin)
 from .verify import VerifyError, VerifyWarning
 
 from ...extern.six import string_types, iteritems
-from ...utils import lazyproperty, isiterable, indent
+from ...utils import lazyproperty, isiterable, indent, OrderedDict
 from ...utils.compat import ignored
 
 
@@ -84,6 +85,19 @@ KEYWORD_ATTRIBUTES = ['name', 'format', 'unit', 'null', 'bscale', 'bzero',
                       'disp', 'start', 'dim']
 """This is a list of the attributes that can be set on `Column` objects."""
 
+
+KEYWORD_TO_ATTRIBUTE = \
+    OrderedDict((keyword, attr)
+                for keyword, attr in zip(KEYWORD_NAMES, KEYWORD_ATTRIBUTES))
+
+
+ATTRIBUTE_TO_KEYWORD = \
+    OrderedDict((value, key)
+                for key, value in KEYWORD_TO_ATTRIBUTE.items())
+
+
+# TODO: Define a list of default comments to associate with each table keyword
+
 # TFORMn regular expression
 TFORMAT_RE = re.compile(r'(?P<repeat>^[0-9]*)(?P<format>[LXBIJKAEDCMPQ])'
                         r'(?P<option>[!-~]*)', re.I)
@@ -95,6 +109,12 @@ TFORMAT_ASCII_RE = re.compile(r'(?:(?P<format>[AIJ])(?P<width>[0-9]+)?)|'
                               r'(?:(?P<formatf>[FED])'
                               r'(?:(?P<widthf>[0-9]+)\.'
                               r'(?P<precision>[0-9]+))?)')
+
+TTYPE_RE = re.compile(r'[0-9a-zA-Z_]+')
+"""
+Regular exprssion for valid table column names.  See FITS Standard v3.0 section
+7.2.2.
+"""
 
 # table definition keyword regular expression
 TDEF_RE = re.compile(r'(?P<label>^T[A-Z]*)(?P<num>[1-9][0-9 ]*$)')
@@ -350,7 +370,78 @@ class _FormatQ(_FormatP):
     _descriptor_format = '2i8'
 
 
-class Column(object):
+class ColumnAttribute(object):
+    """
+    Descriptor for attributes of `Column` that are associated with keywords
+    in the FITS header and describe properties of the column as specified in
+    the FITS standard.
+
+    Each `ColumnAttribute` may have a ``validator`` method defined on it.
+    This validates values set on this attribute to ensure that they meet the
+    FITS standard.  Invalid values will raise a warning and will not be used in
+    formatting the column.  The validator should take two arguments--the
+    `Column` it is being assigned to, and the new value for the attribute, and
+    it must raise an `AssertionError` if the value is invalid.
+
+    The `ColumnAttribute` itself is a decorator that can be used to define the
+    ``validator`` for each column attribute.  For example::
+
+        @ColumnAttribute('TTYPE')
+        def name(col, name):
+            assert isinstance(name, str)
+
+    The actual object returned by this decorator is the `ColumnAttribute`
+    instance though, not the ``name`` function.  As such ``name`` is not a
+    method of the class it is defined in.
+
+    The setter for `ColumnAttribute` also updates the header of any table
+    HDU this column is attached to in order to reflect the change.  The
+    ``validator`` should ensure that the value is valid for inclusion in a FITS
+    header.
+    """
+
+    def __init__(self, keyword):
+        self._keyword = keyword
+        self._validator = None
+
+        # The name of the attribute associated with this keyword is currently
+        # determined from the KEYWORD_NAMES/ATTRIBUTES lists.  This could be
+        # make more flexible in the future, for example, to support custom
+        # column attributes.
+        self._attr = KEYWORD_TO_ATTRIBUTE[self._keyword]
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        else:
+            return getattr(obj, '_' + self._attr)
+
+    def __set__(self, obj, value):
+        if self._validator is not None:
+            self._validator(obj, value)
+
+        old_value = getattr(obj, '_' + self._attr, None)
+        setattr(obj, '_' + self._attr, value)
+        obj._notify('column_attribute_changed', obj, self._attr, old_value,
+                    value)
+
+    def __call__(self, func):
+        """
+        Set the validator for this column attribute.
+
+        Returns ``self`` so that this can be used as a decorator, as described
+        in the docs for this class.
+        """
+
+        self._validator = func
+
+        return self
+
+    def __repr__(self):
+        return "{0}('{1}')".format(self.__class__.__name__, self._keyword)
+
+
+class Column(NotifierMixin):
     """
     Class which contains the definition of one column, e.g.  ``ttype``,
     ``tform``, etc. and the array containing values for the column.
@@ -431,7 +522,6 @@ class Column(object):
                 msg.append(indent(val[1]))
 
             raise VerifyError('\n'.join(msg))
-
 
         for attr in KEYWORD_ATTRIBUTES:
             setattr(self, attr, valid_kwargs.get(attr))
@@ -523,6 +613,40 @@ class Column(object):
         """
 
         return hash((self.name.lower(), self.format))
+
+    @ColumnAttribute('TTYPE')
+    def name(col, name):
+        if name is None:
+            # Allow None to indicate deleting the name, or to just indicate an
+            # unspecified name (when creating a new Column).
+            return
+
+        # Check that the name meets the recommended standard--other column
+        # names are *allowed*, but will be discouraged
+        if isinstance(name, string_types) and not TTYPE_RE.match(name):
+            warnings.warn(
+                'It is strongly recommended that column names contain only '
+                'upper and lower-case ASCII letters, digits, or underscores '
+                'for maximum compatibility with other software '
+                '(got {0!r}).'.format(name), VerifyWarning)
+
+        # This ensures that the new name can fit into a single FITS card
+        # without any special extension like CONTINUE cards or the like.
+        assert (isinstance(name, string_types) and
+                len(str(Card('TTYPE', name))) == CARD_LENGTH), \
+                    ('Column name must be a string able to fit in a single '
+                     'FITS card--typically this means a maximum of 68 '
+                     'characters, though it may be fewer if the string '
+                     'contains special characters like quotes.')
+
+    format = ColumnAttribute('TFORM')
+    unit = ColumnAttribute('TUNIT')
+    null = ColumnAttribute('TNULL')
+    bscale = ColumnAttribute('TSCAL')
+    bzero = ColumnAttribute('TZERO')
+    disp = ColumnAttribute('TDISP')
+    start = ColumnAttribute('TBCOL')
+    dim = ColumnAttribute('TDIM')
 
     @lazyproperty
     def dtype(self):
@@ -868,7 +992,7 @@ class Column(object):
                 return _convert_array(array, dtype)
 
 
-class ColDefs(object):
+class ColDefs(NotifierMixin):
     """
     Column definitions class.
 
@@ -959,6 +1083,10 @@ class ColDefs(object):
             raise TypeError('Input to ColDefs must be a table HDU, a list '
                             'of Columns, or a record/field array.')
 
+        # Listen for changes on all columns
+        for col in self.columns:
+            col._add_listener(self)
+
     def _init_from_coldefs(self, coldefs):
         """Initialize from an existing ColDefs object (just copy the
         columns and convert their formats if necessary).
@@ -1025,8 +1153,7 @@ class ColDefs(object):
             if keyword in KEYWORD_NAMES:
                 col = int(key.group('num'))
                 if col <= nfields and col > 0:
-                    idx = KEYWORD_NAMES.index(keyword)
-                    attr = KEYWORD_ATTRIBUTES[idx]
+                    attr = KEYWORD_TO_ATTRIBUTE[keyword]
                     if attr == 'format':
                         # Go ahead and convert the format value to the
                         # appropriate ColumnFormat container now
@@ -1054,7 +1181,11 @@ class ColDefs(object):
 
         # now build the columns
         self.columns = [Column(**attrs) for attrs in col_keywords]
-        self._listener = weakref.proxy(table)
+
+        # Add the table HDU is a listener to changes to the columns
+        # (either changes to individual columns, or changes to the set of
+        # columns (add/remove/etc.))
+        self._add_listener(table)
 
     def __copy__(self):
         return self.__class__(self)
@@ -1203,14 +1334,25 @@ class ColDefs(object):
         tmp = [self[i] for i in indx]
         return ColDefs(tmp)
 
-    def _update_listener(self):
-        if hasattr(self, '_listener'):
-            try:
-                if self._listener._data_loaded:
-                    del self._listener.data
-                self._listener.columns = self
-            except ReferenceError:
-                del self._listener
+    def _update_column_attribute_changed(self, column, attr, old_value,
+                                         new_value):
+        """
+        Handle column attribute changed notifications from columns that are
+        members of this `ColDefs`.
+
+        `ColDefs` itself does not currently do anything with this, and just
+        bubbles the notification up to any listening table HDUs that may need
+        to update their headers, etc.  However, this also informs the table of
+        the numerical index of the column that changed.
+        """
+
+        idx = 0
+        for idx, col in enumerate(self.columns):
+            if col is column:
+                break
+
+        self._notify('column_attribute_changed', column, idx, attr, old_value,
+                     new_value)
 
     def add_col(self, column):
         """
@@ -1218,10 +1360,6 @@ class ColDefs(object):
         """
 
         assert isinstance(column, Column)
-
-        for cname in KEYWORD_ATTRIBUTES:
-            attr = getattr(self, cname + 's')
-            attr.append(getattr(column, cname))
 
         self._arrays.append(column.array)
         # Obliterate caches of certain things
@@ -1233,7 +1371,7 @@ class ColDefs(object):
 
         # If this ColDefs is being tracked by a Table, inform the
         # table that its data is now invalid.
-        self._update_listener()
+        self._notify('column_added', self, column)
         return self
 
     def del_col(self, col_name):
@@ -1246,10 +1384,6 @@ class ColDefs(object):
 
         indx = _get_index(self.names, col_name)
 
-        for cname in KEYWORD_ATTRIBUTES:
-            attr = getattr(self, cname + 's')
-            del attr[indx]
-
         del self._arrays[indx]
         # Obliterate caches of certain things
         del self.dtype
@@ -1258,9 +1392,11 @@ class ColDefs(object):
 
         del self.columns[indx]
 
-        # If this ColDefs is being tracked by a Table, inform the
-        # table that its data is now invalid.
-        self._update_listener()
+        # If this ColDefs is being tracked by a table HDU, inform the HDU (or
+        # any other listeners) that the column has been removed
+        # Just send a reference to self, and the index of the column that was
+        # removed
+        self._notify('column_removed', self, indx)
         return self
 
     def change_attrib(self, col_name, attrib, new_value):
@@ -1281,10 +1417,6 @@ class ColDefs(object):
 
         setattr(self[col_name], attrib, new_value)
 
-        # If this ColDefs is being tracked by a Table, inform the
-        # table that its data is now invalid.
-        self._update_listener()
-
     def change_name(self, col_name, new_name):
         """
         Change a `Column`'s name.
@@ -1303,10 +1435,6 @@ class ColDefs(object):
         else:
             self.change_attrib(col_name, 'name', new_name)
 
-        # If this ColDefs is being tracked by a Table, inform the
-        # table that its data is now invalid.
-        self._update_listener()
-
     def change_unit(self, col_name, new_unit):
         """
         Change a `Column`'s unit.
@@ -1321,10 +1449,6 @@ class ColDefs(object):
         """
 
         self.change_attrib(col_name, 'unit', new_unit)
-
-        # If this ColDefs is being tracked by a Table, inform the
-        # table that its data is now invalid.
-        self._update_listener()
 
     def info(self, attrib='all', output=None):
         """
@@ -1456,6 +1580,9 @@ class _AsciiColDefs(ColDefs):
 
         self._spans = spans
         self._width = end_col
+
+
+# Utilities
 
 
 class _VLF(np.ndarray):

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1367,6 +1367,9 @@ class ColDefs(NotifierMixin):
 
         self.columns.append(column)
 
+        # Listen for changes on the new column
+        column._add_listener(self)
+
         # If this ColDefs is being tracked by a Table, inform the
         # table that its data is now invalid.
         self._notify('column_added', self, column)
@@ -1381,6 +1384,7 @@ class ColDefs(NotifierMixin):
         """
 
         indx = _get_index(self.names, col_name)
+        col = self.columns[indx]
 
         del self._arrays[indx]
         # Obliterate caches of certain things
@@ -1389,6 +1393,8 @@ class ColDefs(NotifierMixin):
         del self._dims
 
         del self.columns[indx]
+
+        col._remove_listener(self)
 
         # If this ColDefs is being tracked by a table HDU, inform the HDU (or
         # any other listeners) that the column has been removed

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1154,6 +1154,9 @@ class ColDefs(object):
         return [col._dims for col in self.columns]
 
     def __getitem__(self, key):
+        if isinstance(key, string_types):
+            key = _get_index(self.names, key)
+
         x = self.columns[key]
         if _is_int(key):
             return x
@@ -1509,9 +1512,9 @@ class _VLF(np.ndarray):
 
 def _get_index(names, key):
     """
-    Get the index of the `key` in the `names` list.
+    Get the index of the ``key`` in the ``names`` list.
 
-    The `key` can be an integer or string.  If integer, it is the index
+    The ``key`` can be an integer or string.  If integer, it is the index
     in the list.  If string,
 
         a. Field (column) names are case sensitive: you can have two

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1279,8 +1279,7 @@ class ColDefs(object):
             The new value for the attribute
         """
 
-        indx = _get_index(self.names, col_name)
-        getattr(self, attrib + 's')[indx] = new_value
+        setattr(self[col_name], attrib, new_value)
 
         # If this ColDefs is being tracked by a Table, inform the
         # table that its data is now invalid.

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -170,6 +170,14 @@ class _BaseColumnFormat(str):
     def __hash__(self):
         return hash(self.canonical)
 
+    @lazyproperty
+    def dtype(self):
+        """
+        The Numpy dtype object created from the format's associated recformat.
+        """
+
+        return np.dtype(self.recformat)
+
     @classmethod
     def from_column_format(cls, format):
         """Creates a column format object from another column format object
@@ -650,7 +658,7 @@ class Column(NotifierMixin):
 
     @lazyproperty
     def dtype(self):
-        return np.dtype(_convert_format(self.format))
+        return self.format.dtype
 
     def copy(self):
         """

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -88,7 +88,7 @@ class _File(object):
         memmap = True if memmap is None else memmap
 
         if fileobj is None:
-            self.__file = None
+            self._file = None
             self.closed = False
             self.binary = True
             self.mode = mode
@@ -133,7 +133,7 @@ class _File(object):
         self.readonly = False
         self.writeonly = False
 
-        # Initialize the internal self.__file object
+        # Initialize the internal self._file object
         if _is_random_access_file_backed(fileobj):
             self._open_fileobj(fileobj, mode, clobber)
         elif isinstance(fileobj, string_types):
@@ -141,7 +141,7 @@ class _File(object):
         else:
             self._open_filelike(fileobj, mode, clobber)
 
-        self.fileobj_mode = fileobj_mode(self.__file)
+        self.fileobj_mode = fileobj_mode(self._file)
 
         if isinstance(fileobj, (_astropy_gzip.GzipFile, _system_gzip.GzipFile)):
             self.compression = 'gzip'
@@ -159,18 +159,18 @@ class _File(object):
         # For 'ab+' mode, the pointer is at the end after the open in
         # Linux, but is at the beginning in Solaris.
         if (mode == 'ostream' or self.compression or
-            not hasattr(self.__file, 'seek')):
+            not hasattr(self._file, 'seek')):
             # For output stream start with a truncated file.
             # For compressed files we can't really guess at the size
             self.size = 0
         else:
-            pos = self.__file.tell()
-            self.__file.seek(0, 2)
-            self.size = self.__file.tell()
-            self.__file.seek(pos)
+            pos = self._file.tell()
+            self._file.seek(0, 2)
+            self.size = self._file.tell()
+            self._file.seek(pos)
 
         if self.memmap:
-            if not isfile(self.__file):
+            if not isfile(self._file):
                 self.memmap = False
             elif not self.readonly and not self._test_mmap():
                 # Test mmap.flush--see
@@ -179,7 +179,7 @@ class _File(object):
 
     def __repr__(self):
         return '<%s.%s %s>' % (self.__module__, self.__class__.__name__,
-                               self.__file)
+                               self._file)
 
     # Support the 'with' statement
     def __enter__(self):
@@ -191,13 +191,13 @@ class _File(object):
     def readable(self):
         if self.writeonly:
             return False
-        return isreadable(self.__file)
+        return isreadable(self._file)
 
     def read(self, size=None):
-        if not hasattr(self.__file, 'read'):
+        if not hasattr(self._file, 'read'):
             raise EOFError
         try:
-            return self.__file.read(size)
+            return self._file.read(size)
         except IOError:
             # On some versions of Python, it appears, GzipFile will raise an
             # IOError if you try to read past its end (as opposed to just
@@ -216,7 +216,7 @@ class _File(object):
         it's provided for compatibility.
         """
 
-        if not hasattr(self.__file, 'read'):
+        if not hasattr(self._file, 'read'):
             raise EOFError
 
         if not isinstance(dtype, np.dtype):
@@ -246,26 +246,26 @@ class _File(object):
             shape = (1,)
 
         if self.memmap:
-            return Memmap(self.__file, offset=offset,
+            return Memmap(self._file, offset=offset,
                           mode=MEMMAP_MODES[self.mode], dtype=dtype,
                           shape=shape).view(np.ndarray)
         else:
             count = reduce(lambda x, y: x * y, shape)
-            pos = self.__file.tell()
-            self.__file.seek(offset)
-            data = _array_from_file(self.__file, dtype, count, '')
+            pos = self._file.tell()
+            self._file.seek(offset)
+            data = _array_from_file(self._file, dtype, count, '')
             data.shape = shape
-            self.__file.seek(pos)
+            self._file.seek(pos)
             return data
 
     def writable(self):
         if self.readonly:
             return False
-        return iswritable(self.__file)
+        return iswritable(self._file)
 
     def write(self, string):
-        if hasattr(self.__file, 'write'):
-            _write_string(self.__file, string)
+        if hasattr(self._file, 'write'):
+            _write_string(self._file, string)
 
     def writearray(self, array):
         """
@@ -275,51 +275,51 @@ class _File(object):
         the file on disk reflects the data written.
         """
 
-        if hasattr(self.__file, 'write'):
-            _array_to_file(array, self.__file)
+        if hasattr(self._file, 'write'):
+            _array_to_file(array, self._file)
 
     def flush(self):
-        if hasattr(self.__file, 'flush'):
-            self.__file.flush()
+        if hasattr(self._file, 'flush'):
+            self._file.flush()
 
     def seek(self, offset, whence=0):
         # In newer Python versions, GzipFiles support the whence argument, but
         # I don't think it was added until 2.6; instead of assuming it's
         # present, we implement our own support for it here
-        if not hasattr(self.__file, 'seek'):
+        if not hasattr(self._file, 'seek'):
             return
-        if isinstance(self.__file, (_astropy_gzip.GzipFile, _system_gzip.GzipFile)):
+        if isinstance(self._file, (_astropy_gzip.GzipFile, _system_gzip.GzipFile)):
             if whence:
                 if whence == 1:
-                    offset = self.__file.offset + offset
+                    offset = self._file.offset + offset
                 else:
                     raise ValueError('Seek from end not supported')
-            self.__file.seek(offset)
+            self._file.seek(offset)
         else:
-            self.__file.seek(offset, whence)
+            self._file.seek(offset, whence)
 
-        pos = self.__file.tell()
+        pos = self._file.tell()
         if self.size and pos > self.size:
             warnings.warn('File may have been truncated: actual file length '
                           '(%i) is smaller than the expected size (%i)' %
                           (self.size, pos), AstropyUserWarning)
 
     def tell(self):
-        if not hasattr(self.__file, 'tell'):
+        if not hasattr(self._file, 'tell'):
             raise EOFError
-        return self.__file.tell()
+        return self._file.tell()
 
     def truncate(self, size=None):
-        if hasattr(self.__file, 'truncate'):
-            self.__file.truncate(size)
+        if hasattr(self._file, 'truncate'):
+            self._file.truncate(size)
 
     def close(self):
         """
         Close the 'physical' FITS file.
         """
 
-        if hasattr(self.__file, 'close'):
-            self.__file.close()
+        if hasattr(self._file, 'close'):
+            self._file.close()
 
         self.closed = True
 
@@ -366,16 +366,16 @@ class _File(object):
                 raise ValueError(
                     "Mode argument '%s' does not match mode of the input "
                     "file (%s)." % (mode, fmode))
-            self.__file = fileobj
+            self._file = fileobj
         elif isfile(fileobj):
-            self.__file = fileobj_open(self.name, PYFITS_MODES[mode])
+            self._file = fileobj_open(self.name, PYFITS_MODES[mode])
         else:
-            self.__file = _astropy_gzip.open(self.name, PYFITS_MODES[mode])
+            self._file = _astropy_gzip.open(self.name, PYFITS_MODES[mode])
 
         if fmode == 'ab+':
             # Return to the beginning of the file--in Python 3 when opening in
             # append mode the file pointer is at the end of the file
-            self.__file.seek(0)
+            self._file.seek(0)
 
     def _open_filelike(self, fileobj, mode, clobber):
         """Open a FITS file from a file-like object, i.e. one that has
@@ -383,7 +383,7 @@ class _File(object):
         """
 
         self.file_like = True
-        self.__file = fileobj
+        self._file = fileobj
 
         if fileobj_closed(fileobj):
             raise IOError("Cannot read from/write to a closed file-like "
@@ -391,15 +391,15 @@ class _File(object):
 
         if isinstance(fileobj, zipfile.ZipFile):
             self._open_zipfile(fileobj, mode)
-            self.__file.seek(0)
+            self._file.seek(0)
             # We can bypass any additional checks at this point since now
-            # self.__file points to the temp file extracted from the zip
+            # self._file points to the temp file extracted from the zip
             return
 
         # If there is not seek or tell methods then set the mode to
         # output streaming.
-        if (not hasattr(self.__file, 'seek') or
-            not hasattr(self.__file, 'tell')):
+        if (not hasattr(self._file, 'seek') or
+            not hasattr(self._file, 'tell')):
             self.mode = mode = 'ostream'
 
         if mode == 'ostream':
@@ -407,13 +407,13 @@ class _File(object):
 
         # Any "writeable" mode requires a write() method on the file object
         if (self.mode in ('update', 'append', 'ostream') and
-            not hasattr(self.__file, 'write')):
+            not hasattr(self._file, 'write')):
             raise IOError("File-like object does not have a 'write' "
                           "method, required for mode '%s'."
                           % self.mode)
 
         # Any mode except for 'ostream' requires readability
-        if self.mode != 'ostream' and not hasattr(self.__file, 'read'):
+        if self.mode != 'ostream' and not hasattr(self._file, 'read'):
             raise IOError("File-like object does not have a 'read' "
                           "method, required for mode %r."
                           % self.mode)
@@ -434,15 +434,15 @@ class _File(object):
 
         if ext == '.gz' or magic.startswith(GZIP_MAGIC):
             # Handle gzip files
-            self.__file = _astropy_gzip.open(self.name, PYFITS_MODES[mode])
+            self._file = _astropy_gzip.open(self.name, PYFITS_MODES[mode])
             self.compression = 'gzip'
         elif ext == '.zip' or magic.startswith(PKZIP_MAGIC):
             # Handle zip files
             self._open_zipfile(self.name, mode)
         else:
-            self.__file = fileobj_open(self.name, PYFITS_MODES[mode])
+            self._file = fileobj_open(self.name, PYFITS_MODES[mode])
             # Make certain we're back at the beginning of the file
-        self.__file.seek(0)
+        self._file.seek(0)
 
     def _test_mmap(self):
         """Tests that mmap, and specifically mmap.flush works.  This may
@@ -508,8 +508,8 @@ class _File(object):
         if len(namelist) != 1:
             raise IOError(
               "Zip files with multiple members are not supported.")
-        self.__file = tempfile.NamedTemporaryFile(suffix='.fits')
-        self.__file.write(zfile.read(namelist[0]))
+        self._file = tempfile.NamedTemporaryFile(suffix='.fits')
+        self._file.write(zfile.read(namelist[0]))
 
         if close:
             zfile.close()

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -591,6 +591,7 @@ class FITS_rec(np.recarray):
         # NOTE: The *column* index may not be the same as the field index in
         # the recarray, if the column is a phantom column
         col_indx = _get_index(self.columns.names, key)
+
         if self.columns[col_indx]._phantom:
             warnings.warn(
                 'Field %r has a repeat count of 0 in its format code, '

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -494,8 +494,6 @@ class FITS_rec(np.recarray):
             del dummy
 
             out._coldefs._arrays = arrays
-            out._coldefs._shape = len(arrays[0])
-
             return out
 
         # if not a slice, do this because Record has no __getstate__.

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -756,6 +756,15 @@ class _BaseHDU(object):
         self._data_size = datsize
         self._data_replaced = False
 
+    def _close(self, closed=True):
+        # If the data was mmap'd, close the underlying mmap (this will
+        # prevent any future access to the .data attribute if there are
+        # not other references to it; if there are other references then
+        # it is up to the user to clean those up
+        if (closed and self._data_loaded and
+                _get_array_mmap(self.data) is not None):
+            del self.data
+
 # For backwards-compatibility, though nobody should have
 # been using this directly:
 _AllHDU = _BaseHDU

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1663,7 +1663,6 @@ class CompImageHDU(BinTableHDU):
         self.compressed_data._coldefs = self.columns
         self.compressed_data._heapoffset = self._theap
         self.compressed_data._heapsize = heapsize
-        self.compressed_data.formats = self.columns.formats
 
     @deprecated('0.3', alternative='(refactor your code)')
     def updateCompressedData(self):

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -150,7 +150,7 @@ class GroupData(FITS_rec):
             if bitpix is None:
                 bitpix = _ImageBaseHDU.ImgCode[input.dtype.name]
 
-            fits_fmt = GroupsHDU._width2format[bitpix]  # -32 -> 'E'
+            fits_fmt = GroupsHDU._bitpix2tform[bitpix]  # -32 -> 'E'
             format = FITS2NUMPY[fits_fmt]  # 'E' -> 'f4'
             data_fmt = '%s%s' % (str(input.shape[1:]), format)
             formats = ','.join(([format] * npars) + [data_fmt])
@@ -169,19 +169,30 @@ class GroupData(FITS_rec):
                                                  formats=formats,
                                                  names=coldefs.names,
                                                  shape=gcount))
+
+            # By default the data field will just be 'DATA', but it may be
+            # uniquified if 'DATA' is already used by one of the group names
+            self._data_field = unique_parnames[-1]
+
             self._coldefs = coldefs
             self.parnames = parnames
 
             for idx, name in enumerate(unique_parnames[:-1]):
-                scale, zero = self._get_scale_factors(idx)[3:5]
+                column = coldefs[idx]
+                # Note: _get_scale_factors is used here and in other cases
+                # below to determine whether the column has non-default
+                # scale/zero factors.
+                # TODO: Find a better way to do this than using this interface
+                scale, zero = self._get_scale_factors(column)[3:5]
                 if scale or zero:
                     self._converted[name] = pardata[idx]
                 else:
                     np.rec.recarray.field(self, idx)[:] = pardata[idx]
 
-            scale, zero = self._get_scale_factors(npars)[3:5]
+            column = coldefs[self._data_field]
+            scale, zero = self._get_scale_factors(column)[3:5]
             if scale or zero:
-                self._converted['DATA'] = input
+                self._converted[self._data_field] = input
             else:
                 np.rec.recarray.field(self, npars)[:] = input
         else:
@@ -245,16 +256,17 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     details on working with this type of HDU.
     """
 
-    _width2format = {8: 'B', 16: 'I', 32: 'J', 64: 'K', -32: 'E', -64: 'D'}
+    _bitpix2tform = {8: 'B', 16: 'I', 32: 'J', 64: 'K', -32: 'E', -64: 'D'}
     _data_type = GroupData
+    _data_field = 'DATA'
+    """
+    The name of the table record array field that will contain the group data
+    for each group; 'DATA' by default, but may be preceded by any number of
+    underscores if 'DATA' is already a parameter name
+    """
 
     def __init__(self, data=None, header=None):
         super(GroupsHDU, self).__init__(data=data, header=header)
-
-        # The name of the table record array field that will contain the group
-        # data for each group; 'data' by default, but may be preceded by any
-        # number of underscores if 'data' is already a parameter name
-        self._data_field = 'DATA'
 
         # Update the axes; GROUPS HDUs should always have at least one axis
         if len(self._axes) <= 0:
@@ -295,37 +307,41 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         if self._has_data and hasattr(self.data, '_coldefs'):
             return self.data._coldefs
 
-        format = self._width2format[self._header['BITPIX']]
+        format = self._bitpix2tform[self._header['BITPIX']]
         pcount = self._header['PCOUNT']
         parnames = []
         bscales = []
         bzeros = []
 
         for idx in range(pcount):
-            bscales.append(self._header.get('PSCAL' + str(idx + 1), 1))
-            bzeros.append(self._header.get('PZERO' + str(idx + 1), 0))
+            bscales.append(self._header.get('PSCAL' + str(idx + 1), None))
+            bzeros.append(self._header.get('PZERO' + str(idx + 1), None))
             parnames.append(self._header['PTYPE' + str(idx + 1)])
+
+        formats = [format] * len(parnames)
+        dim = [None] * len(parnames)
 
         # Now create columns from collected parameters, but first add the DATA
         # column too, to contain the group data.
-        formats = [format] * len(parnames)
         parnames.append('DATA')
-        bscales.append(self._header.get('BSCALE', 1))
-        bzeros.append(self._header.get('BZEROS', 0))
+        bscales.append(self._header.get('BSCALE'))
+        bzeros.append(self._header.get('BZEROS'))
         data_shape = self.shape[:-1]
-        formats.append(str(int(np.array(data_shape).sum())) + format)
+        formats.append(str(int(np.prod(data_shape))) + format)
+        dim.append(data_shape)
         parnames = _unique_parnames(parnames)
+
         self._data_field = parnames[-1]
 
-        cols = [Column(name=name, format=fmt, bscale=bscale, bzero=bzero)
-                for name, fmt, bscale, bzero in
-                zip(parnames, formats, bscales, bzeros)]
+        cols = [Column(name=name, format=fmt, bscale=bscale, bzero=bzero,
+                       dim=dim)
+                for name, fmt, bscale, bzero, dim in
+                zip(parnames, formats, bscales, bzeros, dim)]
 
         coldefs = ColDefs(cols)
         # TODO: Something has to be done about this spaghetti code of arbitrary
         # attributes getting tacked on to the coldefs here.
         coldefs._shape = self._header['GCOUNT']
-        coldefs._dat_format = FITS2NUMPY[format]
         return coldefs
 
     @lazyproperty
@@ -394,22 +410,22 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                              after='NAXIS' + str(len(self._axes)))
             self._header.set('PCOUNT', len(self.data.parnames), after='GROUPS')
             self._header.set('GCOUNT', len(self.data), after='PCOUNT')
-            npars = len(self.data.parnames)
-            scale, zero = self.data._get_scale_factors(npars)[3:5]
+
+            column = self.data._coldefs[self.data._data_field]
+            scale, zero = self.data._get_scale_factors(column)[3:5]
             if scale:
-                self._header.set('BSCALE', self.data._coldefs.bscales[npars])
+                self._header.set('BSCALE', column.bscale)
             if zero:
-                self._header.set('BZERO', self.data._coldefs.bzeros[npars])
-            for idx in range(npars):
-                self._header.set('PTYPE' + str(idx + 1),
-                                 self.data.parnames[idx])
-                scale, zero = self.data._get_scale_factors(idx)[3:5]
+                self._header.set('BZERO', column.bzero)
+
+            for idx, name in enumerate(self.data.parnames):
+                self._header.set('PTYPE' + str(idx + 1), name)
+                column = self.data._coldefs[idx]
+                scale, zero = self.data._get_scale_factors(column)[3:5]
                 if scale:
-                    self._header.set('PSCAL' + str(idx + 1),
-                                     self.data._coldefs.bscales[idx])
+                    self._header.set('PSCAL' + str(idx + 1), column.bscale)
                 if zero:
-                    self._header.set('PZERO' + str(idx + 1),
-                                     self.data._coldefs.bzeros[idx])
+                    self._header.set('PZERO' + str(idx + 1), column.bzero)
 
         # Update the position of the EXTEND keyword if it already exists
         if 'EXTEND' in self._header:
@@ -418,14 +434,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
             else:
                 after = 'NAXIS'
             self._header.set('EXTEND', after=after)
-
-    def _get_tbdata(self):
-        # get the right shape for the data part of the random group,
-        # since binary table does not support ND yet
-        self.columns._recformats[-1] = (repr(self.shape[:-1]) +
-                                        self.columns._dat_format)
-
-        return super(GroupsHDU, self)._get_tbdata()
 
     def _writedata_internal(self, fileobj):
         """

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -277,7 +277,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
         data = self._get_tbdata()
         data._coldefs = self.columns
-        data.formats = self.columns.formats
         data.parnames = self.parnames
         del self.columns
         return data

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -172,16 +172,16 @@ class GroupData(FITS_rec):
             self._coldefs = coldefs
             self.parnames = parnames
 
-            for idx in range(npars):
+            for idx, name in enumerate(unique_parnames[:-1]):
                 scale, zero = self._get_scale_factors(idx)[3:5]
                 if scale or zero:
-                    self._convert[idx] = pardata[idx]
+                    self._converted[name] = pardata[idx]
                 else:
                     np.rec.recarray.field(self, idx)[:] = pardata[idx]
 
             scale, zero = self._get_scale_factors(npars)[3:5]
             if scale or zero:
-                self._convert[npars] = input
+                self._converted['DATA'] = input
             else:
                 np.rec.recarray.field(self, npars)[:] = input
         else:

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -339,10 +339,16 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                 zip(parnames, formats, bscales, bzeros, dim)]
 
         coldefs = ColDefs(cols)
-        # TODO: Something has to be done about this spaghetti code of arbitrary
-        # attributes getting tacked on to the coldefs here.
-        coldefs._shape = self._header['GCOUNT']
         return coldefs
+
+    @property
+    def _nrows(self):
+        if not self._data_loaded:
+            # The number of 'groups' equates to the number of rows in the table
+            # representation of the data
+            return self._header.get('GCOUNT', 0)
+        else:
+            return len(self.data)
 
     @lazyproperty
     def _theap(self):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -712,6 +712,10 @@ class HDUList(list, _Verify):
             if closed and hasattr(self._file, 'close'):
                 self._file.close()
 
+        # Give individual HDUs an opportunity to do on-close cleanup
+        for hdu in self:
+            hdu._close(closed=closed)
+
     def info(self, output=None):
         """
         Summarize the info of the HDUs in this `HDUList`.

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -349,7 +349,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     def data(self):
         data = self._get_tbdata()
         data._coldefs = self.columns
-        data.formats = self.columns.formats
         # Columns should now just return a reference to the data._coldefs
         del self.columns
         return data

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1237,6 +1237,9 @@ class BinTableHDU(_TableBaseHDU):
         # new_table() could use a similar feature.
         hdu = BinTableHDU.from_columns(np.recarray(shape=1, dtype=dtype),
                                        nrows=nrows, fill=True)
+
+        # TODO: It seems to me a lot of this could/should be handled from
+        # within the FITS_rec class rather than here.
         data = hdu.data
         for idx, length in enumerate(vla_lengths):
             if length is not None:
@@ -1249,7 +1252,8 @@ class BinTableHDU(_TableBaseHDU):
                 # warning that this is not supported.
                 recformats[idx] = _FormatP(dt, max=length)
                 data.columns._recformats[idx] = recformats[idx]
-                data._convert[idx] = _makep(arr, arr, recformats[idx])
+                name = data.columns.names[idx]
+                data._converted[name] = _makep(arr, arr, recformats[idx])
 
         def format_value(col, val):
             # Special formatting for a couple particular data types

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -176,10 +176,9 @@ class _TableLikeHDU(_ValidHDU):
         # pass the attributes
         fidx = 0
         for idx in range(len(columns)):
-            if not columns[idx]._phantom:
-                # get the data for each column object from the rec.recarray
-                columns[idx].array = data.field(fidx)
-                fidx += 1
+            # get the data for each column object from the rec.recarray
+            columns[idx].array = data.field(fidx)
+            fidx += 1
 
         # delete the _arrays attribute so that it is recreated to point to the
         # new data placed in the column object above
@@ -639,8 +638,7 @@ class TableHDU(_TableBaseHDU):
 
     def _get_tbdata(self):
         columns = self.columns
-        names = [n for idx, n in enumerate(columns.names)
-                 if not columns[idx]._phantom]
+        names = [n for idx, n in enumerate(columns.names)]
 
         # determine if there are duplicate field names and if there
         # are throw an exception

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -353,7 +353,7 @@ class TestChecksumFunctions(FitsTestCase):
         with fits.open(self.temp('checksum.fits')) as hdul:
             assert 'CHECKSUM' in hdul[1].header
             assert 'DATASUM' in hdul[1].header
-            assert (data == hdul[1].data).all()
+            assert comparerecords(data, hdul[1].data)
 
     def test_open_update_mode_update_checksum(self):
         """

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -859,7 +859,7 @@ class TestCompressedImage(FitsTestCase):
         """
 
         hdu = fits.CompImageHDU()
-        hdu.data is None
+        assert hdu.data is None
         hdu.writeto(self.temp('test.fits'))
 
         with fits.open(self.temp('test.fits'), mode='update') as hdul:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2514,3 +2514,14 @@ class TestColumnFunctions(FitsTestCase):
             zwc_pd = pickle.dumps(zwc[2].data)
             zwc_pl = pickle.loads(zwc_pd)
             assert comparerecords(zwc_pl, zwc[2].data)
+
+    def test_column_lookup_by_name(self):
+        """Tests that a `ColDefs` can be indexed by column name."""
+
+        a = fits.Column(name='a', format='D')
+        b = fits.Column(name='b', format='D')
+
+        cols = fits.ColDefs([a, b])
+
+        assert cols['a'] == cols[0]
+        assert cols['b'] == cols[1]

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1789,9 +1789,10 @@ class TestTableFunctions(FitsTestCase):
         s4 = data[:1]
         for s in [s1, s2, s3, s4]:
             assert isinstance(s, fits.FITS_rec)
-        assert (s1 == s2).all()
-        assert (s2 == s3).all()
-        assert (s3 == s4).all()
+
+        assert comparerecords(s1, s2)
+        assert comparerecords(s2, s3)
+        assert comparerecords(s3, s4)
 
     def test_array_broadcasting(self):
         """
@@ -1824,9 +1825,9 @@ class TestTableFunctions(FitsTestCase):
         s4 = data[:1]
         for s in [s1, s2, s3, s4]:
             assert isinstance(s, fits.FITS_rec)
-        assert (s1 == s2).all()
-        assert (s2 == s3).all()
-        assert (s3 == s4).all()
+        assert comparerecords(s1, s2)
+        assert comparerecords(s2, s3)
+        assert comparerecords(s3, s4)
 
     def test_dump_load_round_trip(self):
         """
@@ -2527,3 +2528,53 @@ class TestColumnFunctions(FitsTestCase):
 
         assert cols['a'] == cols[0]
         assert cols['b'] == cols[1]
+
+    def test_column_attribute_change_after_removal(self):
+        """
+        This is a test of the column attribute change notification system.
+
+        After a column has been removed from a table (but other references
+        are kept to that same column) changes to that column's attributes
+        should not trigger a notification on the table it was removed from.
+        """
+
+        # One way we can check this is to ensure there are no further changes
+        # to the header
+        table = fits.BinTableHDU.from_columns([
+            fits.Column('a', format='D'),
+            fits.Column('b', format='D')])
+
+        b = table.columns['b']
+
+        table.columns.del_col('b')
+        assert table.data.dtype.names == ('a',)
+
+        b.name = 'HELLO'
+
+        assert b.name == 'HELLO'
+        assert 'TTYPE2' not in table.header
+        assert table.header['TTYPE1'] == 'a'
+        assert table.columns.names == ['a']
+
+        with pytest.raises(KeyError):
+            table.columns['b']
+
+        # Make sure updates to the remaining column still work
+        table.columns.change_name('a', 'GOODBYE')
+        with pytest.raises(KeyError):
+            table.columns['a']
+
+        assert table.columns['GOODBYE'].name == 'GOODBYE'
+        assert table.data.dtype.names == ('GOODBYE',)
+        assert table.columns.names == ['GOODBYE']
+        assert table.data.columns.names == ['GOODBYE']
+
+        table.columns['GOODBYE'].name = 'foo'
+        with pytest.raises(KeyError):
+            table.columns['GOODBYE']
+
+        assert table.columns['foo'].name == 'foo'
+        assert table.data.dtype.names == ('foo',)
+        assert table.columns.names == ['foo']
+        assert table.data.columns.names == ['foo']
+

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1529,6 +1529,7 @@ class TestTableFunctions(FitsTestCase):
         # The ORBPARM column should not be in the data, though the data should
         # be readable
         assert 'ORBPARM' in tbhdu.data.names
+        assert 'ORBPARM' in tbhdu.data.dtype.names
         # Verify that some of the data columns are still correctly accessible
         # by name
         assert tbhdu.data[0]['ANNAME'] == 'VLA:_W16'
@@ -1552,6 +1553,7 @@ class TestTableFunctions(FitsTestCase):
         # Verify that the previous tests still hold after writing
         assert 'ORBPARM' in tbhdu.columns.names
         assert 'ORBPARM' in tbhdu.data.names
+        assert 'ORBPARM' in tbhdu.data.dtype.names
         assert tbhdu.data[0]['ANNAME'] == 'VLA:_W16'
         assert comparefloats(
             tbhdu.data[0]['STABXYZ'],

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -45,5 +45,37 @@ def _monkeypatch_unicode_mask_fill_values():
         ma_core._check_fill_value = _check_fill_value
 
 
+def _register_patched_dtype_reduce():
+    """
+    Numpy < 1.7 has a bug when copying/pickling dtype objects with a
+    zero-width void type--i.e. ``np.dtype('V0')``.  Specifically, although
+    creating a void type is perfectly valid, it crashes when instantiating
+    a dtype using a format string of 'V0', which is what is normally returned
+    by dtype.__reduce__() for these dtypes.
+
+    See https://github.com/astropy/astropy/pull/3283#issuecomment-81667461
+    """
+
+    if NUMPY_LT_1_7:
+        import numpy as np
+        import copy_reg
+
+        # Originally this created an alternate constructor that fixed this
+        # issue, and returned that constructor from the new reduce_dtype;
+        # however that broke pickling since functions can't be pickled, so now
+        # we fix the issue directly within the custom __reduce__
+
+        def reduce_dtype(obj):
+            info = obj.__reduce__()
+            args = info[1]
+            if args[0] == 'V0':
+                args = ('V',) + args[1:]
+                info = (info[0], args) + info[2:]
+            return info
+
+        copy_reg.pickle(np.dtype, reduce_dtype)
+
+
 if not _ASTROPY_SETUP_:
     _monkeypatch_unicode_mask_fill_values()
+    _register_patched_dtype_reduce()

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -16,6 +16,7 @@ py:class astropy.modeling.projections.Projection
 
 # astropy.io.fits
 py:class astropy.io.fits.hdu.base.ExtensionHDU
+py:class astropy.io.fits.util.NotifierMixin
 
 # astropy.utils
 py:class astropy.extern.six.Iterator


### PR DESCRIPTION
The old PyFITS `ColDefs` class for representing a set of table columns has three methods, [`change_attrib`](http://docs.astropy.org/en/stable/io/fits/api/tables.html#astropy.io.fits.ColDefs.change_attrib), [`change_name`](http://docs.astropy.org/en/stable/io/fits/api/tables.html#astropy.io.fits.ColDefs.change_name), and [`change_unit`](http://docs.astropy.org/en/stable/io/fits/api/tables.html#astropy.io.fits.ColDefs.change_unit) that I fairly frequently get questions about--these should be mentioned in the FAQ.

They never really worked properly because although they can change the column objects in-place, they don't actually change the data in the table which is confusing.  They're from a time before PyFITS really had a thought out data model (and it still doesn't really, especially not for tables).  Anyways, using these methods only results in confusion, as do some of the other `ColDefs` methods.  They should all be marked deprecated, and documentation provided for how to perform various tasks for updating FITS tables.  This can serve as a first step to replacing the FITS table interface entirely.

**UPDATE:** A mentioned in some of the comments below, instead of deprecating these I finally went ahead and tried to fix them instead.  My feeling about this used to be that it was too much trouble to fix within the current interface, and that instead it should wait until the table interface is completely redone to use Astropy Table, and then the whole thing could be scrapped.  But on further thought it wasn't all that hard to fix, and the approach I've taken I think will prove useful in transitioning to Astropy Tables as well.