### PR TITLE
Suppress numpy Nan-related warnings in table info generation

### DIFF
--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -3,6 +3,7 @@
 
 # TEST_UNICODE_LITERALS
 
+import warnings
 import numpy as np
 
 from ...extern import six
@@ -225,3 +226,10 @@ def test_class_attribute():
         out = six.moves.cStringIO()
         t.info(out=out)
         assert out.getvalue().splitlines() == exp
+
+
+def test_ignore_warnings():
+    t = table.Table([[np.nan, np.nan]])
+    with warnings.catch_warnings(record=True) as warns:
+        t.info('stats', out=None)
+        assert len(warns) == 0

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -11,10 +11,16 @@ from copy import deepcopy
 import weakref
 import numpy as np
 from functools import partial
+import warnings
 
 from ..extern import six
 from ..utils import OrderedDict
 from ..utils.compat import NUMPY_LT_1_8
+
+
+# Tuple of filterwarnings kwargs to ignore when calling info
+IGNORE_WARNINGS = (dict(category=RuntimeWarning,
+                        module=r'numpy\.lib\.nanfunctions'),)
 
 def data_info_factory(names, funcs):
     """
@@ -274,7 +280,11 @@ class DataInfo(object):
                 else:
                     raise ValueError('option={0} is not an allowed information type'
                                      .format(option))
-            info.update(option(dat))
+
+            with warnings.catch_warnings():
+                for ignore_kwargs in IGNORE_WARNINGS:
+                    warnings.filterwarnings('ignore', **ignore_kwargs)
+                info.update(option(dat))
 
         if hasattr(dat, 'mask'):
             n_bad = np.count_nonzero(dat.mask)


### PR DESCRIPTION
Follow-up to #3731 as noted by by @cdeil.