### PR TITLE
Speed up distance calculations by ~10-20x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,8 +31,8 @@ New Features
     are now > 10x faster for the supplied cosmologies. [#3767]
 
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
-    should use the new public interfaces ``FLRW.tfunc`` and ``FLRW.xfunc``
-    instead. [#3767]
+    should use the new public interfaces ``FLRW.lookback_time_integrand`` 
+    and ``FLRW.abs_distance_integrand`` instead. [#3767]
 
 - ``astropy.io.ascii``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,13 @@ New Features
 
   - Add Planck 2015 cosmology [#3476]
 
+  - Distance calculations in cosmologies with massless (or no) neutrinos
+    are now > 10x faster for the supplied cosmologies. [#3767]
+
+  - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
+    should use the new public interfaces ``FLRW.tfunc`` and ``FLRW.xfunc``
+    instead. [#3767]
+
 - ``astropy.io.ascii``
 
   - Automatically use ``guess=False`` when reading if the file ``format`` is

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -649,7 +649,12 @@ def test_tnu():
 
 
 def test_efunc_vs_invefunc():
-    # Test that efunc and inv_efunc give inverse values
+    """ Test that efunc and inv_efunc give inverse values"""
+
+    # Note that all of the subclasses here don't need
+    #  scipy because they don't need to call de_density_scale
+    # The test following this tests the case where that is needed.
+
     z0 = 0.5
     z = np.array([0.5, 1.0, 2.0, 5.0])
 
@@ -684,23 +689,21 @@ def test_efunc_vs_invefunc():
     assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
     assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
-    # Now do non-standard subclasses
-    cosmo = test_cos_sub()
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = test_cos_subnu()
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_efunc_vs_invefunc_flrw():
+    """ Test that efunc and inv_efunc give inverse values"""
     z0 = 0.5
     z = np.array([0.5, 1.0, 2.0, 5.0])
 
     # FLRW is abstract, so requires test_cos_sub defined earlier
-    # This requires scipy, unlike the built-ins
+    # This requires scipy, unlike the built-ins, because it
+    # calls de_density_scale, which has an integral in it
     cosmo = test_cos_sub()
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    # Add neutrinos
+    cosmo = test_cos_subnu()
     assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
     assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -410,10 +410,19 @@ def test_zeroing():
 # This class is to test whether the routines work correctly
 # if one only overloads w(z)
 class test_cos_sub(core.FLRW):
-
     def __init__(self):
         core.FLRW.__init__(self, 70.0, 0.27, 0.73, Tcmb0=0.0, name="test_cos")
         self._w0 = -0.9
+
+    def w(self, z):
+        return self._w0 * np.ones_like(z)
+
+# Similar, but with neutrinos
+class test_cos_subnu(core.FLRW):
+    def __init__(self):
+        core.FLRW.__init__(self, 70.0, 0.27, 0.73, Tcmb0=3.0,
+                           m_nu = 0.1 * u.eV, name="test_cos_nu")
+        self._w0 = -0.8
 
     def w(self, z):
         return self._w0 * np.ones_like(z)
@@ -445,13 +454,7 @@ def test_de_subclass():
                     [1.12934694, 1.23114444], rtol=1e-4)
 
     # Add neutrinos for efunc, inv_efunc
-    # These are not from Ned Wright's calculator, which doesn't do this
-    cosmo = core.wCDM(H0=70, Om0=0.27, Ode0=0.73, w0=-0.9, Tcmb0=3.0,
-                      m_nu = 0.1 * u.eV)
-    assert allclose(cosmo.efunc([0.5, 1.0]),
-                    [1.32127873,  1.75920792], rtol=1e-5)
-    assert allclose(cosmo.inv_efunc([0.5, 1.0]),
-                    [0.75684258,  0.56843764], rtol=1e-5)
+
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -678,6 +681,14 @@ def test_efunc_vs_invefunc():
     assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
     assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
     cosmo = core.w0wzCDM(55.0, 0.4, 0.8, w0=-1.05, wz=-0.2)
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+
+    # Now do non-standard subclasses
+    cosmo = test_cos_sub()
+    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
+    cosmo = test_cos_subnu()
     assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
     assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
@@ -1150,6 +1161,7 @@ def test_massivenu_basic():
     assert len(mnu) == 3
     assert mnu.unit == u.eV
     assert allclose(mnu, [0.1, 0.1, 0.1] * u.eV)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_distances():

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -293,13 +293,17 @@ def test_clone():
 
 
 def test_xtfuncs():
-    """ Test of xfunc, tfunc"""
+    """ Test of absorption and lookback integrand"""
     cosmo = core.LambdaCDM(70, 0.3, 0.5)
     z = np.array([2.0, 3.2])
-    assert allclose(cosmo.tfunc(3), 0.052218976654969378, rtol=1e-4)
-    assert allclose(cosmo.tfunc(z), [0.10333179, 0.04644541], rtol=1e-4)
-    assert allclose(cosmo.xfunc(3), 3.3420145059180402, rtol=1e-4)
-    assert allclose(cosmo.xfunc(z), [2.7899584, 3.44104758], rtol=1e-4)
+    assert allclose(cosmo.lookback_time_integrand(3), 0.052218976654969378,
+                    rtol=1e-4)
+    assert allclose(cosmo.lookback_time_integrand(z),
+                    [0.10333179, 0.04644541], rtol=1e-4)
+    assert allclose(cosmo.abs_distance_integrand(3), 3.3420145059180402,
+                    rtol=1e-4)
+    assert allclose(cosmo.abs_distance_integrand(z),
+                    [2.7899584, 3.44104758], rtol=1e-4)
 
 
 def test_repr():

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -315,7 +315,9 @@ species of neutrinos with non-zero mass (which is not included in
 
 Adding massive neutrinos has significant performance implications.
 In particular, the computation of distance measures and lookback times
-are factors of ten slower than in the massless neutrino case.
+are factors of ten slower than in the massless neutrino case.  Therefore,
+if you need to compute a lot of distances in such a cosmology, it is
+particularly useful to calculate them on a grid and use interpolation.
 
 The contribution of photons and neutrinos to the total mass-energy density
 can be found as a function of redshift::

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -289,7 +289,9 @@ constructor of a new subclass be available as properties, since the
 ``clone`` method assumes this is the case.  It is also advisable
 to stick to subclassing `~astropy.cosmology.FLRW` rather than one of
 its subclasses, since some of them use internal optimizations that
-also need to be propagated to any subclasses.
+also need to be propagated to any subclasses.  Users wishing to
+use similar tricks (which can make distance calculations much faster)
+should consult the cosmology module source code for details.
 
 Photons and Neutrinos
 ---------------------

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -286,7 +286,10 @@ Users can specify their own equation of state by sub-classing
 `~astropy.cosmology.FLRW`.  See the provided subclasses for
 examples. It is recommended, but not required, that all arguments to the
 constructor of a new subclass be available as properties, since the
-``clone`` method assumes this is the case.
+``clone`` method assumes this is the case.  It is also advisable
+to stick to subclassing `~astropy.cosmology.FLRW` rather than one of
+its subclasses, since some of them use internal optimizations that
+also need to be propagated to any subclasses.
 
 Photons and Neutrinos
 ---------------------

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -313,6 +313,10 @@ and that the Planck13 and Planck15 cosmologies includes a single
 species of neutrinos with non-zero mass (which is not included in
 :math:`\Omega_{m0}`).
 
+Adding massive neutrinos has significant performance implications.
+In particular, the computation of distance measures and lookback times
+are factors of ten slower than in the massless neutrino case.
+
 The contribution of photons and neutrinos to the total mass-energy density
 can be found as a function of redshift::
 


### PR DESCRIPTION
* Break out some internal functions for the integrators to call
  directly
* Tests pass, distances are about 10x faster than before, now
  about 5x faster than cosmolopy.
* Related to #3764, but doesn't necessarily close it.

This is only done for a) distances, b) FlatLambdaCDM.  The idea
is to show exactly how ugly this solution is so we can decide
if it's worth implementing for the other cosmologies.  Sure
does speed things up though...