### PR TITLE
Bug: visualization: mpl_style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -667,6 +667,12 @@ Bug Fixes
     additional copies of modules under a package imported like
     ``resolve_name('numpy')``. [#4084]
 
+- ``astropy.visualization``
+
+  - The color for axes labels was set to white. Since white labels on white
+    background are hard to read, the label color has been changed to black. 
+    [#4143]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -59,7 +59,7 @@ astropy_mpl_style_1 = {
     'axes.grid': True,
     'axes.titlesize': 'x-large',
     'axes.labelsize': 'large',
-    'axes.labelcolor': '#FFFFFF',
+    'axes.labelcolor': 'k',
     'axes.axisbelow': True,
     'axes.color_cycle': ['#348ABD',   # blue
                          '#7A68A6',   # purple


### PR DESCRIPTION
In the current setting axis labels are printed white on a white background.
This clearly is a bug, thus I don't increase the version number of astropy_style, but rather I suggest to fix in in the current setup.
(When I wrote that "version scheme" for the styles originally, I envisioned it for different artistic choices, not for bugs that make parts of the plot unreadable.)

@mdboom