### PR TITLE
Issue 3601 -- astropy.stats.funcs.bootstrap now accepts bootfuncs with multiple outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3666,6 +3666,9 @@ New Features
   - Add ``axis=int`` option to ``stropy.stats.funcs.sigma_clip`` to allow
     clipping along a given axis for multidimensional data. [#1083]
 
+  - Add ``output_index`` option to ``astropy.stats.funcs.bootstrap`` which
+    allows the user to supply functions with multiple outputs to ``bootfunc``
+
 - ``astropy.table``
 
   - New columns can be added to a table via assignment to a non-existing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -309,6 +309,9 @@ New Features
     of several standard formulae for the error bars on the mean of a Poisson variable
     estimated from a single sample.
 
+  - Updated ``bootstrap`` to allow bootstrapping statistics with multiple
+    outputs. [#3601]
+
 - ``astropy.table``
 
   - ``add_column()`` and ``add_columns()`` now have ``rename_duplicate``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3669,9 +3669,6 @@ New Features
   - Add ``axis=int`` option to ``stropy.stats.funcs.sigma_clip`` to allow
     clipping along a given axis for multidimensional data. [#1083]
 
-  - Add ``output_index`` option to ``astropy.stats.funcs.bootstrap`` which
-    allows the user to supply functions with multiple outputs to ``bootfunc`` 
-
 - ``astropy.table``
 
   - New columns can be added to a table via assignment to a non-existing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3667,7 +3667,7 @@ New Features
     clipping along a given axis for multidimensional data. [#1083]
 
   - Add ``output_index`` option to ``astropy.stats.funcs.bootstrap`` which
-    allows the user to supply functions with multiple outputs to ``bootfunc``
+    allows the user to supply functions with multiple outputs to ``bootfunc`` 
 
 - ``astropy.table``
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -926,6 +926,44 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
         Bootstrapped data. Each row is a bootstrap resample of the data. The
         columns will correspond to the outputs of bootfunc.
 
+    Examples
+    --------
+    Obtain a twice resampled array:
+
+    >>> from astropy.stats import bootstrap
+    >>> import numpy as np
+    >>> from astropy.utils import NumpyRNGContext
+    >>> bootarr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])
+    >>> with NumpyRNGContext(1):
+    ...     bootresult = bootstrap(bootarr, 2)
+    ...
+    >>> bootresult
+    array([[ 6.,  9.,  0.,  6.,  1.,  1.,  2.,  8.,  7.,  0.],
+           [ 3.,  5.,  6.,  3.,  5.,  3.,  5.,  8.,  8.,  0.]])
+    >>> bootresult.shape
+    (2, 10)
+
+    Obtain a statistic on the array
+
+    >>> with NumpyRNGContext(1):
+    ...     bootresult = bootstrap(bootarr, 2, bootfunc=np.mean)
+    ...
+    >>> bootresult
+    array([ 4. ,  4.6])
+
+    Obtain a statistic with two outputs on the array
+
+    >>> from scipy.stats import spearmanr
+    >>> with NumpyRNGContext(1):
+    ...     bootresult = bootstrap(bootarr, 3, bootfunc=spearmanr)
+    ...
+    >>> bootresult
+    array([[ 0.60629737,  0.06314051],
+           [ 0.14159484,  0.69639692],
+           [ 0.54091829,  0.10640863]])
+    >>> bootresult.shape
+    (3, 2)
+
     """
     if samples is None:
         samples = data.shape[0]
@@ -937,7 +975,8 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
     if bootfunc is None:
         resultdims = (bootnum,) + (samples,) + data.shape[1:]
     else:
-        # test number of outputs from bootfunc
+        # test number of outputs from bootfunc, avoid single outputs which are
+        # array-like
         try:
             resultdims = (bootnum, len(bootfunc(data)))
         except TypeError:

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -953,26 +953,25 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
 
     Obtain a statistic with two outputs on the array
 
-    >>> from scipy.stats import spearmanr
+    >>> test_statistic = lambda x: (np.sum(x), np.mean(x))
     >>> with NumpyRNGContext(1):
-    ...     bootresult = bootstrap(bootarr, 3, bootfunc=spearmanr)
-    ...
+    ...     bootresult = bootstrap(bootarr, 3, bootfunc=test_statistic)
     >>> bootresult
-    array([[ 0.60629737,  0.06314051],
-           [ 0.14159484,  0.69639692],
-           [ 0.54091829,  0.10640863]])
+    array([[ 40. ,   4. ],
+           [ 46. ,   4.6],
+           [ 35. ,   3.5]])
     >>> bootresult.shape
     (3, 2)
 
     Obtain a statistic with two outputs on the array, keeping only the first
     output
 
-    >>> bootfunc = lambda x:spearmanr(x)[0]
+    >>> bootfunc = lambda x:test_statistic(x)[0]
     >>> with NumpyRNGContext(1):
     ...     bootresult = bootstrap(bootarr, 3, bootfunc=bootfunc)
     ...
     >>> bootresult
-    array([ 0.60629737,  0.14159484,  0.54091829])
+    array([ 40.,  46.,  35.])
     >>> bootresult.shape
     (3,)
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -895,7 +895,9 @@ def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,
     return signal / noise
 
 
-def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
+def bootstrap(data, bootnum=100, samples=None, bootfunc=None,
+        output_index=0):
+
     """Performs bootstrap resampling on numpy arrays.
 
     Bootstrap resampling is used to understand confidence intervals of sample
@@ -919,6 +921,11 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
         Function to reduce the resampled data. Each bootstrap resample will
         be put through this function and the results returned. If `None`, the
         bootstrapped data will be returned
+    output_index : int, tuple
+        Index or tuple of indices corresponding to which indices of the
+        bootfunc output should be stored in the bootstrap resample. If the
+        bootfunc returns only one output, output_index will be ignored. Default
+        is 0.
 
     Returns
     -------
@@ -926,26 +933,65 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
         Bootstrapped data. Each row is a bootstrap resample of the data.
 
     """
+
     if samples is None:
         samples = data.shape[0]
 
     # make sure the input is sane
     assert samples > 0, "samples cannot be less than one"
     assert bootnum > 0, "bootnum cannot be less than one"
+    assert type(data) is np.ndarray, "data must be a numpy.ndarray"
 
     if bootfunc is None:
-        resultdims = (bootnum,) + (samples,) + data.shape[1:]
-        boot = np.empty(resultdims)
+        resultdims = [bootnum,] + [samples,] + list(data.shape[1:])
     else:
-        resultdims = (bootnum,)
-        boot = np.empty(resultdims)
+        resultdims = [bootnum,]
 
+        # Get number of outputs from bootfunc,  adjust output accordingly
+        output = bootfunc(data)
+
+        try:
+            # if the output is not a tuple or array, this check will raise a
+            # TypeError
+            if len(output) > 1:
+                single_output = False
+            else:
+                single_output = True
+        except TypeError:
+            single_output = True
+
+        if not single_output:
+            # indices will be a list of the output index/indices
+            indices = []
+
+            if type(output_index) is not int:
+                resultdims.append(len(output_index))
+
+                [indices.append(index) for index in output_index]
+            else:
+                indices.append(output_index)
+
+    boot = np.empty(resultdims)
+
+    # Perform bootstrapping
     for i in xrange(bootnum):
         bootarr = np.random.randint(low=0, high=data.shape[0], size=samples)
+
         if bootfunc is None:
             boot[i] = data[bootarr]
-        else:
+        elif single_output:
+            # if bootfunc has only one output
             boot[i] = bootfunc(data[bootarr])
+        else:
+            # if bootfunc has more than one output
+            output = bootfunc(data[bootarr])
+
+            # Check if single output, if not index the output
+            if len(indices) == 1:
+                boot[i] = output[indices[0]]
+            else:
+                for j, index in enumerate(indices):
+                    boot[i][j] = output[index]
 
     return boot
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -964,6 +964,18 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
     >>> bootresult.shape
     (3, 2)
 
+    Obtain a statistic with two outputs on the array, keeping only the first
+    output
+
+    >>> bootfunc = lambda x:spearmanr(x)[0]
+    >>> with NumpyRNGContext(1):
+    ...     bootresult = bootstrap(bootarr, 3, bootfunc=bootfunc)
+    ...
+    >>> bootresult
+    array([ 0.60629737,  0.14159484,  0.54091829])
+    >>> bootresult.shape
+    (3,)
+
     """
     if samples is None:
         samples = data.shape[0]

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -940,7 +940,7 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None,
     # make sure the input is sane
     assert samples > 0, "samples cannot be less than one"
     assert bootnum > 0, "bootnum cannot be less than one"
-    assert type(data) is np.ndarray, "data must be a numpy.ndarray"
+    isinstance(data, np.ndarray)
 
     if bootfunc is None:
         resultdims = [bootnum,] + [samples,] + list(data.shape[1:])
@@ -964,7 +964,7 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None,
             # indices will be a list of the output index/indices
             indices = []
 
-            if type(output_index) is not int:
+            if not isinstance(output_index, int):
                 resultdims.append(len(output_index))
 
                 [indices.append(index) for index in output_index]

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -923,8 +923,10 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
     Returns
     -------
     boot : numpy.ndarray
-        Bootstrapped data. Each row is a bootstrap resample of the data. The
-        columns will correspond to the outputs of bootfunc.
+
+        If bootfunc is None, then each row is a bootstrap resample of the data.
+        If bootfunc is specified, then the columns will correspond to the
+        outputs of bootfunc.
 
     Examples
     --------

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -238,22 +238,30 @@ def test_bootstrap():
         bootresult = np.mean(funcs.bootstrap(bootarr, 10000, bootfunc=np.mean))
         assert_allclose(np.mean(bootarr), bootresult, atol=0.01)
 
-    #test a bootfunc with several output values
+    # test a bootfunc with several output values
+    # return just bootstrapping with one output from bootfunc
     with NumpyRNGContext(42):
         bootarr = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
                             [4, 8, 8, 3, 6, 5, 2, 8, 6, 2]]).T
-        spearmanr(bootarr)
 
-        print('one output')
-        bootresult = np.mean(funcs.bootstrap(bootarr, 2,
-                                             bootfunc=spearmanr))
+        answer = np.array((0.19425, 0.02094))
 
-        print('two output')
-        bootresult = np.mean(funcs.bootstrap(bootarr, 2,
-                                             bootfunc=spearmanr,
-                                             output_index=(0,1)))
+        bootresult = funcs.bootstrap(bootarr, 2,
+                                     bootfunc=spearmanr)
 
-        #assert_allclose(spearmanr(bootarr), bootresult, atol=1e-3)
+        assert_allclose(answer, bootresult, atol=1e-3)
+
+    # return just bootstrapping with two outputs from bootfunc
+    with NumpyRNGContext(42):
+        answer = np.array(((0.1942, 0.5907),
+                           (0.0209, 0.9541),
+                           (0.4286, 0.2165)))
+        bootresult = funcs.bootstrap(bootarr, 3,
+                                     bootfunc=spearmanr,
+                                     output_index=(0,1))
+
+        assert bootresult.shape == (3, 2)
+        assert_allclose(answer, bootresult, atol=1e-3)
 
 
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -250,8 +250,10 @@ def test_bootstrap_multiple_outputs():
 
         answer = np.array((0.19425, 0.02094))
 
+        bootfunc = lambda x:spearmanr(x)[0]
+
         bootresult = funcs.bootstrap(bootarr, 2,
-                                     bootfunc=spearmanr)
+                                     bootfunc=bootfunc)
 
         assert_allclose(answer, bootresult, atol=1e-3)
 
@@ -264,9 +266,10 @@ def test_bootstrap_multiple_outputs():
         answer = np.array((0.5907,
                            0.9541))
 
+        bootfunc = lambda x:spearmanr(x)[1]
+
         bootresult = funcs.bootstrap(bootarr, 2,
-                                     bootfunc=spearmanr,
-                                     output_index=1)
+                                     bootfunc=bootfunc)
 
         assert_allclose(answer, bootresult, atol=1e-3)
 
@@ -275,27 +278,14 @@ def test_bootstrap_multiple_outputs():
         answer = np.array(((0.1942, 0.5907),
                            (0.0209, 0.9541),
                            (0.4286, 0.2165)))
+
+        bootfunc = lambda x:spearmanr(x)
+
         bootresult = funcs.bootstrap(bootarr, 3,
-                                     bootfunc=spearmanr,
-                                     output_index=(0,1))
+                                     bootfunc=bootfunc)
 
         assert bootresult.shape == (3, 2)
         assert_allclose(answer, bootresult, atol=1e-3)
-
-    # return just bootstrapping with two outputs from bootfunc, switch order of
-    # outputs
-    with NumpyRNGContext(42):
-        answer = np.array(((0.5907, 0.1942),
-                           (0.9541, 0.0209),
-                           (0.2165, 0.4286)))
-        bootresult = funcs.bootstrap(bootarr, 3,
-                                     bootfunc=spearmanr,
-                                     output_index=(1, 0))
-
-        assert bootresult.shape == (3, 2)
-        assert_allclose(answer, bootresult, atol=1e-3)
-
-
 
 def test_mad_std():
     with NumpyRNGContext(12345):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -9,6 +9,8 @@ from numpy.random import randn, normal
 from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
+from scipy.stats import spearmanr
+
 try:
     import scipy
 except ImportError:
@@ -235,6 +237,25 @@ def test_bootstrap():
     with NumpyRNGContext(42):
         bootresult = np.mean(funcs.bootstrap(bootarr, 10000, bootfunc=np.mean))
         assert_allclose(np.mean(bootarr), bootresult, atol=0.01)
+
+    #test a bootfunc with several output values
+    with NumpyRNGContext(42):
+        bootarr = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+                            [4, 8, 8, 3, 6, 5, 2, 8, 6, 2]]).T
+        spearmanr(bootarr)
+
+        print('one output')
+        bootresult = np.mean(funcs.bootstrap(bootarr, 2,
+                                             bootfunc=spearmanr))
+
+        print('two output')
+        bootresult = np.mean(funcs.bootstrap(bootarr, 2,
+                                             bootfunc=spearmanr,
+                                             output_index=(0,1)))
+
+        #assert_allclose(spearmanr(bootarr), bootresult, atol=1e-3)
+
+
 
 
 def test_mad_std():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -9,8 +9,6 @@ from numpy.random import randn, normal
 from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
-from scipy.stats import spearmanr
-
 try:
     import scipy
 except ImportError:
@@ -237,6 +235,12 @@ def test_bootstrap():
     with NumpyRNGContext(42):
         bootresult = np.mean(funcs.bootstrap(bootarr, 10000, bootfunc=np.mean))
         assert_allclose(np.mean(bootarr), bootresult, atol=0.01)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_bootstrap_multiple_outputs():
+
+    from scipy.stats import spearmanr
 
     # test a bootfunc with several output values
     # return just bootstrapping with one output from bootfunc

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -251,6 +251,21 @@ def test_bootstrap():
 
         assert_allclose(answer, bootresult, atol=1e-3)
 
+    # test a bootfunc with several output values
+    # return just bootstrapping with the second output from bootfunc
+    with NumpyRNGContext(42):
+        bootarr = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+                            [4, 8, 8, 3, 6, 5, 2, 8, 6, 2]]).T
+
+        answer = np.array((0.5907,
+                           0.9541))
+
+        bootresult = funcs.bootstrap(bootarr, 2,
+                                     bootfunc=spearmanr,
+                                     output_index=1)
+
+        assert_allclose(answer, bootresult, atol=1e-3)
+
     # return just bootstrapping with two outputs from bootfunc
     with NumpyRNGContext(42):
         answer = np.array(((0.1942, 0.5907),
@@ -263,6 +278,18 @@ def test_bootstrap():
         assert bootresult.shape == (3, 2)
         assert_allclose(answer, bootresult, atol=1e-3)
 
+    # return just bootstrapping with two outputs from bootfunc, switch order of
+    # outputs
+    with NumpyRNGContext(42):
+        answer = np.array(((0.5907, 0.1942),
+                           (0.9541, 0.0209),
+                           (0.2165, 0.4286)))
+        bootresult = funcs.bootstrap(bootarr, 3,
+                                     bootfunc=spearmanr,
+                                     output_index=(1, 0))
+
+        assert bootresult.shape == (3, 2)
+        assert_allclose(answer, bootresult, atol=1e-3)
 
 
 


### PR DESCRIPTION
I have addressed [Issue 3601](https://github.com/astropy/astropy/issues/3601). I implemented the option for users to supply a function with multiple outputs to ``bootfunc``. They can control which ``bootfunc`` outputs to retain with ``output_index``.

This function could be sped up if the ``if`` statements were moved outside of the loop.