### PR TITLE
IERS issue when updating

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -365,6 +365,9 @@ Bug Fixes
   - Fix bug where coordinate representation setting gets reset to default
     value when coordinate array is indexed or sliced. [#3824]
 
+  - Fixed confusing warning message shown when using dates outside current
+    IERS data. [#3844]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -32,10 +32,14 @@ PIOVER2 = np.pi / 2.
 _DEFAULT_PM = (0.035, 0.29)*u.arcsec
 
 _IERS_HINT = """
-If you need enough precision such that this matters (~<10 arcsec), you can download the latest IERS predictions by doing:
-from astropy.utils.data import download_file
-from astropy.utils import iers
-iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True))"""
+If you need enough precision such that this matters (~<10 arcsec), you can
+download the latest IERS predictions by running:
+
+    >>> from astropy.utils.data import download_file
+    >>> from astropy.utils import iers
+    >>> iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True))
+
+"""
 
 
 def get_polar_motion(time):


### PR DESCRIPTION
Hi guys,
I am running astropy '1.0.3' with Python 2.7.8 and get the following error when making a polar plot with matplotlib.

```
WARNING: Tried to get polar motions for times after IERS data is valid. Defaulting to polar motion from the 50-yr mean for those.
If you need enough precision such that this matters (~<10 arcsec), you can download the latest IERS predictions by doing:
from astropy.utils.data import download_file
from astropy.utils import iers
iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True)) [astropy.coordinates.builtin_frames.utils]
```

When I do the steps it suggests, something doesn't seem quite right. I had to import astropy, then astropy.coordinates and then I get an error about using a module in a table. I removed the part in square brackets as I wasn't sure if that should be included or not. The third line in the error executed but when I rerun the plotting code I get the same error. 

Any ideas?

Cheers
James

```
from astropy.utils.data import download_file
from astropy.utils import iers
iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True)) [astropy.coordinates.builtin_frames.utils]
Downloading http://maia.usno.navy.mil/ser7/finals2000A.all
|==========================================| 2.9M/2.9M (100.00%)         6s
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'astropy' is not defined
import astropy
iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True)) [astropy.coordinates.builtin_frames.utils]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'coordinates'
iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True)) 
from astropy import coordinates
iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True)) [astropy.coordinates.builtin_frames.utils]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/astropy/table/table.py", line 868, in __getitem__
    .format(type(item)))
ValueError: Illegal type <type 'module'> for table item access
```