### PR TITLE
fix for first item in 4210 by doing labmda->lamb

### DIFF
--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -39,11 +39,11 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     ----------
     representation : `BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
-    lambda : `Angle`, optional, must be keyword
+    lamb : `Angle`, optional, must be keyword
         The ecliptic longitude for this object (``beta`` must also be given and
         ``representation`` must be None).
     beta : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``lambda`` must also be given and
+        The ecliptic latitde for this object (``lamb`` must also be given and
         ``representation`` must be None).
     delta : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the geocenter.
@@ -51,7 +51,7 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     """
 
     frame_specific_representation_info = {
-        'unitspherical': [RepresentationMapping('lon', 'lambda'),
+        'unitspherical': [RepresentationMapping('lon', 'lamb'),
                           RepresentationMapping('lat', 'beta')]
     }
     frame_specific_representation_info['spherical'] = \

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -39,25 +39,16 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     ----------
     representation : `BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
-    lam : `Angle`, optional, must be keyword
-        The ecliptic longitude for this object (``beta`` must also be given and
+    lon : `Angle`, optional, must be keyword
+        The ecliptic longitude for this object (``lat`` must also be given and
         ``representation`` must be None).
-    beta : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``lam`` must also be given and
+    lat : `Angle`, optional, must be keyword
+        The ecliptic latitde for this object (``lon`` must also be given and
         ``representation`` must be None).
-    delta : `~astropy.units.Quantity`, optional, must be keyword
+    distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the geocenter.
         (``representation`` must be None).
     """
-
-    frame_specific_representation_info = {
-        'unitspherical': [RepresentationMapping('lon', 'lam'),
-                          RepresentationMapping('lat', 'beta')]
-    }
-    frame_specific_representation_info['spherical'] = \
-        frame_specific_representation_info['unitspherical'] + \
-        [RepresentationMapping('distance', 'delta')]
-
     default_representation = SphericalRepresentation
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
@@ -97,15 +88,6 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
         The Distance for this object from the sun's center.
         (``representation`` must be None).
     """
-
-    frame_specific_representation_info = {
-        'unitspherical': [RepresentationMapping('lon', 'l'),
-                          RepresentationMapping('lat', 'b')]
-    }
-    frame_specific_representation_info['spherical'] = \
-        frame_specific_representation_info['unitspherical'] + \
-        [RepresentationMapping('distance', 'r')]
-
     default_representation = SphericalRepresentation
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
@@ -145,15 +127,6 @@ class HeliocentricTrueEcliptic(BaseCoordinateFrame):
         The Distance for this object from the sun's center.
         (``representation`` must be None).
     """
-
-    frame_specific_representation_info = {
-        'unitspherical': [RepresentationMapping('lon', 'l'),
-                          RepresentationMapping('lat', 'b')]
-    }
-    frame_specific_representation_info['spherical'] = \
-        frame_specific_representation_info['unitspherical'] + \
-        [RepresentationMapping('distance', 'r')]
-
     default_representation = SphericalRepresentation
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -39,11 +39,11 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     ----------
     representation : `BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
-    lamb : `Angle`, optional, must be keyword
+    lam : `Angle`, optional, must be keyword
         The ecliptic longitude for this object (``beta`` must also be given and
         ``representation`` must be None).
     beta : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``lamb`` must also be given and
+        The ecliptic latitde for this object (``lam`` must also be given and
         ``representation`` must be None).
     delta : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the geocenter.
@@ -51,7 +51,7 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     """
 
     frame_specific_representation_info = {
-        'unitspherical': [RepresentationMapping('lon', 'lamb'),
+        'unitspherical': [RepresentationMapping('lon', 'lam'),
                           RepresentationMapping('lat', 'beta')]
     }
     frame_specific_representation_info['spherical'] = \

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -20,7 +20,9 @@ def test_against_pytpm_doc_example():
     Currently this is only testing against the example given in the pytpm docs
     """
     fk5_in = FK5('12h22m54.899s', '15d49m20.57s', equinox='J2000')
-    pytpm_out = BarycentricTrueEcliptic(l=178.78256462*u.deg, b=16.7597002513*u.deg, equinox='J2000')
+    pytpm_out = BarycentricTrueEcliptic(lon=178.78256462*u.deg,
+                                        lat=16.7597002513*u.deg,
+                                        equinox='J2000')
     astropy_out = fk5_in.transform_to(pytpm_out)
 
     # we check w/i 1 arcmin because there are some subtle differences in pyTPM's ecl definition
@@ -39,7 +41,7 @@ def test_ecliptic_heliobary():
 
     # make sure there's a sizable distance shift - in 3d hundreds of km, but
     # this is 1D so we allow it to be somewhat smaller
-    assert np.abs(bary.r - helio.r) > 1*u.km
+    assert np.abs(bary.distance - helio.distance) > 1*u.km
 
     # now make something that's got the location of helio but in bary's frame.
     # this is a convenience to allow `separation` to work as expected
@@ -56,4 +58,4 @@ def test_ecl_geo():
     gcrs = GCRS(10*u.deg, 20*u.deg, distance=1.5*R_earth)
     gecl = gcrs.transform_to(GeocentricTrueEcliptic)
 
-    assert quantity_allclose(gecl.delta, gcrs.distance)
+    assert quantity_allclose(gecl.distance, gcrs.distance)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -127,3 +127,16 @@ def test_regression_4082():
     #also check 3d for good measure, although it's not really affected by this bug directly
     cat3d = SkyCoord([10.076,10.00455]*u.deg, [18.54746, 18.54896]*u.deg, distance=[0.1,1.5]*u.kpc)
     search_around_3d(cat3d[0:1], cat3d, 1*u.kpc, storekdtree=False)
+
+
+def test_regression_4210():
+    """
+    Issue: https://github.com/astropy/astropy/issues/4210
+    """
+    crd = SkyCoord(0*u.deg, 0*u.deg, distance=1*u.AU)
+    ecl = crd.geocentrictrueecliptic
+    # bug was that "lambda" is a reserved keyword! So this just exercises
+    # the "lamb" attribute to make sure it actually works
+    ecl.lamb
+    ecl.beta
+    ecl.delta

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -132,6 +132,7 @@ def test_regression_4082():
 def test_regression_4210():
     """
     Issue: https://github.com/astropy/astropy/issues/4210
+    Related PR with actual change: https://github.com/astropy/astropy/pull/4211
     """
     crd = SkyCoord(0*u.deg, 0*u.deg, distance=1*u.AU)
     ecl = crd.geocentrictrueecliptic
@@ -139,4 +140,15 @@ def test_regression_4210():
     # ecliptic longitude, is a reserved keyword. So this just makes sure the
     # new name is are all valid
     ecl.lon
+
+    # and for good measure, check the other ecliptic systems are all the same
+    # names for their attributes
+    from ..builtin_frames import ecliptic
+    for frame_name in ecliptic.__all__:
+        eclcls = getattr(ecliptic, frame_name)
+        eclobj = eclcls(1*u.deg, 2*u.deg, 3*u.AU)
+
+        eclobj.lat
+        eclobj.lon
+        eclobj.distance
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -135,8 +135,8 @@ def test_regression_4210():
     """
     crd = SkyCoord(0*u.deg, 0*u.deg, distance=1*u.AU)
     ecl = crd.geocentrictrueecliptic
-    # bug was that "lambda" is a reserved keyword! So this just exercises
-    # the "lamb" attribute to make sure it actually works
-    ecl.lamb
-    ecl.beta
-    ecl.delta
+    # bug was that "lambda", which at the time was the name of the geocentric
+    # ecliptic longitude, is a reserved keyword. So this just makes sure the
+    # new name is are all valid
+    ecl.lon
+

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -129,7 +129,7 @@ Longitude and Latitude objects
 |Longitude| and |Latitude| are two specialized subclasses of the |Angle|
 class that are used for all of the spherical coordinate classes.
 |Longitude| is used to represent values like right ascension, Galactic
-longitude, and azimuth (for ecliptic, Galactic, and Alt-Az coordinates,
+longitude, and azimuth (for Equatorial, Galactic, and Alt-Az coordinates,
 respectively).  |Latitude| is used for declination, Galactic latitude, and
 elevation.
 


### PR DESCRIPTION
This fixes the issue pointed out in #4210 by simply renaming `lambda` -> `lamb` (the issue was that `lambda` is of course a reserved keyword in python.