### PR TITLE
BinTableHDU.copy generates AstropyDeprecationWarning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -476,6 +476,8 @@ Bug Fixes
     HDU (i.e. non-trivial BSCALE and/or BZERO) with
     ``do_not_scale_image_data=False``. [#3883]
 
+  - Fixed stray deprecation warning in ``BinTableHDU.copy()``. [#3789]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -869,13 +869,6 @@ class FITS_rec(np.recarray):
 
         return field
 
-    def _clone(self, shape):
-        """
-        Overload this to make mask array indexing work properly.
-        """
-
-        return self.copy()
-
     def _get_heap_data(self):
         """
         Returns a pointer into the table's raw data to its heap (if present).

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -874,10 +874,7 @@ class FITS_rec(np.recarray):
         Overload this to make mask array indexing work properly.
         """
 
-        from .hdu.table import new_table
-
-        hdu = new_table(self._coldefs, nrows=shape[0])
-        return hdu.data
+        return self.copy()
 
     def _get_heap_data(self):
         """

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -492,8 +492,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
 
         # touch the data, so it's defined (in the case of reading from a
         # FITS file)
-        self.data
-        return new_table(self.columns, header=self._header)
+        return self.__class__(data=self.data.copy(),
+                              header=self._header.copy())
 
     def _prewriteto(self, checksum=False, inplace=False):
         if self._has_data:


### PR DESCRIPTION
As far as I can see the [astropy.io.fits.BinTableHDU.copy](http://astropy.readthedocs.org/en/latest/io/fits/api/tables.html#astropy.io.fits.BinTableHDU.copy) method is not deprecated, but it is implemented by calling the deprecated `new_table` function and thus generates a `AstropyDeprecationWarning`. Using the [example from the astropy.io.fits docs](http://astropy.readthedocs.org/en/latest/io/fits/index.html#creating-a-new-table-file):
```python
>>> from astropy.io import fits
>>> import numpy as np
>>> a1 = np.array(['NGC1001', 'NGC1002', 'NGC1003'])
>>> a2 = np.array([11.1, 12.3, 15.2])
>>> col1 = fits.Column(name='target', format='20A', array=a1)
>>> col2 = fits.Column(name='V_mag', format='E', array=a2)
>>> cols = fits.ColDefs([col1, col2])
>>> tbhdu = fits.BinTableHDU.from_columns(cols)
>>> tbhdu.copy()
WARNING: AstropyDeprecationWarning: The new_table function is deprecated and may be removed in a future version.
        Use :meth:`BinTableHDU.from_columns` for new BINARY tables or :meth:`TableHDU.from_columns` for new ASCII tables instead. [astropy.io.fits.hdu.table]
<astropy.io.fits.hdu.table.BinTableHDU object at 0x107f4d710>
```
@embray - I guess this needs to be updated?

These seem to be the only calls to `new_table` :
* https://github.com/astropy/astropy/search?utf8=%E2%9C%93&q=new_table
* https://github.com/astropy/astropy/blob/e7c86f9de892c2f27a457162dd050960095ec78b/astropy/io/fits/fitsrec.py#L877
* https://github.com/astropy/astropy/blob/5843241748c1f12c4c1da8ee6519680cf6a3bbe1/astropy/io/fits/hdu/table.py#L496