### PR TITLE
Revert 7186664e, which broke the old config API.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,7 +51,7 @@ New Features
 - ``astropy.time``
 
   - Add support for FITS standard time strings. [#3547]
-  
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]
@@ -93,8 +93,8 @@ API changes
 
 - ``astropy.modeling``
 
-  - Renamed the parameters of ``RotateNative2Celestial`` and 
-    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to 
+  - Renamed the parameters of ``RotateNative2Celestial`` and
+    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]
 
 - ``astropy.nddata``
@@ -264,6 +264,9 @@ Bug Fixes
 ^^^^^^^^^
 
 - ``astropy.config``
+
+  - The pre-astropy-0.4 configuration API has been fixed. It was
+    inadvertently broken in 1.0.1. [#3627]
 
 - ``astropy.constants``
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -225,7 +225,13 @@ class ConfigItem(object):
         from ..utils import isiterable
 
         if module is None:
-            module = self.__class__.__module__
+            module = find_current_module(2)
+            if module is None:
+                msg1 = 'Cannot automatically determine get_config module, '
+                msg2 = 'because it is not called from inside a valid module'
+                raise RuntimeError(msg1 + msg2)
+            else:
+                module = module.__name__
 
         self.module = module
         self.description = description


### PR DESCRIPTION
This was a performance enhancement only, so should have no other negative effects.