### PR TITLE
Introduce absolute and apparent bolometric magnitudes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ New Features
 
 - ``astropy.constants``
 
+  - Add ``L_bol0``, the luminosity corresponding to absolute bolometric
+    magnitude zero. [#4262]
+  
 - ``astropy.convolution``
 
 - ``astropy.coordinates``
@@ -120,6 +123,9 @@ New Features
 
   - Added a ``represents`` property to allow access to the definition of a
     named unit (e.g., ``u.kpc.represents`` yields ``1000 pc``). [#4806]
+
+  - Add bolometric absolute and apparent magnitudes, ``M_bol`` and ``m_bol``.
+    [#4262]
 
 - ``astropy.utils``
 

--- a/astropy/constants/si.py
+++ b/astropy/constants/si.py
@@ -118,6 +118,10 @@ kpc = Constant('kpc', "Kiloparsec",
                1000. * au.uncertainty / np.tan(np.radians(1. / 3600.)),
                "Derived from au", system='si')
 
+# Luminosity
+L_bol0 = Constant('L_bol0', "Luminosity for absolute bolometric magnitude 0",
+                  3.0128e28, "W", 0.0, "IAU 2015 Resolution B 2", system='si')
+
 # Wien wavelength displacement law constant
 b_wien = Constant('b_wien', 'Wien wavelength displacement law constant',
                   2.8977721e-3, 'm K', 0.0000026e-3, 'CODATA 2010', system='si')

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -4,13 +4,16 @@ from __future__ import (absolute_import, unicode_literals,
                         division, print_function)
 import numpy as np
 
-from .. import CompositeUnit, Unit, UnitsError, dimensionless_unscaled, si
+from .. import (CompositeUnit, Unit, UnitsError, dimensionless_unscaled,
+                si, astrophys)
+from ...constants import L_bol0
 from .core import FunctionUnitBase, FunctionQuantity
 from .units import dex, dB, mag
 
 
 __all__ = ['LogUnit', 'MagUnit', 'DexUnit', 'DecibelUnit',
-           'LogQuantity', 'Magnitude', 'Decibel', 'Dex', 'STmag', 'ABmag']
+           'LogQuantity', 'Magnitude', 'Decibel', 'Dex',
+           'STmag', 'ABmag', 'M_bol', 'm_bol']
 
 
 class LogUnit(FunctionUnitBase):
@@ -320,8 +323,24 @@ AB0 = Unit('AB', 10.**(-0.4*48.6) * 1.e-3 * si.W / si.m**2 / si.Hz,
 ST0 = Unit('ST', 10.**(-0.4*21.1) * 1.e-3 * si.W / si.m**2 / si.AA,
            doc="ST magnitude zero flux density.")
 
+Bol0 = Unit('Bol', L_bol0, doc="Luminosity corresponding to "
+            "absolute bolometric magnitude zero")
+
+bol0 = Unit('bol', L_bol0 / (4 * np.pi * (10.*astrophys.pc)**2),
+            doc="Irradiance corresponding to appparent bolometric magnitude "
+            "zero")
+
+
 STmag = MagUnit(ST0)
 STmag.__doc__ = "ST magnitude: STmag=-21.1 corresponds to 1 erg/s/cm2/A"
 
 ABmag = MagUnit(AB0)
 ABmag.__doc__ = "AB magnitude: ABmag=-48.6 corresponds to 1 erg/s/cm2/Hz"
+
+M_bol = MagUnit(Bol0)
+M_bol.__doc__ = ("Absolute bolometric magnitude: M_bol=0 corresponds to "
+                 "L_bol0={0}".format(Bol0.si))
+
+m_bol = MagUnit(bol0)
+m_bol.__doc__ = ("Apparent bolometric magnitude: m_bol=0 corresponds to "
+                 "f_bol0={0}".format(bol0.si))

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -12,8 +12,8 @@ import itertools
 import numpy as np
 from numpy.testing.utils import assert_allclose
 
-from ...tests.helper import pytest
-from ... import units as u
+from ...tests.helper import pytest, assert_quantity_allclose
+from ... import units as u, constants as c
 
 lu_units = [u.dex, u.mag, u.decibel]
 
@@ -69,6 +69,16 @@ class TestLogUnitCreation(object):
 
         with pytest.raises(ValueError):
             lu_cls(physical_unit, u.m)
+
+
+def test_predefined_magnitudes():
+    assert_quantity_allclose((-21.1*u.STmag).physical,
+                             1.*u.erg/u.cm**2/u.s/u.AA)
+    assert_quantity_allclose((-48.6*u.ABmag).physical,
+                             1.*u.erg/u.cm**2/u.s/u.Hz)
+    assert_quantity_allclose((0*u.M_bol).physical, c.L_bol0)
+    assert_quantity_allclose((0*u.m_bol).physical,
+                             c.L_bol0/(4.*np.pi*(10.*c.pc)**2))
 
 
 class TestLogUnitStrings(object):


### PR DESCRIPTION
These use the definitions in IAU 2015 resolution B2. See http://arxiv.org/abs/1510.06262

Not quite sure about best names and abbreviations. Now,
```
In [4]: 0*u.M_bol
Out[4]: <Magnitude 0.0 mag(Bol)>

In [5]: 0*u.m_bol
Out[5]: <Magnitude 0.0 mag(bol)>

In [6]: 0*u.STmag
Out[6]: <Magnitude 0.0 mag(ST)>
```

Also, arguably the ST and AB flux zero points should be part of constants...