### PR TITLE
Fix two bugs in get_sun and related bug in GCRS->ICRS transformation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,6 +312,12 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Fixed ``get_sun`` to yield frames with the ``obstime`` set to what's passed into the function (previously it incorrectly always had J2000). [#3750]
+
+  - Fixed ``get_sun`` to account for aberration of light. [#3750]
+
+  - Fixed error in the GCRS->ICRS transformation that gave incorrect distances. [#3750]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -152,7 +152,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     else:
         #compute the distance as just the cartesian sum from moving to the SSB
         #we have to do this because the ERFA functions throw away distance info
-        distance = np.sum((astrom['eb']*u.au + gcrs_coo.cartesian.xyz.T)**2, -1)**0.5
+        distance = np.sum((astrom['eb']*u.au + gcrs_coo.cartesian.xyz.T)**2, axis=-1)**0.5
         rep = SphericalRepresentation(lat=u.Quantity(icrs_dec, u.radian, copy=False),
                                       lon=u.Quantity(icrs_ra, u.radian, copy=False),
                                       distance=distance, copy=False)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -152,7 +152,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     else:
         #compute the distance as just the cartesian sum from moving to the SSB
         #we have to do this because the ERFA functions throw away distance info
-        distance = np.sum((-astrom['eb']*u.au + gcrs_coo.cartesian.xyz.T)**2, -1)**0.5
+        distance = np.sum((astrom['eb']*u.au + gcrs_coo.cartesian.xyz.T)**2, -1)**0.5
         rep = SphericalRepresentation(lat=u.Quantity(icrs_dec, u.radian, copy=False),
                                       lon=u.Quantity(icrs_ra, u.radian, copy=False),
                                       distance=distance, copy=False)

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -123,13 +123,13 @@ def spherical_to_cartesian(r, lat, lon):
 
 def get_sun(time):
     """
-    Determines the location of the sun at a given time, in
-    geocentric coordinates.
+    Determines the location of the sun at a given time (or times, if the input
+    is an array `~astropy.time.Time` object), in geocentric coordinates.
 
     Parameters
     ----------
-    table : `~astropy.time.Time`
-        The time at which to compute the location of the sun.
+    time : `~astropy.time.Time`
+        The time(s) at which to compute the location of the sun.
 
     Returns
     -------
@@ -152,7 +152,8 @@ def get_sun(time):
     y = -earth_pv_helio[..., 0, 1] * u.AU
     z = -earth_pv_helio[..., 0, 2] * u.AU
     cartrep = CartesianRepresentation(x=x, y=y, z=z)
-    return SkyCoord(cartrep, frame=GCRS)
+    return SkyCoord(cartrep, frame=GCRS(obstime=time))
+
 
 
 def concatenate(coords):


### PR DESCRIPTION
This fixes two bugs I found in ``astropy.coordinates.funcs.get_sun``:

1. The GCRS frame that was being returned was not getting an ``obstime`` corresponding to the input times.  That's not strictly speaking wrong, but it probably is confusing.
2. The ERFA function that's used to get the sun/earth vector says it's in BCRS.  That means it has *not* included the effects of aberration of light, which *is* included in the GCRS frame.  So this PR adds in the effect of abberation.

These effects are quite small for what actually ends up observable (i.e. the AltAz frame), so things like the observing example are unaffected, but this is slightly more correct.

Also included is a fix to a definite bug I uncovered while testing `get_sun` for this fix: the GCRS->ICRS transformation was computing the distance wrong, yielding strange incorrect results like a coordinate near the ICRS origin  comes back via the ICRS->GCRS->ICRS transformation as though it were 2 AU away from the barycenter. The actual fix is just the removal of a minus sign.
 