### PR TITLE
Fix minor bug in astropy.utils.decorators.wraps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -612,6 +612,10 @@ Bug Fixes
     custom metaclass--the metaclass could be dropped from the deprecated
     version of the class. [#3997]
 
+  - The ``wraps`` decorator would copy the wrapped function's name to the
+    wrapper function even when ``'__name__'`` is excluded from the
+    ``assigned`` argument. [#4016]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -618,7 +618,12 @@ def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
     """
 
     def wrapper(func):
-        func = make_function_with_signature(func, name=wrapped.__name__,
+        if '__name__' in assigned:
+            name = wrapped.__name__
+        else:
+            name = func.__name__
+
+        func = make_function_with_signature(func, name=name,
                                             **_get_function_args(wrapped))
         func = functools.update_wrapper(func, wrapped, assigned=assigned,
                                         updated=updated)

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -53,6 +53,8 @@ def test_wraps_keep_orig_name():
     """
     Test that when __name__ is excluded from the ``assigned`` argument
     to ``wrap`` that the function being wrapped keeps its original name.
+
+    Regression test for https://github.com/astropy/astropy/pull/4016
     """
 
     def foo():

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import functools
 import inspect
 import pickle
 
@@ -46,6 +47,29 @@ def test_wraps():
 
     assert argspec.args == ['a', 'b', 'c', 'd', 'e']
     assert argspec.defaults == (1, 2, 3)
+
+
+def test_wraps_keep_orig_name():
+    """
+    Test that when __name__ is excluded from the ``assigned`` argument
+    to ``wrap`` that the function being wrapped keeps its original name.
+    """
+
+    def foo():
+        pass
+
+    assigned = list(functools.WRAPPER_ASSIGNMENTS)
+    assigned.remove('__name__')
+
+    def bar():
+        pass
+
+    orig_bar = bar
+
+    bar = wraps(foo, assigned=assigned)(bar)
+
+    assert bar is not orig_bar
+    assert bar.__name__ == 'bar'
 
 
 def test_deprecated_attribute():


### PR DESCRIPTION
Fixes a bug in the wraps() decorator where the wrapper function inherited the wrapped function's name even if `__name__` is not included in the 'assigned' argument (which lists attributes that shoul be copied from the wrapped function to the wrapper function).