### PR TITLE
Shape changing mixin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ API Changes
 
 - ``astropy.coordinates``
 
+  - Representations can now be reshaped using methods named like the numpy ones
+    for ``ndarray`` (i.e., ``reshape``, ``swapaxes``, etc.) [#4123]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -31,7 +31,11 @@ NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
 # get registered automatically.
 REPRESENTATION_CLASSES = {}
 
-class MetaBaseRepresentation(type):
+# Need to subclass ABCMeta rather than type, so that this meta class can be
+# combined with a ShapedLikeNDArray subclass (which is an ABC).  Without it:
+# "TypeError: metaclass conflict: the metaclass of a derived class must be a
+#  (non-strict) subclass of the metaclasses of all its bases"
+class MetaBaseRepresentation(abc.ABCMeta):
     def __init__(cls, name, bases, dct):
         super(MetaBaseRepresentation, cls).__init__(name, bases, dct)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -119,8 +119,8 @@ class BaseRepresentation(ShapedLikeNDArray):
             name = name[:-14]
         return name
 
-    def _replicate(self, method, *args, **kwargs):
-        """Replicate a coordinate object while applying a method to the arrays.
+    def _apply(self, method, *args, **kwargs):
+        """Create a new coordinate object with ``method`` applied to the arrays.
 
         The method is any of the shape-changing methods for `~numpy.ndarray`
         (``reshape``, ``swapaxes``, etc.), as well as those picking particular

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -122,11 +122,17 @@ class BaseRepresentation(ShapedLikeNDArray):
     def _replicate(self, method, *args, **kwargs):
         """Replicate a coordinate object while applying a method to the arrays.
 
+        The method is any of the shape-changing methods for `~numpy.ndarray`
+        (``reshape``, ``swapaxes``, etc.), as well as those picking particular
+        elements (``__getitem__``, ``take``, etc.). It will be applied to the
+        underlying arrays (e.g., ``x``, ``y``, and ``z`` for
+        `~astropy.coordinates.CartesianRepresentation`), with the results used
+        to create a new instance.
+
         Parameters
         ----------
         method : str
             The method is applied to the internal ``components``.
-            Example methods: ``copy``, ``__getitem__``, ``reshape``.
         args : tuple
             Any positional arguments for ``method``.
         kwargs : dict

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -160,18 +160,6 @@ class BaseRepresentation(ShapedLikeNDArray):
         return getattr(self, self.components[0]).shape
 
     @property
-    def ndim(self):
-        return getattr(self, self.components[0]).ndim
-
-    @property
-    def size(self):
-        return getattr(self, self.components[0]).size
-
-    @property
-    def isscalar(self):
-        return getattr(self, self.components[0]).isscalar
-
-    @property
     def _values(self):
         """Turn the coordinates into a record array with the coordinate values.
 

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -1,0 +1,122 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# TEST_UNICODE_LITERALS
+import numpy as np
+
+from ... import units as u
+from .. import SphericalRepresentation, Longitude, Latitude
+from ...tests.helper import pytest
+from ...utils.compat.numpycompat import NUMPY_LT_1_9
+
+
+class TestManipulation():
+    """Manipulation of Representation shapes.
+
+    Checking that attributes are manipulated correctly.
+
+    Even more exhaustive tests are done in time.tests.test_methods
+    """
+
+    def setup(self):
+        lon = Longitude(np.arange(0, 24, 4), u.hourangle)
+        lat = Latitude(np.arange(-90, 91, 30), u.deg)
+        # With same-sized arrays
+        self.s0 = SphericalRepresentation(
+            lon[:, np.newaxis] * np.ones(lat.shape),
+            lat * np.ones(lon.shape)[:, np.newaxis],
+            np.ones(lon.shape + lat.shape) * u.kpc)
+        # With unequal arrays -> these will be broadcast.
+        self.s1 = SphericalRepresentation(lon[:, np.newaxis], lat, 1. * u.kpc)
+        # For completeness on some tests, also a cartesian one
+        self.c0 = self.s0.to_cartesian()
+
+    def test_ravel(self):
+        s0_ravel = self.s0.ravel()
+        assert s0_ravel.shape == (self.s0.size,)
+        assert np.all(s0_ravel.lon == self.s0.lon.ravel())
+        assert np.may_share_memory(s0_ravel.lon, self.s0.lon)
+        assert np.may_share_memory(s0_ravel.lat, self.s0.lat)
+        assert np.may_share_memory(s0_ravel.distance, self.s0.distance)
+        # Since s1 was broadcast, ravel needs to make a copy.
+        s1_ravel = self.s1.ravel()
+        assert s1_ravel.shape == (self.s1.size,)
+        assert np.all(s1_ravel.lon == self.s1.lon.ravel())
+        assert not np.may_share_memory(s1_ravel.lat, self.s1.lat)
+
+    def test_flatten(self):
+        s0_flatten = self.s0.flatten()
+        assert s0_flatten.shape == (self.s0.size,)
+        assert np.all(s0_flatten.lon == self.s0.lon.flatten())
+        # Flatten always copies.
+        assert not np.may_share_memory(s0_flatten.distance, self.s0.distance)
+        s1_flatten = self.s1.flatten()
+        assert s1_flatten.shape == (self.s1.size,)
+        assert np.all(s1_flatten.lon == self.s1.lon.flatten())
+        assert not np.may_share_memory(s1_flatten.lat, self.s1.lat)
+
+    def test_transpose(self):
+        s0_transpose = self.s0.transpose()
+        assert s0_transpose.shape == (7, 6)
+        assert np.all(s0_transpose.lon == self.s0.lon.transpose())
+        assert np.may_share_memory(s0_transpose.distance, self.s0.distance)
+        s1_transpose = self.s1.transpose()
+        assert s1_transpose.shape == (7, 6)
+        assert np.all(s1_transpose.lat == self.s1.lat.transpose())
+        assert np.may_share_memory(s1_transpose.lat, self.s1.lat)
+        # Only one check on T, since it just calls transpose anyway.
+        # Doing it on the CartesianRepresentation just for variety's sake.
+        c0_T = self.c0.T
+        assert c0_T.shape == (7, 6)
+        assert np.all(c0_T.x == self.c0.x.T)
+        assert np.may_share_memory(c0_T.y, self.c0.y)
+
+    def test_diagonal(self):
+        s0_diagonal = self.s0.diagonal()
+        assert s0_diagonal.shape == (6,)
+        assert np.all(s0_diagonal.lat == self.s0.lat.diagonal())
+        if not NUMPY_LT_1_9:
+            assert np.may_share_memory(s0_diagonal.lat, self.s0.lat)
+
+    def test_swapaxes(self):
+        s1_swapaxes = self.s1.swapaxes(0, 1)
+        assert s1_swapaxes.shape == (7, 6)
+        assert np.all(s1_swapaxes.lat == self.s1.lat.swapaxes(0, 1))
+        assert np.may_share_memory(s1_swapaxes.lat, self.s1.lat)
+
+    def test_reshape(self):
+        s0_reshape = self.s0.reshape(2, 3, 7)
+        assert s0_reshape.shape == (2, 3, 7)
+        assert np.all(s0_reshape.lon == self.s0.lon.reshape(2, 3, 7))
+        assert np.all(s0_reshape.lat == self.s0.lat.reshape(2, 3, 7))
+        assert np.all(s0_reshape.distance == self.s0.distance.reshape(2, 3, 7))
+        assert np.may_share_memory(s0_reshape.lon, self.s0.lon)
+        assert np.may_share_memory(s0_reshape.lat, self.s0.lat)
+        assert np.may_share_memory(s0_reshape.distance, self.s0.distance)
+        s1_reshape = self.s1.reshape(3, 2, 7)
+        assert s1_reshape.shape == (3, 2, 7)
+        assert np.all(s1_reshape.lat == self.s1.lat.reshape(3, 2, 7))
+        assert np.may_share_memory(s1_reshape.lat, self.s1.lat)
+        # For reshape(3, 14), copying is necessary for lon, lat, but not for d
+        s1_reshape2 = self.s1.reshape(3, 14)
+        assert s1_reshape2.shape == (3, 14)
+        assert np.all(s1_reshape2.lon == self.s1.lon.reshape(3, 14))
+        assert not np.may_share_memory(s1_reshape2.lon, self.s1.lon)
+        assert s1_reshape2.distance.shape == (3, 14)
+        assert np.may_share_memory(s1_reshape2.distance, self.s1.distance)
+
+    def test_squeeze(self):
+        s0_squeeze = self.s0.reshape(3, 1, 2, 1, 7).squeeze()
+        assert s0_squeeze.shape == (3, 2, 7)
+        assert np.all(s0_squeeze.lat == self.s0.lat.reshape(3, 2, 7))
+        assert np.may_share_memory(s0_squeeze.lat, self.s0.lat)
+
+    def test_add_dimension(self):
+        s0_adddim = self.s0[:, np.newaxis, :]
+        assert s0_adddim.shape == (6, 1, 7)
+        assert np.all(s0_adddim.lon == self.s0.lon[:, np.newaxis, :])
+        assert np.may_share_memory(s0_adddim.lat, self.s0.lat)
+
+    def test_take(self):
+        s0_take = self.s0.take((5, 2))
+        assert s0_take.shape == (2,)
+        assert np.all(s0_take.lon == self.s0.lon.take((5, 2)))

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -727,7 +727,7 @@ class Time(ShapedLikeNDArray):
         tm : Time object
             Copy of this object
         """
-        return self._replicate(format=format, method='copy')
+        return self._apply(format=format, method='copy')
 
     def replicate(self, format=None, copy=False):
         """
@@ -758,15 +758,10 @@ class Time(ShapedLikeNDArray):
         tm : Time object
             Replica of this object
         """
-        # To avoid recalculating integer day + fraction, no longer just
-        # instantiate a new class instance, but rather do the steps by hand.
-        # This also avoids quite a bit of unnecessary work in __init__
-        #  tm = self.__class__(self._time.jd1, self._time.jd2,
-        #                      format='jd', scale=self.scale, copy=copy)
-        return self._replicate(format=format, method='copy' if copy else None)
+        return self._apply(format=format, method='copy' if copy else None)
 
-    def _replicate(self, method=None, *args, **kwargs):
-        """Replicate a time object, possibly applying a method to the arrays.
+    def _apply(self, method=None, *args, **kwargs):
+        """Create a new time object, possibly applying a method to the arrays.
 
         Parameters
         ----------

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -478,10 +478,6 @@ class Time(ShapedLikeNDArray):
         del self.cache
 
     @property
-    def ndim(self):
-        return self._time.jd1.ndim
-
-    @property
     def shape(self):
         """The shape of the time instances.
 
@@ -506,20 +502,12 @@ class Time(ShapedLikeNDArray):
             if val is not None and val.size > 1:
                 val.shape = shape
 
-    @property
-    def size(self):
-        return self._time.jd1.size
-
     def __bool__(self):
         """Any time should evaluate to True, except when it is empty."""
         return self.size > 0
 
     # In python2, __bool__ is not defined.
     __nonzero__ = __bool__
-
-    @property
-    def isscalar(self):
-        return self.shape == ()
 
     def _shaped_like_input(self, value):
         return value if self._time.jd1.shape else value.item()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -20,6 +20,7 @@ from .. import units as u, constants as const
 from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.decorators import lazyproperty
+from ..utils import ShapedLikeNDArray
 from ..utils.compat.misc import override__dir__
 from ..utils.data_info import MixinInfo, data_info_factory
 from ..utils.compat.numpy import broadcast_to
@@ -111,7 +112,7 @@ class TimeInfo(MixinInfo):
     # funcs = [lambda x: getattr(x, stat)() for stat_name in MixinInfo._stats])
 
 
-class Time(object):
+class Time(ShapedLikeNDArray):
     """
     Represent and manipulate times and dates for astronomy.
 
@@ -871,91 +872,6 @@ class Time(object):
                 pass
 
         return time_iter()
-
-    def __getitem__(self, item):
-        if self.isscalar:
-            raise TypeError('scalar {0!r} object is not subscriptable.'.format(
-                self.__class__.__name__))
-        return self._replicate('__getitem__', item)
-
-    def reshape(self, *args, **kwargs):
-        """Returns a time instance containing the same data with a new shape.
-
-        Parameters are as for :meth:`~numpy.ndarray.reshape`.  Note that it is
-        not always possible to change the shape of an array without copying the
-        data. If you want an error to be raise if the data is copied, you
-        should assign the new shape to the shape attribute.
-        """
-        return self._replicate('reshape', *args, **kwargs)
-
-    def ravel(self, *args, **kwargs):
-        """Return an instance with the time array collapsed into one dimension.
-
-        Parameters are as for :meth:`~numpy.ndarray.ravel`. Note that it is
-        not always possible to unravel an array without copying the data.
-        If you want an error to be raise if the data is copied, you should
-        should assign shape ``(-1,)`` to the shape attribute.
-        """
-        return self._replicate('ravel', *args, **kwargs)
-
-    def flatten(self, *args, **kwargs):
-        """Return a copy with the time array collapsed into one dimension.
-
-        Parameters are as for :meth:`~numpy.ndarray.flatten`.
-        """
-        return self._replicate('flatten', *args, **kwargs)
-
-    def transpose(self, *args, **kwargs):
-        """Return a time instance with the data transposed.
-
-        Parameters are as for :meth:`~numpy.ndarray.transpose`.  All internal
-        data are views of the data of the original.
-        """
-        return self._replicate('transpose', *args, **kwargs)
-
-    @property
-    def T(self):
-        """Return a time instance with the data transposed.
-
-        Parameters are as for :attr:`~numpy.ndarray.T`.  All internal
-        data are views of the data of the original.
-        """
-        if self.ndim < 2:
-            return self
-        else:
-            return self.transpose()
-
-    def swapaxes(self, *args, **kwargs):
-        """Return a time instance with the given axes interchanged.
-
-        Parameters are as for :meth:`~numpy.ndarray.swapaxes`.  All internal
-        data are views of the data of the original.
-        """
-        return self._replicate('swapaxes', *args, **kwargs)
-
-    def diagonal(self, *args, **kwargs):
-        """Return a time instance with the specified diagonals.
-
-        Parameters are as for :meth:`~numpy.ndarray.diagonal`.  All internal
-        data are views of the data of the original.
-        """
-        return self._replicate('diagonal', *args, **kwargs)
-
-    def squeeze(self, *args, **kwargs):
-        """Return a time instance with single-dimensional shape entries removed
-
-        Parameters are as for :meth:`~numpy.ndarray.squeeze`.  All internal
-        data are views of the data of the original.
-        """
-        return self._replicate('squeeze', *args, **kwargs)
-
-    def take(self, indices, axis=None, mode='raise'):
-        """Return a Time object formed from the elements the given indices.
-
-        Parameters are as for :meth:`~numpy.ndarray.take`, except that,
-        obviously, no output array can be given.
-        """
-        return self._replicate('take', indices, axis=axis, mode=mode)
 
     def _advanced_index(self, indices, axis=None, keepdims=False):
         """Turn argmin, argmax output into an advanced index.

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -858,8 +858,8 @@ class ShapedLikeNDArray(object):
 
     The class proper is assumed to have some underlying data, which are arrays
     or array-like structures. It must define a ``shape`` property, which gives
-    the shape of those data, as well as a ``_replicate`` method that creates a
-    new instance in which a `~numpy.ndarray` method has been applied to those.
+    the shape of those data, as well as an ``_apply`` method that creates a new
+    instance in which a `~numpy.ndarray` method has been applied to those.
 
     Furthermore, for consistency with `~numpy.ndarray`, it is recommended to
     define a setter for the ``shape`` property, which, like the
@@ -878,8 +878,8 @@ class ShapedLikeNDArray(object):
         """The shape of the instance and underlying arrays."""
 
     @abc.abstractmethod
-    def _replicate(method, *args, **kwargs):
-        """Replicate an instance, applying ``method`` to the underlying data.
+    def _apply(method, *args, **kwargs):
+        """Create a new instance, with ``method`` applied to underlying data.
 
         The method is any of the shape-changing methods for `~numpy.ndarray`
         (``reshape``, ``swapaxes``, etc.), as well as those picking particular
@@ -921,7 +921,7 @@ class ShapedLikeNDArray(object):
         if self.isscalar:
             raise TypeError('scalar {0!r} object is not subscriptable.'.format(
                 self.__class__.__name__))
-        return self._replicate('__getitem__', item)
+        return self._apply('__getitem__', item)
 
     def reshape(self, *args, **kwargs):
         """Returns an instance containing the same data with a new shape.
@@ -933,7 +933,7 @@ class ShapedLikeNDArray(object):
         the shape attribute (note: this may not be implemented for all classes
         using ``ShapedLikeNDArray``).
         """
-        return self._replicate('reshape', *args, **kwargs)
+        return self._apply('reshape', *args, **kwargs)
 
     def ravel(self, *args, **kwargs):
         """Return an instance with the array collapsed into one dimension.
@@ -943,14 +943,14 @@ class ShapedLikeNDArray(object):
         If you want an error to be raise if the data is copied, you should
         should assign shape ``(-1,)`` to the shape attribute.
         """
-        return self._replicate('ravel', *args, **kwargs)
+        return self._apply('ravel', *args, **kwargs)
 
     def flatten(self, *args, **kwargs):
         """Return a copy with the array collapsed into one dimension.
 
         Parameters are as for :meth:`~numpy.ndarray.flatten`.
         """
-        return self._replicate('flatten', *args, **kwargs)
+        return self._apply('flatten', *args, **kwargs)
 
     def transpose(self, *args, **kwargs):
         """Return an instance with the data transposed.
@@ -958,7 +958,7 @@ class ShapedLikeNDArray(object):
         Parameters are as for :meth:`~numpy.ndarray.transpose`.  All internal
         data are views of the data of the original.
         """
-        return self._replicate('transpose', *args, **kwargs)
+        return self._apply('transpose', *args, **kwargs)
 
     @property
     def T(self):
@@ -979,7 +979,7 @@ class ShapedLikeNDArray(object):
         ``axis1, axis2``.  All internal data are views of the data of the
         original.
         """
-        return self._replicate('swapaxes', *args, **kwargs)
+        return self._apply('swapaxes', *args, **kwargs)
 
     def diagonal(self, *args, **kwargs):
         """Return an instance with the specified diagonals.
@@ -987,7 +987,7 @@ class ShapedLikeNDArray(object):
         Parameters are as for :meth:`~numpy.ndarray.diagonal`.  All internal
         data are views of the data of the original.
         """
-        return self._replicate('diagonal', *args, **kwargs)
+        return self._apply('diagonal', *args, **kwargs)
 
     def squeeze(self, *args, **kwargs):
         """Return an instance with single-dimensional shape entries removed
@@ -995,7 +995,7 @@ class ShapedLikeNDArray(object):
         Parameters are as for :meth:`~numpy.ndarray.squeeze`.  All internal
         data are views of the data of the original.
         """
-        return self._replicate('squeeze', *args, **kwargs)
+        return self._apply('squeeze', *args, **kwargs)
 
     def take(self, indices, axis=None, mode='raise'):
         """Return a new instance formed from the elements at the given indices.
@@ -1003,4 +1003,4 @@ class ShapedLikeNDArray(object):
         Parameters are as for :meth:`~numpy.ndarray.take`, except that,
         obviously, no output array can be given.
         """
-        return self._replicate('take', indices, axis=axis, mode=mode)
+        return self._apply('take', indices, axis=axis, mode=mode)

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -898,8 +898,6 @@ class ShapedLikeNDArray(object):
 
         """
 
-    # Typically, ndim, size, and isscalar will be overridden, but we might as
-    # well set sensible defaults.
     @property
     def ndim(self):
         """The number of dimensions of the instance and underlying arrays."""

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -878,8 +878,8 @@ class ShapedLikeNDArray(object):
             Any keyword arguments for ``method``.
         """
 
-    # Typically, ndim and size will be overridden, but we might as well set
-    # sensible defaults.
+    # Typically, ndim, size, and isscalar will be overridden, but we might as
+    # well set sensible defaults.
     @property
     def ndim(self):
         """The number of dimensions of the instance and underlying arrays."""
@@ -892,6 +892,10 @@ class ShapedLikeNDArray(object):
         for sh in self.shape:
             size *= sh
         return size
+
+    @property
+    def isscalar(self):
+        return self.shape == ()
 
     def __getitem__(self, item):
         if self.isscalar:

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1108,6 +1108,7 @@ Reference/API
 =============
 
 .. automodapi:: astropy.time
+   :inherited-members:
 
 
 Acknowledgments and Licenses


### PR DESCRIPTION
EDIT: this is now a simplied follow-up of #4096, where a new `ShapedLikeNDArray` mixin class is created, which is used in `Time` and in the various coordinate representations. To also use it in frames and coordinates will require that the frame and coordinate attributes are properly broadcast at creating time.

OLD TEXT FOR REFERENCE
This is a first cut at #4096, where following @embray's suggestion the shape-changing methods from `Time` are split off to a new `ShapedLikeNDArray` mixin class and used in `Coordinates`. With it,
```
In [1]: from astropy.coordinates import SkyCoord; import astropy.units as u, numpy as np

In [2]: sc = SkyCoord(ra=np.arange(9)*u.deg, dec=np.arange(10, 19)*u.deg)

In [3]: sc.reshape(3,3).transpose()
Out[3]: 
<SkyCoord (ICRS): (ra, dec) in deg
    [[(0.0, 10.0), (3.0, 13.0), (6.0, 16.0)],
     [(1.0, 11.0), (4.0, 14.0), (7.0, 17.0)],
     [(2.0, 12.0), (5.0, 15.0), (8.0, 18.0)]]>
```

Comments very welcome (as are PRs with test cases; I'd prefer not to have to write them myself; was boring enough for `Time`!). cc: @taldcroft, @eteq.

Note that there are no test cases yet, though it seems all regular tests pass (which means that `__getitem__` is correctly done). A̶l̶s̶o̶,̶ ̶a̶ ̶p̶r̶o̶b̶l̶e̶m̶ ̶i̶s̶ ̶t̶h̶a̶t̶ ̶`̶s̶c̶.̶T̶`̶ ̶d̶o̶e̶s̶ ̶n̶o̶t̶ ̶w̶o̶r̶k̶ (EDIT: this is solved by the last commit)
