### PR TITLE
Update CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -477,6 +477,8 @@ Bug Fixes
 
 - ``astropy.cosmology``
 
+  - Fixed wCDM to not ignore the Ob0 parameter on initialization. [#3934]
+
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``


### PR DESCRIPTION
Bug fix under 1.0.4 astropy.cosmology: "Fixed wCDM to not ignore the Ob0 parameter on initialization. [#3934]"