### PR TITLE
added a fixed flag for parameter representation

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1239,10 +1239,11 @@ class Model(object):
 
         parts = [repr(a) for a in args]
 
-        parts.extend(
-            "{0}={1}".format(name,
-                             array_repr_oneline(getattr(self, name).value))
-            for name in self.param_names)
+        for name in self.param_names:
+            parts.append(
+                "{0}={1}{2}".format(name, array_repr_oneline(
+                    getattr(self, name).value),
+                ' [f]' if getattr(self, name).fixed else ''))
 
         if self.name is not None:
             parts.append('name={0!r}'.format(self.name))

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1241,9 +1241,13 @@ class Model(object):
 
         for name in self.param_names:
             parts.append(
-                "{0}={1}{2}".format(name, array_repr_oneline(
-                    getattr(self, name).value),
-                ' [f]' if getattr(self, name).fixed else ''))
+                "{0}={1}".format(name, array_repr_oneline(
+                    getattr(self, name).value)))
+        fixed_str_parts = [
+            "'{0}'".format(param_name) for param_name in self.param_names
+            if self.fixed[param_name]]
+        fixed_str = '' if len(fixed_str_parts) == 0 else ', fixed=({0})'.format(
+            ', '.join(fixed_str_parts))
 
         if self.name is not None:
             parts.append('name={0!r}'.format(self.name))
@@ -1256,7 +1260,8 @@ class Model(object):
         if len(self) > 1:
             parts.append("n_models={0}".format(len(self)))
 
-        return '<{0}({1})>'.format(self.__class__.__name__, ', '.join(parts))
+        return '<{0}({1}{2})>'.format(self.__class__.__name__,
+                                        ', '.join(parts), fixed_str)
 
     def _format_str(self, keywords=[]):
         """

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -517,3 +517,9 @@ def test_ScaleModel():
 def test_model_instance_repr():
     m = models.Gaussian1D(1, 2, 3)
     assert repr(m) == '<Gaussian1D(amplitude=1.0, mean=2.0, stddev=3.0)>'
+
+def test_model_instance_fixed_repr():
+    m = models.Gaussian1D(1, 2, 3)
+    m.amplitude.fixed = True
+    assert repr(m) == ('<Gaussian1D(amplitude=1.0, mean=2.0, stddev=3.0,'
+                       ' fixed=(\'amplitude\'))>')


### PR DESCRIPTION
This makes it easies to see what parameters are fixed on the model. `<Model a=5.0 [f] b=3.0>`

@embray let me know if you think this is a useful addition.
