### PR TITLE
Validator methods for model parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,10 @@ New Features
 
 - ``astropy.modeling``
 
+  - Added a new ``Parameter.validator`` interface for setting a validation
+    method on individual model parameters.  See the ``Parameter``
+    documentation for more details. [#3910]
+
   - The projection classes that are named based on the 3-letter FITS
     WCS projections (e.g. ``Pix2Sky_TAN``) now have aliases using
     longer, more descriptive names (e.g. ``Pix2Sky_Gnomonic``).
@@ -223,6 +227,10 @@ API changes
   - Renamed the parameters of ``RotateNative2Celestial`` and
     ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]
+
+  - Deprecated the ``Pix2Sky_AZP.check_mu`` and ``Sky2Pix_AZP.check_mu``
+    methods (these were obscure "accidentally public" methods that were
+    probably not used by anyone). [#3910]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1102,10 +1102,27 @@ class Model(object):
 
         self._param_metrics = param_metrics
         self._parameters = np.empty(total_size, dtype=np.float64)
+
         # Now set the parameter values (this will also fill
         # self._parameters)
+        # TODO: This is a bit ugly, but easier to deal with than how this was
+        # done previously.  There's still lots of opportunity for refactoring
+        # though, in particular once we move the _get/set_model_value methods
+        # out of Parameter and into Model (renaming them
+        # _get/set_parameter_value)
         for name, value in params.items():
-            setattr(self, name, value)
+            param_descr = getattr(self, name)
+            value = np.array(value)
+            if param_descr._setter is not None:
+                value = param_descr._setter(value)
+            self._parameters[param_metrics[name]['slice']] = value.ravel()
+
+        # Finally validate all the parameters; we do this last so that
+        # validators that depend on one of the other parameters' values will
+        # work
+        for name in params:
+            param_descr = getattr(self, name)
+            param_descr.validator(param_descr.value)
 
     def _check_param_broadcast(self, params, max_ndim):
         """

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -65,17 +65,19 @@ class Parameter(object):
     "unbound parameter"), or it can act as a proxy for the parameter values on
     an individual model instance (called a "bound parameter").
 
-    Parameter instances never store the actual value of the parameter
-    directly.  Rather, each instance of a model stores its own parameters
-    as either hidden attributes or (in the case of
-    `~astropy.modeling.FittableModel`) in an array.  A *bound*
-    Parameter simply wraps the value in a Parameter proxy which provides some
-    additional information about the parameter such as its constraints.
+    Parameter instances never store the actual value of the parameter directly.
+    Rather, each instance of a model stores its own parameters parameter values
+    in an array.  A *bound* Parameter simply wraps the value in a Parameter
+    proxy which provides some additional information about the parameter such
+    as its constraints.  In other words, this is a high-level interface to a
+    model's adjustable parameter values.
 
     *Unbound* Parameters are not associated with any specific model instance,
     and are merely used by model classes to determine the names of their
     parameters and other information about each parameter such as their default
     values and default constraints.
+
+    See :ref:`modeling-parameters` for more details.
 
     Parameters
     ----------
@@ -459,13 +461,13 @@ class Parameter(object):
         instance (remember, this is a method defined on a `Model`), and
         the value being set for this parameter.  The validator method's
         return value is ignored, but it may raise an exception if the value
-        set on the parameter is invalid (typically an `InputParameteError`
+        set on the parameter is invalid (typically an `InputParameterError`
         should be raised, though this is not currently a requirement).
 
         The decorator *returns* the `Parameter` instance that the validator
         is set on, so the underlying validator method should have the same
         name as the `Parameter` itself (think of this as analogous to
-        `property.setter`).  For example::
+        ``property.setter``).  For example::
 
             >>> from astropy.modeling import Fittable1DModel
             >>> class TestModel(Fittable1DModel):

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -58,9 +58,7 @@ class PolynomialBase(FittableModel):
 
     def __getattr__(self, attr):
         if self._param_names and attr in self._param_names:
-            param = Parameter(attr, default=0.0)
-            param._bind(self)
-            return param
+            return Parameter(attr, default=0.0, model=self)
 
         raise AttributeError(attr)
 
@@ -73,8 +71,7 @@ class PolynomialBase(FittableModel):
         # Parameter.__set__.
         # TODO: I wonder if there might be a way around that though...
         if attr[0] != '_' and self._param_names and attr in self._param_names:
-            param = Parameter(attr, default=0.0)
-            param._bind(self)
+            param = Parameter(attr, default=0.0, model=self)
             # This is a little hackish, but we can actually reuse the
             # Parameter.__set__ method here
             param.__set__(self, value)

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -58,7 +58,9 @@ class PolynomialBase(FittableModel):
 
     def __getattr__(self, attr):
         if self._param_names and attr in self._param_names:
-            return Parameter(attr, default=0.0, model=self)
+            param = Parameter(attr, default=0.0)
+            param._bind(self)
+            return param
 
         raise AttributeError(attr)
 
@@ -71,7 +73,8 @@ class PolynomialBase(FittableModel):
         # Parameter.__set__.
         # TODO: I wonder if there might be a way around that though...
         if attr[0] != '_' and self._param_names and attr in self._param_names:
-            param = Parameter(attr, default=0.0, model=self)
+            param = Parameter(attr, default=0.0)
+            param._bind(self)
             # This is a little hackish, but we can actually reuse the
             # Parameter.__set__ method here
             param.__set__(self, value)

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -78,7 +78,11 @@ the model's class definition using the `~astropy.modeling.Parameter`
 descriptor.  All arguments to the Parameter constructor are optional, and may
 include a default value for that parameter, a text description of the parameter
 (useful for `help` and documentation generation), as well default constraints
-and custom getters/setters for the parameter value.
+and custom getters/setters for the parameter value.  It is also possible to
+define a "validator" method for each parameter, enabling custom code to check
+whether that parameter's value is valid according to the model definition (for
+example if it must be non-negative).  See the example in
+`Parameter.validator <astropy.modeling.Parameter.validator>` for more details.
 
 ::
 


### PR DESCRIPTION
This is some preliminary work I did toward being able to check off one of the checkboxes on #3852, specifically to remove the Parameter getters and setters that transform between values that are stored in models for evaluation to values that are presented to users.  It ended up being an awkward interface in most cases, and was mostly just used for a few models to translate between degrees and radians, for which the new Quantity support is a better use.

There were a few exceptions, however, that used the Parameter setters not to transform parameter values, but just to validate them.  To replace that usage of the setter function, this adds the ability to set a validator function for individual parameters.  This does *not* allow transforming the parameter value in any way, but just allows it to be checked for validity (including comparison to other parameters) when setting the parameter value.  This is *similar* to, but still subtly different from the "tied" constraint for parameters, and is not used as a fitting constraint.

Finally, the validators are not set in the way getters and setters were, by passing a function in to the `Parameter` descriptor's initializer, which was sometimes awkward since the validator had to be defined before the `Parameter` itself.  Instead, a parameter's validator can be set later using a decorator interface (this is similar to how `@property.setter` works).

For example:
```python
from astropy.modeling import Fittable1DModel, Parameter
class TestModel(Fittable1DModel):
    a = Parameter()
    b = Parameter()

    @a.validator
    def a(self, value):
        # Remember, the value can be an array
        if np.any(value < self.b):
            raise InputParameterError(
                "parameter 'a' must be greater than or equal "
                "to parameter 'b'")

    # Could also write a validator for `b` that checks the opposite condition
```
