### PR TITLE
Handle some array corner cases in Table constructor.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,7 +51,7 @@ New Features
 - ``astropy.time``
 
   - Add support for FITS standard time strings. [#3547]
-  
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]
@@ -93,8 +93,8 @@ API changes
 
 - ``astropy.modeling``
 
-  - Renamed the parameters of ``RotateNative2Celestial`` and 
-    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to 
+  - Renamed the parameters of ``RotateNative2Celestial`` and
+    ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]
 
 - ``astropy.nddata``
@@ -292,6 +292,13 @@ Bug Fixes
 - ``astropy.table``
 
   - Ensure ``QTable`` can be pickled [#3590]
+
+  - Some corner cases when instantiating an ``astropy.table.Table``
+    with a Numpy array are handled [#3637]. Notably:
+
+    - a zero-length array is the same as passing ``None``
+    - a scalar raises a ``ValueError``
+    - a one-dimensional array is treated as a single row of a table.
 
 - ``astropy.time``
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -272,10 +272,8 @@ class Table(object):
                 if data.shape == ():
                     raise ValueError('Can not initialize a Table with a scalar')
                 elif len(data.shape) == 1:
-                    n_cols = data.shape[0]
-                    data = np.expand_dims(data, axis=0)
-                else:
-                    n_cols = data.shape[1]
+                    data = data[np.newaxis, :]
+                n_cols = data.shape[1]
 
         elif isinstance(data, dict):
             init_func = self._init_from_dict

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -247,6 +247,11 @@ class Table(object):
 
         default_names = None
 
+        if (isinstance(data, np.ndarray) and
+            data.shape == (0,) and
+            not data.dtype.names):
+            data = None
+
         if isinstance(data, self.Row):
             data = data._table[data._index:data._index + 1]
 
@@ -264,7 +269,13 @@ class Table(object):
                 default_names = data.dtype.names
             else:
                 init_func = self._init_from_ndarray  # _homog
-                n_cols = data.shape[1]
+                if data.shape == ():
+                    raise ValueError('Can not initialize a Table with a scalar')
+                elif len(data.shape) == 1:
+                    n_cols = data.shape[0]
+                    data = np.expand_dims(data, axis=0)
+                else:
+                    n_cols = data.shape[1]
 
         elif isinstance(data, dict):
             init_func = self._init_from_dict

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -248,8 +248,8 @@ class Table(object):
         default_names = None
 
         if (isinstance(data, np.ndarray) and
-            data.shape == (0,) and
-            not data.dtype.names):
+                data.shape == (0,) and
+                not data.dtype.names):
             data = None
 
         if isinstance(data, self.Row):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1386,3 +1386,14 @@ def test_nested_iteration():
         for r2 in t:
             out.append((r1['a'], r2['a']))
     assert out == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+
+def test_table_init_from_degenerate_arrays(table_types):
+    t = table_types.Table(np.array([]))
+    assert len(t.columns) == 0
+
+    with pytest.raises(ValueError):
+        t = table_types.Table(np.array(0))
+
+    t = table_types.Table(np.array([1, 2, 3]))
+    assert len(t.columns) == 3

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -319,7 +319,7 @@ NumPy homogeneous array
 A `numpy` 1-d array is treated as a single row table where each element of the
 array corresponds to a column::
 
-  >>> Table(np.array([1, 2, 3]), names=['a', 'b', 'c'])
+  >>> Table(np.array([1, 2, 3]), names=['a', 'b', 'c'], dtype=('i8', 'i8', 'i8'))
   <Table masked=False length=1>
     a     b     c
   int64 int64 int64


### PR DESCRIPTION
@taldcroft: While investigating #3634, I discovered some corner cases when passing arrays to the `Table` constructor that I'm surprised didn't work.

- Passing an empty non-recarray array (`np.array([])`) should be treated the same as `None`.

- Passing a 1-D non-recarray could be treated as a single row.  (That's perhaps controversial -- I'd be just as happy raising an exception rather than failing in a confusing way).

- Passing a scalar should raise a nicer exception.

Any thoughts?