### PR TITLE
Fix Cone Search validator parse_cs() crashing on incomplete testQuery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -681,6 +681,9 @@ Bug Fixes
 
 - ``astropy.vo``
 
+  - Cone Search validation no longer crashes when the provider gives an
+    incomplete test query. [#4158]
+
 - ``astropy.wcs``
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -682,7 +682,8 @@ Bug Fixes
 - ``astropy.vo``
 
   - Cone Search validation no longer crashes when the provider gives an
-    incomplete test query. [#4158]
+    incomplete test query. It also ensures search radius for a test query
+    is not too large to avoid timeout. [#4158, #4159]
 
 - ``astropy.wcs``
 

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -165,8 +165,8 @@ class TestConeSearch(object):
             assert tab.array.size > 0
 
     @pytest.mark.parametrize(('center', 'radius'),
-                             [((SCS_RA, SCS_DEC), 1.0),
-                              (SCS_CENTER, 1.0 * u.degree)])
+                             [((SCS_RA, SCS_DEC), 0.8),
+                              (SCS_CENTER, 0.8 * u.degree)])
     def test_prediction(self,  center, radius):
         """Prediction tests are not very accurate but will have to do."""
         t_1, tab_1 = conesearch.conesearch_timer(

--- a/astropy/vo/validator/tstquery.py
+++ b/astropy/vo/validator/tstquery.py
@@ -10,7 +10,8 @@ In case USVO service is unstable, it does the following:
     #. If fails, use RA=0 DEC=0 SR=0.1.
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 # STDLIB
 import warnings
@@ -28,12 +29,12 @@ def parse_cs(id):
         id = id.decode('ascii')
 
     # Production server.
-    url = 'http://vao.stsci.edu/directory/getRecord.aspx?' \
-        'id={0}&format=xml'.format(id)
+    url = ('http://vao.stsci.edu/directory/getRecord.aspx?'
+           'id={0}&format=xml'.format(id))
 
     # Test server (in case production server fails).
-    backup_url = 'http://vaotest.stsci.edu/directory/getRecord.aspx?' \
-        'id={0}&format=xml'.format(id)
+    backup_url = ('http://vaotest.stsci.edu/directory/getRecord.aspx?'
+                  'id={0}&format=xml'.format(id))
 
     tqp = ['ra', 'dec', 'sr']
     d = OrderedDict()
@@ -60,13 +61,18 @@ def parse_cs(id):
         tq = dom.getElementsByTagName('testQuery')
         if tq:
             for key in tqp:
-                d[key.upper()] = tq[0].getElementsByTagName(
-                    key)[0].firstChild.nodeValue.strip()
+                try:
+                    d[key.upper()] = tq[0].getElementsByTagName(
+                        key)[0].firstChild.nodeValue.strip()
+                except Exception as e:  # pragma: no cover
+                    urls_failed = True
+                    urls_errmsg = ('Incomplete testQuery for {0}, '
+                                   'using default'.format(id))
         else: # pragma: no cover
             urls_failed = True
             urls_errmsg = 'No testQuery found for {0}, using default'.format(id)
 
-    # If no testQuery found, use RA=0 DEC=0 SR=1
+    # If no testQuery found, use RA=0 DEC=0 SR=0.1
     if urls_failed:  # pragma: no cover
         d = OrderedDict({'RA': '0', 'DEC': '0', 'SR': '0.1'})
         warnings.warn(urls_errmsg, AstropyUserWarning)


### PR DESCRIPTION
This fixes #4158. Also minor PEP-8 and doc fixes.

I have no plans to add a test or change log. This is because `parse_cs()` is for internal use within the validator. And Cone Search services change from time to time, so there is no point to add a test for this.

@embray , you can manually test this if you wish:
```python
>>> from astropy.vo.validator.tstquery import parse_cs
>>> id = 'ivo://CDS.VizieR/J/ApJ/780/34'
>>> parse_cs(id)
WARNING: Incomplete testQuery for ivo://CDS.VizieR/J/ApJ/780/34, using default [astropy.vo.validator.tstquery]
OrderedDict([(u'SR', u'0.1'), (u'DEC', u'0'), (u'RA', u'0')])
```