### PR TITLE
Raise Exception for convolve() independant of normalize_kernel for kernels with sum of 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -612,6 +612,8 @@ Bug Fixes
 
 - ``astropy.convolution``
 
+  - Raise Exception in ``convolve`` for kernels that sum to zero. [#4138]
+
 - ``astropy.coordinates``
 
   - Fix string representation of ``SkyCoord`` objects transformed into

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -150,7 +150,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     # end if normalization was not requested.
     kernel_sum = kernel_internal.sum()
 
-    if kernel_sum < 1. / MAX_NORMALIZATION and normalize_kernel:
+    if kernel_sum < 1. / MAX_NORMALIZATION:
         raise Exception("The kernel can't be normalized, because its sum is "
                         "close to zero. The sum of the given kernel is < {0}"
                         .format(1. / MAX_NORMALIZATION))


### PR DESCRIPTION
I reported the issue that a kernel with a sum of zero will be normalized (and thus be NaN everywhere) without a warning.

I hope I have done everything right. I tried to learn the necessary git commands and read the astropy pull - documentation but still am not sure if I did no mistakes. Feel free to comment this rather small change.

Closes #4138