### PR TITLE
Check for appropriate equivalency of rest value in doppler equivalencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -322,6 +322,9 @@ Bug fixes
 
 - ``astropy.units``
 
+  - Added frequency-equivalency check when declaring doppler equivalencies
+    [#3728]
+
   - Define ``floor_divide`` (``//``) for ``Quantity`` to be consistent
     ``divmod``, such that it only works where the quotient is dimensionless.
     This guarantees that ``(q1 // q2) * q2 + (q1 % q2) == q1``. [#3817]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -210,7 +210,7 @@ def doppler_radio(rest):
 
     try:
         rest.to(u.GHz, u.spectral())
-    except Exception as ex:
+    except (AttributeError,u.UnitsError) as ex:
         raise u.UnitsError("The 'rest' value must be a spectral equivalent "
                            "(frequency, wavelength, or energy).")
 
@@ -281,7 +281,7 @@ def doppler_optical(rest):
 
     try:
         rest.to(u.GHz, u.spectral())
-    except Exception as ex:
+    except (AttributeError,u.UnitsError) as ex:
         raise u.UnitsError("The 'rest' value must be a spectral equivalent "
                            "(frequency, wavelength, or energy).")
 
@@ -360,7 +360,7 @@ def doppler_relativistic(rest):
 
     try:
         rest.to(u.GHz, u.spectral())
-    except Exception as ex:
+    except (AttributeError,u.UnitsError) as ex:
         raise u.UnitsError("The 'rest' value must be a spectral equivalent "
                            "(frequency, wavelength, or energy).")
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -209,11 +209,7 @@ def doppler_radio(rest):
     <Quantity -31.209092088877583 km / s>
     """
 
-    try:
-        rest.to(si.Hz, spectral())
-    except (AttributeError,UnitsError) as ex:
-        raise UnitsError("The 'rest' value must be a spectral equivalent "
-                         "(frequency, wavelength, or energy).")
+    assert_is_spectral_unit(rest)
 
     ckms = _si.c.to('km/s').value
 
@@ -280,11 +276,7 @@ def doppler_optical(rest):
     <Quantity -31.20584348799674 km / s>
     """
 
-    try:
-        rest.to(si.Hz, spectral())
-    except (AttributeError,UnitsError) as ex:
-        raise UnitsError("The 'rest' value must be a spectral equivalent "
-                         "(frequency, wavelength, or energy).")
+    assert_is_spectral_unit(rest)
 
     ckms = _si.c.to('km/s').value
 
@@ -359,11 +351,7 @@ def doppler_relativistic(rest):
     <Quantity 2.6116243681798923 mm>
     """
 
-    try:
-        rest.to(si.Hz, spectral())
-    except (AttributeError,UnitsError) as ex:
-        raise UnitsError("The 'rest' value must be a spectral equivalent "
-                         "(frequency, wavelength, or energy).")
+    assert_is_spectral_unit(rest)
 
     ckms = _si.c.to('km/s').value
 
@@ -498,3 +486,10 @@ def temperature_energy():
     return [
         (si.K, si.eV, lambda x: x / (_si.e.value / _si.k_B),
          lambda x: x * (_si.e.value / _si.k_B))]
+
+def assert_is_spectral_unit(value):
+    try:
+        value.to(si.Hz, spectral())
+    except (AttributeError, UnitsError) as ex:
+        raise UnitsError("The 'rest' value must be a spectral equivalent "
+                         "(frequency, wavelength, or energy).")

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -13,6 +13,7 @@ from . import cgs
 from . import astrophys
 from .function import units as function_units
 from . import dimensionless_unscaled
+from .core import UnitsError
 
 
 __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
@@ -209,10 +210,10 @@ def doppler_radio(rest):
     """
 
     try:
-        rest.to(u.GHz, u.spectral())
-    except (AttributeError,u.UnitsError) as ex:
-        raise u.UnitsError("The 'rest' value must be a spectral equivalent "
-                           "(frequency, wavelength, or energy).")
+        rest.to(si.Hz, spectral())
+    except (AttributeError,UnitsError) as ex:
+        raise UnitsError("The 'rest' value must be a spectral equivalent "
+                         "(frequency, wavelength, or energy).")
 
     ckms = _si.c.to('km/s').value
 
@@ -280,10 +281,10 @@ def doppler_optical(rest):
     """
 
     try:
-        rest.to(u.GHz, u.spectral())
-    except (AttributeError,u.UnitsError) as ex:
-        raise u.UnitsError("The 'rest' value must be a spectral equivalent "
-                           "(frequency, wavelength, or energy).")
+        rest.to(si.Hz, spectral())
+    except (AttributeError,UnitsError) as ex:
+        raise UnitsError("The 'rest' value must be a spectral equivalent "
+                         "(frequency, wavelength, or energy).")
 
     ckms = _si.c.to('km/s').value
 
@@ -359,10 +360,10 @@ def doppler_relativistic(rest):
     """
 
     try:
-        rest.to(u.GHz, u.spectral())
-    except (AttributeError,u.UnitsError) as ex:
-        raise u.UnitsError("The 'rest' value must be a spectral equivalent "
-                           "(frequency, wavelength, or energy).")
+        rest.to(si.Hz, spectral())
+    except (AttributeError,UnitsError) as ex:
+        raise UnitsError("The 'rest' value must be a spectral equivalent "
+                         "(frequency, wavelength, or energy).")
 
     ckms = _si.c.to('km/s').value
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -208,6 +208,12 @@ def doppler_radio(rest):
     <Quantity -31.209092088877583 km / s>
     """
 
+    try:
+        rest.to(u.GHz, u.spectral())
+    except Exception as ex:
+        raise u.UnitsError("The 'rest' value must be a spectral equivalent "
+                           "(frequency, wavelength, or energy).")
+
     ckms = _si.c.to('km/s').value
 
     def to_vel_freq(x):
@@ -272,6 +278,12 @@ def doppler_optical(rest):
     >>> optical_velocity  # doctest: +FLOAT_CMP
     <Quantity -31.20584348799674 km / s>
     """
+
+    try:
+        rest.to(u.GHz, u.spectral())
+    except Exception as ex:
+        raise u.UnitsError("The 'rest' value must be a spectral equivalent "
+                           "(frequency, wavelength, or energy).")
 
     ckms = _si.c.to('km/s').value
 
@@ -345,6 +357,12 @@ def doppler_relativistic(rest):
     >>> relativistic_wavelength  # doctest: +FLOAT_CMP
     <Quantity 2.6116243681798923 mm>
     """
+
+    try:
+        rest.to(u.GHz, u.spectral())
+    except Exception as ex:
+        raise u.UnitsError("The 'rest' value must be a spectral equivalent "
+                           "(frequency, wavelength, or energy).")
 
     ckms = _si.c.to('km/s').value
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -71,17 +71,17 @@ def test_logarithmic(log_unit):
                       1.e-10*log_unit)
 
 
-functions = [u.doppler_optical, u.doppler_radio, u.doppler_relativistic]
+doppler_functions = [u.doppler_optical, u.doppler_radio, u.doppler_relativistic]
 
 
-@pytest.mark.parametrize(('function'), functions)
+@pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_frequency_0(function):
     rest = 105.01 * u.GHz
     velo0 = rest.to(u.km/u.s, equivalencies=function(rest))
     assert velo0.value == 0
 
 
-@pytest.mark.parametrize(('function'), functions)
+@pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_wavelength_0(function):
     rest = 105.01 * u.GHz
     q1 = 0.00285489437196 * u.m
@@ -89,7 +89,7 @@ def test_doppler_wavelength_0(function):
     np.testing.assert_almost_equal(velo0.value, 0, decimal=6)
 
 
-@pytest.mark.parametrize(('function'), functions)
+@pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_energy_0(function):
     rest = 105.01 * u.GHz
     q1 = 0.000434286445543 * u.eV
@@ -97,7 +97,7 @@ def test_doppler_energy_0(function):
     np.testing.assert_almost_equal(velo0.value, 0, decimal=6)
 
 
-@pytest.mark.parametrize(('function'), functions)
+@pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_frequency_circle(function):
     rest = 105.01 * u.GHz
     shifted = 105.03 * u.GHz
@@ -106,7 +106,7 @@ def test_doppler_frequency_circle(function):
     np.testing.assert_almost_equal(freq.value, shifted.value, decimal=7)
 
 
-@pytest.mark.parametrize(('function'), functions)
+@pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_wavelength_circle(function):
     rest = 105.01 * u.nm
     shifted = 105.03 * u.nm
@@ -115,7 +115,7 @@ def test_doppler_wavelength_circle(function):
     np.testing.assert_almost_equal(wav.value, shifted.value, decimal=7)
 
 
-@pytest.mark.parametrize(('function'), functions)
+@pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_energy_circle(function):
     rest = 1.0501 * u.eV
     shifted = 1.0503 * u.eV
@@ -126,7 +126,7 @@ def test_doppler_energy_circle(function):
 
 values_ghz = (999.899940784289,999.8999307714406,999.8999357778647)
 @pytest.mark.parametrize(('function', 'value'),
-                         list(zip(functions, values_ghz)))
+                         list(zip(doppler_functions, values_ghz)))
 def test_30kms(function, value):
     rest = 1000 * u.GHz
     velo = 30 * u.km/u.s
@@ -136,8 +136,8 @@ def test_30kms(function, value):
 
 bad_values = (5, 5*u.Jy, None)
 @pytest.mark.parametrize(('function', 'value'),
-                         list(zip(functions, bad_values)))
-def test_30kms(function, value):
+                         list(zip(doppler_functions, bad_values)))
+def test_bad_restfreqs(function, value):
     with pytest.raises(u.UnitsError):
         function(value)
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -134,6 +134,13 @@ def test_30kms(function, value):
     np.testing.assert_almost_equal(shifted.value, value, decimal=7)
 
 
+bad_values = (5, 5*u.Jy, None)
+@pytest.mark.parametrize(('function', 'value'),
+                         list(zip(functions, bad_values)))
+def test_30kms(function, value):
+    with pytest.raises(u.UnitsError):
+        function(value)
+
 def test_massenergy():
     # The relative tolerance of these tests is set by the uncertainties
     # in the charge of the electron, which is known to about


### PR DESCRIPTION
Without this, it is possible to declare an invalid equivalency, e.g.:
`u.doppler_radio(None)` or `u.doppler_optical(5)`

Only open question: should this catch only `AttributeErrors`?  Probably, so I'll change that.  If anyone can think of other exceptions, let me know.

