### PR TITLE
Fixing the fit_deriv method for Voigt1D class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.1 (unreleased)
+﻿1.1 (unreleased)
 ----------------
 
 New Features
@@ -479,6 +479,8 @@ Bug fixes
 
   - The keyword ``acc`` (for accuracy) is now correctly accepted by
     ``Simplex``. [#3966]
+
+  - Switched first two elements of the returned list of fit_deriv in Voigt1D class. [#4144]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-﻿1.1 (unreleased)
+1.1 (unreleased)
 ----------------
 
 New Features
@@ -479,8 +479,6 @@ Bug fixes
 
   - The keyword ``acc`` (for accuracy) is now correctly accepted by
     ``Simplex``. [#3966]
-
-  - Switched first two elements of the returned list of fit_deriv in Voigt1D class. [#4144]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -818,7 +818,8 @@ class Voigt1D(Fittable1DModel):
         dVdx = np.sum((D/beta - 2 * (X - B) * alpha / np.square(beta)), axis=-1)
         dVdy = np.sum((C/beta - 2 * (Y - A) * alpha / np.square(beta)), axis=-1)
 
-        dyda = [- constant * dVdx * 2 * sqrt_ln2 / fwhm_G, constant * V / amplitude_L,
+        dyda = [- constant * dVdx * 2 * sqrt_ln2 / fwhm_G,
+                constant * V / amplitude_L,
                 constant * (V / fwhm_L + dVdy * sqrt_ln2 / fwhm_G),
                 -constant * (V + (sqrt_ln2 / fwhm_G) * (2 * (x - x_0) * dVdx + fwhm_L * dVdy)) / fwhm_G]
         return dyda

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -818,8 +818,7 @@ class Voigt1D(Fittable1DModel):
         dVdx = np.sum((D/beta - 2 * (X - B) * alpha / np.square(beta)), axis=-1)
         dVdy = np.sum((C/beta - 2 * (Y - A) * alpha / np.square(beta)), axis=-1)
 
-        dyda = [constant * V / amplitude_L,
-                - constant * dVdx * 2 * sqrt_ln2 / fwhm_G,
+        dyda = [- constant * dVdx * 2 * sqrt_ln2 / fwhm_G, constant * V / amplitude_L,
                 constant * (V / fwhm_L + dVdy * sqrt_ln2 / fwhm_G),
                 -constant * (V + (sqrt_ln2 / fwhm_G) * (2 * (x - x_0) * dVdx + fwhm_L * dVdy)) / fwhm_G]
         return dyda

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -6,8 +6,9 @@ from __future__ import (absolute_import, unicode_literals, division,
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 from .. import models
-from astropy.coordinates import Angle
-from astropy.modeling import fitting
+from ...coordinates import Angle
+from .. import fitting
+from ...tests.helper import pytest
 
 try:
     from scipy import optimize

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 from .. import models
 from astropy.coordinates import Angle
+from astropy.modeling import fitting
 
 try:
     from scipy import optimize
@@ -148,3 +149,13 @@ def test_Scale_inverse():
 def test_Shift_inverse():
     m = models.Shift(1.2345)
     assert_allclose(m.inverse(m(6.789)), 6.789)
+
+
+def test_Voigt1D():
+    voi = models.Voigt1D(amplitude_L=-0.5, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)
+    xarr = np.linspace(-5.0,5.0,num=40)
+    yarr = voi(xarr)
+    voi_init = models.Voigt1D(amplitude_L=-1.0, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)
+    fitter = fitting.LevMarLSQFitter()
+    voi_fit = fitter(voi_init, xarr, yarr)
+    assert_allclose(voi_fit.param_sets,voi.param_sets)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -152,11 +152,12 @@ def test_Shift_inverse():
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
+@pytest.mark.skipif("not HAS_SCIPY")
 def test_Voigt1D():
     voi = models.Voigt1D(amplitude_L=-0.5, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)
-    xarr = np.linspace(-5.0,5.0,num=40)
+    xarr = np.linspace(-5.0, 5.0, num=40)
     yarr = voi(xarr)
     voi_init = models.Voigt1D(amplitude_L=-1.0, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)
     fitter = fitting.LevMarLSQFitter()
     voi_fit = fitter(voi_init, xarr, yarr)
-    assert_allclose(voi_fit.param_sets,voi.param_sets)
+    assert_allclose(voi_fit.param_sets, voi.param_sets)


### PR DESCRIPTION
Switched the first two elements in the returned list of the fit_deriv method for the Voigt1D class. 

Closes #4144