### PR TITLE
Add get_info_by_id to VOTable interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ New Features
 
 - ``astropy.io.votable``
 
+  - A new method was added to ``astropy.io.votable.VOTable``,
+    ``get_info_by_id`` to conveniently find an ``INFO`` element by its
+    ``ID`` attribute. [#3633]
+
 - ``astropy.logger.py``
 
 - ``astropy.modeling``
@@ -51,7 +55,7 @@ New Features
 - ``astropy.time``
 
   - Add support for FITS standard time strings. [#3547]
-  
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]
@@ -93,8 +97,8 @@ API changes
 
 - ``astropy.modeling``
 
-  - Renamed the parameters of ``RotateNative2Celestial`` and 
-    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to 
+  - Renamed the parameters of ``RotateNative2Celestial`` and
+    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]
 
 - ``astropy.nddata``

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -258,7 +258,7 @@
      </TR>
     </TABLEDATA>
    </DATA>
-   <INFO ID="Error" name="Error" value="One might expect to find some INFO here, too..."/>
+   <INFO ID="ErrorInfo" name="Error" value="One might expect to find some INFO here, too..."/>
   </TABLE>
   <RESOURCE type="results">
    <TABLE nrows="1" ref="main_table">

--- a/astropy/io/votable/tests/data/regression.xml
+++ b/astropy/io/votable/tests/data/regression.xml
@@ -12,7 +12,7 @@ The VOTable format is an XML standard for the interchange of data represented as
 <PARAM datatype="float" name="INPUT" value="0.000000,0.000000" arraysize="*" unit="km/h" ucd="phys.size;instr.tel">
   <DESCRIPTION>This is the most interesting parameter in the world, and it drinks Dos Equis</DESCRIPTION>
 </PARAM>
-<INFO name="QUERY_STATUS" value="OK">This is some information.</INFO>
+<INFO ID="QUERY_STATUS" name="QUERY_STATUS" value="OK">This is some information.</INFO>
 <RESOURCE type="results">
 <DESCRIPTION>
   This is a resource description
@@ -26,7 +26,7 @@ The VOTable format is an XML standard for the interchange of data represented as
 <DESCRIPTION>
   This describes the table.
 </DESCRIPTION>
-<INFO name="Error" value="One might expect to find some INFO here, too..."/>
+<INFO name="Error" ID="ErrorInfo" value="One might expect to find some INFO here, too..."/>
 <GROUP>
   <PARAMref ref="awesome"/>
 </GROUP>

--- a/astropy/io/votable/tests/data/validation.txt
+++ b/astropy/io/votable/tests/data/validation.txt
@@ -30,7 +30,7 @@ Validation report for /tmp/astropy-test-D69Wr6/lib.linux-x86_64-2.7/astropy/io/v
   ^
 
 29: W26: 'INFO' inside 'TABLE' added in VOTable 1.2
-<INFO name="Error" value="One might expect to find some INFO here, ...
+<INFO name="Error" ID="ErrorInfo" value="One might expect to find s...
 ^
 
 33: W01: Array uses commas rather than whitespace

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -611,6 +611,14 @@ class TestParse:
         assert fields[0].name == "int"
         assert fields[0].values.min == -1000
 
+    def test_get_info_by_id(self):
+        info = self.votable.get_info_by_id('QUERY_STATUS')
+        assert info.value == 'OK'
+
+        if self.votable.version != '1.1':
+            info = self.votable.get_info_by_id("ErrorInfo")
+            assert info.value == "One might expect to find some INFO here, too..."
+
 
 class TestThroughTableData(TestParse):
     def setup_class(self):

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2960,6 +2960,10 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         iterator emitting all matches.
         """)
 
+    def iter_info(self):
+        for info in self.infos:
+            yield info
+
 
 class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
                _DescriptionProperty):
@@ -3176,6 +3180,20 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
         for resource in self.resources:
             for coosys in resource.iter_coosys():
                 yield coosys
+
+    def iter_info(self):
+        """
+        Recursively iterates over all the INFO_ elements in the
+        resource and nested resources.
+        """
+        for info in self.infos:
+            yield info
+        for table in self.tables:
+            for info in table.iter_info():
+                yield info
+        for resource in self.resources:
+            for info in resource.iter_info():
+                yield info
 
 
 class VOTableFile(Element, _IDProperty, _DescriptionProperty):
@@ -3564,6 +3582,21 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
     get_coosys_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_coosys', 'COOSYS',
         """Looks up a COOSYS_ element by the given ID.""")
+
+    def iter_info(self):
+        """
+        Recursively iterate over all INFO_ elements in the VOTABLE_
+        file.
+        """
+        for info in self.infos:
+            yield info
+        for resource in self.resources:
+            for info in resource.iter_info():
+                yield info
+
+    get_info_by_id = _lookup_by_attr_factory(
+        'ID', True, 'iter_info', 'INFO',
+        """Looks up a INFO element by the given ID.""")
 
     def set_all_tables_format(self, format):
         """


### PR DESCRIPTION
Addresses a shortcoming shared on the mailing list thread "getting id value from xml files" by Grigoris Maravelias.  http://mail.scipy.org/pipermail/astropy/2015-March/003661.html

There is currently no way to just find an INFO element by its ID (though there is for everything else with an ID).  This adds that.