### PR TITLE
[WIP] Allow to show a table in the IPython notebook using dataTables. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ New Features
 
 - ``astropy.table``
 
+  - Added a new ``Table.show_in_notebook`` method that allows to show a table in
+    the IPython notebook using dataTables. [#4197]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -743,7 +743,8 @@ class Table(object):
         table.columns = columns
 
     def _base_repr_(self, html=False, descr_vals=None, max_width=None,
-                    tableid=None, show_dtype=True, max_lines=None):
+                    tableid=None, show_dtype=True, max_lines=None,
+                    tableclass=None):
         if descr_vals is None:
             descr_vals = [self.__class__.__name__]
             if self.masked:
@@ -762,7 +763,7 @@ class Table(object):
         data_lines, outs = self.formatter._pformat_table(
             self, tableid=tableid, html=html, max_width=max_width,
             show_name=True, show_unit=None, show_dtype=show_dtype,
-            max_lines=max_lines)
+            max_lines=max_lines, tableclass=tableclass)
 
         out = descr + '\n'.join(data_lines)
         if six.PY2 and isinstance(out, six.text_type):
@@ -860,19 +861,23 @@ class Table(object):
             else:
                 print(line)
 
-    def show_in_notebook(self, tableid=None, table_class="display compact",
-                         css=None, display_length=50):
+    def show_in_notebook(self, tableid=None, css=None, display_length=50,
+                         table_class='table table-striped table-bordered '
+                         'table-condensed'):
         """Render the table in HTML and show it in the IPython notebook.
 
         Parameters
         ----------
         tableid : str or `None`
-            An html ID tag for the table.  Default is ``table{id}``, where id
-            is the unique integer id of the table object, id(self).
+            An html ID tag for the table.  Default is ``table{id}-XXX``, where
+            id is the unique integer id of the table object, id(self), and XXX
+            is a random number to avoid conflicts when printing the same table
+            multiple times.
         table_class : str or `None`
             A string with a list of HTML classes used to style the table.
-            Default is "display compact", and other possible values can be
-            found in http://www.datatables.net/manual/styling/classes
+            Default is "table table-striped table-bordered table-condensed",
+            using Bootstrap which is available in the notebook. See `this page
+            <http://getbootstrap.com/css/#tables>`_ for the list of classes.
         css : string
             A valid CSS string declaring the formatting for the table. Default
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
@@ -890,10 +895,9 @@ class Table(object):
 
         jsv = JSViewer(use_local_files=False, display_length=display_length)
         html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
-                                max_lines=-1, show_dtype=False)
+                                max_lines=-1, show_dtype=False,
+                                tableclass=table_class)
         html += jsv.ipynb(tableid, css=css)
-        html = html.replace('<table', "<table class='table table-striped "
-                            "table-bordered table-condensed' ")
         return HTML(html)
 
     def show_in_browser(self, max_lines=5000, jsviewer=False, ipynb=False,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -882,6 +882,7 @@ class Table(object):
         """
 
         from .jsviewer import JSViewer
+        from IPython.display import HTML
 
         if tableid is None:
             tableid = 'table{0}-{1}'.format(id(self),
@@ -893,7 +894,7 @@ class Table(object):
         html += jsv.ipynb(tableid, css=css)
         html = html.replace('<table', "<table class='table table-striped "
                             "table-bordered table-condensed' ")
-        return html
+        return HTML(html)
 
     def show_in_browser(self, max_lines=5000, jsviewer=False, ipynb=False,
                         browser='default', jskwargs={'use_local_files': True},

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -900,7 +900,7 @@ class Table(object):
         html += jsv.ipynb(tableid, css=css)
         return HTML(html)
 
-    def show_in_browser(self, max_lines=5000, jsviewer=False, ipynb=False,
+    def show_in_browser(self, max_lines=5000, jsviewer=False,
                         browser='default', jskwargs={'use_local_files': True},
                         tableid=None, table_class="display compact",
                         css=None):


### PR DESCRIPTION
This feature existed but was broken (https://github.com/astropy/astropy/issues/3937#issuecomment-131956530). cc @taldcroft @keflavich 
Here a new method `show_in_notebook` is added (it could replace the `_repr_html` but it is probably safer to use a separate method for now). 
The dataTables js file is loaded with requirejs, and a lightweight css style is added using Bootstrap. About the CSS:
- we could use directly the notebook's one but it is not very pretty,
- here I use Bootstrap which is already available in the notebook, ~~so I need to add classes to the HTML table which I do with a ugly `.replace`, it would be cleaner with #4131~~ (done).
- it could also be possible to use the dataTables CSS, but it requires one more external download and it seems not necessary.

![ipynb](https://cloud.githubusercontent.com/assets/311639/10149989/6717d53a-663d-11e5-9e8c-ac6e2d70ff31.png)
