### PR TITLE
Handle sorting NaNs and masked values in jsviewer

### DIFF
--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -367,8 +367,9 @@ class HTML(core.BaseReader):
                             w.data('')  # need this instead of pass to get <script></script>
             with w.tag('body'):
                 if 'js' in self.html:
-                    with w.tag('script'):
-                        w.data(self.html['js'])
+                    with w.xml_cleaning_method('none'):
+                        with w.tag('script'):
+                            w.data(self.html['js'])
                 if isinstance(self.html['table_id'], six.string_types):
                     html_table_id = self.html['table_id']
                 else:

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -51,12 +51,20 @@ require(["datatables"], function(){{
 """
 
 HTML_JS_SCRIPT = """
+jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
+    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return ''; else return b;}},
+    "optionalnum-asc": function (a,b) {{ return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }},
+    "optionalnum-desc": function (a,b) {{ return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }}
+}});
+
 $(document).ready(function() {{
     $('#{tid}').dataTable({{
-        "order": [],
-        "iDisplayLength": {display_length},
-        "aLengthMenu": {display_length_menu},
-        "pagingType": "full_numbers"
+     "iDisplayLength": {display_length},
+     "aLengthMenu": {display_length_menu},
+     "pagingType": "full_numbers",
+     "bJQueryUI": true,
+     "sPaginationType": "full_numbers",
+     "aoColumnDefs": [{{"sType": "optionalnum", "aTargets": {sort_columns}}}]
     }});
 }} );
 """
@@ -137,11 +145,11 @@ class JSViewer(object):
             tid=table_id)
         return html
 
-    def html_js(self, table_id='table0'):
+    def html_js(self, table_id='table0', sort_columns='[]'):
         return HTML_JS_SCRIPT.format(
             display_length=self.display_length,
             display_length_menu=self.display_length_menu,
-            tid=table_id).strip()
+            tid=table_id, sort_columns=sort_columns).strip()
 
 
 def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
@@ -153,13 +161,15 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
     jskwargs = jskwargs or {}
     jsv = JSViewer(**jskwargs)
 
+    sortable_columns = list(i for i, col in enumerate(table.columns.values())
+                            if col.dtype.kind in 'iufc')
     htmldict = {
         'table_id': table_id,
         'table_class': table_class,
         'css': css,
         'cssfiles': jsv.css_urls,
         'jsfiles': jsv.jquery_urls,
-        'js':  jsv.html_js(table_id=table_id)
+        'js':  jsv.html_js(table_id=table_id, sort_columns=sortable_columns)
     }
 
     if max_lines < len(table):

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -52,7 +52,7 @@ require(["datatables"], function(){{
 
 HTML_JS_SCRIPT = """
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
-    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return ''; else return b;}},
+    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;}},
     "optionalnum-asc": function (a,b) {{ return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }},
     "optionalnum-desc": function (a,b) {{ return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }}
 }});

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -51,10 +51,20 @@ require(["datatables"], function(){{
 """
 
 HTML_JS_SCRIPT = """
+var astropy_sort_num = function(a, b) {{
+    var a_num = parseFloat(a);
+    var b_num = parseFloat(b);
+
+    if (isNaN(a_num) && isNaN(b_num))
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    else if (!isNaN(a_num) && !isNaN(b_num))
+        return ((a_num < b_num) ? -1 : ((a_num > b_num) ? 1 : 0));
+    else
+        return isNaN(a_num) ? -1 : 1;
+}}
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
-    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;}},
-    "optionalnum-asc": function (a,b) {{ return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }},
-    "optionalnum-desc": function (a,b) {{ return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }}
+    "optionalnum-asc": astropy_sort_num,
+    "optionalnum-desc": function (a,b) {{ return -astropy_sort_num(a, b); }}
 }});
 
 $(document).ready(function() {{

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -33,7 +33,7 @@ table.dataTable {width: auto !important; margin: 0 !important;}
  <body>
   <script>
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
-    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return ''; else return b;},
+    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;},
     "optionalnum-asc": function (a,b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); },
     "optionalnum-desc": function (a,b) { return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }
 });

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -32,12 +32,20 @@ table.dataTable {width: auto !important; margin: 0 !important;}
  </head>
  <body>
   <script>
+jQuery.extend( jQuery.fn.dataTableExt.oSort, {
+    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return ''; else return b;},
+    "optionalnum-asc": function (a,b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); },
+    "optionalnum-desc": function (a,b) { return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }
+});
+
 $(document).ready(function() {
     $('#%(table_id)s').dataTable({
-        "order": [],
-        "iDisplayLength": %(length)s,
-        "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
-        "pagingType": "full_numbers"
+     "iDisplayLength": %(length)s,
+     "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
+     "pagingType": "full_numbers",
+     "bJQueryUI": true,
+     "sPaginationType": "full_numbers",
+     "aoColumnDefs": [{"sType": "optionalnum", "aTargets": [0]}]
     });
 } );  </script>
   <table class="%(table_class)s" id="%(table_id)s">

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -32,10 +32,20 @@ table.dataTable {width: auto !important; margin: 0 !important;}
  </head>
  <body>
   <script>
+var astropy_sort_num = function(a, b) {
+    var a_num = parseFloat(a);
+    var b_num = parseFloat(b);
+
+    if (isNaN(a_num) && isNaN(b_num))
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    else if (!isNaN(a_num) && !isNaN(b_num))
+        return ((a_num < b_num) ? -1 : ((a_num > b_num) ? 1 : 0));
+    else
+        return isNaN(a_num) ? -1 : 1;
+}
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
-    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;},
-    "optionalnum-asc": function (a,b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); },
-    "optionalnum-desc": function (a,b) { return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }
+    "optionalnum-asc": astropy_sort_num,
+    "optionalnum-desc": function (a,b) { return -astropy_sort_num(a, b); }
 });
 
 $(document).ready(function() {

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -168,6 +168,9 @@ class XMLWriter:
         Any additional keyword arguments will be passed directly to the
         ``clean`` function.
 
+        Finally, use ``method='none'`` to disable any sanitization. This should
+        be used sparingly.
+
         Example::
 
           w = writer.XMLWriter(ListWriter(lines))
@@ -179,8 +182,8 @@ class XMLWriter:
         Parameters
         ----------
         method : str
-            Cleaning method.  Allowed values are "escape_xml" and
-            "bleach_clean".
+            Cleaning method.  Allowed values are "escape_xml",
+            "bleach_clean", and "none".
 
         **clean_kwargs : keyword args
             Additional keyword args that are passed to the
@@ -196,8 +199,10 @@ class XMLWriter:
             else:
                 raise ValueError('bleach package is required when HTML escaping is disabled.\n'
                                  'Use "pip install bleach".')
+        elif method == "none":
+            self.xml_escape_cdata = lambda x: x
         elif method != 'escape_xml':
-            raise ValueError('allowed values of method are "escape_xml" and "bleach_clean"')
+            raise ValueError('allowed values of method are "escape_xml", "bleach_clean", and "none"')
 
         yield
 


### PR DESCRIPTION
This is an attempt at a problem brought up on the astropy@ mailing list, and issue #2966.

Specifically, DataTable autodetects how to do the sorting, and believes columns with a 'nan' or '--' should be sorted as strings. This implementation explicitly marks any int- or float-like column as a new type of sortable column. Since the sorting code uses '<' and '>', I did have to extend the XMLWriter to not escape inserted javascript.
