### PR TITLE
Match __repr__ to attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -447,6 +447,8 @@ Bug fixes
 
 - ``astropy.constants``
 
+  - Rename units -> unit and error -> uncertainty in the ``__repr__`` to match attribute names. [#4147]
+  
 - ``astropy.convolution``
 
 - ``astropy.coordinates``

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -118,7 +118,7 @@ class Constant(Quantity):
         return inst
 
     def __repr__(self):
-        return ('<Constant name={0!r} value={1} error={2} units={3!r} '
+        return ('<Constant name={0!r} value={1} Uncertainty={2} unit={3!r} '
                 'reference={4!r}>'.format(self.name, self.value,
                                           self.uncertainty, str(self.unit),
                                           self.reference))
@@ -126,8 +126,8 @@ class Constant(Quantity):
     def __str__(self):
         return ('  Name   = {0}\n'
                 '  Value  = {1}\n'
-                '  Error  = {2}\n'
-                '  Units  = {3}\n'
+                '  Uncertainty  = {2}\n'
+                '  Unit  = {3}\n'
                 '  Reference = {4}'.format(self.name, self.value,
                                            self.uncertainty, self.unit,
                                            self.reference))

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -31,8 +31,8 @@ different units for example::
     >>> print const.c
       Name   = Speed of light in vacuum
       Value  = 299792458.0
-      Error  = 0.0
-      Units  = m / s
+      Uncertainty  = 0.0
+      Unit  = m / s
       Reference = CODATA 2010
 
     >>> print const.c.to('km/s')


### PR DESCRIPTION
Rename Error -> Uncertainty and Units -> Unit in `__repr__` to match the attributes.
Requested in https://github.com/astropy/astropy/issues/4145
Had to re-do the pull request because I messed up the branches.