### PR TITLE
Import fail if Python is running with -OO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -843,6 +843,8 @@ Bug Fixes
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``
+  - Fixed crash with Python compiler optimization level = 2.
+    [#4231]
 
 - ``astropy.modeling``
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -39,6 +39,7 @@ from ...extern import six
 # STDLIB
 import io
 import re
+import sys
 
 from textwrap import dedent
 from warnings import warn
@@ -1446,7 +1447,8 @@ def _build_doc_string():
     return {'warnings': warnings,
             'exceptions': exceptions}
 
-__doc__ = __doc__.format(**_build_doc_string())
+if sys.flags.optimize < 2:
+    __doc__ = __doc__.format(**_build_doc_string())
 
 __all__.extend([x[0] for x in _get_warning_and_exception_classes('W')])
 __all__.extend([x[0] for x in _get_warning_and_exception_classes('E')])

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -39,7 +39,6 @@ from ...extern import six
 # STDLIB
 import io
 import re
-import sys
 
 from textwrap import dedent
 from warnings import warn
@@ -1447,7 +1446,7 @@ def _build_doc_string():
     return {'warnings': warnings,
             'exceptions': exceptions}
 
-if sys.flags.optimize < 2:
+if __doc__ is not None:
     __doc__ = __doc__.format(**_build_doc_string())
 
 __all__.extend([x[0] for x in _get_warning_and_exception_classes('W')])


### PR DESCRIPTION

Hello,

This fix a crash on Astropy import if Python compilation optimization is set to 2 (Remove docstrings / Run python with -OO argument)