### PR TITLE
Fix reference cycle in NotifierMixin._add_listener

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -546,6 +546,10 @@ Bug Fixes
     ``do_not_scale_image_data=True`` (that is, since we're just reading the
     raw / physical data there is no reason mmap can't be used). [#3766]
 
+  - Fixed a reference cycle that could sometimes cause FITS table-related
+    objects (``BinTableHDU``, ``ColDefs``, etc.) to hang around in memory
+    longer than expected. [#4012]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -34,6 +34,7 @@ from ...extern.six import (string_types, integer_types, text_type,
                            binary_type, next)
 from ...extern.six.moves import zip
 from ...utils import wraps
+from ...utils.compat import ignored
 from ...utils.compat import gzip as _astropy_gzip
 from ...utils.exceptions import AstropyUserWarning
 
@@ -103,18 +104,9 @@ class NotifierMixin(object):
         """
 
         if self._listeners is None:
-            self._listeners = []
+            self._listeners = weakref.WeakValueDictionary()
 
-        def remove(p):
-            self._listeners.remove(p)
-
-        # Make sure this object is not already in the listeners:
-        for ref in self._listeners:
-            if ref() is listener:
-                return
-
-        ref = weakref.ref(listener, remove)
-        self._listeners.append(ref)
+        self._listeners[id(listener)] = listener
 
     def _remove_listener(self, listener):
         """
@@ -125,10 +117,8 @@ class NotifierMixin(object):
         if self._listeners is None:
             return
 
-        for idx, ref in enumerate(self._listeners[:]):
-            if ref() is listener:
-                del self._listeners[idx]
-                break
+        with ignored(KeyError):
+            del self._listeners[id(listener)]
 
     def _notify(self, notification, *args, **kwargs):
         """
@@ -144,7 +134,7 @@ class NotifierMixin(object):
             return
 
         method_name = '_update_{0}'.format(notification)
-        for listener in self._listeners:
+        for listener in self._listeners.itervaluerefs():
             listener = listener()  # dereference weakref
             if hasattr(listener, method_name):
                 method = getattr(listener, method_name)

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -317,7 +317,7 @@ def read(cls, *args, **kwargs):
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary')
                         fileobj = ctx.__enter__()
-                    except Exception as e:
+                    except Exception:
                         fileobj = None
                     else:
                         args = [fileobj] + list(args[1:])


### PR DESCRIPTION
`NotifierMixin._add_listener` had a subtle reference cycle--the inline "remove" callback contained a reference to self which is held in a `__closure__`.  So the cycle is `self._listeners` :arrow_right: 
`self._listeners[n]` :arrow_right: `self._listeners[n].__callback__` :arrow_right: `self._listeners[n].__callback__.__closure__` :arrow_right: `self`.

One possible fix was to change the callback so that it only references the `listeners` list directly, instead of through `self`.  But a better fix was to use a `WeakValueDict` instead, which also helpfully simplifies the code.

(The change in io.registry is mostly incidental--it removes an unused variable I found while hunting for reference cycles.)

This partially fixes the failing test in #4001, but it also depends on #4002 to fix reference cycles that occurred in PLY.