### PR TITLE
Ensure Python 3 syntax highlighting on Python 3-specific example [skip

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -44,7 +44,9 @@ class QuantityInput(object):
             def myfunction(myangle):
                 return myangle**2
 
-        Python 3 only::
+        Python 3 only:
+
+        .. code-block:: python3
 
             import astropy.units as u
             @u.quantity_input


### PR DESCRIPTION
As brought up in an unrelated discussion, the Python 3 only example in [this section](http://docs.astropy.org/en/stable/api/astropy.units.quantity_input.html#astropy.units.quantity_input) of the docs does not render properly due to the default code highlighting being Python 2.