### PR TITLE
WIP: Further separate statistic from optimization

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -515,7 +515,7 @@ class LevMarLSQFitter(object):
 
             if not model.col_fit_deriv:
                 full_deriv = np.asarray(full_deriv).T
-                residues = np.asarray(full_deriv[np.nonzero(ind)])
+                residues = np.asarray(full_deriv[np.nonzero(ind)]).T
             else:
                 residues = full_deriv[np.nonzero(ind)]
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -145,8 +145,22 @@ class Fitter(object):
         This method performs the actual fitting and modifies the parameter list
         of a model.
 
-        Fitter subclasses should implement this method.
+        Parameters
+        ----------
+        model : `~astropy.modeling.FittableModel`
+            model to fit to x, y, z
+        x : array
+            input coordinates
+        y : array
+            input coordinates
+        z : array (optional)
+            input coordinates
+        weights : array (optional)
+            weights
+        kwargs : dict
+            additional keywords to be passed to the optimizer
         """
+
         model_copy = _validate_model(model,
                                      self._opt_method.supported_constraints)
         farg = _convert_input(x, y, z)
@@ -580,6 +594,7 @@ class SLSQPLSQFitter(Fitter):
         model_copy : `~astropy.modeling.FittableModel`
             a copy of the input model with parameters set by the fitter
         """
+
         return super(SLSQPLSQFitter, self).__call__(model, x, y, z,
                                                     weights=None, **kwargs)
 
@@ -620,8 +635,8 @@ class SimplexCashFitter(Fitter):
     supported_constraints = Simplex.supported_constraints
 
     def __init__(self):
-        super(SimplexCashFitter, self).__init__(optimizer=SLSQP,
-                                               statistic=cash)
+        super(SimplexCashFitter, self).__init__(optimizer=Simplex,
+                                                statistic=cash)
         self.fit_info = {}
 
 

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -216,6 +216,7 @@ class Simplex(Optimization):
         """
         if 'maxiter' not in kwargs:
             kwargs['maxiter'] = self._maxiter
+
         if 'acc' in kwargs:
             self._acc = kwargs['acc']
             kwargs.pop('acc')
@@ -226,6 +227,7 @@ class Simplex(Optimization):
         fitparams, final_func_val, numiter, funcalls, exit_mode = self.opt_method(
             objfunc, initval, args=fargs, xtol=self._acc,
             full_output=True, **kwargs)
+
         self.fit_info['final_func_val'] = final_func_val
         self.fit_info['numiter'] = numiter
         self.fit_info['exit_mode'] = exit_mode

--- a/astropy/modeling/statistic.py
+++ b/astropy/modeling/statistic.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 import numpy as np
 
-__all__ = ['leastsquare']
+__all__ = ['leastsquare', 'cash']
 
 
 def leastsquare(measured_vals, updated_model, weights, x, y=None):
@@ -42,3 +42,39 @@ def leastsquare(measured_vals, updated_model, weights, x, y=None):
         return np.sum((model_vals - measured_vals) ** 2)
     else:
         return np.sum((weights * (model_vals - measured_vals)) ** 2)
+
+
+# import numpy as np
+# from scipy import optimize
+# from astropy.modeling.fitting import Fitter
+
+# TODO: This is currently needed to avoid an error in the contructor
+#from astropy.modeling.fitting import constraintsdef
+#constraintsdef['CashFitter'] = ['fixed']
+
+def cash(D, model, *args):#M):
+    """Cash Poisson likelihood statistic.
+    
+    Parameters
+    ----------
+    D : array-like
+        "data", i.e. observed counts per bin
+    M : array-like
+        "model", i.e. expected counts per bin
+    
+    Returns
+    -------
+    cash : array
+        Cash statistic value per bin
+    """
+    D = np.asanyarray(D, dtype=np.float64)
+    #M = np.asanyarray(M, dtype=np.float64)
+    #print('statargs', args[:5])
+    weights = args[0]
+    print('statargs', len(args), weights)
+    M = model(*args[1:])
+    stat = 2 * (M - D * np.log(M))
+    stat = np.where(M > 0, stat, 0)
+
+    return stat.sum()
+

--- a/astropy/modeling/statistic.py
+++ b/astropy/modeling/statistic.py
@@ -44,37 +44,25 @@ def leastsquare(measured_vals, updated_model, weights, x, y=None):
         return np.sum((weights * (model_vals - measured_vals)) ** 2)
 
 
-# import numpy as np
-# from scipy import optimize
-# from astropy.modeling.fitting import Fitter
-
-# TODO: This is currently needed to avoid an error in the contructor
-#from astropy.modeling.fitting import constraintsdef
-#constraintsdef['CashFitter'] = ['fixed']
-
-def cash(D, model, *args):#M):
+def cash(D, model, *args):
     """Cash Poisson likelihood statistic.
-    
+
     Parameters
     ----------
     D : array-like
         "data", i.e. observed counts per bin
-    M : array-like
-        "model", i.e. expected counts per bin
-    
+    model : `~astropy.modeling.Model`
+        "model" to be aevaluated
+
     Returns
     -------
-    cash : array
-        Cash statistic value per bin
+    cash : float
+        Summed array of Cash statistic value per bin
     """
     D = np.asanyarray(D, dtype=np.float64)
-    #M = np.asanyarray(M, dtype=np.float64)
-    #print('statargs', args[:5])
     weights = args[0]
-    print('statargs', len(args), weights)
     M = model(*args[1:])
     stat = 2 * (M - D * np.log(M))
     stat = np.where(M > 0, stat, 0)
-
     return stat.sum()
 


### PR DESCRIPTION
Following on discussions during the PIA workshop this PR further separates statistic from optimization. It is possible now to instantiate fitters by passing an optimizer and a statistic function to the `Fitter` class, e.g. 

```
myfitter = Fitter(optimizer=fitting.SLSQP, statistic=fitting.cash)
```

Although this eliminates the need I think it may still be good to have some predefined fitters available but I'm not a heavy user of this functionality.

@cdeil I added a cash statistic function following an old example you shared. Testing it with a simple 1D Gaussian shows that the amplitude is consistently overestimated. Could you check that it's implemented correctly. 
