### PR TITLE
Fix bug in sigma clip mask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ New Features
   - Added ``sigma_lower`` and ``sigma_upper`` keywords to
     ``sigma_clip`` to allow for unsymmetric clipping. [#3595]
 
+  - Added ``cenfunc``, ``stdfunc``, and ``axis`` keywords to
+    ``sigma_clipped_stats``. [#3792]
+
 - ``astropy.table``
 
   - ``add_column()`` and ``add_columns()`` now have ``rename_duplicate``

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -125,7 +125,6 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
 
     Examples
     --------
-
     This example generates random variates from a Gaussian distribution
     and returns a masked array in which all points that are more than 2
     sample standard deviations from the median are masked::
@@ -206,7 +205,8 @@ sigma_clip.__doc__ = _sigma_clip.__doc__
 
 
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
-                        sigma_lower=None, sigma_upper=None, iters=None):
+                        sigma_lower=None, sigma_upper=None, iters=None,
+                        cenfunc=np.ma.median, stdfunc=np.std, axis=None):
     """
     Calculate sigma-clipped statistics from data.
 
@@ -247,6 +247,33 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         last iteration clips nothing) when calculating the image
         statistics.
 
+    cenfunc : callable, optional
+        The function used to compute the center for the clipping. Must
+        be a callable that takes in a masked array and outputs the
+        central value. Defaults to the median (`numpy.ma.median`).
+
+    stdfunc : callable, optional
+        The function used to compute the standard deviation about the
+        center. Must be a callable that takes in a masked array and
+        outputs a width estimator. Masked (rejected) pixels are those
+        where::
+
+             deviation < (-sigma_lower * stdfunc(deviation))
+             deviation > (sigma_upper * stdfunc(deviation))
+
+        where::
+
+            deviation = data - cenfunc(data [,axis=int])
+
+        Defaults to the standard deviation (`numpy.std`).
+
+    axis : int or `None`, optional
+        If not `None`, clip along the given axis.  For this case,
+        ``axis`` will be passed on to ``cenfunc`` and ``stdfunc``, which
+        are expected to return an array with the axis dimension removed
+        (like the numpy functions).  If `None`, clip over all axes.
+        Defaults to `None`.
+
     Returns
     -------
     mean, median, stddev : float
@@ -259,6 +286,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     if mask_value is not None:
         data = np.ma.masked_values(data, mask_value)
     data_clip = sigma_clip(data, sigma=sigma, sigma_lower=sigma_lower,
-                           sigma_upper=sigma_upper, iters=iters)
+                           sigma_upper=sigma_upper, iters=iters,
+                           cenfunc=cenfunc, stdfunc=stdfunc, axis=axis)
     goodvals = np.ma.compressed(data_clip)
     return np.mean(goodvals), np.median(goodvals), np.std(goodvals)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -206,7 +206,7 @@ sigma_clip.__doc__ = _sigma_clip.__doc__
 
 
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
-                        sigma_lower=3.0, sigma_upper=3.0, iters=None):
+                        sigma_lower=None, sigma_upper=None, iters=None):
     """
     Calculate sigma-clipped statistics from data.
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -195,6 +195,10 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
             filtered_data.mask |= np.ma.masked_greater(deviation,
                                                        std * sigma_upper).mask
 
+    # prevent filtered_data.mask = False (scalar) if no values are clipped
+    if filtered_data.mask.shape == ():
+        filtered_data.mask = False   # .mask shape will now match .data shape
+
     return filtered_data
 
 
@@ -256,5 +260,5 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         data = np.ma.masked_values(data, mask_value)
     data_clip = sigma_clip(data, sigma=sigma, sigma_lower=sigma_lower,
                            sigma_upper=sigma_upper, iters=iters)
-    goodvals = data_clip.data[~data_clip.mask]
+    goodvals = np.ma.compressed(data_clip)
     return np.mean(goodvals), np.median(goodvals), np.std(goodvals)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -82,6 +82,13 @@ def test_compare_to_scipy_sigmaclip():
         assert_equal(astropyres[~astropyres.mask].data, scipyres)
 
 
+def test_sigma_clip_scalar_mask():
+    """Test that the returned mask is not a scalar."""
+    data = np.arange(5)
+    result = sigma_clip(data, sigma=100., iters=1)
+    assert result.mask.shape != ()
+
+
 def test_sigma_clipped_stats():
     """Test list data with input mask or mask_value (#3268)."""
     # test list data with mask


### PR DESCRIPTION
Recent changes to `sigma_clip` (#3595) made it possible for the `mask` to be scalar `False` in the returned masked array in the case where no values are clipped.  The problem with that is the advertised method for getting the good values, `good_only = filtered_data.data[~filtered_data.mask]`, does not work correctly with a scalar mask value.  If the `mask` is scalar `False` then `~mask` is scalar `True`, which is then translated to an index of simply `1`.

This PR ensures the returned `mask` always has the same shape as `data` and uses `np.ma.compressed` in `sigma_clipped_stats` instead of `filtered_data.data[~filtered_data.mask]` to get the good data values.

