### PR TITLE
Make stat.sigma_clip deal with/skip NaN values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,9 @@ New Features
   - Added ``cenfunc``, ``stdfunc``, and ``axis`` keywords to
     ``sigma_clipped_stats``. [#3792]
 
+  - ``sigma_clip`` automatically masks invalid input values (NaNs, Infs) before
+    performing the clipping [#4051]
+
   - Added the ``histogram`` routine, which is similar to ``np.histogram`` but
     includes several additional options for automatic determination of optimal
     histogram bins. Associated helper routines include ``bayesian_blocks``,

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -174,6 +174,9 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
         stdfunc = lambda d: np.expand_dims(stdfunc_in(d, axis=axis),
                                            axis=axis)
 
+    if np.sum(np.isnan(data)) > 0:
+        data = np.ma.array(data, mask=np.isnan(data))
+
     filtered_data = np.ma.array(data, copy=copy)
 
     if iters is None:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -38,8 +38,9 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
     Perform sigma-clipping on the provided data.
 
     The data will be iterated over, each time rejecting points that are
-    discrepant by more than a specified number of standard deviations
-    from a center value.
+    discrepant by more than a specified number of standard deviations from a
+    center value. If the data contains invalid values (NaNs or infs),
+    they are automatically masked before performing the sigma clipping.
 
     .. note::
         `scipy.stats.sigmaclip

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -174,8 +174,10 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
         stdfunc = lambda d: np.expand_dims(stdfunc_in(d, axis=axis),
                                            axis=axis)
 
-    if np.sum(np.isnan(data)) > 0:
-        data = np.ma.array(data, mask=np.isnan(data))
+    if np.any(~np.isfinite(data)):
+        data = np.ma.masked_invalid(data)
+        warnings.warn("Input data contains invalid values (NaNs or infs), "
+                      "which were automatically masked.", AstropyUserWarning)
 
     filtered_data = np.ma.array(data, copy=copy)
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -104,3 +104,22 @@ def test_sigma_clipped_stats():
     assert result2[0] == 1.
     assert result2[1] == 1.
     assert result2[2] == 0.
+
+
+def test_invalid_sigma_clip():
+    """Test sigma_clip of data containing invalid values."""
+
+    data = np.ones((5, 5))
+    data[2, 2] = 1000
+    data[3, 4] = np.nan
+    data[1, 1] = np.inf
+
+    result = sigma_clip(data)
+
+    # Pre #4051 if data contains any NaN or infs sigma_clip returns the mask
+    # containig `False` only or TypeError if data also contains a masked value.
+
+    assert result.mask[2, 2] == True
+    assert result.mask[3, 4] == True
+    assert result.mask[1, 1] == True
+


### PR DESCRIPTION
It would be nice if ``stat.sigma_clip`` would work out of the box with arrays containing NaN values.
 
Currently it needs a workaround to mask those out by creating or updating the mask of the array.

:fireworks: as I managed to convert this issue to a PR, the first time. Still needs a test and docs.
