### PR TITLE
Builds broken due to broken wheel package in conda

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -4,6 +4,11 @@
 conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
 source activate test
 
+# --no-use-wheel requirement is temporary due to
+# https://github.com/astropy/astropy/issues/4180
+# and may be removed once the upstream fix is in place
+export PIP="pip install --no-use-wheel"
+
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]
 then
@@ -13,7 +18,7 @@ fi
 # PEP8
 if [[ $MAIN_CMD == pep8* ]]
 then
-  pip install pep8
+  $PIP pep8
   return  # no more dependencies needed
 fi
 
@@ -23,7 +28,7 @@ conda install --yes pytest Cython jinja2 psutil
 # NUMPY
 if [[ $NUMPY_VERSION == dev ]]
 then
-  pip install git+http://github.com/numpy/numpy.git
+  $PIP git+http://github.com/numpy/numpy.git
   export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION"
 else
   conda install --yes numpy=$NUMPY_VERSION
@@ -37,7 +42,7 @@ fi
 if $OPTIONAL_DEPS
 then
   $CONDA_INSTALL scipy h5py matplotlib pyyaml scikit-image pandas
-  pip install beautifulsoup4
+  $PIP beautifulsoup4
 fi
 
 # DOCUMENTATION DEPENDENCIES
@@ -47,7 +52,7 @@ fi
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib
-  pip install wcsaxes
+  $PIP wcsaxes
 fi
 
 # COVERAGE DEPENDENCIES
@@ -56,6 +61,6 @@ fi
 # the script installed by 'coveralls', unless it's installed first.
 if [[ $SETUP_CMD == 'test --coverage' ]]
 then
-  pip install cpp-coveralls;
-  pip install coverage coveralls;
+  $PIP cpp-coveralls;
+  $PIP coverage coveralls;
 fi

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -7,7 +7,7 @@ source activate test
 # --no-use-wheel requirement is temporary due to
 # https://github.com/astropy/astropy/issues/4180
 # and may be removed once the upstream fix is in place
-export PIP="pip install --no-use-wheel"
+export PIP_INSTALL="pip install --no-use-wheel"
 
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]
@@ -18,7 +18,7 @@ fi
 # PEP8
 if [[ $MAIN_CMD == pep8* ]]
 then
-  $PIP pep8
+  $PIP_INSTALL pep8
   return  # no more dependencies needed
 fi
 
@@ -28,7 +28,7 @@ conda install --yes pytest Cython jinja2 psutil
 # NUMPY
 if [[ $NUMPY_VERSION == dev ]]
 then
-  $PIP git+http://github.com/numpy/numpy.git
+  $PIP_INSTALL git+http://github.com/numpy/numpy.git
   export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION"
 else
   conda install --yes numpy=$NUMPY_VERSION
@@ -42,7 +42,7 @@ fi
 if $OPTIONAL_DEPS
 then
   $CONDA_INSTALL scipy h5py matplotlib pyyaml scikit-image pandas
-  $PIP beautifulsoup4
+  $PIP_INSTALL beautifulsoup4
 fi
 
 # DOCUMENTATION DEPENDENCIES
@@ -52,7 +52,7 @@ fi
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL Sphinx=1.2.2 Pygments matplotlib
-  $PIP wcsaxes
+  $PIP_INSTALL wcsaxes
 fi
 
 # COVERAGE DEPENDENCIES
@@ -61,6 +61,6 @@ fi
 # the script installed by 'coveralls', unless it's installed first.
 if [[ $SETUP_CMD == 'test --coverage' ]]
 then
-  $PIP cpp-coveralls;
-  $PIP coverage coveralls;
+  $PIP_INSTALL cpp-coveralls;
+  $PIP_INSTALL coverage coveralls;
 fi


### PR DESCRIPTION
The `wheel` package for conda is broken as of `wheel==0.26`, which unfortunately is needed for Python 3.5 support.  It's missing important metadata--namely the appropriate entry_points.txt, which is required for setuptools to be able to discover the bdist_wheel command.

This causes some dependencies for our builds--namely those installed by pip instead of conda--to fail to install (since pip now makes wheels of all packages).

This should require an upstream fix, but I'm also seeing if I can find a workaround...