### PR TITLE
Add WCSAxes dependency for doc builds

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -41,12 +41,13 @@ then
 fi
 
 # DOCUMENTATION DEPENDENCIES
-# build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-# this matplotlib will *not* work with py 3.x, but our sphinx build is
+# build_sphinx needs sphinx as well as matplotlib and wcsaxes (for plot_directive). 
+# Note that this matplotlib will *not* work with py 3.x, but our sphinx build is
 # currently 2.7, so that's fine
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib
+  pip install wcsaxes
 fi
 
 # COVERAGE DEPENDENCIES

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -461,6 +461,8 @@ Other Changes and Additions
 
 - The version of ``PLY`` that ships with astropy has been updated to 3.6.
 
+- WCSAxes is now required for doc builds. [#4074]
+
 
 1.0.5 (unreleased)
 ------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -337,6 +337,8 @@ packages:
       and most affiliated packages include this as a submodule in the source
       repository, so it does not need to be installed separately.)
 
+    - `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_
+
 .. note::
 
     Sphinx also requires a reasonably modern LaTeX installation to render

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -235,6 +235,26 @@ ability to use the :class:`~astropy.wcs.WCS` to define projections in
 Matplotlib. More information on installing and using WCSAxes can be found `here
 <http://wcsaxes.readthedocs.org>`__.
 
+.. plot::
+    :include-source:
+
+    from matplotlib import rcParams, pyplot as plt
+    from astropy.io import fits
+    from astropy.wcs import WCS
+    from astropy.utils.data import download_file
+
+    fits_file = 'http://data.astropy.org/tutorials/FITS-images/HorseHead.fits'
+    image_file = download_file(fits_file, cache=True )
+    hdu = fits.open(image_file)[0]
+    wcs = WCS(hdu.header)
+
+    fig = plt.figure()
+    fig.add_subplot(111, projection=wcs)
+    plt.imshow(hdu.data, origin='lower', cmap='cubehelix')
+    plt.xlabel('RA')
+    plt.ylabel('Dec')
+    plt.show()
+
 Other information
 =================
 


### PR DESCRIPTION
An example was added to `docs/wcs/index.rst`, shown here:
![wcsaxes_example](https://cloud.githubusercontent.com/assets/4968596/9260552/3ac93694-41bd-11e5-9895-e832f6b9ff90.png)
