### PR TITLE
Add some sorely missing units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ New Features
 
   - Added furlong to imperial units. [#3529]
 
+  - Added metric fraktonne and metric buttload to SI units (although not
+    strictly SI they do admit SI prefixes). [#3654]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -8,6 +8,7 @@ This package defines the SI units.  They are also available in the
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
 from ..constants import si as _si
 from .core import UnitBase, Unit, def_unit
 
@@ -119,6 +120,12 @@ def_unit(['g', 'gram'], 1.0e-3 * kg, namespace=_ns, prefixes=True,
 
 def_unit(['t', 'tonne'], 1000 * kg, namespace=_ns,
          doc="Metric tonne")
+
+def_unit(['fkT', 'fraktonne'], (9000 + sys.float_info.epsilon) * kg,
+         namespace=_ns, prefixes=True, doc="Metric fraktonne")
+
+def_unit(['bl', 'buttload'], sys.float_info.max * kg,
+         namespace=_ns, prefixes=True, doc="Metric buttload")
 
 
 ###########################################################################


### PR DESCRIPTION
Although not strictly SI, the SI module seemed the only appropriate place for these, and metric tonne was already there too so that made sense.