### PR TITLE
Memory leak with compressed FITS file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -298,6 +298,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed a severe memory leak that occurred when reading tile compressed
+    images. [#3680]
+
   - Fixed bug where column data could be unintentionally byte-swapped when
     copying data from an existing FITS file to a new FITS table with a
     TDIMn keyword for that column. [#3561]

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -810,7 +810,7 @@ fail:
 
 
 void open_from_hdu(fitsfile** fileptr, void** buf, size_t* bufsize,
-                   PyObject* hdu, tcolumn** columns) {
+                   PyObject* hdu, tcolumn** columns, int mode) {
     PyObject* header = NULL;
     FITSfile* Fptr;
 
@@ -846,7 +846,7 @@ void open_from_hdu(fitsfile** fileptr, void** buf, size_t* bufsize,
     Fptr = (*fileptr)->Fptr;
 
     // Now we have some fun munging some of the elements in the fitsfile struct
-    Fptr->writemode = READONLY;
+    Fptr->writemode = mode;
     Fptr->open_count = 1;
     Fptr->hdutype = BINARY_TBL;  /* This is a binary table HDU */
     Fptr->lasthdu = 1;
@@ -917,7 +917,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
         return NULL;
     }
 
-    open_from_hdu(&fileptr, &outbuf, &outbufsize, hdu, &columns);
+    open_from_hdu(&fileptr, &outbuf, &outbufsize, hdu, &columns, READWRITE);
     if (PyErr_Occurred()) {
         goto fail;
     }
@@ -1036,7 +1036,7 @@ PyObject* compression_decompress_hdu(PyObject* self, PyObject* args)
         return Py_None;
     }
 
-    open_from_hdu(&fileptr, &inbuf, &inbufsize, hdu, &columns);
+    open_from_hdu(&fileptr, &inbuf, &inbufsize, hdu, &columns, READONLY);
     if (PyErr_Occurred()) {
         return NULL;
     }

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -403,23 +403,6 @@ int get_header_longlong(PyObject* header, char* keyword, long long* val,
 }
 
 
-void* compression_realloc(void* ptr, size_t size) {
-    // This realloc()-like function actually just mallocs the requested
-    // size and copies from the original memory address into the new one, and
-    // returns the newly malloc'd address.
-    // This is generally less efficient than an actual realloc(), but the
-    // problem with using realloc in this case is that when it succeeds it will
-    // free() the original memory, which may still be in use by the ndarray
-    // using that memory as its data buffer.  This seems like the least hacky
-    // way around that for now.
-    // I'm open to other ideas though.
-    void* tmp;
-    tmp = malloc(size);
-    memcpy(tmp, ptr, size);
-    return tmp;
-}
-
-
 void tcolumns_from_header(fitsfile* fileptr, PyObject* header,
                           tcolumn** columns) {
     // Creates the array of tcolumn structures from the table column keywords

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -598,6 +598,7 @@ void configure_compression(fitsfile* fileptr, PyObject* header) {
         znaxis = MAX_COMPRESS_DIM;
     }
 
+    Fptr->tilerow = NULL;
     Fptr->maxtilelen = 1;
     for (idx = 1; idx <= znaxis; idx++) {
         snprintf(keyword, 9, "ZNAXIS%u", idx);
@@ -859,6 +860,7 @@ void open_from_hdu(fitsfile** fileptr, void** buf, size_t* bufsize,
     Fptr = (*fileptr)->Fptr;
 
     // Now we have some fun munging some of the elements in the fitsfile struct
+    Fptr->writemode = READONLY;
     Fptr->open_count = 1;
     Fptr->hdutype = BINARY_TBL;  /* This is a binary table HDU */
     Fptr->lasthdu = 1;
@@ -1026,7 +1028,7 @@ PyObject* compression_decompress_hdu(PyObject* self, PyObject* args)
     long arrsize;
     unsigned int idx;
 
-    fitsfile* fileptr;
+    fitsfile* fileptr = NULL;
     int anynul = 0;
     int status = 0;
 


### PR DESCRIPTION
Under astropy 0.4.1, as well as under pyfits 3.3, the test case at https://github.com/rubendv/fits_memleak leaks a massive amount of memory. The provided testcase consumes about 6.5 GB on my computer by the end.