### PR TITLE
Fix bug in resolve_name resulting in duplicate imports of numpy (or other packages)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -589,6 +589,10 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - ``resolve_name`` no longer causes ``sys.modules`` to be cluttered with
+    additional copies of modules under a package imported like
+    ``resolve_name('numpy')``. [#4084]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -30,6 +30,7 @@ from .disable_internet import turn_off_internet, turn_on_internet
 from .output_checker import AstropyOutputChecker, FIX, FLOAT_CMP
 from ..utils import OrderedDict
 from ..utils.argparse import writeable_directory
+from ..utils.introspection import resolve_name
 
 # Needed for Python 2.6 compatibility
 try:
@@ -581,7 +582,7 @@ def pytest_report_header(config):
 
     for module_display, module_name in six.iteritems(PYTEST_HEADER_MODULES):
         try:
-            module = __import__(module_name)
+            module = resolve_name(module_name)
         except ImportError:
             s += "{0}: not available\n".format(module_display)
         else:

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -55,23 +55,23 @@ def resolve_name(name):
     if len(parts) == 1:
         # No dots in the name--just a straight up module import
         cursor = 1
-        attr_name = str('')  # Must not be unicode on Python 2
+        fromlist=[]
     else:
         cursor = len(parts) - 1
-        attr_name = parts[-1]
+        fromlist = [parts[-1]]
 
     module_name = parts[:cursor]
 
     while cursor > 0:
         try:
-            ret = __import__(str('.'.join(module_name)), fromlist=[attr_name])
+            ret = __import__(str('.'.join(module_name)), fromlist=fromlist)
             break
         except ImportError:
             if cursor == 0:
                 raise
             cursor -= 1
             module_name = parts[:cursor]
-            attr_name = parts[cursor]
+            fromlist = [parts[cursor]]
             ret = ''
 
     for part in parts[cursor:]:


### PR DESCRIPTION
This fixes the bug that was originally fixed in #4083, but which has now been split off to a separate PR since it should be fixed for the v1.0.x branch.