### PR TITLE
Fix Kernel normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -288,6 +288,8 @@ Bug Fixes
 
 - ``astropy.convolution``
 
+  - Fix issue with repeated normalizations of ``Kernels``. [#3747]
+
 - ``astropy.coordinates``
 
 - ``astropy.cosmology``

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -112,7 +112,7 @@ class Kernel(object):
         else:
             np.divide(self._array, normalization, self._array)
 
-            if (1.0 / normalization) > MAX_NORMALIZATION:
+            if np.abs(1.0 / normalization) > MAX_NORMALIZATION:
                 warnings.warn('The kernel normalization factor is '
                               'exceptionally large,'
                               ' > {0}.'.format(MAX_NORMALIZATION),

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -36,7 +36,7 @@ class Kernel(object):
 
     Parameters
     ----------
-    array : ndarray
+    array : `~numpy.ndarray`
         Kernel array.
     """
     _separable = False
@@ -44,7 +44,7 @@ class Kernel(object):
     _model = None
 
     def __init__(self, array):
-        self._array = array
+        self._array = np.asanyarray(array)
         self.calculate_normalization()
 
     @property
@@ -225,7 +225,7 @@ class Kernel1D(Kernel):
         Model to be evaluated.
     x_size : odd int, optional
         Size of the kernel array. Default = 8 * width.
-    array : ndarray
+    array : `~numpy.ndarray`
         Kernel array.
     width : number
         Width of the filter kernel.
@@ -285,7 +285,7 @@ class Kernel2D(Kernel):
         Size in x direction of the kernel array. Default = 8 * width.
     y_size : odd int, optional
         Size in y direction of the kernel array. Default = 8 * width.
-    array : ndarray
+    array : `~numpy.ndarray`
         Kernel array.
     mode : str, optional
         One of the following discretization modes:

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -320,7 +320,7 @@ class Kernel2D(Kernel):
 
             if y_size is None:
                 y_size = x_size
-            elif x_size != int(x_size):
+            elif y_size != int(y_size):
                 raise TypeError("y_size should be an integer")
 
             # Set ranges where to evaluate the model

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -370,8 +370,8 @@ def kernel_arithmetics(kernel, value, operation):
         if operation == "sub":
             new_array = add_kernel_arrays_1D(kernel.array, -value.array)
         if operation == "mul":
-            raise Exception("Kernel operation not supported. Maybe you want to"
-                             "use convolve(kernel1, kernel2) instead.")
+            raise Exception("Kernel operation not supported. Maybe you want "
+                            "to use convolve(kernel1, kernel2) instead.")
         new_kernel = Kernel1D(array=new_array)
         new_kernel._separable = kernel._separable and value._separable
         new_kernel._is_bool = kernel._is_bool or value._is_bool
@@ -383,8 +383,8 @@ def kernel_arithmetics(kernel, value, operation):
         if operation == "sub":
             new_array = add_kernel_arrays_2D(kernel.array, -value.array)
         if operation == "mul":
-            raise Exception("Kernel operation not supported. Maybe you want to"
-                            "use convolve(kernel1, kernel2) instead.")
+            raise Exception("Kernel operation not supported. Maybe you want "
+                            "to use convolve(kernel1, kernel2) instead.")
         new_kernel = Kernel2D(array=new_array)
         new_kernel._separable = kernel._separable and value._separable
         new_kernel._is_bool = kernel._is_bool or value._is_bool

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -123,9 +123,11 @@ class Kernel(object):
             else:
                 self._normalization = 1. / self._array.sum()
             self._array *= self._normalization
-        if mode == 'peak':
+        elif mode == 'peak':
             np.divide(self._array, self._array.max(), self.array)
             self._normalization = 1. / self._array.sum()
+        else:
+            raise ValueError("invalid mode, must be 'integral' or 'peak'")
 
     @property
     def shape(self):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -93,29 +93,17 @@ class Kernel(object):
 
     def normalize(self, mode='integral'):
         """
-        Force normalization of filter kernel.
+        Normalize the filter kernel.
 
         Parameters
         ----------
         mode : {'integral', 'peak'}
             One of the following modes:
                 * 'integral' (default)
-                    Kernel normalized such that its integral = 1.
+                    Kernel is normalized such that its integral = 1.
                 * 'peak'
-                    Kernel normalized such that its peak = 1.
+                    Kernel is normalized such that its peak = 1.
         """
-
-        # Warn the user for kernels that sum to zero
-        if np.isinf(self._normalization):
-            warnings.warn('Kernel cannot be normalized because the '
-                          'normalization factor is infinite.',
-                          AstropyUserWarning)
-            return
-
-        if np.abs(self._normalization) > MAX_NORMALIZATION:
-            warnings.warn('Normalization factor of kernel is exceptionally '
-                          'large, > {0}.'.format(MAX_NORMALIZATION),
-                          AstropyUserWarning)
 
         if mode == 'integral':
             if self._array.sum() == 0:
@@ -128,6 +116,18 @@ class Kernel(object):
             self._normalization = 1. / self._array.sum()
         else:
             raise ValueError("invalid mode, must be 'integral' or 'peak'")
+
+        # Warn the user for kernels that sum to zero
+        if np.isinf(self._normalization):
+            warnings.warn('Kernel cannot be normalized because the '
+                          'normalization factor is infinite.',
+                          AstropyUserWarning)
+            return
+
+        if np.abs(self._normalization) > MAX_NORMALIZATION:
+            warnings.warn('Normalization factor of kernel is exceptionally '
+                          'large, > {0}.'.format(MAX_NORMALIZATION),
+                          AstropyUserWarning)
 
     @property
     def shape(self):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -45,10 +45,6 @@ class Kernel(object):
 
     def __init__(self, array):
         self._array = array
-        if self._array.sum() == 0:
-            self._normalization = np.inf
-        else:
-            self._normalization = 1. / self._array.sum()
 
     @property
     def truncation(self):
@@ -91,7 +87,7 @@ class Kernel(object):
     @property
     def normalization(self):
         """
-        Kernel normalization factor
+        Kernel normalization factor.
         """
         return self._normalization
 
@@ -108,18 +104,24 @@ class Kernel(object):
                 * 'peak'
                     Kernel normalized such that its peak = 1.
         """
-        # There are kernel that sum to zero and
-        # the user should be warned in this case
+
+        # Warn the user for kernels that sum to zero
         if np.isinf(self._normalization):
             warnings.warn('Kernel cannot be normalized because the '
                           'normalization factor is infinite.',
                           AstropyUserWarning)
             return
+
         if np.abs(self._normalization) > MAX_NORMALIZATION:
-            warnings.warn("Normalization factor of kernel is "
-                          "exceptionally large > {0}.".format(MAX_NORMALIZATION),
+            warnings.warn('Normalization factor of kernel is exceptionally '
+                          'large, > {0}.'.format(MAX_NORMALIZATION),
                           AstropyUserWarning)
+
         if mode == 'integral':
+            if self._array.sum() == 0:
+                self._normalization = np.inf
+            else:
+                self._normalization = 1. / self._array.sum()
             self._array *= self._normalization
         if mode == 'peak':
             np.divide(self._array, self._array.max(), self.array)

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -249,6 +249,8 @@ class Kernel1D(Kernel):
     def __init__(self, model=None, x_size=None, array=None, **kwargs):
         # Initialize from model
         if array is None:
+            if self._model is None:
+                raise TypeError("Must specify either array or model.")
 
             if x_size is None:
                 x_size = self._default_size
@@ -267,8 +269,7 @@ class Kernel1D(Kernel):
         # Initialize from array
         elif array is not None:
             self._model = None
-        else:
-            raise TypeError("Must specify either array or model.")
+
         super(Kernel1D, self).__init__(array)
 
 
@@ -309,6 +310,8 @@ class Kernel2D(Kernel):
 
         # Initialize from model
         if array is None:
+            if self._model is None:
+                raise TypeError("Must specify either array or model.")
 
             if x_size is None:
                 x_size = self._default_size
@@ -337,8 +340,6 @@ class Kernel2D(Kernel):
         # Initialize from array
         elif array is not None:
             self._model = None
-        else:
-            raise TypeError("Must specify either array or model.")
 
         super(Kernel2D, self).__init__(array)
 

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -85,7 +85,7 @@ class Gaussian1DKernel(Kernel1D):
                                         0, stddev)
         self._default_size = _round_up_to_odd_integer(8 * stddev)
         super(Gaussian1DKernel, self).__init__(**kwargs)
-        self._truncation = np.abs(1. - 1 / self._normalization)
+        self._truncation = np.abs(1. - self._array.sum())
 
 
 class Gaussian2DKernel(Kernel2D):
@@ -151,7 +151,7 @@ class Gaussian2DKernel(Kernel2D):
                                         0, stddev, stddev)
         self._default_size = _round_up_to_odd_integer(8 * stddev)
         super(Gaussian2DKernel, self).__init__(**kwargs)
-        self._truncation = np.abs(1. - 1 / self._normalization)
+        self._truncation = np.abs(1. - self._array.sum())
 
 
 class Box1DKernel(Kernel1D):

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -25,12 +25,10 @@ class TestConvolve1D(object):
         """
 
         x = [1, 4, 5, 6, 5, 7, 8]
-
         y = [0.2, 0.6, 0.2]
-
-        z = convolve([1, 4, 5, 6, 5, 7, 8], [0.2, 0.6, 0.2], boundary=None)
-
-        assert_array_almost_equal_nulp(z, np.array([ 0. ,  3.6,  5. ,  5.6,  5.6,  6.8,  0. ]), 10)
+        z = convolve(x, y, boundary=None)
+        assert_array_almost_equal_nulp(z,
+            np.array([0., 3.6, 5., 5.6, 5.6, 6.8, 0.]), 10)
 
     @pytest.mark.parametrize(('dtype_array', 'dtype_kernel'), VALID_DTYPES)
     def test_dtype(self, dtype_array, dtype_kernel):

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -462,7 +462,7 @@ class TestConvolve2D(object):
     def test_big_fail(self):
         """ Test that convolve_fft raises an exception if a too-large array is passed in """
 
-        with pytest.raises((ValueError, MemoryError)) as ex:
+        with pytest.raises((ValueError, MemoryError)):
             # while a good idea, this approach did not work; it actually writes to disk
             #arr = np.memmap('file.np', mode='w+', shape=(512, 512, 512), dtype=np.complex)
             # this just allocates the memory but never touches it; it's better:

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -11,8 +11,7 @@ from ...tests.helper import pytest
 
 from ..utils import discretize_model
 from ...modeling.functional_models import (
-    Gaussian1D, Box1D, MexicanHat1D, Trapezoid1D,
-    Gaussian2D, Box2D, MexicanHat2D)
+    Gaussian1D, Box1D, MexicanHat1D, Gaussian2D, Box2D, MexicanHat2D)
 from ...modeling.tests.example_models import models_1D, models_2D
 from ...modeling.tests.test_models import create_model
 

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -212,6 +212,31 @@ class TestKernels(object):
         gauss_new = gauss * number
         assert type(gauss_new) == Gaussian1DKernel
 
+    def test_multiply_kernel1d(self):
+        """Test that multipling two 1D kernels raises an exception."""
+        gauss = Gaussian1DKernel(3)
+        with pytest.raises(Exception):
+            gauss * gauss
+
+    def test_multiply_kernel2d(self):
+        """Test that multipling two 2D kernels raises an exception."""
+        gauss = Gaussian2DKernel(3)
+        with pytest.raises(Exception):
+            gauss * gauss
+
+    def test_multiply_kernel1d_kernel2d(self):
+        """
+        Test that multipling a 1D kernel with a 2D kernel raises an
+        exception.
+        """
+        with pytest.raises(Exception):
+            Gaussian1DKernel(3) * Gaussian2DKernel(3)
+
+    def test_add_kernel_scalar(self):
+        """Test that adding a scalar to a kernel raises an exception."""
+        with pytest.raises(Exception):
+            Gaussian1DKernel(3) + 1
+
     def test_model_1D_kernel(self):
         """
         Check Model1DKernel against Gaussian1Dkernel

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -308,20 +308,22 @@ class TestKernels(object):
         Check if CustomKernel works when the input array/list
         sums to zero.
         """
-        custom = CustomKernel([-2, -1, 0, 1, 2])
+        array = [-2, -1, 0, 1, 2]
+        custom = CustomKernel(array)
+        custom.normalize()
         assert custom.truncation == 0.
-        assert custom.normalization == np.inf
+        assert custom._kernel_sum == 0.
 
     def test_custom_2D_kernel_zerosum(self):
         """
         Check if CustomKernel works when the input array/list
         sums to zero.
         """
-        custom = CustomKernel([[0, -1, 0],
-                               [-1, 4, -1],
-                               [0, -1, 0]])
+        array = [[0, -1, 0], [-1, 4, -1], [0, -1, 0]]
+        custom = CustomKernel(array)
+        custom.normalize()
         assert custom.truncation == 0.
-        assert custom.normalization == np.inf
+        assert custom._kernel_sum == 0.
 
     def test_custom_kernel_odd_error(self):
         """
@@ -407,7 +409,8 @@ class TestKernels(object):
         assert box.center == [2, 2]
 
         # Check normalization
-        assert_almost_equal(box.normalization, 1., decimal=12)
+        box.normalize()
+        assert_almost_equal(box._kernel_sum, 1., decimal=12)
 
         # Check seperability
         assert box.separable
@@ -469,15 +472,6 @@ class TestKernels(object):
         with pytest.raises(ValueError):
             kernel = CustomKernel(np.ones(3))
             kernel.normalize(mode='invalid')
-
-    def test_kernel_normalization_inf(self, recwarn):
-        """
-        Test that a warning is issued when normalizing a zero-sum kernel.
-        """
-        kernel = CustomKernel(np.array([-1, 0, 1]))
-        kernel.normalize()
-        w = recwarn.pop(AstropyUserWarning)
-        assert issubclass(w.category, AstropyWarning)
 
     def test_kernel_normalization_large(self, recwarn):
         """

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -13,7 +13,7 @@ from ..kernels import (
     Gaussian1DKernel, Gaussian2DKernel, Box1DKernel, Box2DKernel,
     Trapezoid1DKernel, TrapezoidDisk2DKernel, MexicanHat1DKernel,
     Tophat2DKernel, MexicanHat2DKernel, AiryDisk2DKernel, Ring2DKernel,
-    CustomKernel, Model1DKernel, Model2DKernel)
+    CustomKernel, Model1DKernel, Model2DKernel, Kernel1D, Kernel2D)
 
 from ..utils import KernelSizeError
 from ...modeling.models import Box2D, Gaussian1D, Gaussian2D
@@ -463,3 +463,27 @@ class TestKernels(object):
         kernel.normalize()
         w = recwarn.pop(AstropyUserWarning)
         assert issubclass(w.category, AstropyWarning)
+
+    def test_kernel1d_int_size(self):
+        """
+        Test that an error is raised if ``Kernel1D`` ``x_size`` is not
+        an integer.
+        """
+        with pytest.raises(TypeError):
+            Kernel1D(x_size=1.2)
+
+    def test_kernel2d_int_xsize(self):
+        """
+        Test that an error is raised if ``Kernel2D`` ``x_size`` is not
+        an integer.
+        """
+        with pytest.raises(TypeError):
+            Kernel2D(x_size=1.2)
+
+    def test_kernel2d_int_ysize(self):
+        """
+        Test that an error is raised if ``Kernel2D`` ``y_size`` is not
+        an integer.
+        """
+        with pytest.raises(TypeError):
+            Kernel2D(x_size=5, y_size=1.2)

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -495,7 +495,7 @@ class TestKernels(object):
         an integer.
         """
         with pytest.raises(TypeError):
-            Kernel1D(x_size=1.2)
+            Gaussian1DKernel(3, x_size=1.2)
 
     def test_kernel2d_int_xsize(self):
         """
@@ -503,7 +503,7 @@ class TestKernels(object):
         an integer.
         """
         with pytest.raises(TypeError):
-            Kernel2D(x_size=1.2)
+            Gaussian2DKernel(3, x_size=1.2)
 
     def test_kernel2d_int_ysize(self):
         """
@@ -511,7 +511,7 @@ class TestKernels(object):
         an integer.
         """
         with pytest.raises(TypeError):
-            Kernel2D(x_size=5, y_size=1.2)
+            Gaussian2DKernel(3, x_size=5, y_size=1.2)
 
     def test_kernel1d_initialization(self):
         """

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -328,7 +328,7 @@ class TestKernels(object):
         Check if CustomKernel raises if the array size is odd.
         """
         with pytest.raises(KernelSizeError):
-            custom = CustomKernel([1, 1, 1, 1])
+            CustomKernel([1, 1, 1, 1])
 
     def test_add_1D_kernels(self):
         """

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import itertools
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 
 from ...tests.helper import pytest
 from ..convolve import convolve, convolve_fft
@@ -421,4 +421,17 @@ class TestKernels(object):
         assert np.all([_ % 2 != 0 for _ in kernel_2D.shape])
         assert kernel_2D.array.sum() == 1.
 
+    def test_kernel_normalization(self):
+        """
+        Test that repeated normalizations do not change the kernel [#3747].
+        """
 
+        kernel = CustomKernel(np.ones(5))
+        kernel.normalize()
+        data = np.copy(kernel.array)
+
+        kernel.normalize()
+        assert_allclose(data, kernel.array)
+
+        kernel.normalize()
+        assert_allclose(data, kernel.array)

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -487,3 +487,19 @@ class TestKernels(object):
         """
         with pytest.raises(TypeError):
             Kernel2D(x_size=5, y_size=1.2)
+
+    def test_kernel1d_initialization(self):
+        """
+        Test that an error is raised if an array or model is not
+        specified for ``Kernel1D``.
+        """
+        with pytest.raises(TypeError):
+            Kernel1D()
+
+    def test_kernel2d_initialization(self):
+        """
+        Test that an error is raised if an array or model is not
+        specified for ``Kernel2D``.
+        """
+        with pytest.raises(TypeError):
+            Kernel2D()


### PR DESCRIPTION
This PR fixes an issue with kernel normalization.  Currently the normalization factor is defined when the kernel is initialized and never updated.  Consequently, repeatedly running `.normalize()` will continue to apply the original normalization factor.  In this PR the normalization factor is recomputed each time `.normalize()` is called.

Here's an example showing the current bug:
```
import numpy as np
from astropy.convolution import CustomKernel

kernel = CustomKernel(np.ones(5))
kernel.normalize()
print kernel.array
[ 0.2  0.2  0.2  0.2  0.2]

kernel.normalize()
print kernel.array
[ 0.04  0.04  0.04  0.04  0.04]
```