### PR TITLE
Automatically (try to) fix cards with no space after =

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -947,8 +947,23 @@ class Card(_Verify):
         keyword = self._image[:KEYWORD_LENGTH].strip()
         keyword_upper = keyword.upper()
         val_ind_idx = self._image.find(VALUE_INDICATOR)
+        hval_ind_idx = self._image.find(HIERARCH_VALUE_INDICATOR)
 
         special = self._commentary_keywords
+
+        # We couldn't find the value indicator, but it looks like a
+        # non-standard card. Let's try to artificially put the indicator
+        # there.
+        #
+        # If the card ends on ' it will probably by a string and we give up.
+        # Otherwise, we discard the last character to make room (it will
+        # probably be part of the comment, anyway)
+        if (val_ind_idx < 0 and keyword_upper != 'HIERARCH' and
+                hval_ind_idx == KEYWORD_LENGTH and self._image[-1] != "'"):
+            val_ind_idx = hval_ind_idx
+            value_start = val_ind_idx + len(HIERARCH_VALUE_INDICATOR)
+            self._image = VALUE_INDICATOR.join([self._image[:KEYWORD_LENGTH],
+                                                self._image[value_start:-1]])
 
         if (0 <= val_ind_idx <= KEYWORD_LENGTH or keyword_upper in special or
                 keyword_upper == 'CONTINUE'):


### PR DESCRIPTION
This is a fix for `Card._parse_keyword` to support images generated with older tools, producing cards that appear to be invalid/illegal because they lack a proper value indicator (`"= "`).

If the keyword is not `CONTINUE` or in the special class (commentaries), the current code expects to find the value indicator and, if not, it checks for a `HIERARCH`. Otherwise, the image is set as invalid.

The patch identifies the corner case by checking that:
- A legal value indicator was not found
- The keyword is not `HIERARCH`
- There is an equal sign in the appropriate spot

If that is the case and the card does **not** end in a single quote, we just shift the whole value one character to the right, inserting a space after the equal sign, assuming that the trimmed character at the end of the card is part of a comment. After this, the code runs as normal and parses the card in the intended way, if possible.

I don't like too much the idea of modifying the card at this point in the code where we should just be parsing, and I'm not absolutely sure that it could not happen somewhere else, but it's the best I could come with at the moment.
