### PR TITLE
Slight fix to the automatic build-on-import in development mode

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -273,6 +273,9 @@ def _initialize_astropy():
 
 
 def _rebuild_extensions():
+    global __version__
+    global __githash__
+
     import os
     import subprocess
     import sys
@@ -300,6 +303,20 @@ def _rebuild_extensions():
                       'with error code {0}: try rerunning this command '
                       'manually to check what the error was.'.format(
                           sp.returncode))
+
+    # Try re-loading module-level globals from the astropy.version module,
+    # which may not have existed before this function ran
+    try:
+        from .version import version as __version__
+    except ImportError:
+        pass
+
+    try:
+        from .version import githash as __githash__
+    except ImportError:
+        pass
+
+
 # Set the bibtex entry to the article referenced in CITATION
 def _get_bibtex():
     import os


### PR DESCRIPTION
Previously, after running a `git clean -dfx` or in a fresh clone or something similar, if one does

```python
>>> import astropy
```
The extension modules are automatically built:
```
WARNING: You appear to be trying to import astropy from within a source checkout without building the extension modules first.  Attempting to (re)build extension modules: [astropy]
Rebuilding extension modules [Done]
```
but since the `astropy.version` module didn't exist before this point (it's automatically generated by the `setup.py`, which may not have even been run), we get after this:
```python
>>> astropy.__version__
''
```
but we can easily update the `__version__` global after the auto-build has run.