### PR TITLE
Fix running astropy with python -OO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -537,6 +537,10 @@ Bug Fixes
     tree did not automatically build the extension modules if the source is
     from a source distribution (as opposed to a git repository). [#3932]
 
+  - Fixed multiple instances of a bug that prevented Astropy from being used
+    when compiled with the ``python -OO`` flag, due to it causing all
+    docstrings to be stripped out. [#3923]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -49,6 +49,7 @@ for _nm, _c in itertools.chain(sorted(vars(si).items()),
 
 _lines.append(_lines[1])
 
-__doc__ += '\n'.join(_lines)
+if __doc__ is not None:
+    __doc__ += '\n'.join(_lines)
 
 del _lines, _nm, _c

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -630,7 +630,9 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
 
     if closed:
         f.close()
-tabledump.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
+
+if isinstance(tabledump.__doc__, string_types):
+    tabledump.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
 
 
 @deprecated('0.1', alternative=':func:`tabledump`')
@@ -672,7 +674,9 @@ def tableload(datafile, cdfile, hfile=None):
     """
 
     return BinTableHDU.load(datafile, cdfile, hfile, replace=True)
-tableload.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
+
+if isinstance(tableload.__doc__, string_types):
+    tableload.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
 
 
 @deprecated('0.1', alternative=':func:`tableload`')

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1036,7 +1036,8 @@ class BinTableHDU(_TableBaseHDU):
         if hfile:
             self._header.tofile(hfile, sep='\n', endcard=False, padding=False)
 
-    dump.__doc__ += _tdump_file_format.replace('\n', '\n        ')
+    if isinstance(dump.__doc__, string_types):
+        dump.__doc__ += _tdump_file_format.replace('\n', '\n        ')
 
     @deprecated('0.1', alternative=':meth:`dump`')
     def tdump(self, datafile=None, cdfile=None, hfile=None, clobber=False):
@@ -1119,7 +1120,10 @@ class BinTableHDU(_TableBaseHDU):
         hdu = cls(data=data, header=header)
         hdu.columns = coldefs
         return hdu
-    load.__doc__ += _tdump_file_format.replace('\n', '\n        ')
+
+    if isinstance(load.__doc__, string_types):
+        load.__doc__ += _tdump_file_format.replace('\n', '\n        ')
+
     load = classmethod(load)
     # Have to create a classmethod from this here instead of as a decorator;
     # otherwise we can't update __doc__

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -82,6 +82,12 @@ def _update__doc__(data_class, readwrite):
 
     # Get the existing read or write method and its docstring
     class_readwrite_func = getattr(data_class, readwrite)
+
+    if not isinstance(class_readwrite_func.__doc__, six.string_types):
+        # No docstring--could just be test code, or possibly code compiled
+        # without docstrings
+        return
+
     lines = class_readwrite_func.__doc__.splitlines()
 
     # Find the location of the existing formats table if it exists

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -15,6 +15,8 @@ from .polynomial import *
 from .functional_models import *
 from .powerlaws import *
 
+from ..extern.six import string_types
+
 """
 Attach a docstring explaining constraints to all models which support them.
 
@@ -63,4 +65,5 @@ MODELS_WITH_CONSTRAINTS = [
 
 
 for item in MODELS_WITH_CONSTRAINTS:
-    item.__doc__ += CONSTRAINTS_DOC
+    if isinstance(item.__doc__, string_types):
+        item.__doc__ += CONSTRAINTS_DOC

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ... units import dimensionless_unscaled, UnitsError
 from ... import log
+from ...extern.six import string_types
 from ..nduncertainty import IncompatibleUncertaintiesException
 
 __all__ = ['NDArithmeticMixin']
@@ -192,7 +193,9 @@ class NDArithmeticMixin(object):
             propagate_uncertainties = None
         return self._arithmetic(
             operand, propagate_uncertainties, "addition", np.add)
-    add.__doc__ = _arithmetic.__doc__.format(name="Add", operator="+")
+
+    if isinstance(_arithmetic.__doc__, string_types):
+        add.__doc__ = _arithmetic.__doc__.format(name="Add", operator="+")
 
     def subtract(self, operand, propagate_uncertainties=True):
         if propagate_uncertainties:
@@ -201,8 +204,10 @@ class NDArithmeticMixin(object):
             propagate_uncertainties = None
         return self._arithmetic(
             operand, propagate_uncertainties, "subtraction", np.subtract)
-    subtract.__doc__ = _arithmetic.__doc__.format(name="Subtract",
-                                                  operator="-")
+
+    if isinstance(_arithmetic.__doc__, string_types):
+        subtract.__doc__ = _arithmetic.__doc__.format(name="Subtract",
+                                                      operator="-")
 
     def multiply(self, operand, propagate_uncertainties=True):
         if propagate_uncertainties:
@@ -211,8 +216,10 @@ class NDArithmeticMixin(object):
             propagate_uncertainties = None
         return self._arithmetic(
             operand, propagate_uncertainties, "multiplication", np.multiply)
-    multiply.__doc__ = _arithmetic.__doc__.format(name="Multiply",
-                                                  operator="*")
+
+    if isinstance(_arithmetic.__doc__, string_types):
+        multiply.__doc__ = _arithmetic.__doc__.format(name="Multiply",
+                                                      operator="*")
 
     def divide(self, operand, propagate_uncertainties=True):
         if propagate_uncertainties:
@@ -221,4 +228,7 @@ class NDArithmeticMixin(object):
             propagate_uncertainties = None
         return self._arithmetic(
             operand, propagate_uncertainties, "division", np.divide)
-    divide.__doc__ = _arithmetic.__doc__.format(name="Divide", operator="/")
+
+    if isinstance(_arithmetic.__doc__, string_types):
+        divide.__doc__ = _arithmetic.__doc__.format(name="Divide",
+                                                    operator="/")

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -175,7 +175,8 @@ def test_wrap_preserve_signature_docstring():
         """
         pass
 
-    assert wrapped_function_6.__doc__.strip() == "An awesome function"
+    if wrapped_function_6.__doc__ is not None:
+        assert wrapped_function_6.__doc__.strip() == "An awesome function"
 
     signature = inspect.formatargspec(*inspect.getargspec(wrapped_function_6))
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -617,9 +617,11 @@ class Time(object):
 
         gst = self._erfa_sidereal_time(available_models[model.upper()])
         return Longitude(gst + longitude, u.hourangle)
-    sidereal_time.__doc__ = sidereal_time.__doc__.format(
-        'apparent', sorted(SIDEREAL_TIME_MODELS['apparent'].keys()),
-        'mean', sorted(SIDEREAL_TIME_MODELS['mean'].keys()))
+
+    if isinstance(sidereal_time.__doc__, six.string_types):
+        sidereal_time.__doc__ = sidereal_time.__doc__.format(
+            'apparent', sorted(SIDEREAL_TIME_MODELS['apparent'].keys()),
+            'mean', sorted(SIDEREAL_TIME_MODELS['mean'].keys()))
 
     def _erfa_sidereal_time(self, model):
         """Calculate a sidereal time using a IAU precession/nutation model."""

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -155,4 +155,5 @@ del si
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
-__doc__ += _generate_unit_summary(globals())
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -165,7 +165,8 @@ _initialize_module()
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
-__doc__ += _generate_unit_summary(globals())
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())
 
 
 def enable():

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -132,4 +132,5 @@ del Fraction
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
-__doc__ += _generate_unit_summary(globals())
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -44,4 +44,5 @@ del IrreducibleFunctionUnit
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from ..utils import generate_unit_summary as _generate_unit_summary
-__doc__ += _generate_unit_summary(globals())
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -136,7 +136,8 @@ del def_unit
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
-__doc__ += _generate_unit_summary(globals())
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())
 
 
 def enable():

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -239,4 +239,5 @@ del def_unit
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
-__doc__ += _generate_unit_summary(globals())
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -15,6 +15,11 @@ def py3only(func):
     else:
         @wraps(func)
         def wrapper(*args, **kwargs):
+            if func.__doc__ is None:
+                pytest.skip('unable to run this test due to missing '
+                            'docstrings (maybe the module was compiled with '
+                            'optimization flags?)')
+
             code = compile(dedent(func.__doc__), __file__, 'exec')
             # This uses an unqualified exec statement illegally in Python 2,
             # but perfectly allowed in Python 3 so in fact we eval the exec

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -524,7 +524,8 @@ def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
     return wrapper
 
 
-wraps.__doc__ += functools.wraps.__doc__
+if isinstance(wraps.__doc__, six.string_types):
+    wraps.__doc__ += functools.wraps.__doc__
 
 
 if six.PY3:

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -29,7 +29,10 @@ def test_wraps():
     expected = ('test', 1, 2, 3, 4, 5, {'f': 6, 'g': 7})
     assert bar(1, 2, 3, 4, 5, f=6, g=7) == expected
     assert bar.__name__ == 'foo'
-    assert bar.__doc__ == "A test function."
+
+    if foo.__doc__ is not None:
+        # May happen if using optimized opcode
+        assert bar.__doc__ == "A test function."
 
     if hasattr(foo, '__qualname__'):
         assert bar.__qualname__ == foo.__qualname__
@@ -98,10 +101,11 @@ def test_deprecated_class():
         TestA()
 
     assert len(w) == 1
-    assert 'function' not in TestA.__doc__
-    assert 'deprecated' in TestA.__doc__
-    assert 'function' not in TestA.__init__.__doc__
-    assert 'deprecated' in TestA.__init__.__doc__
+    if TestA.__doc__ is not None:
+        assert 'function' not in TestA.__doc__
+        assert 'deprecated' in TestA.__doc__
+        assert 'function' not in TestA.__init__.__doc__
+        assert 'deprecated' in TestA.__init__.__doc__
 
     # Make sure the object is picklable
     pickle.dumps(TestA)
@@ -123,10 +127,11 @@ def test_deprecated_class_with_super():
         TestB(1, 2)
 
     assert len(w) == 1
-    assert 'function' not in TestB.__doc__
-    assert 'deprecated' in TestB.__doc__
-    assert 'function' not in TestB.__init__.__doc__
-    assert 'deprecated' in TestB.__init__.__doc__
+    if TestB.__doc__ is not None:
+        assert 'function' not in TestB.__doc__
+        assert 'deprecated' in TestB.__doc__
+        assert 'function' not in TestB.__init__.__doc__
+        assert 'deprecated' in TestB.__init__.__doc__
 
 
 def test_deprecated_static_and_classmethod():
@@ -138,6 +143,8 @@ def test_deprecated_static_and_classmethod():
     """
 
     class A(object):
+        """Docstring"""
+
         @deprecated('1.0')
         @staticmethod
         def B():
@@ -152,13 +159,15 @@ def test_deprecated_static_and_classmethod():
         A.B()
 
     assert len(w) == 1
-    assert 'deprecated' in A.B.__doc__
+    if A.__doc__ is not None:
+        assert 'deprecated' in A.B.__doc__
 
     with catch_warnings(AstropyDeprecationWarning) as w:
         A.C()
 
     assert len(w) == 1
-    assert 'deprecated' in A.C.__doc__
+    if A.__doc__ is not None:
+        assert 'deprecated' in A.C.__doc__
 
 
 @pytest.mark.skipif('six.PY3')

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -65,4 +65,6 @@ def test_inherit_docstrings():
         def __call__(self, *args):
             pass
 
-    assert Subclass.__call__.__doc__ == "FOO"
+    if Base.__call__.__doc__ is not None:
+        # TODO: Maybe if __doc__ is None this test should be skipped instead?
+        assert Subclass.__call__.__doc__ == "FOO"


### PR DESCRIPTION
Motivated by [this stack overflow question](http://stackoverflow.com/questions/31182015/py2exe-with-import-pyfits-cause-error/31273526#31273526), fixes as many cases as I could find of code that assumes a method, class, or module's docstring will always be there, since when compiling the modules with python's -OO flag the docstrings can be removed, rendering Astropy inoperable due to these cases.

I tested this manually on Python 2 and 3 by running (in clean repos) `python -OO setup.py test`.

There is also an associated change to astropy-helpers that is needed.  I would like to get that in first, then this PR can also include an update to the astropy-helpers submodule (which is overdue anyways).

Related: #960