### PR TITLE
Remove reference to easy_install from various installation instructions

### DIFF
--- a/docs/development/codeguide_emacs.rst
+++ b/docs/development/codeguide_emacs.rst
@@ -18,8 +18,7 @@ For this setup we will need flymake_, pyflakes_ and the pep8_ Python
 script, in addition to ``python-mode``.
 
 Flymake comes with Emacs 23. The rest can be obtained from their websites,
-or can be installed using `easy_install
-<http://pythonhosted.org//setuptools/easy_install.html>`_ or `pip`_.
+or can be installed using `pip`_.
 
 Global settings
 ===============

--- a/docs/development/workflow/virtualenv_detail.rst
+++ b/docs/development/workflow/virtualenv_detail.rst
@@ -27,10 +27,6 @@ your default Python version:
 
        $ pip install virtualenv
 
-   or::
-
-       $ easy_install virtualenv
-
    or (on Debian/Ubuntu)::
 
        $ sudo apt-get install python-virtualenv
@@ -73,9 +69,9 @@ your default Python version:
        (astropy-dev) $ deactivate
 
 #. Now as long as the virtualenv is activated, packages you install with
-   ``pip``, ``easy_install``, or by manually running ``python setup.py
-   install`` will automatically install into your virtualenv instead of the
-   system site-packages.  Consider installing Astropy in develop mode into the
+   ``pip``, or by manually running ``python setup.py install`` will
+   automatically install into your virtualenv instead of the system
+   site-packages.  Consider installing Astropy in develop mode into the
    virtualenv as described :ref:`activate_development_astropy`.
 
 Using virtualenv with IPython


### PR DESCRIPTION
Since use of `easy_install` for installing packages from PyPI is all but deprecated except for a few very narrow use cases, we shouldn't be recommending it in any docs.  (The only place where I kept the reference was in a troubleshooting section relevant to users with very outdated versions of setuptools installed.)