### PR TITLE
Consistent `iters` default for sigma_clip and sigma_clipped_stats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,7 @@ New Features
 
   - Added ``cenfunc``, ``stdfunc``, and ``axis`` keywords to
     ``sigma_clipped_stats``. [#3792]
+
   - Added the ``histogram`` routine, which is similar to ``np.histogram`` but
     includes several additional options for automatic determination of optimal
     histogram bins. Associated helper routines include ``bayesian_blocks``,
@@ -318,6 +319,9 @@ API changes
 
   - Renamed the ``sigma_clipped_stats`` ``mask_val`` keyword to
     ``mask_value``. [#3595]
+
+  - Changed the default ``iters`` keyword value to 5 in both the
+    ``sigma_clip`` and ``sigma_clipped_stats`` functions. [#4067]
 
 - ``astropy.table``
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -32,7 +32,10 @@ def sigma_clip(data, **kwargs):
 
 def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
                 cenfunc=np.ma.median, stdfunc=np.std, axis=None, copy=True):
-    """Perform sigma-clipping on the provided data.
+    """
+    sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5, cenfunc=np.ma.median, stdfunc=np.std, axis=None, copy=True)
+
+    Perform sigma-clipping on the provided data.
 
     The data will be iterated over, each time rejecting points that are
     discrepant by more than a specified number of standard deviations

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -30,7 +30,7 @@ def sigma_clip(data, **kwargs):
     return _sigma_clip(data, **kwargs)
 
 
-def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
+def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
                 cenfunc=np.ma.median, stdfunc=np.std, axis=None, copy=True):
     """Perform sigma-clipping on the provided data.
 
@@ -132,7 +132,7 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=1,
         >>> from astropy.stats import sigma_clip
         >>> from numpy.random import randn
         >>> randvar = randn(10000)
-        >>> filtered_data = sigma_clip(randvar, sigma=2, iters=1)
+        >>> filtered_data = sigma_clip(randvar, sigma=2, iters=5)
 
     This example sigma clips on a similar distribution, but uses 3 sigma
     relative to the sample *mean*, clips until convergence, and does not
@@ -205,7 +205,7 @@ sigma_clip.__doc__ = _sigma_clip.__doc__
 
 
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
-                        sigma_lower=None, sigma_upper=None, iters=None,
+                        sigma_lower=None, sigma_upper=None, iters=5,
                         cenfunc=np.ma.median, stdfunc=np.std, axis=None):
     """
     Calculate sigma-clipped statistics from data.


### PR DESCRIPTION
This PR makes the `iters` default value consistent in `sigma_clip` and `sigma_clipped_stats`.  I chose `iters=5` as the default so that a few iterations are performed, but I'm open to other suggestions.  `sigma_clip` had `iters=1`, but I'd prefer at least a few more iterations.  `sigma_clipped_stats` had `iters=None` (which iterates until convergence), but that could run a very long time for some cases.

This PR also overrides the `sigma_clip` function signature to replace `**kwargs` in the `Sphinx` documentation.

This is a followup to https://github.com/astropy/astropy/pull/4050.