### PR TITLE
Remove "masked=False" from Table repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,7 +112,8 @@ New Features
     name, format, or description. [#3731]
 
   - Updated table and column representation to use the ``dtype_info_name``
-    function for the dtype value. [#3868]
+    function for the dtype value.  Removed the default "masked=False"
+    from the table representation. [#3868, #3869]
 
 - ``astropy.tests``
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -586,9 +586,9 @@ class Table(object):
 
     def _base_repr_(self, html=False):
         descr_vals = [self.__class__.__name__]
-        for attr, val in (('masked', self.masked),
-                          ('length', len(self))):
-            descr_vals.append('{0}={1}'.format(attr, repr(val)))
+        if self.masked:
+            descr_vals.append('masked=True')
+        descr_vals.append('length={0}'.format(len(self)))
 
         descr = '<' + ' '.join(descr_vals) + '>\n'
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -96,7 +96,7 @@ class TestMultiD():
 def test_html_escaping():
     t = table.Table([(str('<script>alert("gotcha");</script>'), 2, 3)])
     assert t._repr_html_().splitlines() == [
-        '&lt;Table masked=False length=3&gt;',
+        '&lt;Table length=3&gt;',
         '<table id="table{id}">'.format(id=id(t)),
         '<thead><tr><th>col0</th></tr></thead>',
         '<thead><tr><th>str33</th></tr></thead>',

--- a/docs/io/ascii/fixed_width_gallery.rst
+++ b/docs/io/ascii/fixed_width_gallery.rst
@@ -43,7 +43,7 @@ FixedWidth
   ... |  2.4   |'s worlds|
   ... """
   >>> ascii.read(table, format='fixed_width')
-  <Table masked=False length=2>
+  <Table length=2>
     Col1     Col2
   float64    str9
   ------- ---------
@@ -60,7 +60,7 @@ FixedWidth
   ... |  2.4   |'s worlds|
   ... """
   >>> ascii.read(table, format='fixed_width', names=['name1', 'name2'])
-  <Table masked=False length=2>
+  <Table length=2>
    name1    name2
   float64    str9
   ------- ---------
@@ -76,7 +76,7 @@ FixedWidth
   ...   2.4   sdf's worlds
   ... """
   >>> ascii.read(table, format='fixed_width')
-  <Table masked=False length=2>
+  <Table length=2>
     Col1    Col2
   float64   str7
   ------- -------
@@ -93,7 +93,7 @@ FixedWidth
   ... |   Bob  | 555-4527 | 192.168.1.9X|
   ... """
   >>> ascii.read(table, format='fixed_width')
-  <Table masked=False length=3>
+  <Table length=3>
   Name  Phone       TCP
   str4   str8      str12
   ---- -------- ------------
@@ -111,7 +111,7 @@ FixedWidth
   ...   Bob  555-4527     192.168.1.9
   ... """
   >>> ascii.read(table, format='fixed_width', delimiter=' ')
-  <Table masked=False length=3>
+  <Table length=3>
   Name --Phone- ----TCP-----
   str4   str8      str12
   ---- -------- ------------
@@ -131,7 +131,7 @@ Use header_start and data_start keywords to indicate no header line.
   ... """
   >>> ascii.read(table, format='fixed_width',
   ...            header_start=None, data_start=0)
-  <Table masked=False length=3>
+  <Table length=3>
   col1   col2       col3
   str4   str8      str12
   ---- -------- ------------
@@ -151,7 +151,7 @@ keywords to indicate no header line.
   >>> ascii.read(table, format='fixed_width',
   ...                 header_start=None, data_start=0,
   ...                 names=('Name', 'Phone', 'TCP'))
-  <Table masked=False length=3>
+  <Table length=3>
   Name  Phone       TCP
   str4   str8      str12
   ---- -------- ------------
@@ -173,7 +173,7 @@ convenience class.**
   ... |   Bob  | 555-4527 | 192.168.1.9|
   ... """
   >>> ascii.read(table, format='fixed_width_no_header')
-  <Table masked=False length=3>
+  <Table length=3>
   col1   col2       col3
   str4   str8      str12
   ---- -------- ------------
@@ -200,7 +200,7 @@ will select the first 6 characters.
   ...                 col_starts=(0, 9, 18),
   ...                 col_ends=(5, 17, 28),
   ...                 )
-  <Table masked=False length=3>
+  <Table length=3>
   Name   Phone      TCP
   str4    str9     str10
   ---- --------- ----------
@@ -235,7 +235,7 @@ The two examples below read the same table and produce the same result
   ...                 names=('Name', 'Phone', 'TCP'),
   ...                 col_starts=(1, 9, 19),
   ...                 )
-  <Table masked=False length=4>
+  <Table length=4>
   Name   Phone         TCP
   str4    str9        str15
   ---- --------- ---------------
@@ -249,7 +249,7 @@ The two examples below read the same table and produce the same result
   ...                 names=('Name', 'Phone', 'TCP'),
   ...                 col_ends=(8, 18, 32),
   ...                 )
-  <Table masked=False length=4>
+  <Table length=4>
   Name   Phone        TCP
   str4    str9       str14
   ---- --------- --------------
@@ -272,7 +272,7 @@ FixedWidthTwoLine
   ...   2.4   's worlds
   ... """
   >>> ascii.read(table, format='fixed_width_two_line')
-  <Table masked=False length=2>
+  <Table length=2>
     Col1     Col2
   float64    str9
   ------- ---------
@@ -292,7 +292,7 @@ FixedWidthTwoLine
   ... """
   >>> ascii.read(table, format='fixed_width_two_line',
   ...                 header_start=1, position_line=2, data_end=-1)
-  <Table masked=False length=2>
+  <Table length=2>
     Col1     Col2
   float64    str9
   ------- ---------
@@ -312,7 +312,7 @@ FixedWidthTwoLine
   ... """
   >>> ascii.read(table, format='fixed_width_two_line', delimiter='+',
   ...                 header_start=1, position_line=0, data_start=3, data_end=-1)
-  <Table masked=False length=2>
+  <Table length=2>
     Col1     Col2
   float64    str9
   ------- ---------

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -163,7 +163,7 @@ data table can be stored and read back as ASCII with no loss of information.
   2.0 True
 
   >>> Table.read(table_string, format='ascii')  # doctest: +SKIP
-  <Table masked=False length=2>
+  <Table length=2>
      x      y
      m
   float32  bool

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -236,7 +236,7 @@ meta-data and column definitions are copied.
 ::
 
   >>> t[2:5]  # Table object with rows 2:5 (reference)
-  <Table masked=False length=3>
+  <Table length=3>
      a       b     c
   m sec^-1
    int32   int32 int32

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -66,7 +66,7 @@ keyword or they will be auto-generated as ``col<N>``.
   >>> c = ['x', 'y']
   >>> t = Table([a, b, c], names=('a', 'b', 'c'))
   >>> t
-  <Table masked=False length=2>
+  <Table length=2>
     a      b     c
   int32 float64 str1
   ----- ------- ----
@@ -79,7 +79,7 @@ Once you have a |Table| then you can make new table by selecting columns
 and putting this into a Python list, e.g. ``[ t['c'], t['a'] ]``::
 
   >>> Table([t['c'], t['a']])
-  <Table masked=False length=2>
+  <Table length=2>
    c     a
   str1 int32
   ---- -----
@@ -93,7 +93,7 @@ directly in arithmetic expressions.  This allows for a compact way of making a
 new table with modified column values::
 
   >>> Table([t['a']**2, t['b'] + 10])
-  <Table masked=False length=2>
+  <Table length=2>
     a      b
   int32 float64
   ----- -------
@@ -111,7 +111,7 @@ of different data types to initialize a table::
   >>> c = Column(['x', 'y'], name='axis')
   >>> arr = (a, b, c)
   >>> Table(arr)  # doctest: +SKIP
-  <Table masked=False length=2>
+  <Table length=2>
    col0 col1 [2] axis
   int64  int64   str1
   ----- -------- ----
@@ -131,7 +131,7 @@ A dictionary of column data can be used to initialize a |Table|.
   ...        'c': ['x', 'y']}
   >>>
   >>> Table(arr)  # doctest: +SKIP
-  <Table masked=False length=2>
+  <Table length=2>
     a    c      b
   int32 str1 float64
   ----- ---- -------
@@ -142,7 +142,7 @@ A dictionary of column data can be used to initialize a |Table|.
 ::
 
   >>> Table(arr, names=('a', 'b', 'c'), dtype=('f8', 'i4', 'S2'))
-  <Table masked=False length=2>
+  <Table length=2>
      a      b    c
   float64 int32 str2
   ------- ----- ----
@@ -157,7 +157,7 @@ The input column data can be any data type that can initialize a |Column| object
   ...        'b': np.array([[2, 3], [5, 6]]),
   ...        'c': Column(['x', 'y'], name='axis')}
   >>> Table(arr, names=('a', 'b', 'c'))  # doctest: +SKIP
-  <Table masked=False length=2>
+  <Table length=2>
     a   b [2]   c
   int64 int64  str1
   ----- ------ ----
@@ -209,7 +209,7 @@ list of dict objects.  The keys determine the column names::
   >>> data = [{'a': 5, 'b': 10},
   ...         {'a': 15, 'b': 20}]
   >>> Table(rows=data)  # doctest: +SKIP
-  <Table masked=False length=2>
+  <Table length=2>
     a     b
   int64 int64
   ----- -----
@@ -263,7 +263,7 @@ created using::
 From ``arr`` it is simple to create the corresponding |Table| object::
 
   >>> Table(arr)
-  <Table masked=False length=2>
+  <Table length=2>
     a      b     c
   int32 float64 str2
   ----- ------- ----
@@ -287,7 +287,7 @@ The column names can be changed from the original values by providing the
 ``names`` argument::
 
   >>> Table(arr, names=('a_new', 'b_new', 'c_new'))
-  <Table masked=False length=2>
+  <Table length=2>
   a_new  b_new  c_new
   int32 float64  str2
   ----- ------- -----
@@ -300,7 +300,7 @@ The column names can be changed from the original values by providing the
 Likewise the data type for each column can by changed with ``dtype``::
 
   >>> Table(arr, dtype=('f4', 'i4', 'S4'))
-  <Table masked=False length=2>
+  <Table length=2>
      a      b    c
   float32 int32 str4
   ------- ----- ----
@@ -308,7 +308,7 @@ Likewise the data type for each column can by changed with ``dtype``::
       4.0     5    y
 
   >>> Table(arr, names=('a_new', 'b_new', 'c_new'), dtype=('f4', 'i4', 'S4'))
-  <Table masked=False length=2>
+  <Table length=2>
    a_new  b_new c_new
   float32 int32  str4
   ------- ----- -----
@@ -322,7 +322,7 @@ A `numpy` 1-d array is treated as a single row table where each element of the
 array corresponds to a column::
 
   >>> Table(np.array([1, 2, 3]), names=['a', 'b', 'c'], dtype=('i8', 'i8', 'i8'))
-  <Table masked=False length=1>
+  <Table length=1>
     a     b     c
   int64 int64 int64
   ----- ----- -----
@@ -339,7 +339,7 @@ generated as ``col<N>`` where ``<N>`` is the column number.
   >>> arr = np.array([[1, 2, 3],
   ...                 [4, 5, 6]], dtype=np.int32)
   >>> Table(arr)
-  <Table masked=False length=2>
+  <Table length=2>
    col0  col1  col2
   int32 int32 int32
   ----- ----- -----
@@ -350,7 +350,7 @@ generated as ``col<N>`` where ``<N>`` is the column number.
 ::
 
   >>> Table(arr, names=('a_new', 'b_new', 'c_new'), dtype=('f4', 'i4', 'S4'))
-  <Table masked=False length=2>
+  <Table length=2>
    a_new  b_new c_new
   float32 int32  str4
   ------- ----- -----
@@ -399,7 +399,7 @@ table::
 
   >>> t = Table(names=('a', 'b', 'c'))
   >>> t['c', 'b', 'a']  # Makes a copy of the data
-  <Table masked=False length=0>
+  <Table length=0>
      c       b       a
   float64 float64 float64
   ------- ------- -------
@@ -409,13 +409,13 @@ An alternate way to use the ``columns`` attribute (explained in the
 columns by their numerical index or name and supports slicing syntax::
 
   >>> Table(t.columns[0:2])
-  <Table masked=False length=0>
+  <Table length=0>
      a       b
   float64 float64
   ------- -------
 
   >>> Table([t.columns[0], t.columns['c']])
-  <Table masked=False length=0>
+  <Table length=0>
      a       c
   float64 float64
   ------- -------

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -72,7 +72,7 @@ There are a few ways to examine the table.  You can get detailed information
 about the table values and column definitions as follows::
 
   >>> t
-  <Table masked=False length=3>
+  <Table length=3>
     a      b     c
   int32 float64 str1
   ----- ------- ----
@@ -85,7 +85,7 @@ assigned, all units would be shown as follows::
 
   >>> t['b'].unit = 's'
   >>> t
-  <Table masked=False length=3>
+  <Table length=3>
     a      b       c
            s
   int32 float64 str1

--- a/docs/table/pandas.rst
+++ b/docs/table/pandas.rst
@@ -34,7 +34,7 @@ It is also possible to create a table from a `DataFrame`_::
 
     >>> t2 = Table.from_pandas(df)
     >>> t2
-    <Table masked=False length=4>
+    <Table length=4>
       a      b
     int64 string8
     ----- -------


### PR DESCRIPTION
I've always been bothered by the default `masked=False` that is in the Table repr.  This is just noise and I don't know why I did it this way given the general precedent of suppressing default / non-informative attributes.

This PR fixes it!  It is based off of #3868 because of all the doc string updates there.