### PR TITLE
Immediately clean up downloaded files in get_readable_fileobj

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -191,7 +191,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
 
     # Get a file object to the content
     if isinstance(name_or_obj, six.string_types):
-        if _is_url(name_or_obj):
+        is_url = _is_url(name_or_obj)
+        if is_url:
             name_or_obj = download_file(
                 name_or_obj, cache=cache, show_progress=show_progress,
                 timeout=remote_timeout)
@@ -199,6 +200,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
             fileobj = io.FileIO(name_or_obj, 'r')
         elif six.PY2:
             fileobj = open(name_or_obj, 'rb')
+        if is_url and not cache:
+            delete_fds.append(fileobj)
         close_fds.append(fileobj)
     else:
         fileobj = name_or_obj

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -14,8 +14,11 @@ import hashlib
 import io
 import os
 import sys
+import tempfile
+from ...extern.six.moves.urllib.request import pathname2url
 
-from ..data import _get_download_cache_locs, CacheMissingWarning
+from ..data import (_get_download_cache_locs, CacheMissingWarning,
+                    get_pkg_data_filename, get_readable_fileobj)
 
 TESTURL = 'http://www.astropy.org'
 
@@ -372,3 +375,24 @@ def test_is_url_in_cache():
 
     download_file(TESTURL, cache=True, show_progress=False)
     assert is_url_in_cache(TESTURL)
+
+
+def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
+    """checks that get_readable_fileobj leaves no temporary files behind"""
+    # Create a 'file://' URL pointing to a path on the local filesystem
+    local_filename = get_pkg_data_filename(os.path.join('data', 'local.dat'))
+    url = 'file://' + pathname2url(local_filename)
+
+    # Save temporary files to a known location
+    monkeypatch.setattr(tempfile, 'tempdir', str(tmpdir))
+
+    # Call get_readable_fileobj() as a context manager
+    with get_readable_fileobj(url) as fileobj:
+        pass
+
+    # Get listing of files in temporary directory
+    tempdir_listing = tmpdir.listdir()
+
+    # Assert that the temporary file was empty after get_readable_fileobj()
+    # context manager finished running
+    assert len(tempdir_listing) == 0


### PR DESCRIPTION
`astropy.utils.data.get_readable_fileobj` cleans up all temporary files that are generated while decompressing or decoding the target, but leaves the temporary file generated by calling `astropy.utils.data.download_file` to linger until the Python interpreter exits.

This patch causes `astropy.utils.data.get_readable_fileobj` to clean up the temporary downloaded file at the exit of the context handler (unless the downloaded file was cached).

See also:
https://mail.scipy.org/pipermail/astropy/2015-September/003937.html