### PR TITLE
Fix comparisons of parameters with arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -224,6 +224,12 @@ API changes
 
 - ``astropy.modeling``
 
+  - Note: Comparisons of model parameters with array-like values now
+    yields a Numpy boolean array as one would get with normal Numpy
+    array comparison.  Previously this returned a scalar True or False,
+    with True only if the comparison was true for all elements compared,
+    which could lead to confusing circumstances. [#3912]
+
   - Renamed the parameters of ``RotateNative2Celestial`` and
     ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -728,22 +728,22 @@ class Parameter(object):
         return val / self.value
 
     def __eq__(self, val):
-        return (np.asarray(self) == np.asarray(val)).all()
+        return np.asanyarray(self) == np.asanyarray(val)
 
     def __ne__(self, val):
-        return not (np.asarray(self) == np.asarray(val)).all()
+        return np.asanyarray(self) != np.asanyarray(val)
 
     def __lt__(self, val):
-        return (np.asarray(self) < np.asarray(val)).all()
+        return np.asanyarray(self) < np.asanyarray(val)
 
     def __gt__(self, val):
-        return (np.asarray(self) > np.asarray(val)).all()
+        return np.asanyarray(self) > np.asanyarray(val)
 
     def __le__(self, val):
-        return (np.asarray(self) <= np.asarray(val)).all()
+        return np.asanyarray(self) <= np.asanyarray(val)
 
     def __ge__(self, val):
-        return (np.asarray(self) >= np.asarray(val)).all()
+        return np.asanyarray(self) >= np.asanyarray(val)
 
     def __neg__(self):
         return -self.value

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -678,10 +678,7 @@ class Parameter(object):
 
     def __array__(self, dtype=None):
         # Make np.asarray(self) work a little more straightforwardly
-        if self._model is None:
-            return np.array([], dtype=np.float)
-        else:
-            return np.asarray(self.value, dtype=dtype)
+        return np.asarray(self.value, dtype=dtype)
 
     def __nonzero__(self):
         if self._model is None:
@@ -728,22 +725,25 @@ class Parameter(object):
         return val / self.value
 
     def __eq__(self, val):
-        return np.asanyarray(self) == np.asanyarray(val)
+        if self._model is None:
+            return super(Parameter, self).__eq__(val)
+
+        return self.__array__() == val
 
     def __ne__(self, val):
-        return np.asanyarray(self) != np.asanyarray(val)
+        return self.__array__() != val
 
     def __lt__(self, val):
-        return np.asanyarray(self) < np.asanyarray(val)
+        return self.__array__() < val
 
     def __gt__(self, val):
-        return np.asanyarray(self) > np.asanyarray(val)
+        return self.__array__() > val
 
     def __le__(self, val):
-        return np.asanyarray(self) <= np.asanyarray(val)
+        return self.__array__() <= val
 
     def __ge__(self, val):
-        return np.asanyarray(self) >= np.asanyarray(val)
+        return self.__array__() >= val
 
     def __neg__(self):
         return -self.value

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -254,7 +254,7 @@ class TestParameters(object):
         p1 = models.Polynomial1D(3, n_models=3)
         utils.assert_equal(p1.parameters, [0.0, 0.0, 0.0, 0, 0, 0,
                                            0, 0, 0, 0, 0, 0])
-        utils.assert_equal(p1.c0, [0, 0, 0])
+        utils.assert_array_equal(p1.c0, [0, 0, 0])
         p1.c0 = [10, 10, 10]
         utils.assert_equal(p1.parameters, [10.0, 10.0, 10.0, 0, 0,
                                            0, 0, 0, 0, 0, 0, 0])
@@ -289,7 +289,7 @@ class TestParameters(object):
     def test_scale_model_parametersnd(self):
         sc1 = models.Scale([2, 2])
         sc1.factor = [3, 3]
-        assert sc1.factor == [3, 3]
+        assert np.all(sc1.factor == [3, 3])
         utils.assert_array_equal(sc1.factor.value, [3, 3])
 
     def test_parameters_wrong_shape(self):


### PR DESCRIPTION
 (or of array-like parameters with scalars or other arrays) to return a Numpy bool array in a Numpy-like fashion.  Also wraps the parameter value and the value it is compared with using np.asanyarray so that Numpy subclasses can be returned (in anticipation of Quantity support).

This addresses a comment from @mhvk made [here](https://github.com/astropy/astropy/pull/3852).

This is unfortunately a backward-incompatible change, with no straightforward way to deprecate the old behavior.  Some could argue, however, that the old behavior was a bug anyways (or at least ill-conceived) and probably isn't relied on anywhere except with gritting of teeth.

When this is merged I will rebase #3852 to incorporate it as well.