### PR TITLE
Improve and fix issues with resolve_name; replace __import__ with resolve_name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -209,6 +209,10 @@ New Features
     files using the ``lzma`` module of Python 3.3+ or, when available, the
     ``backports.lzma`` package on earlier versions. [#3667]
 
+  - The ``resolve_name`` utility now accepts any number of additional
+    positional arguments that are automatically dotted together with the
+    first ``name`` argument. [#4083]
+
 - ``astropy.visualization``
 
   - Added the ``hist`` function, which is similar to ``plt.hist`` but

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -589,6 +589,10 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - ``resolve_name`` no longer causes ``sys.modules`` to be cluttered with
+    additional copies of modules under a package imported like
+    ``resolve_name('numpy')``. [#4084]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -26,6 +26,7 @@ from warnings import warn
 from ..extern.configobj import configobj, validate
 from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from ..utils import find_current_module
+from ..utils.introspection import resolve_name
 from ..utils.misc import InheritDocstrings
 from .paths import get_config_dir
 
@@ -565,11 +566,7 @@ class ConfigAlias(ConfigItem):
             AstropyDeprecationWarning)
 
     def _get_target(self):
-        if self._new_module not in sys.modules:
-            __import__(self._new_module)
-        mod = sys.modules[self._new_module]
-        cfg = getattr(mod, 'conf')
-        return cfg
+        return resolve_name(self._new_module, 'conf')
 
     def set(self, value):
         self._deprecation_warning()
@@ -841,8 +838,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
             identical = False
 
     if version is None:
-        mod = __import__(pkg)
-        version = mod.__version__
+        version = resolve_name(pkg, '__version__')
 
     # Don't install template files for dev versions, or we'll end up
     # spamming `~/.astropy/config`.

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -30,6 +30,7 @@ from .disable_internet import turn_off_internet, turn_on_internet
 from .output_checker import AstropyOutputChecker, FIX, FLOAT_CMP
 from ..utils import OrderedDict
 from ..utils.argparse import writeable_directory
+from ..utils.introspection import resolve_name
 
 # Needed for Python 2.6 compatibility
 try:
@@ -581,7 +582,7 @@ def pytest_report_header(config):
 
     for module_display, module_name in six.iteritems(PYTEST_HEADER_MODULES):
         try:
-            module = __import__(module_name)
+            module = resolve_name(module_name)
         except ImportError:
             s += "{0}: not available\n".format(module_display)
         else:

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -26,6 +26,7 @@ from warnings import warn
 
 from .. import config as _config
 from ..utils.exceptions import AstropyWarning
+from ..utils.introspection import resolve_name
 
 
 __all__ = [
@@ -265,7 +266,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 from backports import lzma
                 from backports.lzma import LZMAFile
                 # when called with file object, returns a non-seekable instance
-                # need a filename here, too, so have to write the data to a 
+                # need a filename here, too, so have to write the data to a
                 # temporary file
                 with NamedTemporaryFile("wb", delete=False) as tmp:
                     tmp.write(fileobj.read())
@@ -827,7 +828,7 @@ def _find_pkg_data_path(data_name):
 
     rootpkgname = pkgname.partition('.')[0]
 
-    rootpkg = __import__(rootpkgname)
+    rootpkg = resolve_name(rootpkgname)
 
     module_path = os.path.dirname(module.__file__)
     path = os.path.join(module_path, data_name)

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -148,7 +148,7 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     if '.' not in version_path:
         have_version = getattr(module, version_path)
     else:
-        have_version = resolve_name('.'.join([module.__name__, version_path]))
+        have_version = resolve_name(module.__name__, version_path)
 
     try:
         from pkg_resources import parse_version
@@ -306,8 +306,7 @@ def find_mod_objs(modname, onlylocals=False):
 
     """
 
-    __import__(modname)
-    mod = sys.modules[modname]
+    mod = resolve_name(modname)
 
     if hasattr(mod, '__all__'):
         pkgitems = [(k, mod.__dict__[k]) for k in mod.__all__]

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -21,7 +21,7 @@ __all__ = ['resolve_name', 'minversion', 'find_current_module',
 __doctest_skip__ = ['find_current_module']
 
 
-def resolve_name(name):
+def resolve_name(name, *additional_parts):
     """Resolve a name like ``module.object`` to an object and return it.
 
     This ends up working like ``from module import object`` but is easier
@@ -37,10 +37,16 @@ def resolve_name(name):
         including parent modules, separated by dots.  Also known as the fully
         qualified name of the object.
 
+    additional_parts : iterable, optional
+        If more than one positional arguments are given, those arguments are
+        automatically dotted together with ``name``.
+
     Examples
     --------
 
     >>> resolve_name('astropy.utils.introspection.resolve_name')
+    <function resolve_name at 0x...>
+    >>> resolve_name('astropy', 'utils', 'introspection', 'resolve_name')
     <function resolve_name at 0x...>
 
     Raises
@@ -48,6 +54,11 @@ def resolve_name(name):
     `ImportError`
         If the module or named object is not found.
     """
+
+    additional_parts = '.'.join(additional_parts)
+
+    if additional_parts:
+        name = name + '.' + additional_parts
 
     # Note: On python 2 these must be str objects and not unicode
     parts = [str(part) for part in name.split('.')]

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -55,23 +55,23 @@ def resolve_name(name):
     if len(parts) == 1:
         # No dots in the name--just a straight up module import
         cursor = 1
-        attr_name = str('')  # Must not be unicode on Python 2
+        fromlist=[]
     else:
         cursor = len(parts) - 1
-        attr_name = parts[-1]
+        fromlist = [parts[-1]]
 
     module_name = parts[:cursor]
 
     while cursor > 0:
         try:
-            ret = __import__(str('.'.join(module_name)), fromlist=[attr_name])
+            ret = __import__(str('.'.join(module_name)), fromlist=fromlist)
             break
         except ImportError:
             if cursor == 0:
                 raise
             cursor -= 1
             module_name = parts[:cursor]
-            attr_name = parts[cursor]
+            fromlist = [parts[cursor]]
             ret = ''
 
     for part in parts[cursor:]:


### PR DESCRIPTION
There are many subtleties to using the `__import__` builtin, and its behavior can often seem (or actually be) buggy at times on different Python versions.  Careless use of `__import__` can lead to bugs like the one in [this build](https://travis-ci.org/astropy/astropy/jobs/75678253).

The `resolve_name` utility attempts to work around those subtleties so that it *just works* (and is actually more powerful than `__import__` since it can also resolve objects in modules).  So this PR implements a general policy of using `resolve_name` instead of `__import__` where appropriate.

This also fixed a bug in `resolve_name` itself--another subtle buglet with `__import__` that occurs on Python 2 that I didn't know about before.