### PR TITLE
Add WCSaxes dependency for doc builds

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -41,12 +41,14 @@ then
 fi
 
 # DOCUMENTATION DEPENDENCIES
-# build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-# this matplotlib will *not* work with py 3.x, but our sphinx build is
+# build_sphinx needs sphinx, matplotlib, and wcsaxes (for plot_directive).
+# Note that this matplotlib will *not* work with py 3.x, but our sphinx build is
 # currently 2.7, so that's fine
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib
+  $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib  
+  pip install wcsaxes
 fi
 
 # COVERAGE DEPENDENCIES

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -563,3 +563,48 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0, crop=True,
         return result
     else:
         return rifft.real
+
+def convolve_model(model, kernel):
+    """
+    Convolve a model with another model. Returns a 
+    `astropy.modeling.CompoundModel` object.
+
+    Parameters
+    ----------
+    model : `astropy.modeling.Model`
+          Source model to be convolved.
+    kernel : `astropy.modeling.Model`
+          Kernal model. Assumed to be normalized. 
+
+    See Also
+    --------
+    convolve_fft, convolve
+
+    Returns
+    -------
+    model : `astropy.model.CompoundModel`
+        Returns a CompoundModel instance that convolves``model`` and ``kernel`` 
+        when evaluated.
+
+    Examples
+    --------
+
+    """
+
+    # Check model and kernel are Model instances
+    if not (isinstance(model, Model) & isinstance(kernel, Model)):
+        raise TypeError("Input model and kernal should be "
+                        "`astropy.modeling.Model` instances.")
+
+    # Check that the number of dimensions is compatible
+    if model.n_inputs != kernel.n_inputs:
+        raise ValueError("Model and kernel must have same number of "
+                         "dimensions")
+
+    convolve_func = partial(fftconvolve, mode='same')
+
+    BINARY_OPERATORS['convolve'] = _make_arithmetic_operator(convolve_func)
+
+    conv = _CompoundModelMeta._from_operator('convolve', model, kernel)
+
+    return conv

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -10,7 +10,10 @@ import numpy as np
 from .core import Kernel, Kernel1D, Kernel2D, MAX_NORMALIZATION
 from ..utils.exceptions import AstropyUserWarning
 from ..utils.console import human_file_size
-
+from ..modeling.core import Model, _make_arithmetic_operator, \
+                       BINARY_OPERATORS, _CompoundModelMeta
+from scipy.signal import fftconvolve
+from functools import partial
 
 # Disabling all doctests in this module until a better way of handling warnings
 # in doctests can be determined

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -337,6 +337,8 @@ packages:
       and most affiliated packages include this as a submodule in the source
       repository, so it does not need to be installed separately.)
 
+    - `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_
+
 .. note::
 
     Sphinx also requires a reasonably modern LaTeX installation to render

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -235,6 +235,29 @@ ability to use the :class:`~astropy.wcs.WCS` to define projections in
 Matplotlib. More information on installing and using WCSAxes can be found `here
 <http://wcsaxes.readthedocs.org>`__.
 
+.. plot::
+    :include-source:
+
+    import numpy as np
+    from matplotlib import rcParams, pyplot as plt
+    from astropy.io import fits
+    from astropy.wcs import WCS
+    from astropy.visualization import astropy_mpl_style
+    rcParams.update(astropy_mpl_style)
+    from astropy.utils.data import download_file
+
+    fits_file = 'http://data.astropy.org/tutorials/FITS-images/HorseHead.fits'
+    image_file = download_file(fits_file, cache=True )
+    hdu = fits.open(image_file)[0]
+    wcs = WCS(hdu.header)
+
+    fig = plt.figure()
+    fig.add_subplot(111, projection=wcs)
+    plt.imshow(hdu.data, origin='lower', cmap='cubehelix')
+    plt.xlabel('RA')
+    plt.ylabel('Dec')
+    plt.show()
+
 Other information
 =================
 


### PR DESCRIPTION
An example was added to `docs/wcs/index.rst`, shown here:
![wcsaxes_example](https://cloud.githubusercontent.com/assets/4968596/9260552/3ac93694-41bd-11e5-9895-e832f6b9ff90.png)
