### PR TITLE
Skip test_multiprocessing_forkserver() on hurd.

### DIFF
--- a/astropy/tests/tests/test_socketblocker.py
+++ b/astropy/tests/tests/test_socketblocker.py
@@ -67,7 +67,7 @@ def _square(x):
     return x ** 2
 
 
-@pytest.mark.skipif('not PY3_4 or sys.platform == "win32"')
+@pytest.mark.skipif('not PY3_4 or sys.platform == "win32" or sys.platform.startswith("gnu0")')
 def test_multiprocessing_forkserver():
     """
     Test that using multiprocessing with forkserver works.  Perhaps


### PR DESCRIPTION
Hurd [does not have functioning sem_open implementation](https://savannah.gnu.org/task/?7050) , and therefore multiprocessing.Pool() will [raise an ImportError](https://bugs.python.org/issue23400). See [this build log](https://buildd.debian.org/status/fetch.php?pkg=python-astropy&arch=hurd-i386&ver=1.0.3-1&stamp=1435096998) for such a failure.
