### PR TITLE
Use converters in Quantity ufuncs instead of just scaling (closes #2496)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -285,6 +285,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Ensure equivalencies that do more than just scale a ``Quantity`` are
+    properly handled also in ``ufunc`` evaluations. [#2496, #3586]
+  
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -786,7 +786,7 @@ class UnitBase(object):
 
         return False
 
-    def _apply_equivalences(self, unit, other, equivalencies):
+    def _apply_equivalencies(self, unit, other, equivalencies):
         """
         Internal function (used from `_get_converter`) to apply
         equivalence pairs.
@@ -846,7 +846,7 @@ class UnitBase(object):
         try:
             scale = self._to(other)
         except UnitsError:
-            return self._apply_equivalences(
+            return self._apply_equivalencies(
                 self, other, self._normalize_equivalencies(equivalencies))
         return lambda val: scale * _condition_arg(val)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -292,23 +292,23 @@ class Quantity(np.ndarray):
         # should be multiplied before being passed to the ufunc, as well as
         # the unit the output from the ufunc will have.
         if function in UFUNC_HELPERS:
-            scales, result_unit = UFUNC_HELPERS[function](function, *units)
+            converters, result_unit = UFUNC_HELPERS[function](function, *units)
         else:
             raise TypeError("Unknown ufunc {0}.  Please raise issue on "
                             "https://github.com/astropy/astropy"
                             .format(function.__name__))
 
-        if any(scale == 0. for scale in scales):
+        if any(converter is False for converter in converters):
             # for two-argument ufuncs with a quantity and a non-quantity,
             # the quantity normally needs to be dimensionless, *except*
             # if the non-quantity can have arbitrary unit, i.e., when it
             # is all zero, infinity or NaN.  In that case, the non-quantity
             # can just have the unit of the quantity
             # (this allows, e.g., `q > 0.` independent of unit)
-            maybe_arbitrary_arg = args[scales.index(0.)]
+            maybe_arbitrary_arg = args[converters.index(False)]
             try:
                 if _can_have_arbitrary_unit(maybe_arbitrary_arg):
-                    scales = [None, None]
+                    converters = [None, None]
                 else:
                     raise UnitsError("Can only apply '{0}' function to "
                                      "dimensionless quantities when other "
@@ -364,8 +364,8 @@ class Quantity(np.ndarray):
             # the array is an integer the output then gets converted to an int
             # and truncated.
             result_dtype = np.result_type(*(args + tuple(
-                (float if scale is not None and scale % 1. != 0. else int)
-                for scale in scales)))
+                (float if converter is not None and converter(1.) % 1. != 0.
+                 else int) for converter in converters)))
             if not np.can_cast(result_dtype, obj.dtype):
                 raise TypeError("Arguments cannot be cast safely to inplace "
                                 "output with dtype={0}".format(self.dtype))
@@ -384,7 +384,7 @@ class Quantity(np.ndarray):
         # the issue is that we can't actually scale the inputs since that
         # would be changing the objects passed to the ufunc, which would not
         # be expected by the user.
-        if any(scales):
+        if any(converters):
 
             # If self is both output and input (which happens for in-place
             # operations), input will get overwritten with junk. To avoid
@@ -411,7 +411,7 @@ class Quantity(np.ndarray):
                     result._contiguous = self.copy()
 
             # ensure we remember the scales we need
-            result._scales = scales
+            result._converters = converters
 
         # unit output will get (setting _unit could prematurely change input
         # if obj is self, which happens for in-place operations; see above)
@@ -434,10 +434,10 @@ class Quantity(np.ndarray):
 
             # We now need to re-calculate quantities for which the input
             # needed to be scaled.
-            if hasattr(obj, '_scales'):
+            if hasattr(obj, '_converters'):
 
-                scales = obj._scales
-                del obj._scales
+                converters = obj._converters
+                del obj._converters
 
                 # For in-place operations, input will get overwritten with
                 # junk. To avoid that, we hid it in a new object in
@@ -458,19 +458,18 @@ class Quantity(np.ndarray):
 
                 # Set the inputs, rescaling as necessary
                 inputs = []
-                for arg, scale in zip(args, scales):
-                    if scale is not None:
-                        inputs.append(arg.value * scale)
-                    else:  # for scale==1, input is not necessarily a Quantity
+                for arg, converter in zip(args, converters):
+                    if converter is not None:
+                        inputs.append(converter(arg.value))
+                    else:  # with no conversion, input can be non-Quantity.
                         inputs.append(getattr(arg, 'value', arg))
 
                 # For output arrays that require scaling, we can reuse the
                 # output array to perform the scaling in place, as long as the
                 # array is not integral. Here, we set the obj_array to `None`
                 # when it can not be used to store the scaled result.
-                if(result_unit is not None and
-                   any(not np.can_cast(scaled_arg, obj_array.dtype)
-                       for scaled_arg in inputs)):
+                if not (result_unit is None or
+                        np.can_cast(np.result_type(*inputs), obj_array.dtype)):
                     obj_array = None
 
                 # Re-compute the output using the ufunc

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -364,8 +364,8 @@ class Quantity(np.ndarray):
             # the array is an integer the output then gets converted to an int
             # and truncated.
             result_dtype = np.result_type(*(args + tuple(
-                (float if converter is not None and converter(1.) % 1. != 0.
-                 else int) for converter in converters)))
+                (float if converter and converter(1.) % 1. != 0. else int)
+                for converter in converters)))
             if not np.can_cast(result_dtype, obj.dtype):
                 raise TypeError("Arguments cannot be cast safely to inplace "
                                 "output with dtype={0}".format(self.dtype))
@@ -459,7 +459,7 @@ class Quantity(np.ndarray):
                 # Set the inputs, rescaling as necessary
                 inputs = []
                 for arg, converter in zip(args, converters):
-                    if converter is not None:
+                    if converter:
                         inputs.append(converter(arg.value))
                     else:  # with no conversion, input can be non-Quantity.
                         inputs.append(getattr(arg, 'value', arg))

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -20,7 +20,7 @@ def get_converter(from_unit, to_unit):
     try:
         scale = from_unit._to(to_unit)
     except UnitsError:
-        return from_unit._apply_equivalences(
+        return from_unit._apply_equivalencies(
                 from_unit, to_unit, get_current_unit_registry().equivalencies)
     if scale == 1.:
         return None

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -476,6 +476,14 @@ def test_equivalency_context():
     assert all(eq in set(eq_on) for eq in eq_off)
     assert set(eq_off) < set(eq_on)
 
+    # Check the equivalency manager also works in ufunc evaluations,
+    # not just using (wrong) scaling. [#2496]
+    l2v = u.doppler_optical(6000 * u.angstrom)
+    l1 = 6010 * u.angstrom
+    assert l1.to(u.km/u.s, equivalencies=l2v) > 100. * u.km / u.s
+    with u.set_enabled_equivalencies(l2v):
+        assert l1 > 100. * u.km / u.s
+        assert abs((l1 - 500. * u.km / u.s).to(u.angstrom)) < 1. * u.km/u.s
 
 def test_equivalency_context_manager():
     base_registry = u.get_current_unit_registry()
@@ -519,7 +527,6 @@ def test_temperature():
 
 
 def test_temperature_energy():
-    from ... import constants
     x = 1000 * u.K
     y = (x * constants.k_B).to(u.keV)
     assert_allclose(x.to(u.keV, u.temperature_energy()).value, y)


### PR DESCRIPTION
In `ufunc` evaluations, quantities are converted to the correct unit by multiplying with a constant.  This is correct in most cases, but not if an equivalency like `u.doppler` is in place, which can not be described by a single scale factor. As a result, with such equivalencies in place, the code is wrong (see #2496). Here, the `ufunc` mechanism is replaced such that instead of a constant scale factor, one uses an actual unit converter function -- this was in fact already used to calculate the scale factor, so should not lead to any slowdown.
cc @mdboom, @astrofrog
