### PR TITLE
Re-enable testing in IPython

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -387,6 +387,11 @@ Other Changes and Additions
   - The number of retries for connections in ``astropy.vo.samp`` can now be
     configured by a ``n_retries`` configuration option. [#3612]
 
+- Testing
+
+  - Running ``astropy.test()`` from within the IPython prompt has been
+    provisionally re-enabled. [#3184]
+
 
 1.0.1 (2015-03-06)
 ------------------

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -107,13 +107,6 @@ class TestRunner(object):
         """
         The docstring for this method lives in astropy/__init__.py:test
         """
-        try:
-            get_ipython()
-        except NameError:
-            pass
-        else:
-            raise RuntimeError(
-                "Running astropy tests inside of IPython is not supported.")
 
         if coverage:
             warnings.warn(

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -708,5 +708,7 @@ def pytest_terminal_summary(terminalreporter):
         'Some tests are known to fail when run from the IPython prompt; '
         'especially, but not limited to tests involving logging and warning '
         'handling.  Unless you are certain as to the cause of the failure, '
-        'please check that the failure occurs outside IPython as well.',
+        'please check that the failure occurs outside IPython as well.  See '
+        'http://docs.astropy.org/en/stable/known_issues.html#failing-logging-'
+        'tests-when-running-the-tests-in-ipython for more information.',
         yellow=True, bold=True)

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -689,3 +689,24 @@ def pytest_unconfigure():
     # turn_off_internet previously called)
     # this is harmless / does nothing if socket connections were never disabled
     turn_on_internet()
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Output a warning to IPython users in case any tests failed."""
+
+    try:
+        get_ipython()
+    except NameError:
+        return
+
+    if not terminalreporter.stats.get('failed'):
+        # Only issue the warning when there are actually failures
+        return
+
+    terminalreporter.ensure_newline()
+    terminalreporter.write_line(
+        'Some tests are known to fail when run from the IPython prompt; '
+        'especially, but not limited to tests involving logging and warning '
+        'handling.  Unless you are certain as to the cause of the failure, '
+        'please check that the failure occurs outside IPython as well.',
+        yellow=True, bold=True)

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -289,7 +289,8 @@ Failing logging tests when running the tests in IPython
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When running the Astropy tests using ``astropy.test()`` in an IPython
-interpreter some of the tests in the ``astropy/tests/test_logger.py`` fail.
+interpreter some of the tests in the ``astropy/tests/test_logger.py`` *might*
+fail, depending on the version of IPython or other factors.
 This is due to mutually incompatible behaviors in IPython and py.test, and is
 not due to a problem with the test itself or the feature being tested.
 


### PR DESCRIPTION
This re-enables running `astropy.test()` (and by extension, same for affiliated packages, thus resolving #3184 and superseding #3254).

I actually haven't been able to get test failures in IPython for a while, and we don't have a lot of information on what tests *can* fail or exactly how.

I think it will be better to re-enable testing in IPython until we have a more concrete issue to look at.  I could also add a message to print at the end of the test run, so that if there are any failures, and the tests were run in IPython, we could mention that there is a known issue with test failures in IPython, and to try running the tests in the standard Python interpreter before reporting a bug.