### PR TITLE
io.ascii inconsistency in expected exception classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -678,6 +678,9 @@ Bug fixes
     when guessing the file format.  Also improved the read trace
     information to better understand format guessing. [#4115]
 
+  - Fix an underlying problem that resulted in an uncaught TypeError
+    exception when reading a CDS-format file with guessing enabled. [#4120]
+
 - ``astropy.io.fits``
 
   - Included a new command-line script called ``fitsinfo`` to display

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -3,6 +3,7 @@
 # TEST_UNICODE_LITERALS
 
 import re
+from io import BytesIO
 
 import numpy as np
 
@@ -1063,24 +1064,18 @@ def test_table_with_no_newline():
     Test that an input file which is completely empty fails in the expected way.
     Test that an input file with one line but no newline succeeds.
     """
-    if six.PY3:
-        import io
-        _StringIO = io.BytesIO
-    else:
-        _StringIO = StringIO
-
     # With guessing
-    table = _StringIO()
+    table = BytesIO()
     with pytest.raises(ascii.InconsistentTableError):
         ascii.read(table)
 
     # Without guessing
-    table = _StringIO()
+    table = BytesIO()
     with pytest.raises(ValueError) as err:
         ascii.read(table, guess=False, fast_reader=False, format='basic')
     assert 'No header line found' in str(err.value)
 
-    table = _StringIO()
+    table = BytesIO()
     with pytest.raises(ValueError) as err:
         ascii.read(table, guess=False, fast_reader=True, format='fast_basic')
     assert 'Inconsistent data column lengths' in str(err.value)
@@ -1089,7 +1084,7 @@ def test_table_with_no_newline():
     for kwargs in [dict(),
                    dict(guess=False, fast_reader=False, format='basic'),
                    dict(guess=False, fast_reader=True, format='fast_basic')]:
-        table = _StringIO()
+        table = BytesIO()
         table.write(b'a b')
         t = ascii.read(table, **kwargs)
         assert t.colnames == ['a', 'b']

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -427,6 +427,13 @@ def _guess(table, read_kwargs, format, fast_reader):
     if len(filtered_guess_kwargs) <= 1:
         return None
 
+    # Define whitelist of exceptions that are expected from readers when
+    # processing invalid inputs.  Note that IOError must fall through here
+    # so one cannot simply catch any exception.
+    guess_exception_classes = (core.InconsistentTableError, ValueError, TypeError,
+                               AttributeError, core.OptionalTableImportError,
+                               core.ParameterError, cparser.CParserError)
+
     # Now cycle through each possible reader and associated keyword arguments.
     # Try to read the table using those args, and if an exception occurs then
     # keep track of the failed guess and move on.
@@ -444,8 +451,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                                 'dt': '{0:.3f} ms'.format((time.time() - t0) * 1000)})
             return dat
 
-        except (core.InconsistentTableError, ValueError, TypeError, AttributeError,
-                core.OptionalTableImportError, core.ParameterError, cparser.CParserError) as err:
+        except guess_exception_classes as err:
             _read_trace.append({'kwargs': guess_kwargs,
                                 'status': '{0}: {1}'.format(err.__class__.__name__,
                                                             str(err)),
@@ -461,8 +467,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                                           '(guessing)'})
             return dat
 
-        except (core.InconsistentTableError, ValueError, ImportError,
-                core.OptionalTableImportError, core.ParameterError, cparser.CParserError) as err:
+        except guess_exception_classes as err:
             _read_trace.append({'kwargs': guess_kwargs,
                                 'status': '{0}: {1}'.format(err.__class__.__name__,
                                                             str(err))})


### PR DESCRIPTION
The list of allowed or expected exception classes in the io.ascii guess process is initially:
```
        except (core.InconsistentTableError, ValueError, TypeError, AttributeError,
                core.OptionalTableImportError, core.ParameterError, cparser.CParserError) as err:
```
But then if everything fails there is a last-gasp try using the original read_kwargs without strict name checking, and there the exception list is:
```
        except (core.InconsistentTableError, ValueError, ImportError,
                core.OptionalTableImportError, core.ParameterError, cparser.CParserError) as err:
```
These should just be factored out into one common list.

This came up in a question on the astropy list where trying to read a CDS file resulted in an uncaught TypeError exception being raised:
```
/data/baffin/tom/git/astropy/astropy/io/ascii/ui.py in _guess(table, read_kwargs, format, fast_reader)
    433         # Failed all guesses, try the original read_kwargs without column requirements
    434         try:
--> 435             reader = get_reader(**read_kwargs)
    436             dat = reader.read(table)
    437             _read_trace.append({'kwargs': read_kwargs,

/data/baffin/tom/git/astropy/astropy/io/ascii/ui.py in get_reader(Reader, Inputter, Outputter, **kwargs)
    162     if Reader is None:
    163         Reader = basic.Basic
--> 164     reader = core._get_reader(Reader, Inputter=Inputter, Outputter=Outputter, **kwargs)
    165     return reader
    166 

/data/baffin/tom/git/astropy/astropy/io/ascii/core.py in _get_reader(Reader, Inputter, Outputter, **kwargs)
   1239         del kwargs['fast_reader'] # ignore fast_reader parameter for slow readers
   1240     reader_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_reader_pars)
-> 1241     reader = Reader(**reader_kwargs)
   1242 
   1243     if Inputter is not None:

TypeError: __init__() got an unexpected keyword argument 'readme'
```
We had a discussion once about why we should not just do `except Exception as err`, but I can't remember the answer.  This list of exception classes is already pretty broad and can certainly be hiding bugs (like the one fixed in #4115).  Do you remember @hamogu?