### PR TITLE
Acquire cache lock in notebook fails after kernel restart

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1342,7 +1342,9 @@ def _acquire_download_cache_lock():
             time.sleep(1)
         else:
             return
-    msg = 'Unable to acquire lock for cache directory ({0} exists)'
+    msg = ("Unable to acquire lock for cache directory ({0} exists). "
+           "You may need to delete the lock if the python interpreter wasn't "
+           "shut down properly.")
     raise RuntimeError(msg.format(lockdir))
 
 


### PR DESCRIPTION
When in a notebook I try to rerun a cell after a kernel restart a ``RuntimeError`` is raised as the cache lock hasn't been removed during the restart.

I'm not sure whether this should be treated as a normal side effect of the notebook, or we can do something within astropy to handle it. 
My current workaround is to delete the lock manually, but there must be a better way to deal with.

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-1-f7724152a086> in <module>()
      2 from photutils import datasets
      3 
----> 4 hdu = datasets.load_star_image()
      5 image = hdu.data[500:700, 500:700]
      6 image -= np.median(image)

/Users/bsipocz/munka/devel/photutils/photutils/datasets/load.py in load_star_image()
    146         plt.imshow(hdu.data, origin='lower', cmap='gray')
    147     """
--> 148     path = get_path('M6707HH.fits.gz', location='remote')
    149     hdu = fits.open(path)[0]
    150 

/Users/bsipocz/munka/devel/photutils/photutils/datasets/load.py in get_path(filename, location)
     46         url = ('https://github.com/astropy/photutils-datasets/blob/master/'
     47                'data/{0}?raw=true'.format(filename))
---> 48         path = download_file(url, cache=True)
     49     else:
     50         raise ValueError('Invalid location: {0}'.format(location))

/Users/bsipocz/munka/devel/astropy/astropy/utils/data.py in download_file(remote_url, cache, show_progress, timeout)
   1067 
   1068         if cache:
-> 1069             _acquire_download_cache_lock()
   1070             try:
   1071                 with _open_shelve(urlmapfn, True) as url2hash:

/Users/bsipocz/munka/devel/astropy/astropy/utils/data.py in _acquire_download_cache_lock()
   1344             return
   1345     msg = 'Unable to acquire lock for cache directory ({0} exists)'
-> 1346     raise RuntimeError(msg.format(lockdir))
   1347 
   1348 

RuntimeError: Unable to acquire lock for cache directory (/Users/bsipocz/.astropy/cache/download/lock exists)
```