### PR TITLE
Add io.ascii.get_read_trace() that shows how table got read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ New Features
     arguments ``col_starts`` or ``col_ends``. Columns will be assumed to begin and
     end immediately adjacent to each other. [#3657]
 
+  - Add a function ``get_read_trace()`` that returns a traceback of the
+    attempted read formats for the last call to ``astropy.io.ascii.read``. [#3688]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -40,6 +40,6 @@ from .sextractor import SExtractor
 from .fixedwidth import (FixedWidth, FixedWidthNoHeader,
                          FixedWidthTwoLine, FixedWidthSplitter,
                          FixedWidthHeader, FixedWidthData)
-from .ui import (set_guess, get_reader, read, get_writer, write, READ_TRIES)
+from .ui import (set_guess, get_reader, read, get_writer, write, get_read_trace)
 
 from . import connect

--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -40,6 +40,6 @@ from .sextractor import SExtractor
 from .fixedwidth import (FixedWidth, FixedWidthNoHeader,
                          FixedWidthTwoLine, FixedWidthSplitter,
                          FixedWidthHeader, FixedWidthData)
-from .ui import (set_guess, get_reader, read, get_writer, write)
+from .ui import (set_guess, get_reader, read, get_writer, write, READ_TRIES)
 
 from . import connect

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -552,7 +552,7 @@ class BaseHeader(object):
                                      .format(name))
         # When guessing require at least two columns
         if guessing and len(self.colnames) <= 1:
-            raise ValueError
+            raise ValueError('Strict name guessing requires at least two columns')
 
         if names is not None and len(names) != len(self.colnames):
             raise ValueError('Length of names argument ({0}) does not match number'

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -309,8 +309,7 @@ Debugging
 In order to get more insight into the guessing process and possibly debug if
 something isn't working as expected, use the
 `~astropy.io.ascii.get_read_trace()` function.  This returns a traceback of the
-attempted read formats for the last call to `~astropy.io.ascii.read()` where
-guessing was enabled.
+attempted read formats for the last call to `~astropy.io.ascii.read()`.
 
 Comments and metadata
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -257,6 +257,8 @@ with numeric columns but no header row, and in this case ``astropy.io.ascii`` wi
 auto-assign column names because of the restriction on column names that
 look like a number.
 
+Guess order
+"""""""""""
 The order of guessing is shown by this Python code, where ``Reader`` is the
 class which actually implements reading the different file formats::
 
@@ -290,6 +292,9 @@ that would conflict are skipped.  For example the call::
 would only try the four delimiter possibilities, skipping all the conflicting
 Reader and quotechar combinations.
 
+Disabling
+"""""""""
+
 Guessing can be disabled in two ways::
 
   import astropy.io.ascii
@@ -297,6 +302,15 @@ Guessing can be disabled in two ways::
   data = astropy.io.ascii.read(table, guess=False)  # disable for this call
   astropy.io.ascii.set_guess(False)                 # set default to False globally
   data = astropy.io.ascii.read(table)               # guessing disabled
+
+Debugging
+"""""""""
+
+In order to get more insight into the guessing process and possibly debug if
+something isn't working as expected, use the
+`~astropy.io.ascii.get_read_trace()` function.  This returns a traceback of the
+attempted read formats for the last call to `~astropy.io.ascii.read()` where
+guessing was enabled.
 
 Comments and metadata
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I've always wanted to have some traceability into what readers got called and how when reading an ASCII table.  This implements that.  For example, without the second commit, which is (strictly speaking) off-topic, one sees there is a problem in that the fast readers are generally not getting called when guessing.  Note the ` "TypeError: __cinit__() got an unexpected keyword argument 'strict_names'"`.
```
In [1]: from astropy.io.ascii.ui import READ_TRIES

In [2]: from astropy.io import ascii

In [3]: b = ascii.read(['a b', '1 2'])

In [4]: READ_TRIES
Out[4]: 
[{'kwargs': {'Reader': astropy.io.ascii.ecsv.Ecsv,
   'fill_values': [('', '0')],
   'strict_names': True},
  'status': 'InconsistentTableError: ECSV header line like "# %ECSV <version>" not found as first line.  This is required for a ECSV file.'},

 {'kwargs': {'Reader': astropy.io.ascii.fixedwidth.FixedWidthTwoLine,
   'fill_values': [('', '0')],
   'strict_names': True},
  'status': 'InconsistentTableError: Position line should only contain delimiters and one other character, e.g. "--- ------- ---".'},

 {'kwargs': {'Reader': astropy.io.ascii.fastbasic.FastBasic,
   'fill_values': [('', '0')],
   'strict_names': True},
  'status': "TypeError: __cinit__() got an unexpected keyword argument 'strict_names'"},

 {'kwargs': {'Reader': astropy.io.ascii.basic.Basic,
   'fill_values': [('', '0')],
   'strict_names': True},
  'status': 'Success (guessing)'}]
```

Actually, there was *another* bug, which is that in the guess list the `Basic` reader was always before the `FastBasic` reader because of the default `fill_values` kwarg which is inserted by `ui.read()`.   So this PR fixes that as well.

In fact, once both commits in this PR are in place, then a third bug appears in that the fast reader doesn't handle a no-header table correctly when guessing and `names` is supplied.  More on that tomorrow.