### PR TITLE
Change ordering of GCRS/ITRS transforms to make more sense

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,13 @@ Bug fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- In ``astropy.coordinates``, the transformations between GCRS, CIRS,
+  and ITRS have been adjusted to more logically reflect the order in
+  which they actually apply.  This should not affect most coordinate
+  transformations, but may affect code that is especially sensitive to
+  machine precision effects that change when the order in which
+  transformations occur is changed. [#4255]
+
 1.1 (unreleased)
 ----------------
 

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -20,21 +20,10 @@ from .cirs import CIRS
 from .itrs import ITRS
 from .utils import get_polar_motion
 
-# first define helper functions
-def gcrs_to_itrs_mat(time):
-    #first compute the celestial-to-intermediate matrix
-    c2imat = erfa.c2i06a(time.jd1, time.jd2)
-
-    #now compute the polar motion p-matrix
-    xp, yp = get_polar_motion(time)
-    sp = erfa.sp00(time.jd1, time.jd2)
-    pmmat = erfa.pom00(xp, yp, sp)
-
-    #now determine the Earth Rotation Angle for the input obstime
-    era = erfa.era00(time.jd1, time.jd2)
-
-    return erfa.c2tcio(c2imat, era, pmmat)
-
+# # first define helper functions
+def gcrs_to_cirs_mat(time):
+    #felestial-to-intermediate matrix
+    return erfa.c2i06a(time.jd1, time.jd2)
 
 def cirs_to_itrs_mat(time):
     #compute the polar motion p-matrix
@@ -56,25 +45,23 @@ def gcrs_precession_mat(equinox):
 
 # now the actual transforms
 
-# the priority for the GCRS<->ITRS transforms are higher (=less traveled) to
-#make GCRS<->ICRS<->CIRS the preferred route over GCRS<->ITRS<->CIRS
-@frame_transform_graph.transform(FunctionTransform, GCRS, ITRS, priority=1.01)
-def gcrs_to_itrs(gcrs_coo, itrs_frame):
+@frame_transform_graph.transform(FunctionTransform, GCRS, CIRS)
+def gcrs_to_cirs(gcrs_coo, cirs_frame):
     # first get us to a 0 pos/vel GCRS at the target obstime
-    gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=itrs_frame.obstime))
+    gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=cirs_frame.obstime))
 
     #now get the pmatrix
-    pmat = gcrs_to_itrs_mat(itrs_frame.obstime)
+    pmat = gcrs_to_cirs_mat(cirs_frame.obstime)
     crepr = cartrepr_from_matmul(pmat, gcrs_coo2)
-    return itrs_frame.realize_frame(crepr)
+    return cirs_frame.realize_frame(crepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, ITRS, GCRS, priority=1.01)
-def itrs_to_gcrs(itrs_coo, gcrs_frame):
+@frame_transform_graph.transform(FunctionTransform, CIRS, GCRS)
+def cirs_to_gcrs(cirs_coo, gcrs_frame):
     #compute the pmatrix, and then multiply by its transpose
-    pmat = gcrs_to_itrs_mat(itrs_coo.obstime)
-    newrepr = cartrepr_from_matmul(pmat, itrs_coo, transpose=True)
-    gcrs = GCRS(newrepr, obstime=itrs_coo.obstime)
+    pmat = gcrs_to_cirs_mat(cirs_coo.obstime)
+    newrepr = cartrepr_from_matmul(pmat, cirs_coo, transpose=True)
+    gcrs = GCRS(newrepr, obstime=cirs_coo.obstime)
 
     #now do any needed offsets (no-op if same obstime and 0 pos/vel)
     return gcrs.transform_to(gcrs_frame)


### PR DESCRIPTION
This is an adjustment to the `coordinates` transformation graph that was inspired by (but not directly related to) #4254 .  Basically, while working on that, I realized that the transformations since v0.4 included a rather illogical transform chain, which I think was originally just a workaround because we didn't have it all implemented yet.  If you look at Fig 2 of [sofa's precession/nutation guide](http://www.iausofa.org/sofa_pn.pdf) (or the simpler version in Fig 1 of [the astrometry guide](http://www.iausofa.org/sofa_ast_c.pdf), which I've put at the bottom of this issue), you'll see how the IAU2000 transform chain is supposed to work.  

Right now we don't do all of these steps because ERFA lets us jump over some of them in a single step.  But if you want to go from GCRS to AltAz, right now there's an extra transform than necessary: GCRS->ITRS->CIRS->AltAz ... worse yet, the CIRS->AltAz transform internally goes through ITRS, so it's completely wasted computation.  

This PR removes the GCRS<->ITRS transformation and replaces it with a GCRS<->CIRS transformation.  That serves to make the whole thing more linear where relevant, and also reduces the wasted computation going from GCRS<->AltAz 

cc @mhvk @adrn @astrofrog

One logistical question - I'm not sure if this is something we should backport to v1.1.x vs. leaving as new in v1.2.  It's not clear whether you call this a bug or a feature - it's a performance enhancement but also fixing something that was originally (in v0.4) intended as a temporary measure to get stuff up-and-running quickly.  So it's sort of just changing the behavior to what was originally intended.  @astrofrog or @embray have any thoughts here?

![transforms](https://cloud.githubusercontent.com/assets/346587/10623462/39c26cb8-775d-11e5-9a85-bc60933d74cf.png)