### PR TITLE
Support record array columns in astropy.table.Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,8 @@ New Features
 
   - Initializing a ``Table`` with ``Column`` objects no longer requires
     that the column ``name`` attribute be defined. [#3781]
+  - Table columns may now have a structured (recarray) dtype.  For
+    example, a column could be an (integer, string) pair. [#3759]
 
 - ``astropy.tests``
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -970,6 +970,8 @@ class MaskedColumn(Column, ma.MaskedArray):
         # with MaskedArray.
         self_data = BaseColumn(data, dtype=dtype, shape=shape, length=length, name=name,
                                unit=unit, format=format, description=description, meta=meta, copy=copy)
+        if self_data.dtype.names and mask is None:
+            mask = np.ma.nomask
         self = ma.MaskedArray.__new__(cls, data=self_data, mask=mask)
 
         # Note: do not set fill_value in the MaskedArray constructor because this does not

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -779,7 +779,7 @@ class Column(BaseColumn):
         unit = None if self.unit is None else str(self.unit)
         shape = None if self.ndim <= 1 else self.shape[1:]
         for attr, val in (('name', self.name),
-                          ('dtype', self.dtype.name),
+                          ('dtype', pprint.pprint_dtype(self)),
                           ('shape', shape),
                           ('unit', unit),
                           ('format', self.format),

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -370,10 +370,7 @@ class TableFormatter(object):
         if show_dtype:
             i_centers.append(n_header)
             n_header += 1
-            try:
-                dtype = col.dtype.name
-            except AttributeError:
-                dtype = 'object'
+            dtype = pprint_dtype(col)
             yield six.text_type(dtype)
         if show_unit or show_name or show_dtype:
             i_dashes = n_header
@@ -669,3 +666,17 @@ class TableFormatter(object):
             if i0 >= len(tabcol) - delta_lines:
                 i0 = len(tabcol) - delta_lines
             print("\n")
+
+
+def pprint_dtype(col):
+    def _numpy_dtype_to_str(dtype):
+        if dtype.fields:
+            return str('({0})').format(str(', ').join(
+                _numpy_dtype_to_str(np.dtype(x[1])) for x in dtype.descr))
+        else:
+            return dtype.name
+
+    if hasattr(col, 'dtype'):
+        return _numpy_dtype_to_str(col.dtype)
+    else:
+        return str('object')

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -258,7 +258,7 @@ class TableFormatter(object):
             col_strs.insert(0, '<table>')
             col_strs.append('</table>')
 
-        # Now bring all the column string values to the same fixed width        
+        # Now bring all the column string values to the same fixed width
         else:
             col_width = max(len(x) for x in col_strs) if col_strs else 1
 
@@ -307,12 +307,11 @@ class TableFormatter(object):
                         justify = (lambda col_str, col_width:
                                    getattr(col_str, 'rjust')(col_width))
                 col_strs[i] = justify(col_str, col_width)
-                
+
         if outs['show_length']:
             col_strs.append('Length = {0} rows'.format(len(col)))
 
         return col_strs, outs
-
 
     def _pformat_col_iter(self, col, max_lines, show_name, show_unit, outs,
                           show_dtype=False, show_length=None):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -44,7 +44,7 @@ def descr(col):
     This returns a 3-tuple (name, type, shape) that can always be
     used in a structured array dtype definition.
     """
-    col_dtype_str = col.dtype.str if hasattr(col, 'dtype') else 'O'
+    col_dtype_str = col.dtype if hasattr(col, 'dtype') else 'O'
     col_shape = col.shape[1:] if hasattr(col, 'shape') else ()
     return (col_getattr(col, 'name'), col_dtype_str, col_shape)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -44,9 +44,9 @@ def descr(col):
     This returns a 3-tuple (name, type, shape) that can always be
     used in a structured array dtype definition.
     """
-    col_dtype_str = col.dtype if hasattr(col, 'dtype') else 'O'
+    col_dtype = col.dtype if hasattr(col, 'dtype') else 'O'
     col_shape = col.shape[1:] if hasattr(col, 'shape') else ()
-    return (col_getattr(col, 'name'), col_dtype_str, col_shape)
+    return (col_getattr(col, 'name'), col_dtype, col_shape)
 
 
 def is_mixin_class(obj):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -164,6 +164,8 @@ def mixin_cols(request):
     cols['i'] = table.Column([0, 1, 2, 3], name='i')
     cols['a'] = table.Column(['a', 'b', 'b', 'c'], name='a')
     cols['b'] = table.Column(['b', 'c', 'a', 'd'], name='b')
+    cols['c'] = table.Column([(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')],
+                             dtype=str('<i4, |S1'), name='c')
     cols['m'] = mixin_cols[request.param]
 
     return cols

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -20,6 +20,7 @@ class SetupData(object):
         self.d_mask = np.array([False, True, False])
         self.d = MaskedColumn(name='d', data=[7, 8, 7], mask=self.d_mask)
         self.e = MaskedColumn(name='e', data=[(7, 'a'), (8, 'b'), (7, 'c')],
+                              dtype=b'<i4, |S1',
                               mask=[[False, True], [True, False], [False, False]])
         self.t = Table([self.a, self.b], masked=True)
         self.ca = Column(name='ca', data=[1, 2, 3])

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -19,6 +19,8 @@ class SetupData(object):
         self.c = MaskedColumn(name='c', data=[7, 8, 9], mask=False)
         self.d_mask = np.array([False, True, False])
         self.d = MaskedColumn(name='d', data=[7, 8, 7], mask=self.d_mask)
+        self.e = MaskedColumn(name='e', data=[(7, 'a'), (8, 'b'), (7, 'c')],
+                              mask=[[False, True], [True, False], [False, False]])
         self.t = Table([self.a, self.b], masked=True)
         self.ca = Column(name='ca', data=[1, 2, 3])
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -73,12 +73,11 @@ def test_make_table(table_types, mixin_cols):
     check_mixin_type(t, t['m'], mixin_cols['m'])
 
     cols = list(mixin_cols.values())
-    t = table_types.Table(cols, names=('a', 'b', 'c', 'm'))
+    t = table_types.Table(cols, names=('i', 'a', 'b', 'c', 'm'))
     check_mixin_type(t, t['m'], mixin_cols['m'])
 
     t = table_types.Table(cols)
-    check_mixin_type(t, t['col3'], mixin_cols['m'])
-
+    check_mixin_type(t, t['col4'], mixin_cols['m'])
 
 def test_io_ascii_write():
     """

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -545,7 +545,13 @@ def test_pprint_recarray_col():
     col = table.Column(
         [(1, ('a', 42.))],
         dtype=[(str('f0'), str('i4')), (str('f1'), [(str('f2'), str('S1')), (str('f3'), str('f8'))])])
-    assert "dtype='(int32, (string8, float64))'" in repr(col)
+    if PY3:
+        assert "dtype='(int32, (bytes8, float64))'" in repr(col)
+    else:
+        assert "dtype='(int32, (string8, float64))'" in repr(col)
 
     t = table.Table([col, table.Column([1])], names=['a', 'b'])
-    assert "(int32, (string8, float64)) int64" in repr(t)
+    if PY3:
+        assert "(int32, (bytes8, float64)) int64" in repr(t)
+    else:
+        assert "(int32, (string8, float64)) int64" in repr(t)

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -550,7 +550,7 @@ def test_pprint_recarray_col():
     else:
         assert "dtype='(int32, (string8, float64))'" in repr(col)
 
-    t = table.Table([col, table.Column([1])], names=['a', 'b'])
+    t = table.Table([col, table.Column(np.array([1], np.int64))], names=['a', 'b'])
     if PY3:
         assert "(int32, (bytes8, float64)) int64" in repr(t)
     else:

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -539,3 +539,13 @@ def test_pprint_nameless_col():
     """
     col = table.Column([1.,2.])
     assert str(col).startswith('None')
+
+
+def test_pprint_recarray_col():
+    col = table.Column(
+        [(1, ('a', 42.))],
+        dtype=[(str('f0'), str('i4')), (str('f1'), [(str('f2'), str('S1')), (str('f3'), str('f8'))])])
+    assert "dtype='(int32, (string8, float64))'" in repr(col)
+
+    t = table.Table([col, table.Column([1])], names=['a', 'b'])
+    assert "(int32, (string8, float64)) int64" in repr(t)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -60,6 +60,15 @@ class SetupData(object):
             return self._d
 
     @property
+    def e(self):
+        if self._column_type is not None:
+            if not hasattr(self, '_e'):
+                self._e = self._column_type(np.array(
+                    [(7, 'a'), (8, 'b'), (7, 'c')],
+                    dtype=str('<i4,|U1')), 'e')
+            return self._e
+
+    @property
     def obj(self):
         if self._column_type is not None:
             if not hasattr(self, '_obj'):
@@ -204,6 +213,13 @@ class TestSetTableColumn(SetupData):
         # Wrong size
         with pytest.raises(ValueError):
             t['b'] = [1, 2]
+
+    def test_recarray_column(self, table_types):
+        """Test that structured array columns works"""
+        self._setup(table_types)
+        t = table_types.Table([self.a, self.e])
+        assert t['e'].dtype == np.dtype(
+            [(str('f0'), str('<i4')), (str('f1'), str('<U1'))])
 
 
 @pytest.mark.usefixtures('table_types')


### PR DESCRIPTION
In the interest of generality over in ASDF (see https://github.com/spacetelescope/asdf-standard/pull/83), I thought it would be worth supporting table columns where the data type is a record array.  This is not the same as nested Tables, obviously, which would be quite a bit more work, but it seemed like only a couple of minor changes were necessary to have a Column dtype like "<i4,S1".