### PR TITLE
Add step to affiliated package release instructions

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -504,12 +504,12 @@ replace ``CHANGES.rst`` by ``CHANGES.md`` in the instructions.
 #. Check out the release commit with ``git checkout v<version>``.
    Run ``git clean -fxd`` to remove any non-committed files.
 
-#. (optional) Run the tests in a virtual environment that mocks up a
-   "typical user" scenario.  This is not strictly necessary because you ran the
-   tests above, but it can sometimes be useful to catch subtle bugs that might
-   come from you using a customized developer environment.  For more on setting
-   up virtual environments, see :ref:`virtual-envs`, but for the sake of example
-   we will assume you're using `Anaconda <http://conda.pydata.org/docs/>`_. Do::
+#. (optional) Run the tests in an environment that mocks up a "typical user"
+   scenario. This is not strictly necessary because you ran the tests above, but
+   it can sometimes be useful to catch subtle bugs that might come from you
+   using a customized developer environment.  For more on setting up virtual
+   environments, see :ref:`virtual-envs`, but for the sake of example we will
+   assume you're using `Anaconda <http://conda.pydata.org/docs/>`_. Do::
 
        conda create -n myaffilpkg_rel_test astropy <any more dependencies here>
        source activate myaffilpkg_rel_test

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -519,7 +519,9 @@ replace ``CHANGES.rst`` by ``CHANGES.md`` in the instructions.
        source deactivate
        cd <back to your source>
 
-   Assuming the tests all passed, you can proceed on.
+   You may want to repeat this for other combinations of dependencies if you think
+   your users might have other relevant packages installed.  Assuming the tests
+   all pass, you can proceed on.
 
 #. If you did the previous step, do ``git clean -fxd`` again to remove anything
    you made there. Then either release with::

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -501,8 +501,28 @@ replace ``CHANGES.rst`` by ``CHANGES.md`` in the instructions.
 
         git commit -m "Back to development: <next_version>"
 
-#. Check out the release commit with ``git checkout v<version>``. Run
-   ``git clean -fxd`` to remove any non-committed files, then either release with::
+#. Check out the release commit with ``git checkout v<version>``.
+   Run ``git clean -fxd`` to remove any non-committed files.
+
+#. (optional) Run the tests in a virtual environment that mocks up a
+   "typical user" scenario.  This is not strictly necessary because you ran the
+   tests above, but it can sometimes be useful to catch subtle bugs that might
+   come from you using a customized developer environment.  For more on setting
+   up virtual environments, see :ref:`virtual-envs`, but for the sake of example
+   we will assume you're using `Anaconda <http://conda.pydata.org/docs/>`_. Do::
+
+       conda create -n myaffilpkg_rel_test astropy <any more dependencies here>
+       source activate myaffilpkg_rel_test
+       python setup.py install
+       cd <anywhere not your package's source directory>
+       python -c 'import myaffilpkg; myaffilpkg.test()'
+       source deactivate
+       cd <back to your source>
+
+   Assuming the tests all passed, you can proceed on.
+
+#. If you did the previous step, do ``git clean -fxd`` again to remove anything
+   you made there. Then either release with::
 
         python setup.py register build sdist --format=gztar upload
 

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -513,8 +513,9 @@ replace ``CHANGES.rst`` by ``CHANGES.md`` in the instructions.
 
        conda create -n myaffilpkg_rel_test astropy <any more dependencies here>
        source activate myaffilpkg_rel_test
-       python setup.py install
-       cd <anywhere not your package's source directory>
+       python setup.py sdist
+       cd dist
+       pip install myaffilpkg-version.tar.gz
        python -c 'import myaffilpkg; myaffilpkg.test()'
        source deactivate
        cd <back to your source>

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -508,7 +508,7 @@ replace ``CHANGES.rst`` by ``CHANGES.md`` in the instructions.
    scenario. This is not strictly necessary because you ran the tests above, but
    it can sometimes be useful to catch subtle bugs that might come from you
    using a customized developer environment.  For more on setting up virtual
-   environments, see :ref:`virtual-envs`, but for the sake of example we will
+   environments, see :ref:`virtual_envs`, but for the sake of example we will
    assume you're using `Anaconda <http://conda.pydata.org/docs/>`_. Do::
 
        conda create -n myaffilpkg_rel_test astropy <any more dependencies here>


### PR DESCRIPTION
This PR just adds a checking step to the release instructions for affiliated packages.  This was triggered by experiences from @bmorris3 doing a first release for astroplan, and issues I've encountered when doing astropy releases.

The step added tells the maintainer that before they do the final pypi register/upload, they should try to install into a completely fresh environment with dependency combinations users are likely to have. My main motivation for adding this is that it's not that uncommon for developer's "regular" environment to have all kinds of packages that may or may not be out-of-date or installed weirdly which mask problems that show up for a more typical user (who often has just the standard dependencies from conda or whatever).  I know I've caught subtle bugs this way before (and we did so again in the astroplan release), so I'm suggesting it here at least as an "optional" step.

cc @astrofrog @cdeil