### PR TITLE
cosmoslogy: core: factor out square

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1449,7 +1449,7 @@ class FLRW(Cosmology):
         dh = self._hubble_distance
         da = self.angular_diameter_distance(z)
         zp1 = 1.0 + z
-        return dh * (zp1 ** 2.0 * da ** 2.0) / u.Quantity(self.efunc(z),
+        return dh * ((zp1 * da) ** 2.0) / u.Quantity(self.efunc(z),
                                                           u.steradian)
 
     def kpc_comoving_per_arcmin(self, z):


### PR DESCRIPTION
An exponent of 2 can be factored out from the term so that only one power operator is needed.