### PR TITLE
Update astropy-helpers submodule and ah_bootstrap.py to v1.0.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,6 +197,8 @@ Other Changes and Additions
 
 - Astropy now supports Python 3.5. [#4027]
 
+- Updated bundled version of astropy-helpers to 1.0.5. [#4215]
+
 - Updated tests to support py.test 2.7, and upgraded the bundled copy of
   py.test to v2.7.3. [#4027]
 

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "


### PR DESCRIPTION
Pins astropy-helpers submodule to v1.0.4 for the Astropy 1.0.5 release.