### PR TITLE
NDArithmetic: Use zero if no uncertainty is set in uncertainty propagation

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -146,18 +146,18 @@ class NDArithmeticMixin(object):
             result.uncertainty = None
         elif self.uncertainty is None and operand.uncertainty is None:
             result.uncertainty = None
-        elif self.uncertainty is None:
-            result.uncertainty = operand_uncertainty
-        elif operand.uncertainty is None:
-            result.uncertainty = self.uncertainty.__class__(self.uncertainty,
-                                                            copy=True)
-        else:  # both self and operand have uncertainties
-            if (conf.warn_unsupported_correlated and
-                (not self.uncertainty.support_correlated or
-                 not operand.uncertainty.support_correlated)):
-                log.info("The uncertainty classes used do not support the "
-                         "propagation of correlated errors, so uncertainties"
-                         " will be propagated assuming they are uncorrelated")
+        else:
+            if self.uncertainty is None:
+                self.uncertainty = operand.uncertainty.__class__([0])
+            elif operand.uncertainty is None:
+                operand_uncertainty = self.uncertainty.__class__([0])
+            else:
+                if (conf.warn_unsupported_correlated and
+                  (not self.uncertainty.support_correlated or
+                   not operand.uncertainty.support_correlated)):
+                    log.info("The uncertainty classes used do not support the"
+                        " propagation of correlated errors, so uncertainties"
+                        " will be propagated assuming they are uncorrelated")
             operand_scaled = operand.__class__(operand_data,
                                                uncertainty=operand_uncertainty,
                                                unit=operand.unit,


### PR DESCRIPTION
But this produces additional computation time for addition/subtraction. But for multiplication and division the resulting uncertainty is now correct.

Closes #4152 