### PR TITLE
Adding date to test header

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -13,6 +13,7 @@ from ..extern.six.moves import filter
 
 import ast
 import doctest
+import datetime
 import fnmatch
 import imp
 import io
@@ -561,6 +562,8 @@ def pytest_report_header(config):
             TESTED_VERSIONS['Astropy'])
 
     s += "Running tests in {0}.\n\n".format(" ".join(args))
+
+    s += "Date: {0}\n\n".format(datetime.datetime.now().isoformat()[:19])
 
     from platform import platform
     plat = platform()


### PR DESCRIPTION
Having the date somewhere in the test header can be valuable when the tests halt, and one starts wonder when the given session started, etc.