### PR TITLE
Add default value for Ellipse2D model theta parameter.

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -678,7 +678,7 @@ class Ellipse2D(Fittable2DModel):
     b : float
         The length of the semiminor axis.
 
-    theta : float, optional
+    theta : float
         The rotation angle in radians of the semimajor axis.  The
         rotation angle increases counterclockwise from the positive x
         axis.
@@ -727,11 +727,11 @@ class Ellipse2D(Fittable2DModel):
         plt.show()
     """
 
-    amplitude = Parameter()
-    x_0 = Parameter()
-    y_0 = Parameter()
-    a = Parameter()
-    b = Parameter()
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    a = Parameter(default=1)
+    b = Parameter(default=1)
     theta = Parameter(default=0)
 
     @staticmethod

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -732,7 +732,7 @@ class Ellipse2D(Fittable2DModel):
     y_0 = Parameter()
     a = Parameter()
     b = Parameter()
-    theta = Parameter()
+    theta = Parameter(default=0)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, a, b, theta):


### PR DESCRIPTION
The Ellipse2D model parameter `theta` is optional in the docstring but no default is set. I think it makes sense to be optional, so I set `default=0` rather than editing the doc. 