### PR TITLE
Fixed typo in "units/decorators.py"

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -121,7 +121,7 @@ class QuantityInput(object):
                             error_msg = "a 'unit' attribute without an 'is_equivalent' method"
                         else:
                             error_msg = "no 'unit' attribute"
-                        raise TypeError("Argument '{0}' to function has '{1}' {2}. "
+                        raise TypeError("Argument '{0}' to function '{1}' has {2}. "
                               "You may want to pass in an astropy Quantity instead."
                                  .format(param.name, wrapped_function.__name__, error_msg))
 

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -118,7 +118,7 @@ def test_not_quantity3():
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100)
-    assert str(e.value) == "Argument 'solary' to function has 'myfunc_args' no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
     """
 
 
@@ -214,7 +214,7 @@ def test_kwarg_not_quantity3():
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100)
-    assert str(e.value) == "Argument 'solary' to function has 'myfunc_args' no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
     """
 
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -79,7 +79,7 @@ def test_not_quantity():
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100)
-    assert str(e.value) == "Argument 'solary' to function has 'myfunc_args' no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
 
 def test_kwargs():
     @u.quantity_input(solarx=u.arcsec, myk=u.deg)
@@ -138,7 +138,7 @@ def test_kwarg_not_quantity():
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100)
-    assert str(e.value) == "Argument 'solary' to function has 'myfunc_args' no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
 
 def test_kwarg_default():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)
@@ -166,7 +166,7 @@ def test_no_equivalent():
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(test_quantity())
 
-        assert str(e.value) == "Argument 'solarx' to function has 'myfunc_args' a 'unit' attribute without an 'is_equivalent' method. You may want to pass in an astropy Quantity instead."
+        assert str(e.value) == "Argument 'solarx' to function 'myfunc_args' has a 'unit' attribute without an 'is_equivalent' method. You may want to pass in an astropy Quantity instead."
 
 def test_kwargs_input():
     @u.quantity_input(solarx=u.arcsec, solary=u.deg)


### PR DESCRIPTION
See also issue #3999 .

"astropy/units/decorators.py":
- Changed order of error message output.