### PR TITLE
Redefine floor_divide to require quantities with equivalent units.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -224,6 +224,10 @@ Bug fixes
 
 - ``astropy.units``
 
+  - Define ``floor_divide`` (``//``) for ``Quantity`` to be consistent
+    ``divmod``, such that it only works where the quotient is dimensionless.
+    This guarantees that ``(q1 // q2) * q2 + (q1 % q2) == q1``. [#3817] 
+    
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -815,13 +815,8 @@ class Quantity(np.ndarray):
         return self.__rdiv__(other)
 
     def __divmod__(self, other):
-        if isinstance(other, (six.string_types, UnitBase)):
-            return (self / other,
-                    self._new_view(np.array(0.), dimensionless_unscaled))
-
         other_value = self._to_own_unit(other)
-        result_tuple = super(Quantity, self.__class__).__divmod__(
-            self.view(np.ndarray), other_value)
+        result_tuple = divmod(self.value, other_value)
 
         return (self._new_view(result_tuple[0], dimensionless_unscaled),
                 self._new_view(result_tuple[1]))

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -202,7 +202,6 @@ helper_division = lambda f, unit1, unit2: ([None, None], _d(unit1) / _d(unit2))
 
 UFUNC_HELPERS[np.divide] = helper_division
 UFUNC_HELPERS[np.true_divide] = helper_division
-UFUNC_HELPERS[np.floor_divide] = helper_division
 
 
 def helper_power(f, unit1, unit2):
@@ -317,10 +316,17 @@ UFUNC_HELPERS[np.equal] = helper_twoarg_comparison
 
 def helper_twoarg_invtrig(f, unit1, unit2):
     from .si import radian
-    scales, _ = get_converters_and_unit(f, unit1, unit2)
-    return scales, radian
+    converters, _ = get_converters_and_unit(f, unit1, unit2)
+    return converters, radian
 
 UFUNC_HELPERS[np.arctan2] = helper_twoarg_invtrig
 # another private function in numpy; use getattr in case it disappears
 if isinstance(getattr(np.core.umath, '_arg', None), np.ufunc):
     UFUNC_HELPERS[np.core.umath._arg] = helper_twoarg_invtrig
+
+
+def helper_twoarg_floor_divide(f, unit1, unit2):
+    converters, _ = get_converters_and_unit(f, unit1, unit2)
+    return converters, dimensionless_unscaled
+
+UFUNC_HELPERS[np.floor_divide] = helper_twoarg_floor_divide

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -211,35 +211,34 @@ class TestQuantityMathFuncs(object):
         assert np.all(np.multiply(np.arange(3.) * u.m, 2. / u.s) ==
                       np.arange(0, 6., 2.) * u.m / u.s)
 
-    @pytest.mark.parametrize('function', (np.divide, np.true_divide,
-                                          np.floor_divide))
+    @pytest.mark.parametrize('function', (np.divide, np.true_divide))
     def test_divide_scalar(self, function):
         assert function(4. * u.m, 2. * u.s) == function(4., 2.) * u.m / u.s
         assert function(4. * u.m, 2.) == function(4., 2.) * u.m
         assert function(4., 2. * u.s) == function(4., 2.) / u.s
 
-    @pytest.mark.parametrize('function', (np.divide, np.true_divide,
-                                          np.floor_divide))
+    @pytest.mark.parametrize('function', (np.divide, np.true_divide))
     def test_divide_array(self, function):
         assert np.all(function(np.arange(3.) * u.m, 2. * u.s) ==
                       function(np.arange(3.), 2.) * u.m / u.s)
 
-    def test_divmod(self):
+    def test_divmod_and_floor_divide(self):
         inch = u.Unit(0.0254 * u.m)
-        quotient, remainder = divmod(
-            np.array([1., 2., 3.]) * u.m,
-            np.array([3., 4., 5.]) * inch)
+        dividend = np.array([1., 2., 3.]) * u.m
+        divisor = np.array([3., 4., 5.]) * inch
+        quotient = dividend // divisor
         assert_allclose(quotient.value, [13., 19., 23.])
         assert quotient.unit == u.dimensionless_unscaled
+        quotient2, remainder = divmod(dividend, divisor)
+        assert np.all(quotient2 == quotient)
         assert_allclose(remainder.value, [0.0094, 0.0696, 0.079])
-        assert remainder.unit == u.m
+        assert remainder.unit == dividend.unit
 
-        quotient, remainder = divmod(
-            np.array([1., 2., 3.]) * u.m, u.km)
-        assert_allclose(quotient.value, [1., 2., 3.])
-        assert quotient.unit == u.m / u.km
-        assert remainder.value == 0.
-        assert remainder.unit == u.dimensionless_unscaled
+        with pytest.raises(TypeError):
+            divmod(dividend, u.km)
+
+        with pytest.raises(TypeError):
+            dividend // u.km
 
     def test_sqrt_scalar(self):
         assert np.sqrt(4. * u.m) == 2. * u.m ** 0.5


### PR DESCRIPTION
Normally, `//` and `%` are defined such that it is guaranteed that:
```
(a // b) * b + (a % b) == a
```
For `Quantity`, `divmod` gives consistent results but `//` and `%` do not:
```
a = 1.230*u.km
b = 100.*u.m
divmod(a, b)
# (<Quantity 12.0>, <Quantity 0.029999999999999916 km>)
a % b
# <Quantity 0.029999999999999916 km>
a // b
# <Quantity 0.0 km / m>
```
The problem is that `floor_divide` ignores the units. This PR ensures it is consistent with `divmod` and `%` by converting the second argument to unit of the first.

The above also implies that it is no longer possible to `floor_divide` two numbers for which the ratio is not dimensionless. This may be logical, since it is unclear what the meaning of `floor` is for quantities that are not dimensionless.

That said, in principle, it would be nice to do something like
```
divmod(1.23 * u.m, 1.*u.m/u.s)
# -> (<Quantity 1.0 s>, <Quantity 0.23 km>)
```
However, it is not quite clear what one should do when the units do not obviously have the same parts. E.g., 
```
divmod(1230*u.mm, 1.*u.m/u.s)
# Probably should be (<Quantity 1.0 s>, <Quantity 230 mm>)
divmod(1230*u.mm, 1.*u.km/u.ks)
# same?? Or (0 ks, 1230 mm)??
```
So maybe best to leave that for further discussion, or rather insist that if one wants to do that, one is explicit about the units.

p.s.  Since we may decide that `unit1 // unit2` gets meaning based on such further discussion, I removed the part where `divmod(q1, unit) -> (q/unit, 0)`. I don't think anyone would want to do that anyway!