### PR TITLE
Fix icon in stability docs

### DIFF
--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -152,7 +152,7 @@ The current planned and existing sub-packages are:
                 astropy.io.misc
             </td>
             <td align='center'>
-                <img alt="mature" src="_images/dev.png">
+                <span class="mature"></span>
             </td>
             <td>
                  The functionality that is currently present is stable, but this sub-package will likely see major additions in future.


### PR DESCRIPTION
This one was still being shown in the "old" way using an image and not a Unicode character, possibly due to a merge gone wrong.