### PR TITLE
Allow reshape, ravel, transpose etc. of Time objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,8 @@ New Features
   - Allow the ``format`` attribute to be updated in place to change the
     default representation of a ``Time`` object. [#3673]
 
+  - Add support for shape manipulation (reshape, ravel, etc.). [#3224]
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -495,6 +495,18 @@ class Time(object):
 
     @property
     def shape(self):
+        """The shape of the time instances.
+
+        Like `~numpy.ndarray.shape`, can be set to a new shape by assigning a
+        tuple.
+
+        Raises
+        ------
+        AttributeError: if the shape of the ``jd1``, ``jd2``, ``location``,
+        ``delta_ut1_utc``, or ``delta_tdb_tt`` attributes cannot be changed
+        without the arrays being copied.  For these cases, use the
+        `Time.reshape` method.
+        """
         return self._time.jd1.shape
 
     @shape.setter
@@ -792,7 +804,7 @@ class Time(object):
     def reshape(self, *args, **kwargs):
         """Returns a time instance containing the same data with a new shape.
 
-        Parameters are as for meth:`~numpy.ndarray.reshape`.  Note that it is
+        Parameters are as for :meth:`~numpy.ndarray.reshape`.  Note that it is
         not always possible to change the shape of an array without copying the
         data. If you want an error to be raise if the data is copied, you
         should assign the new shape to the shape attribute.
@@ -802,21 +814,25 @@ class Time(object):
     def ravel(self, *args, **kwargs):
         """Return an instance with the time array collapsed into one dimension.
 
-        Parameters are as for meth:`~numpy.ndarray.ravel`.
+        Parameters are as for :meth:`~numpy.ndarray.ravel`. Note that it is
+        not always possible to unravel an array without copying the data.
+        If you want an error to be raise if the data is copied, you should
+        should assign shape ``(-1,)`` to the shape attribute.
         """
         return self._replicate('ravel', *args, **kwargs)
 
     def flatten(self, *args, **kwargs):
         """Return a copy with the time array collapsed into one dimension.
 
-        Parameters are as for meth:`~numpy.ndarray.flatten`.
+        Parameters are as for :meth:`~numpy.ndarray.flatten`.
         """
         return self._replicate('flatten', *args, **kwargs)
 
     def transpose(self, *args, **kwargs):
         """Return a time instance with the data transposed.
 
-        Parameters are as for meth:`~numpy.ndarray.transpose`.
+        Parameters are as for :meth:`~numpy.ndarray.transpose`.  All internal
+        data are views of the data of the original.
         """
         return self._replicate('transpose', *args, **kwargs)
 
@@ -824,7 +840,8 @@ class Time(object):
     def T(self):
         """Return a time instance with the data transposed.
 
-        Parameters are as for meth:`~numpy.ndarray.T`.
+        Parameters are as for :attr:`~numpy.ndarray.T`.  All internal
+        data are views of the data of the original.
         """
         if self.ndim < 2:
             return self
@@ -834,28 +851,31 @@ class Time(object):
     def swapaxes(self, *args, **kwargs):
         """Return a time instance with the given axes interchanged.
 
-        Parameters are as for meth:`~numpy.ndarray.swapaxes`
+        Parameters are as for :meth:`~numpy.ndarray.swapaxes`.  All internal
+        data are views of the data of the original.
         """
         return self._replicate('swapaxes', *args, **kwargs)
 
     def diagonal(self, *args, **kwargs):
         """Return a time instance with the specified diagonals.
 
-        Parameters are as for meth:`~numpy.ndarray.diagonal`.
+        Parameters are as for :meth:`~numpy.ndarray.diagonal`.  All internal
+        data are views of the data of the original.
         """
         return self._replicate('diagonal', *args, **kwargs)
 
     def squeeze(self, *args, **kwargs):
         """Return a time instance with single-dimensional shape entries removed
 
-        Parameters are as for meth:`~numpy.ndarray.squeeze`.
+        Parameters are as for :meth:`~numpy.ndarray.squeeze`.  All internal
+        data are views of the data of the original.
         """
         return self._replicate('squeeze', *args, **kwargs)
 
     def take(self, indices, axis=None, mode='raise'):
         """Return a Time object formed from the elements the given indices.
 
-        Parameters are as for meth:`~numpy.ndarray.take`, except that,
+        Parameters are as for :meth:`~numpy.ndarray.take`, except that,
         obviously, no output array can be given.
         """
         return self._replicate('take', indices, axis=axis, mode=mode)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -497,6 +497,15 @@ class Time(object):
     def shape(self):
         return self._time.jd1.shape
 
+    @shape.setter
+    def shape(self, shape):
+        self._time.jd1.shape = shape
+        self._time.jd2.shape = shape
+        for attr in ('_delta_ut1_utc', '_delta_tdb_tt', 'location'):
+            val = getattr(self, attr, None)
+            if val is not None and val.size > 1:
+                val.shape = shape
+
     @property
     def size(self):
         return self._time.jd1.size
@@ -783,7 +792,10 @@ class Time(object):
     def reshape(self, *args, **kwargs):
         """Returns a time instance containing the same data with a new shape.
 
-        Parameters are as for meth:`~numpy.ndarray.reshape`.
+        Parameters are as for meth:`~numpy.ndarray.reshape`.  Note that it is
+        not always possible to change the shape of an array without copying the
+        data. If you want an error to be raise if the data is copied, you
+        should assign the new shape to the shape attribute.
         """
         return self._replicate('reshape', *args, **kwargs)
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -490,6 +490,10 @@ class Time(object):
         self._out_subfmt = val
 
     @property
+    def ndim(self):
+        return self._time.jd1.ndim
+
+    @property
     def shape(self):
         return self._time.jd1.shape
 
@@ -775,6 +779,74 @@ class Time(object):
                     continue
 
         return tm
+
+    def reshape(self, *args, **kwargs):
+        """Returns a time instance containing the same data with a new shape.
+
+        Parameters are as for meth:`~numpy.ndarray.reshape`.
+        """
+        return self._replicate('reshape', *args, **kwargs)
+
+    def ravel(self, *args, **kwargs):
+        """Return an instance with the time array collapsed into one dimension.
+
+        Parameters are as for meth:`~numpy.ndarray.ravel`.
+        """
+        return self._replicate('ravel', *args, **kwargs)
+
+    def flatten(self, *args, **kwargs):
+        """Return a copy with the time array collapsed into one dimension.
+
+        Parameters are as for meth:`~numpy.ndarray.flatten`.
+        """
+        return self._replicate('flatten', *args, **kwargs)
+
+    def transpose(self, *args, **kwargs):
+        """Return a time instance with the data transposed.
+
+        Parameters are as for meth:`~numpy.ndarray.transpose`.
+        """
+        return self._replicate('transpose', *args, **kwargs)
+
+    @property
+    def T(self):
+        """Return a time instance with the data transposed.
+
+        Parameters are as for meth:`~numpy.ndarray.T`.
+        """
+        if self.ndim < 2:
+            return self
+        else:
+            return self.transpose()
+
+    def swapaxes(self, *args, **kwargs):
+        """Return a time instance with the given axes interchanged.
+
+        Parameters are as for meth:`~numpy.ndarray.swapaxes`
+        """
+        return self._replicate('swapaxes', *args, **kwargs)
+
+    def diagonal(self, *args, **kwargs):
+        """Return a time instance with the specified diagonals.
+
+        Parameters are as for meth:`~numpy.ndarray.diagonal`.
+        """
+        return self._replicate('diagonal', *args, **kwargs)
+
+    def squeeze(self, *args, **kwargs):
+        """Return a time instance with single-dimensional shape entries removed
+
+        Parameters are as for meth:`~numpy.ndarray.squeeze`.
+        """
+        return self._replicate('squeeze', *args, **kwargs)
+
+    def take(self, indices, axis=None, mode='raise'):
+        """Return a Time object formed from the elements the given indices.
+
+        Parameters are as for meth:`~numpy.ndarray.take`, except that,
+        obviously, no output array can be given.
+        """
+        return self._replicate('take', indices, axis=axis, mode=mode)
 
     def __getattr__(self, attr):
         """

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -157,11 +157,28 @@ class TestBasic():
         assert np.all(t7[:, 2]._time.jd2 == t7._time.jd2[:, 2])
         assert np.all(t7[:, 0]._time.jd1 == t._time.jd1)
         assert np.all(t7[:, 0]._time.jd2 == t._time.jd2)
+        # Get tdb to check that delta_tdb_tt attribute is sliced properly.
+        t7_tdb = t7.tdb
+        assert t7_tdb[0, 0].delta_tdb_tt == t7_tdb.delta_tdb_tt[0, 0]
+        assert np.all(t7_tdb[5].delta_tdb_tt == t7_tdb.delta_tdb_tt[5])
+        assert np.all(t7_tdb[:, 2].delta_tdb_tt == t7_tdb.delta_tdb_tt[:, 2])
+        # Explicitly set delta_tdb_tt attrbite. Now it should not be sliced.
+        t7.delta_tdb_tt = 0.1
+        t7_tdb2 = t7.tdb
+        assert t7_tdb2[0, 0].delta_tdb_tt == 0.1
+        assert t7_tdb2[5].delta_tdb_tt == 0.1
+        assert t7_tdb2[:, 2].delta_tdb_tt == 0.1
+        # Check broadcasting of location.
+        t8 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
+                  location=(np.arange(len(frac)), np.arange(len(frac))))
+        assert t8[0, 0].location == t8.location[0, 0]
+        assert np.all(t8[5].location == t8.location[5])
+        assert np.all(t8[:, 2].location == t8.location[:, 2])
         # Finally check empty array.
-        t8 = t[:0]
-        assert t8.isscalar is False
-        assert t8.shape == (0,)
-        assert t8.size == 0
+        t9 = t[:0]
+        assert t9.isscalar is False
+        assert t9.shape == (0,)
+        assert t9.size == 0
 
     def test_properties(self):
         """Use properties to convert scales and formats.  Note that the UT1 to
@@ -277,18 +294,18 @@ class TestBasic():
         t3 = Time(mjd, format='mjd', scale='utc', location=(lon, lat))
         assert t3.shape == (4, 2)
         assert t3.location.shape == ()
-        assert t3.tdb.shape == (4, 2)
+        assert t3.tdb.shape == t3.shape
         t4 = Time(mjd, format='mjd', scale='utc',
                   location=(np.array([lon, 0]), np.array([lat, 0])))
         assert t4.shape == (4, 2)
-        assert t4.location.shape == (2,)
-        assert t4.tdb.shape == (4, 2)
+        assert t4.location.shape == t4.shape
+        assert t4.tdb.shape == t4.shape
         t5 = Time(mjd, format='mjd', scale='utc',
                   location=(np.array([[lon], [0], [0], [0]]),
                             np.array([[lat], [0], [0], [0]])))
         assert t5.shape == (4, 2)
-        assert t5.location.shape == (4, 1)
-        assert t5.tdb.shape == (4, 2)
+        assert t5.location.shape == t5.shape
+        assert t5.tdb.shape == t5.shape
 
     def test_all_transforms(self):
         """Test that all transforms work.  Does not test correctness,

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -1,0 +1,214 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# TEST_UNICODE_LITERALS
+import numpy as np
+
+from .. import Time
+from ...utils.compat.numpycompat import NUMPY_LT_1_9
+
+class TestManipulation():
+    """Manipulation of Time objects, ensuring attributes are done correctly."""
+
+    def setup(self):
+        mjd = np.arange(50000, 50010)
+        frac = np.arange(0., 0.999, 0.2)
+        self.t0 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc')
+        self.t1 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
+                       location=('45d', '50d'))
+        self.t2 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
+                       location=(np.arange(len(frac)), np.arange(len(frac))))
+
+    def test_ravel(self):
+        t0_ravel = self.t0.ravel()
+        assert t0_ravel.shape == (self.t0.size,)
+        assert np.all(t0_ravel.jd1 == self.t0.jd1.ravel())
+        assert np.may_share_memory(t0_ravel.jd1, self.t0.jd1)
+        assert t0_ravel.location is None
+        t1_ravel = self.t1.ravel()
+        assert t1_ravel.shape == (self.t1.size,)
+        assert np.all(t1_ravel.jd1 == self.t1.jd1.ravel())
+        assert np.may_share_memory(t1_ravel.jd1, self.t1.jd1)
+        assert t1_ravel.location is self.t1.location
+        t2_ravel = self.t2.ravel()
+        assert t2_ravel.shape == (self.t2.size,)
+        assert np.all(t2_ravel.jd1 == self.t2.jd1.ravel())
+        assert np.may_share_memory(t2_ravel.jd1, self.t2.jd1)
+        assert t2_ravel.location.shape == t2_ravel.shape
+        # Broadcasting and ravelling cannot be done without a copy.
+        assert not np.may_share_memory(t2_ravel.location, self.t2.location)
+
+    def test_flatten(self):
+        t0_flatten = self.t0.flatten()
+        assert t0_flatten.shape == (self.t0.size,)
+        assert t0_flatten.location is None
+        # Flatten always makes a copy.
+        assert not np.may_share_memory(t0_flatten.jd1, self.t0.jd1)
+        t1_flatten = self.t1.flatten()
+        assert t1_flatten.shape == (self.t1.size,)
+        assert not np.may_share_memory(t1_flatten.jd1, self.t1.jd1)
+        assert t1_flatten.location is not self.t1.location
+        assert t1_flatten.location == self.t1.location
+        t2_flatten = self.t2.flatten()
+        assert t2_flatten.shape == (self.t2.size,)
+        assert not np.may_share_memory(t2_flatten.jd1, self.t2.jd1)
+        assert t2_flatten.location.shape == t2_flatten.shape
+        assert not np.may_share_memory(t2_flatten.location, self.t2.location)
+
+    def test_transpose(self):
+        t0_transpose = self.t0.transpose()
+        assert t0_transpose.shape == (5, 10)
+        assert np.all(t0_transpose.jd1 == self.t0.jd1.transpose())
+        assert np.may_share_memory(t0_transpose.jd1, self.t0.jd1)
+        assert t0_transpose.location is None
+        t1_transpose = self.t1.transpose()
+        assert t1_transpose.shape == (5, 10)
+        assert np.all(t1_transpose.jd1 == self.t1.jd1.transpose())
+        assert np.may_share_memory(t1_transpose.jd1, self.t1.jd1)
+        assert t1_transpose.location is self.t1.location
+        t2_transpose = self.t2.transpose()
+        assert t2_transpose.shape == (5, 10)
+        assert np.all(t2_transpose.jd1 == self.t2.jd1.transpose())
+        assert np.may_share_memory(t2_transpose.jd1, self.t2.jd1)
+        assert t2_transpose.location.shape == t2_transpose.shape
+        assert np.may_share_memory(t2_transpose.location, self.t2.location)
+        # Only one check on T, since it just calls transpose anyway.
+        t2_T = self.t2.T
+        assert t2_T.shape == (5, 10)
+        assert np.all(t2_T.jd1 == self.t2.jd1.T)
+        assert np.may_share_memory(t2_T.jd1, self.t2.jd1)
+        assert t2_T.location.shape == t2_T.location.shape
+        assert np.may_share_memory(t2_T.location, self.t2.location)
+
+    def test_diagonal(self):
+        t0_diagonal = self.t0.diagonal()
+        assert t0_diagonal.shape == (5,)
+        assert np.all(t0_diagonal.jd1 == self.t0.jd1.diagonal())
+        assert t0_diagonal.location is None
+        if not NUMPY_LT_1_9:
+            assert np.may_share_memory(t0_diagonal.jd1, self.t0.jd1)
+        t1_diagonal = self.t1.diagonal()
+        assert t1_diagonal.shape == (5,)
+        assert np.all(t1_diagonal.jd1 == self.t1.jd1.diagonal())
+        assert t1_diagonal.location is self.t1.location
+        if not NUMPY_LT_1_9:
+            assert np.may_share_memory(t1_diagonal.jd1, self.t1.jd1)
+        t2_diagonal = self.t2.diagonal()
+        assert t2_diagonal.shape == (5,)
+        assert np.all(t2_diagonal.jd1 == self.t2.jd1.diagonal())
+        assert t2_diagonal.location.shape == t2_diagonal.shape
+        if not NUMPY_LT_1_9:
+            assert np.may_share_memory(t2_diagonal.jd1, self.t2.jd1)
+            assert np.may_share_memory(t2_diagonal.location, self.t2.location)
+
+    def test_swapaxes(self):
+        t0_swapaxes = self.t0.swapaxes(0, 1)
+        assert t0_swapaxes.shape == (5, 10)
+        assert np.all(t0_swapaxes.jd1 == self.t0.jd1.swapaxes(0, 1))
+        assert np.may_share_memory(t0_swapaxes.jd1, self.t0.jd1)
+        assert t0_swapaxes.location is None
+        t1_swapaxes = self.t1.swapaxes(0, 1)
+        assert t1_swapaxes.shape == (5, 10)
+        assert np.all(t1_swapaxes.jd1 == self.t1.jd1.swapaxes(0, 1))
+        assert np.may_share_memory(t1_swapaxes.jd1, self.t1.jd1)
+        assert t1_swapaxes.location is self.t1.location
+        t2_swapaxes = self.t2.swapaxes(0, 1)
+        assert t2_swapaxes.shape == (5, 10)
+        assert np.all(t2_swapaxes.jd1 == self.t2.jd1.swapaxes(0, 1))
+        assert np.may_share_memory(t2_swapaxes.jd1, self.t2.jd1)
+        assert t2_swapaxes.location.shape == t2_swapaxes.shape
+        assert np.may_share_memory(t2_swapaxes.location, self.t2.location)
+
+    def test_reshape(self):
+        t0_reshape = self.t0.reshape(5, 2, 5)
+        assert t0_reshape.shape == (5, 2, 5)
+        assert np.all(t0_reshape.jd1 == self.t0._time.jd1.reshape(5, 2, 5))
+        assert np.all(t0_reshape.jd2 == self.t0._time.jd2.reshape(5, 2, 5))
+        assert np.may_share_memory(t0_reshape.jd1, self.t0.jd1)
+        assert np.may_share_memory(t0_reshape.jd2, self.t0.jd2)
+        assert t0_reshape.location is None
+        t1_reshape = self.t1.reshape(2, 5, 5)
+        assert t1_reshape.shape == (2, 5, 5)
+        assert np.all(t1_reshape.jd1 == self.t1.jd1.reshape(2, 5, 5))
+        assert np.may_share_memory(t1_reshape.jd1, self.t1.jd1)
+        assert t1_reshape.location is self.t1.location
+        # For reshape(5, 2, 5), the location array can remain the same.
+        t2_reshape = self.t2.reshape(5, 2, 5)
+        assert t2_reshape.shape == (5, 2, 5)
+        assert np.all(t2_reshape.jd1 == self.t2.jd1.reshape(5, 2, 5))
+        assert np.may_share_memory(t2_reshape.jd1, self.t2.jd1)
+        assert t2_reshape.location.shape == t2_reshape.shape
+        assert np.may_share_memory(t2_reshape.location, self.t2.location)
+        # But for reshape(5, 5, 2), location has to be broadcast and copied.
+        t2_reshape2 = self.t2.reshape(5, 5, 2)
+        assert t2_reshape2.shape == (5, 5, 2)
+        assert np.all(t2_reshape2.jd1 == self.t2.jd1.reshape(5, 5, 2))
+        assert np.may_share_memory(t2_reshape2.jd1, self.t2.jd1)
+        assert t2_reshape2.location.shape == t2_reshape2.shape
+        assert not np.may_share_memory(t2_reshape2.location, self.t2.location)
+        t2_reshape_t = self.t2.reshape(10, 5).T
+        assert t2_reshape_t.shape == (5, 10)
+        assert np.may_share_memory(t2_reshape_t.jd1, self.t2.jd1)
+        assert t2_reshape_t.location.shape == t2_reshape_t.shape
+        assert np.may_share_memory(t2_reshape_t.location, self.t2.location)
+        # Finally, reshape in a way that cannot be a view.
+        t2_reshape_t_reshape = t2_reshape_t.reshape(10, 5)
+        assert t2_reshape_t_reshape.shape == (10, 5)
+        assert not np.may_share_memory(t2_reshape_t_reshape.jd1, self.t2.jd1)
+        assert (t2_reshape_t_reshape.location.shape ==
+                t2_reshape_t_reshape.shape)
+        assert not np.may_share_memory(t2_reshape_t_reshape.location,
+                                       t2_reshape_t.location)
+
+    def test_squeeze(self):
+        t0_squeeze = self.t0.reshape(5, 1, 2, 1, 5).squeeze()
+        assert t0_squeeze.shape == (5, 2, 5)
+        assert np.all(t0_squeeze.jd1 == self.t0.jd1.reshape(5, 2, 5))
+        assert np.may_share_memory(t0_squeeze.jd1, self.t0.jd1)
+        assert t0_squeeze.location is None
+        t1_squeeze = self.t1.reshape(1, 5, 1, 2, 5).squeeze()
+        assert t1_squeeze.shape == (5, 2, 5)
+        assert np.all(t1_squeeze.jd1 == self.t1.jd1.reshape(5, 2, 5))
+        assert np.may_share_memory(t1_squeeze.jd1, self.t1.jd1)
+        assert t1_squeeze.location is self.t1.location
+        t2_squeeze = self.t2.reshape(1, 1, 5, 2, 5, 1, 1).squeeze()
+        assert t2_squeeze.shape == (5, 2, 5)
+        assert np.all(t2_squeeze.jd1 == self.t2.jd1.reshape(5, 2, 5))
+        assert np.may_share_memory(t2_squeeze.jd1, self.t2.jd1)
+        assert t2_squeeze.location.shape == t2_squeeze.shape
+        assert np.may_share_memory(t2_squeeze.location, self.t2.location)
+
+    def test_add_dimension(self):
+        t0_adddim = self.t0[:, np.newaxis, :]
+        assert t0_adddim.shape == (10, 1, 5)
+        assert np.all(t0_adddim.jd1 == self.t0.jd1[:, np.newaxis, :])
+        assert np.may_share_memory(t0_adddim.jd1, self.t0.jd1)
+        assert t0_adddim.location is None
+        t1_adddim = self.t1[:, :, np.newaxis]
+        assert t1_adddim.shape == (10, 5, 1)
+        assert np.all(t1_adddim.jd1 == self.t1.jd1[:, :, np.newaxis])
+        assert np.may_share_memory(t1_adddim.jd1, self.t1.jd1)
+        assert t1_adddim.location is self.t1.location
+        t2_adddim = self.t2[:, :, np.newaxis]
+        assert t2_adddim.shape == (10, 5, 1)
+        assert np.all(t2_adddim.jd1 == self.t2.jd1[:, :, np.newaxis])
+        assert np.may_share_memory(t2_adddim.jd1, self.t2.jd1)
+        assert t2_adddim.location.shape == t2_adddim.shape
+        assert np.may_share_memory(t2_adddim.location, self.t2.location)
+
+    def test_take(self):
+        t0_take = self.t0.take((5, 2))
+        assert t0_take.shape == (2,)
+        assert np.all(t0_take.jd1 == self.t0._time.jd1.take((5, 2)))
+        assert t0_take.location is None
+        t1_take = self.t1.take((2, 4), axis=1)
+        assert t1_take.shape == (10, 2)
+        assert np.all(t1_take.jd1 == self.t1.jd1.take((2, 4), axis=1))
+        assert t1_take.location is self.t1.location
+        t2_take = self.t2.take((1, 3, 7), axis=0)
+        assert t2_take.shape == (3, 5)
+        assert np.all(t2_take.jd1 == self.t2.jd1.take((1, 3, 7), axis=0))
+        assert t2_take.location.shape == t2_take.shape
+        t2_take2 = self.t2.take((5, 15))
+        assert t2_take2.shape == (2,)
+        assert np.all(t2_take2.jd1 == self.t2.jd1.take((5, 15)))
+        assert t2_take2.location.shape == t2_take2.shape

--- a/astropy/utils/compat/numpy/__init__.py
+++ b/astropy/utils/compat/numpy/__init__.py
@@ -7,4 +7,4 @@ in all supported NumPy versions.  See docs/utils/numpy.rst for details.
 
 from __future__ import division, absolute_import, unicode_literals
 
-from .lib.stride_tricks import broadcast_arrays
+from .lib.stride_tricks import broadcast_arrays, broadcast_to

--- a/astropy/utils/compat/numpy/tests/test_broadcast_arrays.py
+++ b/astropy/utils/compat/numpy/tests/test_broadcast_arrays.py
@@ -11,13 +11,14 @@ import numpy as np
 from astropy.tests.helper import pytest
 import astropy.units as u
 
-from ..lib.stride_tricks import broadcast_arrays, GE1P10
+from ..lib.stride_tricks import broadcast_arrays, broadcast_to, GE1P10
 
 
 def test_import():
     """Check that what is imported from code is what we are testing."""
     from ... import numpy as anp
     assert anp.broadcast_arrays is broadcast_arrays
+    assert anp.broadcast_to is broadcast_to
 
 
 def test_test_function():
@@ -27,11 +28,14 @@ def test_test_function():
     The numpy version may be, in which case we just use it, or it may not,
     it which case we use the patched version.
     """
-    assert GE1P10(broadcast_arrays) is True
-    if GE1P10():
+    from ... import numpy as anp
+    assert GE1P10(module=anp) is True
+    if GE1P10(module=np):
         assert broadcast_arrays is np.broadcast_arrays
+        assert broadcast_to is np.broadcast_to
     else:
         assert broadcast_arrays is not np.broadcast_arrays
+        assert not hasattr(np, 'broadcast_to')
 
 
 def test_broadcast_quantity():
@@ -46,3 +50,11 @@ def test_broadcast_quantity():
     assert bq1.shape == bq2.shape == (2, 4)
     with pytest.raises(ValueError):
         broadcast_arrays(q1, q1[:2], subok=True)
+
+
+def test_broadcast_to():
+    q1 = u.Quantity([1., 2., 3., 4.], u.m)
+    bq1 = broadcast_to(q1, (2, 4), subok=True)
+    assert type(bq1) is type(q1)
+    assert bq1.shape == (2, 4)
+    assert bq1.strides[0] == 0

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -318,6 +318,31 @@ appropriate::
   >>> t[0]
   <Time object: scale='utc' format='mjd' value=[ 50000.   50000.5]>
 
+
+Numpy method analogs
+^^^^^^^^^^^^^^^^^^^^
+
+For |Time| instances holding arrays, many of the same methods and attributes
+that work on `~numpy.ndarray` instances can be used.  E.g., one can reshape
+|Time| instances and take specific parts using
+:meth:`~astropy.time.Time.reshape`,
+:meth:`~astropy.time.Time.ravel`, :meth:`~astropy.time.Time.flatten`,
+:attr:`~astropy.time.Time.T`, :meth:`~astropy.time.Time.transpose`,
+:meth:`~astropy.time.Time.swapaxes`, :meth:`~astropy.time.Time.diagonal`,
+:meth:`~astropy.time.Time.squeeze`, :meth:`~astropy.time.Time.take`::
+
+  >>> t.reshape(2, 3)
+  <Time object: scale='utc' format='mjd' value=[[ 50000.   50000.5  50001. ]
+   [ 50001.5  50002.   50002.5]]>
+  >>> t.T
+  <Time object: scale='utc' format='mjd' value=[[ 50000.   50001.   50002. ]
+   [ 50000.5  50001.5  50002.5]]>
+
+Note that similarly to the `~numpy.ndarray` methods, all but
+:meth:`~astropy.time.Time.flatten` try to use new views of the data,
+with the data copied only if that it is impossible (as discussed, e.g., in
+the documentation for numpy :func:`~numpy.reshape`).
+   
 .. _astropy-time-inferring-input:
 
 Inferring input format


### PR DESCRIPTION
With `Time` becoming multidimensional (#3138), it has acquired a `shape` and `size`. This could be taken further and `TIme` could also acquire other `ndarray` shape-associated properties and methods, such as `reshape`, `ravel`, `transpose`, etc. This is not difficult in principle, though some care must be taken with properly reshaping other array properties as well (`location`, `_delta_ut1_utc`, `_delta_tdb_tt`).

EDIT: for `Table` mixin purposes with grouping, sorting would also be good (including `argsort`).