### PR TITLE
Remove astropy_time from attributes and from formats one can change to.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -406,6 +406,10 @@ Bug Fixes
 
 - ``astropy.time``
 
+  - The ``astropy_time`` attribute, which is senseless and only raised an
+    exception, has been removed, and setting the format to this now raises a
+    much more informative error message. [#3856]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -945,3 +945,14 @@ def test_set_format_does_not_share_subfmt():
     t.format = 'fits'
     assert t.out_subfmt == '*'
     assert t.value == '2000-02-03T00:00:00.000(UTC)'  # date_hms
+
+def test_astropy_time_format_input_only():
+    t = Time('+02000-02-03', format='fits')
+    t2 = Time(t, format='astropy_time')
+    with pytest.raises(AttributeError):
+        t2.astropy_time
+    with pytest.raises(ValueError):
+        t2.format = 'astropy_time'
+    t3 = t.replicate(format='astropy_time')
+    assert t3.format == t.format
+    assert t3 == t


### PR DESCRIPTION
`astropy_time` can be used as an input format for `Time` to specify that the input is other `Time` instances, but it makes no sense to have it as an output format. Indeed, accessing the `t.astropy_time` attribute, or setting `t.format = 'astropy_time'` raises exceptions. This PR removes the attribute, and gives a more useful exception message for setting the format. It also updates the `format` docstring.