### PR TITLE
Do final alignment based on presence of <,>,^,0= in format string (same as #3037)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -590,6 +590,8 @@ New Features
 - ``astropy.tests``
 
   - Added a new Quantity-aware ``assert_quantity_allclose``. [#3273]
+  - Added column alignment formatting for better pprint viewing
+    experience. [#3037]
 
 - ``astropy.time``
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -233,6 +233,7 @@ class TableFormatter(object):
                                                show_dtype=show_dtype, show_length=show_length,
                                                outs=outs)
         col_strs = list(col_strs_iter)
+        col_width = max(len(x) for x in col_strs)
 
         if html:
             from ..utils.xml.writer import xml_escape

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -229,11 +229,14 @@ class TableFormatter(object):
             show_unit = getattr(col, 'unit', None) is not None
 
         outs = {}  # Some values from _pformat_col_iter iterator that are needed here
-        col_strs_iter = self._pformat_col_iter(col, max_lines, show_name=show_name, show_unit=show_unit,
-                                               show_dtype=show_dtype, show_length=show_length,
+        col_strs_iter = self._pformat_col_iter(col, max_lines, show_name=show_name,
+                                               show_unit=show_unit,
+                                               show_dtype=show_dtype,
+                                               show_length=show_length,
                                                outs=outs)
         col_strs = list(col_strs_iter)
-        col_width = max(len(x) for x in col_strs)
+        if len(col_strs) > 0:
+            col_width = max(len(x) for x in col_strs)
 
         if html:
             from ..utils.xml.writer import xml_escape
@@ -277,7 +280,7 @@ class TableFormatter(object):
                             justify_method = justify_methods.get(col.format[0], None)
                             if justify_method is None:
                                 justify_method = justify_methods[col.format[1]]
-                                justify = (lambda col_str, col_width: \
+                                justify = (lambda col_str, col_width:
                                            getattr(col_str, justify_method)(col_width,
                                                                             col.format[0]))
                             else:
@@ -294,7 +297,7 @@ class TableFormatter(object):
                         justify_method = justify_methods.get(align, None)
                         if justify_method is None:
                             justify_method = justify_methods[col.format[1]]
-                            justify = (lambda col_str, col_width: \
+                            justify = (lambda col_str, col_width:
                                        getattr(col_str, justify_method)(col_width,
                                                                         col.format[0]))
                         else:

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -8,7 +8,7 @@ from ..extern.six.moves import xrange
 
 import os
 import sys
-
+import ipdb
 import numpy as np
 
 from .. import log
@@ -185,7 +185,7 @@ class TableFormatter(object):
 
 
     def _pformat_col(self, col, max_lines=None, show_name=True, show_unit=None,
-                     show_dtype=False, show_length=None, html=False):
+                     show_dtype=False, show_length=None, html=False, align='right'):
         """Return a list of formatted string representation of column values.
 
         Parameters
@@ -210,6 +210,9 @@ class TableFormatter(object):
 
         html : bool
             Output column as HTML
+
+        align : str
+            Left/right alignment of a column. Default is 'right'.
 
         Returns
         -------
@@ -248,6 +251,16 @@ class TableFormatter(object):
                 col_strs.pop(n_header - 1)
             col_strs.insert(0, '<table>')
             col_strs.append('</table>')
+
+        # Now bring all the column string values to the same fixed width
+        for i, col_str in enumerate(col_strs):
+            #ipdb.set_trace()
+            if align.upper() == 'RIGHT':
+                col_strs[i] = col_str.rjust(col_width)
+            elif align.upper() == 'LEFT':
+                col_strs[i] = col_str.ljust(col_width)
+            else:
+                log.error('Argument `align` must take either left or right.')
 
         else:
             col_width = max(len(x) for x in col_strs) if col_strs else 1
@@ -376,7 +389,7 @@ class TableFormatter(object):
 
     def _pformat_table(self, table, max_lines=None, max_width=None, show_name=True,
                        show_unit=None, show_dtype=False,
-                       html=False, tableid=None):
+                       html=False, tableid=None, align='right'):
         """Return a list of lines for the formatted string representation of
         the table.
 
@@ -406,6 +419,9 @@ class TableFormatter(object):
             An ID tag for the table; only used if html is set.  Default is
             "table{id}", where id is the unique integer id of the table object,
             id(table)
+
+        align : str
+            Left/right alignment of a column. Default is 'right'.    
 
         Returns
         -------

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -26,7 +26,7 @@ if six.PY3:
 elif six.PY2:
     _format_funcs = {None: lambda format_, val: text_type(val)}
 
-
+import ipdb
 ### The first three functions are helpers for _auto_format_func
 
 
@@ -255,7 +255,21 @@ class TableFormatter(object):
             col_strs.insert(0, '<table>')
             col_strs.append('</table>')
 
-        # Now bring all the column string values to the same fixed width
+        # Now bring all the column string values to the same fixed width        
+        else:
+            col_width = max(len(x) for x in col_strs) if col_strs else 1
+
+            # Center line content and generate dashed headerline
+            for i in outs['i_centers']:
+                col_strs[i] = col_strs[i].center(col_width)
+            if outs['i_dashes'] is not None:
+                col_strs[outs['i_dashes']] = '-' * col_width
+
+            # Now bring all the column string values to the same fixed width
+            for i, col_str in enumerate(col_strs):
+                col_strs[i] = col_str.rjust(col_width)
+
+        '''
         justify_methods = {'<': 'ljust', '^': 'center', '>': 'rjust'}
         try:
             # if col.format is not a string, this raises an exception, causing a default to 'rjust'.
@@ -281,23 +295,13 @@ class TableFormatter(object):
 
         for i, col_str in enumerate(col_strs):
             col_strs[i] = justify(col_str, col_width)
+        '''
 
-        else:
-            col_width = max(len(x) for x in col_strs) if col_strs else 1
-
-            # Center line content and generate dashed headerline
-            for i in outs['i_centers']:
-                col_strs[i] = col_strs[i].center(col_width)
-            if outs['i_dashes'] is not None:
-                col_strs[outs['i_dashes']] = '-' * col_width
-
-            # Now bring all the column string values to the same fixed width
-            for i, col_str in enumerate(col_strs):
-                col_strs[i] = col_str.rjust(col_width)
-
+                
         if outs['show_length']:
             col_strs.append('Length = {0} rows'.format(len(col)))
 
+        #ipdb.set_trace()
         return col_strs, outs
 
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -211,8 +211,10 @@ class TableFormatter(object):
         html : bool
             Output column as HTML
 
-        align : str
-            Left/right alignment of a column. Default is 'right'.
+        align : str or list
+            Left/right alignment of a column. Default is 'right'. A list
+            of strings can be provided for alignment of tables with multiple
+            columns.
 
         Returns
         -------
@@ -254,12 +256,12 @@ class TableFormatter(object):
 
         # Now bring all the column string values to the same fixed width
         for i, col_str in enumerate(col_strs):
-            if align.upper() == 'RIGHT':
+            if align.upper() in ['RIGHT','R']:
                 col_strs[i] = col_str.rjust(col_width)
-            elif align.upper() == 'LEFT':
+            elif align.upper() in ['LEFT','L']:
                 col_strs[i] = col_str.ljust(col_width)
             else:
-                log.error('Argument `align` must take either left or right.')
+                log.error('Argument `align` must take either `left` or `right`.')
 
         else:
             col_width = max(len(x) for x in col_strs) if col_strs else 1
@@ -419,9 +421,11 @@ class TableFormatter(object):
             "table{id}", where id is the unique integer id of the table object,
             id(table)
 
-        align : str
-            Left/right alignment of a column. Default is 'right'.    
-
+        align : str or list
+            Left/right alignment of a column. Default is 'right'. A list
+            of strings can be provided for alignment of tables with multiple
+            columns.
+            
         Returns
         -------
         out : str
@@ -444,6 +448,27 @@ class TableFormatter(object):
             if outs['show_length']:
                 lines = lines[:-1]
             cols.append(lines)
+
+        if isinstance(align,str):
+            align = align
+        elif isinstance(align,list) and len(align) == 1:
+            align = align[0]
+        elif isinstance(align,list) and len(align) == len(table.columns.values()):
+            align = align
+        else:
+            align = 'right'
+
+        # If align remains a list, need to loop over values
+        if type(align) == list:
+            for i,col in enumerate(six.itervalues(table.columns)):
+                lines, n_header = self._pformat_col(col, max_lines, show_name,
+                                                show_unit, align=align[i])
+                cols.append(lines)
+        else:
+            for col in six.itervalues(table.columns):
+                lines, n_header = self._pformat_col(col, max_lines, show_name,
+                                                show_unit, align=align)
+                cols.append(lines)
 
         if not cols:
             return ['<No columns>'], {'show_length': False}

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -8,7 +8,7 @@ from ..extern.six.moves import xrange
 
 import os
 import sys
-import ipdb
+
 import numpy as np
 
 from .. import log
@@ -254,7 +254,6 @@ class TableFormatter(object):
 
         # Now bring all the column string values to the same fixed width
         for i, col_str in enumerate(col_strs):
-            #ipdb.set_trace()
             if align.upper() == 'RIGHT':
                 col_strs[i] = col_str.rjust(col_width)
             elif align.upper() == 'LEFT':

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -425,7 +425,7 @@ class TableFormatter(object):
             Left/right alignment of a column. Default is 'right'. A list
             of strings can be provided for alignment of tables with multiple
             columns.
-            
+
         Returns
         -------
         out : str

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -588,7 +588,8 @@ class Table(object):
         tableid = 'table{id}'.format(id=id(self))
         data_lines, outs = self.formatter._pformat_table(self,
             tableid=tableid, html=html, max_width=(-1 if html else None),
-            show_name=True, show_unit=None, show_dtype=True)
+                                                    show_name=True, show_unit=None,
+                                                         show_dtype=True)
 
         out = descr + '\n'.join(data_lines)
         if six.PY2 and isinstance(out, six.text_type):
@@ -672,7 +673,7 @@ class Table(object):
         """
         lines, outs = self.formatter._pformat_table(self, max_lines, max_width,
                                                     show_name=show_name, show_unit=show_unit,
-                                                    show_dtype=show_dtype)
+                                                    show_dtype=show_dtype, align=align)
         if outs['show_length']:
             lines.append('Length = {0} rows'.format(len(self)))
 
@@ -799,7 +800,7 @@ class Table(object):
         lines, outs = self.formatter._pformat_table(self, max_lines, max_width,
                                                     show_name=show_name, show_unit=show_unit,
                                                     show_dtype=show_dtype, html=html,
-                                                    tableid=tableid)
+                                                    tableid=tableid, align=align)
 
         if outs['show_length']:
             lines.append('Length = {0} rows'.format(len(self)))

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -635,7 +635,7 @@ class Table(object):
         return is_mixin
 
     def pprint(self, max_lines=None, max_width=None, show_name=True,
-               show_unit=None, show_dtype=False):
+               show_unit=None, show_dtype=False, align='right'):
         """Print a formatted string representation of the table.
 
         If no value of ``max_lines`` is supplied then the height of the
@@ -666,6 +666,9 @@ class Table(object):
 
         show_dtype : bool
             Include a header row for column dtypes (default=True)
+
+        align : str
+            Left/right alignment of a column. Default is 'right'.
         """
         lines, outs = self.formatter._pformat_table(self, max_lines, max_width,
                                                     show_name=show_name, show_unit=show_unit,
@@ -674,6 +677,7 @@ class Table(object):
             lines.append('Length = {0} rows'.format(len(self)))
 
         n_header = outs['n_header']
+
         for i, line in enumerate(lines):
             if i < n_header:
                 color_print(line, 'red')
@@ -740,7 +744,8 @@ class Table(object):
                 webbrowser.get(browser).open("file://" + path)
 
     def pformat(self, max_lines=None, max_width=None, show_name=True,
-                show_unit=None, show_dtype=False, html=False, tableid=None):
+                show_unit=None, show_dtype=False, html=False, tableid=None,
+                align='right'):
         """Return a list of lines for the formatted string representation of
         the table.
 
@@ -780,6 +785,9 @@ class Table(object):
             An ID tag for the table; only used if html is set.  Default is
             "table{id}", where id is the unique integer id of the table object,
             id(self)
+            
+        align : str
+            Left/right alignment of a column. Default is 'right'.    
 
         Returns
         -------
@@ -787,6 +795,7 @@ class Table(object):
             Formatted table as a list of strings
 
         """
+
         lines, outs = self.formatter._pformat_table(self, max_lines, max_width,
                                                     show_name=show_name, show_unit=show_unit,
                                                     show_dtype=show_dtype, html=html,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -785,9 +785,9 @@ class Table(object):
             An ID tag for the table; only used if html is set.  Default is
             "table{id}", where id is the unique integer id of the table object,
             id(self)
-            
+
         align : str
-            Left/right alignment of a column. Default is 'right'.    
+            Left/right alignment of a column. Default is 'right'.
 
         Returns
         -------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -588,8 +588,7 @@ class Table(object):
         tableid = 'table{id}'.format(id=id(self))
         data_lines, outs = self.formatter._pformat_table(self,
             tableid=tableid, html=html, max_width=(-1 if html else None),
-                                                    show_name=True, show_unit=None,
-                                                         show_dtype=True)
+            show_name=True, show_unit=None, show_dtype=True)
 
         out = descr + '\n'.join(data_lines)
         if six.PY2 and isinstance(out, six.text_type):

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -370,6 +370,19 @@ class TestFormat():
         with pytest.raises(ValueError):
             str(t['a'])
 
+    def test_column_alignment(self, table_type):
+        t = table_type([[1], [2], [3], [4]],
+                       names=('long title a', 'long title b',
+                              'long title c', 'long title d'))
+        t['long title a'].format = '<'
+        t['long title b'].format = '^'
+        t['long title c'].format = '>'
+        t['long title d'].format = '0='
+        assert str(t['long title a']) == 'long title a\n------------\n1           '
+        assert str(t['long title b']) == 'long title b\n------------\n     2      '
+        assert str(t['long title c']) == 'long title c\n------------\n           3'
+        assert str(t['long title d']) == 'long title d\n------------\n000000000004'
+
 
 class TestFormatWithMaskedElements():
 

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -374,7 +374,7 @@ For columns the syntax and behavior of
   2973.0
   Length = 100 rows
 
-  Column alignment
+Column alignment
 ''''''''''''''''
 
 Individual columns have the ability to be aligned in a number of different

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -374,6 +374,28 @@ For columns the syntax and behavior of
   2973.0
   Length = 100 rows
 
+  Column alignment
+''''''''''''''''
+
+Individual columns have the ability to be aligned in a number of different
+ways, for an enhanced viewing experience.
+
+ >>> t = Table()
+ >>> t['long column name 1'] = [1,2,3]
+ >>> t['long column name 2'] = [4,5,6]
+ >>> t['long column name 3'] = [7,8,9]
+ >>> t['long column name 4'] = [700000,800000,900000]
+ >>> t['long column name 2'].format = '<'
+ >>> t['long column name 3'].format = '0='
+ >>> t['long column name 4'].format = '^'
+ >>> t.pprint()
+   long column name 1 long column name 2 long column name 3 long column name 4
+  ------------------ ------------------ ------------------ ------------------
+                   1 4                  000000000000000007       700000      
+                   2 5                  000000000000000008       800000      
+                   3 6                  000000000000000009       900000      
+
+
 pformat() method
 ''''''''''''''''
 

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -380,22 +380,43 @@ For columns the syntax and behavior of
 Individual columns have the ability to be aligned in a number of different
 ways, for an enhanced viewing experience.
 
- >>> t = Table()
- >>> t['long column name 1'] = [1,2,3]
- >>> t['long column name 2'] = [4,5,6]
- >>> t['long column name 3'] = [7,8,9]
- >>> t['long column name 4'] = [700000,800000,900000]
- >>> t['long column name 2'].format = '<'
- >>> t['long column name 3'].format = '0='
- >>> t['long column name 4'].format = '^'
- >>> t.pprint()
+ >>> t1 = Table()
+ >>> t1['long column name 1'] = [1,2,3]
+ >>> t1['long column name 2'] = [4,5,6]
+ >>> t1['long column name 3'] = [7,8,9]
+ >>> t1['long column name 4'] = [700000,800000,900000]
+ >>> t1['long column name 2'].format = '<'
+ >>> t1['long column name 3'].format = '0='
+ >>> t1['long column name 4'].format = '^'
+ >>> t1.pprint()
    long column name 1 long column name 2 long column name 3 long column name 4
   ------------------ ------------------ ------------------ ------------------
                    1 4                  000000000000000007       700000      
                    2 5                  000000000000000008       800000      
                    3 6                  000000000000000009       900000      
 
+Conveniently, alignment can be handled another way, by passing a list to the
+keyword argument ``align``.
 
+ >>> t1 = Table()
+ >>> t1['column1'] = [1,2,3,4,5]
+ >>> t1['column2'] = [2,4,6,8,10]
+ >>> t1.pprint(align=['<','0='])
+   column1 column2
+ ------- -------
+ 1       0000002
+ 2       0000004
+ 3       0000006
+ 4       0000008
+ 5       0000010
+
+By default, if the length of the list does not match the number of columns
+within the table, alignment defaults to right-aligned columns. This default
+behavior also holds true even if a single alignment character is passed in as a
+list (e.g., align=['^']), where global alignment of all columns within a table
+is intended. For very large tables, this can be a nuissance, and so looping is the
+recommended solution for this task.
+ 
 pformat() method
 ''''''''''''''''
 


### PR DESCRIPTION
This is exactly #3037 from @agroener but rebased and including a final commit to fix the astropy_helpers issue.

Closes #3037.
