### PR TITLE
Make astropy.tests.helper part of the public API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,7 +174,7 @@ New Features
 
   - Enhanced text representation of ``WCS`` objects. [#3604]
 
-- The `astropy.tests.helper` module is now part of the public API (and has a
+- The ``astropy.tests.helper`` module is now part of the public API (and has a
   documentation page).  This module was in previous releases of astropy,
   but was not considered part of the public API until now. [#3890]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,6 +174,10 @@ New Features
 
   - Enhanced text representation of ``WCS`` objects. [#3604]
 
+- The `astropy.tests.helper` module is now part of the public API (and has a
+  documentation page).  This module was in previous releases of astropy,
+  but was not considered part of the public API until now. [#3890]
+
 .. _astroML: http://astroML.org
 
 API changes

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -22,6 +22,12 @@ import tempfile
 import types
 import warnings
 
+__all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
+           'treat_deprecations_as_exceptions', 'catch_warnings',
+           'assert_follows_unicode_guidelines', 'quantity_allclose',
+           'assert_quantity_allclose', 'check_pickling_recovery',
+           'pickle_protocol', 'generic_recursive_equality_test']
+
 try:
     # Import pkg_resources to prevent it from issuing warnings upon being
     # imported from within py.test.  See
@@ -471,7 +477,7 @@ class catch_warnings(warnings.catch_warnings):
     This completely blitzes any memory of any warnings that have
     appeared before so that all warnings will be caught and displayed.
 
-    *args is a set of warning classes to collect.  If no arguments are
+    ``*args`` is a set of warning classes to collect.  If no arguments are
     provided, all warnings are collected.
 
     Use as follows::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,9 @@ check_sphinx_version("1.2.1")
 # own build so we remove it here.
 del intersphinx_mapping['astropy']
 
+# add any custom intersphinx for astropy
+intersphinx_mapping['pytest'] = ('http://pytest.org/latest/', None)
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,6 +106,7 @@ User Documentation
    logging
    warnings
    utils/index
+   testhelpers
 
 **Astropy project details**
 

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -4,15 +4,15 @@
 Astropy Testing helpers (`astropy.tests.helper`)
 ************************************************
 
-To easy development of tests that work with Astropy, the
+To ease development of tests that work with Astropy, the
 `astropy.tests.helper` module provides some utility functions to make
-test that use astropy conventions or classes easier to work with. E.g.,
+tests that use Astropy conventions or classes easier to work with. e.g.,
 functions to test for near-equality of `~astropy.units.Quantity` objects.
 
 The functionality here is not exhaustive, because much of the useful
 tools are either in the standard library, py.test, or
 `numpy.testing <http://docs.scipy.org/doc/numpy/reference/routines.testing.html>`_.
-This module contains primarily functionality specific to astropy or
+This module contains primarily functionality specific to Astropy or
 affiliated packages that follow the package template.
 
 Note that this module also includes the ``remote_data`` marker, which
@@ -27,6 +27,9 @@ It is intended to be used as::
         This test dowloads something from the intenet
         """
         # test code here ...
+
+This test will now only run if the test suite is invoked as
+``python setup.py test --remote-data``.
 
 
 Reference/API

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -1,0 +1,39 @@
+.. _testhelpers:
+
+************************************************
+Astropy Testing helpers (`astropy.tests.helper`)
+************************************************
+
+To easy development of tests that work with Astropy, the
+`astropy.tests.helper` module provides some utility functions to make
+test that use astropy conventions or classes easier to work with. E.g.,
+functions to test for near-equality of `~astropy.units.Quantity` objects.
+
+The functionality here is not exhaustive, because much of the useful
+tools are either in the standard library, py.test, or
+`numpy.testing <http://docs.scipy.org/doc/numpy/reference/routines.testing.html>`_.
+This module contains primarily functionality specific to astropy or
+affiliated packages that follow the package template.
+
+Note that this module also includes the ``remote_data`` marker, which
+is used to indicate a test accesses data from the internet while running.
+It is intended to be used as::
+
+    from astropy.tests.helper import remote_data
+
+    @remote_data
+    def test_something():
+        """
+        This test dowloads something from the intenet
+        """
+        # test code here ...
+
+
+Reference/API
+=============
+
+.. module:: astropy.tests.helper
+
+.. automodapi:: astropy.tests.helper
+    :no-main-docstr:
+    :no-inheritance-diagram:


### PR DESCRIPTION
This grew out of a discussion with @cdeil as part of one of the GSoC projects.  It turns out we aren't currently documenting the functions and markers in `astropy.tests.helper`.  This means e.g. `remote_data` or `quantity_allclose` can't be relied on or understood by affiliated package writers as its not part of the public API.  Some of it is obliquely referenced in the testing guidelines, but not directly documented.

This PR rectifies that by adding `astropy.tests.helper` documentation to the astropy docs, thereby making it part of the public API.  One weird quirk: it turns out `numpy` is not doing intersphinx correctly, so `numpy.testing` doesn't link up to the right numpy doc page.  I worked around this by just explicitly providing a hyperlink, bypassing the intersphinx machinery.