### PR TITLE
Update imports for new release of IPython/Jupyter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -553,6 +553,9 @@ API Changes
 
 - ``astropy.utils``
 
+  - ``console`` was updated to support IPython 4.x and Jupyter 1.x.
+    [#4078]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -42,6 +42,9 @@ else:
             except ImportError:
                 OutStream = None
 
+    from IPython import version_info
+    ipython_major_version = version_info[0]
+
     if OutStream is not None:
         from IPython.utils import io as ipyio
         # On Windows in particular this is necessary, as the io.stdout stream
@@ -493,10 +496,10 @@ class ProgressBar(six.Iterator):
         if ipython_widget:
             # Import only if ipython_widget, i.e., widget in IPython
             # notebook
-            try:
-                from ipywidgets import widgets
-            except ImportError:
+            if ipython_major_version < 4:
                 from IPython.html import widgets
+            else:
+                from ipywidgets import widgets
             from IPython.display import display
 
         if file is None:
@@ -637,16 +640,13 @@ class ProgressBar(six.Iterator):
         # if none exists.
         if not hasattr(self, '_widget'):
             # Import only if an IPython widget, i.e., widget in iPython NB
-            try:
-                from ipywidgets import widgets
-            except ImportError:
+            if ipython_major_version < 4:
                 from IPython.html import widgets
-            from IPython.display import display
-
-            try:
-                self._widget = widgets.FloatProgress()
-            except AttributeError:
                 self._widget = widgets.FloatProgressWidget()
+            else:
+                from ipywidgets import widgets
+                self._widget = widgets.FloatProgress()
+            from IPython.display import display
 
             display(self._widget)
             self._widget.value = 0

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -493,7 +493,10 @@ class ProgressBar(six.Iterator):
         if ipython_widget:
             # Import only if ipython_widget, i.e., widget in IPython
             # notebook
-            from IPython.html import widgets
+            try:
+                from ipywidgets import widgets
+            except ImportError:
+                from IPython.html import widgets
             from IPython.display import display
 
         if file is None:
@@ -634,10 +637,13 @@ class ProgressBar(six.Iterator):
         # if none exists.
         if not hasattr(self, '_widget'):
             # Import only if an IPython widget, i.e., widget in iPython NB
-            from IPython.html import widgets
+            try:
+                from ipywidgets import widgets
+            except ImportError:
+                from IPython.html import widgets
             from IPython.display import display
 
-            self._widget = widgets.FloatProgressWidget()
+            self._widget = widgets.FloatProgress()
             display(self._widget)
             self._widget.value = 0
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -643,7 +643,11 @@ class ProgressBar(six.Iterator):
                 from IPython.html import widgets
             from IPython.display import display
 
-            self._widget = widgets.FloatProgress()
+            try:
+                self._widget = widgets.FloatProgress()
+            except AttributeError:
+                self._widget = widgets.FloatProgressWidget()
+
             display(self._widget)
             self._widget.value = 0
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -32,12 +32,15 @@ except NameError:
     IPythonIOStream = None
 else:
     try:
-        from IPython.zmq.iostream import OutStream
+        from ipykernel.iostream import OutStream
     except ImportError:
         try:
-            from IPython.kernel.zmq.iostream import OutStream
+            from IPython.zmq.iostream import OutStream
         except ImportError:
-            OutStream = None
+            try:
+                from IPython.kernel.zmq.iostream import OutStream
+            except ImportError:
+                OutStream = None
 
     if OutStream is not None:
         from IPython.utils import io as ipyio


### PR DESCRIPTION
`IPython (4.0.0)` and `jupyter (1.0.0)` were released a few days ago [1].  Importing `astropy` in the new jupyter notebook gives a deprecation warning:

```
 ShimWarning: The `IPython.kernel` package has been deprecated. You should import from ipykernel or jupyter_client instead.
```

This PR will try to import from the new `ipykernel` and `ipywidgets` packages (part of the Big Split) if available, otherwise try the `IPython` imports (for < `4.0.0`).  With this change, the `ShimWarning` is no longer issued in the new notebook.

[1] http://blog.jupyter.org/2015/08/12/first-release-of-jupyter/