### PR TITLE
Add _unitrep attr of SphericalRepresentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -350,7 +350,7 @@ API changes
 
 - ``astropy.coordinates``
 
-  - ``SphericalRepresentation`` now has a ``._unitrep`` class attribute to specify 
+  - ``SphericalRepresentation`` now has a ``._unit_representation`` class attribute to specify 
     an equivalent UnitSphericalRepresentation. This allows subclasses of 
     representations to pair up correctly.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,9 +38,9 @@ New Features
 
   - Added ``Supergalactic`` frame to support de Vaucouleurs supergalactic
     coordinates. [#3892]
-  - ``SphericalRepresentation`` now has a ``._unitrep`` class attribute to specify 
+  - ``SphericalRepresentation`` now has a ``._unit_representation`` class attribute to specify 
     an equivalent UnitSphericalRepresentation. This allows subclasses of 
-    representations to pair up correctly.
+    representations to pair up correctly. [#3757]
 
   - Added functionality to support getting the locations of observatories by
     name. See ``astropy.coordinates.EarthLocation.of_site``. [#4042]
@@ -349,10 +349,6 @@ API changes
 - ``astropy.convolution``
 
 - ``astropy.coordinates``
-
-  - ``SphericalRepresentation`` now has a ``._unit_representation`` class attribute to specify 
-    an equivalent UnitSphericalRepresentation. This allows subclasses of 
-    representations to pair up correctly.
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -350,6 +350,10 @@ API changes
 
 - ``astropy.coordinates``
 
+  - ``SphericalRepresentation`` now has a ``._unitrep`` class attribute to specify 
+    an equivalent UnitSphericalRepresentation. This allows subclasses of 
+    representations to pair up correctly.
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,7 @@ New Features
 
   - Added ``Supergalactic`` frame to support de Vaucouleurs supergalactic
     coordinates. [#3892]
-  - `SphericalRepresentation` now has a `._unitrep` class attribute to specify 
+  - ``SphericalRepresentation`` now has a ``._unitrep`` class attribute to specify 
     an equivalent UnitSphericalRepresentation. This allows subclasses of 
     representations to pair up correctly.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ New Features
 
   - Added ``Supergalactic`` frame to support de Vaucouleurs supergalactic
     coordinates. [#3892]
+  - `SphericalRepresentation` now has a `._unitrep` class attribute to specify 
+    an equivalent UnitSphericalRepresentation. This allows subclasses of 
+    representations to pair up correctly.
 
   - Added functionality to support getting the locations of observatories by
     name. See ``astropy.coordinates.EarthLocation.of_site``. [#4042]

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -561,7 +561,7 @@ class BaseCoordinateFrame(object):
                     del repr_kwargs['distance']
                 if (issubclass(self.representation, SphericalRepresentation) and
                         'distance' not in repr_kwargs):
-                    representation_data = UnitSphericalRepresentation(**repr_kwargs)
+                    representation_data = self.representation._unitrep(**repr_kwargs)
                 else:
                     representation_data = self.representation(**repr_kwargs)
 
@@ -709,7 +709,6 @@ class BaseCoordinateFrame(object):
             if repr_unit:
                 out[repr_name] = repr_unit
         return out
-
 
     def realize_frame(self, representation):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -561,7 +561,7 @@ class BaseCoordinateFrame(object):
                     del repr_kwargs['distance']
                 if (issubclass(self.representation, SphericalRepresentation) and
                         'distance' not in repr_kwargs):
-                    representation_data = self.representation._unitrep(**repr_kwargs)
+                    representation_data = self.representation._unit_representation(**repr_kwargs)
                 else:
                     representation_data = self.representation(**repr_kwargs)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1102,14 +1102,14 @@ class BaseCoordinateFrame(object):
 
         from .distances import Distance
 
-        if self.data.__class__ == UnitSphericalRepresentation:
+        if issubclass(self.data.__class__, UnitSphericalRepresentation):
             raise ValueError('This object does not have a distance; cannot '
                              'compute 3d separation.')
 
         # do this first just in case the conversion somehow creates a distance
         other_in_self_system = other.transform_to(self)
 
-        if other_in_self_system.__class__ == UnitSphericalRepresentation:
+        if issubclass(other_in_self_system.__class__, UnitSphericalRepresentation):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -42,8 +42,12 @@ class MetaBaseRepresentation(type):
         if cls.__name__ == 'BaseRepresentation':
             return
 
-        REPRESENTATION_CLASSES[cls.get_name()] = cls
+        repr_name = cls.get_name()
 
+        if repr_name in REPRESENTATION_CLASSES:
+            raise ValueError("Representation class {0} already defined".format(repr_name))
+
+        REPRESENTATION_CLASSES[repr_name] = cls
 
 def _fstyle(precision, x):
     fmt_str = '{0:.{precision}f}'

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -287,125 +287,6 @@ class CartesianRepresentation(BaseRepresentation):
         return self
 
 
-class SphericalRepresentation(BaseRepresentation):
-    """
-    Representation of points in 3D spherical coordinates.
-
-    Parameters
-    ----------
-    lon, lat : `~astropy.units.Quantity`
-        The longitude and latitude of the point(s), in angular units. The
-        latitude should be between -90 and 90 degrees, and the longitude will
-        be wrapped to an angle between 0 and 360 degrees. These can also be
-        instances of `~astropy.coordinates.Angle`,
-        `~astropy.coordinates.Longitude`, or `~astropy.coordinates.Latitude`.
-
-    distance : `~astropy.units.Quantity`
-        The distance to the point(s). If the distance is a length, it is
-        passed to the :class:`~astropy.coordinates.Distance` class, otherwise
-        it is passed to the :class:`~astropy.units.Quantity` class.
-
-    copy : bool, optional
-        If True arrays will be copied rather than referenced.
-    """
-
-    attr_classes = OrderedDict([('lon', Longitude),
-                                ('lat', Latitude),
-                                ('distance', u.Quantity)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
-
-    def __init__(self, lon, lat, distance, copy=True):
-
-        if not isinstance(lon, u.Quantity) or isinstance(lon, Latitude):
-            raise TypeError('lon should be a Quantity, Angle, or Longitude')
-
-        if not isinstance(lat, u.Quantity) or isinstance(lat, Longitude):
-            raise TypeError('lat should be a Quantity, Angle, or Latitude')
-
-        # Let the Longitude and Latitude classes deal with e.g. parsing
-        lon = self.attr_classes['lon'](lon, copy=copy)
-        lat = self.attr_classes['lat'](lat, copy=copy)
-
-        distance = self.attr_classes['distance'](distance, copy=copy)
-        if distance.unit.physical_type == 'length':
-            distance = distance.view(Distance)
-
-        try:
-            lon, lat, distance = broadcast_arrays(lon, lat, distance,
-                                                  subok=True)
-        except ValueError:
-            raise ValueError("Input parameters lon, lat, and distance cannot be broadcast")
-
-        self._lon = lon
-        self._lat = lat
-        self._distance = distance
-
-    @property
-    def lon(self):
-        """
-        The longitude of the point(s).
-        """
-        return self._lon
-
-    @property
-    def lat(self):
-        """
-        The latitude of the point(s).
-        """
-        return self._lat
-
-    @property
-    def distance(self):
-        """
-        The distance from the origin to the point(s).
-        """
-        return self._distance
-
-    def represent_as(self, other_class):
-        # Take a short cut if the other class is a spherical representation
-        if other_class is PhysicsSphericalRepresentation:
-            return PhysicsSphericalRepresentation(phi=self.lon,
-                                                  theta=90 * u.deg - self.lat,
-                                                  r=self.distance)
-        elif other_class is UnitSphericalRepresentation:
-            return UnitSphericalRepresentation(lon=self.lon, lat=self.lat)
-        else:
-            return super(SphericalRepresentation, self).represent_as(other_class)
-
-    def to_cartesian(self):
-        """
-        Converts spherical polar coordinates to 3D rectangular cartesian
-        coordinates.
-        """
-
-        # We need to convert Distance to Quantity to allow negative values.
-        if isinstance(self.distance, Distance):
-            d = self.distance.view(u.Quantity)
-        else:
-            d = self.distance
-
-        x = d * np.cos(self.lat) * np.cos(self.lon)
-        y = d * np.cos(self.lat) * np.sin(self.lon)
-        z = d * np.sin(self.lat)
-
-        return CartesianRepresentation(x=x, y=y, z=z)
-
-    @classmethod
-    def from_cartesian(cls, cart):
-        """
-        Converts 3D rectangular cartesian coordinates to spherical polar
-        coordinates.
-        """
-
-        s = np.hypot(cart.x, cart.y)
-        r = np.hypot(s, cart.z)
-
-        lon = np.arctan2(cart.y, cart.x)
-        lat = np.arctan2(cart.z, s)
-
-        return cls(lon=lon, lat=lat, distance=r)
-
-
 class UnitSphericalRepresentation(BaseRepresentation):
     """
     Representation of points on a unit sphere.
@@ -498,6 +379,127 @@ class UnitSphericalRepresentation(BaseRepresentation):
             return SphericalRepresentation(lon=self.lon, lat=self.lat, distance=1.0)
         else:
             return super(UnitSphericalRepresentation, self).represent_as(other_class)
+
+
+class SphericalRepresentation(BaseRepresentation):
+    """
+    Representation of points in 3D spherical coordinates.
+
+    Parameters
+    ----------
+    lon, lat : `~astropy.units.Quantity`
+        The longitude and latitude of the point(s), in angular units. The
+        latitude should be between -90 and 90 degrees, and the longitude will
+        be wrapped to an angle between 0 and 360 degrees. These can also be
+        instances of `~astropy.coordinates.Angle`,
+        `~astropy.coordinates.Longitude`, or `~astropy.coordinates.Latitude`.
+
+    distance : `~astropy.units.Quantity`
+        The distance to the point(s). If the distance is a length, it is
+        passed to the :class:`~astropy.coordinates.Distance` class, otherwise
+        it is passed to the :class:`~astropy.units.Quantity` class.
+
+    copy : bool, optional
+        If True arrays will be copied rather than referenced.
+    """
+
+    attr_classes = OrderedDict([('lon', Longitude),
+                                ('lat', Latitude),
+                                ('distance', u.Quantity)])
+    recommended_units = {'lon': u.deg, 'lat': u.deg}
+
+    _unitrep = UnitSphericalRepresentation
+
+    def __init__(self, lon, lat, distance, copy=True):
+
+        if not isinstance(lon, u.Quantity) or isinstance(lon, Latitude):
+            raise TypeError('lon should be a Quantity, Angle, or Longitude')
+
+        if not isinstance(lat, u.Quantity) or isinstance(lat, Longitude):
+            raise TypeError('lat should be a Quantity, Angle, or Latitude')
+
+        # Let the Longitude and Latitude classes deal with e.g. parsing
+        lon = self.attr_classes['lon'](lon, copy=copy)
+        lat = self.attr_classes['lat'](lat, copy=copy)
+
+        distance = self.attr_classes['distance'](distance, copy=copy)
+        if distance.unit.physical_type == 'length':
+            distance = distance.view(Distance)
+
+        try:
+            lon, lat, distance = broadcast_arrays(lon, lat, distance,
+                                                  subok=True)
+        except ValueError:
+            raise ValueError("Input parameters lon, lat, and distance cannot be broadcast")
+
+        self._lon = lon
+        self._lat = lat
+        self._distance = distance
+
+    @property
+    def lon(self):
+        """
+        The longitude of the point(s).
+        """
+        return self._lon
+
+    @property
+    def lat(self):
+        """
+        The latitude of the point(s).
+        """
+        return self._lat
+
+    @property
+    def distance(self):
+        """
+        The distance from the origin to the point(s).
+        """
+        return self._distance
+
+    def represent_as(self, other_class):
+        # Take a short cut if the other class is a spherical representation
+        if other_class is PhysicsSphericalRepresentation:
+            return PhysicsSphericalRepresentation(phi=self.lon,
+                                                  theta=90 * u.deg - self.lat,
+                                                  r=self.distance)
+        elif other_class is UnitSphericalRepresentation:
+            return UnitSphericalRepresentation(lon=self.lon, lat=self.lat)
+        else:
+            return super(SphericalRepresentation, self).represent_as(other_class)
+
+    def to_cartesian(self):
+        """
+        Converts spherical polar coordinates to 3D rectangular cartesian
+        coordinates.
+        """
+
+        # We need to convert Distance to Quantity to allow negative values.
+        if isinstance(self.distance, Distance):
+            d = self.distance.view(u.Quantity)
+        else:
+            d = self.distance
+
+        x = d * np.cos(self.lat) * np.cos(self.lon)
+        y = d * np.cos(self.lat) * np.sin(self.lon)
+        z = d * np.sin(self.lat)
+
+        return CartesianRepresentation(x=x, y=y, z=z)
+
+    @classmethod
+    def from_cartesian(cls, cart):
+        """
+        Converts 3D rectangular cartesian coordinates to spherical polar
+        coordinates.
+        """
+
+        s = np.hypot(cart.x, cart.y)
+        r = np.hypot(s, cart.z)
+
+        lon = np.arctan2(cart.y, cart.x)
+        lat = np.arctan2(cart.z, s)
+
+        return cls(lon=lon, lat=lat, distance=r)
 
 
 class PhysicsSphericalRepresentation(BaseRepresentation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -345,8 +345,6 @@ class UnitSphericalRepresentation(BaseRepresentation):
         """
         return self._lat
 
-    # TODO: implement represent_as for efficient transformations
-
     def to_cartesian(self):
         """
         Converts spherical polar coordinates to 3D rectangular cartesian
@@ -376,7 +374,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
     def represent_as(self, other_class):
         # Take a short cut if the other clsss is a spherical representation
         if issubclass(other_class, PhysicsSphericalRepresentation):
-            return other_class(phi=self.lon,theta=90 * u.deg - self.lat, r=1.0)
+            return other_class(phi=self.lon, theta=90 * u.deg - self.lat, r=1.0)
         elif issubclass(other_class, SphericalRepresentation):
             return other_class(lon=self.lon, lat=self.lat, distance=1.0)
         else:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -406,7 +406,7 @@ class SphericalRepresentation(BaseRepresentation):
                                 ('distance', u.Quantity)])
     recommended_units = {'lon': u.deg, 'lat': u.deg}
 
-    _unitrep = UnitSphericalRepresentation
+    _unit_representation = UnitSphericalRepresentation
 
     def __init__(self, lon, lat, distance, copy=True):
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -371,12 +371,10 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
     def represent_as(self, other_class):
         # Take a short cut if the other clsss is a spherical representation
-        if other_class is PhysicsSphericalRepresentation:
-            return PhysicsSphericalRepresentation(phi=self.lon,
-                                                  theta=90 * u.deg - self.lat,
-                                                  r=1.0)
-        elif other_class is SphericalRepresentation:
-            return SphericalRepresentation(lon=self.lon, lat=self.lat, distance=1.0)
+        if issubclass(other_class, PhysicsSphericalRepresentation):
+            return other_class(phi=self.lon,theta=90 * u.deg - self.lat, r=1.0)
+        elif issubclass(other_class, SphericalRepresentation):
+            return other_class(lon=self.lon, lat=self.lat, distance=1.0)
         else:
             return super(UnitSphericalRepresentation, self).represent_as(other_class)
 
@@ -459,12 +457,11 @@ class SphericalRepresentation(BaseRepresentation):
 
     def represent_as(self, other_class):
         # Take a short cut if the other class is a spherical representation
-        if other_class is PhysicsSphericalRepresentation:
-            return PhysicsSphericalRepresentation(phi=self.lon,
-                                                  theta=90 * u.deg - self.lat,
-                                                  r=self.distance)
-        elif other_class is UnitSphericalRepresentation:
-            return UnitSphericalRepresentation(lon=self.lon, lat=self.lat)
+        if issubclass(other_class, PhysicsSphericalRepresentation):
+            return other_class(phi=self.lon, theta=90 * u.deg - self.lat,
+                               r=self.distance)
+        elif issubclass(other_class, UnitSphericalRepresentation):
+            return other_class(lon=self.lon, lat=self.lat)
         else:
             return super(SphericalRepresentation, self).represent_as(other_class)
 
@@ -589,13 +586,11 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
 
     def represent_as(self, other_class):
         # Take a short cut if the other clsss is a spherical representation
-        if other_class is SphericalRepresentation:
-            return SphericalRepresentation(lon=self.phi,
-                                           lat=90 * u.deg - self.theta,
-                                           distance=self.r)
-        elif other_class is UnitSphericalRepresentation:
-            return UnitSphericalRepresentation(lon=self.phi,
-                                               lat=90 * u.deg - self.theta)
+        if issubclass(other_class, SphericalRepresentation):
+            return other_class(lon=self.phi, lat=90 * u.deg - self.theta,
+                               distance=self.r)
+        elif issubclass(other_class, UnitSphericalRepresentation):
+            return other_class(lon=self.phi, lat=90 * u.deg - self.theta)
         else:
             return super(PhysicsSphericalRepresentation, self).represent_as(other_class)
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -674,10 +674,10 @@ class SkyCoord(object):
             raise TypeError('Can only get separation to another SkyCoord or a '
                             'coordinate frame with data')
 
-        if self.data.__class__ == UnitSphericalRepresentation:
+        if issubclass(self.data.__class__, UnitSphericalRepresentation):
             raise ValueError('This object does not have a distance; cannot '
                              'compute 3d separation.')
-        if other.data.__class__ == UnitSphericalRepresentation:
+        if issubclass(other.data.__class__, UnitSphericalRepresentation):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -4,6 +4,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from copy import deepcopy
+
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -11,11 +13,21 @@ from ... import units as u
 from ...tests.helper import pytest
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
-from ..representation import (SphericalRepresentation,
+from ..representation import (REPRESENTATION_CLASSES,
+                              SphericalRepresentation,
                               UnitSphericalRepresentation,
                               CartesianRepresentation,
                               CylindricalRepresentation,
                               PhysicsSphericalRepresentation)
+
+
+def setup_function(func):
+    func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
+
+
+def teardown_function(func):
+    REPRESENTATION_CLASSES.clear()
+    REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
 
 
 def assert_allclose_quantity(q1, q2):

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -8,7 +8,8 @@ from astropy.coordinates.representation import (SphericalRepresentation,
                                                 UnitSphericalRepresentation)
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
-
+from astropy.coordinates import ICRS
+from astropy.coordinates.baseframe import RepresentationMapping
 
 import astropy.units as u
 
@@ -39,8 +40,16 @@ class SphericalWrap180Representation(SphericalRepresentation):
     _unit_representation = UnitSphericalWrap180Representation
 
 
-class myframe(astropy.coordinates.ICRS):
+class myframe(ICRS):
     default_representation = SphericalWrap180Representation
+    frame_specific_representation_info = {
+        'spherical': [RepresentationMapping('lon', 'ra'),
+                      RepresentationMapping('lat', 'dec')]
+    }
+    frame_specific_representation_info['unitspherical'] = \
+    frame_specific_representation_info['unitsphericalwrap180'] = \
+    frame_specific_representation_info['sphericalwrap180'] = \
+        frame_specific_representation_info['spherical']
 
 
 @frame_transform_graph.transform(FunctionTransform,

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -1,0 +1,62 @@
+"""
+This file tests the behaviour of subclasses of Representation and Frames
+"""
+
+from astropy.utils.compat.odict import OrderedDict
+from astropy.coordinates import Longitude, Latitude
+from astropy.coordinates.representation import (SphericalRepresentation,
+                                                UnitSphericalRepresentation)
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import FunctionTransform
+
+
+import astropy.units as u
+
+import astropy.coordinates
+
+# Classes setup, borrowed from SunPy.
+
+
+class Longitude180(Longitude):
+    def __new__(cls, angle, unit=None, wrap_angle=180*u.deg, **kwargs):
+        self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
+                                                wrap_angle=wrap_angle, **kwargs)
+        return self
+
+
+class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
+    attr_classes = OrderedDict([('lon', Longitude180),
+                                ('lat', Latitude)])
+    recommended_units = {'lon': u.deg, 'lat': u.deg}
+
+
+class SphericalWrap180Representation(SphericalRepresentation):
+    attr_classes = OrderedDict([('lon', Longitude180),
+                                ('lat', Latitude),
+                                ('distance', u.Quantity)])
+    recommended_units = {'lon': u.deg, 'lat': u.deg}
+
+    _unit_representation = UnitSphericalWrap180Representation
+
+
+class myframe(astropy.coordinates.ICRS):
+    default_representation = SphericalWrap180Representation
+
+
+@frame_transform_graph.transform(FunctionTransform,
+                                 myframe, astropy.coordinates.ICRS)
+def myframe_to_icrs(myframe_coo, icrs):
+    return icrs.realize_frame(myframe_coo._data)
+
+
+def test_init():
+    f = myframe(10*u.deg, 10*u.deg)
+    assert isinstance(f._data, UnitSphericalWrap180Representation)
+    assert isinstance(f.lon, Longitude180)
+
+
+def test_transform():
+    f = myframe(10*u.deg, 10*u.deg)
+    g = f.transform_to(astropy.coordinates.ICRS)
+    assert isinstance(g, astropy.coordinates.ICRS)
+    assert isinstance(g._data, UnitSphericalWrap180Representation)

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -2,9 +2,12 @@
 This file tests the behaviour of subclasses of Representation and Frames
 """
 
+from copy import deepcopy
+
 from astropy.utils.compat.odict import OrderedDict
 from astropy.coordinates import Longitude, Latitude
-from astropy.coordinates.representation import (SphericalRepresentation,
+from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
+                                                SphericalRepresentation,
                                                 UnitSphericalRepresentation)
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
@@ -17,55 +20,68 @@ import astropy.coordinates
 
 # Classes setup, borrowed from SunPy.
 
-
-class Longitude180(Longitude):
-    def __new__(cls, angle, unit=None, wrap_angle=180*u.deg, **kwargs):
-        self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
-                                                wrap_angle=wrap_angle, **kwargs)
-        return self
+# Here we define the classes *inside* the tests to make sure that we can wipe
+# the slate clean when the tests have finished running.
 
 
-class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
-    attr_classes = OrderedDict([('lon', Longitude180),
-                                ('lat', Latitude)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
+def setup_function(func):
+    func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
 
 
-class SphericalWrap180Representation(SphericalRepresentation):
-    attr_classes = OrderedDict([('lon', Longitude180),
-                                ('lat', Latitude),
-                                ('distance', u.Quantity)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
-
-    _unit_representation = UnitSphericalWrap180Representation
+def teardown_function(func):
+    REPRESENTATION_CLASSES.clear()
+    REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
 
 
-class myframe(ICRS):
-    default_representation = SphericalWrap180Representation
-    frame_specific_representation_info = {
-        'spherical': [RepresentationMapping('lon', 'ra'),
-                      RepresentationMapping('lat', 'dec')]
-    }
-    frame_specific_representation_info['unitspherical'] = \
-    frame_specific_representation_info['unitsphericalwrap180'] = \
-    frame_specific_representation_info['sphericalwrap180'] = \
-        frame_specific_representation_info['spherical']
+def test_unit_representation_subclass():
+
+    class Longitude180(Longitude):
+        def __new__(cls, angle, unit=None, wrap_angle=180*u.deg, **kwargs):
+            self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
+                                                    wrap_angle=wrap_angle, **kwargs)
+            return self
 
 
-@frame_transform_graph.transform(FunctionTransform,
-                                 myframe, astropy.coordinates.ICRS)
-def myframe_to_icrs(myframe_coo, icrs):
-    return icrs.realize_frame(myframe_coo._data)
+    class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude)])
+        recommended_units = {'lon': u.deg, 'lat': u.deg}
 
 
-def test_init():
+    class SphericalWrap180Representation(SphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude),
+                                    ('distance', u.Quantity)])
+        recommended_units = {'lon': u.deg, 'lat': u.deg}
+
+        _unit_representation = UnitSphericalWrap180Representation
+
+
+    class myframe(ICRS):
+        default_representation = SphericalWrap180Representation
+        frame_specific_representation_info = {
+            'spherical': [RepresentationMapping('lon', 'ra'),
+                          RepresentationMapping('lat', 'dec')]
+        }
+        frame_specific_representation_info['unitspherical'] = \
+        frame_specific_representation_info['unitsphericalwrap180'] = \
+        frame_specific_representation_info['sphericalwrap180'] = \
+            frame_specific_representation_info['spherical']
+
+
+    @frame_transform_graph.transform(FunctionTransform,
+                                     myframe, astropy.coordinates.ICRS)
+    def myframe_to_icrs(myframe_coo, icrs):
+        return icrs.realize_frame(myframe_coo._data)
+
     f = myframe(10*u.deg, 10*u.deg)
     assert isinstance(f._data, UnitSphericalWrap180Representation)
-    assert isinstance(f.lon, Longitude180)
+    assert isinstance(f.ra, Longitude180)
 
-
-def test_transform():
-    f = myframe(10*u.deg, 10*u.deg)
     g = f.transform_to(astropy.coordinates.ICRS)
     assert isinstance(g, astropy.coordinates.ICRS)
     assert isinstance(g._data, UnitSphericalWrap180Representation)
+
+    frame_transform_graph.remove_transform(myframe,
+                                           astropy.coordinates.ICRS,
+                                           None)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -766,10 +766,10 @@ class StaticMatrixTransform(CoordinateTransform):
         z = v2[2].reshape(subshape)
 
         newrep = CartesianRepresentation(x, y, z)
-        if fromcoord.data.__class__ == UnitSphericalRepresentation:
+        if issubclass(fromcoord.data.__class__, UnitSphericalRepresentation):
             #need to special-case this because otherwise the new class will
             #think it has a valid distance
-            newrep = newrep.represent_as(UnitSphericalRepresentation)
+            newrep = newrep.represent_as(fromcoord.data.__class__)
 
         frameattrs = dict([(attrnm, getattr(fromcoord, attrnm))
                            for attrnm in self.overlapping_frame_attr_names])
@@ -830,10 +830,10 @@ class DynamicMatrixTransform(CoordinateTransform):
         z = v2[2].reshape(subshape)
 
         newrep = CartesianRepresentation(x, y, z)
-        if fromcoord.data.__class__ == UnitSphericalRepresentation:
+        if issubclass(fromcoord.data.__class__, UnitSphericalRepresentation):
             #need to special-case this because otherwise the new class will
             #think it has a valid distance
-            newrep = newrep.represent_as(UnitSphericalRepresentation)
+            newrep = newrep.represent_as(fromcoord.data.__class__)
 
         return toframe.realize_frame(newrep)
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -183,5 +183,5 @@ A representation class may also have a ``_unit_representation`` attribute
 (although it is not required). This attribute points to the appropriate
 "unit" representation (i.e., a representation that is dimensionless). This is
 probably only meaningful for subclasses of
-`~astropy.coordinates.SphericalRepresentation`, but may be useful for other
-domain-specific representations.
+`~astropy.coordinates.SphericalRepresentation`, where it is assumed that it
+will be a subclass of `~astropy.coordinates.UnitSphericalRepresentation`.

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -178,3 +178,10 @@ Once you do this, you will then automatically be able to call
 ``represent_as`` to convert other representations to/from your representation
 class.  Your representation will also be available for use in |skycoord|
 and all frame classes.
+
+A representation class may also have a ``_unit_representation`` attribute
+(although it is not required). This attribute points to the appropriate
+"unit" representation (i.e., a representation that is dimensionless). This is
+probably only meaningful for subclasses of
+`~astropy.coordinates.SphericalRepresentation`, but may be useful for other
+domain-specific representations.


### PR DESCRIPTION
_unitrep allows subclasses of SphericalRepresntation to define their
UnitSphericalRepresentation equivalent.

The copy argument to relalize_frame allows in place changes to the data
attached to the frame. This provides a way to create a frame and change
the data at high speed.