### PR TITLE
Quantity updates for numpy dev

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -779,7 +779,7 @@ class Quantity(np.ndarray):
             except UnitsError:  # let other try to deal with it
                 return NotImplemented
 
-        return np.multiply(self, other)
+        return super(Quantity, self).__mul__(other)
 
     def __imul__(self, other):
         """In-place multiplication between `Quantity` objects and others."""
@@ -788,7 +788,7 @@ class Quantity(np.ndarray):
             self._unit = other * self.unit
             return self
 
-        return np.multiply(self, other, self)
+        return super(Quantity, self).__imul__(other)
 
     def __rmul__(self, other):
         """ Right Multiplication between `Quantity` objects and other
@@ -797,7 +797,7 @@ class Quantity(np.ndarray):
 
         return self.__mul__(other)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """ Division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
@@ -806,36 +806,36 @@ class Quantity(np.ndarray):
             except UnitsError:  # let other try to deal with it
                 return NotImplemented
 
-        return np.true_divide(self, other)
+        return super(Quantity, self).__truediv__(other)
 
-    def __idiv__(self, other):
+    def __itruediv__(self, other):
         """Inplace division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
             self._unit = self.unit / other
             return self
 
-        return np.true_divide(self, other, self)
+        return super(Quantity, self).__itruediv__(other)
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         """ Right Division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
             return self._new_view(1. / self.value, other / self.unit)
 
-        return np.divide(other, self)
+        return super(Quantity, self).__rtruediv__(other)
 
-    def __truediv__(self, other):
+    def __div__(self, other):
         """ Division between `Quantity` objects. """
-        return self.__div__(other)
+        return self.__truediv__(other)
 
-    def __itruediv__(self, other):
+    def __idiv__(self, other):
         """ Division between `Quantity` objects. """
-        return self.__idiv__(other)
+        return self.__itruediv__(other)
 
-    def __rtruediv__(self, other):
+    def __rdiv__(self, other):
         """ Division between `Quantity` objects. """
-        return self.__rdiv__(other)
+        return self.__rtruediv__(other)
 
     def __divmod__(self, other):
         other_value = self._to_own_unit(other)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -466,8 +466,12 @@ class TestQuantityOperations(object):
                 long(q1)
             assert exc.value.args[0] == converter_err_msg
 
+        # We used to test `q1 * ['a', 'b', 'c'] here, but that that worked
+        # at all was a really odd confluence of bugs.  Since it doesn't work
+        # in numpy >=1.10 any more, just go directly for `__index__` (which
+        # makes the test more similar to the `int`, `long`, etc., tests).
         with pytest.raises(TypeError) as exc:
-            q1 * ['a', 'b', 'c']
+            q1.__index__()
         assert exc.value.args[0] == index_err_msg
 
         # dimensionless but scaled is OK, however
@@ -480,7 +484,7 @@ class TestQuantityOperations(object):
             assert long(q2) == long(q2.to(u.dimensionless_unscaled).value)
 
         with pytest.raises(TypeError) as exc:
-            q2 * ['a', 'b', 'c']
+            q2.__index__()
         assert exc.value.args[0] == index_err_msg
 
         # dimensionless unscaled is OK, though for index needs to be int
@@ -492,7 +496,7 @@ class TestQuantityOperations(object):
             assert long(q3) == 1
 
         with pytest.raises(TypeError) as exc:
-            q1 * ['a', 'b', 'c']
+            q1.__index__()
         assert exc.value.args[0] == index_err_msg
 
         # integer dimensionless unscaled is good for all
@@ -503,7 +507,7 @@ class TestQuantityOperations(object):
         if six.PY2:
             assert long(q4) == 2
 
-        assert q4 * ['a', 'b', 'c'] == ['a', 'b', 'c', 'a', 'b', 'c']
+        assert q4.__index__() == 2
 
         # but arrays are not OK
         q5 = u.Quantity([1, 2], u.m)
@@ -521,7 +525,7 @@ class TestQuantityOperations(object):
             assert exc.value.args[0] == converter_err_msg
 
         with pytest.raises(TypeError) as exc:
-            q5 * ['a', 'b', 'c']
+            q5.__index__()
         assert exc.value.args[0] == index_err_msg
 
     def test_array_converters(self):


### PR DESCRIPTION
WIth https://github.com/numpy/numpy/pull/5964 (for more discussion, see https://github.com/numpy/numpy/pull/5864), a lot of `NotImplemented` handling is removed from the ufuncs. As a result, `np.ufunc` does not return `NotImplemented` any more. This makes much more sense, but brought an inconsistency in our usage to the front, where in `Quantity.__mul__` we called `np.multiply` directly, rather than letting `ndarray.__mul__` take care (which can return `NotImplemented`). This PR corrects that oversight. (I wrote the original myself and am slightly worried there was a reason -- but travis will hopefully tell).

In addition, the above numpy PRs broke the use of `a * list`, where if `a` was integer it would be used to make multiple versions of the list. It was actually rather surprising this ever worked (see numpy PR discussion), and so it was decided not to continue to support that in numpy. Since there seems to be no reason really to support that in `Quantity` either, I changed the tests to more narrowly focus on whether `Quantity.__index__()` does the right thing.