### PR TITLE
problem with memmap when using latest astropy on mac

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -503,6 +503,10 @@ Bug Fixes
     the ``scale_back=True`` argument.  Invalid usage of the ``BLANK`` keyword
     is also better warned about during validation. [#3865]
 
+  - Reading memmaped scaled images won't fail when
+    ``do_not_scale_image_data=True`` (that is, since we're just reading the
+    raw / physical data there is no reason mmap can't be used). [#3766]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1122,3 +1122,8 @@ class TestStreamingFunctions(FitsTestCase):
         pth = self.data('blank.fits')
         with pytest.raises(ValueError):
             fits.open(pth, memmap=True)[0].data
+
+        # However, it should not fail if do_not_scale_image_data was used:
+        # See https://github.com/astropy/astropy/issues/3766
+        hdul = fits.open(pth, memmap=True, do_not_scale_image_data=True)
+        hdul[0].data  # Just make sure it doesn't crash


### PR DESCRIPTION
After upgrading astropy from version 0.4.2 to 1.0.2 I ran into a problem using memory mapped images which did not happen before

a fits file is being loaded using the following line:
```
f = astropy.open(inFile,memmap=True,do_not_scale_image_data=True)
```
or just:
```
f=astropy.open(weightsFile)
```

The code runs fine when working on fits files of 500Mb, however the code crashes when using a larger fitsfile (e.g. 2Gb)

The following error message occurred:

```
  File "/usr/local/lib/python2.7/site-packages/astropy/io/fits/hdu/image.py", line 595, in _get_scaled_image_data
    raise ValueError("Cannot load a memory-mapped image: "
ValueError: Cannot load a memory-mapped image: BZERO/BSCALE/BLANK header keywords present. Set memmap=False.
```

I am running my code on a Macbook pro with OS X 10.10
python 2.7.6
astropy 1.0.2


