### PR TITLE
Fix bugs with evaluating models that accept no inputs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -237,6 +237,8 @@ New Features
 
 - ``astropy.modeling``
 
+  - Fixed crash when evaluating a model that accepts no inputs. [#3772]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2271,6 +2271,11 @@ def _prepare_inputs_single_model(model, params, inputs, **kwargs):
         else:
             # Extend the broadcasts list to include shapes for all outputs
             extra_outputs = model.n_outputs - model.n_inputs
+            if not broadcasts:
+                # If there were no inputs then the broadcasts list is empty
+                # just add an empty tuple since there is no broadcasting of
+                # outputs and inputs necessary
+                broadcasts.append(())
             broadcasts.extend([broadcasts[0]] * extra_outputs)
 
     return inputs, (broadcasts,)
@@ -2354,6 +2359,9 @@ def _prepare_inputs_model_set(model, params, inputs, n_models, model_set_axis,
 
         pivots.append(pivot)
         reshaped.append(new_input)
+
+    if model.n_inputs < model.n_outputs:
+        pivots.extend([model_set_axis] * (model.n_outputs - model.n_inputs))
 
     return reshaped, (pivots,)
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2273,9 +2273,9 @@ def _prepare_inputs_single_model(model, params, inputs, **kwargs):
             extra_outputs = model.n_outputs - model.n_inputs
             if not broadcasts:
                 # If there were no inputs then the broadcasts list is empty
-                # just add an empty tuple since there is no broadcasting of
-                # outputs and inputs necessary
-                broadcasts.append(())
+                # just add a None since there is no broadcasting of outputs and
+                # inputs necessary (see _prepare_outputs_single_model)
+                broadcasts.append(None)
             broadcasts.extend([broadcasts[0]] * extra_outputs)
 
     return inputs, (broadcasts,)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -53,6 +53,26 @@ def test_Model_array_parameter():
     assert_allclose(model.param_sets, [[42], [43], [44]])
 
 
+def test_inputless_model():
+    class TestModel(Model):
+        inputs = ()
+        outputs = ('y',)
+        a = Parameter()
+
+        @staticmethod
+        def evaluate(a):
+            return a
+
+    m = TestModel(1)
+    assert m.a == 1
+    assert m() == 1
+
+    # Test a model set
+    m2 = TestModel(a=[1, 2, 3], model_set_axis=0)
+    assert len(m2) == 3
+    assert np.all(m2() == [1, 2, 3])
+
+
 def test_Model_add_model():
     m = models.Gaussian1D(1,2,3)
     m.add_model(m, 'p')

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -54,6 +54,11 @@ def test_Model_array_parameter():
 
 
 def test_inputless_model():
+    """
+    Regression test for
+    https://github.com/astropy/astropy/pull/3772#issuecomment-101821641
+    """
+
     class TestModel(Model):
         inputs = ()
         outputs = ('y',)
@@ -67,10 +72,20 @@ def test_inputless_model():
     assert m.a == 1
     assert m() == 1
 
+    # Test array-like output
+    m = TestModel([1, 2, 3], model_set_axis=False)
+    assert len(m) == 1
+    assert np.all(m() == [1, 2, 3])
+
     # Test a model set
-    m2 = TestModel(a=[1, 2, 3], model_set_axis=0)
-    assert len(m2) == 3
-    assert np.all(m2() == [1, 2, 3])
+    m = TestModel(a=[1, 2, 3], model_set_axis=0)
+    assert len(m) == 3
+    assert np.all(m() == [1, 2, 3])
+
+    # Test a model set
+    m = TestModel(a=[[1, 2, 3], [4, 5, 6]], model_set_axis=0)
+    assert len(m) == 2
+    assert np.all(m() == [[1, 2, 3], [4, 5, 6]])
 
 
 def test_Model_add_model():


### PR DESCRIPTION
Fixes an issue pointed out by @wkerzendorf, where models with zero inputs did not work.  Incidentally the fix is almost exactly the one he put in temporarily.  Just fixed it in another case as well.