### PR TITLE
Update travis test matrix for 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.10
         - OPTIONAL_DEPS=false
         - MAIN_CMD='python setup.py'
 
@@ -69,6 +69,8 @@ matrix:
           env: PYTHON_VERSION=3.4 SETUP_CMD='test' OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
 
         # Try older numpy versions
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,6 @@ matrix:
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test'
 
         # Try developer version of Numpy
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
         - MAIN_CMD='python setup.py'
 
     matrix:
-        - PYTHON_VERSION=2.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
@@ -49,8 +48,6 @@ matrix:
           # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
 
         # Try all python versions with the latest numpy
-        - os: linux
-          env: PYTHON_VERSION=2.6 SETUP_CMD='test --open-files'
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --open-files'
         - os: linux


### PR DESCRIPTION
This is a first cut at the changes that I think make sense for the testing suite for astropy v1.2 .  It probably makes sense to merge these into master as soon as is reasonable so that we don't have to spend time testing versions we are no longer supporting.  This will *not* work right now, because there's issues with numpy 1.10 (#3854 and, for that matter, I think it's not even in conda yet), but once that's working I can rebase.  

The following key changes are made:
* Main tests use numpy 1.10
* Drop testing of py 2.6 (although *not* actually removing all the compatibility code - that belongs in #3780 )
* Drop testing of numpy 1.6 (do we want to do this? I think it's pretty aged, but I'm not sure exactly what the usage level is.  @astrofrog, was this on one of your surveys?)