### PR TITLE
Initial attempt to get tests to work with pytest 2.3.5

### DIFF
--- a/astropy/analytic_functions/tests/test_blackbody.py
+++ b/astropy/analytic_functions/tests/test_blackbody.py
@@ -24,7 +24,7 @@ else:
 __doctest_skip__ = ['*']
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
+@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_blackbody_scipy():
     """Test Planck function.
@@ -45,7 +45,7 @@ def test_blackbody_scipy():
     np.testing.assert_allclose(intflux, ans.value, rtol=0.01)  # 1% accuracy
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
+@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
 def test_blackbody_overflow():
     """Test Planck function with overflow."""
     photlam = u.photon / (u.cm**2 * u.s * u.AA)
@@ -67,7 +67,7 @@ def test_blackbody_overflow():
     assert flux.value == 0
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
+@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
 def test_blackbody_synphot():
     """Test that it is consistent with IRAF SYNPHOT BBFUNC."""
     # Solid angle of solar radius at 1 kpc

--- a/astropy/constants/tests/test_pickle.py
+++ b/astropy/constants/tests/test_pickle.py
@@ -10,7 +10,7 @@ originals = [const.Constant('h_fake', 'Not Planck',
              const.e]
 xfails = [True, True, True]
 
-@pytest.mark.parametrize("original,xfail", zip(originals, xfails))
+@pytest.mark.parametrize(("original","xfail"), zip(originals, xfails))
 def test_new_constant(pickle_protocol, original, xfail):
     if xfail:
         pytest.xfail()

--- a/astropy/convolution/tests/test_pickle.py
+++ b/astropy/convolution/tests/test_pickle.py
@@ -5,7 +5,7 @@ from ...extern.six.moves import cPickle
 from ... import convolution as conv
 from ...tests.helper import pytest, pickle_protocol, check_pickling_recovery
 
-@pytest.mark.parametrize("name,args,kwargs,xfail",
+@pytest.mark.parametrize(("name","args","kwargs","xfail"),
                          [(conv.CustomKernel, [],
                            {'array':np.random.rand(15)},
                            False),

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -61,7 +61,7 @@ _kwargs = [{'unit':'radian'},
            ]
 
 
-@pytest.mark.parametrize("name,args,kwargs,xfail",
+@pytest.mark.parametrize(("name","args","kwargs","xfail"),
                          zip(_names, _args, _kwargs, _xfail))
 def test_simple_object(pickle_protocol, name, args, kwargs, xfail):
     # Tests easily instantiated objects

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -631,7 +631,7 @@ units_attr_args = ('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','a
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         (x for x in units_attr_sets if x[0] != 'unitspherical'))
+                         list(x for x in units_attr_sets if x[0] != 'unitspherical'))
 def test_skycoord_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3,
                                    representation, c1, c2, c3):
     """
@@ -663,7 +663,7 @@ def test_skycoord_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, 
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         (x for x in units_attr_sets
+                         list(x for x in units_attr_sets
                           if x[0] in ('spherical', 'unitspherical')))
 def test_skycoord_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
                                            attr1, attr2, attr3, representation, c1, c2, c3):
@@ -690,7 +690,7 @@ def test_skycoord_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         (x for x in units_attr_sets if x[0] != 'unitspherical'))
+                         list(x for x in units_attr_sets if x[0] != 'unitspherical'))
 def test_galactic_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3,
                                    representation, c1, c2, c3):
     """
@@ -715,7 +715,7 @@ def test_galactic_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, 
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         (x for x in units_attr_sets
+                         list(x for x in units_attr_sets
                           if x[0] in ('spherical', 'unitspherical')))
 def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
                                            attr1, attr2, attr3, representation, c1, c2, c3):
@@ -736,7 +736,7 @@ def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
 
 
 @pytest.mark.parametrize(('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','attr3'),
-                         (x for x in base_unit_attr_sets if x[0] != 'unitspherical'))
+                         list(x for x in base_unit_attr_sets if x[0] != 'unitspherical'))
 def test_skycoord_coordinate_input(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3):
     c1, c2, c3 = 1, 2, 3
     sc = SkyCoord([(c1, c2, c3)], unit=(unit1, unit2, unit3), representation=repr_name,

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -71,10 +71,10 @@ for rt_frame0 in rt_frames:
                 for obstime0 in (None, 'J1980.0'):
                     for equinox1 in (None, 'J1975.0'):
                         for obstime1 in (None, 'J1980.0'):
-                            rt_sets.append([rt_frame0, rt_frame1,
+                            rt_sets.append((rt_frame0, rt_frame1,
                                             equinox0, equinox1,
-                                            obstime0, obstime1])
-rt_args = 'frame0,frame1,equinox0,equinox1,obstime0,obstime1'
+                                            obstime0, obstime1))
+rt_args = ('frame0','frame1','equinox0','equinox1','obstime0','obstime1')
 
 
 @pytest.mark.parametrize(rt_args, rt_sets)
@@ -627,7 +627,7 @@ for base_unit_attr_set in base_unit_attr_sets:
                     c2 = np.array(c2)
                     c3 = np.array(c3)
                 units_attr_sets.append(base_unit_attr_set + (representation, c1, c2, c3))
-units_attr_args = 'repr_name,unit1,unit2,unit3,cls2,attr1,attr2,attr3,representation,c1,c2,c3'
+units_attr_args = ('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','attr3','representation','c1','c2','c3')
 
 
 @pytest.mark.parametrize(units_attr_args,
@@ -735,7 +735,7 @@ def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2), (attr1, attr2))
 
 
-@pytest.mark.parametrize('repr_name,unit1,unit2,unit3,cls2,attr1,attr2,attr3',
+@pytest.mark.parametrize(('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','attr3'),
                          (x for x in base_unit_attr_sets if x[0] != 'unitspherical'))
 def test_skycoord_coordinate_input(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3):
     c1, c2, c3 = 1, 2, 3
@@ -798,7 +798,7 @@ def test_nodata_failure():
         SkyCoord()
 
 
-@pytest.mark.parametrize('mode, origin', [('wcs', 0),
+@pytest.mark.parametrize(('mode', 'origin'), [('wcs', 0),
                                           ('all', 0),
                                           ('all', 1)])
 def test_wcs_methods(mode, origin):

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -631,7 +631,7 @@ units_attr_args = ('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','a
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         list(x for x in units_attr_sets if x[0] != 'unitspherical'))
+                         [x for x in units_attr_sets if x[0] != 'unitspherical'])
 def test_skycoord_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3,
                                    representation, c1, c2, c3):
     """
@@ -663,8 +663,8 @@ def test_skycoord_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, 
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         list(x for x in units_attr_sets
-                          if x[0] in ('spherical', 'unitspherical')))
+                         [x for x in units_attr_sets
+                          if x[0] in ('spherical', 'unitspherical')])
 def test_skycoord_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
                                            attr1, attr2, attr3, representation, c1, c2, c3):
     """
@@ -690,7 +690,7 @@ def test_skycoord_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         list(x for x in units_attr_sets if x[0] != 'unitspherical'))
+                         [x for x in units_attr_sets if x[0] != 'unitspherical'])
 def test_galactic_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3,
                                    representation, c1, c2, c3):
     """
@@ -715,8 +715,8 @@ def test_galactic_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, 
 
 
 @pytest.mark.parametrize(units_attr_args,
-                         list(x for x in units_attr_sets
-                          if x[0] in ('spherical', 'unitspherical')))
+                         [x for x in units_attr_sets
+                          if x[0] in ('spherical', 'unitspherical')])
 def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
                                            attr1, attr2, attr3, representation, c1, c2, c3):
     """
@@ -736,7 +736,7 @@ def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
 
 
 @pytest.mark.parametrize(('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','attr3'),
-                         list(x for x in base_unit_attr_sets if x[0] != 'unitspherical'))
+                         [x for x in base_unit_attr_sets if x[0] != 'unitspherical'])
 def test_skycoord_coordinate_input(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3):
     c1, c2, c3 = 1, 2, 3
     sc = SkyCoord([(c1, c2, c3)], unit=(unit1, unit2, unit3), representation=repr_name,

--- a/astropy/cosmology/tests/test_pickle.py
+++ b/astropy/cosmology/tests/test_pickle.py
@@ -10,7 +10,7 @@ from ... import cosmology as cosm
 originals = [cosm.FLRW]
 xfails = [False]
 
-@pytest.mark.parametrize("original,xfail",
+@pytest.mark.parametrize(("original","xfail"),
                          zip(originals, xfails))
 def test_flrw(pickle_protocol, original, xfail):
     if xfail:

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -24,7 +24,7 @@ class TestUintFunctions(FitsTestCase):
     @pytest.mark.parametrize(('utype','compressed'),
         [('u2', False), ('u4', False), ('u8', False), ('u2', True),
          ('u4',True)]) #,('u8',True)])
-    @pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
+    @pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
     def test_uint(self, utype, compressed):
         bits = 8*int(utype[1])
         if platform.architecture()[0] == '64bit' or bits != 64:

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -120,7 +120,7 @@ def test_read_write_simple(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_H5PY')
-@pytest.mark.skipif(os.environ.get('APPVEYOR'), reason="fails on AppVeyor")
+@pytest.mark.skipif("os.environ.get('APPVEYOR')", reason="fails on AppVeyor")
 def test_read_write_existing_table(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
     t1 = Table()
@@ -193,7 +193,7 @@ def test_read_write_existing_append_groups(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_H5PY')
-@pytest.mark.skipif(os.environ.get('APPVEYOR'), reason="fails on AppVeyor")
+@pytest.mark.skipif("os.environ.get('APPVEYOR')", reason="fails on AppVeyor")
 def test_read_write_existing_append_overwrite(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
     t1 = Table()

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -437,7 +437,7 @@ class TestParameterInitialization(object):
         assert np.all(t.param_sets[1] == [[1, 2, 3]])
         assert np.all(t.parameters == [10, 20, 30, 40, 50, 60, 1, 2, 3])
 
-    @pytest.mark.parametrize('p1, p2', [
+    @pytest.mark.parametrize(('p1', 'p2'), [
         (1, 2), (1, [2, 3]), ([1, 2], 3), ([1, 2, 3], [4, 5]),
         ([1, 2], [3, 4, 5])])
     def test_two_model_incorrect_scalar_parameters(self, p1, p2):

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -99,7 +99,7 @@ class TestFitting(object):
     # could probably factor out
 
     @pytest.mark.parametrize(('model_class','constraints'),
-                             product(linear1d.keys(), (False, True)))
+                             list(product(linear1d.keys(), (False, True))))
     def test_linear_fitter_1D(self, model_class, constraints):
         """Test fitting with LinearLSQFitter"""
 
@@ -129,7 +129,7 @@ class TestFitting(object):
                             atol=0.2)
 
     @pytest.mark.parametrize(('model_class','constraints'),
-                             product(linear1d.keys(), (False, True)))
+                             list(product(linear1d.keys(), (False, True))))
     def test_non_linear_fitter_1D(self, model_class, constraints):
         """Test fitting with non-linear LevMarLSQFitter"""
 
@@ -157,7 +157,7 @@ class TestFitting(object):
                             atol=0.2)
 
     @pytest.mark.parametrize(('model_class','constraints'),
-                             product(linear2d.keys(), (False, True)))
+                             list(product(linear2d.keys(), (False, True))))
     def test_linear_fitter_2D(self, model_class, constraints):
         """Test fitting with LinearLSQFitter"""
 
@@ -184,8 +184,8 @@ class TestFitting(object):
             assert_allclose(model_lin.parameters, model.parameters,
                             atol=0.2)
 
-    @pytest.mark.parametrize('model_class,constraints',
-                             product(linear2d.keys(), (False, True)))
+    @pytest.mark.parametrize(('model_class','constraints'),
+                             list(product(linear2d.keys(), (False, True))))
     def test_non_linear_fitter_2D(self, model_class, constraints):
         """Test fitting with non-linear LevMarLSQFitter"""
 

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -98,7 +98,7 @@ class TestFitting(object):
     # TODO: Most of these test cases have some pretty repetitive setup that we
     # could probably factor out
 
-    @pytest.mark.parametrize('model_class,constraints',
+    @pytest.mark.parametrize(('model_class','constraints'),
                              product(linear1d.keys(), (False, True)))
     def test_linear_fitter_1D(self, model_class, constraints):
         """Test fitting with LinearLSQFitter"""
@@ -128,7 +128,7 @@ class TestFitting(object):
             assert_allclose(model_lin.parameters, model.parameters,
                             atol=0.2)
 
-    @pytest.mark.parametrize('model_class,constraints',
+    @pytest.mark.parametrize(('model_class','constraints'),
                              product(linear1d.keys(), (False, True)))
     def test_non_linear_fitter_1D(self, model_class, constraints):
         """Test fitting with non-linear LevMarLSQFitter"""
@@ -156,7 +156,7 @@ class TestFitting(object):
             assert_allclose(model_nlin.parameters, model.parameters,
                             atol=0.2)
 
-    @pytest.mark.parametrize('model_class,constraints',
+    @pytest.mark.parametrize(('model_class','constraints'),
                              product(linear2d.keys(), (False, True)))
     def test_linear_fitter_2D(self, model_class, constraints):
         """Test fitting with LinearLSQFitter"""

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -328,7 +328,7 @@ def test_nddata_subtract_uncertainties_mismatch():
                                  'type FakeUncertainty for subtraction')
 
 
-@pytest.mark.parametrize('op1_unc,op2_unc', [
+@pytest.mark.parametrize(('op1_unc','op2_unc'), [
                          (None, None),
                          (StdDevUncertainty([1]), None),
                          (None, StdDevUncertainty([1])),
@@ -362,7 +362,7 @@ def test_arithmetic_result_not_tied_to_operands_uncertainty(op1_unc, op2_unc):
     assert op2.data[0] == 1
 
 
-@pytest.mark.parametrize('op1_mask,op2_mask', [
+@pytest.mark.parametrize(('op1_mask','op2_mask'), [
                          (None, None),
                          (None, np.array([False])),
                          (np.array([False]), None),
@@ -399,7 +399,7 @@ def test_arithmetic_result_not_tied_to_operands_wcs():
 
 
 # first operand has unit km, second has unit m
-@pytest.mark.parametrize('operation,result_unit', [
+@pytest.mark.parametrize(('operation','result_unit'), [
                          ('add', u.km),
                          ('subtract', u.km),
                          ('multiply', u.km * u.m),
@@ -422,7 +422,7 @@ def test_uncertainty_unit_conversion_add_subtract(operation, result_unit):
             np.sqrt(2) * in_km.uncertainty.array * combined.data)
 
 
-@pytest.mark.parametrize('unit1,unit2,op,result_unit', [
+@pytest.mark.parametrize(('unit1','unit2','op','result_unit'), [
                          (None, None, 'add', None),
                          (None, None, 'multiply', None),
                          (None, u.m, 'multiply', u.m),

--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -47,7 +47,7 @@ def test_setitem_invalid_type(value):
     assert exc.value.args[0] == 'flags should be given as a Numpy array'
 
 
-@pytest.mark.skipif(os.environ.get('APPVEYOR'),  reason="fails on AppVeyor")
+@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
 def test_setitem_invalid_shape():
     f = FlagCollection(shape=(1, 2, 3))
     with pytest.raises(ValueError) as exc:

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -190,7 +190,7 @@ def test_progress_bar_as_generator():
         sum += x
     assert sum == 1225
 
-@pytest.mark.parametrize("seconds,string",
+@pytest.mark.parametrize(("seconds","string"),
        [(864088," 1w 3d"),
        (187213, " 2d 4h"),
        (3905,   " 1h 5m"),
@@ -202,7 +202,7 @@ def test_human_time(seconds, string):
     human_time = console.human_time(seconds)
     assert human_time == string
 
-@pytest.mark.parametrize("size,string",
+@pytest.mark.parametrize(("size","string"),
        [(8640882,"8.6M"),
        (187213, "187k"),
        (3905,   "3.9k"),


### PR DESCRIPTION
I'm trying to package up astropy 1.0.3 for EPEL 7.  RHEL7 has pytest 2.3.5, so various tests fail due to using 2.4 syntax in some places.  This is an attempt to fix those to use 2.3 compatible syntax.  However, I am still getting a couple errors that I am unable to figure out:

~~~~~
==================================== ERRORS ====================================
__________ ERROR collecting astropy/modeling/tests/test_polynomial.py __________
/usr/lib/python2.7/site-packages/_pytest/runner.py:129: in __init__
>               self.result = func()
/usr/lib/python2.7/site-packages/_pytest/main.py:368: in _memocollect
>       return self._memoizedcall('_collected', lambda: list(self.collect()))
/usr/lib/python2.7/site-packages/_pytest/main.py:289: in _memoizedcall
>           res = function()
/usr/lib/python2.7/site-packages/_pytest/main.py:368: in <lambda>
>   return self._memoizedcall('_collected', lambda: list(self.collect()))
/usr/lib/python2.7/site-packages/_pytest/python.py:425: in collect
>       return super(Instance, self).collect()
/usr/lib/python2.7/site-packages/_pytest/python.py:280: in collect
>               res = self.makeitem(name, obj)
/usr/lib/python2.7/site-packages/_pytest/python.py:292: in makeitem
>           collector=self, name=name, obj=obj)
/usr/lib/python2.7/site-packages/_pytest/main.py:159: in call_matching_hooks
>       return hookmethod.pcall(plugins, **kwargs)
/usr/lib/python2.7/site-packages/_pytest/core.py:445: in pcall
>       return self._docall(methods, kwargs)
/usr/lib/python2.7/site-packages/_pytest/core.py:452: in _docall
>           res = mc.execute()
/usr/lib/python2.7/site-packages/_pytest/core.py:370: in execute
>           res = method(**kwargs)
/usr/lib/python2.7/site-packages/_pytest/python.py:185: in pytest_pycollect_makeitem
>               return list(collector._genfunctions(name, obj))
/usr/lib/python2.7/site-packages/_pytest/python.py:308: in _genfunctions
>       gentesthook.pcall(plugins, metafunc=metafunc)
/usr/lib/python2.7/site-packages/_pytest/core.py:445: in pcall
>       return self._docall(methods, kwargs)
/usr/lib/python2.7/site-packages/_pytest/core.py:452: in _docall
>           res = mc.execute()
/usr/lib/python2.7/site-packages/_pytest/core.py:370: in execute
>           res = method(**kwargs)
/usr/lib/python2.7/site-packages/_pytest/python.py:105: in pytest_generate_tests
>           metafunc.parametrize(*marker.args, **marker.kwargs)
/usr/lib/python2.7/site-packages/_pytest/python.py:684: in parametrize
>                                    self.function, arg))
E                   ValueError: <function test_non_linear_fitter_2D at 0x809d2a8> uses no fixture u'model_class,constraints'
_______________ ERROR at setup of test_skycoord_three_components _______________
file /builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py, line 633
  @pytest.mark.parametrize(units_attr_args,
                           (x for x in units_attr_sets if x[0] != 'unitspherical'))
  def test_skycoord_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3,
        fixture 'repr_name' not found
        available fixtures: pytestconfig, tmpdir, recwarn, monkeypatch, capfd, capsys
        use 'py.test --fixtures [testpath]' for help on them.

/builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py:633
___________ ERROR at setup of test_skycoord_spherical_two_components ___________
file /builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py, line 665
  @pytest.mark.parametrize(units_attr_args,
                           (x for x in units_attr_sets
                            if x[0] in ('spherical', 'unitspherical')))
  def test_skycoord_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
        fixture 'repr_name' not found
        available fixtures: pytestconfig, tmpdir, recwarn, monkeypatch, capfd, capsys
        use 'py.test --fixtures [testpath]' for help on them.

/builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py:665
_______________ ERROR at setup of test_galactic_three_components _______________
file /builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py, line 692
  @pytest.mark.parametrize(units_attr_args,
                           (x for x in units_attr_sets if x[0] != 'unitspherical'))
  def test_galactic_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3,
        fixture 'repr_name' not found
        available fixtures: pytestconfig, tmpdir, recwarn, monkeypatch, capfd, capsys
        use 'py.test --fixtures [testpath]' for help on them.

/builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py:692
___________ ERROR at setup of test_galactic_spherical_two_components ___________
file /builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py, line 717
  @pytest.mark.parametrize(units_attr_args,
                           (x for x in units_attr_sets
                            if x[0] in ('spherical', 'unitspherical')))
  def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
        fixture 'repr_name' not found
        available fixtures: pytestconfig, tmpdir, recwarn, monkeypatch, capfd, capsys
        use 'py.test --fixtures [testpath]' for help on them.

/builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py:717
_______________ ERROR at setup of test_skycoord_coordinate_input _______________
file /builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py, line 738
  @pytest.mark.parametrize(('repr_name','unit1','unit2','unit3','cls2','attr1','attr2','attr3'),
                           (x for x in base_unit_attr_sets if x[0] != 'unitspherical'))
  def test_skycoord_coordinate_input(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3):
        fixture 'repr_name' not found
        available fixtures: pytestconfig, tmpdir, recwarn, monkeypatch, capfd, capsys
        use 'py.test --fixtures [testpath]' for help on them.

/builddir/build/BUILDROOT/python-astropy-1.0.3-1.el7.x86_64/usr/lib64/python2.7/site-packages/astropy/coordinates/tests/test_sky_coord.py:738
~~~~~
These seem to be caused by incorrect syntax to parametrize(), but I've been unable to figure out what.