### PR TITLE
Make table repr fast

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,9 @@ New Features
   - Initializing a ``Table`` with ``Column`` objects no longer requires
     that the column ``name`` attribute be defined. [#3781]
 
+  - Greatly improved the speed of printing a large table to the screen when
+    only a few rows are being displayed. [#3796]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -391,13 +391,16 @@ class TableFormatter(object):
                 show_length = True
             i0 = n_print2 - (1 if show_length else 0)
             i1 = n_rows - n_print2 - max_lines % 2
+            ii = np.concatenate([np.arange(0, i0 + 1), np.arange(i1 + 1, len(col))])
         else:
-            i0 = len(col)
-            i1 = 0
+            i0 = -1
+            ii = np.arange(len(col))
 
         # Add formatted values if within bounds allowed by max_lines
-        for i in xrange(n_rows):
-            if i < i0 or i > i1:
+        for i in ii:
+            if i == i0:
+                yield '...'
+            else:
                 if multidims:
                     # Prevents columns like Column(data=[[(1,)],[(2,)]], name='a')
                     # with shape (n,1,...,1) from being printed as if there was
@@ -411,8 +414,6 @@ class TableFormatter(object):
                 else:
                     col_str = format_func(col_format, col[i])
                 yield col_str
-            elif i == i0:
-                yield '...'
 
         outs['show_length'] = show_length
         outs['n_header'] = n_header


### PR DESCRIPTION
Currently Table repr is slow if there is lots of data (>10 sec for 10M rows and 10 columns on my machine).

What makes this a bit annoying is that the Table repr gets called and one has to wait for repr to do it's computation even if I just look around, i.e. type `table.info` or `table.info?` or `table.info??` in an IPython session:
```
In [24]: table.info
Out[24]: 
<bound method Table.info of <Table masked=False length=11934944>
EVENT_ID BUNCH_ID OBS_ID      TIME      TLIVE  MULTIP ... ENERGY_ERR  HIL_MSW  HIL_MSW_ERR  HIL_MSL   HIL_MSL_ERR
 int32    int32   int32     float64    float64 int16  ...  float32    float32    float32    float32     float32  
-------- -------- ------ ------------- ------- ------ ... ---------- --------- ----------- ---------- -----------
       7      456  18416 127993845.223     0.0      2 ...   0.277313   1.60066         0.0   -1.00963         0.0
      68      456  18416 127993845.553     0.0      2 ...    0.16089   1.47438         0.0   0.268609         0.0
      71      456  18416 127993845.556     0.0      2 ...   0.107017  0.639672         0.0  -0.869599         0.0
     567      456  18416 127993847.559     0.0      3 ...   0.202796   2.92479         0.0    1.47374         0.0
     814      456  18416  127993848.36     0.0      2 ...  0.0817026      -1.0         0.0       -1.0         0.0
    1108      457  18416 127993851.332     0.0      4 ...  0.0857439  0.226781         0.0  -0.198189         0.0
    1360      457  18416 127993851.957     0.0      4 ...  0.0473889 -0.401416         0.0    0.39542         0.0
    1572      457  18416 127993852.481     0.0      2 ...   0.104282   1.25816         0.0 -0.0189629         0.0
    1745      457  18416 127993852.853     0.0      2 ...   0.154264   0.45221         0.0   -0.73927         0.0
    1776      457  18416 127993852.942     0.0      4 ...  0.0722834      -1.0         0.0       -1.0         0.0
    2309      457  18416 127993854.223     0.0      2 ...  0.0840052   -0.3896         0.0  -0.385342         0.0
    2692      457  18416 127993855.094     0.0      2 ...   0.101622  0.803559         0.0   -1.11253         0.0
    2979      457  18416 127993855.735     0.0      2 ...  0.0857007   2.11584         0.0  -0.179018         0.0
    3882      457  18416 127993858.033     0.0      2 ...  0.0641942   1.79626         0.0  -0.458844         0.0
     ...      ...    ...           ...     ...    ... ...        ...       ...         ...        ...         ...
     669     1901  84604 422291710.714     0.0      2 ...  0.0655686   1.24136         0.0   0.687523         0.0
     675     1901  84604 422291710.755     0.0      2 ...   0.186779 -0.436907         0.0    1.04537         0.0
     701     1901  84604 422291710.854     0.0      2 ...  0.0726709 -0.703618         0.0    1.26275         0.0
     346     1902  84604 422291713.171     0.0      3 ...  0.0790736 -0.784944         0.0   0.422531         0.0
     610     1903  84604 422291718.678     0.0      4 ...  0.0705639   0.96721         0.0   -0.19269         0.0
     226     1904  84604 422291720.601     0.0      2 ...   0.115754  0.299109         0.0   0.411273         0.0
     372     1904  84604 422291721.393     0.0      2 ...   0.099541 -0.265754         0.0    1.23431         0.0
     425     1904  84604  422291721.61     0.0      4 ...  0.0497444  0.233217         0.0   0.623146         0.0
     639     1904  84604 422291722.677     0.0      2 ...    0.26678      -1.0         0.0       -1.0         0.0
     669     1904  84604 422291722.822     0.0      3 ...  0.0899658 0.0789776         0.0  -0.339551         0.0
     769     1904  84604 422291723.254     0.0      2 ...  0.0944477  0.193305         0.0   0.751905         0.0
     775     1904  84604 422291723.298     0.0      2 ...   0.147789      -1.0         0.0       -1.0         0.0
      39     1905  84604 422291723.693     0.0      4 ...  0.0548296  0.425035         0.0   0.124757         0.0
     456     1905  84604 422291725.943     0.0      3 ...  0.0695792  0.113169         0.0   0.584794         0.0>
```

@taldcroft mentioned in https://github.com/astropy/astropy/issues/3012#issuecomment-105281592 that he's aware of the issue, so he might already have an idea how to "fix" this.