### PR TITLE
Support structured array, recarray, or just ndarray as mixin table columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,10 @@ New Features
     function for the dtype value.  Removed the default "masked=False"
     from the table representation. [#3868, #3869]
 
+  - Added capability to include a structured array or recarray in a table
+    as a mixin column.  This allows for an approximation of nested tables.
+    [#3925]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -20,7 +20,7 @@ conf = Conf()
 
 from .column import Column, MaskedColumn
 from .groups import TableGroups, ColumnGroups
-from .table import Table, QTable, TableColumns, Row, TableFormatter
+from .table import Table, QTable, TableColumns, Row, TableFormatter, NdarrayMixin
 from .operations import join, hstack, vstack, unique, TableMergeError
 
 # Import routines that connect readers/writers to astropy.table

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .table import Table, Column
 from ..extern.six.moves import zip, range
-from ..utils.data_info import InfoDescriptor, MixinInfo
+from ..utils.data_info import InfoDescriptor, ParentDtypeInfo
 
 class TimingTables(object):
     """
@@ -144,17 +144,16 @@ class ArrayWrapper(object):
     """
     def __init__(self, data):
         self.data = np.array(data)
-        if isinstance(data, ArrayWrapper):
+        if 'info' in getattr(data, '__dict__', ()):
             self.info = data.info
-        else:
-            self.info.dtype = self.data.dtype
 
     def __getitem__(self, item):
         if isinstance(item, (int, np.integer)):
             out = self.data[item]
         else:
             out = self.__class__(self.data[item])
-            out.info = self.info
+            if 'info' in self.__dict__:
+                out.info = self.info
         return out
 
     def __setitem__(self, item, value):
@@ -163,7 +162,11 @@ class ArrayWrapper(object):
     def __len__(self):
         return len(self.data)
 
-    info = InfoDescriptor(MixinInfo)
+    info = InfoDescriptor(ParentDtypeInfo)
+
+    @property
+    def dtype(self):
+        return self.data.dtype
 
     @property
     def shape(self):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -15,6 +15,7 @@ can not be defined in a module by a different name and still be shared
 between modules.
 """
 from copy import deepcopy
+import numpy as np
 
 from ...tests.helper import pytest
 from ... import table
@@ -138,7 +139,9 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
               'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
                                                dec=[0, 1, 2, 3] * u.deg),
-              'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3])
+              'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3]),
+              'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
+                           dtype='<i4,|S1').view(table.NdarrayMixin),
               }
 
 @pytest.fixture(params=sorted(MIXIN_COLS))

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -464,7 +464,15 @@ def test_ndarray_mixin():
                  dtype='<i4,|S1')
     b = np.array([(10, 'aa'), (20, 'bb'), (30, 'cc'), (40, 'dd')],
                  dtype=[('x', 'i4'), ('y', 'S2')])
-    t = Table([a, b], names=['a', 'b'])
+    c = np.rec.fromrecords([(100, 'raa'), (200, 'rbb'), (300, 'rcc'), (400, 'rdd')],
+                           names=['rx', 'ry'])
+    d = np.arange(8).reshape(4, 2).view(NdarrayMixin)
+
+    # Add one during initialization and the next as a new column.
+    t = Table([a], names=['a'])
+    t['b'] = b
+    t['c'] = c
+    t['d'] = d
 
     assert isinstance(t['a'], NdarrayMixin)
 
@@ -481,3 +489,26 @@ def test_ndarray_mixin():
 
     assert t[1]['b']['x'] == 20
     assert t[1]['b']['y'] == 'bb'
+
+    assert isinstance(t['c'], NdarrayMixin)
+
+    assert t['c'][1]['rx'] == 200
+    assert t['c'][1]['ry'] == 'rbb'
+
+    assert t[1]['c']['rx'] == 200
+    assert t[1]['c']['ry'] == 'rbb'
+
+    assert isinstance(t['d'], NdarrayMixin)
+
+    assert t['d'][1][0] == 2
+    assert t['d'][1][1] == 3
+
+    assert t[1]['d'][0] == 2
+    assert t[1]['d'][1] == 3
+
+    assert t.pformat() == ['   a         b           c       d [2] ',
+                           '-------- ---------- ------------ ------',
+                           "(1, 'a') (10, 'aa') (100, 'raa') 0 .. 1",
+                           "(2, 'b') (20, 'bb') (200, 'rbb') 2 .. 3",
+                           "(3, 'c') (30, 'cc') (300, 'rcc') 4 .. 5",
+                           "(4, 'd') (40, 'dd') (400, 'rdd') 6 .. 7"]

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -90,6 +90,7 @@ def test_make_table(table_types, mixin_cols):
     t = table_types.Table(cols)
     check_mixin_type(t, t['col3'], mixin_cols['m'])
 
+
 def test_io_ascii_write():
     """
     Test that table with mixin column can be written by io.ascii for

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -19,6 +22,7 @@ except ImportError:
 import numpy as np
 import copy
 
+from ...extern import six
 from ...extern.six.moves import cPickle as pickle
 from ...tests.helper import pytest
 from ...table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
@@ -461,9 +465,9 @@ def test_ndarray_mixin():
     tests apply.
     """
     a = np.array([(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')],
-                 dtype='<i4,|S1')
+                 dtype='<i4,' + ('|S1' if six.PY2 else '|U1'))
     b = np.array([(10, 'aa'), (20, 'bb'), (30, 'cc'), (40, 'dd')],
-                 dtype=[('x', 'i4'), ('y', 'S2')])
+                 dtype=[('x', 'i4'), ('y', ('S2' if six.PY2 else 'U2'))])
     c = np.rec.fromrecords([(100, 'raa'), (200, 'rbb'), (300, 'rcc'), (400, 'rdd')],
                            names=['rx', 'ry'])
     d = np.arange(8).reshape(4, 2).view(NdarrayMixin)
@@ -476,35 +480,35 @@ def test_ndarray_mixin():
 
     assert isinstance(t['a'], NdarrayMixin)
 
-    assert t['a'][1][1] == 'b'
-    assert t['a'][2][0] == 3
+    assert t['a'][1][1] == a[1][1]
+    assert t['a'][2][0] == a[2][0]
 
-    assert t[1]['a'][1] == 'b'
-    assert t[2]['a'][0] == 3
+    assert t[1]['a'][1] == a[1][1]
+    assert t[2]['a'][0] == a[2][0]
 
     assert isinstance(t['b'], NdarrayMixin)
 
-    assert t['b'][1]['x'] == 20
-    assert t['b'][1]['y'] == 'bb'
+    assert t['b'][1]['x'] == b[1]['x']
+    assert t['b'][1]['y'] == b[1]['y']
 
-    assert t[1]['b']['x'] == 20
-    assert t[1]['b']['y'] == 'bb'
+    assert t[1]['b']['x'] == b[1]['x']
+    assert t[1]['b']['y'] == b[1]['y']
 
     assert isinstance(t['c'], NdarrayMixin)
 
-    assert t['c'][1]['rx'] == 200
-    assert t['c'][1]['ry'] == 'rbb'
+    assert t['c'][1]['rx'] == c[1]['rx']
+    assert t['c'][1]['ry'] == c[1]['ry']
 
-    assert t[1]['c']['rx'] == 200
-    assert t[1]['c']['ry'] == 'rbb'
+    assert t[1]['c']['rx'] == c[1]['rx']
+    assert t[1]['c']['ry'] == c[1]['ry']
 
     assert isinstance(t['d'], NdarrayMixin)
 
-    assert t['d'][1][0] == 2
-    assert t['d'][1][1] == 3
+    assert t['d'][1][0] == d[1][0]
+    assert t['d'][1][1] == d[1][1]
 
-    assert t[1]['d'][0] == 2
-    assert t[1]['d'][1] == 3
+    assert t[1]['d'][0] == d[1][0]
+    assert t[1]['d'][1] == d[1][1]
 
     assert t.pformat() == ['   a         b           c       d [2] ',
                            '-------- ---------- ------------ ------',

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -21,7 +21,7 @@ import copy
 
 from ...extern.six.moves import cPickle as pickle
 from ...tests.helper import pytest
-from ...table import Table, QTable, join, hstack, vstack
+from ...table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
 from ... import time
 from ... import coordinates
 from ... import units as u
@@ -62,7 +62,8 @@ def test_attributes(mixin_cols):
 
 
 def check_mixin_type(table, table_col, in_col):
-    if isinstance(in_col, u.Quantity) and type(table) is not QTable:
+    if ((isinstance(in_col, u.Quantity) and type(table) is not QTable)
+            or isinstance(in_col, Column)):
         assert type(table_col) is table.ColumnClass
     else:
         assert type(table_col) is type(in_col)
@@ -79,12 +80,11 @@ def test_make_table(table_types, mixin_cols):
     check_mixin_type(t, t['m'], mixin_cols['m'])
 
     cols = list(mixin_cols.values())
-    t = table_types.Table(cols, names=('a', 'b', 'c', 'm'))
+    t = table_types.Table(cols, names=('i', 'a', 'b', 'm'))
     check_mixin_type(t, t['m'], mixin_cols['m'])
 
     t = table_types.Table(cols)
     check_mixin_type(t, t['col3'], mixin_cols['m'])
-
 
 def test_io_ascii_write():
     """
@@ -304,7 +304,7 @@ def test_insert_row(mixin_cols):
     """
     t = QTable(mixin_cols)
     t['m'].info.description = 'd'
-    if isinstance(t['m'], u.Quantity):
+    if isinstance(t['m'], (u.Quantity, Column)):
         t.insert_row(1, t[-1])
         assert t[1] == t[-1]
         assert t['m'].info.description == 'd'
@@ -452,3 +452,32 @@ def test_skycoord_representation():
                            '  m,deg,m   ',
                            '------------',
                            '1.0,90.0,0.0']
+
+
+def test_ndarray_mixin():
+    """
+    Test directly adding a plain structured array into a table instead of the
+    view as an NdarrayMixin.  Once added as an NdarrayMixin then all the previous
+    tests apply.
+    """
+    a = np.array([(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')],
+                 dtype='<i4,|S1')
+    b = np.array([(10, 'aa'), (20, 'bb'), (30, 'cc'), (40, 'dd')],
+                 dtype=[('x', 'i4'), ('y', 'S2')])
+    t = Table([a, b], names=['a', 'b'])
+
+    assert isinstance(t['a'], NdarrayMixin)
+
+    assert t['a'][1][1] == 'b'
+    assert t['a'][2][0] == 3
+
+    assert t[1]['a'][1] == 'b'
+    assert t[2]['a'][0] == 3
+
+    assert isinstance(t['b'], NdarrayMixin)
+
+    assert t['b'][1]['x'] == 20
+    assert t['b'][1]['y'] == 'bb'
+
+    assert t[1]['b']['x'] == 20
+    assert t[1]['b']['y'] == 'bb'

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -22,7 +22,7 @@ from .format.latex import Latex
 from ..utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
 from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.data_info import MixinInfo, InfoDescriptor
+from ..utils.data_info import InfoDescriptor, ParentDtypeInfo
 from .utils import validate_power
 from .. import config as _config
 
@@ -113,7 +113,7 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityInfo(MixinInfo):
+class QuantityInfo(ParentDtypeInfo):
     """
     Container for meta information like name, description, format.  This is
     required when the object is used as a mixin column within a table, but can

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -384,3 +384,8 @@ class BaseColumnInfo(DataInfo):
 
 class MixinInfo(BaseColumnInfo):
     pass
+
+class ParentDtypeInfo(MixinInfo):
+    """Mixin that gets info.dtype from parent"""
+
+    attrs_from_parent = set(['dtype'])  # dtype and unit taken from parent


### PR DESCRIPTION
This is re-do of #3759 using a mixin class `NdarrayMixin`.  This is a light subclass of `ndarray` that adds an `info` attribute and the minimum other machinery to function as a mixin column.

In addition to being able to explicitly view any `ndarray` as `NdarrayMixin` for table ingest, if an ndarray is a structured array or recarray then `Table` will automatically take the view and add to the table as a mixin.

cc: @mdboom @mhvk