### PR TITLE
Change AstropyUserWarning -> AstropyWarning in warnings docs

### DIFF
--- a/docs/warnings.rst
+++ b/docs/warnings.rst
@@ -34,20 +34,20 @@ for simple call `warnings.simplefilter`::
 
     >>> warnings.simplefilter('ignore', UserWarning)
 
-Astropy includes its own warning class,
-`~astropy.utils.exceptions.AstropyUserWarning`, on which all warnings from
-Astropy are based.  So one can also ignore warnings from Astropy (while still
-allowing through warnings from other libraries like Numpy) by using something
-like::
+Astropy includes its own warning classes,
+`~astropy.utils.exceptions.AstropyWarning` and `~astropy.utils.exceptions.AstropyUserWarning`,
+on which all warnings from Astropy are based.  So one can also ignore warnings
+from Astropy (while still allowing through warnings from other libraries
+like Numpy) by using something like::
 
-    >>> from astropy.utils.exceptions import AstropyUserWarning
-    >>> warnings.simplefilter('ignore', category=AstropyUserWarning)
+    >>> from astropy.utils.exceptions import AstropyWarning
+    >>> warnings.simplefilter('ignore', category=AstropyWarning)
 
 However, warning filters may also be modified just within a certain context
 using the `warnings.catch_warnings` context manager::
 
     >>> with warnings.catch_warnings():
-    ...     warnings.simplefilter('ignore', AstropyUserWarning)
+    ...     warnings.simplefilter('ignore', AstropyWarning)
     ...     fits.writeto(filename, data, clobber=True)
 
 Astropy also issues warnings when deprecated API features are used.  If you

--- a/docs/warnings.rst
+++ b/docs/warnings.rst
@@ -35,20 +35,33 @@ for simple call `warnings.simplefilter`::
     >>> warnings.simplefilter('ignore', UserWarning)
 
 Astropy includes its own warning classes,
-`~astropy.utils.exceptions.AstropyWarning` and `~astropy.utils.exceptions.AstropyUserWarning`,
-on which all warnings from Astropy are based.  So one can also ignore warnings
-from Astropy (while still allowing through warnings from other libraries
-like Numpy) by using something like::
+`~astropy.utils.exceptions.AstropyWarning` and
+`~astropy.utils.exceptions.AstropyUserWarning`.  All warnings from Astropy are
+based on these warning classes (see below for the distinction between them). One
+can thus ignore all warnings from Astropy (while still allowing through
+warnings from other libraries like Numpy) by using something like::
 
     >>> from astropy.utils.exceptions import AstropyWarning
     >>> warnings.simplefilter('ignore', category=AstropyWarning)
 
-However, warning filters may also be modified just within a certain context
-using the `warnings.catch_warnings` context manager::
+Warning filters may also be modified just within a certain context using the
+`warnings.catch_warnings` context manager::
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter('ignore', AstropyWarning)
     ...     fits.writeto(filename, data, clobber=True)
+
+As mentioned above, there are actually *two* base classes for Astropy warnings.
+The main distinction is that `~astropy.utils.exceptions.AstropyUserWarning` is
+for warnings that are *intended* for typical users (e.g. "Warning: Ambiguous
+unit", something that might be because of improper input).  In contrast,
+`~astropy.utils.exceptions.AstropyWarning` warnings that are *not*
+`~astropy.utils.exceptions.AstropyUserWarning` may be for lower-level warnings
+more useful for developers writing code that *uses* Astropy (e.g., the
+deprecation warnings discussed below).  So if you're a user that just wants to
+silence everything, the code above will suffice, but if you are a developer and
+want to hide development-related warnings from your users, you may wish to still
+allow through `~astropy.utils.exceptions.AstropyUserWarning`.
 
 Astropy also issues warnings when deprecated API features are used.  If you
 wish to *squelch* deprecation warnings, you can start Python with


### PR DESCRIPTION
This is a small tweak to the documentation about astropy warnings.  It gives the impression that everyone should be catching `AstropyUserWarning` for any warnings, but I think that's incorrect: that's only when it's actually a *user* issueing the warning that that should be used, right?  `AstropyWarning` is what astropy actually throws in real code.

cc @embray as the original author of this section (or at least the last edit)