### PR TITLE
astropy.utils.misc.isiterable returns True for scalar times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -621,6 +621,10 @@ Bug Fixes
 
 - ``astropy.time``
 
+  - Fixed iteration of scalar ``Time`` objects so that ``iter()`` correctly
+    raises a ``TypeError`` on them (while still allowing ``Time`` arrays to
+    be iterated). [#4048]
+
 - ``astropy.units``
 
   - Fixed the documentation of supported units to correctly report support for

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -10,6 +10,7 @@ astronomy.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import itertools
 import fnmatch
 import time
 import re
@@ -791,6 +792,21 @@ class Time(object):
         copy of the JD arrays.
         """
         return self.copy()
+
+    def __iter__(self):
+        if self.isscalar:
+            raise TypeError('scalar {0!r} object is not iterable.'.format(
+                self.__class__.__name__))
+
+        def time_iter():
+            try:
+                for idx in itertools.count():
+                    yield self[idx]
+            except IndexError:
+                # Results in StopIteration
+                pass
+
+        return time_iter()
 
     def __getitem__(self, item):
         if self.isscalar:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from ...tests.helper import pytest, catch_warnings
 from ...extern import six
+from ...utils import isiterable
 from .. import Time, ScaleValueError, erfa_time, TIME_SCALES, TimeString
 from ...coordinates import EarthLocation
 
@@ -983,3 +984,18 @@ def test_remove_astropy_time():
     with pytest.raises(ValueError) as err:
         Time(t1, format='astropy_time')
     assert 'format must be one of' in str(err)
+
+def test_isiterable():
+    """
+    Ensure that scalar `Time` instances are not reported as iterable by the
+    `isiterable` utility.
+
+    Regression test for https://github.com/astropy/astropy/issues/4048
+    """
+
+    t1 = Time.now()
+    assert not isiterable(t1)
+
+    t2 = Time(['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00'],
+              format='iso', scale='utc')
+    assert isiterable(t2)


### PR DESCRIPTION
The `astropy.utils.misc.isiterable` tool misleadingly handles scalar times:

```python
>>> from astropy.time import Time
>>> from astropy.utils.misc import isiterable
>>> scalar_time = Time.now()    # Produce a scalar time
>>> scalar_time.isscalar
True
>>> isiterable(scalar_time)    # Should not be iterable?
True
>>> scalar_time[0] 
TypeError: scalar 'Time' object is not subscriptable.
```