### PR TITLE
Create ColumnInfo class for mixin columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,14 @@ New Features
   - Initializing a ``Table`` with ``Column`` objects no longer requires
     that the column ``name`` attribute be defined. [#3781]
 
+  - Added an ``info`` property to ``Table`` objects which provides configurable
+    summary information about the table and its columns. [#3731]
+
+  - Added an ``info`` property to column classes (``Column`` or mixins).  This
+    serves a dual function of providing configurable summary information about
+    the column, and acting as a manager of column attributes such as
+    name, format, or description. [#3731]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1020,7 +1020,9 @@ class BaseCoordinateFrame(object):
 
     def __getitem__(self, view):
         if self.has_data:
-            return self.realize_frame(self.data[view])
+            out = self.realize_frame(self.data[view])
+            out.representation = self.representation
+            return out
         else:
             raise ValueError('Cannot index a frame with no data')
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,7 +13,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.column_info import DataInfo, BaseDataInfo
+from ..utils.column_info import DataInfo, BaseInfo
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
@@ -42,7 +42,7 @@ def FRAME_ATTR_NAMES_SET():
     return out
 
 
-class SkyCoordDataInfo(BaseDataInfo):
+class SkyCoordDataInfo(BaseInfo):
     _attrs_from_parent = set(['unit'])
 
     @staticmethod

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -48,7 +48,7 @@ class SkyCoordInfo(DataInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    attrs_from_parent = set(['unit'])  # Unit is read-only and None
+    attrs_from_parent = set(['unit'])  # Unit is read-only
 
     @staticmethod
     def default_format(val):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -14,6 +14,7 @@ from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
 from ..utils.column_info import ColumnInfo
+from ..utils import lazyproperty
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
@@ -190,14 +191,9 @@ class SkyCoord(object):
         if not self._sky_coord_frame.has_data:
             raise ValueError('Cannot create a SkyCoord without data')
 
-    @property
+    @lazyproperty
     def info(self):
-        """
-        Mixin column information (attributes)
-        """
-        if not hasattr(self, '_info'):
-            self._info = SkyCoordColumnInfo(self)
-        return self._info
+        return SkyCoordColumnInfo(self)
 
     @property
     def frame(self):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -43,7 +43,12 @@ def FRAME_ATTR_NAMES_SET():
 
 
 class SkyCoordInfo(DataInfo):
-    attrs_from_parent = set(['unit'])
+    """
+    Container for meta information like name, description, format.  This is
+    required when the object is used as a mixin column within a table, but can
+    be used as a general way to store meta information.
+    """
+    attrs_from_parent = set(['unit'])  # Unit is read-only and None
 
     @staticmethod
     def default_format(val):
@@ -55,7 +60,7 @@ class SkyCoordInfo(DataInfo):
     @property
     def unit(self):
         repr_data = self._repr_data
-        unit = ','.join(str(getattr(repr_data, comp).unit)
+        unit = ','.join(str(getattr(repr_data, comp).unit) or 'None'
                         for comp in repr_data.components)
         return unit
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,7 +13,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.column_info import DataInfo, BaseInfo
+from ..utils.data_info import DataInfo, BaseInfo
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,8 +13,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.column_info import ColumnInfo
-from ..utils import lazyproperty
+from ..utils.column_info import DataInfo, BaseDataInfo
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
@@ -43,7 +42,7 @@ def FRAME_ATTR_NAMES_SET():
     return out
 
 
-class SkyCoordColumnInfo(ColumnInfo):
+class SkyCoordDataInfo(BaseDataInfo):
     _attrs_from_parent = set(['unit'])
 
     @staticmethod
@@ -204,10 +203,7 @@ class SkyCoord(object):
         if not self._sky_coord_frame.has_data:
             raise ValueError('Cannot create a SkyCoord without data')
 
-    @lazyproperty
-    def info(self):
-        print('here in info routine')
-        return SkyCoordColumnInfo(self)
+    info = DataInfo(SkyCoordDataInfo)
 
     @property
     def frame(self):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -177,8 +177,8 @@ class SkyCoord(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            from ..table import ColumnAttributes
-            self._info = ColumnAttributes()
+            from ..table import ColumnInfo
+            self._info = ColumnInfo()
         return self._info
 
     @property

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -43,7 +43,7 @@ def FRAME_ATTR_NAMES_SET():
 
 
 class SkyCoordDataInfo(BaseInfo):
-    _attrs_from_parent = set(['unit'])
+    attrs_from_parent = set(['unit'])
 
     @staticmethod
     def default_format(val):
@@ -61,10 +61,10 @@ class SkyCoordDataInfo(BaseInfo):
 
     @property
     def _repr_data(self):
-        if self._parent_col is None:
+        if self._parent_ref is None:
             return None
 
-        sc = self._parent_col()
+        sc = self._parent_ref()
         if (issubclass(sc.representation, SphericalRepresentation) and
                 isinstance(sc.data, UnitSphericalRepresentation)):
             repr_data = sc.represent_as(sc.data.__class__, in_frame_units=True)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -178,7 +178,7 @@ class SkyCoord(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            self._info = ColumnInfo()
+            self._info = ColumnInfo(self)
         return self._info
 
     @property

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -172,6 +172,16 @@ class SkyCoord(object):
             raise ValueError('Cannot create a SkyCoord without data')
 
     @property
+    def info(self):
+        """
+        Mixin column information (attributes)
+        """
+        if not hasattr(self, '_info'):
+            from ..table import ColumnAttributes
+            self._info = ColumnAttributes()
+        return self._info
+
+    @property
     def frame(self):
         return self._sky_coord_frame
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -232,7 +232,7 @@ class SkyCoord(object):
             # First turn `self` into a mockup of the thing we want - we can copy
             # this to get all the right attributes
             self._sky_coord_frame = self_frame[item]
-            return SkyCoord(self)
+            return SkyCoord(self, representation=self.representation)
         finally:
             # now put back the right frame in self
             self._sky_coord_frame = self_frame

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,7 +13,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.data_info import DataInfo, BaseInfo
+from ..utils.data_info import InfoDescriptor, DataInfo
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
@@ -42,7 +42,7 @@ def FRAME_ATTR_NAMES_SET():
     return out
 
 
-class SkyCoordDataInfo(BaseInfo):
+class SkyCoordInfo(DataInfo):
     attrs_from_parent = set(['unit'])
 
     @staticmethod
@@ -203,7 +203,7 @@ class SkyCoord(object):
         if not self._sky_coord_frame.has_data:
             raise ValueError('Cannot create a SkyCoord without data')
 
-    info = DataInfo(SkyCoordDataInfo)
+    info = InfoDescriptor(SkyCoordInfo)
 
     @property
     def frame(self):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,6 +13,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
+from ..utils.column_info import ColumnInfo
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
@@ -177,7 +178,6 @@ class SkyCoord(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            from ..table import ColumnInfo
             self._info = ColumnInfo()
         return self._info
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -649,3 +649,14 @@ def test_representation_subclass():
                 representation=NewSphericalRepresentation)
 
     assert repr(frame) == "<FK5 Coordinate (equinox=J2000.000):  spam spam spam>"
+
+
+def test_getitem_representation():
+    """
+    Make sure current representation survives __getitem__ even if different
+    from data representation.
+    """
+    from ..builtin_frames import ICRS
+    c = ICRS([1, 1] * u.deg, [2, 2] * u.deg)
+    c.representation = 'cartesian'
+    assert c[0].representation is representation.CartesianRepresentation

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1144,3 +1144,13 @@ def test_constellations_with_nameresolve():
     assert SkyCoord.from_name('Coma Cluster').get_constellation(short_name=True) == 'Com'
     assert SkyCoord.from_name('UMa II').get_constellation() == 'Ursa Major'
     assert SkyCoord.from_name('Triangulum Galaxy').get_constellation() == 'Triangulum'
+
+
+def test_getitem_representation():
+    """
+    Make sure current representation survives __getitem__ even if different
+    from data representation.
+    """
+    sc = SkyCoord([1, 1] * u.deg, [2, 2] * u.deg)
+    sc.representation = 'cartesian'
+    assert sc[0].representation is CartesianRepresentation

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from . import core
-from ...table.column import col_getattr
 
 class BasicHeader(core.BaseHeader):
     '''Basic table Header Reader
@@ -321,7 +320,7 @@ class RdbHeader(TabHeader):
         rdb_types = []
         for col in self.cols:
             # Check if dtype.kind is string or unicode.  See help(np.core.numerictypes)
-            rdb_type = 'S' if col_getattr(col, 'dtype').kind in ('S', 'U') else 'N'
+            rdb_type = 'S' if col.info.dtype.kind in ('S', 'U') else 'N'
             rdb_types.append(rdb_type)
 
         lines.append(self.splitter.join(rdb_types))

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -25,7 +25,7 @@ from ...extern.six.moves import cStringIO as StringIO
 from ...utils.exceptions import AstropyWarning
 
 from ...table import Table
-from ...table.column import col_getattr, col_setattr, col_iter_str_vals
+from ...table.column import col_iter_str_vals
 from ...utils.compat import ignored
 from ...utils.data import get_readable_fileobj
 from ...utils import OrderedDict
@@ -503,12 +503,12 @@ class BaseHeader(object):
             for i, spacer_line in zip(range(self.start_line),
                                       itertools.cycle(self.write_spacer_lines)):
                 lines.append(spacer_line)
-            lines.append(self.splitter.join([col_getattr(x, 'name') for x in self.cols]))
+            lines.append(self.splitter.join([x.info.name for x in self.cols]))
 
     @property
     def colnames(self):
         """Return the column names of the table"""
-        return tuple(col.name if isinstance(col, Column) else col_getattr(col, 'name')
+        return tuple(col.name if isinstance(col, Column) else col.info.name
                      for col in self.cols)
 
     def get_type_map_key(self, col):
@@ -729,8 +729,8 @@ class BaseData(object):
         """
         """
         for col in self.cols:
-            if col_getattr(col, 'name') in self.formats:
-                col_setattr(col, 'format', self.formats[col.name])
+            if col.info.name in self.formats:
+                col.info.format = self.formats[col.name]
 
 
 def convert_numpy(numpy_type):

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -53,7 +53,7 @@ class EcsvHeader(basic.BasicHeader):
         for col in self.cols:
             if len(getattr(col, 'shape', ())) > 1:
                 raise ValueError("ECSV format does not support multidimensional column '{0}'"
-                                 .format(col_getattr(col, 'name')))
+                                 .format(col.info.name))
 
         # Now assemble the header dict that will be serialized by the YAML dumper
         header = {'cols': self.cols}

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -10,7 +10,6 @@ from ...utils import OrderedDict
 from ...extern import six
 
 from . import core, basic
-from ...table.column import col_getattr
 from ...table import meta
 
 ECSV_VERSION = '0.9'
@@ -71,7 +70,7 @@ class EcsvHeader(basic.BasicHeader):
                              + meta.get_yaml_from_header(header))
 
         lines.extend([self.write_comment + line for line in header_yaml_lines])
-        lines.append(self.splitter.join([col_getattr(x, 'name') for x in self.cols]))
+        lines.append(self.splitter.join([x.info.name for x in self.cols]))
 
     def write_comments(self, lines, meta):
         """

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -11,7 +11,6 @@ fixedwidth.py:
 from __future__ import absolute_import, division, print_function
 
 from ...extern.six.moves import zip
-from ...table.column import col_getattr
 
 from . import core
 from .core import InconsistentTableError, DefaultSplitter
@@ -241,12 +240,12 @@ class FixedWidthData(basic.BasicData):
         for i, col in enumerate(self.cols):
             col.width = max([len(vals[i]) for vals in vals_list])
             if self.header.start_line is not None:
-                col.width = max(col.width, len(col_getattr(col, 'name')))
+                col.width = max(col.width, len(col.info.name))
 
         widths = [col.width for col in self.cols]
 
         if self.header.start_line is not None:
-            lines.append(self.splitter.join([col_getattr(col, 'name') for col in self.cols],
+            lines.append(self.splitter.join([col.info.name for col in self.cols],
                                             widths))
 
         if self.header.position_line is not None:

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -14,7 +14,7 @@ from ...extern.six.moves import zip as izip
 
 from . import core
 from ...table import Column
-from ...table.column import col_iter_str_vals, col_getattr
+from ...table.column import col_iter_str_vals
 from ...utils.xml import writer
 
 from copy import deepcopy
@@ -358,7 +358,7 @@ class HTML(core.BaseReader):
                                     w.start('th', colspan=col.shape[1])
                                 else:
                                     w.start('th')
-                                w.data(col_getattr(col, 'name').strip())
+                                w.data(col.info.name.strip())
                                 w.end(indent=False)
                         col_str_iters = []
                         for col in cols:

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -24,7 +24,6 @@ from . import basic
 from ...utils import OrderedDict
 from ...utils.exceptions import AstropyUserWarning
 from ...table.pprint import _format_funcs, _auto_format_func
-from ...table.column import col_getattr
 
 
 class IpacFormatErrorDBMS(Exception):
@@ -260,9 +259,9 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
         unitlist = []
         nullist = []
         for col in self.cols:
-            col_dtype = col_getattr(col, 'dtype')
-            col_unit = col_getattr(col, 'unit')
-            col_format = col_getattr(col, 'format')
+            col_dtype = col.info.dtype
+            col_unit = col.info.unit
+            col_format = col.info.format
 
             if col_dtype.kind in ['i', 'u']:
                 dtypelist.append('long')

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -273,7 +273,7 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             if col_unit is None:
                 unitlist.append('')
             else:
-                unitlist.append(str(col.unit))
+                unitlist.append(str(col.info.unit))
             # This may be incompatible with mixin columns
             null = col.fill_values[core.masked]
             try:

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -14,7 +14,6 @@ import re
 
 from ...extern import six
 from . import core
-from ...table.column import col_getattr
 
 latexdicts = {'AA':  {'tabletype': 'table',
                       'header_start': r'\hline \hline', 'header_end': r'\hline',
@@ -129,7 +128,7 @@ class LatexHeader(core.BaseHeader):
             lines.append(r'\caption{' + self.latex['caption'] + '}')
         lines.append(self.header_start + r'{' + self.latex['col_align'] + r'}')
         add_dictval_to_list(self.latex, 'header_start', lines)
-        col_units = [col_getattr(col, 'unit') for col in self.cols]
+        col_units = [col.info.unit for col in self.cols]
         lines.append(self.splitter.join(self.colnames))
         units = dict((name, unit.to_string(format='latex_inline'))
                      for name, unit in zip(self.colnames, col_units) if unit)
@@ -356,7 +355,7 @@ class AASTexHeader(LatexHeader):
         if 'caption' in self.latex:
             lines.append(r'\tablecaption{' + self.latex['caption'] + '}')
         tablehead = ' & '.join([r'\colhead{' + name + '}' for name in self.colnames])
-        col_units = [col_getattr(col, 'unit') for col in self.cols]
+        col_units = [col.info.unit for col in self.cols]
         units = dict((name, unit.to_string(format='latex_inline'))
                      for name, unit in zip(self.colnames, col_units) if unit)
         if 'units' in self.latex:

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -115,6 +115,17 @@ class LatexHeader(core.BaseHeader):
         else:
             return None
 
+    def _get_units(self):
+        units = {}
+        col_units = [col.info.unit for col in self.cols]
+        for name, unit in zip(self.colnames, col_units):
+            if unit:
+                try:
+                    units[name] = unit.to_string(format='latex_inline')
+                except AttributeError:
+                    units[name] = unit
+        return units
+
     def write(self, lines):
         if not 'col_align' in self.latex:
             self.latex['col_align'] = len(self.cols) * 'c'
@@ -128,10 +139,8 @@ class LatexHeader(core.BaseHeader):
             lines.append(r'\caption{' + self.latex['caption'] + '}')
         lines.append(self.header_start + r'{' + self.latex['col_align'] + r'}')
         add_dictval_to_list(self.latex, 'header_start', lines)
-        col_units = [col.info.unit for col in self.cols]
         lines.append(self.splitter.join(self.colnames))
-        units = dict((name, unit.to_string(format='latex_inline'))
-                     for name, unit in zip(self.colnames, col_units) if unit)
+        units = self._get_units()
         if 'units' in self.latex:
             units.update(self.latex['units'])
         if units:
@@ -355,9 +364,7 @@ class AASTexHeader(LatexHeader):
         if 'caption' in self.latex:
             lines.append(r'\tablecaption{' + self.latex['caption'] + '}')
         tablehead = ' & '.join([r'\colhead{' + name + '}' for name in self.colnames])
-        col_units = [col.info.unit for col in self.cols]
-        units = dict((name, unit.to_string(format='latex_inline'))
-                     for name, unit in zip(self.colnames, col_units) if unit)
+        units = self._get_units()
         if 'units' in self.latex:
             units.update(self.latex['units'])
         if units:

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn, ColumnInfo, add_column_info
+from .column import Column, MaskedColumn, add_column_info
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn
+from .column import Column, MaskedColumn, ColumnAttributes, add_column_info
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn, ColumnAttributes, add_column_info
+from .column import Column, MaskedColumn, ColumnInfo, add_column_info
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn, add_column_info
+from .column import Column, MaskedColumn
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter
 from .operations import join, hstack, vstack, unique, TableMergeError

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import BaseInfo, DataInfo
+from ..utils.data_info import DataInfo, InfoDescriptor
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -53,7 +53,7 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
         return
 
     if not hasattr(newcol, 'info'):
-        newcol.__class__.info = DataInfo(BaseInfo)
+        newcol.__class__.info = InfoDescriptor(DataInfo)
 
     attrs = newcol.info.attr_names - set(exclude_attrs) - newcol.info.attrs_from_parent
     for attr in attrs:
@@ -109,8 +109,8 @@ class FalseArray(np.ndarray):
                              .format(self.__class__.__name__))
 
 
-class ColumnInfo(BaseInfo):
-    attrs_from_parent = BaseInfo.attr_names
+class ColumnInfo(DataInfo):
+    attrs_from_parent = DataInfo.attr_names
 
 
 class BaseColumn(np.ndarray):
@@ -184,7 +184,7 @@ class BaseColumn(np.ndarray):
         else:
             self._parent_table = weakref.ref(table)
 
-    info = DataInfo(ColumnInfo)
+    info = InfoDescriptor(ColumnInfo)
 
     def copy(self, order='C', data=None, copy_data=True):
         """

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -78,13 +78,18 @@ def col_copy(col):
     if isinstance(col, BaseColumn):
         return col.copy()
 
+    # The new column should have None for the parent_table ref.  If the
+    # original parent_table weakref there at the point of copying then it
+    # generates an infinite recursion.  Instead temporarily remove the weakref
+    # on the original column and restore after the copy in an exception-safe
+    # manner.
+
     parent_table = col.info.parent_table
     col.info.parent_table = None
 
     try:
         newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
         newcol.info = col.info.copy()
-        newcol.info._parent_ref = weakref.ref(newcol)
     finally:
         col.info.parent_table = parent_table
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -48,8 +48,6 @@ _comparison_functions = set(
 def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
     """
     Copy info from mixin `col` to `newcol`.  Does nothing for BaseColumn cols.
-
-    Warning: this function is subject to change or removal.
     """
     if isinstance(newcol, BaseColumn):
         return
@@ -66,8 +64,6 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
 def col_iter_str_vals(col):
     """
     This is a mixin-safe version of Column.iter_str_vals.
-
-    Warning: this function is subject to change or removal.
     """
     parent_table = col.info.parent_table
     formatter = FORMATTER if parent_table is None else parent_table.formatter

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.column_info import COLUMN_ATTRS, BaseDataInfo, DataInfo
+from ..utils.column_info import COLUMN_ATTRS, BaseInfo, DataInfo
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -55,7 +55,7 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
         return
 
     if not hasattr(newcol, 'info'):
-        newcol.__class__.info = DataInfo(BaseDataInfo)
+        newcol.__class__.info = DataInfo(BaseInfo)
 
     attrs = COLUMN_ATTRS - set(exclude_attrs) - newcol.info._attrs_from_parent
     for attr in attrs:
@@ -100,7 +100,7 @@ def add_column_info(col):
     Add mixin column information to ``col`` class.
     """
     if not hasattr(col, 'info'):
-        col.__class__.info = DataInfo(BaseDataInfo)
+        col.__class__.info = DataInfo(BaseInfo)
 
 
 class FalseArray(np.ndarray):
@@ -121,7 +121,7 @@ class FalseArray(np.ndarray):
                              .format(self.__class__.__name__))
 
 
-class ColumnInfo(BaseDataInfo):
+class ColumnInfo(BaseInfo):
     _attrs_from_parent=COLUMN_ATTRS
 
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -45,23 +45,6 @@ _comparison_functions = set(
      np.isfinite, np.isinf, np.isnan, np.sign, np.signbit])
 
 
-def col_setattr(col, attr, value):
-    """
-    Set one of the column attributes.
-    """
-    setattr(col.info, attr, value)
-
-def col_getattr(col, attr, default=None):
-    """
-    Get one of the column attributes
-
-    Warning: this function is subject to change or removal.
-    """
-    value = getattr(col.info, attr)
-    if value is None:
-        value = default
-    return value
-
 def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
     """
     Update _astropy_column_attrs from mixin `col` to `newcol`.  Does nothing
@@ -88,7 +71,7 @@ def col_iter_str_vals(col):
 
     Warning: this function is subject to change or removal.
     """
-    parent_table = col_getattr(col, 'parent_table')
+    parent_table = col.info.parent_table
     formatter = FORMATTER if parent_table is None else parent_table.formatter
     _pformat_col_iter = formatter._pformat_col_iter
     for str_val in _pformat_col_iter(col, -1, False, False, {}):
@@ -171,11 +154,11 @@ class BaseColumn(np.ndarray):
             else:
                 self_data = np.array(data.to(unit), dtype=dtype, copy=copy)
             if description is None:
-                description = col_getattr(data, 'description')
+                description = data.info.description
             if format is None:
-                format = col_getattr(data, 'format')
+                format = data.info.format
             if meta is None:
-                meta = deepcopy(col_getattr(data, 'meta'))
+                meta = deepcopy(data.info.meta)
 
         else:
             self_data = np.array(data, dtype=dtype, copy=copy)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -52,9 +52,6 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
     if isinstance(newcol, BaseColumn):
         return
 
-    if not hasattr(newcol, 'info'):
-        newcol.__class__.info = InfoDescriptor(DataInfo)
-
     attrs = newcol.info.attr_names - set(exclude_attrs) - newcol.info.attrs_from_parent
     for attr in attrs:
         val = getattr(col.info, attr)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.column_info import COLUMN_ATTRS, BaseInfo, DataInfo
+from ..utils.column_info import BaseInfo, DataInfo
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -57,7 +57,7 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
     if not hasattr(newcol, 'info'):
         newcol.__class__.info = DataInfo(BaseInfo)
 
-    attrs = COLUMN_ATTRS - set(exclude_attrs) - newcol.info._attrs_from_parent
+    attrs = newcol.info.attr_names - set(exclude_attrs) - newcol.info.attrs_from_parent
     for attr in attrs:
         val = getattr(col.info, attr)
         if val is not None:
@@ -88,7 +88,7 @@ def col_copy(col):
     try:
         newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
         newcol.info = col.info.copy()
-        newcol.info._parent_col = weakref.ref(newcol)
+        newcol.info._parent_ref = weakref.ref(newcol)
     finally:
         col.info.parent_table = parent_table
 
@@ -122,7 +122,7 @@ class FalseArray(np.ndarray):
 
 
 class ColumnInfo(BaseInfo):
-    _attrs_from_parent=COLUMN_ATTRS
+    attrs_from_parent = BaseInfo.attr_names
 
 
 class BaseColumn(np.ndarray):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -46,7 +46,7 @@ _comparison_functions = set(
 
 COLUMN_ATTRS = set(['name', 'unit', 'dtype', 'format', 'description', 'meta', 'parent_table'])
 
-class ColumnAttributes(object):
+class ColumnInfo(object):
     cols_from_parent = set()
 
     def __init__(self, parent_col=None):
@@ -61,7 +61,7 @@ class ColumnAttributes(object):
         try:
             value = self._attrs[attr]
         except KeyError:
-            super(ColumnAttributes, self).__getattr__(attr)  # Generate AttributeError
+            super(ColumnInfo, self).__getattr__(attr)  # Generate AttributeError
 
         # Weak ref for parent table
         if attr == 'parent_table' and callable(value):
@@ -79,7 +79,7 @@ class ColumnAttributes(object):
             return
 
         if attr.startswith('_'):
-            super(ColumnAttributes, self).__setattr__(attr, value)
+            super(ColumnInfo, self).__setattr__(attr, value)
             return
 
         if attr not in COLUMN_ATTRS:
@@ -127,7 +127,7 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
 
     if not hasattr(newcol, 'info'):
         info_attr = '_info' if hasattr(col.__class__, 'info') else 'info'
-        setattr(newcol, info_attr, ColumnAttributes())
+        setattr(newcol, info_attr, ColumnInfo())
 
     attrs = COLUMN_ATTRS - set(exclude_attrs) - newcol.info.cols_from_parent
     for attr in attrs:
@@ -169,7 +169,7 @@ def add_column_info(col):
     Add mixin column information to ``col``.
     """
     if not hasattr(col, 'info'):
-        col.info = ColumnAttributes()
+        col.info = ColumnInfo()
 
 
 class FalseArray(np.ndarray):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.column_info import BaseInfo, DataInfo
+from ..utils.data_info import BaseInfo, DataInfo
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -93,14 +93,6 @@ def col_copy(col):
         col.info.parent_table = parent_table
 
     return newcol
-
-
-def add_column_info(col):
-    """
-    Add mixin column information to ``col`` class.
-    """
-    if not hasattr(col, 'info'):
-        col.__class__.info = DataInfo(BaseInfo)
 
 
 class FalseArray(np.ndarray):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -82,11 +82,15 @@ def col_copy(col):
     if isinstance(col, BaseColumn):
         return col.copy()
 
-    col.info.parent_table = None  # Don't copy weakref to parent table
+    parent_table = col.info.parent_table
+    col.info.parent_table = None
 
-    newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
-    newcol.info = col.info.copy()
-    newcol.info._parent_col = weakref.ref(newcol)
+    try:
+        newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
+        newcol.info = col.info.copy()
+        newcol.info._parent_col = weakref.ref(newcol)
+    finally:
+        col.info.parent_table = parent_table
 
     return newcol
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -47,8 +47,7 @@ _comparison_functions = set(
 
 def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
     """
-    Update _astropy_column_attrs from mixin `col` to `newcol`.  Does nothing
-    for BaseColumn cols
+    Copy info from mixin `col` to `newcol`.  Does nothing for BaseColumn cols.
 
     Warning: this function is subject to change or removal.
     """
@@ -56,8 +55,7 @@ def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
         return
 
     if not hasattr(newcol, 'info'):
-        info_attr = '_info' if hasattr(col.__class__, 'info') else 'info'
-        setattr(newcol, info_attr, ColumnInfo(newcol))
+        newcol.info = ColumnInfo(newcol)
 
     attrs = COLUMN_ATTRS - set(exclude_attrs) - newcol.info._attrs_from_parent
     for attr in attrs:
@@ -87,8 +85,7 @@ def col_copy(col):
     col.info.parent_table = None  # Don't copy weakref to parent table
 
     newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
-    info_attr = '_info' if hasattr(col.__class__, 'info') else 'info'
-    setattr(newcol, info_attr, col.info.copy())
+    newcol.info = col.info.copy()
     newcol.info._parent_col = weakref.ref(newcol)
 
     return newcol

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -216,7 +216,7 @@ class ColumnGroups(BaseGroups):
             return self._keys
 
     def aggregate(self, func):
-        from .column import MaskedColumn, col_getattr
+        from .column import MaskedColumn
 
         i0s, i1s = self.indices[:-1], self.indices[1:]
         par_col = self.parent_column
@@ -236,15 +236,15 @@ class ColumnGroups(BaseGroups):
                 vals = np.array([func(par_col[i0: i1]) for i0, i1 in izip(i0s, i1s)])
         except Exception:
             raise TypeError("Cannot aggregate column '{0}' with type '{1}'"
-                            .format(col_getattr(par_col, 'name'),
-                                    col_getattr(par_col, 'dtype')))
+                            .format(par_col.info.name,
+                                    par_col.info.dtype))
 
         out = par_col.__class__(data=vals,
-                                name=col_getattr(par_col, 'name'),
-                                description=col_getattr(par_col, 'description'),
-                                unit=col_getattr(par_col, 'unit'),
-                                format=col_getattr(par_col, 'format'),
-                                meta=col_getattr(par_col, 'meta'))
+                                name=par_col.info.name,
+                                description=par_col.info.description,
+                                unit=par_col.info.unit,
+                                format=par_col.info.format,
+                                meta=par_col.info.meta)
         return out
 
     def filter(self, func):
@@ -321,7 +321,6 @@ class TableGroups(BaseGroups):
         out : Table
             New table with the aggregated rows.
         """
-        from .column import col_getattr
 
         i0s, i1s = self.indices[:-1], self.indices[1:]
         out_cols = []
@@ -329,7 +328,7 @@ class TableGroups(BaseGroups):
 
         for col in six.itervalues(parent_table.columns):
             # For key columns just pick off first in each group since they are identical
-            if col_getattr(col, 'name') in self.key_colnames:
+            if col.info.name in self.key_colnames:
                 new_col = col.take(i0s)
             else:
                 try:

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -17,7 +17,7 @@ def info(self, option='attributes', out=''):
     Write summary information about column to the ``out`` filehandle.
     By default this prints to standard output via sys.stdout.
 
-    The ``option` argument specifies what type of information
+    The ``option`` argument specifies what type of information
     to include.  This can be a string, a function, or a list of
     strings or functions.  Built-in options are:
 

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -1,0 +1,85 @@
+"""
+Table method and functions related to providing information about
+columns and tables.
+"""
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import sys
+import os
+
+import numpy as np
+
+__all__ = ['info']
+
+def info(self, option='attributes', out=''):
+    """
+    Write summary information about column to the ``out`` filehandle.
+    By default this prints to standard output via sys.stdout.
+
+    The ``option` argument specifies what type of information
+    to include.  This can be a string, a function, or a list of
+    strings or functions.  Built-in options are:
+
+    - ``meta``: basic column meta data like ``dtype`` or ``format``
+    - ``stats``: basic statistics: minimum, mean, and maximum
+
+    If a function is specified then that function will be called with the
+    column as its single argument.  The function must return an OrderedDict
+    containing the information attributes.
+
+    If a list is provided then the information attributes will be
+    appended for each of the options, in order.
+
+    Examples
+    --------
+    >>> from astropy.table.table_helpers import simple_table
+    >>> t = simple_table()
+    >>> t['a'].unit = 'm'
+    >>> t.info()
+    <Table length=3>
+    name  dtype  unit
+    ---- ------- ----
+       a   int32    m
+       b float32
+       c string8
+
+    >>> t.info('stats')
+    <Table length=3>
+    name min mean max
+    ---- --- ---- ---
+       a   1  2.0   3
+       b 1.0  2.0 3.0
+       c  --   --  --
+
+    Parameters
+    ----------
+    option: str, function, list of (str or function)
+        Info option (default='attributes')
+    out: file-like object, None
+        Output destination (default=sys.stdout).  If None then the
+        OrderedDict with information attributes is returned
+    """
+    from .table import Table
+
+    if out == '':
+        out = sys.stdout
+
+    descr_vals = [self.__class__.__name__]
+    if self.masked:
+        descr_vals.append('masked=True')
+    descr_vals.append('length={0}'.format(len(self)))
+
+    outlines = ['<' + ' '.join(descr_vals) + '>']
+
+    infos = []
+    for col in self.columns.values():
+        infos.append(col.info(option, out=None))
+
+    info = Table(infos, names=list(infos[0].keys()))
+    for name in info.colnames:
+        if np.all(info[name] == ''):
+            del info[name]
+
+    outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))
+    out.writelines(outline + os.linesep for outline in outlines)

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -95,9 +95,9 @@ def table_info(tbl, option='attributes', out=''):
 
     if 'class' in info.colnames:
         # Remove 'class' info column if all table columns are the same class
-        # and they are not mixin columns.
+        # and they are the default column class for that table.
         uniq_types = set(type(col) for col in cols)
-        if len(uniq_types) == 1 and not tbl._is_mixin_column(cols[0]):
+        if len(uniq_types) == 1 and isinstance(cols[0], tbl.ColumnClass):
             del info['class']
 
     if 'n_bad' in info.colnames and np.all(info['n_bad'] == 0):

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -76,10 +76,13 @@ def info(self, option='attributes', out=''):
     for col in self.columns.values():
         infos.append(col.info(option, out=None))
 
-    info = Table(infos, names=list(infos[0].keys()))
+    info = Table(infos, names=list(infos[0]))
     for name in info.colnames:
         if np.all(info[name] == ''):
             del info[name]
+
+    if np.all(info['n_bad'] == 0):
+        del info['n_bad']
 
     outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))
     out.writelines(outline + os.linesep for outline in outlines)

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -1,6 +1,5 @@
 """
-Table method and functions related to providing information about
-columns and tables.
+Table method for providing information about table.
 """
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
@@ -79,6 +78,12 @@ def info(self, option='attributes', out=''):
         infos.append(col.info(option, out=None))
 
     info = Table(infos, names=list(infos[0]))
+
+    if out is None:
+        return info
+
+    # Since info is going to a filehandle for viewing then remove uninteresting
+    # columns.
     for name in info.colnames:
         if np.all(info[name] == ''):
             del info[name]
@@ -89,9 +94,6 @@ def info(self, option='attributes', out=''):
     # Standard attributes has 'length' but this is typically redundant
     if 'length' in info.colnames and np.all(info['length'] == len(self)):
         del info['length']
-
-    if out is None:
-        return info
 
     outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))
     out.writelines(outline + os.linesep for outline in outlines)

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -46,11 +46,11 @@ def info(self, option='attributes', out=''):
 
     >>> t.info('stats')
     <Table length=3>
-    name min mean max
-    ---- --- ---- ---
-       a   1  2.0   3
-       b 1.0  2.0 3.0
-       c  --   --  --
+    name mean      std       min max
+    ---- ---- -------------- --- ---
+       a  2.0 0.816496580928   1   3
+       b  2.0       0.816497 1.0 3.0
+       c   --             --  --  --
 
     Parameters
     ----------

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -99,10 +99,6 @@ def info(self, option='attributes', out=''):
         if len(uniq_types) == 1 and not self._is_mixin_column(cols[0]):
             del info['class']
 
-    if 'class' in info.colnames:
-        if np.all(info['class'] == 'Column') or np.all(info['class'] == 'MaskedColumn'):
-            del info['class']
-
     if 'n_bad' in info.colnames and np.all(info['n_bad'] == 0):
         del info['n_bad']
 

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -34,23 +34,21 @@ def info(self, option='attributes', out=''):
     Examples
     --------
     >>> from astropy.table.table_helpers import simple_table
-    >>> t = simple_table()
+    >>> t = simple_table(size=2, kinds='if')
     >>> t['a'].unit = 'm'
     >>> t.info()
-    <Table length=3>
+    <Table length=2>
     name  dtype  unit
     ---- ------- ----
        a   int32    m
        b float32
-       c string8
 
     >>> t.info('stats')
-    <Table length=3>
-    name mean      std       min max
-    ---- ---- -------------- --- ---
-       a  2.0 0.816496580928   1   3
-       b  2.0       0.816497 1.0 3.0
-       c   --             --  --  --
+    <Table length=2>
+    name mean std min max
+    ---- ---- --- --- ---
+       a  1.5 0.5   1   2
+       b  1.5 0.5 1.0 2.0
 
     Parameters
     ----------

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -57,8 +57,12 @@ def info(self, option='attributes', out=''):
     option: str, function, list of (str or function)
         Info option (default='attributes')
     out: file-like object, None
-        Output destination (default=sys.stdout).  If None then the
-        OrderedDict with information attributes is returned
+        Output destination (default=sys.stdout).  If None then a
+        Table with information attributes is returned
+
+    Returns
+    -------
+    info: `~astropy.table.Table` if out==None else None
     """
     from .table import Table
 
@@ -83,6 +87,9 @@ def info(self, option='attributes', out=''):
 
     if np.all(info['n_bad'] == 0):
         del info['n_bad']
+
+    if out is None:
+        return info
 
     outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))
     out.writelines(outline + os.linesep for outline in outlines)

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -86,6 +86,10 @@ def info(self, option='attributes', out=''):
     if np.all(info['n_bad'] == 0):
         del info['n_bad']
 
+    # Standard attributes has 'length' but this is typically redundant
+    if 'length' in info.colnames and np.all(info['length'] == len(self)):
+        del info['length']
+
     if out is None:
         return info
 

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -3,7 +3,6 @@ import copy
 
 from ..utils import OrderedDict
 from ..extern import six
-from .column import col_getattr
 
 
 __all__ = ['get_header_from_yaml', 'get_yaml_from_header', 'get_yaml_from_table']
@@ -163,9 +162,9 @@ def _get_col_attributes(col):
     to fully serialize the column.
     """
     attrs = ColumnDict()
-    attrs['name'] = col_getattr(col, 'name')
+    attrs['name'] = col.info.name
 
-    type_name = col_getattr(col, 'dtype').type.__name__
+    type_name = col.info.dtype.type.__name__
     if six.PY3 and (type_name.startswith('bytes') or type_name.startswith('str')):
         type_name = 'string'
     if type_name.endswith('_'):
@@ -177,7 +176,7 @@ def _get_col_attributes(col):
                                     ('format', lambda x: x is not None, None),
                                     ('description', lambda x: x is not None, None),
                                     ('meta', lambda x: x, None)):
-        col_attr = col_getattr(col, attr)
+        col_attr = getattr(col.info, attr)
         if nontrivial(col_attr):
             attrs[attr] = xform(col_attr) if xform else col_attr
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -20,7 +20,7 @@ import numpy as np
 from numpy import ma
 
 from ..utils import OrderedDict, metadata
-from .column import col_getattr, col_setattr, _col_update_attrs_from
+from .column import _col_update_attrs_from
 
 from . import _np_utils
 from .np_utils import fix_column_name, TableMergeError
@@ -44,14 +44,13 @@ def _merge_col_meta(out, tables, col_name_map, idx_left=0, idx_right=1,
     for out_col in six.itervalues(out.columns):
         for idx_table, table in enumerate(tables):
             left_col = out_col
-            right_name = col_name_map[col_getattr(out_col, 'name')][idx_table]
+            right_name = col_name_map[out_col.info.name][idx_table]
 
             if right_name:
                 right_col = table[right_name]
-                col_setattr(out_col, 'meta',
-                            metadata.merge(col_getattr(left_col, 'meta', {}),
-                                           col_getattr(right_col, 'meta', {}),
-                                           metadata_conflicts=metadata_conflicts))
+                out_col.info.meta = metadata.merge(left_col.info.meta or {},
+                                                   right_col.info.meta or {},
+                                                   metadata_conflicts=metadata_conflicts)
                 for attr in attrs:
 
                     # Pick the metadata item that is not None, or they are both
@@ -73,13 +72,13 @@ def _merge_col_meta(out, tables, col_name_map, idx_left=0, idx_right=1,
                         if metadata_conflicts == 'warn':
                             warnings.warn("In merged column '{0}' the '{1}' attribute does not match "
                                           "({2} != {3}).  Using {3} for merged output"
-                                          .format(col_getattr(out_col, 'name'), attr,
+                                          .format(out_col.info.name, attr,
                                                   left_attr, right_attr),
                                           metadata.MergeConflictWarning)
                         elif metadata_conflicts == 'error':
                             raise metadata.MergeConflictError(
                                 'In merged column {0!r} the {1!r} attribute does not match '
-                                '({2} != {3})'.format(col_getattr(out_col, 'name'), attr,
+                                '({2} != {3})'.format(out_col.info.name, attr,
                                                       left_attr, right_attr))
                         elif metadata_conflicts != 'silent':
                             raise ValueError('metadata_conflicts argument must be one of "silent",'

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -226,7 +226,7 @@ class TableFormatter(object):
 
         """
         if show_unit is None:
-            show_unit = getattr(col, 'unit', None) is not None
+            show_unit = col.info.unit is not None
 
         outs = {}  # Some values from _pformat_col_iter iterator that are needed here
         col_strs_iter = self._pformat_col_iter(col, max_lines, show_name=show_name,
@@ -365,7 +365,7 @@ class TableFormatter(object):
         if show_unit:
             i_centers.append(n_header)
             n_header += 1
-            yield six.text_type(getattr(col, 'unit', None) or '')
+            yield six.text_type(col.info.unit or '')
         if show_dtype:
             i_centers.append(n_header)
             n_header += 1
@@ -384,7 +384,10 @@ class TableFormatter(object):
         n_rows = len(col)
 
         col_format = col.info.format
-        format_func = _format_funcs.get(col_format, _auto_format_func)
+        if col_format is None and hasattr(col.info, 'default_format_func'):
+            format_func = col.info.default_format_func
+        else:
+            format_func = _format_funcs.get(col_format, _auto_format_func)
         if len(col) > max_lines:
             if show_length is None:
                 show_length = True
@@ -472,7 +475,7 @@ class TableFormatter(object):
         cols = []
 
         if show_unit is None:
-            show_unit = any([getattr(col, 'unit', None) for col in six.itervalues(table.columns)])
+            show_unit = any([col.info.unit for col in six.itervalues(table.columns)])
 
         # Figure out align
         if isinstance(align,str):

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -71,6 +71,9 @@ def _auto_format_func(format_, val):
 
     Returns the formatted value.
     """
+    if format_ in _format_funcs:
+        return _format_funcs[format_](format_, val)
+
     if six.callable(format_):
         format_func = lambda format_, val: format_(val)
         if NUMPY_LT_1_6_1:
@@ -383,11 +386,8 @@ class TableFormatter(object):
         n_print2 = max_lines // 2
         n_rows = len(col)
 
-        col_format = col.info.format
-        if col_format is None and hasattr(col.info, 'default_format_func'):
-            format_func = col.info.default_format_func
-        else:
-            format_func = _format_funcs.get(col_format, _auto_format_func)
+        col_format = col.info.format or getattr(col.info, 'default_format', None)
+        format_func = _format_funcs.get(col_format, _auto_format_func)
         if len(col) > max_lines:
             if show_length is None:
                 show_length = True

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -342,7 +342,6 @@ class TableFormatter(object):
             Must be a dict which is used to pass back additional values
             defined within the iterator.
         """
-        from .column import col_getattr
         max_lines, _ = self._get_pprint_size(max_lines, -1)
 
         multidims = getattr(col, 'shape', [0])[1:]
@@ -357,7 +356,7 @@ class TableFormatter(object):
         if show_name:
             i_centers.append(n_header)
             # Get column name (or 'None' if not set)
-            col_name = six.text_type(col_getattr(col, 'name'))
+            col_name = six.text_type(col.info.name)
             if multidims:
                 col_name += ' [{0}]'.format(
                     ','.join(six.text_type(n) for n in multidims))
@@ -384,7 +383,7 @@ class TableFormatter(object):
         n_print2 = max_lines // 2
         n_rows = len(col)
 
-        col_format = col_getattr(col, 'format')
+        col_format = col.info.format
         format_func = _format_funcs.get(col_format, _auto_format_func)
         if len(col) > max_lines:
             if show_length is None:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -25,7 +25,7 @@ from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      ColumnInfo)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
-
+from . import info as table_info
 
 # Prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
 # sorting of structured arrays containing Unicode columns to
@@ -2174,6 +2174,8 @@ class Table(object):
                 out[name] = Column(data=data, name=name)
 
         return cls(out)
+
+    info = table_info.info
 
 
 class QTable(Table):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -18,6 +18,7 @@ from ..units import Quantity
 from ..utils import OrderedDict, isiterable, deprecated, minversion
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
+from ..utils.data_info import InfoDescriptor
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
@@ -25,7 +26,7 @@ from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      ColumnInfo)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
-from . import info as table_info
+from .info import TableInfo
 
 # Prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
 # sorting of structured arrays containing Unicode columns to
@@ -2175,7 +2176,7 @@ class Table(object):
 
         return cls(out)
 
-    info = table_info.info
+    info = InfoDescriptor(TableInfo)
 
 
 class QTable(Table):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -60,7 +60,7 @@ def is_mixin_class(obj):
     obj : object
         Object being queried for mixin compatibility
     """
-    return hasattr(obj, 'info') and isinstance(obj.info, ColumnInfo)
+    return hasattr(obj, 'info') and not isinstance(obj.info, ColumnInfo)
 
 
 class TableColumns(OrderedDict):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -21,7 +21,8 @@ from ..utils.metadata import MetaData
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
-                     col_getattr, col_setattr, col_copy, _col_update_attrs_from)
+                     col_getattr, col_setattr, col_copy, _col_update_attrs_from,
+                     ColumnAttributes)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 
@@ -59,7 +60,7 @@ def is_mixin_class(obj):
     obj : object
         Object being queried for mixin compatibility
     """
-    return hasattr(obj, '_astropy_column_attrs')
+    return hasattr(obj, 'info') and isinstance(obj.info, ColumnAttributes)
 
 
 class TableColumns(OrderedDict):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -22,7 +22,7 @@ from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      col_getattr, col_setattr, col_copy, _col_update_attrs_from,
-                     ColumnAttributes)
+                     ColumnInfo)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 
@@ -60,7 +60,7 @@ def is_mixin_class(obj):
     obj : object
         Object being queried for mixin compatibility
     """
-    return hasattr(obj, 'info') and isinstance(obj.info, ColumnAttributes)
+    return hasattr(obj, 'info') and isinstance(obj.info, ColumnInfo)
 
 
 class TableColumns(OrderedDict):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .table import Table, Column
 from ..extern.six.moves import zip, range
-from ..utils.column_info import DataInfo, BaseDataInfo
+from ..utils.column_info import DataInfo, BaseInfo
 
 class TimingTables(object):
     """
@@ -159,7 +159,7 @@ class ArrayWrapper(object):
     def __len__(self):
         return len(self.data)
 
-    info = DataInfo(BaseDataInfo)
+    info = DataInfo(BaseInfo)
 
     @property
     def shape(self):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -12,7 +12,7 @@ from itertools import cycle
 import string
 import numpy as np
 
-from .table import Table, Column, col_setattr, col_getattr
+from .table import Table, Column
 from ..extern.six.moves import zip, range
 from ..utils.column_info import ColumnInfo
 
@@ -144,7 +144,7 @@ class ArrayWrapper(object):
     """
     def __init__(self, data):
         self.data = np.array(data)
-        col_setattr(self, 'dtype', self.data.dtype)
+        self.info.dtype = self.data.dtype
 
     def __getitem__(self, item):
         if isinstance(item, (int, np.integer)):
@@ -174,4 +174,4 @@ class ArrayWrapper(object):
 
     def __repr__(self):
         return ("<{0} name='{1}' data={2}>"
-                .format(self.__class__.__name__, col_getattr(self, 'name'), self.data))
+                .format(self.__class__.__name__, self.info.name, self.data))

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -141,8 +141,6 @@ class ArrayWrapper(object):
     """
     Minimal mixin using a simple wrapper around a numpy array
     """
-    _astropy_column_attrs = None
-
     def __init__(self, data):
         self.data = np.array(data)
         col_setattr(self, 'dtype', self.data.dtype)
@@ -159,6 +157,16 @@ class ArrayWrapper(object):
 
     def __len__(self):
         return len(self.data)
+
+    @property
+    def info(self):
+        """
+        Mixin column information (attributes)
+        """
+        if not hasattr(self, '_info'):
+            from ..table import ColumnAttributes
+            self._info = ColumnAttributes()
+        return self._info
 
     @property
     def shape(self):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .table import Table, Column
 from ..extern.six.moves import zip, range
-from ..utils.column_info import DataInfo, BaseInfo
+from ..utils.data_info import DataInfo, BaseInfo
 
 class TimingTables(object):
     """

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from .table import Table, Column, col_setattr, col_getattr
 from ..extern.six.moves import zip, range
+from ..utils.column_info import ColumnInfo
 
 class TimingTables(object):
     """
@@ -164,7 +165,6 @@ class ArrayWrapper(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            from ..table import ColumnInfo
             self._info = ColumnInfo()
         return self._info
 

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -165,7 +165,7 @@ class ArrayWrapper(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            self._info = ColumnInfo()
+            self._info = ColumnInfo(self)
         return self._info
 
     @property

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,8 +14,7 @@ import numpy as np
 
 from .table import Table, Column
 from ..extern.six.moves import zip, range
-from ..utils.column_info import ColumnInfo
-from ..utils import lazyproperty
+from ..utils.column_info import DataInfo, BaseDataInfo
 
 class TimingTables(object):
     """
@@ -160,9 +159,7 @@ class ArrayWrapper(object):
     def __len__(self):
         return len(self.data)
 
-    @lazyproperty
-    def info(self):
-        return ColumnInfo(self)
+    info = DataInfo(BaseDataInfo)
 
     @property
     def shape(self):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .table import Table, Column
 from ..extern.six.moves import zip, range
-from ..utils.data_info import DataInfo, BaseInfo
+from ..utils.data_info import InfoDescriptor, DataInfo
 
 class TimingTables(object):
     """
@@ -159,7 +159,7 @@ class ArrayWrapper(object):
     def __len__(self):
         return len(self.data)
 
-    info = DataInfo(BaseInfo)
+    info = InfoDescriptor(DataInfo)
 
     @property
     def shape(self):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -164,8 +164,8 @@ class ArrayWrapper(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            from ..table import ColumnAttributes
-            self._info = ColumnAttributes()
+            from ..table import ColumnInfo
+            self._info = ColumnInfo()
         return self._info
 
     @property

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -15,6 +15,7 @@ import numpy as np
 from .table import Table, Column
 from ..extern.six.moves import zip, range
 from ..utils.column_info import ColumnInfo
+from ..utils import lazyproperty
 
 class TimingTables(object):
     """
@@ -159,14 +160,9 @@ class ArrayWrapper(object):
     def __len__(self):
         return len(self.data)
 
-    @property
+    @lazyproperty
     def info(self):
-        """
-        Mixin column information (attributes)
-        """
-        if not hasattr(self, '_info'):
-            self._info = ColumnInfo(self)
-        return self._info
+        return ColumnInfo(self)
 
     @property
     def shape(self):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -16,13 +16,6 @@ between modules.
 """
 from copy import deepcopy
 
-try:
-    import pandas
-except ImportError:
-    HAS_PANDAS = False
-else:
-    HAS_PANDAS = True
-
 from ...tests.helper import pytest
 from ... import table
 from ...table import table_helpers
@@ -147,8 +140,6 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
                                                dec=[0, 1, 2, 3] * u.deg),
               'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3])
               }
-if HAS_PANDAS:
-    MIXIN_COLS['pandas'] = pandas.Series([0, 1, 2, 3])
 
 @pytest.fixture(params=sorted(MIXIN_COLS))
 def mixin_cols(request):
@@ -159,8 +150,6 @@ def mixin_cols(request):
     """
     cols = OrderedDict()
     mixin_cols = deepcopy(MIXIN_COLS)
-    if HAS_PANDAS:
-        table.add_column_info(mixin_cols['pandas'])
     cols['i'] = table.Column([0, 1, 2, 3], name='i')
     cols['a'] = table.Column(['a', 'b', 'b', 'c'], name='a')
     cols['b'] = table.Column(['b', 'c', 'a', 'd'], name='b')

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -160,7 +160,7 @@ def mixin_cols(request):
     cols = OrderedDict()
     mixin_cols = deepcopy(MIXIN_COLS)
     if HAS_PANDAS:
-        mixin_cols['pandas']._astropy_column_attrs = None
+        table.add_column_info(mixin_cols['pandas'])
     cols['i'] = table.Column([0, 1, 2, 3], name='i')
     cols['a'] = table.Column(['a', 'b', 'b', 'c'], name='a')
     cols['b'] = table.Column(['b', 'c', 'a', 'd'], name='b')

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -65,24 +65,24 @@ def test_info_others(table_types):
     t.info('stats', out=out)
     table_header_line = '<{0} {1}length=4>'.format(t.__class__.__name__, masked)
     exp = [table_header_line,
-           'name min mean std max',
-           '---- --- ---- --- ---',
-           '   a   1  1.5 0.5   2',
-           '   b 1.0  1.5 0.5 2.0',
-           '   c  --   --  --  --',
-           '   d 1.0   --  -- 2.0']
+           'name mean std min max',
+           '---- ---- --- --- ---',
+           '   a  1.5 0.5   1   2',
+           '   b  1.5 0.5 1.0 2.0',
+           '   c   --  --  --  --',
+           '   d   --  -- 1.0 2.0']
     assert out.getvalue().splitlines() == exp
 
     # option = ['attributes', 'stats']
     out = six.moves.cStringIO()
     t.info(['attributes', 'stats'], out=out)
     exp = [table_header_line,
-           'name  dtype  class min mean std max',
-           '---- ------- ----- --- ---- --- ---',
-           '   a   int32         1  1.5 0.5   2',
-           '   b float32       1.0  1.5 0.5 2.0',
-           '   c string8        --   --  --  --',
-           '   d  object  Time 1.0   --  -- 2.0']
+           'name  dtype  class mean std min max',
+           '---- ------- ----- ---- --- --- ---',
+           '   a   int32        1.5 0.5   1   2',
+           '   b float32        1.5 0.5 1.0 2.0',
+           '   c string8         --  --  --  --',
+           '   d  object  Time   --  -- 1.0 2.0']
     assert out.getvalue().splitlines() == exp
 
     # option = ['attributes', custom]

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -10,6 +10,8 @@ from ... import units as u
 from ... import time
 from ...utils.column_info import column_info_factory
 
+STRING8 = 'string8' if six.PY2 else 'bytes8'
+
 def test_info_attributes(table_types):
     """
     Test the info() method of printing a summary of table column attributes
@@ -18,45 +20,35 @@ def test_info_attributes(table_types):
     b = np.array([1, 2, 3], dtype='float32')
     c = np.array(['a', 'c', 'e'], dtype='|S1')
     t = table_types.Table([a, b, c], names=['a', 'b', 'c'])
-    masked = 'masked=True ' if t.masked else ''
-    string8 = 'string8' if six.PY2 else ' bytes8'
 
     # Minimal output for a typical table
-    out = six.moves.cStringIO()
-    t.info(out=out)
-    exp = ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
-           'name  dtype ',
-           '---- -------',
-           '   a   int32',
-           '   b float32',
-           '   c {0}'.format(string8)]
-    assert out.getvalue().splitlines() == exp
+    tinfo = t.info(out=None)
+    assert tinfo.colnames == ['name', 'dtype']
+    assert np.all(tinfo['name'] == ['a', 'b', 'c'])
+    assert np.all(tinfo['dtype'] == ['int32', 'float32', STRING8])
 
     # All output fields including a mixin column
     t['d'] = [1,2,3] * u.m
     t['d'].description = 'description'
     t['a'].format = '%02d'
-    t['e'] = time.Time([1,2,3], format='cxcsec')
-    out = six.moves.cStringIO()
-    t.info(out=out)
-    exp = ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
-           'name  dtype  unit format description class',
-           '---- ------- ---- ------ ----------- -----',
-           '   a   int32        %02d                  ',
-           '   b float32                              ',
-           '   c {0}                              '.format(string8),
-           '   d float64    m        description      ',
-           '   e  object                          Time']
-    assert out.getvalue().splitlines() == exp
+    t['e'] = time.Time([1,2,3], format='mjd')
+    tinfo = t.info(out=None)
+    assert tinfo.colnames == 'name  dtype  unit format description class'.split()
+    assert np.all(tinfo['name'] == 'a b c d e'.split())
+    assert np.all(tinfo['dtype'] == ['int32', 'float32', STRING8, 'float64', 'object'])
+    assert np.all(tinfo['unit'] == ['', '', '', 'm', ''])
+    assert np.all(tinfo['format'] == ['%02d', '', '', '', ''])
+    assert np.all(tinfo['description'] == ['', '', '', 'description', ''])
+    assert np.all(tinfo['class'] == ['', '', '', '', 'Time'])
 
-def test_info_others(table_types):
+def test_info_stats(table_types):
     """
     Test the info() method of printing a summary of table column statistics
     """
     a = np.array([1, 2, 1, 2], dtype='int32')
     b = np.array([1, 2, 1, 2], dtype='float32')
     c = np.array(['a', 'c', 'e', 'f'], dtype='|S1')
-    d = time.Time([1, 2, 1, 2], format='cxcsec')
+    d = time.Time([1, 2, 1, 2], format='mjd')
     t = table_types.Table([a, b, c, d], names=['a', 'b', 'c', 'd'])
 
     # option = 'stats'
@@ -74,27 +66,21 @@ def test_info_others(table_types):
     assert out.getvalue().splitlines() == exp
 
     # option = ['attributes', 'stats']
-    out = six.moves.cStringIO()
-    t.info(['attributes', 'stats'], out=out)
-    exp = [table_header_line,
-           'name  dtype  class mean std min max',
-           '---- ------- ----- ---- --- --- ---',
-           '   a   int32        1.5 0.5   1   2',
-           '   b float32        1.5 0.5 1.0 2.0',
-           '   c string8         --  --  --  --',
-           '   d  object  Time   --  -- 1.0 2.0']
-    assert out.getvalue().splitlines() == exp
+    tinfo = t.info(['attributes', 'stats'], out=None)
+    assert tinfo.colnames == 'name  dtype  class mean std min max'.split()
+    assert np.all(tinfo['mean'] == ['1.5', '1.5', '--', '--'])
+    assert np.all(tinfo['std'] == ['0.5', '0.5', '--', '--'])
+    assert np.all(tinfo['min'] == ['1', '1.0', '--', '1.0'])
+    assert np.all(tinfo['max'] == ['2', '2.0', '--', '2.0'])
 
     # option = ['attributes', custom]
     custom = column_info_factory(names=['sum', 'first'],
                                  funcs=[np.sum, lambda col: col[0]])
     out = six.moves.cStringIO()
-    t.info(['attributes', custom], out=out)
-    exp = [table_header_line,
-           'name  dtype  class sum first',
-           '---- ------- ----- --- -----',
-           '   a   int32         6     1',
-           '   b float32       6.0   1.0',
-           '   c string8        --     a',
-           '   d  object  Time  --   1.0']
-    assert out.getvalue().splitlines() == exp
+    tinfo = t.info(['attributes', custom], out=None)
+    assert tinfo.colnames == 'name dtype class sum first'.split()
+    assert np.all(tinfo['name'] == ['a', 'b', 'c', 'd'])
+    assert np.all(tinfo['dtype'] == ['int32', 'float32', STRING8, 'object'])
+    assert np.all(tinfo['class'] == ['', '', '', 'Time'])
+    assert np.all(tinfo['sum'] == ['6', '6.0', '--', '--'])
+    assert np.all(tinfo['first'] == ['1', '1.0', 'a' if six.PY2 else "b'a'", '1.0'])

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -193,3 +193,30 @@ def test_empty_table():
     t.info(out=out)
     exp = ['<Table length=0>', '<No columns>']
     assert out.getvalue().splitlines() == exp
+
+
+def test_class_attribute():
+    """
+    Test that class info column is suppressed only for identical non-mixin
+    columns.
+    """
+    vals = [[1] * u.m, [2] * u.m]
+
+    texp = ['<Table length=1>',
+            'name  dtype  unit',
+            '---- ------- ----',
+            'col0 float64    m',
+            'col1 float64    m']
+
+    qexp = ['<QTable length=1>',
+            'name  dtype  unit  class  ',
+            '---- ------- ---- --------',
+            'col0 float64    m Quantity',
+            'col1 float64    m Quantity']
+
+    for table_cls, exp in ((table.Table, texp),
+                           (table.QTable, qexp)):
+        t = table_cls(vals)
+        out = six.moves.cStringIO()
+        t.info(out=out)
+        assert out.getvalue().splitlines() == exp

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -54,6 +54,11 @@ def test_table_info_attributes(table_types):
     cls = t.ColumnClass.__name__
     assert np.all(tinfo['class'] == [cls, cls, cls, cls, 'Time', 'SkyCoord'])
 
+    # Test that repr(t.info) is same as t.info()
+    out = six.moves.cStringIO()
+    t.info(out=out)
+    assert repr(t.info) == out.getvalue()
+
 def test_table_info_stats(table_types):
     """
     Test the info() method of printing a summary of table column statistics

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# TEST_UNICODE_LITERALS
+
+import numpy as np
+
+from ...extern import six
+from ... import units as u
+from ... import time
+
+def test_info(table_types):
+    """
+    Test the info() method of printing a table summary
+    """
+    a = np.array([1, 2, 3], dtype='int32')
+    b = np.array([1, 2, 3], dtype='float32')
+    c = np.array(['a', 'c', 'e'], dtype='|S1')
+    t = table_types.Table([a, b, c], names=['a', 'b', 'c'])
+    masked = 'masked=True ' if t.masked else ''
+    string8 = 'string8' if six.PY2 else ' bytes8'
+
+    # Minimal output for a typical table
+    out = six.moves.cStringIO()
+    t.info(out=out)
+    assert out.getvalue().splitlines() == ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
+                                           'name  dtype ',
+                                           '---- -------',
+                                           '   a   int32',
+                                           '   b float32',
+                                           '   c {0}'.format(string8)]
+
+    # All output fields including a mixin column
+    t['d'] = [1,2,3] * u.m
+    t['d'].description = 'description'
+    t['a'].format = '%02d'
+    t['e'] = time.Time([1,2,3], format='cxcsec')
+    out = six.moves.cStringIO()
+    t.info(out=out)
+    assert out.getvalue().splitlines() == ['<{0} {1}length=3>'.format(t.__class__.__name__, masked),
+                                           'name  dtype  unit format description class',
+                                           '---- ------- ---- ------ ----------- -----',
+                                           '   a   int32        %02d                  ',
+                                           '   b float32                              ',
+                                           '   c {0}                              '.format(string8),
+                                           '   d float64    m        description      ',
+                                           '   e  object                          Time']

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -9,7 +9,7 @@ from ...extern import six
 from ... import units as u
 from ... import time
 from ... import table
-from ...utils.column_info import column_info_factory
+from ...utils.data_info import data_info_factory
 from ...utils import OrderedDict
 
 STRING8 = 'string8' if six.PY2 else 'bytes8'
@@ -80,8 +80,8 @@ def test_info_stats(table_types):
     assert np.all(tinfo['max'] == ['2', '2.0', '--', '2.0'])
 
     # option = ['attributes', custom]
-    custom = column_info_factory(names=['sum', 'first'],
-                                 funcs=[np.sum, lambda col: col[0]])
+    custom = data_info_factory(names=['sum', 'first'],
+                               funcs=[np.sum, lambda col: col[0]])
     out = six.moves.cStringIO()
     tinfo = t.info(['attributes', custom], out=None)
     assert tinfo.colnames == 'name dtype class sum first'.split()
@@ -90,7 +90,7 @@ def test_info_stats(table_types):
     assert np.all(tinfo['sum'] == ['6', '6.0', '--', '--'])
     assert np.all(tinfo['first'] == ['1', '1.0', 'a' if six.PY2 else "b'a'", '1.0'])
 
-def test_column_info():
+def test_data_info():
     """
     Test getting info for just a column.
     """
@@ -133,7 +133,7 @@ def test_column_info():
                                      ('n_bad', 1),
                                      ('length', 3)])
 
-def test_column_info_subclass():
+def test_data_info_subclass():
     class Column(table.Column):
         """
         Confusingly named Column on purpose, but that is legal.

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -139,7 +139,7 @@ def test_data_info_subclass():
         Confusingly named Column on purpose, but that is legal.
         """
         pass
-    c = Column([1, 2])
+    c = Column([1, 2], dtype='int64')
     cinfo = c.info(out=None)
     assert cinfo == OrderedDict([('dtype', 'int64'),
                                  ('shape', ''),

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -378,3 +378,49 @@ def test_setitem_as_column_name():
     t['b'] = 'b'  # Previously was failing with KeyError
     assert np.all(t['a'] == ['x', 'y'])
     assert np.all(t['b'] == ['b', 'b'])
+
+
+def test_quantity_representation():
+    """
+    Test that table representation of quantities does not have unit
+    """
+    t = QTable([[1, 2] * u.m])
+    assert t.pformat() == ['col0',
+                           ' m  ',
+                           '----',
+                           ' 1.0',
+                           ' 2.0']
+
+
+def test_skycoord_representation():
+    """
+    Test that skycoord representation works, both in the way that the
+    values are output and in changing the frame representation.
+    """
+    # With no unit we get "None" in the unit row
+    c = coordinates.SkyCoord([0], [1], [0], representation='cartesian')
+    t = Table([c])
+    assert t.pformat() == ['     col0     ',
+                           'None,None,None',
+                           '--------------',
+                           '   0.0,1.0,0.0']
+
+    # Test that info works with a dynamically changed representation
+    c = coordinates.SkyCoord([0], [1], [0], unit='m', representation='cartesian')
+    t = Table([c])
+    assert t.pformat() == ['    col0   ',
+                           '   m,m,m   ',
+                           '-----------',
+                           '0.0,1.0,0.0']
+
+    t['col0'].representation = 'unitspherical'
+    assert t.pformat() == ['  col0  ',
+                           'deg,deg ',
+                           '--------',
+                           '90.0,0.0']
+
+    t['col0'].representation = 'cylindrical'
+    assert t.pformat() == ['    col0    ',
+                           '  m,deg,m   ',
+                           '------------',
+                           '1.0,90.0,0.0']

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -20,8 +20,9 @@ import numpy as np
 
 from ...tests.helper import pytest
 from ...table import Table, QTable, join, hstack, vstack
-from ... import units as u
+from ... import time
 from ... import coordinates
+from ... import units as u
 from .. import table_helpers
 from .conftest import MIXIN_COLS
 
@@ -37,9 +38,13 @@ def test_attributes(mixin_cols):
     m.info.description = 'a'
     assert m.info.description == 'a'
 
-    if not isinstance(m, u.Quantity):
+    # Cannot set unit for these classes
+    if isinstance(m, (u.Quantity, coordinates.SkyCoord, time.Time)):
+        with pytest.raises(AttributeError):
+            m.info.unit = u.m
+    else:
         m.info.unit = u.m
-    assert m.info.unit is u.m
+        assert m.info.unit is u.m
 
     m.info.format = 'a'
     assert m.info.format == 'a'

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from ...tests.helper import pytest
 from ...table import Table, QTable, join, hstack, vstack
-from ..column import col_setattr, col_getattr
 from ... import units as u
 from ... import coordinates
 from .. import table_helpers
@@ -32,27 +31,27 @@ def test_attributes(mixin_cols):
     Required attributes for a column can be set.
     """
     m = mixin_cols['m']
-    col_setattr(m, 'name', 'a')
-    assert col_getattr(m, 'name') == 'a'
+    m.info.name = 'a'
+    assert m.info.name == 'a'
 
-    col_setattr(m, 'description', 'a')
-    assert col_getattr(m, 'description') == 'a'
+    m.info.description = 'a'
+    assert m.info.description == 'a'
 
     if not isinstance(m, u.Quantity):
-        col_setattr(m, 'unit', u.m)
-    assert col_getattr(m, 'unit') is u.m
+        m.info.unit = u.m
+    assert m.info.unit is u.m
 
-    col_setattr(m, 'format', 'a')
-    assert col_getattr(m, 'format') == 'a'
+    m.info.format = 'a'
+    assert m.info.format == 'a'
 
-    col_setattr(m, 'meta', {'a': 1})
-    assert col_getattr(m, 'meta') == {'a': 1}
-
-    with pytest.raises(AttributeError):
-        col_setattr(m, 'bad_attr', 1)
+    m.info.meta = {'a': 1}
+    assert m.info.meta == {'a': 1}
 
     with pytest.raises(AttributeError):
-        col_getattr(m, 'bad_attr')
+        m.info.bad_attr = 1
+
+    with pytest.raises(AttributeError):
+        m.info.bad_attr
 
 
 def check_mixin_type(table, table_col, in_col):
@@ -62,7 +61,7 @@ def check_mixin_type(table, table_col, in_col):
         assert type(table_col) is type(in_col)
 
     # Make sure in_col got copied and creating table did not touch it
-    assert col_getattr(in_col, 'name') is None
+    assert in_col.info.name is None
 
 def test_make_table(table_types, mixin_cols):
     """
@@ -128,8 +127,8 @@ def test_join(table_types):
     t2['a'] = ['b', 'c', 'a', 'd']
 
     for name, col in MIXIN_COLS.items():
-        col_setattr(t1[name], 'description', name)
-        col_setattr(t2[name], 'description', name + '2')
+        t1[name].info.description = name
+        t2[name].info.description = name + '2'
 
     for join_type in ('inner', 'left'):
         t12 = join(t1, t2, keys='a', join_type=join_type)
@@ -140,8 +139,8 @@ def test_join(table_types):
             name2 = name + '_2'
             assert_table_name_col_equal(t12, name1, col[idx1])
             assert_table_name_col_equal(t12, name2, col[idx2])
-            assert col_getattr(t12[name1], 'description') == name
-            assert col_getattr(t12[name2], 'description') == name + '2'
+            assert t12[name1].info.description == name
+            assert t12[name2].info.description == name + '2'
 
     for join_type in ('outer', 'right'):
         with pytest.raises(ValueError) as exc:
@@ -165,8 +164,8 @@ def test_hstack(table_types):
     t1['i'] = table_types.Column([0, 1, 2, 3])
     for name, col in MIXIN_COLS.items():
         t1[name] = col
-        col_setattr(t1[name], 'description', name)
-        col_setattr(t1[name], 'meta', {'a': 1})
+        t1[name].info.description = name
+        t1[name].info.meta = {'a': 1}
 
     for join_type in ('inner', 'outer'):
         for chop in (True, False):
@@ -188,8 +187,8 @@ def test_hstack(table_types):
                 assert_table_name_col_equal(t12, name1, col[idx1])
                 assert_table_name_col_equal(t12, name2, col[idx2])
                 for attr in ('description', 'meta'):
-                    assert col_getattr(t1[name], attr) == col_getattr(t12[name1], attr)
-                    assert col_getattr(t2[name], attr) == col_getattr(t12[name2], attr)
+                    assert getattr(t1[name].info, attr) == getattr(t12[name1].info, attr)
+                    assert getattr(t2[name].info, attr) == getattr(t12[name2].info, attr)
 
 
 def assert_table_name_col_equal(t, name, col):
@@ -213,16 +212,16 @@ def test_get_items(mixin_cols):
     """
     attrs = ('name', 'unit', 'dtype', 'format', 'description', 'meta')
     m = mixin_cols['m']
-    col_setattr(m, 'name', 'm')
-    col_setattr(m, 'format', '{0}')
-    col_setattr(m, 'description', 'd')
-    col_setattr(m, 'meta', {'a': 1})
+    m.info.name = 'm'
+    m.info.format = '{0}'
+    m.info.description = 'd'
+    m.info.meta = {'a': 1}
     t = QTable([m])
     for item in ([1, 3], np.array([0, 2]), slice(1, 3)):
         t2 = t[item]
         assert_table_name_col_equal(t2, 'm', m[item])
         for attr in attrs:
-            assert col_getattr(t2['m'], attr) == col_getattr(m, attr)
+            assert getattr(t2['m'].info, attr) == getattr(m.info, attr)
 
 def test_add_column(mixin_cols):
     """
@@ -230,32 +229,32 @@ def test_add_column(mixin_cols):
     """
     attrs = ('name', 'unit', 'dtype', 'format', 'description', 'meta')
     m = mixin_cols['m']
-    assert col_getattr(m, 'name') is None
+    assert m.info.name is None
 
     # Make sure adding column in various ways doesn't touch
     t = QTable([m], names=['a'])
-    assert col_getattr(m, 'name') is None
+    assert m.info.name is None
 
     t['new'] = m
-    assert col_getattr(m, 'name') is None
+    assert m.info.name is None
 
-    col_setattr(m, 'name', 'm')
-    col_setattr(m, 'format', '{0}')
-    col_setattr(m, 'description', 'd')
-    col_setattr(m, 'meta', {'a': 1})
+    m.info.name = 'm'
+    m.info.format = '{0}'
+    m.info.description = 'd'
+    m.info.meta = {'a': 1}
     t = QTable([m])
 
     # Add columns m2 and m3 by two different methods and test expected equality
     t['m2'] = m
-    col_setattr(m, 'name', 'm3')
+    m.info.name = 'm3'
     t.add_columns([m], copy=True)
-    col_setattr(m, 'name', 'm4')
+    m.info.name = 'm4'
     t.add_columns([m], copy=False)
     for name in ('m2', 'm3', 'm4'):
         assert_table_name_col_equal(t, 'm', t[name])
         for attr in attrs:
             if attr != 'name':
-                assert col_getattr(t['m'], attr) == col_getattr(t[name], attr)
+                assert getattr(t['m'].info, attr) == getattr(t[name].info, attr)
 
 def test_vstack():
     """
@@ -271,11 +270,11 @@ def test_insert_row(mixin_cols):
     Test inserting a row, which only works for BaseColumn and Quantity
     """
     t = QTable(mixin_cols)
-    col_setattr(t['m'], 'description', 'd')
+    t['m'].info.description = 'd'
     if isinstance(t['m'], u.Quantity):
         t.insert_row(1, t[-1])
         assert t[1] == t[-1]
-        assert col_getattr(t['m'], 'description') == 'd'
+        assert t['m'].info.description == 'd'
     else:
         with pytest.raises(ValueError) as exc:
             t.insert_row(1, t[-1])
@@ -339,11 +338,11 @@ def test_conversion_qtable_table():
     qt = QTable(MIXIN_COLS)
     names = qt.colnames
     for name in names:
-        col_setattr(qt[name], 'description', name)
+        qt[name].info.description = name
 
     t = Table(qt)
     for name in names:
-        assert col_getattr(t[name], 'description') == name
+        assert t[name].info.description == name
         if name == 'quantity':
             assert np.all(t['quantity'] == qt['quantity'].value)
             assert np.all(t['quantity'].unit is qt['quantity'].unit)
@@ -353,7 +352,7 @@ def test_conversion_qtable_table():
 
     qt2 = QTable(qt)
     for name in names:
-        assert col_getattr(qt2[name], 'description') == name
+        assert qt2[name].info.description == name
         assert_table_name_col_equal(qt2, name, qt[name])
 
 @pytest.mark.xfail

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,7 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
-from ..utils.data_info import DataInfo, BaseInfo, data_info_factory
+from ..utils.data_info import InfoDescriptor, DataInfo, data_info_factory
 from ..extern import six
 
 
@@ -114,7 +114,7 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa_time.gst94, 'scales': ('ut1',)}}}
 
 
-class TimeInfo(BaseInfo):
+class TimeInfo(DataInfo):
     """
     Make dtype and unit be None and be read-only.  Setting attrs_from_parent
     to these read-only values is needed so they don't get copied.
@@ -126,10 +126,10 @@ class TimeInfo(BaseInfo):
         return None
 
     info_summary_stats = staticmethod(
-        data_info_factory(names=BaseInfo._stats,
-                          funcs=[getattr(np, stat) for stat in BaseInfo._stats]))
+        data_info_factory(names=DataInfo._stats,
+                          funcs=[getattr(np, stat) for stat in DataInfo._stats]))
     # When Time has mean, std, min, max methods:
-    # funcs = [lambda x: getattr(x, stat)() for stat_name in BaseInfo._stats])
+    # funcs = [lambda x: getattr(x, stat)() for stat_name in DataInfo._stats])
 
 class Time(object):
     """
@@ -330,7 +330,7 @@ class Time(object):
         dtnow = datetime.utcnow()
         return cls(val=dtnow, format='datetime', scale='utc')
 
-    info = DataInfo(TimeInfo)
+    info = InfoDescriptor(TimeInfo)
 
     @property
     def format(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -319,7 +319,7 @@ class Time(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            self._info = ColumnInfo()
+            self._info = ColumnInfo(self)
         return self._info
 
     @property

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -116,10 +116,10 @@ SIDEREAL_TIME_MODELS = {
 
 class TimeInfo(BaseInfo):
     """
-    Make dtype and unit be None and be read-only.  Setting _attrs_from_parent
+    Make dtype and unit be None and be read-only.  Setting attrs_from_parent
     to these read-only values is needed so they don't get copied.
     """
-    _attrs_from_parent = set(['unit'])
+    attrs_from_parent = set(['unit'])
 
     @property
     def unit(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -24,6 +24,7 @@ from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
 from ..utils.column_info import ColumnInfo
+from ..utils import lazyproperty
 from ..extern import six
 
 
@@ -313,14 +314,9 @@ class Time(object):
         dtnow = datetime.utcnow()
         return cls(val=dtnow, format='datetime', scale='utc')
 
-    @property
+    @lazyproperty
     def info(self):
-        """
-        Mixin column information (attributes)
-        """
-        if not hasattr(self, '_info'):
-            self._info = ColumnInfo(self)
-        return self._info
+        return ColumnInfo(self)
 
     @property
     def format(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,6 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
+from ..utils.column_info import ColumnInfo
 from ..extern import six
 
 
@@ -318,7 +319,6 @@ class Time(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            from ..table import ColumnInfo
             self._info = ColumnInfo()
         return self._info
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -116,10 +116,11 @@ SIDEREAL_TIME_MODELS = {
 
 class TimeInfo(DataInfo):
     """
-    Make dtype and unit be None and be read-only.  Setting attrs_from_parent
-    to these read-only values is needed so they don't get copied.
+    Container for meta information like name, description, format.  This is
+    required when the object is used as a mixin column within a table, but can
+    be used as a general way to store meta information.
     """
-    attrs_from_parent = set(['unit'])
+    attrs_from_parent = set(['unit'])  # unit is read-only and None
 
     @property
     def unit(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,7 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
-from ..utils.column_info import DataInfo, BaseInfo, column_info_factory
+from ..utils.data_info import DataInfo, BaseInfo, data_info_factory
 from ..extern import six
 
 
@@ -126,8 +126,8 @@ class TimeInfo(BaseInfo):
         return None
 
     info_summary_stats = staticmethod(
-        column_info_factory(names=BaseInfo._stats,
-                            funcs=[getattr(np, stat) for stat in BaseInfo._stats]))
+        data_info_factory(names=BaseInfo._stats,
+                          funcs=[getattr(np, stat) for stat in BaseInfo._stats]))
     # When Time has mean, std, min, max methods:
     # funcs = [lambda x: getattr(x, stat)() for stat_name in BaseInfo._stats])
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,7 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
-from ..utils.column_info import DataInfo, BaseDataInfo, column_info_factory
+from ..utils.column_info import DataInfo, BaseInfo, column_info_factory
 from ..extern import six
 
 
@@ -114,7 +114,7 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa_time.gst94, 'scales': ('ut1',)}}}
 
 
-class TimeInfo(BaseDataInfo):
+class TimeInfo(BaseInfo):
     """
     Make dtype and unit be None and be read-only.  Setting _attrs_from_parent
     to these read-only values is needed so they don't get copied.
@@ -126,10 +126,10 @@ class TimeInfo(BaseDataInfo):
         return None
 
     info_summary_stats = staticmethod(
-        column_info_factory(names=BaseDataInfo._stats,
-                            funcs=[getattr(np, stat) for stat in BaseDataInfo._stats]))
+        column_info_factory(names=BaseInfo._stats,
+                            funcs=[getattr(np, stat) for stat in BaseInfo._stats]))
     # When Time has mean, std, min, max methods:
-    # funcs = [lambda x: getattr(x, stat)() for stat_name in BaseDataInfo._stats])
+    # funcs = [lambda x: getattr(x, stat)() for stat_name in BaseInfo._stats])
 
 class Time(object):
     """

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,8 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
-from ..utils.column_info import ColumnInfo
-from ..utils import lazyproperty
+from ..utils.column_info import DataInfo, BaseDataInfo
 from ..extern import six
 
 
@@ -115,7 +114,7 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa_time.gst94, 'scales': ('ut1',)}}}
 
 
-class TimeColumnInfo(ColumnInfo):
+class TimeDataInfo(BaseDataInfo):
     """
     Make dtype and unit be None and be read-only.  Setting _attrs_from_parent
     to these read-only values is needed so they don't get copied.
@@ -326,9 +325,7 @@ class Time(object):
         dtnow = datetime.utcnow()
         return cls(val=dtnow, format='datetime', scale='utc')
 
-    @lazyproperty
-    def info(self):
-        return TimeColumnInfo(self)
+    info = DataInfo(TimeDataInfo)
 
     @property
     def format(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -318,8 +318,8 @@ class Time(object):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            from ..table import ColumnAttributes
-            self._info = ColumnAttributes()
+            from ..table import ColumnInfo
+            self._info = ColumnInfo()
         return self._info
 
     @property

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,7 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
-from ..utils.column_info import DataInfo, BaseDataInfo
+from ..utils.column_info import DataInfo, BaseDataInfo, column_info_factory
 from ..extern import six
 
 
@@ -114,7 +114,7 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa_time.gst94, 'scales': ('ut1',)}}}
 
 
-class TimeDataInfo(BaseDataInfo):
+class TimeInfo(BaseDataInfo):
     """
     Make dtype and unit be None and be read-only.  Setting _attrs_from_parent
     to these read-only values is needed so they don't get copied.
@@ -125,6 +125,11 @@ class TimeDataInfo(BaseDataInfo):
     def unit(self):
         return None
 
+    info_summary_stats = staticmethod(
+        column_info_factory(names=BaseDataInfo._stats,
+                            funcs=[getattr(np, stat) for stat in BaseDataInfo._stats]))
+    # When Time has mean, std, min, max methods:
+    # funcs = [lambda x: getattr(x, stat)() for stat_name in BaseDataInfo._stats])
 
 class Time(object):
     """
@@ -325,7 +330,7 @@ class Time(object):
         dtnow = datetime.utcnow()
         return cls(val=dtnow, format='datetime', scale='utc')
 
-    info = DataInfo(TimeDataInfo)
+    info = DataInfo(TimeInfo)
 
     @property
     def format(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -115,6 +115,18 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa_time.gst94, 'scales': ('ut1',)}}}
 
 
+class TimeColumnInfo(ColumnInfo):
+    """
+    Make dtype and unit be None and be read-only.  Setting _attrs_from_parent
+    to these read-only values is needed so they don't get copied.
+    """
+    _attrs_from_parent = set(['unit'])
+
+    @property
+    def unit(self):
+        return None
+
+
 class Time(object):
     """
     Represent and manipulate times and dates for astronomy.
@@ -316,7 +328,7 @@ class Time(object):
 
     @lazyproperty
     def info(self):
-        return ColumnInfo(self)
+        return TimeColumnInfo(self)
 
     @property
     def format(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -313,6 +313,16 @@ class Time(object):
         return cls(val=dtnow, format='datetime', scale='utc')
 
     @property
+    def info(self):
+        """
+        Mixin column information (attributes)
+        """
+        if not hasattr(self, '_info'):
+            from ..table import ColumnAttributes
+            self._info = ColumnAttributes()
+        return self._info
+
+    @property
     def format(self):
         """Get time format"""
         return self._format

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,7 +24,7 @@ from ..utils import lazyproperty
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.data_info import BaseInfo, DataInfo
+from ..utils.data_info import DataInfo, InfoDescriptor
 from .utils import validate_power
 from .. import config as _config
 
@@ -115,7 +115,7 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityInfo(BaseInfo):
+class QuantityInfo(DataInfo):
     attrs_from_parent = set(['dtype', 'unit'])
 
     def default_format_func(self, format, val):
@@ -615,7 +615,7 @@ class Quantity(np.ndarray):
             self.unit.to(unit, self.value, equivalencies=equivalencies))
         return self._new_view(new_val, unit)
 
-    info = DataInfo(QuantityInfo)
+    info = InfoDescriptor(QuantityInfo)
 
     @property
     def value(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -116,9 +116,15 @@ class QuantityIterator(object):
 
 
 class QuantityInfo(DataInfo):
-    attrs_from_parent = set(['dtype', 'unit'])
+    """
+    Container for meta information like name, description, format.  This is
+    required when the object is used as a mixin column within a table, but can
+    be used as a general way to store meta information.
+    """
+    attrs_from_parent = set(['dtype', 'unit'])  # dtype and unit taken from parent
 
-    def default_format_func(self, format, val):
+    @staticmethod
+    def default_format(val):
         return '{0.value:}'.format(val)
 
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -608,6 +608,15 @@ class Quantity(np.ndarray):
         return self._new_view(new_val, unit)
 
     @property
+    def info(self):
+        if not hasattr(self, '_info'):
+            from ..table import column
+            class ColumnAttributes(column.ColumnAttributes):
+                cols_from_parent = set(['dtype', 'unit'])
+            self._info = ColumnAttributes(self)
+        return self._info
+
+    @property
     def value(self):
         """ The numerical value of this quantity. """
         value = self.view(np.ndarray)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -115,6 +115,16 @@ class QuantityIterator(object):
     next = __next__
 
 
+class QuantityColumnInfo(ColumnInfo):
+    _attrs_from_parent = set(['dtype', 'unit'])
+
+    def __init__(self, *args, **kwargs):
+        super(QuantityColumnInfo, self).__init__(*args, **kwargs)
+
+    def default_format_func(self, format, val):
+        return '{0.value:}'.format(val)
+
+
 @six.add_metaclass(InheritDocstrings)
 class Quantity(np.ndarray):
     """ A `~astropy.units.Quantity` represents a number with some associated unit.
@@ -614,7 +624,7 @@ class Quantity(np.ndarray):
         Mixin column information (attributes)
         """
         if not hasattr(self, '_info'):
-            self._info = ColumnInfo(self, attrs_from_parent=['dtype', 'unit'])
+            self._info = QuantityColumnInfo(self)
         return self._info
 
     @property

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,7 +24,7 @@ from ..utils import lazyproperty
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.column_info import ColumnInfo
+from ..utils.column_info import BaseDataInfo, DataInfo
 from .utils import validate_power
 from .. import config as _config
 
@@ -115,7 +115,7 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityColumnInfo(ColumnInfo):
+class QuantityInfo(BaseDataInfo):
     _attrs_from_parent = set(['dtype', 'unit'])
 
     def default_format_func(self, format, val):
@@ -615,9 +615,7 @@ class Quantity(np.ndarray):
             self.unit.to(unit, self.value, equivalencies=equivalencies))
         return self._new_view(new_val, unit)
 
-    @lazyproperty
-    def info(self):
-        return QuantityColumnInfo(self)
+    info = DataInfo(QuantityInfo)
 
     @property
     def value(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,7 +24,7 @@ from ..utils import lazyproperty
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.column_info import BaseDataInfo, DataInfo
+from ..utils.column_info import BaseInfo, DataInfo
 from .utils import validate_power
 from .. import config as _config
 
@@ -115,7 +115,7 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityInfo(BaseDataInfo):
+class QuantityInfo(BaseInfo):
     _attrs_from_parent = set(['dtype', 'unit'])
 
     def default_format_func(self, format, val):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -615,14 +615,9 @@ class Quantity(np.ndarray):
             self.unit.to(unit, self.value, equivalencies=equivalencies))
         return self._new_view(new_val, unit)
 
-    @property
+    @lazyproperty
     def info(self):
-        """
-        Mixin column information (attributes)
-        """
-        if not hasattr(self, '_info'):
-            self._info = QuantityColumnInfo(self)
-        return self._info
+        return QuantityColumnInfo(self)
 
     @property
     def value(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,6 +24,7 @@ from ..utils import lazyproperty
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
+from ..utils.column_info import ColumnInfo
 from .utils import validate_power
 from .. import config as _config
 
@@ -49,6 +50,10 @@ class Conf(_config.ConfigNamespace):
         'negative number means that the value will instead be whatever numpy '
         'gets from get_printoptions.')
 conf = Conf()
+
+
+class QuantityColumnInfo(ColumnInfo):
+    cols_from_parent = set(['dtype', 'unit'])
 
 
 def _can_have_arbitrary_unit(value):
@@ -610,10 +615,7 @@ class Quantity(np.ndarray):
     @property
     def info(self):
         if not hasattr(self, '_info'):
-            from ..table import column
-            class ColumnInfo(column.ColumnInfo):
-                cols_from_parent = set(['dtype', 'unit'])
-            self._info = ColumnInfo(self)
+            self._info = QuantityColumnInfo(self)
         return self._info
 
     @property

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -52,10 +52,6 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-class QuantityColumnInfo(ColumnInfo):
-    cols_from_parent = set(['dtype', 'unit'])
-
-
 def _can_have_arbitrary_unit(value):
     """Test whether the items in value can have arbitrary units
 
@@ -614,8 +610,11 @@ class Quantity(np.ndarray):
 
     @property
     def info(self):
+        """
+        Mixin column information (attributes)
+        """
         if not hasattr(self, '_info'):
-            self._info = QuantityColumnInfo(self)
+            self._info = ColumnInfo(self, attrs_from_parent=['dtype', 'unit'])
         return self._info
 
     @property

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -611,9 +611,9 @@ class Quantity(np.ndarray):
     def info(self):
         if not hasattr(self, '_info'):
             from ..table import column
-            class ColumnAttributes(column.ColumnAttributes):
+            class ColumnInfo(column.ColumnInfo):
                 cols_from_parent = set(['dtype', 'unit'])
-            self._info = ColumnAttributes(self)
+            self._info = ColumnInfo(self)
         return self._info
 
     @property

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -116,7 +116,7 @@ class QuantityIterator(object):
 
 
 class QuantityInfo(BaseInfo):
-    _attrs_from_parent = set(['dtype', 'unit'])
+    attrs_from_parent = set(['dtype', 'unit'])
 
     def default_format_func(self, format, val):
         return '{0.value:}'.format(val)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,7 +24,7 @@ from ..utils import lazyproperty
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.column_info import BaseInfo, DataInfo
+from ..utils.data_info import BaseInfo, DataInfo
 from .utils import validate_power
 from .. import config as _config
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -118,9 +118,6 @@ class QuantityIterator(object):
 class QuantityColumnInfo(ColumnInfo):
     _attrs_from_parent = set(['dtype', 'unit'])
 
-    def __init__(self, *args, **kwargs):
-        super(QuantityColumnInfo, self).__init__(*args, **kwargs)
-
     def default_format_func(self, format, val):
         return '{0.value:}'.format(val)
 

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -8,8 +8,6 @@ from functools import partial
 from ..extern import six
 from ..utils import OrderedDict
 
-INFO_SUMMARY_ATTRS = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
-
 
 def column_info_factory(names, funcs):
     """
@@ -117,6 +115,7 @@ class BaseInfo(object):
     attrs_from_parent = set()
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description',
                       'meta', 'parent_table'])
+    _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
     _parent_ref = None
 
     def __init__(self):
@@ -189,9 +188,9 @@ class BaseInfo(object):
         return out
 
     info_summary_attributes = staticmethod(
-        column_info_factory(names=INFO_SUMMARY_ATTRS,
+        column_info_factory(names=_info_summary_attrs,
                             funcs=[partial(_get_column_attribute, attr=attr)
-                                   for attr in INFO_SUMMARY_ATTRS]))
+                                   for attr in _info_summary_attrs]))
 
     info_summary_stats = staticmethod(
         column_info_factory(names=_stats,

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -142,8 +142,8 @@ class ColumnInfo(object):
                                    for attr in ('dtype', 'unit', 'format', 'description', 'class')]))
 
     info_summary_stats = staticmethod(
-        column_info_factory(names=['min', 'mean', 'max'],
-                            funcs=[np.min, np.mean, np.max]))
+        column_info_factory(names=['min', 'mean', 'std', 'max'],
+                            funcs=[np.min, np.mean, np.std, np.max]))
 
     def __call__(self, option='attributes', out=''):
         """

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -100,6 +100,7 @@ class BaseDataInfo(object):
     _parent_col = None
     # By default the unit and dtype attributes should refer to the parent properties
     _attrs_from_parent = set()
+    _stats = ['mean', 'std', 'min', 'max']
 
     def __init__(self):
         self._attrs = dict((attr, None) for attr in COLUMN_ATTRS)
@@ -174,8 +175,8 @@ class BaseDataInfo(object):
                                    for attr in INFO_SUMMARY_ATTRS]))
 
     info_summary_stats = staticmethod(
-        column_info_factory(names=['mean', 'std', 'min', 'max'],
-                            funcs=[np.nanmean, np.nanstd, np.nanmin, np.nanmax]))
+        column_info_factory(names=_stats,
+                            funcs=[getattr(np, 'nan' + stat) for stat in _stats]))
 
     def __call__(self, option='attributes', out=''):
         """

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -19,7 +19,7 @@ def column_info_factory(names, funcs):
 
     Examples
     --------
-    >>> from astropy.table.info import column_info_factory
+    >>> from astropy.utils.column_info import column_info_factory
     >>> from astropy.table import Column
     >>> c = Column([4., 3., 2., 1.])
     >>> mystats = column_info_factory(names=['min', 'median', 'max'],
@@ -28,6 +28,8 @@ def column_info_factory(names, funcs):
     min = 1.0
     median = 2.5
     max = 4.0
+    n_bad = 0
+    length = 4
 
     Parameters
     ----------
@@ -201,16 +203,22 @@ class BaseDataInfo(object):
         --------
 
         >>> from astropy.table import Column
-        >>> c = Column([1, 2, 3], unit='m', dtype='int32')
+        >>> c = Column([1, 2], unit='m', dtype='int32')
         >>> c.info()
-        dtype = int64
+        dtype = int32
         unit = m
+        n_bad = 0
+        length = 2
+
         >>> c.info(['attributes', 'stats'])
         dtype = int32
         unit = m
+        mean = 1.5
+        std = 0.5
         min = 1
-        mean = 2.0
-        max = 3
+        max = 2
+        n_bad = 0
+        length = 2
 
         Parameters
         ----------

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -146,8 +146,8 @@ class ColumnInfo(object):
                                    for attr in INFO_SUMMARY_ATTRS]))
 
     info_summary_stats = staticmethod(
-        column_info_factory(names=['min', 'mean', 'std', 'max'],
-                            funcs=[np.min, np.mean, np.std, np.max]))
+        column_info_factory(names=['mean', 'std', 'min', 'max'],
+                            funcs=[np.mean, np.std, np.min, np.max]))
 
     def __call__(self, option='attributes', out=''):
         """

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from copy import deepcopy
 import weakref
@@ -228,4 +229,4 @@ class ColumnInfo(object):
 
         for key, val in info.items():
             if val != '':
-                out.write('{0} = {1}\n'.format(key, val))
+                out.write('{0} = {1}'.format(key, val) + os.linesep)

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -1,28 +1,82 @@
+import sys
 from copy import deepcopy
 import weakref
 import numpy as np
 
+from ..extern import six
+from ..utils import OrderedDict
+
 COLUMN_ATTRS = set(['name', 'unit', 'dtype', 'format', 'description', 'meta', 'parent_table'])
 
-class ColumnInfo(object):
-    cols_from_parent = set()
 
-    def __init__(self, parent_col=None):
-        self._attrs = dict((attr, None) for attr in COLUMN_ATTRS)
+def column_info_factory(names, funcs):
+    """
+    Factory to create a function that can be used as an ``option``
+    for outputting table or column summary information.
+
+    Examples
+    --------
+    >>> from astropy.table.info import column_info_factory
+    >>> from astropy.table import Column
+    >>> c = Column([4., 3., 2., 1.])
+    >>> mystats = column_info_factory(names=['min', 'median', 'max'],
+    ...                               funcs=[np.min, np.median, np.max])
+    >>> c.info(option=mystats)
+    min = 1.0
+    median = 2.5
+    max = 4.0
+
+    Parameters
+    ----------
+    names: list
+        List of information attribute names
+    funcs: list
+        List of functions that compute the corresponding information attribute
+
+    Returns
+    -------
+    func: function
+        Function that can be used as a table or column info option
+    """
+    def func(col):
+        outs = []
+        for name, func in zip(names, funcs):
+            try:
+                if isinstance(func, six.string_types):
+                    out = getattr(col, func)()
+                else:
+                    out = func(col)
+            except:
+                outs.append('--')
+            else:
+                outs.append(str(out))
+
+        return OrderedDict(zip(names, outs))
+    return func
+
+
+class ColumnInfo(object):
+    _parent_col = None
+    _attrs_from_parent = set()
+
+    def __init__(self, parent_col=None, attrs_from_parent=None):
         if parent_col is not None:
             self._parent_col = weakref.ref(parent_col)
+        if attrs_from_parent is not None:
+            self._attrs_from_parent = set(attrs_from_parent)
+        self._attrs = dict((attr, None) for attr in COLUMN_ATTRS)
 
     def __getstate__(self):
-        return self._attrs
+        return (self._attrs, self._attrs_from_parent)
 
     def __setstate__(self, state):
-        self._attrs = state
+        self._attrs, self._attrs_from_parent = state
 
     def __getattr__(self, attr):
         if attr.startswith('_'):
             return super(ColumnInfo, self).__getattribute__(attr)
 
-        if attr in self.cols_from_parent:
+        if attr in self._attrs_from_parent:
             return getattr(self._parent_col(), attr)
 
         try:
@@ -41,7 +95,7 @@ class ColumnInfo(object):
         return value
 
     def __setattr__(self, attr, value):
-        if attr in self.cols_from_parent:
+        if attr in self._attrs_from_parent:
             setattr(self._parent_col(), attr, value)
             return
 
@@ -58,9 +112,106 @@ class ColumnInfo(object):
         self._attrs[attr] = value
 
     def copy(self):
-        out = self.__class__()
-        for attr in COLUMN_ATTRS - self.cols_from_parent:
+        out = self.__class__(attrs_from_parent=self._attrs_from_parent)
+        for attr in COLUMN_ATTRS - self._attrs_from_parent:
             setattr(out, attr, deepcopy(getattr(self, attr)))
 
         return out
 
+    @staticmethod
+    def info_summary_attributes(col):
+        """
+        Info function that returns basic metadata.
+        """
+        from ..table.column import BaseColumn
+
+        attrs = ('dtype', 'unit', 'format', 'description', 'class')
+        info = OrderedDict()
+        for attr in attrs:
+            if attr == 'class':
+                val = '' if isinstance(col, BaseColumn) else col.__class__.__name__
+            elif attr == 'dtype':
+                val = col.info.dtype.name
+            else:
+                val = getattr(col.info, attr)
+            if val is None:
+                val = ''
+            info[attr] = str(val)
+
+        return info
+
+    info_summary_stats = staticmethod(
+        column_info_factory(names=['min', 'mean', 'max'],
+                            funcs=[np.min, np.mean, np.max]))
+
+    def __call__(self, option='attributes', out=''):
+        """
+        Write summary information about column to the ``out`` filehandle.
+        By default this prints to standard output via sys.stdout.
+
+        The ``option` argument specifies what type of information
+        to include.  This can be a string, a function, or a list of
+        strings or functions.  Built-in options are:
+
+        - ``attributes``: column attributes like ``dtype`` and ``format``
+        - ``stats``: basic statistics: min, mean, and max
+
+        If a function is specified then that function will be called with the
+        column as its single argument.  The function must return an OrderedDict
+        containing the information attributes.
+
+        If a list is provided then the information attributes will be
+        appended for each of the options, in order.
+
+        Examples
+        --------
+
+        >>> from astropy.table import Column
+        >>> c = Column([1, 2, 3], unit='m', dtype='int32')
+        >>> c.info()
+        dtype = int64
+        unit = m
+        >>> c.info(['attributes', 'stats'])
+        dtype = int32
+        unit = m
+        min = 1
+        mean = 2.0
+        max = 3
+
+        Parameters
+        ----------
+        option: str, function, list of (str or function)
+            Info option (default='attributes')
+        out: file-like object, None
+            Output destination (default=sys.stdout).  If None then the
+            OrderedDict with information attributes is returned
+
+        Returns
+        -------
+        info: OrderedDict if out==None else None
+        """
+        if out == '':
+            out = sys.stdout
+
+        col = self._parent_col()
+        info = OrderedDict()
+        name = col.info.name
+        if name is not None:
+            info['name'] = name
+
+        options = option if isinstance(option, (list, tuple)) else [option]
+        for option in options:
+            if isinstance(option, six.string_types):
+                if hasattr(self, 'info_summary_' + option):
+                    option = getattr(self, 'info_summary_' + option)
+                else:
+                    raise ValueError('option={0} is not an allowed information type'
+                                     .format(option))
+            info.update(option(col))
+
+        if out is None:
+            return info
+
+        for key, val in info.items():
+            if val != '':
+                out.write('{0} = {1}\n'.format(key, val))

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -147,7 +147,7 @@ class ColumnInfo(object):
 
     info_summary_stats = staticmethod(
         column_info_factory(names=['mean', 'std', 'min', 'max'],
-                            funcs=[np.mean, np.std, np.min, np.max]))
+                            funcs=[np.nanmean, np.nanstd, np.nanmin, np.nanmax]))
 
     def __call__(self, option='attributes', out=''):
         """

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -92,13 +92,13 @@ class DataInfo(object):
         return instance.__dict__['info']
 
     def __set__(self, instance, value):
-        if isinstance(value, BaseDataInfo):
+        if isinstance(value, BaseInfo):
             instance.__dict__['info'] = value
         else:
-            raise TypeError('info must be set with a BaseDataInfo instance')
+            raise TypeError('info must be set with a BaseInfo instance')
 
 
-class BaseDataInfo(object):
+class BaseInfo(object):
     _parent_col = None
     # By default the unit and dtype attributes should refer to the parent properties
     _attrs_from_parent = set()
@@ -115,7 +115,7 @@ class BaseDataInfo(object):
 
     def __getattr__(self, attr):
         if attr.startswith('_'):
-            return super(BaseDataInfo, self).__getattribute__(attr)
+            return super(BaseInfo, self).__getattribute__(attr)
 
         if attr in self._attrs_from_parent:
             return getattr(self._parent_col(), attr)
@@ -123,7 +123,7 @@ class BaseDataInfo(object):
         try:
             value = self._attrs[attr]
         except KeyError:
-            super(BaseDataInfo, self).__getattribute__(attr)  # Generate AttributeError
+            super(BaseInfo, self).__getattribute__(attr)  # Generate AttributeError
 
         # Weak ref for parent table
         if attr == 'parent_table' and callable(value):
@@ -153,7 +153,7 @@ class BaseDataInfo(object):
             return
 
         if attr.startswith('_'):
-            super(BaseDataInfo, self).__setattr__(attr, value)
+            super(BaseInfo, self).__setattr__(attr, value)
             return
 
         if attr not in COLUMN_ATTRS:

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -62,10 +62,10 @@ def _get_column_attribute(col, attr=None):
     """
     Get a column attribute for the ``attributes`` info summary method
     """
-    from ..table.column import BaseColumn
+    from ..table.column import Column, MaskedColumn
 
     if attr == 'class':
-        val = '' if isinstance(col, BaseColumn) else col.__class__.__name__
+        val = '' if type(col) in (Column, MaskedColumn) else type(col).__name__
     elif attr == 'dtype':
         val = col.info.dtype.name
     elif attr == 'shape':
@@ -252,9 +252,16 @@ class BaseDataInfo(object):
                 n_bad = 0
         info['n_bad'] = n_bad
 
+        info['length'] = len(col)
+
         if out is None:
             return info
 
         for key, val in info.items():
             if val != '':
                 out.write('{0} = {1}'.format(key, val) + os.linesep)
+
+    def __repr__(self):
+        with six.moves.cStringIO() as out:
+            self.__call__(out=out)
+            return out.getvalue()

--- a/astropy/utils/column_info.py
+++ b/astropy/utils/column_info.py
@@ -1,0 +1,66 @@
+from copy import deepcopy
+import weakref
+import numpy as np
+
+COLUMN_ATTRS = set(['name', 'unit', 'dtype', 'format', 'description', 'meta', 'parent_table'])
+
+class ColumnInfo(object):
+    cols_from_parent = set()
+
+    def __init__(self, parent_col=None):
+        self._attrs = dict((attr, None) for attr in COLUMN_ATTRS)
+        if parent_col is not None:
+            self._parent_col = weakref.ref(parent_col)
+
+    def __getstate__(self):
+        return self._attrs
+
+    def __setstate__(self, state):
+        self._attrs = state
+
+    def __getattr__(self, attr):
+        if attr.startswith('_'):
+            return super(ColumnInfo, self).__getattribute__(attr)
+
+        if attr in self.cols_from_parent:
+            return getattr(self._parent_col(), attr)
+
+        try:
+            value = self._attrs[attr]
+        except KeyError:
+            super(ColumnInfo, self).__getattribute__(attr)  # Generate AttributeError
+
+        # Weak ref for parent table
+        if attr == 'parent_table' and callable(value):
+            value = value()
+
+        # Mixins have a default dtype of Object if nothing else was set
+        if attr == 'dtype' and value is None:
+            value = np.dtype('O')
+
+        return value
+
+    def __setattr__(self, attr, value):
+        if attr in self.cols_from_parent:
+            setattr(self._parent_col(), attr, value)
+            return
+
+        if attr.startswith('_'):
+            super(ColumnInfo, self).__setattr__(attr, value)
+            return
+
+        if attr not in COLUMN_ATTRS:
+            raise AttributeError("attribute must be one of {0}".format(COLUMN_ATTRS))
+
+        if attr == 'parent_table':
+            value = None if value is None else weakref.ref(value)
+
+        self._attrs[attr] = value
+
+    def copy(self):
+        out = self.__class__()
+        for attr in COLUMN_ATTRS - self.cols_from_parent:
+            setattr(out, attr, deepcopy(getattr(self, attr)))
+
+        return out
+

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -9,18 +9,18 @@ from ..extern import six
 from ..utils import OrderedDict
 
 
-def column_info_factory(names, funcs):
+def data_info_factory(names, funcs):
     """
     Factory to create a function that can be used as an ``option``
     for outputting table or column summary information.
 
     Examples
     --------
-    >>> from astropy.utils.column_info import column_info_factory
+    >>> from astropy.utils.data_info import data_info_factory
     >>> from astropy.table import Column
     >>> c = Column([4., 3., 2., 1.])
-    >>> mystats = column_info_factory(names=['min', 'median', 'max'],
-    ...                               funcs=[np.min, np.median, np.max])
+    >>> mystats = data_info_factory(names=['min', 'median', 'max'],
+    ...                             funcs=[np.min, np.median, np.max])
     >>> c.info(option=mystats)
     min = 1.0
     median = 2.5
@@ -188,13 +188,13 @@ class BaseInfo(object):
         return out
 
     info_summary_attributes = staticmethod(
-        column_info_factory(names=_info_summary_attrs,
-                            funcs=[partial(_get_column_attribute, attr=attr)
-                                   for attr in _info_summary_attrs]))
+        data_info_factory(names=_info_summary_attrs,
+                          funcs=[partial(_get_column_attribute, attr=attr)
+                                 for attr in _info_summary_attrs]))
 
     info_summary_stats = staticmethod(
-        column_info_factory(names=_stats,
-                            funcs=[getattr(np, 'nan' + stat) for stat in _stats]))
+        data_info_factory(names=_stats,
+                          funcs=[getattr(np, 'nan' + stat) for stat in _stats]))
 
     def __call__(self, option='attributes', out=''):
         """

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Note: these functions and classes are tested extensively in astropy table
+# tests via their use in providing mixin column info, and in
+# astropy/tests/test_info for providing table and column info summary data.
+
 import os
 import sys
 from copy import deepcopy

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from ..extern import six
 from ..utils import OrderedDict
-
+from ..utils.compat import NUMPY_LT_1_8
 
 def data_info_factory(names, funcs):
     """
@@ -192,9 +192,11 @@ class BaseInfo(object):
                           funcs=[partial(_get_column_attribute, attr=attr)
                                  for attr in _info_summary_attrs]))
 
+    # No nan* methods in numpy < 1.8
     info_summary_stats = staticmethod(
         data_info_factory(names=_stats,
-                          funcs=[getattr(np, 'nan' + stat) for stat in _stats]))
+                          funcs=[getattr(np, ('' if NUMPY_LT_1_8 else 'nan') + stat)
+                                 for stat in _stats]))
 
     def __call__(self, option='attributes', out=''):
         """

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -77,7 +77,7 @@ def _get_column_attribute(col, attr=None):
     return str(val)
 
 
-class DataInfo(object):
+class InfoDescriptor(object):
     """
     Descriptor that data classes use to add an ``info`` attribute for storing
     data attributes in a uniform and portable way.  Note that it *must* be
@@ -91,7 +91,7 @@ class DataInfo(object):
     Parameters
     ----------
     info_cls : class
-        Class reference for the BaseInfo subclass that actually stores info
+        Class reference for the DataInfo subclass that actually stores info
     """
     def __init__(self, info_cls):
         self.info_cls = info_cls
@@ -103,13 +103,13 @@ class DataInfo(object):
         return instance.__dict__['info']
 
     def __set__(self, instance, value):
-        if isinstance(value, BaseInfo):
+        if isinstance(value, DataInfo):
             instance.__dict__['info'] = value
         else:
-            raise TypeError('info must be set with a BaseInfo instance')
+            raise TypeError('info must be set with a DataInfo instance')
 
 
-class BaseInfo(object):
+class DataInfo(object):
 
     _stats = ['mean', 'std', 'min', 'max']
     attrs_from_parent = set()
@@ -129,7 +129,7 @@ class BaseInfo(object):
 
     def __getattr__(self, attr):
         if attr.startswith('_'):
-            return super(BaseInfo, self).__getattribute__(attr)
+            return super(DataInfo, self).__getattribute__(attr)
 
         if attr in self.attrs_from_parent:
             return getattr(self._parent_ref(), attr)
@@ -137,7 +137,7 @@ class BaseInfo(object):
         try:
             value = self._attrs[attr]
         except KeyError:
-            super(BaseInfo, self).__getattribute__(attr)  # Generate AttributeError
+            super(DataInfo, self).__getattribute__(attr)  # Generate AttributeError
 
         # Weak ref for parent table
         if attr == 'parent_table' and callable(value):
@@ -168,7 +168,7 @@ class BaseInfo(object):
 
         # Private attr names get directly set
         if attr.startswith('_'):
-            super(BaseInfo, self).__setattr__(attr, value)
+            super(DataInfo, self).__setattr__(attr, value)
             return
 
         # Finally this must be an actual data attribute that this class is handling.

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -278,7 +278,10 @@ class DataInfo(object):
                 n_bad = 0
         info['n_bad'] = n_bad
 
-        info['length'] = len(col)
+        try:
+            info['length'] = len(col)
+        except TypeError:
+            pass
 
         if out is None:
             return info
@@ -288,6 +291,6 @@ class DataInfo(object):
                 out.write('{0} = {1}'.format(key, val) + os.linesep)
 
     def __repr__(self):
-        with six.moves.cStringIO() as out:
-            self.__call__(out=out)
-            return out.getvalue()
+        out = six.moves.cStringIO()
+        self.__call__(out=out)
+        return out.getvalue()

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -230,12 +230,14 @@ class DataInfo(object):
         >>> c.info()
         dtype = int32
         unit = m
+        class = Column
         n_bad = 0
         length = 2
 
         >>> c.info(['attributes', 'stats'])
         dtype = int32
         unit = m
+        class = Column
         mean = 1.5
         std = 0.5
         min = 1

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -68,10 +68,8 @@ def _get_column_attribute(col, attr=None):
     """
     Get a column attribute for the ``attributes`` info summary method
     """
-    from ..table.column import Column, MaskedColumn
-
     if attr == 'class':
-        val = '' if type(col) in (Column, MaskedColumn) else type(col).__name__
+        val = type(col).__name__
     elif attr == 'dtype':
         val = col.info.dtype.name
     elif attr == 'shape':

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -100,6 +100,21 @@ For all the following examples it is assumed that the table has been created as 
        9.000  10  11
       12.000  13  14
 
+
+Summary information
+"""""""""""""""""""
+
+You can get summary information about the table as follows::
+
+  >>> t.info()
+  <Table length=5>
+  name dtype   unit   format       description
+  ---- ----- -------- ------ ------------------------
+     a int32 m sec^-1  %6.3f unladen swallow velocity
+     b int32
+     c int32
+
+
 Accessing properties
 """"""""""""""""""""
 

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -106,13 +106,57 @@ Summary information
 
 You can get summary information about the table as follows::
 
-  >>> t.info()
+  >>> t.info
   <Table length=5>
   name dtype   unit   format       description
   ---- ----- -------- ------ ------------------------
      a int32 m sec^-1  %6.3f unladen swallow velocity
      b int32
      c int32
+
+If called as a function then one can supply an ``option`` that specifies
+the type of information to return.  The built-in ``option`` choices are
+``attributes`` (column attributes, which is the default) or ``stats``
+(basic column statistics).  The ``option`` argument can also be a list
+of available options::
+
+  >>> t.info('stats')  # doctest: +FLOAT_CMP
+  <Table length=5>
+  name mean      std      min max
+  ---- ---- ------------- --- ---
+     a  6.0 4.24264068712   0  12
+     b  7.0 4.24264068712   1  13
+     c  8.0 4.24264068712   2  14
+
+  >>> t.info(['attributes', 'stats'])  # doctest: +FLOAT_CMP
+  <Table length=5>
+  name dtype   unit   format       description        mean      std      min max
+  ---- ----- -------- ------ ------------------------ ---- ------------- --- ---
+     a int32 m sec^-1  %6.3f unladen swallow velocity  6.0 4.24264068712   0  12
+     b int32                                           7.0 4.24264068712   1  13
+     c int32                                           8.0 4.24264068712   2  14
+
+Columns also have an ``info`` property that has the behavior and arguments,
+but provides information about a single column::
+
+  >>> t['a'].info
+  name = a
+  dtype = int32
+  unit = m sec^-1
+  format = %6.3f
+  description = unladen swallow velocity
+  class = Column
+  n_bad = 0
+  length = 5
+
+  >>> t['a'].info('stats')  # doctest: +FLOAT_CMP
+  name = a
+  mean = 6.0
+  std = 4.24264068712
+  min = 0
+  max = 12
+  n_bad = 0
+  length = 5
 
 
 Accessing properties

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -120,7 +120,7 @@ the type of information to return.  The built-in ``option`` choices are
 (basic column statistics).  The ``option`` argument can also be a list
 of available options::
 
-  >>> t.info('stats')  # doctest: +FLOAT_CMP
+  >>> t.info('stats')  # doctest: +SKIP
   <Table length=5>
   name mean      std      min max
   ---- ---- ------------- --- ---
@@ -128,7 +128,7 @@ of available options::
      b  7.0 4.24264068712   1  13
      c  8.0 4.24264068712   2  14
 
-  >>> t.info(['attributes', 'stats'])  # doctest: +FLOAT_CMP
+  >>> t.info(['attributes', 'stats'])  # doctest: +SKIP
   <Table length=5>
   name dtype   unit   format       description        mean      std      min max
   ---- ----- -------- ------ ------------------------ ---- ------------- --- ---
@@ -149,7 +149,7 @@ but provides information about a single column::
   n_bad = 0
   length = 5
 
-  >>> t['a'].info('stats')  # doctest: +FLOAT_CMP
+  >>> t['a'].info('stats')  # doctest: +SKIP
   name = a
   mean = 6.0
   std = 4.24264068712

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -96,7 +96,7 @@ assigned, all units would be shown as follows::
 
 Finally, you can get summary information about the table as follows::
 
-  >>> t.info()
+  >>> t.info
   <Table length=3>
   name  dtype  unit
   ---- ------- ----

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -94,6 +94,16 @@ assigned, all units would be shown as follows::
       4     5.0       y
       5     8.2       z
 
+Finally, you can get summary information about the table as follows::
+
+  >>> t.info()
+  <Table length=3>
+  name  dtype  unit
+  ---- ------- ----
+     a   int32
+     b float64    s
+     c string8
+
 A column with a unit works with and can be easily converted to an
 `~astropy.units.Quantity` object::
 

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -104,16 +104,6 @@ So instead let's do the same thing using a quantity table |QTable|::
   >>> qt['time'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
   >>> qt['velocity'] = [3, 4] * u.m / u.s
 
-Now we print the table again but this time notice that the individual values
-all have units because this is how |Quantity| prints a single array element::
-
-  >>> print(qt)
-  index           time           velocity
-                                  m / s
-  ----- ----------------------- ---------
-      1 2001-01-02T12:34:56.000 3.0 m / s
-      2 2001-02-03T00:01:02.000 4.0 m / s
-
 The ``velocity`` column is now a |Quantity| and behaves accordingly::
 
   >>> type(qt['velocity'])


### PR DESCRIPTION
This is an initial implementation for #3518 to create `ColumnInfo` (aka `ColumnAttribute`) class for mixin columns.

One point is that for classes with built-in mixin support the `info` attribute is a class property wrapping `_info` as a `ColumnInfo` object, while for external classes (e.g. pandas Series), `info` is just a plain attribute which is a `ColumnInfo` object.  

Currently all the calls to `col_setattr` and `col_getattr` have been left in place, but those methods are now trivial calls to inspect the `col.info` object.  Will get around to doing the replacement once @mhvk is happy with the direction in this PR.

Closes #3518.

