### PR TITLE
Miscellaneous minor refactoring of the unit formatters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -348,6 +348,12 @@ API changes
     - The ``*`` character is accepted as a separator between the scale
       and the units.
 
+  - Unit formatter classes now require the ``parse`` and ``to_string``
+    methods are now required to be classmethods (and the formatter
+    classes themselves are assumed to be singletons that are not
+    instantiated).  As unit formatters are mostly an internal implementation
+    detail this is not likely to affect any users. [#4001]
+
 - ``astropy.utils``
 
   - ``astropy.utils.iers`` now uses a ``QTable`` internally, which means that

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -498,22 +498,22 @@ class UnitBase(object):
         -------
         Latex string
         """
-        return unit_format.Latex().to_string(self)
+        return unit_format.Latex.to_string(self)
 
     def __bytes__(self):
         """Return string representation for unit"""
-        return unit_format.Generic().to_string(self).encode('ascii')
+        return unit_format.Generic.to_string(self).encode('ascii')
     if six.PY2:
         __str__ = __bytes__
 
     def __unicode__(self):
         """Return string representation for unit"""
-        return unit_format.Generic().to_string(self)
+        return unit_format.Generic.to_string(self)
     if six.PY3:
         __str__ = __unicode__
 
     def __repr__(self):
-        string = unit_format.Generic().to_string(self)
+        string = unit_format.Generic.to_string(self)
         if six.PY2:
             string = string.encode('unicode_escape')
 
@@ -1798,9 +1798,9 @@ class _UnitMetaClass(InheritDocstrings):
                 if parse_strict == 'silent':
                     pass
                 else:
-                    # Deliberately not isinstance here. Subclasses
+                    # Deliberately not issubclass here. Subclasses
                     # should use their name.
-                    if type(f) is not unit_format.Generic:
+                    if f is not unit_format.Generic:
                         format_clause = f.name + ' '
                     else:
                         format_clause = ''

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -458,11 +458,6 @@ class UnitConversionError(UnitsError, ValueError):
     """
 
 
-# Maintain error in old location for backward compatibility
-from .format import fits as _fits
-_fits.UnitScaleError = UnitScaleError
-
-
 class UnitsWarning(AstropyWarning):
     """
     The base class for unit-specific exceptions.
@@ -591,6 +586,7 @@ class UnitBase(object):
             The name of a format or a formatter object.  If not
             provided, defaults to the generic format.
         """
+
         f = unit_format.get_format(format)
         return f.to_string(self)
 
@@ -1697,7 +1693,7 @@ class UnrecognizedUnit(IrreducibleUnit):
     if six.PY3:
         __str__ = __unicode__
 
-    def to_string(self, format=unit_format.Generic):
+    def to_string(self, format=None):
         return self.name
 
     def _unrecognized_operator(self, *args, **kwargs):
@@ -2324,3 +2320,7 @@ def _condition_arg(value):
 dimensionless_unscaled = CompositeUnit(1, [], [], _error_check=False)
 # Abbreviation of the above, see #1980
 one = dimensionless_unscaled
+
+# Maintain error in old location for backward compatibility
+# TODO: Is this still needed? Should there be a deprecation warning?
+unit_format.fits.UnitScaleError = UnitScaleError

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -7,6 +7,12 @@ A collection of different unit formats.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+# This is pretty atrocious, but it will prevent a circular import for those
+# formatters that need access to the units.core module An entry for it should
+# exist in sys.modules since astropy.units.core imports this module
+import sys
+core = sys.modules['astropy.units.core']
+
 from .base import Base
 from .generic import Generic, Unscaled
 from .cds import CDS

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     'Base', 'Generic', 'CDS', 'Console', 'Fits', 'Latex', 'LatexInline',
     'OGIP', 'Unicode', 'Unscaled', 'VOUnit', 'get_format']
 
+
 def get_format(format=None):
     """
     Get a formatter by name.
@@ -39,8 +40,6 @@ def get_format(format=None):
         The requested formatter.
     """
     if isinstance(format, type) and issubclass(format, Base):
-        return format()
-    elif isinstance(format, Base):
         return format
     elif not (isinstance(format, string_types) or format is None):
         raise TypeError(
@@ -54,7 +53,7 @@ def get_format(format=None):
     format_lower = format.lower()
 
     if format_lower in Base.registry:
-        return Base.registry[format_lower]()
+        return Base.registry[format_lower]
 
     raise ValueError("Unknown format {0!r}.  Valid formatter names are: "
                      "[{1}]".format(format, ', '.join(Base.registry)))

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -38,10 +38,11 @@ class Base(object):
         raise NotImplementedError(
             "Can not parse {0}".format(self.__class__.__name__))
 
-    def to_string(self, u):
+    @classmethod
+    def to_string(cls, u):
         """
         Convert a unit object to a string.
         """
 
         raise NotImplementedError(
-            "Can not output in {0} format".format(self.__class__.__name__))
+            "Can not output in {0} format".format(cls.__name__))

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -30,13 +30,14 @@ class Base(object):
     The abstract base class of all unit formats.
     """
 
-    def parse(self, s):
+    @classmethod
+    def parse(cls, s):
         """
         Convert a string to a unit object.
         """
 
         raise NotImplementedError(
-            "Can not parse {0}".format(self.__class__.__name__))
+            "Can not parse {0}".format(cls.__name__))
 
     @classmethod
     def to_string(cls, u):

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -30,6 +30,12 @@ class Base(object):
     The abstract base class of all unit formats.
     """
 
+    def __new__(cls, *args, **kwargs):
+        # This __new__ is to make it clear that there is no reason to
+        # instantiate a Formatter--if you try to you'll just get back the
+        # class
+        return cls
+
     @classmethod
     def parse(cls, s):
         """

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -16,7 +16,7 @@ from ...extern import six
 from ...extern.six.moves import zip
 
 from .base import Base
-from . import utils
+from . import core, utils
 from ..utils import is_effectively_unity
 from ...utils import classproperty
 from ...utils.misc import did_you_mean
@@ -319,8 +319,6 @@ class CDS(Base):
 
     @classmethod
     def to_string(cls, unit):
-        from .. import core
-
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -18,6 +18,7 @@ from ...extern.six.moves import zip
 from .base import Base
 from . import utils
 from ..utils import is_effectively_unity
+from ...utils import classproperty
 from ...utils.misc import did_you_mean
 
 
@@ -32,13 +33,30 @@ class CDS(Base):
     <http://vizier.u-strasbg.fr/cgi-bin/Unit>`_.  This format is used
     by VOTable up to version 1.2.
     """
-    def __init__(self):
-        # Build this on the class, so it only gets generated once.
-        if not '_units' in CDS.__dict__:
-            CDS._units = self._generate_unit_names()
 
-        if '_parser' not in CDS.__dict__:
-            CDS._parser, CDS._lexer = self._make_parser()
+    _tokens = (
+        'PRODUCT',
+        'DIVISION',
+        'OPEN_PAREN',
+        'CLOSE_PAREN',
+        'X',
+        'SIGN',
+        'UINT',
+        'UFLOAT',
+        'UNIT'
+    )
+
+    @classproperty(lazy=True)
+    def _units(cls):
+        return cls._generate_unit_names()
+
+    @classproperty(lazy=True)
+    def _parser(cls):
+        return cls._make_parser()
+
+    @classproperty(lazy=True)
+    def _lexer(cls):
+        return cls._make_lexer()
 
     @staticmethod
     def _generate_unit_names():
@@ -54,28 +72,10 @@ class CDS(Base):
         return names
 
     @classmethod
-    def _make_parser(cls):
-        """
-        The grammar here is based on the description in the `Standards
-        for Astronomical Catalogues 2.0
-        <http://cds.u-strasbg.fr/doc/catstd-3.2.htx>`_, which is not
-        terribly precise.  The exact grammar is here is based on the
-        YACC grammar in the `unity library
-        <https://bitbucket.org/nxg/unity/>`_.
-        """
-        from ...extern.ply import lex, yacc
+    def _make_lexer(cls):
+        from ...extern.ply import lex
 
-        tokens = (
-            'PRODUCT',
-            'DIVISION',
-            'OPEN_PAREN',
-            'CLOSE_PAREN',
-            'X',
-            'SIGN',
-            'UINT',
-            'UFLOAT',
-            'UNIT'
-            )
+        tokens = cls._tokens
 
         t_PRODUCT = r'\.'
         t_DIVISION = r'/'
@@ -122,6 +122,23 @@ class CDS(Base):
         lexer = lex.lex(optimize=True, lextab='cds_lextab',
                         outputdir=os.path.dirname(__file__),
                         reflags=re.UNICODE)
+
+        return lexer
+
+    @classmethod
+    def _make_parser(cls):
+        """
+        The grammar here is based on the description in the `Standards
+        for Astronomical Catalogues 2.0
+        <http://cds.u-strasbg.fr/doc/catstd-3.2.htx>`_, which is not
+        terribly precise.  The exact grammar is here is based on the
+        YACC grammar in the `unity library
+        <https://bitbucket.org/nxg/unity/>`_.
+        """
+
+        from ...extern.ply import yacc
+
+        tokens = cls._tokens
 
         def p_main(p):
             '''
@@ -239,7 +256,7 @@ class CDS(Base):
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)
 
-        return parser, lexer
+        return parser
 
     @classmethod
     def _get_unit(cls, t):
@@ -264,7 +281,8 @@ class CDS(Base):
 
         return cls._units[unit]
 
-    def parse(self, s, debug=False):
+    @classmethod
+    def parse(cls, s, debug=False):
         if ' ' in s:
             raise ValueError('CDS unit must not contain whitespace')
 
@@ -274,10 +292,10 @@ class CDS(Base):
         # This is a short circuit for the case where the string
         # is just a single unit name
         try:
-            return self._parse_unit(s, detailed_exception=False)
+            return cls._parse_unit(s, detailed_exception=False)
         except ValueError:
             try:
-                return self._parser.parse(s, lexer=self._lexer, debug=debug)
+                return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
             except ValueError as e:
                 if six.text_type(e):
                     raise ValueError(six.text_type(e))

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -284,24 +284,27 @@ class CDS(Base):
                 else:
                     raise ValueError("Syntax error")
 
-    def _get_unit_name(self, unit):
+    @staticmethod
+    def _get_unit_name(unit):
         return unit.get_format_name('cds')
 
-    def _format_unit_list(self, units):
+    @classmethod
+    def _format_unit_list(cls, units):
         out = []
         for base, power in units:
             if power == 1:
-                out.append(self._get_unit_name(base))
+                out.append(cls._get_unit_name(base))
             else:
                 out.append('{0}{1}'.format(
-                    self._get_unit_name(base), int(power)))
+                    cls._get_unit_name(base), int(power)))
         return '.'.join(out)
 
-    def to_string(self, unit):
+    @classmethod
+    def to_string(cls, unit):
         from .. import core
 
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(unit, self._get_unit_name)
+        unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
         if isinstance(unit, core.CompositeUnit):
             if(unit.physical_type == 'dimensionless' and
@@ -325,9 +328,9 @@ class CDS(Base):
             if len(pairs) > 0:
                 pairs.sort(key=lambda x: x[1], reverse=True)
 
-                s += self._format_unit_list(pairs)
+                s += cls._format_unit_list(pairs)
 
         elif isinstance(unit, core.NamedUnit):
-            s = self._get_unit_name(unit)
+            s = cls._get_unit_name(unit)
 
         return s

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -8,8 +8,7 @@ Handles the "Console" unit format.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from . import base
-from . import utils
+from . import base, core, utils
 
 
 class Console(base.Base):
@@ -66,8 +65,6 @@ class Console(base.Base):
 
     @classmethod
     def to_string(cls, unit):
-        from .. import core
-
         if isinstance(unit, core.CompositeUnit):
             if unit.scale == 1:
                 s = ''

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -25,8 +25,6 @@ class Console(base.Base):
       2.1798721*10^-18 ------
                         s^2
     """
-    def __init__(self):
-        pass
 
     _times = "*"
     _line = "-"

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -66,39 +66,40 @@ class Console(base.Base):
 
         return cls._times.join(parts)
 
-    def to_string(self, unit):
+    @classmethod
+    def to_string(cls, unit):
         from .. import core
 
         if isinstance(unit, core.CompositeUnit):
             if unit.scale == 1:
                 s = ''
             else:
-                s = self.format_exponential_notation(unit.scale)
+                s = cls.format_exponential_notation(unit.scale)
 
             if len(unit.bases):
                 positives, negatives = utils.get_grouped_by_powers(
                     unit.bases, unit.powers)
                 if len(negatives):
                     if len(positives):
-                        positives = self._format_unit_list(positives)
+                        positives = cls._format_unit_list(positives)
                     else:
                         positives = '1'
-                    negatives = self._format_unit_list(negatives)
+                    negatives = cls._format_unit_list(negatives)
                     l = len(s)
                     r = max(len(positives), len(negatives))
                     f = "{{0:^{0}s}} {{1:^{1}s}}".format(l, r)
 
                     lines = [
                         f.format('', positives),
-                        f.format(s, self._line * r),
+                        f.format(s, cls._line * r),
                         f.format('', negatives)
                     ]
 
                     s = '\n'.join(lines)
                 else:
-                    positives = self._format_unit_list(positives)
+                    positives = cls._format_unit_list(positives)
                     s += positives
         elif isinstance(unit, core.NamedUnit):
-            s = self._get_unit_name(unit)
+            s = cls._get_unit_name(unit)
 
         return s

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -24,15 +24,8 @@ class Fits(generic.Generic):
     This supports the format defined in the Units section of the `FITS
     Standard <http://fits.gsfc.nasa.gov/fits_standard.html>`_.
     """
+
     name = 'fits'
-
-    def __init__(self):
-        # Build this on the class, so it only gets generated once.
-        if '_parser' not in Fits.__dict__:
-            Fits._parser, Fits._lexer = self._make_parser()
-
-        if not '_units' in Fits.__dict__:
-            Fits._units, Fits._deprecated_units = self._generate_unit_names()
 
     @staticmethod
     def _generate_unit_names():
@@ -79,7 +72,7 @@ class Fits(generic.Generic):
         for unit in deprecated_units:
             deprecated_names.add(unit)
 
-        return names, deprecated_names
+        return names, deprecated_names, []
 
     @classmethod
     def _validate_unit(cls, unit, detailed_exception=True):
@@ -154,8 +147,9 @@ class Fits(generic.Generic):
                 cls.to_string(unit), scale)
         return s
 
-    def parse(self, s, debug=False):
-        result = super(Fits, self).parse(s, debug)
+    @classmethod
+    def parse(cls, s, debug=False):
+        result = super(Fits, cls).parse(s, debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported for "
                              "FITS units.")

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -13,8 +13,7 @@ import numpy as np
 import copy
 import keyword
 
-from . import generic
-from . import utils
+from . import core, generic, utils
 
 
 class Fits(generic.Generic):
@@ -104,8 +103,6 @@ class Fits(generic.Generic):
 
     @classmethod
     def to_string(cls, unit):
-        from .. import core
-
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -135,8 +132,6 @@ class Fits(generic.Generic):
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):
-        from .. import core
-
         try:
             s = cls.to_string(unit)
         except core.UnitScaleError:

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -13,14 +13,12 @@ import os
 import re
 import warnings
 
-from . import utils
+from . import core, utils
 from .base import Base
 from ...utils import classproperty
 from ...utils.misc import did_you_mean
 
 def _to_string(cls, unit):
-    from .. import core
-
     if isinstance(unit, core.CompositeUnit):
         parts = []
 
@@ -433,8 +431,7 @@ class Generic(Base):
 
     @classmethod
     def _parse_unit(cls, s, detailed_exception=True):
-        from ..core import get_current_unit_registry
-        registry = get_current_unit_registry().registry
+        registry = core.get_current_unit_registry().registry
         if s == '%':
             return registry['percent']
         elif s in registry:
@@ -454,11 +451,10 @@ class Generic(Base):
 
         result = cls._do_parse(s, debug=debug)
         if s.count('/') > 1:
-            from ..core import UnitsWarning
             warnings.warn(
                 "'{0}' contains multiple slashes, which is "
                 "discouraged by the FITS standard".format(s),
-                UnitsWarning)
+                core.UnitsWarning)
         return result
 
     @classmethod

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -21,8 +21,6 @@ class Latex(base.Base):
     Attempts to follow the `IAU Style Manual
     <http://www.iau.org/static/publications/stylemanual1989.pdf>`_.
     """
-    def __init__(self):
-        pass
 
     @classmethod
     def _latex_escape(cls, name):
@@ -68,7 +66,8 @@ class Latex(base.Base):
 
         return s
 
-    def to_string(self, unit):
+    @classmethod
+    def to_string(cls, unit):
         from .. import core
 
         latex_name = None
@@ -81,13 +80,13 @@ class Latex(base.Base):
             if unit.scale == 1:
                 s = ''
             else:
-                s = self.format_exponential_notation(unit.scale) + r'\,'
+                s = cls.format_exponential_notation(unit.scale) + r'\,'
 
             if len(unit.bases):
-                s += self._format_bases(unit)
+                s += cls._format_bases(unit)
 
         elif isinstance(unit, core.NamedUnit):
-            s = self._latex_escape(unit.name)
+            s = cls._latex_escape(unit.name)
 
         return r'$\mathrm{{{0}}}$'.format(s)
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -9,8 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from . import base
-from . import utils
+from . import base, core, utils
 from ...extern.six.moves import zip
 
 
@@ -68,8 +67,6 @@ class Latex(base.Base):
 
     @classmethod
     def to_string(cls, unit):
-        from .. import core
-
         latex_name = None
         if hasattr(unit, '_format'):
             latex_name = unit._format.get('latex')

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -17,8 +17,7 @@ import math
 import os
 import warnings
 
-from . import generic
-from . import utils
+from . import core, generic, utils
 from ...utils.compat.fractions import Fraction
 
 
@@ -388,9 +387,8 @@ class OGIP(generic.Generic):
             # just a single unit name
             return cls._parse_unit(s, detailed_exception=False)
         except ValueError:
-            from ..core import Unit
             try:
-                return Unit(
+                return core.Unit(
                     cls._parser.parse(s, lexer=cls._lexer, debug=debug))
             except ValueError as e:
                 if six.text_type(e):
@@ -425,8 +423,6 @@ class OGIP(generic.Generic):
 
     @classmethod
     def to_string(cls, unit):
-        from .. import core
-
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -443,8 +439,6 @@ class OGIP(generic.Generic):
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):
-        from .. import core
-
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -26,9 +26,6 @@ class Unicode(console.Console):
                        s²
     """
 
-    def __init__(self):
-        pass
-
     _times = "×"
     _line = "─"
 

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -8,8 +8,7 @@ Handles the "Unicode" unit format.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from . import console
-from . import utils
+from . import console, utils
 
 
 class Unicode(console.Console):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -29,14 +29,6 @@ class VOUnit(generic.Generic):
     _custom_unit_regex = re.compile("^((?!\d)\w)+$")
     _custom_units = {}
 
-    def __init__(self):
-        if '_parser' not in VOUnit.__dict__:
-            VOUnit._parser, VOUnit._lexer = self._make_parser()
-
-        if not '_units' in VOUnit.__dict__:
-            unit_names = VOUnit._generate_unit_names()
-            VOUnit._units, VOUnit._deprecated_units = unit_names
-
     @staticmethod
     def _generate_unit_names():
         from ... import units as u
@@ -87,9 +79,10 @@ class VOUnit(generic.Generic):
         do_defines(binary_bases, si_prefixes + binary_prefixes, ['dB', 'dbyte'])
         do_defines(simple_units, [''])
 
-        return names, deprecated_names
+        return names, deprecated_names, []
 
-    def parse(self, s, debug=False):
+    @classmethod
+    def parse(cls, s, debug=False):
         from ... import units as u
 
         if s in ('unknown', 'UNKNOWN'):
@@ -101,7 +94,7 @@ class VOUnit(generic.Generic):
             raise UnitsError(
                 "'{0}' contains multiple slashes, which is "
                 "disallowed by the VOUnit standard".format(s))
-        result = self._do_parse(s, debug=debug)
+        result = cls._do_parse(s, debug=debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported in "
                              "VOUnit.")

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -13,8 +13,7 @@ import keyword
 import re
 import warnings
 
-from . import generic
-from . import utils
+from . import core, generic, utils
 
 
 class VOUnit(generic.Generic):
@@ -83,15 +82,12 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def parse(cls, s, debug=False):
-        from ... import units as u
-
         if s in ('unknown', 'UNKNOWN'):
             return None
         if s == '':
-            return u.dimensionless_unscaled
+            return core.dimensionless_unscaled
         if s.count('/') > 1:
-            from ..core import UnitsError
-            raise UnitsError(
+            raise core.UnitsError(
                 "'{0}' contains multiple slashes, which is "
                 "disallowed by the VOUnit standard".format(s))
         result = cls._do_parse(s, debug=debug)
@@ -102,8 +98,6 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):
-        from ... import units as u
-
         if unit not in cls._units:
             if cls._explicit_custom_unit_regex.match(unit):
                 return cls._def_custom_unit(unit)
@@ -117,7 +111,7 @@ class VOUnit(generic.Generic):
                     unit, utils.did_you_mean_units(
                         unit, cls._units, cls._deprecated_units,
                         cls._to_decomposed_alternative)),
-                u.UnitsWarning)
+                core.UnitsWarning)
 
             return cls._def_custom_unit(unit)
 
@@ -130,11 +124,9 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def _get_unit_name(cls, unit):
-        from ... import units as u
-
         # The da- and d- prefixes are discouraged.  This has the
         # effect of adding a scale to value in the result.
-        if isinstance(unit, u.PrefixUnit):
+        if isinstance(unit, core.PrefixUnit):
             if unit._represents.scale == 10.0:
                 raise ValueError(
                     "In '{0}': VOUnit can not represent units with the 'da' "
@@ -162,32 +154,30 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def _def_custom_unit(cls, unit):
-        from ... import units as u
-
         def def_base(name):
             if name in cls._custom_units:
                 return cls._custom_units[name]
 
             if name.startswith("'"):
-                return u.def_unit(
+                return core.def_unit(
                     [name[1:-1], name],
                     format={'vounit': name},
                     namespace=cls._custom_units)
             else:
-                return u.def_unit(
+                return core.def_unit(
                     name, namespace=cls._custom_units)
 
         if unit in cls._custom_units:
             return cls._custom_units[unit]
 
-        for short, full, factor in u.si_prefixes:
+        for short, full, factor in core.si_prefixes:
             for prefix in short:
                 if unit.startswith(prefix):
                     base_name = unit[len(prefix):]
                     base_unit = def_base(base_name)
-                    return u.PrefixUnit(
+                    return core.PrefixUnit(
                         [prefix + x for x in base_unit.names],
-                        u.CompositeUnit(factor, [base_unit], [1],
+                        core.CompositeUnit(factor, [base_unit], [1],
                                         _error_check=False),
                         format={'vounit': prefix + base_unit.names[-1]},
                         namespace=cls._custom_units)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -25,7 +25,7 @@ from ..utils import is_effectively_unity
 def test_unit_grammar():
     def _test_unit_grammar(s, unit):
         print(s)
-        unit2 = u_format.Generic().parse(s)
+        unit2 = u_format.Generic.parse(s)
         assert unit2 == unit
 
     data = [
@@ -54,7 +54,7 @@ def test_unit_grammar():
 def test_unit_grammar_fail():
     @raises(ValueError)
     def _test_unit_grammar_fail(s):
-        u_format.Generic().parse(s)
+        u_format.Generic.parse(s)
 
     data = ['sin( /pixel /s)',
             'mag(mag)',
@@ -68,7 +68,7 @@ def test_unit_grammar_fail():
 def test_cds_grammar():
     def _test_cds_grammar(s, unit):
         print(s)
-        unit2 = u_format.CDS().parse(s)
+        unit2 = u_format.CDS.parse(s)
         assert unit2 == unit
 
     data = [
@@ -113,7 +113,7 @@ def test_cds_grammar_fail():
     @raises(ValueError)
     def _test_cds_grammar_fail(s):
         print(s)
-        u_format.CDS().parse(s)
+        u_format.CDS.parse(s)
 
     data = ['0.1 nm',
             'solMass(3/2)',
@@ -138,7 +138,7 @@ def test_cds_grammar_fail():
 def test_ogip_grammar():
     def _test_ogip_grammar(s, unit):
         print(s)
-        unit2 = u_format.OGIP().parse(s)
+        unit2 = u_format.OGIP.parse(s)
         assert unit2 == unit
 
     # These examples are taken from the EXAMPLES section of
@@ -180,7 +180,7 @@ def test_ogip_grammar():
 def test_ogip_grammar_fail():
     @raises(ValueError)
     def _test_ogip_grammar_fail(s):
-        u_format.OGIP().parse(s)
+        u_format.OGIP.parse(s)
 
     data = ['log(photon /m**2 /s /Hz)',
             'sin( /pixel /s)',
@@ -215,7 +215,7 @@ def test_roundtrip_vo_unit():
         b = core.Unit(u, format='vounit')
         assert_allclose(b.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
-    x = u_format.VOUnit()
+    x = u_format.VOUnit
     for key, val in x._units.items():
         if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_vo_unit, val, val in (u.mag, u.dB)
@@ -227,7 +227,7 @@ def test_roundtrip_fits():
         a = core.Unit(s, format='fits')
         assert_allclose(a.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
-    for key, val in u_format.Fits()._units.items():
+    for key, val in u_format.Fits._units.items():
         if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_fits, val
 
@@ -242,7 +242,7 @@ def test_roundtrip_cds():
             return
         assert_allclose(b.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
-    x = u_format.CDS()
+    x = u_format.CDS
     for key, val in x._units.items():
         if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_cds, val
@@ -258,22 +258,22 @@ def test_roundtrip_ogip():
             return
         assert_allclose(b.decompose().scale, unit.decompose().scale, rtol=1e-2)
 
-    x = u_format.OGIP()
+    x = u_format.OGIP
     for key, val in x._units.items():
         if isinstance(val, core.UnitBase) and not isinstance(val, core.PrefixUnit):
             yield _test_roundtrip_ogip, val
 
 
 def test_fits_units_available():
-    u_format.Fits()
+    u_format.Fits._units
 
 
 def test_vo_units_available():
-    u_format.VOUnit()
+    u_format.VOUnit._units
 
 
 def test_cds_units_available():
-    u_format.CDS()
+    u_format.CDS._units
 
 
 def test_latex():

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -320,7 +320,7 @@ class classproperty(property):
 
     lazy : bool, optional
         If True, caches the value returned by the first call to the getter
-        function, so that it is only caused once (used for lazy evaluation
+        function, so that it is only called once (used for lazy evaluation
         of an attribute).  This is analogous to `lazyproperty`.  The ``lazy``
         argument can also be used when `classproperty` is used as a decorator
         (see the third example below).  When used in the decorator syntax this


### PR DESCRIPTION
Most of these changes were driven by the observation I made, upon going to make some changes for #3986, that on some of the formatter classes (including the `Base` class) the `to_string` method was a normal instance method, while on others (about half) it was a `classmethod`.  This incongruity bugged me.

After looking over the other classes I decided it would be possible to make the `parse` and `to_string` methods on all the formatter classes into `classmethods`, so that now each formatter class is basically acting as a singleton (it would actually be a good use case for a general Singleton type, but I decided to leave that as an exercise for another time).

I think there are probably others bits of repetition between the formatter implementations, but I think that's about all I feel like addressing for now.

This also removed all inline imports from `parse` and `to_string` methods.  A bit of a hack, but doable.  Between eliminating formatter instantiation and inline imports, the time to instantiate a `Unit` from a string with the generic formatter (after already using the formatter at least once, so parser/lexer setup is excluded from this timing) went from about 13.1µs to about 9.2µs, or about 30%.  Not super-dramatic, but still worthwhile.