### PR TITLE
Getting errors while fitting polynomial model with tied  parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -295,6 +295,12 @@ Bug Fixes
 
 - ``astropy.modeling``
 
+  - Fixed instantiation of polynomial models with constraints for parameters
+    (constraints could still be assigned after instantiation, but not during).
+    [#3606]
+
+  - Fixed fitting of 2D polynomial models with the ``LeVMarLSQFitter``. [#3606]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -913,7 +913,7 @@ class Model(object):
         # Pop any constraints off the keyword arguments
         for constraint in self.parameter_constraints:
             values = kwargs.pop(constraint, {})
-            self._constraints[constraint] = values
+            self._constraints[constraint] = values.copy()
 
             # Update with default parameter constraints
             for param_name in self.param_names:

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -491,6 +491,7 @@ class LevMarLSQFitter(object):
         constraints, instead of using p directly, we set the parameter list in
         this function.
         """
+
         if any(model.fixed.values()) or any(model.tied.values()):
 
             if z is None:
@@ -508,7 +509,7 @@ class LevMarLSQFitter(object):
 
             if not model.col_fit_deriv:
                 full_deriv = np.asarray(full_deriv).T
-                residues = np.asarray(full_deriv[np.nonzero(ind)])
+                residues = np.asarray(full_deriv[np.nonzero(ind)]).T
             else:
                 residues = full_deriv[np.nonzero(ind)]
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -78,14 +78,6 @@ class PolynomialBase(FittableModel):
         else:
             super(PolynomialBase, self).__setattr__(attr, value)
 
-    def _validate_params(self, **params):
-        valid_params = set(self._param_names)
-        provided_params = set(params)
-        intersection = valid_params.intersection(provided_params)
-        if len(intersection) != len(provided_params):
-            diff = list(provided_params.difference(valid_params))
-            raise TypeError('Unrecognized input parameters: %s' % diff)
-
 
 class PolynomialModel(PolynomialBase):
     """
@@ -101,9 +93,6 @@ class PolynomialModel(PolynomialBase):
         self._degree = degree
         self._order = self.get_num_coeff(self.n_inputs)
         self._param_names = self._generate_coeff_names(self.n_inputs)
-
-        if params:
-            self._validate_params(**params)
 
         super(PolynomialModel, self).__init__(
             n_models=n_models, model_set_axis=model_set_axis, name=name,
@@ -208,9 +197,6 @@ class OrthoPolynomialBase(PolynomialBase):
         self.x_window = x_window
         self.y_window = y_window
         self._param_names = self._generate_coeff_names()
-
-        if params:
-            self._validate_params(**params)
 
         super(OrthoPolynomialBase, self).__init__(
             n_models=n_models, model_set_axis=model_set_axis,
@@ -967,9 +953,6 @@ class _SIP1D(PolynomialBase):
         self.order = order
         self.coeff_prefix = coeff_prefix
         self._param_names = self._generate_coeff_names(coeff_prefix)
-
-        if params:
-            self._validate_params(**params)
 
         super(_SIP1D, self).__init__(n_models=n_models,
                                      model_set_axis=model_set_axis,


### PR DESCRIPTION
Hi! Found two different errors, one for each kind of syntax suggested by the documentation (http://astropy.readthedocs.org/en/latest/modeling/fitting.html), while trying to get 'tied' parameters to work while fitting a model.

I'm using Python 3 in Fedora 21 (therefore Astropy 0.3.2-2.fc20).

I can fit without the ties using NonLinearLSQFitter over a model Polynomial2D, using:

```python
from astropy.modeling import models
from astropy.modeling.fitting import NonLinearLSQFitter as LevMarLSQFitter
Polynomial2D_model = models.Polynomial2D ( degree = 2 )
LevMarLSQFitter_fit = LevMarLSQFitter ( )
polynomial_fit = LevMarLSQFitter_fit ( model = Polynomial2D_model, x = iia_x_dimension, y = iia_y_dimension, z = self.__ffa_unwrapped )
```

But this modified code fails:

```python
def tied_c2_0 ( o_model ):
  o_c2_0 = o_model.c0_2
  return o_c2_0

Polynomial2D_model = models.Polynomial2D ( degree = 2, tied = { 'c2_0' : tied_c2_0 } )
LevMarLSQFitter_fit = LevMarLSQFitter ( )
polynomial_fit = LevMarLSQFitter_fit ( model = Polynomial2D_model, x = iia_x_dimension, y = iia_y_dimension, z = self.__ffa_unwrapped )
```
```
Traceback (most recent call last):
  File "./eg_highres_pipeline.py", line 111, in <module>
    unwrap_phase_map ( )
  File "./eg_highres_pipeline.py", line 40, in unwrap_phase_map
    f_scanning_wavelength = 6616.895 )
  File "/home/nix/cloud_essential2/tuna/github/tools/phase_map/high_resolution.py", line 112, in __init__
    ffa_unwrapped = self.unwrapped_phase_map )
  File "/home/nix/cloud_essential2/tuna/github/tools/models/parabola.py", line 80, in fit_parabolic_model_by_Polynomial2D
    o_parabola.create_model_map_by_Polynomial2D ( )
  File "/home/nix/cloud_essential2/tuna/github/tools/models/parabola.py", line 36, in create_model_map_by_Polynomial2D
    tied = { 'c2_0': tied_c2_0 } )
  File "/usr/lib64/python3.3/site-packages/astropy/modeling/polynomial.py", line 672, in __init__
    param_dim=param_dim, **params)
  File "/usr/lib64/python3.3/site-packages/astropy/modeling/polynomial.py", line 131, in __init__
    self._validate_params(**params)
  File "/usr/lib64/python3.3/site-packages/astropy/modeling/polynomial.py", line 183, in _validate_params
    assert(len(params) == numcoeff)
AssertionError
```
The other syntax also is problematic:

```python
def tied_c2_0 ( o_model ):
  o_c2_0 = o_model.c0_2
  return o_c2_0

Polynomial2D_model = models.Polynomial2D ( degree = 2 )
Polynomial2D_model.c2_0.tied = tied_c2_0
LevMarLSQFitter_fit = LevMarLSQFitter ( )
polynomial_fit = LevMarLSQFitter_fit ( model = Polynomial2D_model, x = iia_x_dimension, y = iia_y_dimension, z = self.__ffa_unwrapped )
```
```
Traceback (most recent call last):
  File "./eg_highres_pipeline.py", line 111, in <module>
    unwrap_phase_map ( )
  File "./eg_highres_pipeline.py", line 40, in unwrap_phase_map
    f_scanning_wavelength = 6616.895 )
  File "/home/nix/cloud_essential2/tuna/github/tools/phase_map/high_resolution.py", line 112, in __init__
    ffa_unwrapped = self.unwrapped_phase_map )
  File "/home/nix/cloud_essential2/tuna/github/tools/models/parabola.py", line 80, in fit_parabolic_model_by_Polynomial2D
    o_parabola.create_model_map_by_Polynomial2D ( )
  File "/home/nix/cloud_essential2/tuna/github/tools/models/parabola.py", line 46, in create_model_map_by_Polynomial2D
    z = self.__ffa_unwrapped )
  File "/usr/lib64/python3.3/site-packages/astropy/modeling/fitting.py", line 465, in __call__
    full_output=True)
  File "/usr/lib64/python3.3/site-packages/scipy/optimize/minpack.py", line 369, in leastsq
    _check_func('leastsq', 'Dfun', Dfun, x0, args, n, (m,n))
  File "/usr/lib64/python3.3/site-packages/scipy/optimize/minpack.py", line 30, in _check_func
    raise TypeError(msg)
TypeError: leastsq: there is a mismatch between the input and output shape of the 'Dfun' argument '_wrap_deriv'.
```
At least one other person on the user ML can reproduce these errors.