### PR TITLE
Coordinates docs updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,7 @@ New Features
   - Added ``Supergalactic`` frame to support de Vaucouleurs supergalactic
     coordinates. [#3892]
 
-  - Added ecliptic coordinates, including ``GeocentricTrueEcliptic``, 
+  - Added ecliptic coordinates, including ``GeocentricTrueEcliptic``,
     ``BarycentricTrueEcliptic``, and ``HeliocentricTrueEcliptic``. [#3749]
 
 - ``astropy.cosmology``
@@ -526,6 +526,13 @@ Other Changes and Additions
 
 - Updated ``astropy.tests`` test runner code to work with Coverage v4.0 when
   generating test coverage reports. [#4176]
+
+- The migration guide from pre-v0.4 coordinates has been removed to avoid
+  cluttering the ``astropy.coordinates`` documentation with increasingly
+  irrelevant material.  To see the migration guide, we recommend you simply look
+  to the archived documentation for previous versions, e.g.
+  http://docs.astropy.org/en/v1.0/coordinates/index.html#migrating-from-pre-v0-4-coordinates 
+  [#4203]
 
 
 1.0.5 (unreleased)

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -1,14 +1,16 @@
 .. _coordinates-galactocentric:
 
-==========================================
-Transforming to Galactocentric coordinates
-==========================================
+========================================================
+Description of Galactocentric coordinates transformation
+========================================================
 
 This document describes the mathematics behind the transformation from
 :class:`~astropy.coordinates.ICRS` to `~astropy.coordinates.Galactocentric`
-coordinates. For examples of how to use this transformation in code, see
-the *Examples* section of the
-`~astropy.coordinates.Galactocentric` class documentation.
+coordinates. This is described in detail here both due to the mathematical
+subtleties and the fact that there is no official standard/definition for this
+frame. For examples of how to use this transformation in code, see the
+the *Examples* section of the `~astropy.coordinates.Galactocentric` class
+documentation.
 
 We assume that we start with a 3D position in the ICRS reference frame:
 a Right Ascension, Declination, and heliocentric distance,
@@ -112,4 +114,3 @@ midplane.
 The full transformation is then:
 
 .. math:: \boldsymbol{r}_{\rm GC} = \boldsymbol{H} \left( \boldsymbol{R}\boldsymbol{r}_{\rm icrs} - d_{\rm GC}\hat{\boldsymbol{x}}_{\rm GC}\right).
-

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -13,13 +13,6 @@ The `~astropy.coordinates` package provides classes for representing a
 variety of celestial/spatial  coordinates, as well as tools for
 converting between common coordinate systems in a uniform way.
 
-.. note::
-
-    If you have existing code that uses `~astropy.coordinates` functionality from
-    Astropy version 0.3.x or earlier, please see the section on `Migrating from
-    pre-v0.4 coordinates`_.  The interface has changed in ways that are not
-    backward compatible in many circumstances.
-
 Getting Started
 ===============
 
@@ -284,57 +277,6 @@ IPython session::
 
     In [1]: from astropy.coordinates.tests import test_api_ape5
     In [2]: test_api_ape5??
-
-
-Migrating from pre-v0.4 coordinates
-===================================
-
-For typical users, the major change is that the recommended way to use
-coordinate functionality is via the `~astropy.coordinates.SkyCoord` class,
-instead of classes like `~astropy.coordinates.ICRS` classes (now called
-"frame classes").
-
-For most users of pre-v0.4 coordinates, this means that the best way to
-adapt old code to the new framework is to change code like::
-
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import ICRS  # or FK5, or Galactic, or similar
-    >>> coordinate = ICRS(123.4*u.deg, 56.7*u.deg)
-
-to instead be::
-
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
-    >>> coordinate = SkyCoord(123.4*u.deg, 56.7*u.deg, frame='icrs')
-
-Note that usage like::
-
-    >>> coordinate = ICRS(123.4, 56.7, unit=('deg', 'deg'))  # NOT RECOMMENDED!
-
-will continue to work in v0.4, but will yield a `~astropy.coordinates.SkyCoord`
-instead of an `~astropy.coordinates.ICRS` object (the former behaves
-more like the pre-v0.4 `~astropy.coordinates.ICRS`).  This compatibility
-feature will issue a deprecation warning, and will be removed in the next major
-version, so you should update your code to use `~astropy.coordinates.SkyCoord`
-directly by the next release.
-
-Users should also be aware that if they continue to use the first form (directly
-creating `~astropy.coordinates.ICRS` frame objects), old code may still
-work if it uses basic coordinate functionality, but many of the
-convenience functions like catalog matching or attribute-based
-transforms like ``coordinate.galactic`` will no longer work.  These
-features are now all in `~astropy.coordinates.SkyCoord`.
-
-For advanced users or developers who have defined their own coordinates,
-take note that the extensive internal changes will require re-writing
-user-defined coordinate frames.  The :ref:`sgr-example` document has
-been updated for the new framework to provide a worked example of how
-custom coordinates work.
-
-More detailed information about the new framework and using it to define
-custom coordinates is available at :ref:`astropy-coordinates-overview`,
-:ref:`astropy-coordinates-definitions`, :ref:`astropy-coordinates-design`,
-and :ref:`astropy-coordinates-create-repr`.
 
 
 .. _astropy-coordinates-seealso:

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -264,8 +264,8 @@ listed below.
    representations
    frames
    sgr-example
-   definitions
    galactocentric
+   definitions
 
 
 In addition, another resource for the capabilities of this package is the


### PR DESCRIPTION
This PR contains a few minor documentation changes in `coordinates` that I noticed while working on some other things.  Specifically:

1. It removes the migration guide for pre-v0.4 coordinates.  I'm thinking this is OK because it's been over a year now since that change was made, and at this point I think it's more of a distraction than anything. I could also update this PR to add it as a separate *document* instead of a section on the index page as it has been up until now, though, if we prefer not to get rid of it completely.
2. adjusts the ordering in the index to keep "important definitions" as the last entry (as intended)
3. Some slight wording changes in the Galactocentric coordinates description

cc @astrofrog @taldcroft @adrn (mainly about removing the migration guide)