### PR TITLE
Add Sersic1D and Sersic2D model classes. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ New Features
     longer, more descriptive names (e.g. ``Pix2Sky_Gnomonic``).
     [#3583]
 
+    - Added ``Sersic1D`` and ``Sersic2D`` model classes. 
+
 - ``astropy.nddata``
 
   - Added ``block_reduce`` and ``block_replicate`` functions. [#3453]

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -56,7 +56,7 @@ MODELS_WITH_CONSTRAINTS = [
     Const1D, Const2D, Ellipse2D, Disk2D,
     Gaussian1D, GaussianAbsorption1D, Gaussian2D,
     Linear1D, Lorentz1D, MexicanHat1D, MexicanHat2D,
-    PowerLaw1D, Sine1D, Trapezoid1D, TrapezoidDisk2D,
+    PowerLaw1D, Sersic1D, Sersic2D, Sine1D, Trapezoid1D, TrapezoidDisk2D,
     Chebyshev1D, Chebyshev2D, Legendre2D, Legendre1D,
     Polynomial1D, Polynomial2D
 ]

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -32,7 +32,7 @@ Explanation of keywords of the dictionaries:
 
 "log_fit" : bool
     PowerLaw models should be tested over a few magnitudes. So log_fit should
-    be true.
+    be true.  
 
 "requires_scipy" : bool
     If a model requires scipy (Bessel functions etc.) set this flag.
@@ -57,7 +57,7 @@ from ..functional_models import (
     MexicanHat1D, Trapezoid1D, Const1D, Moffat1D,
     Gaussian2D, Const2D, Box2D, MexicanHat2D,
     TrapezoidDisk2D, AiryDisk2D, Moffat2D, Disk2D,
-    Ring2D)
+    Ring2D, Sersic1D, Sersic2D)
 from ..polynomial import Polynomial1D, Polynomial2D
 from ..powerlaws import (
     PowerLaw1D, BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
@@ -184,6 +184,16 @@ models_1D = {
         'x_values': [1, 10, 100],
         'y_values': [3, 111, 10101],
         'x_lim': [-3, 3]
+     },
+
+    Sersic1D: {
+        'parameters': [1, 20, 4],
+        'x_values': [0.1, 1, 10, 100],
+        'y_values': [2.78629391e+02, 5.69791430e+01, 3.38788244e+00,
+                     2.23941982e-02],
+        'requires_scipy': True,
+        'x_lim': [0,10],
+        'log_fit': True
     }
 }
 
@@ -289,5 +299,15 @@ models_2D = {
         'x_lim': [-10, 10],
         'y_lim': [-10, 10],
         'integral': np.pi * (10 ** 2 - 5 ** 2)
+    },
+
+    Sersic2D: {
+        'parameters': [1, 25, 4, 50, 50, 0.5, -1],
+        'x_values': [0.0, 1, 10, 100],
+        'y_values': [1, 100, 0.0, 10],
+        'z_values': [1.686398e-02, 9.095221e-02, 2.341879e-02, 9.419231e-02],
+        'requires_scipy': True,
+        'x_lim': [1,1e10],
+        'y_lim': [1,1e10]
     }
 }


### PR DESCRIPTION
I've added model classes for one and two dimensional Sersic surface brightness profiles. Currently there are no derivatives defined for a fit_deriv method. The factor b(n) is calculated with the incomplete gamma function and  solved for numerically. I'm not sure how to go about defining the derivate for this. There are polynomial approximations that could be implemented for different ranges of n. @eteq, thoughts?
@cdeil, @adonath 

[preview docs](https://www.dropbox.com/sh/glr7bwro53ssdva/AADKh-kiM87iVe5Qa6P_z-X7a?dl=0)


