### PR TITLE
Allow package to be manually specified in get_pkg_data_* functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,6 +208,11 @@ New Features
     these classes for more details. Coordinate frames and models now use this
     interface. [#3679]
 
+  - The ``get_pkg_data_*`` functions now take an optional ``package`` argument
+    which allows specifying any package to read package data filenames or
+    content out of, as opposed to only being able to use data from the package
+    that the function is called from. [#4079]
+
   - Added function ``dtype_info_name`` to the ``data_info`` module to provide
     the name of a ``dtype`` for human-readable informational purposes. [#3868]
 
@@ -391,6 +396,11 @@ API changes
     detail this is not likely to affect any users. [#4001]
 
 - ``astropy.utils``
+
+  - All of the ``get_pkg_data_*`` functions take an optional ``package``
+    argument as their second positional argument.  So any code that previously
+    passed other arguments to these functions as positional arguments might
+    break.  Use keyword argument passing instead to mitigate this. [#4079]
 
   - ``astropy.utils.iers`` now uses a ``QTable`` internally, which means that
     the numerical columns are stored as ``Quantity``, with full support for

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -738,7 +738,7 @@ def test_open_files():
     def test_file(filename):
         parse(filename, pedantic=False)
 
-    for filename in get_pkg_data_filenames('data', '*.xml'):
+    for filename in get_pkg_data_filenames('data', pattern='*.xml'):
         if filename.endswith('custom_datatype.xml'):
             continue
         yield test_file, filename

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -23,7 +23,7 @@ def test_maps():
             world = wcsobj.wcs_pix2world(x, 1)
             pix = wcsobj.wcs_world2pix(x, 1)
 
-    hdr_file_list = list(get_pkg_data_filenames("maps", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:
@@ -62,7 +62,7 @@ def test_spectra():
             world = wcsobj.wcs_pix2world(x, 1)
             pix = wcsobj.wcs_world2pix(x, 1)
 
-    hdr_file_list = list(get_pkg_data_filenames("spectra", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("spectra", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -46,7 +46,7 @@ def test_maps():
         assert_array_almost_equal(pix, [[97, 97]], decimal=0)
 
     # get the list of the hdr files that we want to test
-    hdr_file_list = list(get_pkg_data_filenames("maps", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:
@@ -91,7 +91,7 @@ def test_spectra():
         assert len(all_wcs) == 9
 
     # get the list of the hdr files that we want to test
-    hdr_file_list = list(get_pkg_data_filenames("spectra", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("spectra", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:


### PR DESCRIPTION
Add optional ``package`` argument to ``get_pkg_data_*`` functions so that package data can be retrieved from packages other than the one the function was called from.  I got annoyed in writing some tests that I couldn't do this already.

Also converted most of the examples for those functions into working doctests, which revealed some bugs in both the tests and the functions themselves.

One such test is skipped due to
https://github.com/astropy/astropy-data/issues/4