### PR TITLE
Fixing typos 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,8 +38,8 @@ New Features
 
   - Added ``Supergalactic`` frame to support de Vaucouleurs supergalactic
     coordinates. [#3892]
-  - ``SphericalRepresentation`` now has a ``._unit_representation`` class attribute to specify 
-    an equivalent UnitSphericalRepresentation. This allows subclasses of 
+  - ``SphericalRepresentation`` now has a ``._unit_representation`` class attribute to specify
+    an equivalent UnitSphericalRepresentation. This allows subclasses of
     representations to pair up correctly. [#3757]
 
   - Added functionality to support getting the locations of observatories by
@@ -53,7 +53,7 @@ New Features
   - Add Planck 2015 cosmology [#3476]
 
   - Distance calculations now > 20-40x faster for the supplied
-    cosmologies due to implementing cython scalar versions of
+    cosmologies due to implementing Cython scalar versions of
     ``FLRW.inv_efunc``.[#4127]
 
   - ``FLRW._tfunc`` and ``FLRW._xfunc`` are marked as deprecated.  Users
@@ -577,7 +577,7 @@ Other Changes and Additions
   cluttering the ``astropy.coordinates`` documentation with increasingly
   irrelevant material.  To see the migration guide, we recommend you simply look
   to the archived documentation for previous versions, e.g.
-  http://docs.astropy.org/en/v1.0/coordinates/index.html#migrating-from-pre-v0-4-coordinates 
+  http://docs.astropy.org/en/v1.0/coordinates/index.html#migrating-from-pre-v0-4-coordinates
   [#4203]
 
 
@@ -733,7 +733,7 @@ Bug Fixes
   - Fix string representation of ``SkyCoord`` objects transformed into
     the ``AltAz`` frame [#4055]
 
-  - Fix the ``search_around_sky`` function to allow ``storekdtree`` to be 
+  - Fix the ``search_around_sky`` function to allow ``storekdtree`` to be
     ``False`` as was intended. [#4082]
 
 - ``astropy.io.fits``
@@ -787,7 +787,7 @@ Bug Fixes
     ``resolve_name('numpy')``. [#4084]
 
   - ``console`` was updated to support IPython 4.x and Jupyter 1.x.
-    This should supress a ShimWarning that was appearing at
+    This should suppress a ShimWarning that was appearing at
     import of astropy with IPython 4.0 or later. [#4078]
 
   - Temporary downloaded files created by ``get_readable_fileobj`` when passed

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -19,7 +19,7 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     plane of the ecliptic for that date.
 
     Be aware that the definition of "geocentric" here means that this frame
-    *includes* light deflection from the sun, abberation, etc when transfoming
+    *includes* light deflection from the sun, aberration, etc when transforming
     to/from e.g. ICRS.
 
     This frame has one frame attribute:
@@ -43,7 +43,7 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
         The ecliptic longitude for this object (``lat`` must also be given and
         ``representation`` must be None).
     lat : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``lon`` must also be given and
+        The ecliptic latitude for this object (``lon`` must also be given and
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the geocenter.
@@ -82,7 +82,7 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
         The ecliptic longitude for this object (``b`` must also be given and
         ``representation`` must be None).
     b : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``l`` must also be given and
+        The ecliptic latitude for this object (``l`` must also be given and
         ``representation`` must be None).
     r : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the sun's center.
@@ -121,7 +121,7 @@ class HeliocentricTrueEcliptic(BaseCoordinateFrame):
         The ecliptic longitude for this object (``b`` must also be given and
         ``representation`` must be None).
     b : `Angle`, optional, must be keyword
-        The ecliptic latitde for this object (``l`` must also be given and
+        The ecliptic latitude for this object (``l`` must also be given and
         ``representation`` must be None).
     r : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the sun's center.

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 from ..representation import SphericalRepresentation
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping, TimeFrameAttribute
+from ..baseframe import BaseCoordinateFrame, TimeFrameAttribute
 from .utils import EQUINOX_J2000
 
 

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -56,7 +56,7 @@ def gcrs_precession_mat(equinox):
 
 # now the actual transforms
 
-# the priority for the GCRS<->ITRS trasnsforms are higher (=less traveled) to
+# the priority for the GCRS<->ITRS transforms are higher (=less traveled) to
 #make GCRS<->ICRS<->CIRS the preferred route over GCRS<->ITRS<->CIRS
 @frame_transform_graph.transform(FunctionTransform, GCRS, ITRS, priority=1.01)
 def gcrs_to_itrs(gcrs_coo, itrs_frame):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -372,7 +372,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         return cls(lon=lon, lat=lat)
 
     def represent_as(self, other_class):
-        # Take a short cut if the other clsss is a spherical representation
+        # Take a short cut if the other class is a spherical representation
         if issubclass(other_class, PhysicsSphericalRepresentation):
             return other_class(phi=self.lon, theta=90 * u.deg - self.lat, r=1.0)
         elif issubclass(other_class, SphericalRepresentation):
@@ -587,7 +587,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         return self._distance
 
     def represent_as(self, other_class):
-        # Take a short cut if the other clsss is a spherical representation
+        # Take a short cut if the other class is a spherical representation
         if issubclass(other_class, SphericalRepresentation):
             return other_class(lon=self.phi, lat=90 * u.deg - self.theta,
                                distance=self.r)

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -2,7 +2,7 @@
 """
 Observatories accessible without internet access originate from the IRAF
 Observatory Database, and are stored in ``data/observatories.json``.  This is
-inteded mainly as a fallback file, and the online file is where new changes
+intended mainly as a fallback file, and the online file is where new changes
 should go.
 
 Additions or corrections to the observatory list can be submitted via Pull
@@ -29,7 +29,7 @@ class SiteRegistry(Mapping):
     This acts as a mapping (dict-like object) but with the important caveat that
     it's always transforms its inputs to lower-case.  So keys are always all
     lower-case, and even if you ask for something that's got mixed case, it will
-    be interepreted as the all lower-case version.
+    be interpreted as the all lower-case version.
     """
     def __init__(self):
         # the keys to this are always lower-case

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -40,7 +40,7 @@ class DaophotHeader(core.BaseHeader):
 
     def parse_col_defs(self, grouped_lines_dict):
         """
-        Parse a series of column defintion lines like below.  There may be several
+        Parse a series of column definition lines like below.  There may be several
         such blocks in a single file (where continuation characters have already been
         stripped).
         #N ID    XCENTER   YCENTER   MAG         MERR          MSKY           NITER

--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -48,7 +48,7 @@ def sortmore(*args, **kw):
         revert to sorting by key function
     globalkey: callable
         Sort by evaluated value for all items in the lists
-        (call signiture of this function needs to be such that it accepts an
+        (call signature of this function needs to be such that it accepts an
         argument tuple of items from each list.
         eg.: globalkey = lambda *l: sum(l) will order all the lists by the
         sum of the items from each list

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -688,7 +688,7 @@ class TestImageFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(data=arr)
         hdu.scale('int16', bscale=1.23)
 
-        # Creating data that uses BLANK is currently kludgy--a speparate issue
+        # Creating data that uses BLANK is currently kludgy--a separate issue
         # TODO: Rewrite this test when scaling with blank support is better
         # supported
 

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -24,7 +24,6 @@ from .core import Model
 from .parameters import Parameter, InputParameterError
 
 from ..utils import deprecated
-from ..utils.compat import ignored
 
 from . import _projections
 
@@ -200,7 +199,7 @@ class Pix2Sky_ZenithalPerspective(Pix2SkyProjection, Zenithal):
         return _projections.azpx2s(x, y, mu, np.rad2deg(gamma))
 
     @deprecated('1.1', message='this method was never intended as part of '
-                               'the public API and wil be removed; if you '
+                               'the public API and will be removed; if you '
                                'do need its functionality use '
                                'model.mu.validator(val)')
     def check_mu(self, value):
@@ -300,7 +299,7 @@ class Pix2Sky_SlantZenithalPerspective(Pix2SkyProjection, Zenithal):
             x, y, mu, np.rad2deg(phi0), np.rad2deg(theta0))
 
     @deprecated('1.1', message='this method was never intended as part of '
-                               'the public API and wil be removed; if you '
+                               'the public API and will be removed; if you '
                                'do need its functionality use '
                                'model.mu.validator(val)')
     def check_mu(self, value):

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -868,7 +868,7 @@ def test_pickle_compound():
     assert np.all(m.parameters == m2.parameters)
     assert np.all(m(0) == m2(0))
 
-    # Test picling a concrete class
+    # Test pickling a concrete class
     p = pickle.dumps(_TestPickleModel, protocol=0)
     # Note: This is very dependent on the specific protocol, but the point of
     # this test is that the "concrete" model is pickled in a very simple way

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -169,7 +169,7 @@ def extract_array(array_large, shape, position, mode='partial',
         `int`).  See the ``mode`` keyword for additional details.
     position : tuple of numbers or number
         The position of the small array's center with respect to the
-        large array.  The pixel cordinates should be in the same order
+        large array.  The pixel coordinates should be in the same order
         as the array shape.  Integer positions are at the pixel centers
         (for 1D arrays, this can be a number).
     mode : {'partial', 'trim', 'strict'}, optional

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -117,7 +117,7 @@ def test_invalid_sigma_clip():
     result = sigma_clip(data)
 
     # Pre #4051 if data contains any NaN or infs sigma_clip returns the mask
-    # containig `False` only or TypeError if data also contains a masked value.
+    # containing `False` only or TypeError if data also contains a masked value.
 
     assert result.mask[2, 2] == True
     assert result.mask[3, 4] == True

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -184,7 +184,7 @@ class Index(object):
 
     def get_row_specifier(self, row_specifier):
         '''
-        Return an interable corresponding to the
+        Return an iterable corresponding to the
         input row specifier.
 
         Parameters

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -96,7 +96,7 @@ class JSViewer(object):
     Parameters
     ----------
     use_local_files : bool, optional
-        Use local files or a CDN for JavaScript librairies. Default False.
+        Use local files or a CDN for JavaScript libraries. Default False.
     display_length : int, optional
         Number or rows to show. Default to 50.
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -637,7 +637,7 @@ def _join(left, right, keys=None, join_type='inner',
         # accordingly.  Check for columns that don't support a mask attribute.
         if masked:
             # array_mask is 1-d corresponding to length of output column.  We need
-            # make it have the correct shape for broadcasting, ie. (length, 1, 1, ..).
+            # make it have the correct shape for broadcasting, i.e. (length, 1, 1, ..).
             # Mixin columns might not have ndim attribute so use len(col.shape).
             array_mask.shape = (out[out_name].shape[0],) + (1,) * (len(out[out_name].shape) - 1)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -235,7 +235,7 @@ class Table(object):
         data = empty_init(len(self), dtype=dtype)
         for col in cols:
             # When assigning from one array into a field of a structured array,
-            # Numpy will automatically swap thos columns to their destination
+            # Numpy will automatically swap those columns to their destination
             # byte order where applicable
             data[col.info.name] = col
 
@@ -923,8 +923,8 @@ class Table(object):
             This allows in-browser searching & sorting.
         jskwargs : dict
             Passed to the `astropy.table.JSViewer` init. Default to
-            ``{'use_local_files': True}`` which means that the JavaScipt
-            librairies will be served from local copies.
+            ``{'use_local_files': True}`` which means that the JavaScript
+            libraries will be served from local copies.
         tableid : str or `None`
             An html ID tag for the table.  Default is ``table{id}``, where id
             is the unique integer id of the table object, id(self).

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -717,7 +717,7 @@ class Time(object):
             except AttributeError:
                 continue
 
-            # Appy the method to any value arrays (though skip if there is only
+            # Apply the method to any value arrays (though skip if there is only
             # a single element and the method would return a view, since in
             # that case nothing would change).
             if method is not None and val is not None:
@@ -899,7 +899,7 @@ class Time(object):
         axis : int or None
             axis along which argmin or argmax was used.
         keepdims : bool
-            Whether to contruct indices that keep or remove the axis along
+            Whether to construct indices that keep or remove the axis along
             which argmin or argmax was used.  Default: ``False``.
 
         Returns

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -170,7 +170,7 @@ class TestBasic():
         assert t7_tdb[0, 0].delta_tdb_tt == t7_tdb.delta_tdb_tt[0, 0]
         assert np.all(t7_tdb[5].delta_tdb_tt == t7_tdb.delta_tdb_tt[5])
         assert np.all(t7_tdb[:, 2].delta_tdb_tt == t7_tdb.delta_tdb_tt[:, 2])
-        # Explicitly set delta_tdb_tt attrbite. Now it should not be sliced.
+        # Explicitly set delta_tdb_tt attribute. Now it should not be sliced.
         t7.delta_tdb_tt = 0.1
         t7_tdb2 = t7.tdb
         assert t7_tdb2[0, 0].delta_tdb_tt == 0.1

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -256,7 +256,7 @@ class TestTimeDeltaScales():
         self.dt = dict((scale, self.t[scale]-self.t[scale][0])
                        for scale in TIME_SCALES)
 
-    def test_delta_scales_defintion(self):
+    def test_delta_scales_definition(self):
         for scale in list(TIME_DELTA_SCALES) + [None]:
             TimeDelta([0., 1., 10.], format='sec', scale=scale)
 

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Time utilites.
+"""Time utilities.
 
-In particular, routines to do basic arithmatic on numbers represented by two
+In particular, routines to do basic arithmetic on numbers represented by two
 doubles, using the procedure of Shewchuk, 1997, Discrete & Computational
 Geometry 18(3):305-363 -- http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
 """

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -47,7 +47,7 @@ class TestLogUnitCreation(object):
     @pytest.mark.parametrize('lu_unit, physical_unit',
                              itertools.product(lu_units, pu_sample))
     def test_call_units(self, lu_unit, physical_unit):
-        """Create a LogUnit subclass using the callable unit and physcal unit,
+        """Create a LogUnit subclass using the callable unit and physical unit,
         and do basic check that output is right."""
         lu1 = lu_unit(physical_unit)
         assert lu1.physical_unit == physical_unit

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -647,7 +647,7 @@ class TestInplaceUfuncs(object):
         a2 += (20.*u.km)
         assert a2.unit is u.m
         assert a2.dtype == np.float32
-        # For integer, in-place only workds if no conversion is done.
+        # For integer, in-place only works if no conversion is done.
         a3 = u.Quantity([1, 2, 3, 4], u.m, dtype=np.int32)
         a3 += u.Quantity(10, u.m, dtype=np.int64)
         assert a3.unit is u.m

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -43,8 +43,8 @@ def _get_first_sentence(s):
 
 def _iter_unit_summary(namespace):
     """
-    Generates the ``(unit, doc, rperesents, aliases, prefixes)``
-    tuplse used to format the unit summary docs in `generate_unit_summary`.
+    Generates the ``(unit, doc, represents, aliases, prefixes)``
+    tuple used to format the unit summary docs in `generate_unit_summary`.
     """
 
     from . import core

--- a/astropy/utils/compat/numpy/lib/stride_tricks.py
+++ b/astropy/utils/compat/numpy/lib/stride_tricks.py
@@ -116,7 +116,7 @@ else:
 
 
     def _broadcast_shape(*args):
-        """Returns the shape of the ararys that would result from broadcasting the
+        """Returns the shape of the arrays that would result from broadcasting the
         supplied arrays against each other.
         """
         if not args:

--- a/docs/modeling/bounding-boxes.rst
+++ b/docs/modeling/bounding-boxes.rst
@@ -1,38 +1,38 @@
 .. _bounding-boxes:
 
-Efficient Model Rendering with Bounding Boxes 
+Efficient Model Rendering with Bounding Boxes
 =============================================
 
 .. versionadded:: 1.1
 
-All `astropy.modeling.Model` subclasses have a ``bounding_box`` attribute that 
-can be used to set the limits over which the model is significant. This greatly 
-improves the effciency of evaluation when the input range is much larger than 
-the characteristic width of the model itself. For example, to create a sky model 
-image from a large survey catalog, each source should only be evaluated over the 
-pixels to which it contributes a significant amount of flux. This task can 
-otherwise be computationally prohibitive on an average CPU. 
+All `astropy.modeling.Model` subclasses have a ``bounding_box`` attribute that
+can be used to set the limits over which the model is significant. This greatly
+improves the efficiency of evaluation when the input range is much larger than
+the characteristic width of the model itself. For example, to create a sky model
+image from a large survey catalog, each source should only be evaluated over the
+pixels to which it contributes a significant amount of flux. This task can
+otherwise be computationally prohibitive on an average CPU.
 
-The `astropy.modeling.render_model` function can be used to evaluate a model on 
-an input array, or coordinates, limiting the evaluation to the ``bounding_box`` 
+The `astropy.modeling.render_model` function can be used to evaluate a model on
+an input array, or coordinates, limiting the evaluation to the ``bounding_box``
 region if it is set. This function will also produce postage stamp images of the
 model if no other input array is passed. To instead extract postage
-stamps from the data array itself, see :ref:`cutout_images`. 
+stamps from the data array itself, see :ref:`cutout_images`.
 
 Using the Bounding Box
------------------------ 
+-----------------------
 
 For basic usage, see `astropy.modeling.Model.bounding_box`.
-By default no bounding box is set (``bounding_box`` is `None`), except for 
-individual model subclasses that have a ``bounding_box_default`` function 
-defined. ``bounding_box_default`` returns the minimum rectangular region 
+By default no bounding box is set (``bounding_box`` is `None`), except for
+individual model subclasses that have a ``bounding_box_default`` function
+defined. ``bounding_box_default`` returns the minimum rectangular region
 symmetric about the position that fully contains the model if the model has a
-finite extent. If a model does not have a finite extent, the choice for the 
+finite extent. If a model does not have a finite extent, the choice for the
 ``bounding_box_default`` limits is noted in the docstring. For example, see
 `astropy.modeling.functional_models.Gaussian2D.bounding_box_default`.
 
-The default function can also be set to any callable. This is particularly 
-useful for fitting ``custom_model`` or ``CompoundModel`` instances. 
+The default function can also be set to any callable. This is particularly
+useful for fitting ``custom_model`` or ``CompoundModel`` instances.
 
     >>> from astropy.modeling import custom_model
     >>> def ellipsoid(x, y, z, x0=0, y0=0, z0=0, a=2, b=3, c=4, amp=1):
@@ -55,21 +55,21 @@ useful for fitting ``custom_model`` or ``CompoundModel`` instances.
 Efficient evaluation with ``render_model``
 ------------------------------------------
 
-When a model is evaluated over a range much larger than the model itself, it may 
-be prudent to use `astropy.modeling.render_model` if efficiency is a concern. 
-The ``render_model`` function can be used to evaluate a model on an array of the 
-same dimensions. If no array is given, ``render_model`` will return a "postage 
-stamp" array corresponding to the bounding box region. However, if 
-``bounding_box`` is `None` an image or coordinates must be passed. 
+When a model is evaluated over a range much larger than the model itself, it may
+be prudent to use `astropy.modeling.render_model` if efficiency is a concern.
+The ``render_model`` function can be used to evaluate a model on an array of the
+same dimensions. If no array is given, ``render_model`` will return a "postage
+stamp" array corresponding to the bounding box region. However, if
+``bounding_box`` is `None` an image or coordinates must be passed.
 
-In this example, we generate a 300x400 pixel image of 100 2D 
-Gaussian sources both with and without using bounding boxes. Using bounding 
-boxes, the evaluation speed increases by approximately a factor of 10 with 
+In this example, we generate a 300x400 pixel image of 100 2D
+Gaussian sources both with and without using bounding boxes. Using bounding
+boxes, the evaluation speed increases by approximately a factor of 10 with
 negligible loss of information.
 
 .. plot::
     :include-source:
-    
+
 	import numpy as np
 	from time import time
 	from astropy.modeling import models, render_model
@@ -79,7 +79,7 @@ negligible loss of information.
 	from astropy.visualization import astropy_mpl_style
 	astropy_mpl_style['axes.grid'] = False
 	astropy_mpl_style['axes.labelcolor'] = 'k'
-	mpl.rcParams.update(astropy_mpl_style) 
+	mpl.rcParams.update(astropy_mpl_style)
 
 	np.random.seed(0)
 
@@ -97,13 +97,13 @@ negligible loss of information.
 
 	model_list = [models.Gaussian2D(**kwargs) for kwargs in model_params]
 
-	#Evaluate all models over their bounded regions and over the full image 
-	#for comparison. 
+	#Evaluate all models over their bounded regions and over the full image
+	#for comparison.
 
 	def make_image(model_list, shape=imshape, mode='bbox'):
 	    image = np.zeros(imshape)
 	    t1 = time()
-	    for i,model in enumerate(model_list): 
+	    for i,model in enumerate(model_list):
 	        if mode == 'full': model.bounding_box = None
 	        elif mode == 'auto': model.bounding_box = 'auto'
 	        image = render_model(model, image)
@@ -132,7 +132,7 @@ negligible loss of information.
 	for model in model_list:
 	    y1,y2,x1,x2 = np.reshape(model.bounding_box_default(),(4,))
 	    plt.plot([x1,x2,x2,x1,x1], [y1,y1,y2,y2,y1], 'w-',alpha=.2)
-	    
+
 	plt.axis([0,imshape[1],0,imshape[0]])
 	plt.title('Bounded Models\nTiming: %.2f seconds' % (t_bb), fontsize=16)
 	plt.xlabel('x', fontsize=14)
@@ -146,4 +146,4 @@ negligible loss of information.
 	plt.xlabel('x', fontsize=14)
 	plt.ylabel('y', fontsize=14)
 	plt.show()
-	
+

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -24,7 +24,7 @@ It is intended to be used as::
     @remote_data
     def test_something():
         """
-        This test dowloads something from the intenet
+        This test downloads something from the intenet
         """
         # test code here ...
 

--- a/docs/wcs/relax.rst
+++ b/docs/wcs/relax.rst
@@ -125,7 +125,7 @@ The flag bits are:
 
 - ``WCSHDR_RADECSYS``: Accept ``RADECSYS``.  This appeared in early
   drafts of WCS Paper I+II and was subsequently replaced by
-  ``RADESYSa``.  The construtor accepts ``RADECSYS`` only if
+  ``RADESYSa``.  The constructor accepts ``RADECSYS`` only if
   ``WCSHDR_AUXIMG`` is also enabled.
 
 - ``WCSHDR_VSOURCE``: Accept ``VSOURCEa`` or ``VSOUna``.  This appeared


### PR DESCRIPTION
These are for the 1.1 branch, some of these are obviously in master, too. I can open another one for master later.
(I didn't included the [skip ci] as there was a seemingly unused import, and prefer to run the test whenever those are removed).