### PR TITLE
Fix NameError in table stack exception message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -718,6 +718,8 @@ Bug Fixes
   - Fix issue with the web browser opening with an empty page, and ensure that
     the url is correctly formatted for Windows. [#4132]
 
+  - Fix NameError in table stack exception message. [#4213]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -475,7 +475,7 @@ def get_descrs(arrays, col_name_map):
         # Make sure all input shapes are the same
         uniq_shapes = set(col.shape[1:] for col in in_cols)
         if len(uniq_shapes) != 1:
-            raise TableMergeError('Key columns {0!r} have different shape'.format(name))
+            raise TableMergeError('Key columns {0!r} have different shape'.format(names))
         shape = uniq_shapes.pop()
 
         out_descrs.append((fix_column_name(out_name), dtype, shape))

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -548,6 +548,13 @@ class TestVStack():
         with pytest.raises(TableMergeError):
             table.vstack([self.t1, self.t2], join_type='exact')
 
+        t1_reshape = self.t1.copy()
+        t1_reshape['b'].shape = [2, 1]
+        with pytest.raises(TableMergeError) as excinfo:
+            table.vstack([self.t1, t1_reshape])
+        assert "have different shape" in str(excinfo)
+
+
     def test_vstack_one_masked(self):
         t1 = self.t1
         t4 = self.t4


### PR DESCRIPTION
Fixes #4208.

Note: no changelog entry.  This is a trivial fix, and I don't know if this would be in 1.1, 1.0.6 (which doesn't exist yet in CHANGES.rst) or 1.0.5.  I think that none of the above is fine.  @embray?
