### PR TITLE
Allow initialization of Table from Column with no name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,9 @@ New Features
   - Added ``Table.to_pandas`` and ``Table.from_pandas`` for converting to/from
     pandas dataframes. [#3504]
 
+  - Initializing a ``Table`` with ``Column`` objects no longer requires
+    that the column ``name`` attribute be defined. [#3781]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -446,7 +446,7 @@ class Table(object):
 
         for col, name, def_name, dtype in zip(data, names, def_names, dtype):
             if isinstance(col, (Column, MaskedColumn)):
-                col = self.ColumnClass(name=(name or col_getattr(col, 'name')),
+                col = self.ColumnClass(name=(name or col_getattr(col, 'name') or def_name),
                                        data=col, dtype=dtype,
                                        copy=copy)
             elif self._is_mixin_column(col):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -272,12 +272,13 @@ class TestNewFromColumns():
             table_types.Table(cols)
 
     def test_name_none(self, table_types):
-        """Column with name=None can init a table IFF names are supplied"""
-        c = table_types.Column(data=[1, 2])
-        table_types.Table([c], names=('c',))
-        with pytest.raises(TypeError):
-            table_types.Table([c])
-
+        """Column with name=None can init a table whether or not names are supplied"""
+        c = table_types.Column(data=[1, 2], name='c')
+        d = table_types.Column(data=[3, 4])
+        t = table_types.Table([c, d], names=(None, 'd'))
+        assert t.colnames == ['c', 'd']
+        t = table_types.Table([c, d])
+        assert t.colnames == ['c', 'col1']
 
 @pytest.mark.usefixtures('table_types')
 class TestReverse():


### PR DESCRIPTION
I don't remember the reason that it was required that a `Column` object needed the `name` to be defined in order to use when initializing a `Table`.  I can't think of a problem that would come up, and this change makes `Column` a bit more like other objects that can be used in a list to init a table.

@astrofrog @mhvk

This helps testing for #3759.