### PR TITLE
Minor performance tweak to classproperty

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -457,7 +457,7 @@ class classproperty(property):
         # Using stock functools.wraps instead of the fancier version
         # found later in this module, which is overkill for this purpose
 
-        @wraps(orig_fget)
+        @functools.wraps(orig_fget)
         def fget(obj):
             return orig_fget(obj.__class__)
 


### PR DESCRIPTION
The comment above this change wasn't actually true--this was using the Astropy version of the wraps decorator, not the stock functools.wraps.  The performance impact of this is small, but not non-existent.