### PR TITLE
astropy test framework's disable_internet is incompatible with python 3.4 multiprocessing forkserver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,6 +314,12 @@ Bug Fixes
 
 - ``astropy.table``
 
+- ``astropy.testing``
+
+  - The Astropy py.test plugins that disable unintential internet access
+    in tests were also blocking use of local UNIX sockets in tests, which
+    prevented testing some multiprocessing code--fixed. [#3713]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/tests/tests/test_socketblocker.py
+++ b/astropy/tests/tests/test_socketblocker.py
@@ -1,11 +1,15 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+
+import sys
+import time
+
+from threading import Thread
+
 from ..helper import pytest
 from ..disable_internet import no_internet
 from astropy.extern.six.moves import BaseHTTPServer, SimpleHTTPServer
 from astropy.extern.six.moves.urllib.request import urlopen
-from threading import Thread
-import time
 
 
 def test_outgoing_fails():
@@ -52,3 +56,31 @@ def test_localconnect_succeeds(localhost):
     time.sleep(0.1)
 
     urlopen('http://{localhost:s}:{port:d}'.format(localhost=localhost,port=port)).close()
+
+
+PY3_4 = sys.version_info[:2] >= (3, 4)
+
+
+# Used for the below test--inline functions aren't pickleable
+# by multiprocessing?
+def _square(x):
+    return x ** 2
+
+
+@pytest.mark.skipif('not PY3_4 or sys.platform == "win32"')
+def test_multiprocessing_forkserver():
+    """
+    Test that using multiprocessing with forkserver works.  Perhaps
+    a simpler more direct test would be to just open some local
+    sockets and pass something through them.
+
+    Regression test for https://github.com/astropy/astropy/pull/3713
+    """
+
+    import multiprocessing
+    ctx = multiprocessing.get_context('forkserver')
+    pool = ctx.Pool(1)
+    result = pool.map(_square, [1, 2, 3, 4, 5])
+    pool.close()
+    pool.join()
+    assert result == [1, 4, 9, 16, 25]


### PR DESCRIPTION
Attn @embray, @mdboom, @josephoenix - 

Here's another case of the astropy test framework customizations having unintended consequences for packages using the affiliated package template. 

For [poppy](https://github.com/mperrin/poppy) on Python 3.4 when doing multiprocess parallelized calculations I just switched it to use the new (as of Python 3.4) `forkserver` method for starting additional processes. (See https://github.com/mperrin/poppy/issues/23 and https://github.com/numpy/numpy/issues/5752 for the reasons why).   The code works as intended in normal operations, but under testing it gets blocked by `astropy/tests/disable_internet.py`. Here's the tail end of the exception traceback:

```python
/Users/mperrin/software/macports/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/multiprocessing/forkserver.py:108:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<socket.socket [closed] fd=-1, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>, '/var/folders/wj/p62fp78j0z1b4xyr2yql1prw00042w/T/pymp-g72qatlv/listener-paqlzej6')
kwargs = {}, hostname = 'peregrine.stsci.edu', fqdn = 'peregrine.stsci.edu', valid_hosts = ('localhost', '127.0.0.1', '::1')

    def new_function(*args, **kwargs):
        hostname = socket.gethostname()
        fqdn = socket.getfqdn()

        if isinstance(args[0], socket.socket):
            host = args[1][0]
            valid_hosts = ('localhost', '127.0.0.1', '::1')
            if host in (hostname, fqdn):
                host = 'localhost'
                args = (args[0], (host, args[1][1])) + args[2:]
        else:
            host = args[0][0]
            valid_hosts = ('localhost', '127.0.0.1')
            if host in (hostname, fqdn):
                host = 'localhost'
                args = ((host, args[0][1]),) + args[1:]

        if any([h in host for h in valid_hosts]):
            return original_function(*args, **kwargs)
        else:
>           raise IOError("An attempt was made to connect to the internet "
                          "by a test that was not marked `remote_data`.")
E           OSError: An attempt was made to connect to the internet by a test that was not marked `remote_data`.

```

So for some reason `forkserver` is using the fully qualified domain name of my computer instead of "localhost" and thus it's getting blocked. 

Not sure what the best solution here is. I'd sort of like to be able to decorate that test function and say "please run this anyway; it's allowed to use network sockets even if remote_data is off". It feels slightly kludgy to turn on `remote_data` for this because it truly does not access any data remotely.  Also it's not obvious to me how one would set remote_data from the command line, in particular for our Travis CI build matrix. 

```
 > python setup.py test --remote_data
error: option --remote_data not recognized
```

What do you think is the best approach? 