### PR TITLE
Update Row repr to be consistent with Table repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,10 @@ New Features
     function for the dtype value.  Removed the default "masked=False"
     from the table representation. [#3868, #3869]
 
+  - Updated row representation to be consistent with the corresponding
+    table representation for that row.  Added HTML representation so a
+    row displays nicely in IPython notebook.
+
   - Added capability to include a structured array or recarray in a table
     as a mixin column.  This allows for an approximation of nested tables.
     [#3925]

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -173,9 +173,35 @@ class Row(object):
     def dtype(self):
         return self._table.dtype
 
+    def _base_repr_(self, html=False):
+        """
+        Display row as a single-line table but with appropriate header line.
+        """
+        index = self.index if (self.index >= 0) else self.index + len(self._table)
+        table = self._table[index:index + 1]
+        descr_vals = [self.__class__.__name__,
+                      'index={0}'.format(self.index)]
+        if table.masked:
+            descr_vals.append('masked=True')
+
+        return table._base_repr_(html, descr_vals, max_width=-1)
+
+    def _repr_html_(self):
+        return self._base_repr_(html=True)
+
     def __repr__(self):
-        return "<{3} {0} of table\n values={1!r}\n dtype={2}>".format(
-            self.index, self.as_void(), self.dtype, self.__class__.__name__)
+        return self._base_repr_(html=False)
+
+    def __unicode__(self):
+        index = self.index if (self.index >= 0) else self.index + len(self._table)
+        return '\n'.join(self.table[index:index + 1].pformat(max_width=-1))
+    if six.PY3:
+        __str__ = __unicode__
+
+    def __bytes__(self):
+        return six.text_type(self).encode('utf-8')
+    if six.PY2:
+        __str__ = __bytes__
 
 
 collections.Sequence.register(Row)

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -23,9 +23,11 @@ class Row(object):
       ...               dtype=('int32', 'int32'))
       >>> row = table[1]
       >>> row
-      <Row 1 of table
-       values=(2, 4)
-       dtype=[('a', '<i4'), ('b', '<i4')]>
+      <Row index=1>
+        a     b
+      int32 int32
+      ----- -----
+          2     4
       >>> row['a']
       2
       >>> row[1]
@@ -184,7 +186,8 @@ class Row(object):
         if table.masked:
             descr_vals.append('masked=True')
 
-        return table._base_repr_(html, descr_vals, max_width=-1)
+        return table._base_repr_(html, descr_vals, max_width=-1,
+                                 tableid='table{0}'.format(id(self._table)))
 
     def _repr_html_(self):
         return self._base_repr_(html=True)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -579,11 +579,12 @@ class Table(object):
 
         table.columns = columns
 
-    def _base_repr_(self, html=False):
-        descr_vals = [self.__class__.__name__]
-        if self.masked:
-            descr_vals.append('masked=True')
-        descr_vals.append('length={0}'.format(len(self)))
+    def _base_repr_(self, html=False, descr_vals=None, max_width=None):
+        if descr_vals is None:
+            descr_vals = [self.__class__.__name__]
+            if self.masked:
+                descr_vals.append('masked=True')
+            descr_vals.append('length={0}'.format(len(self)))
 
         descr = '<' + ' '.join(descr_vals) + '>\n'
 
@@ -592,9 +593,10 @@ class Table(object):
             descr = xml_escape(descr)
 
         tableid = 'table{id}'.format(id=id(self))
-        data_lines, outs = self.formatter._pformat_table(self,
-            tableid=tableid, html=html, max_width=(-1 if html else None),
-            show_name=True, show_unit=None, show_dtype=True)
+        data_lines, outs = self.formatter._pformat_table(self, tableid=tableid, html=html,
+                                                         max_width=max_width,
+                                                         show_name=True, show_unit=None,
+                                                         show_dtype=True)
 
         out = descr + '\n'.join(data_lines)
         if six.PY2 and isinstance(out, six.text_type):
@@ -603,10 +605,10 @@ class Table(object):
         return out
 
     def _repr_html_(self):
-        return self._base_repr_(html=True)
+        return self._base_repr_(html=True, max_width=-1)
 
     def __repr__(self):
-        return self._base_repr_(html=False)
+        return self._base_repr_(html=False, max_width=None)
 
     def __unicode__(self):
         return '\n'.join(self.pformat())

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -579,7 +579,7 @@ class Table(object):
 
         table.columns = columns
 
-    def _base_repr_(self, html=False, descr_vals=None, max_width=None):
+    def _base_repr_(self, html=False, descr_vals=None, max_width=None, tableid=None):
         if descr_vals is None:
             descr_vals = [self.__class__.__name__]
             if self.masked:
@@ -592,7 +592,9 @@ class Table(object):
             from ..utils.xml.writer import xml_escape
             descr = xml_escape(descr)
 
-        tableid = 'table{id}'.format(id=id(self))
+        if tableid is None:
+            tableid = 'table{id}'.format(id=id(self))
+
         data_lines, outs = self.formatter._pformat_table(self, tableid=tableid, html=html,
                                                          max_width=max_width,
                                                          show_name=True, show_unit=None,

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -145,7 +145,27 @@ class TestRow():
         self._setup(table_types)
         table = self.t
         row = table[0]
-        assert format(row, "").startswith("<{0} 0 of table".format(row.__class__.__name__))
+        assert repr(row).splitlines() == ['<{0} {1}{2}>'
+                                          .format(row.__class__.__name__,
+                                                  'index=0',
+                                                  ' masked=True' if table.masked else ''),
+                                          '  a     b  ',
+                                          'int64 int64',
+                                          '----- -----',
+                                          '    1     4']
+        assert str(row).splitlines() == [' a   b ',
+                                         '--- ---',
+                                         '  1   4']
+
+        assert row._repr_html_().splitlines() == ['&lt;{0} {1}{2}&gt;'
+                                                  .format(row.__class__.__name__,
+                                                          'index=0',
+                                                          ' masked=True' if table.masked else ''),
+                                                  '<table id="table{0}">'.format(id(table)),
+                                                  '<thead><tr><th>a</th><th>b</th></tr></thead>',
+                                                  '<thead><tr><th>int64</th><th>int64</th></tr></thead>',
+                                                  '<tr><td>1</td><td>4</td></tr>',
+                                                  '</table>']
 
     def test_data_and_as_void(self, table_types):
         """Test the deprecated data property and as_void() method"""

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -217,9 +217,12 @@ column representation above and how it appears via ``print()`` or ``str()``::
 Likewise a table row and a column from that row can be selected::
 
   >>> t[1]  # Row object corresponding to row 1
-  <Row 1 of table
-   values=(3, 4, 5)
-   dtype=[('a', '<i4'), ('b', '<i8'), ('c', '<i8')]>
+  <Row index=1>
+     a       b     c
+  m sec^-1
+   int32   int32 int32
+  -------- ----- -----
+     3.000     4     5
 
   >>> t[1]['a']  # Column 'a' of row 1
   3

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -171,10 +171,14 @@ Access the data by column or row using familiar `numpy` structured array syntax:
   >>> t['a'][1]    # Row 1 of column 'a'
   4
 
-  >>> t[1]         # Row obj for with row 1 values
-  <Row 1 of table
-   values=(4, 5.0, 'y')
-   dtype=[('a', '<i4'), ('b', '<f8'), ('c', 'S1')]>
+  >>> t[1]         # Row object for table row index=1
+  <Row index=1>
+    a      b     c
+           s
+  int32 float64 str1
+  ----- ------- ----
+      4   5.000    y
+
 
   >>> t[1]['a']    # Column 'a' of row 1
   4


### PR DESCRIPTION
This updates the `Row` representation to be consistent with the corresponding `Table` representation for that row.  It also adds HTML representation so a row displays nicely in IPython notebook.

The one substantive difference between the Row and Table repr is that for Row the `max_width` is set to `-1`, corresponding to no limit on the width.  I think that when examining a Row is it more natural to get all the values even if it ends up wrapping.  Also a row object has no `pformat` or `pprint` methods so there would be no way to get the full set of values for a wide table.  Of course we could add those methods, but I don't think there is a huge need in this case.
