### PR TITLE
Allow time format to be mutable (set in place)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,9 @@ New Features
 
   - Add support for FITS standard time strings. [#3547]
 
+  - Allow the ``format`` attribute to be updated in place to change the
+    default representation of a ``Time`` object. [#3673]
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -230,6 +230,18 @@ class TestTimeDelta():
             assert not hasattr(t3, '_delta_tdb_tt')
             assert not hasattr(t3, '_delta_ut1_utc')
 
+    def test_set_format(self):
+        """
+        Test basics of setting format attribute.
+        """
+        dt = TimeDelta(86400.0, format='sec')
+        assert dt.value == 86400.0
+        assert dt.format == 'sec'
+
+        dt.format = 'jd'
+        assert dt.value == 1.0
+        assert dt.format == 'jd'
+
 
 class TestTimeDeltaScales():
     """Test scale conversion for Time Delta.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -67,6 +67,14 @@ formats by requesting the corresponding |Time| attributes::
   >>> t.mjd
   array([ 51179.00000143,  55197.        ])
 
+The default representation can be changed by setting the `format` attribute::
+
+  >>> t.format = 'fits'
+  >>> t
+  <Time object: scale='utc' format='fits' value=['1999-01-01T00:00:00.123(UTC)'
+                                                 '2010-01-01T00:00:00.000(UTC)']>
+  >>> t.format = 'isot'
+
 We can also convert to a different time scale, for instance from UTC to
 TT.  This uses the same attribute mechanism as above but now returns a new
 |Time| object::
@@ -168,6 +176,31 @@ yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:0
    such as ``UT(NIST)`` is stored only as long as the time scale is not changed.
 .. [#] `Rots et al. 2015, A&A 574:A36 <http://adsabs.harvard.edu/abs/2015A%26A...574A..36R>`_
 	  
+Changing format
+"""""""""""""""
+
+The default representation can be changed by setting the ``format`` attribute in place::
+
+  >>> t = Time('2000-01-02')
+  >>> t.format = 'jd'
+  >>> t
+  <Time object: scale='utc' format='jd' value=2451545.5>
+
+Be aware that when changing format, the current output subformat (see section below)
+may not exist in the new format.  In this case the subformat will not be
+preserved::
+
+  >>> t = Time('2000-01-02', format='fits', out_subfmt='longdate')
+  >>> t.value
+  '+02000-01-02(UTC)'
+  >>> t.format = 'iso'
+  >>> t.out_subfmt
+  u'*'
+  >>> t.format = 'fits'
+  >>> t.value
+  '2000-01-02T00:00:00.000(UTC)'
+
+
 Subformat
 """""""""
 


### PR DESCRIPTION
This is a proposal to allow the `format` attribute of a `Time` object to be updated in place.  The underlying `jd1` and `jd2` are unaffected so the basic concept of an immutable `Time` object is still enforced, but you get to change the external representation.  Pretty much the same idea as `representation` in coordinates, and if I could go back in time I think I would use `representation` for time as well.

I'm not running CI and writing specific tests until getting an initial thumbs up on the idea.  I *think* this doesn't break anything.

Examples:
```
In [2]: from astropy.time import Time

In [3]: t = Time.now()

In [4]: t
Out[4]: <Time object: scale='utc' format='datetime' value=2015-05-08 16:54:48.718411>

In [5]: t.format = 'unix'

In [6]: t
Out[6]: <Time object: scale='utc' format='unix' value=1431104088.72>

In [7]: t.format = 'fits'

In [8]: t
Out[8]: <Time object: scale='utc' format='fits' value=2015-05-08T16:54:48.718(UTC)>

In [9]: t.out_subfmt = 'longdate_hms'

In [10]: t
Out[10]: <Time object: scale='utc' format='fits' value=+02015-05-08T16:54:48.718(UTC)>

In [11]: t.format = 'cxcsec'

In [12]: t
Out[12]: <Time object: scale='utc' format='cxcsec' value=547491355.902>

In [13]: t.format = 'datetime'

In [14]: t
Out[14]: <Time object: scale='utc' format='datetime' value=2015-05-08 16:54:48.718411>
```