### PR TITLE
Fix Ellipse2D model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,6 +304,9 @@ Bug Fixes
 
 - ``astropy.modeling``
 
+  - Fixed the ``Ellipse2D`` model to be consistent with ``Disk2D`` in
+    how pixels are included. [#3736]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -744,7 +744,7 @@ class Ellipse2D(Fittable2DModel):
         sint = np.sin(theta)
         numerator1 = (xx * cost) + (yy * sint)
         numerator2 = -(xx * sint) + (yy * cost)
-        in_ellipse = (((numerator1 / a) ** 2 + (numerator2 / b) ** 2) < 1.)
+        in_ellipse = (((numerator1 / a) ** 2 + (numerator2 / b) ** 2) <= 1.)
         return np.select([in_ellipse], [amplitude])
 
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -720,7 +720,7 @@ class Ellipse2D(Fittable2DModel):
                       theta=theta.radian)
         y, x = np.mgrid[0:50, 0:50]
         fig, ax = plt.subplots(1, 1)
-        ax.imshow(e(x, y), origin='lower', cmap='Greys_r')
+        ax.imshow(e(x, y), origin='lower', interpolation='none', cmap='Greys_r')
         e2 = mpatches.Ellipse((x0, y0), 2*a, 2*b, theta.degree,
                               edgecolor='red', facecolor='none')
         ax.add_patch(e2)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -128,6 +128,18 @@ def test_Ellipse2D():
     assert e1(*point1) == e2(*point2)
 
 
+def test_Ellipse2D_circular():
+    """Test that circular Ellipse2D agrees with Disk2D [3736]."""
+    amplitude = 7.5
+    radius = 10
+    size = (radius * 2) + 1
+    y, x = np.mgrid[0:size, 0:size]
+    ellipse = models.Ellipse2D(amplitude, radius, radius, radius, radius,
+                               theta=0)(x, y)
+    disk = models.Disk2D(amplitude, radius, radius, radius)(x, y)
+    assert np.all(ellipse == disk)
+
+
 def test_Scale_inverse():
     m = models.Scale(1.2345)
     assert_allclose(m.inverse(m(6.789)), 6.789)


### PR DESCRIPTION
This PR fixes the `Ellipse2D` model to be inclusive (`<=` instead of `<`) as documented and consistent with `Disk2D`.  This is my bug from when I originally added `Ellipse2D` in #3124.  Sorry!

This PR also turns off the `imshow` interpolation when plotting the example to not give the impression that pixels can be partially in the ellipse (they are either 1 or 0).