### PR TITLE
Plot style should not set interactive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -357,6 +357,11 @@ API changes
 
 - ``astropy.visualization``
 
+  - The ``astropy_mpl_style`` no longer sets ``interactive`` to
+    ``True``, but instead leaves it at the user preference.  This
+    makes using the style compatible with building docs with Sphinx,
+    and other non-interactive contexts. [#4030]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``
@@ -642,7 +647,7 @@ Bug Fixes
   - Fixed multiple instances of a bug that prevented Astropy from being used
     when compiled with the ``python -OO`` flag, due to it causing all
     docstrings to be stripped out. [#3923]
-    
+
   - Removed source code template files that were being installed
     accidentally alongside installed Python modules. [#4014]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -357,11 +357,6 @@ API changes
 
 - ``astropy.visualization``
 
-  - The ``astropy_mpl_style`` no longer sets ``interactive`` to
-    ``True``, but instead leaves it at the user preference.  This
-    makes using the style compatible with building docs with Sphinx,
-    and other non-interactive contexts. [#4030]
-
 - ``astropy.vo``
 
 - ``astropy.wcs``
@@ -538,6 +533,13 @@ API Changes
 - ``astropy.units``
 
 - ``astropy.utils``
+
+- ``astropy.visualization``
+
+  - The ``astropy_mpl_style`` no longer sets ``interactive`` to
+    ``True``, but instead leaves it at the user preference.  This
+    makes using the style compatible with building docs with Sphinx,
+    and other non-interactive contexts. [#4030]
 
 - ``astropy.vo``
 

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -95,7 +95,6 @@ astropy_mpl_style_1 = {
 
     # Other
     'savefig.dpi': 72,
-    'interactive': True,
     'toolbar': 'toolbar2',
     'timezone': 'UTC'
 }


### PR DESCRIPTION
A style should not tinker with the interactive mode.  Importantly, this means if you use it in a non-interactive context, such as building Sphinx docs or in a web server the plots take on the order of 10-20x longer to render.

This is somewhat a matplotlib bug that this even works in the first place (see matplotlib/matplotlib#4855).

However, in the meantime, I think we should just remove this from `astropy_mpl_style`.

Not exactly sure how to milestone this -- it probably belongs as a bugfix, but's it could trip someone up who was inadvertently depending on this behavior.