### PR TITLE
Add ecliptic frames and transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ New Features
   - Added ``Supergalactic`` frame to support de Vaucouleurs supergalactic
     coordinates. [#3892]
 
+  - Added ecliptic coordinates, including ``GeocentricTrueEcliptic``, 
+    ``BarycentricTrueEcliptic``, and ``HeliocentricTrueEcliptic``. [#3749]
+
 - ``astropy.cosmology``
 
   - Add Planck 2015 cosmology [#3476]

--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -21,4 +21,15 @@ from .representation import *
 from .sky_coordinate import *
 from .funcs import *
 
-__doc__ += builtin_frames._transform_graph_docs
+__doc__ += builtin_frames._transform_graph_docs + """
+
+.. note::
+
+    The ecliptic coordinate systems (added in Astropy v1.1) have not been
+    extensively tested for accuracy or consistency with other implementations of
+    ecliptic coordinates.  We welcome contributions to add such testing, but in
+    the meantime, users who depend on consistency with other implementations may
+    wish to check test inputs against good datasets before using Astropy's
+    ecliptic coordinates.
+
+"""

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -34,7 +34,7 @@ from .altaz import AltAz
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic
+from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 
 #need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
@@ -50,7 +50,7 @@ from . import ecliptic_transforms
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS',
            'PrecessedGeocentric', 'GeocentricTrueEcliptic',
-           'BarycentricTrueEcliptic']
+           'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic']
 
 def _make_transform_graph_docs():
     """

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -34,7 +34,7 @@ from .altaz import AltAz
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .ecliptic import GeocentricEcliptic, HeliocentricEcliptic
+from .ecliptic import GeocentricEcliptic, BarycentricEcliptic
 
 #need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
@@ -49,8 +49,7 @@ from . import ecliptic_transforms
 # we define an __all__ because otherwise the transformation modules get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS',
-           'PrecessedGeocentric', 'GeocentricEcliptic', 'HeliocentricEcliptic']
-
+           'PrecessedGeocentric', 'GeocentricEcliptic', 'BarycentricEcliptic']
 
 def _make_transform_graph_docs():
     """

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -34,7 +34,7 @@ from .altaz import AltAz
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .ecliptic import GeocentricEcliptic, BarycentricEcliptic
+from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic
 
 #need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
@@ -49,7 +49,8 @@ from . import ecliptic_transforms
 # we define an __all__ because otherwise the transformation modules get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS',
-           'PrecessedGeocentric', 'GeocentricEcliptic', 'BarycentricEcliptic']
+           'PrecessedGeocentric', 'GeocentricTrueEcliptic',
+           'BarycentricTrueEcliptic']
 
 def _make_transform_graph_docs():
     """

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -34,6 +34,7 @@ from .altaz import AltAz
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
+from .ecliptic import GeocentricEcliptic, HeliocentricEcliptic
 
 #need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
@@ -43,11 +44,13 @@ from . import supergalactic_transforms
 from . import icrs_cirs_transforms
 from . import cirs_observed_transforms
 from . import intermediate_rotation_transforms
+from . import ecliptic_transforms
 
 # we define an __all__ because otherwise the transformation modules get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS',
-           'PrecessedGeocentric']
+           'PrecessedGeocentric', 'GeocentricEcliptic', 'HeliocentricEcliptic']
+
 
 def _make_transform_graph_docs():
     """

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -95,3 +95,45 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
     default_representation = SphericalRepresentation
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
+
+
+class HeliocentricTrueEcliptic(BaseCoordinateFrame):
+    """
+    Heliocentric ecliptic coordinates.  These origin of the coordinates are the
+    center of the sun, with the x axis pointing in the direction of
+    the *true* (not mean) equinox as at the time specified by the ``equinox``
+    attribute (as seen from Earth), and the xy-plane in the plane of the
+    ecliptic for that date.
+
+    This frame has one frame attribute:
+
+    * ``equinox``
+        The date to assume for the .  Determines the location of
+        the x-axis and the location of the Earth and Sun.
+
+    Parameters
+    ----------
+    representation : `BaseRepresentation` or None
+        A representation object or None to have no data (or use the other keywords)
+    l : `Angle`, optional, must be keyword
+        The ecliptic longitude for this object (``b`` must also be given and
+        ``representation`` must be None).
+    b : `Angle`, optional, must be keyword
+        The ecliptic latitde for this object (``l`` must also be given and
+        ``representation`` must be None).
+    r : `~astropy.units.Quantity`, optional, must be keyword
+        The Distance for this object from the sun's center.
+        (``representation`` must be None).
+    """
+
+    frame_specific_representation_info = {
+        'unitspherical': [RepresentationMapping('lon', 'l'),
+                          RepresentationMapping('lat', 'b')]
+    }
+    frame_specific_representation_info['spherical'] = \
+        frame_specific_representation_info['unitspherical'] + \
+        [RepresentationMapping('distance', 'r')]
+
+    default_representation = SphericalRepresentation
+
+    equinox = TimeFrameAttribute(default=EQUINOX_J2000)

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -54,13 +54,13 @@ class GeocentricEcliptic(BaseCoordinateFrame):
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
 
 
-class HeliocentricEcliptic(BaseCoordinateFrame):
+class BarycentricEcliptic(BaseCoordinateFrame):
     """
-    Heliocentric (or barycentric) ecliptic coordinates.  These origin of the
-    coordinates are the barycenter of the solar system, with the x axis pointing
-    in the direction of the *true* (not mean) equinox as at the time specified
-    by the ``equinox`` attribute (as seen from Earth), and the xy-plane in the
-    plane of the ecliptic for that date.
+    Barycentric ecliptic coordinates.  These origin of the coordinates are the
+    barycenter of the solar system, with the x axis pointing in the direction of
+    the *true* (not mean) equinox as at the time specified by the ``equinox``
+    attribute (as seen from Earth), and the xy-plane in the plane of the
+    ecliptic for that date.
 
     This frame has one frame attribute:
 

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -8,7 +8,7 @@ from ..baseframe import BaseCoordinateFrame, RepresentationMapping, TimeFrameAtt
 from .utils import EQUINOX_J2000
 
 
-class GeocentricEcliptic(BaseCoordinateFrame):
+class GeocentricTrueEcliptic(BaseCoordinateFrame):
     """
     Geocentric ecliptic coordinates.  These origin of the coordinates are the
     geocenter (Earth), with the x axis pointing to the *true* (not mean) equinox
@@ -54,7 +54,7 @@ class GeocentricEcliptic(BaseCoordinateFrame):
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
 
 
-class BarycentricEcliptic(BaseCoordinateFrame):
+class BarycentricTrueEcliptic(BaseCoordinateFrame):
     """
     Barycentric ecliptic coordinates.  These origin of the coordinates are the
     barycenter of the solar system, with the x axis pointing in the direction of

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -8,6 +8,9 @@ from ..baseframe import BaseCoordinateFrame, RepresentationMapping, TimeFrameAtt
 from .utils import EQUINOX_J2000
 
 
+__all__ = ['GeocentricTrueEcliptic', 'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic']
+
+
 class GeocentricTrueEcliptic(BaseCoordinateFrame):
     """
     Geocentric ecliptic coordinates.  These origin of the coordinates are the

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -22,9 +22,9 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     This frame has one frame attribute:
 
     * ``equinox``
-        The date to assume for the .  Determines the location of
-        the x-axis and the location of the Earth (necessary for transformation
-        to non-geocentric systems)
+        The date to assume for this frame.  Determines the location of the
+        x-axis and the location of the Earth (necessary for transformation to
+        non-geocentric systems).
 
     Parameters
     ----------
@@ -65,9 +65,8 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
     This frame has one frame attribute:
 
     * ``equinox``
-        The date to assume for the .  Determines the location of
-        the x-axis and the location of the Earth (necessary for transformation
-        to non-geocentric systems)
+        The date to assume for this frame.  Determines the location of the
+        x-axis and the location of the Earth and Sun.
 
     Parameters
     ----------
@@ -108,8 +107,8 @@ class HeliocentricTrueEcliptic(BaseCoordinateFrame):
     This frame has one frame attribute:
 
     * ``equinox``
-        The date to assume for the .  Determines the location of
-        the x-axis and the location of the Earth and Sun.
+        The date to assume for this frame.  Determines the location of the
+        x-axis and the location of the Earth and Sun.
 
     Parameters
     ----------

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -29,6 +29,12 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
         x-axis and the location of the Earth (necessary for transformation to
         non-geocentric systems).
 
+    .. warning::
+        In the current version of astropy, the ecliptic frames do not yet have
+        stringent accuracy tests.  We recommend you test to "known-good" cases
+        to ensure this frames are what you are looking for. (and then ideally
+        you would contribute these tests to Astropy!)
+
     Parameters
     ----------
     representation : `BaseRepresentation` or None
@@ -71,6 +77,12 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
         The date to assume for this frame.  Determines the location of the
         x-axis and the location of the Earth and Sun.
 
+    .. warning::
+        In the current version of astropy, the ecliptic frames do not yet have
+        stringent accuracy tests.  We recommend you test to "known-good" cases
+        to ensure this frames are what you are looking for. (and then ideally
+        you would contribute these tests to Astropy!)
+
     Parameters
     ----------
     representation : `BaseRepresentation` or None
@@ -112,6 +124,12 @@ class HeliocentricTrueEcliptic(BaseCoordinateFrame):
     * ``equinox``
         The date to assume for this frame.  Determines the location of the
         x-axis and the location of the Earth and Sun.
+
+    .. warning::
+        In the current version of astropy, the ecliptic frames do not yet have
+        stringent accuracy tests.  We recommend you test to "known-good" cases
+        to ensure this frames are what you are looking for. (and then ideally
+        you would contribute these tests to Astropy!)
 
     Parameters
     ----------

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+from ..representation import SphericalRepresentation
+from ..baseframe import BaseCoordinateFrame, RepresentationMapping, TimeFrameAttribute
+from .utils import EQUINOX_J2000
+
+
+class GeocentricEcliptic(BaseCoordinateFrame):
+    """
+    Geocentric ecliptic coordinates.  These origin of the coordinates are the
+    geocenter (Earth), with the x axis pointing to the *true* (not mean) equinox
+    at the time specified by the ``equinox`` attribute, and the xy-plane in the
+    plane of the ecliptic for that date.
+
+    Be aware that the definition of "geocentric" here means that this frame
+    *includes* light deflection from the sun, abberation, etc when transfoming
+    to/from e.g. ICRS.
+
+    This frame has one frame attribute:
+
+    * ``equinox``
+        The date to assume for the .  Determines the location of
+        the x-axis and the location of the Earth (necessary for transformation
+        to non-geocentric systems)
+
+    Parameters
+    ----------
+    representation : `BaseRepresentation` or None
+        A representation object or None to have no data (or use the other keywords)
+    lambda : `Angle`, optional, must be keyword
+        The ecliptic longitude for this object (``beta`` must also be given and
+        ``representation`` must be None).
+    beta : `Angle`, optional, must be keyword
+        The ecliptic latitde for this object (``lambda`` must also be given and
+        ``representation`` must be None).
+    delta : `~astropy.units.Quantity`, optional, must be keyword
+        The Distance for this object from the geocenter.
+        (``representation`` must be None).
+    """
+
+    frame_specific_representation_info = {
+        'unitspherical': [RepresentationMapping('lon', 'lambda'),
+                          RepresentationMapping('lat', 'beta')]
+    }
+    frame_specific_representation_info['spherical'] = \
+        frame_specific_representation_info['unitspherical'] + \
+        [RepresentationMapping('distance', 'delta')]
+
+    default_representation = SphericalRepresentation
+
+    equinox = TimeFrameAttribute(default=EQUINOX_J2000)
+
+
+class HeliocentricEcliptic(BaseCoordinateFrame):
+    """
+    Heliocentric (or barycentric) ecliptic coordinates.  These origin of the
+    coordinates are the barycenter of the solar system, with the x axis pointing
+    in the direction of the *true* (not mean) equinox as at the time specified
+    by the ``equinox`` attribute (as seen from Earth), and the xy-plane in the
+    plane of the ecliptic for that date.
+
+    This frame has one frame attribute:
+
+    * ``equinox``
+        The date to assume for the .  Determines the location of
+        the x-axis and the location of the Earth (necessary for transformation
+        to non-geocentric systems)
+
+    Parameters
+    ----------
+    representation : `BaseRepresentation` or None
+        A representation object or None to have no data (or use the other keywords)
+    l : `Angle`, optional, must be keyword
+        The ecliptic longitude for this object (``beta`` must also be given and
+        ``representation`` must be None).
+    b : `Angle`, optional, must be keyword
+        The ecliptic latitde for this object (``lambda`` must also be given and
+        ``representation`` must be None).
+    r : `~astropy.units.Quantity`, optional, must be keyword
+        The Distance for this object from the sun's center.
+        (``representation`` must be None).
+    """
+
+    frame_specific_representation_info = {
+        'unitspherical': [RepresentationMapping('lon', 'l'),
+                          RepresentationMapping('lat', 'b')]
+    }
+    frame_specific_representation_info['spherical'] = \
+        frame_specific_representation_info['unitspherical'] + \
+        [RepresentationMapping('distance', 'r')]
+
+    default_representation = SphericalRepresentation
+
+    equinox = TimeFrameAttribute(default=EQUINOX_J2000)

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -74,10 +74,10 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
     representation : `BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
     l : `Angle`, optional, must be keyword
-        The ecliptic longitude for this object (``beta`` must also be given and
+        The ecliptic longitude for this object (``b`` must also be given and
         ``representation`` must be None).
     b : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``lambda`` must also be given and
+        The ecliptic latitde for this object (``l`` must also be given and
         ``representation`` must be None).
     r : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the sun's center.

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -12,13 +12,13 @@ from ... import units as u
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform, DynamicMatrixTransform
 from ..angles import rotation_matrix
+from ..representation import CartesianRepresentation
 from ... import _erfa as erfa
 
 from .icrs import ICRS
 from .gcrs import GCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 from .utils import cartrepr_from_matmul
-from .representation import CartesianRepresentation
 
 
 def _gcrs_to_geoecliptic_matrix(equinox):

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Contains the transformation functions for getting to/from ecliptic systems.
+"""
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import numpy as np
+
+from ... import units as u
+from ..baseframe import frame_transform_graph
+from ..transformations import FunctionTransform, DynamicMatrixTransform
+from ..angles import rotation_matrix
+from ... import _erfa as erfa
+
+from .icrs import ICRS
+from .gcrs import GCRS
+from .ecliptic import GeocentricEcliptic, HeliocentricEcliptic
+from .utils import cartrepr_from_matmul
+
+
+def _gcrs_to_geoecliptic_matrix(equinox):
+    rnpb = erfa.pnm06a(equinox.jd1, equinox.jd2)
+    obl = erfa.obl06(equinox.jd1, equinox.jd2)*u.radian
+    return np.dot(rotation_matrix(obl, 'x'), rnpb)
+
+
+@frame_transform_graph.transform(FunctionTransform, GCRS, GeocentricEcliptic)
+def gcrs_to_geoecliptic(from_coo, to_frame):
+    if np.any(from_coo.obstime != to_frame.equinox):
+        # if they GCRS obstime and ecliptic equinox are not the same, we first
+        # have to move to a GCRS where they are.
+        frameattrs = from_coo.get_frame_attr_names()
+        frameattrs['obstime'] = to_frame.equinox
+        from_coo = from_coo.transform_to(GCRS(**frameattrs))
+
+    rmat = _gcrs_to_geoecliptic_matrix(to_frame.equinox)
+    newrepr = cartrepr_from_matmul(rmat, from_coo)
+    return to_frame.realize_frame(newrepr)
+
+
+@frame_transform_graph.transform(FunctionTransform, GeocentricEcliptic, GCRS)
+def geoecliptic_to_gcrs(from_coo, to_frame):
+    rmat = _gcrs_to_geoecliptic_matrix(to_frame.equinox)
+    newrepr = cartrepr_from_matmul(rmat, from_coo, transpose=True)
+
+    if np.all(from_coo.equinox == to_frame.obstime):
+        return to_frame.realize_frame(newrepr)
+    else:
+        # if the GCRS obstime and ecliptic equinox don't match, need to move
+        # to one where they do
+        frameattrs = to_frame.get_frame_attr_names()
+        frameattrs['obstime'] = from_coo.equinox
+        return GCRS(newrepr, **frameattrs).transform_to(to_frame)
+
+
+
+@frame_transform_graph.transform(DynamicMatrixTransform, ICRS, HeliocentricEcliptic)
+def icrs_to_helioecliptic(from_coo, to_frame):
+    rnpb = erfa.pnm06a(to_frame.equinox.jd1, to_frame.equinox.jd2)
+
+    obl = erfa.obl06(to_frame.equinox.jd1, to_frame.equinox.jd2)*u.radian
+    return np.dot(rotation_matrix(obl, 'x'), rnpb)
+
+
+@frame_transform_graph.transform(DynamicMatrixTransform, HeliocentricEcliptic, ICRS)
+def helioecliptic_to_icrs(from_coo, to_frame):
+    return icrs_to_helioecliptic(to_frame, from_coo).T

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -16,7 +16,7 @@ from ... import _erfa as erfa
 
 from .icrs import ICRS
 from .gcrs import GCRS
-from .ecliptic import GeocentricEcliptic, BarycentricEcliptic
+from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic
 from .utils import cartrepr_from_matmul
 
 
@@ -26,7 +26,7 @@ def _gcrs_to_geoecliptic_matrix(equinox):
     return np.dot(rotation_matrix(obl, 'x'), rnpb)
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, GeocentricEcliptic)
+@frame_transform_graph.transform(FunctionTransform, GCRS, GeocentricTrueEcliptic)
 def gcrs_to_geoecliptic(from_coo, to_frame):
     if np.any(from_coo.obstime != to_frame.equinox):
         # if they GCRS obstime and ecliptic equinox are not the same, we first
@@ -40,7 +40,7 @@ def gcrs_to_geoecliptic(from_coo, to_frame):
     return to_frame.realize_frame(newrepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, GeocentricEcliptic, GCRS)
+@frame_transform_graph.transform(FunctionTransform, GeocentricTrueEcliptic, GCRS)
 def geoecliptic_to_gcrs(from_coo, to_frame):
     rmat = _gcrs_to_geoecliptic_matrix(to_frame.equinox)
     newrepr = cartrepr_from_matmul(rmat, from_coo, transpose=True)
@@ -55,15 +55,13 @@ def geoecliptic_to_gcrs(from_coo, to_frame):
         return GCRS(newrepr, **frameattrs).transform_to(to_frame)
 
 
-
-@frame_transform_graph.transform(DynamicMatrixTransform, ICRS, BarycentricEcliptic)
-def icrs_to_helioecliptic(from_coo, to_frame):
+@frame_transform_graph.transform(DynamicMatrixTransform, ICRS, BarycentricTrueEcliptic)
+def icrs_to_baryecliptic(from_coo, to_frame):
     rnpb = erfa.pnm06a(to_frame.equinox.jd1, to_frame.equinox.jd2)
-
     obl = erfa.obl06(to_frame.equinox.jd1, to_frame.equinox.jd2)*u.radian
     return np.dot(rotation_matrix(obl, 'x'), rnpb)
 
 
-@frame_transform_graph.transform(DynamicMatrixTransform, BarycentricEcliptic, ICRS)
-def helioecliptic_to_icrs(from_coo, to_frame):
-    return icrs_to_helioecliptic(to_frame, from_coo).T
+@frame_transform_graph.transform(DynamicMatrixTransform, BarycentricTrueEcliptic, ICRS)
+def baryecliptic_to_icrs(from_coo, to_frame):
+    return icrs_to_baryecliptic(to_frame, from_coo).T

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -16,7 +16,7 @@ from ... import _erfa as erfa
 
 from .icrs import ICRS
 from .gcrs import GCRS
-from .ecliptic import GeocentricEcliptic, HeliocentricEcliptic
+from .ecliptic import GeocentricEcliptic, BarycentricEcliptic
 from .utils import cartrepr_from_matmul
 
 
@@ -56,7 +56,7 @@ def geoecliptic_to_gcrs(from_coo, to_frame):
 
 
 
-@frame_transform_graph.transform(DynamicMatrixTransform, ICRS, HeliocentricEcliptic)
+@frame_transform_graph.transform(DynamicMatrixTransform, ICRS, BarycentricEcliptic)
 def icrs_to_helioecliptic(from_coo, to_frame):
     rnpb = erfa.pnm06a(to_frame.equinox.jd1, to_frame.equinox.jd2)
 
@@ -64,6 +64,6 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     return np.dot(rotation_matrix(obl, 'x'), rnpb)
 
 
-@frame_transform_graph.transform(DynamicMatrixTransform, HeliocentricEcliptic, ICRS)
+@frame_transform_graph.transform(DynamicMatrixTransform, BarycentricEcliptic, ICRS)
 def helioecliptic_to_icrs(from_coo, to_frame):
     return icrs_to_helioecliptic(to_frame, from_coo).T

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform
-from ..representation import CartesianRepresentation
+from .utils import cartrepr_from_matmul
 from ... import _erfa as erfa
 
 from .gcrs import GCRS, PrecessedGeocentric
@@ -52,28 +52,6 @@ def cirs_to_itrs_mat(time):
 def gcrs_precession_mat(equinox):
     gamb, phib, psib, epsa = erfa.pfw06(equinox.jd1, equinox.jd2)
     return erfa.fw2m(gamb, phib, psib, epsa)
-
-
-def cartrepr_from_matmul(pmat, coo, transpose=False):
-    if pmat.shape[-2:] != (3, 3):
-        raise ValueError("tried to do matrix multiplication with an array that "
-                         "doesn't end in 3x3")
-    if coo.isscalar:
-        # a simpler path for scalar coordinates
-        if transpose:
-            pmat = pmat.T
-        newxyz = np.sum(pmat * coo.cartesian.xyz, axis=-1)
-    else:
-        xyz = coo.cartesian.xyz.T
-        # these expression are the same as iterating over the first dimension of
-        # pmat and xyz and doing matrix multiplication on each in turn.  resulting
-        # dimension is <coo shape> x 3
-        pmat = pmat.reshape(pmat.size//9, 3, 3)
-        if transpose:
-            pmat = pmat.transpose(0, 2, 1)
-        newxyz = np.sum(pmat * xyz.reshape(xyz.size//3, 1, 3), axis=-1).T
-
-    return CartesianRepresentation(newxyz)
 
 
 # now the actual transforms

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -43,6 +43,9 @@ use the latest IERS predictions by running:
 
 
 def cartrepr_from_matmul(pmat, coo, transpose=False):
+    """
+    Note that pmat should be an ndarray, *not* a matrix.
+    """
     if pmat.shape[-2:] != (3, 3):
         raise ValueError("tried to do matrix multiplication with an array that "
                          "doesn't end in 3x3")

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -15,6 +15,7 @@ from ... import units as u
 from ...time import Time
 from ...utils import iers
 from ...utils.exceptions import AstropyWarning
+from ..representation import CartesianRepresentation
 
 # The UTC time scale is not properly defined prior to 1960, so Time('B1950',
 # scale='utc') will emit a warning. Instead, we use Time('B1950', scale='tai')
@@ -39,6 +40,28 @@ use the latest IERS predictions by running:
     >>> iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
 
 """
+
+
+def cartrepr_from_matmul(pmat, coo, transpose=False):
+    if pmat.shape[-2:] != (3, 3):
+        raise ValueError("tried to do matrix multiplication with an array that "
+                         "doesn't end in 3x3")
+    if coo.isscalar:
+        # a simpler path for scalar coordinates
+        if transpose:
+            pmat = pmat.T
+        newxyz = np.sum(pmat * coo.cartesian.xyz, axis=-1)
+    else:
+        xyz = coo.cartesian.xyz.T
+        # these expression are the same as iterating over the first dimension of
+        # pmat and xyz and doing matrix multiplication on each in turn.  resulting
+        # dimension is <coo shape> x 3
+        pmat = pmat.reshape(pmat.size//9, 3, 3)
+        if transpose:
+            pmat = pmat.transpose(0, 2, 1)
+        newxyz = np.sum(pmat * xyz.reshape(xyz.size//3, 1, 3), axis=-1).T
+
+    return CartesianRepresentation(newxyz)
 
 
 def get_polar_motion(time):

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -5,6 +5,8 @@ Accuracy tests for Ecliptic coordinate systems.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import numpy as np
+
 from ....tests.helper import quantity_allclose
 from .... import units as u
 from ...builtin_frames import FK5, ICRS, GCRS, GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
@@ -37,11 +39,11 @@ def test_ecliptic_heliobary():
 
     # make sure there's a sizable distance shift - in 3d hundreds of km, but
     # this is 1D so we allow it to be somewhat smaller
-    assert np.abs(bary.distance - helio.distance) > 1*u.km
+    assert np.abs(bary.r - helio.r) > 1*u.km
 
     # now make something that's got the location of helio but in bary's frame.
     # this is a convenience to allow `separation` to work as expected
-    helio_in_bary_frame = bary.represent_as(helio.cartesian)
+    helio_in_bary_frame = bary.realize_frame(helio.cartesian)
     assert bary.separation(helio_in_bary_frame) > 1*u.arcmin
 
 
@@ -54,4 +56,4 @@ def test_ecl_geo():
     gcrs = GCRS(10*u.deg, 20*u.deg, distance=1.5*R_earth)
     gecl = gcrs.transform_to(GeocentricTrueEcliptic)
 
-    assert quantity_allclose(gecl.distance, gcrs.distance)
+    assert quantity_allclose(gecl.delta, gcrs.distance)

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -1,0 +1,57 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Accuracy tests for Ecliptic coordinate systems.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ....tests.helper import quantity_allclose
+from .... import units as u
+from ...builtin_frames import FK5, ICRS, GCRS, GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
+from ....constants import R_sun, R_earth
+
+
+def test_against_pytpm_doc_example():
+    """
+    Check that Astropy's Ecliptic systems give answers consistent with pyTPM
+
+    Currently this is only testing against the example given in the pytpm docs
+    """
+    fk5_in = FK5('12h22m54.899s', '15d49m20.57s', equinox='J2000')
+    pytpm_out = BarycentricTrueEcliptic(l=178.78256462*u.deg, b=16.7597002513*u.deg, equinox='J2000')
+    astropy_out = fk5_in.transform_to(pytpm_out)
+
+    # we check w/i 1 arcmin because there are some subtle differences in pyTPM's ecl definition
+    assert pytpm_out.separation(astropy_out) < (1*u.arcmin)
+
+
+def test_ecliptic_heliobary():
+    """
+    Check that the ecliptic transformations for heliocentric and barycentric
+    at least more or less make sense
+    """
+    icrs = ICRS(1*u.deg, 2*u.deg, distance=1.5*R_sun)
+
+    bary = icrs.transform_to(BarycentricTrueEcliptic)
+    helio = icrs.transform_to(HeliocentricTrueEcliptic)
+
+    # make sure there's a sizable distance shift - in 3d hundreds of km, but
+    # this is 1D so we allow it to be somewhat smaller
+    assert np.abs(bary.distance - helio.distance) > 1*u.km
+
+    # now make something that's got the location of helio but in bary's frame.
+    # this is a convenience to allow `separation` to work as expected
+    helio_in_bary_frame = bary.represent_as(helio.cartesian)
+    assert bary.separation(helio_in_bary_frame) > 1*u.arcmin
+
+
+def test_ecl_geo():
+    """
+    Check that the geocentric version at least gets well away from GCRS.  For a
+    true "accuracy" test we need a comparison dataset that is similar to the
+    geocentric/GCRS comparison we want to do here.  Contributions welcome!
+    """
+    gcrs = GCRS(10*u.deg, 20*u.deg, distance=1.5*R_earth)
+    gecl = gcrs.transform_to(GeocentricTrueEcliptic)
+
+    assert quantity_allclose(gecl.distance, gcrs.distance)


### PR DESCRIPTION
This closes #1430 by adding frames (and transforms into the rest of the coordinate graph) for ecliptic coordinates.

As implemented here I think everything is at least internally self-consistent, but before merging it would be useful to hear from some people who actually *use* ecliptic coordinates, because I had trouble finding authoritative definitions of exactly how such coordinates are defined (like many coordinate frames...).  So @mperrin, @mtbannister, @ijiraq, @Cadair, or anyone else who uses these systems, maybe you can comment on the following uncertainties:

1. There's two systems here, one for geocentric and the other for heliocentric.  The former I've defined relative to GCRS, so it nominally includes effects like aberration and GR light deflection by the sun/planets.  Is that what's normally assumed?  It doesn't really matter "internally" - that is, if you just want to use ecliptic coordinates relative to each other.  But it does matter if you want to convert to ICRS or AltAz or various other systems (because the light deflection and such will then need to be un-done).
2. The heliocentric version is simply a rotation to the equinox of date and obliquity, relative to ICRS. This then does *not* include the above effects.  It also means it's not strictly heliocentric, but rather solar system barycentric.  My thinking is that for ecliptic coordinates the barycenter is actually a more useful origin than the center of the sun itself (although of course they are very close).  But someone more familiar with how this is used might be able to comment better.
3. For simplicity/less confusion here, both frames only include an ``equniox`` frame attribute.  For the geocentric one, one could conceivably also have an ``obstime``, which would set the location of the Earth, independent of the orientation of the axes (that is ``equinox`` would set where the 0-meridian is, while ``obstime`` would determine where the origin is based on the Earth's location).  That seems really confusing, so I am implcitly always assuming these are the same.  But are there applications where it's useful to have the orientation fixed to a particular equinox but the earth location be somewhere that does not match that equinox?
4. Also needs a changelog entry and tests, which I'll add once the above issues are addressed.

cc @adrn @mhvk