### PR TITLE
Opt in to travis-ci container-based builds

### DIFF
--- a/.continuous-integration/travis/setup_environment_linux.sh
+++ b/.continuous-integration/travis/setup_environment_linux.sh
@@ -7,12 +7,8 @@ chmod +x miniconda.sh
 export PATH=/home/travis/miniconda/bin:$PATH
 conda update --yes conda
 
-# Install non-Python dependencies for documentation
-if [[ $SETUP_CMD == build_sphinx* ]]
-then
-  sudo apt-get update
-  sudo apt-get install graphviz texlive-latex-extra dvipng
-fi
+# Installation of non-Python dependencies for documentation is now
+# in .travis.yml
 
 # Install Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ language: c
 os:
     - linux
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
 env:
     global:
         # Set defaults to avoid repeating in most cases
         - NUMPY_VERSION=1.9
         - OPTIONAL_DEPS=false
         - MAIN_CMD='python setup.py'
+
     matrix:
         - PYTHON_VERSION=2.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ os:
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
+# The apt packages below are needed for sphinx builds, which can no longer
+# be installed with sudo apt-get.
+addons:
+    apt:
+        packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
 env:
     global:
         # Set defaults to avoid repeating in most cases


### PR DESCRIPTION
Travis [launched](http://docs.travis-ci.com/user/migrating-from-legacy/) their container-based builds for everyone. This opts us in to those builds, which launch almost instantly.