### PR TITLE
Fix nddata.mixins test imports

### DIFF
--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -8,13 +8,13 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ..compat import NDDataArray
-from ..nduncertainty import (StdDevUncertainty,
-                             IncompatibleUncertaintiesException,
-                             NDUncertainty)
-from ...tests.helper import pytest
-from ... import units as u
-from ...utils import NumpyRNGContext
+from ...compat import NDDataArray
+from ...nduncertainty import (StdDevUncertainty,
+                              IncompatibleUncertaintiesException,
+                              NDUncertainty)
+from ....tests.helper import pytest
+from .... import units as u
+from ....utils import NumpyRNGContext
 
 
 class FakeUncertainty(NDUncertainty):

--- a/astropy/nddata/mixins/tests/test_ndio.py
+++ b/astropy/nddata/mixins/tests/test_ndio.py
@@ -1,8 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..nddata import NDData
-from ..io import NDIOMixin
+from ...nddata import NDData
+from ...mixins.ndio import NDIOMixin
 
 
 # Define minimal class that uses the I/O mixin


### PR DESCRIPTION
It seems these tests were never picked up by the tester due to the missing ``__init__.py``, and they also had incorrect import paths.