### PR TITLE
Fix issue with webbrowser opening with an empty page.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -652,7 +652,10 @@ Bug Fixes
   - Fix an issue with setting fill value when column dtype is changed. [#4088]
 
   - Fix bug when unpickling a bare Column where the _parent_table
-    attibute was not set.  This impacted the Column representation. [#4099]
+    attribute was not set.  This impacted the Column representation. [#4099]
+
+  - Fix issue with the web browser opening with an empty page, and ensure that
+    the url is correctly formatted for Windows. [#4132]
 
 - ``astropy.time``
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -22,6 +22,7 @@ from .column import Column, MaskedColumn
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter, NdarrayMixin
 from .operations import join, hstack, vstack, unique, TableMergeError
+from .jsviewer import JSViewer
 
 # Import routines that connect readers/writers to astropy.table
 from ..io.ascii import connect

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -96,9 +96,23 @@ $(document).ready(function() {{
 
 
 class JSViewer(object):
-    def __init__(self,
-                 use_local_files=False,
-                 display_length=50):
+    """Provides an interactive HTML export of a Table.
+
+    This class provides an interface to the `DataTables
+    <http://datatables.net/>`_ library, which allow to visualize interactively
+    an HTML table. It is used by the `~astropy.table.Table.show_in_browser`
+    method.
+
+    Parameters
+    ----------
+    use_local_files : bool, optional
+        Use local files or a CDN for JavaScript librairies. Default False.
+    display_length : int, optional
+        Number or rows to show. Default to 50.
+
+    """
+
+    def __init__(self, use_local_files=False, display_length=50):
         self._use_local_files = use_local_files
         self.display_length_menu = [[10, 25, 50, 100, 500, 1000, -1],
                                     [10, 25, 50, 100, 500, 1000, "All"]]

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -736,17 +736,18 @@ class Table(object):
             Maximum number of rows to export to the table (set low by default
             to avoid memory issues, since the browser view requires duplicating
             the table in memory).  A negative value of ``max_lines`` indicates
-            no row limit
+            no row limit.
         jsviewer : bool
             If `True`, prepends some javascript headers so that the table is
-            rendered as a https://datatables.net data table.  This allows
-            in-browser searching & sorting.  See `JSViewer
-            <http://www.jsviewer.com/>`_
+            rendered as a `DataTables <https://datatables.net>`_ data table.
+            This allows in-browser searching & sorting.
         jskwargs : dict
-            Passed to the `JSViewer`_ init.
+            Passed to the `astropy.table.JSViewer` init. Default to
+            ``{'use_local_files': True}`` which means that the JavaScipt
+            librairies will be served from local copies.
         tableid : str or `None`
-            An html ID tag for the table.  Default is "table{id}", where id is
-            the unique integer id of the table object, id(self).
+            An html ID tag for the table.  Default is ``table{id}``, where id
+            is the unique integer id of the table object, id(self).
         browser : str
             Any legal browser name, e.g. ``'firefox'``, ``'chrome'``,
             ``'safari'`` (for mac, you may need to use ``'open -a

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -758,6 +758,8 @@ class Table(object):
         import os
         import webbrowser
         import tempfile
+        from ..extern.six.moves.urllib.parse import urljoin
+        from ..extern.six.moves.urllib.request import pathname2url
 
         # We can't use NamedTemporaryFile here because it gets deleted as
         # soon as it gets garbage collected.
@@ -772,10 +774,12 @@ class Table(object):
             else:
                 self.write(tmp, format='html')
 
-        if browser == 'default':
-            webbrowser.open("file://" + path)
+        try:
+            br = webbrowser.get(None if browser == 'default' else browser)
+        except webbrowser.Error:
+            log.error("Browser '%s' not found." % browser)
         else:
-            webbrowser.get(browser).open("file://" + path)
+            br.open(urljoin('file:', pathname2url(path)))
 
     def pformat(self, max_lines=None, max_width=None, show_name=True,
                 show_unit=None, show_dtype=False, html=False, tableid=None,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -765,17 +765,16 @@ class Table(object):
         path = os.path.join(tmpdir, 'table.html')
 
         with open(path, 'w') as tmp:
-
             if jsviewer:
                 self.write(tmp, format='jsviewer', css=css, max_lines=max_lines,
                            jskwargs=jskwargs, table_id=tableid)
             else:
                 self.write(tmp, format='html')
 
-            if browser == 'default':
-                webbrowser.open("file://" + path)
-            else:
-                webbrowser.get(browser).open("file://" + path)
+        if browser == 'default':
+            webbrowser.open("file://" + path)
+        else:
+            webbrowser.get(browser).open("file://" + path)
 
     def pformat(self, max_lines=None, max_width=None, show_name=True,
                 show_unit=None, show_dtype=False, html=False, tableid=None,


### PR DESCRIPTION
In `Table.show_in_browser`, if webbrowser is called inside the `with open` block, the file may not be written yet and the browser shows an empty page, after reloading the page is correctly displayed. So calling webbrowser after the with block solves the issue.