### PR TITLE
Silence various gcc warnings

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "

--- a/astropy/_erfa/core.c.templ
+++ b/astropy/_erfa/core.c.templ
@@ -8,8 +8,9 @@
    update it. */
 
 
-#include "Python.h"
-#include "numpy/arrayobject.h"
+#include <Python.h>
+#include <numpy/npy_no_deprecated_api.h>
+#include <numpy/arrayobject.h>
 #include "erfa.h"
 
 

--- a/astropy/_erfa/core.c.templ
+++ b/astropy/_erfa/core.c.templ
@@ -9,7 +9,7 @@
 
 
 #include <Python.h>
-#include <numpy/npy_no_deprecated_api.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include "erfa.h"
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -117,7 +117,7 @@ cdef class FileString:
     cdef:
         object fhandle
         object mmap
-        void *mmap_ptr
+        const void *mmap_ptr
         Py_buffer buf
 
     def __cinit__(self, fname):

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -7,6 +7,7 @@ from distutils.core import Extension
 from glob import glob
 
 from astropy_helpers import setup_helpers
+from astropy_helpers.distutils_helpers import get_distutils_build_option
 
 
 def get_extensions():
@@ -27,15 +28,20 @@ def get_extensions():
                     '/D', '"_USRDLL"',
                     '/D', '"_CRT_SECURE_NO_DEPRECATE"'])
         else:
-            # All of these switches are to silence warnings from compiling CFITSIO
             cfg['extra_compile_args'].extend([
-                '-Wno-unused-variable', '-Wno-parentheses',
-                '-Wno-uninitialized', '-Wno-format', '-Wno-strict-prototypes',
-                '-Wno-unused', '-Wno-comments', '-Wno-switch',
-                '-Wno-declaration-after-statement',
-                '-Wno-strict-aliasing', '-Wno-return-type', '-Wno-address',
-                '-Wno-unused-result'
+                '-Wno-declaration-after-statement'
             ])
+
+            if not get_distutils_build_option('debug'):
+                # All of these switches are to silence warnings from compiling
+                # CFITSIO
+                cfg['extra_compile_args'].extend([
+                    '-Wno-unused-variable', '-Wno-parentheses',
+                    '-Wno-uninitialized', '-Wno-format',
+                    '-Wno-strict-prototypes', '-Wno-unused', '-Wno-comments',
+                    '-Wno-switch', '-Wno-strict-aliasing', '-Wno-return-type',
+                    '-Wno-address', '-Wno-unused-result'
+                ])
 
         cfitsio_path = os.path.join('cextern', 'cfitsio')
         cfitsio_files = glob(os.path.join(cfitsio_path, '*.c'))

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -32,7 +32,8 @@ def get_extensions():
                 '-Wno-unused-variable', '-Wno-parentheses',
                 '-Wno-uninitialized', '-Wno-format', '-Wno-strict-prototypes',
                 '-Wno-unused', '-Wno-comments', '-Wno-switch',
-                '-Wno-declaration-after-statement'
+                '-Wno-declaration-after-statement',
+                '-Wno-strict-aliasing', '-Wno-return-type', '-Wno-address'
             ])
 
         cfitsio_path = os.path.join('cextern', 'cfitsio')

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -33,7 +33,8 @@ def get_extensions():
                 '-Wno-uninitialized', '-Wno-format', '-Wno-strict-prototypes',
                 '-Wno-unused', '-Wno-comments', '-Wno-switch',
                 '-Wno-declaration-after-statement',
-                '-Wno-strict-aliasing', '-Wno-return-type', '-Wno-address'
+                '-Wno-strict-aliasing', '-Wno-return-type', '-Wno-address',
+                '-Wno-unused-result'
             ])
 
         cfitsio_path = os.path.join('cextern', 'cfitsio')

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -270,7 +270,7 @@ int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
     }
     else {
         PyErr_Clear();
-        *val = def;
+        strncpy(val, def, 72);
         retval = 1;
     }
 

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -91,11 +91,12 @@
 /* Include the Python C API */
 
 #include <math.h>
+#include <string.h>
 
 #include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <fitsio2.h>
-#include <string.h>
 #include "compressionmodule.h"
 
 /* Some defines for Python3 support--bytes objects should be used where */
@@ -931,8 +932,8 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
 
     indata = (PyArrayObject*) PyObject_GetAttrString(hdu, "data");
 
-    fits_write_img(fileptr, datatype, 1, PyArray_SIZE(indata), indata->data,
-                   &status);
+    fits_write_img(fileptr, datatype, 1, PyArray_SIZE(indata),
+                   PyArray_DATA(indata), &status);
     if (status != 0) {
         process_status_err(status);
         goto fail;
@@ -1057,8 +1058,8 @@ PyObject* compression_decompress_hdu(PyObject* self, PyObject* args)
     /* Create and allocate a new array for the decompressed data */
     outdata = (PyArrayObject*) PyArray_SimpleNew(zndim, znaxis, npdatatype);
 
-    fits_read_img(fileptr, datatype, 1, arrsize, NULL, outdata->data, &anynul,
-                  &status);
+    fits_read_img(fileptr, datatype, 1, arrsize, NULL, PyArray_DATA(outdata),
+                  &anynul, &status);
     if (status != 0) {
         process_status_err(status);
         outdata = NULL;

--- a/astropy/modeling/src/projections.c.templ
+++ b/astropy/modeling/src/projections.c.templ
@@ -8,6 +8,7 @@
 
 #include <Python.h> /* Python */
 
+#include <numpy/npy_no_deprecated_api.h>
 #include <numpy/arrayobject.h> /* Numpy */
 #include <numpy/npy_math.h> /* Numpy */
 
@@ -41,9 +42,9 @@ static PyObject *do_work(struct prjprm *prj, PyObject *in[2],
                          int (*prjset)(struct prjprm *),
                          int (*prjtrn)(struct prjprm *, int, int, int, int, const double[], const double[], double[], double[], int[]))
 {
-  PyObject* in_array[2] = { NULL, NULL };
-  PyObject* out_array[2] = { NULL, NULL };
-  PyObject* stat_array = NULL;
+  PyArrayObject* in_array[2] = { NULL, NULL };
+  PyArrayObject* out_array[2] = { NULL, NULL };
+  PyArrayObject* stat_array = NULL;
   Py_ssize_t n;
   Py_ssize_t i;
   PyObject* result = NULL;
@@ -60,7 +61,8 @@ static PyObject *do_work(struct prjprm *prj, PyObject *in[2],
      we should broadcast */
 
   for (i = 0; i < 2; ++i) {
-    in_array[i] = PyArray_ContiguousFromObject(in[i], PyArray_DOUBLE, 1, NPY_MAXDIMS);
+    in_array[i] = (PyArrayObject *) PyArray_ContiguousFromObject(
+        in[i], NPY_DOUBLE, 1, NPY_MAXDIMS);
     if (in_array[i] == NULL) {
       goto exit;
     }
@@ -81,15 +83,15 @@ static PyObject *do_work(struct prjprm *prj, PyObject *in[2],
   }
 
   for (i = 0; i < 2; ++i) {
-    out_array[i] = PyArray_SimpleNew(
-        PyArray_NDIM(in_array[0]), PyArray_DIMS(in_array[0]), PyArray_DOUBLE);
+    out_array[i] = (PyArrayObject *) PyArray_SimpleNew(
+        PyArray_NDIM(in_array[0]), PyArray_DIMS(in_array[0]), NPY_DOUBLE);
     if (out_array[i] == NULL) {
       goto exit;
     }
   }
 
-  stat_array = PyArray_SimpleNew(
-      PyArray_NDIM(in_array[0]), PyArray_DIMS(in_array[0]), PyArray_INT);
+  stat_array = (PyArrayObject *) PyArray_SimpleNew(
+      PyArray_NDIM(in_array[0]), PyArray_DIMS(in_array[0]), NPY_INT);
   if (stat_array == NULL) {
     goto exit;
   }

--- a/astropy/modeling/src/projections.c.templ
+++ b/astropy/modeling/src/projections.c.templ
@@ -8,7 +8,7 @@
 
 #include <Python.h> /* Python */
 
-#include <numpy/npy_no_deprecated_api.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h> /* Numpy */
 #include <numpy/npy_math.h> /* Numpy */
 

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -12,8 +12,23 @@
 
 #include <Python.h>
 
+#include <numpy/npy_no_deprecated_api.h>
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>
+
+/* A few Numpy constants that don't have consistent (undeprecated) spellings
+   between Numpy 1.6 and the current version */
+#ifndef NPY_ARRAY_C_CONTIGUOUS
+#define NPY_ARRAY_C_CONTIGUOUS NPY_C_CONTIGUOUS
+#endif
+
+#ifndef NPY_ARRAY_WRITEABLE
+#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
+#endif
+
+#ifndef PyArray_SetBaseObject
+#define PyArray_SetBaseObject(arr, base) (arr->base = (PyObject *)base)
+#endif
 
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
@@ -257,7 +272,7 @@ get_double_array(
     const npy_intp* dims,
     /*@shared@*/ PyObject* owner) {
 
-  return PyArrayProxy_New(owner, ndims, dims, PyArray_DOUBLE, value);
+  return PyArrayProxy_New(owner, ndims, dims, NPY_DOUBLE, value);
 }
 
 /*@null@*/ static INLINE PyObject*
@@ -268,7 +283,7 @@ get_double_array_readonly(
     const npy_intp* dims,
     /*@shared@*/ PyObject* owner) {
 
-  return PyArrayReadOnlyProxy_New(owner, ndims, dims, PyArray_DOUBLE, value);
+  return PyArrayReadOnlyProxy_New(owner, ndims, dims, NPY_DOUBLE, value);
 }
 
 int
@@ -287,7 +302,7 @@ get_int_array(
     const npy_intp* dims,
     /*@shared@*/ PyObject* owner) {
 
-  return PyArrayProxy_New(owner, ndims, dims, PyArray_INT, value);
+  return PyArrayProxy_New(owner, ndims, dims, NPY_INT, value);
 }
 
 int

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -12,7 +12,7 @@
 
 #include <Python.h>
 
-#include <numpy/npy_no_deprecated_api.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>
 

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -27,7 +27,7 @@
 #endif
 
 #ifndef PyArray_SetBaseObject
-#define PyArray_SetBaseObject(arr, base) (arr->base = (PyObject *)base)
+#define PyArray_SetBaseObject(arr, baseobj) ((arr)->base = (PyObject *)baseobj)
 #endif
 
 #if PY_MAJOR_VERSION >= 3

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -16,6 +16,7 @@ from distutils.dep_util import newer_group
 
 
 from astropy_helpers import setup_helpers
+from astropy_helpers.distutils_helpers import get_distutils_build_option
 from astropy.extern import six
 
 WCSROOT = os.path.relpath(os.path.dirname(__file__))
@@ -238,12 +239,13 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
 
     # Squelch a few compilation warnings in WCSLIB
     if setup_helpers.get_compiler_option() in ('unix', 'mingw32'):
-        cfg['extra_compile_args'].extend([
-            '-Wno-strict-prototypes',
-            '-Wno-unused-function',
-            '-Wno-unused-value',
-            '-Wno-uninitialized',
-            '-Wno-unused-but-set-variable'])
+        if not get_distutils_build_option('debug'):
+            cfg['extra_compile_args'].extend([
+                '-Wno-strict-prototypes',
+                '-Wno-unused-function',
+                '-Wno-unused-value',
+                '-Wno-uninitialized',
+                '-Wno-unused-but-set-variable'])
 
 
 

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -242,7 +242,8 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
             '-Wno-strict-prototypes',
             '-Wno-unused-function',
             '-Wno-unused-value',
-            '-Wno-uninitialized'])
+            '-Wno-uninitialized',
+            '-Wno-unused-but-set-variable'])
 
 
 

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -197,7 +197,7 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
         ('_GNU_SOURCE', None)])
 
     if (not setup_helpers.use_system_library('wcslib') or
-        sys.platform == 'win32'):
+            sys.platform == 'win32'):
         write_wcsconfig_h(include_paths)
 
         wcslib_path = join("cextern", "wcslib")  # Path to wcslib
@@ -235,6 +235,15 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
 
     if sys.platform.startswith('linux'):
         cfg['define_macros'].append(('HAVE_SINCOS', None))
+
+    # Squelch a few compilation warnings in WCSLIB
+    if setup_helpers.get_compiler_option() in ('unix', 'mingw32'):
+        cfg['extra_compile_args'].extend([
+            '-Wno-strict-prototypes',
+            '-Wno-unused-function',
+            '-Wno-unused-value',
+            '-Wno-uninitialized'])
+
 
 
 def get_extensions():

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -222,7 +222,7 @@ Wcs_all_pix2world(
 
   naxis = self->x.wcs->naxis;
 
-  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, PyArray_DOUBLE, 2, 2);
+  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, NPY_DOUBLE, 2, 2);
   if (pixcrd == NULL) {
     return NULL;
   }
@@ -235,7 +235,7 @@ Wcs_all_pix2world(
     goto exit;
   }
 
-  world = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+  world = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (world == NULL) {
     goto exit;
   }
@@ -302,7 +302,7 @@ Wcs_p4_pix2foc(
     return pixcrd_obj;
   }
 
-  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, PyArray_DOUBLE, 2, 2);
+  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, NPY_DOUBLE, 2, 2);
   if (pixcrd == NULL) {
     return NULL;
   }
@@ -312,7 +312,7 @@ Wcs_p4_pix2foc(
     goto exit;
   }
 
-  foccrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+  foccrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (foccrd == NULL) {
     status = 2;
     goto exit;
@@ -370,7 +370,7 @@ Wcs_det2im(
     return detcrd_obj;
   }
 
-  detcrd = (PyArrayObject*)PyArray_ContiguousFromAny(detcrd_obj, PyArray_DOUBLE, 2, 2);
+  detcrd = (PyArrayObject*)PyArray_ContiguousFromAny(detcrd_obj, NPY_DOUBLE, 2, 2);
   if (detcrd == NULL) {
     return NULL;
   }
@@ -380,7 +380,7 @@ Wcs_det2im(
     goto exit;
   }
 
-  imcrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(detcrd), PyArray_DOUBLE);
+  imcrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(detcrd), NPY_DOUBLE);
   if (imcrd == NULL) {
     status = 2;
     goto exit;
@@ -433,7 +433,7 @@ Wcs_pix2foc(
     return NULL;
   }
 
-  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, PyArray_DOUBLE, 2, 2);
+  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, NPY_DOUBLE, 2, 2);
   if (pixcrd == NULL) {
     return NULL;
   }
@@ -443,7 +443,7 @@ Wcs_pix2foc(
     goto _exit;
   }
 
-  foccrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+  foccrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (foccrd == NULL) {
     goto _exit;
   }

--- a/astropy/wcs/src/distortion.c
+++ b/astropy/wcs/src/distortion.c
@@ -172,12 +172,16 @@ p4_pix2deltas(
   const double* pix0;
   const double* pixend;
 
+#ifndef NDEBUG
+  unsigned int k;
+#endif
+
   assert(naxes == NAXES);
   assert(lookup != NULL);
   assert(pix != NULL);
   assert(foc != NULL);
+
 #ifndef NDEBUG
-  unsigned int k;
   for (k = 0; k < naxes; ++k) {
     if (lookup[k] != NULL) {
       assert(lookup[k]->data != NULL);

--- a/astropy/wcs/src/distortion_wrap.c
+++ b/astropy/wcs/src/distortion_wrap.c
@@ -78,7 +78,7 @@ PyDistLookup_init(
     return -1;
   }
 
-  array_obj = (PyArrayObject*)PyArray_ContiguousFromAny(py_array_obj, PyArray_FLOAT32, 2, 2);
+  array_obj = (PyArrayObject*)PyArray_ContiguousFromAny(py_array_obj, NPY_FLOAT32, 2, 2);
   if (array_obj == NULL) {
     return -1;
   }
@@ -183,7 +183,7 @@ PyDistLookup_set_data(
     return 0;
   }
 
-  value_array = (PyArrayObject*)PyArray_ContiguousFromAny(value, PyArray_FLOAT32, 2, 2);
+  value_array = (PyArrayObject*)PyArray_ContiguousFromAny(value, NPY_FLOAT32, 2, 2);
 
   if (value_array == NULL) {
     return -1;

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -38,14 +38,14 @@ _PyArrayProxy_New(
       nd, (npy_intp*)dims,
       NULL,
       (void*)data,
-      NPY_C_CONTIGUOUS | flags,
+      NPY_ARRAY_C_CONTIGUOUS | flags,
       NULL);
 
   if (result == NULL) {
     return NULL;
   }
   Py_INCREF(self);
-  PyArray_BASE(result) = (PyObject*)self;
+  PyArray_SetBaseObject((PyArrayObject *)result, self);
   return result;
 }
 
@@ -57,7 +57,7 @@ PyArrayProxy_New(
     int typenum,
     const void* data) {
 
-  return _PyArrayProxy_New(self, nd, dims, typenum, data, NPY_WRITEABLE);
+  return _PyArrayProxy_New(self, nd, dims, typenum, data, NPY_ARRAY_WRITEABLE);
 }
 
 /*@null@*/ PyObject*
@@ -538,7 +538,7 @@ set_double_array(
     return -1;
   }
 
-  value_array = (PyArrayObject*)PyArray_ContiguousFromAny(value, PyArray_DOUBLE,
+  value_array = (PyArrayObject*)PyArray_ContiguousFromAny(value, NPY_DOUBLE,
                                                           ndims, ndims);
   if (value_array == NULL) {
     return -1;
@@ -580,7 +580,7 @@ set_int_array(
     return -1;
   }
 
-  value_array = (PyArrayObject*)PyArray_ContiguousFromAny(value, PyArray_INT,
+  value_array = (PyArrayObject*)PyArray_ContiguousFromAny(value, NPY_INT,
                                                           ndims, ndims);
   if (value_array == NULL) {
     return -1;

--- a/astropy/wcs/src/sip_wrap.c
+++ b/astropy/wcs/src/sip_wrap.c
@@ -47,7 +47,7 @@ convert_matrix(
   }
 
   *array = (PyArrayObject*)PyArray_ContiguousFromAny(
-      pyobj, PyArray_DOUBLE, 2, 2);
+      pyobj, NPY_DOUBLE, 2, 2);
   if (*array == NULL) {
     return -1;
   }
@@ -102,7 +102,7 @@ PySip_init(
     goto exit;
   }
 
-  crpix = (PyArrayObject*)PyArray_ContiguousFromAny(py_crpix, PyArray_DOUBLE,
+  crpix = (PyArrayObject*)PyArray_ContiguousFromAny(py_crpix, NPY_DOUBLE,
                                                     1, 1);
   if (crpix == NULL) {
     goto exit;
@@ -167,7 +167,7 @@ PySip_pix2foc(
     return NULL;
   }
 
-  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, PyArray_DOUBLE, 2, 2);
+  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, NPY_DOUBLE, 2, 2);
   if (pixcrd == NULL) {
     goto exit;
   }
@@ -178,7 +178,7 @@ PySip_pix2foc(
   }
 
   foccrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(pixcrd),
-                                             PyArray_DOUBLE);
+                                             NPY_DOUBLE);
   if (foccrd == NULL) {
     goto exit;
   }
@@ -250,7 +250,7 @@ PySip_foc2pix(
     return NULL;
   }
 
-  foccrd = (PyArrayObject*)PyArray_ContiguousFromAny(foccrd_obj, PyArray_DOUBLE, 2, 2);
+  foccrd = (PyArrayObject*)PyArray_ContiguousFromAny(foccrd_obj, NPY_DOUBLE, 2, 2);
   if (foccrd == NULL) {
     goto exit;
   }
@@ -261,7 +261,7 @@ PySip_foc2pix(
   }
 
   pixcrd = (PyArrayObject*)PyArray_SimpleNew(2, PyArray_DIMS(foccrd),
-                                             PyArray_DOUBLE);
+                                             NPY_DOUBLE);
   if (pixcrd == NULL) {
     status = 2;
     goto exit;

--- a/astropy/wcs/src/sip_wrap.c
+++ b/astropy/wcs/src/sip_wrap.c
@@ -233,7 +233,6 @@ PySip_foc2pix(
   PyArrayObject* pixcrd     = NULL;
   int            status     = -1;
   double*        foccrd_data = NULL;
-  double*        pixcrd_data = NULL;
   unsigned int   nelem      = 0;
   unsigned int   i, j;
   const char*    keywords[] = {

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -213,6 +213,7 @@ PyWcsprm_init(
   int            keysel        = -1;
   PyObject*      colsel        = Py_None;
   PyArrayObject* colsel_array  = NULL;
+  int*           colsel_data  = NULL;
   int*           colsel_ints   = NULL;
   int            warnings      = 1;
   int            nreject       = 0;
@@ -323,7 +324,7 @@ PyWcsprm_init(
 
     if (colsel != Py_None) {
       colsel_array = (PyArrayObject*) PyArray_ContiguousFromAny(
-        colsel, 1, 1, PyArray_INT);
+        colsel, 1, 1, NPY_INT);
       if (colsel_array == NULL) {
         return -1;
       }
@@ -338,8 +339,9 @@ PyWcsprm_init(
       }
 
       colsel_ints[0] = (int)PyArray_DIM(colsel_array, 0);
+      colsel_data = (int *)PyArray_DATA(colsel_array);
       for (i = 0; i < colsel_ints[0]; ++i) {
-        colsel_ints[i+1] = colsel_array->data[i];
+        colsel_ints[i+1] = colsel_data[i];
       }
 
       Py_DECREF(colsel_array);
@@ -785,7 +787,7 @@ PyWcsprm_cylfix(
 
   if (naxis_obj != NULL && naxis_obj != Py_None) {
     naxis_array = (PyArrayObject*)PyArray_ContiguousFromAny(
-        naxis_obj, 1, 1, PyArray_INT);
+        naxis_obj, 1, 1, NPY_INT);
     if (naxis_array == NULL) {
       return NULL;
     }
@@ -888,7 +890,7 @@ PyWcsprm_fix(
 
   if (naxis_obj != NULL && naxis_obj != Py_None) {
     naxis_array = (PyArrayObject*)PyArray_ContiguousFromAny(
-        naxis_obj, 1, 1, PyArray_INT);
+        naxis_obj, 1, 1, NPY_INT);
     if (naxis_array == NULL) {
       return NULL;
     }
@@ -1091,7 +1093,7 @@ PyWcsprm_mix(
   }
 
   world = (PyArrayObject*)PyArray_ContiguousFromAny
-    (world_obj, PyArray_DOUBLE, 1, 1);
+    (world_obj, NPY_DOUBLE, 1, 1);
   if (world == NULL) {
     PyErr_SetString(
         PyExc_TypeError,
@@ -1108,7 +1110,7 @@ PyWcsprm_mix(
   }
 
   pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny
-    (pixcrd_obj, PyArray_DOUBLE, 1, 1);
+    (pixcrd_obj, NPY_DOUBLE, 1, 1);
   if (pixcrd == NULL) {
     PyErr_SetString(
         PyExc_TypeError,
@@ -1145,19 +1147,19 @@ PyWcsprm_mix(
    */
   naxis = (Py_ssize_t)self->x.naxis;
   phi = (PyArrayObject*)PyArray_SimpleNew
-    (1, &naxis, PyArray_DOUBLE);
+    (1, &naxis, NPY_DOUBLE);
   if (phi == NULL) {
     goto exit;
   }
 
   theta = (PyArrayObject*)PyArray_SimpleNew
-    (1, &naxis, PyArray_DOUBLE);
+    (1, &naxis, NPY_DOUBLE);
   if (theta == NULL) {
     goto exit;
   }
 
   imgcrd = (PyArrayObject*)PyArray_SimpleNew
-    (1, &naxis, PyArray_DOUBLE);
+    (1, &naxis, NPY_DOUBLE);
   if (imgcrd == NULL) {
     goto exit;
   }
@@ -1246,7 +1248,7 @@ PyWcsprm_p2s(
   naxis = self->x.naxis;
 
   pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny
-    (pixcrd_obj, PyArray_DOUBLE, 2, 2);
+    (pixcrd_obj, NPY_DOUBLE, 2, 2);
   if (pixcrd == NULL) {
     return NULL;
   }
@@ -1262,31 +1264,31 @@ PyWcsprm_p2s(
   /* Now we allocate a bunch of numpy arrays to store the results in.
    */
   imgcrd = (PyArrayObject*)PyArray_SimpleNew(
-      2, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+      2, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (imgcrd == NULL) {
     goto exit;
   }
 
   phi = (PyArrayObject*)PyArray_SimpleNew(
-      1, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+      1, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (phi == NULL) {
     goto exit;
   }
 
   theta = (PyArrayObject*)PyArray_SimpleNew(
-      1, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+      1, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (theta == NULL) {
     goto exit;
   }
 
   world = (PyArrayObject*)PyArray_SimpleNew(
-      2, PyArray_DIMS(pixcrd), PyArray_DOUBLE);
+      2, PyArray_DIMS(pixcrd), NPY_DOUBLE);
   if (world == NULL) {
     goto exit;
   }
 
   stat = (PyArrayObject*)PyArray_SimpleNew(
-      1, PyArray_DIMS(pixcrd), PyArray_INT);
+      1, PyArray_DIMS(pixcrd), NPY_INT);
   if (stat == NULL) {
     goto exit;
   }
@@ -1388,7 +1390,7 @@ PyWcsprm_s2p(
   naxis = self->x.naxis;
 
   world = (PyArrayObject*)PyArray_ContiguousFromAny(
-      world_obj, PyArray_DOUBLE, 2, 2);
+      world_obj, NPY_DOUBLE, 2, 2);
   if (world == NULL) {
     return NULL;
   }
@@ -1405,31 +1407,31 @@ PyWcsprm_s2p(
    * results in.
    */
   phi = (PyArrayObject*)PyArray_SimpleNew(
-      1, PyArray_DIMS(world), PyArray_DOUBLE);
+      1, PyArray_DIMS(world), NPY_DOUBLE);
   if (phi == NULL) {
     goto exit;
   }
 
   theta = (PyArrayObject*)PyArray_SimpleNew(
-      1, PyArray_DIMS(world), PyArray_DOUBLE);
+      1, PyArray_DIMS(world), NPY_DOUBLE);
   if (phi == NULL) {
     goto exit;
   }
 
   imgcrd = (PyArrayObject*)PyArray_SimpleNew(
-      2, PyArray_DIMS(world), PyArray_DOUBLE);
+      2, PyArray_DIMS(world), NPY_DOUBLE);
   if (theta == NULL) {
     goto exit;
   }
 
   pixcrd = (PyArrayObject*)PyArray_SimpleNew(
-      2, PyArray_DIMS(world), PyArray_DOUBLE);
+      2, PyArray_DIMS(world), NPY_DOUBLE);
   if (pixcrd == NULL) {
     goto exit;
   }
 
   stat = (PyArrayObject*)PyArray_SimpleNew(
-      1, PyArray_DIMS(world), PyArray_INT);
+      1, PyArray_DIMS(world), NPY_INT);
   if (stat == NULL) {
     goto exit;
   }


### PR DESCRIPTION
This disables a number of warnings from gcc that have been bugging me, as part of a broader effort to clean up the amount of line noise one gets (by default) when building Astropy.

In the case of C extensions developed by and for Astropy I've made appropriate fixes to actually fix code that was generating warnings (there were only a handful of these).  There were also a handful of places where we were using deprecated (as of Numpy 1.7) Numpy API, so I tried to actually fix those.

The rest is to squelch warnings from external C libraries that we include.  The downside to this is that in the case of astropy.io.fits and astropy.wcs, since CFITSIO and WCSLIB are compiled into their respective extension modules, this means we could also be squelching warnings in our own code.  For now I'd just recommend either manually adding an additional `-Wall` when building those extension modules while doing development work on them, or use a linter on them anyways.  Though if anyone thinks this is a problem we could also look into separating the builds of the external libs into a separate build stage that we can parameterize independently from the build of the extension modules themselves.

This also includes an update to astropy-helpers for astropy/astropy-helpers#183 which is needed to quiet the last bunch of warnings.

Note: I've only tested this on my local copy of gcc 4.4.7.  YMMV with different compilers/versions.