### PR TITLE
Cannot use `coordinates.angle_utilities.position_angle` with `floats`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,9 @@ Bug fixes
 
 - ``astropy.coordinates``
 
+  - Ensure that ``angle_utilities.position_angle`` accepts floats, as stated
+    in the docstring. [#3800]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -684,4 +684,4 @@ def position_angle(lon1, lat1, lon2, lat2):
     x = np.sin(lat2) * np.cos(lat1) - colat * np.sin(lat1) * np.cos(deltalon)
     y = np.sin(deltalon) * colat
 
-    return Angle(np.arctan2(y, x)).wrap_at(360*u.deg)
+    return Angle(np.arctan2(y, x), u.radian).wrap_at(360*u.deg)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -586,6 +586,14 @@ def test_position_angle():
     assert cicrs.position_angle(cfk5) < 91.0 * u.deg
 
 
+def test_position_angle_directly():
+    """Regression check for #3800: position_angle should accept floats."""
+    from ..angle_utilities import position_angle
+    result = position_angle(10., 20., 10., 20.)
+    assert result.unit is u.radian
+    assert result.value == 0.
+
+
 def test_table_to_coord():
     """
     Checks "end-to-end" use of `Table` with `SkyCoord` - the `Quantity`


### PR DESCRIPTION
While the documentation states that `position_angle` can be used with `float`s (in radians), it crashes during the conversion to `Angle`:
```
UnitsError: No unit was given - must be some kind of angle
```
Shouldn't `position_angle` returns a `Quantity`, as `angular_separation`, rather than an `Angle`?