### PR TITLE
Make Column repr and str work for scalar values

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -775,6 +775,10 @@ class Column(BaseColumn):
         return self
 
     def _base_repr_(self, html=False):
+        # If scalar then just convert to correct numpy type and use numpy repr
+        if self.ndim == 0:
+            return repr(self.dtype.type(self))
+
         descr_vals = [self.__class__.__name__]
         unit = None if self.unit is None else str(self.unit)
         shape = None if self.ndim <= 1 else self.shape[1:]
@@ -811,6 +815,10 @@ class Column(BaseColumn):
         return self._base_repr_(html=False)
 
     def __unicode__(self):
+        # If scalar then just convert to correct numpy type and use numpy repr
+        if self.ndim == 0:
+            return str(self.dtype.type(self))
+
         lines, outs = self._formatter._pformat_col(self)
         return '\n'.join(lines)
     if six.PY3:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -777,7 +777,7 @@ class Column(BaseColumn):
     def _base_repr_(self, html=False):
         # If scalar then just convert to correct numpy type and use numpy repr
         if self.ndim == 0:
-            return repr(self.dtype.type(self))
+            return repr(self.item())
 
         descr_vals = [self.__class__.__name__]
         unit = None if self.unit is None else str(self.unit)
@@ -817,7 +817,7 @@ class Column(BaseColumn):
     def __unicode__(self):
         # If scalar then just convert to correct numpy type and use numpy repr
         if self.ndim == 0:
-            return str(self.dtype.type(self))
+            return str(self.item())
 
         lines, outs = self._formatter._pformat_col(self)
         return '\n'.join(lines)

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -499,3 +499,15 @@ def test_unicode_guidelines():
     c = table.Column(arr, name='a')
 
     assert_follows_unicode_guidelines(c)
+
+
+def test_scalar_column():
+    """
+    Column is not designed to hold scalars, but for numpy 1.6 this can happen:
+
+      >> type(np.std(table.Column([1, 2])))
+      astropy.table.column.Column
+    """
+    c = table.Column(1.5)
+    assert repr(c) == '1.5'
+    assert str(c) == '1.5'


### PR DESCRIPTION
Although `Column` is not designed to hold scalar values, in numpy 1.6 this can happen as a result of a bug in `np.std` in which the return value is a scalar `Column` object with the std dev value.  This results in a failure like below when printing value:
```
In [2]: c = Column(1.5)
In [3]: c
Out[3]: <repr(<astropy.table.column.Column at 0x10659fe60>) failed: TypeError: len() of unsized object>
```
