### PR TITLE
use return instead of exit in sub-script to allow egg-info to run

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -7,14 +7,14 @@ source activate test
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]
 then
-  exit  # no more dependencies needed
+  return  # no more dependencies needed
 fi
 
 # PEP8
 if [[ $MAIN_CMD == pep8* ]]
 then
   pip install pep8
-  exit  # no more dependencies needed
+  return  # no more dependencies needed
 fi
 
 # CORE DEPENDENCIES

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -208,13 +208,13 @@ def test_read_col_starts():
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[1][2], "192.168.1.")
     assert_equal(dat[2][2], "192.168.1")  # col_end=28 cuts this column off
-    
+
 
 def test_read_detect_col_starts_or_ends():
     """Table with no delimiter with only column start or end values specified"""
     table = """
 #1       9        19                <== Column start indexes
-#|       |         |                <== Column start positions 
+#|       |         |                <== Column start positions
 #<------><--------><------------->  <== Inferred column positions
   John   555- 1234 192.168.1.10
   Mary   555- 2134 192.168.1.123

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -551,7 +551,7 @@ class Model(object):
     _custom_inverse = None
 
     # If a bounding_box_default function is defined in the model,
-    # then the _bounding_box attribute should be set to 'auto' in the model. 
+    # then the _bounding_box attribute should be set to 'auto' in the model.
     # Otherwise, the default is None for no bounding box.
     _bounding_box = None
 
@@ -773,18 +773,18 @@ class Model(object):
     @property
     def bounding_box(self):
         """
-        A `tuple` of length `n_inputs` defining the bounding box limits, or 
-        `None` for no bounding box. 
+        A `tuple` of length `n_inputs` defining the bounding box limits, or
+        `None` for no bounding box.
 
         The default is `None`, unless ``bounding_box_default`` is defined.
-        `bounding_box` can be set manually to an array-like  object of shape 
+        `bounding_box` can be set manually to an array-like  object of shape
         ``(model.n_inputs, 2)``. For further usage, including how to set the
         ``bounding_box_default``, see :ref:`bounding-boxes`
 
         The limits are ordered according to the `numpy` indexing
         convention, and are the reverse of the model input order,
         e.g. for inputs ``('x', 'y', 'z')`` the ``bounding_box`` is defined:
-        
+
         * for 1D: ``(x_low, x_high)``
         * for 2D: ``((y_low, y_high), (x_low, x_high))``
         * for 3D: ``((z_low, z_high), (y_low, y_high), (x_low, x_high))``
@@ -830,7 +830,7 @@ class Model(object):
     @bounding_box.setter
     def bounding_box(self, limits):
         """
-        Assigns the bounding box limits. 
+        Assigns the bounding box limits.
         """
 
         if limits == 'auto':
@@ -2384,15 +2384,15 @@ def render_model(model, arr=None, coords=None):
     arr : `numpy.ndarray`, optional
         Array on which the model is evaluated.
     coords : array-like, optional
-        Coordinate arrays mapping to ``arr``, such that 
+        Coordinate arrays mapping to ``arr``, such that
         ``arr[coords] == arr``.
 
     Returns
     -------
     array : `numpy.ndarray`
-        The model evaluated on the input ``arr`` or a new array from ``coords``.  
-        If ``arr`` and ``coords`` are both `None`, the returned array is 
-        limited to the `Model.bounding_box` limits. If 
+        The model evaluated on the input ``arr`` or a new array from ``coords``.
+        If ``arr`` and ``coords`` are both `None`, the returned array is
+        limited to the `Model.bounding_box` limits. If
         `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be passed.
 
     Examples
@@ -2428,7 +2428,7 @@ def render_model(model, arr=None, coords=None):
 
     if bbox is not None:
         # assures position is at center pixel, important when using add_array
-        pd = pos, delta = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2)) 
+        pd = pos, delta = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2))
                                     for bb in bbox]).astype(int).T
 
         if coords is not None:
@@ -2436,7 +2436,7 @@ def render_model(model, arr=None, coords=None):
             sub_coords = np.array([extract_array(c, sub_shape, pos) for c in coords])
         else:
             limits = [slice(p - d, p + d + 1, 1) for p, d in pd.T]
-            sub_coords = np.mgrid[limits]         
+            sub_coords = np.mgrid[limits]
 
         sub_coords = sub_coords[::-1]
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -96,14 +96,14 @@ class Gaussian1D(Fittable1DModel):
 
     def bounding_box_default(self, factor=5.5):
         """
-        Tuple defining the default ``bounding_box`` limits, 
+        Tuple defining the default ``bounding_box`` limits,
         ``(x_low, x_high)``
 
         Parameters
         ----------
         factor : float
-            The multiple of `stddev` used to define the limits. 
-            The default is 5.5-sigma, corresponding to a relative error < 1e-7. 
+            The multiple of `stddev` used to define the limits.
+            The default is 5.5-sigma, corresponding to a relative error < 1e-7.
 
         Examples
         --------
@@ -112,7 +112,7 @@ class Gaussian1D(Fittable1DModel):
         >>> model.bounding_box
         (-11.0, 11.0)
 
-        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by 
+        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by
         using a different factor, like:
 
         >>> model.bounding_box = model.bounding_box_default(factor=2)
@@ -317,17 +317,17 @@ class Gaussian2D(Fittable2DModel):
 
     def bounding_box_default(self, factor=5.5):
         """
-        Tuple defining the default ``bounding_box`` limits in each dimension, 
+        Tuple defining the default ``bounding_box`` limits in each dimension,
         ``((y_low, y_high), (x_low, x_high))``
 
-        The default offset from the mean is 5.5-sigma, corresponding 
+        The default offset from the mean is 5.5-sigma, corresponding
         to a relative error < 1e-7. The limits are adjusted for rotation.
 
         Parameters
         ----------
         factor : float, optional
-            The multiple of `x_stddev` and `y_stddev` used to define the limits. 
-            The default is 5.5. 
+            The multiple of `x_stddev` and `y_stddev` used to define the limits.
+            The default is 5.5.
 
         Examples
         --------
@@ -336,7 +336,7 @@ class Gaussian2D(Fittable2DModel):
         >>> model.bounding_box
         ((-11.0, 11.0), (-5.5, 5.5))
 
-        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by 
+        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by
         using a different factor like:
 
         >>> model.bounding_box = model.bounding_box_default(factor=2)

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -222,7 +222,7 @@ class Simplex(Optimization):
         if 'xtol' in kwargs:
             self._acc = kwargs['xtol']
             kwargs.pop('xtol')
-  
+
         fitparams, final_func_val, numiter, funcalls, exit_mode = self.opt_method(
             objfunc, initval, args=fargs, xtol=self._acc,
             full_output=True, **kwargs)

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -36,7 +36,7 @@ class EulerAngleRotation(Model):
     Implements Euler angle intrinsic rotations.
 
     Rotates one coordinate system into another (fixed) coordinate system.
-    All coordinate systems are right-handed. The sign of the angles is 
+    All coordinate systems are right-handed. The sign of the angles is
     determined by the right-hand rule..
 
     Parameters

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -219,7 +219,7 @@ def test_custom_model_bounding_box():
         return val
 
     def ellipsoid_bbox(self):
-        return ((self.z0 - self.c, self.z0 + self.c), 
+        return ((self.z0 - self.c, self.z0 + self.c),
                 (self.y0 - self.b, self.y0 + self.b),
                 (self.x0 - self.a, self.x0 + self.a))
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -448,7 +448,7 @@ def binned_binom_proportion(x, success, bins=10, range=None, conf=0.68269,
 
 def poisson_conf_interval(n, interval='root-n', sigma=1):
     r"""Poisson parameter confidence interval given observed counts
-    
+
     Parameters
     ----------
     n : int or numpy.ndarray
@@ -459,7 +459,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1):
     sigma : float
         Number of sigma for confidence interval; only supported for
         the 'frequentist-confidence' mode.
-    
+
 
     Returns
     -------
@@ -495,7 +495,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1):
 
     **2. 'root-n-0'** This is identical to the above except that where
     n is zero the interval returned is (0,1).
-        
+
     **3. 'pearson'** This is an only-slightly-more-complicated rule
     based on Pearson's chi-squared rule (as [explained][pois_eb] by
     the CDF working group). It also has the nice feature that
@@ -570,7 +570,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1):
            [  4.8074176 ,  10.1925824 ],
            [  5.62771868,  11.37228132],
            [  6.45861873,  12.54138127]])
-    
+
     >>> poisson_conf_interval(np.arange(10),
     ...                       interval='frequentist-confidence').T
     array([[  0.        ,   1.84102165],
@@ -587,19 +587,19 @@ def poisson_conf_interval(n, interval='root-n', sigma=1):
     >>> poisson_conf_interval(7,
     ...                       interval='frequentist-confidence').T
     array([  4.41852954,  10.77028072])
-                   
+
     [pois_eb]: http://www-cdf.fnal.gov/physics/statistics/notes/pois_eb.txt
-    
+
     [ErrorBars]: http://www.pp.rhul.ac.uk/~cowan/atlas/ErrorBars.pdf
-    
+
     [ac12]: http://adsabs.harvard.edu/abs/2012EPJP..127...24A
-    
+
     [maxw11]: http://adsabs.harvard.edu/abs/2011arXiv1102.0822M
-    
+
     [gehrels86]: http://adsabs.harvard.edu/abs/1986ApJ...303..336G
 
     [sherpa_gehrels]: http://cxc.harvard.edu/sherpa4.4/statistics/#chigehrels
-    
+
     """
 
     if not np.isscalar(n):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -279,7 +279,7 @@ def test_poisson_conf_array_rootn0_zero():
                     funcs.poisson_conf_interval(n[0,0,0], interval='root-n-0')[:,None,None,None]*np.ones_like(n))
 
     assert not np.any(np.isnan(funcs.poisson_conf_interval(n, interval='root-n-0')))
-    
+
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_poisson_conf_array_frequentist_confidence_zero():
     n = np.zeros((3,4,5))
@@ -287,14 +287,14 @@ def test_poisson_conf_array_frequentist_confidence_zero():
                     funcs.poisson_conf_interval(n[0,0,0], interval='frequentist-confidence')[:,None,None,None]*np.ones_like(n))
 
     assert not np.any(np.isnan(funcs.poisson_conf_interval(n, interval='root-n-0')))
-    
+
 def test_poisson_conf_list_rootn0_zero():
     n = [0,0,0]
     assert_allclose(funcs.poisson_conf_interval(n, interval='root-n-0'),
                     [[0,0,0],[1,1,1]])
 
     assert not np.any(np.isnan(funcs.poisson_conf_interval(n, interval='root-n-0')))
-    
+
 def test_poisson_conf_array_rootn0():
     n = 7*np.ones((3,4,5))
     assert_allclose(funcs.poisson_conf_interval(n, interval='root-n-0'),
@@ -340,7 +340,7 @@ def test_poisson_conf_frequentist_confidence_gehrels_2sigma():
     Note: I think there's a typo (transposition of digits) in Gehrels 1986,
     specifically for the two-sigma lower limit for 3 events; they claim
     0.569 but this function returns 0.59623...
-    
+
     """
     nlh = np.array([(0, 2, 0, 3.783),
                     (1, 2, 2.30e-2, 5.683),

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -86,7 +86,7 @@ def test_histogram_range(N=1000, rseed=0):
     rng = np.random.RandomState(rseed)
     x = rng.randn(N)
     range = (0.1, 0.8)
-    
+
     for bins in ['scott', 'freedman', 'blocks']:
         counts, bins = histogram(x, bins, range=range)
 
@@ -128,7 +128,7 @@ def test_histogram_output():
     assert_allclose(counts, [3, 27, 41, 29])
     assert_allclose(bins, [-2.55298982, -1.7162764 , -0.42062562,
                            0.46422235, 2.26975462])
-        
+
 
 def test_histogram_badargs(N=1000, rseed=0):
     rng = np.random.RandomState(rseed)
@@ -143,4 +143,4 @@ def test_histogram_badargs(N=1000, rseed=0):
     with pytest.raises(ValueError):
         histogram(x, bins='bad_argument')
 
-    
+

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -262,7 +262,7 @@ class TableFormatter(object):
             col_strs.insert(0, '<table>')
             col_strs.append('</table>')
 
-        # Now bring all the column string values to the same fixed width        
+        # Now bring all the column string values to the same fixed width
         else:
             col_width = max(len(x) for x in col_strs) if col_strs else 1
 
@@ -311,7 +311,7 @@ class TableFormatter(object):
                         justify = (lambda col_str, col_width:
                                    getattr(col_str, 'rjust')(col_width))
                 col_strs[i] = justify(col_str, col_width)
-                
+
         if outs['show_length']:
             col_strs.append('Length = {0} rows'.format(len(col)))
 


### PR DESCRIPTION
This fixes a subtle but rather important bug in the `egg-info` and `pep8` test.  It turns out these were not actually running because the testing script setting up the dependencies used `exit` instead of `return`, which actually exited the *entire test* rather than exiting just from the dependency-installing script.  This fix addresses that.

Note that I think this will cause the `pep8` tests to fail because problems have been introduced between now and when the pep8 tests were (accidentally) disabled. How do we want to deal with that?  I'm not sure how that pep8 test is set up...

cc @embray, @astrofrog (I think you wrote this iteration of the travis stuff?), @cdeil (for noting the problem initially in gammapy and helping figure out the solution)