### PR TITLE
Unexpected exception type for empty file in astropy.ascii.read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -637,6 +637,9 @@ Bug Fixes
     opposed to opening the file with ``fits.open`` and accessing the HDUs
     through the ``HDUList`` object). [#4097]
 
+  - Fix bug where reading a file without a newline failed with an
+    unrelated / unhelpful exception. [#4160]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1058,20 +1058,22 @@ def test_table_with_no_newline():
     """
     if six.PY3:
         import io
-        StringIO = io.BytesIO
+        _StringIO = io.BytesIO
+    else:
+        _StringIO = StringIO
 
     # With guessing
-    table = StringIO()
+    table = _StringIO()
     with pytest.raises(ascii.InconsistentTableError):
         ascii.read(table)
 
     # Without guessing
-    table = StringIO()
+    table = _StringIO()
     with pytest.raises(ValueError) as err:
         ascii.read(table, guess=False, fast_reader=False, format='basic')
     assert 'No header line found' in str(err.value)
 
-    table = StringIO()
+    table = _StringIO()
     with pytest.raises(ValueError) as err:
         ascii.read(table, guess=False, fast_reader=True, format='fast_basic')
     assert 'Inconsistent data column lengths' in str(err.value)
@@ -1080,7 +1082,7 @@ def test_table_with_no_newline():
     for kwargs in [dict(),
                    dict(guess=False, fast_reader=False, format='basic'),
                    dict(guess=False, fast_reader=True, format='fast_basic')]:
-        table = StringIO()
+        table = _StringIO()
         table.write(b'a b')
         t = ascii.read(table, **kwargs)
         assert t.colnames == ['a', 'b']

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -290,6 +290,14 @@ def read(table, guess=None, **kwargs):
             except:
                 pass
             else:
+                # Ensure that `table` has at least one \r or \n in it
+                # so that the core.BaseInputter test of
+                # ('\n' not in table and '\r' not in table)
+                # will fail and so `table` cannot be interpreted there
+                # as a filename.  See #4160.
+                if not re.search(r'[\r\n]', table):
+                    table = table + os.linesep
+
                 # If the table got successfully read then look at the content
                 # to see if is probably HTML, but only if it wasn't already
                 # identified as HTML based on the filename.


### PR DESCRIPTION
It was surprising to me that trying to read an empty file with `astropy.ascii.read` results in `IOError: [Errno 2] No such file or directory: ''` rather than a more descriptive error message. It might be worth it to raise a different exception in the case of a zero-length file.

I'm using astropy 1.0.1 on Python 2.7.10 with Mac OS X 10.10.4.

```
In [10]: !touch foo.txt

In [11]: ascii.read('foo.txt')
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-11-569f208f4a4d> in <module>()
----> 1 ascii.read('foo.txt')

/Users/jlong/lib/python2.7/site-packages/astropy/io/ascii/ui.pyc in read(table, guess, **kwargs)
    203         guess = _GUESS
    204     if guess:
--> 205         dat = _guess(table, new_kwargs, format, fast_reader_param)
    206     else:
    207         reader = get_reader(**new_kwargs)

/Users/jlong/lib/python2.7/site-packages/astropy/io/ascii/ui.pyc in _guess(table, read_kwargs, format, fast_reader)
    281             reader = get_reader(**guess_kwargs)
    282             reader.guessing = True
--> 283             return reader.read(table)
    284
    285         except (core.InconsistentTableError, ValueError, TypeError, AttributeError,

/Users/jlong/lib/python2.7/site-packages/astropy/io/ascii/core.pyc in read(self, table)
   1003
   1004         # Get a list of the lines (rows) in the table
-> 1005         self.lines = self.inputter.get_lines(table)
   1006
   1007         # Set self.data.data_lines to a slice of lines contain the data rows

/Users/jlong/lib/python2.7/site-packages/astropy/io/ascii/core.pyc in get_lines(self, table)
    181             if (hasattr(table, 'read') or
    182                     ('\n' not in table + '' and '\r' not in table + '')):
--> 183                 with get_readable_fileobj(table) as file_obj:
    184                     table = file_obj.read()
    185             lines = table.splitlines()

/Users/jlong/homebrew/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.pyc in __enter__(self)
     15     def __enter__(self):
     16         try:
---> 17             return self.gen.next()
     18         except StopIteration:
     19             raise RuntimeError("generator didn't yield")

/Users/jlong/lib/python2.7/site-packages/astropy/utils/data.pyc in get_readable_fileobj(name_or_obj, encoding, cache, show_progress, remote_timeout)
    197             fileobj = io.FileIO(name_or_obj, 'r')
    198         elif six.PY2:
--> 199             fileobj = open(name_or_obj, 'rb')
    200         close_fds.append(fileobj)
    201     else:

IOError: [Errno 2] No such file or directory: ''
```