### PR TITLE
Remove 'astropy_time' from public time FORMATS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,11 @@ API changes
 
 - ``astropy.time``
 
+  - The ``astropy_time`` attribute and time format has been removed from the
+    public interface.  Existing code that instantiates a new time object using
+    ``format='astropy_time'`` can simply omit the ``format``
+    specification. [#3857]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -295,7 +295,7 @@ class Time(object):
                        'optional {0}'.format([name for name, cls in formats]))
             # AstropyTime is a pseudo-format that isn't in the TIME_FORMATS registry,
             # but try to guess it at the end.
-            formats.insert(0, ('astropy_time', TimeAstropyTime))
+            formats.append(('astropy_time', TimeAstropyTime))
 
         elif not (isinstance(format, six.string_types) and
                   format.lower() in self.FORMATS):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -296,6 +296,7 @@ class Time(object):
             # AstropyTime is a pseudo-format that isn't in the TIME_FORMATS registry,
             # but try to guess it at the end.
             formats.insert(0, ('astropy_time', TimeAstropyTime))
+
         elif not (isinstance(format, six.string_types) and
                   format.lower() in self.FORMATS):
             if format is None:
@@ -346,7 +347,19 @@ class Time(object):
 
     @property
     def format(self):
-        """Get time format"""
+        """
+        Get or set time format.
+
+        The format defines the way times are represented when accessed via the
+        ``.value`` attribute.  By default it is the same as the format used for
+        initializing the `Time` instance, but it can be set to any other value
+        that could be used for initialization.  These can be listed with::
+
+          >>> list(Time.FORMATS)
+          ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
+           'datetime', 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str',
+           'jyear_str']
+        """
         return self._format
 
     @format.setter
@@ -679,6 +692,9 @@ class Time(object):
         # Make the new internal _time object corresponding to the format
         # in the copy.  If the format is unchanged this process is lightweight
         # and does not create any new arrays.
+        if format not in tm.FORMATS:
+            raise ValueError('format must be one of {0}'
+                             .format(list(tm.FORMATS)))
 
         NewFormat = tm.FORMATS[format]
         tm._time = NewFormat(tm._time.jd1, tm._time.jd2,

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -146,7 +146,7 @@ class Time(object):
     The allowed values for ``format`` can be listed with::
 
       >>> list(Time.FORMATS)
-      ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'astropy_time',
+      ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
        'datetime', 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str',
        'jyear_str']
 
@@ -293,6 +293,9 @@ class Time(object):
                        if issubclass(cls, TimeUnique)]
             err_msg = ('any of the formats where the format keyword is '
                        'optional {0}'.format([name for name, cls in formats]))
+            # AstropyTime is a pseudo-format that isn't in the TIME_FORMATS registry,
+            # but try to guess it at the end.
+            formats.insert(0, ('astropy_time', TimeAstropyTime))
         elif not (isinstance(format, six.string_types) and
                   format.lower() in self.FORMATS):
             if format is None:
@@ -1373,7 +1376,10 @@ class TimeFormatMeta(type):
     def __new__(mcls, name, bases, members):
         cls = super(TimeFormatMeta, mcls).__new__(mcls, name, bases, members)
 
-        if 'name' in members:
+        # Register time formats that have a name, but leave out astropy_time since
+        # it is not a user-accessible format and is only used for initialization into
+        # a different format.
+        if 'name' in members and cls.name != 'astropy_time':
             mcls._registry[cls.name] = cls
 
         if 'subfmts' in members:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -945,3 +945,24 @@ def test_set_format_does_not_share_subfmt():
     t.format = 'fits'
     assert t.out_subfmt == '*'
     assert t.value == '2000-02-03T00:00:00.000(UTC)'  # date_hms
+
+def test_replicate_value_error():
+    """
+    Passing a bad format to replicate should raise ValueError, not KeyError.
+    PR #xxxx.
+    """
+    t1 = Time('2007:001', scale='tai')
+    with pytest.raises(ValueError) as err:
+        t1.replicate(format='definitely_not_a_valid_format')
+    assert 'format must be one of' in str(err)
+
+def test_remove_astropy_time():
+    """
+    Make sure that 'astropy_time' format is really gone after #xxxx.  Kind of
+    silly test but just to be sure.
+    """
+    t1 = Time('2007:001', scale='tai')
+    assert 'astropy_time' not in t1.FORMATS
+    with pytest.raises(ValueError) as err:
+        Time(t1, format='astropy_time')
+    assert 'format must be one of' in str(err)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -949,7 +949,7 @@ def test_set_format_does_not_share_subfmt():
 def test_replicate_value_error():
     """
     Passing a bad format to replicate should raise ValueError, not KeyError.
-    PR #xxxx.
+    PR #3857.
     """
     t1 = Time('2007:001', scale='tai')
     with pytest.raises(ValueError) as err:
@@ -958,7 +958,7 @@ def test_replicate_value_error():
 
 def test_remove_astropy_time():
     """
-    Make sure that 'astropy_time' format is really gone after #xxxx.  Kind of
+    Make sure that 'astropy_time' format is really gone after #3857.  Kind of
     silly test but just to be sure.
     """
     t1 = Time('2007:001', scale='tai')


### PR DESCRIPTION
Inspired by #3856 and #3831, this removes `astropy_time` as a publicly visible time format.  This format was always somewhat broken and not like the others since it is only for input.  It was not in the narrative docs nor in the Reference API.  Removing it without deprecation should be OK.

To be honest I don't understand why the `TimeAstropyTime` class was not in the API docs, but it's a good thing.

Closes #3856.