### PR TITLE
do not attempt to delete keyword which is not in header

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -388,8 +388,12 @@ def test_to_header_warning():
 def test_no_comments_in_header():
     w = wcs.WCS()
     header = w.to_header()
-    assert '' not in header
-    assert 'COMMENT' not in header
+    assert w.wcs.alt not in header
+    assert 'COMMENT' + w.wcs.alt.strip() not in header
+    wkey = 'P'
+    header = w.to_header(key=wkey)
+    assert wkey not in header
+    assert 'COMMENT' + wkey not in header
 
 
 @raises(wcs.InvalidTransformError)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2467,7 +2467,13 @@ reduce these to 2 dimensions using the naxis kwarg.
                 if key is not None:
                     self.wcs.alt = orig_key
             header = fits.Header.fromstring(header_string)
-            for kw in ["", " ", "COMMENT"]:
+            if key is not None:
+                keys_to_remove = [key, "COMMENT"+key]
+            elif self.wcs.alt.strip() is not "":
+                keys_to_remove = [self.wcs.alt, "COMMENT"+self.wcs.alt]
+            else:
+                keys_to_remove = ["", " ", "COMMENT"]
+            for kw in keys_to_remove:
                 if kw in header:
                     del header[kw]
         else:

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2467,8 +2467,9 @@ reduce these to 2 dimensions using the naxis kwarg.
                 if key is not None:
                     self.wcs.alt = orig_key
             header = fits.Header.fromstring(header_string)
-            del header['']
-            del header['COMMENT']
+            for kw in ["", " ", "COMMENT"]:
+                if kw in header:
+                    del header[kw]
         else:
             header = fits.Header()
 


### PR DESCRIPTION
`astropy.io.fits` now raises an error when deleting a keyword which is not in the header. This is an addition to #3968.