### PR TITLE
AttributeError: record array has no attribute _data_field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -360,6 +360,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed crash when updating data in a random groups HDU opened in update
+    mode. [#3730]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -417,7 +417,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
             self._header.set('PCOUNT', len(self.data.parnames), after='GROUPS')
             self._header.set('GCOUNT', len(self.data), after='PCOUNT')
 
-            column = self.data._coldefs[self.data._data_field]
+            column = self.data._coldefs[self._data_field]
             scale, zero = self.data._get_scale_factors(column)[3:5]
             if scale:
                 self._header.set('BSCALE', column.bscale)

--- a/astropy/io/fits/tests/test_groups.py
+++ b/astropy/io/fits/tests/test_groups.py
@@ -60,6 +60,19 @@ class TestGroupsFunctions(FitsTestCase):
         # opening and closing it.
         assert mtime == os.stat(self.temp('random_groups.fits')).st_mtime
 
+    def test_random_groups_data_update(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/3730 and
+        for https://github.com/spacetelescope/PyFITS/issues/102
+        """
+
+        self.copy_file('random_groups.fits')
+        with fits.open(self.temp('random_groups.fits'), mode='update') as h:
+            h[0].data['UU'] = 0.42
+
+        with fits.open(self.temp('random_groups.fits'), mode='update') as h:
+            assert np.all(h[0].data['UU'] == 0.42)
+
     def test_parnames_round_trip(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/130


### PR DESCRIPTION
Hi Astropy

Much respect to all of you for creating the powerful and practical Astropy package--thank you!

I have recently begun using it to read, manipulate and write FITS formatted radio visibility data.  The data was recorded at the ATCA interferometer (Australia) and then exported to FITS using the Miriad 'fits' task.

After successfully reading a FITS file into python using astropy.io.fits, an error occurs when writing it back out to a FITS file.

Below are the commands issued that lead to the error and below that is output from astropy.test()

Thank you, kindly, for considering this issue.

Jordan

-----------

```
>>> from astropy.io import fits
>>> hdulist = fits.open('if4_1253_055.fits',mode='update')
>>> data = hdulist[0].data['data']
>>> hdulist.flush()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/astropy/utils/decorators.py", line 517, in flush
    **_get_function_args(wrapped))
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/util.py", line 260, in wrapped
    func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/hdu/hdulist.py", line 583, in flush
    self.verify(option=output_verify)
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/verify.py", line 74, in verify
    errs = self._verify(opt)
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/hdu/hdulist.py", line 915, in _verify
    result = hdu._verify(option)
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/hdu/groups.py", line 491, in _verify
    errs = super(GroupsHDU, self)._verify(option=option)
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/hdu/image.py", line 888, in _verify
    errs = super(PrimaryHDU, self)._verify(option=option)
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/hdu/image.py", line 482, in _verify
    self.update_header()
  File "/usr/local/lib/python2.7/dist-packages/astropy/io/fits/hdu/groups.py", line 420, in update_header
    column = self.data._coldefs[self.data._data_field]
  File "/usr/lib/python2.7/dist-packages/numpy/core/records.py", line 418, in __getattribute__
    raise AttributeError("record array has no attribute %s" % attr)
AttributeError: record array has no attribute _data_field
```

-----------


```
In [1]: import astropy

In [2]: astropy.test()
============================= test session starts ==============================
platform linux2 -- Python 2.7.6 -- pytest-2.5.1

Running tests with Astropy version 1.0.2.
Running tests in /usr/local/lib/python2.7/dist-packages/astropy.

Platform: Linux-3.16.0-34-generic-x86_64-with-Ubuntu-14.04-trusty

Executable: /usr/bin/python

Full Python Version:
2.7.6 (default, Mar 22 2014, 22:59:56)
[GCC 4.8.2]

encodings: sys: ascii, locale: UTF-8, filesystem: UTF-8, unicode bits: 20
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.8.2
Scipy: 0.13.3
Matplotlib: 1.3.1
h5py: not available
```