### PR TITLE
Installation failed on Solaris 11 x64

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -3,10 +3,22 @@ from __future__ import absolute_import
 
 import os
 
+from distutils import sysconfig
 from distutils.core import Extension
 from glob import glob
 
 from astropy_helpers import setup_helpers
+
+
+def _get_c_compiler():
+    # TODO: There should be an easier way to do this
+    # through astropy_helpers
+    if 'CC' in os.environ:
+        compiler = os.environ['CC']
+    else:
+        compiler = sysconfig.get_config_var('CC')
+
+    return setup_helpers.get_compiler_version(compiler)
 
 
 def get_extensions():
@@ -26,7 +38,7 @@ def get_extensions():
                     '/D', '"_MBCS"',
                     '/D', '"_USRDLL"',
                     '/D', '"_CRT_SECURE_NO_DEPRECATE"'])
-        else:
+        elif 'Sun C' not in _get_c_compiler():
             # All of these switches are to silence warnings from compiling CFITSIO
             cfg['extra_compile_args'].extend([
                 '-Wno-unused-variable', '-Wno-parentheses',

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -18,7 +18,7 @@ def _get_c_compiler():
     else:
         compiler = sysconfig.get_config_var('CC')
 
-    return setup_helpers.get_compiler_version(compiler)
+    return setup_helpers.get_compiler_version(compiler).decode('latin1')
 
 
 def get_extensions():


### PR DESCRIPTION
```
$ python --version
Python 2.7.5
```

```
$ which cc
/opt/solarisstudio12.3/bin/cc
```

astropy-0.2.4

```
$ python setup.py build
cc: Warning: Option --version passed to ld, if ld is invoked, ignored otherwise
usage: cc [ options ] files.  Use 'cc -flags' for details
Traceback (most recent call last):
  File "setup.py", line 56, in <module>
    adjust_compiler(NAME)
  File "/home/borut/admin/python/astropy-0.2.4/astropy/setup_helpers.py", line 95, in adjust_compiler
    version = get_compiler_version(c_compiler)
  File "/home/borut/admin/python/astropy-0.2.4/astropy/setup_helpers.py", line 178, in get_compiler_version
    version = output.split()[0]
IndexError: list index out of range
```

Any ideas?