### PR TITLE
Update stats.sigma_clipping to use less memory

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -157,19 +157,33 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
     Note that along the other axis, no points would be masked, as the
     variance is higher.
     """
+    def perform_clip(_filtered_data, _kwargs):
+        """
+        Perform sigma clip by comparing the data to the minimum and maximum
+        values (median + sig * standard deviation). Use sigma_lower and
+        sigma_upper to get the correct limits. Data values less or greater
+        than the minimum / maximum values will have True set in the mask array.
+        """
+        max_value = cenfunc(_filtered_data, **_kwargs)
+        standard_deviations = stdfunc(_filtered_data, **_kwargs)
+        min_value = max_value - standard_deviations * sigma_lower
+        max_value += standard_deviations * sigma_upper
+        if axis is not None:
+            if axis > 0:
+                min_value = np.expand_dims(min_value, axis=axis)
+                max_value = np.expand_dims(max_value, axis=axis)
+        _filtered_data.mask |= _filtered_data > max_value
+        _filtered_data.mask |= _filtered_data < min_value
 
     if sigma_lower is None:
         sigma_lower = sigma
     if sigma_upper is None:
         sigma_upper = sigma
 
+    kwargs = dict()
+
     if axis is not None:
-        cenfunc_in = cenfunc
-        stdfunc_in = stdfunc
-        cenfunc = lambda d: np.expand_dims(cenfunc_in(d, axis=axis),
-                                           axis=axis)
-        stdfunc = lambda d: np.expand_dims(stdfunc_in(d, axis=axis),
-                                           axis=axis)
+        kwargs['axis'] = axis
 
     filtered_data = np.ma.array(data, copy=copy)
 
@@ -179,20 +193,10 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
         while filtered_data.count() != lastrej:
             i += 1
             lastrej = filtered_data.count()
-            deviation = filtered_data - cenfunc(filtered_data)
-            std = stdfunc(filtered_data)
-            filtered_data.mask |= np.ma.masked_less(deviation,
-                                                    -std * sigma_lower).mask
-            filtered_data.mask |= np.ma.masked_greater(deviation,
-                                                       std * sigma_upper).mask
+            perform_clip(filtered_data, kwargs)
     else:
         for i in range(iters):
-            deviation = filtered_data - cenfunc(filtered_data)
-            std = stdfunc(filtered_data)
-            filtered_data.mask |= np.ma.masked_less(deviation,
-                                                    -std * sigma_lower).mask
-            filtered_data.mask |= np.ma.masked_greater(deviation,
-                                                       std * sigma_upper).mask
+            perform_clip(filtered_data, kwargs)
 
     # prevent filtered_data.mask = False (scalar) if no values are clipped
     if filtered_data.mask.shape == ():

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -165,9 +165,9 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
         than the minimum / maximum values will have True set in the mask array.
         """
         max_value = cenfunc(_filtered_data, **_kwargs)
-        standard_deviations = stdfunc(_filtered_data, **_kwargs)
-        min_value = max_value - standard_deviations * sigma_lower
-        max_value += standard_deviations * sigma_upper
+        std = stdfunc(_filtered_data, **_kwargs)
+        min_value = max_value - std * sigma_lower
+        max_value += std * sigma_upper
         if axis is not None:
             if axis > 0:
                 min_value = np.expand_dims(min_value, axis=axis)


### PR DESCRIPTION
This is a new pull request for #3738 with the changes that were made in #3595. This tries to reduce the memory used by the sigma_clipping function, especially when used on a data cube, for example a  stack of images. I was having problems with the old version when trying to sigma clip a large stack of images. To summarise the memory used before and after this change:

Data Cube | Before Pull (MiB) | After Pull (MiB)
------------ | ------------- | ------------- 
4096x4096x5  |  464  | 288
4096x4096x10  | 864   |  368 
4096x4096x20  | 1664  |  528
4096x4096x40  | 3264  |  848

Using memory_profiler you can see where the old version is creating temporary arrays:

```
   162   1542.0 MiB      0.0 MiB       if sigma_lower is None:
   163   1542.0 MiB      0.0 MiB           sigma_lower = sigma
   164   1542.0 MiB      0.0 MiB       if sigma_upper is None:
   165   1542.0 MiB      0.0 MiB           sigma_upper = sigma
   166                             
   167   1542.0 MiB      0.0 MiB       if axis is not None:
   168   1542.0 MiB      0.0 MiB           cenfunc_in = cenfunc
   169   1542.0 MiB      0.0 MiB           stdfunc_in = stdfunc
   170   1542.0 MiB      0.0 MiB           cenfunc = lambda d: np.expand_dims(cenfunc_in(d, axis=axis),
   171   2822.0 MiB   1280.0 MiB                                              axis=axis)
   172   1542.0 MiB  -1280.0 MiB           stdfunc = lambda d: np.expand_dims(stdfunc_in(d, axis=axis),
   173   2886.0 MiB   1344.0 MiB                                              axis=axis)
   174                             
   175   1542.0 MiB  -1344.0 MiB       filtered_data = np.ma.array(data, copy=copy)
   176                             
   177   1542.0 MiB      0.0 MiB       if iters is None:
   178                                     i = -1
   179                                     lastrej = filtered_data.count() + 1
   180                                     while filtered_data.count() != lastrej:
   181                                         i += 1
   182                                         lastrej = filtered_data.count()
   183                                         deviation = filtered_data - cenfunc(filtered_data)
   184                                         std = stdfunc(filtered_data)
   185                                         filtered_data.mask |= np.ma.masked_less(deviation,
   186                                                                                 -std * sigma_lower).mask
   187                                         filtered_data.mask |= np.ma.masked_greater(deviation,
   188                                                                                    std * sigma_upper).mask
   189                                 else:
   190   3206.0 MiB   1664.0 MiB           for i in range(iters):
   191                                         deviation = filtered_data - cenfunc(filtered_data)
   192                                         std = stdfunc(filtered_data)
   193   2886.0 MiB   -320.0 MiB               filtered_data.mask |= np.ma.masked_less(deviation,
   194   3206.0 MiB    320.0 MiB                                                       -std * sigma_lower).mask
   195   3206.0 MiB      0.0 MiB               filtered_data.mask |= np.ma.masked_greater(deviation,
   196   3206.0 MiB      0.0 MiB                                                          std * sigma_upper).mask
   197                             
   198                                 # prevent filtered_data.mask = False (scalar) if no values are clipped
   199   3206.0 MiB      0.0 MiB       if filtered_data.mask.shape == ():
   200                                     filtered_data.mask = False   # .mask shape will now match .data shape
   201                             
   202   3206.0 MiB      0.0 MiB       return filtered_data


Filename: sigma_clipping_org.py

Line #    Mem usage    Increment   Line Contents
================================================
   172   2886.0 MiB      0.0 MiB           stdfunc = lambda d: np.expand_dims(stdfunc_in(d, axis=axis),
   173   2886.0 MiB      0.0 MiB                                              axis=axis)


Filename: sigma_clipping_org.py

Line #    Mem usage    Increment   Line Contents
================================================
   170   1606.0 MiB      0.0 MiB           cenfunc = lambda d: np.expand_dims(cenfunc_in(d, axis=axis),
   171   1606.0 MiB      0.0 MiB                                              axis=axis)
```

and compare with the new version in this pull request:

```
   161   1558.1 MiB      0.0 MiB       def perform_clip(_filtered_data, _kwargs):
   162                                     """
   163                                     Perform sigma clip by comparing the data to the minimum and maximum
   164                                     values (median + sig * standard deviation). Use sigma_lower and
   165                                     sigma_upper to get the correct limits. Data values less or greater
   166                                     than the minimum / maximum values will have True set in the mask array.
   167                                     """
   168                                     max_value = cenfunc(_filtered_data, **_kwargs)
   169                                     standard_deviations = stdfunc(_filtered_data, **_kwargs)
   170                                     min_value = max_value - standard_deviations * sigma_lower
   171                                     max_value += standard_deviations * sigma_upper
   172                                     if axis is not None:
   173                                         if axis > 0:
   174                                             min_value = np.expand_dims(min_value, axis=axis)
   175                                             max_value = np.expand_dims(max_value, axis=axis)
   176                                     _filtered_data.mask |= _filtered_data > max_value
   177   1862.1 MiB    304.0 MiB           _filtered_data.mask |= _filtered_data < min_value
   178                             
   179   1558.1 MiB   -304.0 MiB       if sigma_lower is None:
   180   1558.1 MiB      0.0 MiB           sigma_lower = sigma
   181   1558.1 MiB      0.0 MiB       if sigma_upper is None:
   182   1558.1 MiB      0.0 MiB           sigma_upper = sigma
   183                             
   184   1558.1 MiB      0.0 MiB       kwargs = dict()
   185                             
   186   1558.1 MiB      0.0 MiB       if axis is not None:
   187   1558.1 MiB      0.0 MiB           kwargs['axis'] = axis
   188                             
   189   1558.1 MiB      0.0 MiB       filtered_data = np.ma.array(data, copy=copy)
   190                             
   191   1558.1 MiB      0.0 MiB       if iters is None:
   192                                     i = -1
   193                                     lastrej = filtered_data.count() + 1
   194                                     while filtered_data.count() != lastrej:
   195                                         i += 1
   196                                         lastrej = filtered_data.count()
   197                                         perform_clip(filtered_data, kwargs)
   198                                 else:
   199   1862.1 MiB    304.0 MiB           for i in range(iters):
   200                                         perform_clip(filtered_data, kwargs)
   201                             
   202                                 # prevent filtered_data.mask = False (scalar) if no values are clipped
   203   1862.1 MiB      0.0 MiB       if filtered_data.mask.shape == ():
   204                                     filtered_data.mask = False   # .mask shape will now match .data shape
   205                             
   206   1862.1 MiB      0.0 MiB       return filtered_data


Filename: sigma_clipping_new.py

Line #    Mem usage    Increment   Line Contents
================================================
   161   1558.1 MiB      0.0 MiB       def perform_clip(_filtered_data, _kwargs):
   162                                     """
   163                                     Perform sigma clip by comparing the data to the minimum and maximum
   164                                     values (median + sig * standard deviation). Use sigma_lower and
   165                                     sigma_upper to get the correct limits. Data values less or greater
   166                                     than the minimum / maximum values will have True set in the mask array.
   167                                     """
   168   1622.1 MiB     64.0 MiB           max_value = cenfunc(_filtered_data, **_kwargs)
   169   1686.1 MiB     64.0 MiB           standard_deviations = stdfunc(_filtered_data, **_kwargs)
   170   1766.1 MiB     80.0 MiB           min_value = max_value - standard_deviations * sigma_lower
   171   1766.1 MiB      0.0 MiB           max_value += standard_deviations * sigma_upper
   172   1766.1 MiB      0.0 MiB           if axis is not None:
   173   1766.1 MiB      0.0 MiB               if axis > 0:
   174                                             min_value = np.expand_dims(min_value, axis=axis)
   175                                             max_value = np.expand_dims(max_value, axis=axis)
   176   2086.1 MiB    320.0 MiB           _filtered_data.mask |= _filtered_data > max_value
   177   2086.1 MiB      0.0 MiB           _filtered_data.mask |= _filtered_data < min_value
```