### PR TITLE
Retry --open-files check once after garbage collection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -565,6 +565,12 @@ Bug Fixes
 
 - ``astropy.table``
 
+- ``astropy.tests``
+
+  - Reduced the likelihood of false positives with the ``--open-files`` option
+    due to open file objects still lingering before garbage collection when
+    the open files are counted. [#4002]
+
 - ``astropy.time``
 
 - ``astropy.units``


### PR DESCRIPTION
When the --open-files option detects files that weren't closed, before declaring them not closed and raising an exception, perform a full garbage collection cycle, then try again.  This will ensure any file handles hanging around in the garbage have been closed.

In other words, this only tries the garbage collection after some files left open were already detected (usually an uncommon case), rather than running the garbage collection on every test, which caused a surprising amount of sluggishness.

This seems to fix the issue in testing #4001, though that could be as much a fluke as that issue is in the first place.  Still, this seems like a likely fix--if things are time _just so_, such that a file is closed and a test ends just after a garbage collection cycle this could happen.
