### PR TITLE
Correctly handle adding commentary cards in Header.extend in edge cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,7 +201,7 @@ New Features
 
   - Added ``classproperty`` decorator--this is to ``property`` as
     ``classmethod`` is to normal instance methods. [#3982]
-  - ``iers.open`` now handles network URLs, as well as local paths. [#3850] 
+  - ``iers.open`` now handles network URLs, as well as local paths. [#3850]
 
   - The ``astropy.utils.wraps`` decorator now takes an optional
     ``exclude_args`` argument not shared by the standard library ``wraps``
@@ -579,6 +579,9 @@ Bug Fixes
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``
+
+  - Fix bug when extending one header (without comments) with another
+    (with comments). [#3967]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1359,8 +1359,6 @@ class Header(object):
                 else:
                     extend_cards.append(card)
             else:
-                # First parentheses needed because of operator precedence.
-                # Second is just for clarity.
                 if (unique or update) and keyword in self:
                     if card.is_blank:
                         extend_cards.append(card)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1359,7 +1359,9 @@ class Header(object):
                 else:
                     extend_cards.append(card)
             else:
-                if unique or update and keyword in self:
+                # First parentheses needed because of operator precedence.
+                # Second is just for clarity.
+                if (unique or update) and keyword in self:
                     if card.is_blank:
                         extend_cards.append(card)
                         continue

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1184,6 +1184,7 @@ class TestHeaderFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU()
         hdu2 = fits.ImageHDU()
         hdu.header['MYKEY'] = ('some val', 'some comment')
+        hdu2.header['MYKEY'] = ('some other val', 'some other comment')
         hdu.header.extend(hdu2.header, unique=True)
         assert len(hdu.header) == 5
         assert hdu.header[-1] == 'some val'

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1189,6 +1189,22 @@ class TestHeaderFunctions(FitsTestCase):
         assert len(hdu.header) == 5
         assert hdu.header[-1] == 'some val'
 
+    def test_header_extend_unique_commentary(self):
+        """
+        Test extending header with and without unique=True and commentary
+        cards in the header being added. Issue astropy/astropy#3967
+        """
+        for commentary_card in ['', 'COMMENT', 'HISTORY']:
+            for is_unique in [True, False]:
+                hdu = fits.PrimaryHDU()
+                # Make sure we are testing the case we want.
+                assert commentary_card not in hdu.header
+                hdu2 = fits.ImageHDU()
+                hdu2.header[commentary_card] = 'My text'
+                hdu.header.extend(hdu2.header, unique=is_unique)
+                assert len(hdu.header) == 5
+                assert hdu.header[commentary_card][0] == 'My text'
+
     def test_header_extend_update(self):
         """
         Test extending the header with and without update=True.
@@ -1219,6 +1235,25 @@ class TestHeaderFunctions(FitsTestCase):
         assert hdu.header['MYKEY'] == 'some other val'
         assert len(hdu.header['HISTORY']) == 2
         assert hdu.header[-1] == 'history 2'
+
+    def test_header_extend_update_commentary(self):
+        """
+        Test extending header with and without unique=True and commentary
+        cards in the header being added.
+
+        Though not quite the same as astropy/astropy#3967, update=True hits
+        the same if statement as that issue.
+        """
+        for commentary_card in ['', 'COMMENT', 'HISTORY']:
+            for is_update in [True, False]:
+                hdu = fits.PrimaryHDU()
+                # Make sure we are testing the case we want.
+                assert commentary_card not in hdu.header
+                hdu2 = fits.ImageHDU()
+                hdu2.header[commentary_card] = 'My text'
+                hdu.header.extend(hdu2.header, update=is_update)
+                assert len(hdu.header) == 5
+                assert hdu.header[commentary_card][0] == 'My text'
 
     def test_header_extend_exact(self):
         """


### PR DESCRIPTION
This PR fixes #3967, an error that comes up when calling `io.fits.Header.extend` with `unique=True` when the header being extended does not contain a commentary card but the header it is being extended by does.

It also adds one line to the test `test_header_extend_unique` to ensure it is testing a case with a keyword in both headers.