### PR TITLE
Reword CITATION to make it clear that recommendation is requested but not required

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,6 +1,6 @@
 If you use Astropy for work/research presented in a publication (whether
-directly, or as a dependency to another package), please include the following
-acknowledgment:
+directly, or as a dependency to another package), we recommend and encourage 
+(but do not explicitly require) the following acknowledgment:
 
   This research made use of Astropy, a community-developed core Python package
   for Astronomy (Astropy Collaboration, 2013).

--- a/CITATION
+++ b/CITATION
@@ -1,6 +1,6 @@
 If you use Astropy for work/research presented in a publication (whether
 directly, or as a dependency to another package), we recommend and encourage 
-(but do not explicitly require) the following acknowledgment:
+the following acknowledgment:
 
   This research made use of Astropy, a community-developed core Python package
   for Astronomy (Astropy Collaboration, 2013).


### PR DESCRIPTION
This PR is motivated by [this comment](https://groups.google.com/forum/#!topic/numfocus/_BJgDYGc6Q0) from @mdboom's on the numfocus group.  The basic concern is that some journals might push back if the software "requires" citation.  So the wording here is that we really want people to cite the astropy paper, but explicitly do not *require* it.

cc @astrofrog