### PR TITLE
Additional keyword arguments for Simplex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -341,6 +341,10 @@ Bug fixes
 
 - ``astropy.modeling``
 
+  - Simplex method now correctly passes additional keywords arguments to the scipy solver. [#3966]
+  
+  - The keyword ``acc`` (for accuracy) is now correctly accepted by Simplex [#3966]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -216,6 +216,12 @@ class Simplex(Optimization):
         """
         if 'maxiter' not in kwargs:
             kwargs['maxiter'] = self._maxiter
+        if 'acc' in kwargs:
+            self._acc = kwargs['acc']
+            kwargs.pop['acc']
+        if 'xtol' in kwargs:
+            self._acc = kwargs['xtol']
+            kwargs.pop['xtol']
   
         fitparams, final_func_val, numiter, funcalls, exit_mode = self.opt_method(
             objfunc, initval, args=fargs, xtol=self._acc,

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -218,10 +218,10 @@ class Simplex(Optimization):
             kwargs['maxiter'] = self._maxiter
         if 'acc' in kwargs:
             self._acc = kwargs['acc']
-            kwargs.pop['acc']
+            kwargs.pop('acc')
         if 'xtol' in kwargs:
             self._acc = kwargs['xtol']
-            kwargs.pop['xtol']
+            kwargs.pop('xtol')
   
         fitparams, final_func_val, numiter, funcalls, exit_mode = self.opt_method(
             objfunc, initval, args=fargs, xtol=self._acc,

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -216,11 +216,10 @@ class Simplex(Optimization):
         """
         if 'maxiter' not in kwargs:
             kwargs['maxiter'] = self._maxiter
-        if 'acc' not in kwargs:
-            kwargs['acc'] = self._acc
+  
         fitparams, final_func_val, numiter, funcalls, exit_mode = self.opt_method(
             objfunc, initval, args=fargs, xtol=self._acc,
-            full_output=True)
+            full_output=True, **kwargs)
         self.fit_info['final_func_val'] = final_func_val
         self.fit_info['numiter'] = numiter
         self.fit_info['exit_mode'] = exit_mode


### PR DESCRIPTION
Additional arguments (_kwargs_) were not passed to the opt_method (scipy.optimize.fmin). 
Also, `'acc'` was not one of the keyword arguments accepted by `fmin`, and threw an error.
This fixes the issue in my use case (I needed to pass maxfun to `fmin`)