### PR TITLE
Fix bug when doing outer join on multi-dim columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -545,6 +545,10 @@ Bug Fixes
 
   - Added missing default values for ``Ellipse2D`` parameters. [#3903]
 
+- ``astropy.table``
+
+  - Fix bug when doing outer join on multi-dimensional columns. [#4060]
+
 - ``astropy.time``
 
   - Fixed iteration of scalar ``Time`` objects so that ``iter()`` correctly

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -636,8 +636,14 @@ def _join(left, right, keys=None, join_type='inner',
         # If the output table is masked then set the output column masking
         # accordingly.  Check for columns that don't support a mask attribute.
         if masked:
+            # array_mask is 1-d corresponding to length of output column.  We need
+            # make it have the correct shape for broadcasting, ie. (length, 1, 1, ..).
+            # Mixin columns might not have ndim attribute so use len(col.shape).
+            mask_shape = [out[out_name].shape[0]] + [1] * (len(out[out_name].shape) - 1)
+            array_mask = array_mask.reshape(mask_shape)
+
             if array.masked:
-                array_mask = array_mask | array[name].mask.take(array_out)
+                array_mask = array_mask | array[name].mask[array_out]
             try:
                 out[out_name].mask[:] = array_mask
             except ValueError:

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -639,8 +639,7 @@ def _join(left, right, keys=None, join_type='inner',
             # array_mask is 1-d corresponding to length of output column.  We need
             # make it have the correct shape for broadcasting, ie. (length, 1, 1, ..).
             # Mixin columns might not have ndim attribute so use len(col.shape).
-            mask_shape = [out[out_name].shape[0]] + [1] * (len(out[out_name].shape) - 1)
-            array_mask = array_mask.reshape(mask_shape)
+            array_mask.shape = (out[out_name].shape[0],) + (1,) * (len(out[out_name].shape) - 1)
 
             if array.masked:
                 array_mask = array_mask | array[name].mask[array_out]

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -371,6 +371,43 @@ class TestJoin():
         np.testing.assert_allclose(t3['c'], t2['c'])
 
 
+    def test_join_multidimensional_masked(self):
+        """
+        Test for outer join with multidimensional columns where masking is required.
+        """
+        a = table.MaskedColumn([1, 2, 3], name='a')
+        a2 = table.Column([1, 3, 4], name='a')
+        b = table.MaskedColumn([[1, 2],
+                                [3, 4],
+                                [5, 6]],
+                               name='b',
+                               mask=[[1, 0],
+                                     [0, 1],
+                                     [0, 0]])
+        c = table.Column([[1, 1],
+                          [2, 2],
+                          [3, 3]],
+                         name='c')
+        t1 = Table([a, b])
+        t2 = Table([a2, c])
+        t12 = table.join(t1, t2, join_type='inner')
+
+        assert np.all(t12['b'].mask == [[ True, False],
+                                        [False, False]])
+        assert np.all(t12['c'].mask == [[False, False],
+                                        [False, False]])
+
+        t12 = table.join(t1, t2, join_type='outer')
+        assert np.all(t12['b'].mask == [[True, False],
+                                        [False, True],
+                                        [False, False],
+                                        [ True, True]])
+        assert np.all(t12['c'].mask == [[False, False],
+                                        [True, True],
+                                        [False, False],
+                                        [False, False]])
+
+
 class TestVStack():
 
     def setup_method(self, method):

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -374,6 +374,7 @@ class TestJoin():
     def test_join_multidimensional_masked(self):
         """
         Test for outer join with multidimensional columns where masking is required.
+        (Issue #4059).
         """
         a = table.MaskedColumn([1, 2, 3], name='a')
         a2 = table.Column([1, 3, 4], name='a')


### PR DESCRIPTION
This fixes a bug reported in #4059.

@embray - would like to get this in 1.0.4 if possible.