### PR TITLE
Fix erfa warning when passing arrays

### DIFF
--- a/astropy/_erfa/core.c.templ
+++ b/astropy/_erfa/core.c.templ
@@ -38,7 +38,10 @@ typedef struct {
 
 static PyObject *Py_{{ func.pyname }}(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    {%- for arg in func.args_by_inout('in|inout|out|ret|stat') %}
+    {%- for arg in func.args_by_inout('in|inout|out') %}
+    {{ arg.ctype }} (*_{{ arg.name }}){{ arg.cshape }};
+    {%- endfor %}
+    {%- for arg in func.args_by_inout('ret|stat') %}
     {{ arg.ctype_ptr }} _{{ arg.name }};
     {%- endfor %}
     {%- if func.args_by_inout('stat')|length > 0 %}
@@ -52,10 +55,10 @@ static PyObject *Py_{{ func.pyname }}(PyObject *self, PyObject *args, PyObject *
 
     do {
         {%- for arg in func.args_by_inout('in|inout|out') %}
-        _{{ arg.name }} = (({{ arg.ctype }} *)(dataptrarray[{{ func.args.index(arg) }}])){%- if arg.ctype_ptr[-1] != '*' %}[0]{%- endif %};
+        _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }})(dataptrarray[{{ func.args.index(arg) }}]));
         {%- endfor %}
 
-        {{ func.args_by_inout('ret|stat')|map(attribute='name')|surround('_', ' = ')|join }}{{func.name}}({{ func.args_by_inout('in|inout|out')|map(attribute='name')|prefix('_')|join(', ') }});
+        {{ func.args_by_inout('ret|stat')|map(attribute='name')|surround('_', ' = ')|join }}{{func.name}}({{ func.args_by_inout('in|inout|out')|map(attribute='name_for_call')|join(', ') }});
 
         {%- for arg in func.args_by_inout('ret|stat') %}
         *(({{ arg.ctype_ptr }} *)(dataptrarray[{{ func.args.index(arg) }}])) = _{{ arg.name }};

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 import os.path
-from collections import OrderedDict
+from astropy.utils.compat.odict import OrderedDict
 
 
 ctype_to_dtype = {'double'     : "numpy.double",

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 import os.path
+from collections import OrderedDict
 
 
 ctype_to_dtype = {'double'     : "numpy.double",
@@ -378,7 +379,7 @@ def main(srcdir, outfn, templateloc, verbose=True):
     with open(erfahfn, "r") as f:
         erfa_h = f.read()
 
-    funcs = {}
+    funcs = OrderedDict()
     section_subsection_functions = re.findall('/\* (\w*)/(\w*) \*/\n(.*?)\n\n',
                                               erfa_h, flags=re.DOTALL|re.MULTILINE)
     for section, subsection, functions in section_subsection_functions:

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -186,6 +186,13 @@ class Argument(object):
     def cshape(self):
         return ''.join(['[{0}]'.format(s) for s in self.shape])
 
+    @property
+    def name_for_call(self):
+        if self.is_ptr:
+            return '_'+self.name
+        else:
+            return '*_'+self.name
+
     def __repr__(self):
         return "Argument('{0}', name='{1}', ctype='{2}', inout_state='{3}')".format(self.definition, self.name, self.ctype, self.inout_state)
 

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -182,6 +182,10 @@ class Argument(object):
     def ndim(self):
         return len(self.shape)
 
+    @property
+    def cshape(self):
+        return ''.join(['[{0}]'.format(s) for s in self.shape])
+
     def __repr__(self):
         return "Argument('{0}', name='{1}', ctype='{2}', inout_state='{3}')".format(self.definition, self.name, self.ctype, self.inout_state)
 

--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -10,6 +10,7 @@ omit =
    astropy/utils/compat/*
    astropy/version*
    astropy/wcs/docstrings*
+   astropy/_erfa/erfa_generator.py
 
 [report]
 exclude_lines =


### PR DESCRIPTION
These are the warnings:

    astropy/_erfa/core.c:315:42: warning: incompatible pointer types passing 'double *' to parameter of type 'double (*)[3]' [-Wincompatible-pointer-types]
            eraC2ixy(_date1, _date2, _x, _y, _rc2i);
                                             ^~~~~
    cextern/erfa/erfa.h:173:22: note: passing argument to parameter 'rc2i' here
                  double rc2i[3][3]);
                         ^