### PR TITLE
BaseHeader counts lines with only spaces in header_start processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -154,6 +154,12 @@ API changes
 
 - ``astropy.io.ascii``
 
+  - The default header line processing was made to be consistent with data line
+    processing in that it now ignores blank lines that may have whitespace
+    characters.  Any code that explicitly specifies a ``header_start`` value
+    for parsing a file with blank lines in the header containing whitespace will
+    need to be updated. [#2654]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -485,12 +485,12 @@ class BaseHeader(object):
         self._set_cols_from_names()
 
     def process_lines(self, lines):
-        """Generator to yield non-comment lines"""
+        """Generator to yield non-blank and non-comment lines"""
         if self.comment:
             re_comment = re.compile(self.comment)
         # Yield non-comment lines
         for line in lines:
-            if line and (not self.comment or not re_comment.match(line)):
+            if line.strip() and (not self.comment or not re_comment.match(line)):
                 yield line
 
     def write_comments(self, lines, meta):

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -283,7 +283,7 @@ int skip_lines(tokenizer_t *self, int offset, int header)
             signif_chars = 0;
             comment = 0;
         }
-        else if ((c != ' ' && c != '\t') || !self->strip_whitespace_lines || header)
+        else if ((c != ' ' && c != '\t') || !self->strip_whitespace_lines)
         {
                 // comment line
                 if (!signif_chars && self->comment != 0 && c == self->comment)
@@ -291,9 +291,7 @@ int skip_lines(tokenizer_t *self, int offset, int header)
                 else if (comment && !header)
                     push_comment(self, c);
 
-                // significant character encountered; during header
-                // tokenization, we count whitespace unlike data tokenization
-                // (see #2654)
+                // significant character encountered
                 ++signif_chars;
         }
         else if (comment && !header)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1009,11 +1009,11 @@ def test_data_header_start(fast_reader):
 
              (['# comment',
                '',
-               ' ',
+               ' \t',
                'skip this line',  # line 0
                'a b',  # line 1
                '',
-               ' ',
+               ' \t',
                'skip this line',  # line 2
                '1 2'],  # line 3
               [{'header_start': 1, 'data_start': 3}]),

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -16,7 +16,7 @@ from ....units import Unit
 from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true, setup_function, teardown_function)
 from .. import core
-from ..ui import _probably_html
+from ..ui import _probably_html, get_read_trace
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
@@ -992,3 +992,51 @@ def test_probably_html():
                   [[1, 2, 3]],
     ):
         assert _probably_html(table) is False
+
+
+@pytest.mark.parametrize('fast_reader', [True, False, 'force'])
+def test_data_header_start(fast_reader):
+    tests = [(['# comment',
+               '',
+               ' ',
+               'skip this line',  # line 0
+               'a b',  # line 1
+               '1 2'],  # line 2
+              [{'header_start': 1},
+               {'header_start': 1, 'data_start': 2}
+           ]
+           ),
+
+             (['# comment',
+               '',
+               ' ',
+               'skip this line',  # line 0
+               'a b',  # line 1
+               '',
+               ' ',
+               'skip this line',  # line 2
+               '1 2'],  # line 3
+              [{'header_start': 1, 'data_start': 3}]),
+
+             (['# comment',
+               '',
+               ' ',
+               'a b',  # line 0
+               '',
+               ' ',
+               'skip this line',  # line 1
+               '1 2'],  # line 2
+              [{'header_start': 0, 'data_start': 2},
+               {'data_start': 2}])]
+
+    for lines, kwargs_list in tests:
+        for kwargs in kwargs_list:
+
+            t = ascii.read(lines, format='basic', fast_reader=fast_reader,
+                           guess=True, **kwargs)
+            assert t.colnames == ['a', 'b']
+            assert len(t) == 1
+            assert np.all(t['a'] == [1])
+            # Sanity check that the expected Reader is being used
+            assert get_read_trace()[-1]['kwargs']['Reader'] is (
+                ascii.Basic if (fast_reader is False) else ascii.FastBasic)

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -125,11 +125,14 @@ def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
     quotechar : str
         One-character string to quote fields containing special characters
     header_start : int
-        Line index for the header line not counting comment lines
+        Line index for the header line not counting comment or blank lines.
+        A line with only whitespace is considered blank.
     data_start : int
-        Line index for the start of data not counting comment lines
+        Line index for the start of data not counting comment or blank lines.
+        A line with only whitespace is considered blank.
     data_end : int
-        Line index for the end of data (can be negative to count from end)
+        Line index for the end of data not counting comment or blank lines.
+        This value can be negative to count from the end.
     converters : dict
         Dictionary of converters
     data_Splitter : `~astropy.io.ascii.BaseSplitter`
@@ -201,11 +204,14 @@ def read(table, guess=None, **kwargs):
     quotechar : str
         One-character string to quote fields containing special characters
     header_start : int
-        Line index for the header line not counting comment lines
+        Line index for the header line not counting comment or blank lines.
+        A line with only whitespace is considered blank.
     data_start : int
-        Line index for the start of data not counting comment lines
+        Line index for the start of data not counting comment or blank lines.
+        A line with only whitespace is considered blank.
     data_end : int
-        Line index for the end of data (can be negative to count from end)
+        Line index for the end of data not counting comment or blank lines.
+        This value can be negative to count from the end.
     converters : dict
         Dictionary of converters
     data_Splitter : `~astropy.io.ascii.BaseSplitter`

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -148,7 +148,7 @@ find the header and data.
 
 When processing of a file into a header and data components any blank lines
 (which might have whitespace characters) and commented lines (starting with the
-comment character ``#``) are stripped out *before* the header and data
+comment character, typically ``#``) are stripped out *before* the header and data
 parsing code sees the table content. For example imagine you have the file
 below. The column on the left is not part of the file but instead shows how
 ``io.ascii`` is viewing each line and the line count index.  ::

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -244,7 +244,7 @@ be the string ``'0'``,
 otherwise you may get unexpected behavior [#f1]_.  By default the
 ``<missing_spec>`` is applied to all columns unless column name strings are
 supplied.  An alterate way to limit the columns is via the
-n``fill_include_names`` and ``fill_exclude_names`` keyword arguments in |read|.
+``fill_include_names`` and ``fill_exclude_names`` keyword arguments in |read|.
 
 In the example below we read back the weather table after filling the missing
 values in with typical placeholders::


### PR DESCRIPTION
`BaseHeader.process_lines()` doesn't throw away lines that have only one or more spaces, while `BaseData.process_lines()` does.  This is inconsistent and super confusing if you have a file that requires specifying `header_start` and `data_start`.

The fix is pretty trivial, but I'm worried it constitutes an API change since people may have code that is working in the context of the current inconsistent behavior.  So we should defer this past 0.4 and think a bit about it.