### PR TITLE
WIP Variable class that includes uncertainties; application to UQuantity

### DIFF
--- a/astropy/uncertainty/__init__.py
+++ b/astropy/uncertainty/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 This sub-package contains classes and functions for creating distributions that
 work similar to `~astropy.units.Quantity` or array objects, but can propogate
 uncertainties.
 """
 
-
 from .core import *
 from .distributions import *
+from .uncertainty import *
+from .uquantity import *

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 Distribution class and associated machinery.
 """
-
 import numpy as np
 
 from astropy import units as u
 from astropy import stats
+
 
 __all__ = ['Distribution']
 

--- a/astropy/uncertainty/tests/test_uquantity.py
+++ b/astropy/uncertainty/tests/test_uquantity.py
@@ -1,0 +1,112 @@
+# coding: utf-8
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from ... import units as u
+from ... import constants as c
+from .. import UQuantity
+
+
+def test_initialisation():
+    v1 = UQuantity(5, 2, u.km)
+    assert v1.value == 5
+    assert v1.unit == u.km
+    assert v1.uncertainty == 2
+    v2 = UQuantity(5 * u.km, 2)
+    assert v2.value == 5
+    assert v2.unit == u.km
+    assert v2.uncertainty == 2
+    v3 = UQuantity(5 * u.km, 2000 * u.m)
+    assert v3.value == 5
+    assert v3.unit == u.km
+    assert v3.uncertainty == 2
+    v4 = UQuantity(np.arange(5.), 2., u.km)
+    assert np.all(v4.value == np.arange(5.))
+    assert v4.unit == u.km
+    assert v4.uncertainty == 2
+    v5 = UQuantity(np.arange(5.), np.array([1., 2., 1., 2., 1.]), u.km)
+    assert np.all(v5.value == np.arange(5.))
+    assert v5.unit == u.km
+    assert np.all(v5.uncertainty == np.array([1., 2., 1., 2., 1.]))
+
+
+class TestBasics():
+    def setup(self):
+        self.v = UQuantity(5., 2., u.km)
+        self.a = UQuantity(np.arange(1., 5.), 1., u.s)
+        self.b = UQuantity(np.array([1., 2., 3.]), np.array([0.1, 0.2, 0.1]),
+                           u.m)
+
+    def test_addition(self):
+        c1 = self.v + UQuantity(12, 5, self.v.unit)
+        assert c1.value == self.v.value + 12
+        assert c1.unit == u.km
+        # Uncertainties under addition add in quadrature
+        assert np.allclose(c1.uncertainty,
+                           np.sqrt(self.v.uncertainty**2 + 5**2))
+        # now with different units
+        c2 = self.v + UQuantity(12000., 5000., u.m)
+        assert c2.value == self.v.value + 12
+        assert c2.unit == u.km
+        assert np.allclose(c2.uncertainty,
+                           np.sqrt(self.v.uncertainty**2 + 5**2))
+        # try array
+        c3 = self.v + self.b
+        assert np.all(c3.nominal_value ==
+                      self.v.nominal_value + self.b.nominal_value)
+        assert np.allclose(c3.uncertainty,
+                           np.sqrt((self.v.uncertainty * self.v.unit)**2 +
+                                   (self.b.uncertainty * self.b.unit)**2)
+                           .to(c3.unit).value)
+        # try adding regular Quantity
+        c4 = self.v + 10. * self.v.unit
+        assert c4.value == self.v.value + 10.
+        assert c4.uncertainty == self.v.uncertainty
+
+    def test_subtraction(self):
+        c1 = self.v - UQuantity(12, 5, self.v.unit)
+        assert c1.value == self.v.value - 12
+        assert c1.unit == u.km
+        # Uncertainties under addition add in quadrature
+        assert np.allclose(c1.uncertainty,
+                           np.sqrt(self.v.uncertainty**2 + 5**2))
+
+    def test_multiplication(self):
+        c1 = self.v * self.a
+        assert np.all(c1.nominal_value ==
+                      self.v.nominal_value * self.a.nominal_value)
+
+        # Fractional uncertainties under multiplication add in quadrature
+        assert np.allclose(c1.uncertainty/c1.value,
+                           np.sqrt((self.v.uncertainty/self.v.value)**2 +
+                                   (self.a.uncertainty/self.a.value)**2))
+        # Test multiplication with straight Quantity
+        c2 = self.a * (10. * u.s)
+        assert np.all(c2.value == self.a.value * 10.)
+        assert c2.unit == self.a.unit * u.s
+        assert np.all(c2.uncertainty == self.a.uncertainty * 10.)
+
+    def test_division(self):
+        c1 = self.v / self.a
+        assert np.allclose(c1.value, (self.v.nominal_value /
+                                      self.a.nominal_value).to(c1.unit).value)
+        # Fractional uncertainties under division add in quadrature
+        assert np.allclose(c1.uncertainty/c1.value,
+                           np.sqrt((self.v.uncertainty/self.v.value)**2 +
+                                   (self.a.uncertainty/self.a.value)**2))
+
+
+def test_more_complex():
+    G = UQuantity(c.G, subok=False)
+    m1 = UQuantity(1e15, 1e5, u.kg)
+    m2 = UQuantity(100, 10, u.kg)
+    r = UQuantity(10000, 500, u.m)
+    F = G * (m1 * m2) / r**2
+    assert np.allclose(F.value, c.G.si.value * (1e15 * 100) / 10000**2)
+    assert F.unit == u.N
+    # Uncertainties calculated using partial derivative method
+    assert np.allclose(F.uncertainty, np.sqrt(
+        (m1.value*m2.value/(r.value**2)*G.uncertainty)**2 +
+        (G.value*m2.value/(r.value**2)*m1.uncertainty)**2 +
+        (G.value*m1.value/(r.value**2)*m2.uncertainty)**2 +
+        (-2*G.value*m1.value*m2.value/(r.value**3)*r.uncertainty)**2))

--- a/astropy/uncertainty/tests/test_variable.py
+++ b/astropy/uncertainty/tests/test_variable.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from .. import Variable
+
+
+def test_initialisation():
+    v1 = Variable(5, 2)
+    assert v1.nominal_value == 5
+    assert v1.uncertainty == 2
+    v2 = Variable(5, None)
+    assert v2.nominal_value == 5
+    assert v2._uncertainty is None
+    assert v2.uncertainty == 0
+    v4 = Variable(np.arange(5.), 2.)
+    assert np.all(v4.nominal_value == np.arange(5.))
+    assert v4.uncertainty == 2
+    v5 = Variable(np.arange(5.), np.array([1., 2., 1., 2., 1.]))
+    assert np.all(v5.nominal_value == np.arange(5.))
+    assert np.all(v5.uncertainty == np.array([1., 2., 1., 2., 1.]))
+
+
+class TestBasics():
+    def setup(self):
+        self.v = Variable(5., 2.)
+        self.a = Variable(np.arange(1., 5.), 1.)
+        self.b = Variable(np.array([1., 2., 3.]), np.array([0.1, 0.2, 0.1]))
+
+    def test_addition(self):
+        c = self.v + Variable(12, 5)
+        assert c.nominal_value == self.v.nominal_value + 12
+        # Uncertainties under addition add in quadrature
+        assert c.uncertainty == np.sqrt(self.v.uncertainty**2 + 5**2)
+        # try array
+        c3 = self.v + self.b
+        assert np.all(c3.nominal_value ==
+                      self.v.nominal_value + self.b.nominal_value)
+        assert np.allclose(c3.uncertainty, np.sqrt(self.v.uncertainty**2 +
+                                                   self.b.uncertainty**2))
+        # Try adding a regular number.
+        c4 = self.v + 10.
+        assert c4.nominal_value == self.v.nominal_value + 10.
+        assert c4.uncertainty == self.v.uncertainty
+        # And a variable without an uncertainty.
+        c5 = self.v + Variable(10., None)
+        assert c5.nominal_value == self.v.nominal_value + 10.
+        assert len(c5._uncertainty.derivatives) == 1
+        assert c5.uncertainty == self.v.uncertainty
+
+    def test_subtraction(self):
+        c = self.v - Variable(12, 5)
+        assert c.nominal_value == self.v.nominal_value - 12
+        # Uncertainties under addition add in quadrature
+        assert c.uncertainty == np.sqrt(self.v.uncertainty**2 + 5**2)
+
+    def test_multiplication(self):
+        c = self.v * self.a
+        assert np.all(c.nominal_value ==
+                      self.v.nominal_value * self.a.nominal_value)
+
+        # Fractional uncertainties under multiplication add in quadrature
+        assert np.allclose(c.uncertainty / c.nominal_value, np.sqrt(
+            (self.v.uncertainty / self.v.nominal_value)**2 +
+            (self.a.uncertainty / self.a.nominal_value)**2))
+
+        # Test multiplication with straight number
+        c2 = self.a * 10.
+        assert np.all(c2.nominal_value == self.a.nominal_value * 10.)
+        assert np.all(c2.uncertainty == self.a.uncertainty * 10.)
+
+    def test_division(self):
+        c = self.v / self.a
+        assert np.allclose(c.nominal_value, (self.v.nominal_value /
+                                             self.a.nominal_value))
+        # Fractional uncertainties under division add in quadrature
+        assert np.allclose(c.uncertainty/c.nominal_value, np.sqrt(
+            (self.v.uncertainty / self.v.nominal_value)**2 +
+            (self.a.uncertainty / self.a.nominal_value)**2))
+
+    def test_tracking(self):
+        c = Variable(12, 5) + self.v
+        assert c.uncertainty == np.sqrt(5**2 + self.v.uncertainty**2)
+        c = c - self.v
+        assert c.nominal_value == 12
+        assert c.uncertainty == 5
+        c2 = self.v - self.v
+        assert c2.nominal_value == 0
+        assert c2.uncertainty == 0

--- a/astropy/uncertainty/uncertainty.py
+++ b/astropy/uncertainty/uncertainty.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Distribution class and associated machinery.
+"""
+import numpy as np
+
+from astropy import units as u
+from astropy.utils.misc import isiterable
+
+
+__all__ = ['Uncertainty', 'Variable']
+
+
+# Derivatives of ufuncs relative to their input(s).
+UFUNC_DERIVATIVES = {
+    np.add: (lambda x, y: 1.,
+             lambda x, y: 1.),
+    np.subtract: (lambda x, y: 1.,
+                  lambda x, y: -1.),
+    np.multiply: (lambda x, y: y,
+                  lambda x, y: x),
+    np.true_divide: (lambda x, y: 1/y,
+                     lambda x, y: -x/y**2),
+    np.arccos: lambda x: -1/np.sqrt(1-x**2),
+    np.arccosh: lambda x: 1/np.sqrt(x**2-1),
+    np.arcsin: lambda x: 1/np.sqrt(1-x**2),
+    np.arcsinh: lambda x: 1/np.sqrt(1+x**2),
+    np.arctan: lambda x: 1/(1+x**2),
+    np.arctan2: (lambda y, x: x/(x**2+y**2),
+                 lambda y, x: -y/(x**2+y**2)),
+    np.arctanh: lambda x: 1/(1-x**2),
+    np.copysign: (lambda x, y: np.where(x >= 0, np.copysign(1, y),
+                                        -np.copysign(1, y)),
+                  lambda x, y: 0),
+    np.cos: lambda x: -np.sin(x),
+    np.cosh: np.sinh,
+    np.degrees: lambda x: np.degrees(1.),
+    np.exp: np.exp,
+    np.expm1: np.exp,
+    np.fabs: lambda x: np.where(x >= 0., 1., -1.),
+    np.hypot: (lambda x, y: x / np.hypot(x, y),
+               lambda x, y: y / np.hypot(x, y)),
+    np.log: lambda x: 1/x,
+    np.log10: lambda x: 1/x/np.log(10),
+    np.log1p: lambda x: 1/(1+x),
+    np.power: (lambda x, y: x**(y-1) * y,   # explicitly zero y==0?
+               lambda x, y: np.log(x)*x**y),
+    # above: explicityly zero np.logical_and(x==0, y>0)?
+    np.radians: lambda x: np.radians(1),
+    np.sin: np.cos,
+    np.sinh: np.cosh,
+    np.sqrt: lambda x: 0.5/np.sqrt(x),
+    np.square: lambda x: 2.0*x,
+    np.tan: lambda x: 1+np.tan(x)**2,
+    np.tanh: lambda x: 1-np.tanh(x)**2}
+
+UFUNC_DERIVATIVES[np.divide] = UFUNC_DERIVATIVES[np.true_divide]
+UFUNC_DERIVATIVES[np.abs] = UFUNC_DERIVATIVES[np.fabs]
+UFUNC_DERIVATIVES[np.cbrt] = lambda x: 1./(3.*np.cbrt(x)**2)
+
+
+class Uncertainty:
+    """Measurement Uncertainty.
+
+    Parameters
+    ----------
+    uncertainty : `~numpy.ndarray` or subclass
+        Measurement uncertainties
+    check : Bool
+        Whether to convert ``uncertainty`` to an array, and check it is
+        positive (default: ``True``).
+
+    Notes
+    -----
+    This class is mostly for internal use by `Variable`.
+    """
+    def __init__(self, uncertainty, check=True):
+        if check and np.any(uncertainty < 0):
+                raise ValueError("The uncertainty cannot be negative.")
+        self.uncertainty = uncertainty
+        # Set up an ID that uses the memory location and the array strides;
+        # the latter helps keep track of slices.
+        self.id = (uncertainty.__array_interface__['data'][0],
+                   uncertainty.__array_interface__['strides'])
+        # Any derived uncertainty will use this dictionary, ensuring there is
+        # a link that keeps the value in memory until it is not used any more.
+        self.derivatives = {self.id: [self, 1.]}
+
+    def __call__(self):
+        """Get the uncertainty.  Returns simply the stored value."""
+        return self.uncertainty
+
+    def __getitem__(self, item):
+        # Particular items are stored in a new instance, with a new ID.
+        return self.__class__(uncertainty=self.uncertainty[item], check=False)
+
+    def __repr__(self):
+        return '{0}({1})'.format(type(self).__name__, self.uncertainty)
+
+
+class DerivedUncertainty:
+    """Derived Uncertainty.
+
+    Parameters
+    ----------
+    derivatives : dict
+        A dictionary keyed on uncertainty IDs, containing both the uncertainty
+        and the derivative with which a variable depends on it.
+
+    Notes
+    -----
+    This class is mostly for internal use by `Variable`.
+    """
+    def __init__(self, derivatives):
+        self.derivatives = derivatives
+
+    @property
+    def uncertainty_components(self):
+        """Iterator over the different components of the uncertainty."""
+        for unc_id, (uncertainty, derivative) in self.derivatives.items():
+            uncertainty = uncertainty.uncertainty
+            component = np.abs(derivative * uncertainty)
+            # The component is generally an array; if any derivatives are
+            # undefined, but the uncertainty is 0, the component is zero too.
+            # [Twice faster is to do: np.isnan(np.max(a))]
+            if np.any(np.isnan(derivative)):
+                component[np.logical_and(np.isnan(derivative),
+                                         uncertainty == 0.)] = 0.
+            yield component
+
+    def __call__(self):
+        """Calculate the uncertainty as the rms of the components."""
+        variance = None
+        for delta in self.uncertainty_components:
+            variance = delta**2 if variance is None else variance + delta**2
+        return np.sqrt(variance)
+
+    def __getitem__(self, item):
+        # Get the item from each of the uncertainties that contribute.
+        # TODO: this needs proper support for slicing, incl. broadcasting, etc.
+        derivatives = {}
+        for unc_id, (uncertainty, derivative) in self.derivatives.items():
+            uncertainty = uncertainty[item]
+            if isiterable(derivative):
+                derivative = derivative[item]
+            derivatives[uncertainty.id] = [uncertainty, derivative]
+        return self.__class__(derivatives)
+
+    def __repr__(self):
+        return '{0}({1})'.format(type(self).__name__, self.derivatives)
+
+
+class Variable(np.ndarray):
+    """Value with an uncertainty.
+
+    Parameters
+    ----------
+    value : array
+        The nominal value of the variable.
+    uncertainty : array
+        The associated measurement uncertainty.  This is assumed to have no
+        dependences on any other variables.
+    kwargs: dict
+        Any further arguments passed on the `~numpy.array` initializer.
+        By default, ``subok=True``, i.e., subclasses are passed through.
+    """
+
+    __array_priority__ = 100000
+
+    def __new__(cls, value, uncertainty, **kwargs):
+        kwargs.setdefault('subok', True)
+        value = np.array(value, **kwargs)
+        if uncertainty is not None:
+            uncertainty = Uncertainty(np.array(uncertainty, **kwargs))
+        # We keep the nominal value separately.  It points to the same data
+        # as `self`, but can have a different class (e.g., Quantity).
+        self = value.view(cls)
+        self._nominal_value = value
+        self._uncertainty = uncertainty
+        return self
+
+    @property
+    def nominal_value(self):
+        return self._nominal_value
+
+    @property
+    def uncertainty(self):
+        """Uncertainty associated with the variable.
+
+        Returns either the measurement uncertainty, or the uncertainty derived
+        by propagating the uncertainties of the underlying measurements.
+        """
+        return self._uncertainty() if self._uncertainty is not None else 0
+
+    def __getitem__(self, item):
+        nominal_value = self._nominal_value[item]
+        result = nominal_value.view(type(self))
+        result._nominal_value = nominal_value
+        result._uncertainty = self._uncertainty[item]
+        return result
+
+    def __array_finalize__(self, obj):
+        if super().__array_finalize__:
+            super().__array_finalize__(obj)
+        self._nominal_value = getattr(obj, '_nominal_value', obj)
+        self._uncertainty = getattr(obj, '_uncertainty', None)
+
+    def __array_prepare__(self, obj, context=None):
+        if context is None:
+            return obj
+        # The calculation will be on the data proper, so will produce the
+        # nominal value.  Hence, here we prepare the object that will become
+        # the nominal value using the nominal input values and the
+        # __array_prepare__ of the highest ranked one.
+        function = context[0]
+        nominal_values = tuple(getattr(arg, 'nominal_value', arg)
+                               for arg in context[1][:function.nin])
+        nv_context = (context[0], nominal_values + context[1][function.nin:],
+                      context[2])
+        prepare = self._nominal_value.__array_prepare__
+        priority = self._nominal_value.__array_priority__
+        for nv in nominal_values:
+            if getattr(nv, '__array_priority__', priority) > priority:
+                prepare = nv.__array_prepare__
+                priority = nv.__array_priority__
+
+        return prepare(obj, nv_context)
+
+    def __array_wrap__(self, obj, context=None):
+        if context is None:
+            return obj
+        # First finish the calculation of the nominal value, by wrapping using
+        # the nominal input context and the highest priority __array_wrap__.
+        function = context[0]
+        inputs = context[1][:function.nin]
+        nominal_values = tuple(getattr(arg, 'nominal_value', arg)
+                               for arg in inputs)
+        nv_context = (context[0], nominal_values + context[1][function.nin:],
+                      context[2])
+        wrap = self._nominal_value.__array_wrap__
+        priority = self._nominal_value.__array_priority__
+        for nv in nominal_values:
+            if getattr(nv, '__array_priority__', priority) > priority:
+                wrap = nv.__array_wrap__
+                priority = nv.__array_priority__
+
+        nominal_value = wrap(obj, nv_context)
+
+        obj = nominal_value.view(type(self))
+        obj._nominal_value = nominal_value
+        return obj._add_derivatives(function, inputs, nominal_values)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """Evaluate a function on the nominal value, deriving its uncertainty.
+
+        The derivation is done by error propagation, using the derivatives of
+        the given function.
+        """
+        # No support yet for ufunc methods (at, reduce, reduceat, outer, etc.).
+        assert method == '__call__'
+        # No support yet for output arguments.
+        assert 'out' not in kwargs
+        # Apply the function to the nominal values.
+        values = [getattr(arg, 'nominal_value', arg) for arg in inputs]
+        value = ufunc(*values, **kwargs)
+        # Set up the output as a Variable that contains a derived uncertainty.
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        result = value.view(type(self))
+        return result._add_derivatives(ufunc, inputs, values)
+
+    def _add_derivatives(self, ufunc, inputs, nominal_values):
+        # get the functions that calculate derivatives of the ufunc
+        # relative to the nominal input values.
+        ufunc_derivs = UFUNC_DERIVATIVES[ufunc]
+        if len(inputs) == 1:
+            ufunc_derivs = (ufunc_derivs,)
+
+        # For Variable inputs, get possible derivatives to other variables.
+        deriv_dicts = [getattr(getattr(arg, '_uncertainty', None),
+                               'derivatives', {}) for arg in inputs]
+        # Set up a new derivatives dictionary, with entries to all variables
+        # the result depends on.
+        derivatives = {}
+        for deriv_dict in deriv_dicts:
+            for k, [u, d] in deriv_dict.items():
+                derivatives[k] = [u, None]
+        # Add to derivatives using chain rule.
+        for ufunc_deriv, deriv_dict in zip(ufunc_derivs, deriv_dicts):
+            if deriv_dict:
+                new_deriv = ufunc_deriv(*nominal_values)
+            for unc_id, (uncertainty, derivative) in deriv_dict.items():
+                if derivatives[unc_id][1] is None:
+                    derivatives[unc_id][1] = new_deriv * derivative
+                else:
+                    derivatives[unc_id][1] += new_deriv * derivative
+        self._uncertainty = DerivedUncertainty(derivatives)
+        return self
+
+    def __str__(self):
+        return '{0}±{1}'.format(self.nominal_value, self.uncertainty)
+
+    def __repr__(self):
+        return '{0}(value={1}, uncertainty={2})'.format(
+            type(self).__name__, self.nominal_value, self.uncertainty)

--- a/astropy/uncertainty/uquantity.py
+++ b/astropy/uncertainty/uquantity.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+
+from ..units import Quantity
+from .uncertainty import Variable
+
+__all__ = ["UQuantity"]
+
+
+class UQuantity(Variable, Quantity):
+
+    def __new__(cls, value, uncertainty=None, unit=None, **kwargs):
+        if uncertainty is None:
+            uncertainty = getattr(value, 'uncertainty', None)
+        value = getattr(value, 'nominal_value', value)
+        subok = kwargs.pop('subok', True)
+        if subok and isinstance(value, Quantity):
+            q_cls = type(value)
+            cls = _subclasses[q_cls]
+        else:
+            q_cls = Quantity
+        value = q_cls(value, unit, **kwargs)
+        if uncertainty is not None:
+            uncertainty = q_cls(uncertainty, value.unit)
+        return super().__new__(cls, value, uncertainty, **kwargs)
+
+    @property
+    def uncertainty(self):
+        return (0 if self._uncertainty is None
+                else self._uncertainty().to(self.unit).value)
+
+    def __quantity_subclass__(self, unit):
+        q_cls = self._nominal_value.__quantity_subclass__(unit)[0]
+        return _subclasses[q_cls], True
+
+    def __str__(self):
+        return '{0}±{1}{2:s}'.format(self.value, self.uncertainty,
+                                     self._unitstr)
+
+    def __repr__(self):
+        prefix1 = '<' + self.__class__.__name__ + ' '
+        if self.isscalar:
+            return '{0}{1}±{2}{3:s}>'.format(prefix1, self.value,
+                                             self.uncertainty, self._unitstr)
+
+        prefix2 = ' ' * (len(prefix1) - 1) + '±'
+        valstr = np.array2string(self.value, separator=',', prefix=prefix1)
+        errstr = np.array2string(self.uncertainty, separator=',',
+                                 prefix=prefix2)
+        return '{0}{1}\n{2}{3}{4:s}>'.format(prefix1, valstr,
+                                             prefix2, errstr, self._unitstr)
+
+
+class _SubclassDict(dict):
+    def __getitem__(self, q_cls):
+        if q_cls not in self:
+            # Use str('U') to avoid unicode for class name in python2.
+            self[q_cls] = type(str('U') + q_cls.__name__,
+                               (UQuantity, Variable, q_cls), {})
+        return super().__getitem__(q_cls)
+
+
+_subclasses = _SubclassDict()
+_subclasses[Quantity] = UQuantity


### PR DESCRIPTION
EDIT: updated: this PR provides ways to propagate uncertainties analytically, keeping track of correlations. It is meant as a companion to the `Distribution` class, which follows, effectively, a Monte-Carlo approach to propagating uncertainties.  Items still to do:

- [ ] Decide on a name (`Variable` is poor, `Measurement` does not include propagation/correlated errors, `Variate` suggests random number generation; `Measurand` may be closest but is not common);
- [ ] Like for `Distribution`, consider auto-generating subclasses (`VariableArray`, `VariableQuantity`, etc.).
- [ ] Make PR consistent with current minimum numpy version (i.e., use `__array_ufunc__` only, no `__array_prepare__`, etc.)
- [ ] Implement reductions; by default, these should drop correlations.

Follow-up of this PR might include:
- Implement user-control for when/whether correlations are kept.
- Ensure that error propagation could can be used as module in `nddata`

BELOW IS THE OUTDATED ORIGINAL TEXT

_Very much work in progress, so do not merge_

This is a first stab at a general `Variable` class, a subclass of `ndarray` that tracks uncertainties. Also implemented is an application to `UQuantity`, i.e., a mixin with `Quantity`. It is still inspired by the `uncertainties` package [1], written by @lebigot, and many of the test cases are taken from the GSoC work of @Epitrochoid. Unlike those efforts, however, this is a proper `ndarray` subclass (while in @Epitrochoid's approach arrays were not yet possible, while in `uncertainties`,  object arrays (holding `Variable` instances) are used, which is much slower).

Note that I started writing this using `__numpy_ufunc__`, which is the most logical and fastest approach, and hence this PR includes the commits of #2583 and #2948. Upon further thought, however, it became clear that this would work with the usual `__array_prepare__` and `__array_wrap__` as well; for now, I didn't feel it was worth removing the `__numpy_ufunc__` machinery.

Anyway, as is, this works well for generic `ufunc` operations. One big outstanding issue is what to do with methods that combine (parts of) an array, such as `sum` or `mean`. E.g., if we do `x - x.mean()`, where `x` is some large array, do we want to track for every element of `x` its dependence on every other element of `x` (which, for a 1000x1000 image would imply a 1000x1000x1000 derivative matrix). 

cc: @wkerzendorf, @eteq, @mwcraig

@lebigot: please let me know if you are interested in using this in your package.

[1] https://github.com/lebigot/uncertainties
