### PR TITLE
Improvements to cache location management and documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@ New Features
 
 - ``astropy.config``
 
+  - Added new tools ``set_temp_config`` and ``set_temp_cache`` which can be
+    used either as function decorators or context managers to temporarily
+    use alternative directories in which to read/write the Astropy config
+    files and download caches respectively.  This is especially useful for
+    testing, though ``set_temp_cache`` may also be used as a way to provide
+    an alternative (application specific) download cache for large data files,
+    rather than relying on the default cache location in users' home
+    directories. [#3975]
+
 - ``astropy.conftest.py``
 
 - ``astropy.constants``
@@ -138,6 +147,12 @@ New Features
     [#3925]
 
 - ``astropy.tests``
+
+  - Added new test config options, ``config_dir`` and ``cache_dir``  (these
+    can be edited in ``setup.cfg`` or as extra command-line options to
+    py.test) for setting the locations to use for the Astropy config files
+    and download caches (see also the related ``set_temp_config/cache``
+    features added in ``astropy.config``). [#3975]
 
 - ``astropy.time``
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -6,12 +6,15 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..extern import six
+from ..utils.decorators import wraps
 
 import os
+import shutil
 import sys
 
 
-__all__ = ['get_config_dir', 'get_cache_dir']
+__all__ = ['get_config_dir', 'get_cache_dir', 'set_temp_config',
+           'set_temp_cache']
 
 
 def _find_home():
@@ -105,6 +108,15 @@ def get_config_dir(create=True):
 
     # symlink will be set to this if the directory is created
     linkto = None
+
+    # If using set_temp_config, that overrides all
+    if set_temp_config._temp_path is not None:
+        xch = set_temp_config._temp_path
+        config_path = os.path.join(xch, 'astropy')
+        if not os.path.exists(config_path):
+            os.mkdir(config_path)
+        return os.path.abspath(config_path)
+
     # first look for XDG_CONFIG_HOME
     xch = os.environ.get('XDG_CONFIG_HOME')
 
@@ -137,6 +149,15 @@ def get_cache_dir():
 
     # symlink will be set to this if the directory is created
     linkto = None
+
+    # If using set_temp_cache, that overrides all
+    if set_temp_cache._temp_path is not None:
+        xch = set_temp_cache._temp_path
+        cache_path = os.path.join(xch, 'astropy')
+        if not os.path.exists(cache_path):
+            os.mkdir(cache_path)
+        return os.path.abspath(cache_path)
+
     # first look for XDG_CACHE_HOME
     xch = os.environ.get('XDG_CACHE_HOME')
 
@@ -149,6 +170,116 @@ def get_cache_dir():
                 linkto = xchpth
 
     return os.path.abspath(_find_or_create_astropy_dir('cache', linkto))
+
+
+class _SetTempPath(object):
+    _temp_path = None
+    _default_path_getter = None
+
+    def __init__(self, path=None, delete=False):
+        if path is not None:
+            path = os.path.abspath(path)
+
+        self._path = path
+        self._delete = delete
+        self._prev_path = self.__class__._temp_path
+
+    def __enter__(self):
+        self.__class__._temp_path = self._path
+        return self._default_path_getter()
+
+    def __exit__(self, *args):
+        self.__class__._temp_path = self._prev_path
+
+        if self._delete and self._path is not None:
+            shutil.rmtree(self._path)
+
+    def __call__(self, func):
+        """Implements use as a decorator."""
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with self:
+                func(*args, **kwargs)
+
+        return wrapper
+
+
+class set_temp_config(_SetTempPath):
+    """
+    Context manager to set a temporary path for the Astropy config, primarily
+    for use with testing.
+
+    If the path set by this context manager does not already exist it will be
+    created, if possible.
+
+    This may also be used as a decorator on a function to set the config path
+    just within that function.
+
+    Parameters
+    ----------
+
+    path : str, optional
+        The directory (which must exist) in which to find the Astropy config
+        files, or create them if they do not already exist.  If None, this
+        restores the config path to the user's default config path as returned
+        by `get_config_dir` as though this context manager were not in effect
+        (this is useful for testing).  In this case the ``delete`` argument is
+        always ignored.
+
+    delete : bool, optional
+        If True, cleans up the temporary directory after exiting the temp
+        context (default: False).
+    """
+
+    _default_path_getter = staticmethod(get_config_dir)
+
+    def __enter__(self):
+        # Special case for the config case, where we need to reset all the
+        # cached config objects
+        from .configuration import _cfgobjs
+
+        path = super(set_temp_config, self).__enter__()
+        _cfgobjs.clear()
+        return path
+
+    def __exit__(self, *args):
+        from .configuration import _cfgobjs
+
+        super(set_temp_config, self).__exit__(*args)
+        _cfgobjs.clear()
+
+
+class set_temp_cache(_SetTempPath):
+    """
+    Context manager to set a temporary path for the Astropy download cache,
+    primarily for use with testing (though there may be other applications
+    for setting a different cache directory, for example to switch to a cache
+    dedicated to large files).
+
+    If the path set by this context manager does not already exist it will be
+    created, if possible.
+
+    This may also be used as a decorator on a function to set the cache path
+    just within that function.
+
+    Parameters
+    ----------
+
+    path : str
+        The directory (which must exist) in which to find the Astropy cache
+        files, or create them if they do not already exist.  If None, this
+        restores the cache path to the user's default cache path as returned
+        by `get_cache_dir` as though this context manager were not in effect
+        (this is useful for testing).  In this case the ``delete`` argument is
+        always ignored.
+
+    delete : bool, optional
+        If True, cleans up the temporary directory after exiting the temp
+        context (default: False).
+    """
+
+    _default_path_getter = staticmethod(get_cache_dir)
 
 
 def _find_or_create_astropy_dir(dirnm, linkto):

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -264,6 +264,9 @@ class TestRunner(object):
         from ..table import Table
 
         # Have to use nested with statements for cross-Python support
+        # Note, using these context managers here is superfluous if the
+        # config_dir or cache_dir options to py.test are in use, but it's
+        # also harmless to nest the contexts
         with set_temp_config(astropy_config, delete=True):
             with set_temp_cache(astropy_cache, delete=True):
                 return pytest.main(args=all_args, plugins=plugins)

--- a/astropy/utils/argparse.py
+++ b/astropy/utils/argparse.py
@@ -1,0 +1,56 @@
+"""Utilities and extensions for use with `argparse`."""
+
+
+import os
+
+from .compat import argparse
+from ..extern.six import string_types
+
+
+def directory(arg):
+    """
+    An argument type (for use with the ``type=`` argument to
+    `argparse.ArgumentParser.add_argument` which determines if the argument is
+    an existing directory (and returns the absolute path).
+    """
+
+    if not isinstance(arg, string_types) and os.path.isdir(arg):
+        raise argparse.ArgumentTypeError(
+            "{0} is not a directory or does not exist (the directory must "
+            "be created first)".format(arg))
+
+    return os.path.abspath(arg)
+
+
+def readable_directory(arg):
+    """
+    An argument type (for use with the ``type=`` argument to
+    `argparse.ArgumentParser.add_argument` which determines if the argument is
+    a directory that exists and is readable (and returns the absolute path).
+    """
+
+    arg = directory(arg)
+
+    if not os.access(arg, os.R_OK):
+        raise argparse.ArgumentTypeError(
+            "{0} exists but is not readable with its current "
+            "permissions".format(arg))
+
+    return arg
+
+
+def writeable_directory(arg):
+    """
+    An argument type (for use with the ``type=`` argument to
+    `argparse.ArgumentParser.add_argument` which determines if the argument is
+    a directory that exists and is writeable (and returns the absolute path).
+    """
+
+    arg = directory(arg)
+
+    if not os.access(arg, os.W_OK):
+        raise argparse.ArgumentTypeError(
+            "{0} exists but is not writeable with its current "
+            "permissions".format(arg))
+
+    return arg

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -222,6 +222,9 @@ def test_data_noastropy_fallback(monkeypatch):
     monkeypatch.setenv(str('XDG_CACHE_HOME'), 'bar')
     monkeypatch.delenv(str('XDG_CACHE_HOME'))
 
+    monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
+    monkeypatch.setattr(paths.set_temp_cache, '_temp_path', None)
+
     # make sure the _find_or_create_astropy_dir function fails as though the
     # astropy dir could not be accessed
     def osraiser(dirnm, linkto):
@@ -334,6 +337,7 @@ def test_invalid_location_download():
 
     with pytest.raises(URLError):
         download_file('http://astropy.org/nonexistentfile')
+
 
 def test_invalid_location_download_noconnect():
     """

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -355,7 +355,8 @@ Tests that need to make use of a data file should use the
 search locally first, and then on the astropy data server or an arbitrary
 URL, and return a file-like object or a local filename, respectively.  They
 automatically cache the data locally if remote data is obtained, and from
-then on the local copy will be used transparently.
+then on the local copy will be used transparently.  See the next section for
+note specific to dealing with the cache in tests.
 
 They also support the use of an MD5 hash to get a specific version of a data
 file.  This hash can be obtained prior to submitting a file to the astropy
@@ -401,6 +402,33 @@ The ``get_remote_test_data`` will place the files in a temporary directory
 indicated by the ``tempfile`` module, so that the test files will eventually
 get removed by the system. In the long term, once test data files become too
 large, we will need to design a mechanism for removing test data immediately.
+
+Tests that use the file cache
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, the Astropy test runner sets up a clean file cache in a temporary
+directory that is used only for that test run and then destroyed.  This is to
+ensure consistency between test runs, as well as to not clutter users' caches
+(i.e. the cache directory returned by `~astropy.config.get_cache_dir`) with
+test files.
+
+However, some test authors (especially for affiliated packages) may find it
+desirable to cache files downloaded during a test run in a more permanent
+location (e.g. for large data sets).  To this end the
+`~astropy.config.set_temp_cache` helper may be used.  It can be used either as
+a context manager within a test to temporarily set the cache to a custom
+location, or as a *decorator* that takes effect for an entire test function
+(not including setup or teardown, which would have to be decorated separately).
+
+Furthermore, it is possible to set an option ``cache_dir`` in the py.test
+config file which sets the cache location for the entire test run.  A
+``--cache-dir`` command-line option is also supported (which overrides all
+other settings).  Currently it is not directly supported by the
+``./setup.py test`` command, so it is necessary to use it with the ``-a``
+argument like::
+
+    $ ./setup.py test -a "--cache-dir=/path/to/custom/cache/dir"
+
 
 Tests that create files
 -----------------------


### PR DESCRIPTION
Inspired by a [similar feature](https://github.com/astropy/halotools/pull/101) @aphearin recently added for testing halotools, and various other discussions with @cdeil and others around this issue, this PR adds a new helper called `set_temp_cache` which can temporarily set the cache directory used by all functions that access the cache, to a custom location.  `set_temp_cache` can be used either as a decorator or as a context manager (using the "with" statement).  It is accompanied by a similar `set_temp_config` for setting the config directory in a similar manner, though this has less immediate use.  This all works, also, without dorking around with environment variables.

This also adds a `cache_dir` test option that can be set either in the py.test config file (or setup.cfg), or via the command-line.  This sets the cache directory for the entire test run, overriding the default use of a disposable temp dir for the cache.  Any combination of these techniques may be used within a single test suite to control use of the download cache.

A bit of documentation about this has been added to the test writing guidelines, but it's only a mere start to the more comprehensive data management documentation discussed in #700.