### PR TITLE
u.picobarn, u.femtobarn etc. missing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -356,6 +356,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Supported full SI prefixes for the barn unit ("picobarn", "femtobarn",
+    etc.)  [#3753]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -43,7 +43,7 @@ def_unit(['lyr', 'lightyear'], _si.c.value * si.yr.to(si.s) * si.m,
 ###########################################################################
 # AREAS
 
-def_unit(['barn'], 10 ** -28 * si.m ** 2, namespace=_ns, prefixes=True,
+def_unit(['barn', 'barn'], 10 ** -28 * si.m ** 2, namespace=_ns, prefixes=True,
          doc="barn: unit of area used in HEP")
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -585,6 +585,13 @@ def test_fits_hst_unit():
     assert x == u.erg * u.s ** -1 * u.cm ** -2 * u.angstrom ** -1
 
 
+def test_barn_prefixes():
+    """Regression test for https://github.com/astropy/astropy/issues/3753"""
+
+    assert u.fbarn is u.femtobarn
+    assert u.pbarn is u.picobarn
+
+
 def test_fractional_powers():
     """See #2069"""
     m = 1e9 * u.Msun


### PR DESCRIPTION
Although the [`barn`](https://github.com/astropy/astropy/blob/master/astropy/units/astrophys.py#L46) unit accepts SI prefixes, the full names `picobarn`, `femtobarn`, etc. are missing from the units package namespace.  However, it does have "pbarn" and "fbarn".  

The bug here seems to be that most units that take SI prefixes have an abbreviation like "m", and a full name like "metre".  And so it's assuming that the first name for a unit is its abbreviation and so the prefix abbreviation should be used with it.  Unfortunately, although "barn" is abbreviated "b", we don't have that in the unit definition since it conflicts with "b" for "bit".  I'm a little less concerned about that right now since if I'm doing a lot of work with crosssectional areas I can define my own aliases.  But it took me a bit to realize "fbarn" was there but not "femtobarn".  We should try to find a workaround for this.  Maybe for the unit name it could be something like `[None, "barn"]` to specify that "barn" is the full name, and that an abbreviation doesn't exist, or something.  This is complicated though by the fact that some units can have more than 2 names too.  I haven't looked into exactly what the logic is right now.