### PR TITLE
Allow regular expressions in TimeString subformats

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import fnmatch
 import time
+import re
 
 from datetime import datetime
 
@@ -1255,6 +1256,33 @@ class TimeDelta(Time):
                           u.day).to(*args, **kwargs)
 
 
+def _regexify_subfmts(subfmts):
+    """
+    Iterate through each of the sub-formats and try substituting simple
+    regular expressions for the strptime codes for year, month, day-of-month,
+    hour, minute, second.  If no % characters remain then turn the final string
+    into a compiled regex.  This assumes time formats do not have a % in them.
+    """
+    new_subfmts = []
+    for subfmt_tuple in subfmts:
+        subfmt_in = subfmt_tuple[1]
+        for strptime_code, regex in (('%Y', r'(?P<year>\d\d\d\d)'),
+                                     ('%m', r'(?P<mon>\d{1,2})'),
+                                     ('%d', r'(?P<mday>\d{1,2})'),
+                                     ('%H', r'(?P<hour>\d{1,2})'),
+                                     ('%M', r'(?P<min>\d{1,2})'),
+                                     ('%S', r'(?P<sec>\d{1,2})')):
+            subfmt_in = re.sub(strptime_code, regex, subfmt_in)
+
+        if '%' not in subfmt_in:
+            subfmt_tuple = (subfmt_tuple[0],
+                            re.compile(subfmt_in + '$'),
+                            subfmt_tuple[2])
+        new_subfmts.append(subfmt_tuple)
+
+    return tuple(new_subfmts)
+
+
 class TimeFormatMeta(type):
     """
     Metaclass that adds `TimeFormat` and `TimeDeltaFormat` to the
@@ -1268,6 +1296,9 @@ class TimeFormatMeta(type):
 
         if 'name' in members:
             mcls._registry[cls.name] = cls
+
+        if 'subfmts' in members:
+            cls.subfmts = _regexify_subfmts(members['subfmts'])
 
         return cls
 
@@ -1769,6 +1800,12 @@ class TimeString(TimeUnique):
 
         iterator = np.nditer([val1, None, None, None, None, None, None],
                              op_dtypes=[val1.dtype] + 5*[np.intc] + [np.double])
+
+        # Datetime components required for conversion to JD by ERFA, along
+        # with the default values.
+        time_comps = ('year', 'mon', 'mday', 'hour', 'min', 'sec')
+        comp_defaults = (None, 1, 1, 0, 0, 0)
+
         for val, iy, im, id, ihr, imin, dsec in iterator:
             timestr = val.item()
             # Handle trailing 'Z' for UTC time
@@ -1787,19 +1824,26 @@ class TimeString(TimeUnique):
                 timestr, fracsec = timestr[:idot], timestr[idot:]
                 fracsec = float(fracsec)
 
-            for _, strptime_fmt, _ in subfmts:
-                try:
-                    tm = time.strptime(timestr, strptime_fmt)
-                except ValueError:
-                    pass
+            for _, strptime_fmt_or_regex, _ in subfmts:
+                if isinstance(strptime_fmt_or_regex, six.string_types):
+                    try:
+                        tm = time.strptime(timestr, strptime_fmt_or_regex)
+                    except ValueError:
+                        continue
+                    tm_vals = [getattr(tm, 'tm_' + comp) for comp in time_comps]
+
                 else:
-                    iy[...] = tm.tm_year
-                    im[...] = tm.tm_mon
-                    id[...] = tm.tm_mday
-                    ihr[...] = tm.tm_hour
-                    imin[...] = tm.tm_min
-                    dsec[...] = tm.tm_sec + fracsec
-                    break
+                    tm = re.match(strptime_fmt_or_regex, timestr)
+                    if tm is None:
+                        continue
+                    tm = tm.groupdict()
+                    tm_vals = [int(tm.get(comp, default)) for comp, default
+                               in six.moves.zip(time_comps, comp_defaults)]
+
+                iy[...], im[...], id[...], ihr[...], imin[...], dsec[...] = tm_vals
+                dsec[...] += fracsec
+                break
+
             else:
                 raise ValueError('Time {0} does not match {1} format'
                                  .format(timestr, self.name))

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1262,6 +1262,9 @@ def _regexify_subfmts(subfmts):
     regular expressions for the strptime codes for year, month, day-of-month,
     hour, minute, second.  If no % characters remain then turn the final string
     into a compiled regex.  This assumes time formats do not have a % in them.
+
+    This is done both to speed up parsing of strings and to allow mixed formats
+    where strptime does not quite work well enough.
     """
     new_subfmts = []
     for subfmt_tuple in subfmts:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ...tests.helper import pytest, catch_warnings
 from ...extern import six
-from .. import Time, ScaleValueError, erfa_time, TIME_SCALES
+from .. import Time, ScaleValueError, erfa_time, TIME_SCALES, TimeString
 from ...coordinates import EarthLocation
 
 
@@ -814,3 +814,16 @@ def test_datetime_tzinfo():
     d = datetime(2002, 1, 2, 10, 3, 4, tzinfo=TZm6())
     t = Time(d)
     assert t.value == datetime(2002, 1, 2, 16, 3, 4)
+
+def test_subfmts_regex():
+    """
+    Test having a custom subfmts with a regular expression
+    """
+    class TimeLongYear(TimeString):
+        name = 'longyear'
+        subfmts = (('date',
+                    r'(?P<year>[+-]\d{5})-%m-%d',  # hybrid
+                    '{year:+06d}-{mon:02d}-{day:02d}'),)
+    t = Time('+02000-02-03', format='longyear')
+    assert t.value == '+02000-02-03'
+    assert t.jd == Time('2000-02-03').jd


### PR DESCRIPTION
This is a proof of concept for using regex instead of `strptime` for parsing date strings.

This was inspired by #3547 where the use of `strptime` is problematic because it cannot handle the FITS long year format (with 5 digits and leading +/-).  For an input list of 1000 date strings this version using regex improves performance by a factor of 2.

This PR conflicts with the refactoring improvements in #3547.  But it points to a possible way forward which is to take these changes and pull out the refactoring from #3547 in to a separate PR, and then have #3547 be strictly about the TimeFITS format.

[EDIT: the new version is fully backward compatible]

The question is whether the second arg of the `subfmts` class attribute is considered "public", in which case this change would be an API break.  As far as user documentation this is not mentioned anywhere, except that it does show up in the API docs as a class attribute.  If necessary we can retain back compatibility, at the expense of having two divergent code paths.  Maybe this could just be for a release and we deprecate using the `strptime` format.

@mhvk 