### PR TITLE
Cannot create Time object from a Column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -330,7 +330,7 @@ Bug Fixes
 - ``astropy.time``
 
   - Ensure a ``Column`` without units is treated as an ``array``, not as an 
-    dimensionless ``Quantity``.
+    dimensionless ``Quantity``. [#3648]
 
 - ``astropy.units``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -329,6 +329,9 @@ Bug Fixes
 
 - ``astropy.time``
 
+  - Ensure a ``Column`` without units is treated as an ``array``, not as an 
+    dimensionless ``Quantity``.
+
 - ``astropy.units``
 
   - Ensure equivalencies that do more than just scale a ``Quantity`` are

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1372,15 +1372,14 @@ class TimeFormat(object):
             raise TypeError('Input values for {0} class must be finite doubles'
                             .format(self.name))
 
-        if hasattr(val1, 'to'):
+        if getattr(val1, 'unit', None) is not None:
             # set possibly scaled unit any quantities should be converted to
             _unit = u.CompositeUnit(getattr(self, 'unit', 1.), [u.day], [1])
             val1 = val1.to(_unit).value
             if val2 is not None:
                 val2 = val2.to(_unit).value
-        else:
-            if hasattr(val2, 'to'):
-                raise TypeError('Cannot mix float and Quantity inputs')
+        elif getattr(val2, 'unit', None) is not None:
+            raise TypeError('Cannot mix float and Quantity inputs')
 
         if val2 is None:
             val2 = np.zeros_like(val1)

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -6,6 +6,7 @@ import numpy as np
 from ...tests.helper import pytest
 from .. import Time, TimeDelta, OperandTypeError
 from ... import units as u
+from ...table import Column
 
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol
@@ -52,6 +53,20 @@ class TestTimeQuantity():
 
         with pytest.raises(u.UnitsError):
             Time(2450000.*u.dimensionless_unscaled, format='jd', scale='utc')
+
+    def test_column_with_and_without_units(self):
+        """Ensure a Column without a unit is treated as an array [#3648]"""
+        a = np.arange(50000., 50010.)
+        ta = Time(a, format='mjd')
+        c1 = Column(np.arange(50000., 50010.), name='mjd')
+        tc1 = Time(c1, format='mjd')
+        assert np.all(ta == tc1)
+        c2 = Column(np.arange(50000., 50010.), name='mjd', unit='day')
+        tc2 = Time(c2, format='mjd')
+        assert np.all(ta == tc2)
+        c3 = Column(np.arange(50000., 50010.), name='mjd', unit='m')
+        with pytest.raises(u.UnitsError):
+            Time(c3, format='mjd')
 
     def test_no_quantity_input_allowed(self):
         """Time formats that are not allowed to take Quantity input."""


### PR DESCRIPTION
This is a regression introduced in 1.0.  The problem is [here](https://github.com/astropy/astropy/blob/f764be8a2e2e5312279fa7828d3dd4827335eba2/astropy/time/core.py#L1375)

I'm not a huge fan of duck-typing by simply looking for a `to` attribute (and *hoping* that object is sufficiently Quantity-like), but given the existing code the best way out might just be to handle the possibility of a `unit` attribute that is None.

@mhvk 

```
In [1]: from astropy.table import Column
In [2]: from astropy.time import Time
In [3]: x = Column([1])
In [4]: Time(x, format='jd')
---------------------------------------------------------------------------
UnitsError                                Traceback (most recent call last)
<ipython-input-4-2acb9071d863> in <module>()
----> 1 Time(x, format='jd')

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/time/core.pyc in __init__(self, val, val2, format, scale, precision, in_subfmt, out_subfmt, location, copy)
    196                 self._set_scale(scale)
    197         else:
--> 198             self._init_from_vals(val, val2, format, scale, copy)
    199 
    200         if self.location:

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/time/core.pyc in _init_from_vals(self, val, val2, format, scale, copy)
    238 
    239         # Parse / convert input values into internal jd1, jd2 based on format
--> 240         self._time = self._get_time_fmt(val, val2, format, scale)
    241         self._format = self._time.name
    242 

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/time/core.pyc in _get_time_fmt(self, val, val2, format, scale)
    272             try:
    273                 return FormatClass(val, val2, scale, self.precision,
--> 274                                    self.in_subfmt, self.out_subfmt)
    275             except (ValueError, TypeError):
    276                 pass

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/time/core.pyc in __init__(self, val1, val2, scale, precision, in_subfmt, out_subfmt, from_jd)
   1296             self.jd2 = val2
   1297         else:
-> 1298             val1, val2 = self._check_val_type(val1, val2)
   1299             self.set_jds(val1, val2)
   1300 

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/time/core.pyc in _check_val_type(self, val1, val2)
   1323             # set possibly scaled unit any quantities should be converted to
   1324             _unit = u.CompositeUnit(getattr(self, 'unit', 1.), [u.day], [1])
-> 1325             val1 = val1.to(_unit).value
   1326             if val2 is not None:
   1327                 val2 = val2.to(_unit).value

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/table/column.pyc in to(self, unit, equivalencies, **kwargs)
    686             ``unit``.
    687         """
--> 688         return self.quantity.to(unit, equivalencies)
    689 
    690     def _copy_attrs(self, obj):

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/units/quantity.pyc in to(self, unit, equivalencies)
    603         unit = Unit(unit)
    604         new_val = np.asarray(
--> 605             self.unit.to(unit, self.value, equivalencies=equivalencies))
    606         return self._new_view(new_val, unit)
    607 

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/units/core.pyc in to(self, other, value, equivalencies)
    943             If units are inconsistent
    944         """
--> 945         return self._get_converter(other, equivalencies=equivalencies)(value)
    946 
    947     def in_units(self, other, value=1.0, equivalencies=[]):

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/units/core.pyc in _get_converter(self, other, equivalencies)
    847         except UnitsError:
    848             return self._apply_equivalences(
--> 849                 self, other, self._normalize_equivalencies(equivalencies))
    850         return lambda val: scale * _condition_arg(val)
    851 

/Users/aldcroft/anaconda/lib/python2.7/site-packages/astropy/units/core.pyc in _apply_equivalences(self, unit, other, equivalencies)
    838         raise UnitsError(
    839             "{0} and {1} are not convertible".format(
--> 840                 unit_str, other_str))
    841 
    842     def _get_converter(self, other, equivalencies=[]):

UnitsError: '' (dimensionless) and 'd' (time) are not convertible
```

