### PR TITLE
Updates to bounding box interface and cleanup

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -48,7 +48,7 @@ from .parameters import Parameter, InputParameterError
 
 
 __all__ = ['Model', 'FittableModel', 'Fittable1DModel', 'Fittable2DModel',
-           'custom_model', 'ModelDefinitionError', 'render_model']
+           'custom_model', 'ModelDefinitionError']
 
 
 class ModelDefinitionError(TypeError):
@@ -571,10 +571,7 @@ class Model(object):
     _inverse = None
     _user_inverse = None
 
-    # If a bounding_box_default function is defined in the model,
-    # then the _bounding_box attribute should be set to 'auto' in the model.
-    # Otherwise, the default is None for no bounding box.
-    _bounding_box = None
+    _bounding_box = 'auto'
 
     # Default n_models attribute, so that __len__ is still defined even when a
     # model hasn't completed initialization yet
@@ -830,6 +827,13 @@ class Model(object):
 
         del self._user_inverse
 
+    def bounding_box_default(self):
+        """
+        Raises a ``NotImplementedError`` by default. This is overridden by defining
+        `bounding_box_default` in the subclass.
+        """
+        raise NotImplementedError("The bounding box is not set for this model.")
+
     @property
     def has_user_inverse(self):
         """
@@ -852,14 +856,14 @@ class Model(object):
         A `tuple` of length `n_inputs` defining the bounding box limits, or
         `None` for no bounding box.
 
-        The default is `None`, unless ``bounding_box_default`` is defined.
-        `bounding_box` can be set manually to an array-like  object of shape
-        ``(model.n_inputs, 2)``. For further usage, including how to set the
-        ``bounding_box_default``, see :ref:`bounding-boxes`
+        The default limits are given by the `bounding_box_default` method, which
+        in some cases are `None`. `bounding_box` can be set manually to an
+        array-like object of shape ``(model.n_inputs, 2)``. For further usage,
+        including how to set `bounding_box_default`, see :ref:`bounding-boxes`
 
         The limits are ordered according to the `numpy` indexing
         convention, and are the reverse of the model input order,
-        e.g. for inputs ``('x', 'y', 'z')`` the ``bounding_box`` is defined:
+        e.g. for inputs ``('x', 'y', 'z')``, `bounding_box` is defined:
 
         * for 1D: ``(x_low, x_high)``
         * for 2D: ``((y_low, y_high), (x_low, x_high))``
@@ -867,19 +871,18 @@ class Model(object):
 
         Examples
         --------
-        Setting the bounding boxes for a 1D, 2D, and custom 3D model.
 
-        >>> from astropy.modeling.models import Gaussian1D, Gaussian2D, custom_model
+        Setting the `bounding_box` limits for a 1D and 2D model.
+
+        >>> from astropy.modeling.models import Gaussian1D, Gaussian2D
         >>> model_1d = Gaussian1D()
         >>> model_2d = Gaussian2D(x_stddev=1, y_stddev=1)
-
-        Set the bounding box like:
-
         >>> model_1d.bounding_box = (-5, 5)
         >>> model_2d.bounding_box = ((-6, 6), (-5, 5))
 
-        For a user-defined 3D model:
+        Setting the bounding_box limits for a user-defined 3D `custom_model`:
 
+        >>> from astropy.modeling.models import custom_model
         >>> def const3d(x, y, z, amp=1):
         ...    return amp
         ...
@@ -887,17 +890,19 @@ class Model(object):
         >>> model_3d = Const3D()
         >>> model_3d.bounding_box = ((-6, 6), (-5, 5), (-4, 4))
 
-        To reset the default:
+        To reset `bounding_box` to its default limits:
 
         >>> model_1d.bounding_box = 'auto'
 
-        To turn off the bounding box:
+        To turn off or unset `bounding_box`:
 
         >>> model_1d.bounding_box = None
-
         """
 
-        if self._bounding_box == 'auto':
+        if self._bounding_box is None:
+            raise NotImplementedError("No bounding box is set for this model.")
+
+        elif self._bounding_box =='auto':
             return self.bounding_box_default()
 
         else:
@@ -909,12 +914,7 @@ class Model(object):
         Assigns the bounding box limits.
         """
 
-        if limits == 'auto':
-            if not hasattr(self, 'bounding_box_default'):
-                warnings.warn('The default for this model is None.')
-                limits = None
-
-        elif limits is None:
+        if limits in ('auto', None):
             pass
 
         else:
@@ -929,7 +929,7 @@ class Model(object):
                     limits = tuple([tuple(lim) for lim in limits])
 
             except AssertionError:
-                raise AssertionError('If not \'auto\' or None, bounding_box must be '
+                raise ValueError('If not \'auto\' or None, bounding_box must be '
                                      'array-like of shape ``(model.n_inputs, 2)``.')
 
         self._bounding_box = limits
@@ -939,6 +939,104 @@ class Model(object):
     @abc.abstractmethod
     def evaluate(self, *args, **kwargs):
         """Evaluate the model on some input variables."""
+
+    def render(self, out=None, coords=None):
+        """
+        Evaluates a model on an input array. Evaluation is limited to
+        a bounding box if the `Model.bounding_box` attribute is set.
+
+        Parameters
+        ----------
+        out : `numpy.ndarray`, optional
+            The array on which the model is to be evaluated.
+        coords : array-like, optional
+            Coordinate arrays mapping to ``arr``, such that
+            ``arr[coords] == arr``.
+
+        Returns
+        -------
+        out : `numpy.ndarray`
+            The model evaluated on the input array if given, or else a new array from
+            ``coords``.
+            If ``out`` and ``coords`` are both `None`, the returned array is
+            limited to the `Model.bounding_box` limits. If
+            `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be passed.
+
+        Examples
+        --------
+        :ref:`bounding-boxes`
+        """
+
+        try:
+            bbox = self.bounding_box
+        except NotImplementedError:
+            bbox = None
+
+        ndim = self.n_inputs
+
+        if (coords is None) and (out is None) and (bbox is None):
+            raise ValueError('If no bounding_box is set, '
+                                 'coords or out must be input.')
+
+        # for consistent indexing
+        if ndim == 1:
+            if coords is not None:
+                coords = [coords]
+            if bbox is not None:
+                bbox = [bbox]
+
+        if coords is not None:
+            # Check dimensions match out and model
+            assert len(coords) == ndim
+            if out is not None:
+                assert coords[0].shape == out.shape
+            else:
+                out = np.zeros(coords[0].shape)
+
+        if out is not None:
+            try:
+                assert out.ndim == ndim
+            except AssertionError:
+                raise AssertionError('The array and model must have the same number '
+                                     'of dimensions.')
+
+        if bbox is not None:
+
+            # assures position is at center pixel, important when using add_array
+            pd = pos, delta = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2))
+                                        for bb in bbox]).astype(int).T
+
+            if coords is not None:
+                sub_shape = tuple(delta * 2 + 1)
+                sub_coords = np.array([extract_array(c, sub_shape, pos)
+                                       for c in coords])
+            else:
+                limits = [slice(p - d, p + d + 1, 1) for p, d in pd.T]
+                sub_coords = np.mgrid[limits]
+
+            sub_coords = sub_coords[::-1]
+
+            if out is None:
+                out = self(*sub_coords)
+            else:
+                try:
+                    out = add_array(out, self(*sub_coords), pos)
+                except ValueError:
+                    raise ValueError('The `bounding_box` is larger than the input'
+                                     ' out in one or more dimensions. Set '
+                                     '`model.bounding_box = None`.')
+        else:
+
+            if coords is None:
+                im_shape = out.shape
+                limits = [slice(i) for i in im_shape]
+                coords = np.mgrid[limits]
+
+            coords = coords[::-1]
+
+            out += self(*coords)
+
+        return out
 
     def prepare_inputs(self, *inputs, **kwargs):
         """
@@ -1493,7 +1591,6 @@ class Model(object):
             parts.append(indent(str(param_table), width=4))
 
         return '\n'.join(parts)
-
 
 class FittableModel(Model):
     """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1055,6 +1055,16 @@ class Model(object):
     def bounding_box(self):
         self._user_bounding_box = None
 
+    @property
+    def has_user_bounding_box(self):
+        """
+        A flag indicating whether or not a custom bounding_box has been
+        assigned to this model by a user, via assignment to
+        ``model.bounding_box``.
+        """
+
+        return self._user_bounding_box is not None
+
     # *** Public methods ***
 
     @abc.abstractmethod

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -945,14 +945,16 @@ class Model(object):
         A `tuple` of length `n_inputs` defining the bounding box limits, or
         `None` for no bounding box.
 
-        The default limits are given by the `bounding_box_default` method, which
-        in some cases are `None`. `bounding_box` can be set manually to an
-        array-like object of shape ``(model.n_inputs, 2)``. For further usage,
-        including how to set `bounding_box_default`, see :ref:`bounding-boxes`
+        The default limits are given by a ``bounding_box`` property or method
+        defined in the class body of a specific model.  If not defined then
+        this property just raises `NotImplementedError` by default (but may be
+        assigned a custom value by a user).  ``bounding_box`` can be set
+        manually to an array-like object of shape ``(model.n_inputs, 2)``. For
+        further usage, see :ref:`bounding-boxes`
 
         The limits are ordered according to the `numpy` indexing
         convention, and are the reverse of the model input order,
-        e.g. for inputs ``('x', 'y', 'z')``, `bounding_box` is defined:
+        e.g. for inputs ``('x', 'y', 'z')``, ``bounding_box`` is defined:
 
         * for 1D: ``(x_low, x_high)``
         * for 2D: ``((y_low, y_high), (x_low, x_high))``
@@ -961,7 +963,7 @@ class Model(object):
         Examples
         --------
 
-        Setting the `bounding_box` limits for a 1D and 2D model::
+        Setting the ``bounding_box`` limits for a 1D and 2D model:
 
         >>> from astropy.modeling.models import Gaussian1D, Gaussian2D
         >>> model_1d = Gaussian1D()
@@ -969,7 +971,7 @@ class Model(object):
         >>> model_1d.bounding_box = (-5, 5)
         >>> model_2d.bounding_box = ((-6, 6), (-5, 5))
 
-        Setting the bounding_box limits for a user-defined 3D `custom_model`::
+        Setting the bounding_box limits for a user-defined 3D `custom_model`:
 
         >>> from astropy.modeling.models import custom_model
         >>> def const3d(x, y, z, amp=1):
@@ -981,12 +983,12 @@ class Model(object):
 
         To reset ``bounding_box`` to its default limits just delete the
         user-defined value--this will reset it back to the default defined
-        on the class::
+        on the class:
 
         >>> del model_1d.bounding_box
 
         To disable the bounding box entirely (including the default),
-        set ``bounding_box`` to `None`::
+        set ``bounding_box`` to `None`:
 
         >>> model_1d.bounding_box = None
         >>> model_1d.bounding_box  # doctest: +IGNORE_EXCEPTION_DETAIL
@@ -1107,7 +1109,7 @@ class Model(object):
 
         if (coords is None) and (out is None) and (bbox is None):
             raise ValueError('If no bounding_box is set, '
-                                 'coords or out must be input.')
+                             'coords or out must be input.')
 
         # for consistent indexing
         if ndim == 1:
@@ -1128,14 +1130,16 @@ class Model(object):
             try:
                 assert out.ndim == ndim
             except AssertionError:
-                raise AssertionError('The array and model must have the same number '
-                                     'of dimensions.')
+                raise AssertionError(
+                    'The array and model must have the same number '
+                    'of dimensions.')
 
         if bbox is not None:
 
             # assures position is at center pixel, important when using add_array
-            pd = pos, delta = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2))
-                                        for bb in bbox]).astype(int).T
+            pd = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2))
+                           for bb in bbox]).astype(int).T
+            pos, delta = pd
 
             if coords is not None:
                 sub_shape = tuple(delta * 2 + 1)
@@ -1153,11 +1157,11 @@ class Model(object):
                 try:
                     out = add_array(out, self(*sub_coords), pos)
                 except ValueError:
-                    raise ValueError('The `bounding_box` is larger than the input'
-                                     ' out in one or more dimensions. Set '
-                                     '`model.bounding_box = None`.')
+                    raise ValueError(
+                        'The `bounding_box` is larger than the input out in '
+                        'one or more dimensions. Set '
+                        '`model.bounding_box = None`.')
         else:
-
             if coords is None:
                 im_shape = out.shape
                 limits = [slice(i) for i in im_shape]

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -96,7 +96,6 @@ class Gaussian1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
-    _bounding_box = 'auto'
 
     def bounding_box_default(self, factor=5.5):
         """
@@ -107,7 +106,7 @@ class Gaussian1D(Fittable1DModel):
         ----------
         factor : float
             The multiple of `stddev` used to define the limits.
-            The default is 5.5-sigma, corresponding to a relative error < 1e-7.
+            The default is 5.5, corresponding to a relative error < 1e-7.
 
         Examples
         --------
@@ -116,8 +115,9 @@ class Gaussian1D(Fittable1DModel):
         >>> model.bounding_box
         (-11.0, 11.0)
 
-        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by
-        using a different factor, like:
+        This range can be set directly (see: `Model.bounding_box
+        <astropy.modeling.Model.bounding_box>`) or by using a different factor,
+        like:
 
         >>> model.bounding_box = model.bounding_box_default(factor=2)
         >>> model.bounding_box
@@ -176,6 +176,37 @@ class GaussianAbsorption1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
+
+    def bounding_box_default(self, factor=5.5):
+        """
+        Tuple defining the default ``bounding_box`` limits,
+        ``(x_low, x_high)``
+
+        Parameters
+        ----------
+        factor : float
+            The multiple of `stddev` used to define the limits.
+            The default is 5.5, corresponding to a relative error < 1e-7.
+
+        Examples
+        --------
+        >>> from astropy.modeling.models import Gaussian1D
+        >>> model = Gaussian1D(mean=0, stddev=2)
+        >>> model.bounding_box
+        (-11.0, 11.0)
+
+        This range can be set directly (see: ``help(model.bounding_box)``) or by
+        using a different factor, like:
+
+        >>> model.bounding_box = model.bounding_box_default(factor=2)
+        >>> model.bounding_box
+        (-4.0, 4.0)
+        """
+
+        x0 = self.mean.value
+        dx = factor * self.stddev
+
+        return (x0 - dx, x0 + dx)
 
     @staticmethod
     def evaluate(x, amplitude, mean, stddev):
@@ -277,7 +308,6 @@ class Gaussian2D(Fittable2DModel):
     x_stddev = Parameter(default=1)
     y_stddev = Parameter(default=1)
     theta = Parameter(default=0)
-    _bounding_box = 'auto'
 
     def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
                  y_mean=y_mean.default, x_stddev=None, y_stddev=None,
@@ -340,8 +370,9 @@ class Gaussian2D(Fittable2DModel):
         >>> model.bounding_box
         ((-11.0, 11.0), (-5.5, 5.5))
 
-        This range can be set directly (see: `astropy.modeling.Model.bounding_box`) or by
-        using a different factor like:
+        This range can be set directly (see: `Model.bounding_box
+        <astropy.modeling.Model.bounding_box>`) or by using a different factor
+        like:
 
         >>> model.bounding_box = model.bounding_box_default(factor=2)
         >>> model.bounding_box
@@ -446,7 +477,6 @@ class Shift(Model):
     def evaluate(x, offset):
         return x + offset
 
-
 class Scale(Model):
     """
     Multiply a model by a factor.
@@ -472,7 +502,6 @@ class Scale(Model):
     @staticmethod
     def evaluate(x, factor):
         return factor * x
-
 
 class Redshift(Fittable1DModel):
     """
@@ -512,7 +541,6 @@ class Redshift(Fittable1DModel):
         inv = self.copy()
         inv.z = 1.0 / (1.0 + self.z) - 1.0
         return inv
-
 
 class Sersic1D(Fittable1DModel):
     r"""
@@ -599,7 +627,6 @@ class Sersic1D(Fittable1DModel):
         """One dimensional Sersic profile function."""
         return amplitude * np.exp(-cls._gammaincinv(2 * n, 0.5) * ((r / r_eff) ** (1 / n) - 1))
 
-
 class Sine1D(Fittable1DModel):
     """
     One dimensional Sine model.
@@ -645,7 +672,6 @@ class Sine1D(Fittable1DModel):
         d_phase = (2 * np.pi * amplitude *
                    np.cos(2 * np.pi * frequency * x + 2 * np.pi * phase))
         return [d_amplitude, d_frequency, d_phase]
-
 
 class Linear1D(Fittable1DModel):
     """
@@ -742,7 +768,6 @@ class Lorentz1D(Fittable1DModel):
         d_fwhm = 2 * amplitude * d_amplitude / fwhm * (1 - d_amplitude)
         return [d_amplitude, d_x_0, d_fwhm]
 
-
 class Voigt1D(Fittable1DModel):
     """
     One dimensional model for the Voigt profile.
@@ -834,7 +859,6 @@ class Voigt1D(Fittable1DModel):
                 -constant * (V + (sqrt_ln2 / fwhm_G) * (2 * (x - x_0) * dVdx + fwhm_L * dVdy)) / fwhm_G]
         return dyda
 
-
 class Const1D(Fittable1DModel):
     """
     One dimensional Constant model.
@@ -880,7 +904,6 @@ class Const1D(Fittable1DModel):
         d_amplitude = np.ones_like(x)
         return [d_amplitude]
 
-
 class Const2D(Fittable2DModel):
     """
     Two dimensional Constant model.
@@ -918,7 +941,6 @@ class Const2D(Fittable2DModel):
             x = amplitude * np.ones_like(x)
 
         return x
-
 
 class Ellipse2D(Fittable2DModel):
     """
@@ -996,26 +1018,6 @@ class Ellipse2D(Fittable2DModel):
     a = Parameter(default=1)
     b = Parameter(default=1)
     theta = Parameter(default=0)
-    _bounding_box = 'auto'
-
-    def bounding_box_default(self):
-        """
-        Tuple defining the default ``bounding_box`` limits around the ellipse.
-
-        ``((y_low, y_high), (x_low, x_high))``
-
-        References
-        ----------
-        `astropy.modeling.Model.bounding_box`
-        """
-
-        a = self.a
-        b = self.b
-        theta = self.theta.value
-        dx, dy = ellipse_extent(a, b, theta)
-
-        return ((self.y_0 - dy, self.y_0 + dy),
-                (self.x_0 - dx, self.x_0 + dx))
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, a, b, theta):
@@ -1030,6 +1032,20 @@ class Ellipse2D(Fittable2DModel):
         in_ellipse = (((numerator1 / a) ** 2 + (numerator2 / b) ** 2) <= 1.)
         return np.select([in_ellipse], [amplitude])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        a = self.a
+        b = self.b
+        theta = self.theta.value
+        dx, dy = ellipse_extent(a, b, theta)
+
+        return ((self.y_0 - dy, self.y_0 + dy),
+                (self.x_0 - dx, self.x_0 + dx))
 
 class Disk2D(Fittable2DModel):
     """
@@ -1076,6 +1092,16 @@ class Disk2D(Fittable2DModel):
         rr = (x - x_0) ** 2 + (y - y_0) ** 2
         return np.select([rr <= R_0 ** 2], [amplitude])
 
+
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        return ((self.y_0 - self.R_0, self.y_0 + self.R_0),
+                (self.x_0 - self.R_0, self.x_0 + self.R_0))
 
 class Ring2D(Fittable2DModel):
     """
@@ -1145,6 +1171,17 @@ class Ring2D(Fittable2DModel):
         r_range = np.logical_and(rr >= r_in ** 2, rr <= (r_in + width) ** 2)
         return np.select([r_range], [amplitude])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box``.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        dr = self.r_in + self.width
+
+        return ((self.y_0 - dr, self.y_0 + dr),
+                (self.x_0 - dr, self.x_0 + dr))
 
 class Delta1D(Fittable1DModel):
     """One dimensional Dirac delta function."""
@@ -1212,6 +1249,16 @@ class Box1D(Fittable1DModel):
         d_width = np.zeros_like(x)
         return [d_amplitude, d_x_0, d_width]
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``(x_low, x_high))``
+        """
+
+        dx = self.width / 2
+
+        return (self.x_0 - dx, self.x_0 + dx)
 
 class Box2D(Fittable2DModel):
     """
@@ -1266,6 +1313,18 @@ class Box2D(Fittable2DModel):
                                  y <= y_0 + y_width / 2.)
         return np.select([np.logical_and(x_range, y_range)], [amplitude], 0)
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box``.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        dx = self.x_width / 2
+        dy = self.y_width / 2
+
+        return ((self.y_0 - dy, self.y_0 + dy),
+                (self.x_0 - dx, self.x_0 + dx))
 
 class Trapezoid1D(Fittable1DModel):
     """
@@ -1312,6 +1371,16 @@ class Trapezoid1D(Fittable1DModel):
         val_c = slope * (x4 - x)
         return np.select([range_a, range_b, range_c], [val_a, val_b, val_c])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box`` limits.
+
+        ``(x_low, x_high))``
+        """
+
+        dx = self.width / 2 + self.amplitude / self.slope
+
+        return (self.x_0 - dx, self.x_0 + dx)
 
 class TrapezoidDisk2D(Fittable2DModel):
     """
@@ -1352,6 +1421,17 @@ class TrapezoidDisk2D(Fittable2DModel):
         val_2 = amplitude + slope * (R_0 - r)
         return np.select([range_1, range_2], [val_1, val_2])
 
+    def bounding_box_default(self):
+        """
+        Tuple defining the default ``bounding_box``.
+
+        ``((y_low, y_high), (x_low, x_high))``
+        """
+
+        dr = self.R_0 + self.amplitude / self.slope
+
+        return ((self.y_0 - dr, self.y_0 + dr),
+                (self.x_0 - dr, self.x_0 + dr))
 
 class MexicanHat1D(Fittable1DModel):
     """
@@ -1391,7 +1471,6 @@ class MexicanHat1D(Fittable1DModel):
 
         xx_ww = (x - x_0) ** 2 / (2 * sigma ** 2)
         return amplitude * (1 - 2 * xx_ww) * np.exp(-xx_ww)
-
 
 class MexicanHat2D(Fittable2DModel):
     """
@@ -1435,7 +1514,6 @@ class MexicanHat2D(Fittable2DModel):
 
         rr_ww = ((x - x_0) ** 2 + (y - y_0) ** 2) / (2 * sigma ** 2)
         return amplitude * (1 - rr_ww) * np.exp(- rr_ww)
-
 
 class AiryDisk2D(Fittable2DModel):
     """
@@ -1526,7 +1604,6 @@ class AiryDisk2D(Fittable2DModel):
         z *= amplitude
         return z
 
-
 class Moffat1D(Fittable1DModel):
     """
     One dimensional Moffat model.
@@ -1577,7 +1654,6 @@ class Moffat1D(Fittable1DModel):
                    (gamma ** 3 * d_A ** alpha))
         d_alpha = -amplitude * d_A * np.log(1 + (x - x_0) ** 2 / gamma ** 2)
         return [d_A, d_x_0, d_gamma, d_alpha]
-
 
 class Moffat2D(Fittable2DModel):
     """
@@ -1636,7 +1712,6 @@ class Moffat2D(Fittable2DModel):
         d_alpha = -amplitude * d_A * np.log(1 + rr_gg)
         d_gamma = 2 * amplitude * alpha * d_A * (rr_gg / (gamma * (1 + rr_gg)))
         return [d_A, d_x_0, d_y_0, d_gamma, d_alpha]
-
 
 class Sersic2D(Fittable2DModel):
     r"""
@@ -1745,7 +1820,6 @@ class Sersic2D(Fittable2DModel):
         z = np.sqrt((x_maj / a) ** 2 + (x_min / b) ** 2)
 
         return amplitude * np.exp(-bn * (z ** (1 / n) - 1))
-
 
 @deprecated('1.0', alternative='astropy.modeling.models.custom_model',
             pending=True)

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -97,7 +97,7 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
-    def bounding_box_default(self, factor=5.5):
+    def bounding_box(self, factor=5.5):
         """
         Tuple defining the default ``bounding_box`` limits,
         ``(x_low, x_high)``
@@ -119,7 +119,7 @@ class Gaussian1D(Fittable1DModel):
         <astropy.modeling.Model.bounding_box>`) or by using a different factor,
         like:
 
-        >>> model.bounding_box = model.bounding_box_default(factor=2)
+        >>> model.bounding_box = model.bounding_box(factor=2)
         >>> model.bounding_box
         (-4.0, 4.0)
         """
@@ -177,7 +177,7 @@ class GaussianAbsorption1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
-    def bounding_box_default(self, factor=5.5):
+    def bounding_box(self, factor=5.5):
         """
         Tuple defining the default ``bounding_box`` limits,
         ``(x_low, x_high)``
@@ -198,7 +198,7 @@ class GaussianAbsorption1D(Fittable1DModel):
         This range can be set directly (see: ``help(model.bounding_box)``) or by
         using a different factor, like:
 
-        >>> model.bounding_box = model.bounding_box_default(factor=2)
+        >>> model.bounding_box = model.bounding_box(factor=2)
         >>> model.bounding_box
         (-4.0, 4.0)
         """
@@ -349,7 +349,7 @@ class Gaussian2D(Fittable2DModel):
             amplitude=amplitude, x_mean=x_mean, y_mean=y_mean,
             x_stddev=x_stddev, y_stddev=y_stddev, theta=theta, **kwargs)
 
-    def bounding_box_default(self, factor=5.5):
+    def bounding_box(self, factor=5.5):
         """
         Tuple defining the default ``bounding_box`` limits in each dimension,
         ``((y_low, y_high), (x_low, x_high))``
@@ -374,7 +374,7 @@ class Gaussian2D(Fittable2DModel):
         <astropy.modeling.Model.bounding_box>`) or by using a different factor
         like:
 
-        >>> model.bounding_box = model.bounding_box_default(factor=2)
+        >>> model.bounding_box = model.bounding_box(factor=2)
         >>> model.bounding_box
         ((-4.0, 4.0), (-2.0, 2.0))
         """
@@ -477,6 +477,7 @@ class Shift(Model):
     def evaluate(x, offset):
         return x + offset
 
+
 class Scale(Model):
     """
     Multiply a model by a factor.
@@ -502,6 +503,7 @@ class Scale(Model):
     @staticmethod
     def evaluate(x, factor):
         return factor * x
+
 
 class Redshift(Fittable1DModel):
     """
@@ -541,6 +543,7 @@ class Redshift(Fittable1DModel):
         inv = self.copy()
         inv.z = 1.0 / (1.0 + self.z) - 1.0
         return inv
+
 
 class Sersic1D(Fittable1DModel):
     r"""
@@ -627,6 +630,7 @@ class Sersic1D(Fittable1DModel):
         """One dimensional Sersic profile function."""
         return amplitude * np.exp(-cls._gammaincinv(2 * n, 0.5) * ((r / r_eff) ** (1 / n) - 1))
 
+
 class Sine1D(Fittable1DModel):
     """
     One dimensional Sine model.
@@ -672,6 +676,7 @@ class Sine1D(Fittable1DModel):
         d_phase = (2 * np.pi * amplitude *
                    np.cos(2 * np.pi * frequency * x + 2 * np.pi * phase))
         return [d_amplitude, d_frequency, d_phase]
+
 
 class Linear1D(Fittable1DModel):
     """
@@ -768,6 +773,7 @@ class Lorentz1D(Fittable1DModel):
         d_fwhm = 2 * amplitude * d_amplitude / fwhm * (1 - d_amplitude)
         return [d_amplitude, d_x_0, d_fwhm]
 
+
 class Voigt1D(Fittable1DModel):
     """
     One dimensional model for the Voigt profile.
@@ -859,6 +865,7 @@ class Voigt1D(Fittable1DModel):
                 -constant * (V + (sqrt_ln2 / fwhm_G) * (2 * (x - x_0) * dVdx + fwhm_L * dVdy)) / fwhm_G]
         return dyda
 
+
 class Const1D(Fittable1DModel):
     """
     One dimensional Constant model.
@@ -904,6 +911,7 @@ class Const1D(Fittable1DModel):
         d_amplitude = np.ones_like(x)
         return [d_amplitude]
 
+
 class Const2D(Fittable2DModel):
     """
     Two dimensional Constant model.
@@ -941,6 +949,7 @@ class Const2D(Fittable2DModel):
             x = amplitude * np.ones_like(x)
 
         return x
+
 
 class Ellipse2D(Fittable2DModel):
     """
@@ -1032,7 +1041,8 @@ class Ellipse2D(Fittable2DModel):
         in_ellipse = (((numerator1 / a) ** 2 + (numerator2 / b) ** 2) <= 1.)
         return np.select([in_ellipse], [amplitude])
 
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box`` limits.
 
@@ -1046,6 +1056,7 @@ class Ellipse2D(Fittable2DModel):
 
         return ((self.y_0 - dy, self.y_0 + dy),
                 (self.x_0 - dx, self.x_0 + dx))
+
 
 class Disk2D(Fittable2DModel):
     """
@@ -1092,8 +1103,8 @@ class Disk2D(Fittable2DModel):
         rr = (x - x_0) ** 2 + (y - y_0) ** 2
         return np.select([rr <= R_0 ** 2], [amplitude])
 
-
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box`` limits.
 
@@ -1102,6 +1113,7 @@ class Disk2D(Fittable2DModel):
 
         return ((self.y_0 - self.R_0, self.y_0 + self.R_0),
                 (self.x_0 - self.R_0, self.x_0 + self.R_0))
+
 
 class Ring2D(Fittable2DModel):
     """
@@ -1171,7 +1183,8 @@ class Ring2D(Fittable2DModel):
         r_range = np.logical_and(rr >= r_in ** 2, rr <= (r_in + width) ** 2)
         return np.select([r_range], [amplitude])
 
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box``.
 
@@ -1182,6 +1195,7 @@ class Ring2D(Fittable2DModel):
 
         return ((self.y_0 - dr, self.y_0 + dr),
                 (self.x_0 - dr, self.x_0 + dr))
+
 
 class Delta1D(Fittable1DModel):
     """One dimensional Dirac delta function."""
@@ -1249,7 +1263,8 @@ class Box1D(Fittable1DModel):
         d_width = np.zeros_like(x)
         return [d_amplitude, d_x_0, d_width]
 
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box`` limits.
 
@@ -1259,6 +1274,7 @@ class Box1D(Fittable1DModel):
         dx = self.width / 2
 
         return (self.x_0 - dx, self.x_0 + dx)
+
 
 class Box2D(Fittable2DModel):
     """
@@ -1313,7 +1329,8 @@ class Box2D(Fittable2DModel):
                                  y <= y_0 + y_width / 2.)
         return np.select([np.logical_and(x_range, y_range)], [amplitude], 0)
 
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box``.
 
@@ -1325,6 +1342,7 @@ class Box2D(Fittable2DModel):
 
         return ((self.y_0 - dy, self.y_0 + dy),
                 (self.x_0 - dx, self.x_0 + dx))
+
 
 class Trapezoid1D(Fittable1DModel):
     """
@@ -1371,7 +1389,8 @@ class Trapezoid1D(Fittable1DModel):
         val_c = slope * (x4 - x)
         return np.select([range_a, range_b, range_c], [val_a, val_b, val_c])
 
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box`` limits.
 
@@ -1381,6 +1400,7 @@ class Trapezoid1D(Fittable1DModel):
         dx = self.width / 2 + self.amplitude / self.slope
 
         return (self.x_0 - dx, self.x_0 + dx)
+
 
 class TrapezoidDisk2D(Fittable2DModel):
     """
@@ -1421,7 +1441,8 @@ class TrapezoidDisk2D(Fittable2DModel):
         val_2 = amplitude + slope * (R_0 - r)
         return np.select([range_1, range_2], [val_1, val_2])
 
-    def bounding_box_default(self):
+    @property
+    def bounding_box(self):
         """
         Tuple defining the default ``bounding_box``.
 
@@ -1432,6 +1453,7 @@ class TrapezoidDisk2D(Fittable2DModel):
 
         return ((self.y_0 - dr, self.y_0 + dr),
                 (self.x_0 - dr, self.x_0 + dr))
+
 
 class MexicanHat1D(Fittable1DModel):
     """
@@ -1471,6 +1493,7 @@ class MexicanHat1D(Fittable1DModel):
 
         xx_ww = (x - x_0) ** 2 / (2 * sigma ** 2)
         return amplitude * (1 - 2 * xx_ww) * np.exp(-xx_ww)
+
 
 class MexicanHat2D(Fittable2DModel):
     """
@@ -1514,6 +1537,7 @@ class MexicanHat2D(Fittable2DModel):
 
         rr_ww = ((x - x_0) ** 2 + (y - y_0) ** 2) / (2 * sigma ** 2)
         return amplitude * (1 - rr_ww) * np.exp(- rr_ww)
+
 
 class AiryDisk2D(Fittable2DModel):
     """
@@ -1604,6 +1628,7 @@ class AiryDisk2D(Fittable2DModel):
         z *= amplitude
         return z
 
+
 class Moffat1D(Fittable1DModel):
     """
     One dimensional Moffat model.
@@ -1654,6 +1679,7 @@ class Moffat1D(Fittable1DModel):
                    (gamma ** 3 * d_A ** alpha))
         d_alpha = -amplitude * d_A * np.log(1 + (x - x_0) ** 2 / gamma ** 2)
         return [d_A, d_x_0, d_gamma, d_alpha]
+
 
 class Moffat2D(Fittable2DModel):
     """
@@ -1712,6 +1738,7 @@ class Moffat2D(Fittable2DModel):
         d_alpha = -amplitude * d_A * np.log(1 + rr_gg)
         d_gamma = 2 * amplitude * alpha * d_A * (rr_gg / (gamma * (1 + rr_gg)))
         return [d_A, d_x_0, d_y_0, d_gamma, d_alpha]
+
 
 class Sersic2D(Fittable2DModel):
     r"""
@@ -1820,6 +1847,7 @@ class Sersic2D(Fittable2DModel):
         z = np.sqrt((x_maj / a) ** 2 + (x_min / b) ** 2)
 
         return amplitude * np.exp(-bn * (z ** (1 / n) - 1))
+
 
 @deprecated('1.0', alternative='astropy.modeling.models.custom_model',
             pending=True)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -322,7 +322,8 @@ def test_render_model_3d():
         return val
 
     class Ellipsoid3D(custom_model(ellipsoid)):
-        def bounding_box_default(self):
+        @property
+        def bounding_box(self):
             return ((self.z0 - self.c, self.z0 + self.c),
                     (self.y0 - self.b, self.y0 + self.b),
                     (self.x0 - self.a, self.x0 + self.a))

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import numpy as np
 from numpy.testing.utils import assert_allclose
-from ..core import Model, InputParameterError, custom_model, render_model
+from ..core import Model, InputParameterError, custom_model
 from ..parameters import Parameter
 from .. import models
 
@@ -239,43 +239,52 @@ def test_custom_inverse_reset():
 
 
 def test_render_model_2d():
-
     imshape = (71, 141)
     image = np.zeros(imshape)
     coords = y, x = np.indices(imshape)
 
-    model = models.Gaussian2D(x_stddev=6.1, y_stddev=3.9, theta=np.pi / 4)
+    model = models.Gaussian2D(x_stddev=6.1, y_stddev=3.9, theta=np.pi / 3)
 
     # test points for edges
     ye, xe = [0, 35, 70], [0, 70, 140]
     # test points for floating point positions
     yf, xf = [35.1, 35.5, 35.9], [70.1, 70.5, 70.9]
 
-    test_pts = [(a, b) for a in xe for b in ye] + [(a, b) for a in xf for b in yf]
+    test_pts = [(a, b) for a in xe for b in ye]
+    test_pts += [(a, b) for a in xf for b in yf]
 
     for x0, y0 in test_pts:
         model.x_mean = x0
         model.y_mean = y0
         expected = model(x, y)
-        for im in [image, None]:
-            for xy in [coords, None]:
+        for xy in [coords, None]:
+            for im in [image.copy(), None]:
                 if (im is None) & (xy is None):
                     # this case is tested in Fittable2DModelTester
                     continue
-                actual = render_model(model, arr=image, coords=xy)
+                actual = model.render(out=im, coords=xy)
+                if im is None:
+                    assert_allclose(actual, model.render(coords=xy))
                 # assert images match
-                assert_allclose(expected, actual, atol=2e-7)
-                # assert flux conserved
-                assert ((np.sum(expected) - np.sum(actual)) / np.sum(expected)) < 1e-7
+                assert_allclose(expected, actual, atol=3e-7)
+                # assert model fully captured
+                if (x0, y0) == (70, 35):
+                    boxed = model.render()
+                    flux = np.sum(expected)
+                    assert ((flux - np.sum(boxed)) / flux) < 1e-7
+    # test an error is raised when the bounding box is larger than the input array
+    try:
+        actual = model.render(out=np.zeros((1, 1)))
+    except ValueError:
+        pass
 
 
 def test_render_model_1d():
-
     npix = 101
     image = np.zeros(npix)
     coords = np.arange(npix)
 
-    model = models.Gaussian1D(stddev=49.5)
+    model = models.Gaussian1D()
 
     # test points
     test_pts = [0, 49.1, 49.5, 49.9, 100]
@@ -283,20 +292,23 @@ def test_render_model_1d():
     # test widths
     test_stdv = np.arange(5.5, 6.7, .2)
 
-    for x0, stdv in zip(test_pts, test_stdv):
+    for x0, stdv in [(p, s) for p in test_pts for s in test_stdv]:
         model.mean = x0
         model.stddev = stdv
         expected = model(coords)
-        for im in [image, None]:
-            for x in [coords, None]:
+        for x in [coords, None]:
+            for im in [image.copy(), None]:
                 if (im is None) & (x is None):
                     # this case is tested in Fittable1DModelTester
                     continue
-                actual = render_model(model, arr=image, coords=x)
+                actual = model.render(out=im, coords=x)
                 # assert images match
-                assert_allclose(expected, actual, atol=2e-7)
-                # assert flux conserved
-                assert ((np.sum(expected) - np.sum(actual)) / np.sum(expected)) < 1e-7
+                assert_allclose(expected, actual, atol=3e-7)
+                # assert model fully captured
+                if (x0, stdv) == (49.5, 5.5):
+                    boxed = model.render()
+                    flux = np.sum(expected)
+                    assert ((flux - np.sum(boxed)) / flux) < 1e-7
 
 
 def test_render_model_3d():
@@ -309,7 +321,11 @@ def test_render_model_3d():
         val = (rsq < 1) * amp
         return val
 
-    Ellipsoid3D = models.custom_model(ellipsoid)
+    class Ellipsoid3D(custom_model(ellipsoid)):
+        def bounding_box_default(self):
+            return ((self.z0 - self.c, self.z0 + self.c),
+                    (self.y0 - self.b, self.y0 + self.b),
+                    (self.x0 - self.a, self.x0 + self.a))
 
     model = Ellipsoid3D()
 
@@ -321,17 +337,20 @@ def test_render_model_3d():
     test_pts = [(x, y, z) for x in xe for y in ye for z in ze]
     test_pts += [(x, y, z) for x in xf for y in yf for z in zf]
 
-    for x0, y0, z0 in [(8,10,13)]:#test_pts:
+    for x0, y0, z0 in test_pts:
         model.x0 = x0
         model.y0 = y0
         model.z0 = z0
         expected = model(*coords[::-1])
-        for im in [image, None]:
-            for c in [coords, None]:
+        for c in [coords, None]:
+            for im in [image.copy(), None]:
                 if (im is None) & (c is None):
                     continue
-                actual = render_model(model, arr=image, coords=c)
+                actual = model.render(out=im, coords=c)
+                boxed = model.render()
                 # assert images match
                 assert_allclose(expected, actual)
-                # assert flux conserved
-                assert ((np.sum(expected) - np.sum(actual)) / np.sum(expected)) == 0
+                # assert model fully captured
+                if (z0, y0, x0) == (8, 10, 13):
+                    boxed = model.render()
+                    assert (np.sum(expected) - np.sum(boxed)) == 0

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -34,7 +34,7 @@ def test_GaussianAbsorption1D():
     assert_allclose(g_ab(xx), 1 - g_em(xx))
     assert_allclose(g_ab.fit_deriv(xx[0], 0.8, 3000, 20),
                     -np.array(g_em.fit_deriv(xx[0], 0.8, 3000, 20)))
-    assert g_ab.bounding_box_default() == g_em.bounding_box
+    assert g_ab.bounding_box == g_em.bounding_box
 
 
 def test_Gaussian2D():
@@ -120,7 +120,6 @@ def test_Ellipse2D():
     e = em(x, y)
     assert np.all(e[e > 0] == amplitude)
     assert e[y0, x0] == amplitude
-    assert em.bounding_box_default() == em.bounding_box
 
     rotation = models.Rotation2D(angle=theta.degree)
     point1 = [2, 0]      # Rotation2D center is (0, 0)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -34,6 +34,7 @@ def test_GaussianAbsorption1D():
     assert_allclose(g_ab(xx), 1 - g_em(xx))
     assert_allclose(g_ab.fit_deriv(xx[0], 0.8, 3000, 20),
                     -np.array(g_em.fit_deriv(xx[0], 0.8, 3000, 20)))
+    assert g_ab.bounding_box_default() == g_em.bounding_box
 
 
 def test_Gaussian2D():
@@ -119,6 +120,7 @@ def test_Ellipse2D():
     e = em(x, y)
     assert np.all(e[e > 0] == amplitude)
     assert e[y0, x0] == amplitude
+    assert em.bounding_box_default() == em.bounding_box
 
     rotation = models.Rotation2D(angle=theta.degree)
     point1 = [2, 0]      # Rotation2D center is (0, 0)

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -8,7 +8,6 @@ import operator
 import numpy as np
 
 from ..utils import ExpressionTree as ET, ellipse_extent
-from ..core import render_model
 from ..models import Ellipse2D
 
 
@@ -91,7 +90,7 @@ def test_ellipse_extent():
 
     model.bounding_box = limits
 
-    actual = render_model(model, coords=coords)
+    actual = model.render(coords=coords)
 
     expected = model(x, y)
 

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -676,11 +676,11 @@ class Cutout2D(object):
         self.input_position_original = position
         self.shape_input = shape
 
-        ((self.xmin_original, self.xmax_original),
-         (self.ymin_original, self.ymax_original)) = self.bbox_original
+        ((self.ymin_original, self.ymax_original),
+         (self.xmin_original, self.xmax_original)) = self.bbox_original
 
-        ((self.xmin_cutout, self.xmax_cutout),
-         (self.ymin_cutout, self.ymax_cutout)) = self.bbox_cutout
+        ((self.ymin_cutout, self.ymax_cutout),
+         (self.xmin_cutout, self.xmax_cutout)) = self.bbox_cutout
 
         # the true origin pixel of the cutout array, including any
         # filled cutout values
@@ -786,14 +786,14 @@ class Cutout2D(object):
     @staticmethod
     def _calc_bbox(slices):
         """
-        Calculate a minimal bounding box in the form ``((xmin, xmax),
-        (ymin, ymax))``.  Note these are pixel locations, not slice
+        Calculate a minimal bounding box in the form ``((ymin, ymax),
+        (xmin, xmax))``.  Note these are pixel locations, not slice
         indices.  For ``mode='partial'``, the bounding box indices are
         for the valid (non-filled) cutout values.
         """
         # (stop - 1) to return the max pixel location, not the slice index
-        return ((slices[1].start, slices[1].stop - 1),
-                (slices[0].start, slices[0].stop - 1))
+        return ((slices[0].start, slices[0].stop - 1),
+                (slices[1].start, slices[1].stop - 1))
 
     @lazyproperty
     def origin_original(self):
@@ -853,7 +853,7 @@ class Cutout2D(object):
     @lazyproperty
     def bbox_original(self):
         """
-        The bounding box ``(ymin, xmin, ymax, xmax)`` of the minimal
+        The bounding box ``((ymin, ymax), (xmin, xmax))`` of the minimal
         rectangular region of the cutout array with respect to the
         original array.  For ``mode='partial'``, the bounding box
         indices are for the valid (non-filled) cutout values.
@@ -863,7 +863,7 @@ class Cutout2D(object):
     @lazyproperty
     def bbox_cutout(self):
         """
-        The bounding box ``(ymin, xmin, ymax, xmax)`` of the minimal
+        The bounding box ``((ymin, ymax), (xmin, xmax))`` of the minimal
         rectangular region of the cutout array with respect to the
         cutout array.  For ``mode='partial'``, the bounding box indices
         are for the valid (non-filled) cutout values.

--- a/docs/modeling/bounding-boxes.rst
+++ b/docs/modeling/bounding-boxes.rst
@@ -47,7 +47,8 @@ be set by the user to any callable. This is particularly useful for fitting
     ...
     >>> class Ellipsoid3D(custom_model(ellipsoid)):
     ...     # A 3D ellipsoid model
-    ...     def bounding_box_default(self):
+    ...     @property
+    ...     def bounding_box(self):
     ...         return ((self.z0 - self.c, self.z0 + self.c),
     ...                 (self.y0 - self.b, self.y0 + self.b),
     ...                 (self.x0 - self.a, self.x0 + self.a))
@@ -131,7 +132,7 @@ speed increases by approximately a factor of 10 with negligible loss of informat
 	ax = plt.subplot(122)
 	plt.imshow(bb_image, origin='lower')
 	for model in model_list:
-	    dy, dx = np.diff(model.bounding_box_default()).flatten()
+	    dy, dx = np.diff(model.bounding_box).flatten()
 	    pos = (model.x_mean.value - dx / 2, model.y_mean.value - dy / 2)
 	    r = Rectangle(pos, dx, dy, edgecolor='w', facecolor='none', alpha=.25)
 	    ax.add_patch(r)

--- a/docs/modeling/bounding-boxes.rst
+++ b/docs/modeling/bounding-boxes.rst
@@ -5,7 +5,8 @@ Efficient Model Rendering with Bounding Boxes
 
 .. versionadded:: 1.1
 
-All `astropy.modeling.Model` subclasses have a ``bounding_box`` attribute that
+All `Model <astropy.modeling.Model>` subclasses have a
+`bounding_box <astropy.modeling.Model.bounding_box>` attribute that
 can be used to set the limits over which the model is significant. This greatly
 improves the efficiency of evaluation when the input range is much larger than
 the characteristic width of the model itself. For example, to create a sky model
@@ -13,137 +14,138 @@ image from a large survey catalog, each source should only be evaluated over the
 pixels to which it contributes a significant amount of flux. This task can
 otherwise be computationally prohibitive on an average CPU.
 
-The `astropy.modeling.render_model` function can be used to evaluate a model on
-an input array, or coordinates, limiting the evaluation to the ``bounding_box``
-region if it is set. This function will also produce postage stamp images of the
-model if no other input array is passed. To instead extract postage
-stamps from the data array itself, see :ref:`cutout_images`.
+The :func:`Model.render <astropy.modeling.Model.render>` method can be used to
+evaluate a model on an output array, or input coordinate arrays, limiting the
+evaluation to the `bounding_box <astropy.modeling.Model.bounding_box>` region if
+it is set. This function will also produce postage stamp images of the model if
+no other input array is passed. To instead extract postage stamps from the data
+array itself, see :ref:`cutout_images`.
 
 Using the Bounding Box
 -----------------------
 
-For basic usage, see `astropy.modeling.Model.bounding_box`.
-By default no bounding box is set (``bounding_box`` is `None`), except for
-individual model subclasses that have a ``bounding_box_default`` function
-defined. ``bounding_box_default`` returns the minimum rectangular region
-symmetric about the position that fully contains the model if the model has a
-finite extent. If a model does not have a finite extent, the choice for the
-``bounding_box_default`` limits is noted in the docstring. For example, see
-`astropy.modeling.functional_models.Gaussian2D.bounding_box_default`.
+For basic usage, see `Model.bounding_box <astropy.modeling.Model.bounding_box>`.
+By default no `bounding_box <astropy.modeling.Model.bounding_box>` is set
+(:func:`Model.bounding_box_default <astropy.modeling.Model.bounding_box_default>`
+returns `None`), except for model subclasses where :func:`bounding_box_default
+<astropy.modeling.Model.bounding_box_default>` is explicity defined. The default
+is then the minimum rectangular region symmetric about the position that fully
+contains the model. If the model does not have a finite extent, the containment
+criteria are noted in the documentation. For example, see
+`Gaussian2D.bounding_box_default
+<astropy.modeling.functional_models.Gaussian2D.bounding_box_default>`.
 
-The default function can also be set to any callable. This is particularly
-useful for fitting ``custom_model`` or ``CompoundModel`` instances.
+`Model.bounding_box_default <astropy.modeling.Model.bounding_box_default>` can
+be set by the user to any callable. This is particularly useful for fitting
+``custom_model`` or ``CompoundModel`` instances.
 
     >>> from astropy.modeling import custom_model
     >>> def ellipsoid(x, y, z, x0=0, y0=0, z0=0, a=2, b=3, c=4, amp=1):
-    ...     rsq = ((x-x0)/a) ** 2 + ((y-y0)/b) ** 2 + ((z-z0)/c) ** 2
+    ...     rsq = ((x - x0) / a) ** 2 + ((y - y0) / b) ** 2 + ((z - z0) / c) ** 2
     ...     val = (rsq < 1) * amp
     ...     return val
     ...
-    >>> def ellipsoid_bb(self):
-    ...     return ((self.z0 - self.c, self.z0 + self.c),
-    ...             (self.y0 - self.b, self.y0 + self.b),
-    ...             (self.x0 - self.a, self.x0 + self.a))
+    >>> class Ellipsoid3D(custom_model(ellipsoid)):
+    ...     # A 3D ellipsoid model
+    ...     def bounding_box_default(self):
+    ...         return ((self.z0 - self.c, self.z0 + self.c),
+    ...                 (self.y0 - self.b, self.y0 + self.b),
+    ...                 (self.x0 - self.a, self.x0 + self.a))
     ...
-    >>> Ellipsoid3D = custom_model(ellipsoid)
-    >>> Ellipsoid3D.bounding_box_default = ellipsoid_bb
     >>> model = Ellipsoid3D()
-    >>> model.bounding_box = 'auto'
     >>> model.bounding_box
     ((-4.0, 4.0), (-3.0, 3.0), (-2.0, 2.0))
 
-Efficient evaluation with ``render_model``
-------------------------------------------
+Efficient evaluation with :func:`Model.render() <astropy.modeling.Model.render>`
+--------------------------------------------------------------------------------
 
 When a model is evaluated over a range much larger than the model itself, it may
-be prudent to use `astropy.modeling.render_model` if efficiency is a concern.
-The ``render_model`` function can be used to evaluate a model on an array of the
-same dimensions. If no array is given, ``render_model`` will return a "postage
-stamp" array corresponding to the bounding box region. However, if
-``bounding_box`` is `None` an image or coordinates must be passed.
+be prudent to use the :func:`Model.render <astropy.modeling.Model.render>`
+method if efficiency is a concern. The :func:`render <astropy.modeling.Model.render>`
+method can be used to evaluate the model on an array of the same dimensions.
+``model.render()`` can be called with no arguments to return a "postage
+stamp" of the bounding box region.
 
 In this example, we generate a 300x400 pixel image of 100 2D
-Gaussian sources both with and without using bounding boxes. Using bounding
-boxes, the evaluation speed increases by approximately a factor of 10 with
-negligible loss of information.
+Gaussian sources. For comparison, the models are evaluated
+both with and without using bounding boxes. By using bounding boxes, the evaluation
+speed increases by approximately a factor of 10 with negligible loss of information.
 
 .. plot::
     :include-source:
 
 	import numpy as np
 	from time import time
-	from astropy.modeling import models, render_model
-
-	import matplotlib as mpl
+	from astropy.modeling import models
 	import matplotlib.pyplot as plt
-	from astropy.visualization import astropy_mpl_style
-	astropy_mpl_style['axes.grid'] = False
-	astropy_mpl_style['axes.labelcolor'] = 'k'
-	mpl.rcParams.update(astropy_mpl_style)
-
-	np.random.seed(0)
+	from matplotlib.patches import Rectangle
 
 	imshape = (300, 400)
-	nsrc = 100
+	y, x = np.indices(imshape)
 
+	# Generate random source model list
+	np.random.seed(0)
+	nsrc = 100
 	model_params = [
-	    dict(amplitude = np.random.uniform(0, 1),
-	         x_mean = np.random.uniform(0, imshape[1]),
-	         y_mean = np.random.uniform(0, imshape[0]),
-	         x_stddev = np.abs(np.random.uniform(3, 6)),
-	         y_stddev = np.abs(np.random.uniform(3, 6)),
-	         theta = np.random.uniform(0, 2 * np.pi))
-	    for i in range(nsrc)]
+	    dict(amplitude=np.random.uniform(.5, 1),
+	         x_mean=np.random.uniform(0, imshape[1] - 1),
+	         y_mean=np.random.uniform(0, imshape[0] - 1),
+	         x_stddev=np.random.uniform(2, 6),
+	         y_stddev=np.random.uniform(2, 6),
+	         theta=np.random.uniform(0, 2 * np.pi))
+	    for _ in range(nsrc)]
 
 	model_list = [models.Gaussian2D(**kwargs) for kwargs in model_params]
 
-	#Evaluate all models over their bounded regions and over the full image
-	#for comparison.
+	# Render models to image using bounding boxes
+	bb_image = np.zeros(imshape)
+	t_bb = time()
+	for model in model_list:
+	    model.render(bb_image)
+	t_bb = time() - t_bb
 
-	def make_image(model_list, shape=imshape, mode='bbox'):
-	    image = np.zeros(imshape)
-	    t1 = time()
-	    for i,model in enumerate(model_list):
-	        if mode == 'full': model.bounding_box = None
-	        elif mode == 'auto': model.bounding_box = 'auto'
-	        image = render_model(model, image)
-	    t2 = time()
-	    return image, (t2 - t1)
-
-	bb_image, t_bb = make_image(model_list, mode='auto')
-	full_image, t_full = make_image(model_list, mode='full')
+	# Render models to image using full evaluation
+	full_image = np.zeros(imshape)
+	t_full = time()
+	for model in model_list:
+	    model.bounding_box = None
+	    model.render(full_image)
+	t_full = time() - t_full
 
 	flux = full_image.sum()
 	diff = (full_image - bb_image)
 	max_err = diff.max()
 
+	# Plots
 	plt.figure(figsize=(16, 7))
-	plt.subplots_adjust(left=.05,right=.97,bottom=.03,top=.97,wspace=0.1)#07)
+	plt.subplots_adjust(left=.05, right=.97, bottom=.03, top=.97, wspace=0.15)
 
+	# Full model image
 	plt.subplot(121)
 	plt.imshow(full_image, origin='lower')
-	plt.axis([0,imshape[1],0,imshape[0]])
-	plt.title('Full Models\nTiming: %.2f seconds' % (t_full), fontsize=16)
-	plt.xlabel('x', fontsize=14)
-	plt.ylabel('y', fontsize=14)
+	plt.title('Full Models\nTiming: {:.2f} seconds'.format(t_full), fontsize=16)
+	plt.xlabel('x')
+	plt.ylabel('y')
 
-	plt.subplot(122)
+	# Bounded model image with boxes overplotted
+	ax = plt.subplot(122)
 	plt.imshow(bb_image, origin='lower')
 	for model in model_list:
-	    y1,y2,x1,x2 = np.reshape(model.bounding_box_default(),(4,))
-	    plt.plot([x1,x2,x2,x1,x1], [y1,y1,y2,y2,y1], 'w-',alpha=.2)
+	    dy, dx = np.diff(model.bounding_box_default()).flatten()
+	    pos = (model.x_mean.value - dx / 2, model.y_mean.value - dy / 2)
+	    r = Rectangle(pos, dx, dy, edgecolor='w', facecolor='none', alpha=.25)
+	    ax.add_patch(r)
+	plt.title('Bounded Models\nTiming: {:.2f} seconds'.format(t_bb), fontsize=16)
+	plt.xlabel('x')
+	plt.ylabel('y')
 
-	plt.axis([0,imshape[1],0,imshape[0]])
-	plt.title('Bounded Models\nTiming: %.2f seconds' % (t_bb), fontsize=16)
-	plt.xlabel('x', fontsize=14)
-	plt.ylabel('y', fontsize=14)
-
-	plt.figure(figsize=(16,8))
+	# Difference image
+	plt.figure(figsize=(16, 8))
+	plt.subplot(111)
 	plt.imshow(diff, vmin=-max_err, vmax=max_err)
 	plt.colorbar(format='%.1e')
-	plt.title('Difference Image\nTotal Flux Err = %.0e'
-	            %((flux - np.sum(bb_image)) / flux), fontsize=16)
-	plt.xlabel('x', fontsize=14)
-	plt.ylabel('y', fontsize=14)
+	plt.title('Difference Image\nTotal Flux Err = {:.0e}'.format(
+	    ((flux - np.sum(bb_image)) / flux)))
+	plt.xlabel('x')
+	plt.ylabel('y')
 	plt.show()
-

--- a/docs/modeling/bounding-boxes.rst
+++ b/docs/modeling/bounding-boxes.rst
@@ -24,20 +24,17 @@ array itself, see :ref:`cutout_images`.
 Using the Bounding Box
 -----------------------
 
-For basic usage, see `Model.bounding_box <astropy.modeling.Model.bounding_box>`.
-By default no `bounding_box <astropy.modeling.Model.bounding_box>` is set
-(:func:`Model.bounding_box_default <astropy.modeling.Model.bounding_box_default>`
-returns `None`), except for model subclasses where :func:`bounding_box_default
-<astropy.modeling.Model.bounding_box_default>` is explicity defined. The default
-is then the minimum rectangular region symmetric about the position that fully
-contains the model. If the model does not have a finite extent, the containment
-criteria are noted in the documentation. For example, see
-`Gaussian2D.bounding_box_default
-<astropy.modeling.functional_models.Gaussian2D.bounding_box_default>`.
+For basic usage, see `Model.bounding_box
+<astropy.modeling.Model.bounding_box>`.  By default no
+`~astropy.modeling.Model.bounding_box` is set, except on model subclasses where
+a ``bounding_box`` property or method is explicity defined. The default is then
+the minimum rectangular region symmetric about the position that fully contains
+the model. If the model does not have a finite extent, the containment criteria
+are noted in the documentation. For example, see ``Gaussian2D.bounding_box``.
 
-`Model.bounding_box_default <astropy.modeling.Model.bounding_box_default>` can
-be set by the user to any callable. This is particularly useful for fitting
-``custom_model`` or ``CompoundModel`` instances.
+`Model.bounding_box <astropy.modeling.Model.bounding_box>` can be set by the
+user to any callable. This is particularly useful for fitting models created
+with `~astropy.modeling.custom_model` or as a compound model::
 
     >>> from astropy.modeling import custom_model
     >>> def ellipsoid(x, y, z, x0=0, y0=0, z0=0, a=2, b=3, c=4, amp=1):
@@ -57,96 +54,105 @@ be set by the user to any callable. This is particularly useful for fitting
     >>> model.bounding_box
     ((-4.0, 4.0), (-3.0, 3.0), (-2.0, 2.0))
 
-Efficient evaluation with :func:`Model.render() <astropy.modeling.Model.render>`
---------------------------------------------------------------------------------
+.. warning::
 
-When a model is evaluated over a range much larger than the model itself, it may
-be prudent to use the :func:`Model.render <astropy.modeling.Model.render>`
-method if efficiency is a concern. The :func:`render <astropy.modeling.Model.render>`
-method can be used to evaluate the model on an array of the same dimensions.
-``model.render()`` can be called with no arguments to return a "postage
-stamp" of the bounding box region.
+    Note: Currently when creating a new compound model by combining multiple
+    models, the bounding boxes of the components (if any) are not currently
+    combined.  So bounding boxes for compound models must be assigned
+    explicitly.  A future release will determine the appropriate bounding box
+    for a compound model where possible.
 
-In this example, we generate a 300x400 pixel image of 100 2D
-Gaussian sources. For comparison, the models are evaluated
-both with and without using bounding boxes. By using bounding boxes, the evaluation
-speed increases by approximately a factor of 10 with negligible loss of information.
+Efficient evaluation with `Model.render() <astropy.modeling.Model.render>`
+--------------------------------------------------------------------------
+
+When a model is evaluated over a range much larger than the model itself, it
+may be prudent to use the :func:`Model.render <astropy.modeling.Model.render>`
+method if efficiency is a concern. The :func:`render
+<astropy.modeling.Model.render>` method can be used to evaluate the model on an
+array of the same dimensions.  ``model.render()`` can be called with no
+arguments to return a "postage stamp" of the bounding box region.
+
+In this example, we generate a 300x400 pixel image of 100 2D Gaussian sources.
+For comparison, the models are evaluated both with and without using bounding
+boxes. By using bounding boxes, the evaluation speed increases by approximately
+a factor of 10 with negligible loss of information.
 
 .. plot::
     :include-source:
 
-	import numpy as np
-	from time import time
-	from astropy.modeling import models
-	import matplotlib.pyplot as plt
-	from matplotlib.patches import Rectangle
+    import numpy as np
+    from time import time
+    from astropy.modeling import models
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
 
-	imshape = (300, 400)
-	y, x = np.indices(imshape)
+    imshape = (300, 400)
+    y, x = np.indices(imshape)
 
-	# Generate random source model list
-	np.random.seed(0)
-	nsrc = 100
-	model_params = [
-	    dict(amplitude=np.random.uniform(.5, 1),
-	         x_mean=np.random.uniform(0, imshape[1] - 1),
-	         y_mean=np.random.uniform(0, imshape[0] - 1),
-	         x_stddev=np.random.uniform(2, 6),
-	         y_stddev=np.random.uniform(2, 6),
-	         theta=np.random.uniform(0, 2 * np.pi))
-	    for _ in range(nsrc)]
+    # Generate random source model list
+    np.random.seed(0)
+    nsrc = 100
+    model_params = [
+        dict(amplitude=np.random.uniform(.5, 1),
+             x_mean=np.random.uniform(0, imshape[1] - 1),
+             y_mean=np.random.uniform(0, imshape[0] - 1),
+             x_stddev=np.random.uniform(2, 6),
+             y_stddev=np.random.uniform(2, 6),
+             theta=np.random.uniform(0, 2 * np.pi))
+        for _ in range(nsrc)]
 
-	model_list = [models.Gaussian2D(**kwargs) for kwargs in model_params]
+    model_list = [models.Gaussian2D(**kwargs) for kwargs in model_params]
 
-	# Render models to image using bounding boxes
-	bb_image = np.zeros(imshape)
-	t_bb = time()
-	for model in model_list:
-	    model.render(bb_image)
-	t_bb = time() - t_bb
+    # Render models to image using bounding boxes
+    bb_image = np.zeros(imshape)
+    t_bb = time()
+    for model in model_list:
+        model.render(bb_image)
+    t_bb = time() - t_bb
 
-	# Render models to image using full evaluation
-	full_image = np.zeros(imshape)
-	t_full = time()
-	for model in model_list:
-	    model.bounding_box = None
-	    model.render(full_image)
-	t_full = time() - t_full
+    # Render models to image using full evaluation
+    full_image = np.zeros(imshape)
+    t_full = time()
+    for model in model_list:
+        model.bounding_box = None
+        model.render(full_image)
+    t_full = time() - t_full
 
-	flux = full_image.sum()
-	diff = (full_image - bb_image)
-	max_err = diff.max()
+    flux = full_image.sum()
+    diff = (full_image - bb_image)
+    max_err = diff.max()
 
-	# Plots
-	plt.figure(figsize=(16, 7))
-	plt.subplots_adjust(left=.05, right=.97, bottom=.03, top=.97, wspace=0.15)
+    # Plots
+    plt.figure(figsize=(16, 7))
+    plt.subplots_adjust(left=.05, right=.97, bottom=.03, top=.97, wspace=0.15)
 
-	# Full model image
-	plt.subplot(121)
-	plt.imshow(full_image, origin='lower')
-	plt.title('Full Models\nTiming: {:.2f} seconds'.format(t_full), fontsize=16)
-	plt.xlabel('x')
-	plt.ylabel('y')
+    # Full model image
+    plt.subplot(121)
+    plt.imshow(full_image, origin='lower')
+    plt.title('Full Models\nTiming: {:.2f} seconds'.format(t_full), fontsize=16)
+    plt.xlabel('x')
+    plt.ylabel('y')
 
-	# Bounded model image with boxes overplotted
-	ax = plt.subplot(122)
-	plt.imshow(bb_image, origin='lower')
-	for model in model_list:
-	    dy, dx = np.diff(model.bounding_box).flatten()
-	    pos = (model.x_mean.value - dx / 2, model.y_mean.value - dy / 2)
-	    r = Rectangle(pos, dx, dy, edgecolor='w', facecolor='none', alpha=.25)
-	    ax.add_patch(r)
-	plt.title('Bounded Models\nTiming: {:.2f} seconds'.format(t_bb), fontsize=16)
-	plt.xlabel('x')
-	plt.ylabel('y')
+    # Bounded model image with boxes overplotted
+    ax = plt.subplot(122)
+    plt.imshow(bb_image, origin='lower')
+    for model in model_list:
+        del model.bounding_box  # Reset bounding_box to its default
+        dy, dx = np.diff(model.bounding_box).flatten()
+        pos = (model.x_mean.value - dx / 2, model.y_mean.value - dy / 2)
+        r = Rectangle(pos, dx, dy, edgecolor='w', facecolor='none', alpha=.25)
+        ax.add_patch(r)
+    plt.title('Bounded Models\nTiming: {:.2f} seconds'.format(t_bb), fontsize=16)
+    plt.xlabel('x')
+    plt.ylabel('y')
 
-	# Difference image
-	plt.figure(figsize=(16, 8))
-	plt.subplot(111)
-	plt.imshow(diff, vmin=-max_err, vmax=max_err)
-	plt.colorbar(format='%.1e')
-	plt.title('Difference Image\nTotal Flux Err = {:.0e}'.format(
-	    ((flux - np.sum(bb_image)) / flux)))
-	plt.xlabel('x')
-	plt.ylabel('y')
-	plt.show()
+    # Difference image
+    plt.figure(figsize=(16, 8))
+    plt.subplot(111)
+    plt.imshow(diff, vmin=-max_err, vmax=max_err)
+    plt.colorbar(format='%.1e')
+    plt.title('Difference Image\nTotal Flux Err = {:.0e}'.format(
+        ((flux - np.sum(bb_image)) / flux)))
+    plt.xlabel('x')
+    plt.ylabel('y')
+    plt.show()

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -62,5 +62,6 @@ py:meth list.pop
 py:obj list.remove
 py:class classmethod
 py:obj RuntimeError
+py:obj NotImplementedError
 py:obj AttributeError
 py:obj NotImplementedError

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -238,7 +238,7 @@ Matplotlib. More information on installing and using WCSAxes can be found `here
 .. plot::
     :include-source:
 
-    from matplotlib import rcParams, pyplot as plt
+    from matplotlib import pyplot as plt
     from astropy.io import fits
     from astropy.wcs import WCS
     from astropy.utils.data import download_file


### PR DESCRIPTION
This is the update to #4040--it includes all the fixes from #4040, but also includes my updates to the bounding box interface.

The purpose of these updates, as explained in the commit message of 779ef3e5bb14d9711dc24ae26578bfd7c22d618b, is to make the interface for `bounding_box` fairly consistent with the interface for `Model.inverse`.  To that end the `bounding_box_default` method is eliminated, and model classes that define a bounding box can do so as a class-level attribute, method, or property simply called `bounding_box`, which is then wrapped by the Model metaclass to incorporate the default getter/setter behavior for the `Model.bounding_box` property.  This is similar to how `Model.inverse` works.

One downside to this that I just noticed while testing the documentation is that if a `Model` subclass has a `bounding_box` with its own docstring, that docstring usually gets thrown away.  We definitely don't want that, so I am going to open a separate issue to fix that later.