### PR TITLE
Problem with BLANK keyword in FITS file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -490,6 +490,13 @@ Bug Fixes
 
   - Fixed stray deprecation warning in ``BinTableHDU.copy()``. [#3789]
 
+  - Better handling of the ``BLANK`` keyword when auto-scaling scaled image
+    data.  The ``BLANK`` keyword is now removed from the header after
+    auto-scaling is applied, and it is restored properly (with floating
+    point NaNs replaced by the filler value) when updating a file opened with
+    the ``scale_back=True`` argument.  Invalid usage of the ``BLANK`` keyword
+    is also better warned about during validation. [#3865]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -448,7 +448,7 @@ class _ImageBaseHDU(_ValidHDU):
                 pass
 
         if _scale and _scale != 1:
-            self.data /= _scale
+            self.data = self.data / _scale
             self._header['BSCALE'] = _scale
         else:
             try:


### PR DESCRIPTION
@embray, cc @eso-panda

This FITS file causes problems:
```
In [50]: f = fits.open('fred.fits')

In [51]: f.writeto('test.fits', clobber=True)
Traceback (most recent call last):
  File "<ipython-input-51-6f852bc3c99a>", line 1, in <module>
    f.writeto('test.fits', clobber=True)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/hdulist.py", line 682, in writeto
    hdu._writeto(hdulist._file)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/base.py", line 698, in _writeto
    data_offset, data_size = self._writedata(fileobj)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/base.py", line 634, in _writedata
    if self.data is not None:
  File "/Users/adam/repos/astropy/astropy/utils/decorators.py", line 341, in __get__
    val = self._fget(obj)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/image.py", line 239, in data
    data = self._get_scaled_image_data(self._data_offset, self.shape)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/image.py", line 642, in _get_scaled_image_data
    data.flat[blanks] = np.nan
UnboundLocalError: local variable 'blanks' referenced before assignment
```

It has a header keyword:
```
BLANK   = -9223372036854775808
```

Beyond that, let me know if there's more you need - the data are proprietary but @eso-panda is probably willing to send it on privately if needed.