### PR TITLE
Replace cosmology inv_efunc internal methods with cython.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,8 +43,9 @@ New Features
 
   - Add Planck 2015 cosmology [#3476]
 
-  - Distance calculations in cosmologies with massless (or no) neutrinos
-    are now > 10x faster for the supplied cosmologies. [#3767]
+  - Distance calculations now > 20-40x faster for the supplied
+    cosmologies due to implementing cython scalar versions of
+    ``FLRW.inv_efunc``.[#4127]
 
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
     should use the new public interfaces ``FLRW.lookback_time_integrand``

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -266,7 +266,7 @@ class FLRW(Cosmology):
             # Compute Neutrino Omega and total relativistic component
             # for massive neutrinos.  We also store a list version,
             # since that is more efficient to do integrals with (perhaps
-            # surpisingly!  But small python lists are much more efficient
+            # surprisingly!  But small python lists are more efficient
             # than small numpy arrays).
             if self._massivenu:
                 nu_y = self._massivenu_mass / (kB_evK * self._Tnu0)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -758,7 +758,12 @@ class FLRW(Cosmology):
         analytical fitting formula given in Komatsu et al. 2011, ApJS 192, 18.
         """
 
+        # Note that there is also a scalar-z-only cython implementation of
+        # this in scalar_inv_efuncs.pyx, so if you find a problem in this
+        # you need to update there too.
+
         # See Komatsu et al. 2011, eq 26 and the surrounding discussion
+        # for an explanation of what we are doing here.
         # However, this is modified to handle multiple neutrino masses
         # by computing the above for each mass, then summing
         prefac = 0.22710731766  # 7/8 (4/11)^4/3 -- see any cosmo book
@@ -774,7 +779,7 @@ class FLRW(Cosmology):
 
         # These are purely fitting constants -- see the Komatsu paper
         p = 1.83
-        invp = 1.0 / p
+        invp = 0.54644808743  # 1.0 / p
         k = 0.3173
 
         z = np.asarray(z)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -10,6 +10,8 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
+from . import scalar_inv_efuncs
+
 from .. import constants as const
 from .. import units as u
 from ..utils import isiterable, deprecated
@@ -45,15 +47,17 @@ __doctest_requires__ = {'*': ['scipy.integrate']}
 # The second, and more advanced, option is to also explicitly
 #  provide a scalar only version of inv_efunc.  This results in a fairly
 #  large speedup (>10x in most cases) in the distance and age integrals,
-#  because testing whether the inputs are iterable or pure scalars turns out
-#  to be rather expensive. If somebody making a new subclass wants to pursue
-#  this optimization, the key thing is to explicitly set the
+#  even if only done in python,  because testing whether the inputs are
+#  iterable or pure scalars turns out to be rather expensive. To take
+#  advantage of this, the key thing is to explicitly set the
 #  instance variables self._inv_efunc_scalar and self._inv_efunc_scalar_args
 #  in the constructor for the subclass, where the latter are all the
 #  arguments except z to _inv_efunc_scalar.
-#  Again, the provided classes do use this optimization, and in fact go
-#   even further and provide optimizations for no radiation, and for radiation
-#   with massless neutrinos.  Consult the subclasses for details.
+#
+#  The provided classes do use this optimization, and in fact go
+#  even further and provide optimizations for no radiation, and for radiation
+#  with massless neutrinos coded in cython.  Consult the subclasses for
+#  details, and scalar_inv_efuncs for the details.
 #
 #  However, the important point is that it is -not- necessary to do this.
 
@@ -260,10 +264,14 @@ class FLRW(Cosmology):
             self._Tnu0 = 0.7137658555036082 * self._Tcmb0
 
             # Compute Neutrino Omega and total relativistic component
-            # for massive neutrinos
+            # for massive neutrinos.  We also store a list version,
+            # since that is more efficient to do integrals with (perhaps
+            # surpisingly!  But small python lists are much more efficient
+            # than small numpy arrays).
             if self._massivenu:
                 nu_y = self._massivenu_mass / (kB_evK * self._Tnu0)
                 self._nu_y = nu_y.value
+                self._nu_y_list = self._nu_y.tolist()
                 self._Onu0 = self._Ogamma0 * self.nu_relative_density(0)
             else:
                 # This case is particularly simple, so do it directly
@@ -764,17 +772,15 @@ class FLRW(Cosmology):
                 return prefac * self._Neff *\
                     np.ones(np.asanyarray(z).shape, dtype=np.float)
 
+        # These are purely fitting constants -- see the Komatsu paper
         p = 1.83
         invp = 1.0 / p
-        if np.isscalar(z):
-            curr_nu_y = self._nu_y / (1.0 + z)  # only includes massive ones
-            rel_mass_per = (1.0 + (0.3173 * curr_nu_y) ** p) ** invp
-            rel_mass = rel_mass_per.sum() + self._nmasslessnu
-        else:
-            z = np.asarray(z)
-            curr_nu_y = self._nu_y / (1. + np.expand_dims(z, axis=-1))
-            rel_mass_per = (1. + (0.3173 * curr_nu_y) ** p) ** invp
-            rel_mass = rel_mass_per.sum(-1) + self._nmasslessnu
+        k = 0.3173
+
+        z = np.asarray(z)
+        curr_nu_y = self._nu_y / (1. + np.expand_dims(z, axis=-1))
+        rel_mass_per = (1.0 + (k * curr_nu_y) ** p) ** invp
+        rel_mass = rel_mass_per.sum(-1) + self._nmasslessnu
 
         return prefac * self._neff_per_nu * rel_mass
 
@@ -1589,17 +1595,18 @@ class LambdaCDM(FLRW):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._lcdm_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._lcdm_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0 + self._Onu0)
         else:
-            self._inv_efunc_scalar = self._lcdm_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list)
 
     def w(self, z):
         """Returns dark energy equation of state at redshift ``z``.
@@ -1714,25 +1721,6 @@ class LambdaCDM(FLRW):
 
         return (zp1 ** 2 * ((Or * zp1 + Om0) * zp1 + Ok0) + Ode0)**(-0.5)
 
-    # The stuff below here for this class is -not- something
-    # you need to overload for your own classes.  It is done
-    # purely for efficiency reasons.
-    @staticmethod
-    def _lcdm_inv_efunc_norel(z, Om0, Ode0, Ok0):
-        opz = 1.0 + z
-        return (opz**2 * (opz * Om0 + Ok0) + Ode0)**(-0.5)
-
-    @staticmethod
-    def _lcdm_inv_efunc_nomnu(z, Om0, Ode0, Ok0, Or0):
-        opz = 1.0 + z
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0)**(-0.5)
-
-    @staticmethod
-    def _lcdm_inv_efunc(z, Om0, Ode0, Ok0, Ogamma0, nufunc):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0)**(-0.5)
-
 
 class FlatLambdaCDM(LambdaCDM):
     """FLRW cosmology with a cosmological constant and no curvature.
@@ -1795,17 +1783,18 @@ class FlatLambdaCDM(LambdaCDM):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._flcdm_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._flcdm_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._Ogamma0 + self._Onu0)
         else:
-            self._inv_efunc_scalar = self._flcdm_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list)
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.
@@ -1873,25 +1862,6 @@ class FlatLambdaCDM(LambdaCDM):
         return retstr.format(self._namelead(), self._H0, self._Om0,
                              self._Tcmb0, self._Neff, self.m_nu,
                              _float_or_none(self._Ob0))
-
-    # The stuff below here for this class is -not- something
-    # you need to overload for your own classes.  It is done
-    # purely for efficiency reasons, and results in a 10x speedup
-    # in distance calculations.
-    @staticmethod
-    def _flcdm_inv_efunc_norel(z, Om0, Ode0):
-        return ((1. + z)**3 * Om0 + Ode0)**(-0.5)
-
-    @staticmethod
-    def _flcdm_inv_efunc_nomnu(z, Om0, Ode0, Or0):
-        opz = 1.0 + z
-        return (opz**3 * (opz * Or0 + Om0) + Ode0)**(-0.5)
-
-    @staticmethod
-    def _flcdm_inv_efunc(z, Om0, Ode0, Ogamma0, nufunc):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        return (opz**3 * (opz * Or0 + Om0) + Ode0)**(-0.5)
 
 
 class wCDM(FLRW):
@@ -1964,20 +1934,20 @@ class wCDM(FLRW):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._wcdm_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._w0)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._wcdm_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0 + self._Onu0,
                                            self._w0)
         else:
-            self._inv_efunc_scalar = self._wcdm_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density,
-                                           self._w0)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list, self._w0)
 
     @property
     def w0(self):
@@ -2102,27 +2072,6 @@ class wCDM(FLRW):
                              self._Ode0, self._w0, self._Tcmb0, self._Neff,
                              self.m_nu, _float_or_none(self._Ob0))
 
-    # Please see "Notes about speeding up integrals" for discussion
-    # about what is being done here.
-    @staticmethod
-    def _wcdm_inv_efunc_norel(z, Om0, Ode0, Ok0, w0):
-        opz = 1.0 + z
-        return (opz**2 * (opz * Om0 + Ok0) +
-                Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
-
-    @staticmethod
-    def _wcdm_inv_efunc_nomnu(z, Om0, Ode0, Ok0, Or0, w0):
-        opz = 1.0 + z
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
-
-    @staticmethod
-    def _wcdm_inv_efunc(z, Om0, Ode0, Ok0, Ogamma0, nufunc, w0):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
-
 
 class FlatwCDM(wCDM):
     """FLRW cosmology with a constant dark energy equation of state
@@ -2192,20 +2141,20 @@ class FlatwCDM(wCDM):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._fwcdm_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._w0)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._fwcdm_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._Ogamma0 + self._Onu0,
                                            self._w0)
         else:
-            self._inv_efunc_scalar = self._fwcdm_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density,
-                                           self._w0)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list, self._w0)
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.
@@ -2273,27 +2222,6 @@ class FlatwCDM(wCDM):
         return retstr.format(self._namelead(), self._H0, self._Om0, self._w0,
                              self._Tcmb0, self._Neff, self.m_nu,
                              _float_or_none(self._Ob0))
-
-    # Please see "Notes about speeding up integrals" for discussion
-    # about what is being done here.
-    @staticmethod
-    def _fwcdm_inv_efunc_norel(z, Om0, Ode0, w0):
-        opz = 1.0 + z
-        return (opz**3 * Om0 + Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
-
-    @staticmethod
-    def _fwcdm_inv_efunc_nomnu(z, Om0, Ode0, Or0, w0):
-        opz = 1.0 + z
-        return (opz**3 * (opz * Or0 + Om0) +
-                Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
-
-    @staticmethod
-    def _fwcdm_inv_efunc(z, Om0, Ode0, Ogamma0, nufunc, w0):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        return (opz**3 * (opz * Or0 + Om0) +
-                Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
-
 
 class w0waCDM(FLRW):
     """FLRW cosmology with a CPL dark energy equation of state and curvature.
@@ -2370,20 +2298,21 @@ class w0waCDM(FLRW):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._w0wa_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._w0, self._wa)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._w0wa_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0 + self._Onu0,
                                            self._w0, self._wa)
         else:
-            self._inv_efunc_scalar = self._w0wa_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density,
-                                           self._w0, self._wa)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list, self._w0,
+                                           self._wa)
 
     @property
     def w0(self):
@@ -2461,31 +2390,6 @@ class w0waCDM(FLRW):
                              self._Tcmb0, self._Neff, self.m_nu,
                              _float_or_none(self._Ob0))
 
-    # The stuff below here for this class is -not- something
-    # you need to overload for your own classes.  It is done
-    # purely for efficiency reasons, and results in a 10x speedup
-    # in distance calculations.
-    @staticmethod
-    def _w0wa_inv_efunc_norel(z, Om0, Ode0, Ok0, w0, wa):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-        return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _w0wa_inv_efunc_nomnu(z, Om0, Ode0, Ok0, Or0, w0, wa):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _w0wa_inv_efunc(z, Om0, Ode0, Ok0, Ogamma0, nufunc, w0, wa):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * Odescl)**(-0.5)
-
 
 class Flatw0waCDM(w0waCDM):
     """FLRW cosmology with a CPL dark energy equation of state and no
@@ -2561,20 +2465,21 @@ class Flatw0waCDM(w0waCDM):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._fw0wa_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._w0, self._wa)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._fw0wa_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
                                            self._Ogamma0 + self._Onu0,
                                            self._w0, self._wa)
         else:
-            self._inv_efunc_scalar = self._fw0wa_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density,
-                                           self._w0, self._wa)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list, self._w0,
+                                           self._wa)
 
     def __repr__(self):
         retstr = "{0}H0={1:.3g}, Om0={2:.3g}, "\
@@ -2583,27 +2488,6 @@ class Flatw0waCDM(w0waCDM):
         return retstr.format(self._namelead(), self._H0, self._Om0, self._w0,
                              self._Tcmb0, self._Neff, self.m_nu,
                              _float_or_none(self._Ob0))
-
-    # Please see "Notes about speeding up integrals" for discussion
-    # about what is being done here.
-    @staticmethod
-    def _fw0wa_inv_efunc_norel(z, Om0, Ode0, w0, wa):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-        return (Om0 * opz**3 + Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _fw0wa_inv_efunc_nomnu(z, Om0, Ode0, Or0, w0, wa):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-        return ((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _fw0wa_inv_efunc(z, Om0, Ode0, Ogamma0, nufunc, w0, wa):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-        return ((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl)**(-0.5)
 
 
 class wpwaCDM(FLRW):
@@ -2691,20 +2575,21 @@ class wpwaCDM(FLRW):
         # about what is being done here.
         apiv = 1.0 / (1.0 + self._zp)
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._wpwa_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._wp, apiv, self._wa)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._wpwa_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0 + self._Onu0,
                                            self._wp, apiv, self._wa)
         else:
-            self._inv_efunc_scalar = self._wpwa_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density,
-                                           self._wp, apiv, self._wa)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list, self._wp,
+                                           apiv, self._wa)
 
     @property
     def wp(self):
@@ -2792,31 +2677,6 @@ class wpwaCDM(FLRW):
                              self._Tcmb0, self._Neff, self.m_nu,
                              _float_or_none(self._Ob0))
 
-    # The stuff below here for this class is -not- something
-    # you need to overload for your own classes.  It is done
-    # purely for efficiency reasons, and results in a 10x speedup
-    # in distance calculations.
-    @staticmethod
-    def _wpwa_inv_efunc_norel(z, Om0, Ode0, Ok0, wp, apiv, wa):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
-        return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _wpwa_inv_efunc_nomnu(z, Om0, Ode0, Ok0, Or0, wp, apiv, wa):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _wpwa_inv_efunc(z, Om0, Ode0, Ok0, Ogamma0, nufunc, wp, apiv, wa):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * Odescl)**(-0.5)
-
 
 class w0wzCDM(FLRW):
     """FLRW cosmology with a variable dark energy equation of state
@@ -2896,20 +2756,21 @@ class w0wzCDM(FLRW):
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = self._w0wz_inv_efunc_norel
+            self._inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._w0, self._wz)
         elif not self._massivenu:
-            self._inv_efunc_scalar = self._w0wz_inv_efunc_nomnu
+            self._inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
                                            self._Ogamma0 + self._Onu0,
                                            self._w0, self._wz)
         else:
-            self._inv_efunc_scalar = self._w0wz_inv_efunc
+            self._inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0,
-                                           self._Ogamma0,
-                                           self.nu_relative_density,
-                                           self._w0, self._wz)
+                                           self._Ogamma0, self._neff_per_nu,
+                                           self._nmasslessnu,
+                                           self._nu_y_list, self._w0,
+                                           self._wz)
 
     @property
     def w0(self):
@@ -2985,29 +2846,6 @@ class w0wzCDM(FLRW):
         return retstr.format(self._namelead(), self._H0, self._Om0,
                              self._Ode0, self._w0, self._wz, self._Tcmb0,
                              self._Neff, self.m_nu, _float_or_none(self._Ob0))
-
-    # Please see "Notes about speeding up integrals" for discussion
-    # about what is being done here.
-    @staticmethod
-    def _w0wz_inv_efunc_norel(z, Om0, Ode0, Ok0, w0, wz):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
-        return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _w0wz_inv_efunc_nomnu(z, Om0, Ode0, Ok0, Or0, w0, wz):
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * Odescl)**(-0.5)
-
-    @staticmethod
-    def _w0wz_inv_efunc(z, Om0, Ode0, Ok0, Ogamma0, nufunc, w0, wz):
-        Or0 = Ogamma0 * (1. + nufunc(z))
-        opz = 1.0 + z
-        Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
-        return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-                Ode0 * Odescl)**(-0.5)
 
 
 def _float_or_none(x, digits=3):

--- a/astropy/cosmology/scalar_inv_efuncs.pyx
+++ b/astropy/cosmology/scalar_inv_efuncs.pyx
@@ -1,0 +1,222 @@
+""" Cython inverse efuncs for cosmology integrals"""
+
+cimport cython
+from libc.math cimport exp
+
+## Inverse efunc methods for various dark energy subclasses
+## These take only scalar arguments since that is what the integral
+## routines give them.
+
+## Implementation notes:
+##  * Using a python list for nu_y seems to be faster than a ndarray,
+##     given that nu_y generally has a small number of elements
+##  * Using x**(-0.5) is faster than 1.0 / sqrt(x)
+##  * Hardwiring in the p, 1/p, k, prefac values in nufunc is
+##       nontrivially faster than declaring them with cdef
+
+######### LambdaCDM
+# No relativistic species
+def lcdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0):
+  cdef double opz = 1.0 + z
+  return (opz**2 * (opz * Om0 + Ok0) + Ode0)**(-0.5)
+
+# Massless neutrinos
+def lcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
+    double Or0):
+  cdef double opz = 1.0 + z
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0)**(-0.5)
+
+# With massive neutrinos
+def lcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0)**(-0.5)
+
+######## FlatLambdaCDM
+# No relativistic species
+def flcdm_inv_efunc_norel(double z, double Om0, double Ode0):
+  return ((1. + z)**3 * Om0 + Ode0)**(-0.5)
+
+# Massless neutrinos
+def flcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Or0):
+  cdef double opz = 1.0 + z
+  return (opz**3 * (opz * Or0 + Om0) + Ode0)**(-0.5)
+
+# With massive neutrinos
+def flcdm_inv_efunc(double z, double Om0, double Ode0, double Ogamma0,
+    double NeffPerNu, int nmasslessnu, list nu_y):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  return (opz**3 * (opz * Or0 + Om0) + Ode0)**(-0.5)
+
+######## wCDM
+# No relativistic species
+def wcdm_inv_efunc_norel(double z, double Om0, double Ode0,
+    double Ok0, double w0):
+  cdef double opz = 1.0 + z
+  return (opz**2 * (opz * Om0 + Ok0) +
+            Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+
+# Massless neutrinos
+def wcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
+    double Or0, double w0):
+  cdef double opz = 1.0 + z
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+
+# With massive neutrinos
+def wcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+
+######## Flat wCDM
+# No relativistic species
+def fwcdm_inv_efunc_norel(double z, double Om0, double Ode0, double w0):
+  cdef double opz = 1.0 + z
+  return (opz**3 * Om0 + Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+
+# Massless neutrinos
+def fwcdm_inv_efunc_nomnu(double z, double Om0, double Ode0,
+    double Or0, double w0):
+  cdef double opz = 1.0 + z
+  return (opz**3 * (opz * Or0 + Om0) +
+            Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+
+# With massive neutrinos
+def fwcdm_inv_efunc(double z, double Om0, double Ode0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  return (opz**3 * (opz * Or0 + Om0) + Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+
+######## w0waCDM
+# No relativistic species
+def w0wacdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
+    double w0, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
+  return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
+
+# Massless neutrinos
+def w0wacdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
+    double Or0, double w0, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * Odescl)**(-0.5)
+
+def w0wacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0,
+    double wa):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl)**(-0.5)
+
+######## Flatw0waCDM
+# No relativistic species
+def fw0wacdm_inv_efunc_norel(double z, double Om0, double Ode0,
+    double w0, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
+  return (opz**3 * Om0 + Ode0 * Odescl)**(-0.5)
+
+# Massless neutrinos
+def fw0wacdm_inv_efunc_nomnu(double z, double Om0, double Ode0,
+    double Or0, double w0, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
+  return ((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl)**(-0.5)
+
+# With massive neutrinos
+def fw0wacdm_inv_efunc(double z, double Om0, double Ode0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0,
+    double wa):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
+  return ((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl)**(-0.5)
+
+######## wpwaCDM
+# No relativistic species
+def wpwacdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
+    double wp, double apiv, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
+  return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
+
+# Massless neutrinos
+def wpwacdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
+    double Or0, double wp, double apiv, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * Odescl)**(-0.5)
+
+# With massive neutrinos
+def wpwacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double wp,
+    double apiv, double wa):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl)**(-0.5)
+
+######## w0wzCDM
+# No relativistic species
+def w0wzcdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
+    double w0, double wz):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
+
+# Massless neutrinos
+def w0wzcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
+    double Or0, double w0, double wz):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * Odescl)**(-0.5)
+
+# With massive neutrinos
+def w0wzcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0,
+    double wz):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl)**(-0.5)
+
+######## Neutrino relative density function
+# Scalar equivalent to FLRW.nu_realative_density in core.py
+#  Please see that for further discussion.
+# This should only be called with massive neutrinos (e.g., nu_y is not empty)
+# Briefly, this is just a numerical fitting function to the true relationship,
+#  which is too expensive to want to evaluate directly.  The
+#  constants which appear are:
+#    p = 1.83  -> numerical fitting constant from Komatsu et al.
+#  1/p = 0.54644... -> same constant
+#    k = 0.3173 -> another fitting constant
+#  7/8 (4/11)^(4/3) = 0.2271... -> fermion/boson constant for neutrino
+#                                   contribution -- see any cosmology book
+#  The Komatsu reference is: Komatsu et al. 2011, ApJS 192, 18
+
+cdef nufunc(double opz, double NeffPerNu, int nmasslessnu, list nu_y):
+  cdef int N = len(nu_y)
+  cdef double k = 0.3173 / opz
+  cdef double rel_mass_sum = nmasslessnu
+  for i in range(N):
+    rel_mass_sum += (1.0 + (k * nu_y[i])**1.83)**0.54644808743
+  return 0.22710731766 * NeffPerNu * rel_mass_sum

--- a/astropy/cosmology/scalar_inv_efuncs.pyx
+++ b/astropy/cosmology/scalar_inv_efuncs.pyx
@@ -1,7 +1,8 @@
 """ Cython inverse efuncs for cosmology integrals"""
+#cython boundcheck=False
 
 cimport cython
-from libc.math cimport exp
+from libc.math cimport exp, pow
 
 ## Inverse efunc methods for various dark energy subclasses
 ## These take only scalar arguments since that is what the integral
@@ -9,8 +10,10 @@ from libc.math cimport exp
 
 ## Implementation notes:
 ##  * Using a python list for nu_y seems to be faster than a ndarray,
-##     given that nu_y generally has a small number of elements
-##  * Using x**(-0.5) is faster than 1.0 / sqrt(x)
+##     given that nu_y generally has a small number of elements,
+##     even when you turn off bounds checking, etc.
+##  * Using pow(x, -0.5) is slightly faster than x**(-0.5) and
+##    even more so than 1.0 / sqrt(x)
 ##  * Hardwiring in the p, 1/p, k, prefac values in nufunc is
 ##       nontrivially faster than declaring them with cdef
 
@@ -18,13 +21,13 @@ from libc.math cimport exp
 # No relativistic species
 def lcdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0):
   cdef double opz = 1.0 + z
-  return (opz**2 * (opz * Om0 + Ok0) + Ode0)**(-0.5)
+  return pow(opz**2 * (opz * Om0 + Ok0) + Ode0, -0.5)
 
 # Massless neutrinos
 def lcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
     double Or0):
   cdef double opz = 1.0 + z
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0, -0.5)
 
 # With massive neutrinos
 def lcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
@@ -32,17 +35,17 @@ def lcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
 
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0, -0.5)
 
 ######## FlatLambdaCDM
 # No relativistic species
 def flcdm_inv_efunc_norel(double z, double Om0, double Ode0):
-  return ((1. + z)**3 * Om0 + Ode0)**(-0.5)
+  return pow((1. + z)**3 * Om0 + Ode0, -0.5)
 
 # Massless neutrinos
 def flcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Or0):
   cdef double opz = 1.0 + z
-  return (opz**3 * (opz * Or0 + Om0) + Ode0)**(-0.5)
+  return pow(opz**3 * (opz * Or0 + Om0) + Ode0, -0.5)
 
 # With massive neutrinos
 def flcdm_inv_efunc(double z, double Om0, double Ode0, double Ogamma0,
@@ -50,22 +53,22 @@ def flcdm_inv_efunc(double z, double Om0, double Ode0, double Ogamma0,
 
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
-  return (opz**3 * (opz * Or0 + Om0) + Ode0)**(-0.5)
+  return pow(opz**3 * (opz * Or0 + Om0) + Ode0, -0.5)
 
 ######## wCDM
 # No relativistic species
 def wcdm_inv_efunc_norel(double z, double Om0, double Ode0,
     double Ok0, double w0):
   cdef double opz = 1.0 + z
-  return (opz**2 * (opz * Om0 + Ok0) +
-            Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+  return pow(opz**2 * (opz * Om0 + Ok0) +
+            Ode0 * opz**(3. * (1.0 + w0)), -0.5)
 
 # Massless neutrinos
 def wcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
     double Or0, double w0):
   cdef double opz = 1.0 + z
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-          Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * opz**(3. * (1.0 + w0)), -0.5)
 
 # With massive neutrinos
 def wcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
@@ -73,21 +76,21 @@ def wcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
 
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-          Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * opz**(3. * (1.0 + w0)), -0.5)
 
 ######## Flat wCDM
 # No relativistic species
 def fwcdm_inv_efunc_norel(double z, double Om0, double Ode0, double w0):
   cdef double opz = 1.0 + z
-  return (opz**3 * Om0 + Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+  return pow(opz**3 * Om0 + Ode0 * opz**(3. * (1.0 + w0)), -0.5)
 
 # Massless neutrinos
 def fwcdm_inv_efunc_nomnu(double z, double Om0, double Ode0,
     double Or0, double w0):
   cdef double opz = 1.0 + z
-  return (opz**3 * (opz * Or0 + Om0) +
-            Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+  return pow(opz**3 * (opz * Or0 + Om0) +
+            Ode0 * opz**(3. * (1.0 + w0)), -0.5)
 
 # With massive neutrinos
 def fwcdm_inv_efunc(double z, double Om0, double Ode0,
@@ -95,7 +98,7 @@ def fwcdm_inv_efunc(double z, double Om0, double Ode0,
 
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
-  return (opz**3 * (opz * Or0 + Om0) + Ode0 * opz**(3. * (1.0 + w0)))**(-0.5)
+  return pow(opz**3 * (opz * Or0 + Om0) + Ode0 * opz**(3. * (1.0 + w0)), -0.5)
 
 ######## w0waCDM
 # No relativistic species
@@ -103,15 +106,15 @@ def w0wacdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
     double w0, double wa):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-  return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
+  return pow(opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl, -0.5)
 
 # Massless neutrinos
 def w0wacdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
     double Or0, double w0, double wa):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-          Ode0 * Odescl)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * Odescl, -0.5)
 
 def w0wacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
     double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0,
@@ -120,7 +123,7 @@ def w0wacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
   cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl, -0.5)
 
 ######## Flatw0waCDM
 # No relativistic species
@@ -128,14 +131,14 @@ def fw0wacdm_inv_efunc_norel(double z, double Om0, double Ode0,
     double w0, double wa):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-  return (opz**3 * Om0 + Ode0 * Odescl)**(-0.5)
+  return pow(opz**3 * Om0 + Ode0 * Odescl, -0.5)
 
 # Massless neutrinos
 def fw0wacdm_inv_efunc_nomnu(double z, double Om0, double Ode0,
     double Or0, double w0, double wa):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-  return ((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl)**(-0.5)
+  return pow((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl, -0.5)
 
 # With massive neutrinos
 def fw0wacdm_inv_efunc(double z, double Om0, double Ode0,
@@ -145,7 +148,7 @@ def fw0wacdm_inv_efunc(double z, double Om0, double Ode0,
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
   cdef Odescl = opz**(3. * (1 + w0 + wa)) * exp(-3.0 * wa * z / opz)
-  return ((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl)**(-0.5)
+  return pow((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl, -0.5)
 
 ######## wpwaCDM
 # No relativistic species
@@ -153,15 +156,15 @@ def wpwacdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
     double wp, double apiv, double wa):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
-  return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
+  return pow(opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl, -0.5)
 
 # Massless neutrinos
 def wpwacdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
     double Or0, double wp, double apiv, double wa):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-          Ode0 * Odescl)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * Odescl, -0.5)
 
 # With massive neutrinos
 def wpwacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
@@ -171,7 +174,7 @@ def wpwacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
   cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl, -0.5)
 
 ######## w0wzCDM
 # No relativistic species
@@ -179,15 +182,15 @@ def w0wzcdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
     double w0, double wz):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
-  return (opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl)**(-0.5)
+  return pow(opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl, -0.5)
 
 # Massless neutrinos
 def w0wzcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
     double Or0, double w0, double wz):
   cdef double opz = 1.0 + z
   cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
-          Ode0 * Odescl)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
+          Ode0 * Odescl, -0.5)
 
 # With massive neutrinos
 def w0wzcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
@@ -197,7 +200,7 @@ def w0wzcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
   cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
-  return ((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl)**(-0.5)
+  return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl, -0.5)
 
 ######## Neutrino relative density function
 # Scalar equivalent to FLRW.nu_realative_density in core.py
@@ -212,11 +215,11 @@ def w0wzcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
 #  7/8 (4/11)^(4/3) = 0.2271... -> fermion/boson constant for neutrino
 #                                   contribution -- see any cosmology book
 #  The Komatsu reference is: Komatsu et al. 2011, ApJS 192, 18
-
 cdef nufunc(double opz, double NeffPerNu, int nmasslessnu, list nu_y):
   cdef int N = len(nu_y)
   cdef double k = 0.3173 / opz
   cdef double rel_mass_sum = nmasslessnu
+  cdef unsigned int i
   for i in range(N):
-    rel_mass_sum += (1.0 + (k * nu_y[i])**1.83)**0.54644808743
+    rel_mass_sum += pow(1.0 + (k * <double>nu_y[i])**1.83, 0.54644808743)
   return 0.22710731766 * NeffPerNu * rel_mass_sum

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1305,6 +1305,30 @@ def test_distances():
                     [2676.73467639, 3940.57967585, 4686.90810278,
                      5191.54178243] * u.Mpc, rtol=1e-4)
 
+    # Also test different numbers of massive neutrinos
+    # for FlatLambdaCDM to give the scalar nu density functions a
+    # work out
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0,
+                             m_nu=u.Quantity([10.0, 0, 0], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2777.71589173, 4186.91111666, 5046.0300719,
+                     5636.10397302] * u.Mpc, rtol=1e-4)
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0,
+                             m_nu=u.Quantity([10.0, 5, 0], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2636.48149391, 3913.14102091, 4684.59108974,
+                     5213.07557084] * u.Mpc, rtol=1e-4)
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0,
+                             m_nu=u.Quantity([4.0, 5, 9], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2563.5093049 , 3776.63362071, 4506.83448243,
+                     5006.50158829] * u.Mpc, rtol=1e-4)
+    cos = core.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0, Neff=4.2,
+                             m_nu=u.Quantity([1.0, 4.0, 5, 9], u.eV))
+    assert allclose(cos.comoving_distance(z),
+                    [2525.58017482, 3706.87633298, 4416.58398847,
+                     4901.96669755] * u.Mpc, rtol=1e-4)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_massivenu_density():

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -323,11 +323,12 @@ and that the Planck13 and Planck15 cosmologies includes a single
 species of neutrinos with non-zero mass (which is not included in
 :math:`\Omega_{m0}`).
 
-Adding massive neutrinos has significant performance implications.
+Adding massive neutrinos can have significant performance implications.
 In particular, the computation of distance measures and lookback times
-are factors of ten slower than in the massless neutrino case.  Therefore,
-if you need to compute a lot of distances in such a cosmology, it is
-particularly useful to calculate them on a grid and use interpolation.
+are factors of 3-4 slower than in the massless neutrino case.  Therefore,
+if you need to compute a lot of distances in such a cosmology and
+performance is critical, it is particularly useful to calculate them on
+a grid and use interpolation.
 
 The contribution of photons and neutrinos to the total mass-energy density
 can be found as a function of redshift::


### PR DESCRIPTION
* Follow on to #3767, mostly finishes #3764, replaces #3814
* All unit tests pass, and some more added.
* Also done for massive neutrinos.
* Speedup is ~ 2x over non-cython scalar version without massive neutrinos, and 20x in massive nu case.  So compared with before this whole optimization thing started with #3764, we're about 20-50x faster.