### PR TITLE
IERS.open accepts network URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,7 @@ New Features
 
   - Added ``classproperty`` decorator--this is to ``property`` as
     ``classmethod`` is to normal instance methods. [#3982]
+  - ``iers.open`` now handles network URLs, as well as local paths. [#3850] 
 
 - ``astropy.visualization``
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -33,11 +33,10 @@ _DEFAULT_PM = (0.035, 0.29)*u.arcsec
 
 _IERS_HINT = """
 If you need enough precision such that this matters (~<10 arcsec), you can
-download the latest IERS predictions by running:
+use the latest IERS predictions by running:
 
-    >>> from astropy.utils.data import download_file
     >>> from astropy.utils import iers
-    >>> iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True))
+    >>> iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
 
 """
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -108,6 +108,9 @@ class IERS(QTable):
             for passing on to the `read` class methods (further optional
             arguments that are available for some IERS subclasses can be added).
             If None, use the default location from the `read` class method.
+        cache : bool
+            Whether to use cache. Defaults to False, since IERS files
+            are regularly updated.
 
         Returns
         -------

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -55,7 +55,10 @@ Instead of local copies of IERS files, one can also download them, using
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 import numpy as np
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -48,9 +48,7 @@ Instead of local copies of IERS files, one can also download them, using
 `iers.IERS_A_URL` and `iers.IERS_B_URL`::
 
     >>> from astropy.utils.iers import IERS_A, IERS_A_URL
-    >>> from astropy.utils.data import download_file
-    >>> iers_a_file = download_file(IERS_A_URL, cache=True)  # doctest: +SKIP
-    >>> iers_a = IERS_A.open(iers_a_file)                    # doctest: +SKIP
+    >>> iers_a = IERS_A.open(IERS_A_URL)                    # doctest: +SKIP
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -98,7 +98,7 @@ class IERS(QTable):
     iers_table = None
 
     @classmethod
-    def open(cls, file=None, **kwargs):
+    def open(cls, file=None, cache=False, **kwargs):
         """Open an IERS table, reading it from a file if not loaded before.
 
         Parameters
@@ -130,7 +130,7 @@ class IERS(QTable):
         if file is not None or cls.iers_table is None:
             if file is not None:
                 if urlparse(file).netloc:
-                    kwargs.update(file=download_file(file))
+                    kwargs.update(file=download_file(file, cache=cache))
                 else:
                     kwargs.update(file=file)
             cls.iers_table = cls.read(**kwargs)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import numpy as np
 
-from ....tests.helper import pytest, assert_quantity_allclose, remote_data
+from ....tests.helper import pytest, assert_quantity_allclose
 from .. import iers
 from .... import units as u
 from ....table import QTable

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -22,7 +22,6 @@ else:
     HAS_IERS_A = True
 
 IERS_A_EXCERPT = os.path.join(os.path.dirname(__file__), 'iers_a_excerpt')
-IERS_A_EXCERPT_NETWORK = "https://raw.githubusercontent.com/astropy/astropy/master/astropy/utils/iers/tests/iers_a_excerpt"
 
 class TestBasic():
     """Basic tests that IERS_B returns correct values"""
@@ -72,7 +71,7 @@ class TestBasic():
     @remote_data
     def test_open_network_url(self):
         iers.IERS_A.close()
-        iers.IERS_A.open(IERS_A_EXCERPT_NETWORK)
+        iers.IERS_A.open("file://" + IERS_A_EXCERPT)
         assert iers.IERS_A.iers_table is not None
         assert isinstance(iers.IERS_A.iers_table, QTable)
         iers.IERS_A.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -22,7 +22,6 @@ else:
     HAS_IERS_A = True
 
 IERS_A_EXCERPT = os.path.join(os.path.dirname(__file__), 'iers_a_excerpt')
-IERS_A_EXCEPRT_NETWORK = "https://mstuchli.fedorapeople.org/iers_a_excerpt"
 
 class TestBasic():
     """Basic tests that IERS_B returns correct values"""
@@ -72,7 +71,7 @@ class TestBasic():
     @remote_data
     def test_open_network_url(self):
         iers.IERS_A.close()
-        iers.IERS_A.open(IERS_A_EXCEPRT_NETWORK)
+        iers.IERS_A.open(iers.IERS_A_URL)
         assert iers.IERS_A.iers_table is not None
         assert isinstance(iers.IERS_A.iers_table, QTable)
         iers.IERS_A.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -68,7 +68,6 @@ class TestBasic():
         with pytest.raises(FILE_NOT_FOUND_ERROR):
             iers.IERS.open('surely this does not exist')
 
-    @remote_data
     def test_open_network_url(self):
         iers.IERS_A.close()
         iers.IERS_A.open("file://" + IERS_A_EXCERPT)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -22,6 +22,7 @@ else:
     HAS_IERS_A = True
 
 IERS_A_EXCERPT = os.path.join(os.path.dirname(__file__), 'iers_a_excerpt')
+IERS_A_EXCERPT_NETWORK = "https://raw.githubusercontent.com/astropy/astropy/master/astropy/utils/iers/tests/iers_a_excerpt"
 
 class TestBasic():
     """Basic tests that IERS_B returns correct values"""
@@ -71,7 +72,7 @@ class TestBasic():
     @remote_data
     def test_open_network_url(self):
         iers.IERS_A.close()
-        iers.IERS_A.open(iers.IERS_A_URL)
+        iers.IERS_A.open(IERS_A_EXCERPT_NETWORK)
         assert iers.IERS_A.iers_table is not None
         assert isinstance(iers.IERS_A.iers_table, QTable)
         iers.IERS_A.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import numpy as np
 
-from ....tests.helper import pytest, assert_quantity_allclose
+from ....tests.helper import pytest, assert_quantity_allclose, remote_data
 from .. import iers
 from .... import units as u
 from ....table import QTable
@@ -22,6 +22,7 @@ else:
     HAS_IERS_A = True
 
 IERS_A_EXCERPT = os.path.join(os.path.dirname(__file__), 'iers_a_excerpt')
+IERS_A_EXCEPRT_NETWORK = "https://mstuchli.fedorapeople.org/iers_a_excerpt"
 
 class TestBasic():
     """Basic tests that IERS_B returns correct values"""
@@ -67,6 +68,14 @@ class TestBasic():
         iers.IERS.close()
         with pytest.raises(FILE_NOT_FOUND_ERROR):
             iers.IERS.open('surely this does not exist')
+
+    @remote_data
+    def test_open_network_url(self):
+        iers.IERS_A.close()
+        iers.IERS_A.open(IERS_A_EXCEPRT_NETWORK)
+        assert iers.IERS_A.iers_table is not None
+        assert isinstance(iers.IERS_A.iers_table, QTable)
+        iers.IERS_A.close()
 
 class TestIERS_AExcerpt():
     def test_simple(self):

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -10,6 +10,7 @@ from .. import iers
 from .... import units as u
 from ....table import QTable
 from ....time import Time
+from ....extern.six.moves import urllib
 
 
 FILE_NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', IOError)
@@ -70,7 +71,7 @@ class TestBasic():
 
     def test_open_network_url(self):
         iers.IERS_A.close()
-        iers.IERS_A.open("file://" + IERS_A_EXCERPT)
+        iers.IERS_A.open("file:" + urllib.request.pathname2url(IERS_A_EXCERPT))
         assert iers.IERS_A.iers_table is not None
         assert isinstance(iers.IERS_A.iers_table, QTable)
         iers.IERS_A.close()


### PR DESCRIPTION
If the 'file' argument contains a network location, the method now downloads it via download_file and operates on the local copy. (Fixes #3850)

Right now it does not accept additional arguments for download_file, let me know if that feature is critical to accepting this PR, or if there's anything else wrong with it. :)

Also, where should I put the test IERS file? It's currently hosted on my server, but that's clearly just a makeshift solution.