### PR TITLE
Speed up distances with massive neutrinos by 6-7x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ New Features
     are now > 10x faster for the supplied cosmologies. [#3767]
 
   - Distances with massive neutrinos are 3-6x faster for the most
-    common cases of 1-3 massive neutrino species. [#3813]
+    common cases of 1-3 massive neutrino species. [#3814]
 
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
     should use the new public interfaces ``FLRW.lookback_time_integrand`` 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,8 +30,7 @@ New Features
   - Distance calculations in cosmologies with massless (or no) neutrinos
     are now > 10x faster for the supplied cosmologies. [#3767]
 
-  - Distances with massive neutrinos are 3-6x faster for the most
-    common cases of 1-3 massive neutrino species. [#3814]
+  - Distances with massive neutrinos are 5-7x faster [#3814]
 
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
     should use the new public interfaces ``FLRW.lookback_time_integrand`` 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ New Features
   - Distance calculations in cosmologies with massless (or no) neutrinos
     are now > 10x faster for the supplied cosmologies. [#3767]
 
+  - Distances with massive neutrinos are 3-6x faster for the most
+    common cases of 1-3 massive neutrino species. [#3813]
+
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
     should use the new public interfaces ``FLRW.lookback_time_integrand`` 
     and ``FLRW.abs_distance_integrand`` instead. [#3767]

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -777,6 +777,139 @@ class FLRW(Cosmology):
 
         return prefac * self._neff_per_nu * rel_mass
 
+    def _get_nufunc_scalar(self):
+        """ Get the scalar nu density function for integrals"""
+
+        nu_dict = {0: lambda x : 0.22710731766 * self._Neff,
+                   1: self._nu_relative_density_scalar_single,
+                   2: self._nu_relative_density_scalar_double,
+                   3: self._nu_relative_density_scalar_triple}
+        return nu_dict.get(self._nmassivenu,
+                           self._nu_relative_density_scalar)
+
+    def _nu_relative_density_scalar_single(self, z):
+        """ Neutrino density function relative to the energy density in
+        photons.
+
+        Parameters
+        ----------
+        z : scalar
+           Redshift
+
+        Returns
+        -------
+         f : float
+           The neutrino density scaling factor relative to the density
+           in photons at the specified redshift
+
+        Notes
+        -----
+        This version is specialized to scalar z and a single
+        massive neutrino flavor for performance reasons.
+        """
+
+        prefac = 0.22710731766
+        p = 1.83
+        invp = 0.5464480874316939
+        curr_nu_y = self._nu_y[0] / (1.0 + z)
+        rel_mass_per = (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        rel_mass = rel_mass_per + self._nmasslessnu
+        return prefac * self._neff_per_nu * rel_mass
+
+    def _nu_relative_density_scalar_double(self, z):
+        """ Neutrino density function relative to the energy density in
+        photons.
+
+        Parameters
+        ----------
+        z : scalar
+           Redshift
+
+        Returns
+        -------
+         f : float
+           The neutrino density scaling factor relative to the density
+           in photons at the specified redshift
+
+        Notes
+        -----
+        This version is specialized to scalar z and two
+        massive neutrino flavor for performance reasons.
+        """
+
+        prefac = 0.22710731766
+        p = 1.83
+        invp = 0.5464480874316939
+        invz = 1.0 / (1.0 + z)
+        curr_nu_y = self._nu_y[0] * invz
+        rel_mass_per = (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        curr_nu_y = self._nu_y[1] * invz
+        rel_mass_per += (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        rel_mass = rel_mass_per + self._nmasslessnu
+        return prefac * self._neff_per_nu * rel_mass
+
+    def _nu_relative_density_scalar_triple(self, z):
+        """ Neutrino density function relative to the energy density in
+        photons.
+
+        Parameters
+        ----------
+        z : scalar
+           Redshift
+
+        Returns
+        -------
+         f : float
+           The neutrino density scaling factor relative to the density
+           in photons at the specified redshift
+
+        Notes
+        -----
+        This version is specialized to scalar z and three
+        massive neutrino flavor for performance reasons.
+        """
+
+        prefac = 0.22710731766
+        p = 1.83
+        invp = 0.5464480874316939
+        invz = 1.0 / (1.0 + z)
+        curr_nu_y = self._nu_y[0] * invz
+        rel_mass_per = (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        curr_nu_y = self._nu_y[1] * invz
+        rel_mass_per += (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        curr_nu_y = self._nu_y[2] * invz
+        rel_mass_per += (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        rel_mass = rel_mass_per + self._nmasslessnu
+        return prefac * self._neff_per_nu * rel_mass
+
+    def _nu_relative_density_scalar(self, z):
+        """ Neutrino density function relative to the energy density in
+        photons.
+
+        Parameters
+        ----------
+        z : scalar
+           Redshift
+
+        Returns
+        -------
+         f : float
+           The neutrino density scaling factor relative to the density
+           in photons at the specified redshift
+
+        Notes
+        -----
+        This version is specialized to scalar z for performance reasons.
+        """
+
+        prefac = 0.22710731766
+        p = 1.83
+        invp = 0.5464480874316939
+        curr_nu_y = self._nu_y / (1.0 + z)
+        rel_mass_per = (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
+        rel_mass = rel_mass_per.sum() + self._nmasslessnu
+        return prefac * self._neff_per_nu * rel_mass
+
     def _w_integrand(self, ln1pz):
         """ Internal convenience function for w(z) integral."""
 
@@ -1591,7 +1724,7 @@ class LambdaCDM(FLRW):
             self._inv_efunc_scalar = self._lcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0,
-                                           self.nu_relative_density)
+                                           self._get_nufunc_scalar())
 
     def w(self, z):
         """Returns dark energy equation of state at redshift ``z``.
@@ -1790,7 +1923,7 @@ class FlatLambdaCDM(LambdaCDM):
             self._inv_efunc_scalar = self._flcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._Ogamma0,
-                                           self.nu_relative_density)
+                                           self._get_nufunc_scalar())
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.
@@ -1958,7 +2091,7 @@ class wCDM(FLRW):
             self._inv_efunc_scalar = self._wcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0,
-                                           self.nu_relative_density,
+                                           self._get_nufunc_scalar(),
                                            self._w0)
 
     @property
@@ -2183,7 +2316,7 @@ class FlatwCDM(wCDM):
             self._inv_efunc_scalar = self._fwcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._Ogamma0,
-                                           self.nu_relative_density,
+                                           self._get_nufunc_scalar(),
                                            self._w0)
 
     def efunc(self, z):
@@ -2358,7 +2491,7 @@ class w0waCDM(FLRW):
             self._inv_efunc_scalar = self._w0wa_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0,
-                                           self.nu_relative_density,
+                                           self._get_nufunc_scalar(),
                                            self._w0, self._wa)
 
     @property
@@ -2546,7 +2679,7 @@ class Flatw0waCDM(w0waCDM):
             self._inv_efunc_scalar = self._fw0wa_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._Ogamma0,
-                                           self.nu_relative_density,
+                                           self._get_nufunc_scalar(),
                                            self._w0, self._wa)
 
     def __repr__(self):
@@ -2673,7 +2806,7 @@ class wpwaCDM(FLRW):
             self._inv_efunc_scalar = self._wpwa_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0,
-                                           self.nu_relative_density,
+                                           self._get_nufunc_scalar(),
                                            self._wp, apiv, self._wa)
 
     @property
@@ -2874,7 +3007,7 @@ class w0wzCDM(FLRW):
             self._inv_efunc_scalar = self._w0wz_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0,
-                                           self.nu_relative_density,
+                                           self._get_nufunc_scalar(),
                                            self._w0, self._wz)
 
     @property

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1303,6 +1303,30 @@ def test_distances():
                     [2676.73467639, 3940.57967585, 4686.90810278,
                      5191.54178243] * u.Mpc, rtol=1e-4)
 
+    # Now also test different numbers of massive neutrinos
+    # for FlatLambdaCDM to give the scalar nu density functions a
+    # work out
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0,
+                             m_nu=u.Quantity([10.0, 0, 0], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2777.71589173, 4186.91111666, 5046.0300719,
+                     5636.10397302] * u.Mpc, rtol=1e-4)
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0,
+                             m_nu=u.Quantity([10.0, 5, 0], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2636.48149391, 3913.14102091, 4684.59108974,
+                     5213.07557084] * u.Mpc, rtol=1e-4)
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0,
+                             m_nu=u.Quantity([4.0, 5, 9], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2563.5093049 , 3776.63362071, 4506.83448243,
+                     5006.50158829] * u.Mpc, rtol=1e-4)
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0, Neff=4.2,
+                             m_nu=u.Quantity([1.0, 4.0, 5, 9], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2525.58017482, 3706.87633298, 4416.58398847,
+                     4901.96669755] * u.Mpc, rtol=1e-4)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_massivenu_density():

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -319,7 +319,7 @@ species of neutrinos with non-zero mass (which is not included in
 
 Adding massive neutrinos has significant performance implications.
 In particular, the computation of distance measures and lookback times
-are factors of ten slower than in the massless neutrino case.  Therefore,
+are factors of 3-4 slower than in the massless neutrino case.  Therefore,
 if you need to compute a lot of distances in such a cosmology, it is
 particularly useful to calculate them on a grid and use interpolation.
 


### PR DESCRIPTION
* Follow on to #3767, which is partially addressing #3764
* Add scalar function to compute massive neutrino densities in
  integrals to get speedup for arbitrary number of neutrinos.
  This buys about 20% speedup.
* Add 1, 2, and 3 massive neutrino specializations for much larger
  speedups by avoiding the (surprisingly) expensive numpy.sum
  operations.  These should be by far the most common cases.
* Some unit tests added for the new scalar functions