### PR TITLE
Remove tracebacks from exceptions in code examples

### DIFF
--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -169,10 +169,9 @@ being specified will raise a ``ValueError``:
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
   >>> cosmo.Odm(1)
   Traceback (most recent call last):
-      cosmo.Odm(1)
-    File "astropy/cosmology/core.py", line 539, in Odm
-      raise ValueError("Baryonic density not set for this cosmology, "
-  ValueError: Baryonic density not set for this cosmology, unclear meaning of dark matter density
+  ...
+  ValueError: Baryonic density not set for this cosmology, unclear
+  meaning of dark matter density
 
 Cosmological instances have an optional ``name`` attribute which can be
 used to describe the cosmology::

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -499,13 +499,15 @@ literal and repeat all slashes, e.g. ``"\\usepackage{foo}"``.
 The following shows the problem on Python 2::
 
     >>> ur'\u'
-      File "<stdin>", line 1
+    Traceback (most recent call last):
+    ...
     SyntaxError: (unicode error) 'rawunicodeescape' codec can't decode bytes in
     position 0-1: truncated \uXXXX
     >>> ur'\\u'
     u'\\\\u'
     >>> u'\u'
-      File "<stdin>", line 1
+    Traceback (most recent call last):
+    ...
     SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in
     position 0-1: truncated \uXXXX escape
     >>> u'\\u'

--- a/docs/io/fits/appendix/history.rst
+++ b/docs/io/fits/appendix/history.rst
@@ -2601,13 +2601,7 @@ The following enhancements were made:
       >>> del cl[0]
       >>> print cl['DP1.AXIS.1']
       Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-      File "NP_pyfits.py", line 977, in __getitem__
-        return self.ascard[key].value
-      File "NP_pyfits.py", line 1258, in __getitem__
-        _key = self.index_of(key)
-      File "NP_pyfits.py", line 1403, in index_of
-        raise KeyError, 'Keyword %s not found.' % `key`
+      ...
       KeyError: "Keyword 'DP1.AXIS.1' not found."
       >>> hdr['DP1.AXIS.1']
       4.0

--- a/docs/io/fits/usage/headers.rst
+++ b/docs/io/fits/usage/headers.rst
@@ -350,11 +350,7 @@ Examples follow::
     10
     >>> h.header['ABCDEFGHI']
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-      File "astropy/io/fits/header.py", line 121, in __getitem__
-        return self._cards[self._cardindex(key)].value
-      File "astropy/io/fits/header.py", line 1106, in _cardindex
-        raise KeyError("Keyword %r not found." % keyword)
+    ...
     KeyError: "Keyword 'ABCDEFGI.' not found."
     >>> h.header
     SIMPLE = T / conforms to FITS standard

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -270,11 +270,7 @@ unless the table ID is specified via the ``table_id=`` argument::
 
     >>> t = Table.read('catalog.xml')
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-      File "/Volumes/Raptor/Library/Python/2.7/lib/python/site-packages/astropy/table/table.py", line 1559, in read
-        table = reader(*args, **kwargs)
-      File "/Volumes/Raptor/Library/Python/2.7/lib/python/site-packages/astropy/io/votable/connect.py", line 44, in read_table_votable
-        raise ValueError("Multiple tables found: table id should be set via the id= argument. The available tables are " + ', '.join(tables.keys()))
+    ...
     ValueError: Multiple tables found: table id should be set via the table_id= argument. The available tables are twomass, spitzer
 
     >>> t = Table.read('catalog.xml', table_id='twomass')

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -255,14 +255,10 @@ or greater they have run into the following crash when trying to create a
 
     >>> datetime = Time('2012-03-01T13:08:00', scale='utc')
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-      File "/usr/lib/python2.7/site-packages/astropy/time/core.py", line 198, in __init__
-        self._init_from_vals(val, val2, format, scale, copy)
-      File "/usr/lib/python2.7/site-packages/astropy/time/core.py", line 240, in _init_from_vals
-        self._time = self._get_time_fmt(val, val2, format, scale)
-      File "/usr/lib/python2.7/site-packages/astropy/time/core.py", line 278, in _get_time_fmt
-        raise ValueError('Input values did not match {0}'.format(err_msg))
-    ValueError: Input values did not match any of the formats where the format keyword is optional [u'astropy_time', u'datetime', u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']
+    ...
+    ValueError: Input values did not match any of the formats where
+    the format keyword is optional [u'astropy_time', u'datetime',
+    u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']
 
 This problem can occur when there is a version mismatch between the compiled
 ERFA library (this is included as part of Astropy in most distributions), and


### PR DESCRIPTION
This is just a simple doc cleanup.  I noticed there were a few places where an entire traceback was included in example console sessions.  I think this just detracts from the main point which is the exception message.  In some cases the tracebacks went through older versions of the code, which could potentially confuse the reader as well.