### PR TITLE
Fix exception handler crash on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -664,6 +664,10 @@ Bug Fixes
   - Removed source code template files that were being installed
     accidentally alongside installed Python modules. [#4014]
 
+  - Fixed a bug in the exception logging that caused a crash in the exception
+    handler itself on Python 3 when exceptions do not include a message.
+    [#4056]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 
 from . import config as _config
 from . import conf as _conf
-from .extern.six import PY3
+from .extern.six import PY3, text_type
 from .utils import find_current_module
 from .utils.console import color_print
 from .utils.exceptions import AstropyWarning, AstropyUserWarning
@@ -284,7 +284,7 @@ class AstropyLogger(Logger):
         if len(value.args) > 0:
             message = '{0}: {1}'.format(etype.__name__, str(value))
         else:
-            message = unicode(etype.__name__)
+            message = text_type(etype.__name__)
 
         if mod is not None:
             self.error(message, extra={'origin': mod.__name__})
@@ -536,7 +536,7 @@ class AstropyLogger(Logger):
             except (IOError, OSError) as e:
                 warnings.warn(
                     'log file {0!r} could not be opened for writing: '
-                    '{1}'.format(log_file_path, unicode(e)), RuntimeWarning)
+                    '{1}'.format(log_file_path, text_type(e)), RuntimeWarning)
             else:
                 formatter = logging.Formatter(conf.log_file_format)
                 fh.setFormatter(formatter)

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -261,6 +261,27 @@ def test_exception_logging_origin():
     assert log_list[0].origin == 'astropy.utils.collections'
 
 
+@pytest.mark.xfail(str("ip is not None"))
+def test_exception_logging_argless_exception():
+    """
+    Regression test for a crash that occurred on Python 3 when logging an
+    exception that was instantiated with no arguments (no message, etc.)
+    """
+
+    try:
+        log.enable_exception_logging()
+        with log.log_to_list() as log_list:
+            raise Exception()
+    except Exception as exc:
+        sys.excepthook(*sys.exc_info())
+    else:
+        assert False  # exception should have been raised
+    assert len(log_list) == 1
+    assert log_list[0].levelname == 'ERROR'
+    assert log_list[0].message == 'Exception [astropy.tests.test_logger]'
+    assert log_list[0].origin == 'astropy.tests.test_logger'
+
+
 @pytest.mark.parametrize(('level'), [None, 'DEBUG', 'INFO', 'WARN', 'ERROR'])
 def test_log_to_list(level):
 

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -266,6 +266,8 @@ def test_exception_logging_argless_exception():
     """
     Regression test for a crash that occurred on Python 3 when logging an
     exception that was instantiated with no arguments (no message, etc.)
+
+    Regression test for https://github.com/astropy/astropy/pull/4056
     """
 
     try:


### PR DESCRIPTION
Fixes long-standing bug in exception hook on Python 3 (use of `unicode` builtin in the narrow case of message-less exceptions).