### PR TITLE
format_str for models without formal parameters.

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1352,13 +1352,10 @@ class Model(object):
         else:
             columns = [getattr(self, name).value
                        for name in self.param_names]
-        # check for models without parameters
-        if not columns:
-            return '\n'.join(parts)
 
-        param_table = Table(columns, names=self.param_names)
-
-        parts.append(indent(str(param_table), width=4))
+        if columns:
+            param_table = Table(columns, names=self.param_names)
+            parts.append(indent(str(param_table), width=4))
 
         return '\n'.join(parts)
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1352,6 +1352,9 @@ class Model(object):
         else:
             columns = [getattr(self, name).value
                        for name in self.param_names]
+        # check for models without parameters
+        if not columns:
+            return '\n'.join(parts)
 
         param_table = Table(columns, names=self.param_names)
 


### PR DESCRIPTION
A minor change to `_format_str` to handle models without parameters.
