### PR TITLE
Don't include source templates in package data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -628,6 +628,9 @@ Bug Fixes
   - Fixed multiple instances of a bug that prevented Astropy from being used
     when compiled with the ``python -OO`` flag, due to it causing all
     docstrings to be stripped out. [#3923]
+    
+  - Removed source code template files that were being installed
+    accidentally alongside installed Python modules. [#4014]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
 include astropy/tests/coveragerc
-recursive-include astropy *.pyx *.c *.h *.map
+recursive-include astropy *.pyx *.c *.h *.map *.templ
 
 include astropy/astropy.cfg
 

--- a/astropy/_erfa/setup_package.py
+++ b/astropy/_erfa/setup_package.py
@@ -115,7 +115,3 @@ def get_external_libraries():
 
 def requires_2to3():
     return False
-
-
-def get_package_data():
-    return {'astropy._erfa': ['core.py.templ', 'core.c.templ']}


### PR DESCRIPTION
As I mentioned in [this comment](https://github.com/astropy/astropy/pull/3166#issuecomment-65459848) we shouldn't be including source code templates in installed package data, but it seems we never got around to fixing that.