### PR TITLE
Add ECSV to table of supported ASCII formats for table I/O

### DIFF
--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -163,6 +163,7 @@ indicates which support write functionality.
 ``ascii.sextractor``                         :class:`~astropy.io.ascii.SExtractor`: SExtractor format table
 ``ascii.tab``                            Yes :class:`~astropy.io.ascii.Tab`: Basic table with tab-separated values
 ``ascii.csv``                     .csv   Yes :class:`~astropy.io.ascii.Csv`: Basic table with comma-separated values
+``ascii.ecsv``                   .ecsv   Yes :class:`~astropy.io.ascii.Ecsv`: Basic table with Enhanced CSV (supporting metadata)
 =============================== ====== ===== ============================================================================================
 
 .. note::


### PR DESCRIPTION
[This page](http://docs.astropy.org/en/stable/io/unified.html#ascii-formats) lists ECSV in the table of all supported readers/writers, but neglects to mention it in the later table of supported ASCII formats.

(On a related note, I think we should also include in one of these tables a column indicating what type of column metadata each format supports, but I'm not exactly sure where to put it or how to word it).