### PR TITLE
Do not scale data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -428,6 +428,11 @@ Bug Fixes
 
 - ``astropy.wcs``
 
+- Misc
+
+  - ``fitscheck`` no longer causes scaled image data to be rescaled when 
+    adding checksums to existing files. [#3884]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -173,7 +173,7 @@ def update(filename):
     Also updates fixes standards violations if possible and requested.
     """
 
-    hdulist = fits.open(filename)
+    hdulist = fits.open(filename, do_not_scale_image_data=True)
     try:
         output_verify = 'silentfix' if OPTIONS.compliance else 'ignore'
         hdulist.writeto(filename, checksum=OPTIONS.checksum_kind, clobber=True,


### PR DESCRIPTION
When adding the checksum and "updating" a file do not scale the image data.