### PR TITLE
Fix bug unpickling bare Column: _parent_table attr not set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -612,6 +612,9 @@ Bug Fixes
 
   - Fix an issue with setting fill value when column dtype is changed. [#4088]
 
+  - Fix bug when unpickling a bare Column where the _parent_table
+    attibute was not set.  This impacted the Column representation. [#4099]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -284,6 +284,7 @@ class BaseColumn(np.ndarray):
         self.format = format
         self.description = description
         self.meta = meta
+        self._parent_table = None
 
     def __reduce__(self):
         """

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -15,6 +15,8 @@ def test_pickle_column(protocol):
     cp = pickle.loads(cs)
     assert np.all(cp == c)
     assert cp.attrs_equal(c)
+    assert cp._parent_table is None
+    assert repr(c) == repr(cp)
 
 
 def test_pickle_masked_column(protocol):
@@ -30,6 +32,8 @@ def test_pickle_masked_column(protocol):
     assert np.all(cp.mask == c.mask)
     assert cp.attrs_equal(c)
     assert cp.fill_value == -99
+    assert cp._parent_table is None
+    assert repr(c) == repr(cp)
 
 
 def test_pickle_table(protocol):


### PR DESCRIPTION
Previously after unpickling a Column the resultant object had no `_parent_table` attribute.  This wasn't a problem for accessing the data and meta values, but `repr` failed (and in general it is expected that a `Column` has a `_parent_table` attribute).