### PR TITLE
WIP: Changes to astropy to support wcslib 5.0.

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -2095,6 +2095,12 @@ See also
 astropy.wcs.Wcsprm.specsys, astropy.wcs.Wcsprm.ssysobs
 """
 
+velref = """
+``int`` AIPS velocity code.
+
+From ``VELREF`` keyword.
+"""
+
 wcs = """
 A `~astropy.wcs.Wcsprm` object to perform the basic `wcslib`_ WCS
 transformation.

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -985,6 +985,16 @@ struct module_state {
     INITERROR;
   }
 
+#ifdef HAVE_WCSLIB_VERSION
+  if (PyModule_AddStringConstant(m, "WCSLIB_VERSION", wcslib_version())) {
+    INITERROR;
+  }
+#else
+  if (PyModule_AddStringConstant(m, "WCSLIB_VERSION", "4.x")) {
+    INITERROR;
+  }
+#endif
+
 #if PY3K
   return m;
 #endif

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -986,7 +986,7 @@ struct module_state {
   }
 
 #ifdef HAVE_WCSLIB_VERSION
-  if (PyModule_AddStringConstant(m, "WCSLIB_VERSION", wcslib_version())) {
+  if (PyModule_AddStringConstant(m, "WCSLIB_VERSION", wcslib_version(NULL))) {
     INITERROR;
   }
 #else

--- a/astropy/wcs/src/pipeline.c
+++ b/astropy/wcs/src/pipeline.c
@@ -5,6 +5,7 @@
 
 #include "astropy_wcs/pipeline.h"
 #include "astropy_wcs/util.h"
+#include "wcserr.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/astropy/wcs/src/sip.c
+++ b/astropy/wcs/src/sip.c
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <wcserr.h>
+
 #define SIP_ERRMSG(status) WCSERR_SET(status)
 
 void

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -64,15 +64,13 @@ convert_rejections_to_warnings() {
   PyObject *wcs_module = NULL;
   PyObject *FITSFixedWarning = NULL;
   int status = -1;
-  int vers[3];
   char delimiter;
 
-  wcslib_version(vers);
-  if (vers[0] >= 5) {
-      delimiter = ',';
-  } else {
-      delimiter = ':';
-  }
+#ifdef HAS_WCSLIB_VERSION
+  delimiter = ',';
+#else
+  delimiter = ':';
+#endif
 
   if (wcsprintf_buf()[0] == 0) {
     return 0;

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -3456,7 +3456,9 @@ _setup_wcsprm_type(
     CONSTANT(WCSHDR_none)      ||
     CONSTANT(WCSHDR_all)       ||
     CONSTANT(WCSHDR_reject)    ||
+#ifdef WCSHDR_strict
     CONSTANT(WCSHDR_strict)    ||
+#endif
     CONSTANT(WCSHDR_CROTAia)   ||
     CONSTANT(WCSHDR_EPOCHa)    ||
     CONSTANT(WCSHDR_VELREFa)   ||

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -18,6 +18,7 @@
 #include <wcsmath.h>
 #include <wcsprintf.h>
 #include <wcsunits.h>
+#include <tab.h>
 
 #include "astropy_wcs/isnan.h"
 #include "astropy_wcs/distortion.h"
@@ -63,6 +64,15 @@ convert_rejections_to_warnings() {
   PyObject *wcs_module = NULL;
   PyObject *FITSFixedWarning = NULL;
   int status = -1;
+  int vers[3];
+  char delimiter;
+
+  wcslib_version(vers);
+  if (vers[0] >= 5) {
+      delimiter = ',';
+  } else {
+      delimiter = ':';
+  }
 
   if (wcsprintf_buf()[0] == 0) {
     return 0;
@@ -105,7 +115,7 @@ convert_rejections_to_warnings() {
     /* For the second line, remove everything up to and including the
        first colon */
     for (; *src != 0; ++src) {
-      if (*src == ':') {
+      if (*src == delimiter) {
         ++src;
         break;
       }
@@ -291,8 +301,6 @@ PyWcsprm_init(
             "relax must be True, False or an integer.");
         return -1;
       }
-      /* Mask out any invalid flags */
-      relax &= WCSHDR_all;
     }
 
     if (!is_valid_alt_key(key)) {
@@ -575,9 +583,6 @@ PyWcsprm_find_all_wcs(
           "relax must be True, False or an integer.");
       return NULL;
     }
-
-    /* Mask out any invalid flags */
-    relax &= WCSHDR_all;
   }
 
   /* Call the header parser twice, the first time to get warnings
@@ -2031,8 +2036,6 @@ PyWcsprm_set_alt(
 
   strncpy(self->x.alt, value_string, 2);
 
-  note_change(self);
-
   return 0;
 }
 
@@ -2195,8 +2198,6 @@ PyWcsprm_set_cname(
     return -1;
   }
 
-  note_change(self);
-
   return set_str_list("cname", value, (Py_ssize_t)self->x.naxis, 0, self->x.cname);
 }
 
@@ -2230,8 +2231,6 @@ PyWcsprm_set_colax(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  note_change(self);
-
   return set_int_array("colax", value, 1, &naxis, self->x.colax);
 }
 
@@ -2248,8 +2247,6 @@ PyWcsprm_set_colnum(
     PyWcsprm* self,
     PyObject* value,
     /*@unused@*/ void* closure) {
-
-  note_change(self);
 
   return set_int("colnum", value, &self->x.colnum);
 }
@@ -2283,8 +2280,6 @@ PyWcsprm_set_crder(
   }
 
   naxis = (Py_ssize_t)self->x.naxis;
-
-  note_change(self);
 
   return set_double_array("crder", value, 1, &naxis, self->x.crder);
 }
@@ -2441,8 +2436,6 @@ PyWcsprm_set_csyer(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  note_change(self);
-
   return set_double_array("csyer", value, 1, &naxis, self->x.csyer);
 }
 
@@ -2543,8 +2536,6 @@ PyWcsprm_set_dateavg(
     return -1;
   }
 
-  note_change(self);
-
   /* TODO: Verify that this looks like a date string */
 
   return set_string("dateavg", value, self->x.dateavg, 72);
@@ -2572,8 +2563,6 @@ PyWcsprm_set_dateobs(
     return -1;
   }
 
-  note_change(self);
-
   return set_string("dateobs", value, self->x.dateobs, 72);
 }
 
@@ -2595,8 +2584,6 @@ PyWcsprm_set_equinox(
     self->x.equinox = (double)NPY_NAN;
     return 0;
   }
-
-  note_change(self);
 
   return set_double("equinox", value, &self->x.equinox);
 }
@@ -2741,8 +2728,6 @@ PyWcsprm_set_mjdavg(
     PyObject* value,
     /*@unused@*/ void* closure) {
 
-  note_change(self);
-
   if (value == NULL) {
     self->x.mjdavg = (double)NPY_NAN;
     return 0;
@@ -2797,8 +2782,6 @@ PyWcsprm_set_name(
     return -1;
   }
 
-  note_change(self);
-
   return set_string("name", value, self->x.wcsname, 72);
 }
 
@@ -2835,8 +2818,6 @@ PyWcsprm_set_obsgeo(
   if (is_null(self->x.obsgeo)) {
     return -1;
   }
-
-  note_change(self);
 
   if (value == NULL) {
     self->x.obsgeo[0] = NPY_NAN;
@@ -2991,8 +2972,6 @@ PyWcsprm_set_radesys(
     return -1;
   }
 
-  note_change(self);
-
   return set_string("radesys", value, self->x.radesys, 72);
 }
 
@@ -3074,8 +3053,6 @@ PyWcsprm_set_specsys(
     return -1;
   }
 
-  note_change(self);
-
   return set_string("specsys", value, self->x.specsys, 72);
 }
 
@@ -3127,8 +3104,6 @@ PyWcsprm_set_ssyssrc(
   if (is_null(self->x.ssyssrc)) {
     return -1;
   }
-
-  note_change(self);
 
   return set_string("ssyssrc", value, self->x.ssyssrc, 72);
 }
@@ -3209,8 +3184,6 @@ PyWcsprm_set_velangl(
     return 0;
   }
 
-  note_change(self);
-
   return set_double("velangl", value, &self->x.velangl);
 }
 
@@ -3233,9 +3206,29 @@ PyWcsprm_set_velosys(
     return 0;
   }
 
-  note_change(self);
-
   return set_double("velosys", value, &self->x.velosys);
+}
+
+static PyObject*
+PyWcsprm_get_velref(
+    PyWcsprm* self,
+    /*@unused@*/ void* closure) {
+
+  return get_int("velref", self->x.velref);
+}
+
+static int
+PyWcsprm_set_velref(
+    PyWcsprm* self,
+    PyObject* value,
+    /*@unused@*/ void* closure) {
+
+  if (value == NULL) { /* deletion */
+    self->x.velref = 0;
+    return 0;
+  }
+
+  return set_int("velref", value, &self->x.velref);
 }
 
 /* static PyObject* */
@@ -3290,8 +3283,6 @@ PyWcsprm_set_zsource(
     return 0;
   }
 
-  note_change(self);
-
   return set_double("zsource", value, &self->x.zsource);
 }
 
@@ -3345,6 +3336,7 @@ static PyGetSetDef PyWcsprm_getset[] = {
   {"theta0", (getter)PyWcsprm_get_theta0, (setter)PyWcsprm_set_theta0, (char *)doc_theta0},
   {"velangl", (getter)PyWcsprm_get_velangl, (setter)PyWcsprm_set_velangl, (char *)doc_velangl},
   {"velosys", (getter)PyWcsprm_get_velosys, (setter)PyWcsprm_set_velosys, (char *)doc_velosys},
+  {"velref", (getter)PyWcsprm_get_velref, (setter)PyWcsprm_set_velref, (char *)doc_velref},
   /* {"wtb", (getter)PyWcsprm_get_wtb, NULL, (char *)doc_tab}, */
   {"zsource", (getter)PyWcsprm_get_zsource, (setter)PyWcsprm_set_zsource, (char *)doc_zsource},
   {NULL}
@@ -3463,12 +3455,26 @@ _setup_wcsprm_type(
     CONSTANT(WCSHDR_PIXLIST)   ||
     CONSTANT(WCSHDR_none)      ||
     CONSTANT(WCSHDR_all)       ||
+    CONSTANT(WCSHDR_reject)    ||
+    CONSTANT(WCSHDR_strict)    ||
     CONSTANT(WCSHDR_CROTAia)   ||
     CONSTANT(WCSHDR_EPOCHa)    ||
     CONSTANT(WCSHDR_VELREFa)   ||
     CONSTANT(WCSHDR_CD00i00j)  ||
     CONSTANT(WCSHDR_PC00i00j)  ||
     CONSTANT(WCSHDR_PROJPn)    ||
+#ifdef WCSHDR_CD0i_0ja
+    CONSTANT(WCSHDR_CD0i_0ja)  ||
+#endif
+#ifdef WCSHDR_PC0i_0ja
+    CONSTANT(WCSHDR_PC0i_0ja)  ||
+#endif
+#ifdef WCSHDR_PV0i_0ma
+    CONSTANT(WCSHDR_PV0i_0ma)  ||
+#endif
+#ifdef WCSHDR_PS0i_0ma
+    CONSTANT(WCSHDR_PS0i_0ma)  ||
+#endif
     CONSTANT(WCSHDR_RADECSYS)  ||
     CONSTANT(WCSHDR_VSOURCE)   ||
     CONSTANT(WCSHDR_DOBSn)     ||

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -66,7 +66,7 @@ convert_rejections_to_warnings() {
   int status = -1;
   char delimiter;
 
-#ifdef HAS_WCSLIB_VERSION
+#ifdef HAVE_WCSLIB_VERSION
   delimiter = ',';
 #else
   delimiter = ':';

--- a/astropy/wcs/tests/data/validate.5.0.txt
+++ b/astropy/wcs/tests/data/validate.5.0.txt
@@ -1,0 +1,16 @@
+HDU 1:
+  WCS key ' ':
+    - RADECSYS= 'ICRS ' / Astrometric system
+      the RADECSYS keyword is deprecated, use RADESYSa.
+    - The WCS transformation has more axes (2) than the image it is
+      associated with (0)
+    - Removed redundant SCAMP distortion parameters because SIP
+      parameters are also present
+
+HDU 2:
+  WCS key ' ':
+    - The WCS transformation has more axes (3) than the image it is
+      associated with (0)
+    - 'celfix' made the change 'In CUNIT3 : Mismatched units type
+      'length': have 'Hz', want 'm''.
+    - 'unitfix' made the change 'Changed units: 'HZ      ' -> 'Hz''.

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -385,8 +385,13 @@ def test_validate():
     with catch_warnings():
         results = wcs.validate(get_pkg_data_filename("data/validate.fits"))
         results_txt = repr(results)
-        with open(get_pkg_data_filename("data/validate.txt"), "r") as fd:
-            assert set([x.strip() for x in fd.readlines()]) == set([
+        if getattr(wcs._wcs, 'WCSLIB_VERSION', '4.16')[0] == '5':
+            filename = 'data/validate.5.0.txt'
+        else:
+            filename = 'data/validate.txt'
+        with open(get_pkg_data_filename(filename), "r") as fd:
+            lines = fd.readlines()
+            assert set([x.strip() for x in lines]) == set([
                 x.strip() for x in results_txt.splitlines()])
 
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -385,7 +385,7 @@ def test_validate():
     with catch_warnings():
         results = wcs.validate(get_pkg_data_filename("data/validate.fits"))
         results_txt = repr(results)
-        if getattr(wcs._wcs, 'WCSLIB_VERSION', '4.16')[0] == '5':
+        if wcs._wcs.WCSLIB_VERSION[0] == '5':
             filename = 'data/validate.5.0.txt'
         else:
             filename = 'data/validate.txt'

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2994,7 +2994,8 @@ def validate(source):
 
         with warnings.catch_warnings(record=True) as warning_lines:
             wcses = find_all_wcs(
-                hdu.header, relax=True, fix=False, _do_set=False)
+                hdu.header, relax=_wcs.WCSHDR_reject,
+                fix=False, _do_set=False)
 
         for wcs in wcses:
             wcs_results = _WcsValidateWcsResult(wcs.wcs.alt)
@@ -3013,7 +3014,8 @@ def validate(source):
                 try:
                     WCS(hdu.header,
                         key=wcs.wcs.alt or ' ',
-                        relax=True, fix=True, _do_set=False)
+                        relax=_wcs.WCSHDR_reject,
+                        fix=True, _do_set=False)
                 except WcsError as e:
                     wcs_results.append(str(e))
 

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -171,6 +171,11 @@ through `Wcsprm.cunit <astropy.wcs.Wcsprm.cunit>`), for example,
 - ``HPX``: HEALPix
 - ``XPH``: HEALPix polar, aka "butterfly"
 
+And, if built with wcslib 5.0 or later:
+
+- ``TPV``: Polynomial distortion
+- ``TUV``: Polynomial distortion
+
 Subsetting and Pixel Scales
 ===========================
 

--- a/docs/wcs/relax.rst
+++ b/docs/wcs/relax.rst
@@ -58,6 +58,32 @@ The flag bits are:
 - ``WCSHDR_all``: Accept all extensions recognized by the parser.  (This
   is equivalent to the default behavior or passing `True`).
 
+- ``WCSHDR_reject``: Reject non-standard keyrecords (that are not
+  otherwise explicitly accepted by one of the flags below).  A warning
+  will be displayed by default.
+
+  This flag may be used to signal the presence of non-standard
+  keywords, otherwise they are simply passed over as though they did
+  not exist in the header.  It is mainly intended for testing
+  conformance of a FITS header to the WCS standard.
+
+  Keyrecords may be non-standard in several ways:
+
+  - The keyword may be syntactically valid but with keyvalue of
+    incorrect type or invalid syntax, or the keycomment may be
+    malformed.
+
+  - The keyword may strongly resemble a WCS keyword but not, in fact,
+    be one because it does not conform to the standard.  For example,
+    ``CRPIX01`` looks like a ``CRPIXja`` keyword, but in fact the
+    leading zero on the axis number violates the basic FITS standard.
+    Likewise, ``LONPOLE2`` is not a valid ``LONPOLEa`` keyword in the
+    WCS standard, and indeed there is nothing the parser can sensibly
+    do with it.
+
+  - Use of the keyword may be deprecated by the standard.  Such will
+    be rejected if not explicitly accepted via one of the flags below.
+
 - ``WCSHDR_CROTAia``: Accept ``CROTAia``, ``iCROTna``, ``TCROTna``
 - ``WCSHDR_EPOCHa``:  Accept ``EPOCHa``.
 - ``WCSHDR_VELREFa``: Accept ``VELREFa``.
@@ -79,6 +105,23 @@ The flag bits are:
         ``PVi_ma`` for the primary representation ``(a = ' ')``.
         ``PROJPn`` is equivalent to ``PVi_ma`` with ``m`` = ``n`` <=
         9, and is associated exclusively with the latitude axis.
+
+
+- ``WCSHDR_CD0i_0ja``: Accept ``CD0i_0ja`` (wcspih()).
+- ``WCSHDR_PC0i_0ja``: Accept ``PC0i_0ja`` (wcspih()).
+- ``WCSHDR_PV0i_0ma``: Accept ``PV0i_0ja`` (wcspih()).
+- ``WCSHDR_PS0i_0ma``: Accept ``PS0i_0ja`` (wcspih()).
+
+        Allow the numerical index to have a leading zero in doubly-
+        parameterized keywords, for example, ``PC01_01``.  WCS Paper I
+        (Sects 2.1.2 & 2.1.4) explicitly disallows leading zeroes.
+        The FITS 3.0 standard document (Sect. 4.1.2.1) states that the
+        index in singly-parameterized keywords (e.g. ``CTYPEia``) "shall
+        not have leading zeroes", and later in Sect. 8.1 that "leading
+        zeroes must not be used" on ``PVi_ma`` and ``PSi_ma``.  However, by an
+        oversight, it is silent on ``PCi_ja`` and ``CDi_ja``.
+
+        Only available if built with wcslib 5.0 or later.
 
 - ``WCSHDR_RADECSYS``: Accept ``RADECSYS``.  This appeared in early
   drafts of WCS Paper I+II and was subsequently replaced by


### PR DESCRIPTION
These changes are intended to be backward compatible, so we can still build against wcslib 4.x

This doesn't actually upgrade wcslib itself -- this is just a testing PR to make sure that the changes required for wcslib 5.0 don't break compatibility for wcslib 4.x.