### PR TITLE
Import TestRunner into astropy.tests.helper for backward-compatibility

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -32,6 +32,9 @@ from ..utils.exceptions import (AstropyWarning,
                                 AstropyPendingDeprecationWarning)
 
 
+# For backward-compatibility with affiliated packages
+from .runner import TestRunner
+
 __all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
            'treat_deprecations_as_exceptions', 'catch_warnings',
            'assert_follows_unicode_guidelines', 'quantity_allclose',


### PR DESCRIPTION
If we don't do this, the testing in all affiliated packages will break. I think we need to keep this for a little while. This is due to a change in https://github.com/astropy/astropy/pull/4020.

See also https://github.com/astropy/astroscrappy/issues/3

cc @embray