### PR TITLE
Time max, min, ptp, sort

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,8 @@ New Features
 
   - Add support for shape manipulation (reshape, ravel, etc.). [#3224]
 
+  - Add argmin, argmax, argsort, min, max, ptp, sort methods. [#3581]
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -973,32 +973,54 @@ class Time(object):
         else:
             return np.lexsort(keys=(self._time.jd2, self._time.jd1), axis=axis)
 
-    def min(self, axis=None, keepdims=False):
+    def min(self, axis=None, out=None, keepdims=False):
         """Minimum along a given axis.
 
         This is similar to :meth:`~numpy.ndarray.min`, but adapted to ensure
         that the full precision given by the two doubles ``jd1`` and ``jd2``
         is used, and that corresponding attributes are copied.
+
+        Note that the ``out`` argument is present only for compatibility with
+        ``np.min``; since `Time` instances are immutable, it is not possible
+        to have an actual ``out`` to store the result in.
         """
+        if out is not None:
+            raise ValueError("Since `Time` instances are immutable, ``out`` "
+                             "cannot be set to anything but ``None``.")
         return self[self._advanced_index(self.argmin(axis), axis, keepdims)]
 
-    def max(self, axis=None, keepdims=False):
+    def max(self, axis=None, out=None, keepdims=False):
         """Maximum along a given axis.
 
         This is similar to :meth:`~numpy.ndarray.max`, but adapted to ensure
         that the full precision given by the two doubles ``jd1`` and ``jd2``
         is used, and that corresponding attributes are copied.
+
+        Note that the ``out`` argument is present only for compatibility with
+        ``np.max``; since `Time` instances are immutable, it is not possible
+        to have an actual ``out`` to store the result in.
         """
+        if out is not None:
+            raise ValueError("Since `Time` instances are immutable, ``out`` "
+                             "cannot be set to anything but ``None``.")
         return self[self._advanced_index(self.argmax(axis), axis, keepdims)]
 
-    def ptp(self, axis=None, keepdims=False):
+    def ptp(self, axis=None, out=None, keepdims=False):
         """Peak to peak (maximum - minimum) along a given axis.
 
         This is similar to :meth:`~numpy.ndarray.ptp`, but adapted to ensure
         that the full precision given by the two doubles ``jd1`` and ``jd2``
         is used.
+
+        Note that the ``out`` argument is present only for compatibility with
+        `~numpy.ptp`; since `Time` instances are immutable, it is not possible
+        to have an actual ``out`` to store the result in.
         """
-        return self.max(axis, keepdims) - self.min(axis, keepdims)
+        if out is not None:
+            raise ValueError("Since `Time` instances are immutable, ``out`` "
+                             "cannot be set to anything but ``None``.")
+        return (self.max(axis, keepdims=keepdims) -
+                self.min(axis, keepdims=keepdims))
 
     def sort(self, axis=-1):
         """Return a copy sorted along the specified axis.

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # TEST_UNICODE_LITERALS
+import itertools
 import numpy as np
 
 from .. import Time
@@ -246,11 +247,45 @@ class TestManipulation():
 
 class TestArithmetic():
     """Arithmetic on Time objects, using both doubles."""
+    kwargs = ({}, {'axis': None}, {'axis': 0}, {'axis': 1}, {'axis': 2})
+    functions = ('min', 'max', 'sort')
 
     def setup(self):
-        mjd = np.arange(50000, 50010)
+        mjd = np.arange(50000, 50100, 10).reshape(2, 5, 1)
         frac = np.array([0.1, 0.1+1.e-15, 0.1-1.e-15, 0.9+2.e-16, 0.9])
-        self.t0 = Time(mjd.reshape(2, 5, 1), frac, format='mjd', scale='utc')
+        self.t0 = Time(mjd, frac, format='mjd', scale='utc')
+
+        # Define arrays with same ordinal properties
+        frac = np.array([1, 2, 0, 4, 3])
+        self.t1 = Time(mjd + frac, format='mjd', scale='utc')
+        self.jd = mjd + frac
+
+    @pytest.mark.parametrize('kw, func', itertools.product(kwargs, functions))
+    def test_argfuncs(self, kw, func):
+        """
+        Test that np.argfunc(jd, **kw) is the same as t0.argfunc(**kw) where
+        jd is a similarly shaped array with the same ordinal properties but
+        all integer values.  Also test the same for t1 which has the same
+        integral values as jd.
+        """
+        t0v = getattr(self.t0, 'arg' + func)(**kw)
+        t1v = getattr(self.t1, 'arg' + func)(**kw)
+        jdv = getattr(np, 'arg' + func)(self.jd, **kw)
+        assert np.all(t0v == jdv)
+        assert np.all(t1v == jdv)
+        assert t0v.shape == jdv.shape
+        assert t1v.shape == jdv.shape
+
+    @pytest.mark.parametrize('kw, func', itertools.product(kwargs, functions))
+    def test_funcs(self, kw, func):
+        """
+        Test that np.func(jd, **kw) is the same as t1.func(**kw) where
+        jd is a similarly shaped array and the same integral values.
+        """
+        t1v = getattr(self.t1, func)(**kw)
+        jdv = getattr(np, func)(self.jd, **kw)
+        assert np.all(t1v.value == jdv)
+        assert t1v.shape == jdv.shape
 
     def test_argmin(self):
         assert self.t0.argmin() == 2

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -342,7 +342,18 @@ Note that similarly to the `~numpy.ndarray` methods, all but
 :meth:`~astropy.time.Time.flatten` try to use new views of the data,
 with the data copied only if that it is impossible (as discussed, e.g., in
 the documentation for numpy :func:`~numpy.reshape`).
-   
+
+Some arithmetic methods are supported as well: :meth:`~astropy.time.Time.min`,
+:meth:`~astropy.time.Time.max`, :meth:`~astropy.time.Time.ptp`,
+:meth:`~astropy.time.Time.sort`, :meth:`~astropy.time.Time.argmin`,
+:meth:`~astropy.time.Time.argmax`, and :meth:`~astropy.time.Time.argsort`.
+E.g.::
+
+  >> t.max()
+  <Time object: scale='utc' format='mjd' value=50002.5>
+  >> t.ptp(axis=0)
+  <TimeDelta object: scale='tai' format='jd' value=[ 2.  2.]>
+
 .. _astropy-time-inferring-input:
 
 Inferring input format


### PR DESCRIPTION
Following on #3224, this adds `argmin`, `argmax`, `max`, `min`, and `ptp` methods to `Time`. In order to properly propagate `location` and the two `delta` attributes, `min` and `max` internally use `argmin` and `argmax` to get indices of the location that should be extracted.

@taldcroft - as this builds on #3224, you may want to either just look here, or just look at specific commit adding these methods. 

EDIT: also added `argsort` and `sort`.