### PR TITLE
Some polynomial model refactoring (WIP?)

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -405,7 +405,7 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
             kwargs = []
 
         for cons in cls.parameter_constraints + cls.model_constraints:
-            kwargs.append((cons, None))
+            kwargs.append((cons, {}))
 
         kwargs += [('n_models', None), ('model_set_axis', None)]
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -404,8 +404,11 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
             args = ('self',) + cls.param_names
             kwargs = []
 
-        for cons in cls.parameter_constraints + cls.model_constraints:
+        for cons in cls.parameter_constraints:
             kwargs.append((cons, {}))
+
+        for cons in cls.model_constraints:
+            kwargs.append((cons, []))
 
         kwargs += [('n_models', None), ('model_set_axis', None)]
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -111,7 +111,7 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
 
         mcls._handle_special_methods(members, cls, parameters)
 
-        if not inspect.isabstract(cls) and not name.startswith('_'):
+        if cls._is_concrete:
             mcls.registry.add(cls)
 
         return cls
@@ -364,8 +364,10 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
             update_wrapper(new_call, cls)
             cls.__call__ = new_call
 
-        if ('__init__' not in members and not inspect.isabstract(cls) and
-                parameters):
+        make_init, parameters = mcls._make_custom_init(cls, members,
+                                                       parameters)
+
+        if make_init:
 
             def __init__(self, *params, **kwargs):
                 return super(cls, self).__init__(*params, **kwargs)
@@ -378,6 +380,64 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
                     varkwargs=varkwargs)
             update_wrapper(new_init, cls)
             cls.__init__ = new_init
+
+    @staticmethod
+    def _make_custom_init(cls, members, parameters):
+        """
+        Determine whether an ``__init__`` method with a customized signature
+        should be created.  The rules are this:
+
+            1. If an ``__init__`` method is found in the class definitions'
+               members the the class has a manually-defined ``__init__`` and
+               so that should be used.
+            2. If the class is not "concrete" as defined by the
+              ``_is_concrete`` property there's no sense in making a custom
+              ``__init__``.  This mostly applies to generic subclasses (like
+              `Fittable1DModel`) or base classes like `Model` that aren't
+              generally used or inspected directly by users (outside a
+              development context).
+            3. If no ``__init__`` is found in the members, but no parameters
+               were found in the class definition either (i.e. ``parameters``
+               is empty) this may be a subclass of some more generic class in
+               which the parameters were defined (see for example some of the
+               projection models).  In those cases see if the base classes are
+               concrete and have a custom ``__init__``.  In that case lookup
+               of the class's ``__init__`` should fall back to that one.
+               In this case this method also returns a new parameters dict
+               containing the `Parameter` descriptors found on the base class.
+            4. If no ``__init__`` is found, but parameters were defined in this
+               class's body then it may have different parameters from its base
+               class, so go ahead and make the custom ``__init__``.
+            5. If this is a concrete class with simply no parameters defined
+               either in the class body or the base class still define a custom
+               ``__init__` that simply accepts no parameter arguments.
+        """
+
+        if '__init__' in members or not cls._is_concrete:
+            return False, parameters
+        elif parameters:
+            return True, parameters
+        else:
+            # No __init__, no parameters, but is concrete.  This is case 3 in
+            # the docstring
+            for base_cls in cls.mro():
+                if (hasattr(base_cls, 'param_names') and
+                        isinstance(base_cls.param_names, tuple) and
+                        base_cls.param_names):
+                    # The base class defines the parameters
+                    # If the base class is concrete we can just fall back to
+                    # its __init__
+                    if base_cls._is_concrete:
+                        return False, parameters
+                    # Otherwise we want to use parameters from the base class,
+                    # but we do need to make our own __init__
+                    parameters = dict((name, getattr(base_cls, name))
+                                      for name in base_cls.param_names)
+                    return (True, parameters)
+
+            # Failing all else make a custom __init__ with no parameters
+            return (True, parameters)
+
 
     @classmethod
     def _get_init_signature(mcls, cls, parameters):
@@ -392,25 +452,30 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
         same names.
         """
 
+        args = ('self',)
+        kwargs = []
+
         # This is the default signature, which consists of the parameters
         # first (either as positional arguments, or as keyword arguments *if*
         # all parameters have a default value)
         if all(p.default is not None
                for p in six.itervalues(parameters)):
-            args = ('self',)
-            kwargs = [(name, parameters[name].default)
-                      for name in cls.param_names]
+            kwargs += [(name, parameters[name].default)
+                       for name in cls.param_names]
         else:
-            args = ('self',) + cls.param_names
-            kwargs = []
+            args += cls.param_names
 
-        for cons in cls.parameter_constraints:
-            kwargs.append((cons, {}))
+        if parameters:
+            for cons in cls.parameter_constraints:
+                kwargs.append((cons, {}))
 
         for cons in cls.model_constraints:
+            # Since these don't map to from specific parameters their defaults
+            # are just []
             kwargs.append((cons, []))
 
-        kwargs += [('n_models', None), ('model_set_axis', None)]
+        kwargs += [('n_models', None), ('model_set_axis', None),
+                   ('name', None), ('meta', None)]
 
         return (args, kwargs, None, None)
 
@@ -463,9 +528,8 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
             for base in cls.mro()[1:]:
                 if not issubclass(base, Model):
                     continue
-                elif (inspect.isabstract(base) or
-                        base.__name__.startswith('_')):
-                    break
+                elif not base._is_concrete:
+                    continue
                 bases.append(base.name)
             if bases:
                 return '{0} ({1})'.format(cls.name, ' -> '.join(bases))
@@ -1344,6 +1408,10 @@ class Model(object):
         formatting.
         """
 
+        if not hasattr(self, '_parameters'):
+            # Primarily in here for debugging purposes
+            return object.__repr__(self)
+
         # TODO: I think this could be reworked to preset model sets better
 
         parts = [repr(a) for a in args]
@@ -1803,6 +1871,18 @@ class _CompoundModelMeta(_ModelMeta):
 
         # TODO: Remove this at the same time as removing
         # _ModelMeta._handle_backwards_compat
+        return
+
+    @classmethod
+    def _handle_special_methods(mcls, members, cls, parameters):
+        # Don't make generated __init__ or __call__ methods--since compound
+        # model class's parameters aren't determined at class creation time we
+        # can't make methods with custom arguments either (we could for
+        # __call__, technically, but nevermind that, it's still overly
+        # time-consuming for little benefit)
+
+        # TODO: We could still do this lazily on an as-needed basis.  That'll
+        # be low-priority though.
         return
 
     @classmethod

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -364,7 +364,7 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
             update_wrapper(new_call, cls)
             cls.__call__ = new_call
 
-        make_init, parameters = mcls._make_custom_init(cls, members,
+        make_init, parameters = mcls._should_make_init(cls, members,
                                                        parameters)
 
         if make_init:
@@ -382,7 +382,7 @@ class _ModelMeta(InheritDocstrings, abc.ABCMeta):
             cls.__init__ = new_init
 
     @staticmethod
-    def _make_custom_init(cls, members, parameters):
+    def _should_make_init(cls, members, parameters):
         """
         Determine whether an ``__init__`` method with a customized signature
         should be created.  The rules are this:

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 import abc
-import copyreg
 import itertools
 
 import numpy as np
@@ -18,6 +17,7 @@ from .functional_models import Shift
 from .parameters import Parameter
 from .utils import poly_map_domain, comb, check_broadcast, polynomial_exponents
 from ..extern import six
+from ..extern.six.moves import copyreg
 from ..utils import lazyproperty, classproperty, indent, deprecated
 from ..utils.compat import funcsigs
 from ..utils.compat.functools import lru_cache

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -7,23 +7,133 @@ This module contains predefined polynomial models.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
+import abc
+import copyreg
+import itertools
+
 import numpy as np
 
-from .core import FittableModel, Model
+from .core import ModelDefinitionError, FittableModel, Model, _ModelMeta
 from .functional_models import Shift
 from .parameters import Parameter
-from .utils import poly_map_domain, comb, check_broadcast
-from ..utils import lazyproperty, indent
+from .utils import poly_map_domain, comb, check_broadcast, polynomial_exponents
+from ..extern import six
+from ..utils import lazyproperty, classproperty, indent, deprecated
+from ..utils.compat import funcsigs
+from ..utils.compat.functools import lru_cache
 
 
 __all__ = [
     'Chebyshev1D', 'Chebyshev2D', 'InverseSIP',
     'Legendre1D', 'Legendre2D', 'Polynomial1D',
-    'Polynomial2D', 'SIP', 'OrthoPolynomialBase',
-    'PolynomialModel'
+    'Polynomial2D', 'SIP', 'PolynomialBase', 'OrthoPolynomialBase'
 ]
 
 
+class _PolynomialModelMeta(_ModelMeta):
+    def __init__(cls, name, bases, members):
+        # Skip the _get_subclass_for_degree setup if this is already a concrete
+        # subclass
+        if members.get('_is_dynamic'):
+            return
+
+        # This is so that each subclass gets its own lru_cache for per-degree
+        # subclasses
+        cache_wrapper = lru_cache(maxsize=cls._degree_subclass_cache_maxsize)
+
+        # Use __func__--otherwise lru_cache will wrap the existing class
+        # method, which makes re-wrapping it as a classmethod on the
+        # metaclass instance tricky...
+        if hasattr(cls._get_subclass_for_degree, '__wrapper__'):
+            getter = cls._get_subclass_for_degree.__wrapper__.__func__
+        else:
+            getter = cls._get_subclass_for_degree.__func__
+
+        # This goes directly into the class __dict__, so we have to make it
+        # a classmethod object (otherwise lookup on this method won't go
+        # through the `type` class's method-getter).
+        cls._get_subclass_for_degree = classmethod(cache_wrapper(getter))
+
+    def _get_subclass_for_degree(cls, *degrees):
+        # Creates a subclass of the given Polynomial class that has its degree
+        # fixed (and has the appropriate coefficient Parameters to go with it)
+        # If only one degree is given this is the maximum degree for any term
+        # in the polynomial (regardless of number of variables).
+        # If multiple degrees are given these correspond with each independent
+        # variable individually (as in the orthogonal polynomial classes)
+
+        # 'degree' attributes are implemented as classproperties so that we
+        # can given them docstrings too
+
+        # Internal '_degrees' attribute mostly just for book-keeping
+        members = {
+            '_degrees': degrees,
+            '_is_dynamic': True  # See _ModelMeta.__reduce__
+        }
+
+        degree_attrs = cls._get_degree_attrs()
+
+        for attr, degree in zip(degree_attrs, degrees):
+            name, doc = attr
+
+            def _degree_getter(cls, name=name):
+                return getattr(cls, '_' + name)
+
+            members['_' + name] = degree
+            members[name] = classproperty(_degree_getter, doc=doc)
+
+        for exponents in cls._term_powers(*degrees):
+            coeff_name = cls._coefficient_name(*exponents)
+            parameter = cls._make_coefficient_parameter(coeff_name,
+                                                        *exponents)
+            members[coeff_name] = parameter
+
+        classname = 'Degree_{0}_{1}'.format('_'.join(str(x) for x in degrees),
+                                            cls.__name__)
+
+        return type(str(classname), (cls,), members)
+
+    @classmethod
+    def _get_init_signature(mcls, cls, parameters):
+        # Overrides _ModelMeta version of this
+        degree_attrs = tuple(attr[0] for attr in cls._get_degree_attrs())
+        arg_types = super(_PolynomialModelMeta, mcls)._get_init_signature(
+                cls, parameters)
+        args = arg_types[0]
+        kwargs = arg_types[1]
+
+        # args[0] should be 'self'
+        args = (args[0],) + degree_attrs + args[1:]
+
+        # add domain/window keyword args--get the default values from the
+        # base class
+        base_cls = cls.__bases__[0]  # TODO: This could by flaky
+        base_init_sig = funcsigs.signature(base_cls.__init__)
+        if cls.n_inputs == 1:
+            arg_prefixes = ('',)
+        else:
+            arg_prefixes = (in_ + '_' for in_ in cls.inputs[::-1])
+
+        n_params = len(cls.param_names)
+
+        for arg_prefix in arg_prefixes:
+            for arg_base in ('window', 'domain'):
+                # Just 'domain' for 1D; x_domain, y_domain, etc.
+                # for >= 2D
+                arg_name = arg_prefix + arg_base
+                param = base_init_sig.parameters.get(arg_name)
+
+                if param is None:
+                    # Maybe this model doesn't take a window/domain argument?
+                    continue
+
+                # Insert into kwargs list after the parameter kwargs
+                kwargs.insert(n_params, (arg_name, param.default))
+
+        return (args,) + arg_types[1:]
+
+
+@six.add_metaclass(_PolynomialModelMeta)
 class PolynomialBase(FittableModel):
     """
     Base class for all polynomial-like models with an arbitrary number of
@@ -33,292 +143,266 @@ class PolynomialBase(FittableModel):
     ``__getattr__`` rather than through class descriptors.
     """
 
-    # Default _param_names list; this will be filled in by the implementation's
-    # __init__
-    _param_names = ()
-
     linear = True
     col_fit_deriv = False
 
-    @lazyproperty
-    def param_names(self):
-        """Coefficient names generated based on the model's polynomial degree
-        and number of dimensions.
+    default_coefficient = 0.0
+    """Default value given to all coefficients."""
 
-        Subclasses should implement this to return parameter names in the
-        desired format.
-
-        On most `Model` classes this is a class attribute, but for polynomial
-        models it is an instance attribute since each polynomial model instance
-        can have different parameters depending on the degree of the polynomial
-        and the number of dimensions, for example.
-        """
-
-        return self._param_names
-
-    def __getattr__(self, attr):
-        if self._param_names and attr in self._param_names:
-            return Parameter(attr, default=0.0, model=self)
-
-        raise AttributeError(attr)
-
-    def __setattr__(self, attr, value):
-        # TODO: Support a means of specifying default values for coefficients
-        # Check for self._ndim first--if it hasn't been defined then the
-        # instance hasn't been initialized yet and self.param_names probably
-        # won't work.
-        # This has to vaguely duplicate the functionality of
-        # Parameter.__set__.
-        # TODO: I wonder if there might be a way around that though...
-        if attr[0] != '_' and self._param_names and attr in self._param_names:
-            param = Parameter(attr, default=0.0, model=self)
-            # This is a little hackish, but we can actually reuse the
-            # Parameter.__set__ method here
-            param.__set__(self, value)
-        else:
-            super(PolynomialBase, self).__setattr__(attr, value)
-
-
-class PolynomialModel(PolynomialBase):
+    n_degrees = 1
     """
-    Base class for polynomial models.
+    Specifies the number of 'degrees' of the polynomial.  Typically this is
+    just 1, as in an N-degree polynomial.  Alternatively, this may equal
+    cls.n_inputs, in which case the index/exponent on each variable may range
+    from 0 to N, 0 to M, and so on (where N, M, etc. are the degrees in each
+    variable).
 
-    Its main purpose is to determine how many coefficients are needed
-    based on the polynomial order and dimension and to provide their
-    default values, names and ordering.
+    See for example `OrthoPolynomialBase`.
     """
 
-    def __init__(self, degree, n_models=None, model_set_axis=None,
-                 name=None, meta=None, **params):
-        self._degree = degree
-        self._order = self.get_num_coeff(self.n_inputs)
-        self._param_names = self._generate_coeff_names(self.n_inputs)
-
-        super(PolynomialModel, self).__init__(
-            n_models=n_models, model_set_axis=model_set_axis, name=name,
-            meta=meta, **params)
-
-    def __repr__(self):
-        return self._format_repr([self.degree])
-
-    def __str__(self):
-        return self._format_str([('Degree', self.degree)])
-
-    @property
-    def degree(self):
-        """Degree of polynomial."""
-
-        return self._degree
-
-    def get_num_coeff(self, ndim):
-        """
-        Return the number of coefficients in one parameter set
-        """
-
-        if self.degree < 0:
-            raise ValueError("Degree of polynomial must be positive or null")
-        # deg+1 is used to account for the difference between iraf using
-        # degree and numpy using exact degree
-        if ndim != 1:
-            nmixed = comb(self.degree, ndim)
-        else:
-            nmixed = 0
-        numc = self.degree * ndim + nmixed + 1
-        return numc
-
-    def _invlex(self):
-        c = []
-        lencoeff = self.degree + 1
-        for i in range(lencoeff):
-            for j in range(lencoeff):
-                if i + j <= self.degree:
-                    c.append((j, i))
-        return c[::-1]
-
-    def _generate_coeff_names(self, ndim):
-        names = []
-        if ndim == 1:
-            for n in range(self._order):
-                names.append('c{0}'.format(n))
-        else:
-            for i in range(self.degree + 1):
-                names.append('c{0}_{1}'.format(i, 0))
-            for i in range(1, self.degree + 1):
-                names.append('c{0}_{1}'.format(0, i))
-            for i in range(1, self.degree):
-                for j in range(1, self.degree):
-                    if i + j < self.degree + 1:
-                        names.append('c{0}_{1}'.format(i, j))
-        return tuple(names)
-
-
-class OrthoPolynomialBase(PolynomialBase):
+    _degrees = None
     """
-    This is a base class for the 2D Chebyshev and Legendre models.
+    This internal attribute is set by
+    _PolynomialModelMeta._get_subclass_for_degree, and just stores the degree
+    of the polynomial (or degrees for multiple-indexed polynomials).  A None
+    value for this attribute indicates an "abstract" polynomial in the sense
+    that it does not have a specific degree, and can't be instantiated by
+    itself.
+    """
 
-    The polynomials implemented here require a maximum degree in x and y.
+    @abc.abstractproperty
+    def coefficient_template(self):
+        """
+        Template for coefficient parameter names.  Template should use
+        positional template arguments corresponding to exponent on each of
+        the input variables.
+
+        For example for a 2D polynomial one might use::
+
+            coefficient_template = 'c{0}_{1}'
+
+        This will generate coefficient names like ``c1_2`` corresponding
+        to the coefficient on the :math:`xy^2` term.
+        """
+
+    _degree_subclass_cache_maxsize = 16
+    """
+    When creating a Polynomial instance of a given degree, a subclass of that
+    Polynomial class is created representing a polynomial of that degree.
+    These subclasses are cached in order to speed up instance creation, but
+    there is a cap on the number of classes that are cached.
+
+    If, in the rare case that cap needs to be changed (say, we're creating
+    lots of polynomials of a wide range of degrees) that cap can be lifted
+    by creating a subclass of the polynomial type in question with an
+    increased value for this attribute.
+
+    The default value of 16 is probably reasonable, but chosen somewhat
+    arbitrarily (though the cache gets best performance if the size is a power
+    of two).
+    """
+
+    # TODO: The argument parsing in __new__ is awkward--might be good to have a
+    # better way of specifying how to look for the 'degree' arguments
+
+    def __new__(cls, *args, **kwargs):
+        if cls._degrees is None:
+            degrees = []
+            for idx, arg in enumerate(cls._get_degree_attrs()):
+                if arg[0] in kwargs:
+                    degrees.append(kwargs[arg[0]])
+                elif args and idx <= len(args) - 1:
+                    # The first N positional arguments should be the N
+                    # different degree arguments for n_degrees = N
+                    degrees.append(args[idx])
+                else:
+                    raise TypeError("missing required argument '{0}'".format(
+                        arg[0]))
+
+            new_cls = cls._get_subclass_for_degree(*degrees)
+        else:
+            # Just pass through the existing cls, which already has some
+            # specific degree--this can happen in the case of copying /
+            # unpickling an existing polynomial model with fixed degree
+            new_cls = cls
+        return super(PolynomialBase, cls).__new__(new_cls)
+
+    # TODO: Make this 'lazy'
+    @classproperty
+    def n_coefficients(cls):
+        """
+        The number of coefficients in this polynomial (equivalently the
+        number of terms in the polynomial).
+
+        In most cases this will be identical to ``len(model.param_names)``
+        since each coefficient is a fittable parameter.  However, some classes
+        may define additional parameters that are not coefficients.
+        """
+
+        return len(list(cls._term_powers(*cls._degrees)))
+
+    # The following classmethods may be overridden by subclasses to determine
+    # the number of terms in the polynomial and indexing / naming of
+    # coefficients
+
+    @classmethod
+    def _get_degree_attrs(cls):
+        """
+        Returns the names of class attributes representing the degree of the
+        polynomial (or per-variable degrees).
+
+        Also returns docstrings for those attributes as ``(name, doc)`` tuples.
+        """
+
+        if cls.n_degrees == 1:
+            degree_attrs = ('degree',)
+            degree_docs = ("Degree of the polynomial.",)
+        else:
+            degree_attrs = tuple('{0}_degree'.format(input_)
+                                 for input_ in cls.inputs)
+            doc_templ = "Maximum degree in the '{0}' variable."
+            degree_docs = tuple(doc_templ.format(input_)
+                                for input_ in cls.inputs)
+
+        return zip(degree_attrs, degree_docs)
+
+    @classmethod
+    def _term_powers(cls, *degrees):
+        """
+        Returns an iterator over exponents for terms in the polynomial of given
+        degrees (if one degree is given it is the maximum degree of terms in
+        polynomial; if multiple degrees are given it is the maximum degree in
+        each of the polynomial's variables).
+
+        Here the term "exponents" may be interpreted as any set of indices
+        used to index terms in a generalized polynomial.
+        """
+
+        if len(degrees) == 1:
+            # Note: This could just as well be done with itertools.product,
+            # however that doesn't return the coefficients in the same order as
+            # the original implementation, so this implementation is used to
+            # not break backward-compatibility unnecessarily.
+
+            return polynomial_exponents(cls.n_inputs, degrees[0])
+        else:
+            # The original implementation increments the x degree fastest,
+            # while itertools.product increments the y degree fastest,
+            # hence the reverses
+            def exponents():
+                ranges = (range(d + 1) for d in degrees[::-1])
+                for ind in itertools.product(*ranges):
+                    yield ind[::-1]
+
+            return exponents()
+
+    @classmethod
+    def _coefficient_name(cls, *powers):
+        """
+        Generates the parameter name for the coefficient to the term with
+        the given exponents (in order of the model's inputs).  By default
+        this simply uses the `~ParameterBase.coefficient_template` class
+        attribute as a template, but this may be overridden by subclasses
+        in order to take complete control.
+
+        An alternative implementation may choose to ignore
+        ``coefficient_template`` entirely if necessary.
+        """
+
+        return cls.coefficient_template.format(*powers)
+
+    @classmethod
+    def _make_coefficient_parameter(cls, name, *powers):
+        """
+        Creates a `Parameter` instance to serve as the unbound parameter
+        descriptor for the given coefficient, given the coefficient's name,
+        and the exponents on the independent variables identifying which term
+        this is the coefficient of.
+
+        `PolynomialBase` subclasses may override this to control creation of
+        `Parameter` descriptors (for example to add default constraints, etc.)
+
+        The default just returns a `Parameter` with the given name and the
+        default determined by the `~PolynomialBase.default_coefficient` class
+        attribute.
+        """
+
+        return Parameter(name=name, default=cls.default_coefficient)
+
+    @deprecated('1.1.0', alternative='model.n_coefficients')
+    def get_num_coeff(self):
+        return self.n_coefficients
+
+
+class Polynomial1D(PolynomialBase):
+    """
+    1D Polynomial model.
 
     Parameters
     ----------
-
-    x_degree : int
-        degree in x
-    y_degree : int
-        degree in y
-    x_domain : list or None
-        domain of the x independent variable
-    x_window : list or None
-        range of the x independent variable
-    y_domain : list or None
-        domain of the y independent variable
-    y_window : list or None
-        range of the y independent variable
+    degree : int
+        degree of the series
+    domain : list or None
+    window : list or None
+        If None, it is set to [-1,1]
+        Fitters will remap the domain to this window
     param_dim : int
         number of parameter sets
     **params : dict
-        {keyword: value} pairs, representing {parameter_name: value}
+        keyword: value pairs, representing parameter_name: value
     """
 
-    inputs = ('x', 'y')
-    outputs = ('z',)
+    inputs = ('x',)
+    outputs = ('y',)
+    coefficient_template = 'c{0}'
 
-    def __init__(self, x_degree, y_degree, x_domain=None, x_window=None,
-                 y_domain=None, y_window=None, n_models=None,
+    def __init__(self, degree, domain=[-1, 1], window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        # TODO: Perhaps some of these other parameters should be properties?
-        # TODO: An awful lot of the functionality in this method is still
-        # shared by PolynomialModel; perhaps some of it can be generalized in
-        # PolynomialBase
-        self.x_degree = x_degree
-        self.y_degree = y_degree
-        self._order = self.get_num_coeff()
-        self.x_domain = x_domain
-        self.y_domain = y_domain
-        self.x_window = x_window
-        self.y_window = y_window
-        self._param_names = self._generate_coeff_names()
+        self.domain = domain
+        self.window = window
+        super(Polynomial1D, self).__init__(n_models=n_models,
+                                           model_set_axis=model_set_axis,
+                                           name=name, meta=meta, **params)
 
-        super(OrthoPolynomialBase, self).__init__(
-            n_models=n_models, model_set_axis=model_set_axis,
-            name=name, meta=meta, **params)
+    def evaluate(self, x, *coeffs):
+        if self.domain is not None:
+            x = poly_map_domain(x, self.domain, self.window)
+        return self.horner(x, coeffs)
 
-    def __repr__(self):
-        return self._format_repr([self.x_degree, self.y_degree])
-
-    def __str__(self):
-        return self._format_str(
-            [('X-Degree', self.x_degree),
-             ('Y-Degree', self.y_degree)])
-
-    def get_num_coeff(self):
+    def fit_deriv(self, x, *params):
         """
-        Determine how many coefficients are needed
+        Computes the Vandermonde matrix.
+
+        Parameters
+        ----------
+        x : ndarray
+            input
+        params : throw away parameter
+            parameter list returned by non-linear fitters
 
         Returns
         -------
-        numc : int
-            number of coefficients
+        result : ndarray
+            The Vandermonde matrix
         """
 
-        return (self.x_degree + 1) * (self.y_degree + 1)
+        v = np.empty((self.degree + 1,) + x.shape, dtype=np.float)
+        v[0] = 1
+        if self.degree > 0:
+            v[1] = x
+            for i in range(2, self.degree + 1):
+                v[i] = v[i - 1] * x
+        return np.rollaxis(v, 0, v.ndim)
 
-    def _invlex(self):
-        # TODO: This is a very slow way to do this; fix it and related methods
-        # like _alpha
-        c = []
-        xvar = np.arange(self.x_degree + 1)
-        yvar = np.arange(self.y_degree + 1)
-        for j in yvar:
-            for i in xvar:
-                c.append((i, j))
-        return np.array(c[::-1])
-
-    def invlex_coeff(self):
-        coeff = []
-        xvar = np.arange(self.x_degree + 1)
-        yvar = np.arange(self.y_degree + 1)
-        for j in yvar:
-            for i in xvar:
-                name = 'c{0}_{1}'.format(i, j)
-                coeff.append(getattr(self, name))
-        return np.array(coeff[::-1])
-
-    def _alpha(self):
-        invlexdeg = self._invlex()
-        invlexdeg[:, 1] = invlexdeg[:, 1] + self.x_degree + 1
-        nx = self.x_degree + 1
-        ny = self.y_degree + 1
-        alpha = np.zeros((ny * nx + 3, ny + nx))
-        for n in range(len(invlexdeg)):
-            alpha[n][invlexdeg[n]] = [1, 1]
-            alpha[-2, 0] = 1
-            alpha[-3, nx] = 1
-        return alpha
-
-    def imhorner(self, x, y, coeff):
-        _coeff = list(coeff)
-        _coeff.extend([0, 0, 0])
-        alpha = self._alpha()
-        r0 = _coeff[0]
-        nalpha = len(alpha)
-
-        karr = np.diff(alpha, axis=0)
-        kfunc = self._fcache(x, y)
-        x_terms = self.x_degree + 1
-        y_terms = self.y_degree + 1
-        nterms = x_terms + y_terms
-        for n in range(1, nterms + 1 + 3):
-            setattr(self, 'r' + str(n), 0.)
-
-        for n in range(1, nalpha):
-            k = karr[n - 1].nonzero()[0].max() + 1
-            rsum = 0
-            for i in range(1, k + 1):
-                rsum = rsum + getattr(self, 'r' + str(i))
-            val = kfunc[k - 1] * (r0 + rsum)
-            setattr(self, 'r' + str(k), val)
-            r0 = _coeff[n]
-            for i in range(1, k):
-                setattr(self, 'r' + str(i), 0.)
-        result = r0
-        for i in range(1, nterms + 1 + 3):
-            result = result + getattr(self, 'r' + str(i))
-        return result
-
-    def _generate_coeff_names(self):
-        names = []
-        for j in range(self.y_degree + 1):
-            for i in range(self.x_degree + 1):
-                names.append('c{0}_{1}'.format(i, j))
-        return tuple(names)
-
-    def _fcache(self, x, y):
-        # TODO: Write a docstring explaining the actual purpose of this method
-        """To be implemented by subclasses"""
-
-        raise NotImplementedError("Subclasses should implement this")
-
-    def evaluate(self, x, y, *coeffs):
-        if self.x_domain is not None:
-            x = poly_map_domain(x, self.x_domain, self.x_window)
-        if self.y_domain is not None:
-            y = poly_map_domain(y, self.y_domain, self.y_window)
-        invcoeff = self.invlex_coeff()
-        return self.imhorner(x, y, invcoeff)
-
-    def prepare_inputs(self, x, y, **kwargs):
-        inputs, format_info = \
-                super(OrthoPolynomialBase, self).prepare_inputs(x, y, **kwargs)
-
-        x, y = inputs
-
-        if x.shape != y.shape:
-            raise ValueError("Expected input arrays to have the same shape")
-
-        return (x, y), format_info
+    @staticmethod
+    def horner(x, coeffs):
+        c0 = coeffs[-1] + x * 0
+        for i in range(2, len(coeffs) + 1):
+            c0 = coeffs[-i] + c0 * x
+        return c0
 
 
-class Chebyshev1D(PolynomialModel):
+class Chebyshev1D(Polynomial1D):
     """
     1D Chebyshev polynomial of the 1st kind.
 
@@ -336,16 +420,11 @@ class Chebyshev1D(PolynomialModel):
         keyword : value pairs, representing parameter_name: value
     """
 
-    inputs = ('x',)
-    outputs = ('y',)
-
     def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        self.domain = domain
-        self.window = window
         super(Chebyshev1D, self).__init__(
-            degree, n_models=n_models, model_set_axis=model_set_axis,
-            name=name, meta=meta, **params)
+                degree, domain=domain, window=window, n_models=n_models,
+                model_set_axis=model_set_axis, name=name, meta=meta, **params)
 
     def fit_deriv(self, x, *params):
         """
@@ -400,7 +479,7 @@ class Chebyshev1D(PolynomialModel):
         return c0 + c1 * x
 
 
-class Legendre1D(PolynomialModel):
+class Legendre1D(Polynomial1D):
     """
     1D Legendre polynomial.
 
@@ -418,16 +497,11 @@ class Legendre1D(PolynomialModel):
         keyword: value pairs, representing parameter_name: value
     """
 
-    inputs = ('x',)
-    outputs = ('y',)
-
     def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        self.domain = domain
-        self.window = window
         super(Legendre1D, self).__init__(
-            degree, n_models=n_models, model_set_axis=model_set_axis,
-            name=name, meta=meta, **params)
+                degree, domain=domain, window=window, n_models=n_models,
+                model_set_axis=model_set_axis, name=name, meta=meta, **params)
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
@@ -480,74 +554,7 @@ class Legendre1D(PolynomialModel):
         return c0 + c1 * x
 
 
-class Polynomial1D(PolynomialModel):
-    """
-    1D Polynomial model.
-
-    Parameters
-    ----------
-    degree : int
-        degree of the series
-    domain : list or None
-    window : list or None
-        If None, it is set to [-1,1]
-        Fitters will remap the domain to this window
-    param_dim : int
-        number of parameter sets
-    **params : dict
-        keyword: value pairs, representing parameter_name: value
-    """
-
-    inputs = ('x',)
-    outputs = ('y',)
-
-    def __init__(self, degree, domain=[-1, 1], window=[-1, 1], n_models=None,
-                 model_set_axis=None, name=None, meta=None, **params):
-        self.domain = domain
-        self.window = window
-        super(Polynomial1D, self).__init__(
-            degree, n_models=n_models, model_set_axis=model_set_axis,
-            name=name, meta=meta, **params)
-
-    def evaluate(self, x, *coeffs):
-        if self.domain is not None:
-            x = poly_map_domain(x, self.domain, self.window)
-        return self.horner(x, coeffs)
-
-    def fit_deriv(self, x, *params):
-        """
-        Computes the Vandermonde matrix.
-
-        Parameters
-        ----------
-        x : ndarray
-            input
-        params : throw away parameter
-            parameter list returned by non-linear fitters
-
-        Returns
-        -------
-        result : ndarray
-            The Vandermonde matrix
-        """
-
-        v = np.empty((self.degree + 1,) + x.shape, dtype=np.float)
-        v[0] = 1
-        if self.degree > 0:
-            v[1] = x
-            for i in range(2, self.degree + 1):
-                v[i] = v[i - 1] * x
-        return np.rollaxis(v, 0, v.ndim)
-
-    @staticmethod
-    def horner(x, coeffs):
-        c0 = coeffs[-1] + x * 0
-        for i in range(2, len(coeffs) + 1):
-            c0 = coeffs[-i] + c0 * x
-        return c0
-
-
-class Polynomial2D(PolynomialModel):
+class Polynomial2D(PolynomialBase):
     """
     2D Polynomial  model.
 
@@ -579,13 +586,15 @@ class Polynomial2D(PolynomialModel):
 
     inputs = ('x', 'y')
     outputs = ('z',)
+    coefficient_template = 'c{0}_{1}'
 
     def __init__(self, degree, x_domain=[-1, 1], y_domain=[-1, 1],
                  x_window=[-1, 1], y_window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
         super(Polynomial2D, self).__init__(
-            degree, n_models=n_models, model_set_axis=model_set_axis,
-            name=name, meta=meta, **params)
+                n_models=n_models, model_set_axis=model_set_axis,
+                name=name, meta=meta, **params)
+        # TODO: Perhaps some of these other parameters should be properties?
         self.x_domain = x_domain
         self.y_domain = y_domain
         self.x_window = x_window
@@ -696,6 +705,149 @@ class Polynomial2D(PolynomialModel):
                 r1 = x * (r0 + r1)
             r0 = coeffs[n + 1]
         return r0 + r1 + r2
+
+    def _invlex(self):
+        c = []
+        lencoeff = self.degree + 1
+        for i in range(lencoeff):
+            for j in range(lencoeff):
+                if i + j <= self.degree:
+                    c.append((j, i))
+        return c[::-1]
+
+
+class OrthoPolynomialBase(Polynomial2D):
+    """
+    This is a base class for the 2D Chebyshev and Legendre models.
+
+    The polynomials implemented here require a maximum degree in x and y.
+
+    Parameters
+    ----------
+
+    x_degree : int
+        degree in x
+    y_degree : int
+        degree in y
+    x_domain : list or None
+        domain of the x independent variable
+    x_window : list or None
+        range of the x independent variable
+    y_domain : list or None
+        domain of the y independent variable
+    y_window : list or None
+        range of the y independent variable
+    param_dim : int
+        number of parameter sets
+    **params : dict
+        {keyword: value} pairs, representing {parameter_name: value}
+    """
+
+    n_degrees = 2
+
+    def __init__(self, x_degree, y_degree, x_domain=None, x_window=None,
+                 y_domain=None, y_window=None, n_models=None,
+                 model_set_axis=None, name=None, meta=None, **params):
+        super(OrthoPolynomialBase, self).__init__(x_degree + y_degree,
+                x_domain=x_domain, x_window=x_window, y_domain=y_domain,
+                y_window=y_window, n_models=n_models,
+                model_set_axis=model_set_axis, name=name, meta=meta, **params)
+
+    def __repr__(self):
+        return self._format_repr([self.x_degree, self.y_degree])
+
+    def __str__(self):
+        return self._format_str(
+            [('X-Degree', self.x_degree),
+             ('Y-Degree', self.y_degree)])
+
+    def _invlex(self):
+        # TODO: This is a very slow way to do this; fix it and related methods
+        # like _alpha
+        c = []
+        xvar = np.arange(self.x_degree + 1)
+        yvar = np.arange(self.y_degree + 1)
+        for j in yvar:
+            for i in xvar:
+                c.append((i, j))
+        return np.array(c[::-1])
+
+    def invlex_coeff(self):
+        coeff = []
+        xvar = np.arange(self.x_degree + 1)
+        yvar = np.arange(self.y_degree + 1)
+        for j in yvar:
+            for i in xvar:
+                name = 'c{0}_{1}'.format(i, j)
+                coeff.append(getattr(self, name))
+        return np.array(coeff[::-1])
+
+    def _alpha(self):
+        invlexdeg = self._invlex()
+        invlexdeg[:, 1] = invlexdeg[:, 1] + self.x_degree + 1
+        nx = self.x_degree + 1
+        ny = self.y_degree + 1
+        alpha = np.zeros((ny * nx + 3, ny + nx))
+        for n in range(len(invlexdeg)):
+            alpha[n][invlexdeg[n]] = [1, 1]
+            alpha[-2, 0] = 1
+            alpha[-3, nx] = 1
+        return alpha
+
+    def imhorner(self, x, y, coeff):
+        _coeff = list(coeff)
+        _coeff.extend([0, 0, 0])
+        alpha = self._alpha()
+        r0 = _coeff[0]
+        nalpha = len(alpha)
+
+        karr = np.diff(alpha, axis=0)
+        kfunc = self._fcache(x, y)
+        x_terms = self.x_degree + 1
+        y_terms = self.y_degree + 1
+        nterms = x_terms + y_terms
+        for n in range(1, nterms + 1 + 3):
+            setattr(self, 'r' + str(n), 0.)
+
+        for n in range(1, nalpha):
+            k = karr[n - 1].nonzero()[0].max() + 1
+            rsum = 0
+            for i in range(1, k + 1):
+                rsum = rsum + getattr(self, 'r' + str(i))
+            val = kfunc[k - 1] * (r0 + rsum)
+            setattr(self, 'r' + str(k), val)
+            r0 = _coeff[n]
+            for i in range(1, k):
+                setattr(self, 'r' + str(i), 0.)
+        result = r0
+        for i in range(1, nterms + 1 + 3):
+            result = result + getattr(self, 'r' + str(i))
+        return result
+
+    def _fcache(self, x, y):
+        # TODO: Write a docstring explaining the actual purpose of this method
+        """To be implemented by subclasses"""
+
+        raise NotImplementedError("Subclasses should implement this")
+
+    def evaluate(self, x, y, *coeffs):
+        if self.x_domain is not None:
+            x = poly_map_domain(x, self.x_domain, self.x_window)
+        if self.y_domain is not None:
+            y = poly_map_domain(y, self.y_domain, self.y_window)
+        invcoeff = self.invlex_coeff()
+        return self.imhorner(x, y, invcoeff)
+
+    def prepare_inputs(self, x, y, **kwargs):
+        inputs, format_info = \
+                super(OrthoPolynomialBase, self).prepare_inputs(x, y, **kwargs)
+
+        x, y = inputs
+
+        if x.shape != y.shape:
+            raise ValueError("Expected input arrays to have the same shape")
+
+        return (x, y), format_info
 
 
 class Chebyshev2D(OrthoPolynomialBase):
@@ -930,12 +1082,13 @@ class _SIP1D(PolynomialBase):
 
     inputs = ('u', 'v')
     outputs = ('w',)
+    coefficient_template = '{0}_{1}_{2}'
+    # The first item in the above template is the coeff_prefix
 
     def __init__(self, order, coeff_prefix, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        self.order = order
-        self.coeff_prefix = coeff_prefix
-        self._param_names = self._generate_coeff_names(coeff_prefix)
+        if order < 2 or order > 9:
+            raise ValueError("Degree of polynomial must be 2 < deg < 9")
 
         super(_SIP1D, self).__init__(n_models=n_models,
                                      model_set_axis=model_set_axis,
@@ -949,36 +1102,25 @@ class _SIP1D(PolynomialBase):
             [('Order', self.order),
              ('Coeff. Prefix', self.coeff_prefix)])
 
+    @classmethod
+    def _get_degree_attrs(cls):
+        # Note: coeff_prefix isn't really a 'degree', but we still need it to
+        # generate the coefficient names for this model so we include it here
+        return [('order', 'Order/degree of the polynomial'),
+                ('coeff_prefix', 'Alphabetic prefix to the coefficient names')]
+
+    @classmethod
+    def _term_powers(cls, order, coeff_prefix):
+        for exponents in polynomial_exponents(2, order):
+            # Note: SIP distortion polynomials exclude monomial terms
+            if sum(exponents) >= 2:
+                yield (coeff_prefix,) + exponents
+
     def evaluate(self, x, y, *coeffs):
         # TODO: Rewrite this so that it uses a simpler method of determining
         # the matrix based on the number of given coefficients.
         mcoef = self._coeff_matrix(self.coeff_prefix, coeffs)
         return self._eval_sip(x, y, mcoef)
-
-    def get_num_coeff(self, ndim):
-        """
-        Return the number of coefficients in one param set
-        """
-
-        if self.order < 2 or self.order > 9:
-            raise ValueError("Degree of polynomial must be 2< deg < 9")
-
-        nmixed = comb(self.order, ndim)
-        # remove 3 terms because SIP deg >= 2
-        numc = self.order * ndim + nmixed - 2
-        return numc
-
-    def _generate_coeff_names(self, coeff_prefix):
-        names = []
-        for i in range(2, self.order + 1):
-            names.append('{0}_{1}_{2}'.format(coeff_prefix, i, 0))
-        for i in range(2, self.order + 1):
-            names.append('{0}_{1}_{2}'.format(coeff_prefix, 0, i))
-        for i in range(1, self.order):
-            for j in range(1, self.order):
-                if i + j < self.order + 1:
-                    names.append('{0}_{1}_{2}'.format(coeff_prefix, i, j))
-        return names
 
     def _coeff_matrix(self, coeff_prefix, coeffs):
         mat = np.zeros((self.order + 1, self.order + 1))
@@ -1163,3 +1305,6 @@ class InverseSIP(Model):
         x1 = self.sip1d_ap.evaluate(x, y, *self.sip1d_ap.param_sets)
         y1 = self.sip1d_bp.evaluate(x, y, *self.sip1d_bp.param_sets)
         return x1, y1
+
+
+copyreg.pickle(_PolynomialModelMeta, _PolynomialModelMeta.__reduce__)

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -374,14 +374,6 @@ class Chebyshev1D(PolynomialModel):
                 v[i] = v[i - 1] * x2 - v[i - 2]
         return np.rollaxis(v, 0, v.ndim)
 
-    def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(PolynomialModel, self).prepare_inputs(x, **kwargs)
-
-        x = inputs[0]
-
-        return (x,), format_info
-
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
             x = poly_map_domain(x, self.domain, self.window)
@@ -436,14 +428,6 @@ class Legendre1D(PolynomialModel):
         super(Legendre1D, self).__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
-
-    def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(PolynomialModel, self).prepare_inputs(x, **kwargs)
-
-        x = inputs[0]
-
-        return (x,), format_info
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
@@ -524,13 +508,6 @@ class Polynomial1D(PolynomialModel):
         super(Polynomial1D, self).__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
-
-    def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(Polynomial1D, self).prepare_inputs(x, **kwargs)
-
-        x = inputs[0]
-        return (x,), format_info
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -821,6 +821,29 @@ def test_compound_custom_inverse():
         (model1 & poly).inverse
 
 
+def test_call_argument_parsing():
+    """
+    Regression test to ensure that arguments to compound models' ``__call__``
+    method are not mishandled (in particular that positional arguments are
+    interpreted correctly with respect to which positional arguments are
+    input variables).
+    """
+
+    poly = Polynomial1D(5)
+    shift = Shift(3)
+    model = poly | shift
+
+    # The second positional argument should be interpreted as model_set_axis,
+    # which is irrelevant here--if arguments aren't bound correctly this ends
+    # up getting passed in as an additional "input", which in the case of
+    # compound model evaluation ends up being treated as the first parameter to
+    # the polynomial part of the model--oops!
+    assert model(1, 2) == model(1) == 3
+
+    with pytest.raises(TypeError):
+        model(x=1, y=2)
+
+
 @pytest.mark.parametrize('poly',
                          [Chebyshev1D(5), Legendre1D(5), Polynomial1D(5)])
 def test_compound_with_polynomials_1d(poly):

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -821,9 +821,27 @@ def test_compound_custom_inverse():
         (model1 & poly).inverse
 
 
-@pytest.mark.parametrize('poly', [Chebyshev2D(1, 2), Polynomial2D(2), Legendre2D(1, 2),
-                                  Chebyshev1D(5), Legendre1D(5), Polynomial1D(5)])
-def test_compound_with_polynomials(poly):
+@pytest.mark.parametrize('poly',
+                         [Chebyshev1D(5), Legendre1D(5), Polynomial1D(5)])
+def test_compound_with_polynomials_1d(poly):
+    """
+    Tests that polynomials are scaled when used in compound models.
+    Issue #3699
+    """
+
+    poly.parameters = [1, 2, 3, 4, 1, 2]
+    shift = Shift(3)
+    model = poly | shift
+    x = np.arange(20)
+    result_compound = model(x)
+    result = shift(poly(x))
+    assert_allclose(result, result_compound)
+
+
+@pytest.mark.parametrize('poly',
+                         [Chebyshev2D(1, 2), Polynomial2D(2),
+                          Legendre2D(1, 2)])
+def test_compound_with_polynomials_2d(poly):
     """
     Tests that polynomials are scaled when used in compound models.
     Issue #3699

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -108,6 +108,10 @@ def test_custom_model_signature():
     methods of custom models are useful.
     """
 
+    param_constraints = ['fixed', 'tied', 'bounds']
+    generic_init_args = ['eqcons', 'ineqcons', 'n_models', 'model_set_axis',
+                         'name', 'meta']
+
     @custom_model
     def model_a(x):
         return x
@@ -115,7 +119,7 @@ def test_custom_model_signature():
     assert model_a.param_names == ()
     assert model_a.n_inputs == 1
     argspec = inspect.getargspec(model_a.__init__)
-    assert argspec.args == ['self']
+    assert argspec.args == ['self'] + generic_init_args
     argspec = inspect.getargspec(model_a.__call__)
     assert argspec.args == ['self', 'x', 'model_set_axis']
 
@@ -126,8 +130,9 @@ def test_custom_model_signature():
     assert model_b.param_names == ('a', 'b')
     assert model_b.n_inputs == 1
     argspec = inspect.getargspec(model_b.__init__)
-    assert argspec.args == ['self', 'a', 'b']
-    assert argspec.defaults == (1, 2)
+    assert argspec.args == (['self', 'a', 'b'] + param_constraints +
+                            generic_init_args)
+    assert argspec.defaults[:2] == (1, 2)
     argspec = inspect.getargspec(model_b.__call__)
     assert argspec.args == ['self', 'x', 'model_set_axis']
 
@@ -138,14 +143,19 @@ def test_custom_model_signature():
     assert model_c.param_names == ('a', 'b')
     assert model_c.n_inputs == 2
     argspec = inspect.getargspec(model_c.__init__)
-    assert argspec.args == ['self', 'a', 'b']
-    assert argspec.defaults == (1, 2)
+    assert argspec.args == (['self', 'a', 'b'] + param_constraints +
+                            generic_init_args)
+    assert argspec.defaults[:2] == (1, 2)
     argspec = inspect.getargspec(model_c.__call__)
     assert argspec.args == ['self', 'x', 'y', 'model_set_axis']
 
 
 def test_custom_model_subclass():
     """Test that custom models can be subclassed."""
+
+    param_constraints = ['fixed', 'tied', 'bounds']
+    generic_init_args = ['eqcons', 'ineqcons', 'n_models', 'model_set_axis',
+                         'name', 'meta']
 
     @custom_model
     def model_a(x, a=1):
@@ -163,7 +173,8 @@ def test_custom_model_subclass():
     assert b(1) == -1
 
     argspec = inspect.getargspec(model_b.__init__)
-    assert argspec.args == ['self', 'a']
+    assert argspec.args == (['self', 'a'] + param_constraints +
+                            generic_init_args)
     argspec = inspect.getargspec(model_b.__call__)
     assert argspec.args == ['self', 'x', 'model_set_axis']
 

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -8,6 +8,11 @@ import os
 
 from itertools import product
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 import numpy as np
 
 from numpy.testing.utils import assert_allclose
@@ -347,3 +352,16 @@ def test_zero_degree_polynomial(cls):
         p2_fit = fitter(p2_init, x, y, z)
 
         assert_allclose(p2_fit.c0_0, 1, atol=0.10)
+
+
+def test_pickle_polynomial():
+    """
+    Polynomial instances have dynamically generated classes, which are often
+    tricky when dealing with pickling.
+    """
+
+    p_orig = Polynomial1D(5, 0, 1, 2, 3, 4, 5)
+    p = pickle.loads(pickle.dumps(p_orig))
+    assert np.all(p.parameters == p_orig.parameters)
+    assert p.param_names == p_orig.param_names
+    assert p.degree == p_orig.degree

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 from collections import deque, MutableMapping
+from itertools import product, combinations
 
 import numpy as np
 
@@ -466,6 +467,69 @@ def comb(N, k):
     for j in xrange(min(k, N - k)):
         val = (val * (N - j)) / (j + 1)
     return val
+
+
+def polynomial_exponents(n, degree):
+    """
+    Generates the exponents for the terms of an ``n``-dimensional polynomial
+    of the given degree in the order:
+
+    .. math:
+
+        1 + x_1 + \cdots + x_1^d + \cdots x_n + \cdots x_n^d + x_1x_2 +
+        x_1x_2^2 + \cdots + x_1x_2^{d-1} + \cdots x_1x_n + \cdots +
+        x_1x_n^{d-1} + \cdots
+
+    Parameters
+    ----------
+    n : int
+        The dimension of the polynomial
+    degree : int
+        The degree of the polynomial
+
+    Examples
+    --------
+
+    ::
+
+        >>> list(polynomial_exponents(1, 3))
+        [(0,), (1,), (2,), (3,)]
+
+    Which corresponds to :math:`1 + x + x^2 + x^3`.
+
+    ::
+
+        >>> list(polynomial_exponents(2, 3))
+        [(0, 0), (1, 0), (2, 0), (3, 0), (0, 1), (0, 2), (0, 3),
+        (1, 1), (1, 2), (2, 1)]
+
+    Which corresponds to :math:`1 + x + y + xy + xy^2 + x^2y`.
+
+    ::
+
+        >>> list(polynomial_exponents(3, 3))
+        [(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0), (0, 1, 0), (0, 2, 0),
+        (0, 3, 0), (0, 0, 1), (0, 0, 2), (0, 0, 3), (1, 1, 0), (1, 2, 0),
+        (2, 1, 0), (1, 0, 1), (1, 0, 2), (2, 0, 1), (0, 1, 1), (0, 1, 2),
+        (0, 2, 1), (1, 1, 1)]
+
+    Which corresponds to :math:`1 + x + y + z + xy + xy^2 + x^2y + xz + xz^2 +
+    x^2z + xyz`
+    """
+
+    for m in range(min(degree + 1, n + 1)):
+        # m is the number of variables appearing with non-zero exponents in the
+        # current term
+        for indices in combinations(range(0, n), m):
+            # indices basically selects which variables will have non-zero
+            # exponents in the product-loop below
+            ranges = (range(1, degree + 1) if idx in indices else (0,)
+                      for idx in range(n))
+            for powers in product(*ranges):
+                # powers is only ever empty if n == 0 in which case we stop
+                # iteration immediately
+                if powers and sum(powers) <= degree:
+                    yield powers
 
 
 def array_repr_oneline(array):

--- a/astropy/utils/compat/_functools/lru_cache.py
+++ b/astropy/utils/compat/_functools/lru_cache.py
@@ -1,0 +1,166 @@
+from collections import namedtuple
+from functools import update_wrapper
+from threading import RLock
+
+_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+
+
+class _HashedSeq(list):
+    __slots__ = 'hashvalue'
+
+    def __init__(self, tup, hash=hash):
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+
+def _make_key(args, kwds, typed,
+              kwd_mark=(object(),),
+              fasttypes=set([int, str, frozenset, type(None)]),
+              sorted=sorted, tuple=tuple, type=type, len=len):
+    'Make a cache key from optionally typed positional and keyword arguments'
+    key = args
+    if kwds:
+        sorted_items = sorted(kwds.items())
+        key += kwd_mark
+        for item in sorted_items:
+            key += item
+    if typed:
+        key += tuple(type(v) for v in args)
+        if kwds:
+            key += tuple(type(v) for k, v in sorted_items)
+    elif len(key) == 1 and type(key[0]) in fasttypes:
+        return key[0]
+    return _HashedSeq(key)
+
+
+def lru_cache(maxsize=100, typed=False):
+    """Least-recently-used cache decorator.
+
+    If *maxsize* is set to None, the LRU features are disabled and the cache
+    can grow without bound.
+
+    If *typed* is True, arguments of different types will be cached separately.
+    For example, f(3.0) and f(3) will be treated as distinct calls with
+    distinct results.
+
+    Arguments to the cached function must be hashable.
+
+    View the cache statistics named tuple (hits, misses, maxsize, currsize) with
+    f.cache_info().  Clear the cache and statistics with f.cache_clear().
+    Access the underlying function with f.__wrapped__.
+
+    See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+
+    """
+
+    # Users should only access the lru_cache through its public API:
+    #       cache_info, cache_clear, and f.__wrapped__
+    # The internals of the lru_cache are encapsulated for thread safety and
+    # to allow the implementation to change (including a possible C version).
+
+    def decorating_function(user_function):
+
+        cache = dict()
+        stats = [0, 0]                  # make statistics updateable non-locally
+        HITS, MISSES = 0, 1             # names for the stats fields
+        make_key = _make_key
+        cache_get = cache.get           # bound method to lookup key or return None
+        _len = len                      # localize the global len() function
+        lock = RLock()                  # because linkedlist updates aren't threadsafe
+        root = []                       # root of the circular doubly linked list
+        root[:] = [root, root, None, None]      # initialize by pointing to self
+        nonlocal_root = [root]                  # make updateable non-locally
+        PREV, NEXT, KEY, RESULT = 0, 1, 2, 3    # names for the link fields
+
+        if maxsize == 0:
+
+            def wrapper(*args, **kwds):
+                # no caching, just do a statistics update after a successful call
+                result = user_function(*args, **kwds)
+                stats[MISSES] += 1
+                return result
+
+        elif maxsize is None:
+
+            def wrapper(*args, **kwds):
+                # simple caching without ordering or size limit
+                key = make_key(args, kwds, typed)
+                result = cache_get(key, root)   # root used here as a unique not-found sentinel
+                if result is not root:
+                    stats[HITS] += 1
+                    return result
+                result = user_function(*args, **kwds)
+                cache[key] = result
+                stats[MISSES] += 1
+                return result
+
+        else:
+
+            def wrapper(*args, **kwds):
+                # size limited caching that tracks accesses by recency
+                key = make_key(args, kwds, typed) if kwds or typed else args
+                with lock:
+                    link = cache_get(key)
+                    if link is not None:
+                        # record recent use of the key by moving it to the front of the list
+                        root, = nonlocal_root
+                        link_prev, link_next, key, result = link
+                        link_prev[NEXT] = link_next
+                        link_next[PREV] = link_prev
+                        last = root[PREV]
+                        last[NEXT] = root[PREV] = link
+                        link[PREV] = last
+                        link[NEXT] = root
+                        stats[HITS] += 1
+                        return result
+                result = user_function(*args, **kwds)
+                with lock:
+                    root, = nonlocal_root
+                    if key in cache:
+                        # getting here means that this same key was added to the
+                        # cache while the lock was released.  since the link
+                        # update is already done, we need only return the
+                        # computed result and update the count of misses.
+                        pass
+                    elif _len(cache) >= maxsize:
+                        # use the old root to store the new key and result
+                        oldroot = root
+                        oldroot[KEY] = key
+                        oldroot[RESULT] = result
+                        # empty the oldest link and make it the new root
+                        root = nonlocal_root[0] = oldroot[NEXT]
+                        oldkey = root[KEY]
+                        root[KEY] = root[RESULT] = None
+                        # now update the cache dictionary for the new links
+                        del cache[oldkey]
+                        cache[key] = oldroot
+                    else:
+                        # put result in a new link at the front of the list
+                        last = root[PREV]
+                        link = [last, root, key, result]
+                        last[NEXT] = root[PREV] = cache[key] = link
+                    stats[MISSES] += 1
+                return result
+
+        def cache_info():
+            """Report cache statistics"""
+            with lock:
+                return _CacheInfo(stats[HITS], stats[MISSES], maxsize, len(cache))
+
+        def cache_clear():
+            """Clear the cache and cache statistics"""
+            with lock:
+                cache.clear()
+                root = nonlocal_root[0]
+                root[:] = [root, root, None, None]
+                stats[:] = [0, 0]
+
+        wrapper.__wrapped__ = user_function
+        wrapper.cache_info = cache_info
+        wrapper.cache_clear = cache_clear
+        return update_wrapper(wrapper, user_function)
+
+    return decorating_function

--- a/astropy/utils/compat/functools.py
+++ b/astropy/utils/compat/functools.py
@@ -1,0 +1,10 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Includes a backport of functools.lru_cache from
+# http://code.activestate.com/recipes/578078/
+# (C) Raymond Hettinger 2012, under the MIT license.
+from __future__ import absolute_import
+
+try:
+    from functools import lru_cache
+except ImportError:
+    from ._functools.lru_cache import lru_cache


### PR DESCRIPTION
This is some work I've started on changing how polynomial models are implemented, so that they end up a little more like any other model.

Most models have a set of `Parameter` descriptors defined in their class bodies that specify the parameters that the model takes.  But for polynomial models the parameters (in this case the coefficients) always depended on the degree of the polynomial which could be arbitrary, and which was only specified when instantiating a polynomial model (e.g. `Polynomial1D(degree=3)`).

To make this work, the previous implementation defined a `__getattr__` method that generated the appropriate `Parameter` lookups.  This worked well enough, but it still made polynomials very different from other models.  It was also awkward to define other polynomial-like models (see for example the [`BSplineModel`](https://github.com/astropy/specutils/blob/master/specutils/models/BSplineModel.py) in specutils--to my knowledge this is the only implementation of a "polynomial-like" Model subclass outside the Astropy core.  It contains a bunch of boilerplate that had to be copied over from `PolynomialBase`, and various other awkward elements.  So a goal here was to try to make it a little? easier to define new classes of polynomial models.  I'm not _sure_ if this succeeds in that.  But it does make polynomial models more similar to other models.

The main difference this has over the previous implementation is that it no longer relies on `__getattr__` to supply the coefficient parameters.  Instead, when you instantiate a `Polynomial1D` (or any other subclass of `PolynomialBase`) it looks at the degree of the polynomial and creates a new subclass specifically for that degree and instantiates that instead.  For example `Polynomial1D(3)` returns an instance of a `Degree_3_Polynomial1D`.  This generated subclass is just like any other `Model` and has all the coefficients pre-defined at the class-level as `Parameter` descriptors.

The `PolynomialBase` class also has several methods that can be overridden by subclasses to control how the terms in the polynomial are enumerated and indexed, as well as how the coefficients to those terms are labeled.  With the exception of `coefficient_template` (which isn't even a method) these methods have underscore names, since they are not meant to be used directly.  But authors of `Model` subclasses may override them:
- [`coefficient_template`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L163) - This is just a string formatting template that is used to generate the coefficient names.  The arguments to the template are any indices used to label terms in the polynomial.  In the basic 1D case these are just the exponents 0, 1, 2, ... _d_.
- [`_get_degree_attrs`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L238) This just returns the names of attributes on the class that specify the degree of the polynomial.  In the generic case this is just `'degree'`.  However, if you look at [`OrthoPolynomialBase`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L728) in that case there are two "degrees" used to indicate terms--`x_degree` and `y_degree`.  I've thought of renaming this one to something a little more generic than "degree".  For example in the case of [`_SIP1D`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L1088) this also returns `coeff_prefix`.  Really these are any properties used to distinguish polynomials within a given class.
- [`_term_powers`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L251) - This actually enumerates the terms of the polynomial.  For a 3 degree 2D polynomial for example this lists `(0, 0), (1, 0), (0, 1), (1, 1), (2, 1), (1, 2)` corresponding to `1 + x + y + xy + x^2y + xy^2`.  As in `_get_degree_attrs`, the term "powers" here is used loosely.  In the basic case it does correspond to exponents, but it can really be any tuple of indices used to index terms of the polynomial.
- [`_coefficient_name`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L265) - Given a tuple returned from `_term_powers`, returns the name of the corresponding coefficient parameter.  In the base implementation this just passes them to `coefficient_template`, but this is allowed to be overridden entirely.
- [`_make_coefficient_parameter`](https://github.com/embray/astropy/blob/246fdd679dea00ba72794c6aa347ae38fecd47d7/astropy/modeling/polynomial.py#L280) - This actually returns an instance of `Parameter` for a given coefficient (given its name as returned by `_coefficient_name`, as well as the associated index tuple).  This is used when building the degree-specific subclass.  Usually there's no reason to override this, but it is there so that subclasses may override it if they want to do anything special with the parameters (provide default constraints, for example) that they would normally do by defining parameters in the class body, but that polynomial models don't allow.

An alternative to all this, which has been discussed before, is some kind of `ParameterSet` or `ParameterTemplate` that generates a sequence of parameters.  This might still be worth considering in the future.  But the approach here maintains backwards compatibility and solves some of the problems I had with dealing with the existing polynomial models.
