### PR TITLE
Update `bounding_box` property and new `Model.render()` method  in `astropy.modeling`

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -92,7 +92,6 @@ class Gaussian1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
-    _bounding_box = 'auto'
 
     def bounding_box_default(self, factor=5.5):
         """
@@ -103,7 +102,7 @@ class Gaussian1D(Fittable1DModel):
         ----------
         factor : float
             The multiple of `stddev` used to define the limits. 
-            The default is 5.5-sigma, corresponding to a relative error < 1e-7. 
+            The default is 5.5, corresponding to a relative error < 1e-7. 
 
         Examples
         --------
@@ -112,7 +111,7 @@ class Gaussian1D(Fittable1DModel):
         >>> model.bounding_box
         (-11.0, 11.0)
 
-        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by 
+        This range can be set directly (see: ``help(model.bounding_box)``) or by 
         using a different factor, like:
 
         >>> model.bounding_box = model.bounding_box_default(factor=2)
@@ -172,6 +171,37 @@ class GaussianAbsorption1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
+
+    def bounding_box_default(self, factor=5.5):
+        """
+        Tuple defining the default ``bounding_box`` limits, 
+        ``(x_low, x_high)``
+
+        Parameters
+        ----------
+        factor : float
+            The multiple of `stddev` used to define the limits. 
+            The default is 5.5, corresponding to a relative error < 1e-7. 
+
+        Examples
+        --------
+        >>> from astropy.modeling.models import Gaussian1D
+        >>> model = Gaussian1D(mean=0, stddev=2)
+        >>> model.bounding_box
+        (-11.0, 11.0)
+
+        This range can be set directly (see: ``help(model.bounding_box)``) or by 
+        using a different factor, like:
+
+        >>> model.bounding_box = model.bounding_box_default(factor=2)
+        >>> model.bounding_box
+        (-4.0, 4.0)
+        """
+
+        x0 = self.mean.value
+        dx = factor * self.stddev
+
+        return (x0 - dx, x0 + dx)
 
     @staticmethod
     def evaluate(x, amplitude, mean, stddev):
@@ -273,7 +303,6 @@ class Gaussian2D(Fittable2DModel):
     x_stddev = Parameter(default=1)
     y_stddev = Parameter(default=1)
     theta = Parameter(default=0)
-    _bounding_box = 'auto'
 
     def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
                  y_mean=y_mean.default, x_stddev=None, y_stddev=None,
@@ -336,7 +365,7 @@ class Gaussian2D(Fittable2DModel):
         >>> model.bounding_box
         ((-11.0, 11.0), (-5.5, 5.5))
 
-        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by 
+        This range can be set directly (see: ``help(model.bounding_box)``) or by 
         using a different factor like:
 
         >>> model.bounding_box = model.bounding_box_default(factor=2)
@@ -442,7 +471,6 @@ class Shift(Model):
     def evaluate(x, offset):
         return x + offset
 
-
 class Scale(Model):
     """
     Multiply a model by a factor.
@@ -468,7 +496,6 @@ class Scale(Model):
     @staticmethod
     def evaluate(x, factor):
         return factor * x
-
 
 class Redshift(Fittable1DModel):
     """
@@ -508,7 +535,6 @@ class Redshift(Fittable1DModel):
         inv = self.copy()
         inv.z = 1.0 / (1.0 + self.z) - 1.0
         return inv
-
 
 class Sersic1D(Fittable1DModel):
     r"""
@@ -595,7 +621,6 @@ class Sersic1D(Fittable1DModel):
         """One dimensional Sersic profile function."""
         return amplitude * np.exp(-cls._gammaincinv(2 * n, 0.5) * ((r / r_eff) ** (1 / n) - 1))
 
-
 class Sine1D(Fittable1DModel):
     """
     One dimensional Sine model.
@@ -642,7 +667,6 @@ class Sine1D(Fittable1DModel):
                    np.cos(2 * np.pi * frequency * x + 2 * np.pi * phase))
         return [d_amplitude, d_frequency, d_phase]
 
-
 class Linear1D(Fittable1DModel):
     """
     One dimensional Line model.
@@ -683,7 +707,6 @@ class Linear1D(Fittable1DModel):
         d_slope = x
         d_intercept = np.ones_like(x)
         return [d_slope, d_intercept]
-
 
 class Lorentz1D(Fittable1DModel):
     """
@@ -731,7 +754,6 @@ class Lorentz1D(Fittable1DModel):
                  (fwhm ** 2 + (x - x_0) ** 2))
         d_fwhm = 2 * amplitude * d_amplitude / fwhm * (1 - d_amplitude)
         return [d_amplitude, d_x_0, d_fwhm]
-
 
 class Voigt1D(Fittable1DModel):
     """
@@ -824,7 +846,6 @@ class Voigt1D(Fittable1DModel):
                 -constant * (V + (sqrt_ln2 / fwhm_G) * (2 * (x - x_0) * dVdx + fwhm_L * dVdy)) / fwhm_G]
         return dyda
 
-
 class Const1D(Fittable1DModel):
     """
     One dimensional Constant model.
@@ -870,7 +891,6 @@ class Const1D(Fittable1DModel):
         d_amplitude = np.ones_like(x)
         return [d_amplitude]
 
-
 class Const2D(Fittable2DModel):
     """
     Two dimensional Constant model.
@@ -908,7 +928,6 @@ class Const2D(Fittable2DModel):
             x = amplitude * np.ones_like(x)
 
         return x
-
 
 class Ellipse2D(Fittable2DModel):
     """
@@ -986,26 +1005,6 @@ class Ellipse2D(Fittable2DModel):
     a = Parameter(default=1)
     b = Parameter(default=1)
     theta = Parameter(default=0)
-    _bounding_box = 'auto'
-
-    def bounding_box_default(self):
-        """
-        Tuple defining the default ``bounding_box`` limits around the ellipse.
-
-        ``((y_low, y_high), (x_low, x_high))``
-
-        References
-        ----------
-        `astropy.modeling.Model.bounding_box`
-        """
-
-        a = self.a
-        b = self.b
-        theta = self.theta.value
-        dx, dy = ellipse_extent(a, b, theta)
-
-        return ((self.y_0 - dy, self.y_0 + dy),
-                (self.x_0 - dx, self.x_0 + dx))
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, a, b, theta):
@@ -1020,6 +1019,20 @@ class Ellipse2D(Fittable2DModel):
         in_ellipse = (((numerator1 / a) ** 2 + (numerator2 / b) ** 2) <= 1.)
         return np.select([in_ellipse], [amplitude])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        a = self.a
+        b = self.b
+        theta = self.theta.value
+        dx, dy = ellipse_extent(a, b, theta)
+
+        return ((self.y_0 - dy, self.y_0 + dy),
+                (self.x_0 - dx, self.x_0 + dx))
 
 class Disk2D(Fittable2DModel):
     """
@@ -1066,6 +1079,16 @@ class Disk2D(Fittable2DModel):
         rr = (x - x_0) ** 2 + (y - y_0) ** 2
         return np.select([rr <= R_0 ** 2], [amplitude])
 
+
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        return ((self.y_0 - self.R_0, self.y_0 + self.R_0),
+                (self.x_0 - self.R_0, self.x_0 + self.R_0))
 
 class Ring2D(Fittable2DModel):
     """
@@ -1135,6 +1158,17 @@ class Ring2D(Fittable2DModel):
         r_range = np.logical_and(rr >= r_in ** 2, rr <= (r_in + width) ** 2)
         return np.select([r_range], [amplitude])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box``.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        dr = self.r_in + self.width
+
+        return ((self.y_0 - dr, self.y_0 + dr),
+                (self.x_0 - dr, self.x_0 + dr))
 
 class Delta1D(Fittable1DModel):
     """One dimensional Dirac delta function."""
@@ -1202,6 +1236,16 @@ class Box1D(Fittable1DModel):
         d_width = np.zeros_like(x)
         return [d_amplitude, d_x_0, d_width]
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``(x_low, x_high))``
+        """
+
+        dx = self.width / 2
+
+        return (self.x_0 - dx, self.x_0 + dx)
 
 class Box2D(Fittable2DModel):
     """
@@ -1256,6 +1300,18 @@ class Box2D(Fittable2DModel):
                                  y <= y_0 + y_width / 2.)
         return np.select([np.logical_and(x_range, y_range)], [amplitude], 0)
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box``.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        dx = self.x_width / 2
+        dy = self.y_width / 2
+
+        return ((self.y_0 - dy, self.y_0 + dy),
+                (self.x_0 - dx, self.x_0 + dx))
 
 class Trapezoid1D(Fittable1DModel):
     """
@@ -1302,6 +1358,16 @@ class Trapezoid1D(Fittable1DModel):
         val_c = slope * (x4 - x)
         return np.select([range_a, range_b, range_c], [val_a, val_b, val_c])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``(x_low, x_high))``
+        """
+
+        dx = self.width / 2 + self.amplitude / self.slope
+
+        return (self.x_0 - dx, self.x_0 + dx)
 
 class TrapezoidDisk2D(Fittable2DModel):
     """
@@ -1330,7 +1396,7 @@ class TrapezoidDisk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     R_0 = Parameter(default=1)
     slope = Parameter(default=1)
-
+ 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0, slope):
         """Two dimensional Trapezoid Disk model function"""
@@ -1342,6 +1408,17 @@ class TrapezoidDisk2D(Fittable2DModel):
         val_2 = amplitude + slope * (R_0 - r)
         return np.select([range_1, range_2], [val_1, val_2])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box``.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        dr = self.R_0 + self.amplitude / self.slope
+
+        return ((self.y_0 - dr, self.y_0 + dr),
+                (self.x_0 - dr, self.x_0 + dr))
 
 class MexicanHat1D(Fittable1DModel):
     """
@@ -1381,7 +1458,6 @@ class MexicanHat1D(Fittable1DModel):
 
         xx_ww = (x - x_0) ** 2 / (2 * sigma ** 2)
         return amplitude * (1 - 2 * xx_ww) * np.exp(-xx_ww)
-
 
 class MexicanHat2D(Fittable2DModel):
     """
@@ -1425,7 +1501,6 @@ class MexicanHat2D(Fittable2DModel):
 
         rr_ww = ((x - x_0) ** 2 + (y - y_0) ** 2) / (2 * sigma ** 2)
         return amplitude * (1 - rr_ww) * np.exp(- rr_ww)
-
 
 class AiryDisk2D(Fittable2DModel):
     """
@@ -1516,7 +1591,6 @@ class AiryDisk2D(Fittable2DModel):
         z *= amplitude
         return z
 
-
 class Moffat1D(Fittable1DModel):
     """
     One dimensional Moffat model.
@@ -1567,7 +1641,6 @@ class Moffat1D(Fittable1DModel):
                    (gamma ** 3 * d_A ** alpha))
         d_alpha = -amplitude * d_A * np.log(1 + (x - x_0) ** 2 / gamma ** 2)
         return [d_A, d_x_0, d_gamma, d_alpha]
-
 
 class Moffat2D(Fittable2DModel):
     """
@@ -1626,7 +1699,6 @@ class Moffat2D(Fittable2DModel):
         d_alpha = -amplitude * d_A * np.log(1 + rr_gg)
         d_gamma = 2 * amplitude * alpha * d_A * (rr_gg / (gamma * (1 + rr_gg)))
         return [d_A, d_x_0, d_y_0, d_gamma, d_alpha]
-
 
 class Sersic2D(Fittable2DModel):
     r"""
@@ -1734,7 +1806,6 @@ class Sersic2D(Fittable2DModel):
         z = np.sqrt((x_maj / a) ** 2 + (x_min / b) ** 2)
 
         return amplitude * np.exp(-bn * (z ** (1 / n) - 1))
-
 
 @deprecated('1.0', alternative='astropy.modeling.models.custom_model',
             pending=True)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -32,6 +32,7 @@ def test_GaussianAbsorption1D():
     assert_allclose(g_ab(xx), 1 - g_em(xx))
     assert_allclose(g_ab.fit_deriv(xx[0], 0.8, 3000, 20),
                     -np.array(g_em.fit_deriv(xx[0], 0.8, 3000, 20)))
+    assert g_ab.bounding_box_default() == g_em.bounding_box
 
 
 def test_Gaussian2D():
@@ -117,6 +118,7 @@ def test_Ellipse2D():
     e = em(x, y)
     assert np.all(e[e > 0] == amplitude)
     assert e[y0, x0] == amplitude
+    assert em.bounding_box_default() == em.bounding_box
 
     rotation = models.Rotation2D(angle=theta.degree)
     point1 = [2, 0]      # Rotation2D center is (0, 0)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -22,7 +22,7 @@ from numpy.testing import utils
 from .example_models import models_1D, models_2D
 from .. import (fitting, models, LabeledInput, SerialCompositeModel,
                 SummedCompositeModel)
-from ..core import FittableModel, render_model
+from ..core import FittableModel
 from ..polynomial import PolynomialBase
 from ...tests.helper import pytest
 
@@ -213,43 +213,36 @@ def test_custom_model_defaults():
 def test_custom_model_bounding_box():
     """Test bounding box evaluation for a 3D model"""
 
-    def ellipsoid(x, y, z, x0=13., y0=10., z0=8., a=4., b=3., c=2., amp=1.):
+    def ellipsoid(x, y, z, x0=13, y0=10, z0=8, a=4, b=3, c=2, amp=1):
         rsq = ((x - x0) / a) ** 2 + ((y - y0) / b) ** 2 + ((z - z0) / c) ** 2
         val = (rsq < 1) * amp
         return val
 
-    def ellipsoid_bbox(self):
-        return ((self.z0 - self.c, self.z0 + self.c), 
-                (self.y0 - self.b, self.y0 + self.b),
-                (self.x0 - self.a, self.x0 + self.a))
-
-    Ellipsoid3D = models.custom_model(ellipsoid)
-    Ellipsoid3D.bounding_box_default = ellipsoid_bbox
+    class Ellipsoid3D(models.custom_model(ellipsoid)):
+        def bounding_box_default(self):
+            return ((self.z0 - self.c, self.z0 + self.c),
+                    (self.y0 - self.b, self.y0 + self.b),
+                    (self.x0 - self.a, self.x0 + self.a))
 
     model = Ellipsoid3D()
-    model.bounding_box = 'auto'
     bbox = model.bounding_box
-    if bbox is None:
-        pytest.skip("Bounding_box is not defined for model.")
 
-    # Check for exact agreement within bounded region
+    assert bbox == model.bounding_box_default()
+
     zlim, ylim, xlim = bbox
-    dx = np.ceil((xlim[1] - xlim[0]) / 2)
-    dy = np.ceil((ylim[1] - ylim[0]) / 2)
-    dz = np.ceil((zlim[1] - zlim[0]) / 2)
-    z0, y0, x0 = np.mean(bbox, axis=1).astype(int)
-    z, y, x = np.mgrid[z0 - dz: z0 + dz + 1, y0 - dy:
-                                y0 + dy + 1, x0 - dx: x0 + dx + 1]
+    dz, dy, dx = np.diff(bbox) / 2
+    z1, y1, x1 = np.mgrid[slice(zlim[0], zlim[1] + 1),
+                          slice(ylim[0], ylim[1] + 1),
+                          slice(xlim[0], xlim[1] + 1)]
+    z2, y2, x2 = np.mgrid[slice(zlim[0] - dz, zlim[1] + dz + 1),
+                          slice(ylim[0] - dy, ylim[1] + dy + 1),
+                          slice(xlim[0] - dx, xlim[1] + dx + 1)]
 
-    expected = model(x, y, z)
-    actual = render_model(model)
+    arr = model(x2, y2, z2)
+    sub_arr = model(x1, y1, z1)
 
-    utils.assert_allclose(actual, expected, rtol=0, atol=0)
-
-    # check result with no bounding box defined
-    model.bounding_box = None
-    actual = render_model(model, coords=[z,y,x])
-    utils.assert_allclose(actual, expected, rtol=0, atol=0)
+    # check for flux agreement
+    assert abs(arr.sum() - sub_arr.sum()) < arr.sum() * 1e-7
 
 
 class Fittable2DModelTester(object):
@@ -297,27 +290,36 @@ class Fittable2DModelTester(object):
 
         model = create_model(model_class, test_parameters)
 
-        bbox = model.bounding_box
-        if bbox is None:
+        # testing setter
+        model.bounding_box = ((-5, 5), (-5, 5))
+        model.bounding_box = None
+        model.bounding_box = 'auto'
+        
+        # test the exception of dimensions don't match
+        try:
+            model.bounding_box = (-5, 5)
+        except ValueError:
+            pass
+
+        try :
+            bbox = model.bounding_box
+        except NotImplementedError:
             pytest.skip("Bounding_box is not defined for model.")
 
-        # Check for exact agreement within bounded region
-        xlim, ylim = bbox
-        dx = np.ceil((xlim[1] - xlim[0]) / 2)
-        dy = np.ceil((ylim[1] - ylim[0]) / 2)
-        x0, y0 = np.mean(bbox, axis=1).astype(int)
-        y, x = np.mgrid[y0 - dy: y0 + dy + 1,
-                        x0 - dx: x0 + dx + 1]
+        assert bbox == model.bounding_box_default()
 
-        expected = model(x, y)
-        actual = render_model(model)
+        ylim, xlim = bbox
+        dy, dx = np.diff(bbox)/2
+        y1, x1 = np.mgrid[slice(ylim[0], ylim[1] + 1),
+                          slice(xlim[0], xlim[1] + 1)]
+        y2, x2 = np.mgrid[slice(ylim[0] - dy, ylim[1] + dy + 1),
+                          slice(xlim[0] - dx, xlim[1] + dx + 1)]
 
-        utils.assert_allclose(actual, expected, rtol=0, atol=0)
+        arr = model(x2, y2)
+        sub_arr = model(x1, y1)
 
-        # check result with no bounding box defined
-        model.bounding_box = None
-        actual = render_model(model, coords=[y, x])
-        utils.assert_allclose(actual, expected, rtol=0, atol=0)
+        # check for flux agreement
+        assert abs(arr.sum() - sub_arr.sum()) < arr.sum() * 1e-7
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_fitter2D(self, model_class, test_parameters):
@@ -461,24 +463,33 @@ class Fittable1DModelTester(object):
 
         model = create_model(model_class, test_parameters)
 
-        bbox = model.bounding_box
-        if bbox is None:
+        # testing setter
+        model.bounding_box = (-5, 5)
+        model.bounding_box = None
+        model.bounding_box = 'auto'
+
+        # test exception if dimensions don't match
+        try:
+            model.bounding_box = 5
+        except ValueError:
+            pass
+
+        try:
+            bbox = model.bounding_box
+        except NotImplementedError:
             pytest.skip("Bounding_box is not defined for model.")
 
-        # Check for exact agreement within bounded region
-        dx = np.ceil(np.diff(model.bounding_box)[0] / 2)
-        x0 = int(np.mean(bbox))
-        x = np.mgrid[x0 - dx: x0 + dx + 1]
+        assert bbox == model.bounding_box_default()
 
-        expected = model(x)
-        actual = render_model(model)
+        dx = np.diff(bbox) / 2
+        x1 = np.mgrid[slice(bbox[0], bbox[1] + 1)]
+        x2 = np.mgrid[slice(bbox[0] - dx, bbox[1] + dx + 1)]
 
-        utils.assert_allclose(actual, expected, rtol=0, atol=0)
+        arr = model(x2)
+        sub_arr = model(x1)
 
-        # check result with no bounding box defined
-        model.bounding_box = None
-        actual = render_model(model, coords=x)
-        utils.assert_allclose(actual, expected, rtol=0, atol=0)
+        # check for flux agreement
+        assert abs(arr.sum() - sub_arr.sum()) < arr.sum() * 1e-7
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_fitter1D(self, model_class, test_parameters):

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -8,7 +8,6 @@ import operator
 import numpy as np
 
 from ..utils import ExpressionTree as ET, ellipse_extent
-from ..core import render_model
 from ..models import Ellipse2D
 
 
@@ -91,7 +90,7 @@ def test_ellipse_extent():
 
     model.bounding_box = limits
 
-    actual = render_model(model, coords=coords)
+    actual = model.render(coords=coords)
 
     expected = model(x, y)
 

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -633,11 +633,11 @@ class Cutout2D(object):
         self.input_position_original = position
         self.shape_input = shape
 
-        ((self.xmin_original, self.xmax_original),
-         (self.ymin_original, self.ymax_original)) = self.bbox_original
+        ((self.ymin_original, self.ymax_original),
+         (self.xmin_original, self.xmax_original)) = self.bbox_original
 
-        ((self.xmin_cutout, self.xmax_cutout),
-         (self.ymin_cutout, self.ymax_cutout)) = self.bbox_cutout
+        ((self.ymin_cutout, self.ymax_cutout),
+         (self.xmin_cutout, self.xmax_cutout)) = self.bbox_cutout
 
         # the true origin pixel of the cutout array, including any
         # filled cutout values
@@ -743,14 +743,14 @@ class Cutout2D(object):
     @staticmethod
     def _calc_bbox(slices):
         """
-        Calculate a minimal bounding box in the form ``((xmin, xmax),
-        (ymin, ymax))``.  Note these are pixel locations, not slice
+        Calculate a minimal bounding box in the form ``((ymin, ymax),
+        (xmin, xmax))``.  Note these are pixel locations, not slice
         indices.  For ``mode='partial'``, the bounding box indices are
         for the valid (non-filled) cutout values.
         """
         # (stop - 1) to return the max pixel location, not the slice index
-        return ((slices[1].start, slices[1].stop - 1),
-                (slices[0].start, slices[0].stop - 1))
+        return ((slices[0].start, slices[0].stop - 1),
+                (slices[1].start, slices[1].stop - 1))
 
     @lazyproperty
     def origin_original(self):
@@ -810,7 +810,7 @@ class Cutout2D(object):
     @lazyproperty
     def bbox_original(self):
         """
-        The bounding box ``(ymin, xmin, ymax, xmax)`` of the minimal
+        The bounding box ``((ymin, ymax), (xmin, xmax))`` of the minimal
         rectangular region of the cutout array with respect to the
         original array.  For ``mode='partial'``, the bounding box
         indices are for the valid (non-filled) cutout values.
@@ -820,7 +820,7 @@ class Cutout2D(object):
     @lazyproperty
     def bbox_cutout(self):
         """
-        The bounding box ``(ymin, xmin, ymax, xmax)`` of the minimal
+        The bounding box ``((ymin, ymax), (xmin, xmax))`` of the minimal
         rectangular region of the cutout array with respect to the
         cutout array.  For ``mode='partial'``, the bounding box indices
         are for the valid (non-filled) cutout values.

--- a/docs/modeling/bounding-boxes.rst
+++ b/docs/modeling/bounding-boxes.rst
@@ -5,7 +5,8 @@ Efficient Model Rendering with Bounding Boxes
 
 .. versionadded:: 1.1
 
-All `astropy.modeling.Model` subclasses have a ``bounding_box`` attribute that 
+All `Model <astropy.modeling.Model>` subclasses have a 
+`bounding_box <astropy.modeling.Model.bounding_box>` attribute that 
 can be used to set the limits over which the model is significant. This greatly 
 improves the effciency of evaluation when the input range is much larger than 
 the characteristic width of the model itself. For example, to create a sky model 
@@ -13,137 +14,138 @@ image from a large survey catalog, each source should only be evaluated over the
 pixels to which it contributes a significant amount of flux. This task can 
 otherwise be computationally prohibitive on an average CPU. 
 
-The `astropy.modeling.render_model` function can be used to evaluate a model on 
-an input array, or coordinates, limiting the evaluation to the ``bounding_box`` 
-region if it is set. This function will also produce postage stamp images of the
-model if no other input array is passed. To instead extract postage
-stamps from the data array itself, see :ref:`cutout_images`. 
+The :func:`Model.render <astropy.modeling.Model.render>` method can be used to 
+evaluate a model on an output array, or input coordinate arrays, limiting the 
+evaluation to the `bounding_box <astropy.modeling.Model.bounding_box>` region if 
+it is set. This function will also produce postage stamp images of the model if 
+no other input array is passed. To instead extract postage stamps from the data 
+array itself, see :ref:`cutout_images`. 
 
 Using the Bounding Box
 ----------------------- 
 
-For basic usage, see `astropy.modeling.Model.bounding_box`.
-By default no bounding box is set (``bounding_box`` is `None`), except for 
-individual model subclasses that have a ``bounding_box_default`` function 
-defined. ``bounding_box_default`` returns the minimum rectangular region 
-symmetric about the position that fully contains the model if the model has a
-finite extent. If a model does not have a finite extent, the choice for the 
-``bounding_box_default`` limits is noted in the docstring. For example, see
-`astropy.modeling.functional_models.Gaussian2D.bounding_box_default`.
+For basic usage, see `Model.bounding_box <astropy.modeling.Model.bounding_box>`.
+By default no `bounding_box <astropy.modeling.Model.bounding_box>` is set 
+(:func:`Model.bounding_box_default <astropy.modeling.Model.bounding_box_default>` 
+returns `None`), except for model subclasses where :func:`bounding_box_default 
+<astropy.modeling.Model.bounding_box_default>` is explicity defined. The default 
+is then the minimum rectangular region symmetric about the position that fully 
+contains the model. If the model does not have a finite extent, the containment 
+criteria are noted in the documentation. For example, see 
+`Gaussian2D.bounding_box_default 
+<astropy.modeling.functional_models.Gaussian2D.bounding_box_default>`.
 
-The default function can also be set to any callable. This is particularly 
-useful for fitting ``custom_model`` or ``CompoundModel`` instances. 
+`Model.bounding_box_default <astropy.modeling.Model.bounding_box_default>` can 
+be set by the user to any callable. This is particularly useful for fitting 
+``custom_model`` or ``CompoundModel`` instances. 
 
     >>> from astropy.modeling import custom_model
     >>> def ellipsoid(x, y, z, x0=0, y0=0, z0=0, a=2, b=3, c=4, amp=1):
-    ...     rsq = ((x-x0)/a) ** 2 + ((y-y0)/b) ** 2 + ((z-z0)/c) ** 2
+    ...     rsq = ((x - x0) / a) ** 2 + ((y - y0) / b) ** 2 + ((z - z0) / c) ** 2
     ...     val = (rsq < 1) * amp
     ...     return val
     ...
-    >>> def ellipsoid_bb(self):
-    ...     return ((self.z0 - self.c, self.z0 + self.c),
-    ...             (self.y0 - self.b, self.y0 + self.b),
-    ...             (self.x0 - self.a, self.x0 + self.a))
+    >>> class Ellipsoid3D(custom_model(ellipsoid)):
+    ...     # A 3D ellipsoid model
+    ...     def bounding_box_default(self):
+    ...         return ((self.z0 - self.c, self.z0 + self.c),
+    ...                 (self.y0 - self.b, self.y0 + self.b),
+    ...                 (self.x0 - self.a, self.x0 + self.a))
     ...
-    >>> Ellipsoid3D = custom_model(ellipsoid)
-    >>> Ellipsoid3D.bounding_box_default = ellipsoid_bb
     >>> model = Ellipsoid3D()
-    >>> model.bounding_box = 'auto'
     >>> model.bounding_box
     ((-4.0, 4.0), (-3.0, 3.0), (-2.0, 2.0))
 
-Efficient evaluation with ``render_model``
-------------------------------------------
+Efficient evaluation with :func:`Model.render() <astropy.modeling.Model.render>`
+--------------------------------------------------------------------------------
 
 When a model is evaluated over a range much larger than the model itself, it may 
-be prudent to use `astropy.modeling.render_model` if efficiency is a concern. 
-The ``render_model`` function can be used to evaluate a model on an array of the 
-same dimensions. If no array is given, ``render_model`` will return a "postage 
-stamp" array corresponding to the bounding box region. However, if 
-``bounding_box`` is `None` an image or coordinates must be passed. 
+be prudent to use the :func:`Model.render <astropy.modeling.Model.render>` 
+method if efficiency is a concern. The :func:`render <astropy.modeling.Model.render>` 
+method can be used to evaluate the model on an array of the same dimensions. 
+``model.render()`` can be called with no arguments to return a "postage 
+stamp" of the bounding box region. 
 
 In this example, we generate a 300x400 pixel image of 100 2D 
-Gaussian sources both with and without using bounding boxes. Using bounding 
-boxes, the evaluation speed increases by approximately a factor of 10 with 
-negligible loss of information.
+Gaussian sources. For comparison, the models are evaluated
+both with and without using bounding boxes. By using bounding boxes, the evaluation 
+speed increases by approximately a factor of 10 with negligible loss of information.
 
 .. plot::
     :include-source:
     
 	import numpy as np
 	from time import time
-	from astropy.modeling import models, render_model
-
-	import matplotlib as mpl
+	from astropy.modeling import models
 	import matplotlib.pyplot as plt
-	from astropy.visualization import astropy_mpl_style
-	astropy_mpl_style['axes.grid'] = False
-	astropy_mpl_style['axes.labelcolor'] = 'k'
-	mpl.rcParams.update(astropy_mpl_style) 
-
-	np.random.seed(0)
+	from matplotlib.patches import Rectangle
 
 	imshape = (300, 400)
-	nsrc = 100
+	y, x = np.indices(imshape)
 
+	# Generate random source model list
+	np.random.seed(0)
+	nsrc = 100
 	model_params = [
-	    dict(amplitude = np.random.uniform(0, 1),
-	         x_mean = np.random.uniform(0, imshape[1]),
-	         y_mean = np.random.uniform(0, imshape[0]),
-	         x_stddev = np.abs(np.random.uniform(3, 6)),
-	         y_stddev = np.abs(np.random.uniform(3, 6)),
-	         theta = np.random.uniform(0, 2 * np.pi))
-	    for i in range(nsrc)]
+	    dict(amplitude=np.random.uniform(.5, 1),
+	         x_mean=np.random.uniform(0, imshape[1] - 1),
+	         y_mean=np.random.uniform(0, imshape[0] - 1),
+	         x_stddev=np.random.uniform(2, 6),
+	         y_stddev=np.random.uniform(2, 6),
+	         theta=np.random.uniform(0, 2 * np.pi))
+	    for _ in range(nsrc)]
 
 	model_list = [models.Gaussian2D(**kwargs) for kwargs in model_params]
 
-	#Evaluate all models over their bounded regions and over the full image 
-	#for comparison. 
+	# Render models to image using bounding boxes
+	bb_image = np.zeros(imshape)
+	t_bb = time()
+	for model in model_list:
+	    model.render(bb_image)
+	t_bb = time() - t_bb
 
-	def make_image(model_list, shape=imshape, mode='bbox'):
-	    image = np.zeros(imshape)
-	    t1 = time()
-	    for i,model in enumerate(model_list): 
-	        if mode == 'full': model.bounding_box = None
-	        elif mode == 'auto': model.bounding_box = 'auto'
-	        image = render_model(model, image)
-	    t2 = time()
-	    return image, (t2 - t1)
-
-	bb_image, t_bb = make_image(model_list, mode='auto')
-	full_image, t_full = make_image(model_list, mode='full')
+	# Render models to image using full evaluation
+	full_image = np.zeros(imshape)
+	t_full = time()
+	for model in model_list:
+	    model.bounding_box = None
+	    model.render(full_image)
+	t_full = time() - t_full
 
 	flux = full_image.sum()
 	diff = (full_image - bb_image)
 	max_err = diff.max()
 
+	# Plots
 	plt.figure(figsize=(16, 7))
-	plt.subplots_adjust(left=.05,right=.97,bottom=.03,top=.97,wspace=0.1)#07)
+	plt.subplots_adjust(left=.05, right=.97, bottom=.03, top=.97, wspace=0.15)
 
+	# Full model image
 	plt.subplot(121)
 	plt.imshow(full_image, origin='lower')
-	plt.axis([0,imshape[1],0,imshape[0]])
-	plt.title('Full Models\nTiming: %.2f seconds' % (t_full), fontsize=16)
-	plt.xlabel('x', fontsize=14)
-	plt.ylabel('y', fontsize=14)
+	plt.title('Full Models\nTiming: {:.2f} seconds'.format(t_full), fontsize=16)
+	plt.xlabel('x')
+	plt.ylabel('y')
 
-	plt.subplot(122)
+	# Bounded model image with boxes overplotted
+	ax = plt.subplot(122)
 	plt.imshow(bb_image, origin='lower')
 	for model in model_list:
-	    y1,y2,x1,x2 = np.reshape(model.bounding_box_default(),(4,))
-	    plt.plot([x1,x2,x2,x1,x1], [y1,y1,y2,y2,y1], 'w-',alpha=.2)
-	    
-	plt.axis([0,imshape[1],0,imshape[0]])
-	plt.title('Bounded Models\nTiming: %.2f seconds' % (t_bb), fontsize=16)
-	plt.xlabel('x', fontsize=14)
-	plt.ylabel('y', fontsize=14)
+	    dy, dx = np.diff(model.bounding_box_default()).flatten()
+	    pos = (model.x_mean.value - dx / 2, model.y_mean.value - dy / 2)
+	    r = Rectangle(pos, dx, dy, edgecolor='w', facecolor='none', alpha=.25)
+	    ax.add_patch(r)
+	plt.title('Bounded Models\nTiming: {:.2f} seconds'.format(t_bb), fontsize=16)
+	plt.xlabel('x')
+	plt.ylabel('y')
 
-	plt.figure(figsize=(16,8))
+	# Difference image
+	plt.figure(figsize=(16, 8))
+	plt.subplot(111)
 	plt.imshow(diff, vmin=-max_err, vmax=max_err)
 	plt.colorbar(format='%.1e')
-	plt.title('Difference Image\nTotal Flux Err = %.0e'
-	            %((flux - np.sum(bb_image)) / flux), fontsize=16)
-	plt.xlabel('x', fontsize=14)
-	plt.ylabel('y', fontsize=14)
+	plt.title('Difference Image\nTotal Flux Err = {:.0e}'.format(
+	    ((flux - np.sum(bb_image)) / flux)))
+	plt.xlabel('x')
+	plt.ylabel('y')
 	plt.show()
-	

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -238,7 +238,7 @@ Matplotlib. More information on installing and using WCSAxes can be found `here
 .. plot::
     :include-source:
 
-    from matplotlib import rcParams, pyplot as plt
+    from matplotlib import pyplot as plt
     from astropy.io import fits
     from astropy.wcs import WCS
     from astropy.utils.data import download_file


### PR DESCRIPTION
This PR follows on #3909. The changes are:

- [x] Adding a `bounding_box_default` function to all functional models where it makes sense. 
- [x] Update `Cutout2D` class bounding box definitions for consistency.
- [x] Replace `render_model` function with `Model.render()` method.
- [x] Misc. other fixes and edits to docs and tests.
- [x] ~~Add WCS support to the `render_model` function~~
