### PR TITLE
Correct checks for dtype preservation in in-place operations (closes #3976).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -573,6 +573,8 @@ Bug Fixes
     will now "set" rather than "add" units to the active set to avoid
     the namespace clash with the default units. [#3873]
 
+  - Ensure in-place operations on ``float32`` quantities work. [#4007]
+
 - ``astropy.utils``
 
   - The ``deprecated`` decorator did not correctly wrap classes that have a

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -383,8 +383,8 @@ class Quantity(np.ndarray):
             # decomposed, which involves being scaled by a float, but since
             # the array is an integer the output then gets converted to an int
             # and truncated.
-            result_dtype = np.result_type(*((args +(float,)) if any(converters)
-                                            else args))
+            result_dtype = np.result_type(*((args + (float,))
+                                            if any(converters) else args))
             if not np.can_cast(result_dtype, obj.dtype, casting='same_kind'):
                 raise TypeError("Arguments cannot be cast safely to inplace "
                                 "output with dtype={0}".format(self.dtype))

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -383,10 +383,9 @@ class Quantity(np.ndarray):
             # decomposed, which involves being scaled by a float, but since
             # the array is an integer the output then gets converted to an int
             # and truncated.
-            result_dtype = np.result_type(*(args + tuple(
-                (float if converter and converter(1.) % 1. != 0. else int)
-                for converter in converters)))
-            if not np.can_cast(result_dtype, obj.dtype):
+            result_dtype = np.result_type(*((args +(float,)) if any(converters)
+                                            else args))
+            if not np.can_cast(result_dtype, obj.dtype, casting='same_kind'):
                 raise TypeError("Arguments cannot be cast safely to inplace "
                                 "output with dtype={0}".format(self.dtype))
 

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -633,3 +633,25 @@ class TestInplaceUfuncs(object):
         s2 += 1. * u.cm
         assert np.all(s[::2] > s_copy[::2])
         assert np.all(s[1::2] == s_copy[1::2])
+
+    def test_ufunc_inplace_non_standard_dtype(self):
+        """Check that inplace operations check properly for casting.
+
+        First two tests that check that float32 is kept close #3976.
+        """
+        a1 = u.Quantity([1, 2, 3, 4], u.m, dtype=np.float32)
+        a1 *= np.float32(10)
+        assert a1.unit is u.m
+        assert a1.dtype == np.float32
+        a2 = u.Quantity([1, 2, 3, 4], u.m, dtype=np.float32)
+        a2 += (20.*u.km)
+        assert a2.unit is u.m
+        assert a2.dtype == np.float32
+        # For integer, in-place only workds if no conversion is done.
+        a3 = u.Quantity([1, 2, 3, 4], u.m, dtype=np.int32)
+        a3 += u.Quantity(10, u.m, dtype=np.int64)
+        assert a3.unit is u.m
+        assert a3.dtype == np.int32
+        a4 = u.Quantity([1, 2, 3, 4], u.m, dtype=np.int32)
+        with pytest.raises(TypeError):
+            a4 += u.Quantity(10, u.mm, dtype=np.int64)


### PR DESCRIPTION
This simplifies the check whether an in-place operation will be able to succeed, ensuring that it is true for any type of `float` *hence closes #3976), but false any time the result type is integer yet conversion has to be done (it is no longer attempted to check the conversion itself is an integer multiplication, as this is really rather fragile).