### PR TITLE
Data mismatch when converting FITS random group data to binary table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -287,6 +287,10 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed bug where column data could be unintentionally byte-swapped when
+    copying data from an existing FITS file to a new FITS table with a
+    TDIMn keyword for that column. [#3561]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -438,7 +438,9 @@ class FITS_rec(np.recarray):
                 continue
 
             if inarr.shape != outarr.shape:
-                if inarr.dtype != outarr.dtype:
+                if (inarr.dtype.kind == outarr.dtype.kind and
+                        inarr.dtype.kind in ('U', 'S') and
+                        inarr.dtype != outarr.dtype):
                     inarr = inarr.view(outarr.dtype)
 
                 # This is a special case to handle input arrays with


### PR DESCRIPTION
Hi -- was trying to convert a FITS random group into a binary table, and I went a bit crazy because the data in wasn't the same as the data out.

Here's a script that will reproduce what I was seeing (it will wget a small file from the fits registry):

``` python
import os
from astropy.io import fits as pf
import numpy as np

filename_out = "test_bin.fits"

# Load random group data
# here's one from the fits registry that's pretty small:
# Shape of DATA is (7956, 1, 1, 1, 4, 3)
os.system("wget http://fits.gsfc.nasa.gov/samples/DDTSUVDATA.fits")
a = pf.open('DDTSUVDATA.fits')
d_in = a[0].data["DATA"]

# Convert to column
c_a =  pf.Column(name='TEST', array=d_in, dim="(3,4,1,1,1)", format="12E")
hdu = pf.BinTableHDU.from_columns([c_a])

# Remove output files
if os.path.exists(filename_out):
    os.remove(filename_out)

# Write to a file, then reload the file
hdu.writeto(filename_out)
hdul_b = pf.open(filename_out)
d_out = hdul_b[1].data["TEST"]

# Compare the two files
print d_in.shape, d_in.dtype
print d_out.shape, d_in.dtype

print d_in[0]
print d_out[0]

print np.allclose(d_in[0], d_out[0])
```

The print outputs are:

```
(7956, 1, 1, 1, 4, 3) >f4
(7956, 1, 1, 1, 4, 3) >f4
[[[[[ 12.4308672    0.56860745   3.99993873]
    [ 12.74043655   0.31398511   3.99993873]
    [  0.           0.           3.99993873]
    [  0.           0.           3.99993873]]]]]
[[[[[ -3.13737987e+13   7.20336838e+01              nan]
    [ -7.43180390e+12  -2.16078206e-14              nan]
    [  0.00000000e+00   0.00000000e+00              nan]
    [  0.00000000e+00   0.00000000e+00              nan]]]]]
False
```

It seems to be related with endianess, as if I change the line to say 

`d_in = a[0].data["DATA"].astype('<f4')`

everything is dandy.

I would have thought that this kind of thing should be handled transparently?

PS: I'm running Python 2.7.6 on Mac yosemite, with astropy 1.0, numpy 1.9.2.