### PR TITLE
Table indexing should not affect Mixin classes except through info

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -703,17 +703,13 @@ class Table(object):
         table.meta.update(deepcopy(self.meta))
         cols = self.columns.values()
 
+        newcols = []
         for col in cols:
             col.info._copy_indices = self._copy_indices
-
-        def _get_slice(col, slice_):
-            out = col[slice_]
+            newcol = col[slice_]
             if col.info.indices:
-                out = col.info.slice_indices(out, slice_, len(col))
-            return out
-
-        newcols = [_get_slice(col, slice_) for col in cols]
-        for col in cols:
+                newcol = col.info.slice_indices(newcol, slice_, len(col))
+            newcols.append(newcol)
             col.info._copy_indices = True
 
         self._make_table_from_cols(table, newcols)
@@ -2576,4 +2572,3 @@ class NdarrayMixin(np.ndarray):
         nd_state, own_state = state
         super(NdarrayMixin, self).__setstate__(nd_state)
         self.__dict__.update(own_state)
-

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -786,11 +786,7 @@ class Time(object):
         if self.isscalar:
             raise TypeError('scalar {0!r} object is not subscriptable.'.format(
                 self.__class__.__name__))
-        tm = self._replicate('__getitem__', item)
-        if not tm.isscalar and tm.info.indices:
-            # update indices based on slice
-            tm = self.info.slice_indices(tm, item, len(self))
-        return tm
+        return self._replicate('__getitem__', item)
 
     def reshape(self, *args, **kwargs):
         """Returns a time instance containing the same data with a new shape.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -904,9 +904,6 @@ class Quantity(np.ndarray):
         # need a new view as a Quantity.
         if type(out) is not type(self):
             out = self._new_view(out)
-        # adjust indices of slice as necessary
-        if not out.isscalar and out.info.indices:
-            out = self.info.slice_indices(out, key, len(self))
         return out
 
     def __setitem__(self, i, value):


### PR DESCRIPTION
#3915 introduced a very nice indexing system to `Table`, but as part of that `__getitem__` is being changed in indentical ways in `Quantity` and `Time`. Separation of concerns suggests this should be factored out and done explicitly in `Table` itself, or (somehow) made part of the `info` class.

p.s. Noticed this because it causes a merge conflict for my shape-changing PR #4123. Raising this partially as a reminder to myself, partially as a general call-out to try hard to avoid creating tangled messes.