### PR TITLE
Un-xfail sites tests with download of sites file

### DIFF
--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -113,6 +113,7 @@ class SiteRegistry(Mapping):
             location.info.name = site_info['name']
 
             reg.add_site([site] + site_info['aliases'], location)
+        reg._loaded_jsondb = jsondb
         return reg
 
 

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -129,5 +129,5 @@ def get_downloaded_sites(jsonurl='http://data.astropy.org/coordinates/sites.json
     """
     Load observatory database from data.astropy.org and parse into a SiteRegistry
     """
-    jsondb = json.loads(get_file_contents(jsonurl))
+    jsondb = json.loads(get_file_contents(jsonurl, show_progress=False))
     return SiteRegistry.from_json(jsondb)

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -32,7 +32,6 @@ def test_builtin_sites():
     with pytest.raises(KeyError):
         reg['nonexistent site']
 
-@pytest.mark.xfail  # remove this when the data file gets uploaded
 @remote_data
 def test_online_stes():
     reg = get_downloaded_sites()
@@ -85,7 +84,6 @@ def test_EarthLocation_state_offline():
     assert oldreg is not newreg
 
 
-@pytest.mark.xfail  # remove this when the data file gets uploaded
 @remote_data
 def test_EarthLocation_state_online():
     EarthLocation._site_registry = None

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -358,7 +358,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
             os.remove(fd.name)
 
 
-def get_file_contents(name_or_obj, encoding=None, cache=False):
+def get_file_contents(*args, **kwargs):
     """
     Retrieves the contents of a filename or file-like object.
 
@@ -370,7 +370,7 @@ def get_file_contents(name_or_obj, encoding=None, cache=False):
         The content of the file (as requested by ``encoding``).
 
     """
-    with get_readable_fileobj(name_or_obj, encoding, cache) as f:
+    with get_readable_fileobj(*args, **kwargs) as f:
         return f.read()
 
 


### PR DESCRIPTION
This is a follow-on to astropy/astropy-data#6 and #4042 - it restores the tests that were xfailed because the sites file had not yet been uploaded to astropy-data.  It's now present, so the tests are passing.

It also makes one substansive change ti #4042: it removes the progress bar (which also required a small bug-fix in `astropy.utils.data.get_file_contents`).  My thinking is that it's distracting to see it, given that it's clear from the docs that `of_site` tries to do a download (similar to `SkyCoord.from_name`, which also does not show a progress bar).