### PR TITLE
Add phase parameter to Sine1D model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -258,6 +258,8 @@ API changes
     methods (these were obscure "accidentally public" methods that were
     probably not used by anyone). [#3910]
 
+  - Added a phase parameter to the Sine1D model. [#3807]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -535,6 +535,8 @@ class Sine1D(Fittable1DModel):
         Oscillation amplitude
     frequency : float
         Oscillation frequency
+    phase : float
+        Osciallation phase
 
     See Also
     --------
@@ -545,26 +547,29 @@ class Sine1D(Fittable1DModel):
     -----
     Model formula:
 
-        .. math:: f(x) = A \\sin(2 \\pi f x)
+        .. math:: f(x) = A \\sin(2 \\pi f x + 2 \\pi p)
     """
 
     amplitude = Parameter(default=1)
     frequency = Parameter(default=1)
+    phase = Parameter(default=0)
 
     @staticmethod
-    def evaluate(x, amplitude, frequency):
+    def evaluate(x, amplitude, frequency, phase):
         """One dimensional Sine model function"""
 
-        return amplitude * np.sin(2 * np.pi * frequency * x)
+        return amplitude * np.sin(2 * np.pi * frequency * x + np.pi * phase)
 
     @staticmethod
-    def fit_deriv(x, amplitude, frequency):
+    def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional Sine model derivative"""
 
-        d_amplitude = np.sin(2 * np.pi * frequency * x)
+        d_amplitude = np.sin(2 * np.pi * frequency * x + 2 * np.pi * phase)
         d_frequency = (2 * np.pi * x * amplitude *
-                       np.cos(2 * np.pi * frequency * x))
-        return [d_amplitude, d_frequency]
+                       np.cos(2 * np.pi * frequency * x + 2 * np.pi * phase))
+        d_phase = (2 * np.pi * amplitude *
+                   np.cos(2 * np.pi * frequency * x + 2 * np.pi * phase))
+        return [d_amplitude, d_frequency, d_phase]
 
 
 class Linear1D(Fittable1DModel):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -558,7 +558,7 @@ class Sine1D(Fittable1DModel):
     def evaluate(x, amplitude, frequency, phase):
         """One dimensional Sine model function"""
 
-        return amplitude * np.sin(2 * np.pi * frequency * x + np.pi * phase)
+        return amplitude * np.sin(2 * np.pi * frequency * x + 2 * np.pi * phase)
 
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -75,7 +75,7 @@ models_1D = {
     },
 
     Sine1D: {
-        'parameters': [1, 0.1],
+        'parameters': [1, 0.1, 0],
         'x_values': [0, 2.5],
         'y_values': [0, 1],
         'x_lim': [-10, 10],

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -272,7 +272,7 @@ It is also possible, and sometimes useful, to make a compound model from a
 combination of classes *and* instances in the same expression::
 
     >>> from astropy.modeling.models import Linear1D, Sine1D
-    >>> MyModel = Linear1D + Sine1D(amplitude=1, frequency=1)
+    >>> MyModel = Linear1D + Sine1D(amplitude=1, frequency=1, phase=0)
     >>> MyModel
     <class '__main__.CompoundModel...'>
     Name: CompoundModel...
@@ -287,7 +287,7 @@ combination of classes *and* instances in the same expression::
         Outputs: ('y',)
         Fittable parameters: ('slope', 'intercept')
     <BLANKLINE>
-        [1]: <Sine1D(amplitude=1.0, frequency=1.0)>
+        [1]: <Sine1D(amplitude=1.0, frequency=1.0, phase=0.0)>
 
 In this case the result is always a class.  However (and this is not
 immediately obvious by the representation) the difference is that the

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -278,7 +278,7 @@ combination of classes *and* instances in the same expression::
     Name: CompoundModel...
     Inputs: ('x',)
     Outputs: ('y',)
-    Fittable parameters: ('slope_0', 'intercept_0', 'amplitude_1', 'frequency_1')
+    Fittable parameters: ('slope_0', 'intercept_0', 'amplitude_1', 'frequency_1', 'phase_1')
     Expression: [0] + [1]
     Components:
         [0]: <class 'astropy.modeling.functional_models.Linear1D'>


### PR DESCRIPTION
This PR does not pass tests right now, with the following:
```
____________________________ [doctest] compound-models.rst ____________________________
267         [0]: <Gaussian1D(amplitude=1.0, mean=0.0, stddev=0.2)>
268     <BLANKLINE>
269         [1]: <Gaussian1D(amplitude=2.5, mean=0.5, stddev=0.1)>
270 
271 It is also possible, and sometimes useful, to make a compound model from a
272 combination of classes *and* instances in the same expression::
273 
274     >>> from astropy.modeling.models import Linear1D, Sine1D
275     >>> MyModel = Linear1D + Sine1D(amplitude=1, frequency=1, phase=0)
276     >>> MyModel
Differences (unified diff with -expected +actual):
    @@ -1,13 +1,13 @@
    -<class '__main__.CompoundModel...'>
    -Name: CompoundModel...
    -Inputs: ('x',)
    -Outputs: ('y',)
    -Fittable parameters: ('slope_0', 'intercept_0', 'amplitude_1', 'frequency_1')
    +<class '__main__.CompoundModel256'>
    +Name: CompoundModel256
    +Inputs: (u'x',)
    +Outputs: (u'y',)
    +Fittable parameters: (u'slope_0', u'intercept_0', u'amplitude_1', u'frequency_1', u'phase_1')
     Expression: [0] + [1]
    -Components:
    +Components:
         [0]: <class 'astropy.modeling.functional_models.Linear1D'>
         Name: Linear1D
    -    Inputs: ('x',)
    -    Outputs: ('y',)
    +    Inputs: (u'x',)
    +    Outputs: (u'y',)
         Fittable parameters: ('slope', 'intercept')
     <BLANKLINE>
```

I'll try to figure out what's wrong, but if you have an idea as to what could be the issue, please let me know! :)

This RP should resolve #3807.