### PR TITLE
Implement sigma_to_logp and its inverse plus tests

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -825,6 +825,7 @@ def sigma_to_logp(sigma, two_sided=True):
     --------
     >>> np.exp(sigma_to_logp(3))
     0.0026997960632601926
+    
     """
     import scipy.special
     s = sigma/np.sqrt(2)
@@ -834,7 +835,7 @@ def sigma_to_logp(sigma, two_sided=True):
 def logp_to_sigma(logp, two_sided=True):
     """Convert log-probability to number-of-sigma
 
-        Detection probabilities are often naturally expressed as a
+    Detection probabilities are often naturally expressed as a
     false positive probability. On the other hand, astronomers
     are used to thinking of small probabilities in terms of
     how many standard deviations out on a normal distribution
@@ -845,7 +846,7 @@ def logp_to_sigma(logp, two_sided=True):
 
     Parameters
     ----------
-    logp : number
+    logp : float
         The (natural) logarithm of the corresponding probability
     two_sided : boolean
         If True (the default) use a two-tailed probability (probability
@@ -853,13 +854,14 @@ def logp_to_sigma(logp, two_sided=True):
 
     Returns
     -------
-    sigma : number
+    sigma : float
         The number of sigma
 
     Examples
     --------
     >>> logp_to_sigma(np.log(0.05))
     1.9599639845400545
+    
     """
     import scipy.special
     import scipy.optimize

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -832,6 +832,8 @@ def sigma_to_logp(sigma, two_sided=True):
     
     """
     import scipy.special
+    if not np.isscalar(sigma):
+        sigma = np.asanyarray(sigma)
     r = scipy.special.log_ndtr(-sigma)+(np.log(2) if two_sided else 0)
     if two_sided:
         if np.any(sigma<0):
@@ -845,6 +847,7 @@ def sigma_to_logp(sigma, two_sided=True):
     return r
 
 # TODO Note scipy dependency
+@np.vectorize
 def logp_to_sigma(logp, two_sided=True):
     """Convert log-probability to number-of-sigma
 
@@ -860,7 +863,7 @@ def logp_to_sigma(logp, two_sided=True):
 
     Parameters
     ----------
-    logp : float
+    logp : array-like
         The (natural) logarithm of the corresponding probability
     two_sided : boolean
         If True (the default) use a two-tailed probability (probability
@@ -884,7 +887,7 @@ def logp_to_sigma(logp, two_sided=True):
     import scipy.special
     import scipy.optimize
     if logp>0:
-        raise ValueError("probabilities must be <= 1 but logp was %g" % logp)
+        raise ValueError("probabilities must be <= 1 but logp was {0:g}".format(logp))
     if not two_sided and logp>np.log(0.5): # sigma will be negative
         return -logp_to_sigma(np.log(1-np.exp(logp)),two_sided=two_sided)
     s = scipy.optimize.brentq(

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -832,17 +832,16 @@ def sigma_to_logp(sigma, two_sided=True):
     
     """
     import scipy.special
-    s = sigma/np.sqrt(2)
-    r = -s**2+np.log(scipy.special.erfcx(s))+(0 if two_sided else -np.log(2))
+    r = scipy.special.log_ndtr(-sigma)+(np.log(2) if two_sided else 0)
     if two_sided:
-        if np.any(s<0):
-            raise ValueError("two-sided tail probability doesn't make sense for negative sigmas: %s" % s)
+        if np.any(sigma<0):
+            raise ValueError("two-sided tail probability doesn't make sense for negative sigmas: %s" % sigma)
     else:
-        if np.isscalar(s):
-            if s<0:
-                return np.log(scipy.stats.norm.sf(np.sqrt(2)*s))
+        if np.isscalar(sigma):
+            if sigma<0:
+                return np.log(scipy.stats.norm.sf(sigma))
         else:
-            r[s<0] = np.log(scipy.stats.norm.sf(np.sqrt(2)*s[s<0]))
+            r[sigma<0] = np.log(scipy.stats.norm.sf(sigma[sigma<0]))
     return r
 
 # TODO Note scipy dependency

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -23,7 +23,9 @@ __all__ = ['binom_conf_interval', 'binned_binom_proportion',
            'sigma_to_logp', 'logp_to_sigma']
 
 __doctest_skip__ = ['binned_binom_proportion']
-__doctest_requires__ = {'binom_conf_interval': ['scipy.special']}
+__doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
+                        'sigma_to_logp': ['scipy.special'],
+                        'logp_to_sigma': ['scipy.special','scipy.optimize']}
 
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -23,9 +23,9 @@ __all__ = ['binom_conf_interval', 'binned_binom_proportion',
            'sigma_to_logp', 'logp_to_sigma']
 
 __doctest_skip__ = ['binned_binom_proportion']
-__doctest_requires__ = {'binom_conf_interval': ['scipy.special'],}
-#                        'sigma_to_logp': ['scipy.special'],
-#                        'logp_to_sigma': ['scipy.special','scipy.optimize']}
+__doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
+                        'sigma_to_logp': ['scipy.special'],
+                        'logp_to_sigma': ['scipy.special','scipy.optimize']}
 
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -856,7 +856,8 @@ def logp_to_sigma(logp, two_sided=True):
     they are. This function converts between these two
     representations in a way that works even for probabilities
     too small to represent in floating point (this happens at
-    about 40-sigma for double precision).
+    about 40-sigma for double precision). Both one- and two-tailed
+    versions are available.
 
     Parameters
     ----------

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -23,9 +23,9 @@ __all__ = ['binom_conf_interval', 'binned_binom_proportion',
            'sigma_to_logp', 'logp_to_sigma']
 
 __doctest_skip__ = ['binned_binom_proportion']
-__doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
-                        'sigma_to_logp': ['scipy.special'],
-                        'logp_to_sigma': ['scipy.special','scipy.optimize']}
+__doctest_requires__ = {'binom_conf_interval': ['scipy.special'],}
+#                        'sigma_to_logp': ['scipy.special'],
+#                        'logp_to_sigma': ['scipy.special','scipy.optimize']}
 
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))
@@ -826,6 +826,9 @@ def sigma_to_logp(sigma, two_sided=True):
     --------
     >>> np.exp(sigma_to_logp(3))
     0.0026997960632601926
+
+    >>> sigma_to_logp(50)/np.log(10)
+    -544.66530586633246
     
     """
     import scipy.special
@@ -873,6 +876,9 @@ def logp_to_sigma(logp, two_sided=True):
     --------
     >>> logp_to_sigma(np.log(0.05))
     1.9599639845400545
+    
+    >>> logp_to_sigma(-500*np.log(10))
+    47.89983732050132
     
     """
     import scipy.special

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -11,6 +11,7 @@ from numpy.testing.utils import assert_allclose
 
 try:
     import scipy
+    import scipy.stats
 except ImportError:
     HAS_SCIPY = False
 else:
@@ -256,3 +257,34 @@ def test_gaussian_sigma_to_fwhm():
 def test_gaussian_sigma_to_fwhm_to_sigma():
     assert_allclose(funcs.gaussian_fwhm_to_sigma *
                     funcs.gaussian_sigma_to_fwhm, 1.0)
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_small():
+    assert_allclose(funcs.sigma_to_logp(5),
+                    np.log(2*scipy.stats.norm.sf(5)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_small():
+    assert_allclose(funcs.logp_to_sigma(-5),
+                    scipy.stats.norm.isf(0.5*np.exp(-5)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_small_one_sided():
+    assert_allclose(funcs.sigma_to_logp(5, two_sided=False),
+                    np.log(scipy.stats.norm.sf(5)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_small_one_sided():
+    assert_allclose(funcs.logp_to_sigma(-5, two_sided=False),
+                    scipy.stats.norm.isf(np.exp(-5)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_roundtrip():
+    assert_allclose(funcs.sigma_to_logp(funcs.logp_to_sigma(-50)),
+                    -50)
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_roundtrip():
+    assert_allclose(funcs.logp_to_sigma(funcs.sigma_to_logp(50)),
+                    50)
+    

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -269,6 +269,11 @@ def test_logp_to_sigma_small():
                     scipy.stats.norm.isf(0.5*np.exp(-5)))
 
 @pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_verysmall():
+    assert_allclose(funcs.logp_to_sigma(-0.01),
+                    scipy.stats.norm.isf(0.5*np.exp(-0.01)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_sigma_to_logp_small_one_sided():
     assert_allclose(funcs.sigma_to_logp(5, two_sided=False),
                     np.log(scipy.stats.norm.sf(5)))

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -264,6 +264,14 @@ def test_sigma_to_logp_small():
                     np.log(2*scipy.stats.norm.sf(5)))
 
 @pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_list():
+    funcs.sigma_to_logp([1,2,3])
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_list():
+    funcs.logp_to_sigma([-1,-2,-3])
+
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_logp_to_sigma_small():
     assert_allclose(funcs.logp_to_sigma(-5),
                     scipy.stats.norm.isf(0.5*np.exp(-5)))

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -288,3 +288,40 @@ def test_sigma_to_logp_roundtrip():
     assert_allclose(funcs.logp_to_sigma(funcs.sigma_to_logp(50)),
                     50)
     
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_negative():
+    assert_allclose(funcs.sigma_to_logp(-5, two_sided=False),
+                    np.log(scipy.stats.norm.sf(-5)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_negative_large():
+    assert_allclose(funcs.sigma_to_logp(-500, two_sided=False),
+                    0)
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_array():
+    s = 100*np.ones((3,4,5))
+    assert_allclose(funcs.sigma_to_logp(s),
+                    funcs.sigma_to_logp(s[0,0,0])*np.ones(s.shape))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_sigma_to_logp_array_negative():
+    s = -np.ones((3,4,5))
+    assert_allclose(funcs.sigma_to_logp(s, two_sided=False),
+                    funcs.sigma_to_logp(s[0,0,0], two_sided=False)*np.ones(s.shape))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_small():
+    assert_allclose(funcs.logp_to_sigma(-0.01, two_sided=False),
+                    scipy.stats.norm.isf(np.exp(-0.01)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_large():
+    assert_allclose(funcs.logp_to_sigma(-1e-10, two_sided=False),
+                    scipy.stats.norm.isf(np.exp(-1e-10)))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_logp_to_sigma_small_two():
+    assert_allclose(funcs.logp_to_sigma(-0.01),
+                    scipy.stats.norm.isf(0.5*np.exp(-0.01)))
+


### PR DESCRIPTION
Provide functions to convert between a log-probability and a number of sigma that work even for probabilities too small to represent as doubles.
