### PR TITLE
Allow specifying a physical type in quantity_input decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,10 +89,10 @@ New Features
     appropriate logarithmic quantity class if ``subok=True``. For instance,
     ``Quantity(1, u.dex(u.m), subok=True)`` yields ``<Dex 1.0 dex(m)>``. [#5928]
 
-  - The ``quantity_input`` decorator now accepts a string physical type instead
-    of a unit object to specify the expected input ``Quantity``'s physical type.
-    For example, ``@u.quantity_input(x='angle')`` is now functionally the same
-    as ``@u.quantity_input(x=u.degree)``. [#3847]
+  - The ``quantity_input`` decorator now accepts a string physical type in
+    addition to of a unit object to specify the expected input ``Quantity``'s
+    physical type. For example, ``@u.quantity_input(x='angle')`` is now
+    functionally the same as ``@u.quantity_input(x=u.degree)``. [#3847]
 
 - ``astropy.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,10 @@ New Features
     appropriate logarithmic quantity class if ``subok=True``. For instance,
     ``Quantity(1, u.dex(u.m), subok=True)`` yields ``<Dex 1.0 dex(m)>``. [#5928]
 
+  - The ``quantity_input`` decorator now accepts a string physical type instead
+    of a unit object to specify the expected input ``Quantity``'s physical type.
+    [#3847]
+
 - ``astropy.utils``
 
   - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,7 +91,8 @@ New Features
 
   - The ``quantity_input`` decorator now accepts a string physical type instead
     of a unit object to specify the expected input ``Quantity``'s physical type.
-    [#3847]
+    For example, ``@u.quantity_input(x='angle')`` is now functionally the same
+    as ``@u.quantity_input(x=u.degree)``. [#3847]
 
 - ``astropy.utils``
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -120,7 +120,11 @@ class QuantityInput(object):
                     if isinstance(target_unit, str):
                         # user specified a physical type instead of a unit
                         ureg = get_current_unit_registry()
-                        target_units = ureg._by_physical_type[_unit_physical_mapping[target_unit]]
+                        try:
+                            physical_type_id = _unit_physical_mapping[target_unit]
+                        except KeyError:
+                            raise ValueError("Invalid physical type '{0}'.".format(target_unit))
+                        target_units = ureg._by_physical_type[physical_type_id]
                         target_unit = target_units.pop() # HACK
 
                     try:

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -134,7 +134,7 @@ class QuantityInput(object):
 
                             ureg = get_current_unit_registry()
                             target_units = ureg._by_physical_type[physical_type_id]
-                            target_unit = target_units.pop() # just grab the first valid unit
+                            target_unit = next(iter(target_units)) # get first valid unit from set
 
                     else:
                         str_target_unit = target_unit.to_string()

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -6,7 +6,8 @@ __all__ = ['quantity_input']
 from ..utils.decorators import wraps
 from ..utils.compat import funcsigs
 
-from .core import UnitsError, add_enabled_equivalencies, get_current_unit_registry
+from .core import (UnitsError, add_enabled_equivalencies,
+                   get_current_unit_registry)
 from .physical import _unit_physical_mapping
 
 class QuantityInput(object):
@@ -122,18 +123,15 @@ class QuantityInput(object):
 
                         try: # unit passed in as a string
                             target_unit = Unit(target_unit)
-                            phys_type = False
                         except ValueError:
-                            phys_type = True
-
-                        if phys_type:
                             # user specified a physical type instead of a unit
-                            ureg = get_current_unit_registry()
                             try:
                                 physical_type_id = _unit_physical_mapping[target_unit]
                             except KeyError:
                                 raise ValueError("Invalid physical type '{0}'."
                                                  .format(target_unit))
+
+                            ureg = get_current_unit_registry()
                             target_units = ureg._by_physical_type[physical_type_id]
                             target_unit = target_units.pop() # just grab the first valid unit
 
@@ -144,10 +142,9 @@ class QuantityInput(object):
                         if not equivalent:
                             raise UnitsError("Argument '{0}' to function '{1}'"
                                              " must be in units convertible to"
-                                             " physical type '{2}'."
-                                             .format(param.name,
-                                                     wrapped_function.__name__,
-                                                     target_unit.physical_type))
+                                             " '{2}'.".format(param.name,
+                                                              wrapped_function.__name__,
+                                                              target_unit.to_string()))
 
                     # Either there is no .unit or no .is_equivalent
                     except AttributeError:

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -129,7 +129,7 @@ class QuantityInput(object):
                                 physical_type_id = _unit_physical_mapping[target_unit]
                                 str_target_unit = target_unit
                             except KeyError:
-                                raise ValueError("Invalid physical type '{0}'."
+                                raise ValueError("Invalid unit of physical type '{0}'."
                                                  .format(target_unit))
 
                             ureg = get_current_unit_registry()

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -23,6 +23,7 @@ __all__ = ['def_physical_type', 'get_physical_type']
 
 
 _physical_unit_mapping = {}
+_unit_physical_mapping = {}
 
 
 def def_physical_type(unit, name):
@@ -43,6 +44,7 @@ def def_physical_type(unit, name):
             "{0!r} ({1!r}) already defined as {2!r}".format(
                 r, name, _physical_unit_mapping[r]))
     _physical_unit_mapping[r] = name
+    _unit_physical_mapping[name] = r
 
 
 def get_physical_type(unit):

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -106,7 +106,7 @@ def test_wrong_unit3():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
     """
 
 
@@ -202,7 +202,7 @@ def test_kwarg_wrong_unit3():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
     """
 
 

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -9,19 +9,14 @@ import pytest
 from ... import units as u  # pylint: disable=W0611
 from ...extern import six
 
-
 def py3only(func):
     if six.PY2:
         return pytest.mark.skipif('six.PY2')(func)
     else:
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if func.__doc__ is None:
-                pytest.skip('unable to run this test due to missing '
-                            'docstrings (maybe the module was compiled with '
-                            'optimization flags?)')
-
-            code = compile(dedent(func.__doc__), __file__, 'exec')
+            src = func(*args, **kwargs)
+            code = compile(dedent(src), __file__, 'exec')
             # This uses an unqualified exec statement illegally in Python 2,
             # but perfectly allowed in Python 3 so in fact we eval the exec
             # call :)
@@ -31,10 +26,13 @@ def py3only(func):
 
 
 @py3only
-def test_args3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.arcsec"),
+                         ("'angle'", "'angle'")])
+def test_args3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary: u.arcsec):
+    def myfunc_args(solarx: {0}, solary: {1}):
         return solarx, solary
 
     solarx, solary = myfunc_args(1*u.arcsec, 1*u.arcsec)
@@ -44,14 +42,18 @@ def test_args3():
 
     assert solarx.unit == u.arcsec
     assert solary.unit == u.arcsec
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_args_noconvert3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.arcsec"),
+                         ("'angle'", "'angle'")])
+def test_args_noconvert3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input()
-    def myfunc_args(solarx: u.arcsec, solary: u.arcsec):
+    def myfunc_args(solarx: {0}, solary: {1}):
         return solarx, solary
 
     solarx, solary = myfunc_args(1*u.deg, 1*u.arcmin)
@@ -61,14 +63,17 @@ def test_args_noconvert3():
 
     assert solarx.unit == u.deg
     assert solary.unit == u.arcmin
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_args_nonquantity3():
-    """
+@pytest.mark.parametrize("solarx_unit", [
+                         "u.arcsec", "'angle'"])
+def test_args_nonquantity3(solarx_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary):
+    def myfunc_args(solarx: {0}, solary):
         return solarx, solary
 
     solarx, solary = myfunc_args(1*u.arcsec, 100)
@@ -77,14 +82,18 @@ def test_args_nonquantity3():
     assert isinstance(solary, int)
 
     assert solarx.unit == u.arcsec
-    """
+    """.format(solarx_unit)
+    return src
 
 
 @py3only
-def test_arg_equivalencies3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.eV"),
+                         ("'angle'", "'energy'")])
+def test_arg_equivalencies3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input(equivalencies=u.mass_energy())
-    def myfunc_args(solarx: u.arcsec, solary: u.eV):
+    def myfunc_args(solarx: {0}, solary: {1}):
         return solarx, solary+(10*u.J)  # Add an energy to check equiv is working
 
     solarx, solary = myfunc_args(1*u.arcsec, 100*u.gram)
@@ -94,38 +103,49 @@ def test_arg_equivalencies3():
 
     assert solarx.unit == u.arcsec
     assert solary.unit == u.gram
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_wrong_unit3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_wrong_unit3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary: u.deg):
+    def myfunc_args(solarx: {0}, solary: {1}):
         return solarx, solary
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
-    """
+
+    str_to = str({1})
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to '{{0}}'.".format(str_to)
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_not_quantity3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_not_quantity3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary: u.deg):
+    def myfunc_args(solarx: {0}, solary: {1}):
         return solarx, solary
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
 def test_decorator_override():
-    """
+    src = """
     @u.quantity_input(solarx=u.arcsec)
     def myfunc_args(solarx: u.km, solary: u.arcsec):
         return solarx, solary
@@ -138,13 +158,17 @@ def test_decorator_override():
     assert solarx.unit == u.arcsec
     assert solary.unit == u.arcsec
     """
+    return src
 
 
 @py3only
-def test_kwargs3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_kwargs3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary, myk: u.arcsec=1*u.arcsec):
+    def myfunc_args(solarx: {0}, solary, myk: {1}=1*u.arcsec):
         return solarx, solary, myk
 
     solarx, solary, myk = myfunc_args(1*u.arcsec, 100, myk=100*u.deg)
@@ -154,14 +178,18 @@ def test_kwargs3():
     assert isinstance(myk, u.Quantity)
 
     assert myk.unit == u.deg
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_unused_kwargs3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_unused_kwargs3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary, myk: u.arcsec=1*u.arcsec, myk2=1000):
+    def myfunc_args(solarx: {0}, solary, myk: {1}=1*u.arcsec, myk2=1000):
         return solarx, solary, myk, myk2
 
     solarx, solary, myk, myk2 = myfunc_args(1*u.arcsec, 100, myk=100*u.deg, myk2=10)
@@ -173,14 +201,18 @@ def test_unused_kwargs3():
 
     assert myk.unit == u.deg
     assert myk2 == 10
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_kwarg_equivalencies3():
-    """
+@pytest.mark.parametrize("solarx_unit,energy", [
+                         ("u.arcsec", "u.eV"),
+                         ("'angle'", "'energy'")])
+def test_kwarg_equivalencies3(solarx_unit, energy):
+    src = """
     @u.quantity_input(equivalencies=u.mass_energy())
-    def myfunc_args(solarx: u.arcsec, energy: u.eV=10*u.eV):
+    def myfunc_args(solarx: {0}, energy: {1}=10*u.eV):
         return solarx, energy+(10*u.J)  # Add an energy to check equiv is working
 
     solarx, energy = myfunc_args(1*u.arcsec, 100*u.gram)
@@ -190,48 +222,63 @@ def test_kwarg_equivalencies3():
 
     assert solarx.unit == u.arcsec
     assert energy.unit == u.gram
-    """
+    """.format(solarx_unit, energy)
+    return src
 
 
 @py3only
-def test_kwarg_wrong_unit3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_kwarg_wrong_unit3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary: u.deg=10*u.deg):
+    def myfunc_args(solarx: {0}, solary: {1}=10*u.deg):
         return solarx, solary
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
-    """
+
+    str_to = str({1})
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to '{{0}}'.".format(str_to)
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_kwarg_not_quantity3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_kwarg_not_quantity3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary: u.deg=10*u.deg):
+    def myfunc_args(solarx: {0}, solary: {1}=10*u.deg):
         return solarx, solary
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 
 @py3only
-def test_kwarg_default3():
-    """
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         ("u.arcsec", "u.deg"),
+                         ("'angle'", "'angle'")])
+def test_kwarg_default3(solarx_unit, solary_unit):
+    src = """
     @u.quantity_input
-    def myfunc_args(solarx: u.arcsec, solary: u.deg=10*u.deg):
+    def myfunc_args(solarx: {0}, solary: {1}=10*u.deg):
         return solarx, solary
 
     solarx, solary = myfunc_args(1*u.arcsec)
-    """
+    """.format(solarx_unit, solary_unit)
+    return src
 
 @py3only
 def test_return_annotation():
-    """
+    src = """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec) -> u.deg:
         return solarx
@@ -239,3 +286,4 @@ def test_return_annotation():
     solarx = myfunc_args(1*u.arcsec)
     assert solarx.unit is u.deg
     """
+    return src

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -106,7 +106,7 @@ def test_wrong_unit3():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
     """
 
 
@@ -202,7 +202,7 @@ def test_kwarg_wrong_unit3():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
     """
 
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -68,7 +68,7 @@ def test_wrong_unit():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
 
 def test_not_quantity():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)
@@ -127,7 +127,7 @@ def test_kwarg_wrong_unit():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
 
 def test_kwarg_not_quantity():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)
@@ -207,6 +207,19 @@ def test_args_physical_type():
     assert solarx.unit == u.arcsec
     assert solary.unit == u.arcsec
 
+def test_args_pass_string():
+    @u.quantity_input(solarx='degree', solary='degree')
+    def myfunc_args(solarx, solary):
+        return solarx, solary
+
+    solarx, solary = myfunc_args(1*u.arcsec, 1*u.arcsec)
+
+    assert isinstance(solarx, u.Quantity)
+    assert isinstance(solary, u.Quantity)
+
+    assert solarx.unit == u.arcsec
+    assert solary.unit == u.arcsec
+
 def test_arg_equivalencies_physical_type():
     @u.quantity_input(solarx='angle', solary='energy', equivalencies=u.mass_energy())
     def myfunc_args(solarx, solary):
@@ -227,7 +240,7 @@ def test_kwarg_wrong_unit_physical_type():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
 
 def test_kwarg_invalid_physical_type():
     @u.quantity_input(solarx='angle', solary='africanswallow')

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -234,6 +234,6 @@ def test_kwarg_invalid_physical_type():
     def myfunc_args(solarx, solary=10*u.deg):
         return solarx, solary
 
-    with pytest.raises(u.ValueError) as e:
+    with pytest.raises(ValueError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.deg)
     assert str(e.value) == "Invalid physical type 'africanswallow'."

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -74,7 +74,7 @@ def test_arg_equivalencies(solarx_unit, solary_unit):
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [
                          (u.arcsec, u.deg),
-                         ('angle', 'angle')]) # TODO: broken right now
+                         ('angle', 'angle')])
 def test_wrong_unit(solarx_unit, solary_unit):
     @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary):
@@ -82,7 +82,9 @@ def test_wrong_unit(solarx_unit, solary_unit):
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
+
+    str_to = str(solary_unit)
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to '{0}'.".format(str_to)
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [
                          (u.arcsec, u.deg),
@@ -148,7 +150,7 @@ def test_kwarg_equivalencies(solarx_unit, energy_unit):
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [
                          (u.arcsec, u.deg),
-                         ('angle', 'angle')]) # TODO: broken because of error check
+                         ('angle', 'angle')])
 def test_kwarg_wrong_unit(solarx_unit, solary_unit):
     @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary=10*u.deg):
@@ -156,7 +158,9 @@ def test_kwarg_wrong_unit(solarx_unit, solary_unit):
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
+
+    str_to = str(solary_unit)
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to '{0}'.".format(str_to)
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [
                          (u.arcsec, u.deg),

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -9,8 +9,11 @@ from ... import units as u
 from .py3_test_quantity_annotations import *
 
 
-def test_args():
-    @u.quantity_input(solarx=u.arcsec, solary=u.arcsec)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.arcsec),
+                         ('angle', 'angle')])
+def test_args(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary):
         return solarx, solary
 
@@ -22,8 +25,11 @@ def test_args():
     assert solarx.unit == u.arcsec
     assert solary.unit == u.arcsec
 
-def test_args_noconvert():
-    @u.quantity_input(solarx=u.arcsec, solary=u.arcsec)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.arcsec),
+                         ('angle', 'angle')])
+def test_args_noconvert(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary):
         return solarx, solary
 
@@ -36,8 +42,10 @@ def test_args_noconvert():
     assert solary.unit == u.arcmin
 
 
-def test_args_nonquantity():
-    @u.quantity_input(solarx=u.arcsec)
+@pytest.mark.parametrize("solarx_unit", [
+                         u.arcsec, 'angle'])
+def test_args_nonquantity(solarx_unit):
+    @u.quantity_input(solarx=solarx_unit)
     def myfunc_args(solarx, solary):
         return solarx, solary
 
@@ -48,8 +56,11 @@ def test_args_nonquantity():
 
     assert solarx.unit == u.arcsec
 
-def test_arg_equivalencies():
-    @u.quantity_input(solarx=u.arcsec, solary=u.eV, equivalencies=u.mass_energy())
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.eV),
+                         ('angle', 'energy')])
+def test_arg_equivalencies(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit, equivalencies=u.mass_energy())
     def myfunc_args(solarx, solary):
         return solarx, solary+(10*u.J)  # Add an energy to check equiv is working
 
@@ -61,17 +72,23 @@ def test_arg_equivalencies():
     assert solarx.unit == u.arcsec
     assert solary.unit == u.gram
 
-def test_wrong_unit():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')]) # TODO: broken right now
+def test_wrong_unit(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary):
         return solarx, solary
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
 
-def test_not_quantity():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')])
+def test_not_quantity(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary):
         return solarx, solary
 
@@ -79,8 +96,11 @@ def test_not_quantity():
         solarx, solary = myfunc_args(1*u.arcsec, 100)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
 
-def test_kwargs():
-    @u.quantity_input(solarx=u.arcsec, myk=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')])
+def test_kwargs(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, myk=solary_unit)
     def myfunc_args(solarx, solary, myk=1*u.arcsec):
         return solarx, solary, myk
 
@@ -92,8 +112,11 @@ def test_kwargs():
 
     assert myk.unit == u.deg
 
-def test_unused_kwargs():
-    @u.quantity_input(solarx=u.arcsec, myk=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')])
+def test_unused_kwargs(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, myk=solary_unit)
     def myfunc_args(solarx, solary, myk=1*u.arcsec, myk2=1000):
         return solarx, solary, myk, myk2
 
@@ -107,8 +130,11 @@ def test_unused_kwargs():
     assert myk.unit == u.deg
     assert myk2 == 10
 
-def test_kwarg_equivalencies():
-    @u.quantity_input(solarx=u.arcsec, energy=u.eV, equivalencies=u.mass_energy())
+@pytest.mark.parametrize("solarx_unit,energy_unit", [
+                         (u.arcsec, u.eV),
+                         ('angle', 'energy')])
+def test_kwarg_equivalencies(solarx_unit, energy_unit):
+    @u.quantity_input(solarx=solarx_unit, energy=energy_unit, equivalencies=u.mass_energy())
     def myfunc_args(solarx, energy=10*u.eV):
         return solarx, energy+(10*u.J)  # Add an energy to check equiv is working
 
@@ -120,17 +146,23 @@ def test_kwarg_equivalencies():
     assert solarx.unit == u.arcsec
     assert energy.unit == u.gram
 
-def test_kwarg_wrong_unit():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')]) # TODO: broken because of error check
+def test_kwarg_wrong_unit(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary=10*u.deg):
         return solarx, solary
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
 
-def test_kwarg_not_quantity():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')])
+def test_kwarg_not_quantity(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary=10*u.deg):
         return solarx, solary
 
@@ -138,8 +170,11 @@ def test_kwarg_not_quantity():
         solarx, solary = myfunc_args(1*u.arcsec, solary=100)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
 
-def test_kwarg_default():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')])
+def test_kwarg_default(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx, solary=10*u.deg):
         return solarx, solary
 
@@ -166,8 +201,11 @@ def test_no_equivalent():
 
         assert str(e.value) == "Argument 'solarx' to function 'myfunc_args' has a 'unit' attribute without an 'is_equivalent' method. You may want to pass in an astropy Quantity instead."
 
-def test_kwargs_input():
-    @u.quantity_input(solarx=u.arcsec, solary=u.deg)
+@pytest.mark.parametrize("solarx_unit,solary_unit", [
+                         (u.arcsec, u.deg),
+                         ('angle', 'angle')])
+def test_kwargs_input(solarx_unit, solary_unit):
+    @u.quantity_input(solarx=solarx_unit, solary=solary_unit)
     def myfunc_args(solarx=1*u.arcsec, solary=1*u.deg):
         return solarx, solary
 
@@ -180,8 +218,10 @@ def test_kwargs_input():
     assert solarx.unit == u.arcsec
     assert solary.unit == u.deg
 
-def test_kwargs_extra():
-    @u.quantity_input(solary=u.deg)
+@pytest.mark.parametrize("solarx_unit", [
+                         u.arcsec, 'angle'])
+def test_kwargs_extra(solarx_unit):
+    @u.quantity_input(solarx=solarx_unit)
     def myfunc_args(solarx, **kwargs):
         return solarx
 
@@ -190,57 +230,6 @@ def test_kwargs_extra():
     assert isinstance(solarx, u.Quantity)
 
     assert solarx.unit == u.deg
-
-# ---------------------------------------------------------------
-# Repeat core tests with physical types instead of units
-
-def test_args_physical_type():
-    @u.quantity_input(solarx='angle', solary='angle')
-    def myfunc_args(solarx, solary):
-        return solarx, solary
-
-    solarx, solary = myfunc_args(1*u.arcsec, 1*u.arcsec)
-
-    assert isinstance(solarx, u.Quantity)
-    assert isinstance(solary, u.Quantity)
-
-    assert solarx.unit == u.arcsec
-    assert solary.unit == u.arcsec
-
-def test_args_pass_string():
-    @u.quantity_input(solarx='degree', solary='degree')
-    def myfunc_args(solarx, solary):
-        return solarx, solary
-
-    solarx, solary = myfunc_args(1*u.arcsec, 1*u.arcsec)
-
-    assert isinstance(solarx, u.Quantity)
-    assert isinstance(solary, u.Quantity)
-
-    assert solarx.unit == u.arcsec
-    assert solary.unit == u.arcsec
-
-def test_arg_equivalencies_physical_type():
-    @u.quantity_input(solarx='angle', solary='energy', equivalencies=u.mass_energy())
-    def myfunc_args(solarx, solary):
-        return solarx, solary+(10*u.J)  # Add an energy to check equiv is working
-
-    solarx, solary = myfunc_args(1*u.arcsec, 100*u.gram)
-
-    assert isinstance(solarx, u.Quantity)
-    assert isinstance(solary, u.Quantity)
-
-    assert solarx.unit == u.arcsec
-    assert solary.unit == u.gram
-
-def test_kwarg_wrong_unit_physical_type():
-    @u.quantity_input(solarx='angle', solary='angle')
-    def myfunc_args(solarx, solary=10*u.deg):
-        return solarx, solary
-
-    with pytest.raises(u.UnitsError) as e:
-        solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to physical type 'angle'."
 
 def test_kwarg_invalid_physical_type():
     @u.quantity_input(solarx='angle', solary='africanswallow')

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -190,3 +190,41 @@ def test_kwargs_extra():
     assert isinstance(solarx, u.Quantity)
 
     assert solarx.unit == u.deg
+
+# ---------------------------------------------------------------
+# Repeat core tests with physical types instead of units
+
+def test_args_physical_type():
+    @u.quantity_input(solarx='angle', solary='angle')
+    def myfunc_args(solarx, solary):
+        return solarx, solary
+
+    solarx, solary = myfunc_args(1*u.arcsec, 1*u.arcsec)
+
+    assert isinstance(solarx, u.Quantity)
+    assert isinstance(solary, u.Quantity)
+
+    assert solarx.unit == u.arcsec
+    assert solary.unit == u.arcsec
+
+def test_arg_equivalencies_physical_type():
+    @u.quantity_input(solarx='angle', solary='energy', equivalencies=u.mass_energy())
+    def myfunc_args(solarx, solary):
+        return solarx, solary+(10*u.J)  # Add an energy to check equiv is working
+
+    solarx, solary = myfunc_args(1*u.arcsec, 100*u.gram)
+
+    assert isinstance(solarx, u.Quantity)
+    assert isinstance(solary, u.Quantity)
+
+    assert solarx.unit == u.arcsec
+    assert solary.unit == u.gram
+
+def test_kwarg_wrong_unit_physical_type():
+    @u.quantity_input(solarx='angle', solary='angle')
+    def myfunc_args(solarx, solary=10*u.deg):
+        return solarx, solary
+
+    with pytest.raises(u.UnitsError) as e:
+        solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -228,3 +228,12 @@ def test_kwarg_wrong_unit_physical_type():
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."
+
+def test_kwarg_invalid_physical_type():
+    @u.quantity_input(solarx='angle', solary='africanswallow')
+    def myfunc_args(solarx, solary=10*u.deg):
+        return solarx, solary
+
+    with pytest.raises(u.ValueError) as e:
+        solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.deg)
+    assert str(e.value) == "Invalid physical type 'africanswallow'."

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -242,4 +242,4 @@ def test_kwarg_invalid_physical_type():
 
     with pytest.raises(ValueError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.deg)
-    assert str(e.value) == "Invalid physical type 'africanswallow'."
+    assert str(e.value) == "Invalid unit of physical type 'africanswallow'."

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -68,7 +68,7 @@ def test_wrong_unit():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."
 
 def test_not_quantity():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)
@@ -127,7 +127,7 @@ def test_kwarg_wrong_unit():
 
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to 'deg'."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to physical type 'angle'."
 
 def test_kwarg_not_quantity():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -39,7 +39,7 @@ specifying a value and unit:
 The constructor gives a few more options.  In particular, it allows one to
 merge sequences of |quantity| objects (as long as all of their units are
 equivalent), and to parse simple strings (which may help, e.g., to parse
-configuration files, etc.):    
+configuration files, etc.):
 
     >>> qlst = [60 * u.s, 1 * u.min]
     >>> u.Quantity(qlst, u.minute)
@@ -346,17 +346,27 @@ Functions Accepting Quantities
 Validation of quantity arguments to functions can lead to many repetitions
 of the same checking code. A decorator is provided which verifies that certain
 arguments to a function are `~astropy.units.Quantity` objects and that the units
-are compatible with a desired unit.
+are compatible with a desired unit or physical type.
 
-The decorator does not convert the unit to the desired unit, say arcseconds
-to degrees, it merely checks that such a conversion is possible, thus verifying
-that the `~astropy.units.Quantity` argument can be used in calculations.
+The decorator does not convert the input quantity to the desired unit, say
+arcseconds to degrees in the example below, it merely checks that such a
+conversion is possible, thus verifying that the `~astropy.units.Quantity`
+argument can be used in calculations.
 
 The decorator `~astropy.units.quantity_input` accepts keyword arguments to
 specify which arguments should be validated and what unit they are expected to
 be compatible with:
 
     >>> @u.quantity_input(myarg=u.deg)
+    ... def myfunction(myarg):
+    ...     return myarg.unit
+
+    >>> myfunction(100*u.arcsec)
+    Unit("arcsec")
+
+It is also possible to instead specify the physical type of the desired unit:
+
+    >>> @u.quantity_input(myarg='angle')
     ... def myfunction(myarg):
     ...     return myarg.unit
 


### PR DESCRIPTION
Right now, the [quantity_input](http://docs.astropy.org/en/latest/api/astropy.units.quantity_input.html#astropy.units.quantity_input) decorator requires you to specify a specific unit, but usually we don't care about the particular unit of the quantity so much as the physical type of the quantity object passed in. This PR is a hack to allow the user to specify, e.g., 

``` python
@quantity_input(some_arg='angle')
def func(some_arg):
    ang = some_arg.to(u.rad)
    # ...
```

or, for backwards compatibility, a particular unit.

In adding this functionality, I realized 2 things:
1. (This was also brought up by @demitri) Physical types are currently just strings that are passed around. It might make more sense for us to define (singleton?) classes for each physical type that store the string internally. This way, we can add them to a namespace, e.g., `astropy.units.physical_types` so the user can easily see what physical types are available without having to remember how to type, e.g., 'spectral flux density wav'.
2.  We are missing functionality to easily get a `Unit` object given a physical type. I hacked together an inverse mapping from physical type ID to a unit, but ideally we'd want some way to say, e.g., "I want an angle unit in whatever base unit system is enabled" (or does this already exist?).

cc @eteq @mdboom 
