### PR TITLE
Fix an issue with setting fill value when column dtype is changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -457,6 +457,8 @@ Bug fixes
 
 - ``astropy.table``
 
+  - Fix an issue with setting fill value when column dtype is changed. [#4088]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -457,8 +457,6 @@ Bug fixes
 
 - ``astropy.table``
 
-  - Fix an issue with setting fill value when column dtype is changed. [#4088]
-
 - ``astropy.tests``
 
 - ``astropy.time``
@@ -611,6 +609,8 @@ Bug Fixes
 - ``astropy.table``
 
   - Fix bug when doing outer join on multi-dimensional columns. [#4060]
+
+  - Fix an issue with setting fill value when column dtype is changed. [#4088]
 
 - ``astropy.time``
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -957,8 +957,10 @@ class MaskedColumn(Column, ma.MaskedArray):
 
         # Note: do not set fill_value in the MaskedArray constructor because this does not
         # go through the fill_value workarounds (see _fix_fill_value below).
-        if fill_value is None and hasattr(data, 'fill_value'):
-            fill_value = data.fill_value
+        if fill_value is None and hasattr(data, 'fill_value') and data.fill_value is not None:
+            # Coerce the fill_value to the correct type since `data` may be a
+            # different dtype than self.
+            fill_value = self.dtype.type(data.fill_value)
         self.fill_value = fill_value
 
         self.parent_table = None
@@ -1005,11 +1007,6 @@ class MaskedColumn(Column, ma.MaskedArray):
         #
         # To handle this we are forced to reset a private variable first:
         self._fill_value = None
-
-        # At the end of all workarounds / fixes, coerce the fill value `val`
-        # to the correct dtype.
-        if val is not None:
-            val = self.dtype.type(val)
 
         self.set_fill_value(val)  # defer to native ma.MaskedArray method
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1006,6 +1006,11 @@ class MaskedColumn(Column, ma.MaskedArray):
         # To handle this we are forced to reset a private variable first:
         self._fill_value = None
 
+        # At the end of all workarounds / fixes, coerce the fill value `val`
+        # to the correct dtype.
+        if val is not None:
+            val = self.dtype.type(val)
+
         self.set_fill_value(val)  # defer to native ma.MaskedArray method
 
     @property

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -397,3 +397,23 @@ def test_setting_from_masked_column():
         mask_before_add = t.mask.copy()
         t['d'] = np.arange(len(t))
         assert np.all(t.mask['b'] == mask_before_add['b'])
+
+
+def test_coercing_fill_value_type():
+    """
+    Test that masked column fill_value is coerced into the correct column type.
+    """
+    # This is the original example posted on the astropy@scipy mailing list
+    t = Table({'a': ['1']}, masked=True)
+    t['a'].set_fill_value('0')
+    u = Table(t, names=['a'], dtype=[np.int])
+
+    # Unit test of underlying change where any value that can be coerced into
+    # column dtype is acceptable.
+    t = Table({'a': [1]}, masked=True)
+
+    t['a'].fill_value = '0'
+    assert t['a'].fill_value == 0
+
+    t['a'].fill_value = 0.0
+    assert t['a'].fill_value == 0

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -406,14 +406,11 @@ def test_coercing_fill_value_type():
     # This is the original example posted on the astropy@scipy mailing list
     t = Table({'a': ['1']}, masked=True)
     t['a'].set_fill_value('0')
-    u = Table(t, names=['a'], dtype=[np.int])
+    t2 = Table(t, names=['a'], dtype=[np.int32])
+    assert isinstance(t2['a'].fill_value, np.int32)
 
-    # Unit test of underlying change where any value that can be coerced into
-    # column dtype is acceptable.
-    t = Table({'a': [1]}, masked=True)
-
-    t['a'].fill_value = '0'
-    assert t['a'].fill_value == 0
-
-    t['a'].fill_value = 0.0
-    assert t['a'].fill_value == 0
+    # Unit test the same thing.
+    c = MaskedColumn(['1'])
+    c.set_fill_value('0')
+    c2 = MaskedColumn(c, dtype=np.int32)
+    assert isinstance(c2.fill_value, np.int32)


### PR DESCRIPTION
As noted in email from Gregory Simonian on astropy@scipy.org:
```
t = Table({'a': ['1']}, masked=True)
t['a'].set_fill_value('0')
u = Table(t, names=['a'], dtype=[np.int])
> TypeError: Cannot set fill value of string with array of dtype int64
```

This fix updates the `fill_value` setter to always coerce the new fill_value to the column dtype (unless the fill value is `None`).