### PR TITLE
classproperty docstring bug

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -352,6 +352,13 @@ class classproperty(property):
 
         super(classproperty, self).__init__(fget=fget, doc=doc)
 
+        # There is a buglet in Python where self.__doc__ doesn't
+        # get set properly on instances of property subclasses if
+        # the doc argument was used rather than taking the docstring
+        # from fget
+        if doc is not None:
+            self.__doc__ = doc
+
     def __get__(self, obj, objtype=None):
         if objtype is not None:
             # The base property.__get__ will just return self here;

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -6,7 +6,8 @@ import functools
 import inspect
 import pickle
 
-from ..decorators import deprecated_attribute, deprecated, wraps, sharedmethod
+from ..decorators import (deprecated_attribute, deprecated, wraps,
+                          sharedmethod, classproperty)
 from ..exceptions import AstropyDeprecationWarning
 from ...extern import six
 from ...tests.helper import pytest, catch_warnings
@@ -334,3 +335,30 @@ def test_sharedmethod_reuse_on_subclasses():
         x = 5
 
     assert B.foo() == 5
+
+
+def test_classproperty_docstring():
+    """
+    Tests that the docstring is set correctly on classproperties.
+
+    This failed previously due to a bug in Python that didn't always
+    set __doc__ properly on instances of property subclasses.
+    """
+
+    class A(object):
+        # Inherits docstring from getter
+        @classproperty
+        def foo(cls):
+            """The foo."""
+
+            return 1
+
+    assert A.__dict__['foo'].__doc__ == "The foo."
+
+    class B(object):
+        # Use doc passed to classproperty constructor
+        def _get_foo(cls): return 1
+
+        foo = classproperty(_get_foo, doc="The foo.")
+
+    assert B.__dict__['foo'].__doc__ == "The foo."


### PR DESCRIPTION
Workaround for a bug in Python that was causing the docstring of `classproperty` instances to not be set properly in some cases.

I'll send a patch to CPython tomorrow (if it isn't already fixed there).