### PR TITLE
Table.as_array() converts to native byteorder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,6 +164,9 @@ New Features
     as a mixin column.  This allows for an approximation of nested tables.
     [#3925]
 
+  - Added ``keep_byteorder`` option to ``Table.as_array()``.  See the
+    "API Changes" section below. [#4080]
+
 - ``astropy.tests``
 
   - Added new test config options, ``config_dir`` and ``cache_dir``  (these
@@ -341,6 +344,10 @@ API changes
     ``sigma_clip`` and ``sigma_clipped_stats`` functions. [#4067]
 
 - ``astropy.table``
+
+  - ``Table.as_array()`` always returns a structured array with each column in
+    the system's native byte order.  The optional ``keep_byteorder=True``
+    option will keep each column's data in its original byteorder. [#4080]
 
 - ``astropy.tests``
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -738,7 +738,7 @@ def test_open_files():
     def test_file(filename):
         parse(filename, pedantic=False)
 
-    for filename in get_pkg_data_filenames('data', '*.xml'):
+    for filename in get_pkg_data_filenames('data', pattern='*.xml'):
         if filename.endswith('custom_datatype.xml'):
             continue
         yield test_file, filename

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -223,8 +223,9 @@ class Table(object):
         empty_init = ma.empty if self.masked else np.empty
         data = empty_init(len(self), dtype=dtype)
         for col in cols:
-            # This should automatically swap columns to their destination byte
-            # order where applicable
+            # When assigning from one array into a field of a structured array,
+            # Numpy will automatically swap thos columns to their destination
+            # byte order where applicable
             data[col.info.name] = col
 
         return data

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -23,7 +23,7 @@ def test_maps():
             world = wcsobj.wcs_pix2world(x, 1)
             pix = wcsobj.wcs_world2pix(x, 1)
 
-    hdr_file_list = list(get_pkg_data_filenames("maps", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:
@@ -62,7 +62,7 @@ def test_spectra():
             world = wcsobj.wcs_pix2world(x, 1)
             pix = wcsobj.wcs_world2pix(x, 1)
 
-    hdr_file_list = list(get_pkg_data_filenames("spectra", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("spectra", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -46,7 +46,7 @@ def test_maps():
         assert_array_almost_equal(pix, [[97, 97]], decimal=0)
 
     # get the list of the hdr files that we want to test
-    hdr_file_list = list(get_pkg_data_filenames("maps", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:
@@ -91,7 +91,7 @@ def test_spectra():
         assert len(all_wcs) == 9
 
     # get the list of the hdr files that we want to test
-    hdr_file_list = list(get_pkg_data_filenames("spectra", "*.hdr"))
+    hdr_file_list = list(get_pkg_data_filenames("spectra", pattern="*.hdr"))
 
     # actually perform a test for each one
     for filename in hdr_file_list:


### PR DESCRIPTION
As discussed in #4069, this changes `Table.as_array()` to always convert all fields in the output structured array to native byteorder.  Since this method makes a copy of all the table data anyways, there's little advantage to keeping fields in non-native byteorder, in most cases.

Given the experience of @taldcroft and several others previous, this seems like the most useful default.  Though if `keep_byteorder=True` the output structured array keeps all fields in their byte orders.

This isn't a total solution to #4069 but it should help alleviate the issue.

(Note: This PR depends on #4079, but can reworked to not require it if that PR isn't merged first.)