### PR TITLE
Add a `step` argument to `ProgressBar.map`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -246,6 +246,9 @@ New Features
   - Added ``is_url_in_cache`` for resolving paths to cached files via URLS
     and checking if files exist. [#4095]
 
+  - Added a ``step`` argument to the ``ProgressBar.map`` method to give
+    users control over the update frequency of the progress bar. [#4191]
+
 - ``astropy.visualization``
 
   - Added the ``hist`` function, which is similar to ``plt.hist`` but

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -697,7 +697,7 @@ class ProgressBar(six.Iterator):
             If ``multiprocess`` is `True`, this will affect the size
             of the chunks of ``items`` that are submitted as separate tasks
             to the process pool.  A large step size may make the job
-            complete faster if `items` is very long.
+            complete faster if ``items`` is very long.
         """
 
         results = []

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -694,8 +694,8 @@ class ProgressBar(six.Iterator):
 
         step : int, optional
             Update the progress bar at least every *step* steps (default: 100).
-            If `multiprocess` is `True`, this will affect the size
-            of the chunks of `items` that are submitted as separate tasks
+            If ``multiprocess`` is `True`, this will affect the size
+            of the chunks of ``items`` that are submitted as separate tasks
             to the process pool.  A large step size may make the job
             complete faster if `items` is very long.
         """


### PR DESCRIPTION
I :heart: `ProgressBar.map()`, but it is an annoyance that this method only updates the progress bar after every 200 processing steps, which is a hard-coded choice.  This causes a sluggish user experience when the method is used to track the progress of a series of time-consuming jobs, e.g. something like this:

```Python
from astropy.utils.console import ProgressBar
import time
myfunction = lambda x: time.sleep(1)
ProgressBar.map(myfunction, range(5000))
```

This PR increases the default frequency to 100 steps, and adds a `step` argument to `ProgressBar.map` to allow the user to change the update frequency as desired.

(The default is not simply 1 because that would hurt performance when `multiprocess` is `True`.)