### PR TITLE
Initializing empty Table with dtype doesn't work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1253,6 +1253,9 @@ API Changes
   - The representation of Table and Column objects has been changed to
     be formatted similar to the print output. [#3239]
 
+  - An empty table can now be initialized without a ``names`` argument as long
+    as a valid ``dtype`` argument (with names embedded) is supplied. [#3977]
+
 - ``astropy.time``
 
   - The ``Time.val`` and ``Time.vals`` properties (deprecated in v0.3) and the

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -278,8 +278,18 @@ class Table(object):
 
         elif data is None:
             if names is None:
-                return  # Empty table
-            else:
+                if dtype is None:
+                    return  # Empty table
+                try:
+                    # No data nor names but dtype is available.  This must be
+                    # valid to initialize a structured array.
+                    tmp = np.empty(0, dtype=dtype)
+                    names = tmp.dtype.names
+                    dtype = [tmp.dtype[i] for i in range(len(tmp.dtype))]
+                except:
+                    raise ValueError('dtype was specified but could not be '
+                                     'parsed for column names')
+            if names is not None:
                 init_func = self._init_from_list
                 n_cols = len(names)
                 data = [[]] * n_cols

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -283,9 +283,9 @@ class Table(object):
                 try:
                     # No data nor names but dtype is available.  This must be
                     # valid to initialize a structured array.
-                    tmp = np.empty(0, dtype=dtype)
-                    names = tmp.dtype.names
-                    dtype = [tmp.dtype[i] for i in range(len(tmp.dtype))]
+                    dtype = np.dtype(dtype)
+                    names = dtype.names
+                    dtype = [dtype[name] for name in names]
                 except:
                     raise ValueError('dtype was specified but could not be '
                                      'parsed for column names')

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -289,10 +289,11 @@ class Table(object):
                 except:
                     raise ValueError('dtype was specified but could not be '
                                      'parsed for column names')
-            if names is not None:
-                init_func = self._init_from_list
-                n_cols = len(names)
-                data = [[]] * n_cols
+            # names is guaranteed to be set at this point
+            init_func = self._init_from_list
+            n_cols = len(names)
+            data = [[]] * n_cols
+
         else:
             raise ValueError('Data type {0} not allowed to init Table'
                              .format(type(data)))

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -4,12 +4,9 @@
 
 from __future__ import print_function  # For print debugging with python 2 or 3
 
-from distutils import version
-
 import numpy as np
 
 from ...tests.helper import pytest
-from ... import table
 from ...table import Column, TableColumns
 from ...utils import OrderedDict
 

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -394,14 +394,23 @@ class TestInitFromNone():
     # table and adding data.
 
     def test_data_none_with_cols(self, table_type):
-        t = table_type(names=('a', 'b'))
-        assert len(t['a']) == 0
-        assert len(t['b']) == 0
-        assert t.colnames == ['a', 'b']
-        t = table_type(names=('a', 'b'), dtype=('f4', 'i4'))
-        assert t['a'].dtype.type == np.float32
-        assert t['b'].dtype.type == np.int32
-        assert t.colnames == ['a', 'b']
+        """
+        Test different ways of initing an empty table
+        """
+        np_t = np.empty(0, dtype=[(str('a'), 'f4', (2,)),
+                                  (str('b'), 'i4')])
+        for kwargs in ({'names': ('a', 'b')},
+                       {'names': ('a', 'b'), 'dtype': (('f4', (2,)), 'i4')},
+                       {'dtype': [(str('a'), 'f4', (2,)), (str('b'), 'i4')]},
+                       {'dtype': np_t.dtype}):
+            t = table_type(**kwargs)
+            assert t.colnames == ['a', 'b']
+            assert len(t['a']) == 0
+            assert len(t['b']) == 0
+            if 'dtype' in kwargs:
+                assert t['a'].dtype.type == np.float32
+                assert t['b'].dtype.type == np.int32
+                assert t['a'].shape[1:] == (2,)
 
 
 @pytest.mark.usefixtures('table_types')

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -49,6 +49,8 @@ size, columns, or data are not known.
   >>> t.add_row((1, 2.0, 'x'))
   >>> t.add_row((4, 5.0, 'y'))
 
+  >>> t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+
 
 List of columns
 """""""""""""""


### PR DESCRIPTION
Initializing an empty table with ``names`` works, but not with ``dtype``:

```python
In [1]: from astropy.table import Table

In [2]: t = Table(names=['a','b','c'])

In [3]: t.dtype.names
Out[3]: ('a', 'b', 'c')

In [4]: t = Table(dtype=[('a',float), ('b',float), ('c', float)])

In [5]: t.dtype.names
Out[5]: ()
```

I don't have time to look into this in the near future, so if someone else would like to, please feel free to!