### PR TITLE
Adding astropy.time.Time.to_datetime convenience method for #4119

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,9 @@ matrix:
 install:
     - source .continuous-integration/travis/setup_environment_$TRAVIS_OS_NAME.sh
 
+    # OPTIONAL DEPENDENCIES
+    - if $OPTIONAL_DEPS; then $CONDA_INSTALL pytz; fi
+
 script:
     - $MAIN_CMD $SETUP_CMD
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,6 +192,9 @@ New Features
 
   - Add argmin, argmax, argsort, min, max, ptp, sort methods. [#3581]
 
+  - Add ``Time.to_datetime`` method for converting ``Time`` objects to
+    timezone-aware datetimes
+
 - ``astropy.units``
 
   - Added furlong to imperial units. [#3529]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,7 +193,7 @@ New Features
   - Add argmin, argmax, argsort, min, max, ptp, sort methods. [#3581]
 
   - Add ``Time.to_datetime`` method for converting ``Time`` objects to
-    timezone-aware datetimes
+    timezone-aware datetimes. [#4119]
 
 - ``astropy.units``
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython scipy h5py beautiful-soup jinja2 pyyaml scikit-image hdf5=1.8.13"
+    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython scipy h5py beautiful-soup jinja2 pyyaml scikit-image hdf5=1.8.13 pytz"
 
 # Not a .NET project, we build SunPy in the install step instead
 build: false

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1412,7 +1412,7 @@ class Time(object):
     def __ge__(self, other):
         return self._time_difference(other, '>=') >= 0.
 
-    def to_datetime(self, timezone):
+    def to_datetime(self, timezone=None):
         tm = self.replicate(format='datetime')
         return tm._shaped_like_input(tm._time.to_value(timezone))
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -25,7 +25,7 @@ from ..utils.compat.numpy import broadcast_to
 from ..extern import six
 from .utils import day_frac
 from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
-                      TimeJD, TimeUnique, TimeAstropyTime)
+                      TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
 # Import TimeFromEpoch to avoid breaking code that followed the old example of
 # making a custom timescale in the documentation.
 from .formats import TimeFromEpoch
@@ -1411,6 +1411,13 @@ class Time(object):
 
     def __ge__(self, other):
         return self._time_difference(other, '>=') >= 0.
+
+    def to_datetime(self, timezone):
+        tm = self.replicate(format='datetime')
+        return tm._shaped_like_input(tm._time.to_value(timezone))
+
+    to_datetime.__doc__ = TimeDatetime.to_value.__doc__
+
 
 
 class TimeDelta(Time):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -604,26 +604,43 @@ class TimeDatetime(TimeUnique):
 
 class TimezoneInfo(datetime.tzinfo):
     """
-    Class for a `~datetime.tzinfo` object, used in the
-    `TimeDatetime.to_datetime` method.
+    Subclass of the `~datetime.tzinfo` object, used in the
+    `TimeDatetime.to_datetime` method to specify timezones.
+
+    It may be safer in most cases to use a timezone database package like
+    `~pytz` rather than defining your own timezones.
     """
-    def __init__(self, utc_offset=0, dst=0, tzname=None):
+    @u.quantity_input(utc_offset=u.day, dst=u.day)
+    def __init__(self, utc_offset=0*u.day, dst=0*u.day, tzname=None):
         """
         Parameters
         ----------
-        utc_offset : int, float (optional)
-            Offset from UTC in days. Defaults to zero (UTC).
-        dst : int, float (optional)
+        utc_offset : `~astropy.units.Quantity` (optional)
+            Offset from UTC in days. Defaults to zero.
+        dst : `~astropy.units.Quantity` (optional)
             Daylight Savings Time offset in days. Defaults to zero
             (no daylight savings).
         tzname : string, `None` (optional)
             Name of timezone
+
+        Examples
+        --------
+        >>> from datetime import datetime
+        >>> from astropy.time import TimezoneInfo  # Specifies a timezone
+        >>> import astropy.units as u
+        >>> utc = TimezoneInfo()    # Defaults to UTC
+        >>> utc_plus_one_hour = TimezoneInfo(utc_offset=1*u.hour)  # UTC+1
+        >>> dt_aware = datetime(2000, 1, 1, 0, 0, 0, tzinfo=utc_plus_one_hour)
+        >>> print(dt_aware)
+        2000-01-01 00:00:00+01:00
+        >>> print(dt_aware.astimezone(utc))
+        1999-12-31 23:00:00+00:00
         """
         if utc_offset == 0 and dst == 0 and tzname is None:
             tzname = 'UTC'
-        self._utcoffset = datetime.timedelta(utc_offset)
+        self._utcoffset = datetime.timedelta(utc_offset.to(u.day).value)
         self._tzname = tzname
-        self._dst = datetime.timedelta(dst)
+        self._dst = datetime.timedelta(dst.to(u.day).value)
 
     def utcoffset(self, dt):
         return self._utcoffset

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -605,10 +605,11 @@ class TimeDatetime(TimeUnique):
 class TimezoneInfo(datetime.tzinfo):
     """
     Subclass of the `~datetime.tzinfo` object, used in the
-    `to_datetime` method to specify timezones.
+    to_datetime method to specify timezones.
 
     It may be safer in most cases to use a timezone database package like
-    `~pytz` rather than defining your own timezones.
+    pytz rather than defining your own timezones - this class is mainly
+    a workaround for users without pytz.
     """
     @u.quantity_input(utc_offset=u.day, dst=u.day)
     def __init__(self, utc_offset=0*u.day, dst=0*u.day, tzname=None):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -31,7 +31,8 @@ __all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',
            'TimeEpochDate', 'TimeBesselianEpoch', 'TimeJulianEpoch',
            'TimeDeltaFormat', 'TimeDeltaSec', 'TimeDeltaJD',
            'TimeEpochDateString', 'TimeBesselianEpochString',
-           'TimeJulianEpochString', 'TIME_FORMATS', 'TIME_DELTA_FORMATS']
+           'TimeJulianEpochString', 'TIME_FORMATS', 'TIME_DELTA_FORMATS',
+           'TimezoneInfo']
 
 __doctest_skip__ = ['TimePlotDate']
 
@@ -612,22 +613,35 @@ class TimeDatetime(TimeUnique):
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
             if timezone is not None:
                 out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec,
-                                             tzinfo=_UTCTimezoneInfo()).astimezone(timezone)
+                                             tzinfo=TimezoneInfo()).astimezone(timezone)
             else:
                 out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
         return iterator.operands[-1]
 
     value = property(to_value)
 
-class _UTCTimezoneInfo(datetime.tzinfo):
+class TimezoneInfo(datetime.tzinfo):
     """
-    Class for a UTC `~datetime.timezone` object, used in the
+    Class for a `~datetime.tzinfo` object, used in the
     `TimeDatetime.to_datetime` method.
     """
-    def __init__(self):
-        self._utcoffset = datetime.timedelta(0)
-        self._tzname = 'UTC'
-        self._dst = datetime.timedelta(0)
+    def __init__(self, utc_offset=0, dst=0, tzname=None):
+        """
+        Parameters
+        ----------
+        utc_offset : int, float (optional)
+            Offset from UTC in days. Defaults to zero (UTC).
+        dst : int, float (optional)
+            Daylight Savings Time offset in days. Defaults to zero
+            (no daylight savings).
+        tzname : string, `None` (optional)
+            Name of timezone
+        """
+        if utc_offset == 0 and dst == 0:
+            tzname = 'UTC'
+        self._utcoffset = datetime.timedelta(utc_offset)
+        self._tzname = tzname
+        self._dst = datetime.timedelta(dst)
 
     def utcoffset(self, dt):
         return self._utcoffset

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -605,7 +605,7 @@ class TimeDatetime(TimeUnique):
 class TimezoneInfo(datetime.tzinfo):
     """
     Subclass of the `~datetime.tzinfo` object, used in the
-    `TimeDatetime.to_datetime` method to specify timezones.
+    `to_datetime` method to specify timezones.
 
     It may be safer in most cases to use a timezone database package like
     `~pytz` rather than defining your own timezones.

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -544,7 +544,7 @@ class TimeDatetime(TimeUnique):
             dt = val.item()
 
             if dt.tzinfo is not None:
-               dt = (dt - dt.utcoffset()).replace(tzinfo=None)
+                dt = (dt - dt.utcoffset()).replace(tzinfo=None)
 
             iy[...] = dt.year
             im[...] = dt.month

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -556,24 +556,6 @@ class TimeDatetime(TimeUnique):
         self.jd1, self.jd2 = erfa_time.dtf_jd(
             self.scale.upper().encode('utf8'), *iterator.operands[1:])
 
-    @property
-    def value(self):
-        iys, ims, ids, ihmsfs = erfa_time.jd_dtf(self.scale.upper()
-                                                 .encode('utf8'),
-                                                 6,  # precision=6 for microsec
-                                                 self.jd1, self.jd2)
-        ihrs = ihmsfs[..., 0]
-        imins = ihmsfs[..., 1]
-        isecs = ihmsfs[..., 2]
-        ifracs = ihmsfs[..., 3]
-        iterator = np.nditer([iys, ims, ids, ihrs, imins, isecs, ifracs, None],
-                             flags=['refs_ok'],
-                             op_dtypes=7*[iys.dtype] + [np.object])
-        for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
-            out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
-
-        return iterator.operands[-1]
-
     def to_value(self, timezone=None):
         """
         Convert to (potentially timezone-aware) `~datetime.datetime` object.
@@ -637,7 +619,7 @@ class TimezoneInfo(datetime.tzinfo):
         tzname : string, `None` (optional)
             Name of timezone
         """
-        if utc_offset == 0 and dst == 0:
+        if utc_offset == 0 and dst == 0 and tzname is None:
             tzname = 'UTC'
         self._utcoffset = datetime.timedelta(utc_offset)
         self._tzname = tzname

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 import fnmatch
 import time
 import re
-from datetime import datetime, tzinfo, timedelta
+import datetime
 
 import numpy as np
 
@@ -528,7 +528,7 @@ class TimeDatetime(TimeUnique):
 
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class
-        if not all(isinstance(val, datetime) for val in val1.flat):
+        if not all(isinstance(val, datetime.datetime) for val in val1.flat):
             raise TypeError('Input values for {0} class must be '
                             'datetime objects'.format(self.name))
         return val1, None
@@ -569,7 +569,7 @@ class TimeDatetime(TimeUnique):
                              flags=['refs_ok'],
                              op_dtypes=7*[iys.dtype] + [np.object])
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
-            out[...] = datetime(iy, im, id, ihr, imin, isec, ifracsec)
+            out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
 
         return iterator.operands[-1]
 
@@ -611,23 +611,23 @@ class TimeDatetime(TimeUnique):
 
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
             if timezone is not None:
-                out[...] = datetime(iy, im, id, ihr, imin, isec, ifracsec,
-                                    tzinfo=_UTCTimezoneInfo()).astimezone(timezone)
+                out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec,
+                                             tzinfo=_UTCTimezoneInfo()).astimezone(timezone)
             else:
-                out[...] = datetime(iy, im, id, ihr, imin, isec, ifracsec)
+                out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
         return iterator.operands[-1]
 
     value = property(to_value)
 
-class _UTCTimezoneInfo(tzinfo):
+class _UTCTimezoneInfo(datetime.tzinfo):
     """
     Class for a UTC `~datetime.timezone` object, used in the
     `TimeDatetime.to_datetime` method.
     """
     def __init__(self):
-        self._utcoffset = timedelta(0)
+        self._utcoffset = datetime.timedelta(0)
         self._tzname = 'UTC'
-        self._dst = timedelta(0)
+        self._dst = datetime.timedelta(0)
 
     def utcoffset(self, dt):
         return self._utcoffset
@@ -737,7 +737,7 @@ class TimeString(TimeUnique):
         for iy, im, id, ihr, imin, isec, ifracsec in np.nditer(
                 [iys, ims, ids, ihrs, imins, isecs, ifracs]):
             if has_yday:
-                yday = datetime(iy, im, id).timetuple().tm_yday
+                yday = datetime.datetime(iy, im, id).timetuple().tm_yday
 
             yield {'year': int(iy), 'mon': int(im), 'day': int(id),
                    'hour': int(ihr), 'min': int(imin), 'sec': int(isec),

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -632,7 +632,7 @@ class _UTCTimezoneInfo(tzinfo):
         return self._utcoffset
 
     def tzname(self, dt):
-        return self._tzname
+        return str(self._tzname)
 
     def dst(self, dt):
         return self._dst

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -577,7 +577,7 @@ class TimeDatetime(TimeUnique):
         """
         Convert to (potentially timezone-aware) `~datetime.datetime` object.
 
-        If ``timezone`` is not `None`, return a timezone-aware datetime
+        If ``timezone`` is not ``None``, return a timezone-aware datetime
         object.
 
         Parameters
@@ -588,14 +588,15 @@ class TimeDatetime(TimeUnique):
         Returns
         -------
         `~datetime.datetime`
-            If ``timezone`` is not `None`, output will be timezone-aware.
+            If ``timezone`` is not ``None``, output will be timezone-aware.
         """
         if timezone is not None:
             if self._scale != 'utc':
-                raise ScaleValueError("Scale is {}, must be UTC."
-                                      "".format(self._scale))
+                raise ScaleValueError("scale is {}, must be 'utc' when timezone "
+                                      "is supplied.".format(self._scale))
 
-        # Below is mostly copied from self.value, with added timezone handling
+        # Rather than define a value property directly, we have a function,
+        # since we want to be able to pass in timezone information.
         iys, ims, ids, ihmsfs = erfa_time.jd_dtf(self.scale.upper()
                                                  .encode('utf8'),
                                                  6,  # precision=6 for microsec

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -12,9 +12,10 @@ import numpy as np
 from ...tests.helper import pytest, catch_warnings
 from ...extern import six
 from ...utils import isiterable
-from .. import Time, ScaleValueError, erfa_time, TIME_SCALES, TimeString
+from .. import (Time, ScaleValueError, erfa_time, TIME_SCALES, TimeString,
+                TimezoneInfo)
 from ...coordinates import EarthLocation
-
+from ... import units as u
 try:
     import pytz
     HAS_PYTZ = True
@@ -1007,32 +1008,7 @@ def test_isiterable():
     assert isiterable(t2)
 
 def test_to_datetime():
-    class TimezoneInfo(datetime.tzinfo):
-        """
-        This defines a timezone with UTC offset ``utcoffset``, meant as
-        a replacement for the `datetime.tzinfo` objects output by
-        `pytz.timezone`. For example, to simulate a timezone like
-        `pytz.timezone("US/Hawaii")`, try
-        `TimezoneInfo(utcoffset=datetime.timedelta(hours=-10))`
-        """
-        def __init__(self, utcoffset=None, tzname=None, dst=None):
-            self._utcoffset = utcoffset
-            self._tzname = tzname
-            self._dst = dst
-
-        def utcoffset(self, dt):
-            return self._utcoffset
-
-        def tzname(self, dt):
-            return str(self._tzname)
-
-        def dst(self, dt):
-            if self._dst is None:
-                return datetime.timedelta(0)
-            else:
-                return self._dst
-
-    tz = TimezoneInfo(utcoffset=datetime.timedelta(hours=-10), tzname='US/Hawaii')
+    tz = TimezoneInfo(utc_offset=-10*u.hour, tzname='US/Hawaii')
     # The above lines produces a `datetime.tzinfo` object similar to:
     #     tzinfo = pytz.timezone('US/Hawaii')
     time = Time('2010-09-03 00:00:00')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -906,9 +906,9 @@ def test_datetime_tzinfo():
         def utcoffset(self, dt):
             return datetime.timedelta(hours=-6)
 
-    d = datetime(2002, 1, 2, 10, 3, 4, tzinfo=TZm6())
+    d = datetime.datetime(2002, 1, 2, 10, 3, 4, tzinfo=TZm6())
     t = Time(d)
-    assert t.value == datetime(2002, 1, 2, 16, 3, 4)
+    assert t.value == datetime.datetime(2002, 1, 2, 16, 3, 4)
 
 def test_subfmts_regex():
     """

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -5,6 +5,7 @@
 import copy
 import functools
 import sys
+import pytz
 
 from datetime import datetime, tzinfo, timedelta
 
@@ -999,3 +1000,21 @@ def test_isiterable():
     t2 = Time(['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00'],
               format='iso', scale='utc')
     assert isiterable(t2)
+
+def test_scalar_to_datetime():
+    tzinfo = pytz.timezone('US/Hawaii')
+    time = Time('2010-09-03 00:00:00')
+    tz_aware_datetime = time.to_datetime(tzinfo)
+    forced_to_astropy_time = Time(tz_aware_datetime)
+    assert tzinfo.tzname(time.datetime) == tz_aware_datetime.tzname()
+    assert time == forced_to_astropy_time
+
+def test_nonscalar_to_datetime():
+    tzinfo = pytz.timezone('US/Hawaii')
+    time = Time(['2010-09-03 00:00:00', '2005-09-03 06:00:00',
+                 '1990-09-03 06:00:00'])
+    tz_aware_datetime = time.to_datetime(tzinfo)
+    forced_to_astropy_time = Time(tz_aware_datetime)
+    for dt, tz_dt in zip(time.datetime, tz_aware_datetime):
+        assert tzinfo.tzname(dt) == tz_dt.tzname()
+    assert np.all(time == forced_to_astropy_time)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1018,7 +1018,7 @@ def test_to_datetime():
             return self._utcoffset
 
         def tzname(self, dt):
-            return self._tzname
+            return str(self._tzname)
 
         def dst(self, dt):
             if self._dst is None:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -5,8 +5,7 @@
 import copy
 import functools
 import sys
-
-from datetime import datetime, tzinfo, timedelta
+import datetime
 
 import numpy as np
 
@@ -206,7 +205,7 @@ class TestBasic():
         assert allclose_sec(t.unix, 1262304000.0)
         assert allclose_sec(t.cxcsec, 378691266.184)
         assert allclose_sec(t.gps, 946339215.0)
-        assert t.datetime == datetime(2010, 1, 1)
+        assert t.datetime == datetime.datetime(2010, 1, 1)
 
     def test_precision(self):
         """Set the output precision which is used for some formats.  This is
@@ -349,7 +348,7 @@ class TestBasic():
         Time(0.0, 51544.0333981, format='mjd', scale='tai')
         Time('2000:001:12:23:34.0', format='yday', scale='tai')
         Time('2000:001:12:23:34.0Z', format='yday', scale='utc')
-        dt = datetime(2000, 1, 2, 3, 4, 5, 123456)
+        dt = datetime.datetime(2000, 1, 2, 3, 4, 5, 123456)
         Time(dt, format='datetime', scale='tai')
         Time([dt, dt], format='datetime', scale='tai')
 
@@ -358,8 +357,8 @@ class TestBasic():
         Test datetime format, including guessing the format from the input type
         by not providing the format keyword to Time.
         """
-        dt = datetime(2000, 1, 2, 3, 4, 5, 123456)
-        dt2 = datetime(2001, 1, 1)
+        dt = datetime.datetime(2000, 1, 2, 3, 4, 5, 123456)
+        dt2 = datetime.datetime(2001, 1, 1)
         t = Time(dt, scale='utc', precision=9)
         assert t.iso == '2000-01-02 03:04:05.123456000'
         assert t.datetime == dt
@@ -371,7 +370,7 @@ class TestBasic():
         assert np.all(t.value == [dt, dt2])
 
         t = Time('2000-01-01 01:01:01.123456789', scale='tai')
-        assert t.datetime == datetime(2000, 1, 1, 1, 1, 1, 123457)
+        assert t.datetime == datetime.datetime(2000, 1, 1, 1, 1, 1, 123457)
 
         # broadcasting
         dt3 = (dt + (dt2-dt)*np.arange(12)).reshape(4, 3)
@@ -787,7 +786,7 @@ def test_now():
     Tests creating a Time object with the `now` class method.
     """
 
-    now = datetime.utcnow()
+    now = datetime.datetime.utcnow()
     t = Time.now()
 
     assert t.format == 'datetime'
@@ -903,9 +902,9 @@ def test_datetime_tzinfo():
     """
     Test #3160 that time zone info in datetime objects is respected.
     """
-    class TZm6(tzinfo):
+    class TZm6(datetime.tzinfo):
         def utcoffset(self, dt):
-            return timedelta(hours=-6)
+            return datetime.timedelta(hours=-6)
 
     d = datetime(2002, 1, 2, 10, 3, 4, tzinfo=TZm6())
     t = Time(d)
@@ -931,7 +930,7 @@ def test_set_format_basic():
     for format, value in (('jd', 2451577.5),
                           ('mjd', 51577.0),
                           ('cxcsec', 65923200.0),
-                          ('datetime', datetime(2000, 2, 3, 0, 0)),
+                          ('datetime', datetime.datetime(2000, 2, 3, 0, 0)),
                           ('iso', '2000-02-03 00:00:00.000')):
         t = Time('+02000-02-03', format='fits')
         t0 = t.replicate()
@@ -1008,7 +1007,7 @@ def test_isiterable():
     assert isiterable(t2)
 
 def test_to_datetime():
-    class TimezoneInfo(tzinfo):
+    class TimezoneInfo(datetime.tzinfo):
         """
         This defines a timezone with UTC offset ``utcoffset``, meant as
         a replacement for the `datetime.tzinfo` objects output by
@@ -1029,15 +1028,16 @@ def test_to_datetime():
 
         def dst(self, dt):
             if self._dst is None:
-                return timedelta(0)
+                return datetime.timedelta(0)
             else:
                 return self._dst
 
-    tz = TimezoneInfo(utcoffset=timedelta(hours=-10), tzname='US/Hawaii')
+    tz = TimezoneInfo(utcoffset=datetime.timedelta(hours=-10), tzname='US/Hawaii')
     # The above lines produces a `datetime.tzinfo` object similar to:
     #     tzinfo = pytz.timezone('US/Hawaii')
     time = Time('2010-09-03 00:00:00')
     tz_aware_datetime = time.to_datetime(tz)
+    assert tz_aware_datetime.time() == datetime.time(14, 0)
     forced_to_astropy_time = Time(tz_aware_datetime)
     assert tz.tzname(time.datetime) == tz_aware_datetime.tzname()
     assert time == forced_to_astropy_time
@@ -1058,6 +1058,7 @@ def test_to_datetime_pytz():
     time = Time('2010-09-03 00:00:00')
     tz_aware_datetime = time.to_datetime(tz)
     forced_to_astropy_time = Time(tz_aware_datetime)
+    assert tz_aware_datetime.time() == datetime.time(14, 0)
     assert tz.tzname(time.datetime) == tz_aware_datetime.tzname()
     assert time == forced_to_astropy_time
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,6 +33,8 @@ Astropy also depends on other packages for optional features:
 
 - `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To use `astropy.wcs` to define projections in Matplotlib. 
 
+- `pytz <http://pythonhosted.org/pytz/>`_: To specify and convert between timezones
+
 However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -952,6 +952,32 @@ guidance, but if you get stuck the astropy developers are more than happy to
 help.  If you write a format class that is widely useful then we might want to
 include it in the core!
 
+
+Timezones
+---------
+
+When a `~astropy.time.Time` object is constructed from a timezone-aware
+`~datetime.datetime`, no timezone information is saved in the
+`~astropy.time.Time` object. However, `~astropy.time.Time` objects can be
+converted to timezone-aware datetime objects using
+`~astropy.time.Time.to_datetime`::
+
+  >>> from datetime import datetime
+  >>> from astropy.time import Time, TimezoneInfo
+  >>> import astropy.units as u
+  >>> utc_plus_one_hour = TimezoneInfo(utc_offset=1*u.hour)
+  >>> dt_aware = datetime(2000, 1, 1, 0, 0, 0, tzinfo=utc_plus_one_hour)
+  >>> t = Time(dt_aware)  # Loses timezone info, converts to UTC
+  >>> print(t)            # will return UTC
+  1999-12-31 23:00:00
+  >>> print(t.to_datetime(timezone=utc_plus_one_hour)) # to timezone-aware datetime
+  2000-01-01 00:00:00+01:00
+
+Timezone database packages, like `pytz <http://pythonhosted.org/pytz/>`_
+for example, may be more convenient to use to create `~datetime.tzinfo`
+objects used to specify timezones rather than the `~astropy.time.TimezoneInfo`
+object.
+
 Reference/API
 =============
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -959,8 +959,7 @@ Timezones
 When a `~astropy.time.Time` object is constructed from a timezone-aware
 `~datetime.datetime`, no timezone information is saved in the
 `~astropy.time.Time` object. However, `~astropy.time.Time` objects can be
-converted to timezone-aware datetime objects using
-`~astropy.time.Time.to_datetime`::
+converted to timezone-aware datetime objects::
 
   >>> from datetime import datetime
   >>> from astropy.time import Time, TimezoneInfo


### PR DESCRIPTION
This is a preliminary version of the timezone-handling convenience method `astropy.time.Time.to_datetime` in response to #4119. 

For example, an `astropy.time.Time` object can be represented as a timezone-aware datetime like so: 

```python
>>> from astropy.time import Time
>>> import pytz
>>> time = Time.now()
>>> timezone = pytz.timezone('US/Hawaii')
>>> time.to_datetime()
datetime.datetime(2015, 9, 3, 22, 36, 54, 439862)
>>> time.to_datetime(timezone=timezone)
datetime.datetime(2015, 9, 3, 12, 36, 54, 439862, tzinfo=<DstTzInfo 'US/Hawaii' HST-1 day, 14:00:00 STD>)
```
cc @taldcroft @mhvk @eteq @ejeschke