### PR TITLE
Follow-on to mixin changes - tidying and simplifying

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -240,7 +240,7 @@ class SkyCoord(object):
             # Copy other 'info' attr only if it has actually been defined.
             # See PR #3898 for further explanation and justification, along
             # with Quantity.__array_finalize__
-            if 'info' in getattr(self, '__dict__', ()):
+            if 'info' in self.__dict__:
                 out.info = self.info
 
             return out

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -236,7 +236,13 @@ class SkyCoord(object):
             # this to get all the right attributes
             self._sky_coord_frame = self_frame[item]
             out = SkyCoord(self, representation=self.representation)
-            out.info = self.info
+
+            # Copy other 'info' attr only if it has actually been defined.
+            # See PR #3898 for further explanation and justification, along
+            # with Quantity.__array_finalize__
+            if 'info' in getattr(self, '__dict__', ()):
+                out.info = self.info
+
             return out
         finally:
             # now put back the right frame in self
@@ -282,7 +288,9 @@ class SkyCoord(object):
                 # along with any frame attributes like equinox or obstime which
                 # were explicitly specified in the coordinate object (i.e. non-default).
                 coord_kwargs = _parse_coordinate_arg(args[0], frame, units, kwargs)
-                if hasattr(args[0], 'info'):
+
+                # Copy other 'info' attr only if it has actually been defined.
+                if 'info' in getattr(args[0], '__dict__', ()):
                     self.info = args[0].info
 
             elif len(args) <= 3:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -66,10 +66,10 @@ class SkyCoordInfo(MixinInfo):
 
     @property
     def _repr_data(self):
-        if self._parent_ref is None:
+        if self._parent is None:
             return None
 
-        sc = self._parent_ref()
+        sc = self._parent
         if (issubclass(sc.representation, SphericalRepresentation) and
                 isinstance(sc.data, UnitSphericalRepresentation)):
             repr_data = sc.represent_as(sc.data.__class__, in_frame_units=True)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,7 +13,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.data_info import InfoDescriptor, DataInfo
+from ..utils.data_info import InfoDescriptor, MixinInfo
 
 from .distances import Distance
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
@@ -42,7 +42,7 @@ def FRAME_ATTR_NAMES_SET():
     return out
 
 
-class SkyCoordInfo(DataInfo):
+class SkyCoordInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is
     required when the object is used as a mixin column within a table, but can

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -176,10 +176,10 @@ class SkyCoord(object):
             Cartesian coordinates values for the Galactic frame.
     """
 
-
     # Declare that SkyCoord can be used as a Table column by defining the
-    # attribute where column attributes will be stored.
-    _astropy_column_attrs = None
+    # info property.
+    info = InfoDescriptor(SkyCoordInfo)
+
 
     def __init__(self, *args, **kwargs):
 
@@ -208,8 +208,6 @@ class SkyCoord(object):
         if not self._sky_coord_frame.has_data:
             raise ValueError('Cannot create a SkyCoord without data')
 
-    info = InfoDescriptor(SkyCoordInfo)
-
     @property
     def frame(self):
         return self._sky_coord_frame
@@ -237,7 +235,9 @@ class SkyCoord(object):
             # First turn `self` into a mockup of the thing we want - we can copy
             # this to get all the right attributes
             self._sky_coord_frame = self_frame[item]
-            return SkyCoord(self, representation=self.representation)
+            out = SkyCoord(self, representation=self.representation)
+            out.info = self.info.copy()
+            return out
         finally:
             # now put back the right frame in self
             self._sky_coord_frame = self_frame
@@ -282,6 +282,8 @@ class SkyCoord(object):
                 # along with any frame attributes like equinox or obstime which
                 # were explicitly specified in the coordinate object (i.e. non-default).
                 coord_kwargs = _parse_coordinate_arg(args[0], frame, units, kwargs)
+                if hasattr(args[0], 'info'):
+                    self.info = args[0].info.copy()
 
             elif len(args) <= 3:
                 frame_attr_names = frame.representation_component_names.keys()

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -236,7 +236,7 @@ class SkyCoord(object):
             # this to get all the right attributes
             self._sky_coord_frame = self_frame[item]
             out = SkyCoord(self, representation=self.representation)
-            out.info = self.info.copy()
+            out.info = self.info
             return out
         finally:
             # now put back the right frame in self
@@ -283,7 +283,7 @@ class SkyCoord(object):
                 # were explicitly specified in the coordinate object (i.e. non-default).
                 coord_kwargs = _parse_coordinate_arg(args[0], frame, units, kwargs)
                 if hasattr(args[0], 'info'):
-                    self.info = args[0].info.copy()
+                    self.info = args[0].info
 
             elif len(args) <= 3:
                 frame_attr_names = frame.representation_component_names.keys()

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -25,7 +25,6 @@ from ...extern.six.moves import cStringIO as StringIO
 from ...utils.exceptions import AstropyWarning
 
 from ...table import Table
-from ...table.column import col_iter_str_vals
 from ...utils.compat import ignored
 from ...utils.data import get_readable_fileobj
 from ...utils import OrderedDict
@@ -708,7 +707,7 @@ class BaseData(object):
         self._set_fill_values(self.cols)
         self._set_col_formats()
         for col in self.cols:
-            col.str_vals = list(col_iter_str_vals(col))
+            col.str_vals = list(col.info.iter_str_vals())
         self._replace_vals(self.cols)
         return [col.str_vals for col in self.cols]
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -360,7 +360,6 @@ class HTML(core.BaseReader):
                                 w.data(col.info.name.strip())
                                 w.end(indent=False)
                         col_str_iters = []
-                        new_cols = []
                         for col in cols:
                             if len(col.shape) > 1 and self.html['multicol']:
                                 span = col.shape[1]
@@ -368,7 +367,6 @@ class HTML(core.BaseReader):
                                     # Split up multicolumns into separate columns
                                     new_col = Column([el[i] for el in col])
                                     col_str_iters.append(new_col.info.iter_str_vals())
-                                    new_cols.append(new_col)
                             else:
                                 col_str_iters.append(col.info.iter_str_vals())
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -14,7 +14,6 @@ from ...extern.six.moves import zip as izip
 
 from . import core
 from ...table import Column
-from ...table.column import col_iter_str_vals
 from ...utils.xml import writer
 
 from copy import deepcopy
@@ -361,15 +360,17 @@ class HTML(core.BaseReader):
                                 w.data(col.info.name.strip())
                                 w.end(indent=False)
                         col_str_iters = []
+                        new_cols = []
                         for col in cols:
                             if len(col.shape) > 1 and self.html['multicol']:
                                 span = col.shape[1]
                                 for i in range(span):
                                     # Split up multicolumns into separate columns
                                     new_col = Column([el[i] for el in col])
-                                    col_str_iters.append(col_iter_str_vals(new_col))
+                                    col_str_iters.append(new_col.info.iter_str_vals())
+                                    new_cols.append(new_col)
                             else:
-                                col_str_iters.append(col_iter_str_vals(col))
+                                col_str_iters.append(col.info.iter_str_vals())
 
                     for row in izip(*col_str_iters):
                         with w.tag('tr'):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -45,16 +45,6 @@ _comparison_functions = set(
      np.isfinite, np.isinf, np.isnan, np.sign, np.signbit])
 
 
-def col_iter_str_vals(col):
-    """
-    This is a mixin-safe version of Column.iter_str_vals.
-    """
-    parent_table = col.info.parent_table
-    formatter = FORMATTER if parent_table is None else parent_table.formatter
-    _pformat_col_iter = formatter._pformat_col_iter
-    for str_val in _pformat_col_iter(col, -1, False, False, {}):
-        yield str_val
-
 def col_copy(col):
     """
     This is a mixin-safe version of Column.copy() (with copy_data=True).

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -45,19 +45,6 @@ _comparison_functions = set(
      np.isfinite, np.isinf, np.isnan, np.sign, np.signbit])
 
 
-def _col_update_attrs_from(newcol, col, exclude_attrs=['name', 'parent_table']):
-    """
-    Copy info from mixin `col` to `newcol`.  Does nothing for BaseColumn cols.
-    """
-    if isinstance(newcol, BaseColumn):
-        return
-
-    attrs = newcol.info.attr_names - set(exclude_attrs) - newcol.info.attrs_from_parent
-    for attr in attrs:
-        val = getattr(col.info, attr)
-        if val is not None:
-            setattr(newcol.info, attr, deepcopy(val))
-
 def col_iter_str_vals(col):
     """
     This is a mixin-safe version of Column.iter_str_vals.
@@ -86,7 +73,7 @@ def col_copy(col):
 
     try:
         newcol = col.copy() if hasattr(col, 'copy') else deepcopy(col)
-        newcol.info = col.info.copy()
+        newcol.info = col.info
     finally:
         col.info.parent_table = parent_table
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import MixinInfo, InfoDescriptor, dtype_info_name
+from ..utils.data_info import BaseColumnInfo, InfoDescriptor, dtype_info_name
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -88,8 +88,8 @@ class FalseArray(np.ndarray):
                              .format(self.__class__.__name__))
 
 
-class ColumnInfo(MixinInfo):
-    attrs_from_parent = MixinInfo.attr_names
+class ColumnInfo(BaseColumnInfo):
+    attrs_from_parent = BaseColumnInfo.attr_names
 
 
 class BaseColumn(np.ndarray):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -14,7 +14,7 @@ from ..units import Unit, Quantity
 from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import DataInfo, InfoDescriptor, dtype_info_name
+from ..utils.data_info import MixinInfo, InfoDescriptor, dtype_info_name
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -111,8 +111,8 @@ class FalseArray(np.ndarray):
                              .format(self.__class__.__name__))
 
 
-class ColumnInfo(DataInfo):
-    attrs_from_parent = DataInfo.attr_names
+class ColumnInfo(MixinInfo):
+    attrs_from_parent = MixinInfo.attr_names
 
 
 class BaseColumn(np.ndarray):

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -115,10 +115,10 @@ def table_info(tbl, option='attributes', out=''):
     out.writelines(outline + os.linesep for outline in outlines)
 
 class TableInfo(object):
-    _parent_ref = None
+    _parent = None
 
     def __call__(self, option='attributes', out=''):
-        return table_info(self._parent_ref(), option, out)
+        return table_info(self._parent, option, out)
 
     __call__.__doc__ = table_info.__doc__
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -20,7 +20,6 @@ import numpy as np
 from numpy import ma
 
 from ..utils import OrderedDict, metadata
-from .column import _col_update_attrs_from
 
 from . import _np_utils
 from .np_utils import fix_column_name, TableMergeError
@@ -633,7 +632,6 @@ def _join(left, right, keys=None, join_type='inner',
 
         # Finally add the joined column to the output table.
         out[out_name] = array[name][array_out]
-        _col_update_attrs_from(out[out_name], array[name])
 
         # If the output table is masked then set the output column masking
         # accordingly.  Check for columns that don't support a mask attribute.
@@ -842,8 +840,6 @@ def _hstack(arrays, join_type='exact', uniq_col_name='{col_name}_{table_name}',
                                      .format(out_name, out[out_name].__class__.__name__))
             else:
                 out[out_name] = array[name][:n_rows]
-
-            _col_update_attrs_from(out[out_name], array[name])
 
     # If col_name_map supplied as a dict input, then update.
     if isinstance(_col_name_map, collections.Mapping):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -18,7 +18,7 @@ from ..units import Quantity
 from ..utils import OrderedDict, isiterable, deprecated, minversion
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import InfoDescriptor
+from ..utils.data_info import InfoDescriptor, MixinInfo
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -77,7 +77,7 @@ class TableColumns(OrderedDict):
             # columns (BaseColumn or mixins) in the list.
             newcols = []
             for col in cols:
-                if (hasattr(col, 'info') and isinstance(col.info, BaseColumnInfo)):
+                if has_info_class(col, BaseColumnInfo):
                     newcols.append((col.info.name, col))
                 else:
                     newcols.append(col)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -18,7 +18,7 @@ from ..units import Quantity
 from ..utils import OrderedDict, isiterable, deprecated, minversion
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import InfoDescriptor
+from ..utils.data_info import InfoDescriptor, BaseColumnInfo
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
@@ -86,8 +86,7 @@ class TableColumns(OrderedDict):
             # columns (BaseColumn or mixins) in the list.
             newcols = []
             for col in cols:
-                if (isinstance(col, (BaseColumn, Quantity))
-                        or is_mixin_class(col)):
+                if (hasattr(col, 'info') and isinstance(col.info, BaseColumnInfo)):
                     newcols.append((col.info.name, col))
                 else:
                     newcols.append(col)

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -145,7 +145,7 @@ class ArrayWrapper(object):
     def __init__(self, data):
         self.data = np.array(data)
         if isinstance(data, ArrayWrapper):
-            self.info = data.info.copy()
+            self.info = data.info
         else:
             self.info.dtype = self.data.dtype
 
@@ -154,7 +154,7 @@ class ArrayWrapper(object):
             out = self.data[item]
         else:
             out = self.__class__(self.data[item])
-            out.info = self.info.copy()
+            out.info = self.info
         return out
 
     def __setitem__(self, item, value):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .table import Table, Column
 from ..extern.six.moves import zip, range
-from ..utils.data_info import InfoDescriptor, DataInfo
+from ..utils.data_info import InfoDescriptor, MixinInfo
 
 class TimingTables(object):
     """
@@ -159,7 +159,7 @@ class ArrayWrapper(object):
     def __len__(self):
         return len(self.data)
 
-    info = InfoDescriptor(DataInfo)
+    info = InfoDescriptor(MixinInfo)
 
     @property
     def shape(self):

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -144,13 +144,17 @@ class ArrayWrapper(object):
     """
     def __init__(self, data):
         self.data = np.array(data)
-        self.info.dtype = self.data.dtype
+        if isinstance(data, ArrayWrapper):
+            self.info = data.info.copy()
+        else:
+            self.info.dtype = self.data.dtype
 
     def __getitem__(self, item):
         if isinstance(item, (int, np.integer)):
             out = self.data[item]
         else:
             out = self.__class__(self.data[item])
+            out.info = self.info.copy()
         return out
 
     def __setitem__(self, item, value):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -798,7 +798,7 @@ class Time(object):
                     setattr(tm, attr, val[item])
                 except IndexError:  # location may be scalar (same for all)
                     continue
-        tm.info = self.info.copy()
+        tm.info = self.info
 
         return tm
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -744,12 +744,18 @@ class Time(object):
 
             setattr(tm, attr, val)
 
-        for attr in ('precision', 'in_subfmt', 'out_subfmt', 'info'):
+        for attr in ('precision', 'in_subfmt', 'out_subfmt'):
             val = getattr(self, attr)
             if method in ('copy', 'flatten') and hasattr(val, 'copy'):
                 val = val.copy()
 
             setattr(tm, attr, val)
+
+        # Copy other 'info' attr only if it has actually been defined.
+        # See PR #3898 for further explanation and justification, along
+        # with Quantity.__array_finalize__
+        if 'info' in getattr(self, '__dict__', ()):
+            tm.info = self.info
 
         # Make the new internal _time object corresponding to the format
         # in the copy.  If the format is unchanged this process is lightweight
@@ -798,7 +804,10 @@ class Time(object):
                     setattr(tm, attr, val[item])
                 except IndexError:  # location may be scalar (same for all)
                     continue
-        tm.info = self.info
+
+        # Copy other 'info' attr only if it has actually been defined.
+        if 'info' in getattr(self, '__dict__', ()):
+            tm.info = self.info
 
         return tm
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -798,6 +798,7 @@ class Time(object):
                     setattr(tm, attr, val[item])
                 except IndexError:  # location may be scalar (same for all)
                     continue
+        tm.info = self.info.copy()
 
         return tm
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,7 +23,7 @@ from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.compat.odict import OrderedDict
 from ..utils.compat.misc import override__dir__
-from ..utils.data_info import InfoDescriptor, DataInfo, data_info_factory
+from ..utils.data_info import InfoDescriptor, MixinInfo, data_info_factory
 from ..utils.compat.numpy import broadcast_to
 from ..extern import six
 
@@ -115,7 +115,7 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa_time.gst94, 'scales': ('ut1',)}}}
 
 
-class TimeInfo(DataInfo):
+class TimeInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is
     required when the object is used as a mixin column within a table, but can
@@ -128,10 +128,10 @@ class TimeInfo(DataInfo):
         return None
 
     info_summary_stats = staticmethod(
-        data_info_factory(names=DataInfo._stats,
-                          funcs=[getattr(np, stat) for stat in DataInfo._stats]))
+        data_info_factory(names=MixinInfo._stats,
+                          funcs=[getattr(np, stat) for stat in MixinInfo._stats]))
     # When Time has mean, std, min, max methods:
-    # funcs = [lambda x: getattr(x, stat)() for stat_name in DataInfo._stats])
+    # funcs = [lambda x: getattr(x, stat)() for stat_name in MixinInfo._stats])
 
 class Time(object):
     """

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -754,7 +754,7 @@ class Time(object):
         # Copy other 'info' attr only if it has actually been defined.
         # See PR #3898 for further explanation and justification, along
         # with Quantity.__array_finalize__
-        if 'info' in getattr(self, '__dict__', ()):
+        if 'info' in self.__dict__:
             tm.info = self.info
 
         # Make the new internal _time object corresponding to the format
@@ -806,7 +806,7 @@ class Time(object):
                     continue
 
         # Copy other 'info' attr only if it has actually been defined.
-        if 'info' in getattr(self, '__dict__', ()):
+        if 'info' in self.__dict__:
             tm.info = self.info
 
         return tm

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -744,7 +744,7 @@ class Time(object):
 
             setattr(tm, attr, val)
 
-        for attr in ('precision', 'in_subfmt', 'out_subfmt'):
+        for attr in ('precision', 'in_subfmt', 'out_subfmt', 'info'):
             val = getattr(self, attr)
             if method in ('copy', 'flatten') and hasattr(val, 'copy'):
                 val = val.copy()

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -274,8 +274,10 @@ class Quantity(np.ndarray):
 
     def __array_finalize__(self, obj):
         self._unit = getattr(obj, '_unit', None)
-        if hasattr(obj, 'info'):
-            self.info = obj.info.copy()
+
+        # Copy info (except for a scalar output for performance reasons)
+        if self.ndim > 0 and hasattr(obj, 'info'):
+            self.info = obj.info
 
     def __array_prepare__(self, obj, context=None):
         # This method gets called by Numpy whenever a ufunc is called on the

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,7 +24,7 @@ from ..utils import lazyproperty
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.data_info import DataInfo, InfoDescriptor
+from ..utils.data_info import MixinInfo, InfoDescriptor
 from .utils import validate_power
 from .. import config as _config
 
@@ -115,7 +115,7 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityInfo(DataInfo):
+class QuantityInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is
     required when the object is used as a mixin column within a table, but can

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -280,7 +280,7 @@ class Quantity(np.ndarray):
         # works, `'info' in obj.__dict__` is False until the `info` attribute
         # is accessed or set.  Note that `obj` can be an ndarray which doesn't
         # have a `__dict__`.
-        if self.ndim > 0 and hasattr(obj, '__dict__') and 'info' in obj.__dict__:
+        if 'info' in getattr(obj, '__dict__', ()):
             self.info = obj.info
 
     def __array_prepare__(self, obj, context=None):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -275,8 +275,12 @@ class Quantity(np.ndarray):
     def __array_finalize__(self, obj):
         self._unit = getattr(obj, '_unit', None)
 
-        # Copy info (except for a scalar output for performance reasons)
-        if self.ndim > 0 and hasattr(obj, 'info'):
+        # Copy info (except for a scalar output for performance reasons) if the
+        # original had `info` defined.  Because of the way the InfoDescriptor
+        # works, `'info' in obj.__dict__` is False until the `info` attribute
+        # is accessed or set.  Note that `obj` can be an ndarray which doesn't
+        # have a `__dict__`.
+        if self.ndim > 0 and hasattr(obj, '__dict__') and 'info' in obj.__dict__:
             self.info = obj.info
 
     def __array_prepare__(self, obj, context=None):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -275,11 +275,10 @@ class Quantity(np.ndarray):
     def __array_finalize__(self, obj):
         self._unit = getattr(obj, '_unit', None)
 
-        # Copy info (except for a scalar output for performance reasons) if the
-        # original had `info` defined.  Because of the way the InfoDescriptor
-        # works, `'info' in obj.__dict__` is False until the `info` attribute
-        # is accessed or set.  Note that `obj` can be an ndarray which doesn't
-        # have a `__dict__`.
+        # Copy info if the original had `info` defined.  Because of the way the
+        # InfoDescriptor works, `'info' in obj.__dict__` is False until the
+        # `info` attribute is accessed or set.  Note that `obj` can be an
+        # ndarray which doesn't have a `__dict__`.
         if 'info' in getattr(obj, '__dict__', ()):
             self.info = obj.info
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -274,6 +274,8 @@ class Quantity(np.ndarray):
 
     def __array_finalize__(self, obj):
         self._unit = getattr(obj, '_unit', None)
+        if hasattr(obj, 'info'):
+            self.info = obj.info.copy()
 
     def __array_prepare__(self, obj, context=None):
         # This method gets called by Numpy whenever a ufunc is called on the

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -357,3 +357,15 @@ class DataInfo(object):
 class MixinInfo(DataInfo):
     attr_names = DataInfo.attr_names.union(['parent_table'])
     _attrs_no_copy = set(['parent_table'])
+
+    def iter_str_vals(self):
+        """
+        This is a mixin-safe version of Column.iter_str_vals.
+        """
+        from ..table.column import FORMATTER
+        col = self._parent_ref()
+        parent_table = self.parent_table
+        formatter = FORMATTER if parent_table is None else parent_table.formatter
+        _pformat_col_iter = formatter._pformat_col_iter
+        for str_val in _pformat_col_iter(col, -1, False, False, {}):
+            yield str_val

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -169,8 +169,8 @@ class DataInfo(object):
 
     _stats = ['mean', 'std', 'min', 'max']
     attrs_from_parent = set()
-    attr_names = set(['name', 'unit', 'dtype', 'format', 'description',
-                      'meta', 'parent_table'])
+    attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
+    _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
     _parent_ref = None
 
@@ -238,7 +238,7 @@ class DataInfo(object):
 
     def copy(self):
         out = self.__class__()
-        for attr in self.attr_names - self.attrs_from_parent:
+        for attr in self.attr_names - self.attrs_from_parent - self._attrs_no_copy:
             setattr(out, attr, deepcopy(getattr(self, attr)))
 
         return out
@@ -356,3 +356,8 @@ class DataInfo(object):
         out = six.moves.cStringIO()
         self.__call__(out=out)
         return out.getvalue()
+
+
+class MixinInfo(DataInfo):
+    attr_names = DataInfo.attr_names.union(['parent_table'])
+    _attrs_no_copy = set(['parent_table'])

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -155,7 +155,7 @@ class InfoDescriptor(object):
     def __get__(self, instance, owner_cls):
         if 'info' not in instance.__dict__:
             instance.__dict__['info'] = self.info_cls()
-        instance.__dict__['info']._parent_ref = weakref.ref(instance)
+        instance.__dict__['info']._parent = instance
         return instance.__dict__['info']
 
     def __set__(self, instance, value):
@@ -175,7 +175,7 @@ class DataInfo(object):
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
-    _parent_ref = None
+    _parent = None
 
     def __init__(self):
         self._attrs = dict((attr, None) for attr in self.attr_names)
@@ -191,7 +191,7 @@ class DataInfo(object):
             return super(DataInfo, self).__getattribute__(attr)
 
         if attr in self.attrs_from_parent:
-            return getattr(self._parent_ref(), attr)
+            return getattr(self._parent, attr)
 
         try:
             value = self._attrs[attr]
@@ -215,7 +215,7 @@ class DataInfo(object):
         # class property (getter/setter) for this attribute then set
         # attribute directly in parent.
         if attr in self.attrs_from_parent and not isinstance(propobj, property):
-            setattr(self._parent_ref(), attr, value)
+            setattr(self._parent, attr, value)
             return
 
         # Check if there is a property setter and use it if possible.
@@ -307,7 +307,7 @@ class DataInfo(object):
         if out == '':
             out = sys.stdout
 
-        dat = self._parent_ref()
+        dat = self._parent
         info = OrderedDict()
         name = dat.info.name
         if name is not None:
@@ -363,7 +363,7 @@ class MixinInfo(DataInfo):
         This is a mixin-safe version of Column.iter_str_vals.
         """
         from ..table.column import FORMATTER
-        col = self._parent_ref()
+        col = self._parent
         parent_table = self.parent_table
         formatter = FORMATTER if parent_table is None else parent_table.formatter
         _pformat_col_iter = formatter._pformat_col_iter

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -239,13 +239,6 @@ class DataInfo(object):
 
         self._attrs[attr] = value
 
-    def copy(self):
-        out = self.__class__()
-        for attr in self.attr_names - self.attrs_from_parent - self._attrs_no_copy:
-            setattr(out, attr, deepcopy(getattr(self, attr)))
-
-        return out
-
     info_summary_attributes = staticmethod(
         data_info_factory(names=_info_summary_attrs,
                           funcs=[partial(_get_data_attribute, attr=attr)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -160,7 +160,10 @@ class InfoDescriptor(object):
 
     def __set__(self, instance, value):
         if isinstance(value, DataInfo):
-            instance.__dict__['info'] = value
+            info = instance.__dict__['info'] = self.info_cls()
+            for attr in info.attr_names - info.attrs_from_parent - info._attrs_no_copy:
+                setattr(info, attr, deepcopy(getattr(value, attr)))
+
         else:
             raise TypeError('info must be set with a DataInfo instance')
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -372,10 +372,12 @@ class BaseColumnInfo(DataInfo):
         """
         This is a mixin-safe version of Column.iter_str_vals.
         """
-        from ..table.column import FORMATTER
         col = self._parent
-        parent_table = self.parent_table
-        formatter = FORMATTER if parent_table is None else parent_table.formatter
+        if self.parent_table is None:
+            from ..table.column import FORMATTER as formatter
+        else:
+            formatter = self.parent_table.formatter
+
         _pformat_col_iter = formatter._pformat_col_iter
         for str_val in _pformat_col_iter(col, -1, False, False, {}):
             yield str_val

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -162,7 +162,7 @@ class InfoDescriptor(object):
         if isinstance(value, DataInfo):
             info = instance.__dict__['info'] = self.info_cls()
             for attr in info.attr_names - info.attrs_from_parent - info._attrs_no_copy:
-                setattr(info, attr, deepcopy(getattr(value, attr)))
+                info._attrs[attr] = deepcopy(getattr(value, attr))
 
         else:
             raise TypeError('info must be set with a DataInfo instance')

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -354,7 +354,17 @@ class DataInfo(object):
         return out.getvalue()
 
 
-class MixinInfo(DataInfo):
+class BaseColumnInfo(DataInfo):
+    """
+    Base info class for anything that can be a column in an astropy
+    Table.  There are at least two classes that inherit from this:
+
+      ColumnInfo: for native astropy Column / MaskedColumn objects
+      MixinInfo: for mixin column objects
+
+    Note that this class is defined here so that mixins can use it
+    without importing the table package.
+    """
     attr_names = DataInfo.attr_names.union(['parent_table'])
     _attrs_no_copy = set(['parent_table'])
 
@@ -369,3 +379,6 @@ class MixinInfo(DataInfo):
         _pformat_col_iter = formatter._pformat_col_iter
         for str_val in _pformat_col_iter(col, -1, False, False, {}):
             yield str_val
+
+class MixinInfo(BaseColumnInfo):
+    pass


### PR DESCRIPTION
The addition of mixin columns came at the price of some ugly functions in column.py like _col_copy_attrs_from etc.  This cleans up all that cruft (with the exception of `col_copy`).

It also takes the liberty of making our three built-in mixin columns work just a bit better by insisting that things like getitem, pickle, copy, and initialization all propagate `info` correctly.  This imposes additional requirements on mixin classes, but I think we are moving in that direction anyway (making things work better at the expense of more burden on mixin classes).

It also tries to clarify/simplify some of the confusing logic about adding columns to tables.

There are a lot of smallish commits because I was making sure tests pass for each idea so as not to get totally screwed up at some point.