### PR TITLE
A few minor improvements to scaling and uint support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -218,6 +218,13 @@ API changes
 
 - ``astropy.io.fits``
 
+  - The ``uint`` argument to ``fits.open`` is now True by default; that is,
+    arrays using the FITS unsigned integer convention will be detected, and
+    read as unsigned integers by default.  A new config option for
+    ``io.fits``, ``enable_uint``, can be changed to False to revert to the
+    original behavior of ignoring the ``uint`` convention unless it is
+    explicitly requested with ``uint=True``. [#3916]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.votable``

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -46,6 +46,13 @@ class Conf(_config.ConfigNamespace):
         'FITS files. This generally provides better performance, especially '
         'for large files, but may affect performance in I/O-heavy '
         'applications.')
+    enable_uint = _config.ConfigItem(
+        True,
+        'If True, default to recognizing the convention for representing '
+        'unsigned integers in FITS--if an array has BITPIX > 0, BSCALE = 1, '
+        'and BZERO = 2**BITPIX, represent the data as unsigned integers '
+        'per this convention.')
+
 conf = Conf()
 
 

--- a/astropy/io/fits/hdu/__init__.py
+++ b/astropy/io/fits/hdu/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
-from .base import register_hdu, unregister_hdu, DELAYED
+from .base import (register_hdu, unregister_hdu, DELAYED, BITPIX2DTYPE,
+                   DTYPE2BITPIX)
 from .compressed import CompImageHDU
 from .groups import GroupsHDU, GroupData, Group
 from .hdulist import HDUList
@@ -11,4 +12,5 @@ from .table import TableHDU, BinTableHDU
 
 __all__ = ['HDUList', 'PrimaryHDU', 'ImageHDU', 'TableHDU', 'BinTableHDU',
            'GroupsHDU', 'GroupData', 'Group', 'CompImageHDU', 'FitsHDU',
-           'StreamingHDU', 'register_hdu', 'unregister_hdu', 'DELAYED']
+           'StreamingHDU', 'register_hdu', 'unregister_hdu', 'DELAYED',
+           'BITPIX2DTYPE', 'DTYPE2BITPIX']

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -29,6 +29,20 @@ class _Delayed(object):
 DELAYED = _Delayed()
 
 
+BITPIX2DTYPE = {8: 'uint8', 16: 'int16', 32: 'int32', 64: 'int64',
+                -32: 'float32', -64: 'float64'}
+"""Maps FITS BITPIX values to Numpy dtype names."""
+
+DTYPE2BITPIX = {'uint8': 8, 'int16': 16, 'uint16': 16, 'int32': 32,
+                'uint32': 32, 'int64': 64, 'uint64': 64, 'float32': -32,
+                'float64': -64}
+"""
+Maps Numpy dtype names to FITS BITPIX values (this includes unsigned
+integers, with the assumption that the pseudo-unsigned integer convention
+will be used in this case.
+"""
+
+
 class InvalidHDUException(Exception):
     """
     A custom exception class used mainly to signal to _BaseHDU.__new__ that

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -3,7 +3,8 @@
 import sys
 import numpy as np
 
-from .image import _ImageBaseHDU, PrimaryHDU
+from .base import DTYPE2BITPIX
+from .image import PrimaryHDU
 from .table import _TableLikeHDU
 from ..column import Column, ColDefs, FITS2NUMPY
 from ..fitsrec import FITS_rec, FITS_record
@@ -148,7 +149,7 @@ class GroupData(FITS_rec):
             unique_parnames = _unique_parnames(parnames + ['DATA'])
 
             if bitpix is None:
-                bitpix = _ImageBaseHDU.ImgCode[input.dtype.name]
+                bitpix = DTYPE2BITPIX[input.dtype.name]
 
             fits_fmt = GroupsHDU._bitpix2tform[bitpix]  # -32 -> 'E'
             format = FITS2NUMPY[fits_fmt]  # 'E' -> 'f4'
@@ -391,7 +392,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
             else:
                 raise ValueError('incorrect array type')
 
-            self._header['BITPIX'] = _ImageBaseHDU.ImgCode[field0_code]
+            self._header['BITPIX'] = DTYPE2BITPIX[field0_code]
 
         self._header['NAXIS'] = len(self._axes)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -113,8 +113,9 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
     """
 
+    from .. import conf
+
     if memmap is None:
-        from .. import conf
         # distinguish between True (kwarg explicitly set)
         # and None (preference for memmap in config, might be ignored)
         memmap = None if conf.use_memmap else False
@@ -127,6 +128,9 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         warnings.warn(
             'The uint16 keyword argument is deprecated since v1.1.0.  Use '
             'the uint argument instead.', AstropyDeprecationWarning)
+
+    if 'uint' not in kwargs:
+        kwargs['uint'] = conf.enable_uint
 
     if not name:
         raise ValueError('Empty filename: %s' % repr(name))

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -19,7 +19,7 @@ from ..util import (_is_int, _tmp_name, fileobj_closed, ignore_sigint,
 from ..verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from ....extern.six import string_types
 from ....utils import indent
-from ....utils.exceptions import AstropyUserWarning
+from ....utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
@@ -122,6 +122,9 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
     if 'uint16' in kwargs and 'uint' not in kwargs:
         kwargs['uint'] = kwargs['uint16']
         del kwargs['uint16']
+        warnings.warn(
+            'The uint16 keyword argument is deprecated since v1.1.0.  Use '
+            'the uint argument instead.', AstropyDeprecationWarning)
 
     if not name:
         raise ValueError('Empty filename: %s' % repr(name))

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -62,6 +62,8 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
             central value and ``BSCALE == 1`` as unsigned integer
             data.  For example, ``int16`` data with ``BZERO = 32768``
             and ``BSCALE = 1`` would be treated as ``uint16`` data.
+            This is enabled by default so that the pseudo-unsigned
+            integer convention is assumed.
 
             Note, for backward compatibility, the kwarg **uint16** may
             be used instead.  The kwarg was renamed when support was

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -834,12 +834,12 @@ class PrimaryHDU(_ImageBaseHDU):
 
         do_not_scale_image_data : bool, optional
             If `True`, image data is not scaled using BSCALE/BZERO values
-            when read.
+            when read. (default: False)
 
         ignore_blank : bool, optional
             If `True`, the BLANK header keyword will be ignored if present.
             Otherwise, pixels equal to this value will be replaced with
-            NaNs.
+            NaNs. (default: False)
 
         uint : bool, optional
             Interpret signed integer data where ``BZERO`` is the
@@ -852,7 +852,9 @@ class PrimaryHDU(_ImageBaseHDU):
             image data, restore the data to the original type and reapply the
             original BSCALE/BZERO values.  This could lead to loss of accuracy
             if scaling back to integer values after performing floating point
-            operations on the data.
+            operations on the data.  Pseudo-unsigned integers are automatically
+            rescaled unless scale_back is explicitly set to `False`.
+            (default: None)
         """
 
         super(PrimaryHDU, self).__init__(
@@ -927,7 +929,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
 
         do_not_scale_image_data : bool, optional
             If `True`, image data is not scaled using BSCALE/BZERO values
-            when read.
+            when read. (default: False)
 
         uint : bool, optional
             Interpret signed integer data where ``BZERO`` is the
@@ -940,7 +942,9 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
             image data, restore the data to the original type and reapply the
             original BSCALE/BZERO values.  This could lead to loss of accuracy
             if scaling back to integer values after performing floating point
-            operations on the data.
+            operations on the data.  Pseudo-unsigned integers are automatically
+            rescaled unless scale_back is explicitly set to `False`.
+            (default: None)
         """
 
         # This __init__ currently does nothing differently from the base class,

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -37,7 +37,7 @@ class _ImageBaseHDU(_ValidHDU):
     }
 
     def __init__(self, data=None, header=None, do_not_scale_image_data=False,
-                 uint=False, scale_back=False, ignore_blank=False, **kwargs):
+                 uint=True, scale_back=False, ignore_blank=False, **kwargs):
 
         from .groups import GroupsHDU
 
@@ -819,7 +819,7 @@ class PrimaryHDU(_ImageBaseHDU):
 
     def __init__(self, data=None, header=None, do_not_scale_image_data=False,
                  ignore_blank=False,
-                 uint=False, scale_back=None):
+                 uint=True, scale_back=None):
         """
         Construct a primary HDU.
 
@@ -846,6 +846,7 @@ class PrimaryHDU(_ImageBaseHDU):
             central value and ``BSCALE == 1`` as unsigned integer
             data.  For example, ``int16`` data with ``BZERO = 32768``
             and ``BSCALE = 1`` would be treated as ``uint16`` data.
+            (default: True)
 
         scale_back : bool, optional
             If `True`, when saving changes to a file that contained scaled
@@ -910,7 +911,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
     _extension = 'IMAGE'
 
     def __init__(self, data=None, header=None, name=None,
-                 do_not_scale_image_data=False, uint=False, scale_back=None):
+                 do_not_scale_image_data=False, uint=True, scale_back=None):
         """
         Construct an image HDU.
 
@@ -936,6 +937,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
             central value and ``BSCALE == 1`` as unsigned integer
             data.  For example, ``int16`` data with ``BZERO = 32768``
             and ``BSCALE = 1`` would be treated as ``uint16`` data.
+            (default: True)
 
         scale_back : bool, optional
             If `True`, when saving changes to a file that contained scaled

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -5,13 +5,13 @@ import warnings
 
 import numpy as np
 
-from .base import DELAYED, _ValidHDU, ExtensionHDU
+from .base import DELAYED, _ValidHDU, ExtensionHDU, BITPIX2DTYPE, DTYPE2BITPIX
 from ..header import Header
 from ..util import _is_pseudo_unsigned, _unsigned_zero, _is_int
 from ..verify import VerifyWarning
 
 from ....extern.six import string_types
-from ....utils import isiterable, lazyproperty
+from ....utils import isiterable, lazyproperty, deprecated
 
 
 class _ImageBaseHDU(_ValidHDU):
@@ -25,14 +25,6 @@ class _ImageBaseHDU(_ValidHDU):
     data
         image data
     """
-
-    # mappings between FITS and numpy typecodes
-    # TODO: Maybe make these module-level constants instead...
-    NumCode = {8: 'uint8', 16: 'int16', 32: 'int32', 64: 'int64',
-               -32: 'float32', -64: 'float64'}
-    ImgCode = {'uint8': 8, 'int16': 16, 'uint16': 16, 'int32': 32,
-               'uint32': 32, 'int64': 64, 'uint64': 64, 'float32': -32,
-               'float64': -64}
 
     standard_keyword_comments = {
         'SIMPLE': 'conforms to FITS standard',
@@ -264,7 +256,7 @@ class _ImageBaseHDU(_ValidHDU):
         self._modified = True
 
         if isinstance(data, np.ndarray):
-            self._bitpix = _ImageBaseHDU.ImgCode[data.dtype.name]
+            self._bitpix = DTYPE2BITPIX[data.dtype.name]
             self._orig_bitpix = self._bitpix
             self._orig_bscale = 1
             self._orig_bzero = 0
@@ -371,7 +363,7 @@ class _ImageBaseHDU(_ValidHDU):
             if dtype is None:
                 dtype = self._dtype_for_bitpix()
             if dtype is not None:
-                self._header['BITPIX'] = _ImageBaseHDU.ImgCode[dtype.name]
+                self._header['BITPIX'] = DTYPE2BITPIX[dtype.name]
 
             self._bzero = 0
             self._bscale = 1
@@ -409,7 +401,7 @@ class _ImageBaseHDU(_ValidHDU):
 
         # Determine the destination (numpy) data type
         if type is None:
-            type = self.NumCode[self._bitpix]
+            type = BITPIX2DTYPE[self._bitpix]
         _type = getattr(np, type)
 
         # Determine how to scale the data
@@ -464,7 +456,7 @@ class _ImageBaseHDU(_ValidHDU):
             self.data = np.array(np.around(self.data), dtype=_type)
 
         # Update the BITPIX Card to match the data
-        self._bitpix = _ImageBaseHDU.ImgCode[self.data.dtype.name]
+        self._bitpix = DTYPE2BITPIX[self.data.dtype.name]
         self._bzero = self._header.get('BZERO', 0)
         self._bscale = self._header.get('BSCALE', 1)
         self._header['BITPIX'] = self._bitpix
@@ -485,7 +477,7 @@ class _ImageBaseHDU(_ValidHDU):
 
     def _prewriteto(self, checksum=False, inplace=False):
         if self._scale_back:
-            self.scale(self.NumCode[self._orig_bitpix])
+            self.scale(BITPIX2DTYPE[self._orig_bitpix])
 
         self.update_header()
         if not inplace and not self._has_data:
@@ -580,7 +572,7 @@ class _ImageBaseHDU(_ValidHDU):
         supports alternate offset/shape for Section support.
         """
 
-        code = _ImageBaseHDU.NumCode[self._orig_bitpix]
+        code = BITPIX2DTYPE[self._orig_bitpix]
 
         raw_data = self._get_raw_data(shape, code, offset)
         raw_data.dtype = raw_data.dtype.newbyteorder('>')
@@ -662,7 +654,7 @@ class _ImageBaseHDU(_ValidHDU):
             if self.shape and all(self.shape):
                 # Only show the format if all the dimensions are non-zero
                 # if data is not touched yet, use header info.
-                format = self.NumCode[self._bitpix]
+                format = BITPIX2DTYPE[self._bitpix]
             else:
                 format = ''
 
@@ -712,6 +704,14 @@ class _ImageBaseHDU(_ValidHDU):
             # all.  This can also be handled in a generic manner.
             return super(_ImageBaseHDU, self)._calculate_datasum(
                 blocking=blocking)
+
+    @deprecated('1.1.0', alternative='the module level constant BITPIX2DTYPE')
+    def NumCode(self):
+        return BITPIX2DTYPE
+
+    @deprecated('1.1.0', alternative='the module level constant DTYPE2BITPIX')
+    def ImgCode(self):
+        return DTYPE2BITPIX
 
 
 class Section(object):

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -5,9 +5,9 @@ import os
 
 from ..file import _File
 from ..header import _pad_length
-from .base import _BaseHDU
+from .base import _BaseHDU, BITPIX2DTYPE
 from .hdulist import HDUList
-from .image import PrimaryHDU, _ImageBaseHDU
+from .image import PrimaryHDU
 from ..util import fileobj_name
 
 
@@ -171,7 +171,7 @@ class StreamingHDU(object):
             raise IOError('Attempt to write more data to the stream than the '
                           'header specified.')
 
-        if _ImageBaseHDU.NumCode[self._header['BITPIX']] != data.dtype.name:
+        if BITPIX2DTYPE[self._header['BITPIX']] != data.dtype.name:
             raise TypeError('Supplied data does not match the type specified '
                             'in the header.')
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -150,7 +150,7 @@ class TestCore(FitsTestCase):
         assert header.ascard['BITPIX'].comment == comment
 
     def test_uint(self):
-        hdulist_f = fits.open(self.data('o4sp040b0_raw.fits'))
+        hdulist_f = fits.open(self.data('o4sp040b0_raw.fits'), uint=False)
         hdulist_i = fits.open(self.data('o4sp040b0_raw.fits'), uint=True)
 
         assert hdulist_f[1].data.dtype == np.float32

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -398,6 +398,8 @@ extensions (a default PRIMARY HDU is prepended automatically if one was not
 provided manually).
 
 
+.. _fits-scaled-data-faq:
+
 Why is an image containing integer data being converted unexpectedly to floats?
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -97,6 +97,29 @@ because by that point you're likely to run out of physical memory anyways), but
 	out of scope, or manually call ``del hdul[0].data`` (this works so long as there are no other
 	references held to the data array).
 
+Unsigned integers
+"""""""""""""""""
+
+Due to the FITS format's FORTRAN origins, FITS does not natively support
+unsigned integer data in images or tables.  However, there is a common
+convention to store unsigned integers as signed integers, along with a
+*shift* instruction (a ``BZERO`` keyword with value ``2 ** (BITPIX - 1)``) to
+shift up all signed integers to unsigned inters.  For example, when writing
+the value ``0`` as an unsigned 32-bit integer, it is stored in the FITS
+file as ``-32768``, along with the header keyword ``BZERO = 32768``.
+
+Astropy recognizes and applies this convention by default, so that all data
+that looks like it should be interpreted as unsigned integers is automatically
+converted (this applies to both images and tables).  In Astropy versions prior
+to v1.1.0 this was *not* applied automatically, and it is necessary to pass the
+argument ``uint=True`` to :func:`open`.  In v1.1.0 or later this is the
+default.
+
+Even with ``uint=False``, the ``BZERO`` shift is still applied, but the
+returned array is of "float64" type.  To disable scaling/shifting entirely, use
+``do_not_scale_image_data=True`` (see :ref:`fits-scaled-data-faq` in the FAQ
+for more details).
+
 Working with compressed files
 """""""""""""""""""""""""""""
 


### PR DESCRIPTION
Just a grab bag of minor improvements from a branch I started but didn't do much else with yet (I think I had planned to do more but better to start fresh).

This improves somewhat on the surprising behavior that a FITS HDU's type changes *after* accessing the data when scaled data is present.  Now, `fits.info()` gives more info about scaled images ahead of time.

This also enables unsigned integer support by default.  The current version of the FITS standard even describes the convention of using BZERO=2**(BITPIX - 1) to represent unsigned ints.  Although it is still "merely" a convention there's almost no reason not to assume this was the intent in practice.  This hopefully shouldn't break anything existing, but in the odd case that it does the default can be changed via a config flag.