### PR TITLE
Model.inverse tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -553,6 +553,11 @@ API changes
     been assigned to the model and is still equivalent to setting
     ``model.inverse = None``). [#4236]
 
+  - Adds a ``model.has_user_inverse`` attribute which indicates whether or not
+    a user has assigned a custom inverse to ``model.inverse``.  This is just
+    for informational purposes, for example, for software that introspects
+    model objects. [#4236]
+
   - Renamed the parameters of ``RotateNative2Celestial`` and
     ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -545,6 +545,14 @@ API changes
     with True only if the comparison was true for all elements compared,
     which could lead to confusing circumstances. [#3912]
 
+  - Using ``model.inverse = None`` to reset a model's inverse to its
+    default is deprecated.  In the future this syntax will explicitly make
+    a model not have an inverse (even if it has a default).  Instead, use
+    ``del model.inverse`` to reset a model's inverse to its default (if it
+    has a default, otherwise this just deletes any custom inverse that has
+    been assigned to the model and is still equivalent to setting
+    ``model.inverse = None``). [#4236]
+
   - Renamed the parameters of ``RotateNative2Celestial`` and
     ``RotateCelestial2Native`` from ``phi``, ``theta``, ``psi`` to
     ``lon``, ``lat`` and ``lon_pole``. [#3578]

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -781,6 +781,10 @@ class Model(object):
         `~astropy.modeling.polynomial.PolynomialModel`, but not by
         requirement).
 
+        A custom inverse can be deleted with ``del model.inverse``.  In this
+        case the model's inverse is reset to its default, if a default exists
+        (otherwise the default is to raise `NotImplementedError`).
+
         Note to authors of `~astropy.modeling.Model` subclasses:  To define an
         inverse for a model simply override this property to return the
         appropriate model representing the inverse.  The machinery that will

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -767,8 +767,6 @@ class Model(object):
 
         return self._constraints['ineqcons']
 
-    # *** Public methods ***
-
     @property
     def inverse(self):
         """
@@ -831,6 +829,22 @@ class Model(object):
         """
 
         del self._user_inverse
+
+    @property
+    def has_user_inverse(self):
+        """
+        A flag indicating whether or not a custom inverse model has been
+        assigned to this model by a user, via assignment to ``model.inverse``.
+        """
+
+        return self._user_inverse is not None
+
+    @property
+    def _custom_inverse(self):
+        # Deprecated alias for _user_inverse--included solely for temporary
+        # backwards compatibility for pyasdf--remove after Astropy v1.1
+        # release.
+        return self._user_inverse
 
     @property
     def bounding_box(self):
@@ -919,6 +933,8 @@ class Model(object):
                                      'array-like of shape ``(model.n_inputs, 2)``.')
 
         self._bounding_box = limits
+
+    # *** Public methods ***
 
     @abc.abstractmethod
     def evaluate(self, *args, **kwargs):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -804,7 +804,29 @@ class Model(object):
                 "instance or `None` (where `None` restores the default "
                 "inverse for this model if one is defined.")
 
+        if value is None:
+            warnings.warn(
+                "Currently setting `model.inverse = None` resets the inverse "
+                "to the default inverse (if one exists).  However, starting "
+                "in Astropy 1.2, setting `model.inverse = None` explicitly "
+                "forces a model to have no inverse (such that accessing "
+                "`model.inverse` raises a NotImplementedError) even if that "
+                "model's class has a default inverse.\n\n"
+                "Instead, call `del model.inverse` to reset the inverse to "
+                "its default (if a default exists for that model's class--"
+                "otherwise the model is reset to having no inverse.",
+                AstropyDeprecationWarning)
+
         self._user_inverse = value
+
+    @inverse.deleter
+    def inverse(self):
+        """
+        Resets the model's inverse to its default (if one exists, otherwise
+        the model will have no inverse).
+        """
+
+        del self._user_inverse
 
     @property
     def bounding_box(self):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -688,6 +688,12 @@ class Linear1D(Fittable1DModel):
         d_intercept = np.ones_like(x)
         return [d_slope, d_intercept]
 
+    @property
+    def inverse(self):
+        new_slope = self.slope ** -1
+        new_intercept = -self.intercept / self.slope
+        return self.__class__(slope=new_slope, intercept=new_intercept)
+
 
 class Lorentz1D(Fittable1DModel):
     """

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -30,6 +30,19 @@ a model may be instantiated with all scalar parameters::
     >>> g
     <Gaussian1D(amplitude=1.0, mean=0.0, stddev=1.0)>
 
+The newly created model instance ``g`` now works like a Gaussian function
+with the given parameters fixed.  It takes a single input::
+
+    >>> g.inputs
+    ('x',)
+    >>> g(x=0)
+    1.0
+
+The model can also be called without explicitly using keyword arguments::
+
+    >>> g(0)
+    1.0
+
 Or it may use all array parameters.  For example if all parameters are 2x2
 arrays the model is computed element-wise using all elements in the arrays::
 
@@ -179,26 +192,6 @@ treated as though any of its dimensions map to models in a model set.  And
 rather, the given input should be used to evaluate all the models in the model
 set.  For scalar inputs like ``g(0)``, ``model_set_axis=False`` is implied
 automatically.  But for array inputs it is necessary to avoid ambiguity.
-
-
-Inputs and Outputs
-==================
-
-Models have an `~astropy.modeling.Model.n_inputs` attribute, which shows how
-many coordinates the model expects as an input. All models expect coordinates
-as separate arguments.  For example a 2-D model expects x and y coordinate
-values to be passed separately, i.e. as two scalars or array-like values.
-
-Models also have an attribute `~astropy.modeling.Model.n_outputs`, which shows
-the number of output coordinates. The `~astropy.modeling.Model.n_inputs` and
-`~astropy.modeling.Model.n_outputs` attributes can be used when chaining
-transforms by adding models in :class:`series
-<astropy.modeling.SerialCompositeModel>` or in :class:`parallel
-<astropy.modeling.SummedCompositeModel>`. Because composite models can be
-nested within other composite models, creating theoretically infinitely complex
-models, a mechanism to map input data to models is needed. In this case the
-input may be wrapped in a `~astropy.modeling.LabeledInput` object-- a dict-like
-object whose items are ``{label: data}`` pairs.
 
 
 Further examples

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -194,6 +194,64 @@ set.  For scalar inputs like ``g(0)``, ``model_set_axis=False`` is implied
 automatically.  But for array inputs it is necessary to avoid ambiguity.
 
 
+Model Inverses
+==============
+
+All models have a `Model.inverse <astropy.modeling.Model.inverse>` property
+which may, for some models, return a new model that is the analytic inverse of
+the model it is attached to.  For example::
+
+    >>> from astropy.modeling.models import Linear1D
+    >>> linear = Linear1D(slope=0.8, intercept=1.0)
+    >>> linear.inverse
+    <Linear1D(slope=1.25, intercept=-1.25)>
+
+The inverse of a model will always be a fully instantiated model in its own
+right, and so can be evaluated directly like::
+
+    >>> linear.inverse(2.0)
+    1.25
+
+It is also possible to assign a *custom* inverse to a model.  This may be
+useful, for example, in cases where a model does not have an analytic inverse,
+but may have an approximate inverse that was computed numerically and is
+represented by a polynomial.  This works even if the target model has a
+default analytic inverse--in this case the default is overridden with the
+custom inverse::
+
+    >>> from astropy.modeling.models import Polynomial1D
+    >>> linear.inverse = Polynomial1D(degree=1, c0=-1.25, c1=1.25)
+    >>> linear.inverse
+    <Polynomial1D(1, c0=-1.25, c1=1.25)>
+
+If a custom inverse has been assigned to a model, it can be deleted with
+``del model.inverse``.  This resets the inverse to its default (if one exists).
+If a default does not exist, accessing ``model.inverse`` raises a
+`NotImplementedError`.  For example polynomial models do not have a default
+inverse::
+
+    >>> del linear.inverse
+    >>> linear.inverse
+    <Linear1D(slope=1.25, intercept=-1.25)>
+    >>> p = Polynomial1D(degree=2, c0=1.0, c1=2.0, c2=3.0)
+    >>> p.inverse
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "astropy\modeling\core.py", line 796, in inverse
+        raise NotImplementedError("An analytical inverse transform has not "
+    NotImplementedError: An analytical inverse transform has not been
+    implemented for this model. 
+
+One may certainly compute an inverse and assign it to a polynomial model
+though.
+
+.. note::
+
+    When assigning a custom inverse to a model no validation is performed to
+    ensure that it is actually an inverse or even approximate inverse.  So
+    assign custom inverses at your own risk.
+
+
 Further examples
 ================
 

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -268,6 +268,11 @@ input``.
             new_intercept = -self.intercept / self.slope
             return LineModel(slope=new_slope, intercept=new_intercept)
 
+.. note::
+
+    The above example is essentially equivalent to the built-in
+    `~astropy.modeling.functional_models.Linear1D` model.
+
 
 Defining New Fitter Classes
 ===========================

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -63,3 +63,4 @@ py:obj list.remove
 py:class classmethod
 py:obj RuntimeError
 py:obj AttributeError
+py:obj NotImplementedError


### PR DESCRIPTION
These changes started in the context of finishing up #4040.  My goal in #4040 is to just make a few slight interface tweaks so that the `.bounding_box` attribute works consistently with how the `.inverse` attribute works, since they have a few similarities (ex: Some models have a default method that produces a bounding box, but not all, and in either case users can override the default bounding box with a custom one, but can also reset back to the default if they wish).

In working on that I realized there are some small tweaks I can make to how `.inverse` is implemented that will also make `.bounding_box` easier to do in the same way, and that will also make it easier to create a consistent interface between them.  In particular I want to be able to reset back to the default by using the `del` operator.  This is new functionality, but I need it in order to finish up #4040 in a consistent manner.