### PR TITLE
QTable cannot be pickled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -289,6 +289,8 @@ Bug Fixes
 
 - ``astropy.table``
 
+  - Ensure ``QTable`` can be pickled [#3590]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2109,3 +2109,8 @@ class QTable(Table):
         If ``col`` is a string then it refers to a column name in this table.
         """
         return super(QTable, self)._is_mixin_column(col, quantity_is_mixin=True)
+
+    def __getstate__(self):
+        columns = dict((key, col if isinstance(col, BaseColumn) else col_copy(col))
+                for key, col in self.columns.items())
+        return (columns, self.meta)

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -4,7 +4,9 @@ import numpy as np
 import pytest
 
 from ...table import Table, Column, MaskedColumn, QTable
-from ...units import Quantity
+from ...units import Quantity, deg
+from ...time import Time
+from ...coordinates import SkyCoord
 
 
 def test_pickle_column(protocol):
@@ -48,18 +50,25 @@ def test_pickle_qtable(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
     b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',
                meta={'b': 1})
-    t = QTable([a, b], meta={'a': 1})
-    c = Quantity([1, 2], unit='m')
-    t['c'] = c
+    t = QTable([a, b], meta={'a': 1, 'b':Quantity(10,unit='s')})
+    t['c'] = Quantity([1, 2], unit='m')
+    t['d'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+    t['e'] = SkyCoord([125.0,180.0]*deg, [-45.0,36.5]*deg)
     ts = pickle.dumps(t)
     tp = pickle.loads(ts)
 
     assert np.all(tp['a'] == t['a'])
     assert np.all(tp['b'] == t['b'])
+    # test mixin columns
     assert np.all(tp['c'] == t['c'])
-    assert tp['a'].attrs_equal(t['a'])
-    assert tp['b'].attrs_equal(t['b'])
+    assert np.all(tp['d'] == t['d'])
+    assert np.all(tp['e'].ra == t['e'].ra)
+    assert np.all(tp['e'].dec == t['e'].dec)
+    assert type(tp['c']) == type(t['c'])
+    assert type(tp['d']) == type(t['d'])
+    assert type(tp['e']) == type(t['e'])
     assert tp.meta == t.meta
+    assert type(tp) == type(t)
 
 def test_pickle_masked_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -3,7 +3,8 @@ from ...extern.six.moves import cPickle as pickle
 import numpy as np
 import pytest
 
-from ...table import Table, Column, MaskedColumn
+from ...table import Table, Column, MaskedColumn, QTable
+from ...units import Quantity
 
 
 def test_pickle_column(protocol):
@@ -43,6 +44,22 @@ def test_pickle_table(protocol):
     assert tp['b'].attrs_equal(t['b'])
     assert tp.meta == t.meta
 
+def test_pickle_qtable(protocol):
+    a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
+    b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',
+               meta={'b': 1})
+    t = QTable([a, b], meta={'a': 1})
+    c = Quantity([1, 2], unit='m')
+    t['c'] = c
+    ts = pickle.dumps(t)
+    tp = pickle.loads(ts)
+
+    assert np.all(tp['a'] == t['a'])
+    assert np.all(tp['b'] == t['b'])
+    assert np.all(tp['c'] == t['c'])
+    assert tp['a'].attrs_equal(t['a'])
+    assert tp['b'].attrs_equal(t['b'])
+    assert tp.meta == t.meta
 
 def test_pickle_masked_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})


### PR DESCRIPTION
While pickling an `astropy.table.Table` works fine, QTables are unable to be pickled:

```python
In [3]: from astropy.table import QTable
In [4]: t=QTable()
In [5]: t['a']=np.linspace(1,10)*u.m
In [6]: t['b']=np.linspace(1,10)*u.s
In [7]: pickle.dumps(t)
---------------------------------------------------------------------------
PicklingError                             Traceback (most recent call last)
<ipython-input-7-f90063f6658b> in <module>()
----> 1 pickle.dumps(t)

PicklingError: Can't pickle <class 'weakref'>: attribute lookup weakref on builtins failed
```

This is not a problem in general use, but prevents QTables from being used with multiprocessing, which pickles all the objects it passes to the function calls. 
