### PR TITLE
#3564 assume sensible default for col_ends or col_starts if omitted for fixed-width table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -241,6 +241,10 @@ API Changes
 
 - ``astropy.io.ascii``
 
+  - Calls to ascii.read() for fixed-width tables may now omit one of the keyword
+    arguments ``col_starts`` or ``col_ends``. Columns will be assumed to begin and
+    end immediately adjacent to each other. [#3564]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ New Features
   - Automatically use ``guess=False`` when reading if the file ``format`` is
     provided and the format parameters are uniquely specified.  This update
     also removes duplicate format guesses to improve performance. [#3418]
+    
+  - Calls to ascii.read() for fixed-width tables may now omit one of the keyword
+    arguments ``col_starts`` or ``col_ends``. Columns will be assumed to begin and
+    end immediately adjacent to each other. [#3657]
 
 - ``astropy.io.fits``
 
@@ -240,10 +244,6 @@ API Changes
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
-
-  - Calls to ascii.read() for fixed-width tables may now omit one of the keyword
-    arguments ``col_starts`` or ``col_ends``. Columns will be assumed to begin and
-    end immediately adjacent to each other. [#3564]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -190,6 +190,12 @@ class FixedWidthHeader(basic.BasicHeader):
             if len(starts) != len(ends):
                 raise ValueError('Fixed width col_starts and col_ends must have the same length')
             vals = [line[start:end].strip() for start, end in zip(starts, ends)]
+        elif self.col_starts is not None and self.col_ends is None:
+            # Figure out column end positions from start positions and data line length
+            starts = list(self.col_starts)
+            ends = list(self.col_starts[1:]) # Assume each col ends where the next starts
+            ends.append(len(self.data.data_lines[0])) # Assume final column ends at end of data line
+            vals = [line[start:end].strip() for start, end in zip(starts, ends)]
         else:
             # There might be a cleaner way to do this but it works...
             vals = line.split(self.splitter.delimiter)

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -191,10 +191,12 @@ class FixedWidthHeader(basic.BasicHeader):
                 raise ValueError('Fixed width col_starts and col_ends must have the same length')
             vals = [line[start:end].strip() for start, end in zip(starts, ends)]
         elif self.col_starts is not None and self.col_ends is None:
-            # Figure out column end positions from start positions and data line length
+            # Figure out column end positions from start positions and the length
+            # of the longest data line
             starts = list(self.col_starts)
             ends = list(self.col_starts[1:]) # Assume each col ends where the next starts
-            ends.append(len(self.data.data_lines[0])) # Assume final column ends at end of data line
+            end_of_last_col = max(len(s) for s in self.data.data_lines)
+            ends.append(end_of_last_col)
             vals = [line[start:end].strip() for start, end in zip(starts, ends)]
         else:
             # There might be a cleaner way to do this but it works...

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -208,6 +208,53 @@ def test_read_col_starts():
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[1][2], "192.168.1.")
     assert_equal(dat[2][2], "192.168.1")  # col_end=28 cuts this column off
+    
+    
+def test_read_detect_col_ends():
+    print("RUNNING YOUR NEW TEST")
+    """Table with no delimiter with only column start values specified"""
+    table = """
+#1       9        19                <== Column start indexes
+#|       |         |                <== Column start positions 
+#<------><--------><------------->  <== Inferred column positions
+  John   555- 1234 192.168.1.10
+  Mary   555- 2134 192.168.1.123
+   Bob   555- 4527  192.168.1.9
+   Bill  555-9875  192.255.255.255
+"""
+    dat = ascii.read(table,
+                    Reader=ascii.FixedWidthNoHeader,
+                    names=('Name', 'Phone', 'TCP'),
+                    col_starts=(1, 9, 19),
+                    )
+    assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
+    assert_equal(dat[0][1], "555- 1234")
+    assert_equal(dat[1][0], "Mary")
+    assert_equal(dat[1][2], "192.168.1.123")
+    assert_equal(dat[3][2], "192.255.255.255")
+   
+    
+def test_read_detect_col_starts():
+    """Table with no delimiter with only column end values specified"""
+    table = """
+#       8        18          30  <== Column end indexes
+#       |         |           |  <== Column end positions 
+#<------><--------><---------->  <== Inferred column positions
+  John   555- 1234 192.168.1.10
+  Mary   555- 2134 192.168.1.123
+   Bob   555- 4527  192.168.1.9
+   Bill  555-9875  192.255.255.255
+"""
+    dat = ascii.read(table,
+                    Reader=ascii.FixedWidthNoHeader,
+                    names=('Name', 'Phone', 'TCP'),
+                    col_ends=(8, 18, 30),
+                    )
+    assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
+    assert_equal(dat[0][1], "555- 1234")
+    assert_equal(dat[1][0], "Mary")
+    assert_equal(dat[1][2], "192.168.1.12")
+    assert_equal(dat[3][2], "192.255.255.")
 
 
 table = """\

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -209,10 +209,9 @@ def test_read_col_starts():
     assert_equal(dat[1][2], "192.168.1.")
     assert_equal(dat[2][2], "192.168.1")  # col_end=28 cuts this column off
     
-    
-def test_read_detect_col_ends():
-    print("RUNNING YOUR NEW TEST")
-    """Table with no delimiter with only column start values specified"""
+
+def test_read_detect_col_starts_or_ends():
+    """Table with no delimiter with only column start or end values specified"""
     table = """
 #1       9        19                <== Column start indexes
 #|       |         |                <== Column start positions 
@@ -222,39 +221,17 @@ def test_read_detect_col_ends():
    Bob   555- 4527  192.168.1.9
    Bill  555-9875  192.255.255.255
 """
-    dat = ascii.read(table,
-                    Reader=ascii.FixedWidthNoHeader,
-                    names=('Name', 'Phone', 'TCP'),
-                    col_starts=(1, 9, 19),
-                    )
-    assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
-    assert_equal(dat[0][1], "555- 1234")
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[1][2], "192.168.1.123")
-    assert_equal(dat[3][2], "192.255.255.255")
-   
-    
-def test_read_detect_col_starts():
-    """Table with no delimiter with only column end values specified"""
-    table = """
-#       8        18          30  <== Column end indexes
-#       |         |           |  <== Column end positions 
-#<------><--------><---------->  <== Inferred column positions
-  John   555- 1234 192.168.1.10
-  Mary   555- 2134 192.168.1.123
-   Bob   555- 4527  192.168.1.9
-   Bill  555-9875  192.255.255.255
-"""
-    dat = ascii.read(table,
-                    Reader=ascii.FixedWidthNoHeader,
-                    names=('Name', 'Phone', 'TCP'),
-                    col_ends=(8, 18, 30),
-                    )
-    assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
-    assert_equal(dat[0][1], "555- 1234")
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[1][2], "192.168.1.12")
-    assert_equal(dat[3][2], "192.255.255.")
+    for kwargs in ({'col_starts': (1,9,19)},
+                   {'col_ends': (8,18,33)}):
+        dat = ascii.read(table,
+                         Reader=ascii.FixedWidthNoHeader,
+                         names=('Name', 'Phone', 'TCP'),
+                         **kwargs)
+        assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
+        assert_equal(dat[0][1], "555- 1234")
+        assert_equal(dat[1][0], "Mary")
+        assert_equal(dat[1][2], "192.168.1.123")
+        assert_equal(dat[3][2], "192.255.255.255")
 
 
 table = """\

--- a/docs/io/ascii/fixed_width_gallery.rst
+++ b/docs/io/ascii/fixed_width_gallery.rst
@@ -208,11 +208,17 @@ will select the first 6 characters.
       Mary 555- 2134 192.168.1.
        Bob 555- 4527  192.168.1
        
-**Table with no delimiter with only column start values specified.**
+**Table with no delimiter with only column start or end values specified.**
 
 If only the col_starts keyword is given, it is assumed that each column
 ends where the next column starts, and the final column ends at the same
 position as the longest line of data.
+
+Conversely, if only the col_ends keyword is given, it is assumed that the first column
+starts at position 0 and that each successive column starts immediately after
+the previous one.
+
+The two examples below read the same table and produce the same result
 ::
 
   >>> table = """
@@ -237,36 +243,20 @@ position as the longest line of data.
       Mary 555- 2134   192.168.1.123
        Bob 555- 4527     192.168.1.9
       Bill  555-9875 192.255.255.255
-
-**Table with no delimiter with only column end values specified.**
-
-If only the col_ends keyword is given, it is assumed that the first column
-starts at position 0 and that each successive column starts immediately after
-the previous one.
-::
-
-  >>> table = """
-  ... #       8        18          30  <== Column end indexes
-  ... #       |         |           |  <== Column end positions 
-  ... #<------><--------><---------->  <== Inferred column positions
-  ...   John   555- 1234 192.168.1.10
-  ...   Mary   555- 2134 192.168.1.123
-  ...    Bob   555- 4527  192.168.1.9
-  ...    Bill  555-9875  192.255.255.255
-  ... """
   >>> ascii.read(table,
   ...                 format='fixed_width_no_header',
   ...                 names=('Name', 'Phone', 'TCP'),
-  ...                 col_ends=(8, 18, 30),
+  ...                 col_ends=(8, 18, 32),
   ...                 )
   <Table masked=False length=4>
-    Name     Phone       TCP     
-  string32  string72   string96  
-  -------- --------- ------------
-      John 555- 1234 192.168.1.10
-      Mary 555- 2134 192.168.1.12
-       Bob 555- 4527  192.168.1.9
-      Bill  555-9875 192.255.255.
+    Name     Phone        TCP      
+  string32  string72   string112   
+  -------- --------- --------------
+      John 555- 1234   192.168.1.10
+      Mary 555- 2134  192.168.1.123
+       Bob 555- 4527    192.168.1.9
+      Bill  555-9875 192.255.255.25
+
 
 FixedWidthTwoLine
 """""""""""""""""

--- a/docs/io/ascii/fixed_width_gallery.rst
+++ b/docs/io/ascii/fixed_width_gallery.rst
@@ -207,6 +207,66 @@ will select the first 6 characters.
       John 555- 1234 192.168.1.
       Mary 555- 2134 192.168.1.
        Bob 555- 4527  192.168.1
+       
+**Table with no delimiter with only column start values specified.**
+
+If only the col_starts keyword is given, it is assumed that each column
+ends where the next column starts, and the final column ends at the same
+position as the longest line of data.
+::
+
+  >>> table = """
+  ... #1       9        19                <== Column start indexes
+  ... #|       |         |                <== Column start positions 
+  ... #<------><--------><------------->  <== Inferred column positions
+  ...   John   555- 1234 192.168.1.10
+  ...   Mary   555- 2134 192.168.1.123
+  ...    Bob   555- 4527  192.168.1.9
+  ...    Bill  555-9875  192.255.255.255
+  ... """
+  >>> ascii.read(table,
+  ...                 format='fixed_width_no_header',
+  ...                 names=('Name', 'Phone', 'TCP'),
+  ...                 col_starts=(1, 9, 19),
+  ...                 )
+  <Table masked=False length=4>
+    Name     Phone         TCP      
+  string32  string72    string120   
+  -------- --------- ---------------
+      John 555- 1234    192.168.1.10
+      Mary 555- 2134   192.168.1.123
+       Bob 555- 4527     192.168.1.9
+      Bill  555-9875 192.255.255.255
+
+**Table with no delimiter with only column end values specified.**
+
+If only the col_ends keyword is given, it is assumed that the first column
+starts at position 0 and that each successive column starts immediately after
+the previous one.
+::
+
+  >>> table = """
+  ... #       8        18          30  <== Column end indexes
+  ... #       |         |           |  <== Column end positions 
+  ... #<------><--------><---------->  <== Inferred column positions
+  ...   John   555- 1234 192.168.1.10
+  ...   Mary   555- 2134 192.168.1.123
+  ...    Bob   555- 4527  192.168.1.9
+  ...    Bill  555-9875  192.255.255.255
+  ... """
+  >>> ascii.read(table,
+  ...                 format='fixed_width_no_header',
+  ...                 names=('Name', 'Phone', 'TCP'),
+  ...                 col_ends=(8, 18, 30),
+  ...                 )
+  <Table masked=False length=4>
+    Name     Phone       TCP     
+  string32  string72   string96  
+  -------- --------- ------------
+      John 555- 1234 192.168.1.10
+      Mary 555- 2134 192.168.1.12
+       Bob 555- 4527  192.168.1.9
+      Bill  555-9875 192.255.255.
 
 FixedWidthTwoLine
 """""""""""""""""


### PR DESCRIPTION
This is to resolve #3564. I've changed the structure of an if-statement in io.ascii.fixedwidth.py inside the FixedWidthHeader.get_fixedwidth_params method to allow me to handle the case where only one of col_starts or col_ends is specified. The behavious for other cases is not changed.

I've also added tests, and two examples in the documentation.

I have run

    python setup.py test --package=io.ascii

using Python 2.7.6 and 3.4.0 for this change and received no failures.