### PR TITLE
Use a single mmap per file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -592,6 +592,16 @@ Bug Fixes
   - Fix bug when extending one header (without comments) with another
     (with comments). [#3967]
 
+  - Somewhat improved resource usage for FITS data--previously a new ``mmap``
+    was opened for each HDU of a FITS file accessed through an ``HDUList``.
+    Each ``mmap`` used up a single file descriptor, causing problems with
+    system resource limits for some users.  Now only a single ``mmap`` is
+    opened, and shared for the data of all HDUs.  Note: The problem still
+    persists with using the "convenience" functions.  For example using
+    ``fits.getdata`` will create one ``mmap`` per HDU read this way (as
+    opposed to opening the file with ``fits.open`` and accessing the HDUs
+    through the ``HDUList`` object). [#4097]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -107,7 +107,10 @@ class _BaseHDUMeta(type):
                         # are hanging around (perhaps the user ran ``data =
                         # hdu.data``) don't even consider this:
                         if sys.getrefcount(self.data) == 2:
-                            self._file._maybe_close_memmap(refcount_delta=1)
+                            # Add 1 to refcount since by the time this deleter
+                            # is called, the data array isn't actually deleted
+                            # *yet*, but will be shortly after
+                            self._file._maybe_close_mmap(refcount_delta=1)
 
                 setattr(cls, 'data', data_prop.deleter(data))
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -6,6 +6,7 @@ from __future__ import division
 import datetime
 import inspect
 import os
+import sys
 import warnings
 
 import numpy as np
@@ -18,7 +19,7 @@ from ..util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
                     _get_array_mmap, _array_to_file, first)
 from ..verify import _Verify, _ErrList
 
-from ....extern.six import string_types
+from ....extern.six import string_types, add_metaclass
 from ....utils import lazyproperty, deprecated
 from ....utils.compat import ignored
 from ....utils.exceptions import AstropyUserWarning
@@ -84,9 +85,36 @@ def _hdu_class_from_header(cls, header):
 
     return klass
 
+class _BaseHDUMeta(type):
+    def __init__(cls, name, bases, members):
+        # The sole purpose of this metaclass right now is to add the same
+        # data.deleter to all HDUs with a data property.
+        # It's unfortunate, but there's otherwise no straightforward way
+        # that a property can inherit setters/deleters of the property of the
+        # same name on base classes
+        if 'data' in members:
+            data_prop = members['data']
+            if (isinstance(data_prop, (lazyproperty, property)) and
+                    data_prop.fdel is None):
+                # Don't do anything if the class has already explicitly
+                # set the deleter for its data property
+                def data(self):
+                    # The deleter
+                    if self._file is not None and self._data_loaded:
+                        # Don't even do this unless the *only* reference to the
+                        # .data array is the one we're deleting by deleting
+                        # this attribute; if any other references to the array
+                        # are hanging around (perhaps the user ran ``data =
+                        # hdu.data``) don't even consider this:
+                        if sys.getrefcount(self.data) == 2:
+                            self._file._maybe_close_memmap(refcount_delta=1)
+
+                setattr(cls, 'data', data_prop.deleter(data))
+
 
 # TODO: Come up with a better __repr__ for HDUs (and for HDULists, for that
 # matter)
+@add_metaclass(_BaseHDUMeta)
 class _BaseHDU(object):
     """Base class for all HDU (header data unit) classes."""
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1428,7 +1428,10 @@ class CompImageHDU(BinTableHDU):
         # data) from the file, if there is any.
         compressed_data = super(BinTableHDU, self).data
         if isinstance(compressed_data, np.rec.recarray):
-            del self.data
+            # Make sure not to use 'del self.data' so we don't accidentally
+            # go through the self.data.fdel and close the mmap underlying
+            # the compressed_data array
+            del self.__dict__['data']
             return compressed_data
         else:
             # This will actually set self.compressed_data with the

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -880,25 +880,25 @@ class TestFileFunctions(FitsTestCase):
                          'support')
 
         with fits.open(self.data('test0.fits'), memmap=True) as hdul:
-            assert hdul._file._memmap is None
+            assert hdul._file._mmap is None
 
             hdul[1].data
-            assert hdul._file._memmap is not None
+            assert hdul._file._mmap is not None
 
             del hdul[1].data
             # Should be no more references to data in the file so close the
             # mmap
-            assert hdul._file._memmap is None
+            assert hdul._file._mmap is None
 
             hdul[1].data
             hdul[2].data
             del hdul[1].data
             # hdul[2].data is still references so keep the mmap open
-            assert hdul._file._memmap is not None
+            assert hdul._file._mmap is not None
             del hdul[2].data
-            assert hdul._file._memmap is None
+            assert hdul._file._mmap is None
 
-        assert hdul._file._memmap is None
+        assert hdul._file._mmap is None
 
         with fits.open(self.data('test0.fits'), memmap=True) as hdul:
             hdul[1].data
@@ -906,7 +906,7 @@ class TestFileFunctions(FitsTestCase):
         # When the only reference to the data is on the hdu object, and the
         # hdulist it belongs to has been closed, the mmap should be closed as
         # well
-        assert hdul._file._memmap is None
+        assert hdul._file._mmap is None
 
         with fits.open(self.data('test0.fits'), memmap=True) as hdul:
             data = hdul[1].data


### PR DESCRIPTION
We've had some users running into trouble when accessing all HDUs of several different files simultaneously (on systems with strangely low file access limits), such that they hit their OS-allowed limit for open file handles in a process.

I've been wanting to address this issue for a long time as part of a more comprehensive overhaul of I/O handling in the `io.fits` module, which would also include caching of file objects and FITS headers.  

But the file handle thing in particular has really gotten to be a problem for some users, and I think I can improve that significantly by caching a single mmap instance (probably attached to the `_File` object) which HDUs can use to access their data, rather than creating one mmap per HDU.

So this will at least reduce the file handle usage proportional to the average number of HDUs per simultaneously-read file.