### PR TITLE
Use astropy_mpl_style in docs

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -481,19 +481,19 @@ class Sersic1D(Fittable1DModel):
         import matplotlib.pyplot as plt
 
         plt.figure()
-        plt.subplot(111,xscale='log',yscale='log')
+        plt.subplot(111, xscale='log', yscale='log')
         s1 = Sersic1D(amplitude=1, r_eff=5)
-        r=np.arange(0,100,.01)
+        r=np.arange(0, 100, .01)
 
-        for n in range(1,10):
+        for n in range(1, 10):
              s1.n = n
-             plt.plot(r,s1(r),color='k',alpha=0.5,lw=2)
+             plt.plot(r, s1(r), color=str(float(n) / 15))
 
-        plt.axis([1e-1,30,1e-2,1e3])
-        plt.xlabel('log Radius',fontsize=16)
-        plt.ylabel('log Surface Brightness',fontsize=16)
-        plt.text(.25,1.5,'n=1',fontsize=16)
-        plt.text(.25,300,'n=10',fontsize=16)
+        plt.axis([1e-1, 30, 1e-2, 1e3])
+        plt.xlabel('log Radius')
+        plt.ylabel('log Surface Brightness')
+        plt.text(.25, 1.5, 'n=1')
+        plt.text(.25, 300, 'n=10')
         plt.xticks([])
         plt.yticks([])
         plt.show()
@@ -699,7 +699,7 @@ class Voigt1D(Fittable1DModel):
         import matplotlib.pyplot as plt
 
         plt.figure()
-        x = np.arange(0, 10, 0.1)
+        x = np.arange(0, 10, 0.01)
         v1 = Voigt1D(x_0=5, amplitude_L=10, fwhm_L=0.5, fwhm_G=0.9)
         plt.plot(x, v1(x))
         plt.show()
@@ -903,8 +903,8 @@ class Ellipse2D(Fittable2DModel):
         y, x = np.mgrid[0:50, 0:50]
         fig, ax = plt.subplots(1, 1)
         ax.imshow(e(x, y), origin='lower', interpolation='none', cmap='Greys_r')
-        e2 = mpatches.Ellipse((x0, y0), 2*a, 2*b, theta.degree,
-                              edgecolor='red', facecolor='none')
+        e2 = mpatches.Ellipse((x0, y0), 2*a, 2*b, theta.degree, edgecolor='red',
+                              facecolor='none')
         ax.add_patch(e2)
         plt.show()
     """
@@ -1587,21 +1587,22 @@ class Sersic2D(Fittable2DModel):
         from astropy.modeling.models import Sersic2D
         import matplotlib.pyplot as plt
 
-        x,y = np.meshgrid(np.arange(100),np.arange(100))
+        x,y = np.meshgrid(np.arange(100), np.arange(100))
 
-        mod = Sersic2D(amplitude = 1, r_eff = 25, n=4, x_0=50, y_0=50, ellip=.5,theta=-1)
-        img = mod(x,y)
+        mod = Sersic2D(amplitude = 1, r_eff = 25, n=4, x_0=50, y_0=50,
+                       ellip=.5, theta=-1)
+        img = mod(x, y)
         log_img = np.log10(img)
 
 
         plt.figure()
-        plt.imshow(log_img, origin='lower', interpolation='nearest', cmap='binary_r',
-                    vmin=-1, vmax=2)
-        plt.xlabel('x', fontsize=16)
-        plt.ylabel('y', fontsize=16)
-        cbar=plt.colorbar()
-        cbar.set_label('Log Brightness', rotation=270, labelpad=25, fontsize=16)
-        cbar.set_ticks([-1,0,1,2],update_ticks=True)
+        plt.imshow(log_img, origin='lower', interpolation='nearest',
+                   vmin=-1, vmax=2)
+        plt.xlabel('x')
+        plt.ylabel('y')
+        cbar = plt.colorbar()
+        cbar.set_label('Log Brightness', rotation=270, labelpad=25)
+        cbar.set_ticks([-1, 0, 1, 2], update_ticks=True)
         plt.show()
 
     References

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -368,8 +368,7 @@ def binned_binom_proportion(x, success, bins=10, range=None, conf=0.68269,
        plt.errorbar(bins, p, xerr=binshw, yerr=perr, ls='none', marker='o',
                     label='estimate')
        X = np.linspace(20., 30., 1000)
-       plt.plot(X, true_efficiency(X), ls='-', color='r',
-                label='true efficiency')
+       plt.plot(X, true_efficiency(X), label='true efficiency')
        plt.ylim(0., 1.)
        plt.title('Detection efficiency vs magnitude')
        plt.xlabel('Magnitude')
@@ -409,8 +408,7 @@ def binned_binom_proportion(x, success, bins=10, range=None, conf=0.68269,
        plt.errorbar(bins, p, xerr=binshw, yerr=perr, ls='none', marker='o',
                     label='estimate')
        X = np.linspace(20., 30., 1000)
-       plt.plot(X, true_efficiency(X), ls='-', color='r',
-                label='true efficiency')
+       plt.plot(X, true_efficiency(X), label='true efficiency')
        plt.ylim(0., 1.)
        plt.title('The Wald interval can give nonsensical uncertainties')
        plt.xlabel('Magnitude')

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -110,3 +110,20 @@ Most recent version of the astropy plotting style for matplotlib.
 
 This style improves some settings over the matplotlib default.
 '''
+
+astropy_mpl_docs_style = astropy_mpl_style_1.copy()
+'''
+The style used in the astropy documentation.
+'''
+
+astropy_mpl_docs_style['axes.color_cycle'] = [
+    '#E24A33',   # orange
+    '#348ABD',   # blue
+    '#467821',   # green
+    '#A60628',   # red
+    '#7A68A6',   # purple
+    '#CF4457',   # pink
+    '#188487'    # turquoise
+]
+
+astropy_mpl_docs_style['axes.grid'] = False

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -97,8 +97,6 @@ astropy_mpl_style_1 = {
 
     # Other
     'savefig.dpi': 72,
-    'toolbar': 'toolbar2',
-    'timezone': 'UTC'
 }
 '''
 Version 1 astropy plotting style for matplotlib.

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -61,13 +61,15 @@ astropy_mpl_style_1 = {
     'axes.labelsize': 'large',
     'axes.labelcolor': '#FFFFFF',
     'axes.axisbelow': True,
-    'axes.color_cycle': ['#348ABD',   # blue
-                         '#7A68A6',   # purple
-                         '#A60628',   # red
-                         '#467821',   # green
-                         '#CF4457',   # pink
-                         '#188487',   # turquoise
-                         '#E24A33'],  # orange
+    'axes.color_cycle': [
+        '#E24A33',   # orange
+        '#348ABD',   # blue
+        '#467821',   # green
+        '#A60628',   # red
+        '#7A68A6',   # purple
+        '#CF4457',   # pink
+        '#188487'    # turquoise
+    ],
 
     # Ticks
     'xtick.major.size': 0,

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -61,15 +61,13 @@ astropy_mpl_style_1 = {
     'axes.labelsize': 'large',
     'axes.labelcolor': '#FFFFFF',
     'axes.axisbelow': True,
-    'axes.color_cycle': [
-        '#E24A33',   # orange
-        '#348ABD',   # blue
-        '#467821',   # green
-        '#A60628',   # red
-        '#7A68A6',   # purple
-        '#CF4457',   # pink
-        '#188487'    # turquoise
-    ],
+    'axes.color_cycle': ['#348ABD',   # blue
+                         '#7A68A6',   # purple
+                         '#A60628',   # red
+                         '#467821',   # green
+                         '#CF4457',   # pink
+                         '#188487',   # turquoise
+                         '#E24A33'],  # orange
 
     # Ticks
     'xtick.major.size': 0,

--- a/docs/analytic_functions/index.rst
+++ b/docs/analytic_functions/index.rst
@@ -95,7 +95,7 @@ Plot a blackbody spectrum for 5000 K:
     with np.errstate(all='ignore'):
         flux = blackbody_lambda(waveset, temperature)
 
-    fig, ax = plt.subplots(figsize=(8,5))
+    fig, ax = plt.subplots(figsize=(8, 5))
     ax.plot(waveset.value, flux.value)
     ax.axvline(wavemax.value, ls='--')
     ax.get_yaxis().get_major_formatter().set_powerlimits((0, 1))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,6 @@ import astropy
 
 # Use the astropy style when building docs
 from astropy import visualization
-from matplotlib import pyplot as plt
 plot_rcparams = visualization.astropy_mpl_style
 plot_apply_rcparams = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ import astropy
 
 # Use the astropy style when building docs
 from astropy import visualization
-plot_rcparams = visualization.astropy_mpl_style
+plot_rcparams = visualization.astropy_mpl_docs_style
 plot_apply_rcparams = True
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,12 @@ from astropy.extern import six
 
 import astropy
 
+# Use the astropy style when building docs
+from astropy import visualization
+from matplotlib import pyplot as plt
+plot_rcparams = visualization.astropy_mpl_style
+plot_apply_rcparams = True
+
 
 # -- General configuration ----------------------------------------------------
 

--- a/docs/convolution/index.rst
+++ b/docs/convolution/index.rst
@@ -120,7 +120,7 @@ The kernel can then be used directly when calling
 
     # Plot data before and after convolution
     plt.plot(x, y, 'k.')
-    plt.plot(x, z, 'r-', lw=3)
+    plt.plot(x, z)
     plt.show()
 
 

--- a/docs/convolution/kernels.rst
+++ b/docs/convolution/kernels.rst
@@ -171,7 +171,7 @@ Note that it has a slightly different color scale compared to the original image
         smoothed = convolve(data_2D, kernel)
         im = ax.imshow(smoothed, vmin=-0.01, vmax=0.08, origin='lower', interpolation='None')
         title = kernel.__class__.__name__
-        ax.set_title(title)
+        ax.set_title(title, fontsize=12)
         ax.set_yticklabels([])
         ax.set_xticklabels([])
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -799,7 +799,7 @@ its usual position to avoid overlap with the axis labels.
     plt.title("Aitoff projection of our random data", y=1.08)
     plt.grid(True)
     plt.plot(ra_rad, dec_rad, 'o', markersize=2, alpha=0.3)
-    plt.subplots_adjust(top=0.95,bottom=0.0)
+    plt.subplots_adjust(top=0.95, bottom=0.0)
     plt.show()
 
 

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -412,11 +412,11 @@ example, to create the following compound model:
     g0 = RedshiftedGaussian(z_0=0)
 
     plt.figure(figsize=(8, 3))
-    plt.plot(x, g0(x), 'g--', lw=2, label='$z=0$')
+    plt.plot(x, g0(x), 'g--', label='$z=0$')
 
     for z in (0.2, 0.4, 0.6):
         g = RedshiftedGaussian(z_0=z)
-        plt.plot(x, g(x), color=plt.cm.OrRd(z), lw=2,
+        plt.plot(x, g(x), color=plt.cm.OrRd(z),
                  label='$z={0}$'.format(z))
 
     plt.xlabel('Energy')

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -125,8 +125,8 @@ and `~astropy.modeling.functional_models.Trapezoid1D` models and the
     # Plot the data with the best-fit model
     plt.figure(figsize=(8,5))
     plt.plot(x, y, 'ko')
-    plt.plot(x, t(x), 'b-', lw=2, label='Trapezoid')
-    plt.plot(x, g(x), 'r-', lw=2, label='Gaussian')
+    plt.plot(x, t(x), label='Trapezoid')
+    plt.plot(x, g(x), label='Gaussian')
     plt.xlabel('Position')
     plt.ylabel('Flux')
     plt.legend(loc=2)
@@ -166,15 +166,15 @@ background in an image.
         p = fit_p(p_init, x, y, z)
 
     # Plot the data with the best-fit model
-    plt.figure(figsize=(8,2.5))
-    plt.subplot(1,3,1)
+    plt.figure(figsize=(8, 2.5))
+    plt.subplot(1, 3, 1)
     plt.imshow(z, origin='lower', interpolation='nearest', vmin=-1e4, vmax=5e4)
     plt.title("Data")
-    plt.subplot(1,3,2)
+    plt.subplot(1, 3, 2)
     plt.imshow(p(x, y), origin='lower', interpolation='nearest', vmin=-1e4,
                vmax=5e4)
     plt.title("Model")
-    plt.subplot(1,3,3)
+    plt.subplot(1, 3, 3)
     plt.imshow(z - p(x, y), origin='lower', interpolation='nearest', vmin=-1e4,
                vmax=5e4)
     plt.title("Residual")
@@ -306,7 +306,7 @@ These new compound models can also be fitted to data, like most other models:
     # Plot the data with the best-fit model
     plt.figure(figsize=(8,5))
     plt.plot(x, y, 'ko')
-    plt.plot(x, gg_fit(x), 'r-', lw=2)
+    plt.plot(x, gg_fit(x))
     plt.xlabel('Position')
     plt.ylabel('Flux')
 
@@ -343,4 +343,3 @@ Reference/API
 .. automodapi:: astropy.modeling.fitting
 .. automodapi:: astropy.modeling.optimizers
 .. automodapi:: astropy.modeling.statistic
-

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -48,7 +48,7 @@ of two Gaussians:
 
     # Plot the data and the best fit
     plt.plot(x, y, 'o', color='k')
-    plt.plot(x, m(x), color='r', lw=2)
+    plt.plot(x, m(x))
 
 
 This decorator also supports setting a model's

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -150,7 +150,7 @@ instance:
 
     # Make the figure
     fig = plt.figure()
-    ax = fig.add_subplot(1,1,1)
+    ax = fig.add_subplot(1, 1, 1)
     im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
 


### PR DESCRIPTION
This turns on the astropy_mpl_style for all plots in the astropy docs.

Most of the changes involve removing places where colors are explicitly set in order to let the style be applied.

Some points for discussion:

I changed the color cycle.  The first two colors in the cycle (blue and purple) were very close together visually.  I also thought it best to put orange first as that's the "astropy brand" and it blends well with the default astropy color map (though it isn't very visible on top of it, obviously).

The astropy style turns on gridlines by default.  I think this makes most of the plots in the docs harder to read and in some cases really obscures the data.  For the modeling docs, for example, it's the shape of the curves, and not really their scale that matters anyway, so the gridlines are pretty superfluous.  I think I'd prefer to just remove the gridlines in the style, or short of that set it to False only for building astropy's docs but not change the style for others.

![utils-1](https://cloud.githubusercontent.com/assets/38294/9040035/5e1b9d3c-39cd-11e5-9aaf-aacc8e732bf1.png)

#4008 should probably be rebased on this before merging (or vice versa) to make sure there aren't any negative side effects.