### PR TITLE
Handle parser error in wcslib header parser

### DIFF
--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -163,6 +163,9 @@ void
 wcs_to_python_exc(const struct wcsprm *wcs);
 
 void
+wcshdr_err_to_python_exc(int status);
+
+void
 wcserr_fix_to_python_exc(const struct wcserr *err);
 
 /***************************************************************************

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -11,6 +11,7 @@
 #include "astropy_wcs/docstrings.h"
 
 #include "wcsfix.h"
+#include "wcshdr.h"
 #include "wcsprintf.h"
 #include "wcsunits.h"
 
@@ -351,6 +352,16 @@ wcserr_fix_to_python_exc(const struct wcserr *err) {
     PyErr_SetString(exc, wcsprintf_buf());
   }
 }
+
+void
+wcshdr_err_to_python_exc(int status) {
+  if (status > 0 && status != WCSHDRERR_PARSER) {
+    PyErr_SetString(PyExc_MemoryError, "Memory allocation error");
+  } else {
+    PyErr_SetString(PyExc_ValueError, "Internal error in wcslib header parser");
+  }
+}
+
 
 /***************************************************************************
   Property helpers

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -376,9 +376,7 @@ PyWcsprm_init(
 
     if (status != 0) {
       free(colsel_ints);
-      PyErr_SetString(
-          PyExc_MemoryError,
-          "Memory allocation error.");
+      wcshdr_err_to_python_exc(wcs->err);
       return -1;
     }
 
@@ -414,9 +412,7 @@ PyWcsprm_init(
     free(colsel_ints);
 
     if (status != 0) {
-      PyErr_SetString(
-          PyExc_MemoryError,
-          "Memory allocation error.");
+      wcshdr_err_to_python_exc(wcs->err);
       return -1;
     }
 
@@ -615,9 +611,7 @@ PyWcsprm_find_all_wcs(
   Py_END_ALLOW_THREADS
 
   if (status != 0) {
-    PyErr_SetString(
-        PyExc_MemoryError,
-        "Memory allocation error.");
+    wcshdr_err_to_python_exc(wcs->err);
     return NULL;
   }
 
@@ -652,9 +646,7 @@ PyWcsprm_find_all_wcs(
   Py_END_ALLOW_THREADS
 
   if (status != 0) {
-    PyErr_SetString(
-        PyExc_MemoryError,
-        "Memory allocation error.");
+    wcshdr_err_to_python_exc(wcs->err);
     return NULL;
   }
 


### PR DESCRIPTION
Partial fix for #4089.

The header parsing functions in wcslib (`wcspih` and `wcsbth`) can return a "parser error" code (`WCSHDRERR_PARSER`) as of wcslib 5.x.

This was not being handled correctly, as it was assumed that any error code coming from those functions was a memory error.

Unfortunately, wcslib doesn't give us any clues as to *why* the parsing failed, but at least it will provide some clue to the user that the error is due to the input data and not something else.