### PR TITLE
Allow object arrays of mixed unit Quantities to be printed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -255,7 +255,10 @@ New Features
 - ``astropy.units``
 
   - Fixed printing of object ndarrays containing multiple Quantity
-    objects with differing / incompatible units. [#3778]
+    objects with differing / incompatible units. Note: Unit conversion errors
+    now cause a ``UnitConversionError`` exception to be raised.  However, this
+    is a subclass of the ``UnitsError`` exception used previously, so existing
+    code that catches ``UnitsError`` should still work. [#3778]
 
 - ``astropy.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -254,6 +254,9 @@ New Features
 
 - ``astropy.units``
 
+  - Fixed printing of object ndarrays containing multiple Quantity
+    objects with differing / incompatible units. [#3778]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from ..units import UnitsError, Unit
+from ..units import UnitsError, UnitConversionError, Unit
 from .. import log
 
 from .nddata import NDData
@@ -115,9 +115,9 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
                     try:
                         scaling = (1 * value._unit).to(self.unit)
                     except UnitsError:
-                        raise UnitsError('Cannot convert unit of uncertainty '
-                                         'to unit of '
-                                         '{0} object.'.format(class_name))
+                        raise UnitConversionError(
+                            'Cannot convert unit of uncertainty to unit of '
+                            '{0} object.'.format(class_name))
                     value.array *= scaling
                 elif not self.unit and value._unit:
                     # Raise an error if uncertainty has unit and data does not

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from .. import units as u
 from .. import _erfa as erfa
+from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
 from ..extern import six
@@ -282,6 +283,8 @@ class Time(object):
             try:
                 return FormatClass(val, val2, scale, self.precision,
                                    self.in_subfmt, self.out_subfmt)
+            except UnitConversionError:
+                raise
             except (ValueError, TypeError):
                 pass
         else:

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -27,8 +27,8 @@ from . import format as unit_format
 # TODO: Support functional units, e.g. log(x), ln(x)
 
 __all__ = [
-    'UnitsError', 'UnitsWarning', 'UnitBase', 'NamedUnit',
-    'IrreducibleUnit', 'Unit', 'def_unit', 'CompositeUnit',
+    'UnitsError', 'UnitsWarning', 'UnitConversionError', 'UnitBase',
+    'NamedUnit', 'IrreducibleUnit', 'Unit', 'def_unit', 'CompositeUnit',
     'PrefixUnit', 'UnrecognizedUnit', 'get_current_unit_registry',
     'set_enabled_units', 'add_enabled_units',
     'set_enabled_equivalencies', 'add_enabled_equivalencies',
@@ -451,6 +451,13 @@ class UnitScaleError(UnitsError, ValueError):
     pass
 
 
+class UnitConversionError(UnitsError, ValueError):
+    """
+    Used specifically for errors related to converting between units or
+    interpreting units in terms of other units.
+    """
+
+
 # Maintain error in old location for backward compatibility
 from .format import fits as _fits
 _fits.UnitScaleError = UnitScaleError
@@ -837,7 +844,7 @@ class UnitBase(object):
         unit_str = get_err_str(orig_unit)
         other_str = get_err_str(orig_other)
 
-        raise UnitsError(
+        raise UnitConversionError(
             "{0} and {1} are not convertible".format(
                 unit_str, other_str))
 
@@ -910,7 +917,7 @@ class UnitBase(object):
                in zip(self_decomposed.bases, other_decomposed.bases))):
             return self_decomposed.scale / other_decomposed.scale
 
-        raise UnitsError(
+        raise UnitConversionError(
             "'{0!r}' is not a scaled version of '{1!r}'".format(self, other))
 
     def to(self, other, value=1.0, equivalencies=[]):
@@ -1636,7 +1643,7 @@ class IrreducibleUnit(NamedUnit):
                         return CompositeUnit(scale, [base], [1],
                                              _error_check=False)
 
-            raise UnitsError(
+            raise UnitConversionError(
                 "Unit {0} can not be decomposed into the requested "
                 "bases".format(self))
 

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -2,7 +2,7 @@
 # quantities (http://pythonhosted.org/quantities/) package.
 
 import numpy as np
-from .core import (UnitsError, dimensionless_unscaled,
+from .core import (UnitsError, UnitConversionError, dimensionless_unscaled,
                    get_current_unit_registry)
 from ..utils.compat.fractions import Fraction
 
@@ -279,7 +279,7 @@ def get_converters_and_unit(f, *units):
             converters[changeable] = get_converter(units[changeable],
                                                    units[fixed])
         except UnitsError:
-            raise UnitsError(
+            raise UnitConversionError(
                 "Can only apply '{0}' function to quantities "
                 "with compatible dimensions"
                 .format(f.__name__))

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1167,5 +1167,11 @@ def test_repr_array_of_quantity():
     """
 
     a = np.array([1 * u.m, 2 * u.s], dtype=object)
-    assert repr(a) == 'array([<Quantity 1.0 m>, <Quantity 2.0 s>], dtype=object)'
-    assert str(a) == '[<Quantity 1.0 m> <Quantity 2.0 s>]'
+    if NUMPY_LT_1_7:
+        # Numpy 1.6.x has some different defaults for how to display object
+        # arrays (it uses the str() of the objects instead of the repr()
+        assert repr(a) == 'array([1.0 m, 2.0 s], dtype=object)'
+        assert str(a) == '[1.0 m 2.0 s]'
+    else:
+        assert repr(a) == 'array([<Quantity 1.0 m>, <Quantity 2.0 s>], dtype=object)'
+        assert str(a) == '[<Quantity 1.0 m> <Quantity 2.0 s>]'

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1155,3 +1155,17 @@ def test_insert():
     q2 = q.insert(1, 10 * u.m, axis=1)
     assert np.all(q2.value == [[  1,  10, 2],
                                [  3,  10, 4]])
+
+
+def test_repr_array_of_quantity():
+    """
+    Test print/repr of object arrays of Quantity objects with different
+    units.
+
+    Regression test for the issue first reported in
+    https://github.com/astropy/astropy/issues/3777
+    """
+
+    a = np.array([1 * u.m, 2 * u.s], dtype=object)
+    assert repr(a) == 'array([<Quantity 1.0 m>, <Quantity 2.0 s>], dtype=object)'
+    assert str(a) == '[<Quantity 1.0 m> <Quantity 2.0 s>]'

--- a/docs/units/conversion.rst
+++ b/docs/units/conversion.rst
@@ -34,7 +34,7 @@ If you attempt to convert to a incompatible unit, an exception will result:
   >>> cms.to(u.km)
   Traceback (most recent call last):
     ...
-  UnitsError: 'cm / s' (speed) and 'km' (length) are not convertible
+  UnitConversionError: 'cm / s' (speed) and 'km' (length) are not convertible
 
 You can check whether a particular conversion is possible using the
 `~astropy.units.core.UnitBase.is_equivalent` method::

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -38,7 +38,7 @@ Length and angles are not normally convertible, so
   >>> (8.0 * u.arcsec).to(u.parsec)
   Traceback (most recent call last):
     ...
-  UnitsError: 'arcsec' (angle) and 'pc' (length) are not convertible
+  UnitConversionError: 'arcsec' (angle) and 'pc' (length) are not convertible
 
 However, when passing the result of
 :func:`~astropy.units.equivalencies.parallax` as the third argument to the
@@ -68,11 +68,11 @@ dimensionless).  For instance, normally the following raise exceptions::
   >>> u.degree.to('')
   Traceback (most recent call last):
     ...
-  UnitsError: 'deg' (angle) and '' (dimensionless) are not convertible
+  UnitConversionError: 'deg' (angle) and '' (dimensionless) are not convertible
   >>> (u.kg * u.m**2 * (u.cycle / u.s)**2).to(u.J)
   Traceback (most recent call last):
     ...
-  UnitsError: 'cycle2 kg m2 / s2' and 'J' (energy) are not convertible
+  UnitConversionError: 'cycle2 kg m2 / s2' and 'J' (energy) are not convertible
 
 But when passing we pass the proper conversion function,
 :func:`~astropy.units.equivalencies.dimensionless_angles`, it works.

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -104,7 +104,7 @@ conversion from wavelength to frequency doesn't normally work:
     >>> (1000 * u.nm).to(u.Hz)
     Traceback (most recent call last):
       ...
-    UnitsError: 'nm' (length) and 'Hz' (frequency) are not convertible
+    UnitConversionError: 'nm' (length) and 'Hz' (frequency) are not convertible
 
 but by passing an equivalency list, in this case ``spectral()``, it does:
 


### PR DESCRIPTION
This partially addresses the issue raised in #3777 that printing/repr-ing an `ndarray` of `dtype=object` containing quantities of different units resulted in a crash.

I still think it would be nice to have a class specifically for this purpose as discussed in #3777, but this solves the immediate problem, and I will need this for further work.