### PR TITLE
Coordinate representation lost in `__getitem__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -360,6 +360,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Fix bug where coordinate representation setting gets reset to default
+    value when coordinate array is indexed or sliced. [#3824]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1020,7 +1020,9 @@ class BaseCoordinateFrame(object):
 
     def __getitem__(self, view):
         if self.has_data:
-            return self.realize_frame(self.data[view])
+            out = self.realize_frame(self.data[view])
+            out.representation = self.representation
+            return out
         else:
             raise ValueError('Cannot index a frame with no data')
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -198,7 +198,7 @@ class SkyCoord(object):
             # First turn `self` into a mockup of the thing we want - we can copy
             # this to get all the right attributes
             self._sky_coord_frame = self_frame[item]
-            return SkyCoord(self)
+            return SkyCoord(self, representation=self.representation)
         finally:
             # now put back the right frame in self
             self._sky_coord_frame = self_frame

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -649,3 +649,14 @@ def test_representation_subclass():
                 representation=NewSphericalRepresentation)
 
     assert repr(frame) == "<FK5 Coordinate (equinox=J2000.000):  spam spam spam>"
+
+
+def test_getitem_representation():
+    """
+    Make sure current representation survives __getitem__ even if different
+    from data representation.
+    """
+    from ..builtin_frames import ICRS
+    c = ICRS([1, 1] * u.deg, [2, 2] * u.deg)
+    c.representation = 'cartesian'
+    assert c[0].representation is representation.CartesianRepresentation

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1144,3 +1144,13 @@ def test_constellations_with_nameresolve():
     assert SkyCoord.from_name('Coma Cluster').get_constellation(short_name=True) == 'Com'
     assert SkyCoord.from_name('UMa II').get_constellation() == 'Ursa Major'
     assert SkyCoord.from_name('Triangulum Galaxy').get_constellation() == 'Triangulum'
+
+
+def test_getitem_representation():
+    """
+    Make sure current representation survives __getitem__ even if different
+    from data representation.
+    """
+    sc = SkyCoord([1, 1] * u.deg, [2, 2] * u.deg)
+    sc.representation = 'cartesian'
+    assert sc[0].representation is CartesianRepresentation


### PR DESCRIPTION
When a SkyCoord or Frame is reduced via `__getitem__` then the representation always goes back to that of the internal representation data:
```
In [2]: c = SkyCoord([90], [0], unit='deg')

In [3]: c.representation = 'cartesian'

In [4]: c
Out[4]: 
<SkyCoord (ICRS): (x, y, z) [dimensionless]
    (0.0, 1.0, 0.0)>

In [5]: c[0]
Out[5]: 
<SkyCoord (ICRS): (ra, dec) in deg
    (90.0, 0.0)>
```

This is fixed in 8765e59 within #3731.  I didn't want to lose momentum on #3731 so I didn't stop to make a separate PR and wait for that to get merged.  We can cherry pick that commit to make a formal PR to fix this bug if everything looks fine.