### PR TITLE
Custom inverse copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ New Features
     are now > 10x faster for the supplied cosmologies. [#3767]
 
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
-    should use the new public interfaces ``FLRW.lookback_time_integrand`` 
+    should use the new public interfaces ``FLRW.lookback_time_integrand``
     and ``FLRW.abs_distance_integrand`` instead. [#3767]
 
 - ``astropy.io.ascii``
@@ -235,6 +235,8 @@ Bug fixes
 - ``astropy.logger.py``
 
 - ``astropy.modeling``
+
+  - A copy of the model is made before it's assigned as an inverse [#3828].
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -255,6 +255,8 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
                     "instance or `None` (where `None` restores the default "
                     "inverse for this model if one is defined.")
 
+            if isinstance(value, Model):
+                value = value.copy()
             self._custom_inverse = value
 
         members['inverse'] = property(wrapped_fget, fset,

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -255,7 +255,7 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
                     "instance or `None` (where `None` restores the default "
                     "inverse for this model if one is defined.")
 
-            if isinstance(value, Model):
+            if not isinstance(value, (_CompoundModel, type(None))):
                 value = value.copy()
             self._custom_inverse = value
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -16,7 +16,7 @@ from ..core import Model, ModelDefinitionError
 from ..parameters import Parameter
 from ..models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
                       Gaussian2D, Polynomial1D, Polynomial2D,
-                      Chebyshev2D, Legendre2D, Chebyshev1D, Legendre1D, 
+                      Chebyshev2D, Legendre2D, Chebyshev1D, Legendre1D,
                       AffineTransformation2D, Identity, Mapping)
 
 
@@ -834,3 +834,16 @@ def test_compound_with_polynomials(poly):
     result_compound = model(x, y)
     result = shift(poly(x, y))
     assert_allclose(result, result_compound)
+
+
+def test_inverse_copy():
+    """
+    Tests that the inverse of a model is a copy.
+    Issue #3828
+    """
+    poly1 = Polynomial1D(1)
+    poly2 = Polynomial1D(1)
+    poly1.inverse = poly2
+    poly2.parameters = (1, 2)
+    assert_allclose(poly1(1), 0)
+


### PR DESCRIPTION
This makes a copy of the model when assigning a single model as an inverse to a compound model. When the inverse is a compound model, a copy is already made elsewhere.

Currently this is what happens:

```
p1 = Polynomial1D(1)
p2 = Polynomial1D(1)
compound = p1 + p2
compound.inverse = p1
compound.inverse(1)
Out[63]: 0.0

p1.parameters = 1, 2
compound.inverse(1)
Out[67]: 3.0
```

@embray Let me know if this is the right place for the copy and I'll add a test.
