### PR TITLE
Fortran-exponents

### DIFF
--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -211,7 +211,7 @@ cdef class CParser:
             fast_reader = {}
         elif fast_reader is False: # shouldn't happen
             raise core.ParameterError("fast_reader cannot be False for fast readers")
-        expchar = fast_reader.pop('fortran_exp', 'E').upper()
+        expchar = fast_reader.pop('exponent_style', 'E').upper()
         # parallel and use_fast_reader are False by default, but only the latter
         # supports Fortran double precision notation 
         if expchar == 'E':
@@ -219,7 +219,9 @@ cdef class CParser:
         else:
             use_fast_converter = fast_reader.pop('use_fast_converter', True)
             if not use_fast_converter:
-                raise core.FastOptionsError("fast_reader: fortran_exp requires use_fast_converter")
+                raise core.FastOptionsError("fast_reader: exponent_style requires use_fast_converter")
+            if expchar.startswith('FORT'):
+                expchar = 'A'
         parallel = fast_reader.pop('parallel', False)
 
         if fast_reader:

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -578,19 +578,24 @@ cdef class CParser:
                 cols[name] = self._convert_int(t, i, num_rows)
             except ValueError:
                 try:
-                    if try_float and not try_float[name]:
-                        raise ValueError()
                     if t.code == OVERFLOW_ERROR:
                         # Overflow during int conversion (extending range)
-                        warnings.warn("OverflowError converting to {0} in column {1}, reverting to Float."
+                        warnings.warn("OverflowError converting to {0} in column {1}, reverting to String."
                                   .format('IntType', name), AstropyWarning)
+                        if try_string and not try_string[name]:
+                            raise ValueError('Column {0} failed to convert'.format(name))
                         t.code = NO_ERROR
-                    cols[name] = self._convert_float(t, i, num_rows)
-                    if t.code == OVERFLOW_ERROR:
-                        # Overflow during float conversion (extending range)
-                        warnings.warn("OverflowError converting to {0} in column {1}, possibly resulting in degraded precision."
-                                  .format('FloatType', name), AstropyWarning)
+                        cols[name] = self._convert_str(t, i, num_rows)
+                    else:
+                        if try_float and not try_float[name]:
+                            raise ValueError()
                         t.code = NO_ERROR
+                        cols[name] = self._convert_float(t, i, num_rows)
+                        if t.code == OVERFLOW_ERROR:
+                            # Overflow during float conversion (extending range)
+                            warnings.warn("OverflowError converting to {0} in column {1}, possibly resulting in degraded precision."
+                                          .format('FloatType', name), AstropyWarning)
+                            t.code = NO_ERROR
                 except ValueError:
                     if try_string and not try_string[name]:
                         raise ValueError('Column {0} failed to convert'.format(name))

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -211,16 +211,17 @@ cdef class CParser:
             fast_reader = {}
         elif fast_reader is False: # shouldn't happen
             raise core.ParameterError("fast_reader cannot be False for fast readers")
-        # parallel and use_fast_reader are False by default
-        use_fast_converter = fast_reader.pop('use_fast_converter', False)
-        parallel = fast_reader.pop('parallel', False)
-        fortran_dexp = fast_reader.pop('fortran_dexp', False)
-        # Fortran double precision notation only supported with fast converter
-        if fortran_dexp:
-            expchar='D'
-            use_fast_converter = True
+        expchar = fast_reader.pop('fortran_exp', 'E').upper()
+        # parallel and use_fast_reader are False by default, but only the latter
+        # supports Fortran double precision notation 
+        if expchar == 'E':
+            use_fast_converter = fast_reader.pop('use_fast_converter', False)
         else:
-            expchar='E'
+            use_fast_converter = fast_reader.pop('use_fast_converter', True)
+            if not use_fast_converter:
+                raise core.FastOptionsError("fast_reader: fortran_exp requires use_fast_converter")
+        parallel = fast_reader.pop('parallel', False)
+
         if fast_reader:
             raise core.FastOptionsError("Invalid parameter in fast_reader dict")
         if parallel and os.name == 'nt':

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -877,7 +877,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
     if (num_digits == 0)
     {
         errno = ERANGE;
-        return 0.0;
+        number = 0.0;
     }
 
     // Correct for sign
@@ -925,7 +925,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
             if (num_exp != 0 && (exp == '+' || exp == '-'))
             {
                errno = ERANGE;
-               return 0.0;
+               number = 0.0;
             }
 
             if (negative)

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -770,13 +770,14 @@ conversion_error:
 //
 
 double xstrtod(const char *str, char **endptr, char decimal,
-               char sci, char tsep, int skip_trailing)
+               char expchar, char tsep, int skip_trailing)
 {
     double number;
     int exponent;
     int negative;
     char *p = (char *) str;
     char exp;
+    char sci;
     int num_digits;
     int num_decimals;
     int max_digits = 17;
@@ -877,7 +878,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
     if (negative) number = -number;
 
     // Process an exponent string
-    sci = toupper(sci);
+    sci = toupper(expchar);
     if (sci == 'A')
     {
         // check for possible Fortran exponential notations, including

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -2,7 +2,7 @@
 
 #include "tokenizer.h"
 
-tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar,
+tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar, char expchar,
                               int fill_extra_cols, int strip_whitespace_lines,
                               int strip_whitespace_fields, int use_fast_converter)
 {
@@ -16,6 +16,7 @@ tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar,
     tokenizer->delimiter = delimiter;
     tokenizer->comment = comment;
     tokenizer->quotechar = quotechar;
+    tokenizer->expchar = expchar;
     tokenizer->output_cols = NULL;
     tokenizer->col_ptrs = NULL;
     tokenizer->output_len = NULL;
@@ -645,7 +646,7 @@ double str_to_double(tokenizer_t *self, char *str)
 
     if (self->use_fast_converter)
     {
-        val = xstrtod(str, &tmp, '.', 'E', ',', 1);
+        val = xstrtod(str, &tmp, '.', self->expchar, ',', 1);
 
         if (*tmp)
         {

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -627,7 +627,7 @@ long str_to_long(tokenizer_t *self, char *str)
     char *tmp;
     long ret;
     errno = 0;
-    ret = strtol(str, &tmp, 0);
+    ret = strtol(str, &tmp, 10);
 
     if (tmp == str || *tmp != '\0')
         self->code = CONVERSION_ERROR;

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -771,7 +771,6 @@ double xstrtod(const char *str, char **endptr, char decimal,
     double number;
     int exponent;
     int negative;
-    int autoexp;
     char *p = (char *) str;
     char exp;
     int num_digits;
@@ -811,8 +810,6 @@ double xstrtod(const char *str, char **endptr, char decimal,
                          1e291, 1e292, 1e293, 1e294, 1e295, 1e296, 1e297, 1e298, 1e299, 1e300,
                          1e301, 1e302, 1e303, 1e304, 1e305, 1e306, 1e307, 1e308};
     errno = 0;
-    autoexp = 0;
-    if (toupper(sci) == 'A') autoexp = 1;
 
     // Skip leading whitespace
     while (isspace(*p)) p++;
@@ -875,7 +872,8 @@ double xstrtod(const char *str, char **endptr, char decimal,
     if (negative) number = -number;
 
     // Process an exponent string
-    if (autoexp)
+    sci = toupper(sci);
+    if (sci == 'A')
     {
         // check for possible Fortran exponential notations, including
         // triple-digits with no character
@@ -886,16 +884,20 @@ double xstrtod(const char *str, char **endptr, char decimal,
             negative = 0;
             switch (exp)
             {
-            case '-': negative = 1;   // Fall through to increment pos
-            case '+': p++;
+            case '-':
+                negative = 1;   // Fall through to increment pos
+            case '+':
+                p++;
                 break;
             case 'E':
             case 'D':
             case 'Q':
                 switch (*++p)
                 {
-                case '-': negative = 1;   // Fall through to increment pos
-                case '+': p++;
+                case '-':
+                    negative = 1;   // Fall through to increment pos
+                case '+':
+                    p++;
                 }
             }
 
@@ -913,14 +915,16 @@ double xstrtod(const char *str, char **endptr, char decimal,
                 exponent += n;
         }
     }
-    else if (toupper(*p) == toupper(sci))
+    else if (toupper(*p) == sci)
     {
         // Handle optional sign
         negative = 0;
         switch (*++p)
         {
-        case '-': negative = 1;   // Fall through to increment pos
-        case '+': p++;
+        case '-':
+            negative = 1;   // Fall through to increment pos
+        case '+':
+            p++;
         }
 
         // Process string of digits

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -60,6 +60,7 @@ typedef struct
     char delimiter;        // delimiter character
     char comment;          // comment character
     char quotechar;        // quote character
+    char expchar;          // exponential character in scientific notation
     char **output_cols;    // array of output strings for each column
     char **col_ptrs;       // array of pointers to current output position for each col
     int *output_len;       // length of each output column string
@@ -90,9 +91,9 @@ output_cols: ["A\x0010\x001", "B\x005.\x002", "C\x006\x003"]
 #define INITIAL_COL_SIZE 500
 #define INITIAL_COMMENT_LEN 50
 
-tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar, int fill_extra_cols,
-                              int strip_whitespace_lines, int strip_whitespace_fields,
-                              int use_fast_converter);
+tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar, char expchar,
+                              int fill_extra_cols, int strip_whitespace_lines,
+                              int strip_whitespace_fields, int use_fast_converter);
 void delete_tokenizer(tokenizer_t *tokenizer);
 void delete_data(tokenizer_t *tokenizer);
 void resize_col(tokenizer_t *self, int index);

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -103,7 +103,7 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols);
 long str_to_long(tokenizer_t *self, char *str);
 double str_to_double(tokenizer_t *self, char *str);
 double xstrtod(const char *str, char **endptr, char decimal,
-               char sci, char tsep, int skip_trailing);
+               char expchar, char tsep, int skip_trailing);
 void start_iteration(tokenizer_t *self, int col);
 char *next_field(tokenizer_t *self, int *size);
 long file_len(FILE *fhandle);

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -971,7 +971,7 @@ def test_fortran_reader(parallel):
     expected = Table([['1.0001+1', '.42d0'], ['2.3+10', '0.5'], ['3+1001', '3'],
                       ['2', '4.56-123.4'], [8000, 4.2e-122]], 
                      names=('A', 'B', 'C', 'D', 'E'))
-    if TRAVIS:
+    if parallel and TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -901,8 +901,8 @@ def test_data_out_of_range(parallel, read_basic):
     the C parser; such numbers are returned as strings instead, not so
     with the Python parser!
     """
-    if parallel and TRAVIS:
-        pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
+    if TRAVIS:
+        pytest.xfail("Large exponents can sometimes fail on Travis CI")
     text = 'a b c d\n10.1E+199 3.14e+313 2048e+306 0.6E-414'
     expected = Table([[1.01e+200], ['3.14e+313'], ['2048e+306'], ['0.6E-414']],
                      names=('a', 'b', 'c', 'd'))

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -965,14 +965,24 @@ def test_fortran_reader(parallel):
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)
 
-    # test for invalid exponent-like patterns (no triple-digits) to make sure
-    # they are parsed as strings
+
+@pytest.mark.parametrize("parallel", [
+    pytest.mark.xfail(os.name == 'nt', reason=
+                      "Multiprocessing is currently unsupported on Windows")(True),
+    False])
+def test_fortran_invalid_exp(parallel):
+    """
+    Test Fortran-style exponential notation in the fast_reader with invalid
+    exponent-like patterns (no triple-digits) to make sure they are returned
+    as strings instead, as with the standard C parser.
+    """
+    if TRAVIS:
+        pytest.xfail("Large exponents can sometimes fail on Travis CI")
+
     text = 'A B C D E\n1.0001+1 2.3+10 3+1001 2 8.e3\n.42d0 0.5 3 4.56-123.4 0.42-123'
     expected = Table([['1.0001+1', '.42d0'], ['2.3+10', '0.5'], ['3+1001', '3'],
                       ['2', '4.56-123.4'], [8000, 4.2e-122]],
                      names=('A', 'B', 'C', 'D', 'E'))
-    if parallel and TRAVIS:
-        pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
     table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -23,7 +23,7 @@ from .common import assert_equal, assert_almost_equal, assert_true
 from ....tests.helper import pytest
 from ....extern import six
 
-TRAVIS = os.environ.get('TRAVIS', False)
+TRAVIS = str('TRAVIS') in os.environ
 
 def assert_table_equal(t1, t2, check_meta=False):
     assert_equal(len(t1), len(t2))
@@ -940,6 +940,8 @@ def test_fortran_reader(parallel):
     expected = Table([['1.0001+1', '.42d0'], ['2.3+10', '0.5'], ['3+1001', '3'],
                       ['2', '4.56-123.4'], [8000, 4.2e-122]], 
                      names=('A', 'B', 'C', 'D', 'E'))
+    if parallel and TRAVIS:
+        pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -914,7 +914,7 @@ def test_data_out_of_range(parallel, read_basic):
 
     # non-standard exponent_style at this point treats very small numbers
     # like the Python parser as zeros:
-    text = 'a b c d\n10.1D+199 3.14+d313 2048D+306 0.6d-414'
+    text = 'a b c d\n10.1D+199 3.14d+313 2048D+306 0.6d-414'
     expected = Table([[1.01e+200], ['3.14d+313'], ['2048D+306'], [0.0]],
                      names=('a', 'b', 'c', 'd'))
     table = ascii.read(text, format='basic', guess=False, 

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -916,9 +916,9 @@ def test_fortran_reader(parallel):
                        fast_reader={'parallel': parallel, 'fortran_exp': 'q'})
     assert_table_equal(table, expected)
 
-    # mixes and triple-exponents without any character are not handled (yet)!
-    with pytest.raises(AssertionError):
-        text = 'A B C\n1.00001+101 2.0E0 3\n.42d0 0.5 6.E3'
-        table = ascii.read(text, format='basic', guess=False, 
-                           fast_reader={'parallel': parallel, 'fortran_exp': 'a'})
-        assert_table_equal(table, expected)
+    # mixes and triple-exponents without any character using autodetect option
+    text = 'A B C\n1.0001+101 2.0E0 3\n.42d0 0.5 0.42-123'
+    expected['C'][1] = 4.2e-124
+    table = ascii.read(text, format='basic', guess=False, 
+                       fast_reader={'parallel': parallel, 'fortran_exp': 'a'})
+    assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -914,11 +914,11 @@ def test_data_out_of_range(parallel, read_basic):
 
     # non-standard exponent_style at this point treats very small numbers
     # like the Python parser as zeros:
-    text = 'a b c d\n10.1D+199 3.14+313 2048Q+306 0.6E-414'
-    expected = Table([[1.01e+200], ['3.14+313'], ['2048Q+306'], [0.0]],
+    text = 'a b c d\n10.1D+199 3.14+d313 2048D+306 0.6d-414'
+    expected = Table([[1.01e+200], ['3.14d+313'], ['2048D+306'], [0.0]],
                      names=('a', 'b', 'c', 'd'))
     table = ascii.read(text, format='basic', guess=False, 
-                       fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
+                       fast_reader={'parallel': parallel, 'exponent_style': 'D'})
     assert_table_equal(table, expected)
 
 @pytest.mark.parametrize("parallel", [
@@ -971,7 +971,7 @@ def test_fortran_reader(parallel):
     expected = Table([['1.0001+1', '.42d0'], ['2.3+10', '0.5'], ['3+1001', '3'],
                       ['2', '4.56-123.4'], [8000, 4.2e-122]], 
                      names=('A', 'B', 'C', 'D', 'E'))
-    if parallel and TRAVIS:
+    if TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -903,22 +903,22 @@ def test_fortran_reader(parallel):
     with pytest.raises(FastOptionsError) as e:
         ascii.read(text, format='basic', guess=False, fast_reader=
                    {'parallel': parallel, 'use_fast_converter': False,
-                    'fortran_exp': 'D'})
-    assert 'fast_reader: fortran_exp requires use_fast_converter' in str(e)
+                    'exponent_style': 'D'})
+    assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
 
     # Enable multiprocessing and the fast converter
     table = ascii.read(text, format='basic', guess=False, 
-                       fast_reader={'parallel': parallel, 'fortran_exp': 'D'})
+                       fast_reader={'parallel': parallel, 'exponent_style': 'D'})
     assert_table_equal(table, expected)
 
     text = 'A B C\n0.10001Q102 20.0Q-1 3\n.42q0 0.5 6.Q3'
     table = ascii.read(text, format='basic', guess=False, 
-                       fast_reader={'parallel': parallel, 'fortran_exp': 'q'})
+                       fast_reader={'parallel': parallel, 'exponent_style': 'q'})
     assert_table_equal(table, expected)
 
     # mixes and triple-exponents without any character using autodetect option
     text = 'A B C\n1.0001+101 2.0E0 3\n.42d0 0.5 0.42-123'
     expected['C'][1] = 4.2e-124
     table = ascii.read(text, format='basic', guess=False, 
-                       fast_reader={'parallel': parallel, 'fortran_exp': 'a'})
+                       fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -908,7 +908,7 @@ def test_data_out_of_range(parallel, read_basic):
                      names=('a', 'b', 'c', 'd'))
     # currently different behaviour by the standard (Python) reader
     #table = read_basic(text, parallel=parallel)
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel})
     assert_table_equal(table, expected)
 
@@ -917,7 +917,7 @@ def test_data_out_of_range(parallel, read_basic):
     text = 'a b c d\n10.1D+199 3.14d+313 2048D+306 0.6d-414'
     expected = Table([[1.01e+200], ['3.14d+313'], ['2048D+306'], [0.0]],
                      names=('a', 'b', 'c', 'd'))
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'D'})
     assert_table_equal(table, expected)
 
@@ -931,7 +931,7 @@ def test_fortran_reader(parallel):
     using the fast_reader.
     """
     text = 'A B C\n100.01D+99 2.0 3\n4.2d-1 5.0D-1 0.6D4'
-    expected = Table([[1.0001e101, 0.42], [2, 0.5], [3.0, 6000]], 
+    expected = Table([[1.0001e101, 0.42], [2, 0.5], [3.0, 6000]],
                      names=('A', 'B', 'C'))
 
     # C strtod (not-fast converter) can't handle Fortran exp
@@ -942,26 +942,26 @@ def test_fortran_reader(parallel):
     assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
 
     # Enable multiprocessing and the fast converter
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'D'})
     assert_table_equal(table, expected)
 
     text = 'A B C\n0.10001Q102 20.0Q-1 3\n.42q0 0.5 6.Q3'
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'q'})
     assert_table_equal(table, expected)
 
     # mixes and triple-exponents without any character using autodetect option
     text = 'A B C\n1.0001+101 2.0E0 3\n.42d0 0.5 0.42-123'
     expected['C'][1] = 4.2e-124
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)
 
     # additional corner-case checks
     text = 'A B C\n1.0001+101 2.0+000 3\n0.42+000 0.5 .42-000'
     expected['C'][1] = 4.2e-1
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)
 
@@ -969,10 +969,10 @@ def test_fortran_reader(parallel):
     # they are parsed as strings
     text = 'A B C D E\n1.0001+1 2.3+10 3+1001 2 8.e3\n.42d0 0.5 3 4.56-123.4 0.42-123'
     expected = Table([['1.0001+1', '.42d0'], ['2.3+10', '0.5'], ['3+1001', '3'],
-                      ['2', '4.56-123.4'], [8000, 4.2e-122]], 
+                      ['2', '4.56-123.4'], [8000, 4.2e-122]],
                      names=('A', 'B', 'C', 'D', 'E'))
     if parallel and TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
-    table = ascii.read(text, format='basic', guess=False, 
+    table = ascii.read(text, format='basic', guess=False,
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -904,7 +904,7 @@ def test_data_out_of_range(parallel, read_basic):
     if parallel and TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
         # pytest.xfail("Large exponents can sometimes fail on Travis CI")
-    text = 'a b c d e\n10.1E+199 3.14e+313 2048e+306 0.6E-414 -2.e345'
+    text = 'a b c d e\n10.1E+199 3.14e+313 2048e+306 0.6E-325 -2.e345'
     expected = Table([[1.01e+200], [np.inf], [np.inf], [0.0], [-np.inf]],
                      names=('a', 'b', 'c', 'd', 'e'))
     # currently different behaviour by the standard (Python) reader
@@ -914,7 +914,7 @@ def test_data_out_of_range(parallel, read_basic):
     assert_table_equal(table, expected)
 
     # test non-standard exponent_style with some corner cases
-    text = 'a b c d e\n10.1D+199 0.314d+309 2048D+306 2500d-327 0.6d-326'
+    text = 'a b c d e\n10.1D+199 0.00000314d+314 2048D+306 2500d-327 0.6d-325'
     expected = Table([[1.01e+200], [3.14e+308], [np.inf], [4.94e-324], [0.0]],
                      names=('a', 'b', 'c', 'd', 'e'))
     table = ascii.read(text, format='basic', guess=False,

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -926,3 +926,20 @@ def test_fortran_reader(parallel):
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)
+
+    # additional corner-case checks
+    text = 'A B C\n1.0001+101 2.0+000 3\n0.42+000 0.5 .42-000'
+    expected['C'][1] = 4.2e-1
+    table = ascii.read(text, format='basic', guess=False, 
+                       fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
+    assert_table_equal(table, expected)
+
+    # test for invalid exponent-like patterns (no triple-digits) to make sure
+    # they are parsed as strings
+    text = 'A B C D E\n1.0001+1 2.3+10 3+1001 2 8.e3\n.42d0 0.5 3 4.56-123.4 0.42-123'
+    expected = Table([['1.0001+1', '.42d0'], ['2.3+10', '0.5'], ['3+1001', '3'],
+                      ['2', '4.56-123.4'], [8000, 4.2e-122]], 
+                     names=('A', 'B', 'C', 'D', 'E'))
+    table = ascii.read(text, format='basic', guess=False, 
+                       fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
+    assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -889,7 +889,11 @@ def test_fast_tab_with_names(parallel, read_tab):
     table = read_tab(content, data_start=1,
                      parallel=parallel, names=head)
 
-@pytest.mark.parametrize("parallel", [True, False])
+# catch Windows environment since we cannot use _read() with custom fast_reader
+@pytest.mark.parametrize("parallel", [
+    pytest.mark.xfail(os.name == 'nt', reason=
+                      "Multiprocessing is currently unsupported on Windows")(True),
+    False])
 def test_fortran_reader(parallel):
     """
     Make sure that ascii.read() can read Fortran-style exponential notation
@@ -906,17 +910,12 @@ def test_fortran_reader(parallel):
                     'exponent_style': 'D'})
     assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
 
-    # Enable multiprocessing and the fast converter; have to catch Windows
-    # environment here since we cannot use _read() with custom fast_reader
-    if parallel and os.name == 'nt':
-        pytest.xfail("Multiprocessing is currently unsupported on Windows")
+    # Enable multiprocessing and the fast converter
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'D'})
     assert_table_equal(table, expected)
 
     text = 'A B C\n0.10001Q102 20.0Q-1 3\n.42q0 0.5 6.Q3'
-    if parallel and os.name == 'nt':
-        pytest.xfail("Multiprocessing is currently unsupported on Windows")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'q'})
     assert_table_equal(table, expected)
@@ -924,8 +923,6 @@ def test_fortran_reader(parallel):
     # mixes and triple-exponents without any character using autodetect option
     text = 'A B C\n1.0001+101 2.0E0 3\n.42d0 0.5 0.42-123'
     expected['C'][1] = 4.2e-124
-    if parallel and os.name == 'nt':
-        pytest.xfail("Multiprocessing is currently unsupported on Windows")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -906,12 +906,17 @@ def test_fortran_reader(parallel):
                     'exponent_style': 'D'})
     assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
 
-    # Enable multiprocessing and the fast converter
+    # Enable multiprocessing and the fast converter; have to catch Windows
+    # environment here since we cannot use _read() with custom fast_reader
+    if parallel and os.name == 'nt':
+        pytest.xfail("Multiprocessing is currently unsupported on Windows")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'D'})
     assert_table_equal(table, expected)
 
     text = 'A B C\n0.10001Q102 20.0Q-1 3\n.42q0 0.5 6.Q3'
+    if parallel and os.name == 'nt':
+        pytest.xfail("Multiprocessing is currently unsupported on Windows")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'q'})
     assert_table_equal(table, expected)
@@ -919,6 +924,8 @@ def test_fortran_reader(parallel):
     # mixes and triple-exponents without any character using autodetect option
     text = 'A B C\n1.0001+101 2.0E0 3\n.42d0 0.5 0.42-123'
     expected['C'][1] = 4.2e-124
+    if parallel and os.name == 'nt':
+        pytest.xfail("Multiprocessing is currently unsupported on Windows")
     table = ascii.read(text, format='basic', guess=False, 
                        fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
     assert_table_equal(table, expected)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -40,9 +40,10 @@ else:
 def test_convert_overflow(fast_reader):
     """
     Test reading an extremely large integer, which falls through to
-    string due to an overflow error (#2234).
+    string due to an overflow error (#2234). The C parsers return inf
+    for this now.
     """
-    expected_kind = ('S', 'U')
+    expected_kind = ('S', 'U', 'f')
     dat = ascii.read(['a', '1' * 10000], format='basic',
                      fast_reader=fast_reader, guess=False)
     assert dat['a'].dtype.kind in expected_kind

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -232,9 +232,15 @@ def read(table, guess=None, **kwargs):
         List of names to include in fill_values (default= ``None`` selects all names)
     fill_exclude_names : list
         List of names to exclude from fill_values (applied after ``fill_include_names``)
-    fast_reader : bool
+    fast_reader : bool or dict
         Whether to use the C engine, can also be a dict with options which default to ``False``
-        (default= ``True``)
+        (default= ``True``); parameters for options dict:
+        use_fast_converter: bool
+            enable faster but slightly imprecise floating point conversion method
+        parallel: bool or int
+            multiprocessing conversion using cpu_count() or `number` processes
+        fortran_dexp: bool
+            parse Fortran-style scientific notation like `3.14159D+00`, implies fast converter
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
 
@@ -363,8 +369,16 @@ def _guess(table, read_kwargs, format, fast_reader):
     format : str
         Table format
     fast_reader : bool
+    fast_reader : bool or dict
         Whether to use the C engine, can also be a dict with options which
-        default to ``False`` (default= ``True``)
+        default to ``False`` (default= ``True``); parameters for options dict:
+        use_fast_converter: bool
+            enable faster but slightly imprecise floating point conversion method
+        parallel: bool or int
+            multiprocessing conversion using cpu_count() or `number` processes
+        fortran_dexp: bool
+            parse Fortran-style scientific notation like `3.14159D+00`,
+            implies use_fast_converter
 
     Returns
     -------

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -235,13 +235,15 @@ def read(table, guess=None, **kwargs):
     fast_reader : bool or dict
         Whether to use the C engine, can also be a dict with options which default to ``False``
         (default= ``True``); parameters for options dict:
+
         use_fast_converter: bool
             enable faster but slightly imprecise floating point conversion method
         parallel: bool or int
             multiprocessing conversion using cpu_count() or `number` processes
-        fortran_exp: str
-            One-character string defining the exponent in Fortran-style scientific
-            notation like `3.14159D+00` (`E`, `D`, `Q`); implies fast converter
+        exponent_style: str
+            One-character string defining the exponent or 'Fortran' to auto-detect
+            Fortran-style scientific notation like `3.14159D+00` (`E`, `D`, `Q`),
+            all case-insensitive; default `E`, all other imply use_fast_converter
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
 
@@ -373,13 +375,15 @@ def _guess(table, read_kwargs, format, fast_reader):
     fast_reader : bool or dict
         Whether to use the C engine, can also be a dict with options which
         default to ``False`` (default= ``True``); parameters for options dict:
+
         use_fast_converter: bool
             enable faster but slightly imprecise floating point conversion method
         parallel: bool or int
             multiprocessing conversion using cpu_count() or `number` processes
-        fortran_exp: str
-            Exponent  character in Fortran-style scientific notation
-            like `3.14159D+00` (`E`, `D`, `Q`); implies use_fast_converter
+        exponent_style: str
+            Character to use for exponent or 'Fortran' to auto-detect any
+            Fortran-style scientific notation like `3.14159D+00` (`E`, `D`, `Q`),
+            all case-insensitive; default `E`, all other imply use_fast_converter
 
     Returns
     -------

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -239,11 +239,11 @@ def read(table, guess=None, **kwargs):
         use_fast_converter: bool
             enable faster but slightly imprecise floating point conversion method
         parallel: bool or int
-            multiprocessing conversion using cpu_count() or `number` processes
+            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
         exponent_style: str
-            One-character string defining the exponent or 'Fortran' to auto-detect
-            Fortran-style scientific notation like `3.14159D+00` (`E`, `D`, `Q`),
-            all case-insensitive; default `E`, all other imply use_fast_converter
+            One-character string defining the exponent or `'Fortran'` to auto-detect
+            Fortran-style scientific notation like `'3.14159D+00'` (`'E'`, `'D'`, `'Q'`),
+            all case-insensitive; default `'E'`, all other imply ``use_fast_converter``
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
 
@@ -379,11 +379,11 @@ def _guess(table, read_kwargs, format, fast_reader):
         use_fast_converter: bool
             enable faster but slightly imprecise floating point conversion method
         parallel: bool or int
-            multiprocessing conversion using cpu_count() or `number` processes
+            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
         exponent_style: str
-            Character to use for exponent or 'Fortran' to auto-detect any
-            Fortran-style scientific notation like `3.14159D+00` (`E`, `D`, `Q`),
-            all case-insensitive; default `E`, all other imply use_fast_converter
+            Character to use for exponent or `'Fortran'` to auto-detect any
+            Fortran-style scientific notation like `'3.14159D+00'` (`'E'`, `'D'`, `'Q'`),
+            all case-insensitive; default `'E'`, all other imply ``use_fast_converter``
 
     Returns
     -------

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -239,8 +239,9 @@ def read(table, guess=None, **kwargs):
             enable faster but slightly imprecise floating point conversion method
         parallel: bool or int
             multiprocessing conversion using cpu_count() or `number` processes
-        fortran_dexp: bool
-            parse Fortran-style scientific notation like `3.14159D+00`, implies fast converter
+        fortran_exp: str
+            One-character string defining the exponent in Fortran-style scientific
+            notation like `3.14159D+00` (`E`, `D`, `Q`); implies fast converter
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
 
@@ -376,9 +377,9 @@ def _guess(table, read_kwargs, format, fast_reader):
             enable faster but slightly imprecise floating point conversion method
         parallel: bool or int
             multiprocessing conversion using cpu_count() or `number` processes
-        fortran_dexp: bool
-            parse Fortran-style scientific notation like `3.14159D+00`,
-            implies use_fast_converter
+        fortran_exp: str
+            Exponent  character in Fortran-style scientific notation
+            like `3.14159D+00` (`E`, `D`, `Q`); implies use_fast_converter
 
     Returns
     -------

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -241,9 +241,9 @@ def read(table, guess=None, **kwargs):
         parallel: bool or int
             multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
         exponent_style: str
-            One-character string defining the exponent or `'Fortran'` to auto-detect
-            Fortran-style scientific notation like `'3.14159D+00'` (`'E'`, `'D'`, `'Q'`),
-            all case-insensitive; default `'E'`, all other imply ``use_fast_converter``
+            One-character string defining the exponent or ``'Fortran'`` to auto-detect
+            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
+            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
 
@@ -381,9 +381,9 @@ def _guess(table, read_kwargs, format, fast_reader):
         parallel: bool or int
             multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
         exponent_style: str
-            Character to use for exponent or `'Fortran'` to auto-detect any
-            Fortran-style scientific notation like `'3.14159D+00'` (`'E'`, `'D'`, `'Q'`),
-            all case-insensitive; default `'E'`, all other imply ``use_fast_converter``
+            Character to use for exponent or ``'Fortran'`` to auto-detect any
+            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
+            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
 
     Returns
     -------

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -89,7 +89,7 @@ slightly imprecise conversion method for floating-point values, as described bel
 The ``exponent_style`` parameter allows to define a different character
 from the default ``'e'`` for exponential formats in the input file.
 The special setting ``'fortran'`` enables auto-detection of any valid
-Fortran-style exponent character.
+exponent character under Fortran notation.
 For details see the section on :ref:`fortran_style_exponents`.
 
 Writing

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -64,10 +64,10 @@ These parameters are:
  * ``data_Splitter``
  * ``header_Splitter``
 
+.. _fast_conversion_opts:
 
 Parallel and fast conversion options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. _fast_conversion_opts:
 In addition to ``True`` and ``False``, the parameter ``fast_reader`` can also
 be a dict specifying any of three additional parameters, ``parallel``,
 ``use_fast_converter`` and ``exponent_style``. For example::

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -88,12 +88,9 @@ slightly imprecise conversion method for floating-point values, as described bel
 
 The ``exponent_style`` parameter allows to define a different character
 from the default ``'e'`` for exponential formats in the input file.
-The special setting ``'Fortran'`` enables auto-detection of any valid
-Fortran-style exponent character like in ``'1.495978707D+13'``
-(``'E'``, ``'D'``, ``'Q'``), including triple-digit exponents prefixed
-with no character at all. 
-All values are case-insensitive; any value other than the default
-``'E'``, implies the automatic setting of ``'use_fast_converter': True``.
+The special setting ``'fortran'`` enables auto-detection of any valid
+Fortran-style exponent character.
+For details see the section on :ref:`fortran_style_exponents`.
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -85,12 +85,12 @@ Setting ``use_fast_converter`` to be ``True`` enables a faster but
 slightly imprecise conversion method for floating-point values, as described below.
 
 The ``exponent_style`` parameter allows to define a different character
-from the default ``e`` for exponential formats in the input file.
-The special setting ``Fortran`` enables auto-detection of any valid
-Fortran-style exponent character like ``1.495978707D+13`` (``E``, ``D``, 
-``Q``), including triple-digit exponents printed without a character.
+from the default `'e'` for exponential formats in the input file.
+The special setting `'Fortran'` enables auto-detection of any valid
+Fortran-style exponent character like `'1.495978707D+13'` (`'E'`, `'D'`, 
+`'Q'`), including triple-digit exponents printed without a character.
 All values are case-insensitive; any value other than the default
-``E``, implies the automatic setting of ``'use_fast_converter': True``.
+`'E'`, implies the automatic setting of ``'use_fast_converter': True``.
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -64,8 +64,10 @@ These parameters are:
  * ``data_Splitter``
  * ``header_Splitter``
 
+
 Parallel and fast conversion options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _fast_conversion_opts:
 In addition to ``True`` and ``False``, the parameter ``fast_reader`` can also
 be a dict specifying any of three additional parameters, ``parallel``,
 ``use_fast_converter`` and ``exponent_style``. For example::
@@ -85,12 +87,13 @@ Setting ``use_fast_converter`` to be ``True`` enables a faster but
 slightly imprecise conversion method for floating-point values, as described below.
 
 The ``exponent_style`` parameter allows to define a different character
-from the default `'e'` for exponential formats in the input file.
-The special setting `'Fortran'` enables auto-detection of any valid
-Fortran-style exponent character like `'1.495978707D+13'` (`'E'`, `'D'`, 
-`'Q'`), including triple-digit exponents printed without a character.
+from the default ``'e'`` for exponential formats in the input file.
+The special setting ``'Fortran'`` enables auto-detection of any valid
+Fortran-style exponent character like in ``'1.495978707D+13'``
+(``'E'``, ``'D'``, ``'Q'``), including triple-digit exponents prefixed
+with no character at all. 
 All values are case-insensitive; any value other than the default
-`'E'`, implies the automatic setting of ``'use_fast_converter': True``.
+``'E'``, implies the automatic setting of ``'use_fast_converter': True``.
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -67,8 +67,8 @@ These parameters are:
 Parallel and fast conversion options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In addition to ``True`` and ``False``, the parameter ``fast_reader`` can also
-be a dict specifying one or both of two additional parameters, ``parallel`` and
-``use_fast_converter``. For example::
+be a dict specifying any of three additional parameters, ``parallel``,
+``use_fast_converter`` and ``exponent_style``. For example::
 
    >>> ascii.read('data.txt', format='basic', fast_reader={'parallel': True, 'use_fast_converter': True}) # doctest: +SKIP
 
@@ -83,6 +83,14 @@ IPython Notebook and so enabling multiprocessing in this context is discouraged.
 
 Setting ``use_fast_converter`` to be ``True`` enables a faster but
 slightly imprecise conversion method for floating-point values, as described below.
+
+The ``exponent_style`` parameter allows to define a different character
+from the default ``e`` for exponential formats in the input file.
+The special setting ``Fortran`` enables auto-detection of any valid
+Fortran-style exponent character like ``1.495978707D+13`` (``E``, ``D``, 
+``Q``), including triple-digit exponents printed without a character.
+All values are case-insensitive; any value other than the default
+``E``, implies the automatic setting of ``'use_fast_converter': True``.
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -421,14 +421,13 @@ The default converters for each column can be overridden with the
 
 
 Fortran-style exponents
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
-The fast converter available with the :ref:`C input parser
-<fast_conversion_opts>` provides an
-``exponent_style`` option to define a custom character 
-instead of the standard ``'e'`` for exponential formats in the input
-file, with the special setting ``'Fortran'`` for auto-detection of any valid
-Fortran-style exponent character::
+The :ref:`fast converter <fast_conversion_opts>` available with the C
+input parser provides an ``exponent_style`` option to define a custom
+character instead of the standard ``'e'`` for exponential formats in
+the input file, with the special setting ``'Fortran'`` for
+auto-detection of any valid Fortran-style exponent character::
 
   >>> ascii.read('double.dat', format='basic', guess=False, 
   ...            fast_reader={'exponent_style': 'D'})  # doctest: +SKIP

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -419,6 +419,21 @@ The default converters for each column can be overridden with the
   ...               'col2': [ascii.convert_numpy(np.float32)]}
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
+
+Fortran-style exponents
+^^^^^^^^^^^^^^^^^^^^^^
+
+The fast converter available with the :ref:`C input parser
+<fast_conversion_opts>` provides an
+``exponent_style`` option to define a custom character 
+instead of the standard ``'e'`` for exponential formats in the input
+file, with the special setting ``'Fortran'`` for auto-detection of any valid
+Fortran-style exponent character::
+
+  >>> ascii.read('double.dat', format='basic', guess=False, 
+  ...            fast_reader={'exponent_style': 'D'})  # doctest: +SKIP
+
+
 Advanced customization
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -420,18 +420,27 @@ The default converters for each column can be overridden with the
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
 
+.. _fortran_style_exponents:
+
 Fortran-style exponents
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 The :ref:`fast converter <fast_conversion_opts>` available with the C
 input parser provides an ``exponent_style`` option to define a custom
 character instead of the standard ``'e'`` for exponential formats in
-the input file, with the special setting ``'Fortran'`` for
-auto-detection of any valid Fortran-style exponent character::
+the input file, to read for example Fortran-style double precision
+numbers like ``'1.495978707D+13'``:
 
   >>> ascii.read('double.dat', format='basic', guess=False, 
   ...            fast_reader={'exponent_style': 'D'})  # doctest: +SKIP
 
+The special setting ``'fortran'`` is provided to allow for the
+auto-detection of any valid Fortran exponent character (``'E'``,
+``'D'``, ``'Q'``), as well as of triple-digit exponents prefixed with no
+character at all (e.g. ``'2.1127123261674622-107'``).
+All values and exponent characters in the input data are
+case-insensitive; any value other than the default ``'E'`` implies the
+automatic setting of ``'use_fast_converter': True``.
 
 Advanced customization
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
My next highest priority after having a fast C reader was always being able to read in Fortran-written ascii files in its standard double-precision notation (`1.495978707D+13`…) without further processing,
which required setting up converters for each column with `np.loadtxt` or `np.genfromtxt`.
Taking a shot here at the fast_reader module to enable the c parser to directly recognise 'D' or other characters in the exponent.
This adds ‘fortran_exp’ as new option to the fast_reader arguments.

This patch automatically activates the fast_converter, as changing the call to xstrtod was
by far the simplest implementation. I guess it would be possible to add it to the more
precise parser as well, but don’t know how big the demand for this is. I have yet to see
a case where use_fast_converter gave a different result.
Asking for other exponent characters than 'E' therefore now turns use_fast_converter on by default; however setting it explicitly to False raises a FastOptionsError.

Notes following my initial post:
I have since noted that 'q' or 'Q' may be used in Fortran output as well, see post `#3` here
http://computer-programming-forum.com/17-c-language/9b704e6e49d734b8.htm

and therefore modified the option to `'fortran_exp': 'char'`

Implementing an ‘automatic’ option in `xtstrtod` I've experimented with a bit should be able to recognise any mix of `e`, `d`, `q` (or any other characters) as well as the triple-digit exponents mentioned in the link above, but with a probable performance penalty of 5-10 %. Also might increase the risk of converting strings to float64 one does not want to convert... Could probably try the auto-detection on the first lines and then stick with one format for each column, but that would require getting deeper into the entrails of `cparser.pyx`.
