### PR TITLE
Add dtype_info_name() function in utils.data_info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,9 @@ New Features
     the column, and acting as a manager of column attributes such as
     name, format, or description. [#3731]
 
+  - Updated table and column representation to use the ``dtype_info_name``
+    function for the dtype value. [#3868]
+
 - ``astropy.tests``
 
 - ``astropy.time``
@@ -129,6 +132,9 @@ New Features
     ``Magnitude``, ``Decibel``, and ``Dex``. [#1894]
 
 - ``astropy.utils``
+
+  - Added function ``dtype_info_name`` to the ``data_info`` module to provide
+    the name of a ``dtype`` for human-readable informational purposes. [#3868]
 
 - ``astropy.visualization``
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import DataInfo, InfoDescriptor
+from ..utils.data_info import DataInfo, InfoDescriptor, dtype_info_name
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -731,7 +731,7 @@ class Column(BaseColumn):
         unit = None if self.unit is None else str(self.unit)
         shape = None if self.ndim <= 1 else self.shape[1:]
         for attr, val in (('name', self.name),
-                          ('dtype', self.dtype.name),
+                          ('dtype', dtype_info_name(self.dtype)),
                           ('shape', shape),
                           ('unit', unit),
                           ('format', self.format),

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -15,6 +15,7 @@ from .. import log
 # Note, in numpy <= 1.6, some classes do not properly represent themselves.
 from ..utils.compat import NUMPY_LT_1_6_1
 from ..utils.console import Getch, color_print, terminal_size, conf
+from ..utils.data_info import dtype_info_name
 
 if six.PY3:
     def default_format_func(format_, val):
@@ -373,7 +374,7 @@ class TableFormatter(object):
             i_centers.append(n_header)
             n_header += 1
             try:
-                dtype = col.dtype.name
+                dtype = dtype_info_name(col.dtype)
             except AttributeError:
                 dtype = 'object'
             yield six.text_type(dtype)

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -11,11 +11,9 @@ from ... import units as u
 from ... import time
 from ... import coordinates
 from ... import table
-from ...utils.data_info import data_info_factory
+from ...utils.data_info import data_info_factory, dtype_info_name
 from ...utils import OrderedDict
 from ...utils.compat import NUMPY_LT_1_8
-
-STRING8 = 'string8' if six.PY2 else 'bytes8'
 
 def test_table_info_attributes(table_types):
     """
@@ -32,7 +30,7 @@ def test_table_info_attributes(table_types):
     assert tinfo.colnames == ['name', 'dtype', 'shape', 'unit', 'format',
                               'description', 'class', 'n_bad', 'length']
     assert np.all(tinfo['name'] == ['a', 'b', 'c'])
-    assert np.all(tinfo['dtype'] == ['int32', 'float32', STRING8])
+    assert np.all(tinfo['dtype'] == ['int32', 'float32', dtype_info_name('S1')])
     if subcls:
         assert np.all(tinfo['class'] == ['MyColumn'] * 3)
 
@@ -47,7 +45,7 @@ def test_table_info_attributes(table_types):
 
     tinfo = t.info(out=None)
     assert np.all(tinfo['name'] == 'a b c d e f'.split())
-    assert np.all(tinfo['dtype'] == ['int32', 'float32', STRING8, 'float64',
+    assert np.all(tinfo['dtype'] == ['int32', 'float32', dtype_info_name('S1'), 'float64',
                                      'object', 'object'])
     assert np.all(tinfo['unit'] == ['', '', '', 'm', '', 'deg,deg'])
     assert np.all(tinfo['format'] == ['%02d', '', '', '', '', ''])
@@ -112,7 +110,7 @@ def test_table_info_stats(table_types):
     assert tinfo.colnames == ['name', 'dtype', 'shape', 'unit', 'format', 'description',
                               'class', 'sum', 'first', 'n_bad', 'length']
     assert np.all(tinfo['name'] == ['a', 'b', 'c', 'd'])
-    assert np.all(tinfo['dtype'] == ['int32', 'float32', STRING8, 'object'])
+    assert np.all(tinfo['dtype'] == ['int32', 'float32', dtype_info_name('S1'), 'object'])
     assert np.all(tinfo['sum'] == ['6', '6.0', '--', '--'])
     assert np.all(tinfo['first'] == ['1', '1.0', 'a' if six.PY2 else "b'a'", '1.0'])
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -99,7 +99,7 @@ def test_html_escaping():
         '&lt;Table masked=False length=3&gt;',
         '<table id="table{id}">'.format(id=id(t)),
         '<thead><tr><th>col0</th></tr></thead>',
-        '<thead><tr><th>{0}</th></tr></thead>'.format('str1056' if PY3 else 'string264'),
+        '<thead><tr><th>str33</th></tr></thead>',
         '<tr><td>&lt;script&gt;alert(&quot;gotcha&quot;);&lt;/script&gt;</td></tr>',
         '<tr><td>2</td></tr>',
         '<tr><td>3</td></tr>',

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+# TEST_UNICODE_LITERALS
+
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from ...extern import six
+from ..data_info import dtype_info_name
+from ...tests.helper import pytest
+
+STRING_TYPE_NAMES = {(False, 'S'): 'str',  # not PY3
+                     (False, 'U'): 'unicode',
+                     (True, 'S'): 'bytes', # PY3
+                     (True, 'U'): 'str'}
+
+DTYPE_TESTS = ((np.array(b'abcd').dtype, STRING_TYPE_NAMES[(six.PY3, 'S')] + '4'),
+               (np.array(u'abcd').dtype, STRING_TYPE_NAMES[(six.PY3, 'U')] + '4'),
+               ('S4', STRING_TYPE_NAMES[(six.PY3, 'S')] + '4'),
+               ('U4', STRING_TYPE_NAMES[(six.PY3, 'U')] + '4'),
+               (np.void, 'void'),
+               (np.int32, 'int32'),
+               (np.bool, 'bool'),
+               (bool, 'bool'),
+               (float, 'float64'),
+               ('<f4', 'float32'),
+               ('u8', 'uint64'),
+               ('c16', 'complex128'),
+               ('object', 'object'))
+
+@pytest.mark.parametrize('input,output', DTYPE_TESTS)
+def test_dtype_info_name(input, output):
+    """
+    Test that dtype_info_name is giving the expected output
+
+    Here the available types::
+
+      'b' boolean
+      'i' (signed) integer
+      'u' unsigned integer
+      'f' floating-point
+      'c' complex-floating point
+      'O' (Python) objects
+      'S', 'a' (byte-)string
+      'U' Unicode
+      'V' raw data (void)
+    """
+    assert dtype_info_name(input) == output

--- a/docs/io/ascii/fixed_width_gallery.rst
+++ b/docs/io/ascii/fixed_width_gallery.rst
@@ -45,7 +45,7 @@ FixedWidth
   >>> ascii.read(table, format='fixed_width')
   <Table masked=False length=2>
     Col1     Col2
-  float64  string72
+  float64    str9
   ------- ---------
       1.2   "hello"
       2.4 's worlds
@@ -62,7 +62,7 @@ FixedWidth
   >>> ascii.read(table, format='fixed_width', names=['name1', 'name2'])
   <Table masked=False length=2>
    name1    name2
-  float64  string72
+  float64    str9
   ------- ---------
       1.2   "hello"
       2.4 's worlds
@@ -78,10 +78,10 @@ FixedWidth
   >>> ascii.read(table, format='fixed_width')
   <Table masked=False length=2>
     Col1    Col2
-  float64 string56
-  ------- --------
-      1.2     "hel
-      2.4  df's wo
+  float64   str7
+  ------- -------
+      1.2    "hel
+      2.4 df's wo
 
 **Table with double delimiters**
 ::
@@ -94,12 +94,12 @@ FixedWidth
   ... """
   >>> ascii.read(table, format='fixed_width')
   <Table masked=False length=3>
-    Name    Phone       TCP
-  string32 string64   string96
-  -------- -------- ------------
-      John 555-1234 192.168.1.10
-      Mary 555-2134 192.168.1.12
-       Bob 555-4527  192.168.1.9
+  Name  Phone       TCP
+  str4   str8      str12
+  ---- -------- ------------
+  John 555-1234 192.168.1.10
+  Mary 555-2134 192.168.1.12
+   Bob 555-4527  192.168.1.9
 
 **Table with space delimiter**
 ::
@@ -112,12 +112,12 @@ FixedWidth
   ... """
   >>> ascii.read(table, format='fixed_width', delimiter=' ')
   <Table masked=False length=3>
-    Name   --Phone- ----TCP-----
-  string32 string64   string96
-  -------- -------- ------------
-      John 555-1234 192.168.1.10
-      Mary 555-2134 192.168.1.12
-       Bob 555-4527  192.168.1.9
+  Name --Phone- ----TCP-----
+  str4   str8      str12
+  ---- -------- ------------
+  John 555-1234 192.168.1.10
+  Mary 555-2134 192.168.1.12
+   Bob 555-4527  192.168.1.9
 
 **Table with no header row and auto-column naming.**
 
@@ -132,12 +132,12 @@ Use header_start and data_start keywords to indicate no header line.
   >>> ascii.read(table, format='fixed_width',
   ...            header_start=None, data_start=0)
   <Table masked=False length=3>
-    col1     col2       col3
-  string32 string64   string96
-  -------- -------- ------------
-      John 555-1234 192.168.1.10
-      Mary 555-2134 192.168.1.12
-       Bob 555-4527  192.168.1.9
+  col1   col2       col3
+  str4   str8      str12
+  ---- -------- ------------
+  John 555-1234 192.168.1.10
+  Mary 555-2134 192.168.1.12
+   Bob 555-4527  192.168.1.9
 
 **Table with no header row and with col names provided.**
 
@@ -152,12 +152,12 @@ keywords to indicate no header line.
   ...                 header_start=None, data_start=0,
   ...                 names=('Name', 'Phone', 'TCP'))
   <Table masked=False length=3>
-    Name    Phone       TCP
-  string32 string64   string96
-  -------- -------- ------------
-      John 555-1234 192.168.1.10
-      Mary 555-2134 192.168.1.12
-       Bob 555-4527  192.168.1.9
+  Name  Phone       TCP
+  str4   str8      str12
+  ---- -------- ------------
+  John 555-1234 192.168.1.10
+  Mary 555-2134 192.168.1.12
+   Bob 555-4527  192.168.1.9
 
 
 FixedWidthNoHeader
@@ -174,12 +174,12 @@ convenience class.**
   ... """
   >>> ascii.read(table, format='fixed_width_no_header')
   <Table masked=False length=3>
-    col1     col2       col3
-  string32 string64   string96
-  -------- -------- ------------
-      John 555-1234 192.168.1.10
-      Mary 555-2134 192.168.1.12
-       Bob 555-4527  192.168.1.9
+  col1   col2       col3
+  str4   str8      str12
+  ---- -------- ------------
+  John 555-1234 192.168.1.10
+  Mary 555-2134 192.168.1.12
+   Bob 555-4527  192.168.1.9
 
 **Table with no delimiter with column start and end values specified.**
 
@@ -201,13 +201,13 @@ will select the first 6 characters.
   ...                 col_ends=(5, 17, 28),
   ...                 )
   <Table masked=False length=3>
-    Name     Phone      TCP
-  string32  string72  string80
-  -------- --------- ----------
-      John 555- 1234 192.168.1.
-      Mary 555- 2134 192.168.1.
-       Bob 555- 4527  192.168.1
-       
+  Name   Phone      TCP
+  str4    str9     str10
+  ---- --------- ----------
+  John 555- 1234 192.168.1.
+  Mary 555- 2134 192.168.1.
+   Bob 555- 4527  192.168.1
+
 **Table with no delimiter with only column start or end values specified.**
 
 If only the col_starts keyword is given, it is assumed that each column
@@ -223,7 +223,7 @@ The two examples below read the same table and produce the same result
 
   >>> table = """
   ... #1       9        19                <== Column start indexes
-  ... #|       |         |                <== Column start positions 
+  ... #|       |         |                <== Column start positions
   ... #<------><--------><------------->  <== Inferred column positions
   ...   John   555- 1234 192.168.1.10
   ...   Mary   555- 2134 192.168.1.123
@@ -236,26 +236,27 @@ The two examples below read the same table and produce the same result
   ...                 col_starts=(1, 9, 19),
   ...                 )
   <Table masked=False length=4>
-    Name     Phone         TCP      
-  string32  string72    string120   
-  -------- --------- ---------------
-      John 555- 1234    192.168.1.10
-      Mary 555- 2134   192.168.1.123
-       Bob 555- 4527     192.168.1.9
-      Bill  555-9875 192.255.255.255
+  Name   Phone         TCP
+  str4    str9        str15
+  ---- --------- ---------------
+  John 555- 1234    192.168.1.10
+  Mary 555- 2134   192.168.1.123
+   Bob 555- 4527     192.168.1.9
+  Bill  555-9875 192.255.255.255
+
   >>> ascii.read(table,
   ...                 format='fixed_width_no_header',
   ...                 names=('Name', 'Phone', 'TCP'),
   ...                 col_ends=(8, 18, 32),
   ...                 )
   <Table masked=False length=4>
-    Name     Phone        TCP      
-  string32  string72   string112   
-  -------- --------- --------------
-      John 555- 1234   192.168.1.10
-      Mary 555- 2134  192.168.1.123
-       Bob 555- 4527    192.168.1.9
-      Bill  555-9875 192.255.255.25
+  Name   Phone        TCP
+  str4    str9       str14
+  ---- --------- --------------
+  John 555- 1234   192.168.1.10
+  Mary 555- 2134  192.168.1.123
+   Bob 555- 4527    192.168.1.9
+  Bill  555-9875 192.255.255.25
 
 
 FixedWidthTwoLine
@@ -273,7 +274,7 @@ FixedWidthTwoLine
   >>> ascii.read(table, format='fixed_width_two_line')
   <Table masked=False length=2>
     Col1     Col2
-  float64  string72
+  float64    str9
   ------- ---------
       1.2   "hello"
       2.4 's worlds
@@ -293,7 +294,7 @@ FixedWidthTwoLine
   ...                 header_start=1, position_line=2, data_end=-1)
   <Table masked=False length=2>
     Col1     Col2
-  float64  string72
+  float64    str9
   ------- ---------
       1.2   "hello"
       2.4 's worlds
@@ -313,7 +314,7 @@ FixedWidthTwoLine
   ...                 header_start=1, position_line=0, data_start=3, data_end=-1)
   <Table masked=False length=2>
     Col1     Col2
-  float64  string72
+  float64    str9
   ------- ---------
       1.2   "hello"
       2.4 's worlds

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -35,7 +35,7 @@ size, columns, or data are not known.
 
 .. Note::
    Adding rows requires making a new copy of the entire
-   table each time, so in the case of large tables this may be slow. 
+   table each time, so in the case of large tables this may be slow.
    On the other hand, adding columns is quite fast.
 
 ::
@@ -67,12 +67,11 @@ keyword or they will be auto-generated as ``col<N>``.
   >>> t = Table([a, b, c], names=('a', 'b', 'c'))
   >>> t
   <Table masked=False length=2>
-    a      b       c
-  int32 float64 string8
-  ----- ------- -------
-      1     2.0       x
-      4     5.0       y
-
+    a      b     c
+  int32 float64 str1
+  ----- ------- ----
+      1     2.0    x
+      4     5.0    y
 
 **Make a new table using columns from the first table**
 
@@ -81,11 +80,11 @@ and putting this into a Python list, e.g. ``[ t['c'], t['a'] ]``::
 
   >>> Table([t['c'], t['a']])
   <Table masked=False length=2>
-     c      a
-  string8 int32
-  ------- -----
-        x     1
-        y     4
+   c     a
+  str1 int32
+  ---- -----
+     x     1
+     y     4
 
 **Make a new table using expressions involving columns**
 
@@ -113,11 +112,12 @@ of different data types to initialize a table::
   >>> arr = (a, b, c)
   >>> Table(arr)  # doctest: +SKIP
   <Table masked=False length=2>
-   col0 col1 [2]   axis
-  int64  int64   string8
-  ----- -------- -------
-      1   2 .. 3       x
-      4   5 .. 6       y
+   col0 col1 [2] axis
+  int64  int64   str1
+  ----- -------- ----
+      1   2 .. 3    x
+      4   5 .. 6    y
+
 
 Notice that in the third column the existing column name ``'axis'`` is used.
 
@@ -132,22 +132,22 @@ A dictionary of column data can be used to initialize a |Table|.
   >>>
   >>> Table(arr)  # doctest: +SKIP
   <Table masked=False length=2>
-    a      c       b
-  int32 string8 float64
-  ----- ------- -------
-      1       x     2.0
-      4       y     5.0
+    a    c      b
+  int32 str1 float64
+  ----- ---- -------
+      1    x     2.0
+      4    y     5.0
 
 **Specify the column order and optionally the data types**
 ::
 
   >>> Table(arr, names=('a', 'b', 'c'), dtype=('f8', 'i4', 'S2'))
   <Table masked=False length=2>
-     a      b      c
-  float64 int32 string16
-  ------- ----- --------
-      1.0     2        x
-      4.0     5        y
+     a      b    c
+  float64 int32 str2
+  ------- ----- ----
+      1.0     2    x
+      4.0     5    y
 
 **Different types of column data**
 
@@ -158,11 +158,11 @@ The input column data can be any data type that can initialize a |Column| object
   ...        'c': Column(['x', 'y'], name='axis')}
   >>> Table(arr, names=('a', 'b', 'c'))  # doctest: +SKIP
   <Table masked=False length=2>
-    a   b [2]     c
-  int64 int64  string8
-  ----- ------ -------
-      1 2 .. 3       x
-      4 5 .. 6       y
+    a   b [2]   c
+  int64 int64  str1
+  ----- ------ ----
+      1 2 .. 3    x
+      4 5 .. 6    y
 
 Notice that the key ``'c'`` takes precedence over the existing column name
 ``'axis'`` in the third column.  Also see that the ``'b'`` column is a vector
@@ -264,11 +264,11 @@ From ``arr`` it is simple to create the corresponding |Table| object::
 
   >>> Table(arr)
   <Table masked=False length=2>
-    a      b       c
-  int32 float64 string16
-  ----- ------- --------
-      1     2.0        x
-      4     5.0        y
+    a      b     c
+  int32 float64 str2
+  ----- ------- ----
+      1     2.0    x
+      4     5.0    y
 
 Note that in the above example and most the following ones we are creating a
 table and immediately asking the interactive Python interpreter to print the
@@ -288,11 +288,12 @@ The column names can be changed from the original values by providing the
 
   >>> Table(arr, names=('a_new', 'b_new', 'c_new'))
   <Table masked=False length=2>
-  a_new  b_new   c_new
-  int32 float64 string16
-  ----- ------- --------
-      1     2.0        x
-      4     5.0        y
+  a_new  b_new  c_new
+  int32 float64  str2
+  ----- ------- -----
+      1     2.0     x
+      4     5.0     y
+
 
 **New data types**
 
@@ -300,19 +301,19 @@ Likewise the data type for each column can by changed with ``dtype``::
 
   >>> Table(arr, dtype=('f4', 'i4', 'S4'))
   <Table masked=False length=2>
-     a      b      c
-  float32 int32 string32
-  ------- ----- --------
-      1.0     2        x
-      4.0     5        y
+     a      b    c
+  float32 int32 str4
+  ------- ----- ----
+      1.0     2    x
+      4.0     5    y
 
   >>> Table(arr, names=('a_new', 'b_new', 'c_new'), dtype=('f4', 'i4', 'S4'))
   <Table masked=False length=2>
-   a_new  b_new  c_new
-  float32 int32 string32
-  ------- ----- --------
-      1.0     2        x
-      4.0     5        y
+   a_new  b_new c_new
+  float32 int32  str4
+  ------- ----- -----
+      1.0     2     x
+      4.0     5     y
 
 
 NumPy homogeneous array
@@ -350,11 +351,11 @@ generated as ``col<N>`` where ``<N>`` is the column number.
 
   >>> Table(arr, names=('a_new', 'b_new', 'c_new'), dtype=('f4', 'i4', 'S4'))
   <Table masked=False length=2>
-   a_new  b_new  c_new
-  float32 int32 string32
-  ------- ----- --------
-      1.0     2        3
-      4.0     5        6
+   a_new  b_new c_new
+  float32 int32  str4
+  ------- ----- -----
+      1.0     2     3
+      4.0     5     6
 
 **Referencing the original data**
 

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -73,12 +73,12 @@ about the table values and column definitions as follows::
 
   >>> t
   <Table masked=False length=3>
-    a      b       c
-  int32 float64 string8
-  ----- ------- -------
-      1     2.0       x
-      4     5.0       y
-      5     8.2       z
+    a      b     c
+  int32 float64 str1
+  ----- ------- ----
+      1     2.0    x
+      4     5.0    y
+      5     8.2    z
 
 You can also assign a unit to the columns. If any column has a unit
 assigned, all units would be shown as follows::
@@ -88,11 +88,11 @@ assigned, all units would be shown as follows::
   <Table masked=False length=3>
     a      b       c
            s
-  int32 float64 string8
-  ----- ------- -------
-      1     2.0       x
-      4     5.0       y
-      5     8.2       z
+  int32 float64 str1
+  ----- ------- ----
+      1     2.0    x
+      4     5.0    y
+      5     8.2    z
 
 Finally, you can get summary information about the table as follows::
 
@@ -102,7 +102,7 @@ Finally, you can get summary information about the table as follows::
   ---- ------- ----
      a   int32
      b float64    s
-     c string8
+     c    str1
 
 A column with a unit works with and can be easily converted to an
 `~astropy.units.Quantity` object::
@@ -232,12 +232,12 @@ Lastly, you can create a table with support for missing values, for example by s
   >>> t['a'].mask = [True, True, False]
   >>> t
   <Table masked=True length=3>
-    a      b       c
-  int32 float64 string8
-  ----- ------- -------
-     --     2.0       x
-     --     5.0       y
-      5     8.2       z
+    a      b     c
+  int32 float64 str1
+  ----- ------- ----
+     --     2.0    x
+     --     5.0    y
+      5     8.2    z
 
 .. _using_astropy_table:
 


### PR DESCRIPTION
Per discussion in #3806, this adds a function `dtype_info_name()` that gives the name of a dtype to be used for informational purposes.  This applies to data repr and str outputs and other "informational" output.

In theory this should be used by all astropy sub-packages for uniformity, but tastes may vary.

Closes #3806
