### PR TITLE
Remove HTML format from io.ascii guess list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,10 @@ API changes
 
 - ``astropy.io.ascii``
 
+  - Remove HTML from the list of automatically-guessed formats when reading.
+    This was necessary to avoid a commonly-encountered segmentation fault
+    occurring in the libxml parser on MacOSX. [#3693]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,9 +111,10 @@ API changes
 
 - ``astropy.io.ascii``
 
-  - Remove HTML from the list of automatically-guessed formats when reading.
-    This was necessary to avoid a commonly-encountered segmentation fault
-    occurring in the libxml parser on MacOSX. [#3693]
+  - Remove HTML from the list of automatically-guessed formats when reading if
+    the file does not appear to be HTML.  This was necessary to avoid a
+    commonly-encountered segmentation fault occurring in the libxml parser on
+    MacOSX. [#3693]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -17,6 +17,9 @@ try:
 except ImportError:
     HAS_BEAUTIFUL_SOUP = False
 
+if HAS_BEAUTIFUL_SOUP:
+    files.append('t/html.html')
+
 @pytest.mark.parametrize('filename', files)
 
 def test_read_generic(filename):

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -17,9 +17,6 @@ try:
 except ImportError:
     HAS_BEAUTIFUL_SOUP = False
 
-if HAS_BEAUTIFUL_SOUP:
-    files.append('t/html.html')
-
 @pytest.mark.parametrize('filename', files)
 
 def test_read_generic(filename):

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -16,7 +16,7 @@ from ....units import Unit
 from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true, setup_function, teardown_function)
 from .. import core
-
+from ..ui import _probably_html
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
@@ -962,3 +962,33 @@ def test_commented_header_comments(fast):
              '3 4']
     dat = ascii.read(lines, format='commented_header', fast_reader=fast)
     assert 'comments' not in dat.meta
+
+
+def test_probably_html():
+    """
+    Test the routine for guessing if a table input to ascii.read is probably HTML
+    """
+    for table in ('t/html.html',
+                  'http://blah.com/table.html',
+                  'https://blah.com/table.html',
+                  'file://blah/table.htm',
+                  'ftp://blah.com/table.html',
+                  'file://blah.com/table.htm',
+                  ' <! doctype html > hello world',
+                  'junk < table baz> <tr foo > <td bar> </td> </tr> </table> junk',
+                  ['junk < table baz>', ' <tr foo >', ' <td bar> ', '</td> </tr>',  '</table> junk'],
+                  (' <! doctype html > ', ' hello world'),
+    ):
+        assert _probably_html(table) is True
+
+    for table in ('t/html.htms',
+                  'Xhttp://blah.com/table.html',
+                  ' https://blah.com/table.htm',
+                  'fole://blah/table.htm',
+                  ' < doctype html > hello world',
+                  'junk < tble baz> <tr foo > <td bar> </td> </tr> </table> junk',
+                  ['junk < table baz>', ' <t foo >', ' <td bar> ', '</td> </tr>',  '</table> junk'],
+                  (' <! doctype htm > ', ' hello world'),
+                  [[1, 2, 3]],
+    ):
+        assert _probably_html(table) is False

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -775,7 +775,7 @@ def get_testfiles(name=None):
         testfiles.append({'cols': ('Column 1', 'Column 2', 'Column 3'),
                           'name': 't/html.html',
                           'nrows': 3,
-                          'opts': {'Reader': ascii.HTML, 'guess': False}})
+                          'opts': {'Reader': ascii.HTML}})
     except ImportError:
         pass
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -775,7 +775,7 @@ def get_testfiles(name=None):
         testfiles.append({'cols': ('Column 1', 'Column 2', 'Column 3'),
                           'name': 't/html.html',
                           'nrows': 3,
-                          'opts': {'Reader': ascii.HTML}})
+                          'opts': {'Reader': ascii.HTML, 'guess': False}})
     except ImportError:
         pass
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -429,8 +429,7 @@ def _get_guess_kwargs_list(read_kwargs):
                               dict(Reader=sextractor.SExtractor),
                               dict(Reader=ipac.Ipac),
                               dict(Reader=latex.Latex),
-                              dict(Reader=latex.AASTex),
-                              dict(Reader=html.HTML)
+                              dict(Reader=latex.AASTex)
                               ])
 
     # Cycle through the basic-style readers using all combinations of delimiter

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -68,10 +68,11 @@ def _probably_html(table, maxchars=100000):
         table = table[:maxchars]
 
         # URL ending in .htm or .html
-        if re.match(r'http[s]?:// .+ \.htm[l]?$', table, re.IGNORECASE):
+        if re.match(r'( http[s]? | ftp | file ) :// .+ \.htm[l]?$', table,
+                    re.IGNORECASE | re.VERBOSE):
             return True
 
-        # Filename ending in .htm or .html
+        # Filename ending in .htm or .html which exists
         if re.search(r'\.htm[l]?$', table[-5:], re.IGNORECASE) and os.path.exists(table):
             return True
 

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -262,7 +262,7 @@ class which actually implements reading the different file formats::
 
   for Reader in (Ecsv, FixedWidthTwoLine, FastBasic, Basic,
                  Rdb, FastTab, Tab, Cds, Daophot, SExtractor,
-                 Ipac, Latex, AASTex, HTML):
+                 Ipac, Latex, AASTex):
       read(Reader=Reader)
 
   for Reader in (CommentedHeader, FastBasic, Basic, FastNoHeader, NoHeader):


### PR DESCRIPTION
From #3691 it appears that the HTML-format reader (with the libxml backend for beautifulsoup) can segfault for normal CSV-format input. 

I would suggest mitigating this by taking HTML out of the standard guess list.  It is a bit of an outlier and not something that would commonly appear in a data file of unknown format.

@hamogu @ChrisBeaumont ?