### PR TITLE
Fix astropy-helpers in master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import sys
 import ah_bootstrap
 from setuptools import setup
 
-import astropy
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_package_info, get_debug_option)
 try:
@@ -18,6 +17,8 @@ except:
     from astropy_helpers.setup_helpers import is_distutils_display_option
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
+
+import astropy
 
 NAME = 'astropy'
 

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,6 @@ import sys
 import ah_bootstrap
 from setuptools import setup
 
-#A dirty hack to get around some early import/configurations ambiguities
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
-builtins._ASTROPY_SETUP_ = True
-
 import astropy
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_package_info, get_debug_option)


### PR DESCRIPTION
This fixes the issue I brought up on the mailing list yesterday (or at least works around it).  This will be needed for any code that uses the latest version of astropy-helpers.

Fix to make sure that the `_ASTROPY_SETUP_` global is set very early on in astropy_helpers itself.  This makes up for a bug introduced in astropy/astropy-helpers#184 where `astropy_helpers.command.test` attempts to import astropy (just to check whether a class is importable) but that causes things to go haywire if `_ASTROPY_SETUP_` hasn't been set yet.