### PR TITLE
Candidate fix for issues #4129, #4137

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -479,6 +479,11 @@ Bug fixes
 
 - ``astropy.nddata``
 
+  - Initializing an NDDataArray from another instance now sets ``flags`` as
+    expected and no longer fails when ``uncertainty`` is set [#4129].
+    Initializing an NDData subclass from a parent instance (eg. NDDataArray
+    from NDData) now set attributes other than ``data`` as it should [#4137].
+
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -479,12 +479,6 @@ Bug fixes
 
 - ``astropy.nddata``
 
-  - Initializing ``NDDataArray`` from another instance now sets ``flags`` as
-    expected and no longer fails when ``uncertainty`` is set [#4129].
-    Initializing an ``NDData`` subclass from a parent instance
-    (eg. ``NDDataArray`` from ``NDData``) now sets the attributes other than
-    ``data`` as it should [#4137].
-
 - ``astropy.stats``
 
 - ``astropy.table``
@@ -648,6 +642,12 @@ Bug Fixes
   - Cleaned up ``repr`` of models that have no parameters. [#4076]
 
 - ``astropy.nddata``
+
+  - Initializing ``NDDataArray`` from another instance now sets ``flags`` as
+    expected and no longer fails when ``uncertainty`` is set [#4129].
+    Initializing an ``NDData`` subclass from a parent instance
+    (eg. ``NDDataArray`` from ``NDData``) now sets the attributes other than
+    ``data`` as it should [#4137].
 
 - ``astropy.stats``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -479,10 +479,11 @@ Bug fixes
 
 - ``astropy.nddata``
 
-  - Initializing an NDDataArray from another instance now sets ``flags`` as
+  - Initializing ``NDDataArray`` from another instance now sets ``flags`` as
     expected and no longer fails when ``uncertainty`` is set [#4129].
-    Initializing an NDData subclass from a parent instance (eg. NDDataArray
-    from NDData) now set attributes other than ``data`` as it should [#4137].
+    Initializing an ``NDData`` subclass from a parent instance
+    (eg. ``NDDataArray`` from ``NDData``) now sets the attributes other than
+    ``data`` as it should [#4137].
 
 - ``astropy.stats``
 

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -99,7 +99,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         # Initial flags because it is no longer handled in NDData
         # or NDDataBase.
         data = arg[0]  # do this after parent __init__, to validate the args
-        if isinstance(data, self.__class__):
+        if isinstance(data, NDDataArray):
             if flags is None:
                 flags = data.flags
             else:

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -83,7 +83,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
 
     def __init__(self, *arg, **kwd):
         # Remove the flag argument from input.
-        flag_argument = kwd.pop('flags', None)
+        flags = kwd.pop('flags', None)
 
         # Initialize with the parent...
         super(NDDataArray, self).__init__(*arg, **kwd)
@@ -98,7 +98,14 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
 
         # Initial flags because it is no longer handled in NDData
         # or NDDataBase.
-        self.flags = flag_argument
+        data = arg[0]  # do this after parent __init__, to validate the args
+        if isinstance(data, self.__class__):
+            if flags is None:
+                flags = data.flags
+            else:
+                log.info("Overwriting NDDataArrays's current "
+                         "flags with specified flags")
+        self.flags = flags
 
     # Implement uncertainty as NDUncertainty to support propagation of
     # uncertainties in arithmetic operations

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -82,7 +82,7 @@ class NDData(NDDataBase):
 
         super(NDData, self).__init__()
 
-        if isinstance(data, self.__class__):
+        if isinstance(data, NDData):  # don't use self.__class__ (issue #4137)
             # No need to check the data because data must have successfully
             # initialized.
             self._data = data._data

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -86,11 +86,11 @@ class NDData(NDDataBase):
             # No need to check the data because data must have successfully
             # initialized.
             self._data = data._data
+            self._unit = data.unit
             self.uncertainty = data.uncertainty
             self._mask = data.mask
             self._wcs = data.wcs
             self._meta = data.meta
-            self._unit = data.unit
 
             if uncertainty is not None:
                 self._uncertainty = uncertainty

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -86,7 +86,7 @@ class NDData(NDDataBase):
             # No need to check the data because data must have successfully
             # initialized.
             self._data = data._data
-            self._unit = data.unit
+            self._unit = data.unit  # must set before uncert for NDDataArray
             self.uncertainty = data.uncertainty
             self._mask = data.mask
             self._wcs = data.wcs

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ...tests.helper import pytest
+from ..nddata import NDData
 from ..compat import NDDataArray
 from ..nduncertainty import StdDevUncertainty
 from ... import units as u
@@ -96,10 +97,11 @@ def test_init_of_subclass_in_convert_unit_to():
     np.testing.assert_array_equal(arr1.data, 1000 * result.data)
 
 
+# Test for issue #4129:
 def test_nddataarray_from_nddataarray():
     ndd1 = NDDataArray([1., 4., 9.],
-                      uncertainty=StdDevUncertainty([1., 2., 3.]),
-                      flags=[0, 1, 0])
+                       uncertainty=StdDevUncertainty([1., 2., 3.]),
+                       flags=[0, 1, 0])
     ndd2 = NDDataArray(ndd1)
     # Test that the 2 instances point to the same objects and aren't just
     # equal; this is explicitly documented for the main data array and we
@@ -108,5 +110,16 @@ def test_nddataarray_from_nddataarray():
     assert ndd2.data is ndd1.data
     assert ndd2.uncertainty is ndd1.uncertainty
     assert ndd2.flags is ndd1.flags
+    assert ndd2.meta is ndd1.meta
+
+
+# Test for issue #4137:
+def test_nddataarray_from_nddata():
+    ndd1 = NDData([1., 4., 9.],
+                  uncertainty=StdDevUncertainty([1., 2., 3.]))
+    ndd2 = NDDataArray(ndd1)
+
+    assert ndd2.data is ndd1.data
+    assert ndd2.uncertainty is ndd1.uncertainty
     assert ndd2.meta is ndd1.meta
 

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -94,3 +94,19 @@ def test_init_of_subclass_in_convert_unit_to():
     arr1 = SubNDData(data, unit='m', wcs=5)
     result = arr1.convert_unit_to('km')
     np.testing.assert_array_equal(arr1.data, 1000 * result.data)
+
+
+def test_nddataarray_from_nddataarray():
+    ndd1 = NDDataArray([1., 4., 9.],
+                      uncertainty=StdDevUncertainty([1., 2., 3.]),
+                      flags=[0, 1, 0])
+    ndd2 = NDDataArray(ndd1)
+    # Test that the 2 instances point to the same objects and aren't just
+    # equal; this is explicitly documented for the main data array and we
+    # probably want to catch any future change in behaviour for the other
+    # attributes too and ensure they are intentional.
+    assert ndd2.data is ndd1.data
+    assert ndd2.uncertainty is ndd1.uncertainty
+    assert ndd2.flags is ndd1.flags
+    assert ndd2.meta is ndd1.meta
+


### PR DESCRIPTION
Issue #4129 (creating NDDataArray from another instance fails when uncertainty is set & flags don't get copied from the input). Also added issue #4137 (instantiation from parent object not setting attributes other than data).

Or if you have a better solution, that's fine with me...

I assume this will trigger a Travis test automatically? The nddata tests seem to be passing on my machine.
