### PR TITLE
Persistent --remote-data test failure in Python 2 on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -856,6 +856,10 @@ Bug Fixes
 
 - ``astropy.vo``
 
+  - Fixed ``check_conesearch_sites`` with ``parallel=True`` on Python >= 3.3
+    and on Windows (it was broken in both those cases for separate reasons).
+    [#2970]
+
 - ``astropy.wcs``
 
 Other Changes and Additions

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -24,7 +24,7 @@ from .. import exceptions
 from .. import xmlutil
 
 
-class Result:
+class Result(object):
     def __init__(self, url, root='results', timeout=10):
         self.url = url
         m = hashlib.md5()


### PR DESCRIPTION
There is one test that is persistently failing when I run `setup.py test --remote-data` on Windows, with either Python 2.6 or 2.7.  The issue seems to be related to the multiprocessing module, and I strongly suspect might be an upstream bug in Python.  In particular I was using Python 2.6.6 and 2.7.3 both of which are quite old, and I know that several bugs in `multiprocessing` have been fixed since then.

So I will likely close this as wontfix, but figured it was worth leaving a record of.  The full traceback from the failure is here:

```
================================== FAILURES ==================================
_______________ TestConeSearchValidation.test_validation[True] _______________

self = <astropy.vo.validator.tests.test_validate.TestConeSearchValidation object at 0x10D215B0>
parallel = True

    @pytest.mark.parametrize(('parallel'), [True, False])
    def test_validation(self, parallel):
        if os.path.exists(self.out_dir):
            shutil.rmtree(self.out_dir)

        # For some reason, Python 3.3 does not work
        # using multiprocessing.Pool and callback function.
        # See http://bugs.python.org/issue16307
        try:
            validate.check_conesearch_sites(
>               destdir=self.out_dir, parallel=parallel, url_list=None)

astropy\vo\validator\tests\test_validate.py:65:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = ()
kwargs = {'destdir': 'c:\\users\\embray\\appdata\\local\\temp\\tmptdtkx5', 'parallel': True, 'url_list': None}
ts = 1411502161.45, i = 0

    @wraps(function)
    def wrapper(*args, **kwargs):
        ts = time.time()
        for i in range(num_tries):
>           result = function(*args, **kwargs)

astropy\utils\timer.py:77:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

destdir = 'c:\\users\\embray\\appdata\\local\\temp\\tmptdtkx5', verbose = True
parallel = True, url_list = None

    @timefunc(1)
    def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
                               url_list='default'):
        """Validate Cone Search Services.

        .. note::

            URLs are unescaped prior to validation.

            Only check queries with ``<testQuery>`` parameters.
            Does not perform meta-data and erroneous queries.

        Parameters
        ----------
        destdir : str, optional
            Directory to store output files. Will be created if does
            not exist. Existing files with these names will be deleted
            or replaced:

                * conesearch_good.json
                * conesearch_warn.json
                * conesearch_exception.json
                * conesearch_error.json

        verbose : bool, optional
            Print extra info to log.

        parallel : bool, optional
            Enable multiprocessing.

        url_list : list of string, optional
            Only check these access URLs against
            `astropy.vo.validator.Conf.conesearch_master_list` and ignore
            the others, which will not appear in output files.  By
            default, check those in
            `astropy.vo.validator.Conf.conesearch_urls`.  If `None`, check
            everything.

        Raises
        ------
        IOError
            Invalid destination directory.

        timeout
            URL request timed out.

        ValidationMultiprocessingError
            Multiprocessing failed.

        """
        from . import conf
        global _OUT_ROOT

        if url_list == 'default':
            url_list = conf.conesearch_urls

        if (not isinstance(destdir, six.string_types) or len(destdir) == 0 or
                os.path.exists(destdir) and not os.path.isdir(destdir)):
            raise IOError('Invalid destination directory')  # pragma: no cover

        if not os.path.exists(destdir):
            os.mkdir(destdir)

        # Output dir created by votable.validator
        _OUT_ROOT = os.path.join(destdir, 'results')

        if not os.path.exists(_OUT_ROOT):
            os.mkdir(_OUT_ROOT)

        # Output files
        db_file = OrderedDict()
        db_file['good'] = os.path.join(destdir, 'conesearch_good.json')
        db_file['warn'] = os.path.join(destdir, 'conesearch_warn.json')
        db_file['excp'] = os.path.join(destdir, 'conesearch_exception.json')
        db_file['nerr'] = os.path.join(destdir, 'conesearch_error.json')

        # JSON dictionaries for output files
        js_tree = {}
        for key in db_file:
            js_tree[key] = vos_catalog.VOSDatabase.create_empty()

            # Delete existing files, if any, to be on the safe side.
            # Else can cause confusion if program exited prior to
            # new files being written but old files are still there.
            if os.path.exists(db_file[key]):  # pragma: no cover
                os.remove(db_file[key])
                if verbose:
                    log.info('Existing file {0} deleted'.format(db_file[key]))

        # Master VO database from registry. Silence all the warnings.
        with warnings.catch_warnings():
            warnings.simplefilter('ignore')
            js_mstr = vos_catalog.VOSDatabase.from_registry(
                CS_MSTR_LIST(), encoding='binary', show_progress=verbose)

        # Validate only a subset of the services.
        if url_list is not None:
            # Make sure URL is unique and fixed.
            url_list = set(six.moves.map(unescape_all, [cur_url.encode('utf-8')
if isinstance(cur_url, str) else cur_url for cur_url in url_list]))
            uniq_rows = len(url_list)
            url_list_processed = []  # To track if given URL is valid in registry
            if verbose:
                log.info('Only {0}/{1} site(s) are validated'.format(
                    uniq_rows, len(js_mstr)))
        # Validate all services.
        else:
            uniq_rows = len(js_mstr)

        key_lookup_by_url = {}

        # Process each catalog in the registry.
        for cur_key, cur_cat in js_mstr.get_catalogs():
            cur_url = cur_cat['url']

            # Skip if:
            #   a. not a Cone Search service
            #   b. not in given subset, if any
            if ((cur_cat['capabilityClass'] != b'ConeSearch') or
                    (url_list is not None and cur_url not in url_list)):
                continue

            # Use testQuery to return non-empty VO table with max verbosity.
            testquery_pars = parse_cs(cur_cat['resourceID'])
            cs_pars_arr = ['='.join([key, testquery_pars[key]]).encode('utf-8')
                           for key in testquery_pars]
            cs_pars_arr += [b'VERB=3']

            # Track the service.
            key_lookup_by_url[cur_url + b'&'.join(cs_pars_arr)] = cur_key
            if url_list is not None:
                url_list_processed.append(cur_url)

        # Give warning if any of the user given subset is not in the registry.
        if url_list is not None:
            url_list_skipped = url_list - set(url_list_processed)
            n_skipped = len(url_list_skipped)
            if n_skipped > 0:
                warn_str = '{0} not found in registry! Skipped:\n'.format(n_skipped)
                for cur_url in url_list_skipped:
                    warn_str += '\t{0}\n'.format(cur_url)
                warnings.warn(warn_str, AstropyUserWarning)

        all_urls = list(key_lookup_by_url)

        # Validate URLs
        if parallel:
            mp_list = []
            pool = multiprocessing.Pool()
            mp_proc = pool.map_async(_do_validation, all_urls,
                                     callback=mp_list.append)
            mp_proc.wait()
            if len(mp_list) < 1:  # pragma: no cover
                raise ValidationMultiprocessingError(
>                   'Multiprocessing pool callback returned empty list.')
E               ValidationMultiprocessingError: Multiprocessing pool callback returned empty list.

astropy\vo\validator\validate.py:201: ValidationMultiprocessingError
= 1 failed, 7829 passed, 84 skipped, 18 xfailed, 3 xpassed in 361.71 seconds =
```