### PR TITLE
Speed up single-element Column.__getitem__ for 1-D columns.

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -92,7 +92,7 @@ class ColumnInfo(BaseColumnInfo):
     attrs_from_parent = BaseColumnInfo.attr_names
 
 
-class _NDColumnMixin(np.ndarray):
+class _NDColumnProxyShim(np.ndarray):
     """
     This mixin class exists solely to provide an override to
     ndarray.__getitem__ that provides the desirable behavior for single
@@ -111,7 +111,7 @@ class _NDColumnMixin(np.ndarray):
         if isinstance(item, INTEGER_TYPES):
             return self.data[item]  # Return as plain ndarray or ma.MaskedArray
         else:
-            return super(_NDColumnMixin, self).__getitem__(item)
+            return super(_NDColumnProxyShim, self).__getitem__(item)
 
 
 class BaseColumn(np.ndarray):
@@ -121,7 +121,7 @@ class BaseColumn(np.ndarray):
     _nd_proxy_classes = {}
     """
     Alternate versions of BaseColumn and any subclasses that have the
-    _NDColumnMixin shim, mapped to by the original class.  The shimmed
+    _NDColumnProxyShim, mapped to by the original class.  The shimmed
     classes have the same name as the original class and are otherwise
     indistinguishable.  This hack exists only as a performance tweak.
     """
@@ -181,13 +181,13 @@ class BaseColumn(np.ndarray):
     @classmethod
     def _get_nd_proxy_class(cls):
         """
-        Creates new classes with the _NDColumnMixin shim.  See the docstring
-        for _NDColumnMixin for more detail.
+        Creates new classes with the _NDColumnProxyShim.  See the docstring
+        for _NDColumnProxyShim for more detail.
         """
 
         if cls not in cls._nd_proxy_classes:
             cls._nd_proxy_classes[cls] = type(cls.__name__,
-                                              (_NDColumnMixin, cls), {})
+                                              (_NDColumnProxyShim, cls), {})
         return cls._nd_proxy_classes[cls]
 
     @property


### PR DESCRIPTION
As an alternative to #3929, create copies of `BaseColumn` and subclasses on an as-needed basis when using those columns to store multi-dimensional data.  The new classes have the slower `__getitem__` implementation, while the stock classes go straight through `ndarray.__getitem__` and retain its performance (the shimmed classes are also cached, so this not have much performance impact on Column creation either).

On my laptop, before this patch (on current master)
```python
In [1]: from astropy.table import Column

In [2]: c = Column([1, 2, 3])

In [3]: %timeit c[1]
1000000 loops, best of 3: 1.8 µs per loop
```

After this patch
```python
In [1]: from astropy.table import Column

In [2]: c = Column([1, 2, 3])

In [3]: %timeit c[1]
1000000 loops, best of 3: 195 ns per loop
```

Note, multi-dimensional columns still have to use the slower `__getitem__`, but exhibit the correct behavior:
```python
In [4]: c = Column([[1, 2], [3, 4], [5, 6]])

In [5]: c[1]
Out[5]: array([3, 4])

In [6]: %timeit c[1]
100000 loops, best of 3: 1.97 µs per loop

In [7]: c[1:]
Out[7]: 
<Column dtype='int64' shape=(2,) length=2>
3 .. 4
5 .. 6
```

I think this is probably an acceptable balance, given that the multi-dimensional case is far less common.  All the tests passed locally.