### PR TITLE
Support saving table metadata in HDF5 as YAML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ New Features
 
 - ``astropy.io.misc``
 
+  - Support saving all meta information, description and units of tables and columns
+    in HDF5 files [#4103]
+
 - ``astropy.io.votable``
 
   - A new method was added to ``astropy.io.votable.VOTable``,

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -270,7 +270,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
             dset.attrs[META_KEY] = [h.encode('utf8') for h in header_yaml]
         except Exception as e:
             warnings.warn("Attributes could not be written to the output HDF5 "
-                          "file: {}".format(e))
+                          "file: {0}".format(e))
 
     else:
         # Write the meta-data to the file

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -14,8 +14,10 @@ import warnings
 import numpy as np
 from ...utils.exceptions import AstropyUserWarning
 from ...extern import six
+from ...table import meta
 
 HDF5_SIGNATURE = b'\x89HDF\r\n\x1a\n'
+META_KEY = '__table_column_meta__'
 
 __all__ = ['read_table_hdf5', 'write_table_hdf5']
 
@@ -138,13 +140,26 @@ def read_table_hdf5(input, path=None):
     table = Table(np.array(input))
 
     # Read the meta-data from the file
-    table.meta.update(input.attrs)
+    if META_KEY in input.attrs:
+        header = meta.get_header_from_yaml(
+            h.decode('utf-8') for h in input.attrs[META_KEY])
+        if 'meta' in list(header.keys()):
+            table.meta = header['meta']
+
+        header_cols = dict((x['name'], x) for x in header['datatype'])
+        for col in table.columns.values():
+            for attr in ('description', 'format', 'unit', 'meta'):
+                if attr in header_cols[col.name]:
+                    setattr(col, attr, header_cols[col.name][attr])
+    else:
+        # Read the meta-data from the file
+        table.meta.update(input.attrs)
 
     return table
 
 
 def write_table_hdf5(table, output, path=None, compression=False,
-                     append=False, overwrite=False):
+                     append=False, overwrite=False, serialize_meta=False):
     """
     Write a Table object to an HDF5 file
 
@@ -221,7 +236,8 @@ def write_table_hdf5(table, output, path=None, compression=False,
         try:
             return write_table_hdf5(table, f, path=path,
                                     compression=compression, append=append,
-                                    overwrite=overwrite)
+                                    overwrite=overwrite,
+                                    serialize_meta=serialize_meta)
         finally:
             f.close()
 
@@ -247,12 +263,16 @@ def write_table_hdf5(table, output, path=None, compression=False,
     else:
         dset = output_group.create_dataset(name, data=table.as_array())
 
-    # Write the meta-data to the file
-    for key in table.meta:
-        val = table.meta[key]
-        try:
-            dset.attrs[key] = val
-        except TypeError:
-            warnings.warn("Attribute `{0}` of type {1} cannot be written to "
-                          "HDF5 files - skipping".format(key, type(val)),
-                          AstropyUserWarning)
+    if serialize_meta:
+        header_yaml = meta.get_yaml_from_table(table)
+        dset.attrs[META_KEY] = [h.encode('utf8') for h in header_yaml]
+    else:
+        # Write the meta-data to the file
+        for key in table.meta:
+            val = table.meta[key]
+            try:
+                dset.attrs[key] = val
+            except TypeError:
+                warnings.warn("Attribute `{0}` of type {1} cannot be written to "
+                              "HDF5 files - skipping".format(key, type(val)),
+                              AstropyUserWarning)

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -274,5 +274,6 @@ def write_table_hdf5(table, output, path=None, compression=False,
                 dset.attrs[key] = val
             except TypeError:
                 warnings.warn("Attribute `{0}` of type {1} cannot be written to "
-                              "HDF5 files - skipping".format(key, type(val)),
+                              "HDF5 files - skipping. (Consider specifying "
+                              "serialize_meta=True to write all meta data)".format(key, type(val)),
                               AstropyUserWarning)

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -372,6 +372,40 @@ def test_preserve_meta(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_H5PY')
+def test_preserve_units(tmpdir):
+    test_file = str(tmpdir.join('test.hdf5'))
+
+    t1 = Table()
+    t1.add_column(Column(name='a', data=[1, 2, 3], unit="s"))
+
+    t1.meta['b'] = {"b0": 1}
+
+    t1.write(test_file, path='the_table', serialize_meta=True, overwrite=True)
+
+    t2 = Table.read(test_file, path='the_table')
+
+    assert t1['a'].unit == t2['a'].unit
+
+
+@pytest.mark.skipif('not HAS_H5PY')
+def test_preserve_dict(tmpdir):
+    test_file = str(tmpdir.join('test.hdf5'))
+
+    t1 = Table()
+    t1.add_column(Column(name='a', data=[1, 2, 3]))
+    t1.meta['b'] = {"b0": 1}
+    t1.meta['c'] = {"c0": [0, 1]}
+
+    t1.write(test_file, path='the_table', serialize_meta=True, overwrite=True)
+
+    t2 = Table.read(test_file, path='the_table')
+
+    assert t1.meta['b']['b0'] == t2.meta['b']['b0']
+    assert np.all([x == y for (x, y) in zip(t1.meta['c']['c0'],
+                                            t2.meta['c']['c0'])])
+
+
+@pytest.mark.skipif('not HAS_H5PY')
 def test_skip_meta(tmpdir):
 
     test_file = str(tmpdir.join('test.hdf5'))

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -391,12 +391,8 @@ def test_preserve_serialized(tmpdir):
     assert t1['a'].unit == t2['a'].unit
     assert t1['a'].format == t2['a'].format
     assert t1['a'].description == t2['a'].description
-    assert t1['a'].meta['a0'] == t2['a'].meta['a0']
-    assert np.all([x == y for (x, y) in zip(t1['a'].meta['a1']['a1'],
-                                            t2['a'].meta['a1']['a1'])])
-    assert t1.meta['b'] == t2.meta['b']
-    assert np.all([x == y for (x, y) in zip(t1.meta['c']['c0'],
-                                            t2.meta['c']['c0'])])
+    assert t1['a'].meta == t2['a'].meta
+    assert t1.meta == t2.meta
 
 
 @pytest.mark.skipif('not HAS_H5PY')

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -291,6 +291,12 @@ overwriting existing files. To overwrite only a single table within an HDF5
 file that has multiple datasets, use *both* the ``overwrite=True`` and
 ``append=True`` arguments.
 
+If the metadata of the table cannot be written directly to the HDF5 file 
+(e.g. dictionaries), or if you want to preserve the units and description
+of tables and columns, use using ``serialize_meta=True``::
+
+    >>> t.write('observations.hdf5', path='updated_data', serialized_meta=True)
+ 
 Finally, when writing to HDF5 files, the ``compression=`` argument can be
 used to ensure that the data is compressed on disk::
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -293,7 +293,7 @@ file that has multiple datasets, use *both* the ``overwrite=True`` and
 
 If the metadata of the table cannot be written directly to the HDF5 file 
 (e.g. dictionaries), or if you want to preserve the units and description
-of tables and columns, use using ``serialize_meta=True``::
+of tables and columns, use using ``serialized_meta=True``::
 
     >>> t.write('observations.hdf5', path='updated_data', serialized_meta=True)
  


### PR DESCRIPTION
This is the first draft of implementing YAML meta save in HDF5 I/O using #3723, using as a guide the solution in #3568. This is meant to address a couple of previous Issues (e.g. #3567, #3597). In its current state, #3597 still doesn't pass, but #3567 does.