### PR TITLE
Add handling of duplicate column names in different Table methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,10 @@ New Features
 
 - ``astropy.table``
 
+  - ``add_column()`` and ``add_columns()`` now have ``rename_duplicate``
+    option to rename new column(s) rather than raise exception when its name
+    already exists. [#3592]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1123,15 +1123,15 @@ class Table(object):
 
         Add second column named 'b' with rename_duplicate::
 
-        >>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
-        >>> col_b = Column(name='b', data=[1.1, 1.2, 1.3])
-        >>> t.add_column(col_b, rename_duplicate=True)
-        >>> print(t)
-        a   b   b_1
-        --- --- ---
-          1 0.1 1.1
-          2 0.2 1.2
-          3 0.3 1.3
+            >>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
+            >>> col_b = Column(name='b', data=[1.1, 1.2, 1.3])
+            >>> t.add_column(col_b, rename_duplicate=True)
+            >>> print(t)
+             a   b  b_1
+            --- --- ---
+              1 0.1 1.1
+              2 0.2 1.2
+              3 0.3 1.3
 
         To add several columns use add_columns.
         """
@@ -1207,7 +1207,7 @@ class Table(object):
             >>> col_c = Column(name='c', data=['x', 'y', 'z'])
             >>> t.add_columns([col_b, col_c], rename_duplicate=True)
             >>> print(t)
-            a   b   b_1 c
+             a   b  b_1  c
             --- --- --- ---
               1 0.1 1.1  x
               2 0.2 1.2  y

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1241,10 +1241,10 @@ class Table(object):
                     name = col_getattr(col, 'name')
                     if name in final_names:
                         i = 1
-                        newname = name+'_{0}'.format(i)
+                        newname = '{0}_{1}'.format(name, i)
                         while newname in final_names:
                             i += 1
-                            newname = name+'_{0}'.format(i)
+                            newname = '{0}_{1}'.format(name, i)
                         col_setattr(col, 'name', newname)
                         warnings.warn("Column '{0}' is renamed to '{1}'"
                                       .format(name, newname), AstropyUserWarning)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -15,7 +15,7 @@ from numpy import ma
 
 from .. import log
 from ..io import registry as io_registry
-from ..units import Quantity, Unit
+from ..units import Quantity
 from ..utils import OrderedDict, isiterable, deprecated, minversion
 from ..utils.console import color_print
 from ..utils.metadata import MetaData

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -6,7 +6,6 @@ from ..extern.six.moves import zip as izip
 from ..extern.six.moves import range as xrange
 
 import re
-import warnings
 
 from copy import deepcopy
 
@@ -19,7 +18,6 @@ from ..units import Quantity
 from ..utils import OrderedDict, isiterable, deprecated, minversion
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.exceptions import AstropyUserWarning
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -476,17 +476,25 @@ class TestAddColumns(SetupData):
         t.add_column(self.a)
         with pytest.raises(ValueError):
             t.add_column(table_types.Column(name='a', data=[0, 1, 2]))
+        t.add_column(table_types.Column(name='a', data=[0, 1, 2]),
+                     rename_duplicate=True)
         t.add_column(self.b)
         t.add_column(self.c)
-        assert t.colnames == ['a', 'b', 'c']
+        assert t.colnames == ['a', 'a_1', 'b', 'c']
+        t.add_column(table_types.Column(name='a', data=[0, 1, 2]),
+                     rename_duplicate=True)
+        assert t.colnames == ['a', 'a_1', 'b', 'c', 'a_2']
 
     def test_add_duplicate_columns(self, table_types):
         self._setup(table_types)
         t = table_types.Table([self.a, self.b, self.c])
         with pytest.raises(ValueError):
             t.add_columns([table_types.Column(name='a', data=[0, 1, 2]), table_types.Column(name='b', data=[0, 1, 2])])
+        t.add_columns([table_types.Column(name='a', data=[0, 1, 2]),
+                       table_types.Column(name='b', data=[0, 1, 2])],
+                      rename_duplicate=True)
         t.add_column(self.d)
-        assert t.colnames == ['a', 'b', 'c', 'd']
+        assert t.colnames == ['a', 'b', 'c', 'a_1', 'b_1', 'd']
 
 
 @pytest.mark.usefixtures('table_types')

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -485,12 +485,19 @@ class TestAddColumns(SetupData):
                      rename_duplicate=True)
         assert t.colnames == ['a', 'a_1', 'b', 'c', 'a_2']
 
+        # test adding column from a separate Table
         t1 = table_types.Table()
         t1.add_column(self.a)
         with pytest.raises(ValueError):
             t.add_column(t1['a'])
         t.add_column(t1['a'], rename_duplicate=True)
+
+        t1['a'][0] = 100  # Change original column
         assert t.colnames == ['a', 'a_1', 'b', 'c', 'a_2', 'a_3']
+        assert t1.colnames == ['a']
+
+        # Check new column didn't change (since name conflict forced a copy)
+        assert t['a_3'][0] == self.a[0]
 
     def test_add_duplicate_columns(self, table_types):
         self._setup(table_types)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -485,6 +485,13 @@ class TestAddColumns(SetupData):
                      rename_duplicate=True)
         assert t.colnames == ['a', 'a_1', 'b', 'c', 'a_2']
 
+        t1 = table_types.Table()
+        t1.add_column(self.a)
+        with pytest.raises(ValueError):
+            t.add_column(t1['a'])
+        t.add_column(t1['a'], rename_duplicate=True)
+        assert t.colnames == ['a', 'a_1', 'b', 'c', 'a_2', 'a_3']
+
     def test_add_duplicate_columns(self, table_types):
         self._setup(table_types)
         t = table_types.Table([self.a, self.b, self.c])


### PR DESCRIPTION
Adding a column to a table with an already existing name raises an exception:
```
>>> from astropy.table import Table, Column
>>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
>>> col_b = Column(name='b', data=[1.1, 1.2, 1.3])
>>> t.add_column(col_b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "astropy/table/table.py", line 1124, in add_column
    self.add_columns([col], [index])
  File "astropy/table/table.py", line 1199, in add_columns
    self._init_from_cols(newcols)
  File "astropy/table/table.py", line 534, in _init_from_cols
    self._update_table_from_cols(self, newcols)
  File "astropy/table/table.py", line 566, in _update_table_from_cols
    raise ValueError('Duplicate column names')
ValueError: Duplicate column names
```

``table.join()`` can deal with similar situations and renames the columns in the output table to have unique names. However it may be useful to have it as an option in ``add_column()`` as well, so it would work like this:

```
>>> from astropy.table import Table, Column
>>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
>>> col_b = Column(name='b', data=[1.1, 1.2, 1.3])
>>> t.add_column(col_b, unique_name=True)
>>> print(t)
 a   b  b_1
--- --- ---
  1 0.1 1.1
  2 0.2 1.2
  3 0.3 1.3
>>> t.add_column(col_b, unique_name=True)
>>> print(t)
 a   b  b_1 b_2
--- --- --- ---
  1 0.1 1.1 1.1
  2 0.2 1.2 1.2
  3 0.3 1.3 1.3
```

Please let me know what you think, and if it gets a green light I'll add the tests, some docs and changelog.

cc: @taldcroft 
