### PR TITLE
BUG Numpy dev version has different allclose

### DIFF
--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -11,7 +11,7 @@ Tests for the projected separation stuff
 import numpy as np
 from numpy import testing as npt
 
-from ...tests.helper import pytest
+from ...tests.helper import pytest, assert_quantity_allclose as assert_allclose
 from ... import units as u
 from ..builtin_frames import ICRS, FK5, Galactic
 from .. import Angle, Distance
@@ -74,7 +74,7 @@ def test_proj_separations():
     assert isinstance(sep, Angle)
 
     assert sep.degree == 1
-    npt.assert_allclose(sep.arcminute, 60.)
+    assert_allclose(sep.arcminute, 60.)
 
     # these operations have ambiguous interpretations for points on a sphere
     with pytest.raises(TypeError):
@@ -87,12 +87,12 @@ def test_proj_separations():
 
     # if there is a defined conversion between the relevant coordinate systems,
     # it will be automatically performed to get the right angular separation
-    npt.assert_allclose(ncp.separation(ngp.transform_to(ICRS)).degree,
-                        ncp.separation(ngp).degree)
+    assert_allclose(ncp.separation(ngp.transform_to(ICRS)).degree,
+                    ncp.separation(ngp).degree)
 
     # distance from the north galactic pole to celestial pole
-    npt.assert_allclose(ncp.separation(ngp.transform_to(ICRS)).degree,
-                        62.87174758503201)
+    assert_allclose(ncp.separation(ngp.transform_to(ICRS)).degree,
+                    62.87174758503201)
 
 
 def test_3d_separations():
@@ -105,4 +105,4 @@ def test_3d_separations():
     sep3d = c2.separation_3d(c1)
 
     assert isinstance(sep3d, Distance)
-    npt.assert_allclose(sep3d - 1*u.kpc, 0, atol=1e-12)
+    assert_allclose(sep3d - 1*u.kpc, 0*u.kpc, atol=1e-12*u.kpc)

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -6,7 +6,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ...tests.helper import pytest
+from ...tests.helper import pytest, assert_quantity_allclose as assert_allclose
 
 import numpy as np
 from numpy import testing as npt
@@ -243,13 +243,13 @@ def test_array_indexing():
     assert c2.dec.degree == -10
 
     c3 = c1[2:5]
-    npt.assert_allclose(c3.ra.degree, [80, 120, 160])
-    npt.assert_allclose(c3.dec.degree, [-50, -30, -10])
+    assert_allclose(c3.ra, [80, 120, 160] * u.deg)
+    assert_allclose(c3.dec, [-50, -30, -10] * u.deg)
 
     c4 = c1[np.array([2, 5, 8])]
 
-    npt.assert_allclose(c4.ra.degree, [80, 200, 320])
-    npt.assert_allclose(c4.dec.degree, [-50, 10, 70])
+    assert_allclose(c4.ra, [80, 200, 320] * u.deg)
+    assert_allclose(c4.dec, [-50, 10, 70] * u.deg)
 
     #now make sure the equinox is preserved
     assert c2.equinox == c1.equinox

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -5,11 +5,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from ... import units as u
-from ...tests.helper import pytest
-from ...extern import six
+from ...tests.helper import (pytest, quantity_allclose as allclose,
+                             assert_quantity_allclose as assert_allclose)
 from .. import representation
 
 NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
@@ -353,7 +352,7 @@ def test_sep():
     i4 = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg, distance=[4, 5]*u.kpc)
 
     sep3d = i3.separation_3d(i4)
-    assert_allclose(sep3d.to(u.kpc).value, np.array([1, 1]))
+    assert_allclose(sep3d.to(u.kpc), np.array([1, 1])*u.kpc)
 
 
 def test_time_inputs():
@@ -565,16 +564,16 @@ def test_eloc_attributes():
     # only along the z-axis), but latitude should not. Also, height is relative
     # to the *surface* in EarthLocation, but the ITRS distance is relative to
     # the center of the Earth
-    assert not np.allclose(el2.latitude, it.spherical.lat)
-    assert np.allclose(el2.longitude, it.spherical.lon)
+    assert not allclose(el2.latitude, it.spherical.lat)
+    assert allclose(el2.longitude, it.spherical.lon)
     assert el2.height < -6000*u.km
 
     el3 = AltAz(location=gc).location
     # GCRS inputs implicitly get transformed to ITRS and then onto
     # EarthLocation's elliptical geoid. So both lat and lon shouldn't match
     assert isinstance(el3, EarthLocation)
-    assert not np.allclose(el3.latitude, gc.dec)
-    assert not np.allclose(el3.longitude, gc.ra)
+    assert not allclose(el3.latitude, gc.dec)
+    assert not allclose(el3.longitude, gc.ra)
     assert np.abs(el3.height) < 500*u.km
 
 

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy import testing as npt
-from ...tests.helper import pytest
+from ...tests.helper import pytest, assert_quantity_allclose as assert_allclose
 
 from ... import units as u
 from ...utils import minversion
@@ -61,15 +61,15 @@ def test_matching_function_3d_and_sky():
     npt.assert_array_equal(idx, [2, 3])
 
 
-    npt.assert_allclose(d2d.degree, [1, 1.9])
+    assert_allclose(d2d, [1, 1.9] * u.deg)
     assert np.abs(d3d[0].to(u.kpc).value - np.radians(1)) < 1e-6
     assert np.abs(d3d[1].to(u.kpc).value - 5*np.radians(1.9)) < 1e-5
 
     idx, d2d, d3d = match_coordinates_sky(cmatch, ccatalog)
     npt.assert_array_equal(idx, [3, 1])
 
-    npt.assert_allclose(d2d.degree, [0, 0.1])
-    npt.assert_allclose(d3d.to(u.kpc).value, [4, 4.0000019])
+    assert_allclose(d2d, [0, 0.1] * u.deg)
+    assert_allclose(d3d, [4, 4.0000019] * u.kpc)
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
@@ -108,16 +108,16 @@ def test_matching_method():
     idx2, d2d2, d3d2 = match_coordinates_3d(cmatch, ccatalog)
 
     npt.assert_array_equal(idx1, idx2)
-    npt.assert_allclose(d2d1, d2d2)
-    npt.assert_allclose(d3d1, d3d2)
+    assert_allclose(d2d1, d2d2)
+    assert_allclose(d3d1, d3d2)
 
     #should be the same as above because there's no distance, but just make sure this method works
     idx1, d2d1, d3d1 = SkyCoord(cmatch).match_to_catalog_sky(ccatalog)
     idx2, d2d2, d3d2 = match_coordinates_sky(cmatch, ccatalog)
 
     npt.assert_array_equal(idx1, idx2)
-    npt.assert_allclose(d2d1, d2d2)
-    npt.assert_allclose(d3d1, d3d2)
+    assert_allclose(d2d1, d2d2)
+    assert_allclose(d3d1, d3d2)
 
     assert len(idx1) == len(d2d1) == len(d3d1) == 20
 
@@ -136,7 +136,7 @@ def test_search_around():
 
     assert list(zip(idx1_1deg, idx2_1deg)) == [(0, 2), (0, 3), (1, 1), (1, 2)]
     assert d2d_1deg[0] == 1.0*u.deg
-    npt.assert_allclose(d2d_1deg, [1, 0, .1, .9]*u.deg)
+    assert_allclose(d2d_1deg, [1, 0, .1, .9]*u.deg)
 
     assert list(zip(idx1_0p05deg, idx2_0p05deg)) == [(0, 3)]
 
@@ -145,7 +145,7 @@ def test_search_around():
 
     assert list(zip(idx1_1kpc, idx2_1kpc)) == [(0, 0), (0, 1), (0, 2), (1, 3)]
     assert list(zip(idx1_sm, idx2_sm)) == [(0, 1), (0, 2)]
-    npt.assert_allclose(d2d_sm, [2, 1]*u.deg)
+    assert_allclose(d2d_sm, [2, 1]*u.deg)
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -7,7 +7,7 @@ from io import StringIO
 import numpy as np
 
 from .. import core, funcs
-from ...tests.helper import pytest
+from ...tests.helper import pytest, quantity_allclose as allclose
 from ... import units as u
 
 try:
@@ -52,45 +52,45 @@ def test_init():
 
 def test_basic():
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=2.0, Neff=3.04, Ob0=0.05)
-    assert np.allclose(cosmo.Om0, 0.27)
-    assert np.allclose(cosmo.Ode0, 0.729975, rtol=1e-4)
-    assert np.allclose(cosmo.Ob0, 0.05)
-    assert np.allclose(cosmo.Odm0, 0.27 - 0.05)
+    assert allclose(cosmo.Om0, 0.27)
+    assert allclose(cosmo.Ode0, 0.729975, rtol=1e-4)
+    assert allclose(cosmo.Ob0, 0.05)
+    assert allclose(cosmo.Odm0, 0.27 - 0.05)
     # This next test will fail if astropy.const starts returning non-mks
     #  units by default; see the comment at the top of core.py
-    assert np.allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
-    assert np.allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
-    assert np.allclose(cosmo.Ok0, 0.0)
-    assert np.allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
-                       1.0, rtol=1e-6)
-    assert np.allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
-                       cosmo.Onu(1), 1.0, rtol=1e-6)
-    assert np.allclose(cosmo.Tcmb0.value, 2.0)
-    assert np.allclose(cosmo.Tnu0.value, 1.4275317, rtol=1e-5)
-    assert np.allclose(cosmo.Neff, 3.04)
-    assert np.allclose(cosmo.h, 0.7)
-    assert np.allclose(cosmo.H0.value, 70.0)
+    assert allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
+    assert allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
+    assert allclose(cosmo.Ok0, 0.0)
+    assert allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
+                    1.0, rtol=1e-6)
+    assert allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
+                    cosmo.Onu(1), 1.0, rtol=1e-6)
+    assert allclose(cosmo.Tcmb0, 2.0 * u.K)
+    assert allclose(cosmo.Tnu0, 1.4275317 * u.K, rtol=1e-5)
+    assert allclose(cosmo.Neff, 3.04)
+    assert allclose(cosmo.h, 0.7)
+    assert allclose(cosmo.H0, 70.0 * u.km / u.s / u.Mpc)
 
     # Make sure setting them as quantities gives the same results
     H0 = u.Quantity(70, u.km / (u.s * u.Mpc))
     T = u.Quantity(2.0, u.K)
     cosmo = core.FlatLambdaCDM(H0=H0, Om0=0.27, Tcmb0=T, Neff=3.04, Ob0=0.05)
-    assert np.allclose(cosmo.Om0, 0.27)
-    assert np.allclose(cosmo.Ode0, 0.729975, rtol=1e-4)
-    assert np.allclose(cosmo.Ob0, 0.05)
-    assert np.allclose(cosmo.Odm0, 0.27 - 0.05)
-    assert np.allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
-    assert np.allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
-    assert np.allclose(cosmo.Ok0, 0.0)
-    assert np.allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
+    assert allclose(cosmo.Om0, 0.27)
+    assert allclose(cosmo.Ode0, 0.729975, rtol=1e-4)
+    assert allclose(cosmo.Ob0, 0.05)
+    assert allclose(cosmo.Odm0, 0.27 - 0.05)
+    assert allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
+    assert allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
+    assert allclose(cosmo.Ok0, 0.0)
+    assert allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
                        1.0, rtol=1e-6)
-    assert np.allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
+    assert allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
                        cosmo.Onu(1), 1.0, rtol=1e-6)
-    assert np.allclose(cosmo.Tcmb0.value, 2.0)
-    assert np.allclose(cosmo.Tnu0.value, 1.4275317, rtol=1e-5)
-    assert np.allclose(cosmo.Neff, 3.04)
-    assert np.allclose(cosmo.h, 0.7)
-    assert np.allclose(cosmo.H0.value, 70.0)
+    assert allclose(cosmo.Tcmb0, 2.0 * u.K)
+    assert allclose(cosmo.Tnu0, 1.4275317 * u.K, rtol=1e-5)
+    assert allclose(cosmo.Neff, 3.04)
+    assert allclose(cosmo.h, 0.7)
+    assert allclose(cosmo.H0, 70.0 * u.km / u.s / u.Mpc)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -148,8 +148,8 @@ def test_distance_broadcast():
         assert value_3d.shape == z_reshape3d.shape
         assert value_flat.unit == value_2d.unit
         assert value_flat.unit == value_3d.unit
-        assert np.allclose(value_flat.value, value_2d.flatten().value)
-        assert np.allclose(value_flat.value, value_3d.flatten().value)
+        assert allclose(value_flat, value_2d.flatten())
+        assert allclose(value_flat, value_3d.flatten())
 
     # Also test unitless ones
     methods = ['absorption_distance', 'Om', 'Ode', 'Ok', 'H',
@@ -163,8 +163,8 @@ def test_distance_broadcast():
         assert value_2d.shape == z_reshape2d.shape
         value_3d = g(z_reshape3d)
         assert value_3d.shape == z_reshape3d.shape
-        assert np.allclose(value_flat, value_2d.flatten())
-        assert np.allclose(value_flat, value_3d.flatten())
+        assert allclose(value_flat, value_2d.flatten())
+        assert allclose(value_flat, value_3d.flatten())
 
     # Test some dark energy models
     methods = ['Om', 'Ode', 'w', 'de_density_scale']
@@ -182,8 +182,8 @@ def test_distance_broadcast():
             assert value_2d.shape == z_reshape2d.shape
             value_3d = g(z_reshape3d)
             assert value_3d.shape == z_reshape3d.shape
-            assert np.allclose(value_flat, value_2d.flatten())
-            assert np.allclose(value_flat, value_3d.flatten())
+            assert allclose(value_flat, value_2d.flatten())
+            assert allclose(value_flat, value_3d.flatten())
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -205,33 +205,33 @@ def test_clone():
     assert newclone.__class__ == cosmo.__class__
     assert newclone.name == cosmo.name
     assert not np.allclose(newclone.H0.value, cosmo.H0.value)
-    assert np.allclose(newclone.H0.value, 60.0)
-    assert np.allclose(newclone.Om0, cosmo.Om0)
-    assert np.allclose(newclone.Ok0, cosmo.Ok0)
+    assert allclose(newclone.H0, 60.0 * u.km / u.s / u.Mpc)
+    assert allclose(newclone.Om0, cosmo.Om0)
+    assert allclose(newclone.Ok0, cosmo.Ok0)
     assert not np.allclose(newclone.Ogamma0, cosmo.Ogamma0)
     assert not np.allclose(newclone.Onu0, cosmo.Onu0)
-    assert np.allclose(newclone.Tcmb0.value, cosmo.Tcmb0.value)
-    assert np.allclose(newclone.m_nu.value, cosmo.m_nu.value)
-    assert np.allclose(newclone.Neff, cosmo.Neff)
+    assert allclose(newclone.Tcmb0, cosmo.Tcmb0)
+    assert allclose(newclone.m_nu, cosmo.m_nu)
+    assert allclose(newclone.Neff, cosmo.Neff)
 
     # Compare modified version with directly instantiated one
     cmp = core.FlatLambdaCDM(H0=60 * u.km / u.s / u.Mpc, Om0=0.27,
                              Tcmb0=3.0 * u.K)
     assert newclone.__class__ == cmp.__class__
     assert newclone.name == cmp.name
-    assert np.allclose(newclone.H0.value, cmp.H0.value)
-    assert np.allclose(newclone.Om0, cmp.Om0)
-    assert np.allclose(newclone.Ode0, cmp.Ode0)
-    assert np.allclose(newclone.Ok0, cmp.Ok0)
-    assert np.allclose(newclone.Ogamma0, cmp.Ogamma0)
-    assert np.allclose(newclone.Onu0, cmp.Onu0)
-    assert np.allclose(newclone.Tcmb0, cmp.Tcmb0)
-    assert np.allclose(newclone.m_nu.value, cmp.m_nu.value)
-    assert np.allclose(newclone.Neff, cmp.Neff)
-    assert np.allclose(newclone.Om(z), cmp.Om(z))
-    assert np.allclose(newclone.H(z).value, cmp.H(z).value)
-    assert np.allclose(newclone.luminosity_distance(z).value,
-                       cmp.luminosity_distance(z).value)
+    assert allclose(newclone.H0, cmp.H0)
+    assert allclose(newclone.Om0, cmp.Om0)
+    assert allclose(newclone.Ode0, cmp.Ode0)
+    assert allclose(newclone.Ok0, cmp.Ok0)
+    assert allclose(newclone.Ogamma0, cmp.Ogamma0)
+    assert allclose(newclone.Onu0, cmp.Onu0)
+    assert allclose(newclone.Tcmb0, cmp.Tcmb0)
+    assert allclose(newclone.m_nu, cmp.m_nu)
+    assert allclose(newclone.Neff, cmp.Neff)
+    assert allclose(newclone.Om(z), cmp.Om(z))
+    assert allclose(newclone.H(z), cmp.H(z))
+    assert allclose(newclone.luminosity_distance(z),
+                             cmp.luminosity_distance(z))
 
     # Now try changing multiple things
     newclone = cosmo.clone(name="New name", H0=65 * u.km / u.s / u.Mpc,
@@ -239,34 +239,34 @@ def test_clone():
     assert newclone.__class__ == cosmo.__class__
     assert not newclone.name == cosmo.name
     assert not np.allclose(newclone.H0.value, cosmo.H0.value)
-    assert np.allclose(newclone.H0.value, 65.0)
-    assert np.allclose(newclone.Om0, cosmo.Om0)
-    assert np.allclose(newclone.Ok0, cosmo.Ok0)
+    assert allclose(newclone.H0, 65.0 * u.km / u.s / u.Mpc)
+    assert allclose(newclone.Om0, cosmo.Om0)
+    assert allclose(newclone.Ok0, cosmo.Ok0)
     assert not np.allclose(newclone.Ogamma0, cosmo.Ogamma0)
     assert not np.allclose(newclone.Onu0, cosmo.Onu0)
     assert not np.allclose(newclone.Tcmb0.value, cosmo.Tcmb0.value)
-    assert np.allclose(newclone.Tcmb0.value, 2.8)
-    assert np.allclose(newclone.m_nu.value, cosmo.m_nu.value)
-    assert np.allclose(newclone.Neff, cosmo.Neff)
+    assert allclose(newclone.Tcmb0, 2.8 * u.K)
+    assert allclose(newclone.m_nu, cosmo.m_nu)
+    assert allclose(newclone.Neff, cosmo.Neff)
 
     # And direct comparison
     cmp = core.FlatLambdaCDM(name="New name", H0=65 * u.km / u.s / u.Mpc,
                              Om0=0.27, Tcmb0=2.8 * u.K)
     assert newclone.__class__ == cmp.__class__
     assert newclone.name == cmp.name
-    assert np.allclose(newclone.H0.value, cmp.H0.value)
-    assert np.allclose(newclone.Om0, cmp.Om0)
-    assert np.allclose(newclone.Ode0, cmp.Ode0)
-    assert np.allclose(newclone.Ok0, cmp.Ok0)
-    assert np.allclose(newclone.Ogamma0, cmp.Ogamma0)
-    assert np.allclose(newclone.Onu0, cmp.Onu0)
-    assert np.allclose(newclone.Tcmb0, cmp.Tcmb0)
-    assert np.allclose(newclone.m_nu.value, cmp.m_nu.value)
-    assert np.allclose(newclone.Neff, cmp.Neff)
-    assert np.allclose(newclone.Om(z), cmp.Om(z))
-    assert np.allclose(newclone.H(z).value, cmp.H(z).value)
-    assert np.allclose(newclone.luminosity_distance(z).value,
-                       cmp.luminosity_distance(z).value)
+    assert allclose(newclone.H0, cmp.H0)
+    assert allclose(newclone.Om0, cmp.Om0)
+    assert allclose(newclone.Ode0, cmp.Ode0)
+    assert allclose(newclone.Ok0, cmp.Ok0)
+    assert allclose(newclone.Ogamma0, cmp.Ogamma0)
+    assert allclose(newclone.Onu0, cmp.Onu0)
+    assert allclose(newclone.Tcmb0, cmp.Tcmb0)
+    assert allclose(newclone.m_nu, cmp.m_nu)
+    assert allclose(newclone.Neff, cmp.Neff)
+    assert allclose(newclone.Om(z), cmp.Om(z))
+    assert allclose(newclone.H(z), cmp.H(z))
+    assert allclose(newclone.luminosity_distance(z),
+                             cmp.luminosity_distance(z))
 
     # Try a dark energy class, make sure it can handle w params
     cosmo = core.w0waCDM(name="test w0wa", H0=70 * u.km / u.s / u.Mpc,
@@ -274,14 +274,14 @@ def test_clone():
     newclone = cosmo.clone(w0=-1.1, wa=0.2)
     assert newclone.__class__ == cosmo.__class__
     assert newclone.name == cosmo.name
-    assert np.allclose(newclone.H0.value, cosmo.H0.value)
-    assert np.allclose(newclone.Om0, cosmo.Om0)
-    assert np.allclose(newclone.Ode0, cosmo.Ode0)
-    assert np.allclose(newclone.Ok0, cosmo.Ok0)
+    assert allclose(newclone.H0, cosmo.H0)
+    assert allclose(newclone.Om0, cosmo.Om0)
+    assert allclose(newclone.Ode0, cosmo.Ode0)
+    assert allclose(newclone.Ok0, cosmo.Ok0)
     assert not np.allclose(newclone.w0, cosmo.w0)
-    assert np.allclose(newclone.w0, -1.1)
+    assert allclose(newclone.w0, -1.1)
     assert not np.allclose(newclone.wa, cosmo.wa)
-    assert np.allclose(newclone.wa, 0.2)
+    assert allclose(newclone.wa, 0.2)
 
     # Now test exception if user passes non-parameter
     with pytest.raises(AttributeError):
@@ -364,29 +364,29 @@ def test_flat_z1():
     # iCosmos: http://www.icosmos.co.uk/index.html
 
     # The order of values below is Wright, Kempner, iCosmos'
-    assert np.allclose(cosmo.comoving_distance(z).value,
-                       [3364.5, 3364.8, 3364.7988], rtol=1e-4)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1682.3, 1682.4, 1682.3994], rtol=1e-4)
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [6729.2, 6729.6, 6729.5976], rtol=1e-4)
-    assert np.allclose(cosmo.lookback_time(z).value,
-                       [7.841, 7.84178, 7.843], rtol=1e-3)
-    assert np.allclose(cosmo.lookback_distance(z).value,
-                       [2404.0, 2404.24, 2404.4], rtol=1e-3)
+    assert allclose(cosmo.comoving_distance(z),
+                             [3364.5, 3364.8, 3364.7988] * u.Mpc, rtol=1e-4)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                             [1682.3, 1682.4, 1682.3994] * u.Mpc, rtol=1e-4)
+    assert allclose(cosmo.luminosity_distance(z),
+                             [6729.2, 6729.6, 6729.5976] * u.Mpc, rtol=1e-4)
+    assert allclose(cosmo.lookback_time(z),
+                             [7.841, 7.84178, 7.843] * u.Gyr, rtol=1e-3)
+    assert allclose(cosmo.lookback_distance(z),
+                             [2404.0, 2404.24, 2404.4] * u.Mpc, rtol=1e-3)
 
 
 def test_zeroing():
     """ Tests if setting params to 0s always respects that"""
     # Make sure Ode = 0 behaves that way
     cosmo = core.LambdaCDM(H0=70, Om0=0.27, Ode0=0.0)
-    assert np.allclose(cosmo.Ode([0, 1, 2, 3]), [0, 0, 0, 0])
+    assert allclose(cosmo.Ode([0, 1, 2, 3]), [0, 0, 0, 0])
     # Ogamma0
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=0.0)
-    assert np.allclose(cosmo.Ogamma([0, 1, 2, 3]), [0, 0, 0, 0])
+    assert allclose(cosmo.Ogamma([0, 1, 2, 3]), [0, 0, 0, 0])
     # Obaryon
     cosmo = core.LambdaCDM(H0=70, Om0=0.27, Ode0=0.73, Ob0=0.0)
-    assert np.allclose(cosmo.Ob([0, 1, 2, 3]), [0, 0, 0, 0])
+    assert allclose(cosmo.Ob([0, 1, 2, 3]), [0, 0, 0, 0])
 
 
 # This class is to test whether the routines work correctly
@@ -407,22 +407,22 @@ def test_de_subclass():
     z = [0.2, 0.4, 0.6, 0.9]
     cosmo = core.wCDM(H0=70, Om0=0.27, Ode0=0.73, w0=-0.9, Tcmb0=0.0)
     # Values taken from Ned Wrights advanced cosmo calcluator, Aug 17 2012
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [975.5, 2158.2, 3507.3, 5773.1], rtol=1e-3)
+    assert allclose(cosmo.luminosity_distance(z),
+                             [975.5, 2158.2, 3507.3, 5773.1] * u.Mpc, rtol=1e-3)
     # Now try the subclass that only gives w(z)
     cosmo = test_cos_sub()
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [975.5, 2158.2, 3507.3, 5773.1], rtol=1e-3)
+    assert allclose(cosmo.luminosity_distance(z),
+                             [975.5, 2158.2, 3507.3, 5773.1] * u.Mpc, rtol=1e-3)
     # Test efunc
-    assert np.allclose(cosmo.efunc(1.0), 1.7489240754, rtol=1e-5)
-    assert np.allclose(cosmo.efunc([0.5, 1.0]),
-                       [1.31744953, 1.7489240754], rtol=1e-5)
-    assert np.allclose(cosmo.inv_efunc([0.5, 1.0]),
-                       [0.75904236, 0.57178011], rtol=1e-5)
+    assert allclose(cosmo.efunc(1.0), 1.7489240754, rtol=1e-5)
+    assert allclose(cosmo.efunc([0.5, 1.0]),
+                    [1.31744953, 1.7489240754], rtol=1e-5)
+    assert allclose(cosmo.inv_efunc([0.5, 1.0]),
+                    [0.75904236, 0.57178011], rtol=1e-5)
     # Test de_density_scale
-    assert np.allclose(cosmo.de_density_scale(1.0), 1.23114444, rtol=1e-4)
-    assert np.allclose(cosmo.de_density_scale([0.5, 1.0]),
-                       [1.12934694, 1.23114444], rtol=1e-4)
+    assert allclose(cosmo.de_density_scale(1.0), 1.23114444, rtol=1e-4)
+    assert allclose(cosmo.de_density_scale([0.5, 1.0]),
+                    [1.12934694, 1.23114444], rtol=1e-4)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -433,58 +433,58 @@ def test_varyde_lumdist_mathematica():
     # w0wa models
     z = np.array([0.2, 0.4, 0.9, 1.2])
     cosmo = core.w0waCDM(H0=70, Om0=0.2, Ode0=0.8, w0=-1.1, wa=0.2, Tcmb0=0.0)
-    assert np.allclose(cosmo.w0, -1.1)
-    assert np.allclose(cosmo.wa, 0.2)
+    assert allclose(cosmo.w0, -1.1)
+    assert allclose(cosmo.wa, 0.2)
 
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [1004.0, 2268.62, 6265.76, 9061.84], rtol=1e-4)
-    assert np.allclose(cosmo.de_density_scale(0.0), 1.0, rtol=1e-5)
-    assert np.allclose(cosmo.de_density_scale([0.0, 0.5, 1.5]),
+    assert allclose(cosmo.luminosity_distance(z),
+                             [1004.0, 2268.62, 6265.76, 9061.84] * u.Mpc, rtol=1e-4)
+    assert allclose(cosmo.de_density_scale(0.0), 1.0, rtol=1e-5)
+    assert allclose(cosmo.de_density_scale([0.0, 0.5, 1.5]),
                        [1.0, 0.9246310669529021, 0.9184087000251957])
 
     cosmo = core.w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.9, wa=0.0, Tcmb0=0.0)
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [971.667, 2141.67, 5685.96, 8107.41], rtol=1e-4)
+    assert allclose(cosmo.luminosity_distance(z),
+                             [971.667, 2141.67, 5685.96, 8107.41] * u.Mpc, rtol=1e-4)
     cosmo = core.w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.9, wa=-0.5, Tcmb0=0.0)
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [974.087, 2157.08, 5783.92, 8274.08], rtol=1e-4)
+    assert allclose(cosmo.luminosity_distance(z),
+                       [974.087, 2157.08, 5783.92, 8274.08] * u.Mpc, rtol=1e-4)
 
     # wpwa models
     cosmo = core.wpwaCDM(H0=70, Om0=0.2, Ode0=0.8, wp=-1.1, wa=0.2, zp=0.5,
                          Tcmb0=0.0)
-    assert np.allclose(cosmo.wp, -1.1)
-    assert np.allclose(cosmo.wa, 0.2)
-    assert np.allclose(cosmo.zp, 0.5)
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [1010.81, 2294.45, 6369.45, 9218.95], rtol=1e-4)
+    assert allclose(cosmo.wp, -1.1)
+    assert allclose(cosmo.wa, 0.2)
+    assert allclose(cosmo.zp, 0.5)
+    assert allclose(cosmo.luminosity_distance(z),
+                       [1010.81, 2294.45, 6369.45, 9218.95] * u.Mpc, rtol=1e-4)
 
     cosmo = core.wpwaCDM(H0=70, Om0=0.2, Ode0=0.8, wp=-1.1, wa=0.2, zp=0.9,
                          Tcmb0=0.0)
-    assert np.allclose(cosmo.wp, -1.1)
-    assert np.allclose(cosmo.wa, 0.2)
-    assert np.allclose(cosmo.zp, 0.9)
-    assert np.allclose(cosmo.luminosity_distance(z).value,
-                       [1013.68, 2305.3, 6412.37, 9283.33], rtol=1e-4)
+    assert allclose(cosmo.wp, -1.1)
+    assert allclose(cosmo.wa, 0.2)
+    assert allclose(cosmo.zp, 0.9)
+    assert allclose(cosmo.luminosity_distance(z),
+                       [1013.68, 2305.3, 6412.37, 9283.33] * u.Mpc, rtol=1e-4)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_matter():
     # Test non-relativistic matter evolution
     tcos = core.FlatLambdaCDM(70.0, 0.3, Ob0=0.045)
-    assert np.allclose(tcos.Om0, 0.3)
-    assert np.allclose(tcos.H0.value, 70.0)
-    assert np.allclose(tcos.Om(0), 0.3)
-    assert np.allclose(tcos.Ob(0), 0.045)
+    assert allclose(tcos.Om0, 0.3)
+    assert allclose(tcos.H0, 70.0 * u.km / u.s / u.Mpc)
+    assert allclose(tcos.Om(0), 0.3)
+    assert allclose(tcos.Ob(0), 0.045)
     z = np.array([0.0, 0.5, 1.0, 2.0])
-    assert np.allclose(tcos.Om(z), [0.3, 0.59112134, 0.77387435, 0.91974179],
+    assert allclose(tcos.Om(z), [0.3, 0.59112134, 0.77387435, 0.91974179],
                        rtol=1e-4)
-    assert np.allclose(tcos.Ob(z), [0.045, 0.08866820, 0.11608115,
+    assert allclose(tcos.Ob(z), [0.045, 0.08866820, 0.11608115,
                                     0.13796127], rtol=1e-4)
-    assert np.allclose(tcos.Odm(z), [0.255, 0.50245314, 0.6577932, 0.78178052],
+    assert allclose(tcos.Odm(z), [0.255, 0.50245314, 0.6577932, 0.78178052],
                        rtol=1e-4)
     # Consistency of dark and baryonic matter evolution with all
     # non-relativistic matter
-    assert np.allclose(tcos.Ob(z) + tcos.Odm(z), tcos.Om(z))
+    assert allclose(tcos.Ob(z) + tcos.Odm(z), tcos.Om(z))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -492,21 +492,21 @@ def test_ocurv():
     # Test Ok evolution
     # Flat, boring case
     tcos = core.FlatLambdaCDM(70.0, 0.3)
-    assert np.allclose(tcos.Ok0, 0.0)
-    assert np.allclose(tcos.Ok(0), 0.0)
+    assert allclose(tcos.Ok0, 0.0)
+    assert allclose(tcos.Ok(0), 0.0)
     z = np.array([0.0, 0.5, 1.0, 2.0])
-    assert np.allclose(tcos.Ok(z), [0.0, 0.0, 0.0, 0.0],
+    assert allclose(tcos.Ok(z), [0.0, 0.0, 0.0, 0.0],
                        rtol=1e-6)
 
     # Not flat
     tcos = core.LambdaCDM(70.0, 0.3, 0.5, Tcmb0=u.Quantity(0.0, u.K))
-    assert np.allclose(tcos.Ok0, 0.2)
-    assert np.allclose(tcos.Ok(0), 0.2)
-    assert np.allclose(tcos.Ok(z), [0.2, 0.22929936, 0.21621622, 0.17307692],
+    assert allclose(tcos.Ok0, 0.2)
+    assert allclose(tcos.Ok(0), 0.2)
+    assert allclose(tcos.Ok(z), [0.2, 0.22929936, 0.21621622, 0.17307692],
                        rtol=1e-4)
 
     # Test the sum; note that Ogamma/Onu are 0
-    assert np.allclose(tcos.Ok(z) + tcos.Om(z) + tcos.Ode(z),
+    assert allclose(tcos.Ok(z) + tcos.Om(z) + tcos.Ode(z),
                        [1.0, 1.0, 1.0, 1.0], rtol=1e-5)
 
 
@@ -514,10 +514,10 @@ def test_ocurv():
 def test_ode():
     # Test Ode evolution, turn off neutrinos, cmb
     tcos = core.FlatLambdaCDM(70.0, 0.3, Tcmb0=0)
-    assert np.allclose(tcos.Ode0, 0.7)
-    assert np.allclose(tcos.Ode(0), 0.7)
+    assert allclose(tcos.Ode0, 0.7)
+    assert allclose(tcos.Ode(0), 0.7)
     z = np.array([0.0, 0.5, 1.0, 2.0])
-    assert np.allclose(tcos.Ode(z), [0.7, 0.408759, 0.2258065, 0.07954545],
+    assert allclose(tcos.Ode(z), [0.7, 0.408759, 0.2258065, 0.07954545],
                        rtol=1e-5)
 
 
@@ -539,27 +539,27 @@ def test_ogamma():
     # More accurate tests below using Mathematica
     z = np.array([1.0, 10.0, 500.0, 1000.0])
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=0, Neff=3)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1651.9, 858.2, 26.855, 13.642], rtol=5e-4)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                             [1651.9, 858.2, 26.855, 13.642] * u.Mpc, rtol=5e-4)
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725, Neff=3)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1651.8, 857.9, 26.767, 13.582], rtol=5e-4)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                       [1651.8, 857.9, 26.767, 13.582] * u.Mpc, rtol=5e-4)
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=4.0, Neff=3)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1651.4, 856.6, 26.489, 13.405], rtol=5e-4)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                       [1651.4, 856.6, 26.489, 13.405] * u.Mpc, rtol=5e-4)
 
     # Next compare with doing the integral numerically in Mathematica,
     # which allows more precision in the test.  It is at least as
     # good as 0.01%, possibly better
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=0, Neff=3.04)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1651.91, 858.205, 26.8586, 13.6469], rtol=1e-5)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                       [1651.91, 858.205, 26.8586, 13.6469] * u.Mpc, rtol=1e-5)
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725, Neff=3.04)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1651.76, 857.817, 26.7688, 13.5841], rtol=1e-5)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                       [1651.76, 857.817, 26.7688, 13.5841] * u.Mpc, rtol=1e-5)
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=4.0, Neff=3.04)
-    assert np.allclose(cosmo.angular_diameter_distance(z).value,
-                       [1651.21, 856.411, 26.4845, 13.4028], rtol=1e-5)
+    assert allclose(cosmo.angular_diameter_distance(z),
+                       [1651.21, 856.411, 26.4845, 13.4028] * u.Mpc, rtol=1e-5)
 
     # Just to be really sure, we also do a version where the integral
     # is analytic, which is a Ode = 0 flat universe.  In this case
@@ -569,14 +569,14 @@ def test_ogamma():
     Onu0h2 = Ogamma0h2 * 7.0 / 8.0 * (4.0 / 11.0) ** (4.0 / 3.0) * 3.04
     Or0 = (Ogamma0h2 + Onu0h2) / 0.7 ** 2
     Om0 = 1.0 - Or0
-    hubdis = 299792.458 / 70.0
+    hubdis = (299792.458 / 70.0) * u.Mpc
     cosmo = core.FlatLambdaCDM(H0=70, Om0=Om0, Tcmb0=2.725, Neff=3.04)
     targvals = 2.0 * hubdis * \
         (np.sqrt((1.0 + Or0 * z) / (1.0 + z)) - 1.0) / (Or0 - 1.0)
-    assert np.allclose(cosmo.comoving_distance(z).value, targvals, rtol=1e-5)
+    assert allclose(cosmo.comoving_distance(z), targvals, rtol=1e-5)
 
     # And integers for z
-    assert np.allclose(cosmo.comoving_distance(z.astype(np.int)).value,
+    assert allclose(cosmo.comoving_distance(z.astype(np.int)),
                        targvals, rtol=1e-5)
 
     # Try Tcmb0 = 4
@@ -585,35 +585,35 @@ def test_ogamma():
     cosmo = core.FlatLambdaCDM(H0=70, Om0=Om0, Tcmb0=4.0, Neff=3.04)
     targvals = 2.0 * hubdis * \
         (np.sqrt((1.0 + Or0 * z) / (1.0 + z)) - 1.0) / (Or0 - 1.0)
-    assert np.allclose(cosmo.comoving_distance(z).value, targvals, rtol=1e-5)
+    assert allclose(cosmo.comoving_distance(z), targvals, rtol=1e-5)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_tcmb():
     cosmo = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=2.5)
-    assert np.allclose(cosmo.Tcmb0.value, 2.5)
-    assert np.allclose(cosmo.Tcmb(2).value, 7.5)
+    assert allclose(cosmo.Tcmb0, 2.5 * u.K)
+    assert allclose(cosmo.Tcmb(2), 7.5 * u.K)
     z = [0.0, 1.0, 2.0, 3.0, 9.0]
-    assert np.allclose(cosmo.Tcmb(z).value,
-                       [2.5, 5.0, 7.5, 10.0, 25.0], rtol=1e-6)
+    assert allclose(cosmo.Tcmb(z),
+                             [2.5, 5.0, 7.5, 10.0, 25.0] * u.K, rtol=1e-6)
     # Make sure it's the same for integers
     z = [0, 1, 2, 3, 9]
-    assert np.allclose(cosmo.Tcmb(z).value,
-                       [2.5, 5.0, 7.5, 10.0, 25.0], rtol=1e-6)
+    assert allclose(cosmo.Tcmb(z),
+                       [2.5, 5.0, 7.5, 10.0, 25.0] * u.K, rtol=1e-6)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_tnu():
     cosmo = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=3.0)
-    assert np.allclose(cosmo.Tnu0.value, 2.1412975665108247, rtol=1e-6)
-    assert np.allclose(cosmo.Tnu(2).value, 6.423892699532474, rtol=1e-6)
+    assert allclose(cosmo.Tnu0, 2.1412975665108247 * u.K, rtol=1e-6)
+    assert allclose(cosmo.Tnu(2), 6.423892699532474 * u.K, rtol=1e-6)
     z = [0.0, 1.0, 2.0, 3.0]
-    expected = [2.14129757, 4.28259513, 6.4238927, 8.56519027]
-    assert np.allclose(cosmo.Tnu(z), expected, rtol=1e-6)
+    expected = [2.14129757, 4.28259513, 6.4238927, 8.56519027] * u.K
+    assert allclose(cosmo.Tnu(z), expected, rtol=1e-6)
 
     # Test for integers
     z = [0, 1, 2, 3]
-    assert np.allclose(cosmo.Tnu(z), expected, rtol=1e-6)
+    assert allclose(cosmo.Tnu(z), expected, rtol=1e-6)
 
 
 def test_efunc_vs_invefunc():
@@ -625,32 +625,32 @@ def test_efunc_vs_invefunc():
     # We do the non-standard case in test_efunc_vs_invefunc_flrw,
     # since it requires scipy
     cosmo = core.LambdaCDM(70, 0.3, 0.5)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.LambdaCDM(70, 0.3, 0.5, m_nu=u.Quantity(0.01, u.eV))
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.FlatLambdaCDM(50.0, 0.27)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.wCDM(60.0, 0.27, 0.6, w0=-0.8)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.FlatwCDM(65.0, 0.27, w0=-0.6)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.w0waCDM(60.0, 0.25, 0.4, w0=-0.6, wa=0.1)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.Flatw0waCDM(55.0, 0.35, w0=-0.9, wa=-0.2)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.wpwaCDM(50.0, 0.3, 0.3, wp=-0.9, wa=-0.2, zp=0.3)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.w0wzCDM(55.0, 0.4, 0.8, w0=-1.05, wz=-0.2)
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -661,17 +661,21 @@ def test_efunc_vs_invefunc_flrw():
     # FLRW is abstract, so requires test_cos_sub defined earlier
     # This requires scipy, unlike the built-ins
     cosmo = test_cos_sub()
-    assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_kpc_methods():
     cosmo = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
-    assert np.allclose(cosmo.arcsec_per_kpc_comoving(3).value, 0.0317179)
-    assert np.allclose(cosmo.arcsec_per_kpc_proper(3).value, 0.1268716668)
-    assert np.allclose(cosmo.kpc_comoving_per_arcmin(3).value, 1891.6753126)
-    assert np.allclose(cosmo.kpc_proper_per_arcmin(3).value, 472.918828)
+    assert allclose(cosmo.arcsec_per_kpc_comoving(3),
+                             0.0317179167 * u.arcsec / u.kpc)
+    assert allclose(cosmo.arcsec_per_kpc_proper(3),
+                             0.1268716668 * u.arcsec / u.kpc)
+    assert allclose(cosmo.kpc_comoving_per_arcmin(3),
+                             1891.6753126 * u.kpc / u.arcmin)
+    assert allclose(cosmo.kpc_proper_per_arcmin(3),
+                             472.918828 * u.kpc / u.arcmin)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -684,19 +688,19 @@ def test_comoving_volume():
     # test against ned wright's calculator (cubic Gpc)
     redshifts = np.array([0.5, 1, 2, 3, 5, 9])
     wright_flat = np.array([29.123, 159.529, 630.427, 1178.531, 2181.485,
-                            3654.802]) * 1e9  # convert to Mpc**3
+                            3654.802]) * u.Gpc**3
     wright_open = np.array([20.501, 99.019, 380.278, 747.049, 1558.363,
-                            3123.814]) * 1e9
+                            3123.814]) * u.Gpc**3
     wright_closed = np.array([12.619, 44.708, 114.904, 173.709, 258.82,
-                              358.992]) * 1e9
+                              358.992]) * u.Gpc**3
     # The wright calculator isn't very accurate, so we use a rather
     # modest precision
-    assert np.allclose(c_flat.comoving_volume(redshifts).value, wright_flat,
-                       rtol=1e-2)
-    assert np.allclose(c_open.comoving_volume(redshifts).value,
-                       wright_open, rtol=1e-2)
-    assert np.allclose(c_closed.comoving_volume(redshifts).value,
-                       wright_closed, rtol=1e-2)
+    assert allclose(c_flat.comoving_volume(redshifts), wright_flat,
+                             rtol=1e-2)
+    assert allclose(c_open.comoving_volume(redshifts),
+                             wright_open, rtol=1e-2)
+    assert allclose(c_closed.comoving_volume(redshifts),
+                             wright_closed, rtol=1e-2)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -711,26 +715,26 @@ def test_differential_comoving_volume():
     #  yields same as comoving_volume()
     redshifts = np.array([0.5, 1, 2, 3, 5, 9])
     wright_flat = np.array([29.123, 159.529, 630.427, 1178.531, 2181.485,
-                            3654.802]) * 1e9  # convert to Mpc**3
+                            3654.802]) * u.Gpc**3
     wright_open = np.array([20.501, 99.019, 380.278, 747.049, 1558.363,
-                            3123.814]) * 1e9
+                            3123.814]) * u.Gpc**3
     wright_closed = np.array([12.619, 44.708, 114.904, 173.709, 258.82,
-                              358.992]) * 1e9
+                              358.992]) * u.Gpc**3
     # The wright calculator isn't very accurate, so we use a rather
     # modest precision.
     ftemp = lambda x: c_flat.differential_comoving_volume(x).value
     otemp = lambda x: c_open.differential_comoving_volume(x).value
     ctemp = lambda x: c_closed.differential_comoving_volume(x).value
     # Multiply by solid_angle (4 * pi)
-    assert np.allclose(np.array([4.0 * np.pi * quad(ftemp, 0, redshift)[0]
-                                 for redshift in redshifts]),
-                       wright_flat, rtol=1e-2)
-    assert np.allclose(np.array([4.0 * np.pi * quad(otemp, 0, redshift)[0]
-                                 for redshift in redshifts]),
-                       wright_open, rtol=1e-2)
-    assert np.allclose(np.array([4.0 * np.pi * quad(ctemp, 0, redshift)[0]
-                                 for redshift in redshifts]),
-                       wright_closed, rtol=1e-2)
+    assert allclose(np.array([4.0 * np.pi * quad(ftemp, 0, redshift)[0]
+                                       for redshift in redshifts]) * u.Mpc**3,
+                             wright_flat, rtol=1e-2)
+    assert allclose(np.array([4.0 * np.pi * quad(otemp, 0, redshift)[0]
+                                       for redshift in redshifts]) * u.Mpc**3,
+                             wright_open, rtol=1e-2)
+    assert allclose(np.array([4.0 * np.pi * quad(ctemp, 0, redshift)[0]
+                                       for redshift in redshifts]) * u.Mpc**3,
+                             wright_closed, rtol=1e-2)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -845,68 +849,77 @@ def test_flat_open_closed_icosmo():
 """
 
     redshifts, dm, da, dl = np.loadtxt(StringIO(cosmo_flat), unpack=1)
+    dm = dm * u.Mpc
+    da = da * u.Mpc
+    dl = dl * u.Mpc
     cosmo = core.LambdaCDM(H0=70, Om0=0.3, Ode0=0.70, Tcmb0=0.0)
-    assert np.allclose(cosmo.comoving_transverse_distance(redshifts).value, dm)
-    assert np.allclose(cosmo.angular_diameter_distance(redshifts).value, da)
-    assert np.allclose(cosmo.luminosity_distance(redshifts).value, dl)
+    assert allclose(cosmo.comoving_transverse_distance(redshifts), dm)
+    assert allclose(cosmo.angular_diameter_distance(redshifts), da)
+    assert allclose(cosmo.luminosity_distance(redshifts), dl)
 
     redshifts, dm, da, dl = np.loadtxt(StringIO(cosmo_open), unpack=1)
+    dm = dm * u.Mpc
+    da = da * u.Mpc
+    dl = dl * u.Mpc
     cosmo = core.LambdaCDM(H0=70, Om0=0.3, Ode0=0.1, Tcmb0=0.0)
-    assert np.allclose(cosmo.comoving_transverse_distance(redshifts).value, dm)
-    assert np.allclose(cosmo.angular_diameter_distance(redshifts).value, da)
-    assert np.allclose(cosmo.luminosity_distance(redshifts).value, dl)
+    assert allclose(cosmo.comoving_transverse_distance(redshifts), dm)
+    assert allclose(cosmo.angular_diameter_distance(redshifts), da)
+    assert allclose(cosmo.luminosity_distance(redshifts), dl)
 
     redshifts, dm, da, dl = np.loadtxt(StringIO(cosmo_closed), unpack=1)
+    dm = dm * u.Mpc
+    da = da * u.Mpc
+    dl = dl * u.Mpc
     cosmo = core.LambdaCDM(H0=70, Om0=2, Ode0=0.1, Tcmb0=0.0)
-    assert np.allclose(cosmo.comoving_transverse_distance(redshifts).value, dm)
-    assert np.allclose(cosmo.angular_diameter_distance(redshifts).value, da)
-    assert np.allclose(cosmo.luminosity_distance(redshifts).value, dl)
+    assert allclose(cosmo.comoving_transverse_distance(redshifts), dm)
+    assert allclose(cosmo.angular_diameter_distance(redshifts), da)
+    assert allclose(cosmo.luminosity_distance(redshifts), dl)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_integral():
     # Test integer vs. floating point inputs
     cosmo = core.LambdaCDM(H0=73.2, Om0=0.3, Ode0=0.50)
-    assert np.allclose(cosmo.comoving_distance(3),
+    assert allclose(cosmo.comoving_distance(3),
                        cosmo.comoving_distance(3.0), rtol=1e-7)
-    assert np.allclose(cosmo.comoving_distance([1, 2, 3, 5]),
+    assert allclose(cosmo.comoving_distance([1, 2, 3, 5]),
                        cosmo.comoving_distance([1.0, 2.0, 3.0, 5.0]),
                        rtol=1e-7)
-    assert np.allclose(cosmo.efunc(6), cosmo.efunc(6.0), rtol=1e-7)
-    assert np.allclose(cosmo.efunc([1, 2, 6]),
+    assert allclose(cosmo.efunc(6), cosmo.efunc(6.0), rtol=1e-7)
+    assert allclose(cosmo.efunc([1, 2, 6]),
                        cosmo.efunc([1.0, 2.0, 6.0]), rtol=1e-7)
-    assert np.allclose(cosmo.inv_efunc([1, 2, 6]),
+    assert allclose(cosmo.inv_efunc([1, 2, 6]),
                        cosmo.inv_efunc([1.0, 2.0, 6.0]), rtol=1e-7)
 
 
 def test_wz():
     cosmo = core.LambdaCDM(H0=70, Om0=0.3, Ode0=0.70)
-    assert np.allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
+    assert allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
                        [-1., -1, -1, -1, -1, -1])
 
     cosmo = core.wCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-0.5)
-    assert np.allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
+    assert allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
                        [-0.5, -0.5, -0.5, -0.5, -0.5, -0.5])
-    assert np.allclose(cosmo.w0, -0.5)
+    assert allclose(cosmo.w0, -0.5)
 
     cosmo = core.w0wzCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-1, wz=0.5)
-    assert np.allclose(cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]),
+    assert allclose(cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]),
                        [-1.0, -0.75, -0.5, -0.25, 0.15])
-    assert np.allclose(cosmo.w0, -1.0)
-    assert np.allclose(cosmo.wz, 0.5)
+    assert allclose(cosmo.w0, -1.0)
+    assert allclose(cosmo.wz, 0.5)
 
     cosmo = core.w0waCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-1, wa=-0.5)
-    assert np.allclose(cosmo.w0, -1.0)
-    assert np.allclose(cosmo.wa, -0.5)
-    assert np.allclose(cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]),
+    assert allclose(cosmo.w0, -1.0)
+    assert allclose(cosmo.wa, -0.5)
+    assert allclose(cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]),
                        [-1, -1.16666667, -1.25, -1.3, -1.34848485])
 
     cosmo = core.wpwaCDM(H0=70, Om0=0.3, Ode0=0.70, wp=-0.9,
                          wa=0.2, zp=0.5)
-    assert np.allclose(cosmo.wp, -0.9)
-    assert np.allclose(cosmo.wa, 0.2)
-    assert np.allclose(cosmo.zp, 0.5)
-    assert np.allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
+    assert allclose(cosmo.wp, -0.9)
+    assert allclose(cosmo.wa, 0.2)
+    assert allclose(cosmo.zp, 0.5)
+    assert allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
                        [-0.94848485, -0.93333333, -0.9, -0.84666667,
                         -0.82380952, -0.78266667])
 
@@ -915,49 +928,49 @@ def test_wz():
 def test_de_densityscale():
     cosmo = core.LambdaCDM(H0=70, Om0=0.3, Ode0=0.70)
     z = np.array([0.1, 0.2, 0.5, 1.5, 2.5])
-    assert np.allclose(cosmo.de_density_scale(z),
+    assert allclose(cosmo.de_density_scale(z),
                        [1.0, 1.0, 1.0, 1.0, 1.0])
     # Integer check
-    assert np.allclose(cosmo.de_density_scale(3),
+    assert allclose(cosmo.de_density_scale(3),
                        cosmo.de_density_scale(3.0), rtol=1e-7)
-    assert np.allclose(cosmo.de_density_scale([1, 2, 3]),
+    assert allclose(cosmo.de_density_scale([1, 2, 3]),
                        cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
     cosmo = core.wCDM(H0=70, Om0=0.3, Ode0=0.60, w0=-0.5)
-    assert np.allclose(cosmo.de_density_scale(z),
+    assert allclose(cosmo.de_density_scale(z),
                        [1.15369, 1.31453, 1.83712, 3.95285, 6.5479],
                        rtol=1e-4)
-    assert np.allclose(cosmo.de_density_scale(3),
+    assert allclose(cosmo.de_density_scale(3),
                        cosmo.de_density_scale(3.0), rtol=1e-7)
-    assert np.allclose(cosmo.de_density_scale([1, 2, 3]),
+    assert allclose(cosmo.de_density_scale([1, 2, 3]),
                        cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
     cosmo = core.w0wzCDM(H0=70, Om0=0.3, Ode0=0.50, w0=-1, wz=0.5)
-    assert np.allclose(cosmo.de_density_scale(z),
+    assert allclose(cosmo.de_density_scale(z),
                        [0.746048, 0.5635595, 0.25712378, 0.026664129,
                         0.0035916468], rtol=1e-4)
-    assert np.allclose(cosmo.de_density_scale(3),
+    assert allclose(cosmo.de_density_scale(3),
                        cosmo.de_density_scale(3.0), rtol=1e-7)
-    assert np.allclose(cosmo.de_density_scale([1, 2, 3]),
+    assert allclose(cosmo.de_density_scale([1, 2, 3]),
                        cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
     cosmo = core.w0waCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-1, wa=-0.5)
-    assert np.allclose(cosmo.de_density_scale(z),
+    assert allclose(cosmo.de_density_scale(z),
                        [0.9934201, 0.9767912, 0.897450,
                         0.622236, 0.4458753], rtol=1e-4)
-    assert np.allclose(cosmo.de_density_scale(3),
+    assert allclose(cosmo.de_density_scale(3),
                        cosmo.de_density_scale(3.0), rtol=1e-7)
-    assert np.allclose(cosmo.de_density_scale([1, 2, 3]),
+    assert allclose(cosmo.de_density_scale([1, 2, 3]),
                        cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
     cosmo = core.wpwaCDM(H0=70, Om0=0.3, Ode0=0.70, wp=-0.9,
                          wa=0.2, zp=0.5)
-    assert np.allclose(cosmo.de_density_scale(z),
+    assert allclose(cosmo.de_density_scale(z),
                        [1.012246048, 1.0280102, 1.087439,
                         1.324988, 1.565746], rtol=1e-4)
-    assert np.allclose(cosmo.de_density_scale(3),
+    assert allclose(cosmo.de_density_scale(3),
                        cosmo.de_density_scale(3.0), rtol=1e-7)
-    assert np.allclose(cosmo.de_density_scale([1, 2, 3]),
+    assert allclose(cosmo.de_density_scale([1, 2, 3]),
                        cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
 
@@ -965,18 +978,21 @@ def test_de_densityscale():
 def test_age():
     # WMAP7 but with Omega_relativisitic = 0
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
-    assert np.allclose(tcos.hubble_time.value, 13.889094057856937)
-    assert np.allclose(tcos.age([1., 5.]).value, [5.97113193, 1.20553129])
-    assert np.allclose(tcos.age([1, 5]).value, [5.97113193, 1.20553129])
+    assert allclose(tcos.hubble_time, 13.889094057856937 * u.Gyr)
+    assert allclose(tcos.age([1., 5.]),
+                             [5.97113193, 1.20553129] * u.Gyr)
+    assert allclose(tcos.age([1, 5]), [5.97113193, 1.20553129] * u.Gyr)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_distmod():
     # WMAP7 but with Omega_relativisitic = 0
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
-    assert np.allclose(tcos.hubble_distance.value, 4258.415596590909)
-    assert np.allclose(tcos.distmod([1, 5]).value, [44.124857, 48.40167258])
-    assert np.allclose(tcos.distmod([1., 5.]).value, [44.124857, 48.40167258])
+    assert allclose(tcos.hubble_distance, 4258.415596590909 * u.Mpc)
+    assert allclose(tcos.distmod([1, 5]),
+                             [44.124857, 48.40167258] * u.mag)
+    assert allclose(tcos.distmod([1., 5.]),
+                             [44.124857, 48.40167258] * u.mag)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -984,10 +1000,10 @@ def test_neg_distmod():
     # Cosmology with negative luminosity distances (perfectly okay,
     #  if obscure)
     tcos = core.LambdaCDM(70, 0.2, 1.3, Tcmb0=0)
-    assert np.allclose(tcos.luminosity_distance([50, 100]).value,
-                       [16612.44047622, -46890.79092244])
-    assert np.allclose(tcos.distmod([50, 100]).value,
-                       [46.102167189, 48.355437790944])
+    assert allclose(tcos.luminosity_distance([50, 100]),
+                             [16612.44047622, -46890.79092244] * u.Mpc)
+    assert allclose(tcos.distmod([50, 100]),
+                             [46.102167189, 48.355437790944] * u.mag)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -996,14 +1012,14 @@ def test_critical_density():
     # These tests will fail if astropy.const starts returning non-mks
     #  units by default; see the comment at the top of core.py
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
-    assert np.allclose(tcos.critical_density0.value,
-                       9.31000324385361e-30)
-    assert np.allclose(tcos.critical_density0.value,
-                       tcos.critical_density(0).value)
-    assert np.allclose(tcos.critical_density([1, 5]).value,
-                       [2.70362491e-29, 5.53758986e-28])
-    assert np.allclose(tcos.critical_density([1., 5.]).value,
-                       [2.70362491e-29, 5.53758986e-28])
+    assert allclose(tcos.critical_density0,
+                             9.31000324385361e-30 * u.g / u.cm**3)
+    assert allclose(tcos.critical_density0,
+                       tcos.critical_density(0))
+    assert allclose(tcos.critical_density([1, 5]),
+                             [2.70362491e-29, 5.53758986e-28] * u.g / u.cm**3)
+    assert allclose(tcos.critical_density([1., 5.]),
+                             [2.70362491e-29, 5.53758986e-28] * u.g / u.cm**3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -1019,49 +1035,49 @@ def test_angular_diameter_distance_z1z2():
     with pytest.raises(ValueError):  # test z1 > z2 fail
         tcos.angular_diameter_distance_z1z2(4, 3)
     # Tests that should actually work
-    assert np.allclose(tcos.angular_diameter_distance_z1z2(1, 2).value,
-                       646.22968662822018)
+    assert allclose(tcos.angular_diameter_distance_z1z2(1, 2),
+                             646.22968662822018 * u.Mpc)
     z1 = 0, 0, 1, 0.5, 1
     z2 = 2, 1, 2, 2.5, 1.1
     results = (1760.0628637762106,
                1670.7497657219858,
                646.22968662822018,
                1159.0970895962193,
-               115.72768186186921)
+               115.72768186186921) * u.Mpc
 
-    assert np.allclose(tcos.angular_diameter_distance_z1z2(z1, z2).value,
+    assert allclose(tcos.angular_diameter_distance_z1z2(z1, z2),
                        results)
 
     # Non-flat (positive Ocurv) test
     tcos = core.LambdaCDM(H0=70.4, Om0=0.2, Ode0=0.5, Tcmb0=0.0)
-    assert np.allclose(tcos.angular_diameter_distance_z1z2(1, 2).value,
-                       620.1175337852428)
+    assert allclose(tcos.angular_diameter_distance_z1z2(1, 2),
+                             620.1175337852428 * u.Mpc)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_absorption_distance():
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
-    assert np.allclose(tcos.absorption_distance([1, 3]),
+    assert allclose(tcos.absorption_distance([1, 3]),
                        [1.72576635, 7.98685853])
-    assert np.allclose(tcos.absorption_distance([1., 3.]),
+    assert allclose(tcos.absorption_distance([1., 3.]),
                        [1.72576635, 7.98685853])
-    assert np.allclose(tcos.absorption_distance(3), 7.98685853)
-    assert np.allclose(tcos.absorption_distance(3.), 7.98685853)
+    assert allclose(tcos.absorption_distance(3), 7.98685853)
+    assert allclose(tcos.absorption_distance(3.), 7.98685853)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_massivenu_basic():
     # Test no neutrinos case
     tcos = core.FlatLambdaCDM(70.4, 0.272, Neff=4.05, m_nu=u.Quantity(0, u.eV))
-    assert np.allclose(tcos.Neff, 4.05)
+    assert allclose(tcos.Neff, 4.05)
     assert not tcos.has_massive_nu
     mnu = tcos.m_nu
     assert len(mnu) == 4
     assert mnu.unit == u.eV
-    assert np.allclose(mnu.value, [0.0, 0.0, 0.0, 0.0])
-    assert np.allclose(tcos.nu_relative_density(1.), 0.22710731766 * 4.05,
+    assert allclose(mnu, [0.0, 0.0, 0.0, 0.0] * u.eV)
+    assert allclose(tcos.nu_relative_density(1.), 0.22710731766 * 4.05,
                        rtol=1e-6)
-    assert np.allclose(tcos.nu_relative_density(1), 0.22710731766 * 4.05,
+    assert allclose(tcos.nu_relative_density(1), 0.22710731766 * 4.05,
                        rtol=1e-6)
 
     # Test basic setting, retrieval of values
@@ -1071,17 +1087,17 @@ def test_massivenu_basic():
     mnu = tcos.m_nu
     assert len(mnu) == 3
     assert mnu.unit == u.eV
-    assert np.allclose(mnu.value, [0.0, 0.01, 0.02])
+    assert allclose(mnu, [0.0, 0.01, 0.02] * u.eV)
 
     # All massive neutrinos case
     tcos = core.FlatLambdaCDM(70.4, 0.272, m_nu=u.Quantity(0.1, u.eV),
                               Neff=3.1)
-    assert np.allclose(tcos.Neff, 3.1)
+    assert allclose(tcos.Neff, 3.1)
     assert tcos.has_massive_nu
     mnu = tcos.m_nu
     assert len(mnu) == 3
     assert mnu.unit == u.eV
-    assert np.allclose(mnu.value, [0.1, 0.1, 0.1])
+    assert allclose(mnu, [0.1, 0.1, 0.1] * u.eV)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -1103,21 +1119,21 @@ def test_massivenu_density():
     assert tcos.Neff == 3
     nurel_exp = nuprefac * tcos.Neff * np.array([171969, 85984.5, 57323,
                                                  15633.5, 171.801])
-    assert np.allclose(tcos.nu_relative_density(ztest), nurel_exp, rtol=5e-3)
-    assert np.allclose(tcos.efunc([0.0, 1.0]), [1.0, 7.46144727668], rtol=5e-3)
+    assert allclose(tcos.nu_relative_density(ztest), nurel_exp, rtol=5e-3)
+    assert allclose(tcos.efunc([0.0, 1.0]), [1.0, 7.46144727668], rtol=5e-3)
 
     # Next, slightly less massive
     tcos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0, Neff=3,
                               m_nu=u.Quantity(0.25, u.eV))
     nurel_exp = nuprefac * tcos.Neff * np.array([429.924, 214.964, 143.312,
                                                  39.1005, 1.11086])
-    assert np.allclose(tcos.nu_relative_density(ztest), nurel_exp,
+    assert allclose(tcos.nu_relative_density(ztest), nurel_exp,
                        rtol=5e-3)
 
     # For this one also test Onu directly
     onu_exp = np.array([0.01890217, 0.05244681, 0.0638236,
                         0.06999286, 0.1344951])
-    assert np.allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
+    assert allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
 
     # And fairly light
     tcos = core.FlatLambdaCDM(80.0, 0.30, Tcmb0=3.0, Neff=3,
@@ -1125,14 +1141,14 @@ def test_massivenu_density():
 
     nurel_exp = nuprefac * tcos.Neff * np.array([17.2347, 8.67345, 5.84348,
                                                  1.90671, 1.00021])
-    assert np.allclose(tcos.nu_relative_density(ztest), nurel_exp,
+    assert allclose(tcos.nu_relative_density(ztest), nurel_exp,
                        rtol=5e-3)
     onu_exp = np.array([0.00066599, 0.00172677, 0.0020732,
                         0.00268404, 0.0978313])
-    assert np.allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
-    assert np.allclose(tcos.efunc([1.0, 2.0]), [1.76225893, 2.97022048],
+    assert allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
+    assert allclose(tcos.efunc([1.0, 2.0]), [1.76225893, 2.97022048],
                        rtol=1e-4)
-    assert np.allclose(tcos.inv_efunc([1.0, 2.0]), [0.5674535, 0.33667534],
+    assert allclose(tcos.inv_efunc([1.0, 2.0]), [0.5674535, 0.33667534],
                        rtol=1e-4)
 
     # Now a mixture of neutrino masses, with non-integer Neff
@@ -1140,17 +1156,17 @@ def test_massivenu_density():
                               m_nu=u.Quantity([0.0, 0.01, 0.25], u.eV))
     nurel_exp = nuprefac * tcos.Neff * np.array([149.386233, 74.87915, 50.0518,
                                                  14.002403, 1.03702333])
-    assert np.allclose(tcos.nu_relative_density(ztest), nurel_exp,
+    assert allclose(tcos.nu_relative_density(ztest), nurel_exp,
                        rtol=5e-3)
     onu_exp = np.array([0.00584959, 0.01493142, 0.01772291,
                         0.01963451, 0.10227728])
-    assert np.allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
+    assert allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
 
     # Integer redshifts
     ztest = ztest.astype(np.int)
-    assert np.allclose(tcos.nu_relative_density(ztest), nurel_exp,
+    assert allclose(tcos.nu_relative_density(ztest), nurel_exp,
                        rtol=5e-3)
-    assert np.allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
+    assert allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -1164,19 +1180,19 @@ def test_z_at_value():
     z_at_value = funcs.z_at_value
     cosmo = core.Planck13
     d = cosmo.luminosity_distance(3)
-    assert np.allclose(z_at_value(cosmo.luminosity_distance, d), 3,
+    assert allclose(z_at_value(cosmo.luminosity_distance, d), 3,
                        rtol=1e-8)
-    assert np.allclose(z_at_value(cosmo.age, 2 * u.Gyr), 3.198122684356,
+    assert allclose(z_at_value(cosmo.age, 2 * u.Gyr), 3.198122684356,
                        rtol=1e-6)
-    assert np.allclose(z_at_value(cosmo.luminosity_distance, 1e4 * u.Mpc),
+    assert allclose(z_at_value(cosmo.luminosity_distance, 1e4 * u.Mpc),
                        1.3685790653802761, rtol=1e-6)
-    assert np.allclose(z_at_value(cosmo.lookback_time, 7 * u.Gyr),
+    assert allclose(z_at_value(cosmo.lookback_time, 7 * u.Gyr),
                        0.7951983674601507, rtol=1e-6)
-    assert np.allclose(z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc,
+    assert allclose(z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc,
                                   zmax=2), 0.68127769625288614, rtol=1e-6)
-    assert np.allclose(z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc,
+    assert allclose(z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc,
                                   zmin=2.5), 3.7914908028272083, rtol=1e-6)
-    assert np.allclose(z_at_value(cosmo.distmod, 46 * u.mag),
+    assert allclose(z_at_value(cosmo.distmod, 46 * u.mag),
                        1.9913891680278133, rtol=1e-6)
 
     # test behaviour when the solution is outside z limits (should
@@ -1215,12 +1231,12 @@ def test_z_at_value_roundtrip():
         # angular_diameter_distance and related methods.
         # Be slightly more generous with rtol than the default 1e-8
         # used in z_at_value
-        assert np.allclose(z, funcs.z_at_value(func, fval, zmax=1.5),
+        assert allclose(z, funcs.z_at_value(func, fval, zmax=1.5),
                            rtol=2e-8)
 
     # Test angular_diameter_distance_z1z2
     z2 = 2.0
     func = lambda z1: core.Planck13.angular_diameter_distance_z1z2(z1, z2)
     fval = func(z)
-    assert np.allclose(z, funcs.z_at_value(func, fval, zmax=1.5),
+    assert allclose(z, funcs.z_at_value(func, fval, zmax=1.5),
                        rtol=2e-8)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -616,7 +616,7 @@ def check_pickling_recovery(original, protocol):
 
 
 def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
-                             err_msg='', verbose=True):
+                             **kwargs):
     """
     Raise an assertion if two objects are not equal up to desired tolerance.
 
@@ -626,10 +626,10 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
     import numpy as np
     np.testing.assert_allclose(*_unquantify_allclose_arguments(actual, desired,
                                                                rtol, atol),
-                               err_msg=err_msg, verbose=verbose)
+                               **kwargs)
 
 
-def quantity_allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False):
+def quantity_allclose(a, b, rtol=1.e-5, atol=None, **kwargs):
     """
     Returns True if two arrays are element-wise equal within a tolerance.
 
@@ -638,7 +638,7 @@ def quantity_allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False):
     """
     import numpy as np
     return np.allclose(*_unquantify_allclose_arguments(a, b, rtol, atol),
-                       equal_nan=equal_nan)
+                       **kwargs)
 
 
 def _unquantify_allclose_arguments(actual, desired, rtol, atol):

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -615,15 +615,33 @@ def check_pickling_recovery(original, protocol):
                                     class_history)
 
 
-def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, err_msg='', verbose=True):
+def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
+                             err_msg='', verbose=True):
     """
     Raise an assertion if two objects are not equal up to desired tolerance.
 
     This is a :class:`~astropy.units.Quantity`-aware version of
     :func:`numpy.testing.assert_allclose`.
     """
-
     import numpy as np
+    np.testing.assert_allclose(*_unquantify_allclose_arguments(actual, desired,
+                                                               rtol, atol),
+                               err_msg=err_msg, verbose=verbose)
+
+
+def quantity_allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False):
+    """
+    Returns True if two arrays are element-wise equal within a tolerance.
+
+    This is a :class:`~astropy.units.Quantity`-aware version of
+    :func:`numpy.allclose`.
+    """
+    import numpy as np
+    return np.allclose(*_unquantify_allclose_arguments(a, b, rtol, atol),
+                       equal_nan=equal_nan)
+
+
+def _unquantify_allclose_arguments(actual, desired, rtol, atol):
     from .. import units as u
 
     actual = u.Quantity(actual, subok=True, copy=False)
@@ -632,7 +650,9 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, err_msg='',
     try:
         desired = desired.to(actual.unit)
     except u.UnitsError:
-        raise u.UnitsError("Units for 'desired' ({0}) and 'actual' ({1}) are not convertible".format(desired.unit, actual.unit))
+        raise u.UnitsError("Units for 'desired' ({0}) and 'actual' ({1}) "
+                           "are not convertible"
+                           .format(desired.unit, actual.unit))
 
     if atol is None:
         # by default, we assume an absolute tolerance of 0
@@ -642,7 +662,9 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, err_msg='',
         try:
             atol = atol.to(actual.unit)
         except u.UnitsError:
-            raise u.UnitsError("Units for 'atol' ({0}) and 'actual' ({1}) are not convertible".format(atol.unit, actual.unit))
+            raise u.UnitsError("Units for 'atol' ({0}) and 'actual' ({1}) "
+                               "are not convertible"
+                               .format(atol.unit, actual.unit))
 
     rtol =  u.Quantity(rtol, subok=True, copy=False)
     try:
@@ -650,6 +672,4 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, err_msg='',
     except:
         raise u.UnitsError("`rtol` should be dimensionless")
 
-    np.testing.assert_allclose(actual.value, desired.value,
-                               rtol=rtol.value, atol=atol.value,
-                               err_msg=err_msg, verbose=verbose)
+    return actual.value, desired.value, rtol.value, atol.value

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -519,11 +519,10 @@ def test_temperature():
 
 
 def test_temperature_energy():
-    from ... import constants
     x = 1000 * u.K
     y = (x * constants.k_B).to(u.keV)
-    assert_allclose(x.to(u.keV, u.temperature_energy()).value, y)
-    assert_allclose(y.to(u.K, u.temperature_energy()).value, x)
+    assert_allclose(x.to(u.keV, u.temperature_energy()).value, y.value)
+    assert_allclose(y.to(u.K, u.temperature_energy()).value, x.value)
 
 
 def test_compose_equivalencies():

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -134,7 +134,7 @@ class TestQuantityTrigonometricFuncs(object):
         q3 = q1 / q2
         q4 = 1.
         at2 = np.arctan2(q3, q4)
-        assert_allclose(at2, np.arctan2(q3.to(1).value, q4))
+        assert_allclose(at2.value, np.arctan2(q3.to(1).value, q4))
 
     def test_arctan2_invalid(self):
         with pytest.raises(u.UnitsError) as exc:


### PR DESCRIPTION
This PR partially addresses #3584, that with the numpy development version there are many test errors because the default for `atol` in `np.allclose` and `np.testing.assert_allclose` has changed. Almost all problems were in coordinates (hence, cc @eteq) and cosmology (hence, cc @aconley), where comparisons were often done on quantities rather than on values. Note that the changes are not necessarily complete -- but at least the tests pass.

Of course, it is *logical* to compare on quantities, not values (except perhaps in `units` itself), so I changed the tests to use `Quantity` aware versions where there were problems, adding a new `quantity_allclose` to join the existing `assert_quantity_allclose` in the process (hence, cc @astrofrog). 