### PR TITLE
Testing/test runner refactor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -530,6 +530,15 @@ Bug fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- The ``./setup.py test`` command is now implemented in the ``astropy.tests``
+  module again (previously its implementation had been moved into
+  astropy-helpers).  However, that made it difficult to synchronize changes
+  to the Astropy test runner with changes to the ``./setup.py test`` UI.
+  astropy-helpers v1.1 and above will detect this implementation of the
+  ``test`` command, when present, and use it instead of the old version that
+  was included in astropy-helpers (most users will not notice any difference
+  as a result of this change). [#4020]
+
 - The repr for ``Table`` no longer displays ``masked=False`` since tables
   are not masked by default anyway. [#3869]
 

--- a/astropy/tests/__init__.py
+++ b/astropy/tests/__init__.py
@@ -4,8 +4,3 @@ This package contains utilities to run the astropy test suite, tools
 for writing tests, and general tests that are not associated with a
 particular package.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-from . import helper
-from .disable_internet import turn_off_internet, turn_on_internet

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -110,9 +110,9 @@ class AstropyTest(Command, object):
         cmd_post = ''  # Commands to run after the test function
 
         if self.coverage:
-           pre, post = self._generate_coverage_commands()
-           cmd_pre += pre
-           cmd_post += post
+            pre, post = self._generate_coverage_commands()
+            cmd_pre += pre
+            cmd_post += post
 
         if six.PY3:
             set_flag = "import builtins; builtins._ASTROPY_TEST_ = True"

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -1,0 +1,250 @@
+"""
+Implements the wrapper for the Astropy test runner in the form of the
+``./setup.py test`` distutils command.
+"""
+
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from setuptools import Command
+
+from ..extern import six
+
+
+def _fix_user_options(options):
+    """
+    This is for Python 2.x and 3.x compatibility.  distutils expects Command
+    options to all be byte strings on Python 2 and Unicode strings on Python 3.
+    """
+
+    def to_str_or_none(x):
+        if x is None:
+            return None
+        return str(x)
+
+    return [tuple(to_str_or_none(x) for x in y) for y in options]
+
+
+class AstropyTest(Command, object):
+    description = 'Run the tests for this package'
+
+    user_options = [
+        ('package=', 'P',
+         "The name of a specific package to test, e.g. 'io.fits' or 'utils'.  "
+         "If nothing is specified, all default tests are run."),
+        ('test-path=', 't',
+         'Specify a test location by path.  If a relative path to a  .py file, '
+         'it is relative to the built package, so e.g., a  leading "astropy/" '
+         'is necessary.  If a relative  path to a .rst file, it is relative to '
+         'the directory *below* the --docs-path directory, so a leading '
+         '"docs/" is usually necessary.  May also be an absolute path.'),
+        ('verbose-results', 'V',
+         'Turn on verbose output from pytest.'),
+        ('plugins=', 'p',
+         'Plugins to enable when running pytest.'),
+        ('pastebin=', 'b',
+         "Enable pytest pastebin output. Either 'all' or 'failed'."),
+        ('args=', 'a',
+         'Additional arguments to be passed to pytest.'),
+        ('remote-data', 'R', 'Run tests that download remote data.'),
+        ('pep8', '8',
+         'Enable PEP8 checking and disable regular tests. '
+         'Requires the pytest-pep8 plugin.'),
+        ('pdb', 'd',
+         'Start the interactive Python debugger on errors.'),
+        ('coverage', 'c',
+         'Create a coverage report. Requires the coverage package.'),
+        ('open-files', 'o', 'Fail if any tests leave files open.  Requires the '
+         'psutil package.'),
+        ('parallel=', 'j',
+         'Run the tests in parallel on the specified number of '
+         'CPUs.  If negative, all the cores on the machine will be '
+         'used.  Requires the pytest-xdist plugin.'),
+        ('docs-path=', None,
+         'The path to the documentation .rst files.  If not provided, and '
+         'the current directory contains a directory called "docs", that '
+         'will be used.'),
+        ('skip-docs', None,
+         "Don't test the documentation .rst files."),
+        ('repeat=', None,
+         'How many times to repeat each test (can be used to check for '
+         'sporadic failures).')
+    ]
+
+    user_options = _fix_user_options(user_options)
+
+    package_name = ''
+
+    def initialize_options(self):
+        self.package = None
+        self.test_path = None
+        self.verbose_results = False
+        self.plugins = None
+        self.pastebin = None
+        self.args = None
+        self.remote_data = False
+        self.pep8 = False
+        self.pdb = False
+        self.coverage = False
+        self.open_files = False
+        self.parallel = 0
+        self.docs_path = None
+        self.skip_docs = False
+        self.repeat = None
+
+    def finalize_options(self):
+        # Normally we would validate the options here, but that's handled in
+        # run_tests
+        pass
+
+    def generate_testing_command(self):
+        """
+        Build a Python script to run the tests.
+        """
+
+        cmd_pre = ''  # Commands to run before the test function
+        cmd_post = ''  # Commands to run after the test function
+
+        if self.coverage:
+           pre, post = self._generate_coverage_commands()
+           cmd_pre += pre
+           cmd_post += post
+
+        if six.PY3:
+            set_flag = "import builtins; builtins._ASTROPY_TEST_ = True"
+        else:
+            set_flag = "import __builtin__; __builtin__._ASTROPY_TEST_ = True"
+
+        cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = ('
+               '{1.package_name}.test('
+               'package={1.package!r}, '
+               'test_path={1.test_path!r}, '
+               'args={1.args!r}, '
+               'plugins={1.plugins!r}, '
+               'verbose={1.verbose_results!r}, '
+               'pastebin={1.pastebin!r}, '
+               'remote_data={1.remote_data!r}, '
+               'pep8={1.pep8!r}, '
+               'pdb={1.pdb!r}, '
+               'open_files={1.open_files!r}, '
+               'parallel={1.parallel!r}, '
+               'docs_path={1.docs_path!r}, '
+               'skip_docs={1.skip_docs!r}, '
+               'repeat={1.repeat!r})); '
+               '{cmd_post}'
+               'sys.exit(result)')
+        return cmd.format(set_flag, self, cmd_pre=cmd_pre, cmd_post=cmd_post)
+
+    def run(self):
+        """
+        Run the tests!
+        """
+        # Build a testing install of the package
+        self._build_temp_install()
+
+        # Ensure there is a doc path
+        if self.docs_path is None:
+            if os.path.exists('docs'):
+                self.docs_path = os.path.abspath('docs')
+
+        # Run everything in a try: finally: so that the tmp dir gets deleted.
+        try:
+            # Construct this modules testing command
+            cmd = self.generate_testing_command()
+
+            # Run the tests in a subprocess--this is necessary since
+            # new extension modules may have appeared, and this is the
+            # easiest way to set up a new environment
+
+            # On Python 3.x prior to 3.3, the creation of .pyc files
+            # is not atomic.  py.test jumps through some hoops to make
+            # this work by parsing import statements and carefully
+            # importing files atomically.  However, it can't detect
+            # when __import__ is used, so its carefulness still fails.
+            # The solution here (admittedly a bit of a hack), is to
+            # turn off the generation of .pyc files altogether by
+            # passing the `-B` switch to `python`.  This does mean
+            # that each core will have to compile .py file to bytecode
+            # itself, rather than getting lucky and borrowing the work
+            # already done by another core.  Compilation is an
+            # insignificant fraction of total testing time, though, so
+            # it's probably not worth worrying about.
+            retcode = subprocess.call([sys.executable, '-B', '-c', cmd],
+                                      cwd=self.testing_path, close_fds=False)
+
+        finally:
+            # Remove temporary directory
+            shutil.rmtree(self.tmp_dir)
+
+        raise SystemExit(retcode)
+
+    def _build_temp_install(self):
+        """
+        Build the package and copy the build to a temporary directory for
+        the purposes of testing this avoids creating pyc and __pycache__
+        directories inside the build directory
+        """
+        self.reinitialize_command('build', inplace=True)
+        self.run_command('build')
+        build_cmd = self.get_finalized_command('build')
+        new_path = os.path.abspath(build_cmd.build_lib)
+
+        self.tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-')
+        self.testing_path = os.path.join(self.tmp_dir, os.path.basename(new_path))
+        shutil.copytree(new_path, self.testing_path)
+        shutil.copy('setup.cfg', self.testing_path)
+
+    def _generate_coverage_commands(self):
+        """
+        This method creates the post and pre commands if coverage is to be
+        generated
+        """
+        if self.parallel != 0:
+            raise ValueError(
+                "--coverage can not be used with --parallel")
+
+        try:
+            import coverage
+        except ImportError:
+            raise ImportError(
+                "--coverage requires that the coverage package is "
+                "installed.")
+
+        # Don't use get_pkg_data_filename here, because it
+        # requires importing astropy.config and thus screwing
+        # up coverage results for those packages.
+        coveragerc = os.path.join(
+            self.testing_path, self.package_name, 'tests', 'coveragerc')
+
+        # We create a coveragerc that is specific to the version
+        # of Python we're running, so that we can mark branches
+        # as being specifically for Python 2 or Python 3
+        with open(coveragerc, 'r') as fd:
+            coveragerc_content = fd.read()
+        if six.PY3:
+            ignore_python_version = '2'
+        else:
+            ignore_python_version = '3'
+        coveragerc_content = coveragerc_content.replace(
+            "{ignore_python_version}", ignore_python_version).replace(
+                "{packagename}", self.package_name)
+        tmp_coveragerc = os.path.join(self.tmp_dir, 'coveragerc')
+        with open(tmp_coveragerc, 'wb') as tmp:
+            tmp.write(coveragerc_content.encode('utf-8'))
+
+        cmd_pre = (
+            'import coverage; '
+            'cov = coverage.coverage(data_file="{0}", config_file="{1}"); '
+            'cov.start();'.format(
+                os.path.abspath(".coverage"), tmp_coveragerc))
+        cmd_post = (
+            'cov.stop(); '
+            'from astropy.tests.helper import _save_coverage; '
+            '_save_coverage(cov, result, "{0}", "{1}");'.format(
+                os.path.abspath('.'), self.testing_path))
+
+        return cmd_pre, cmd_post

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -143,13 +143,14 @@ class AstropyTest(Command, object):
         """
         Run the tests!
         """
-        # Build a testing install of the package
-        self._build_temp_install()
 
         # Ensure there is a doc path
         if self.docs_path is None:
             if os.path.exists('docs'):
                 self.docs_path = os.path.abspath('docs')
+
+        # Build a testing install of the package
+        self._build_temp_install()
 
         # Run everything in a try: finally: so that the tmp dir gets deleted.
         try:
@@ -196,7 +197,13 @@ class AstropyTest(Command, object):
         self.tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-')
         self.testing_path = os.path.join(self.tmp_dir, os.path.basename(new_path))
         shutil.copytree(new_path, self.testing_path)
-        shutil.copy('setup.cfg', self.testing_path)
+
+        new_docs_path = os.path.join(self.tmp_dir,
+                                     os.path.basename(self.docs_path))
+        shutil.copytree(self.docs_path, new_docs_path)
+        self.docs_path = new_docs_path
+
+        shutil.copy('setup.cfg', self.tmp_dir)
 
     def _generate_coverage_commands(self):
         """

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -6,27 +6,17 @@ from the installed astropy.  It makes use of the `pytest` testing framework.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..config.paths import set_temp_config, set_temp_cache
-from ..extern import six
-from ..extern.six.moves import cPickle as pickle
-
-import errno
-import shlex
-import sys
 import base64
-import zlib
+import errno
 import functools
-import multiprocessing
 import os
-import tempfile
+import sys
 import types
 import warnings
+import zlib
 
-__all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
-           'treat_deprecations_as_exceptions', 'catch_warnings',
-           'assert_follows_unicode_guidelines', 'quantity_allclose',
-           'assert_quantity_allclose', 'check_pickling_recovery',
-           'pickle_protocol', 'generic_recursive_equality_test']
+from ..extern import six
+from ..extern.six.moves import cPickle as pickle
 
 try:
     # Import pkg_resources to prevent it from issuing warnings upon being
@@ -40,6 +30,13 @@ from .. import test
 from ..utils.exceptions import (AstropyWarning,
                                 AstropyDeprecationWarning,
                                 AstropyPendingDeprecationWarning)
+
+
+__all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
+           'treat_deprecations_as_exceptions', 'catch_warnings',
+           'assert_follows_unicode_guidelines', 'quantity_allclose',
+           'assert_quantity_allclose', 'check_pickling_recovery',
+           'pickle_protocol', 'generic_recursive_equality_test']
 
 
 if os.environ.get('ASTROPY_USE_SYSTEM_PYTEST') or '_pytest' in sys.modules:
@@ -100,177 +97,6 @@ _rewrite._write_pyc = _write_pyc_wrapper
 
 # pytest marker to mark tests which get data from the web
 remote_data = pytest.mark.remote_data
-
-
-class TestRunner(object):
-    def __init__(self, base_path):
-        self.base_path = os.path.abspath(base_path)
-
-    def run_tests(self, package=None, test_path=None, args=None, plugins=None,
-                  verbose=False, pastebin=None, remote_data=False, pep8=False,
-                  pdb=False, coverage=False, open_files=False, parallel=0,
-                  docs_path=None, skip_docs=False, repeat=None):
-        """
-        The docstring for this method lives in astropy/__init__.py:test
-        """
-
-        if coverage:
-            warnings.warn(
-                "The coverage option is ignored on run_tests, since it "
-                "can not be made to work in that context.  Use "
-                "'python setup.py test --coverage' instead.",
-                AstropyWarning)
-
-        all_args = []
-
-        if package is None:
-            package_path = self.base_path
-        else:
-            package_path = os.path.join(self.base_path,
-                                        package.replace('.', os.path.sep))
-
-            if not os.path.isdir(package_path):
-                raise ValueError('Package not found: {0}'.format(package))
-
-        if docs_path is not None and not skip_docs:
-            if package is not None:
-                docs_path = os.path.join(
-                    docs_path, package.replace('.', os.path.sep))
-            if not os.path.exists(docs_path):
-                warnings.warn(
-                    "Can not test .rst docs, since docs path "
-                    "({0}) does not exist.".format(docs_path))
-                docs_path = None
-
-        if test_path:
-            base, ext = os.path.splitext(test_path)
-
-            if ext in ('.rst', ''):
-                if docs_path is None:
-                    # This shouldn't happen from "python setup.py test"
-                    raise ValueError(
-                        "Can not test .rst files without a docs_path "
-                        "specified.")
-
-                abs_docs_path = os.path.abspath(docs_path)
-                abs_test_path = os.path.abspath(
-                    os.path.join(abs_docs_path, os.pardir, test_path))
-
-                common = os.path.commonprefix((abs_docs_path, abs_test_path))
-
-                if os.path.exists(abs_test_path) and common == abs_docs_path:
-                    # Since we aren't testing any Python files within
-                    # the astropy tree, we need to forcibly load the
-                    # astropy py.test plugins, and then turn on the
-                    # doctest_rst plugin.
-                    all_args.extend(['-p', 'astropy.tests.pytest_plugins',
-                                     '--doctest-rst'])
-                    test_path = abs_test_path
-
-            if not (os.path.isdir(test_path) or ext in ('.py', '.rst')):
-                raise ValueError("Test path must be a directory or a path to "
-                                 "a .py or .rst file")
-
-            all_args.append(test_path)
-        else:
-            all_args.append(package_path)
-            if docs_path is not None and not skip_docs:
-                all_args.extend([docs_path, '--doctest-rst'])
-
-        # add any additional args entered by the user
-        if args is not None:
-            all_args.extend(
-                shlex.split(args, posix=not sys.platform.startswith('win')))
-
-        # add verbosity flag
-        if verbose:
-            all_args.append('-v')
-
-        # turn on pastebin output
-        if pastebin is not None:
-            if pastebin in ['failed', 'all']:
-                all_args.append('--pastebin={0}'.format(pastebin))
-            else:
-                raise ValueError("pastebin should be 'failed' or 'all'")
-
-        # run @remote_data tests
-        if remote_data:
-            all_args.append('--remote-data')
-
-        if pep8:
-            try:
-                import pytest_pep8
-            except ImportError:
-                raise ImportError('PEP8 checking requires pytest-pep8 plugin: '
-                                  'http://pypi.python.org/pypi/pytest-pep8')
-            else:
-                all_args.extend(['--pep8', '-k', 'pep8'])
-
-        # activate post-mortem PDB for failing tests
-        if pdb:
-            all_args.append('--pdb')
-
-        # check for opened files after each test
-        if open_files:
-            if parallel != 0:
-                raise SystemError(
-                    "open file detection may not be used in conjunction with "
-                    "parallel testing.")
-
-            try:
-                import psutil
-            except ImportError:
-                raise SystemError(
-                    "open file detection requested, but psutil package "
-                    "is not installed.")
-
-            all_args.append('--open-files')
-
-            print("Checking for unclosed files")
-
-        if parallel != 0:
-            try:
-                import xdist
-            except ImportError:
-                raise ImportError(
-                    'Parallel testing requires the pytest-xdist plugin '
-                    'https://pypi.python.org/pypi/pytest-xdist')
-
-            try:
-                parallel = int(parallel)
-            except ValueError:
-                raise ValueError(
-                    "parallel must be an int, got {0}".format(parallel))
-
-            if parallel < 0:
-                parallel = multiprocessing.cpu_count()
-            all_args.extend(['-n', six.text_type(parallel)])
-
-        if repeat:
-            all_args.append('--repeat={0}'.format(repeat))
-
-        if six.PY2:
-            all_args = [x.encode('utf-8') for x in all_args]
-
-        # override the config locations to not make a new directory nor use
-        # existing cache or config
-        astropy_config = tempfile.mkdtemp('astropy_config')
-        astropy_cache = tempfile.mkdtemp('astropy_cache')
-
-        # This prevents cyclical import problems that make it
-        # impossible to test packages that define Table types on their
-        # own.
-        from ..table import Table
-
-        # Have to use nested with statements for cross-Python support
-        # Note, using these context managers here is superfluous if the
-        # config_dir or cache_dir options to py.test are in use, but it's
-        # also harmless to nest the contexts
-        with set_temp_config(astropy_config, delete=True):
-            with set_temp_cache(astropy_cache, delete=True):
-                return pytest.main(args=all_args, plugins=plugins)
-
-    run_tests.__doc__ = test.__doc__
 
 
 # This is for Python 2.x and 3.x compatibility.  distutils expects

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -266,8 +266,7 @@ class TestRunner(object):
 
         runner = cls(path)
 
-        @wraps(runner.run_tests, ('__doc__', '__annotations__'),
-               exclude_args=('self',))
+        @wraps(runner.run_tests, ('__doc__',), exclude_args=('self',))
         def test(*args, **kwargs):
             return runner.run_tests(*args, **kwargs)
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -1,0 +1,287 @@
+"""Implements the Astropy TestRunner which is a thin wrapper around py.test."""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import multiprocessing
+import os
+import shlex
+import sys
+import tempfile
+import warnings
+
+from ..config.paths import set_temp_config, set_temp_cache
+from ..extern import six
+from ..utils import wraps, find_current_module
+
+
+class TestRunner(object):
+    def __init__(self, base_path):
+        self.base_path = os.path.abspath(base_path)
+
+    def run_tests(self, package=None, test_path=None, args=None, plugins=None,
+                  verbose=False, pastebin=None, remote_data=False, pep8=False,
+                  pdb=False, coverage=False, open_files=False, parallel=0,
+                  docs_path=None, skip_docs=False, repeat=None):
+        """
+        Run Astropy tests using py.test. A proper set of arguments is
+        constructed and passed to `pytest.main`.
+
+        Parameters
+        ----------
+        package : str, optional
+            The name of a specific package to test, e.g. 'io.fits' or 'utils'.
+            If nothing is specified all default Astropy tests are run.
+
+        test_path : str, optional
+            Specify location to test by path. May be a single file or
+            directory. Must be specified absolutely or relative to the
+            calling directory.
+
+        args : str, optional
+            Additional arguments to be passed to `pytest.main` in the `args`
+            keyword argument.
+
+        plugins : list, optional
+            Plugins to be passed to `pytest.main` in the `plugins` keyword
+            argument.
+
+        verbose : bool, optional
+            Convenience option to turn on verbose output from py.test. Passing
+            True is the same as specifying `-v` in `args`.
+
+        pastebin : {'failed','all',None}, optional
+            Convenience option for turning on py.test pastebin output. Set to
+            'failed' to upload info for failed tests, or 'all' to upload info
+            for all tests.
+
+        remote_data : bool, optional
+            Controls whether to run tests marked with @remote_data. These
+            tests use online data and are not run by default. Set to True to
+            run these tests.
+
+        pep8 : bool, optional
+            Turn on PEP8 checking via the pytest-pep8 plugin and disable normal
+            tests. Same as specifying `--pep8 -k pep8` in `args`.
+
+        pdb : bool, optional
+            Turn on PDB post-mortem analysis for failing tests. Same as
+            specifying `--pdb` in `args`.
+
+        open_files : bool, optional
+            Fail when any tests leave files open.  Off by default, because
+            this adds extra run time to the test suite.  Requires the
+            ``psutil`` package.
+
+        parallel : int, optional
+            When provided, run the tests in parallel on the specified
+            number of CPUs.  If parallel is negative, it will use the all
+            the cores on the machine.  Requires the `pytest-xdist` plugin.
+
+        docs_path : str, optional
+            The path to the documentation .rst files.
+
+        skip_docs : bool, optional
+            When `True`, skips running the doctests in the .rst files.
+
+        repeat : int, optional
+            If set, specifies how many times each test should be run. This is
+            useful for diagnosing sporadic failures.
+
+        See Also
+        --------
+        pytest.main : py.test function wrapped by `run_tests`.
+        """
+
+        # Don't import pytest until it's actually needed to run the tests
+        from .helper import pytest
+
+        if coverage:
+            warnings.warn(
+                "The coverage option is ignored on run_tests, since it "
+                "can not be made to work in that context.  Use "
+                "'python setup.py test --coverage' instead.",
+                AstropyWarning)
+
+        all_args = []
+
+        if package is None:
+            package_path = self.base_path
+        else:
+            package_path = os.path.join(self.base_path,
+                                        package.replace('.', os.path.sep))
+
+            if not os.path.isdir(package_path):
+                raise ValueError('Package not found: {0}'.format(package))
+
+        if docs_path is not None and not skip_docs:
+            if package is not None:
+                docs_path = os.path.join(
+                    docs_path, package.replace('.', os.path.sep))
+            if not os.path.exists(docs_path):
+                warnings.warn(
+                    "Can not test .rst docs, since docs path "
+                    "({0}) does not exist.".format(docs_path))
+                docs_path = None
+
+        if test_path:
+            base, ext = os.path.splitext(test_path)
+
+            if ext in ('.rst', ''):
+                if docs_path is None:
+                    # This shouldn't happen from "python setup.py test"
+                    raise ValueError(
+                        "Can not test .rst files without a docs_path "
+                        "specified.")
+
+                abs_docs_path = os.path.abspath(docs_path)
+                abs_test_path = os.path.abspath(
+                    os.path.join(abs_docs_path, os.pardir, test_path))
+
+                common = os.path.commonprefix((abs_docs_path, abs_test_path))
+
+                if os.path.exists(abs_test_path) and common == abs_docs_path:
+                    # Since we aren't testing any Python files within
+                    # the astropy tree, we need to forcibly load the
+                    # astropy py.test plugins, and then turn on the
+                    # doctest_rst plugin.
+                    all_args.extend(['-p', 'astropy.tests.pytest_plugins',
+                                     '--doctest-rst'])
+                    test_path = abs_test_path
+
+            if not (os.path.isdir(test_path) or ext in ('.py', '.rst')):
+                raise ValueError("Test path must be a directory or a path to "
+                                 "a .py or .rst file")
+
+            all_args.append(test_path)
+        else:
+            all_args.append(package_path)
+            if docs_path is not None and not skip_docs:
+                all_args.extend([docs_path, '--doctest-rst'])
+
+        # add any additional args entered by the user
+        if args is not None:
+            all_args.extend(
+                shlex.split(args, posix=not sys.platform.startswith('win')))
+
+        # add verbosity flag
+        if verbose:
+            all_args.append('-v')
+
+        # turn on pastebin output
+        if pastebin is not None:
+            if pastebin in ['failed', 'all']:
+                all_args.append('--pastebin={0}'.format(pastebin))
+            else:
+                raise ValueError("pastebin should be 'failed' or 'all'")
+
+        # run @remote_data tests
+        if remote_data:
+            all_args.append('--remote-data')
+
+        if pep8:
+            try:
+                import pytest_pep8
+            except ImportError:
+                raise ImportError('PEP8 checking requires pytest-pep8 plugin: '
+                                  'http://pypi.python.org/pypi/pytest-pep8')
+            else:
+                all_args.extend(['--pep8', '-k', 'pep8'])
+
+        # activate post-mortem PDB for failing tests
+        if pdb:
+            all_args.append('--pdb')
+
+        # check for opened files after each test
+        if open_files:
+            if parallel != 0:
+                raise SystemError(
+                    "open file detection may not be used in conjunction with "
+                    "parallel testing.")
+
+            try:
+                import psutil
+            except ImportError:
+                raise SystemError(
+                    "open file detection requested, but psutil package "
+                    "is not installed.")
+
+            all_args.append('--open-files')
+
+            print("Checking for unclosed files")
+
+        if parallel != 0:
+            try:
+                import xdist
+            except ImportError:
+                raise ImportError(
+                    'Parallel testing requires the pytest-xdist plugin '
+                    'https://pypi.python.org/pypi/pytest-xdist')
+
+            try:
+                parallel = int(parallel)
+            except ValueError:
+                raise ValueError(
+                    "parallel must be an int, got {0}".format(parallel))
+
+            if parallel < 0:
+                parallel = multiprocessing.cpu_count()
+            all_args.extend(['-n', six.text_type(parallel)])
+
+        if repeat:
+            all_args.append('--repeat={0}'.format(repeat))
+
+        if six.PY2:
+            all_args = [x.encode('utf-8') for x in all_args]
+
+        # override the config locations to not make a new directory nor use
+        # existing cache or config
+        astropy_config = tempfile.mkdtemp('astropy_config')
+        astropy_cache = tempfile.mkdtemp('astropy_cache')
+
+        # This prevents cyclical import problems that make it
+        # impossible to test packages that define Table types on their
+        # own.
+        from ..table import Table
+
+        # Have to use nested with statements for cross-Python support
+        # Note, using these context managers here is superfluous if the
+        # config_dir or cache_dir options to py.test are in use, but it's
+        # also harmless to nest the contexts
+        with set_temp_config(astropy_config, delete=True):
+            with set_temp_cache(astropy_cache, delete=True):
+                return pytest.main(args=all_args, plugins=plugins)
+
+    @classmethod
+    def make_test_runner_in(cls, path):
+        """
+        Constructs a `TestRunner` to run in the given path, and returns a
+        ``test()`` function which takes the same arguments as
+        `TestRunner.run_tests`.
+
+        The returned ``test()`` function will be defined in the module this
+        was called from.  This is used to implement the ``astropy.test()``
+        function (or the equivalent for affiliated packages).
+        """
+
+        runner = cls(path)
+
+        @wraps(runner.run_tests, ('__doc__', '__annotations__'),
+               exclude_args=('self',))
+        def test(*args, **kwargs):
+            return runner.run_tests(*args, **kwargs)
+
+        module = find_current_module(2)
+        if module is not None:
+            test.__module__ = module.__name__
+
+        # A somewhat unusual hack, but delete the attached __wrapped__
+        # attribute--although this is normally used to tell if the function
+        # was wrapped with wraps, on some version of Python this is also
+        # used to determine the signature to display in help() which is
+        # not useful in this case.  We don't really care in this case if the
+        # function was wrapped either
+        if hasattr(test, '__wrapped__'):
+            del test.__wrapped__
+
+        return test

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -12,23 +12,23 @@ import doctest
 from textwrap import dedent
 
 # test helper.run_tests function
-
+from ... import test as run_tests
 from ... extern import six
 
 from .. import helper
-from ... import _get_test_runner
-from .. helper import pytest
+from ..helper import pytest
+
 
 # run_tests should raise ValueError when asked to run on a module it can't find
 def test_module_not_found():
     with helper.pytest.raises(ValueError):
-        _get_test_runner().run_tests('fake.module')
+        run_tests('fake.module')
 
 
 # run_tests should raise ValueError when passed an invalid pastebin= option
 def test_pastebin_keyword():
     with helper.pytest.raises(ValueError):
-        _get_test_runner().run_tests(pastebin='not_an_option')
+        run_tests(pastebin='not_an_option')
 
 
 # TODO: Temporarily disabled, as this seems to non-deterministically fail


### PR DESCRIPTION
Following discussion in #2317, here's some changes that will make it I think a little easier to add changes to the `astropy.tests` test runner.  This also moves the `AstropyTest` distutils command class back into astropy.tests so that it isn't awkwardly separated in astropy-helpers.  There will be an associated change in astropy-helpers, so this PR should include a submodule update before it's merged.

This PR depends on #4017.