### PR TITLE
Update local ERFA to include 2015-Jun-30 leap second

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -265,6 +265,8 @@ New Features
 
 - ``astropy.time``
 
+  - Add support for the 2015-Jun-30 leap second. [#3794]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -402,28 +402,28 @@ class TestBasic():
     def test_utc_leap_sec(self):
         """Time behaves properly near or in UTC leap second.  This
         uses the 2012-06-30 leap second for testing."""
+        for year in ('2012', '2015'):
+            # Start with a day without a leap second and note rollover
+            t1 = Time(year + '-06-01 23:59:60.0', scale='utc')
+            assert t1.iso == year + '-06-02 00:00:00.000'
 
-        # Start with a day without a leap second and note rollover
-        t1 = Time('2012-06-01 23:59:60.0', scale='utc')
-        assert t1.iso == '2012-06-02 00:00:00.000'
+            # Leap second is different
+            t1 = Time(year + '-06-30 23:59:59.900', scale='utc')
+            assert t1.iso == year + '-06-30 23:59:59.900'
 
-        # Leap second is different
-        t1 = Time('2012-06-30 23:59:59.900', scale='utc')
-        assert t1.iso == '2012-06-30 23:59:59.900'
+            t1 = Time(year + '-06-30 23:59:60.000', scale='utc')
+            assert t1.iso == year + '-06-30 23:59:60.000'
 
-        t1 = Time('2012-06-30 23:59:60.000', scale='utc')
-        assert t1.iso == '2012-06-30 23:59:60.000'
+            t1 = Time(year + '-06-30 23:59:60.999', scale='utc')
+            assert t1.iso == year + '-06-30 23:59:60.999'
 
-        t1 = Time('2012-06-30 23:59:60.999', scale='utc')
-        assert t1.iso == '2012-06-30 23:59:60.999'
+            t1 = Time(year + '-06-30 23:59:61.0', scale='utc')
+            assert t1.iso == year + '-07-01 00:00:00.000'
 
-        t1 = Time('2012-06-30 23:59:61.0', scale='utc')
-        assert t1.iso == '2012-07-01 00:00:00.000'
-
-        # Delta time gives 2 seconds here as expected
-        t0 = Time('2012-06-30 23:59:59', scale='utc')
-        t1 = Time('2012-07-01 00:00:00', scale='utc')
-        assert allclose_sec((t1 - t0).sec, 2.0)
+            # Delta time gives 2 seconds here as expected
+            t0 = Time(year + '-06-30 23:59:59', scale='utc')
+            t1 = Time(year + '-07-01 00:00:00', scale='utc')
+            assert allclose_sec((t1 - t0).sec, 2.0)
 
     def test_init_from_time_objects(self):
         """Initialize from one or more Time objects"""

--- a/cextern/erfa/dat.c
+++ b/cextern/erfa/dat.c
@@ -36,7 +36,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **     :  even if no leap seconds have been       :
 **     :  added.                                  :
 **     :                                          :
-**     :  Latest leap second:  2012 June 30       :
+**     :  Latest leap second:  2015 June 30       :
 **     :                                          :
 **     :__________________________________________:
 **
@@ -57,7 +57,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **                      -2 = bad month
 **                      -3 = bad day (Note 3)
 **                      -4 = bad fraction (Note 4)
-**                      -5 = internal error
+**                      -5 = internal error (Note 5)
 **
 **  Notes:
 **
@@ -115,12 +115,12 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **  Called:
 **     eraCal2jd    Gregorian calendar to JD
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Release year for this version of eraDat */
-   enum { IYV = 2014};
+   enum { IYV = 2015};
 
 /* Reference dates (MJD) and drift rates (s/day), pre leap seconds */
    static const double drift[][2] = {
@@ -187,7 +187,8 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
       { 1999,  1, 32.0       },
       { 2006,  1, 33.0       },
       { 2009,  1, 34.0       },
-      { 2012,  7, 35.0       }
+      { 2012,  7, 35.0       },
+      { 2015,  7, 36.0       }
    };
 
 /* Number of Delta(AT) changes */
@@ -228,7 +229,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
    if (i < 0) return -5;
 
 /* Get the Delta(AT). */
-   da = changes[(i < 0) ? 0 : i].delat;
+   da = changes[i].delat;
 
 /* If pre-1972, adjust for drift. */
    if (i < NERA1) da += (djm + fd - drift[i][0]) * drift[i][1];
@@ -243,7 +244,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International


### PR DESCRIPTION
This is a minimal patch to make astropy.time aware of the leap second on 2015-Jun-30.  This simply copies `liberfa/erfa/src/dat.c` to `cextern/erfa/dat.c` and replicates the change to `dat.c` in https://github.com/liberfa/erfa/pull/26.

The other option is to make a new release of ERFA and then include that new release in astropy.  The footprint would be much larger and the scope of changes would be much more than just the leap second.

This is a bit late in coming and we should not wait too long to get something merged and released.