### PR TITLE
ImageNormalize needs to call autoscale_None

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -67,6 +67,9 @@ class ImageNormalize(Normalize):
             # copy because of in-place operations after
             values = np.array(values, copy=True, dtype=float)
 
+        # Set default values for vmin and vmax if not specified
+        self.autoscale_None(values)
+
         # Normalize based on vmin and vmax
         np.subtract(values, self.vmin, out=values)
 

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -61,6 +61,24 @@ def test_normalize_noclip():
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_normalize_implicit_autoscale():
+
+    data = np.linspace(0., 15., 6)
+
+    n = ImageNormalize(vmin=None, vmax=10., stretch=SqrtStretch(), clip=False)
+    n(data)
+
+    assert n.vmin == np.min(data)
+    assert n.vmax == 10.
+
+    n = ImageNormalize(vmin=2., vmax=None, stretch=SqrtStretch(), clip=False)
+    n(data)
+
+    assert n.vmin == 2.
+    assert n.vmax == np.max(data)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_masked_normalize_clip():
 
     data = np.linspace(0., 15., 6)


### PR DESCRIPTION
`__call__()` for the `ImageNormalize` class does not currently include a call to the inherited `autoscale_None()` to be able to handle when `vmin` or `vmax` is set to `None`.  See the analogous call in matplotlib's `Normalize` class: https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/colors.py#L913

This omission was not immediately apparent because matplotlib calls `autoscale_None()` behind the scenes when plotting in many – but not all! – cases.