### PR TITLE
Allow to specify CSS classes for Table.pformat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,7 +193,7 @@ New Features
   - Added a new method ``Table.replace_column()`` to replace an existing
     column with a new data column. [#4090]
 
-  - Added a ``tableclass`` option to ``Table.pformat()`` to allow to specify
+  - Added a ``tableclass`` option to ``Table.pformat()`` to allow specifying
     a list of CSS classes added to the HTML table. [#4131]
 
 - ``astropy.tests``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,9 @@ New Features
   - Added a new method ``Table.replace_column()`` to replace an existing
     column with a new data column. [#4090]
 
+  - Added a ``tableclass`` option to ``Table.pformat()`` to allow to specify
+    a list of CSS classes added to the HTML table. [#4131]
+
 - ``astropy.tests``
 
   - Added new test config options, ``config_dir`` and ``cache_dir``  (these

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -187,7 +187,6 @@ class TableFormatter(object):
 
         return max_lines, max_width
 
-
     def _pformat_col(self, col, max_lines=None, show_name=True, show_unit=None,
                      show_dtype=False, show_length=None, html=False, align=None):
         """Return a list of formatted string representation of column values.
@@ -225,8 +224,9 @@ class TableFormatter(object):
         lines : list
             List of lines with formatted column values
 
-        n_header : int
-            Number of lines in the header
+        outs : dict
+            Dict which is used to pass back additional values
+            defined within the iterator.
 
         """
         if show_unit is None:
@@ -297,7 +297,7 @@ class TableFormatter(object):
                     if align == '0=':
                         justify = (lambda col_str, col_width:
                                        getattr(col_str, 'zfill')(col_width))
-                    elif align in ['<','^','>']:
+                    elif align in ['<', '^', '>']:
                         justify_method = justify_methods.get(align, None)
                         if justify_method is None:
                             justify_method = justify_methods[col.format[1]]
@@ -317,7 +317,6 @@ class TableFormatter(object):
 
         return col_strs, outs
 
-
     def _pformat_col_iter(self, col, max_lines, show_name, show_unit, outs,
                           show_dtype=False, show_length=None):
         """Iterator which yields formatted string representation of column values.
@@ -335,16 +334,16 @@ class TableFormatter(object):
             for units only if one or more columns has a defined value
             for the unit.
 
+        outs : dict
+            Must be a dict which is used to pass back additional values
+            defined within the iterator.
+
         show_dtype : bool
             Include column dtype (default=False)
 
         show_length : bool
             Include column length at end.  Default is to show this only
             if the column is not shown completely.
-
-        out : dict
-            Must be a dict which is used to pass back additional values
-            defined within the iterator.
         """
         max_lines, _ = self._get_pprint_size(max_lines, -1)
 
@@ -423,9 +422,8 @@ class TableFormatter(object):
         outs['i_centers'] = i_centers
         outs['i_dashes'] = i_dashes
 
-
-    def _pformat_table(self, table, max_lines=None, max_width=None, show_name=True,
-                       show_unit=None, show_dtype=False,
+    def _pformat_table(self, table, max_lines=None, max_width=None,
+                       show_name=True, show_unit=None, show_dtype=False,
                        html=False, tableid=None, align='right'):
         """Return a list of lines for the formatted string representation of
         the table.
@@ -464,11 +462,13 @@ class TableFormatter(object):
 
         Returns
         -------
-        out : str
-            Formatted table as a single string
+        rows : list
+            Formatted table as a list of strings
 
-        n_header : int
-            Number of lines in the header
+        outs : dict
+            Dict which is used to pass back additional values
+            defined within the iterator.
+
         """
         # "Print" all the values into temporary lists by column for subsequent
         # use and to determine the width
@@ -479,18 +479,18 @@ class TableFormatter(object):
             show_unit = any([col.info.unit for col in six.itervalues(table.columns)])
 
         # Figure out align
-        if isinstance(align,str):
+        if isinstance(align, str):
             align = align
-        elif isinstance(align,list) and len(align) == 1:
+        elif isinstance(align, list) and len(align) == 1:
             align = align[0]
-        elif isinstance(align,list) and len(align) == len(table.columns.values()):
+        elif isinstance(align, list) and len(align) == len(table.columns.values()):
             align = align
         else:
             align = 'right'
 
         # If align remains a list, need to loop over values
         if type(align) == list:
-            for i,col in enumerate(table.columns.values()):
+            for i, col in enumerate(table.columns.values()):
                 lines, outs = self._pformat_col(col, max_lines, show_name=show_name,
                                                 show_unit=show_unit, show_dtype=show_dtype,
                                                 align=align[i])
@@ -554,9 +554,8 @@ class TableFormatter(object):
 
         return rows, outs
 
-
-    def _more_tabcol(self, tabcol, max_lines=None, max_width=None, show_name=True,
-                     show_unit=None, show_dtype=False):
+    def _more_tabcol(self, tabcol, max_lines=None, max_width=None,
+                     show_name=True, show_unit=None, show_dtype=False):
         """Interactive "more" of a table or column.
 
         Parameters

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -424,7 +424,7 @@ class TableFormatter(object):
 
     def _pformat_table(self, table, max_lines=None, max_width=None,
                        show_name=True, show_unit=None, show_dtype=False,
-                       html=False, tableid=None, align='right'):
+                       html=False, tableid=None, tableclass=None, align='right'):
         """Return a list of lines for the formatted string representation of
         the table.
 
@@ -454,6 +454,10 @@ class TableFormatter(object):
             An ID tag for the table; only used if html is set.  Default is
             "table{id}", where id is the unique integer id of the table object,
             id(table)
+
+        tableclass : str or list of str or `None`
+            CSS classes for the table; only used if html is set.  Default is
+            none
 
         align : str or list
             Left/right alignment of a column. Default is 'right'. A list
@@ -534,7 +538,15 @@ class TableFormatter(object):
 
             if tableid is None:
                 tableid = 'table{id}'.format(id=id(table))
-            rows.append('<table id="{tid}">'.format(tid=tableid))
+
+            if tableclass is not None:
+                if isinstance(tableclass, list):
+                    tableclass = ' '.join(tableclass)
+                rows.append('<table id="{tid}" class="{tcls}">'.format(
+                    tid=tableid, tcls=tableclass))
+            else:
+                rows.append('<table id="{tid}">'.format(tid=tableid))
+
             for i in range(n_rows):
                 # _pformat_col output has a header line '----' which is not needed here
                 if i == n_header - 1:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -927,7 +927,7 @@ class Table(object):
 
     def pformat(self, max_lines=None, max_width=None, show_name=True,
                 show_unit=None, show_dtype=False, html=False, tableid=None,
-                tableclass=None, align='right'):
+                align='right', tableclass=None):
         """Return a list of lines for the formatted string representation of
         the table.
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -968,12 +968,12 @@ class Table(object):
             "table{id}", where id is the unique integer id of the table object,
             id(self)
 
+        align : str
+            Left/right alignment of a column. Default is 'right'.
+
         tableclass : str or list of str or `None`
             CSS classes for the table; only used if html is set.  Default is
             none
-
-        align : str
-            Left/right alignment of a column. Default is 'right'.
 
         Returns
         -------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -927,7 +927,7 @@ class Table(object):
 
     def pformat(self, max_lines=None, max_width=None, show_name=True,
                 show_unit=None, show_dtype=False, html=False, tableid=None,
-                align='right'):
+                tableclass=None, align='right'):
         """Return a list of lines for the formatted string representation of
         the table.
 
@@ -968,6 +968,10 @@ class Table(object):
             "table{id}", where id is the unique integer id of the table object,
             id(self)
 
+        tableclass : str or list of str or `None`
+            CSS classes for the table; only used if html is set.  Default is
+            none
+
         align : str
             Left/right alignment of a column. Default is 'right'.
 
@@ -978,10 +982,10 @@ class Table(object):
 
         """
 
-        lines, outs = self.formatter._pformat_table(self, max_lines, max_width,
-                                                    show_name=show_name, show_unit=show_unit,
-                                                    show_dtype=show_dtype, html=html,
-                                                    tableid=tableid, align=align)
+        lines, outs = self.formatter._pformat_table(
+            self, max_lines, max_width, show_name=show_name,
+            show_unit=show_unit, show_dtype=show_dtype, html=html,
+            tableid=tableid, tableclass=tableclass, align=align)
 
         if outs['show_length']:
             lines.append('Length = {0} rows'.format(len(self)))

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -502,8 +502,8 @@ class TestFormatWithMaskedElements():
         arr = [np.array([[1, 2],
                          [10, 20]])]
         t = Table(arr, names=['a'], masked=True)
-        t['a'].mask[0,1] = True
-        t['a'].mask[1,1] = True
+        t['a'].mask[0, 1] = True
+        t['a'].mask[1, 1] = True
         # mathematical function
         t['a'].format = lambda x: str(x * 3.)
         outstr = '  a [2]   \n----------\n 3.0 .. --\n30.0 .. --'
@@ -537,5 +537,34 @@ def test_pprint_nameless_col():
     """Regression test for #2213, making sure a nameless column can be printed
     using None as the name.
     """
-    col = table.Column([1.,2.])
+    col = table.Column([1., 2.])
     assert str(col).startswith('None')
+
+
+def test_html():
+    """Test HTML printing"""
+    dat = np.array([1., 2.], dtype=np.float32)
+    t = Table([dat], names=['a'])
+
+    lines = t.pformat(html=True)
+    assert lines == ['<table id="table{id}">'.format(id=id(t)),
+                     u'<thead><tr><th>a</th></tr></thead>',
+                     u'<tr><td>1.0</td></tr>',
+                     u'<tr><td>2.0</td></tr>',
+                     u'</table>']
+
+    lines = t.pformat(html=True, tableclass='table-striped')
+    assert lines == [
+        '<table id="table{id}" class="table-striped">'.format(id=id(t)),
+        u'<thead><tr><th>a</th></tr></thead>',
+        u'<tr><td>1.0</td></tr>',
+        u'<tr><td>2.0</td></tr>',
+        u'</table>']
+
+    lines = t.pformat(html=True, tableclass=['table', 'table-striped'])
+    assert lines == [
+        '<table id="table{id}" class="table table-striped">'.format(id=id(t)),
+        u'<thead><tr><th>a</th></tr></thead>',
+        u'<tr><td>1.0</td></tr>',
+        u'<tr><td>2.0</td></tr>',
+        u'</table>']


### PR DESCRIPTION
Currently it is possible to specify an ID when formatting a Table to HTML, this PR add a way to specify CSS classes which is more flexible and useful when integrating tables in an HTML page.

I have also updated several docstring in the pprint module. BTW the `out` dict stuff in the Table.pprint module is pretty weird: for instance `show_length` is not passed to `_pformat_col` but it is check in the out dict just after which seems quite useless. 