### PR TITLE
Use .rindex instead of index to fix AltAz __repr__ bug for #4055

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -448,9 +448,6 @@ Bug fixes
 
 - ``astropy.coordinates``
 
-  - Fix string representation of ``SkyCoord`` objects transformed into
-    the ``AltAz`` frame [#4055]
-
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -608,6 +605,9 @@ Bug Fixes
 - ``astropy.convolution``
 
 - ``astropy.coordinates``
+
+  - Fix string representation of ``SkyCoord`` objects transformed into
+    the ``AltAz`` frame [#4055]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -448,6 +448,9 @@ Bug fixes
 
 - ``astropy.coordinates``
 
+  - Fix string representation of ``SkyCoord`` objects transformed into
+    the ``AltAz`` frame
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -449,7 +449,7 @@ Bug fixes
 - ``astropy.coordinates``
 
   - Fix string representation of ``SkyCoord`` objects transformed into
-    the ``AltAz`` frame
+    the ``AltAz`` frame [#4055]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -485,7 +485,7 @@ class SkyCoord(object):
             frameattrs = ': '+crepr[crepr.index('(')+1:crepr.index('):')]
 
         s = '<{clsnm} ({coonm}{frameattrs})'.format(**locals())
-        return s + crepr[crepr.index(':'):]
+        return s + crepr[crepr.rindex(':'):]
 
     def to_string(self, style='decimal', **kwargs):
         """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -26,6 +26,7 @@ from ...coordinates import Latitude, Longitude, EarthLocation
 from ...time import Time
 from ...utils import minversion
 from ...utils.exceptions import AstropyDeprecationWarning
+from ...utils.compat import NUMPY_LT_1_7
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
@@ -480,7 +481,6 @@ def test_seps():
 
     assert sep3d == 1 * u.kpc
 
-
 def test_repr():
     # Repr tests must use exact floating point vals because Python 2.6
     # outputs values like 0.1 as 0.1000000000001.  No workaround found.
@@ -499,6 +499,10 @@ def test_repr():
     sc_default = SkyCoord(0 * u.deg, 1 * u.deg)
     assert repr(sc_default) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
                                 '    (0.0, 1.0)>')
+
+@pytest.mark.skipif('NUMPY_LT_1_7')
+def test_repr_altaz():
+    sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
     loc = EarthLocation.from_geodetic(-122*u.deg, -47*u.deg)
     time = Time('2005-03-21 00:00:00')
     sc4 = sc2.transform_to(AltAz(location=loc, obstime=time))

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -21,8 +21,8 @@ from ...tests.helper import (pytest, remote_data, catch_warnings,
 from ..representation import REPRESENTATION_CLASSES
 from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             SphericalRepresentation, CartesianRepresentation,
-                            UnitSphericalRepresentation)
-from ...coordinates import Latitude, Longitude
+                            UnitSphericalRepresentation, AltAz)
+from ...coordinates import Latitude, Longitude, EarthLocation
 from ...time import Time
 from ...utils import minversion
 from ...utils.exceptions import AstropyDeprecationWarning
@@ -499,7 +499,17 @@ def test_repr():
     sc_default = SkyCoord(0 * u.deg, 1 * u.deg)
     assert repr(sc_default) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
                                 '    (0.0, 1.0)>')
-
+    loc = EarthLocation.from_geodetic(-122*u.deg, -47*u.deg)
+    time = Time('2005-03-21 00:00:00')
+    sc4 = sc2.transform_to(AltAz(location=loc, obstime=time))
+    assert repr(sc4) == ("<SkyCoord (AltAz: obstime=2005-03-21 00:00:00.000, "
+                         "location=(-2309222.664660742, -3695528.7655007695, "
+                         "-4641764.788820372) m, pressure=0.0 hPa, "
+                         "temperature=0.0 deg_C, relative_humidity=0, "
+                         "obswl=1.0 micron): (az, alt, distance) in "
+                         "(deg, deg, m)\n"
+                         "    (297.31930986, 21.87980592, "
+                         "30856775790428692480.0)>")
 
 def test_ops():
     """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -506,14 +506,12 @@ def test_repr_altaz():
     loc = EarthLocation.from_geodetic(-122*u.deg, -47*u.deg)
     time = Time('2005-03-21 00:00:00')
     sc4 = sc2.transform_to(AltAz(location=loc, obstime=time))
-    assert repr(sc4) == ("<SkyCoord (AltAz: obstime=2005-03-21 00:00:00.000, "
+    assert repr(sc4).startswith("<SkyCoord (AltAz: obstime=2005-03-21 00:00:00.000, "
                          "location=(-2309222.664660742, -3695528.7655007695, "
                          "-4641764.788820372) m, pressure=0.0 hPa, "
                          "temperature=0.0 deg_C, relative_humidity=0, "
                          "obswl=1.0 micron): (az, alt, distance) in "
-                         "(deg, deg, m)\n"
-                         "    (297.31930986, 21.87980592, "
-                         "30856775790428692480.0)>")
+                         "(deg, deg, m)\n")
 
 def test_ops():
     """


### PR DESCRIPTION
The `SkyCoord.__repr__` scans the `repr` of the frame to collect frame attributes. A `SkyCoord` transformed to the `AltAz` frame has an `obstime` attribute which stores a time, which gets represented in ISO format and introduces a few colons to the frame attributes string. This breaks the parsing machinery which intends to put the frame attributes into the `SkyCoord.__repr__` string before the coordinate by searching for the first colon. 

The fix is simply to search for the last colon instead of the first, and everything is peachy. This closes astropy/astropy#4055.