### PR TITLE
changed the repr for Parameter

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -246,7 +246,7 @@ class Parameter(object):
                 # tied constraints
                 args += ', {0}={1}'.format(cons, val)
 
-        return "Parameter({0})".format(args)
+        return "{0}({1})".format(self.__class__.__name__, args)
 
     @property
     def name(self):


### PR DESCRIPTION
As discussed with @embray. Making sure that subclasses of `Parameter ` also have a nice `__repr__` function. 