### PR TITLE
Don't include comments WCS.to_header()

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -373,10 +373,7 @@ def test_to_fits():
     wfits = w.to_fits()
     assert isinstance(wfits, fits.HDUList)
     assert isinstance(wfits[0], fits.PrimaryHDU)
-    if wcs._wcs.__version__[0] == '5':
-        assert header_string == wfits[0].header[-10:]
-    else:
-        assert header_string == wfits[0].header[-8:]
+    assert header_string == wfits[0].header[-8:]
 
 
 def test_to_header_warning():
@@ -386,6 +383,13 @@ def test_to_header_warning():
         x.to_header()
     assert len(w) == 1
     assert 'A_ORDER' in str(w[0])
+
+
+def test_no_comments_in_header():
+    w = wcs.WCS()
+    header = w.to_header()
+    assert '' not in header
+    assert 'COMMENT' not in header
 
 
 @raises(wcs.InvalidTransformError)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2463,6 +2463,8 @@ reduce these to 2 dimensions using the naxis kwarg.
         if self.wcs is not None:
             header_string = self.wcs.to_header(relax)
             header = fits.Header.fromstring(header_string)
+            del header['']
+            del header['COMMENT']
         else:
             header = fits.Header()
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2451,9 +2451,6 @@ reduce these to 2 dimensions using the naxis kwarg.
             display_warning = True
             relax = False
 
-        if key is not None:
-            self.wcs.alt = key
-
         if relax not in (True, False):
             do_sip = relax & WCSHDO_SIP
             relax &= ~WCSHDO_SIP
@@ -2461,7 +2458,14 @@ reduce these to 2 dimensions using the naxis kwarg.
             do_sip = relax
 
         if self.wcs is not None:
-            header_string = self.wcs.to_header(relax)
+            if key is not None:
+                orig_key = self.wcs.alt
+                self.wcs.alt = key
+            try:
+                header_string = self.wcs.to_header(relax)
+            finally:
+                if key is not None:
+                    self.wcs.alt = orig_key
             header = fits.Header.fromstring(header_string)
             del header['']
             del header['COMMENT']


### PR DESCRIPTION
Not including blanks or COMMENT in the output of WCS.to_header() a little easier to deal with.

See discussion here:

https://github.com/astropy/astropy/pull/3905/files#r34798842