### PR TITLE
implement reading / writing .fits.bz2 files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,9 @@ New Features
 
 - ``astropy.io.fits``
 
+  - Support reading and writing from bzip2 compressed files. i.e. ``.fits.bz2``
+    files.
+
 - ``astropy.io.misc``
 
 - ``astropy.io.votable``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ New Features
 - ``astropy.io.fits``
 
   - Support reading and writing from bzip2 compressed files. i.e. ``.fits.bz2``
-    files.
+    files. [#3789]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -961,6 +961,8 @@ class HDUList(list, _Verify):
             # original file, and rename the tmp file to the original file.
             if self._file.compression == 'gzip':
                 new_file = gzip.GzipFile(name, mode='ab+')
+            elif self._file.compression == 'bzip2':
+                new_file = bz2.BZ2File(name, mode='w')
             else:
                 new_file = name
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -628,6 +628,27 @@ class TestFileFunctions(FitsTestCase):
         with ignore_warnings():
             assert len(fits.open(self._make_bzip2_file('test0.xx'))) == 5
 
+    def test_writeto_bzip2_fileobj(self):
+        """Test writing to a bz2.BZ2File file like object"""
+        fileobj = bz2.BZ2File(self.temp('test.fits.bz2'), 'w')
+        h = fits.PrimaryHDU()
+        try:
+            h.writeto(fileobj)
+        finally:
+            fileobj.close()
+
+        with fits.open(self.temp('test.fits.bz2')) as hdul:
+            assert hdul[0].header == h.header
+
+    def test_writeto_bzip2_filename(self):
+        """Test writing to a bzip2 file by name"""
+        filename = self.temp('testname.fits.bz2')
+        h = fits.PrimaryHDU()
+        h.writeto(filename)
+
+        with fits.open(self.temp('testname.fits.bz2')) as hdul:
+            assert hdul[0].header == h.header
+
     def test_open_zipped(self):
         zf = self._make_zip_file()
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -2,6 +2,7 @@
 from __future__ import division, with_statement
 
 import gzip
+import bz2
 import io
 import mmap
 import os
@@ -617,6 +618,16 @@ class TestFileFunctions(FitsTestCase):
         with fits.open(self.temp('test.fits.gz')) as hdul:
             assert hdul[0].header == h.header
 
+    def test_open_bzipped(self):
+        with ignore_warnings():
+            assert len(fits.open(self._make_bzip2_file())) == 5
+
+    def test_detect_bzipped(self):
+        """Test detection of a bzip2 file when the extension is not .bz2."""
+
+        with ignore_warnings():
+            assert len(fits.open(self._make_bzip2_file('test0.xx'))) == 5
+
     def test_open_zipped(self):
         zf = self._make_zip_file()
 
@@ -989,6 +1000,15 @@ class TestFileFunctions(FitsTestCase):
         zfile.close()
 
         return zfile.filename
+
+    def _make_bzip2_file(self, filename='test0.fits.bz2'):
+        bzfile = self.temp(filename)
+        with open(self.data('test0.fits'), 'rb') as f:
+            bz = bz2.BZ2File(bzfile, 'w')
+            bz.write(f.read())
+            bz.close()
+
+        return bzfile
 
 
 class TestStreamingFunctions(FitsTestCase):

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -97,6 +97,23 @@ because by that point you're likely to run out of physical memory anyways), but
 	out of scope, or manually call ``del hdul[0].data`` (this works so long as there are no other
 	references held to the data array).
 
+Working with compressed files
+"""""""""""""""""""""""""""""
+
+The :func:`open` function will seamlessly open FITS files that have been
+compressed with gzip, bzip2 or pkzip. Note that in this context we're talking
+about a fits file that has been compressed with one of these utilities - e.g. a 
+.fits.gz file. Files that use compressed HDUs within the FITS file are discussed
+in :ref:`Compressed Image Data <astropy-io-fits-compressedImageData>`.
+
+There are some limitations with working with compressed files. For example with Zip 
+files that contain multiple compressed files, only the first file will be accessible.
+Also bzip does not support the append or update access modes.
+
+When writing a file (e.g. with the :func:`writeto` function), compression will be
+determined based on the filename extension given, or the compression used in a 
+pre-existing file that is being written to.
+
 Working with FITS Headers
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -386,9 +386,9 @@ to create the HDU itself::
     [ 15., 16., 17., 18., 19.]]]], dtype=float32))
     ]
 
-
 Compressed Image Data
 ^^^^^^^^^^^^^^^^^^^^^
+.. _astropy-io-fits-compressedImageData:
 
 A general technique has been developed for storing compressed image data in
 FITS binary tables.  The principle used in this convention is to first divide


### PR DESCRIPTION
I added support for bzip2 (.bz2) compression to io.fits in file.py, following the way that gzip is supported.

I appreciate that in many cases it's better to use FITS compressed data units, and that the module already supports gzip, but I find myself working with a lot of fits.bz2 files (on the data I have, bzip2 achieves a significantly better compression ratio per unit cpu time than gzip). I also appreciate that it might be perceived as a slippery slope towards wanting support for every possible compression scheme... However, the bzip2 module is part of the python standard library, the changes in io.fits file.py are fairly minimal and clean, and there is significant .fits.bz2 use in the wild.

One thing that I wasn't sure about - the indent of the self._file.seek(0) at line 442/450 did not match the comment that explained it - the comment was inside the if block, the call wasn't. I don't see how the file couldn't be at the start for the file object that had just been directly opened anyway, and this breaks if you call seek on a bzip2 file object other than in read-only, so I moved it into the if block to match the comment.

Finally, I've been lurking a while, this is my first commit, comments / feedback welcome... :-)

- Paul