### PR TITLE
Put FastBasic high in guess list and fix some latent bugs in fast readers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -452,6 +452,10 @@ Bug fixes
   - Fix a segfault in the fast C parser when one of the column headers
     is empty [#3545].
 
+  - Fix several bugs that prevented the fast readers from being used
+    when guessing the file format.  Also improved the read trace
+    information to better understand format guessing. [#4115]
+
 - ``astropy.io.fits``
 
   - Included a new command-line script called ``fitsinfo`` to display

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -248,6 +248,9 @@ class FastCommentedHeader(FastBasic):
                 if len(commented_lines) == self.header_start + 1:
                     break
 
+        if len(commented_lines) <= self.header_start:
+            raise cparser.CParserError('not enough commented lines')
+
         self.engine.setup_tokenizer([commented_lines[self.header_start]])
         self.engine.header_start = 0
         self.engine.read_header()

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -78,6 +78,8 @@ class FastBasic(object):
         elif 'data_Splitter' in self.kwargs or 'header_Splitter' in self.kwargs:
             raise core.ParameterError("The C reader does not use a Splitter class")
 
+        self.strict_names = self.kwargs.pop('strict_names', False)
+
         self.engine = cparser.CParser(table, self.strip_whitespace_lines,
                                       self.strip_whitespace_fields,
                                       delimiter=self.delimiter,
@@ -107,7 +109,7 @@ class FastBasic(object):
             # Impose strict requirements on column names (normally used in guessing)
             bads = [" ", ",", "|", "\t", "'", '"']
             for name in self.engine.get_names():
-                if (_is_number(name) or
+                if (core._is_number(name) or
                     len(name) == 0 or
                     name[0] in bads or
                     name[-1] in bads):
@@ -115,7 +117,7 @@ class FastBasic(object):
                                      .format(name))
         # When guessing require at least two columns
         if self.guessing and len(self.engine.get_names()) <= 1:
-            raise ValueError
+            raise ValueError('Strict name guessing requires at least two columns')
 
     def write(self, table, output):
         """

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -164,21 +164,23 @@ def test_no_header(parallel, read_basic, read_no_header):
     The header should not be read when header_start=None. Unless names is
     passed, the column names should be auto-generated.
     """
-    t1 = read_basic("A B C\n1 2 3\n4 5 6", header_start=None, data_start=0, parallel=parallel)
+    # Cannot set header_start=None for basic format
+    with pytest.raises(ValueError):
+        read_basic("A B C\n1 2 3\n4 5 6", header_start=None, data_start=0, parallel=parallel)
+
     t2 = read_no_header("A B C\n1 2 3\n4 5 6", parallel=parallel)
     expected = Table([['A', '1', '4'], ['B', '2', '5'], ['C', '3', '6']], names=('col1', 'col2', 'col3'))
-    assert_table_equal(t1, expected)
     assert_table_equal(t2, expected)
 
 
 @pytest.mark.parametrize("parallel", [True, False])
-def test_no_header_supplied_names(parallel, read_basic):
+def test_no_header_supplied_names(parallel, read_basic, read_no_header):
     """
     If header_start=None and names is passed as a parameter, header
     data should not be read and names should be used instead.
     """
-    table = read_basic("A B C\n1 2 3\n4 5 6", header_start=None, data_start=0,
-                       names=('X', 'Y', 'Z'), parallel=parallel)
+    table = read_no_header("A B C\n1 2 3\n4 5 6",
+                           names=('X', 'Y', 'Z'), parallel=parallel)
     expected = Table([['A', '1', '4'], ['B', '2', '5'], ['C', '3', '6']], names=('X', 'Y', 'Z'))
     assert_table_equal(table, expected)
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -485,8 +485,7 @@ def test_read_rdb_wrong_type(fast_reader):
     table = """col1\tcol2
 N\tN
 1\tHello"""
-    err_type = ValueError if not fast_reader else ascii.InconsistentTableError
-    with pytest.raises(err_type):
+    with pytest.raises(ValueError):
         ascii.read(table, Reader=ascii.Rdb, fast_reader=fast_reader)
 
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -379,8 +379,13 @@ def _guess(table, read_kwargs, format, fast_reader):
     # Filter the full guess list so that each entry is consistent with user kwarg inputs.
     # This also removes any duplicates from the list.
     filtered_guess_kwargs = []
+    fast_reader = read_kwargs.get('fast_reader')
 
     for guess_kwargs in full_list_guess:
+        # If user specified slow reader then skip all fast readers
+        if fast_reader is False and guess_kwargs['Reader'] in core.FAST_CLASSES.values():
+            continue
+
         guess_kwargs_ok = True  # guess_kwargs are consistent with user_kwargs?
         for key, val in read_kwargs.items():
             # Do guess_kwargs.update(read_kwargs) except that if guess_args has

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -306,7 +306,9 @@ def read(table, guess=None, **kwargs):
 
     if not guess:
         reader = get_reader(**new_kwargs)
-        # Try the fast reader first if applicable
+        # Try the fast reader version of `format` first if applicable.  Note that
+        # if user specified a fast format (e.g. format='fast_basic') this test
+        # will fail and the else-clause below will be used.
         if fast_reader_param and format is not None and 'fast_{0}'.format(format) \
                                                         in core.FAST_CLASSES:
             fast_kwargs = copy.copy(new_kwargs)
@@ -328,8 +330,8 @@ def read(table, guess=None, **kwargs):
         else:
             dat = reader.read(table)
             _read_trace.append({'kwargs': new_kwargs,
-                                'status': 'Success with slow reader which has no fast '
-                                          'reader analog (no guessing)'})
+                                'status': 'Success with specified Reader class '
+                                          '(no guessing)'})
 
     return dat
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -14,7 +14,7 @@ import re
 import os
 import sys
 import copy
-
+import time
 
 from . import core
 from . import basic
@@ -430,15 +430,18 @@ def _guess(table, read_kwargs, format, fast_reader):
 
             reader = get_reader(**guess_kwargs)
             reader.guessing = True
+            t0 = time.time()
             dat = reader.read(table)
-            _read_trace.append({'kwargs': guess_kwargs, 'status': 'Success (guessing)'})
+            _read_trace.append({'kwargs': guess_kwargs, 'status': 'Success (guessing)',
+                                'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
             return dat
 
         except (core.InconsistentTableError, ValueError, TypeError, AttributeError,
                 core.OptionalTableImportError, core.ParameterError, cparser.CParserError) as err:
             _read_trace.append({'kwargs': guess_kwargs,
                                 'status': '{0}: {1}'.format(err.__class__.__name__,
-                                                            str(err))})
+                                                            str(err)),
+                                'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
             failed_kwargs.append(guess_kwargs)
     else:
         # Failed all guesses, try the original read_kwargs without column requirements

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -433,7 +433,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             reader.guessing = True
             dat = reader.read(table)
             _read_trace.append({'kwargs': guess_kwargs, 'status': 'Success (guessing)',
-                                'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
+                                'dt': '{0:.3f} ms'.format((time.time() - t0) * 1000)})
             return dat
 
         except (core.InconsistentTableError, ValueError, TypeError, AttributeError,
@@ -441,7 +441,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             _read_trace.append({'kwargs': guess_kwargs,
                                 'status': '{0}: {1}'.format(err.__class__.__name__,
                                                             str(err)),
-                                'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
+                                'dt': '{0:.3f} ms'.format((time.time() - t0) * 1000)})
             failed_kwargs.append(guess_kwargs)
     else:
         # Failed all guesses, try the original read_kwargs without column requirements

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -543,7 +543,8 @@ def _get_guess_kwargs_list(read_kwargs):
 
     # Cycle through the basic-style readers using all combinations of delimiter
     # and quotechar.
-    for Reader in (basic.CommentedHeader, fastbasic.FastBasic, basic.Basic,
+    for Reader in (fastbasic.FastCommentedHeader, basic.CommentedHeader,
+                   fastbasic.FastBasic, basic.Basic,
                    fastbasic.FastNoHeader, basic.NoHeader):
         for delimiter in ("|", ",", " ", "\s"):
             for quotechar in ('"', "'"):

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -423,6 +423,7 @@ def _guess(table, read_kwargs, format, fast_reader):
     # Try to read the table using those args, and if an exception occurs then
     # keep track of the failed guess and move on.
     for guess_kwargs in filtered_guess_kwargs:
+        t0 = time.time()
         try:
             # If guessing will try all Readers then use strict req'ts on column names
             if 'Reader' not in read_kwargs:
@@ -430,7 +431,6 @@ def _guess(table, read_kwargs, format, fast_reader):
 
             reader = get_reader(**guess_kwargs)
             reader.guessing = True
-            t0 = time.time()
             dat = reader.read(table)
             _read_trace.append({'kwargs': guess_kwargs, 'status': 'Success (guessing)',
                                 'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -509,6 +509,7 @@ def _get_guess_kwargs_list(read_kwargs):
     # FixedWidthTwoLine would also be read by Basic, so it needs to come first.
     if len(read_kwargs) > 0:
         for reader in [fixedwidth.FixedWidthTwoLine,
+                       fastbasic.FastBasic,
                        basic.Basic]:
             first_kwargs = read_kwargs.copy()
             first_kwargs.update(dict(Reader=reader))

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -388,6 +388,10 @@ def _guess(table, read_kwargs, format, fast_reader):
         if fast_reader is False and guess_kwargs['Reader'] in core.FAST_CLASSES.values():
             continue
 
+        # If user required a fast reader with 'force' then skip all non-fast readers
+        if fast_reader == 'force' and guess_kwargs['Reader'] not in core.FAST_CLASSES.values():
+            continue
+
         guess_kwargs_ok = True  # guess_kwargs are consistent with user_kwargs?
         for key, val in read_kwargs.items():
             # Do guess_kwargs.update(read_kwargs) except that if guess_args has


### PR DESCRIPTION
I think we had intended to make the fast readers be used by default for Basic format tables, but the current guessing order was using the slow reader in most cases.  This PR changes that by inserting FastBasic high in the guess list.  As always messing around with the guess list is done with some trepidation, @hamogu.

Doing this revealed a latent issue in the fast readers which was mostly preventing them from participating in the guess process, related to strict_names not being defined and always raising an exception.  This was interpreted as the reader having failed to parse the table.

There is one more latent problem which will show up as Travis failures here:
```
ascii.read(['1 2', '3 4'], names=['a', 'b'], fast_reader='force', format='fast_basic')
Out[6]: 
<Table length=1>
  a     b  
int64 int64
----- -----
    3     4
```
When the table is interpreted as a `basic` format then the column names are `1` and `2`.  However, somewhere along the way the `names` of `['a', 'b']` get set as the parsed column names *before* the test enabled by `strict_names=True` gets done.  With enough effort I might be able to tease out what's happening, but I'm hoping that @mdmueller will see the fix right away and maybe make a PR against my branch.  :pray: