### PR TITLE
Allow units in Cutout2D, and shortcut for square cutouts

### DIFF
--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -10,6 +10,7 @@ from ..utils import (extract_array, add_array, subpixel_indices,
                      Cutout2D)
 from ...wcs import WCS
 from ...coordinates import SkyCoord
+from ... import units as u
 
 try:
     import skimage
@@ -336,23 +337,42 @@ class TestCutout2D(object):
         self.wcs = wcs
 
     def test_cutout(self):
-        position = (2.1, 1.9)
-        shape = (3, 3)
-        c = Cutout2D(self.data, position, shape)
-        assert c.data.shape == shape
-        assert c.data[1, 1] == 10
-        assert c.origin_original == (1, 1)
-        assert c.origin_cutout == (0, 0)
-        assert c.input_position_original == position
-        assert_allclose(c.input_position_cutout, (1.1, 0.9))
-        assert c.position_original == (2., 2.)
-        assert c.position_cutout == (1., 1.)
-        assert c.center_original == (2., 2.)
-        assert c.center_cutout == (1., 1.)
-        assert c.bbox_original == ((1, 3), (1, 3))
-        assert c.bbox_cutout == ((0, 2), (0, 2))
-        assert c.slices_original == (slice(1, 4), slice(1, 4))
-        assert c.slices_cutout == (slice(0, 3), slice(0, 3))
+        for shape in [(3, 3), (3*u.pixel, 3*u.pix)]:
+            position = (2.1, 1.9)
+            c = Cutout2D(self.data, position, shape)
+            assert c.data.shape == (3, 3)
+            assert c.data[1, 1] == 10
+            assert c.origin_original == (1, 1)
+            assert c.origin_cutout == (0, 0)
+            assert c.input_position_original == position
+            assert_allclose(c.input_position_cutout, (1.1, 0.9))
+            assert c.position_original == (2., 2.)
+            assert c.position_cutout == (1., 1.)
+            assert c.center_original == (2., 2.)
+            assert c.center_cutout == (1., 1.)
+            assert c.bbox_original == ((1, 3), (1, 3))
+            assert c.bbox_cutout == ((0, 2), (0, 2))
+            assert c.slices_original == (slice(1, 4), slice(1, 4))
+            assert c.slices_cutout == (slice(0, 3), slice(0, 3))
+
+    def test_cutout_sidelength(self):
+        for side_length in [3, 3*u.pixel]:
+            position = (2.1, 1.9)
+            c = Cutout2D(self.data, position, side_length=side_length)
+            assert c.data.shape == (3, 3)
+            assert c.data[1, 1] == 10
+            assert c.origin_original == (1, 1)
+            assert c.origin_cutout == (0, 0)
+            assert c.input_position_original == position
+            assert_allclose(c.input_position_cutout, (1.1, 0.9))
+            assert c.position_original == (2., 2.)
+            assert c.position_cutout == (1., 1.)
+            assert c.center_original == (2., 2.)
+            assert c.center_cutout == (1., 1.)
+            assert c.bbox_original == ((1, 3), (1, 3))
+            assert c.bbox_cutout == ((0, 2), (0, 2))
+            assert c.slices_original == (slice(1, 4), slice(1, 4))
+            assert c.slices_cutout == (slice(0, 3), slice(0, 3))
 
     def test_cutout_trim_overlap(self):
         shape = (3, 3)

--- a/docs/nddata/utils.rst
+++ b/docs/nddata/utils.rst
@@ -52,8 +52,9 @@ We create a cutout array centered at position ``(x, y) = (49.7,
 100.1)`` with a shape of ``(ny, nx) = (40, 50)``::
 
     >>> from astropy.nddata import Cutout2D
+    >>> from astropy import units as u
     >>> position = (49.7, 100.1)
-    >>> shape = (40, 50)
+    >>> shape = (40*u.pixel, 50*u.pixel)
     >>> cutout = Cutout2D(data, position, shape)
 
 The cutout array is stored in the ``data`` attribute of the
@@ -132,6 +133,29 @@ including::
     >>> # tuple of slice objects for the cutout array
     >>> print(cutout.slices_cutout)
     (slice(0, 40, None), slice(0, 50, None))
+
+Cutouts don't have to be specified by their shape if they are square.
+Let's create another cutout array centered at position ``(x, y) = (49.7,
+100.1)``, but this time with a square cutout that is 55 pixels to a side::
+
+    >>> side_length = 55*u.pixel
+    >>> cutout = Cutout2D(data, position, side_length=side_length)
+
+.. doctest-skip::
+
+    >>> plt.imshow(cutout.data, origin='lower')
+
+.. plot::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from astropy.modeling.models import Gaussian2D
+    from astropy.nddata import Cutout2D
+    y, x = np.mgrid[0:500, 0:500]
+    data = Gaussian2D(1, 50, 100, 10, 5, theta=0.5)(x, y)
+    position = (49.7, 100.1)
+    cutout = Cutout2D(data, position, side_length=55)
+    plt.imshow(cutout.data, origin='lower')
 
 There are also two `~astropy.nddata.utils.Cutout2D` methods to convert
 pixel positions between the original and cutout arrays::

--- a/docs/nddata/utils.rst
+++ b/docs/nddata/utils.rst
@@ -139,11 +139,11 @@ Let's create another cutout array centered at position ``(x, y) = (49.7,
 100.1)``, but this time with a square cutout that is 55 pixels to a side::
 
     >>> side_length = 55*u.pixel
-    >>> cutout = Cutout2D(data, position, side_length=side_length)
+    >>> cutout2 = Cutout2D(data, position, side_length=side_length)
 
 .. doctest-skip::
 
-    >>> plt.imshow(cutout.data, origin='lower')
+    >>> plt.imshow(cutout2.data, origin='lower')
 
 .. plot::
 


### PR DESCRIPTION
This PR is driven by an annoyance with the unreadability of this:

    c = Cutout2D(data, sc, (3,3))

With this PR, one can do:

	c = Cutout2D(data, sc, side_length=3*u.pixel)

This also allows later work on accepting other units (like easily making a 3" cutout around a target).