### PR TITLE
allow fitsdiff to explicitly report type differences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.1 (unreleased)
+﻿1.1 (unreleased)
 ----------------
 
 New Features
@@ -465,6 +465,8 @@ Bug fixes
 
   - Included a new command-line script called ``fitsinfo`` to display
     a summary of the HDUs in one or more FITS files. [#3677]
+
+  - The function ``report_diff_values()`` now explicitly reports type differences. [#4122]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1244,10 +1244,21 @@ def report_diff_values(fileobj, a, b, ind=0):
     for line in difflib.ndiff(str(a).splitlines(), str(b).splitlines()):
         if line[0] == '-':
             line = 'a>' + line[1:]
+            if typea != typeb:
+                padding = max(len(typea.__name__), len(typeb.__name__)) + 3
+                typename = '(' + typea.__name__ + ') '
+                line = typename.rjust(padding) + line
+            
         elif line[0] == '+':
             line = 'b>' + line[1:]
+            if typea != typeb:
+                padding = max(len(typea.__name__), len(typeb.__name__)) + 3
+                typename = '(' + typeb.__name__ + ') '
+                line = typename.rjust(padding) + line
         else:
             line = ' ' + line
+            if typea != typeb:
+                line = ' ' * padding + line
         fileobj.write(indent(u('  %s\n') % line.rstrip('\n'), ind))
 
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1214,6 +1214,8 @@ def diff_values(a, b, tolerance=0.0):
 def report_diff_values(fileobj, a, b, ind=0):
     """Write a diff between two values to the specified file-like object."""
 
+    typea = type(a)
+    typeb = type(b)
     if isinstance(a, (int, float, complex, np.number)):
         a = repr(a)
 
@@ -1240,6 +1242,19 @@ def report_diff_values(fileobj, a, b, ind=0):
             line = 'b>' + line[1:]
         else:
             line = ' ' + line
+        
+        if typea != typeb:
+            if 'a>' in line:
+                line += ' ' + repr(typea)
+            elif 'b' in line:
+                line += ' ' + repr(typeb)
+            elif '?' not in line:
+                line1 = 'a>' + line + ' ' + repr(typea)
+                fileobj.write(indent(u('  %s\n') % line1.rstrip('\n'), ind))
+                line2 = 'b>' + line + ' ' + repr(typeb)
+                fileobj.write(indent(u('  %s\n') % line2.rstrip('\n'), ind))
+                return
+        
         fileobj.write(indent(u('  %s\n') % line.rstrip('\n'), ind))
 
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1216,6 +1216,12 @@ def report_diff_values(fileobj, a, b, ind=0):
 
     typea = type(a)
     typeb = type(b)
+
+    if (isinstance(a, string_types) and not isinstance(b, string_types)): 
+        a = repr(a).lstrip('u')
+    elif (isinstance(b, string_types) and not isinstance(a, string_types)):
+        b = repr(b).lstrip('u')
+    
     if isinstance(a, (int, float, complex, np.number)):
         a = repr(a)
 
@@ -1242,19 +1248,6 @@ def report_diff_values(fileobj, a, b, ind=0):
             line = 'b>' + line[1:]
         else:
             line = ' ' + line
-        
-        if typea != typeb:
-            if 'a>' in line:
-                line += ' ' + repr(typea)
-            elif 'b' in line:
-                line += ' ' + repr(typeb)
-            elif '?' not in line:
-                line1 = 'a>' + line + ' ' + repr(typea)
-                fileobj.write(indent(u('  %s\n') % line1.rstrip('\n'), ind))
-                line2 = 'b>' + line + ' ' + repr(typeb)
-                fileobj.write(indent(u('  %s\n') % line2.rstrip('\n'), ind))
-                return
-        
         fileobj.write(indent(u('  %s\n') % line.rstrip('\n'), ind))
 
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1240,19 +1240,19 @@ def report_diff_values(fileobj, a, b, ind=0):
             fileobj.write(indent(u('  ...and at %d more indices.\n') %
                           (num_diffs - 3), ind))
         return
-
+    
+    padding = max(len(typea.__name__), len(typeb.__name__)) + 3
+    
     for line in difflib.ndiff(str(a).splitlines(), str(b).splitlines()):
         if line[0] == '-':
             line = 'a>' + line[1:]
             if typea != typeb:
-                padding = max(len(typea.__name__), len(typeb.__name__)) + 3
                 typename = '(' + typea.__name__ + ') '
                 line = typename.rjust(padding) + line
             
         elif line[0] == '+':
             line = 'b>' + line[1:]
             if typea != typeb:
-                padding = max(len(typea.__name__), len(typeb.__name__)) + 3
                 typename = '(' + typeb.__name__ + ') '
                 line = typename.rjust(padding) + line
         else:

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -579,6 +579,22 @@ class TestDiff(FitsTestCase):
         assert np.isnan(diff.diff_values[1][1][0])
         assert diff.diff_values[1][1][1] == 2.0
 
+    def test_diff_types(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4122
+        """
+        
+        f = io.StringIO()
+        
+        a = "1.0"
+        b = 1.0
+        
+        report_diff_values(f, a, b)
+        out = f.getvalue()
+        
+        assert 'a>' in out
+        assert 'b>' in out
+
     def test_float_comparison(self):
         """
         Regression test for https://github.com/spacetelescope/PyFITS/issues/21

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -586,14 +586,13 @@ class TestDiff(FitsTestCase):
         
         f = io.StringIO()
         
-        a = "1.0"
-        b = 1.0
+        a = 1.0
+        b = '1.0'
         
         report_diff_values(f, a, b)
         out = f.getvalue()
         
-        assert 'a>' in out
-        assert 'b>' in out
+        assert out.lstrip('u') == "  (float) a> 1.0\n    (str) b> '1.0'\n           ? +   +\n"
 
     def test_float_comparison(self):
         """


### PR DESCRIPTION
I added a bunch of code so that report_diff_values() checks for and explicitly reports type differences, as mentioned in #4122. Not sure if this is the best way to do it though. 
Not sure if a test is needed for this, but added it anyway. 

Closes #4122. 