### PR TITLE
Add remote_data to some doc examples that use from_name

### DIFF
--- a/docs/coordinates/observing-example.rst
+++ b/docs/coordinates/observing-example.rst
@@ -62,7 +62,7 @@ measure of telescope observing conditions::
     import warnings
     warnings.filterwarnings('ignore',module='astropy.coordinates.baseframe')
 
-    m33 = SkyCoord.from_name('M33')
+    m33 = SkyCoord(ra=23.4621*u.deg, dec=30.6599417*u.deg) # same as SkyCoord.from_name('M33'): use the explicit coordinates to allow building doc plots w/o internet
     bear_mountain = EarthLocation(lat=41.3*u.deg, lon=-74*u.deg, height=390*u.m)
     utcoffset = -4*u.hour  # Eastern Daylight Time
     midnight = Time('2012-7-13 00:00:00') - utcoffset
@@ -117,7 +117,7 @@ azimuth::
     import warnings
     warnings.filterwarnings('ignore',module='astropy.coordinates.baseframe')
 
-    m33 = SkyCoord.from_name('M33')
+    m33 = SkyCoord(ra=23.4621*u.deg, dec=30.6599417*u.deg) # same as SkyCoord.from_name('M33'): use the explicit coordinates to allow building doc plots w/o internet
     bear_mountain = EarthLocation(lat=41.3*u.deg, lon=-74*u.deg, height=390*u.m)
     utcoffset = -4*u.hour  # Eastern Daylight Time
     midnight = Time('2012-7-13 00:00:00') - utcoffset

--- a/docs/vo/conesearch/client.rst
+++ b/docs/vo/conesearch/client.rst
@@ -292,7 +292,7 @@ To call a given VO service; In this case, a Cone Search
 
 >>> from astropy import coordinates as coord
 >>> from astropy import units as u
->>> c = coord.SkyCoord.from_name('47 Tuc')
+>>> c = coord.SkyCoord.from_name('47 Tuc')  # doctest: +REMOTE_DATA
 >>> c
 <SkyCoord (ICRS): ra=6.0223292 deg, dec=-72.0814444 deg>
 >>> sr = 0.5 * u.degree
@@ -450,7 +450,7 @@ using cached data, set ``cache=False``:
 
 >>> from astropy import coordinates as coord
 >>> from astropy import units as u
->>> c = coord.SkyCoord.from_name('47 Tuc')
+>>> c = coord.SkyCoord.from_name('47 Tuc')  # doctest: +REMOTE_DATA
 >>> c
 <SkyCoord (ICRS): ra=6.0223292 deg, dec=-72.0814444 deg>
 >>> sr = 0.5 * u.degree

--- a/docs/vo/conesearch/index.rst
+++ b/docs/vo/conesearch/index.rst
@@ -90,7 +90,7 @@ Query the selected 2MASS catalog around M31 with a 0.1-degree search radius:
 
 >>> from astropy.coordinates import SkyCoord
 >>> from astropy import units as u
->>> c = SkyCoord.from_name('M31')
+>>> c = SkyCoord.from_name('M31')  # doctest: +REMOTE_DATA
 >>> c.ra, c.dec
 (<Longitude 10.6847083 deg>, <Latitude 41.26875 deg>)
 >>> result = conesearch.conesearch(c, 0.1 * u.degree, catalog_db=my_catname)


### PR DESCRIPTION
Prompted by a failure in #3756, I noticed a few places where ``SkyCoord.from_name`` is invoked in the docs but the line doesn't have the ``REMOTE_DATA`` tag.  This should hopefully address those.  In the "Observation Planning" example, I also changed invocations of ``from_name`` necessary for making some of the plots to instead build the ``SkyCoord`` from explicitly coordinates.

@embray - there's a pytest plugin that I think you wrote that's supposed to check if the internet is accessed without remote_data being active... But it apparently failed in these cases.  Does that not run on docstrings?  And if so, do you think there's a way to make it do so?

@mwcraig @jakevdp - In #3756 I think one of you noticed the sphinx error that lead to @embray's comment on this...  But it has since disappeared because the test was restarted.  Do you recognize it as one of the places I've fixed here, or was there somewhere else that I missed?