### PR TITLE
barn not listed as having prefixes in documentation, even though it does

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -616,6 +616,11 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Fixed the documentation of supported units to correctly report support for
+    SI prefixes.  Previously the table of supported units incorrectly showed
+    several derived unit as not supporting prefixes, when in fact they do.
+    [#3835]
+
   - Fix a crash when calling ``astropy.units.cds.enable()``.  This
     will now "set" rather than "add" units to the active set to avoid
     the namespace clash with the default units. [#3873]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -700,3 +700,28 @@ def test_enable_unit_groupings():
     from ...units import imperial
     with imperial.enable():
         assert imperial.inch in u.m.find_equivalent_units()
+
+
+def test_unit_summary_prefixes():
+    """
+    Test for a few units that the unit summary table correctly reports
+    whether or not that unit supports prefixes.
+
+    Regression test for https://github.com/astropy/astropy/issues/3835
+    """
+
+    from .. import astrophys
+
+    for summary in utils._iter_unit_summary(astrophys.__dict__):
+        unit, _, _, _, prefixes = summary
+
+        if unit.name == 'lyr':
+            assert prefixes
+        elif unit.name == 'pc':
+            assert prefixes
+        elif unit.name == 'barn':
+            assert prefixes
+        elif unit.name == 'cycle':
+            assert not prefixes
+        elif unit.name == 'vox':
+            assert prefixes

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -41,6 +41,48 @@ def _get_first_sentence(s):
     return s.replace('\n', ' ')
 
 
+def _iter_unit_summary(namespace):
+    """
+    Generates the ``(unit, doc, rperesents, aliases, prefixes)``
+    tuplse used to format the unit summary docs in `generate_unit_summary`.
+    """
+
+    from . import core
+
+    # Get all of the units, and keep track of which ones have SI
+    # prefixes
+    units = []
+    has_prefixes = set()
+    for key, val in six.iteritems(namespace):
+        # Skip non-unit items
+        if not isinstance(val, core.UnitBase):
+            continue
+
+        # Skip aliases
+        if key != val.name:
+            continue
+
+        if isinstance(val, core.PrefixUnit):
+            # This will return the root unit that is scaled by the prefix
+            # attached to it
+            has_prefixes.add(val._represents.bases[0].name)
+        else:
+            units.append(val)
+
+    # Sort alphabetically, case insensitive
+    units.sort(key=lambda x: x.name.lower())
+
+    for unit in units:
+        doc = _get_first_sentence(unit.__doc__).strip()
+        represents = ''
+        if isinstance(unit, core.Unit):
+            represents = ":math:`{0}`".format(
+                unit._represents.to_string('latex')[1:-1])
+        aliases = ', '.join('``{0}``'.format(x) for x in unit.aliases)
+
+        yield (unit, doc, represents, aliases, unit.name in has_prefixes)
+
+
 def generate_unit_summary(namespace):
     """
     Generates a summary of units from a given namespace.  This is used
@@ -58,34 +100,6 @@ def generate_unit_summary(namespace):
         A docstring containing a summary table of the units.
     """
 
-    from . import core
-
-    # Get all of the units, and keep track of which ones have SI
-    # prefixes
-    units = []
-    has_prefixes = set()
-    for key, val in list(six.iteritems(namespace)):
-        # Skip non-unit items
-        if not isinstance(val, core.UnitBase):
-            continue
-
-        # Skip aliases
-        if key != val.name:
-            continue
-
-        if isinstance(val, core.PrefixUnit):
-            decomposed = val.decompose()
-            if len(decomposed.bases):
-                has_prefixes.add(val.decompose().bases[0].name)
-            else:
-                has_prefixes.add('dimensionless')
-
-        else:
-            units.append(val)
-
-    # Sort alphabetically, case insensitive
-    units.sort(key=lambda x: x.name.lower())
-
     docstring = io.StringIO()
 
     docstring.write("""
@@ -100,24 +114,14 @@ def generate_unit_summary(namespace):
      - SI Prefixes
 """)
 
-    for unit in units:
-        if unit.name in has_prefixes:
-            unit_has_prefixes = 'Y'
-        else:
-            unit_has_prefixes = 'N'
-        doc = _get_first_sentence(unit.__doc__).strip()
-        represents = ''
-        if isinstance(unit, core.Unit):
-            represents = ":math:`{0}`".format(
-                unit._represents.to_string('latex')[1:-1])
-        aliases = ', '.join('``{0}``'.format(x) for x in unit.aliases)
+    for unit_summary in _iter_unit_summary(namespace):
         docstring.write("""
    * - ``{0}``
      - {1}
      - {2}
      - {3}
-     - {4}
-""".format(unit, doc, represents, aliases, unit_has_prefixes))
+     - {4!s:.1}
+""".format(*unit_summary))
 
     return docstring.getvalue()
 


### PR DESCRIPTION
`u.barn` is defined as having prefixes, but it is not listed as such in the automatically generated unit summary. The problem seems to be related to how prefix units are handled in `generate_unit_summary`:
https://github.com/astropy/astropy/blob/master/astropy/units/utils.py#L76

cc @mdboom