### PR TITLE
Several changes to sigma clipping functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,9 @@ New Features
 
 - ``astropy.stats``
 
+  - Added ``sigma_lower`` and ``sigma_upper`` keywords to
+    ``sigma_clip`` to allow for unsymmetric clipping. [#3595]
+
 - ``astropy.table``
 
   - ``add_column()`` and ``add_columns()`` now have ``rename_duplicate``
@@ -131,6 +134,13 @@ API changes
 - ``astropy.nddata``
 
 - ``astropy.stats``
+
+  - Renamed the ``sigma_clip`` ``sig`` keyword as ``sigma``. [#3595]
+
+  - Changed the ``sigma_clip`` ``varfunc`` keyword to ``stdfunc``. [#3595]
+
+  - Renamed the ``sigma_clipped_stats`` ``mask_val`` keyword to
+    ``mask_value``. [#3595]
 
 - ``astropy.table``
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -55,7 +55,7 @@ def sigma_clip(*args, **kwargs):
     cenfunc : callable, optional
         The technique to compute the center for the clipping. Must be a
         callable that takes in a masked array and outputs the central value.
-        Defaults to the median (numpy.median).
+        Defaults to the median (`numpy.ma.median`).
     stdfunc : callable, optional
         The technique to compute the standard deviation about the center. Must
         be a callable that takes in a masked array and outputs a width

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -2,7 +2,6 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
 import numpy as np
 
 
@@ -137,14 +136,20 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
         while filtered_data.count() != lastrej:
             i += 1
             lastrej = filtered_data.count()
-            do = filtered_data - cenfunc(filtered_data)
-            filtered_data.mask |= (do < -stdfunc(filtered_data) * sigma_lower)
-            filtered_data.mask |= (do > stdfunc(filtered_data) * sigma_upper)
+            deviation = filtered_data - cenfunc(filtered_data)
+            std = stdfunc(filtered_data)
+            filtered_data.mask |= np.ma.masked_less(deviation,
+                                                    -std * sigma_lower).mask
+            filtered_data.mask |= np.ma.masked_greater(deviation,
+                                                       std * sigma_upper).mask
     else:
         for i in range(iters):
-            do = filtered_data - cenfunc(filtered_data)
-            filtered_data.mask |= (do < -stdfunc(filtered_data) * sigma_lower)
-            filtered_data.mask |= (do > stdfunc(filtered_data) * sigma_upper)
+            deviation = filtered_data - cenfunc(filtered_data)
+            std = stdfunc(filtered_data)
+            filtered_data.mask |= np.ma.masked_less(deviation,
+                                                    -std * sigma_lower).mask
+            filtered_data.mask |= np.ma.masked_greater(deviation,
+                                                       std * sigma_upper).mask
 
     return filtered_data
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -154,7 +154,8 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
     return filtered_data
 
 
-def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
+def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0,
+                        sigma_lower=3.0, sigma_upper=3.0, iters=None):
     """
     Calculate sigma-clipped statistics from data.
 
@@ -196,6 +197,7 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0, iters=None):
         data = np.ma.MaskedArray(data, mask)
     if mask_val is not None:
         data = np.ma.masked_values(data, mask_val)
-    data_clip = sigma_clip(data, sig=sigma, iters=iters)
+    data_clip = sigma_clip(data, sig=sigma, sigma_lower=sigma_lower,
+                           sigma_upper=sigma_upper, iters=iters)
     goodvals = data_clip.data[~data_clip.mask]
     return np.mean(goodvals), np.median(goodvals), np.std(goodvals)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -101,7 +101,8 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
         >>> from numpy.random import randn
         >>> from numpy import mean
         >>> randvar = randn(10000)
-        >>> filtered_data = sigma_clip(randvar, 3, None, mean, copy=False)
+        >>> filtered_data = sigma_clip(randvar, 3, iters=None, cenfunc=mean,
+        ...                            copy=False)
 
     This will clip along one axis on a similar distribution with bad points
     inserted::

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -3,7 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from copy import deepcopy
 from collections import OrderedDict
 from astropy.utils.compat.funcsigs import Parameter, Signature
 import warnings

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -25,32 +25,40 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
     ----------
     data : array-like
         The data to be sigma-clipped (any shape).
-    sigma : float
-        The number of standard deviations (*not* variances) to use as the
-        clipping limit.
-    iters : int or `None`
+    sigma : float, optional
+        The number of standard deviations to use as the lower and upper
+        clipping limit.  These limits are overridden by ``sigma_lower``
+        and ``sigma_upper``, if input.
+    sigma_lower : float, optional
+        The number of standard deviations to use as the lower bound for
+        the clipping limit.  If `None` then the value of ``sigma`` is used.
+    sigma_upper : float, optional
+        The number of standard deviations to use as the upper bound for
+        the clipping limit.  If `None` then the value of ``sigma`` is used.
+    iters : int or `None`, optional
         The number of iterations to perform clipping for, or `None` to clip
         until convergence is achieved (i.e. continue until the last
         iteration clips nothing).
-    cenfunc : callable
+    cenfunc : callable, optional
         The technique to compute the center for the clipping. Must be a
         callable that takes in a masked array and outputs the central value.
         Defaults to the median (numpy.median).
-    stdfunc : callable
+    stdfunc : callable, optional
         The technique to compute the standard deviation about the center. Must
         be a callable that takes in a masked array and outputs a width
-        estimator::
+        estimator.  Masked (rejected) pixels are those where::
 
-             deviation**2 > sig**2 * stdfunc(deviation)**2
+             deviation < (-sigma_lower * stdfunc(deviation))
+             deviation > (sigma_upper * stdfunc(deviation))
 
         Defaults to the standard deviation (`numpy.std`).
 
-    axis : int or `None`
+    axis : int or `None`, optional
         If not `None`, clip along the given axis.  For this case, axis=int will
         be passed on to cenfunc and stdfunc, which are expected to return an
         array with the axis dimension removed (like the numpy functions).
         If `None`, clip over all values.  Defaults to `None`.
-    copy : bool
+    copy : bool, optional
         If `True`, the data array will be copied.  If `False`, the masked array
         data will contain the same array as ``data``.  Defaults to `True`.
 
@@ -68,7 +76,8 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
 
         and then setting a mask for points outside the range::
 
-            data.mask = deviation**2 > sigma**2 * stdfunc(deviation)**2
+           deviation < (-sigma_lower * stdfunc(deviation))
+           deviation > (sigma_upper * stdfunc(deviation))
 
         It will iterate a given number of times, or until no further points are
         rejected.
@@ -92,7 +101,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
         >>> from astropy.stats import sigma_clip
         >>> from numpy.random import randn
         >>> randvar = randn(10000)
-        >>> filtered_data = sigma_clip(randvar, 2, 1)
+        >>> filtered_data = sigma_clip(randvar, 2, iters=1)
 
     This will clipping on a similar distribution, but for 3 sigma relative to
     the sample *mean*, will clip until converged, and does not copy the data::
@@ -115,7 +124,6 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
 
     Note that along the other axis, no points would be masked, as the variance
     is higher.
-
     """
 
     if sigma_lower is None:
@@ -179,7 +187,17 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         in addition to any input ``mask``.
 
     sigma : float, optional
-        The number of standard deviations to use as the clipping limit.
+        The number of standard deviations to use as the lower and upper
+        clipping limit.  These limits are overridden by ``sigma_lower``
+        and ``sigma_upper``, if input.
+
+    sigma_lower : float, optional
+        The number of standard deviations to use as the lower bound for
+        the clipping limit.  If `None` then the value of ``sigma`` is used.
+
+    sigma_upper : float, optional
+        The number of standard deviations to use as the upper bound for
+        the clipping limit.  If `None` then the value of ``sigma`` is used.
 
     iters : int, optional
         The number of iterations to perform sigma clipping, or `None` to

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -8,7 +8,7 @@ import numpy as np
 __all__ = ['sigma_clip', 'sigma_clipped_stats']
 
 
-def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
+def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
                cenfunc=np.ma.median, stdfunc=np.std, axis=None, copy=True):
     """Perform sigma-clipping on the provided data.
 
@@ -25,7 +25,7 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
     ----------
     data : array-like
         The data to be sigma-clipped (any shape).
-    sig : float
+    sigma : float
         The number of standard deviations (*not* variances) to use as the
         clipping limit.
     iters : int or `None`
@@ -68,7 +68,7 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
 
         and then setting a mask for points outside the range::
 
-            data.mask = deviation**2 > sig**2 * stdfunc(deviation)**2
+            data.mask = deviation**2 > sigma**2 * stdfunc(deviation)**2
 
         It will iterate a given number of times, or until no further points are
         rejected.
@@ -111,7 +111,7 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
         >>> from numpy.random import normal
         >>> from numpy import arange, diag, ones
         >>> data = arange(5)+normal(0.,0.05,(5,5))+diag(ones(5))
-        >>> filtered_data = sigma_clip(data, axis=0, sig=2.3)
+        >>> filtered_data = sigma_clip(data, axis=0, sigma=2.3)
 
     Note that along the other axis, no points would be masked, as the variance
     is higher.
@@ -119,9 +119,9 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
     """
 
     if sigma_lower is None:
-        sigma_lower = sig
+        sigma_lower = sigma
     if sigma_upper is None:
-        sigma_upper = sig
+        sigma_upper = sigma
 
     if axis is not None:
         cenfunc_in = cenfunc
@@ -198,7 +198,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         data = np.ma.MaskedArray(data, mask)
     if mask_value is not None:
         data = np.ma.masked_values(data, mask_value)
-    data_clip = sigma_clip(data, sig=sigma, sigma_lower=sigma_lower,
+    data_clip = sigma_clip(data, sigma=sigma, sigma_lower=sigma_lower,
                            sigma_upper=sigma_upper, iters=iters)
     goodvals = data_clip.data[~data_clip.mask]
     return np.mean(goodvals), np.median(goodvals), np.std(goodvals)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -3,13 +3,26 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from collections import OrderedDict
+from astropy.utils.compat.funcsigs import Parameter, Signature
 
 
 __all__ = ['sigma_clip', 'sigma_clipped_stats']
 
 
-def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
-               cenfunc=np.ma.median, stdfunc=np.std, axis=None, copy=True):
+def _make_sigma_clip_signature():
+    _sigma_clip_keywords = OrderedDict([('sigma', 3.), ('sigma_lower', None),
+                                        ('sigma_upper', None), ('iters', 1),
+                                        ('cenfunc', np.ma.median),
+                                        ('stdfunc', np.std), ('axis', None),
+                                        ('copy', True)])
+    params = ([Parameter('data', Parameter.POSITIONAL_ONLY)] +
+              [Parameter(name, Parameter.KEYWORD_ONLY, default=default)
+               for name, default in _sigma_clip_keywords.items()])
+    return Signature(params)
+
+
+def sigma_clip(*args, **kwargs):
     """Perform sigma-clipping on the provided data.
 
     This performs the sigma clipping algorithm - i.e. the data will be iterated
@@ -161,6 +174,9 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
                                                        std * sigma_upper).mask
 
     return filtered_data
+
+
+sigma_clip.__signature__ = _make_sigma_clip_signature()
 
 
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -155,7 +155,7 @@ def sigma_clip(data, sig=3, sigma_lower=None, sigma_upper=None, iters=1,
     return filtered_data
 
 
-def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0,
+def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
                         sigma_lower=3.0, sigma_upper=3.0, iters=None):
     """
     Calculate sigma-clipped statistics from data.
@@ -173,10 +173,10 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0,
         value indicates the corresponding element of ``data`` is masked.
         Masked pixels are excluded when computing the image statistics.
 
-    mask_val : float, optional
+    mask_value : float, optional
         An image data value (e.g., ``0.0``) that is ignored when
-        computing the image statistics.  ``mask_val`` will be masked in
-        addition to any input ``mask``.
+        computing the image statistics.  ``mask_value`` will be masked
+        in addition to any input ``mask``.
 
     sigma : float, optional
         The number of standard deviations to use as the clipping limit.
@@ -196,8 +196,8 @@ def sigma_clipped_stats(data, mask=None, mask_val=None, sigma=3.0,
 
     if mask is not None:
         data = np.ma.MaskedArray(data, mask)
-    if mask_val is not None:
-        data = np.ma.masked_values(data, mask_val)
+    if mask_value is not None:
+        data = np.ma.masked_values(data, mask_value)
     data_clip = sigma_clip(data, sig=sigma, sigma_lower=sigma_lower,
                            sigma_upper=sigma_upper, iters=iters)
     goodvals = data_clip.data[~data_clip.mask]

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -3,28 +3,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from collections import OrderedDict
-from astropy.utils.compat.funcsigs import Parameter, Signature
 import warnings
 from ..utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 
 __all__ = ['sigma_clip', 'sigma_clipped_stats']
-
-
-_sigma_clip_keywords = OrderedDict([('sigma', 3.), ('sigma_lower', None),
-                                    ('sigma_upper', None), ('iters', 1),
-                                    ('cenfunc', np.ma.median),
-                                    ('stdfunc', np.std), ('axis', None),
-                                    ('copy', True), ('sig', 3),
-                                    ('varfunc', np.var)])
-
-
-def _make_sigma_clip_signature(_sigma_clip_keywords):
-    params = ([Parameter('data', Parameter.POSITIONAL_ONLY)] +
-              [Parameter(name, Parameter.KEYWORD_ONLY, default=default)
-               for name, default in _sigma_clip_keywords.items()])
-    return Signature(params)
 
 
 def sigma_clip(data, **kwargs):

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -29,7 +29,7 @@ def test_sigma_clip():
         # Amazing, I've got the same combination on my luggage!
         randvar = randn(10000)
 
-        filtered_data = sigma_clip(randvar, 1, iters=2)
+        filtered_data = sigma_clip(randvar, sigma=1, iters=2)
 
         assert sum(filtered_data.mask) > 0
         assert sum(~filtered_data.mask) < randvar.size
@@ -37,21 +37,22 @@ def test_sigma_clip():
         # this is actually a silly thing to do, because it uses the
         # standard deviation as the variance, but it tests to make sure
         # these arguments are actually doing something
-        filtered_data2 = sigma_clip(randvar, 1, iters=2, stdfunc=np.var)
+        filtered_data2 = sigma_clip(randvar, sigma=1, iters=2, stdfunc=np.var)
         assert not np.all(filtered_data.mask == filtered_data2.mask)
 
-        filtered_data3 = sigma_clip(randvar, 1, iters=2, cenfunc=np.mean)
+        filtered_data3 = sigma_clip(randvar, sigma=1, iters=2,
+                                    cenfunc=np.mean)
         assert not np.all(filtered_data.mask == filtered_data3.mask)
 
         # make sure the iters=None method works at all.
-        filtered_data = sigma_clip(randvar, 3, iters=None)
+        filtered_data = sigma_clip(randvar, sigma=3, iters=None)
 
         # test copying
         assert filtered_data.data[0] == randvar[0]
         filtered_data.data[0] += 1.
         assert filtered_data.data[0] != randvar[0]
 
-        filtered_data = sigma_clip(randvar, 3, iters=None, copy=False)
+        filtered_data = sigma_clip(randvar, sigma=3, iters=None, copy=False)
         assert filtered_data.data[0] == randvar[0]
         filtered_data.data[0] += 1.
         assert filtered_data.data[0] == randvar[0]
@@ -74,7 +75,7 @@ def test_compare_to_scipy_sigmaclip():
 
         randvar = randn(10000)
 
-        astropyres = sigma_clip(randvar, 3, iters=None, cenfunc=np.mean)
+        astropyres = sigma_clip(randvar, sigma=3, iters=None, cenfunc=np.mean)
         scipyres = stats.sigmaclip(randvar, 3, 3)[0]
 
         assert astropyres.count() == len(scipyres)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -29,29 +29,29 @@ def test_sigma_clip():
         # Amazing, I've got the same combination on my luggage!
         randvar = randn(10000)
 
-        filtered_data = sigma_clip(randvar, 1, 2)
+        filtered_data = sigma_clip(randvar, 1, iters=2)
 
         assert sum(filtered_data.mask) > 0
         assert sum(~filtered_data.mask) < randvar.size
 
-        #this is actually a silly thing to do, because it uses the standard
-        #deviation as the variance, but it tests to make sure these arguments
-        #are actually doing something
-        filtered_data2 = sigma_clip(randvar, 1, 2, varfunc=np.std)
+        # this is actually a silly thing to do, because it uses the
+        # standard deviation as the variance, but it tests to make sure
+        # these arguments are actually doing something
+        filtered_data2 = sigma_clip(randvar, 1, iters=2, stdfunc=np.var)
         assert not np.all(filtered_data.mask == filtered_data2.mask)
 
-        filtered_data3 = sigma_clip(randvar, 1, 2, cenfunc=np.mean)
+        filtered_data3 = sigma_clip(randvar, 1, iters=2, cenfunc=np.mean)
         assert not np.all(filtered_data.mask == filtered_data3.mask)
 
         # make sure the iters=None method works at all.
-        filtered_data = sigma_clip(randvar, 3, None)
+        filtered_data = sigma_clip(randvar, 3, iters=None)
 
         # test copying
         assert filtered_data.data[0] == randvar[0]
         filtered_data.data[0] += 1.
         assert filtered_data.data[0] != randvar[0]
 
-        filtered_data = sigma_clip(randvar, 3, None, copy=False)
+        filtered_data = sigma_clip(randvar, 3, iters=None, copy=False)
         assert filtered_data.data[0] == randvar[0]
         filtered_data.data[0] += 1.
         assert filtered_data.data[0] == randvar[0]
@@ -74,7 +74,7 @@ def test_compare_to_scipy_sigmaclip():
 
         randvar = randn(10000)
 
-        astropyres = sigma_clip(randvar, 3, None, np.mean)
+        astropyres = sigma_clip(randvar, 3, iters=None, cenfunc=np.mean)
         scipyres = stats.sigmaclip(randvar, 3, 3)[0]
 
         assert astropyres.count() == len(scipyres)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -82,7 +82,7 @@ def test_compare_to_scipy_sigmaclip():
 
 
 def test_sigma_clipped_stats():
-    """Test list data with input mask or mask_val (#3268)."""
+    """Test list data with input mask or mask_value (#3268)."""
     # test list data with mask
     data = [0, 1]
     mask = np.array([True, False])
@@ -91,8 +91,8 @@ def test_sigma_clipped_stats():
     assert result[1] == 1.
     assert result[2] == 0.
 
-    # test list data with mask_val
-    result2 = sigma_clipped_stats(data, mask_val=0.)
+    # test list data with mask_value
+    result2 = sigma_clipped_stats(data, mask_value=0.)
     assert result2[0] == 1.
     assert result2[1] == 1.
     assert result2[2] == 0.

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -59,9 +59,9 @@ def test_sigma_clip():
         # test axis
         data = np.arange(5) + np.random.normal(0., 0.05, (5, 5)) + \
             np.diag(np.ones(5))
-        filtered_data = sigma_clip(data, axis=0, sig=2.3)
+        filtered_data = sigma_clip(data, axis=0, sigma=2.3)
         assert filtered_data.count() == 20
-        filtered_data = sigma_clip(data, axis=1, sig=2.3)
+        filtered_data = sigma_clip(data, axis=1, sigma=2.3)
         assert filtered_data.count() == 25
 
 


### PR DESCRIPTION
This PR makes several changes to the sigma clipping functions:

 * Added `sigma_lower` and `sigma_upper` keywords to allow for unsymmetric clipping.
 * In `sigma_clip`, I renamed the `sig` keyword to `sigma` (if unspecified then `sigma_lower` and `sigma_upper` default to `sigma`).
 * I changed the `sigma_clip` input from `varfunc` to `stdfunc`.  There are readily available alternate standard deviation estimators, e.g. `astropy.stats.mad_std` or `astropy.stats.biweight_midvariance`, but none that I'm aware of for an alternate variance function.
 * `sigma_clip` now uses the `np.ma.masked_less` and `np.ma.masked_greater` functions to prevent 
`RuntimeWarning` messages: "invalid value encountered in greater filtered_data.mask |= do * do > varfunc(filtered_data) * sig ** 2" that would occur for example when the `data` contain `np.nan`.
 * In `sigma_clipped_stats`, I changed the keyword from `mask_val` to `mask_value`.

In this PR, three parameter names have been changed, breaking the current API.  Is there a good way to issue an `AstropyDeprecationWarning` about these parameter changes?

CC: @perrygreenfield, @hcferguson 