### PR TITLE
Enable auto-inplace build in source distributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -524,6 +524,10 @@ Bug Fixes
   - ``fitscheck`` no longer causes scaled image data to be rescaled when
     adding checksums to existing files. [#3884]
 
+  - Fixed an issue where running ``import astropy`` from within the source
+    tree did not automatically build the extension modules if the source is
+    from a source distribution (as opposed to a git repository). [#3932]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include .astropy-root
 include README.rst
 include CHANGES.rst
 

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -216,9 +216,8 @@ def _initialize_astropy():
 
     # If this __init__.py file is in ./astropy/ then import is within a source dir
     source_dir = os.path.abspath(os.path.dirname(__file__))
-    is_astropy_source_dir = (
-            os.path.exists(os.path.join(source_dir, os.pardir, '.git')) and
-            os.path.isfile(os.path.join(source_dir, os.pardir, 'setup.py')))
+    is_astropy_source_dir = os.path.exists(os.path.join(source_dir, os.pardir,
+                                                        '.astropy-root'))
 
     def _rollback_import(message):
         log.error(message)


### PR DESCRIPTION
When running `import astropy` from within a source checkout, astropy will try to automatically build the extension modules inplace so that the package is fully importable and usable.  However, this relied on `.git` being present to work.  There's no reason it needs to be in git though--it's fine with me if this feature works for source tarballs as well (though really this feature should only be of use to developers, who should have a git repo anyways, at least the warning message that is displayed is informative).

The included `.astropy-root` file allows identification with this being the Astropy source tree fairly unambiguously.

Might be worth adding something similar to the affiliated package template.