### PR TITLE
Fix 4 intertwined coordinates bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -555,6 +555,13 @@ Bug Fixes
   - Fixed confusing warning message shown when using dates outside current
     IERS data. [#3844]
 
+  - ``get_sun`` now yields a scalar when the input time is a scalar (this
+    was a regression in v1.0.3 from v1.0.2) [#3998]
+
+  - Fixed bug where some scalar coordinates were incorrectly being changed
+    to length-1 array coordinates after transforming through certain frames.
+    [#3920]
+
 - ``astropy.cosmology``
 
   - Fixed wCDM to not ignore the Ob0 parameter on initialization. [#3934]
@@ -642,7 +649,7 @@ Bug Fixes
   - Fixed multiple instances of a bug that prevented Astropy from being used
     when compiled with the ``python -OO`` flag, due to it causing all
     docstrings to be stripped out. [#3923]
-    
+
   - Removed source code template files that were being installed
     accidentally alongside installed Python modules. [#4014]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -567,6 +567,10 @@ Bug Fixes
     to length-1 array coordinates after transforming through certain frames.
     [#3920]
 
+  - Made it so that passing in a list of ``SkyCoord`` objects that are in
+    UnitSphericalRepresentation to the ``SkyCoord`` constructor appropriately
+    yields a new object in UnitSphericalRepresentation [#3938]
+
 - ``astropy.cosmology``
 
   - Fixed wCDM to not ignore the Ob0 parameter on initialization. [#3934]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -567,6 +567,9 @@ Bug Fixes
     to length-1 array coordinates after transforming through certain frames.
     [#3920]
 
+  - Fixed bug causing the ``separation`` methods of ``SkyCoord`` and frame
+    classes to fail due to infinite recursion [#4033]
+
   - Made it so that passing in a list of ``SkyCoord`` objects that are in
     UnitSphericalRepresentation to the ``SkyCoord`` constructor appropriately
     yields a new object in UnitSphericalRepresentation [#3938]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -508,6 +508,11 @@ API Changes
 
 - ``astropy.coordinates``
 
+  - Some transformations for an input coordinate that's a scalar now
+    correctly return a scalar.  This was the intend behavior, but it may
+    break code that has been written to work-around this bug, so it may
+    be viewed as an unplanned API change [#3920]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1098,7 +1098,7 @@ class BaseCoordinateFrame(object):
         from .angles import Angle
 
         self_unit_sph = self.represent_as(UnitSphericalRepresentation)
-        other_transformed = other.transform_to(self.__class__)
+        other_transformed = other.transform_to(self)
         other_unit_sph = other_transformed.represent_as(UnitSphericalRepresentation)
 
         # Get the separation as a Quantity, convert to Angle in degrees
@@ -1134,7 +1134,7 @@ class BaseCoordinateFrame(object):
                              'compute 3d separation.')
 
         # do this first just in case the conversion somehow creates a distance
-        other_in_self_system = other.transform_to(self.__class__)
+        other_in_self_system = other.transform_to(self)
 
         if other_in_self_system.__class__ == UnitSphericalRepresentation:
             raise ValueError('The other object does not have a distance; '

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -88,13 +88,12 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     # the 'A' indicates zen/az inputs
     cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)
 
-    dat = altaz_coo.data
-    if dat.get_name() == 'unitspherical'  or dat.to_cartesian().x.unit == u.one:
+    if isinstance(altaz_coo.data, UnitSphericalRepresentation):
         distance = None
     else:
         #now we get the distance as just the cartesian
         #distance from the earth location to the coordinate location
-        distance = altaz_coo.location.itrs.separation_3d(altaz_coo)
+        distance = altaz_coo.separation_3d(altaz_coo.location.itrs)
 
     #the final transform may be a no-op if the obstimes are the same
     return CIRS(ra=cirs_ra*u.radian, dec=cirs_dec*u.radian, distance=distance,

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -58,16 +58,22 @@ def cartrepr_from_matmul(pmat, coo, transpose=False):
     if pmat.shape[-2:] != (3, 3):
         raise ValueError("tried to do matrix multiplication with an array that "
                          "doesn't end in 3x3")
-    xyz = coo.cartesian.xyz.T
-    # these expression are the same as iterating over the first dimension of
-    # pmat and xyz and doing matrix multiplication on each in turn.  resulting
-    # dimension is <coo shape> x 3
-    pmat = pmat.reshape(pmat.size//9, 3, 3)
-    if transpose:
-        pmat = pmat.transpose(0, 2, 1)
-    newxyz = np.sum(pmat * xyz.reshape(xyz.size//3, 1, 3), axis=-1)
+    if coo.isscalar:
+        # a simpler path for scalar coordinates
+        if transpose:
+            pmat = pmat.T
+        newxyz = np.sum(pmat * coo.cartesian.xyz, axis=-1)
+    else:
+        xyz = coo.cartesian.xyz.T
+        # these expression are the same as iterating over the first dimension of
+        # pmat and xyz and doing matrix multiplication on each in turn.  resulting
+        # dimension is <coo shape> x 3
+        pmat = pmat.reshape(pmat.size//9, 3, 3)
+        if transpose:
+            pmat = pmat.transpose(0, 2, 1)
+        newxyz = np.sum(pmat * xyz.reshape(xyz.size//3, 1, 3), axis=-1).T
 
-    return CartesianRepresentation(newxyz.T)
+    return CartesianRepresentation(newxyz)
 
 
 # now the actual transforms

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -162,7 +162,10 @@ def get_sun(time):
     y = -dsun*properdir[..., 1] * u.AU
     z = -dsun*properdir[..., 2] * u.AU
 
-    cartrep = CartesianRepresentation(x=x, y=y, z=z)
+    if time.isscalar:
+        cartrep = CartesianRepresentation(x=x[0], y=y[0], z=z[0])
+    else:
+        cartrep = CartesianRepresentation(x=x, y=y, z=z)
     return SkyCoord(cartrep, frame=GCRS(obstime=time))
 
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -9,6 +9,8 @@ place to live
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import numpy as np
+
 from ... import units as u
 from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS
 from ...time import Time
@@ -98,8 +100,12 @@ def test_regression_4033():
     de_wdistaa = de_wdist.transform_to(aa)
 
     # these work fine
-    assert_quantity_allclose(deaa.separation(albaa), 22.2862*u.deg, rtol=1e-6)
-    assert_quantity_allclose(deaa.separation(alb_wdistaa), 22.2862*u.deg, rtol=1e-6)
+    sepnod = deaa.separation(albaa)
+    sepwd = deaa.separation(alb_wdistaa)
+    assert_quantity_allclose(sepnod, 22.2862*u.deg, rtol=1e-6)
+    assert_quantity_allclose(sepwd, 22.2862*u.deg, rtol=1e-6)
+    # parallax should be present when distance added
+    assert np.abs(sepnod - sepwd) > 1*u.marcsec
 
     # in 4033, the following fail with a recursion error
     assert_quantity_allclose(de_wdistaa.separation(alb_wdistaa), 22.2862*u.deg, rtol=1e-3)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -70,7 +70,7 @@ def test_regression_3998():
     assert sun.isscalar
     # in 3998, the above yields False - `sun` is a length-1 vector
 
-    assert sun.time is time
+    assert sun.obstime is time
 
 
 def test_regression_4033():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -10,7 +10,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ... import units as u
-from .. import AltAz, EarthLocation, SkyCoord, get_sun
+from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS
 from ...time import Time
 
 from ...tests.helper import assert_quantity_allclose
@@ -31,6 +31,12 @@ def test_regression_3920():
     sc2 = SkyCoord(10*u.deg, 3*u.deg, 1*u.AU)
     assert sc2.transform_to(aa).shape == tuple()
     # in 3920 that assert fails, because the shape is (1,)
+
+    # check that the same behavior occurs even if transform is from low-level classes
+    icoo = ICRS(sc.data)
+    icoo2 = ICRS(sc2.data)
+    assert icoo.transform_to(aa).shape == tuple()
+    assert icoo2.transform_to(aa).shape == tuple()
 
 
 def test_regression_3938():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Regression tests for coordinates-related bugs that don't have an obvious other
+place to live
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ... import units as u
+from .. import AltAz, EarthLocation, SkyCoord, get_sun
+from ...time import Time
+
+from ...tests.helper import assert_quantity_allclose
+
+
+def test_regression_3920():
+    """
+    Issue: https://github.com/astropy/astropy/issues/3920
+    """
+    loc = EarthLocation.from_geodetic(0*u.deg, 0*u.deg, 0)
+    time = Time('2010-1-1')
+
+    aa = AltAz(location=loc, obstime=time)
+    sc = SkyCoord(10*u.deg, 3*u.deg)
+    assert sc.transform_to(aa).shape == tuple()
+    # That part makes sense: the input is a scalar so the output is too
+
+    sc2 = SkyCoord(10*u.deg, 3*u.deg, 1*u.AU)
+    assert sc2.transform_to(aa).shape == tuple()
+    # in 3920 that assert fails, because the shape is (1,)
+
+
+def test_regression_3938():
+    """
+    Issue: https://github.com/astropy/astropy/issues/3938
+    """
+    # Set up list of targets - we don't use `from_name` here to avoid
+    # remote_data requirements, but it does the same thing
+    # vega = SkyCoord.from_name('Vega')
+    vega = SkyCoord(279.23473479*u.deg, 38.78368896*u.deg)
+    # capella = SkyCoord.from_name('Capella')
+    capella = SkyCoord(79.17232794*u.deg, 45.99799147*u.deg)
+    # sirius = SkyCoord.from_name('Sirius')
+    sirius = SkyCoord(101.28715533*u.deg, -16.71611586*u.deg)
+    targets = [vega, capella, sirius]
+
+    # Feed list of targets into SkyCoord
+    combined_coords = SkyCoord(targets)
+
+    # Set up AltAz frame
+    time = Time('2012-01-01 00:00:00')
+    location = EarthLocation('10d', '45d', 0)
+    aa = AltAz(location=location, obstime=time)
+
+    combined_coords.transform_to(aa)
+    # in 3938 the above yields ``UnitConversionError: '' (dimensionless) and 'pc' (length) are not convertible``
+
+
+def test_regression_3998():
+    """
+    Issue: https://github.com/astropy/astropy/issues/3998
+    """
+    time = Time('2012-01-01 00:00:00')
+    assert time.isscalar
+
+    sun = get_sun(time)
+    assert sun.isscalar
+    # in 3998, the above yields False - `sun` is a length-1 vector
+
+    assert sun.time is time
+
+
+def test_regression_4033():
+    """
+    Issue: https://github.com/astropy/astropy/issues/4033
+    """
+    # alb = SkyCoord.from_name('Albireo')
+    alb = SkyCoord(292.68033548*u.deg, 27.95968007*u.deg)
+    alb_wdist = SkyCoord(alb, distance=133*u.pc)
+
+    # de = SkyCoord.from_name('Deneb')
+    de = SkyCoord(310.35797975*u.deg, 45.28033881*u.deg)
+    de_wdist = SkyCoord(de, distance=802*u.pc)
+
+    aa = AltAz(location=EarthLocation(lat=45*u.deg, lon=0*u.deg), obstime='2010-1-1')
+    deaa = de.transform_to(aa)
+    albaa = alb.transform_to(aa)
+    alb_wdistaa = alb_wdist.transform_to(aa)
+    de_wdistaa = de_wdist.transform_to(aa)
+
+    # these work fine
+    assert_quantity_allclose(deaa.separation(albaa), 22.2862*u.deg, rtol=1e-6)
+    assert_quantity_allclose(deaa.separation(alb_wdistaa), 22.2862*u.deg, rtol=1e-6)
+
+    # in 4033, the following fail with a recursion error
+    assert_quantity_allclose(de_wdistaa.separation(alb_wdistaa), 22.2862*u.deg, rtol=1e-3)
+    assert_quantity_allclose(alb_wdistaa.separation(deaa), 22.2862*u.deg, rtol=1e-3)


### PR DESCRIPTION
This PR addresses a series of quirk/bugs in `astropy.coordinates`, dealing with a mix of specific inputs that result in inconsistent or incorrect outputs.   

Specifically, this closes #3920, closes #3938, closes #3998, and closes #4033.  While the fixes are mostly independent, they do interact enough that a single PR seemed more straightforward (e.g., the fix  for some of the transforms giving vectors when they should give scalars makes writing the regression test for some of the others easier).

The one questionable piece here is about @astrofrog's item from #3920 .  There's a not totally ignorable argument that the change to fix that is backwards-incompatible because the current version (incorrectly) yields an array coordinate when it should be a scalar.  But that's been in since v1.0, so users *may* have written workarounds.  It's still definitely a bug, but the question is whether we want to, say, delay that to v1.1.  @astrofrog asked for a use case that might lead to it:  the simple use case of starting from a scalar `SkyCoord` with a distance and converting to a locat `AltAz` will do that, which is a pretty standard use... So it is possible this is used in the wild.  On the other hand, no one brought it up, and it is *not* what the documentation claims, so maybe that's over-worrying?

cc @embray @bmorris3 @adrn