### PR TITLE
Quantity operations call `__array_finalize__` too often?

### DIFF
--- a/astropy/analytic_functions/blackbody.py
+++ b/astropy/analytic_functions/blackbody.py
@@ -66,7 +66,7 @@ def blackbody_nu(in_x, temperature):
     # Check if input values are physically possible
     if temp < 0:
         raise ValueError('Invalid temperature {0}'.format(temp))
-    if not np.all(np.isfinite(freq)) or np.any(freq <= 0):  # pragma: no cover
+    if not np.all(np.isfinite(freq)) or np.any(freq <= 0):
         warnings.warn('Input contains invalid wavelength/frequency value(s)',
                       AstropyUserWarning)
 

--- a/astropy/analytic_functions/blackbody.py
+++ b/astropy/analytic_functions/blackbody.py
@@ -66,7 +66,7 @@ def blackbody_nu(in_x, temperature):
     # Check if input values are physically possible
     if temp < 0:
         raise ValueError('Invalid temperature {0}'.format(temp))
-    if np.any(freq <= 0):  # pragma: no cover
+    if not np.all(np.isfinite(freq)) or np.any(freq <= 0):  # pragma: no cover
         warnings.warn('Input contains invalid wavelength/frequency value(s)',
                       AstropyUserWarning)
 

--- a/astropy/analytic_functions/tests/test_blackbody.py
+++ b/astropy/analytic_functions/tests/test_blackbody.py
@@ -12,7 +12,7 @@ import numpy as np
 from ..blackbody import blackbody_nu, blackbody_lambda, FNU
 from ... import units as u
 from ... import constants as const
-from ...tests.helper import pytest
+from ...tests.helper import pytest, catch_warnings
 from ...utils.exceptions import AstropyUserWarning
 
 try:
@@ -95,15 +95,13 @@ def test_blackbody_exceptions_and_warnings():
         blackbody_nu(1000 * u.AA, -100)
 
     # Zero wavelength given for conversion to Hz
-    with warnings.catch_warnings(record=True) as w:
+    with catch_warnings(AstropyUserWarning) as w:
         blackbody_nu(0 * u.AA, 5000)
-    categories = [_w.category for _w in w]
-    assert AstropyUserWarning in categories
-    assert 'invalid' in w[categories.index(AstropyUserWarning)].message.args[0]
+    assert len(w) == 1
+    assert 'invalid' in w[0].message.args[0]
 
     # Negative wavelength given for conversion to Hz
-    with warnings.catch_warnings(record=True) as w:
+    with catch_warnings(AstropyUserWarning) as w:
         blackbody_nu(-1. * u.AA, 5000)
-    categories = [_w.category for _w in w]
-    assert AstropyUserWarning in categories
-    assert 'invalid' in w[categories.index(AstropyUserWarning)].message.args[0]
+    assert len(w) == 1
+    assert 'invalid' in w[0].message.args[0]

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -199,7 +199,7 @@ class TestInput():
         assert loc_slice1.unit is locwgs72.unit
         assert loc_slice1.ellipsoid == locwgs72.ellipsoid == 'WGS72'
         assert not loc_slice1.shape
-        with pytest.raises(IndexError):
+        with pytest.raises(TypeError):
             loc_slice1[0]
         with pytest.raises(IndexError):
             len(loc_slice1)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -855,6 +855,14 @@ class Quantity(np.ndarray):
         return (self._new_view(result_tuple[0], dimensionless_unscaled),
                 self._new_view(result_tuple[1]))
 
+    def __pow__(self, other):
+        if isinstance(other, Fraction):
+            # Avoid getting object arrays by raising the value to a Fraction.
+            return self._new_view(self.value ** float(other),
+                                  self.unit ** other)
+
+        return super(Quantity, self).__pow__(other)
+
     def __pos__(self):
         """
         Plus the quantity. This is implemented in case users use +q where q is

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -18,6 +18,7 @@ from numpy.testing import (assert_allclose, assert_array_equal,
 from ...tests.helper import raises, pytest
 from ...utils import isiterable, minversion
 from ...utils.compat import NUMPY_LT_1_7
+from ...utils.compat.fractions import Fraction
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
 from ...extern.six.moves import xrange
@@ -1088,6 +1089,14 @@ def test_quantity_to_view():
 def test_quantity_tuple_power():
     (5.0 * u.m) ** (1, 2)
 
+
+def test_quantity_fraction_power():
+    q = (25.0 * u.m**2) ** Fraction(1, 2)
+    assert q.value == 5.
+    assert q.unit == u.m
+    # Regression check to ensure we didn't create an object type by raising
+    # the value of the quantity to a Fraction. [#3922]
+    assert q.dtype.kind == 'f'
 
 def test_inherit_docstrings():
     assert u.Quantity.argmax.__doc__ == np.ndarray.argmax.__doc__


### PR DESCRIPTION
This is mostly a reminder that while trying to test speed issues in #3898, we found that `Quantity.__array_finalize__` seems to be called more often than necessary. Eg.,
```
In [2]: q = np.arange(10)*u.m
In __array_finalize__; self, obj= <Quantity [ 0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] (Unit not initialised)> array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.])

In [3]: q[2:3]
In __array_finalize__; self, obj= <Quantity [ 2.] (Unit not initialised)> <Quantity [ 0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>
In __array_finalize__; self, obj= <Quantity [ 2.] (Unit not initialised)> <Quantity [ 2.] m>
In __array_finalize__; self, obj= <Quantity [ 2.] m> <Quantity [ 0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>
Out[3]: <Quantity [ 2.] m>
In [6]: np.square(q)
In __array_finalize__; self, obj= <Quantity [  6.94677988e-310,  2.34355731e-316,  6.94677779e-310,
             6.94677779e-310,  6.94677779e-310,  6.94677779e-310,
             6.94677779e-310,  6.94677779e-310,  6.94677779e-310,
             6.94677781e-310] (Unit not initialised)> array([  6.94677988e-310,   2.34355731e-316,   6.94677779e-310,
         6.94677779e-310,   6.94677779e-310,   6.94677779e-310,
         6.94677779e-310,   6.94677779e-310,   6.94677779e-310,
         6.94677781e-310])
In __array_finalize__; self, obj= <Quantity [  6.94677988e-310,  2.34355731e-316,  6.94677779e-310,
             6.94677779e-310,  6.94677779e-310,  6.94677779e-310,
             6.94677779e-310,  6.94677779e-310,  6.94677779e-310,
             6.94677781e-310] (Unit not initialised)> <Quantity [ 0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>
```
It seems likely this can be sped up a little.