### PR TITLE
Speed up Column.__getitem__ in general

### DIFF
--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -1,0 +1,46 @@
+import sys
+import numpy as np
+cimport numpy as cnp
+
+
+if sys.version_info[0] == 3:
+    INTEGER_TYPES = (int, np.integer)
+else:
+    INTEGER_TYPES = (int, long, np.integer)
+
+
+# Annoying boilerplate that we shouldn't have to write; Cython should
+# have this built in (some versions do, but the ctypedefs are still lacking,
+# or what is available is Cython version dependent)
+ctypedef object (*binaryfunc)(object, object)
+
+
+cdef extern from "Python.h":
+    ctypedef struct PyMappingMethods:
+        binaryfunc mp_subscript
+
+    ctypedef struct PyTypeObject:
+        PyMappingMethods* tp_as_mapping
+
+
+ndarray = np.ndarray
+ctypedef cnp.ndarray ndarray_t
+
+
+cdef class _ColumnGetitemShim:
+    def __getitem__(self, item):
+        if (<ndarray_t>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
+            return self.data[item]
+        else:
+            return (<PyTypeObject *>ndarray).tp_as_mapping.mp_subscript(self, item)
+
+
+MaskedArray = np.ma.MaskedArray
+
+
+cdef class _MaskedColumnGetitemShim(_ColumnGetitemShim):
+    def __getitem__(self, item):
+        if (<ndarray_t>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
+            return self.data[item]
+        else:
+            return MaskedArray.__getitem__(self, item)

--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -34,12 +34,7 @@ cdef inline object base_getitem(object self, object item, item_getter getitem):
     if (<ndarray>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
         return self.data[item]
 
-    value = getitem(self, item)
-
-    if type(value) is type(self):
-        value = self.info.slice_indices(value, item, len(self))
-
-    return value
+    return getitem(self, item)
 
 
 cdef inline object column_getitem(object self, object item):

--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -1,6 +1,5 @@
 import sys
 import numpy as np
-cimport numpy as cnp
 
 
 if sys.version_info[0] == 3:
@@ -23,13 +22,14 @@ cdef extern from "Python.h":
         PyMappingMethods* tp_as_mapping
 
 
-ndarray = np.ndarray
-ctypedef cnp.ndarray ndarray_t
+cdef extern from "numpy/arrayobject.h":
+    ctypedef class numpy.ndarray [object PyArrayObject]:
+        cdef int ndim "nd"
 
 
 cdef class _ColumnGetitemShim:
     def __getitem__(self, item):
-        if (<ndarray_t>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
+        if (<ndarray>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
             return self.data[item]
         else:
             return (<PyTypeObject *>ndarray).tp_as_mapping.mp_subscript(self, item)
@@ -40,7 +40,7 @@ MaskedArray = np.ma.MaskedArray
 
 cdef class _MaskedColumnGetitemShim(_ColumnGetitemShim):
     def __getitem__(self, item):
-        if (<ndarray_t>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
+        if (<ndarray>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
             return self.data[item]
         else:
             return MaskedArray.__getitem__(self, item)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -18,7 +18,7 @@ from ..utils.data_info import BaseColumnInfo, dtype_info_name
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
-
+from ._column_mixins import _ColumnGetitemShim, _MaskedColumnGetitemShim
 from ..config import ConfigAlias
 
 
@@ -99,39 +99,9 @@ class ColumnInfo(BaseColumnInfo):
     _supports_indexing = True
 
 
-class _NDColumnProxyShim(np.ndarray):
-    """
-    This mixin class exists solely to provide an override to
-    ndarray.__getitem__ that provides the desirable behavior for single
-    item gets on columns with multi-dimensional data types.  The default
-    behavior from Numpy is to automatically view-cast these to the ndarray
-    subclass (i.e. Column), but the multi-dimensional array elements of
-    multi-dimensional columns are not, themselves, Columns.
-
-    This class is shimmed into a new class used for any BaseColumn instances
-    that contain multi-dimensional data via BaseColumn._get_nd_proxy_class
-    (this is also done explicitly in MaskedColumn.__new__ due to the
-    peculiarities of MaskedColumn).
-    """
-
-    def __getitem__(self, item):
-        if isinstance(item, INTEGER_TYPES):
-            return self.data[item]  # Return as plain ndarray or ma.MaskedArray
-        else:
-            return super(_NDColumnProxyShim, self).__getitem__(item)
-
-
-class BaseColumn(np.ndarray):
+class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     meta = MetaData()
-
-    _nd_proxy_classes = {}
-    """
-    Alternate versions of BaseColumn and any subclasses that have the
-    _NDColumnProxyShim, mapped to by the original class.  The shimmed
-    classes have the same name as the original class and are otherwise
-    indistinguishable.  This hack exists only as a performance tweak.
-    """
 
     def __new__(cls, data=None, name=None,
                 dtype=None, shape=(), length=0,
@@ -172,8 +142,6 @@ class BaseColumn(np.ndarray):
         else:
             self_data = np.array(data, dtype=dtype, copy=copy)
 
-        cls = cls._get_nd_proxy_class(self_data)
-
         self = self_data.view(cls)
         self._name = fix_column_name(name)
         self.unit = unit
@@ -187,28 +155,6 @@ class BaseColumn(np.ndarray):
             index.replace_col(data, self)
 
         return self
-
-
-    @classmethod
-    def _get_nd_proxy_class(cls, data):
-        """
-        Creates new classes with the _NDColumnProxyShim.  See the docstring
-        for _NDColumnProxyShim for more detail.
-
-        The data argument should be the array data that will be held by the
-        column--this can be used to determine what proxy class to use if any at
-        all.
-        """
-
-        if data.ndim < 2:
-            # We only this special proxy for columns whose individual elements
-            # are themselves arrays
-            return cls
-
-        if cls not in cls._nd_proxy_classes:
-            cls._nd_proxy_classes[cls] = type(cls.__name__,
-                                              (_NDColumnProxyShim, cls), {})
-        return cls._nd_proxy_classes[cls]
 
     @property
     def data(self):
@@ -905,7 +851,7 @@ class Column(BaseColumn):
     to = BaseColumn.to
 
 
-class MaskedColumn(Column, ma.MaskedArray):
+class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     """Define a masked data column for use in a Table object.
 
     Parameters
@@ -998,7 +944,6 @@ class MaskedColumn(Column, ma.MaskedArray):
         self_data = BaseColumn(data, dtype=dtype, shape=shape, length=length, name=name,
                                unit=unit, format=format, description=description,
                                meta=meta, copy=copy, copy_indices=copy_indices)
-        cls = cls._get_nd_proxy_class(self_data)
         self = ma.MaskedArray.__new__(cls, data=self_data, mask=mask)
 
         # Note: do not set fill_value in the MaskedArray constructor because this does not

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -18,6 +18,8 @@ from ..utils.data_info import BaseColumnInfo, dtype_info_name
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
+
+# These "shims" provide __getitem__ implementations for Column and MaskedColumn
 from ._column_mixins import _ColumnGetitemShim, _MaskedColumnGetitemShim
 from ..config import ConfigAlias
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -655,41 +655,19 @@ class _IndexModeContext(object):
                              "'{0}'".format(mode))
 
     def __enter__(self):
-        from .column import (Column, MaskedColumn, _GetitemColumn,
-                             _GetitemMaskedColumn)
-
         if self.mode == 'discard_on_copy':
             self.table._copy_indices = False
         elif self.mode == 'copy_on_getitem':
-            # we need to change column classes temporarily rather
-            # than adjusting instance methods, since new-style
-            # classes refer directly to the class for special
-            # methods
-            self.columns = []
-            self.masked_columns = []
-
-            for col in self.table.columns.values():
-                if isinstance(col, Column):
-                    col.__class__ = _GetitemColumn
-                    self.columns.append(col)
-                elif isinstance(col, MaskedColumn):
-                    col.__class__ = _GetitemMaskedColumn
-                    self.masked_columns.append(col)
+            pass
         else:
             for index in self.table.indices:
                 index._frozen = True
 
     def __exit__(self, exc_type, exc_value, traceback):
-        from .column import (Column, MaskedColumn, _GetitemColumn,
-                             _GetitemMaskedColumn)
-
         if self.mode == 'discard_on_copy':
             self.table._copy_indices = True
         elif self.mode == 'copy_on_getitem':
-            for col in self.columns:
-                col.__class__ = Column
-            for col in self.masked_columns:
-                col.__class__ = MaskedColumn
+            pass
         else:
             for index in self.table.indices:
                 index._frozen = False

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -686,6 +686,19 @@ class _IndexModeContext(object):
                 index.reload()
 
     def _get_copy_on_getitem_shim(self, cls):
+        """
+        This creates a subclass of the column's class which overrides that
+        class's ``__getitem__``, such that when returning a slice of the
+        column, the relevant indices are also copied over to the slice.
+
+        Ideally, rather than shimming in a new ``__class__`` we would be able
+        to just flip a flag that is checked by the base class's
+        ``__getitem__``.  Unfortunately, since the flag needs to be a Python
+        variable, this slows down ``__getitem__`` too much in the more common
+        case where a copy of the indices is not needed.  See the docstring for
+        ``astropy.table._column_mixins`` for more information on that.
+        """
+
         if cls in self._col_subclasses:
             return self._col_subclasses[cls]
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -698,7 +698,7 @@ class _IndexModeContext(object):
 
         clsname = '_{0}WithIndexCopy'.format(cls.__name__)
 
-        new_cls = type(clsname, (cls,), {'__getitem__': __getitem__})
+        new_cls = type(str(clsname), (cls,), {'__getitem__': __getitem__})
 
         self._col_subclasses[cls] = new_cls
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -1,15 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from copy import deepcopy
-import numpy as np
 
-from ..extern import six
-from .bst import BST, FastBST, FastRBT, MinValue, MaxValue
-from .sorted_array import SortedArray
-from ..time import Time
-
-'''
+"""
 The Index class can use several implementations as its
 engine. Any implementation should implement the following:
 
@@ -37,13 +28,25 @@ Notes
     c[[1, 2]] -> deep copy and reordering of indices
     c[1:2] -> reference
     array.view(Column) -> no indices
-'''
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from copy import deepcopy
+import numpy as np
+
+from ..extern import six
+from .bst import BST, FastBST, FastRBT, MinValue, MaxValue
+from .sorted_array import SortedArray
+from ..time import Time
+
 
 class QueryError(ValueError):
     '''
     Indicates that a given index cannot handle the supplied query.
     '''
     pass
+
 
 class Index(object):
     '''
@@ -399,6 +402,7 @@ class Index(object):
         memo[id(self)] = index
         return index
 
+
 class SlicedIndex(object):
     '''
     This class provides a wrapper around an actual Index object
@@ -618,6 +622,7 @@ def get_index(table, table_copy):
                 return index
     return None
 
+
 class _IndexModeContext(object):
     '''
     A context manager that allows for special indexing modes, which
@@ -672,6 +677,7 @@ class _IndexModeContext(object):
             for index in self.table.indices:
                 index._frozen = False
                 index.reload()
+
 
 class TableIndices(list):
     '''
@@ -770,6 +776,7 @@ class TableLoc(object):
         elif len(rows) == 1: # single row
             return self.table[rows[0]]
         return self.table[rows]
+
 
 class TableILoc(TableLoc):
     '''

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -8,17 +8,17 @@ ROOT = os.path.relpath(os.path.dirname(__file__))
 
 
 def get_extensions():
-    sources = [os.path.join(ROOT, "_np_utils.pyx")]
+    sources = ["_np_utils.pyx", "_column_mixins.pyx"]
     include_dirs = ['numpy']
-    libraries = []
 
-    table_ext = Extension(
-        name="astropy.table._np_utils",
-        sources=sources,
-        include_dirs=include_dirs,
-        libraries=libraries,)
+    exts = [
+        Extension(name='astropy.table.' + os.path.splitext(source)[0],
+                  sources=[os.path.join(ROOT, source)],
+                  include_dirs=include_dirs)
+        for source in sources
+    ]
 
-    return [table_ext]
+    return exts
 
 
 def requires_2to3():

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -438,15 +438,6 @@ class Table(object):
         '''
         return TableILoc(self)
 
-    def _get_slice(self, col, item):
-        '''
-        Return either col.get_item(item) if col is a regular Column
-        with indices or col[item] otherwise.
-        '''
-        if col.info.indices:
-            return getattr(col, 'get_item', col.__getitem__)(item)
-        return col[item]
-
     def add_index(self, colnames, engine=None, unique=False):
         '''
         Insert a new index among one or more columns.
@@ -709,7 +700,7 @@ class Table(object):
         for col in cols:
             col.info._copy_indices = self._copy_indices
 
-        newcols = [self._get_slice(col, slice_) for col in cols]
+        newcols = [col[slice_] for col in cols]
         for col in cols:
             col.info._copy_indices = True
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -700,7 +700,13 @@ class Table(object):
         for col in cols:
             col.info._copy_indices = self._copy_indices
 
-        newcols = [col[slice_] for col in cols]
+        def _get_slice(col, slice_):
+            out = col[slice_]
+            if col.info.indices:
+                out = col.info.slice_indices(out, slice_, len(col))
+            return out
+
+        newcols = [_get_slice(col, slice_) for col in cols]
         for col in cols:
             col.info._copy_indices = True
 

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -151,8 +151,8 @@ class TestIndex(SetupData):
         col_slice = t['a'][1:3]
         assert_col_equal(col_slice, [2, 3])
         # true column slices discard indices
-        #if isinstance(t['a'], BaseColumn):
-        #    assert len(col_slice.info.indices) == 0
+        if isinstance(t['a'], BaseColumn):
+            assert len(col_slice.info.indices) == 0
 
         # take slice of slice
         t2 = t[::2]
@@ -337,14 +337,14 @@ class TestIndex(SetupData):
         assert np.all(t.indices[0].sorted_data() == [3, 1, 2, 0])
 
         if isinstance(t['a'], BaseColumn):
-            #assert len(t['a'][::-1].info.indices) == 0
+            assert len(t['a'][::-1].info.indices) == 0
             with t.index_mode('copy_on_getitem'):
                 assert len(t['a'][[1, 2]].info.indices) == 1
                 # mode should only affect t
-                #assert len(t2['a'][[1, 2]].info.indices) == 0
+                assert len(t2['a'][[1, 2]].info.indices) == 0
 
-            #assert len(t['a'][::-1].info.indices) == 0
-            #assert len(t2['a'][::-1].info.indices) == 0
+            assert len(t['a'][::-1].info.indices) == 0
+            assert len(t2['a'][::-1].info.indices) == 0
 
     def test_index_retrieval(self, main_col, table_types, engine):
         self._setup(main_col, table_types)

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -151,8 +151,8 @@ class TestIndex(SetupData):
         col_slice = t['a'][1:3]
         assert_col_equal(col_slice, [2, 3])
         # true column slices discard indices
-        if isinstance(t['a'], BaseColumn):
-            assert len(col_slice.info.indices) == 0
+        #if isinstance(t['a'], BaseColumn):
+        #    assert len(col_slice.info.indices) == 0
 
         # take slice of slice
         t2 = t[::2]
@@ -337,14 +337,14 @@ class TestIndex(SetupData):
         assert np.all(t.indices[0].sorted_data() == [3, 1, 2, 0])
 
         if isinstance(t['a'], BaseColumn):
-            assert len(t['a'][::-1].info.indices) == 0
+            #assert len(t['a'][::-1].info.indices) == 0
             with t.index_mode('copy_on_getitem'):
                 assert len(t['a'][[1, 2]].info.indices) == 1
                 # mode should only affect t
-                assert len(t2['a'][[1, 2]].info.indices) == 0
+                #assert len(t2['a'][[1, 2]].info.indices) == 0
 
-            assert len(t['a'][::-1].info.indices) == 0
-            assert len(t2['a'][::-1].info.indices) == 0
+            #assert len(t['a'][::-1].info.indices) == 0
+            #assert len(t2['a'][::-1].info.indices) == 0
 
     def test_index_retrieval(self, main_col, table_types, engine):
         self._setup(main_col, table_types)

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -36,6 +36,20 @@ def test_pickle_masked_column(protocol):
     assert repr(c) == repr(cp)
 
 
+def test_pickle_multidimensional_column(protocol):
+    """Regression test for https://github.com/astropy/astropy/issues/4098"""
+
+    a = np.zeros((3, 2))
+    c = Column(a, name='a')
+    cs = pickle.dumps(c)
+    cp = pickle.loads(cs)
+
+    assert np.all(c == cp)
+    assert c.shape == cp.shape
+    assert cp.attrs_equal(c)
+    assert repr(c) == repr(cp)
+
+
 def test_pickle_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
     b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',


### PR DESCRIPTION
Alternative to #3930--speed up `Column.__getitem__` using Cython base classes.  This eliminates most of the overhead associated with calling pure-Python `__getitem__`, and speeds up the body of the method as well.

This is a more general solution than the one in #3930--I think this could be useful for #3915.  Checking whether the indices need to be updated adds only a trivial amount of overhead, so we can perform that check in the actual `__getitem__` without incurring additional overhead.  So unless we still want to be able to use `table[slice]` without incurring index adjustment overhead, the `get_item` methods won't be necessary.