### PR TITLE
Allow --open-files to ignore some files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ minversion = 2.3.3
 norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat"
 doctest_plus = enabled
 doctest_norecursedirs = "astropy[\/]sphinx"
+open_files_ignore = "astropy.log" "/etc/hosts"
 
 [bdist_dmg]
 background = static/dmg_background.png


### PR DESCRIPTION
If you're like me and you watch the automated test builds regularly, you've been annoyed by frequent failures on Travis CI with test runs that use the `--open-files` option failing, because some test that uses the network causes `/etc/hosts` to be left open.  Since this isn't really a true problem, the simplest workaround is to just ignore that file.  But since we also already ignore astropy.log I figured the list of files to ignore should be configurable.