### PR TITLE
Add matplotlib and WCSAxes to list of optional dependencies in install docs (fixes #3608)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,6 +29,11 @@ Astropy also depends on other packages for optional features:
 
 - `xmllint <http://www.xmlsoft.org/>`_: To validate VOTABLE XML files.
 
+- `matplotlib <http://matplotlib.org/>`_: To plot 2D data.
+
+- `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To make plots of Astronomical data in Matplotlib. 
+
+
 However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,10 +29,9 @@ Astropy also depends on other packages for optional features:
 
 - `xmllint <http://www.xmlsoft.org/>`_: To validate VOTABLE XML files.
 
-- `matplotlib <http://matplotlib.org/>`_: To plot 2D data.
+- `matplotlib <http://matplotlib.org/>`_: To provide plotting functionality that `astropy.visualization` enhances.
 
-- `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To make plots of Astronomical data in Matplotlib. 
-
+- `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To use `astropy.wcs` to define projections in Matplotlib. 
 
 However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.


### PR DESCRIPTION
added matloptlib and WCSAxes to optional dependencies list 
https://github.com/astropy/astropy/issues/3608