### PR TITLE
Checksum inconsistent when BITPIX changes (io.fits)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -434,6 +434,10 @@ Bug Fixes
   - Fixed crash when updating data in a random groups HDU opened in update
     mode. [#3730]
 
+  - Fixed incorrect checksum / datasum being written when re-writing a scaled
+    HDU (i.e. non-trivial BSCALE and/or BZERO) with
+    ``do_not_scale_image_data=False``. [#3883]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -488,8 +488,11 @@ class _ImageBaseHDU(_ValidHDU):
             self.scale(self.NumCode[self._orig_bitpix])
 
         self.update_header()
-        if not inplace and not self._has_data:
-            self._update_header_scale_info()
+        if not inplace and self._data_needs_rescale:
+            # Go ahead and load the scaled image data and update the header
+            # with the correct post-rescaling headers
+            _ = self.data
+
         return super(_ImageBaseHDU, self)._prewriteto(checksum, inplace)
 
     def _writedata_internal(self, fileobj):

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -99,12 +99,12 @@ class TestChecksumFunctions(FitsTestCase):
 
         # Reopen the new file and save it back again with a checksum
         with fits.open(self.temp('rescaled.fits')) as hdul:
-            hdul.writeto(self.temp('rescaled.fits'), clobber=True,
+            hdul.writeto(self.temp('rescaled2.fits'), clobber=True,
                          checksum=True)
 
         # Now do like in the first writeto but use checksum immediately
         with fits.open(self.data('scale.fits')) as hdul:
-            hdul.writeto(self.temp('rescaled2.fits'), checksum=True)
+            hdul.writeto(self.temp('rescaled3.fits'), checksum=True)
 
         # Also don't rescale the data but add a checksum
         with fits.open(self.data('scale.fits'),
@@ -113,8 +113,8 @@ class TestChecksumFunctions(FitsTestCase):
 
         # Must used nested with statements to support older Python versions
         # (but contextlib.nested is not available in newer Pythons :(
-        with fits.open(self.temp('rescaled.fits')) as hdul1:
-            with fits.open(self.temp('rescaled2.fits')) as hdul2:
+        with fits.open(self.temp('rescaled2.fits')) as hdul1:
+            with fits.open(self.temp('rescaled3.fits')) as hdul2:
                 with fits.open(self.temp('scaled.fits')) as hdul3:
                     hdr1 = hdul1[0].header
                     hdr2 = hdul2[0].header

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
+import contextlib
 import sys
 import warnings
-import sys
 
 import numpy as np
 
@@ -83,11 +83,52 @@ class TestChecksumFunctions(FitsTestCase):
                 assert 'DATASUM' in hdul1[0].header
                 assert hdul1[0].header['DATASUM'] == '1891563534'
 
+    def test_scaled_data_auto_rescale(self):
+        """
+        Regression test for
+        https://github.com/astropy/astropy/issues/3883#issuecomment-115122647
+
+        Ensure that when scaled data is automatically rescaled on
+        opening/writing a file that the checksum and datasum are computed for
+        the rescaled array.
+        """
+
+        with fits.open(self.data('scale.fits')) as hdul:
+            # Write out a copy of the data with the rescaling applied
+            hdul.writeto(self.temp('rescaled.fits'))
+
+        # Reopen the new file and save it back again with a checksum
+        with fits.open(self.temp('rescaled.fits')) as hdul:
+            hdul.writeto(self.temp('rescaled.fits'), clobber=True,
+                         checksum=True)
+
+        # Now do like in the first writeto but use checksum immediately
+        with fits.open(self.data('scale.fits')) as hdul:
+            hdul.writeto(self.temp('rescaled2.fits'), checksum=True)
+
+        # Also don't rescale the data but add a checksum
+        with fits.open(self.data('scale.fits'),
+                       do_not_scale_image_data=True) as hdul:
+            hdul.writeto(self.temp('scaled.fits'), checksum=True)
+
+        # Must used nested with statements to support older Python versions
+        # (but contextlib.nested is not available in newer Pythons :(
+        with fits.open(self.temp('rescaled.fits')) as hdul1:
+            with fits.open(self.temp('rescaled2.fits')) as hdul2:
+                with fits.open(self.temp('scaled.fits')) as hdul3:
+                    hdr1 = hdul1[0].header
+                    hdr2 = hdul2[0].header
+                    hdr3 = hdul3[0].header
+                    assert hdr1['DATASUM'] == hdr2['DATASUM']
+                    assert hdr1['CHECKSUM'] == hdr2['CHECKSUM']
+                    assert hdr1['DATASUM'] != hdr3['DATASUM']
+                    assert hdr1['CHECKSUM'] != hdr3['CHECKSUM']
+
     def test_uint16_data(self):
         checksums = [
-            ('aDcXaCcXaCcXaCcX', '0'), ('84DJ83CH83CH83CH', '1746888714'),
+            ('aDcXaCcXaCcXaCcX', '0'), ('oYiGqXi9oXiEoXi9', '1746888714'),
             ('VhqQWZoQVfoQVZoQ', '0'), ('4cPp5aOn4aOn4aOn', '0'),
-            ('97ZYI7WV97WVG7WV', '1756785133'), ('UhqdUZnbUfnbUZnb', '0'),
+            ('8aCN8X9N8aAN8W9N', '1756785133'), ('UhqdUZnbUfnbUZnb', '0'),
             ('4cQJ5aN94aNG4aN9', '0')]
         with fits.open(self.data('o4sp040b0_raw.fits'), uint=True) as hdul:
             hdul.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)


### PR DESCRIPTION
The checksum being calculated for a fits file I am testing is inconsistent. For example with a fits file test.fits which does not have a checksum:

``` 
$ fitscheck -f -w -i test.fits
$ fitscheck test.fits
BAD 'test.fits' .. verification failed for HDU ('PRIMARY', 1).
1 errors
```

The problem seems to come from the fact that the datasum is calculated differently before and after the image data is loaded.

```
>>> from astropy.io import fits
>>> hdu = fits.open('test.fits')
>>> hdu[0]._calculate_datasum('standard')
3044153422
>>> data = hdu[0].data
>>> hdu[0]._calculate_datasum('standard')
2977440024
```

This fits file has an original BITPIX of 16 and once updated by writeto has a BITPIX of -32 but the checksum is being calculated using the original data.  I am surprised that BITPIX is changing as I thought the image data would just be directly copied if the data is not loaded. But it seems the data is loaded in the writeto mehod and thus changed to -32.

```
>>> from astropy.io import fits
>>> hdu = fits.open('test.fits')
>>> hdulist[0]._data_loaded
False
>>> hdulist.writeto('test2.fits', clobber=True)
>>> hdulist[0]._data_loaded
True
```

I think the probable solution, if the data is going to be changed to a float on writeto, is changing the order of the checksum calculations to make sure it is calculated on the -32 data. I.e. this works with out problems:

```
>>> hdulist = fits.open('test_org.fits')
>>> data = hdulist[0].data
>>> hdulist.writeto('test.fits', clobber=True, checksum=True)

$ fitscheck test.fits
$
```

 I have put the test fits file for this here: https://www.dropbox.com/s/mkvuohp7e2nhpe0/test_org.fits?dl=0 
Cheers, Neiil