### PR TITLE
Back out #3095 and remove the Column __getitem__ override

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,6 +267,12 @@ API changes
 
 - ``astropy.table``
 
+  - PR #3095 fixed an issue where a single-element item access of a multi-
+    dimensional column would return a ``Column`` object instead of the expected
+    ``ndarray``.  Unfortunately this fix made accessing column items or
+    iterating over a column about 10 times slower.  In light of this performance
+    penalty it was decided to back out #3095 and accept this "feature". [#3929]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -29,7 +29,6 @@ AUTO_COLNAME = ConfigAlias(
 # Create a generic TableFormatter object for use by bare columns with no
 # parent table.
 FORMATTER = pprint.TableFormatter()
-INTEGER_TYPES = (int, long, np.integer) if six.PY2 else (int, np.integer)
 
 def _auto_names(n_cols):
     from . import conf
@@ -247,12 +246,6 @@ class BaseColumn(np.ndarray):
         state = state + (column_state,)
 
         return reconstruct_func, reconstruct_func_args, state
-
-    def __getitem__(self, item):
-        if isinstance(item, INTEGER_TYPES):
-            return self.data[item]  # Return as plain ndarray or ma.MaskedArray
-        else:
-            return super(BaseColumn, self).__getitem__(item)
 
     # avoid == and != to be done based on type of subclass
     # (helped solve #1446; see also __array_wrap__)

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -227,8 +227,11 @@ class TestColumn():
 
     def test_item_access_type(self, Column):
         """
-        Tests for #3095, which forces integer item access to always return a plain
-        ndarray or MaskedArray, even in the case of a multi-dim column.
+        Test the type of output for access to Column/MaskedColumn objects.  This
+        was originally written for #3095, which forced integer item access to
+        always return a plain ndarray or MaskedArray, even in the case of a
+        multi-dim column.  However, that was backed out by #3929, so this just
+        tests the the pre-3095 behavior holds.
         """
         integer_types = (int, long, np.int) if six.PY2 else (int, np.int)
 
@@ -237,7 +240,9 @@ class TestColumn():
             i0 = int_type(0)
             i1 = int_type(1)
             assert np.all(c[i0] == [1, 2])
-            assert type(c[i0]) == (np.ma.MaskedArray if hasattr(Column, 'mask') else np.ndarray)
+            # Class was (np.ma.MaskedArray if hasattr(Column, 'mask') else np.ndarray)
+            # with 3095 in place.
+            assert isinstance(c[i0], Column)
             assert c[i0].shape == (2,)
 
             c01 = c[i0:i1]


### PR DESCRIPTION
PR #3095 fixed a corner case issue where a single row item access of a multi-dimensional Column returned a Column object instead of the expected ndarray.  

However, by adding a pure-Python override of the `ndarray.__getitem__` method a significant performance penalty (factor of 10) was incurred for single-element item access (https://github.com/astropy/astropy/issues/3232).  In the discussion of 3232 it was agreed to back out #3095, but in all the activity related to the 1.0 release this didn't get done.

This PR does the back out.



