### PR TITLE
fixed wCMD passing None to FLRW

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -477,6 +477,8 @@ Bug Fixes
 
 - ``astropy.cosmology``
 
+  - Fixed wCDM to not ignore the Ob0 parameter on initialization. [#3934]
+
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1940,7 +1940,7 @@ class wCDM(FLRW):
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), name=None, Ob0=None):
 
         FLRW.__init__(self, H0, Om0, Ode0, Tcmb0, Neff, m_nu, name=name,
-                      Ob0=None)
+                      Ob0=Ob0)
         self._w0 = float(w0)
 
         # Please see "Notes about speeding up integrals" for discussion


### PR DESCRIPTION
`wCMD.__init__` was silently ignoring input parameter `Ob0` and uncondtionally passing None to super class `FLRW.__init__`