### PR TITLE
NDDataBase now (tries to) set the uncertainties parent_nddata attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -655,6 +655,9 @@ Bug Fixes
     (eg. ``NDDataArray`` from ``NDData``) now sets the attributes other than
     ``data`` as it should [#4137].
 
+  - ``NDDataBase`` now tries to set the ``parent_nddata`` attribute of the
+    uncertainty.
+
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -656,7 +656,7 @@ Bug Fixes
     ``data`` as it should [#4137].
 
   - ``NDDataBase`` now tries to set the ``parent_nddata`` attribute of the
-    uncertainty.
+    uncertainty. [#4170]
 
 - ``astropy.stats``
 

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -90,3 +90,9 @@ class NDDataBase(object):
                 raise TypeError('Uncertainty must have attribute '
                                 'uncertainty_type whose type is string.')
         self._uncertainty = value
+        #Try setting the parent for the uncertainty. This is currently an
+        #enforced requirement for `StdDevUncertainty` for error propagation.
+        try:
+            self.uncertainty.parent_nddata = self
+        except:
+            pass

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -93,6 +93,6 @@ class NDDataBase(object):
         #Try setting the parent for the uncertainty. This is currently an
         #enforced requirement for `StdDevUncertainty` for error propagation.
         try:
-            self.uncertainty.parent_nddata = self
+            self._uncertainty.parent_nddata = self
         except:
             pass

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -93,8 +93,6 @@ class NDDataBase(object):
             #enforced requirement for `StdDevUncertainty` for error propagation.
             try:
                 value.parent_nddata = self
-            except:
-                raise AttributeError('Uncertainty must have an attribute '
-                                'parent_nddata.')
+            except AttributeError:
+                pass
         self._uncertainty = value
-        

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -89,10 +89,12 @@ class NDDataBase(object):
 
                 raise TypeError('Uncertainty must have attribute '
                                 'uncertainty_type whose type is string.')
+            #Try setting the parent for the uncertainty. This is currently an
+            #enforced requirement for `StdDevUncertainty` for error propagation.
+            try:
+                value.parent_nddata = self
+            except:
+                raise AttributeError('Uncertainty must have an attribute '
+                                'parent_nddata.')
         self._uncertainty = value
-        #Try setting the parent for the uncertainty. This is currently an
-        #enforced requirement for `StdDevUncertainty` for error propagation.
-        try:
-            self._uncertainty.parent_nddata = self
-        except:
-            pass
+        

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..nddata_base import NDDataBase
+from ..nduncertainty import StdDevUncertainty
 from ...tests.helper import pytest
 
 
@@ -52,9 +53,15 @@ def test_nddata_base_subclass():
     assert a.mask is None
     assert a.unit is None
     assert a.wcs is None
+    a.uncertainty = None
+    with pytest.raises(AttributeError):
+        assert a.uncertainty.parent_nddata is a
     good_uncertainty = MinimalUncertainty(5)
     a.uncertainty = good_uncertainty
     assert a.uncertainty is good_uncertainty
+    assert a.uncertainty.parent_nddata is a
+    a.uncertainty = StdDevUncertainty(None)
+    assert a.uncertainty.parent_nddata is a
     bad_uncertainty = 5
     with pytest.raises(TypeError):
         a.uncertainty = bad_uncertainty


### PR DESCRIPTION
In #4152 I discovered that ``NDData`` togeter with the ``NDArithmeticMixin`` was not able to work with ``StdDevUncertainty`` as uncertainty. The problem was, that only the ``NDDataArray`` did set the ``parent_nddata`` attribute of the uncertainty while setting the uncertainty. Because the ``parent_nddata`` is necessary for ``StdDevUncertainty`` to work I added a few lines which at least try to set it in ``NDDataBase``.

Currently the ``except`` (when the uncertainty has no ``parent_nddata`` attribute) only makes a `pass` but it may also raise an Exception (which fails the current tests) or raise a warning (likewise) or be a case for the ``astropy.logging`` (but I only recently discovered this and I am not sure how to use it properly)

Since this is only an aside issue of the original issue I hope this does not close the original issue.

Any suggestions? And should I add a test case for the original problem (it's quite difficult, because all of ``nddata/mixins/tests/test_ndarithmetic.py``are based on ``NDDataArray`` not the different Mixins)