### PR TITLE
WIP: Prototype for Quantity support in Models

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2051,6 +2051,7 @@ class _CompoundModelMeta(_ModelMeta):
                 # a bound Parameter even if submodel is a Model instance (as
                 # opposed to a Model subclass)
                 new_param = orig_param.copy(name=param_name, default=default,
+                                            unit=orig_param.unit,
                                             **constraints)
 
             setattr(cls, param_name, new_param)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2277,6 +2277,14 @@ class _CompoundModel(Model):
     _submodels = None
 
     def __getattr__(self, attr):
+        # This __getattr__ is necessary, because _CompoundModelMeta creates
+        # Parameter descriptors *lazily*--they do not exist in the class
+        # __dict__ until one of them has been accessed.
+        # However, this is at odds with how Python looks up descriptors (see
+        # (https://docs.python.org/3/reference/datamodel.html#invoking-descriptors)
+        # which is to look directly in the class __dict__
+        # This workaround allows descriptors to work correctly when they are
+        # not initially found in the class __dict__
         value = getattr(self.__class__, attr)
         if hasattr(value, '__get__'):
             # Object is a descriptor, so we should really return the result of

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -38,11 +38,11 @@ from ..utils import (deprecated, sharedmethod, find_current_module,
                      InheritDocstrings)
 from ..utils.codegen import make_function_with_signature
 from ..utils.exceptions import AstropyDeprecationWarning
-from .utils import (array_repr_oneline, check_broadcast, combine_labels,
+from .utils import (check_broadcast, combine_labels,
                     make_binary_operator_eval, ExpressionTree,
                     IncompatibleShapeError, AliasDict, format_unit_with_type)
 
-from .parameters import Parameter, InputParameterError
+from .parameters import Parameter, InputParameterError, param_repr_oneline
 
 
 __all__ = ['Model', 'FittableModel', 'Fittable1DModel', 'Fittable2DModel',
@@ -1515,7 +1515,7 @@ class Model(object):
 
         parts.extend(
             "{0}={1}".format(name,
-                             array_repr_oneline(getattr(self, name).value))
+                             param_repr_oneline(getattr(self, name)))
             for name in self.param_names)
 
         if self.name is not None:
@@ -1562,6 +1562,10 @@ class Model(object):
                        for name in self.param_names]
 
         param_table = Table(columns, names=self.param_names)
+
+        # Set units on the columns
+        for name in self.param_names:
+            param_table[name].unit = getattr(self, name).unit
 
         parts.append(indent(str(param_table), width=4))
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1848,37 +1848,7 @@ class _CompoundModelMeta(_ModelMeta):
         else:
             modname = '__main__'
 
-        # TODO: These aren't the full rules for handling inputs and outputs, but
-        # this will handle most basic cases correctly
-        if operator == '|':
-            inputs = left.inputs
-            outputs = right.outputs
-
-            if left.n_outputs != right.n_inputs:
-                raise ModelDefinitionError(
-                    "Unsupported operands for |: {0} (n_inputs={1}, "
-                    "n_outputs={2}) and {3} (n_inputs={4}, n_outputs={5}); "
-                    "n_outputs for the left-hand model must match n_inputs "
-                    "for the right-hand model.".format(
-                        left.name, left.n_inputs, left.n_outputs, right.name,
-                        right.n_inputs, right.n_outputs))
-        elif operator == '&':
-            inputs = combine_labels(left.inputs, right.inputs)
-            outputs = combine_labels(left.outputs, right.outputs)
-        else:
-            # Without loss of generality
-            inputs = left.inputs
-            outputs = left.outputs
-
-            if (left.n_inputs != right.n_inputs or
-                    left.n_outputs != right.n_outputs):
-                raise ModelDefinitionError(
-                    "Unsupported operands for {0}: {1} (n_inputs={2}, "
-                    "n_outputs={3}) and {4} (n_inputs={5}, n_outputs={6}); "
-                    "models must have the same n_inputs and the same "
-                    "n_outputs for this operator".format(
-                        operator, left.name, left.n_inputs, left.n_outputs,
-                        right.name, right.n_inputs, right.n_outputs))
+        inputs, outputs = mcls._check_inputs_and_outputs(operator, left, right)
 
         if operator in ('|', '+', '-'):
             linear = left.linear and right.linear
@@ -1934,6 +1904,42 @@ class _CompoundModelMeta(_ModelMeta):
         # TODO: Remove this at the same time as removing
         # _ModelMeta._handle_backwards_compat
         return
+
+    @classmethod
+    def _check_inputs_and_outputs(mcls, operator, left, right):
+        # TODO: These aren't the full rules for handling inputs and outputs, but
+        # this will handle most basic cases correctly
+        if operator == '|':
+            inputs = left.inputs
+            outputs = right.outputs
+
+            if left.n_outputs != right.n_inputs:
+                raise ModelDefinitionError(
+                    "Unsupported operands for |: {0} (n_inputs={1}, "
+                    "n_outputs={2}) and {3} (n_inputs={4}, n_outputs={5}); "
+                    "n_outputs for the left-hand model must match n_inputs "
+                    "for the right-hand model.".format(
+                        left.name, left.n_inputs, left.n_outputs, right.name,
+                        right.n_inputs, right.n_outputs))
+        elif operator == '&':
+            inputs = combine_labels(left.inputs, right.inputs)
+            outputs = combine_labels(left.outputs, right.outputs)
+        else:
+            # Without loss of generality
+            inputs = left.inputs
+            outputs = left.outputs
+
+            if (left.n_inputs != right.n_inputs or
+                    left.n_outputs != right.n_outputs):
+                raise ModelDefinitionError(
+                    "Unsupported operands for {0}: {1} (n_inputs={2}, "
+                    "n_outputs={3}) and {4} (n_inputs={5}, n_outputs={6}); "
+                    "models must have the same n_inputs and the same "
+                    "n_outputs for this operator".format(
+                        operator, left.name, left.n_inputs, left.n_outputs,
+                        right.name, right.n_inputs, right.n_outputs))
+
+        return inputs, outputs
 
     @classmethod
     def _make_custom_inverse(mcls, operator, left, right):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -92,6 +92,8 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    output_units = 'amplitude'  # Output must have same units as amplitude
+
     @staticmethod
     def evaluate(x, amplitude, mean, stddev):
         """
@@ -139,6 +141,8 @@ class GaussianAbsorption1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, amplitude, mean, stddev):
@@ -241,6 +245,7 @@ class Gaussian2D(Fittable2DModel):
     y_stddev = Parameter(default=1)
     theta = Parameter(default=0)
 
+    output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
                  y_mean=y_mean.default, x_stddev=None, y_stddev=None,
@@ -359,6 +364,7 @@ class Shift(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+    output_units = 'x'
 
     offset = Parameter(default=0)
 
@@ -385,6 +391,7 @@ class Scale(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+    output_units = lambda factor, x: factor.units * x.units
 
     factor = Parameter(default=1)
     linear = True
@@ -418,6 +425,8 @@ class Redshift(Fittable1DModel):
     """
 
     z = Parameter(description='redshift', default=0)
+
+    output_units = 'x'
 
     @staticmethod
     def evaluate(x, z):
@@ -466,6 +475,8 @@ class Sine1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     frequency = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, frequency):
         """One dimensional Sine model function"""
@@ -507,6 +518,9 @@ class Linear1D(Fittable1DModel):
 
     slope = Parameter(default=1)
     intercept = Parameter(default=0)
+
+    output_units = 'intercept'
+
     linear = True
 
     @staticmethod
@@ -554,6 +568,8 @@ class Lorentz1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     fwhm = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, fwhm):
         """One dimensional Lorentzian model function"""
@@ -593,6 +609,9 @@ class Const1D(Fittable1DModel):
     """
 
     amplitude = Parameter(default=1)
+
+    output_units = 'amplitude'
+
     linear = True
 
     @staticmethod
@@ -639,6 +658,9 @@ class Const2D(Fittable2DModel):
     """
 
     amplitude = Parameter(default=1)
+
+    output_units = 'amplitude'
+
     linear = True
 
     @staticmethod
@@ -734,6 +756,8 @@ class Ellipse2D(Fittable2DModel):
     b = Parameter()
     theta = Parameter()
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, a, b, theta):
         """Two dimensional Ellipse model function."""
@@ -786,6 +810,8 @@ class Disk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     R_0 = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0):
         """Two dimensional Disk model function"""
@@ -795,7 +821,6 @@ class Disk2D(Fittable2DModel):
 
 
 class Ring2D(Fittable2DModel):
-
     """
     Two dimensional radial symmetric Ring model.
 
@@ -839,6 +864,8 @@ class Ring2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     r_in = Parameter(default=1)
     width = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
                  y_0=y_0.default, r_in=r_in.default, width=width.default,
@@ -913,6 +940,8 @@ class Box1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     width = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, width):
         """One dimensional Box model function"""
@@ -974,6 +1003,8 @@ class Box2D(Fittable2DModel):
     x_width = Parameter(default=1)
     y_width = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, x_width, y_width):
         """Two dimensional Box model function"""
@@ -1009,6 +1040,8 @@ class Trapezoid1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     width = Parameter(default=1)
     slope = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, amplitude, x_0, width, slope):
@@ -1059,6 +1092,8 @@ class TrapezoidDisk2D(Fittable2DModel):
     R_0 = Parameter(default=1)
     slope = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0, slope):
         """Two dimensional Trapezoid Disk model function"""
@@ -1103,6 +1138,8 @@ class MexicanHat1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     sigma = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, sigma):
         """One dimensional Mexican Hat model function"""
@@ -1146,6 +1183,8 @@ class MexicanHat2D(Fittable2DModel):
     x_0 = Parameter(default=0)
     y_0 = Parameter(default=0)
     sigma = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, sigma):
@@ -1202,6 +1241,9 @@ class AiryDisk2D(Fittable2DModel):
     x_0 = Parameter(default=0)
     y_0 = Parameter(default=0)
     radius = Parameter(default=1)
+
+    output_units = 'amplitude'
+
     _j1 = None
 
     def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
@@ -1278,6 +1320,8 @@ class Moffat1D(Fittable1DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, gamma, alpha):
         """One dimensional Moffat model function"""
@@ -1333,6 +1377,8 @@ class Moffat2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, gamma, alpha):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -92,6 +92,7 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    input_units = 'mean'  # Input must have same units as mean
     output_units = 'amplitude'  # Output must have same units as amplitude
 
     @staticmethod
@@ -142,6 +143,7 @@ class GaussianAbsorption1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    input_units = 'mean'
     output_units = 'amplitude'
 
     @staticmethod
@@ -245,6 +247,7 @@ class Gaussian2D(Fittable2DModel):
     y_stddev = Parameter(default=1)
     theta = Parameter(default=0)
 
+    input_units = ('x_mean', 'y_mean')
     output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
@@ -364,6 +367,10 @@ class Shift(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+
+    # Input must have compatible units with offset, but output is kept in the
+    # input units
+    input_units = 'offset'
     output_units = 'x'
 
     offset = Parameter(default=0)
@@ -391,6 +398,7 @@ class Scale(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+
     output_units = lambda factor, x: factor.units * x.units
 
     factor = Parameter(default=1)
@@ -475,6 +483,7 @@ class Sine1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     frequency = Parameter(default=1)
 
+    input_units = lambda frequency: 1 / frequency.unit
     output_units = 'amplitude'
 
     @staticmethod
@@ -519,6 +528,7 @@ class Linear1D(Fittable1DModel):
     slope = Parameter(default=1)
     intercept = Parameter(default=0)
 
+    input_units = lambda slope, intercept: intercept.unit / slope.unit
     output_units = 'intercept'
 
     linear = True
@@ -568,6 +578,7 @@ class Lorentz1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     fwhm = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -756,6 +767,7 @@ class Ellipse2D(Fittable2DModel):
     b = Parameter()
     theta = Parameter()
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -810,6 +822,7 @@ class Disk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     R_0 = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -865,6 +878,7 @@ class Ring2D(Fittable2DModel):
     r_in = Parameter(default=1)
     width = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
@@ -1003,6 +1017,7 @@ class Box2D(Fittable2DModel):
     x_width = Parameter(default=1)
     y_width = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1041,6 +1056,7 @@ class Trapezoid1D(Fittable1DModel):
     width = Parameter(default=1)
     slope = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1092,6 +1108,7 @@ class TrapezoidDisk2D(Fittable2DModel):
     R_0 = Parameter(default=1)
     slope = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1138,6 +1155,7 @@ class MexicanHat1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     sigma = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1184,6 +1202,7 @@ class MexicanHat2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     sigma = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1242,6 +1261,7 @@ class AiryDisk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     radius = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     _j1 = None
@@ -1320,6 +1340,7 @@ class Moffat1D(Fittable1DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1378,6 +1399,7 @@ class Moffat2D(Fittable2DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -21,6 +21,7 @@ from ..units import Quantity
 from ..utils import isiterable
 from ..utils.compat import ignored
 from ..extern import six
+from .utils import array_repr_oneline
 
 __all__ = ['Parameter', 'InputParameterError']
 
@@ -753,3 +754,16 @@ class Parameter(object):
     __ge__ = _binary_comparison_operation(operator.ge)
     __neg__ = _unary_arithmetic_operation(operator.neg)
     __abs__ = _unary_arithmetic_operation(operator.abs)
+
+
+def param_repr_oneline(param):
+    """
+    Like array_repr_oneline but works on `Parameter` objects and supports
+    rendering parameters with units like quantities.
+    """
+
+    out = array_repr_oneline(param.value)
+    if param.unit is not None:
+        out = '{0} {1!s}'.format(out, param.unit)
+
+    return out

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -193,7 +193,7 @@ class Parameter(object):
         self._name = name
         self.__doc__ = self._description = description.strip()
         self._default = default
-        self._default_unit = unit
+        self._unit = unit
 
         # We only need to perform this check on unbound parameters
         if (model is None and unit is not None and
@@ -251,9 +251,9 @@ class Parameter(object):
             return self
 
         return self.__class__(self._name, default=self._default,
-                              getter=self._getter, setter=self._setter,
-                              fixed=self._fixed, tied=self._tied,
-                              bounds=self._bounds, model=obj)
+                              unit=self._unit, getter=self._getter,
+                              setter=self._setter, fixed=self._fixed,
+                              tied=self._tied, bounds=self._bounds, model=obj)
 
     def __set__(self, obj, value):
         value, shape = self._validate_value(obj, value)
@@ -310,8 +310,9 @@ class Parameter(object):
                 args += ', default={0}'.format(self._default)
         else:
             args += ', value={0}'.format(self.value)
-            if self.unit is not None:
-                args += ', unit={0}'.format(self.unit)
+
+        if self.unit is not None:
+            args += ', unit={0}'.format(self.unit)
 
         for cons in self.constraints:
             val = getattr(self, cons)
@@ -392,7 +393,7 @@ class Parameter(object):
         """
 
         if self._model is None:
-            return self._default_unit
+            return self._unit
         else:
             return self._model._param_metrics[self.name]['orig_unit']
 
@@ -545,9 +546,9 @@ class Parameter(object):
             raise AttributeError("can't set attribute 'max' on Parameter "
                                  "definition")
 
-    def copy(self, name=None, description=None, default=None, getter=None,
-             setter=None, fixed=False, tied=False, min=None, max=None,
-             bounds=None):
+    def copy(self, name=None, description=None, default=None, unit=None,
+             getter=None, setter=None, fixed=False, tied=False, min=None,
+             max=None, bounds=None):
         """
         Make a copy of this `Parameter`, overriding any of its core attributes
         in the process (or an exact copy).

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -98,7 +98,7 @@ def _binary_comparison_operation(op):
         else:
             self_value = self.value
 
-        return op(self_value, val).all()
+        return np.all(op(self_value, val))
 
     return wrapper
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -722,9 +722,14 @@ class Parameter(object):
     def __array__(self, dtype=None):
         # Make np.asarray(self) work a little more straightforwardly
         if self._model is None:
-            return np.array([], dtype=np.float)
+            arr = np.array([], dtype=np.float)
         else:
-            return np.asarray(self.value, dtype=dtype)
+            arr = np.asarray(self.value, dtype=dtype)
+
+        if self.unit is not None:
+            arr = Quantity(arr, self.unit, copy=False)
+
+        return arr
 
     def __nonzero__(self):
         if self._model is None:

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -46,6 +46,8 @@ class PowerLaw1D(Fittable1DModel):
     x_0 = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha):
         """One dimensional power law model function"""
@@ -105,6 +107,8 @@ class BrokenPowerLaw1D(Fittable1DModel):
     alpha_1 = Parameter(default=1)
     alpha_2 = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_break, alpha_1, alpha_2):
         """One dimensional broken power law model function"""
@@ -161,6 +165,8 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
     alpha = Parameter(default=1)
     x_cutoff = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, x_cutoff):
         """One dimensional exponential cutoff power law model function"""
@@ -214,6 +220,8 @@ class LogParabola1D(Fittable1DModel):
     x_0 = Parameter(default=1)
     alpha = Parameter(default=1)
     beta = Parameter(default=0)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, beta):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -46,6 +46,7 @@ class PowerLaw1D(Fittable1DModel):
     x_0 = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -107,6 +108,7 @@ class BrokenPowerLaw1D(Fittable1DModel):
     alpha_1 = Parameter(default=1)
     alpha_2 = Parameter(default=1)
 
+    input_units = 'x_break'
     output_units = 'amplitude'
 
     @staticmethod
@@ -165,6 +167,7 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
     alpha = Parameter(default=1)
     x_cutoff = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -221,6 +224,7 @@ class LogParabola1D(Fittable1DModel):
     alpha = Parameter(default=1)
     beta = Parameter(default=0)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod

--- a/astropy/modeling/tests/test_quantities.py
+++ b/astropy/modeling/tests/test_quantities.py
@@ -161,3 +161,17 @@ def test_output_units():
     assert m(0 * u.dimensionless_unscaled).unit == (1 / u.s)
     assert m(2 * u.dimensionless_unscaled).unit == (1 / u.s)
     assert m(2 * u.m).unit == (u.m / u.s)
+
+    class TestModelD(Fittable1DModel):
+        output_units = u.m
+
+        @staticmethod
+        def evaluate(x):
+            # This is a no-op model that just always forces the output to be in
+            # meters (if the input is a length)
+            return 2 * x
+
+    m = TestModelD()
+    assert m(0).unit is u.m
+    assert m(1 * u.m) == 2 * u.m
+    assert m(1 * u.km) == 2000 * u.m

--- a/astropy/modeling/tests/test_quantities.py
+++ b/astropy/modeling/tests/test_quantities.py
@@ -1,0 +1,107 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Tests specifically for models that use units and quantities."""
+
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from ..models import Gaussian1D
+from ... import units as u
+from ...units import UnitsError, Quantity
+from ...tests.helper import pytest
+
+
+def test_quantities_as_parameters():
+    """
+    Basic tests for initializing general models (that do not require units)
+    with parameters that have units attached.
+    """
+
+    g = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+    assert g.amplitude.value == 1.0
+    assert g.amplitude.unit is u.J
+    assert g.mean.value == 1.0
+    assert g.mean.unit is u.m
+    assert g.stddev.value == 0.1
+    assert g.stddev.unit is u.m
+
+
+def test_quantity_parameter_arithmetic():
+    """
+    Test that arithmetic operations with properties that have units return the
+    appropriate Quantities.
+    """
+
+    g = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    assert g.mean + (1 * u.m) == 2 * u.m
+    with pytest.raises(UnitsError):
+        g.mean + 1
+    assert (1 * u.m) + g.mean == 2 * u.m
+    with pytest.raises(UnitsError):
+        1 + g.mean
+    assert g.mean * 2 == (2 * u.m)
+    assert 2 * g.mean == (2 * u.m)
+    assert g.mean * (2 * u.m) == (2 * (u.m ** 2))
+    assert (2 * u.m) * g.mean == (2 * (u.m ** 2))
+
+    assert -g.mean == (-1 * u.m)
+    assert abs(-g.mean) == g.mean
+
+
+def test_quantity_parameter_comparison():
+    """
+    Basic test of comparison operations on properties with units.
+    """
+
+    g = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    assert g.mean == 1 * u.m
+    assert 1 * u.m == g.mean
+    assert g.mean != 1
+    assert 1 != g.mean
+
+    assert g.mean < 2 * u.m
+    assert 2 * u.m > g.mean
+    with pytest.raises(UnitsError):
+        g.mean < 2
+    with pytest.raises(UnitsError):
+        2 > g.mean
+
+    g = Gaussian1D([1, 2] * u.J, [1, 2] * u.m, [0.1, 0.2] * u.m)
+
+    assert g.mean == [1, 2] * u.m
+    assert np.all([1, 2] * u.m == g.mean)
+    assert g.mean != [1, 2]
+    assert np.all([1, 2] != g.mean)
+    with pytest.raises(UnitsError):
+        g.mean < [3, 4]
+    with pytest.raises(UnitsError):
+        [3, 4] > g.mean
+
+
+def test_basic_evaluate_with_quantities():
+    """
+    Test evaluation of a single model with Quantity parameters, that does
+    not explicitly require units.
+    """
+
+    g = Gaussian1D(1, 1, 0.1)
+    gq = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    assert isinstance(gq(0), Quantity)
+    assert gq(0).unit is u.J
+    assert g(0) == gq(0).value
+
+    # zero is allowed without explicit units, but other unitless quantities
+    # should be an exception
+    with pytest.raises(UnitsError):
+        gq(1)
+
+    assert gq(1 * u.m).value == g(1)
+
+    # Should get the same numeric result as if we multiplied by 1000
+    assert_allclose(gq(0.0005 * u.km).value, g(0.5))

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -14,6 +14,8 @@ import numpy as np
 from ..extern import six
 from ..extern.six.moves import xrange, zip_longest
 
+from ..units import dimensionless_unscaled
+
 
 __all__ = ['ExpressionTree', 'AliasDict', 'check_broadcast',
            'poly_map_domain', 'comb']
@@ -483,3 +485,14 @@ def combine_labels(left, right):
         right = tuple(r + '1' for r in right)
 
     return left + right
+
+
+def format_unit_with_type(unit):
+    """
+    Returns a string-formatted unit with its physical dimension in parentheses.
+    """
+
+    if unit == dimensionless_unscaled:
+        return '({0})'.format(unit.physical_type)
+    else:
+        return '{0} ({1})'.format(unit, unit.physical_type)

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -483,4 +483,3 @@ def combine_labels(left, right):
         right = tuple(r + '1' for r in right)
 
     return left + right
-


### PR DESCRIPTION
This PR provides initial support for #1464, and builds on the much earlier PR #1796 by @nden with a rough / incomplete vision of how Models can be made to work with Quantities.

To start with, this makes evaluation of models given Quantity objects for parameters and/or inputs/independent variables basically just work.  For example here's a simple custom model that uses Quantities:

```python
>>> from astropy import units as u
>>> from astropy.modeling import custom_model
>>> @custom_model
... def Square(x, amplitude=1):
...     # Note: model defined without any reference to specific quantities
...     return amplitude * x**2
...
>>> s = Square(2 * u.m)  # Instantiate model with Quantity for the amplitude
>>> s.amplitude
Parameter('amplitude', value=2.0, unit=m)
>>> s.amplitude / (2.0 * u.m)  # Quantity arithmetic works on parameters
<Quantity 1.0>
>>> s(3 / u.s)  # The model can be evaluated on Quantities, and what you get is what you get
<Quantity 18.0 m / s2>
```

However, there is more sophistication to this PR than that.  Most of what makes it more interesting than just straight up supporting Quantities is that we can also specify constraints on units when defining the model.  In this PR I added constraints to several of the built-in models (I eschewed polynomials, rotation, and projection models for now, but they can still be supported too).

The constraints are added at model class definition via `input_units` and `output_units` attributes.  You can read the docs for the attributes [starting here](https://github.com/embray/astropy/blob/37abbcf72cbc08c6cbec4dd7db4f3f9e7a3a57c8/astropy/modeling/core.py#L577).
Just as an example, have a look at the new definition for [`Gaussian1D`](https://github.com/embray/astropy/blob/37abbcf72cbc08c6cbec4dd7db4f3f9e7a3a57c8/astropy/modeling/functional_models.py#L95).  It has `input_units = 'mean'`.  This means the model can have inputs in any units so long as they are compatible (including any active equivalencies) with the units of the models "mean" parameter.  It also has `output_units = 'amplitude'` which ensures that no matter *how* the model's `evaluate` method is defined, the output when evaluating the model should be in the same units as the model's "amplitude" parameter.  This also serves as a sanity check on the model's implementation.

These `input_units` and `output_units` attributes are collectively referred to as "unit specs", and may be more complicated (though it turns out for most models they are pretty simple).  For more complicated examples, however, they may also be defined as functions.  An example comes from the [`Linear1D`](https://github.com/embray/astropy/blob/37abbcf72cbc08c6cbec4dd7db4f3f9e7a3a57c8/astropy/modeling/functional_models.py#L531) model, which has `input_units = lambda slope, intercept: intercept.unit / slope.unit`.  This states that when evaluating a `Linear1D` instance the input's units must be the intercept's units divided by the slope's unit, so that it can be evaluated correctly.  This example of course requires knowledge of what Linear1D computes, but of course it's completely reasonable to assume that someone implementing a model knows how it's defined :)  And usually the implementations of the unit specs are much simpler than the model's `evaluate` itself.

Parameters can also be given a default/required unit, though I don't think I've defined any yet for any of the built-in models.  Most of the time we want to leave parameter units flexible, but there are some cases (rotations for example) that it's obvious what to specify.

There are several TODO items for this feature that I will list below.  It seems like a lot, but most of these are easy now that the groundwork is done, and some of them already have prototype implementations in a separate branch.  However, I wanted to get feedback on the current WIP before adding the rest:

* [ ] The biggest TODO is fitting support.  Right now fitting won't generally give reliable results.  This is because parameters are stored internally in whatever units the user specified them in.  But for efficient fitting what we really need to do is convert parameter values to a common set of base units when storing them in the model, as discussed in #1464.  That's the only major barrier to fitting support.
* [ ] Support with compound models.  Fortunately this is mostly straightforward to implement.  Creating compound models from models with units will place more constraints on what operations can be done on two models.  This is a *good thing*.  For example, it will not be possible to add two models together unless all their `output_units` are compatible.  This will make for a good sanity check.
* [ ] More sophisticated unit specs for parameters--currently parameters can be given a required unit but don't support fancier unit specs like inputs and outputs do.  For example, it might be useful to require one parameter's units to be equivalent to another parameter's units.
* [ ] Possible support for per-instance unit spec overrides?  Right now `input_units` and `output_units` are defined at the class-level.  But it may also be useful to write code that defines these at the instance level.  This would allow writing code that requires input to a particular model to always be of some unit, without having to subclass the model type.
* [ ] Clearer support for unit equivalencies.  Right now equivalencies will *just work* both when instantiating and evaluating a model.  However, it might be useful to have equivalencies baked into a model somehow.  For example, when evaluating a model it might be good to automatically apply all equivalencies that were active when the model was instantiated.
* [ ] Implement unit specs on more of the built-in models, assuming people like this scheme.
* [ ] More tests.
* [ ] More documentation.
* [ ] If #3793 gets implemented, that will enable some simplification of the code for this.
* [ ] Deprecate `getter` and `setter` attributes of `Parameters`.  It is currently possible to define a `getter` and `setter` function for a Parameter, which transforms the parameter's value between what the user specifies, and how the parameter is used internally for evaluation.  In practice, this has only been used for angular parameters, to convert between degrees and radians.  Being able to specify that angular parameters should have angular units obviates the need for this feature, which was always awkward to begin with.
* [ ] Open question: Should `Parameter.value` return a `Quantity` or the raw value?  Currently something like `model.amplitude.value` or `model.amplitude.default` does *not* return a `Quantity`.  Instead the `Parameter` object is a `Quantity`-like object in that it has a `.unit` attribute (if units are defined on a parameter).  Sometimes it might be convenient to get a `Quantity`, but on the other hand the current interface feels more consistent with the existing `Quantity` interface.
* [ ] Anything else that comes out of review of this WIP?