### PR TITLE
Consider adding special "arbitrary" unit?

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,10 @@ New Features
   - Added support for functional units, in particular the logarithmic ones
     ``Magnitude``, ``Decibel``, and ``Dex``. [#1894]
 
+  - Added support for the ``arbitrary`` unit, which can convert to any other
+    unit without scale change.  This is useful mostly internally for holding
+    quantities with values all equal to zero. [#3793]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -34,4 +34,4 @@ del bases
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
 
-set_enabled_units([si, cgs, astrophys])
+set_enabled_units([si, cgs, astrophys, arbitrary])

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2020,15 +2020,16 @@ class CompositeUnit(UnitBase):
         A sequence of powers (in parallel with ``bases``) for each
         of the base units.
     """
-    def __new__(cls, scale=None, bases=None, powers=None, decompose=False,
+    def __new__(cls, scale, bases, powers, decompose=False,
                 decompose_bases=set(), _error_check=True):
-        # Have to set defaults of None since we can enter here from picking.
-        # But if not, we need to be able to return arbitrary if relevant.
         if bases and any(base is arbitrary for base in bases):
             return arbitrary
 
         self = super(CompositeUnit, cls).__new__(cls)
         return self
+
+    def __getnewargs__(self):
+        return (self._scale, self._bases, self._powers, False, set(), False)
 
     def __init__(self, scale, bases, powers, decompose=False,
                  decompose_bases=set(), _error_check=True):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1769,10 +1769,7 @@ class ArbitraryUnit(IrreducibleUnit):
             self.__class__._arbitrary_unit = self
 
     def decompose(self, bases=set()):
-        if len(bases) and not self in bases:
-            return bases[0]
-        else:
-            return self
+        return self
 
     def compose(self, equivalencies=[], units=None, max_depth=2,
                 include_prefix_units=False):

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 from .core import (UnitsError, UnitConversionError, dimensionless_unscaled,
-                   get_current_unit_registry)
+                   get_current_unit_registry, arbitrary)
 from ..utils.compat.fractions import Fraction
 
 
@@ -262,7 +262,10 @@ def get_converters_and_unit(f, *units):
     if all(unit is None for unit in units):
         return converters, dimensionless_unscaled
 
-    fixed, changeable = (1, 0) if units[1] is None else (0, 1)
+    # By default, we convert the second argument to the unit of the first,
+    # but not if the second cannot be converted or the first is arbitrary.
+    fixed, changeable = ((1, 0) if units[1] is None or units[0] is arbitrary
+                         else (0, 1))
     if units[fixed] is None:
         try:
             converters[changeable] = get_converter(units[changeable],

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -618,6 +618,21 @@ def test_cgs():
     assert q.cgs.unit == u.barye
 
 
+def test_arbirary_unit():
+    q_au = np.array([1., 4.]) * u.arbitrary
+    assert q_au.unit is u.arbitrary
+    for unit in (u.m, u.dimensionless_unscaled, u.arbitrary, u.kg/u.s):
+        q = q_au.to(unit)
+        assert q.unit is unit
+        assert np.all(q.value == q_au.value)
+        assert np.all(q == q_au)
+
+        q2 = q_au + q
+        assert q2.unit is unit
+        assert np.all(q2.value == 2.*q_au.value)
+        assert np.all(q2 == 2.*q_au)
+
+
 class TestQuantityComparison(object):
 
     def test_quantity_equality(self):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -467,10 +467,16 @@ class TestInvariantUfuncs(object):
 
         q_i1 = np.array([-3.3, 2.1, 10.2]) * u.kg / u.s
         arbitrary_unit_value = np.array([0.])
-        q_o = ufunc(q_i1, arbitrary_unit_value)
-        assert isinstance(q_o, u.Quantity)
-        assert q_o.unit == q_i1.unit
-        assert_allclose(q_o.value, ufunc(q_i1.value, arbitrary_unit_value))
+        q_o1 = ufunc(q_i1, arbitrary_unit_value)
+        assert isinstance(q_o1, u.Quantity)
+        assert q_o1.unit == q_i1.unit
+        assert_allclose(q_o1.value, ufunc(q_i1.value, arbitrary_unit_value))
+        q_o2 = ufunc(arbitrary_unit_value, q_i1)
+        assert q_o2.unit == q_i1.unit
+        assert_allclose(q_o2.value, ufunc(arbitrary_unit_value, q_i1.value))
+        q_o3 = ufunc(arbitrary_unit_value * u.arbitrary, q_i1)
+        assert q_o3.unit == q_i1.unit
+        assert_allclose(q_o3.value, ufunc(arbitrary_unit_value, q_i1.value))
 
     @pytest.mark.parametrize(('ufunc'), [np.add, np.subtract, np.hypot,
                                          np.maximum, np.minimum, np.nextafter,

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -688,3 +688,16 @@ def test_fractional_rounding_errors_simple():
     assert isinstance(x.powers[0], Fraction)
     assert x.powers[0].numerator == 6
     assert x.powers[0].denominator == 5
+
+
+def test_arbitrary_unit():
+    assert u.arbitrary is u.core.ArbitraryUnit()
+    assert repr(u.arbitrary) == 'Unit("arbitrary")'
+    assert str(u.arbitrary) == "arbitrary"
+    assert u.CompositeUnit(10., [u.m, u.arbitrary], [1, 1]) is u.arbitrary
+    assert u.arbitrary**2 is u.arbitrary
+    assert u.arbitrary / u.m is u.arbitrary
+    assert u.m / u.arbitrary is u.arbitrary
+    assert u.m * u.arbitrary is u.arbitrary
+    assert u.m == u.arbitrary
+    assert not (u.m != u.arbitrary)

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -97,6 +97,24 @@ use the `~astropy.units.core.UnitBase.physical_type` property::
    >>> (u.m / u.m) == u.dimensionless_unscaled
    True
 
+.. _arbitrary-unit:
+
+Arbitrary Unit
+--------------
+
+Another special unit is the `arbitrary unit <~astropy.units.core.arbitrary>`.
+It is mostly used internally for quantities which can always be converted to
+the unit of another quantity (as is true, e.g., if the value is zero).  The
+arbitrary unit is equal to any other unit, and unit composition involving the
+arbitrary unit always yield the arbitrary unit::
+
+  >>> u.m == u.arbitrary
+  True
+  >>> u.m / u.s * u.arbitrary
+  Unit("arbitrary")
+  >>> u.m.to(u.arbitrary, 1.0)
+  1.0
+
 .. _enabling-other-units:
 
 Enabling other units
@@ -149,3 +167,4 @@ To enable just specific units, use `~astropy.units.add_enabled_units`::
     >>> with u.add_enabled_units_context([imperial.knot]):
     ...     u.m.find_equivalent_units()  # doctest: +SKIP
     ...
+


### PR DESCRIPTION
Something came up in working on models with units, that I thought might be useful.  Though if it's deemed too "weird" I could live without it (or perhaps this could be implemented just as a hack to use within the modeling package).

There are a couple of special cases in quantity arithmetic--namely the scalars `0.0` and `inf`, in that they may take "arbitrary" units (see [here](https://github.com/astropy/astropy/blob/44a166a104d72c2996cd18872a09f5759fc1bf86/astropy/units/quantity.py#L310)).  This allows expressions like the following:

``` python
In [3]: q = 1 * u.m

In [4]: q + 0
Out[4]: <Quantity 1.0 m>
```

to be clear, this is only allowed at all with zero.  `q + 1` will raise an exception since you cannot add a quantity in meters to a dimensionless quantity (by default scalars get units of dimensionless_unscaled, _except_ in the special case of zero and inf).  In fact, `q + 0` is different from `q + (0 * u.dimensionless_unscaled)`.  The latter is making it explicit that the zero we're adding must be a dimensionless quantity, and can't be added to meters.  This is a _good_ design choice.

However, it makes things a little inconvenient in how I'm trying to implement quantities in models.  What I would like to be able to do is when quantities are being used to evaluate a model, it is convenient to automatically convert all inputs to the model to `Quantity` objects (so that everything has a `.unit`).  In the spirit of how _most_ `Quantity` arithmetic works, inputs without explicit quantities are automatically given units of `dimensionless_unscaled`.  However, I can't do this if the input is zero (or inf) because that actually gives different results than if the model were evaluated with the scalar `0.0`, with its ability to take arbitrary units.

Maybe that's just something that should be rethought outright, though I think it would be confusing if models have different evaluation behavior from other ufuncs with respect to how they treat 0 when combining it with dimensionful quantities.

So I think it might be convenient to be able to create a Quantity whose value is either 0 or inf, and has a special unit called "arbitrary" that just implies the existing behavior of the bare 0/inf, as distinct from dimensionless_unscaled.  This would simplify a lot of code so I don't have to keep treating them as special cases.
