### PR TITLE
Updated CODATA constants with 2014 values from http://physics.nist.go…

### DIFF
--- a/astropy/constants/si.py
+++ b/astropy/constants/si.py
@@ -13,92 +13,93 @@ from .constant import Constant, EMConstant
 # PHYSICAL CONSTANTS
 
 # Planck constant
-h = Constant('h', "Planck constant", 6.62606957e-34, 'J s', 0.00000029e-34,
-             'CODATA 2010', system='si')
+h = Constant('h', "Planck constant", 6.626070040e-34, 'J s', 0.000000081e-34,
+             'CODATA 2014', system='si')
 
 # Reduced Planck constant
 hbar = Constant('hbar', "Reduced Planck constant", h.value * 0.5 / np.pi,
                 'J s', h.uncertainty * 0.5 / np.pi, h.reference, system='si')
 
 # Boltzmann constant
-k_B = Constant('k_B', "Boltzmann constant", 1.3806488e-23, 'J / (K)',
-               0.0000013e-23, 'CODATA 2010', system='si')
+k_B = Constant('k_B', "Boltzmann constant", 1.38064852e-23, 'J / (K)',
+               0.00000079e-23, 'CODATA 2014', system='si')
 
 # Speed of light
 c = Constant('c', "Speed of light in vacuum", 2.99792458e8, 'm / (s)', 0.,
-             'CODATA 2010', system='si')
+             'CODATA 2014', system='si')
 
 # Gravitional constant
-G = Constant('G', "Gravitational constant", 6.67384e-11, 'm3 / (kg s2)',
-             0.00080e-11, 'CODATA 2010', system='si')
+G = Constant('G', "Gravitational constant", 6.67408e-11, 'm3 / (kg s2)',
+             0.00031e-11, 'CODATA 2014', system='si')
 
 # Standard acceleration of gravity
 g0 = Constant('g0', "Standard acceleration of gravity", 9.80665, 'm / s2', 0.0,
-              'CODATA 2010', system='si')
+              'CODATA 2014', system='si')
 
 # Proton mass
-m_p = Constant('m_p', "Proton mass", 1.672621777e-27, 'kg', 0.000000074e-27,
-               'CODATA 2010', system='si')
+m_p = Constant('m_p', "Proton mass", 1.672621898e-27, 'kg', 0.000000021e-27,
+               'CODATA 2014', system='si')
 
 # Neutron mass
-m_n = Constant('m_n', "Neutron mass", 1.674927351e-27, 'kg', 0.000000074e-27,
-               'CODATA 2010', system='si')
+m_n = Constant('m_n', "Neutron mass", 1.674927471e-27, 'kg', 0.000000021e-27,
+               'CODATA 2014', system='si')
 
 # Electron mass
-m_e = Constant('m_e', "Electron mass", 9.10938291e-31, 'kg', 0.00000040e-31,
-               'CODATA 2010', system='si')
+m_e = Constant('m_e', "Electron mass", 9.10938356e-31, 'kg', 0.00000011e-31,
+               'CODATA 2014', system='si')
 
 # Atomic mass
-u = Constant('u', "Atomic mass", 1.660538921e-27, 'kg', 0.000000073e-27,
-             'CODATA 2010', system='si')
+u = Constant('u', "Atomic mass", 1.660539040e-27, 'kg', 0.000000020e-27,
+             'CODATA 2014', system='si')
 
 # Stefan-Boltzmann constant
-sigma_sb = Constant('sigma_sb', "Stefan-Boltzmann constant", 5.670373e-8,
-                    'W / (K4 m2)', 0.000021e-8, 'CODATA 2010', system='si')
+sigma_sb = Constant('sigma_sb', "Stefan-Boltzmann constant", 5.670367e-8,
+                    'W / (K4 m2)', 0.000013e-8, 'CODATA 2014', system='si')
 
 # Electron charge; EM constants require a system to be specified
-e = EMConstant('e', 'Electron charge', 1.602176565e-19, 'C', 0.000000035e-19,
-               'CODATA 2010', system='si')
+e = EMConstant('e', 'Electron charge', 1.6021766208e-19, 'C', 0.0000000098e-19,
+               'CODATA 2014', system='si')
 
 # Electric constant
 eps0 = EMConstant('eps0', 'Electric constant', 8.854187817e-12, 'F/m', 0.0,
-                  'CODATA 2010', system='si')
+                  'CODATA 2014', system='si')
 
 # Avogadro's number
-N_A = Constant('N_A', "Avogadro's number", 6.02214129e23, '1 / (mol)',
-               0.00000027e23, 'CODATA 2010', system='si')
+N_A = Constant('N_A', "Avogadro's number", 6.022140857e23, '1 / (mol)',
+               0.000000074e23, 'CODATA 2014', system='si')
 
 # Gas constant
-R = Constant('R', "Gas constant", 8.3144621, 'J / (K mol)', 0.0000075,
-             'CODATA 2010', system='si')
+R = Constant('R', "Gas constant", 8.3144598, 'J / (K mol)', 0.0000048,
+             'CODATA 2014', system='si')
 
 # Rydberg constant
-Ryd = Constant('Ryd', 'Rydberg constant', 10973731.568539, '1 / (m)', 0.000055,
-               'CODATA 2010', system='si')
+Ryd = Constant('Ryd', 'Rydberg constant', 10973731.568508, '1 / (m)', 0.000065,
+               'CODATA 2014', system='si')
 
 # Bohr radius
-a0 = Constant('a0', "Bohr radius", 0.52917721092e-10, 'm', 0.00000000017e-10,
-              'CODATA 2010', system='si')
+a0 = Constant('a0', "Bohr radius", 0.52917721067e-10, 'm', 0.00000000012e-10,
+              'CODATA 2014', system='si')
 
 # Bohr magneton
-muB = Constant('muB', "Bohr magneton", 927.400968e-26, 'J/T', 0.00002e-26,
-               'CODATA 2010', system='si')
+muB = Constant('muB', "Bohr magneton", 927.4009994e-26, 'J/T', 0.0000057e-26,
+               'CODATA 2014', system='si')
 
 # Fine structure constant
-alpha = Constant('alpha', "Fine-structure constant", 7.2973525698e-3, '',
-                 0.0000000024e-3, 'CODATA 2010', system='si')
+alpha = Constant('alpha', "Fine-structure constant", 7.2973525664e-3, '',
+                 0.0000000017e-3, 'CODATA 2014', system='si')
 
 # Atmosphere
 atm = Constant('atmosphere', "Atmosphere", 101325, 'Pa', 0.0,
-               'CODATA 2010', system='si')
+               'CODATA 2014', system='si')
 
 # Magnetic constant
 mu0 = Constant('mu0', "Magnetic constant", 4.0e-7 * np.pi, 'N/A2', 0.0,
-               'CODATA 2010', system='si')
+               'CODATA 2014', system='si')
 
 # Thomson scattering cross-section
-sigma_T = Constant('sigma_T', "Thomson scattering cross-section", 0.6652458734e-28, 'm2',
-                   0.0000000013e-28, 'CODATA 2010', system='si')
+sigma_T = Constant('sigma_T', "Thomson scattering cross-section",
+                   0.66524587158e-28, 'm2', 0.00000000091e-28, 'CODATA 2014',
+                   system='si')
 
 # DISTANCE
 
@@ -120,7 +121,7 @@ kpc = Constant('kpc', "Kiloparsec",
 
 # Wien wavelength displacement law constant
 b_wien = Constant('b_wien', 'Wien wavelength displacement law constant',
-                  2.8977721e-3, 'm K', 0.0000026e-3, 'CODATA 2010', system='si')
+                  2.8977729e-3, 'm K', 0.0000017e-3, 'CODATA 2014', system='si')
 
 # SOLAR QUANTITIES
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1078,13 +1078,13 @@ def test_critical_density():
     #  units by default; see the comment at the top of core.py
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     assert allclose(tcos.critical_density0,
-                    9.31000324385361e-30 * u.g / u.cm**3)
+                    9.309668456020899e-30 * u.g / u.cm**3)
     assert allclose(tcos.critical_density0,
                     tcos.critical_density(0))
     assert allclose(tcos.critical_density([1, 5]),
-                    [2.70362491e-29, 5.53758986e-28] * u.g / u.cm**3)
+                    [2.70352772e-29, 5.53739080e-28] * u.g / u.cm**3)
     assert allclose(tcos.critical_density([1., 5.]),
-                    [2.70362491e-29, 5.53758986e-28] * u.g / u.cm**3)
+                    [2.70352772e-29, 5.53739080e-28] * u.g / u.cm**3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -21,7 +21,7 @@ class Unicode(console.Console):
       >>> import astropy.units as u
       >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
                       m² kg
-      2.1798721×10⁻¹⁸ ─────
+      2.1798722×10⁻¹⁸ ─────
                        s²
     """
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -92,7 +92,7 @@ def test_doppler_wavelength_0(function):
 @pytest.mark.parametrize(('function'), doppler_functions)
 def test_doppler_energy_0(function):
     rest = 105.01 * u.GHz
-    q1 = 0.000434286445543 * u.eV
+    q1 = 0.0004342864612223 * u.eV
     velo0 = q1.to(u.km/u.s, equivalencies=function(rest))
     np.testing.assert_almost_equal(velo0.value, 0, decimal=6)
 
@@ -439,7 +439,7 @@ def test_irrelevant_equivalency():
 def test_brightness_temperature():
     omega_B = np.pi * (50 * u.arcsec) ** 2
     nu = u.GHz * 5
-    tb = 7.05258885885 * u.K
+    tb = 7.05259028913 * u.K
     np.testing.assert_almost_equal(
         tb.value, (1 * u.Jy).to(
             u.K, equivalencies=u.brightness_temperature(omega_B, nu)).value)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -287,12 +287,12 @@ def test_new_style_latex():
 
 
 def test_latex_scale():
-    latex = '$\\mathrm{2.1798721 \\times 10^{-18}\\,\\frac{m^{2}\\,kg}{s^{2}}}$'
+    latex = '$\\mathrm{2.1798722 \\times 10^{-18}\\,\\frac{m^{2}\\,kg}{s^{2}}}$'
     assert u.Ry.decompose().to_string('latex') == latex
 
 
 def test_latex_inline_scale():
-    latex_inline = '$\\mathrm{2.1798721 \\times 10^{-18}\\,m^{2}\\,kg\\,s^{-2}}$'
+    latex_inline = '$\\mathrm{2.1798722 \\times 10^{-18}\\,m^{2}\\,kg\\,s^{-2}}$'
     assert u.Ry.decompose().to_string('latex_inline') == latex_inline
 
 

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -33,7 +33,7 @@ different units for example::
       Value  = 299792458.0
       Error  = 0.0
       Units  = m / s
-      Reference = CODATA 2010
+      Reference = CODATA 2014
 
     >>> print const.c.to('km/s')
     299792.458 km / s

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -47,7 +47,7 @@ and you can use them in conjunction with unit and other non-constant
     >>> from astropy import units as u
     >>> F = (const.G * 3. * const.M_sun * 100 * u.kg) / (2.2 * u.au) ** 2
     >>> print F.to(u.N)
-    0.367669392028 N
+    0.367682613899 N
 
 It is possible to convert most constants to cgs using e.g.::
 

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -146,7 +146,7 @@ You can see how the density parameters evolve with redshift as well::
 
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
   >>> WMAP7.Om([0, 1.0, 2.0]), WMAP7.Ode([0., 1.0, 2.0])  # doctest: +FLOAT_CMP
-  (array([ 0.272     ,  0.74898524,  0.90905239]),
+  (array([ 0.272     ,  0.74898523,  0.90905237]),
    array([ 0.72791572,  0.25055061,  0.0901026 ]))
 
 Note that these don't quite add up to one even though WMAP7 assumes a

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -337,8 +337,8 @@ can be found as a function of redshift::
   (4.985694972799396e-05, 3.442154948307989e-05)
   >>> z = [0, 1.0, 2.0]
   >>> WMAP7.Ogamma(z), WMAP7.Onu(z)
-  (array([  4.98569497e-05,   2.74574409e-04,   4.99881391e-04]),
-   array([  3.44215495e-05,   1.89567887e-04,   3.45121234e-04]))
+  (array([  4.98586899e-05,   2.74583989e-04,   4.99898824e-04]),
+   array([  3.44227509e-05,   1.89574501e-04,   3.45133270e-04]))
 
 If you want to exclude photons and neutrinos from your calculations,
 simply set ``Tcmb0`` to 0::
@@ -354,7 +354,7 @@ Neutrinos can be removed (while leaving photons) by setting ``Neff`` to 0::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cos = FlatLambdaCDM(70.4, 0.272, Neff=0)
   >>> cos.Ogamma([0, 1, 2])  # Photons are still present  # doctest: +FLOAT_CMP
-  array([  4.98569497e-05,   2.74623215e-04,   5.00051839e-04])
+  array([  4.98586899e-05,   2.74632798e-04,   5.00069284e-04])
   >>> cos.Onu([0, 1, 2])  # But not neutrinos
   array([ 0.,  0.,  0.])
 
@@ -382,7 +382,7 @@ value is provided, all the species are assumed to have the same mass.
   >>> cosmo.m_nu
   <Quantity [ 0.  , 0.05, 0.1 ] eV>
   >>> cosmo.Onu([0, 1.0, 15.0])  # doctest: +FLOAT_CMP
-  array([ 0.00326988,  0.00896783,  0.0125786 ])
+  array([ 0.00327   ,  0.00896814,  0.01257904])
   >>> cosmo.Onu(1) * cosmo.critical_density(1)  # doctest: +FLOAT_CMP
   <Quantity 2.444380380370406e-31 g / cm3>
 

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -49,7 +49,7 @@ redshifts as input:
 
   >>> from astropy.cosmology import WMAP9 as cosmo
   >>> cosmo.comoving_distance([0.5, 1.0, 1.5])  # doctest: +FLOAT_CMP
-  <Quantity [ 1916.0694236 , 3363.07064333, 4451.74756242] Mpc>
+  <Quantity [ 1916.06942039, 3363.0706321 , 4451.74754107] Mpc>
 
 You can create your own FLRW-like cosmology using one of the Cosmology
 classes::
@@ -114,21 +114,21 @@ redshift 4 by:
 .. doctest-requires:: scipy
 
   >>> cosmo.luminosity_distance(4)  # doctest: +FLOAT_CMP
-  <Quantity 35842.353618623194 Mpc>
-
+  <Quantity 35842.35328799687 Mpc>
+  
 or the age of the universe at z = 0:
 
 .. doctest-requires:: scipy
 
   >>> cosmo.age(0)  # doctest: +FLOAT_CMP
-  <Quantity 13.461701658024014 Gyr>
+  <Quantity 13.461701476415707 Gyr>
 
 They also accept arrays of redshifts:
 
 .. doctest-requires:: scipy
 
   >>> cosmo.age([0.5, 1, 1.5]).value  # doctest: +FLOAT_CMP
-  array([ 8.42128047,  5.74698053,  4.19645402])
+  array([ 8.4212803 ,  5.74698037,  4.19645387])
 
 See the `~astropy.cosmology.FLRW` and
 `~astropy.cosmology.FlatLambdaCDM` object docstring for all the
@@ -223,8 +223,8 @@ redshift which it corresponds to, you can use ``z_at_value``:
   >>> import astropy.units as u
   >>> from astropy.cosmology import Planck13, z_at_value
   >>> z_at_value(Planck13.age, 2 * u.Gyr)  # doctest: +FLOAT_CMP
-  3.1981226843560968
-
+  3.1981209656529268
+  
 For some quantities there can be more than one redshift that satisfies
 a value. In this case you can use the ``zmin`` and ``zmax`` keywords
 to restrict the search range. See the ``z_at_value`` docstring for more
@@ -241,7 +241,7 @@ the WMAP and Planck satellite data. For example,
 
   >>> from astropy.cosmology import Planck13  # Planck 2013
   >>> Planck13.lookback_time(2)  # lookback time in Gyr at z=2  # doctest: +FLOAT_CMP
-  <Quantity 10.511841788576083 Gyr>
+  <Quantity 10.511841376920712 Gyr>
 
 A full list of the pre-defined cosmologies is given by
 ``cosmology.parameters.available``, and summarized below:

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -189,7 +189,7 @@ here is an example::
     >>> omega_B = 2 * np.pi * beam_sigma**2
     >>> freq = 5 * u.GHz
     >>> u.Jy.to(u.K, equivalencies=u.brightness_temperature(omega_B, freq))
-    3.526294...
+    3.526295...
 
 .. note:: Despite the Astropy unit on the left being shown as ``u.Jy``, this is
           the conversion factor from Jy/beam to K (because ``u.beam`` cannot
@@ -221,7 +221,7 @@ observations at high-energy, be it for solar or X-ray astronomy. Example::
     >>> import astropy.units as u
     >>> t_k = 1e6 * u.K
     >>> t_k.to(u.eV, equivalencies=u.temperature_energy())  # doctest: +FLOAT_CMP
-    <Quantity 86.17332384960955 eV>
+    <Quantity 86.17330337217213 eV>
 
 Writing new equivalencies
 -------------------------

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -106,7 +106,7 @@ energy can be converted.
   >>> ([1000, 2000] * u.nm).to(u.Hz, equivalencies=u.spectral())
   <Quantity [  2.99792458e+14,  1.49896229e+14] Hz>
   >>> ([1000, 2000] * u.nm).to(u.eV, equivalencies=u.spectral())  # doctest: +FLOAT_CMP
-  <Quantity [ 1.23984193, 0.61992096] eV>
+  <Quantity [ 1.23984197, 0.61992099] eV>
 
 These equivalencies even work with non-base units::
 

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -105,7 +105,7 @@ parentheses to create a corresponding logarithmic quantity::
     <Magnitude -2.5 mag(ct / s)>
     >>> from astropy import constants as c
     >>> u.Dex((c.G * u.M_sun / u.R_sun**2).cgs)  # doctest: +FLOAT_CMP
-    <Dex 4.43842814841305 dex(cm / s2)>
+    <Dex 4.438443765928838 dex(cm / s2)>
     
 `astropy.units` also handles :ref:`equivalencies <unit_equivalencies>`, such as
 that between wavelength and frequency. To use that feature, equivalence objects

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -26,7 +26,7 @@ a logarithmic unit.  For instance::
   >>> -2.5 * u.mag(u.ct / u.s)
   <Magnitude -2.5 mag(ct / s)>
   >>> u.Dex((c.G * u.M_sun / u.R_sun**2).cgs)  # doctest: +FLOAT_CMP
-  <Dex 4.43842814841305 dex(cm / s2)>
+  <Dex 4.438443765928838 dex(cm / s2)>
   >>> np.linspace(2., 5., 7) * u.Unit("dex(cm/s2)")
   <Dex [ 2. , 2.5, 3. , 3.5, 4. , 4.5, 5. ] dex(cm / s2)>
 


### PR DESCRIPTION
Updated constants from CODATA to their 2014 values taken from the database at http://physics.nist.gov/cuu/Constants/

For exact constants (e.g. speed of light in vacuum) the value was confirmed and the reference was updated from 2010 to 2014 as well. 
