### PR TITLE
import logging levels from logging for convenience

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ New Features
 
 - ``astropy.logger.py``
 
+  - Added log levels (e.g., DEBUG, INFO, CRITICAL) to ``astropy.log`` [#3947]
+
 - ``astropy.modeling``
 
   - Added a new ``Parameter.validator`` interface for setting a validation

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -19,6 +19,14 @@ from .utils.exceptions import AstropyWarning, AstropyUserWarning
 
 __all__ = ['Conf', 'conf', 'log', 'AstropyLogger', 'LoggingError']
 
+# import the logging levels from logging so that one can do:
+# log.setLevel(log.DEBUG), for example
+logging_levels = ['DEBUG', 'CRITICAL', 'FATAL', 'ERROR', 'WARN', 'WARNING',
+                  'NOTSET', 'INFO']
+for level in logging_levels:
+    __import__('logging', level)
+__all__ += logging_levels
+
 
 # Initialize by calling _init_log()
 log = None

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -24,7 +24,7 @@ __all__ = ['Conf', 'conf', 'log', 'AstropyLogger', 'LoggingError']
 logging_levels = ['DEBUG', 'CRITICAL', 'FATAL', 'ERROR', 'WARN', 'WARNING',
                   'NOTSET', 'INFO']
 for level in logging_levels:
-    __import__('logging', level)
+    globals()[level] = getattr(logging, level)
 __all__ += logging_levels
 
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -21,8 +21,8 @@ __all__ = ['Conf', 'conf', 'log', 'AstropyLogger', 'LoggingError']
 
 # import the logging levels from logging so that one can do:
 # log.setLevel(log.DEBUG), for example
-logging_levels = ['DEBUG', 'CRITICAL', 'FATAL', 'ERROR', 'WARN', 'WARNING',
-                  'NOTSET', 'INFO']
+logging_levels = ['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',
+                  'FATAL', ]
 for level in logging_levels:
     globals()[level] = getattr(logging, level)
 __all__ += logging_levels


### PR DESCRIPTION
I find it awkward that you can import `log` (`from astropy import log`) and
have access to an awesome logger, but to set the levels, you either have to
separately `import logging` or memorize the numerical logging levels.

For example, now, if I want to enable debugging, I either do:
```
from astropy import log
import logging
log.setLevel(logging.DEBUG)
log.debug("message")
```
or

```
from astropy import log
log.setLevel(10)
log.debug("message")
```

This change imports the DEBUG, CRITICAL, WARN, INFO, FATAL, ERROR, and NOTSET
variables into `astropy.log`'s namespace