### PR TITLE
Update Table documentation to endorse use of QTable and mixins

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2451,7 +2451,9 @@ class QTable(Table):
 
 class NdarrayMixin(np.ndarray):
     """
-    Minimal mixin using a simple subclass of numpy array
+    Mixin column class to allow storage of arbitrary numpy
+    ndarrays within a Table.  This is a subclass of numpy.ndarray
+    and has the same initialization options as ndarray().
     """
     info = ParentDtypeInfo()
 

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -142,6 +142,8 @@ class ArrayWrapper(object):
     """
     Minimal mixin using a simple wrapper around a numpy array
     """
+    info = ParentDtypeInfo()
+
     def __init__(self, data):
         self.data = np.array(data)
         if 'info' in getattr(data, '__dict__', ()):
@@ -161,8 +163,6 @@ class ArrayWrapper(object):
 
     def __len__(self):
         return len(self.data)
-
-    info = ParentDtypeInfo()
 
     @property
     def dtype(self):

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+"""
+This module contains functions and methods that relate to the DataInfo
+class which provides a container class for informational attributes
+as well as summary info methods.  This is currently used in the Table
+class.
+"""
+
 # Note: these functions and classes are tested extensively in astropy table
 # tests via their use in providing mixin column info, and in
 # astropy/tests/test_info for providing table and column info summary data.
@@ -19,7 +26,6 @@ import re
 from ..extern import six
 from ..utils import OrderedDict
 from ..utils.compat import NUMPY_LT_1_8
-
 
 # Tuple of filterwarnings kwargs to ignore when calling info
 IGNORE_WARNINGS = (dict(category=RuntimeWarning,

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""
-This module contains functions and methods that relate to the DataInfo
-class which provides a container class for informational attributes
-as well as summary info methods.  This is currently used in the Table
-class.
+"""This module contains functions and methods that relate to the DataInfo class
+which provides a container for informational attributes as well as summary info
+methods.
+
+A DataInfo object is attached to the Quantity, SkyCoord, and Time classes in
+astropy.  Here it allows those classes to be used in Tables and uniformly carry
+table column attributes such as name, format, dtype, meta, and description.
 """
 
 # Note: these functions and classes are tested extensively in astropy table

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -12,12 +12,10 @@ Quick overview
 ^^^^^^^^^^^^^^
 
 For the impatient, the code below shows the basics of accessing table data.
-Where relevant there is a comment about what sort of object.  Except where
-noted, the table access returns objects that can be modified in order to
-update table data or properties.
-In cases where is returned and how
-the data contained in that object relate to the original table data
-(i.e. whether it is a copy or reference, see :ref:`copy_versus_reference`).
+Where relevant there is a comment about what sort of object is returned.
+Except where noted, table access returns objects that can be modified in order
+to update the original table data or properties.  See also the section on
+:ref:`copy_versus_reference` to learn more about this topic.
 
 **Make table**
 ::
@@ -63,7 +61,7 @@ the data contained in that object relate to the original table data
 **Print table or column**
 ::
 
-  print t      # Print formatted version of table to the screen
+  print(t)     # Print formatted version of table to the screen
   t.pprint()   # Same as above
   t.pprint(show_unit=True)  # Show column unit
   t.pprint(show_name=False)  # Do not show column names
@@ -71,7 +69,7 @@ the data contained in that object relate to the original table data
 
   t.more()  # Interactively scroll through table like Unix "more"
 
-  print t['a'] # Formatted column values
+  print(t['a'])  # Formatted column values
   t['a'].pprint()  # Same as above, with same options as Table.pprint()
   t['a'].more()  # Interactively scroll through column
 

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -532,16 +532,19 @@ any array::
          [[ 5,  6],
           [50, 60]]])
 
-Columns and Quantities
-''''''''''''''''''''''
-Columns with units that the `astropy.units` package understands can be
-converted explicitly to ``~astropy.units.Quantity`` objects via the
+.. _columns_with_units:
+
+Columns with Units
+''''''''''''''''''
+
+A `~astropy.table.Column` object with units within a standard
+`~astropy.table.Table` (as opposed to a `~astropy.table.QTable`) has certain
+quantity-related conveniences available.  To begin with, it can be converted
+explicitly to a `~astropy.units.Quantity` object via the
 :attr:`~astropy.table.Column.quantity` property and the
 :meth:`~astropy.table.Column.to` method::
 
-  >>> from astropy.table import Table
-  >>> from astropy import units as u
-  >>> data = [[1., 2., 3.],[40000., 50000., 60000.]]
+  >>> data = [[1., 2., 3.], [40000., 50000., 60000.]]
   >>> t = Table(data, names=('a', 'b'))
   >>> t['a'].unit = u.m
   >>> t['b'].unit = 'km/s'
@@ -597,10 +600,11 @@ expressions (see the warning below for caveats to this)::
     -0.988031624093
      0.893996663601
 
-  This is wrong both in that it says the unit is degrees, *and* ``sin``
-  treated the values and radians rather than degrees.  If at all in
-  doubt that you'll get the right result, the safest choice is to
-  explicitly convert to `~astropy.units.Quantity`::
+  This is wrong both in that it says the unit is degrees, *and* ``sin`` treated
+  the values and radians rather than degrees.  If at all in doubt that you'll
+  get the right result, the safest choice is to either use
+  `~astropy.table.QTable` or to explicitly convert to
+  `~astropy.units.Quantity`::
 
     >>> np.sin(t['angle'].quantity)  # doctest: +FLOAT_CMP
     <Quantity [ 0.5, 1. ]>

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -86,6 +86,7 @@ For all the following examples it is assumed that the table has been created as 
 
   >>> from astropy.table import Table, Column
   >>> import numpy as np
+  >>> import astropy.units as u
 
   >>> arr = np.arange(15, dtype=np.int32).reshape(5, 3)
   >>> t = Table(arr, names=('a', 'b', 'c'), meta={'keywords': {'key1': 'val1'}})

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -921,7 +921,7 @@ table::
   >>> from astropy import units as u
   >>> t = QTable()
   >>> t['velocity'] = [3, 4] * u.m / u.s
-  >>> type(t['velocity'])
+  >>> type(t['velocity'])  # doctest: +SKIP
   astropy.units.quantity.Quantity
 
 For new code that is quantity-aware we recommend using `~astropy.table.QTable`,
@@ -934,7 +934,7 @@ a `~astropy.table.Column` object with a ``unit`` attribute::
   >>> from astropy.table import Table
   >>> t = Table()
   >>> t['velocity'] = [3, 4] * u.m / u.s
-  >>> type(t['velocity'])
+  >>> type(t['velocity'])  # doctest: +SKIP
   astropy.table.column.Column
   >>> t['velocity'].unit
   Unit("m / s")

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -60,7 +60,7 @@ Quantities`_ for details)::
   >>> from astropy import units as u
   >>> t = QTable()
   >>> t['velocity'] = [3, 4] * u.m / u.s
-  >>> type(t['velocity'])
+  >>> type(t['velocity'])  # doctest: +SKIP
   astropy.units.quantity.Quantity
 
 List of columns

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -36,7 +36,7 @@ size, columns, or data are not known.
 .. Note::
    Adding rows requires making a new copy of the entire
    table each time, so in the case of large tables this may be slow.
-   On the other hand, adding columns is quite fast.
+   On the other hand, adding columns is reasonably fast.
 
 ::
 
@@ -51,6 +51,17 @@ size, columns, or data are not known.
 
   >>> t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
 
+Another option for creating a table is using the `~astropy.table.QTable` class.
+In this case any `~astropy.units.Quantity` column objects will be stored
+natively within the table via the "mixin" column protocol (see `Columns and
+Quantities`_ for details)::
+
+  >>> from astropy.table import QTable
+  >>> from astropy import units as u
+  >>> t = QTable()
+  >>> t['velocity'] = [3, 4] * u.m / u.s
+  >>> type(t['velocity'])
+  astropy.units.quantity.Quantity
 
 List of columns
 """""""""""""""
@@ -894,3 +905,39 @@ fields.  This might look something like::
                   return self.MaskedColumn(name=item, data=values, mask=mask)
 
           # ... and then the rest of the original __getitem__ ...
+
+Columns and Quantities
+""""""""""""""""""""""
+
+Astropy `~astropy.units.Quantity` objects can be handled within tables in two
+complementary ways.  The first method stores the `~astropy.units.Quantity`
+object natively within the table via the "mixin" column protocol.  See the
+sections on :ref:`mixin_columns` and :ref:`quantity_and_qtable` for details,
+but in brief the key difference is using the `~astropy.table.QTable` class to
+indicate that a `~astropy.units.Quantity` should be stored natively within the
+table::
+
+  >>> from astropy.table import QTable
+  >>> from astropy import units as u
+  >>> t = QTable()
+  >>> t['velocity'] = [3, 4] * u.m / u.s
+  >>> type(t['velocity'])
+  astropy.units.quantity.Quantity
+
+For new code that is quantity-aware we recommend using `~astropy.table.QTable`,
+but this may not be possible in all situations (particularly when interfacing
+with legacy code that does not handle quantities) and there are
+:ref:`details_and_caveats` that apply.  In this case use the
+`~astropy.table.Table` class, which will convert a `~astropy.units.Quantity` to
+a `~astropy.table.Column` object with a ``unit`` attribute::
+
+  >>> from astropy.table import Table
+  >>> t = Table()
+  >>> t['velocity'] = [3, 4] * u.m / u.s
+  >>> type(t['velocity'])
+  astropy.table.column.Column
+  >>> t['velocity'].unit
+  Unit("m / s")
+
+To learn more about using standard `~astropy.table.Column` objects with defined
+units, see the :ref:`columns_with_units` section.

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -288,7 +288,7 @@ table and immediately asking the interactive Python interpreter to print the
 table to see what we made.  In real code you might do something like::
 
   >>> table = Table(arr)
-  >>> print table
+  >>> print(table)
    a   b   c
   --- --- ---
     1 2.0   x
@@ -582,11 +582,11 @@ linked, as shown below::
   >>> arr = np.array([(1, 2.0, 'x'),
   ...                 (4, 5.0, 'y')],
   ...                dtype=[('a', 'i8'), ('b', 'f8'), ('c', 'S2')])
-  >>> print arr['a']  # column "a" of the input array
+  >>> print(arr['a'])  # column "a" of the input array
   [1 4]
   >>> t = Table(arr, copy=False)
   >>> t['a'][1] = 99
-  >>> print arr['a']  # arr['a'] got changed when we modified t['a']
+  >>> print(arr['a'])  # arr['a'] got changed when we modified t['a']
   [ 1 99]
 
 Note that when referencing the data it is not possible to change the data types

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -21,11 +21,12 @@ notable capabilities of this package are:
 * Specify a description, units and output formatting for columns.
 * Interactively scroll through long tables similar to using ``more``.
 * Create a new table by selecting rows or columns from a table.
-* Perform :ref:`table_operations` like database joins and concatenation.
+* Perform :ref:`table_operations` like database joins, concatenation, and binning.
 * Maintain a table index for fast retrieval of table items or ranges.
 * Manipulate multidimensional columns.
-* Methods for :ref:`read_write_tables` to files
-* Hooks for :ref:`subclassing_table` and its component classes
+* Handle non-native (mixin) column types within table.
+* Methods for :ref:`read_write_tables` to files.
+* Hooks for :ref:`subclassing_table` and its component classes.
 
 Currently `astropy.table` is used when reading an ASCII table using
 `astropy.io.ascii`.  Future releases of AstroPy are expected to use
@@ -230,7 +231,7 @@ Adding a new row of data to the table is as follows::
   >>> len(t)
   4
 
-Lastly, you can create a table with support for missing values, for example by setting
+You can create a table with support for missing values, for example by setting
 ``masked=True``::
 
   >>> t = Table([a, b, c], names=('a', 'b', 'c'), masked=True, dtype=('i4', 'f8', 'S1'))
@@ -243,6 +244,34 @@ Lastly, you can create a table with support for missing values, for example by s
      --     2.0    x
      --     5.0    y
       5     8.2    z
+
+Lastly, you can include certain object types like `~astropy.time.Time`,
+`~astropy.coordinates.SkyCoord` or `~astropy.units.Quantity` in your table.
+These "mixin" columns behave like a hybrid of a regular `~astropy.table.Column`
+and the native object type (see :ref:`mixin_columns`).  For example::
+
+  >>> from astropy.time import Time
+  >>> from astropy.coordinates import SkyCoord
+  >>> tm = Time(['2000:002', '2002:345'])
+  >>> sc = SkyCoord([10, 20], [-45, +40], unit='deg')
+  >>> t = Table([tm, sc], names=['time', 'skycoord'])
+  >>> t
+  <Table length=2>
+           time          skycoord
+                         deg,deg
+          object          object
+  --------------------- ----------
+  2000:002:00:00:00.000 10.0,-45.0
+  2002:345:00:00:00.000  20.0,40.0
+
+  >>> t['time'].iso
+  array(['2000-01-02 00:00:00.000', '2002-12-11 00:00:00.000'],
+        dtype='|S23')
+
+  >>> t['skycoord'].galactic
+  <SkyCoord (Galactic): (l, b) in deg
+      [(309.48051549, -71.98253481), (128.84961782, -22.54333221)]>
+
 
 .. _using_astropy_table:
 

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -107,7 +107,8 @@ Finally, you can get summary information about the table as follows::
      c    str1
 
 A column with a unit works with and can be easily converted to an
-`~astropy.units.Quantity` object::
+`~astropy.units.Quantity` object (but see :ref:`quantity_and_qtable` for
+a way to natively use `~astropy.units.Quantity` objects in tables)::
 
   >>> t['b'].quantity
   <Quantity [ 2. , 5. , 8.2] s>
@@ -245,7 +246,7 @@ You can create a table with support for missing values, for example by setting
      --     5.0    y
       5     8.2    z
 
-Lastly, you can include certain object types like `~astropy.time.Time`,
+You can include certain object types like `~astropy.time.Time`,
 `~astropy.coordinates.SkyCoord` or `~astropy.units.Quantity` in your table.
 These "mixin" columns behave like a hybrid of a regular `~astropy.table.Column`
 and the native object type (see :ref:`mixin_columns`).  For example::
@@ -264,13 +265,25 @@ and the native object type (see :ref:`mixin_columns`).  For example::
   2000:002:00:00:00.000 10.0,-45.0
   2002:345:00:00:00.000  20.0,40.0
 
-  >>> t['time'].iso
-  array(['2000-01-02 00:00:00.000', '2002-12-11 00:00:00.000'],
-        dtype='|S23')
+The `~astropy.table.QTable` class is a variant of `~astropy.table.Table` that
+allows including a native `~astropy.units.Quantity` in a table instead of
+converting to a `~astropy.table.Column` object (see :ref:`quantity_and_qtable`
+for details)::
 
-  >>> t['skycoord'].galactic
-  <SkyCoord (Galactic): (l, b) in deg
-      [(309.48051549, -71.98253481), (128.84961782, -22.54333221)]>
+  >>> from astropy.table import QTable
+  >>> import astropy.units as u
+  >>> t = QTable()
+  >>> t['dist'] = [1, 2] * u.m
+  >>> t['velocity'] = [3, 4] * u.m / u.s
+  >>> t
+  <QTable length=2>
+    dist  velocity
+     m     m / s
+  float64 float64
+  ------- --------
+      1.0      3.0
+      2.0      4.0
+
 
 
 .. _using_astropy_table:

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -174,25 +174,25 @@ attribute.
   >>> t['a'].fill_value = -99
   >>> t['b'].fill_value = 33
 
-  >>> print t.filled()
+  >>> print(t.filled())
    a   b
   --- ---
     1  33
   -99   4
 
-  >>> print t['a'].filled()
+  >>> print(t['a'].filled())
    a
   ---
     1
   -99
 
-  >>> print t['a'].filled(999)
+  >>> print(t['a'].filled(999))
    a
   ---
     1
   999
 
-  >>> print t.filled(1000)
+  >>> print(t.filled(1000))
    a    b
   ---- ----
      1 1000

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -19,14 +19,7 @@ The available built-in mixin column classes are:
 - |Quantity|
 - |SkyCoord|
 - |Time|
-
-.. Warning::
-
-   The interface for using mixin columns is experimental at this point and it
-   is not recommended to use this feature in production code.  There are known
-   limitations and some table functionality which is not yet implemented for
-   mixin columns.  API changes are likely and since the code is all new there
-   may be some bugs.
+- `~astropy.table.NdarrayMixin`
 
 As a first example we can create a table and add a time column::
 
@@ -125,6 +118,34 @@ You can easily convert |Table| to |QTable| and vice-versa::
   >>> type(t2['velocity'])
   <class 'astropy.table.column.Column'>
 
+Mixin Attributes
+^^^^^^^^^^^^^^^^
+
+The usual column attributes ``name``, ``dtype``, ``unit``, ``format``, and
+``description`` are available in any mixin column via the ``info`` property::
+
+  >>> qt['velocity'].info.name
+  'velocity'
+
+This ``info`` property is a key bit of glue that allows for a
+non-Column object to behave much like a column.
+
+The same ``info`` property is also available in standard
+`~astropy.table.Column` objects.  These ``info`` attributes like
+``t['a'].info.name`` simply refer to the direct `~astropy.table.Column`
+attribute (e.g. ``t['a'].name``) and can be used interchangeably.
+Likewise in a `~astropy.units.Quantity` object, ``info.dtype``
+attribute refers to the native ``dtype`` attribute of the object.
+
+.. Note::
+
+   When writing generalized code that handles column objects which
+   might be mixin columns, one must *always* use the ``info``
+   property to access column attributes.
+
+
+.. _details_and_caveats:
+
 Details and caveats
 ^^^^^^^^^^^^^^^^^^^
 
@@ -202,7 +223,10 @@ that contain mixin columns:
 **Mixin column attributes**
 
 For mixin columns the column attributes ``name``, ``unit``, ``dtype``,
-``format``, ``description`` and ``meta`` are currently stored in a simple
+``format``, ``description`` and ``meta`` are stored in the ``info`` attribute
+
+
+
 dictionary called `_astropy_column_attrs`.  These attributes can be manipulated
 with the functions ``col_getattr`` and ``col_setattr`` which are available in
 the ``astropy.table.column`` module.  These methods are not part of
@@ -230,8 +254,8 @@ with the following properties:
 - Supports getting data as a single item, slicing, or index array access
 - Has a ``shape`` attribute
 - Has a ``__len__`` method for length
-- Has a ``_astropy_column_attrs`` attribute, which tells the |Table| class to
-  use the object natively instead of converting to a |Column|
+- Has an ``info`` class descriptor which is a subclass of the
+  ``astropy.utils.data_info.MixinInfo`` class.
 
 The `Example: ArrayWrapper`_ section shows a working minimal example of a class
 which can be used as a mixin column.  A `pandas.Series
@@ -242,7 +266,8 @@ Other interesting possibilities for mixin columns include:
 
 - Columns which are dynamically computed as a function of other columns (AKA
   spreadsheet)
-- Columns which are themselves a |Table|, i.e. nested tables
+- Columns which are themselves a |Table|, i.e. nested tables.  A `proof of
+  concept <https://github.com/astropy/astropy/pull/3963>`_ is available.
 
 .. _arraywrapper_example:
 
@@ -256,21 +281,26 @@ column.
 
 ::
 
+  from astropy.utils.data_info import ParentDtypeInfo
+
   class ArrayWrapper(object):
       """
       Minimal mixin using a simple wrapper around a numpy array
       """
-      _astropy_column_attrs = None
+      info = ParentDtypeInfo()
 
       def __init__(self, data):
           self.data = np.array(data)
-          col_setattr(self, 'dtype', self.data.dtype)
+          if 'info' in getattr(data, '__dict__', ()):
+              self.info = data.info
 
       def __getitem__(self, item):
           if isinstance(item, (int, np.integer)):
               out = self.data[item]
           else:
               out = self.__class__(self.data[item])
+              if 'info' in self.__dict__:
+                  out.info = self.info
           return out
 
       def __setitem__(self, item, value):
@@ -280,9 +310,13 @@ column.
           return len(self.data)
 
       @property
+      def dtype(self):
+          return self.data.dtype
+
+      @property
       def shape(self):
           return self.data.shape
 
       def __repr__(self):
           return ("<{0} name='{1}' data={2}>"
-                  .format(self.__class__.__name__, col_getattr(self, 'name'), self.data))
+                  .format(self.__class__.__name__, self.info.name, self.data))

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -220,18 +220,6 @@ that contain mixin columns:
    * - :ref:`unique-rows`
      - Not implemented yet, uses grouped operations
 
-**Mixin column attributes**
-
-For mixin columns the column attributes ``name``, ``unit``, ``dtype``,
-``format``, ``description`` and ``meta`` are stored in the ``info`` attribute
-
-
-
-dictionary called `_astropy_column_attrs`.  These attributes can be manipulated
-with the functions ``col_getattr`` and ``col_setattr`` which are available in
-the ``astropy.table.column`` module.  These methods are not part of
-the astropy public API and are likely to change in the future.
-
 **ASCII table writing**
 
 Mixin columns can be written out to file using the `astropy.io.ascii` module,

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -61,6 +61,7 @@ Reference/API
 .. automodapi:: astropy.utils.state
     :no-inheritance-diagram:
 
+
 File Downloads
 --------------
 


### PR DESCRIPTION
Following #3731, the mixin column API should be relatively stable and broader use in the community can be endorsed.  This applies especially to using native Quantities via QTable.

In addition the documentation should be updated to always use the mixin-safe API for accessing column attributes via the `info` attribute.