### PR TITLE
Enable the --inplace option for build_ext by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[build_ext]
+# Always do "inplace" builds by default so that extension modules can be
+# imported from a source checkout
+inplace = 1
+
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build


### PR DESCRIPTION
Motivated by a question from @anizami, I think it would be convenient to have the `--inplace` option for `./setup.py build_ext` enabled by default.  This ensures that when building the package, all compiled extension modules are also copied from the `build/` directory directly into the source tree so that they can be imported when developing from within the source.

Running `./setup.py develop` does this automatically, but this is also convenient for just running `./setup.py build` over and over again (which is faster than the `develop` command, and more obvious).

I think the only downside to this is when installing (i.e. from pip) there's an extra unnecessary copy of the extension modules, but this is negligible.

If this works out we should probably also add this to the package-template.  I'll also update the docs a bit to make it clear that this happens by default.