### PR TITLE
Indicate output data type in io.ascii intro and improve links

### DIFF
--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -36,7 +36,7 @@ be easily accommodated.
 
     It is also possible to use the functionality from
     :mod:`astropy.io.ascii` through a higher-level interface in the
-    :mod:`astropy.table` package. See :ref:`table_io` for more details.
+    :ref:`Data Tables <astropy-table>` package. See :ref:`table_io` for more details.
 
 Getting Started
 ===============
@@ -62,11 +62,13 @@ This table can be read with the following::
     877     0.22 4378 3892   Source 82
 
 The first argument to the |read| function can be the name of a file, a string
-representation of a table, or a list of table lines.  By default |read| will
-try to `guess the table format <#guess-table-format>`_ by trying all the
-`supported formats`_.  If this does not work (for unusually formatted tables) then
-one needs give astropy.io.ascii additional hints about the format, for
-example::
+representation of a table, or a list of table lines.  The return value
+(``data`` in this case) is a :ref:`Table <astropy-table>` object.
+
+By default |read| will try to `guess the table format <#guess-table-format>`_
+by trying all the `supported formats`_.  If this does not work (for unusually
+formatted tables) then one needs give astropy.io.ascii additional hints about
+the format, for example::
 
    >>> lines = ['objID                   & osrcid            & xsrcid       ',
    ...          '----------------------- & ----------------- & -------------',

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -67,7 +67,7 @@ representation of a table, or a list of table lines.  The return value
 
 By default |read| will try to `guess the table format <#guess-table-format>`_
 by trying all the `supported formats`_.  If this does not work (for unusually
-formatted tables) then one needs give astropy.io.ascii additional hints about
+formatted tables) then one needs give ``astropy.io.ascii`` additional hints about
 the format, for example::
 
    >>> lines = ['objID                   & osrcid            & xsrcid       ',

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -117,7 +117,7 @@ Parameters for ``read()``
   This converts the raw data tables value into the
   output object that gets returned by |read|.  The default is
   :class:`~astropy.io.ascii.TableOutputter`, which returns a
-  :class:`~astropy.table.Table` object.
+  :class:`~astropy.table.Table` object (see :ref:`Data Tables <astropy-table>`).
 
 **Inputter**: Inputter class
   This is generally not specified.

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -12,7 +12,10 @@ function::
   >>> data = ascii.read(table)  # doctest: +SKIP
 
 where ``table`` is the name of a file, a string representation of a table, or a
-list of table lines.  By default |read| will try to `guess the table format <#guess-table-format>`_
+list of table lines.  The return value (``data`` in this case) is a :ref:`Table
+<astropy-table>` object.
+
+By default |read| will try to `guess the table format <#guess-table-format>`_
 by trying all the supported formats.  If this does not work (for unusually
 formatted tables) then one needs give `astropy.io.ascii` additional hints about the
 format, for example::


### PR DESCRIPTION
A user pointed out that the data type of the `read()` output is not explicitly documented (except in one obscure location).  This fixes that and improves a couple of other links by linking to the main Data Tables doc page instead of the Table API doc (which is confusing / useless for new users).