### PR TITLE
Fix botched deprecation of class attribute in _ImageBaseHDU

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,6 +182,9 @@ New Features
   - Added function ``dtype_info_name`` to the ``data_info`` module to provide
     the name of a ``dtype`` for human-readable informational purposes. [#3868]
 
+  - Added ``classproperty`` decorator--this is to ``property`` as
+    ``classmethod`` is to normal instance methods. [#3982]
+
 - ``astropy.visualization``
 
   - Added the ``hist`` function, which is similar to ``plt.hist`` but
@@ -256,6 +259,11 @@ API changes
     ``io.fits``, ``enable_uint``, can be changed to False to revert to the
     original behavior of ignoring the ``uint`` convention unless it is
     explicitly requested with ``uint=True``. [#3916]
+
+  - The ``ImageHDU.NumCode`` and ``ImageHDU.ImgCode`` attributes (and same
+    for other classes derived from ``_ImageBaseHDU``) are deprecated.  Instead,
+    the ``astropy.io.fits`` module-level constants ``BITPIX2DTYPE`` and
+    ``DTYPE2BITPIX`` can be used. [#3916]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -11,7 +11,7 @@ from ..util import _is_pseudo_unsigned, _unsigned_zero, _is_int
 from ..verify import VerifyWarning
 
 from ....extern.six import string_types
-from ....utils import isiterable, lazyproperty, deprecated
+from ....utils import isiterable, lazyproperty, classproperty, deprecated
 
 
 class _ImageBaseHDU(_ValidHDU):
@@ -756,12 +756,16 @@ class _ImageBaseHDU(_ValidHDU):
             return super(_ImageBaseHDU, self)._calculate_datasum(
                 blocking=blocking)
 
-    @deprecated('1.1.0', alternative='the module level constant BITPIX2DTYPE')
-    def NumCode(self):
+    @classproperty
+    @deprecated('1.1.0', alternative='the module level constant BITPIX2DTYPE',
+                obj_type='class attribute')
+    def NumCode(cls):
         return BITPIX2DTYPE
 
-    @deprecated('1.1.0', alternative='the module level constant DTYPE2BITPIX')
-    def ImgCode(self):
+    @classproperty
+    @deprecated('1.1.0', alternative='the module level constant DTYPE2BITPIX',
+                obj_type='class attribute')
+    def ImgCode(cls):
         return DTYPE2BITPIX
 
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -384,6 +384,9 @@ class classproperty(property):
         def fget(obj):
             return orig_fget(obj.__class__)
 
+        # Set the __wrapped__ attribute manually for support on Python 2
+        fget.__wrapped__ = orig_fget
+
         return fget
 
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -311,6 +311,8 @@ class classproperty(property):
     Examples
     --------
 
+    ::
+
         >>> class Foo(object):
         ...     _bar_internal = 1
         ...     @classproperty

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -61,7 +61,6 @@ if _wcs is not None:
             "later on the 5.x series are known to work.  The version of wcslib "
             "that ships with astropy may be used.")
 
-from ..utils import deprecated, deprecated_attribute
 from ..utils.compat import possible_filename
 from ..utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
 


### PR DESCRIPTION
Back in #3916 I deprecated a couple of old class attributes `NumCode` and `ImgCode`.  However, it seems there is some old code that actually used these attributes (yay for deprecation!) as found by @mcara.  However, I screwed up my attempt to deprecate those class attributes, by leaving them as methods.  I think I meant to put a `@property` on top of them, but that still wouldn't have worked correctly since they are used at the class level as well.

Although this is a bug fix to v1.1.dev only, I've marked this Affects-release since it also includes a potentially useful new `@classproperty` decorator in order to fix this.