### PR TITLE
Add optional exclude_args argument to astropy.utils.decorators.wraps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,14 @@ New Features
   - Added ``classproperty`` decorator--this is to ``property`` as
     ``classmethod`` is to normal instance methods. [#3982]
 
+  - The ``astropy.utils.wraps`` decorator now takes an optional
+    ``exclude_args`` argument not shared by the standard library ``wraps``
+    decorator (as it is unique to the Astropy version's ability of copying
+    the wrapped function's argument signature).  ``exclude_args`` allows
+    certain arguments on the wrapped function to be excluded from the signature
+    of the wrapper function.  This is particularly useful when wrapping an
+    instance method as a function (to exclude the ``self`` argument). [#4017]
+
 - ``astropy.visualization``
 
   - Added the ``hist`` function, which is similar to ``plt.hist`` but

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -49,6 +49,30 @@ def test_wraps():
     assert argspec.defaults == (1, 2, 3)
 
 
+def test_wraps_exclude_names():
+    """
+    Test the optional ``exclude_names`` argument to the wraps decorator.
+    """
+
+    # This particular test demonstrates wrapping an instance method
+    # as a function and excluding the "self" argument:
+
+    class TestClass(object):
+        def method(self, a, b, c=1, d=2, **kwargs):
+            return (a, b, c, d, kwargs)
+
+    test = TestClass()
+
+    @wraps(test.method, exclude_args=('self',))
+    def func(*args, **kwargs):
+        return test.method(*args, **kwargs)
+
+    argspec = inspect.getargspec(func)
+    assert argspec.args == ['a', 'b', 'c', 'd']
+
+    assert func('a', 'b', e=3) == ('a', 'b', 1, 2, {'e': 3})
+
+
 def test_wraps_keep_orig_name():
     """
     Test that when __name__ is excluded from the ``assigned`` argument


### PR DESCRIPTION
See the supplied changelog message for more details.

Originally I wanted our `wraps` decorator to be exactly identical to the standard lib `functools.wraps` other than its ability to preserve the function signature.  However, I've wanted the ability on more than one occasion to slightly tweak the arguments of the wrapper function, and this provides a way to do it (and is still API-compatible with `functools.wraps`).

This PR depends on #4016.