### PR TITLE
Add Travis job for numpy-dev that is allowed to fail

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # CONDA
 conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
@@ -17,10 +17,14 @@ then
   exit  # no more dependencies needed
 fi
 
+# CORE DEPENDENCIES
+$CONDA_INSTALL pytest Cython jinja2 psutil
+
 # NUMPY
 if [[ $NUMPY_VERSION == dev ]]
 then
-  pip install git+http://github.com/numpy/numpy.git  
+  pip install git+http://github.com/numpy/numpy.git
+  exit # exit to make sure we don't end up accidentally install numpy with conda
 else
   conda install --yes numpy=$NUMPY_VERSION
 fi
@@ -28,9 +32,6 @@ fi
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.
 export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
-
-# CORE DEPENDENCIES
-$CONDA_INSTALL pytest Cython jinja2 psutil
 
 # OPTIONAL DEPENDENCIES
 if $OPTIONAL_DEPS

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -18,7 +18,12 @@ then
 fi
 
 # NUMPY
-conda install --yes numpy=$NUMPY_VERSION
+if [[ $NUMPY_VERSION == dev ]]
+then
+  pip install git+http://github.com/numpy/numpy.git  
+else
+  conda install --yes numpy=$NUMPY_VERSION
+fi
 
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -18,7 +18,7 @@ then
 fi
 
 # CORE DEPENDENCIES
-$CONDA_INSTALL pytest Cython jinja2 psutil
+conda install --yes pytest Cython jinja2 psutil
 
 # NUMPY
 if [[ $NUMPY_VERSION == dev ]]

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -24,14 +24,14 @@ conda install --yes pytest Cython jinja2 psutil
 if [[ $NUMPY_VERSION == dev ]]
 then
   pip install git+http://github.com/numpy/numpy.git
-  exit # exit to make sure we don't end up accidentally install numpy with conda
+  export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION"
 else
   conda install --yes numpy=$NUMPY_VERSION
+  export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
 fi
 
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.
-export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
 
 # OPTIONAL DEPENDENCIES
 if $OPTIONAL_DEPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,10 @@ env:
 
 matrix:
 
-    include:
+    # Don't wait for allowed failures
+    fast_finish: true
 
-        # Try developer version of Numpy
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
+    include:
 
         # Try MacOS X
         - os: osx
@@ -61,6 +60,10 @@ matrix:
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test'
+
+        # Try developer version of Numpy
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
 
         # Do a PEP8 test
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,12 @@ env:
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
 
 matrix:
+
     include:
+
+        # Try developer version of Numpy
+        - os: linux
+          env: NUMPY_VERSION=dev SETUP_CMD='test'
 
         # Try MacOS X
         - os: osx
@@ -60,6 +65,9 @@ matrix:
         # Do a PEP8 test
         - os: linux
           env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
+
+    allow_failures:
+      - env: NUMPY_VERSION=dev SETUP_CMD='test'
 
 install:
     - source .continuous-integration/travis/setup_environment_$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
         # Try developer version of Numpy
         - os: linux
-          env: NUMPY_VERSION=dev SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
 
         # Try MacOS X
         - os: osx
@@ -67,7 +67,7 @@ matrix:
           env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
 
     allow_failures:
-      - env: NUMPY_VERSION=dev SETUP_CMD='test'
+      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
 
 install:
     - source .continuous-integration/travis/setup_environment_$TRAVIS_OS_NAME.sh


### PR DESCRIPTION
In the light of other issues that mention failures with Numpy-dev, this re-instates a build in Travis against numpy-dev **but** marks it as an allowed failure. This way we can easily see what the current failures are, but we don't fail the Travis builds. We can always comment out the allowed failure part once tests do pass, and then uncomment again in future if needed.