### PR TITLE
Edit note that says that adding Column is slow

### DIFF
--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -34,8 +34,9 @@ initial columns.  This is useful for building tables dynamically if the initial
 size, columns, or data are not known.
 
 .. Note::
-   Adding columns or rows requires making a new copy of the entire
-   table table each time, so in the case of large tables this may be slow.
+   Adding rows requires making a new copy of the entire
+   table each time, so in the case of large tables this may be slow. 
+   On the other hand, adding columns is quite fast.
 
 ::
 


### PR DESCRIPTION
With the changes in the internal structure of `Table` that @taldcroft contributed for
astropy 1.0 adding columns is now actually one recommended way to construct a table.

[skip CI]