### PR TITLE
POC: tables within tables within tables!

### DIFF
--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -9,6 +9,7 @@ import os
 
 import numpy as np
 from ..extern import six
+from ..utils.data_info import ParentDtypeInfo
 
 __all__ = ['table_info', 'TableInfo']
 
@@ -114,8 +115,18 @@ def table_info(tbl, option='attributes', out=''):
 
     out.writelines(outline + os.linesep for outline in outlines)
 
-class TableInfo(object):
+class TableInfo(ParentDtypeInfo):
     _parent = None
+
+    @staticmethod
+    def default_format(val):
+        return str(val.as_void())
+
+    @property
+    def unit(self):
+        """Use the unit row to show column names"""
+        unit = '(' + ', '.join(self._parent.colnames) + ')'
+        return unit
 
     def __call__(self, option='attributes', out=''):
         return table_info(self._parent, option, out)


### PR DESCRIPTION
I had hoped this would be easy once #3731 was complete, and at first glance that appears to be the case.  Of course the devil is in the details and I haven't tried running this through the mixin column tests...

```

In [2]: t = simple_table()

In [3]: t2 = simple_table()

In [4]: t3 = simple_table()

In [5]: t2['d'] = t

In [6]: t2
Out[6]: 
<Table length=3>
  a      b     c         d      
                     (a, b, c)  
int32 float32 str1     void72   
----- ------- ---- -------------
    1     1.0    c (1, 1.0, 'c')
    2     2.0    d (2, 2.0, 'd')
    3     3.0    e (3, 3.0, 'e')

In [7]: t3['d'] = t2

In [8]: t3
Out[8]: 
<Table length=3>
  a      b     c                d              
                           (a, b, c, d)        
int32 float32 str1           void144           
----- ------- ---- ----------------------------
    1     1.0    c (1, 1.0, 'c', (1, 1.0, 'c'))
    2     2.0    d (2, 2.0, 'd', (2, 2.0, 'd'))
    3     3.0    e (3, 3.0, 'e', (3, 3.0, 'e'))

In [9]: t3['d']
Out[9]: 
<Table length=3>
  a      b     c         d      
                     (a, b, c)  
int32 float32 str1     void72   
----- ------- ---- -------------
    1     1.0    c (1, 1.0, 'c')
    2     2.0    d (2, 2.0, 'd')
    3     3.0    e (3, 3.0, 'e')

In [10]: t3['d']['d']['c']
Out[10]: 
<Column name='c' dtype='str1' length=3>
c
d
e
```
