### PR TITLE
Fix PyFITS issue #99

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -298,6 +298,10 @@ Bug Fixes
     accurately reflected in any associated table data and its FITS header.
     [#3283, #1539, #2618]
 
+  - Fixes an issue with the ``FITS_rec`` interface to FITS table data, where a
+    ``FITS_rec`` created by copying an existing FITS table but adding new rows
+    could not be sliced or masked correctly.  [#3641]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -461,6 +461,13 @@ class FITS_rec(np.recarray):
             else:
                 outarr[:] = inarr
 
+        # Now replace the original column array references with the new
+        # fields
+        # This is required to prevent the issue reported in
+        # https://github.com/spacetelescope/PyFITS/issues/99
+        for idx in range(len(columns)):
+            columns._arrays[idx] = data.field(idx)
+
         return data
 
     def __repr__(self):


### PR DESCRIPTION
This should fix the issue reported in https://github.com/spacetelescope/PyFITS/issues/99  I have some refactoring in progress that should remove the need for this fix entirely (the problem is that the ColDefs class has a ._arrays attribute that is a list of all the column arrays, and is largely superfluous.  I'm trying to remove it altogether.  In the meantime this was very easy to add a workaround to.