### PR TITLE
WIP: Fix iteration inside wcslib

### DIFF
--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -7,7 +7,7 @@ import gc
 import locale
 import re
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
 
 from ...tests.helper import pytest, raises, catch_warnings
@@ -881,3 +881,40 @@ def test_radesys_defaults_full():
         w.radesys = 'FK4-NO-E'
         w.set()
         assert w.equinox == 1950
+
+
+def test_iteration():
+    world = np.array(
+        [[-0.58995335, -0.5],
+         [0.00664326, -0.5],
+         [-0.58995335, -0.25],
+         [0.00664326, -0.25],
+         [-0.58995335,  0.],
+         [0.00664326,  0.],
+         [-0.58995335,  0.25],
+         [0.00664326,  0.25],
+         [-0.58995335,  0.5],
+         [0.00664326,  0.5]],
+        np.float
+    )
+
+    w = wcs.WCS()
+    w.wcs.ctype = ['GLON-CAR', 'GLAT-CAR']
+    w.wcs.cdelt = [-0.006666666828, 0.006666666828]
+    w.wcs.crpix = [75.907, 74.8485]
+    x = w.wcs_world2pix(world, 1)
+
+    expected = np.array(
+        [[1.64400000e+02, -1.51498185e-01],
+         [7.49105110e+01, -1.51498185e-01],
+         [1.64400000e+02, 3.73485009e+01],
+         [7.49105110e+01, 3.73485009e+01],
+         [1.64400000e+02, 7.48485000e+01],
+         [7.49105110e+01, 7.48485000e+01],
+         [1.64400000e+02, 1.12348499e+02],
+         [7.49105110e+01, 1.12348499e+02],
+         [1.64400000e+02, 1.49848498e+02],
+         [7.49105110e+01, 1.49848498e+02]],
+        np.float)
+
+    assert_array_almost_equal(x, expected)

--- a/cextern/wcslib/C/sph.c
+++ b/cextern/wcslib/C/sph.c
@@ -47,7 +47,7 @@ int sphx2s(
   double lat[])
 
 {
-  int jphi, mphi, mtheta, rowlen, rowoff;
+  int mphi, mtheta, rowlen, rowoff;
   double cosphi, costhe, costhe3, costhe4, dlng, dphi, sinphi, sinthe,
          sinthe3, sinthe4, x, y, z;
   register int iphi, itheta;
@@ -69,13 +69,12 @@ int sphx2s(
     if (eul[1] == 0.0) {
       dlng = fmod(eul[0] + 180.0 - eul[2], 360.0);
 
-      jphi   = 0;
+      lngp = lng;
+      latp = lat;
+      phip   = phi;
       thetap = theta;
-      lngp   = lng;
-      latp   = lat;
-      for (itheta = 0; itheta < ntheta; itheta++, thetap += spt) {
-        phip = phi + jphi%nphi;
-        for (iphi = 0; iphi < mphi; iphi++, phip += spt, jphi++) {
+      for (itheta = 0; itheta < ntheta; itheta++) {
+        for (iphi = 0; iphi < mphi; iphi++) {
           *lngp = *phip + dlng;
           *latp = *thetap;
 
@@ -94,19 +93,20 @@ int sphx2s(
 
           lngp   += sll;
           latp   += sll;
+          phip   += spt;
+          thetap += spt;
         }
       }
 
     } else {
       dlng = fmod(eul[0] + eul[2], 360.0);
 
-      jphi   = 0;
+      lngp = lng;
+      latp = lat;
+      phip   = phi;
       thetap = theta;
-      lngp   = lng;
-      latp   = lat;
-      for (itheta = 0; itheta < ntheta; itheta++, thetap += spt) {
-        phip = phi + jphi%nphi;
-        for (iphi = 0; iphi < mphi; iphi++, phip += spt, jphi++) {
+      for (itheta = 0; itheta < ntheta; itheta++) {
+        for (iphi = 0; iphi < mphi; iphi++) {
           *lngp = dlng - *phip;
           *latp = -(*thetap);
 
@@ -125,6 +125,8 @@ int sphx2s(
 
           lngp   += sll;
           latp   += sll;
+          phip   += spt;
+          thetap += spt;
         }
       }
     }
@@ -230,7 +232,7 @@ int sphs2x(
   double theta[])
 
 {
-  int jlng, mlat, mlng, rowlen, rowoff;
+  int mlat, mlng, rowlen, rowoff;
   double coslat, coslat3, coslat4, coslng, dlng, dphi, sinlat, sinlat3,
          sinlat4, sinlng, x, y, z;
   register int ilat, ilng;
@@ -252,13 +254,12 @@ int sphs2x(
     if (eul[1] == 0.0) {
       dphi = fmod(eul[2] - 180.0 - eul[0], 360.0);
 
-      jlng   = 0;
-      latp   = lat;
+      lngp = lng;
+      latp = lat;
       phip   = phi;
       thetap = theta;
-      for (ilat = 0; ilat < nlat; ilat++, latp += sll) {
-        lngp = lng + jlng%nlng;
-        for (ilng = 0; ilng < mlng; ilng++, lngp += sll, jlng++) {
+      for (ilat = 0; ilat < nlat; ilat++) {
+        for (ilng = 0; ilng < mlng; ilng++) {
           *phip = fmod(*lngp + dphi, 360.0);
           *thetap = *latp;
 
@@ -271,19 +272,20 @@ int sphs2x(
 
           phip   += spt;
           thetap += spt;
+          lngp   += sll;
+          latp   += sll;
         }
       }
 
     } else {
       dphi = fmod(eul[2] + eul[0], 360.0);
 
-      jlng   = 0;
-      latp   = lat;
+      lngp = lng;
+      latp = lat;
       phip   = phi;
       thetap = theta;
-      for (ilat = 0; ilat < nlat; ilat++, latp += sll) {
-        lngp = lng + jlng%nlng;
-        for (ilng = 0; ilng < mlng; ilng++, lngp += sll, jlng++) {
+      for (ilat = 0; ilat < nlat; ilat++) {
+        for (ilng = 0; ilng < mlng; ilng++) {
           *phip = fmod(dphi - *lngp, 360.0);
           *thetap = -(*latp);
 
@@ -296,6 +298,8 @@ int sphs2x(
 
           phip   += spt;
           thetap += spt;
+          lngp   += sll;
+          latp   += sll;
         }
       }
     }


### PR DESCRIPTION
This is a fix for #3891, simply by reverting `sph.c` to an earlier version.  I think these changes were part of an attempt at optimization and not fixing any bug anyway.

We should wait and see what the official fix in wcslib will be (I've reported this to Mark Calabretta), but in the meantime, this provides us with an  alternative.

@olebole: This is a critical enough bug that you may want to apply it to the Debian package of wcslib 5.x if there is one already.