### PR TITLE
accessing  a table column by column number

### DIFF
--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -31,7 +31,7 @@ the data contained in that object relate to the original table data
 **Table properties**
 ::
 
-  t.columns   # Dict of table columns
+  t.columns   # Dict of table columns (access by column name, number, or slice)
   t.colnames  # List of column names
   t.meta      # Dict of meta-data
   len(t)      # Number of table rows
@@ -51,6 +51,8 @@ the data contained in that object relate to the original table data
   dat = np.array(t)  # Copy table data to numpy structured array object
   t['a'].quantity  # an astropy.units.Quantity for Column 'a'
   t['a'].to('km')  # an astropy.units.Quantity for Column 'a' in units of kilometers
+  t.columns[1]  # Column 1 (which is the 'b' column)
+  t.columns[0:2]  # New table with columns 0 and 1
 
 .. Note::
    Although they appear nearly equivalent, there is a factor of two performance

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -31,7 +31,7 @@ the data contained in that object relate to the original table data
 **Table properties**
 ::
 
-  t.columns   # Dict of table columns (access by column name, number, or slice)
+  t.columns   # Dict of table columns (access by column name, index, or slice)
   t.colnames  # List of column names
   t.meta      # Dict of meta-data
   len(t)      # Number of table rows


### PR DESCRIPTION
I want to address a table column by column number but the expected syntax seems unclear to me. Worse its seems that only row access by number seems possible based on the documentation for Table.

The Table documentation has:

```
>>> t['a']       # Column 'a'
<Column name='a' dtype='int32' length=3>
1
4
5

>>> t['a'][1]    # Row 1 of column 'a'
4


>>> t[1]['a']    # Column 'a' of row 1
4
```

The above does seem a little bit confusing to me although maybe there is a good rationale.

I expected that x=data[icol] would return a column but it is returning a row. 

where icol could be the column returned by: Table.index_column

 http://astropy.readthedocs.org/en/latest/api/astropy.table.Table.html#astropy.table.Table.index_column

I can do it with this syntax:

x=data[data.colnames[icol]]

If this is the recommended way as example would be useful.



