### PR TITLE
format_doc decorator.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,8 @@ Bug fixes
 
   - The astropy.utils.compat.fractions module has now been deprecated. Use the
     Python 'fractions' module directly instead. [#4463]
+  - Added ``format_doc`` decorator which allows to replace and/or format the
+    current docstring of an object. [#4242]
 
 - ``astropy.visualization``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ New Features
 - ``astropy.utils``
 
   - Implemented a generic and extensible way of merging metadata. [#4459]
+  - Added ``format_doc`` decorator which allows to replace and/or format the
+    current docstring of an object. [#4242]
 
 - ``astropy.visualization``
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -775,10 +775,10 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
     ----------
     docstring: `str` or ``object``
         The docstring that will replace the docstring of the decorated
-        function/method. If it is an object like a function or class it will
+        object. If it is an object like a function or class it will
         take the docstring of this object. If it is a string it will use the
         string itself. One special case is if the string is ``'self'`` then
-        it will use the decorated functions docstring and format it.
+        it will use the decorated functions docstring and formats it.
 
     arg:
         passed to :meth:`str.format`.
@@ -791,11 +791,11 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
     Raises
     ------
     ValueError:
-        If the interpreted (if it was ``'self'`` or not a string) ``docstring``
-        is empty.
+        If the ``docstring`` (or interpreted docstring if it was ``'self'`` or
+        not a string) is empty.
 
     IndexError, KeyError:
-        If a placeholder in the interpreted ``docstring`` was not filled. see
+        If a placeholder in the (interpreted) ``docstring`` was not filled. see
         :meth:`str.format` for more information.
 
     Notes
@@ -803,10 +803,13 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
     Using this decorator allows, for example Sphinx, to parse the
     correct docstring.
 
-    There might be problems with certain objects which have a nor-writable
-    ``__doc__`` attribute. Like class objects before python 3.
+    There might be problems with certain objects which have a not-writable
+    ``__doc__`` attribute. Like classes in python2.
 
-    Replacing a current docstring is very easy::
+    Examples
+    --------
+
+    Replacing the current docstring is very easy::
 
         >>> from astropy.utils.decorators import replace_and_format_docstring
         >>> doc = '''Perform num1 + num2'''
@@ -918,7 +921,8 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
                 result of num1 + num2
 
     But be aware that this decorator *only* formats the given docstring not
-    the docstring that is formulated inside the function itself::
+    the strings passed as ``args`` or ``kwargs`` (not even the original
+    docstring)::
 
         >>> @replace_and_format_docstring(doc, 'addition', op='+')
         ... def yet_another_add(num1, num2):
@@ -939,8 +943,7 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
                 result of num1 + num2
             This one is good for {0}.
 
-    To work around it you could specify the docstring to be ``'self'``
-    but then the ``args`` and ``kwargs`` don't get formatted::
+    To work around it you could specify the docstring to be ``'self'``::
 
         >>> @replace_and_format_docstring('self', 'addition')
         ... def last_add_i_swear(num1, num2):
@@ -955,8 +958,7 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
 
     Using it with ``'self'`` as docstring allows to use the decorator twice on
     an object to first parse the new docstring and then to parse the original
-    docstring. But since this decorator performs string operations using it
-    too often might affect the performance.
+    docstring or the ``args`` and ``kwargs``.
     """
     def set_docstring(func):
         # Not a string so assume we want the saved doc from the object
@@ -971,8 +973,7 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
             func.__doc__ = None
 
         if not doc:
-            # I guess there is nothing which does contain no doc but better be
-            # prepared.
+            # In case the docstring is empty it's probably not what was wanted.
             raise ValueError('docstring must be a string or containing a'
                              'docstring that is not empty.')
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -764,7 +764,7 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
 
     This decorator keeps the objects signature and only alters the saved
     ``__doc__`` property (so it cannot be used as class decorator in python2).
-    The formatting works like :func:`str.format` and if the decorated object
+    The formatting works like :meth:`str.format` and if the decorated object
     already has a docstring this docstring can be included in the new
     documentation if you use the ``{original_doc}`` placeholder.
     It's primary use is if multiple functions have the same or only
@@ -781,10 +781,10 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
         it will use the decorated functions docstring and format it.
 
     arg:
-        passed to :func:`str.format`.
+        passed to :meth:`str.format`.
 
     kwargs:
-        passed to :func:`str.format`. If the function has a (not empty)
+        passed to :meth:`str.format`. If the function has a (not empty)
         docstring the original docstring is added to the kwargs with the
         keyword ``original_doc``.
 
@@ -960,7 +960,7 @@ def replace_and_format_docstring(docstring, *args, **kwargs):
     """
     def set_docstring(func):
         # Not a string so assume we want the saved doc from the object
-        if not isinstance(docstring, str):
+        if not isinstance(docstring, six.string_types):
             doc = docstring.__doc__
         elif docstring != 'self':
             doc = docstring

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -773,14 +773,14 @@ def format_doc(docstring, *args, **kwargs):
 
     Parameters
     ----------
-    docstring: `str` or ``object``
+    docstring: str or ``object``
         The docstring that will replace the docstring of the decorated
         object. If it is an object like a function or class it will
         take the docstring of this object. If it is a string it will use the
         string itself. One special case is if the string is ``'__doc__'`` then
         it will use the decorated functions docstring and formats it.
 
-    arg:
+    args:
         passed to :meth:`str.format`.
 
     kwargs:

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -974,7 +974,7 @@ def format_doc(docstring, *args, **kwargs):
 
         if not doc:
             # In case the docstring is empty it's probably not what was wanted.
-            raise ValueError('docstring must be a string or containing a'
+            raise ValueError('docstring must be a string or containing a '
                              'docstring that is not empty.')
 
         # If the original has a not-empty docstring append it to the format

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -19,7 +19,8 @@ from ..extern import six
 
 
 __all__ = ['deprecated', 'deprecated_attribute', 'classproperty',
-           'lazyproperty', 'sharedmethod', 'wraps', 'add_docstring']
+           'lazyproperty', 'sharedmethod', 'wraps',
+           'replace_and_format_docstring']
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,
@@ -757,47 +758,72 @@ def _get_function_args(func, exclude_args=()):
     return all_args
 
 
-def add_docstring(docstring, replace=True):
+def replace_and_format_docstring(docstring, *args, **kwargs):
     """
-    Useable for replacing a docstring on a function or method or appending
-    to it.
+    Replaces the docstring of the decorated object and then formats it.
 
-    This decorator keeps the functions signature and only alters the docstring.
-    The primary use-case would be if multiple functions have the same or only
+    This decorator keeps the objects signature and only alters the saved
+    ``__doc__`` property (so it cannot be used as class decorator in python2).
+    The formatting works like :func:`str.format` and if the decorated object
+    already has a docstring this docstring can be included in the new
+    documentation if you use the ``{original_doc}`` placeholder.
+    It's primary use is if multiple functions have the same or only
     a slightly different *long* docstring and you want to DRY
     (https://de.wikipedia.org/wiki/Don%E2%80%99t_repeat_yourself).
 
     Parameters
     ----------
-    docstring: `str`
-        The docstring that will be appended or set for the function/method
+    docstring: `str` or ``object``
+        The docstring that will replace the docstring of the decorated
+        function/method. If it is an object like a function or class it will
+        take the docstring of this object. If it is a string it will use the
+        string itself. One special case is if the string is ``'self'`` then
+        it will use the decorated functions docstring and format it.
 
-    replace: `bool`
-        If ``True`` the original docstring is replaced and if ``False`` the
-        new docstring is added to the original docstring. Default is ``True``
+    arg:
+        passed to :func:`str.format`.
+
+    kwargs:
+        passed to :func:`str.format`. If the function has a (not empty)
+        docstring the original docstring is added to the kwargs with the
+        keyword ``original_doc``.
+
+    Raises
+    ------
+    ValueError:
+        If the interpreted (if it was ``'self'`` or not a string) ``docstring``
+        is empty.
+
+    IndexError, KeyError:
+        If a placeholder in the interpreted ``docstring`` was not filled. see
+        :meth:`str.format` for more information.
 
     Notes
     -----
-    Using this decorator allows Sphinx and the spyder object inspector load the
-    new docstring.
+    Using this decorator allows, for example Sphinx, to parse the
+    correct docstring.
 
-    For example::
+    There might be problems with certain objects which have a nor-writable
+    ``__doc__`` attribute. Like class objects before python 3.
 
-        >>> from astropy.utils.decorators import add_docstring
-        >>> doc = '''Perform num1 {op} num2'''
-        >>> @add_docstring(doc.format(op='+'))
+    Replacing a current docstring is very easy::
+
+        >>> from astropy.utils.decorators import replace_and_format_docstring
+        >>> doc = '''Perform num1 + num2'''
+        >>> @replace_and_format_docstring(doc)
         ... def add(num1, num2):
         ...     return num1+num2
         ...
         >>> help(add) # doctest: +SKIP
         Help on function add in module __main__:
+        <BLANKLINE>
         add(num1, num2)
             Perform num1 + num2
 
-    sometimes only appending some common docstring is required. In that case
-    setting ``replace`` to ``False`` will only append the docstring.
+    sometimes instead of replacing you only want to add to it::
 
         >>> doc = '''
+        ...       {original_doc}
         ...       Parameters
         ...       ----------
         ...       num1, num2 : Numbers
@@ -805,26 +831,154 @@ def add_docstring(docstring, replace=True):
         ...       -------
         ...       result: Number
         ...       '''
-        >>> @add_docstring(doc, replace=False)
+        >>> @replace_and_format_docstring(doc)
         ... def add(num1, num2):
         ...     '''Perform addition.'''
         ...     return num1+num2
         ...
         >>> help(add) # doctest: +SKIP
         Help on function add in module __main__:
+        <BLANKLINE>
         add(num1, num2)
-            Perform addition
+            Perform addition.
             Parameters
             ----------
             num1, num2 : Numbers
             Returns
             -------
             result: Number
+
+    in case one might want to format it further::
+
+        >>> doc = '''
+        ...       Perform {0}.
+        ...       Parameters
+        ...       ----------
+        ...       num1, num2 : Numbers
+        ...       Returns
+        ...       -------
+        ...       result: Number
+        ...           result of num1 {op} num2
+        ...       {original_doc}
+        ...       '''
+        >>> @replace_and_format_docstring(doc, 'addition', op='+')
+        ... def add(num1, num2):
+        ...     return num1+num2
+        ...
+        >>> @replace_and_format_docstring(doc, 'subtraction', op='-')
+        ... def subtract(num1, num2):
+        ...     '''Notes: This one has additional notes.'''
+        ...     return num1-num2
+        ...
+        >>> help(add) # doctest: +SKIP
+        Help on function add in module __main__:
+        <BLANKLINE>
+        add(num1, num2)
+            Perform addition.
+            Parameters
+            ----------
+            num1, num2 : Numbers
+            Returns
+            -------
+            result: Number
+                result of num1 + num2
+        >>> help(subtract) # doctest: +SKIP
+        Help on function subtract in module __main__:
+        <BLANKLINE>
+        subtract(num1, num2)
+            Perform subtraction.
+            Parameters
+            ----------
+            num1, num2 : Numbers
+            Returns
+            -------
+            result: Number
+                result of num1 - num2
+            Notes: This one has additional notes.
+
+    These methods can be combined an even taking the docstring from another
+    object is possible as docstring attribute. You just have to specify the
+    object::
+
+        >>> @replace_and_format_docstring(add)
+        ... def another_add(num1, num2):
+        ...     return num1 + num2
+        ...
+        >>> help(another_add) # doctest: +SKIP
+        Help on function another_add in module __main__:
+        <BLANKLINE>
+        another_add(num1, num2)
+            Perform addition.
+            Parameters
+            ----------
+            num1, num2 : Numbers
+            Returns
+            -------
+            result: Number
+                result of num1 + num2
+
+    But be aware that this decorator *only* formats the given docstring not
+    the docstring that is formulated inside the function itself::
+
+        >>> @replace_and_format_docstring(doc, 'addition', op='+')
+        ... def yet_another_add(num1, num2):
+        ...    '''This one is good for {0}.'''
+        ...    return num1 + num2
+        ...
+        >>> help(yet_another_add) # doctest: +SKIP
+        Help on function yet_another_add in module __main__:
+        <BLANKLINE>
+        yet_another_add(num1, num2)
+            Perform addition.
+            Parameters
+            ----------
+            num1, num2 : Numbers
+            Returns
+            -------
+            result: Number
+                result of num1 + num2
+            This one is good for {0}.
+
+    To work around it you could specify the docstring to be ``'self'``
+    but then the ``args`` and ``kwargs`` don't get formatted::
+
+        >>> @replace_and_format_docstring('self', 'addition')
+        ... def last_add_i_swear(num1, num2):
+        ...    '''This one is good for {0}.'''
+        ...    return num1 + num2
+        ...
+        >>> help(last_add_i_swear) # doctest: +SKIP
+        Help on function last_add_i_swear in module __main__:
+        <BLANKLINE>
+        last_add_i_swear(num1, num2)
+            This one is good for addition.
+
+    Using it with ``'self'`` as docstring allows to use the decorator twice on
+    an object to first parse the new docstring and then to parse the original
+    docstring. But since this decorator performs string operations using it
+    too often might affect the performance.
     """
     def set_docstring(func):
-        if replace:
-            func.__doc__ = docstring
+        # Not a string so assume we want the saved doc from the object
+        if not isinstance(docstring, str):
+            doc = docstring.__doc__
+        elif docstring != 'self':
+            doc = docstring
         else:
-            func.__doc__ = func.__doc__ + docstring
+            doc = func.__doc__
+            # Delete documentation in this case so we don't end up with
+            # awkwardly self-inserted docs.
+            func.__doc__ = None
+
+        if not doc:
+            # I guess there is nothing which does contain no doc but better be
+            # prepared.
+            raise ValueError('docstring must be a string or containing a'
+                             'docstring that is not empty.')
+
+        # If the original has a not-empty docstring append it to the format
+        # kwargs.
+        kwargs['original_doc'] = func.__doc__ or ''
+        func.__doc__ = doc.format(*args, **kwargs)
         return func
     return set_docstring

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -936,7 +936,7 @@ def format_doc(docstring, *args, **kwargs):
                 result of num1 + num2
             This one is good for {0}.
 
-    To work around it you could specify the docstring to be `None``::
+    To work around it you could specify the docstring to be ``None``::
 
         >>> @format_doc(None, 'addition')
         ... def last_add_i_swear(num1, num2):

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -19,7 +19,7 @@ from ..extern import six
 
 
 __all__ = ['deprecated', 'deprecated_attribute', 'classproperty',
-           'lazyproperty', 'sharedmethod', 'wraps']
+           'lazyproperty', 'sharedmethod', 'wraps', 'add_docstring']
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,
@@ -755,3 +755,76 @@ def _get_function_args(func, exclude_args=()):
                 all_args[arg_type] = None
 
     return all_args
+
+
+def add_docstring(docstring, replace=True):
+    """
+    Useable for replacing a docstring on a function or method or appending
+    to it.
+
+    This decorator keeps the functions signature and only alters the docstring.
+    The primary use-case would be if multiple functions have the same or only
+    a slightly different *long* docstring and you want to DRY
+    (https://de.wikipedia.org/wiki/Don%E2%80%99t_repeat_yourself).
+
+    Parameters
+    ----------
+    docstring: `str`
+        The docstring that will be appended or set for the function/method
+
+    replace: `bool`
+        If ``True`` the original docstring is replaced and if ``False`` the
+        new docstring is added to the original docstring. Default is ``True``
+
+    Notes
+    -----
+    Using this decorator allows Sphinx and the spyder object inspector load the
+    new docstring.
+
+    For example::
+
+        >>> from astropy.utils.decorators import add_docstring
+        >>> doc = '''Perform num1 {op} num2'''
+        >>> @add_docstring(doc.format(op='+'))
+        ... def add(num1, num2):
+        ...     return num1+num2
+        ...
+        >>> help(add) # doctest: +SKIP
+        Help on function add in module __main__:
+        add(num1, num2)
+            Perform num1 + num2
+
+    sometimes only appending some common docstring is required. In that case
+    setting ``replace`` to ``False`` will only append the docstring.
+
+        >>> doc = '''
+        ...       Parameters
+        ...       ----------
+        ...       num1, num2 : Numbers
+        ...       Returns
+        ...       -------
+        ...       result: Number
+        ...       '''
+        >>> @add_docstring(doc, replace=False)
+        ... def add(num1, num2):
+        ...     '''Perform addition.'''
+        ...     return num1+num2
+        ...
+        >>> help(add) # doctest: +SKIP
+        Help on function add in module __main__:
+        add(num1, num2)
+            Perform addition
+            Parameters
+            ----------
+            num1, num2 : Numbers
+            Returns
+            -------
+            result: Number
+    """
+    def set_docstring(func):
+        if replace:
+            func.__doc__ = docstring
+        else:
+            func.__doc__ = func.__doc__ + docstring
+        return func
+    return set_docstring

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -773,28 +773,28 @@ def format_doc(docstring, *args, **kwargs):
 
     Parameters
     ----------
-    docstring: str or ``object``
+    docstring : str or object
         The docstring that will replace the docstring of the decorated
         object. If it is an object like a function or class it will
         take the docstring of this object. If it is a string it will use the
         string itself. One special case is if the string is ``'__doc__'`` then
         it will use the decorated functions docstring and formats it.
 
-    args:
+    args :
         passed to :meth:`str.format`.
 
-    kwargs:
+    kwargs :
         passed to :meth:`str.format`. If the function has a (not empty)
         docstring the original docstring is added to the kwargs with the
         keyword ``'__doc__'``.
 
     Raises
     ------
-    ValueError:
+    ValueError
         If the ``docstring`` (or interpreted docstring if it was ``'__doc__'``
         or not a string) is empty.
 
-    IndexError, KeyError:
+    IndexError, KeyError
         If a placeholder in the (interpreted) ``docstring`` was not filled. see
         :meth:`str.format` for more information.
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -371,16 +371,22 @@ def test_add_docstring_function():
     docstring = 'test'
 
     @add_docstring(docstring)
-    def testfunc():
+    def testfunc1():
         pass
 
-    @add_docstring(docstring, replace=False)
+    @add_docstring(docstring)
     def testfunc2():
         """this is a """
         pass
 
-    assert inspect.getdoc(testfunc) == docstring
-    assert inspect.getdoc(testfunc2) == 'this is a test'
+    @add_docstring(docstring, replace=False)
+    def testfunc3():
+        """this is a """
+        pass
+
+    assert inspect.getdoc(testfunc1) == docstring
+    assert inspect.getdoc(testfunc2) == docstring
+    assert inspect.getdoc(testfunc3) == 'this is a test'
 
 
 def test_add_docstring_method():
@@ -388,19 +394,26 @@ def test_add_docstring_method():
 
     class TestClass(object):
         @add_docstring(docstring)
-        def testfunc():
+        def testfunc1():
             pass
 
-        @add_docstring(docstring, replace=False)
+        @add_docstring(docstring)
         def testfunc2():
             """this is a """
             pass
 
-    assert inspect.getdoc(TestClass.testfunc) == docstring
-    assert inspect.getdoc(TestClass.testfunc2) == 'this is a test'
+        @add_docstring(docstring, replace=False)
+        def testfunc3():
+            """this is a """
+            pass
+
+    assert inspect.getdoc(TestClass.testfunc1) == docstring
+    assert inspect.getdoc(TestClass.testfunc2) == docstring
+    assert inspect.getdoc(TestClass.testfunc3) == 'this is a test'
     instance = TestClass()
-    assert inspect.getdoc(instance.testfunc) == docstring
-    assert inspect.getdoc(instance.testfunc2) == 'this is a test'
+    assert inspect.getdoc(instance.testfunc1) == docstring
+    assert inspect.getdoc(instance.testfunc2) == docstring
+    assert inspect.getdoc(instance.testfunc3) == 'this is a test'
 
 
 @pytest.mark.skipif('six.PY2')
@@ -408,17 +421,25 @@ def test_add_docstring_class():
     docstring = 'test'
 
     @add_docstring(docstring)
-    class TestClass(object):
+    class TestClass1(object):
         pass
 
-    @add_docstring(docstring, replace=False)
+    @add_docstring(docstring)
     class TestClass2(object):
         """this is a """
         pass
 
-    assert inspect.getdoc(TestClass) == docstring
-    assert inspect.getdoc(TestClass2) == 'this is a test'
-    instance = TestClass()
+    @add_docstring(docstring, replace=False)
+    class TestClass3(object):
+        """this is a """
+        pass
+
+    assert inspect.getdoc(TestClass1) == docstring
+    assert inspect.getdoc(TestClass2) == docstring
+    assert inspect.getdoc(TestClass3) == 'this is a test'
+    instance1 = TestClass1()
     instance2 = TestClass2()
-    assert inspect.getdoc(instance) == docstring
-    assert inspect.getdoc(instance2) == 'this is a test'
+    instance3 = TestClass3()
+    assert inspect.getdoc(instance1) == docstring
+    assert inspect.getdoc(instance2) == docstring
+    assert inspect.getdoc(instance3) == 'this is a test'

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -490,12 +490,12 @@ def test_format_doc_selfInput_simple():
 
     # Self input while the function has no docstring raises an error
     with pytest.raises(ValueError):
-        @format_doc('__doc__')
+        @format_doc(None)
         def testfunc_fail():
             pass
 
     # Test that it keeps an existing docstring
-    @format_doc('__doc__')
+    @format_doc(None)
     def testfunc_1():
         '''not test'''
         pass
@@ -507,13 +507,13 @@ def test_format_doc_selfInput_format():
 
     # Raises an indexerror if not given the formatted args and kwargs
     with pytest.raises(IndexError):
-        @format_doc('__doc__')
+        @format_doc(None)
         def testfunc_fail():
             '''dum {0} dum {opt}'''
             pass
 
     # Test that the formatting is done right
-    @format_doc('__doc__', 'di', opt='da dum')
+    @format_doc(None, 'di', opt='da dum')
     def testfunc1():
         '''dum {0} dum {opt}'''
         pass
@@ -521,7 +521,7 @@ def test_format_doc_selfInput_format():
 
     # Test that we cannot recursivly insert the original documentation
 
-    @format_doc('__doc__', 'di')
+    @format_doc(None, 'di')
     def testfunc2():
         '''dum {0} dum {__doc__}'''
         pass
@@ -535,7 +535,7 @@ def test_format_doc_onMethod():
 
     class TestClass(object):
         @format_doc(docstring)
-        @format_doc('__doc__', 'strange.')
+        @format_doc(None, 'strange.')
         def test_method(self):
             '''is {0}'''
             pass
@@ -543,7 +543,7 @@ def test_format_doc_onMethod():
     assert inspect.getdoc(TestClass.test_method) == 'what we do is strange.'
 
 
-@pytest.mark.skipif('six.PY2')
+#@pytest.mark.skipif('six.PY2')
 def test_format_doc_onClass():
     # Check if the decorator works on classes too
     docstring = 'what we do {__doc__} {0}{opt}'

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -7,7 +7,7 @@ import inspect
 import pickle
 
 from ..decorators import (deprecated_attribute, deprecated, wraps,
-                          sharedmethod, classproperty)
+                          sharedmethod, classproperty, add_docstring)
 from ..exceptions import AstropyDeprecationWarning
 from ...extern import six
 from ...tests.helper import pytest, catch_warnings
@@ -365,3 +365,59 @@ def test_classproperty_docstring():
         foo = classproperty(_get_foo, doc="The foo.")
 
     assert B.__dict__['foo'].__doc__ == "The foo."
+
+
+def test_add_docstring_function():
+    docstring = 'test'
+
+    @add_docstring(docstring)
+    def testfunc():
+        pass
+
+    @add_docstring(docstring, replace=False)
+    def testfunc2():
+        """this is a """
+        pass
+
+    assert inspect.getdoc(testfunc) == docstring
+    assert inspect.getdoc(testfunc2) == 'this is a test'
+
+
+def test_add_docstring_method():
+    docstring = 'test'
+
+    class TestClass(object):
+        @add_docstring(docstring)
+        def testfunc():
+            pass
+
+        @add_docstring(docstring, replace=False)
+        def testfunc2():
+            """this is a """
+            pass
+
+    assert inspect.getdoc(TestClass.testfunc) == docstring
+    assert inspect.getdoc(TestClass.testfunc2) == 'this is a test'
+    instance = TestClass()
+    assert inspect.getdoc(instance.testfunc) == docstring
+    assert inspect.getdoc(instance.testfunc2) == 'this is a test'
+
+
+def test_add_docstring_class():
+    docstring = 'test'
+
+    @add_docstring(docstring)
+    class TestClass(object):
+        pass
+
+    @add_docstring(docstring, replace=False)
+    class TestClass2(object):
+        """this is a """
+        pass
+
+    assert inspect.getdoc(TestClass) == docstring
+    assert inspect.getdoc(TestClass2) == 'this is a test'
+    instance = TestClass()
+    instance2 = TestClass2()
+    assert inspect.getdoc(instance) == docstring
+    assert inspect.getdoc(instance2) == 'this is a test'

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -8,7 +8,7 @@ import pickle
 
 from ..decorators import (deprecated_attribute, deprecated, wraps,
                           sharedmethod, classproperty,
-                          replace_and_format_docstring)
+                          format_doc)
 from ..exceptions import AstropyDeprecationWarning
 from ...extern import six
 from ...tests.helper import pytest, catch_warnings
@@ -368,62 +368,62 @@ def test_classproperty_docstring():
     assert B.__dict__['foo'].__doc__ == "The foo."
 
 
-def test_replace_and_format_docstring_stringInput_simple():
+def test_format_doc_stringInput_simple():
     # Simple tests with string input
 
     docstring_fail = ''
 
     # Raises an valueerror if input is empty
     with pytest.raises(ValueError):
-        @replace_and_format_docstring(docstring_fail)
+        @format_doc(docstring_fail)
         def testfunc_fail():
             pass
 
     docstring = 'test'
 
     # A first test that replaces an empty docstring
-    @replace_and_format_docstring(docstring)
+    @format_doc(docstring)
     def testfunc_1():
         pass
     assert inspect.getdoc(testfunc_1) == docstring
 
     # Test that it replaces an existing docstring
-    @replace_and_format_docstring(docstring)
+    @format_doc(docstring)
     def testfunc_2():
         '''not test'''
         pass
     assert inspect.getdoc(testfunc_2) == docstring
 
 
-def test_replace_and_format_docstring_stringInput_format():
+def test_format_doc_stringInput_format():
     # Tests with string input and formatting
 
     docstring = 'yes {0} no {opt}'
 
     # Raises an indexerror if not given the formatted args and kwargs
     with pytest.raises(IndexError):
-        @replace_and_format_docstring(docstring)
+        @format_doc(docstring)
         def testfunc1():
             pass
 
     # Test that the formatting is done right
-    @replace_and_format_docstring(docstring, '/', opt='= life')
+    @format_doc(docstring, '/', opt='= life')
     def testfunc2():
         pass
     assert inspect.getdoc(testfunc2) == 'yes / no = life'
 
     # Test that we can include the original docstring
 
-    docstring2 = 'yes {0} no {original_doc}'
+    docstring2 = 'yes {0} no {__doc__}'
 
-    @replace_and_format_docstring(docstring2, '/')
+    @format_doc(docstring2, '/')
     def testfunc3():
         '''= 2 / 2 * life'''
         pass
     assert inspect.getdoc(testfunc3) == 'yes / no = 2 / 2 * life'
 
 
-def test_replace_and_format_docstring_objectInput_simple():
+def test_format_doc_objectInput_simple():
     # Simple tests with object input
 
     def docstring_fail():
@@ -431,7 +431,7 @@ def test_replace_and_format_docstring_objectInput_simple():
 
     # Self input while the function has no docstring raises an error
     with pytest.raises(ValueError):
-        @replace_and_format_docstring(docstring_fail)
+        @format_doc(docstring_fail)
         def testfunc_fail():
             pass
 
@@ -440,20 +440,20 @@ def test_replace_and_format_docstring_objectInput_simple():
         pass
 
     # A first test that replaces an empty docstring
-    @replace_and_format_docstring(docstring0)
+    @format_doc(docstring0)
     def testfunc_1():
         pass
     assert inspect.getdoc(testfunc_1) == inspect.getdoc(docstring0)
 
     # Test that it replaces an existing docstring
-    @replace_and_format_docstring(docstring0)
+    @format_doc(docstring0)
     def testfunc_2():
         '''not test'''
         pass
     assert inspect.getdoc(testfunc_2) == inspect.getdoc(docstring0)
 
 
-def test_replace_and_format_docstring_objectInput_format():
+def test_format_doc_objectInput_format():
     # Tests with object input and formatting
 
     def docstring():
@@ -462,12 +462,12 @@ def test_replace_and_format_docstring_objectInput_format():
 
     # Raises an indexerror if not given the formatted args and kwargs
     with pytest.raises(IndexError):
-        @replace_and_format_docstring(docstring)
+        @format_doc(docstring)
         def testfunc_fail():
             pass
 
     # Test that the formatting is done right
-    @replace_and_format_docstring(docstring, '+', opt='= 2 * test')
+    @format_doc(docstring, '+', opt='= 2 * test')
     def testfunc2():
         pass
     assert inspect.getdoc(testfunc2) == 'test + test = 2 * test'
@@ -475,45 +475,45 @@ def test_replace_and_format_docstring_objectInput_format():
     # Test that we can include the original docstring
 
     def docstring2():
-        '''test {0} test {original_doc}'''
+        '''test {0} test {__doc__}'''
         pass
 
-    @replace_and_format_docstring(docstring2, '+')
+    @format_doc(docstring2, '+')
     def testfunc3():
         '''= 4 / 2 * test'''
         pass
     assert inspect.getdoc(testfunc3) == 'test + test = 4 / 2 * test'
 
 
-def test_replace_and_format_docstring_selfInput_simple():
+def test_format_doc_selfInput_simple():
     # Simple tests with self input
 
     # Self input while the function has no docstring raises an error
     with pytest.raises(ValueError):
-        @replace_and_format_docstring('self')
+        @format_doc('__doc__')
         def testfunc_fail():
             pass
 
     # Test that it keeps an existing docstring
-    @replace_and_format_docstring('self')
+    @format_doc('__doc__')
     def testfunc_1():
         '''not test'''
         pass
     assert inspect.getdoc(testfunc_1) == 'not test'
 
 
-def test_replace_and_format_docstring_selfInput_format():
-    # Tests with string input which is 'self' (special case) and formatting
+def test_format_doc_selfInput_format():
+    # Tests with string input which is '__doc__' (special case) and formatting
 
     # Raises an indexerror if not given the formatted args and kwargs
     with pytest.raises(IndexError):
-        @replace_and_format_docstring('self')
+        @format_doc('__doc__')
         def testfunc_fail():
             '''dum {0} dum {opt}'''
             pass
 
     # Test that the formatting is done right
-    @replace_and_format_docstring('self', 'di', opt='da dum')
+    @format_doc('__doc__', 'di', opt='da dum')
     def testfunc1():
         '''dum {0} dum {opt}'''
         pass
@@ -521,21 +521,21 @@ def test_replace_and_format_docstring_selfInput_format():
 
     # Test that we cannot recursivly insert the original documentation
 
-    @replace_and_format_docstring('self', 'di')
+    @format_doc('__doc__', 'di')
     def testfunc2():
-        '''dum {0} dum {original_doc}'''
+        '''dum {0} dum {__doc__}'''
         pass
     assert inspect.getdoc(testfunc2) == 'dum di dum '
 
 
-def test_replace_and_format_docstring_onMethod():
+def test_format_doc_onMethod():
     # Check if the decorator works on methods too, to spice it up we try double
     # decorator
-    docstring = 'what we do {original_doc}'
+    docstring = 'what we do {__doc__}'
 
     class TestClass(object):
-        @replace_and_format_docstring(docstring)
-        @replace_and_format_docstring('self', 'strange.')
+        @format_doc(docstring)
+        @format_doc('__doc__', 'strange.')
         def test_method(self):
             '''is {0}'''
             pass
@@ -544,11 +544,11 @@ def test_replace_and_format_docstring_onMethod():
 
 
 @pytest.mark.skipif('six.PY2')
-def test_replace_and_format_docstring_onClass():
+def test_format_doc_onClass():
     # Check if the decorator works on classes too
-    docstring = 'what we do {original_doc} {0}{opt}'
+    docstring = 'what we do {__doc__} {0}{opt}'
 
-    @replace_and_format_docstring(docstring, 'strange', opt='.')
+    @format_doc(docstring, 'strange', opt='.')
     class TestClass(object):
         '''is'''
         pass

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -403,6 +403,7 @@ def test_add_docstring_method():
     assert inspect.getdoc(instance.testfunc2) == 'this is a test'
 
 
+@pytest.mark.skipif('six.PY2')
 def test_add_docstring_class():
     docstring = 'test'
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -7,7 +7,8 @@ import inspect
 import pickle
 
 from ..decorators import (deprecated_attribute, deprecated, wraps,
-                          sharedmethod, classproperty, add_docstring)
+                          sharedmethod, classproperty,
+                          replace_and_format_docstring)
 from ..exceptions import AstropyDeprecationWarning
 from ...extern import six
 from ...tests.helper import pytest, catch_warnings
@@ -367,79 +368,189 @@ def test_classproperty_docstring():
     assert B.__dict__['foo'].__doc__ == "The foo."
 
 
-def test_add_docstring_function():
+def test_replace_and_format_docstring_stringInput_simple():
+    # Simple tests with string input
+
+    docstring_fail = ''
+
+    # Raises an valueerror if input is empty
+    with pytest.raises(ValueError):
+        @replace_and_format_docstring(docstring_fail)
+        def testfunc_fail():
+            pass
+
     docstring = 'test'
 
-    @add_docstring(docstring)
-    def testfunc1():
+    # A first test that replaces an empty docstring
+    @replace_and_format_docstring(docstring)
+    def testfunc_1():
         pass
+    assert inspect.getdoc(testfunc_1) == docstring
 
-    @add_docstring(docstring)
-    def testfunc2():
-        """this is a """
+    # Test that it replaces an existing docstring
+    @replace_and_format_docstring(docstring)
+    def testfunc_2():
+        '''not test'''
         pass
-
-    @add_docstring(docstring, replace=False)
-    def testfunc3():
-        """this is a """
-        pass
-
-    assert inspect.getdoc(testfunc1) == docstring
-    assert inspect.getdoc(testfunc2) == docstring
-    assert inspect.getdoc(testfunc3) == 'this is a test'
+    assert inspect.getdoc(testfunc_2) == docstring
 
 
-def test_add_docstring_method():
-    docstring = 'test'
+def test_replace_and_format_docstring_stringInput_format():
+    # Tests with string input and formatting
 
-    class TestClass(object):
-        @add_docstring(docstring)
+    docstring = 'yes {0} no {opt}'
+
+    # Raises an indexerror if not given the formatted args and kwargs
+    with pytest.raises(IndexError):
+        @replace_and_format_docstring(docstring)
         def testfunc1():
             pass
 
-        @add_docstring(docstring)
-        def testfunc2():
-            """this is a """
+    # Test that the formatting is done right
+    @replace_and_format_docstring(docstring, '/', opt='= life')
+    def testfunc2():
+        pass
+    assert inspect.getdoc(testfunc2) == 'yes / no = life'
+
+    # Test that we can include the original docstring
+
+    docstring2 = 'yes {0} no {original_doc}'
+
+    @replace_and_format_docstring(docstring2, '/')
+    def testfunc3():
+        '''= 2 / 2 * life'''
+        pass
+    assert inspect.getdoc(testfunc3) == 'yes / no = 2 / 2 * life'
+
+
+def test_replace_and_format_docstring_objectInput_simple():
+    # Simple tests with object input
+
+    def docstring_fail():
+        pass
+
+    # Self input while the function has no docstring raises an error
+    with pytest.raises(ValueError):
+        @replace_and_format_docstring(docstring_fail)
+        def testfunc_fail():
             pass
 
-        @add_docstring(docstring, replace=False)
-        def testfunc3():
-            """this is a """
+    def docstring0():
+        '''test'''
+        pass
+
+    # A first test that replaces an empty docstring
+    @replace_and_format_docstring(docstring0)
+    def testfunc_1():
+        pass
+    assert inspect.getdoc(testfunc_1) == inspect.getdoc(docstring0)
+
+    # Test that it replaces an existing docstring
+    @replace_and_format_docstring(docstring0)
+    def testfunc_2():
+        '''not test'''
+        pass
+    assert inspect.getdoc(testfunc_2) == inspect.getdoc(docstring0)
+
+
+def test_replace_and_format_docstring_objectInput_format():
+    # Tests with object input and formatting
+
+    def docstring():
+        '''test {0} test {opt}'''
+        pass
+
+    # Raises an indexerror if not given the formatted args and kwargs
+    with pytest.raises(IndexError):
+        @replace_and_format_docstring(docstring)
+        def testfunc_fail():
             pass
 
-    assert inspect.getdoc(TestClass.testfunc1) == docstring
-    assert inspect.getdoc(TestClass.testfunc2) == docstring
-    assert inspect.getdoc(TestClass.testfunc3) == 'this is a test'
-    instance = TestClass()
-    assert inspect.getdoc(instance.testfunc1) == docstring
-    assert inspect.getdoc(instance.testfunc2) == docstring
-    assert inspect.getdoc(instance.testfunc3) == 'this is a test'
+    # Test that the formatting is done right
+    @replace_and_format_docstring(docstring, '+', opt='= 2 * test')
+    def testfunc2():
+        pass
+    assert inspect.getdoc(testfunc2) == 'test + test = 2 * test'
+
+    # Test that we can include the original docstring
+
+    def docstring2():
+        '''test {0} test {original_doc}'''
+        pass
+
+    @replace_and_format_docstring(docstring2, '+')
+    def testfunc3():
+        '''= 4 / 2 * test'''
+        pass
+    assert inspect.getdoc(testfunc3) == 'test + test = 4 / 2 * test'
+
+
+def test_replace_and_format_docstring_selfInput_simple():
+    # Simple tests with self input
+
+    # Self input while the function has no docstring raises an error
+    with pytest.raises(ValueError):
+        @replace_and_format_docstring('self')
+        def testfunc_fail():
+            pass
+
+    # Test that it keeps an existing docstring
+    @replace_and_format_docstring('self')
+    def testfunc_1():
+        '''not test'''
+        pass
+    assert inspect.getdoc(testfunc_1) == 'not test'
+
+
+def test_replace_and_format_docstring_selfInput_format():
+    # Tests with string input which is 'self' (special case) and formatting
+
+    # Raises an indexerror if not given the formatted args and kwargs
+    with pytest.raises(IndexError):
+        @replace_and_format_docstring('self')
+        def testfunc_fail():
+            '''dum {0} dum {opt}'''
+            pass
+
+    # Test that the formatting is done right
+    @replace_and_format_docstring('self', 'di', opt='da dum')
+    def testfunc1():
+        '''dum {0} dum {opt}'''
+        pass
+    assert inspect.getdoc(testfunc1) == 'dum di dum da dum'
+
+    # Test that we cannot recursivly insert the original documentation
+
+    @replace_and_format_docstring('self', 'di')
+    def testfunc2():
+        '''dum {0} dum {original_doc}'''
+        pass
+    assert inspect.getdoc(testfunc2) == 'dum di dum '
+
+
+def test_replace_and_format_docstring_onMethod():
+    # Check if the decorator works on methods too, to spice it up we try double
+    # decorator
+    docstring = 'what we do {original_doc}'
+
+    class TestClass(object):
+        @replace_and_format_docstring(docstring)
+        @replace_and_format_docstring('self', 'strange.')
+        def test_method(self):
+            '''is {0}'''
+            pass
+
+    assert inspect.getdoc(TestClass.test_method) == 'what we do is strange.'
 
 
 @pytest.mark.skipif('six.PY2')
-def test_add_docstring_class():
-    docstring = 'test'
+def test_replace_and_format_docstring_onClass():
+    # Check if the decorator works on classes too
+    docstring = 'what we do {original_doc} {0}{opt}'
 
-    @add_docstring(docstring)
-    class TestClass1(object):
+    @replace_and_format_docstring(docstring, 'strange', opt='.')
+    class TestClass(object):
+        '''is'''
         pass
 
-    @add_docstring(docstring)
-    class TestClass2(object):
-        """this is a """
-        pass
-
-    @add_docstring(docstring, replace=False)
-    class TestClass3(object):
-        """this is a """
-        pass
-
-    assert inspect.getdoc(TestClass1) == docstring
-    assert inspect.getdoc(TestClass2) == docstring
-    assert inspect.getdoc(TestClass3) == 'this is a test'
-    instance1 = TestClass1()
-    instance2 = TestClass2()
-    instance3 = TestClass3()
-    assert inspect.getdoc(instance1) == docstring
-    assert inspect.getdoc(instance2) == docstring
-    assert inspect.getdoc(instance3) == 'this is a test'
+    assert inspect.getdoc(TestClass) == 'what we do is strange.'


### PR DESCRIPTION
In the discussion of #4234 @embray asked me to build a decorator to create dynamical docstrings. Since there might be other use-cases out there and I want to use it in several distinct files/classes I just thought there might be a place in the ``astropy.utils.decorators`` for it.

Please feel free to comment. If there shouldn't be use-cases outside my class or if there is already such a decorator in the python built-ins (I have looked but apparently there is no such thing) just speak up and I will only use this for my classes.

The decorator is very simple just a 4-liner but I tested it with functions, methods and it works within a python console, for sphinx and even (very happy about that) the spyder object inspector.