### PR TITLE
Fix 4082

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -658,6 +658,9 @@ Bug Fixes
   - Fix string representation of ``SkyCoord`` objects transformed into
     the ``AltAz`` frame [#4055]
 
+  - Fix the ``search_around_sky`` function to allow ``storekdtree`` to be 
+    ``False`` as was intended. [#4082]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -332,7 +332,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
 
     kdt1 = _get_cartesian_kdtree(ucoords1, storekdtree)
 
-    if hasattr(coords2, storekdtree):
+    if storekdtree and hasattr(coords2, storekdtree):
         #just use the stored KD-Tree
         kdt2 = getattr(coords2, storekdtree)
     else:
@@ -341,8 +341,9 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
         ucoords2 = coords2.realize_frame(urepr2)
 
         kdt2 = _get_cartesian_kdtree(ucoords2, storekdtree)
-        #save the KD-Tree in coords2, *not* ucoords2
-        setattr(coords2, storekdtree, kdt2)
+        if storekdtree:
+            #save the KD-Tree in coords2, *not* ucoords2
+            setattr(coords2, storekdtree, kdt2)
 
     # this is the *cartesian* 3D distance that corresponds to the given angle
     r = (2 * np.sin(Angle(seplimit) / 2.0)).value

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -16,6 +16,7 @@ from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS
 from ...time import Time
 
 from ...tests.helper import assert_quantity_allclose
+from .test_matching import HAS_SCIPY, OLDER_SCIPY
 
 
 def test_regression_3920():
@@ -112,6 +113,8 @@ def test_regression_4033():
     assert_quantity_allclose(alb_wdistaa.separation(deaa), 22.2862*u.deg, rtol=1e-3)
 
 
+@pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
 def test_regression_4082():
     """
     Issue: https://github.com/astropy/astropy/issues/4082

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -15,7 +15,7 @@ from ... import units as u
 from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS
 from ...time import Time
 
-from ...tests.helper import assert_quantity_allclose
+from ...tests.helper import pytest, assert_quantity_allclose
 from .test_matching import HAS_SCIPY, OLDER_SCIPY
 
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -110,3 +110,17 @@ def test_regression_4033():
     # in 4033, the following fail with a recursion error
     assert_quantity_allclose(de_wdistaa.separation(alb_wdistaa), 22.2862*u.deg, rtol=1e-3)
     assert_quantity_allclose(alb_wdistaa.separation(deaa), 22.2862*u.deg, rtol=1e-3)
+
+
+def test_regression_4082():
+    """
+    Issue: https://github.com/astropy/astropy/issues/4082
+    """
+    from .. import search_around_sky, search_around_3d
+    cat = SkyCoord([10.076,10.00455], [18.54746, 18.54896], unit='deg')
+    search_around_sky(cat[0:1], cat, seplimit=u.arcsec * 60, storekdtree=False)
+    # in the issue, this raises a TypeError
+
+    #also check 3d for good measure, although it's not really affected by this bug directly
+    cat3d = SkyCoord([10.076,10.00455]*u.deg, [18.54746, 18.54896]*u.deg, distance=[0.1,1.5]*u.kpc)
+    search_around_3d(cat3d[0:1], cat3d, 1*u.kpc, storekdtree=False)


### PR DESCRIPTION
This implements a regression test for and closes #4082.

In #4082 @embray suggested the change ``storedkdtree`` -> ``stored_kd_tree``. I like that change, *except* that it's breaking backwards compatibility.  So definitely we should merge this as a bugfix (which then can also go into 1.0.5), but should there also be a PR to do the name change?  Or is it worth it at all given that it's a change to the API?