### PR TITLE
Adding astropy.utils.data.is_url_in_cache method and test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -228,6 +228,9 @@ New Features
     positional arguments that are automatically dotted together with the
     first ``name`` argument. [#4083]
 
+  - Added ``is_url_in_cache`` for resolving paths to cached files via URLS
+    and checking if files exist
+
 - ``astropy.visualization``
 
   - Added the ``hist`` function, which is similar to ``plt.hist`` but

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -36,7 +36,7 @@ __all__ = [
     'get_pkg_data_filenames', 'compute_hash', 'clear_download_cache',
     'CacheMissingWarning', 'get_free_space_in_dir',
     'check_free_space_in_dir', 'download_file',
-    'download_files_in_parallel']
+    'download_files_in_parallel', 'is_url_in_cache']
 
 
 class Conf(_config.ConfigNamespace):
@@ -1064,6 +1064,32 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
     return local_path
 
+def is_url_in_cache(url_key):
+    """
+    Check if a download from ``url_key`` is in the cache.
+
+    Parameters
+    ----------
+    url_key : string
+        The URL retrieved
+
+    Returns
+    -------
+    in_cache : bool
+        `True` if a download from ``url_key`` is in the cache
+    """
+    # The code below is modified from astropy.utils.data.download_file()
+    try:
+        dldir, urlmapfn = _get_download_cache_locs()
+    except (IOError, OSError) as e:
+        msg = 'Remote data cache could not be accessed due to '
+        estr = '' if len(e.args) < 1 else (': ' + str(e))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+        return False
+    with _open_shelve(urlmapfn, True) as url2hash:
+        if url_key in url2hash:
+            return True
+    return False
 
 def _do_download_files_in_parallel(args):
     return download_file(*args, show_progress=False)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -363,3 +363,12 @@ def test_invalid_location_download_noconnect():
     # This should invoke socket's monkeypatched failure
     with pytest.raises(IOError):
         download_file('http://astropy.org/nonexistentfile')
+
+@remote_data
+def test_is_url_in_cache():
+    from ..data import download_file, is_url_in_cache
+
+    assert not is_url_in_cache('http://astropy.org/nonexistentfile')
+
+    download_file(TESTURL, cache=True, show_progress=False)
+    assert is_url_in_cache(TESTURL)


### PR DESCRIPTION
Adding a method for checking whether or not a download from a given URL is in the cache, to knock something off of @eteq's to do list. This comes from work in astropy/astroplan#71.

For example, say you're working with calculations in the near future, and you need the IERS Bulletin A table ([see example on this method for context](http://astropy.readthedocs.org/en/latest/api/astropy.time.Time.html#astropy.time.Time.get_delta_ut1_utc)). Since the cache uses hashed filenames, it's not obvious by using `ls` on the cache directory whether or not the table is in there. With this PR, you can check easily
```python
In [4]: from astropy.utils import data, iers
In [5]: data.is_url_in_cache(iers.IERS_A_URL)
Out[5]: True
```
and you can see that the table is indeed cached there.