### PR TITLE
NDData and NDDataBase Refactor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,13 +100,13 @@ API changes
 
 - ``astropy.nddata``
 
-  - ``NDData.__init__``: got an additional optional parameter ``copy``
+  - ``NDData``: added an optional parameter ``copy``
     which is False by default. If it is True all other parameters are copied
     before saving them as attributes. If False the parameters are only copied
-    if there is no way of saving them as reference.
+    if there is no way of saving them as reference. [#4270]
 
-  - ``NDData.__init__``: ``Masked_Quantity`` objects are allowed as ``data``
-    parameter.
+  - ``NDData``: ``Masked_Quantity`` objects are allowed as ``data``
+    parameter. [#4270]
 
 - ``astropy.stats``
 
@@ -176,25 +176,18 @@ Bug fixes
 
 - ``astropy.nddata``
 
-  - ``NDDataBase`` only defines an abstract ``uncertainty`` getter instead of
-    an actual implementation. The original was moved to ``NDData``.
+  - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,
+    which is now an abstractproperty. [#4270]
 
-  - ``NDDataBase`` doesn't implement an ``uncertainty`` setter. It was moved to
-    ``NDData``. The setter was also modified:
+  - ``NDData`` wraps the ``uncertainty`` inside an ``UnknownUncertainty``
+    if no ``uncertainty_type`` attribute is present in the uncertainty instead
+    of raising an Exception. [#4270]
 
-    - it wraps an ``uncertainty`` inside an ``UnknownUncertainty``
-      if no ``uncertainty_type`` attribute is present in the uncertainty instead
-      of raising an Exception.
+  - ``NDData`` The ``uncertainty_type`` of the ``uncertainty`` is no longer
+    required to be a string, but it is still recommended. [#4270]
 
-    - the uncertainty_type of the uncertainty must not be a string
-      anymore. But it is still recommended.
-
-    - did not set the ``parent_nddata`` of the ``uncertainty`` if the uncertainty
-      was a subclass of ``.NDUncertainty``. #4152
-
-  - ``NDData.__init__``: if the ``data`` is another instance or subclass of
-    ``NDData`` all implicit properties are checked because
-    subclasses might implement another set of restrictions.
+  - ``NDData`` now sets the ``parent_nddata`` of the ``uncertainty`` if the
+    uncertainty is ``NDUncertainty``-like. [#4152, #4270]
 
 - ``astropy.stats``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,14 @@ API changes
 
 - ``astropy.nddata``
 
+  - ``NDData.__init__``: got an additional optional parameter ``copy``
+    which is False by default. If it is True all other parameters are copied
+    before saving them as attributes. If False the parameters are only copied
+    if there is no way of saving them as reference.
+
+  - ``NDData.__init__``: ``Masked_Quantity`` objects are allowed as ``data``
+    parameter.
+
 - ``astropy.stats``
 
 - ``astropy.table``
@@ -167,6 +175,26 @@ Bug fixes
     compound model instances. [#4414]
 
 - ``astropy.nddata``
+
+  - ``NDDataBase`` only defines an abstract ``uncertainty`` getter instead of
+    an actual implementation. The original was moved to ``NDData``.
+
+  - ``NDDataBase`` doesn't implement an ``uncertainty`` setter. It was moved to
+    ``NDData``. The setter was also modified:
+
+    - it wraps an ``uncertainty`` inside an ``UnknownUncertainty``
+      if no ``uncertainty_type`` attribute is present in the uncertainty instead
+      of raising an Exception.
+
+    - the uncertainty_type of the uncertainty must not be a string
+      anymore. But it is still recommended.
+
+    - did not set the ``parent_nddata`` of the ``uncertainty`` if the uncertainty
+      was a subclass of ``.NDUncertainty``. #4152
+
+  - ``NDData.__init__``: if the ``data`` is another instance or subclass of
+    ``NDData`` all implicit properties are checked because
+    subclasses might implement another set of restrictions.
 
 - ``astropy.stats``
 

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -19,7 +19,7 @@ __all__ = ['NDData']
 
 __doctest_skip__ = ['NDData']
 
-# TODO: Change this again after combining PRs
+# TODO: Change this again after remerging of ractoring PRs
 try:
     from .nduncertainty import UnknownUncertainty
 except ImportError:
@@ -27,6 +27,9 @@ except ImportError:
     __all__.append('UnknownUncertainty')
 
     from .nduncertainty import StdDevUncertainty
+
+    # Create a temporary unknownuncertainty as long as the real implementation
+    # is not merged.
 
     class UnknownUncertainty(StdDevUncertainty):
         """
@@ -46,12 +49,6 @@ except ImportError:
             The `NDData` which uses this uncertainty.
         uncertainty_type: ``"unknown"``
             The type of uncertainty is unknown.
-
-        Notes
-        -----
-        This class is only a temporary implementation until `NDUncertainty`
-        and `NDArithmeticMixin` refactor is done. But it should be fully
-        functional.
         """
         # We need to change the type of uncertainty
         def __init__(self, *args, **kwargs):
@@ -82,7 +79,7 @@ class NDData(NDDataBase):
 
     Parameters
     -----------
-    data : `~numpy.ndarray`-like, `NDData`-like or list
+    data : `~numpy.ndarray`-like or `NDData`-like
         The dataset.
 
     uncertainty : any type, optional
@@ -168,7 +165,7 @@ class NDData(NDDataBase):
                  meta=None, unit=None, copy=False):
 
         # Rather pointless since the NDDataBase does not implement any setting
-        # but before (#4234) the NDDataBase did call the uncertainty
+        # but before the NDDataBase did call the uncertainty
         # setter. But if anyone wants to alter this behaviour again the call
         # to the superclass NDDataBase should be in here.
         super(NDData, self).__init__()

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -14,7 +14,6 @@ from .nddata_base import NDDataBase
 from .nduncertainty import NDUncertainty
 from .. import log
 from ..units import Unit, Quantity
-from ..extern import six
 
 __all__ = ['NDData']
 
@@ -63,14 +62,10 @@ class NDData(NDDataBase):
         Uncertainty in the dataset.
         Should have an attribute
         ``uncertainty_type`` that defines what kind of uncertainty is stored,
-        such as ``std`` for standard deviation or
-        ``var`` for variance. A metaclass defining such an interface is
+        such as ``'std'`` for standard deviation or
+        ``'var'`` for variance. A metaclass defining such an interface is
         `~astropy.nddata.NDUncertainty` but isn't mandatory.
         Defaults to ``None``.
-
-        TODO: *Must* or *Should* have this ``uncertainty_type`` ? (mwcraig)
-        I implemented UnknownUncertainty to work around that so what is
-        saved in _uncertainty has an uncertainty_type but it's unknown :-)
 
     mask : any type, optional
         Mask for the dataset.
@@ -124,7 +119,8 @@ class NDData(NDDataBase):
         >>> import astropy.units as u
         >>> q = np.array([1,2,3,4]) * u.m
         >>> nd2 = NDData(q, unit=u.cm)  # doctest: +SKIP
-        INFO: Overwriting Quantity's current unit with specified unit [astropy.nddata.nddata]
+        INFO: Overwriting Quantity's current unit with specified
+        unit [astropy.nddata.nddata]
         >>> nd2.data  # doctest: +SKIP
         array([ 1.,  2.,  3.,  4.])
         >>> nd2.unit  # doctest: +SKIP
@@ -164,8 +160,6 @@ class NDData(NDDataBase):
             # other parameters.
             if (unit is not None and data.unit is not None and
                     unit != data.unit):
-                # TODO: Clarify warning that unit is replaced instead of
-                # converted?
                 log.info("Overwriting NDData's current "
                          "unit with specified unit")
             elif data.unit is not None:
@@ -318,47 +312,21 @@ class NDData(NDDataBase):
         any type : Uncertainty in the dataset, if any.
 
         Should have an attribute ``uncertainty_type`` that defines what kind of
-        uncertainty is stored, such as ``std`` for standard deviation or
-        ``var`` for variance. A metaclass defining such an interface is
+        uncertainty is stored, such as ``'std'`` for standard deviation or
+        ``'var'`` for variance. A metaclass defining such an interface is
         `~astropy.nddata.NDUncertainty` but isn't mandatory.
-
-        TODO: *Must* or *Should* have this ``uncertainty_type`` ? (mwcraig)
-        I implemented UnknownUncertainty to work around that so what is
-        saved in _uncertainty has an uncertainty_type but it's unknown :-)
         """
-        if isinstance(self._uncertainty, UnknownUncertainty):
-            return self._uncertainty.array
-        else:
-            return self._uncertainty
-
-    @property
-    def uncertainty_type(self):
-        """
-        str: The kind of uncertainty that is saved.
-
-        The uncertainty_type is using the convention that standard deviation
-        is abbreviated by ``std``, variance by ``var``, ...
-
-        TODO: This is new and only a shortcut to the uncertainty type since
-        the property hides the really saved uncertainty if it is an
-        ``UnknownUncertainty``.
-        """
-        if self._uncertainty is None:
-            return None
-        else:
-            return self._uncertainty.uncertainty_type
+        return self._uncertainty
 
     @uncertainty.setter
     def uncertainty(self, value):
         if value is not None:
             # There is one requirements on the uncertainty: That
-            # it has an attribute 'uncertainty_type' which is a string.
+            # it has an attribute 'uncertainty_type'.
             # If it does not match this requirement convert it to an unknown
             # uncertainty.
-            if (not hasattr(value, 'uncertainty_type') or
-                    not isinstance(value.uncertainty_type, six.string_types)):
-                log.info('Uncertainty should have attribute uncertainty_type '
-                         'whose type is string.')
+            if not hasattr(value, 'uncertainty_type'):
+                log.info('Uncertainty should have attribute uncertainty_type.')
                 value = UnknownUncertainty(value, copy=False)
 
             # If it is a subclass of NDUncertainty we must set the

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -23,9 +23,36 @@ __doctest_skip__ = ['NDData']
 try:
     from .nduncertainty import UnknownUncertainty
 except ImportError:
+
+    __all__.append('UnknownUncertainty')
+
     from .nduncertainty import StdDevUncertainty
 
     class UnknownUncertainty(StdDevUncertainty):
+        """
+        This is a wrapper for uncertainties that do not have an attribute
+        uncertainty type.
+
+        Parameters
+        ----------
+        args, kwargs:
+            passed to `StdDevUncertainty`.
+
+        Attributes
+        ----------
+        array: any type
+            The uncertainty that is wrapped.
+        parent_nddata: `NDData`
+            The `NDData` which uses this uncertainty.
+        uncertainty_type: ``"unknown"``
+            The type of uncertainty is unknown.
+
+        Notes
+        -----
+        This class is only a temporary implementation until `NDUncertainty`
+        and `NDArithmeticMixin` refactor is done. But it should be fully
+        functional.
+        """
         # We need to change the type of uncertainty
         def __init__(self, *args, **kwargs):
             super(UnknownUncertainty, self).__init__(*args, **kwargs)
@@ -62,8 +89,10 @@ class NDData(NDDataBase):
         Uncertainty in the dataset.
         Should have an attribute
         ``uncertainty_type`` that defines what kind of uncertainty is stored,
-        such as ``'std'`` for standard deviation or
-        ``'var'`` for variance. A metaclass defining such an interface is
+        for example ``"std"`` for standard deviation or
+        ``"var"`` for variance. If the uncertainty has no such attribute the
+        uncertainty is stored inside an `UnknownUncertainty` .
+        A metaclass defining such an interface is
         `~astropy.nddata.NDUncertainty` but isn't mandatory.
         Defaults to ``None``.
 

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -8,160 +8,259 @@ import collections
 from collections import OrderedDict
 
 import numpy as np
+from copy import deepcopy
 
 from .nddata_base import NDDataBase
-from ..units import Unit, Quantity
+from .nduncertainty import NDUncertainty
 from .. import log
+from ..units import Unit, Quantity
+from ..extern import six
 
 __all__ = ['NDData']
 
-
 __doctest_skip__ = ['NDData']
+
+# TODO: Change this again after combining PRs
+try:
+    from .nduncertainty import UnknownUncertainty
+except ImportError:
+    from .nduncertainty import StdDevUncertainty
+
+    class UnknownUncertainty(StdDevUncertainty):
+        # We need to change the type of uncertainty
+        def __init__(self, *args, **kwargs):
+            super(UnknownUncertainty, self).__init__(*args, **kwargs)
+            self.uncertainty_type = 'unknown'
+
+        # Well we need to define the property to alter the setter
+        @property
+        def parent_nddata(self):
+            return super(UnknownUncertainty, self).parent_nddata
+
+        # We want to skip the shape check.
+        @parent_nddata.setter
+        def parent_nddata(self, value):
+            self._parent_nddata = value
 
 
 class NDData(NDDataBase):
     """
-    A basic class for array-based data.
+    A container for `~numpy.ndarray`-based datasets, using the
+    `~astropy.nddata.NDDataBase` interface.
 
-    The key distinction from raw numpy arrays is the presence of
-    additional metadata such as uncertainties, a mask, units,
-    and/or a coordinate system.
+    The key distinction from raw `numpy.ndarray` is the presence of
+    additional metadata such as uncertainty, mask, unit, a coordinate system
+    and/or a `dict` containg further meta information. This class *only*
+    provides a container for *storing* such datasets. For further functionality
+    take a look at the ``See also`` section.
 
     Parameters
     -----------
-    data : `~numpy.ndarray`, `~numpy.ndarray`-like, or `NDData`
-        The actual data contained in this `NDData` object. If possible, data
-        will not be copied`data`, so you should make copy the ``data`` before
-        passing it in if that's the desired behavior.
+    data : `~numpy.ndarray`-like, `NDData`-like or list
+        The dataset.
 
     uncertainty : any type, optional
-        Uncertainty on the data. The uncertainty *must* have a string attribute
-        named ``uncertainty_type``, but there is otherwise no restriction.
+        Uncertainty in the dataset.
+        Should have an attribute
+        ``uncertainty_type`` that defines what kind of uncertainty is stored,
+        such as ``std`` for standard deviation or
+        ``var`` for variance. A metaclass defining such an interface is
+        `~astropy.nddata.NDUncertainty` but isn't mandatory.
+        Defaults to ``None``.
 
-    mask : `~numpy.ndarray`-like, optional
-        Mask for the data. The values must be ``False`` where
-        the data is *valid* and ``True`` when it is not (like Numpy
-        masked arrays). If ``data`` is a numpy masked array, providing
-        ``mask`` here will causes the mask from the masked array to be
-        ignored.
+        TODO: *Must* or *Should* have this ``uncertainty_type`` ? (mwcraig)
+        I implemented UnknownUncertainty to work around that so what is
+        saved in _uncertainty has an uncertainty_type but it's unknown :-)
 
-    wcs : undefined, optional
-        WCS-object containing the world coordinate system for the data.
+    mask : any type, optional
+        Mask for the dataset.
+        Masks should follow the ``numpy`` convention that valid data points are
+        marked by ``False`` and invalid ones with ``True``.
+        Defaults to ``None``.
+
+    wcs : any type, optional
+        A world coordinate system (WCS) for the dataset.
+        Default is ``None``.
 
     meta : `dict`-like object, optional
-        Metadata for this object. Must be dict-like but no further restriction
-        is placed on meta.
+        Meta information about the dataset. If no meta is provided an empty
+        `collections.OrderedDict` is created.
 
-    unit : `~astropy.units.UnitBase` instance or str, optional
-        The units of the data. If data is an `~astropy.units.Quantity` then
-        ``unit`` is set to the unit of the data; is a unit is also explicitly
-        provided an error is raised.
+    unit : `~astropy.units.Unit`-like or str, optional
+        Unit for the dataset.
+        Default is ``None``.
+
+    copy : `bool`, optional
+        Save the attributes as copy or as reference. ``True`` copies every
+        attribute before saving it while ``False`` tries to save every
+        parameter as reference. Note however that it is not always possible to
+        save each input as reference.
+        Default is ``False``.
+
+    Raises
+    ------
+    TypeError:
+        In case any parameter does not fulfill the classes restrictions.
 
     Notes
     -----
-    The data in a `NDData` object should be accessed through the data
+    Each attribute can be accessed through the homonymous instance attribute,
+    such as data in a `NDData` object can be accessed through the ``data``
     attribute.
 
     For example::
 
         >>> from astropy.nddata import NDData
-        >>> x = NDData([1,2,3])
-        >>> x.data
+        >>> nd = NDData([1,2,3])
+        >>> nd.data
         array([1, 2, 3])
+
+    Given an implicit parameter and an explicit one during initialization, for
+    example the ``data`` is a `~astropy.units.Quantity` and the unit parameter
+    is not None. Then the implicit parameter is replaced (without conversion)
+    by the explicit one and a warning is issued::
+
+        >>> import numpy as np
+        >>> import astropy.units as u
+        >>> q = np.array([1,2,3,4]) * u.m
+        >>> nd2 = NDData(q, unit=u.cm)  # doctest: +SKIP
+        INFO: Overwriting Quantity's current unit with specified unit [astropy.nddata.nddata]
+        >>> nd2.data  # doctest: +SKIP
+        array([ 1.,  2.,  3.,  4.])
+        >>> nd2.unit  # doctest: +SKIP
+        Unit("cm")
+
+    See also
+    --------
+
+    NDIOMixin
+    NDSlicingMixin
+    NDArithmeticMixin
+    NDDataArray
     """
 
     def __init__(self, data, uncertainty=None, mask=None, wcs=None,
-                 meta=None, unit=None):
+                 meta=None, unit=None, copy=False):
 
+        # Rather pointless since the NDDataBase does not implement any setting
+        # but before (#4234) the NDDataBase did call the uncertainty
+        # setter. But if anyone wants to alter this behaviour again the call
+        # to the superclass NDDataBase should be in here.
         super(NDData, self).__init__()
 
+        # Check if data is any type from which to collect some implicitly
+        # passed parameters.
         if isinstance(data, NDData):  # don't use self.__class__ (issue #4137)
-            # No need to check the data because data must have successfully
-            # initialized.
-            self._data = data._data
-            self._unit = data.unit  # must set before uncert for NDDataArray
-            self.uncertainty = data.uncertainty
-            self._mask = data.mask
-            self._wcs = data.wcs
-            self._meta = data.meta
+            # Of course we need to check the data because subclasses with other
+            # init-logic might be passed in here. We could skip these
+            # tests if we compared for self.__class__ but that has other
+            # drawbacks.
 
-            if uncertainty is not None:
-                self._uncertainty = uncertainty
-                log.info("Overwriting NDData's current uncertainty being"
-                         " overwritten with specified uncertainty")
+            # Comparing if there is an explicit and an implicit unit parameter.
+            # If that is the case use the explicit one and issue a warning
+            # that there might be a conflict. In case there is no explicit
+            # unit just overwrite the unit parameter with the NDData.unit
+            # and proceed as if that one was given as parameter. Same for the
+            # other parameters.
+            if (unit is not None and data.unit is not None and
+                    unit != data.unit):
+                # TODO: Clarify warning that unit is replaced instead of
+                # converted?
+                log.info("Overwriting NDData's current "
+                         "unit with specified unit")
+            elif data.unit is not None:
+                unit = data.unit
 
-            if mask is not None:
-                self._mask = mask
+            if uncertainty is not None and data.uncertainty is not None:
+                log.info("Overwriting NDData's current "
+                         "uncertainty with specified uncertainty")
+            elif data.uncertainty is not None:
+                uncertainty = data.uncertainty
+
+            if mask is not None and data.mask is not None:
                 log.info("Overwriting NDData's current "
                          "mask with specified mask")
+            elif data.mask is not None:
+                mask = data.mask
 
-            if wcs is not None:
-                self._wcs = wcs
-                log.info("Overwriting NDData's current wcs with specified wcs")
+            if wcs is not None and data.wcs is not None:
+                log.info("Overwriting NDData's current "
+                         "wcs with specified wcs")
+            elif data.wcs is not None:
+                wcs = data.wcs
 
-            if meta is not None:
-                self._meta = meta
-                log.info("Overwriting NDData's current meta "
-                         "with specified meta")
+            if meta is not None and data.meta is not None:
+                log.info("Overwriting NDData's current "
+                         "meta with specified meta")
+            elif data.meta is not None:
+                meta = data.meta
 
-            if unit is not None and unit is not data.unit:
-                raise ValueError('Unit provided in initializer does not '
-                                 'match data unit.')
+            data = data.data
+
         else:
-            if hasattr(data, 'mask'):
-                self._data = np.array(data.data, subok=True, copy=False)
-
+            if hasattr(data, 'mask') and hasattr(data, 'data'):
+                # Seperating data and mask
                 if mask is not None:
-                    self._mask = mask
-                    log.info("NDData was created with a masked array, and a "
-                             "mask was explicitly provided to NDData. The  "
-                             "explicitly passed-in mask will be used and the "
-                             "masked array's mask will be ignored.")
+                    log.info("Overwriting Masked Objects's current "
+                             "mask with specified mask")
                 else:
-                    self._mask = data.mask
-            elif isinstance(data, Quantity):
-                self._data = np.array(data.value, subok=True, copy=False)
-                self._mask = mask
-            elif (not hasattr(data, 'shape') or
-                  not hasattr(data, '__getitem__') or
-                  not hasattr(data, '__array__')):
-                # Data doesn't look like a numpy array, try converting it to
-                # one.
-                self._data = np.array(data, subok=True, copy=False)
-                # Quick check to see if what we got out looks like an array
-                # rather than an object (since numpy will convert a
-                # non-numerical input to an array of objects).
-                if self._data.dtype == 'O':
-                    raise TypeError("Could not convert data to numpy array.")
-                self._mask = mask
-            else:
-                self._data = data  # np.array(data, subok=True, copy=False)
-                self._mask = mask
+                    mask = data.mask
 
-            self._wcs = wcs
-
-            if meta is None:
-                self._meta = OrderedDict()
-            elif not isinstance(meta, collections.Mapping):
-                raise TypeError("meta attribute must be dict-like")
-            else:
-                self._meta = meta
+                # Just save the data for further processing, we could be given
+                # a masked Quantity or something else entirely. Better to check
+                # it first.
+                data = data.data
 
             if isinstance(data, Quantity):
-                if unit is not None:
-                    raise ValueError("Cannot use the unit argument when data "
-                                     "is a Quantity")
+                if unit is not None and unit != data.unit:
+                    log.info("Overwriting Quantity's current "
+                             "unit with specified unit")
                 else:
-                    self._unit = data.unit
-            else:
-                if unit is not None:
-                    self._unit = Unit(unit)
-                else:
-                    self._unit = None
-            # This must come after self's unit has been set so that the unit
-            # of the uncertainty, if any, can be converted to the unit of the
-            # unit of self.
-            self.uncertainty = uncertainty
+                    unit = data.unit
+                data = data.value
+
+        # Quick check on the parameters if they match the requirements.
+        if (not hasattr(data, 'shape') or not hasattr(data, '__getitem__') or
+                not hasattr(data, '__array__')):
+            # Data doesn't look like a numpy array, try converting it to
+            # one.
+            data = np.array(data, subok=True, copy=False)
+
+        # Another quick check to see if what we got looks like an array
+        # rather than an object (since numpy will convert a
+        # non-numerical/non-string inputs to an array of objects).
+        if data.dtype == 'O':
+            raise TypeError("Could not convert data to numpy array.")
+
+        # Check if meta is a dict and create an empty one if no meta was given
+        if meta is None:
+            meta = OrderedDict()
+        elif not isinstance(meta, collections.Mapping):
+            raise TypeError("Meta attribute must be dict-like")
+
+        if unit is not None:
+            unit = Unit(unit)
+
+        if copy:
+            # Data might have been copied before but no way of validating
+            # without another variable.
+            data = deepcopy(data)
+            mask = deepcopy(mask)
+            wcs = deepcopy(wcs)
+            meta = deepcopy(meta)
+            uncertainty = deepcopy(uncertainty)
+            # Actually - copying the unit is unnecessary but better safe
+            # than sorry :-)
+            unit = deepcopy(unit)
+
+        # Store the attributes
+        self._data = data
+        self._mask = mask
+        self._wcs = wcs
+        self._meta = meta
+        self._unit = unit
+        # Call the setter for uncertainty to further check the uncertainty
+        self.uncertainty = uncertainty
 
     def __str__(self):
         return str(self.data)
@@ -173,10 +272,19 @@ class NDData(NDDataBase):
 
     @property
     def data(self):
+        """
+        `~numpy.ndarray`-like : The stored dataset.
+        """
         return self._data
 
     @property
     def mask(self):
+        """
+        any type : Mask for the dataset, if any.
+
+        Masks should follow the ``numpy`` convention that valid data points are
+        marked by ``False`` and invalid ones with ``True``.
+        """
         return self._mask
 
     @mask.setter
@@ -185,12 +293,76 @@ class NDData(NDDataBase):
 
     @property
     def unit(self):
+        """
+        `~astropy.units.Unit` : Unit for the dataset, if any.
+        """
         return self._unit
 
     @property
     def wcs(self):
+        """
+        any type : A world coordinate system (WCS) for the dataset, if any.
+        """
         return self._wcs
 
     @property
     def meta(self):
+        """
+        `dict`-like : Meta information about the dataset, if any.
+        """
         return self._meta
+
+    @property
+    def uncertainty(self):
+        """
+        any type : Uncertainty in the dataset, if any.
+
+        Should have an attribute ``uncertainty_type`` that defines what kind of
+        uncertainty is stored, such as ``std`` for standard deviation or
+        ``var`` for variance. A metaclass defining such an interface is
+        `~astropy.nddata.NDUncertainty` but isn't mandatory.
+
+        TODO: *Must* or *Should* have this ``uncertainty_type`` ? (mwcraig)
+        I implemented UnknownUncertainty to work around that so what is
+        saved in _uncertainty has an uncertainty_type but it's unknown :-)
+        """
+        if isinstance(self._uncertainty, UnknownUncertainty):
+            return self._uncertainty.array
+        else:
+            return self._uncertainty
+
+    @property
+    def uncertainty_type(self):
+        """
+        str: The kind of uncertainty that is saved.
+
+        The uncertainty_type is using the convention that standard deviation
+        is abbreviated by ``std``, variance by ``var``, ...
+
+        TODO: This is new and only a shortcut to the uncertainty type since
+        the property hides the really saved uncertainty if it is an
+        ``UnknownUncertainty``.
+        """
+        if self._uncertainty is None:
+            return None
+        else:
+            return self._uncertainty.uncertainty_type
+
+    @uncertainty.setter
+    def uncertainty(self, value):
+        if value is not None:
+            # There is one requirements on the uncertainty: That
+            # it has an attribute 'uncertainty_type' which is a string.
+            # If it does not match this requirement convert it to an unknown
+            # uncertainty.
+            if (not hasattr(value, 'uncertainty_type') or
+                    not isinstance(value.uncertainty_type, six.string_types)):
+                log.info('Uncertainty should have attribute uncertainty_type '
+                         'whose type is string.')
+                value = UnknownUncertainty(value, copy=False)
+
+            # If it is a subclass of NDUncertainty we must set the
+            # parent_nddata attribute. (#4152)
+            if isinstance(value, NDUncertainty):
+                value.parent_nddata = self
+        self._uncertainty = value

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -14,79 +14,66 @@ __all__ = ['NDDataBase']
 @six.add_metaclass(ABCMeta)
 class NDDataBase(object):
     """
-    Base metaclass that defines the interface for NDData
+    Base metaclass that defines the interface for N-dimensional datasets with
+    associated meta informations used in ``astropy``.
 
-    Classes that wish to use this interface without inheriting from
-    `~astropy.nddata.NDData` should subclass ``NDDataBase`` instead.
-
-    All properties and methods except uncertainty must be override by derived
-    classes.
+    NDDataBase makes no attempt of restricting any attribute or defines how
+    these are stored. Therefore all properties and methods have to be
+    overridden in subclasses. See `~astropy.nddata.NDData` for a subclass that
+    defines this interface on `~numpy.ndarray`-like based ``data``.
     """
 
     @abstractmethod
     def __init__(self):
-        self._uncertainty = None
+        pass
 
     @abstractproperty
     def data(self):
         """
-        The data; should be capable of behaving like a numpy array, though it
-        need not actually be a numpy array.
+        The stored dataset.
         """
         pass
 
     @abstractproperty
     def mask(self):
         """
-        Mask for the data, following the numpy convention that ``True`` means
-        the data should not be used.
+        Mask for the dataset.
+
+        Masks should follow the ``numpy`` convention that valid data points are
+        marked by ``False`` and invalid ones with ``True``.
         """
         return None
 
     @abstractproperty
     def unit(self):
         """
-        Unit for the data, if any.
+        Unit for the dataset.
         """
         return None
 
     @abstractproperty
     def wcs(self):
         """
-        WCS for the data, if any.
+        A world coordinate system (WCS) for the dataset.
         """
         return None
 
     @abstractproperty
     def meta(self):
         """
-        Metadata, if any, must be dict-like.
+        Meta information about the dataset.
+
+        Should be `dict`-like.
         """
         return None
 
-    # uncertainty and its setter are implemented as concrete to enforce the
-    # logic in the uncertainty setter. For a long discussion of the problems
-    # with trying to implement them as abstract (particularly the setter but
-    # not the getter), see http://bugs.python.org/issue11610
-    #
-    # In python >= 3.3 it would be easy to decorate one of these (setter or
-    # getter) as abstract but not the other.
-    @property
+    @abstractproperty
     def uncertainty(self):
         """
-        Uncertainty in the data.
+        Uncertainty in the dataset.
 
-        Uncertainty must have an attribute ``uncertainty_type`` that is
-        a string.
+        Should have an attribute ``uncertainty_type`` that defines what kind of
+        uncertainty is stored, such as ``'std'`` for standard deviation or
+        ``'var'`` for variance.
         """
-        return self._uncertainty
-
-    @uncertainty.setter
-    def uncertainty(self, value):
-        if value is not None:
-            if (not hasattr(value, 'uncertainty_type') or
-                    not isinstance(value.uncertainty_type, six.string_types)):
-
-                raise TypeError('Uncertainty must have attribute '
-                                'uncertainty_type whose type is string.')
-        self._uncertainty = value
+        return None

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -17,10 +17,9 @@ class NDDataBase(object):
     Base metaclass that defines the interface for N-dimensional datasets with
     associated meta informations used in ``astropy``.
 
-    NDDataBase makes no attempt of restricting any attribute or defines how
-    these are stored. Therefore all properties and methods have to be
-    overridden in subclasses. See `~astropy.nddata.NDData` for a subclass that
-    defines this interface on `~numpy.ndarray`-like based ``data``.
+    All properties and methods have to be overridden in subclasses. See
+    `~astropy.nddata.NDData` for a subclass that defines this interface on
+    `~numpy.ndarray`-like based ``data``.
     """
 
     @abstractmethod

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -12,8 +12,8 @@ from numpy.testing import assert_array_equal
 
 from ..nddata import NDData
 from ...utils.compat.odict import OrderedDict
-from ..nduncertainty import StdDevUncertainty  # , NDUncertainty
-from ...tests.helper import pytest  # , raises
+from ..nduncertainty import StdDevUncertainty
+from ...tests.helper import pytest
 from ... import units as u
 from ...utils import NumpyRNGContext
 
@@ -212,7 +212,7 @@ def test_nddata_init_data_quantity(data):
         assert ndd.data[1] != quantity.value[1]
 
 
-def test_nddata_init_data_maskedQuantity():
+def test_nddata_init_data_masked_quantity():
     a = np.array([2, 3])
     q = a * u.m
     m = False
@@ -267,7 +267,7 @@ def test_nddata_init_data_nddata():
     assert nd3.meta != nd1.meta
 
 
-def test_nddata_init_data_nddataSubclass():
+def test_nddata_init_data_nddata_subclass():
     # There might be some incompatible subclasses of NDData around.
     bnd = BadNDDataSubclass(False, True, 3, 2, 'gollum', 100)
     # Before changing the NDData init this would not have raised an error but

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -111,7 +111,7 @@ def test_uncertainty_setter():
     assert isinstance(nd.uncertainty, FakeUncertainty)
     nd.uncertainty = 10
     assert not isinstance(nd.uncertainty, FakeUncertainty)
-    assert nd.uncertainty == 10
+    assert nd.uncertainty.array == 10
 
 
 def test_mask_setter():

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -280,7 +280,7 @@ def test_nddata_init_data_nddataSubclass():
     nd = NDData(bnd_good)
     assert nd.unit == bnd_good.unit
     assert nd.meta == bnd_good.meta
-    assert nd.uncertainty.array == bnd_good.uncertainty.array
+    assert nd.uncertainty.array == bnd_good.uncertainty
     assert nd.mask == bnd_good.mask
     assert nd.wcs == bnd_good.wcs
     assert nd.data is bnd_good.data

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -6,12 +6,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import textwrap
+from collections import OrderedDict
 
 import numpy as np
 from numpy.testing import assert_array_equal
 
 from ..nddata import NDData
-from ...utils.compat.odict import OrderedDict
 from ..nduncertainty import StdDevUncertainty
 from ...tests.helper import pytest
 from ... import units as u

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -280,7 +280,7 @@ def test_nddata_init_data_nddataSubclass():
     nd = NDData(bnd_good)
     assert nd.unit == bnd_good.unit
     assert nd.meta == bnd_good.meta
-    assert nd.uncertainty == bnd_good.uncertainty
+    assert nd.uncertainty.array == bnd_good.uncertainty.array
     assert nd.mask == bnd_good.mask
     assert nd.wcs == bnd_good.wcs
     assert nd.data is bnd_good.data

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -11,31 +11,41 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from ..nddata import NDData
-from ..nduncertainty import StdDevUncertainty, NDUncertainty
-from ...tests.helper import pytest, raises
+from ...utils.compat.odict import OrderedDict
+from ..nduncertainty import StdDevUncertainty  # , NDUncertainty
+from ...tests.helper import pytest  # , raises
 from ... import units as u
 from ...utils import NumpyRNGContext
 
 
-class FakeUncertainty(NDUncertainty):
+# TODO: Changed from NDUncertainty to StdDev because of splitting PRs
+class FakeUncertainty(StdDevUncertainty):
 
-    def __init__(self, *arg, **kwd):
-        self._unit = None
+    # TODO: Uncomment after remerging of PRs:
+    """
+    @property
+    def uncertainty_type(self):
+        return 'fake'
+    """
+    # TODO: Delete this after remerging ( Shape check is deleted in new uncert)
+    @property
+    def parent_nddata(self):
+        return super(FakeUncertainty, self).parent_nddata
+
+    @parent_nddata.setter
+    def parent_nddata(self, value):
+        self._parent_nddata = value
+
+    def _propagate_add(self, data, final_data):
         pass
 
-    def propagate_add(self, data, final_data):
+    def _propagate_subtract(self, data, final_data):
         pass
 
-    def propagate_subtract(self, data, final_data):
+    def _propagate_multiply(self, data, final_data):
         pass
 
-    def propagate_multiply(self, data, final_data):
-        pass
-
-    def propagate_divide(self, data, final_data):
-        pass
-
-    def array(self):
+    def _propagate_divide(self, data, final_data):
         pass
 
 
@@ -57,27 +67,226 @@ class FakeNumpyArray(object):
     def __array__(self):
         pass
 
+    @property
+    def dtype(self):
+        return 'fake'
 
+
+class MinimalUncertainty(object):
+    """
+    Define the minimum attributes acceptable as an uncertainty object.
+    """
+    def __init__(self, value):
+        self._uncertainty = value
+
+    @property
+    def uncertainty_type(self):
+        return "totally and completely fake"
+
+
+class BadNDDataSubclass(NDData):
+
+    def __init__(self, data, uncertainty=None, mask=None, wcs=None,
+                 meta=None, unit=None):
+        self._data = data
+        self._uncertainty = uncertainty
+        self._mask = mask
+        self._wcs = wcs
+        self._unit = unit
+        self._meta = meta
+
+
+# Setter tests
+def test_uncertainty_setter():
+    nd = NDData([1, 2, 3])
+    good_uncertainty = MinimalUncertainty(5)
+    nd.uncertainty = good_uncertainty
+    assert nd.uncertainty is good_uncertainty
+    # Check the fake uncertainty (minimal does not work since it has no
+    # parent_nddata attribute from NDUncertainty)
+    nd.uncertainty = FakeUncertainty(5)
+    assert nd.uncertainty.parent_nddata is nd
+    # Check that it works if the uncertainty was set during init
+    nd = NDData(nd)
+    assert isinstance(nd.uncertainty, FakeUncertainty)
+    nd.uncertainty = 10
+    assert not isinstance(nd.uncertainty, FakeUncertainty)
+    assert nd.uncertainty == 10
+
+
+def test_mask_setter():
+    # Since it just changes the _mask attribute everything should work
+    nd = NDData([1, 2, 3])
+    nd.mask = True
+    assert nd.mask
+    nd.mask = False
+    assert not nd.mask
+    # Check that it replaces a mask from init
+    nd = NDData(nd, mask=True)
+    assert nd.mask
+    nd.mask = False
+    assert not nd.mask
+
+
+# Init tests
 def test_nddata_empty():
     with pytest.raises(TypeError):
         NDData()  # empty initializer should fail
 
 
-def test_nddata_init_with_nonarray():
+def test_nddata_init_data_nonarray():
     inp = [1, 2, 3]
     nd = NDData(inp)
     assert (np.array(inp) == nd.data).all()
 
 
-def test_nddata_simple():
+def test_nddata_init_data_ndarray():
+    # random floats
     with NumpyRNGContext(123):
         nd = NDData(np.random.random((10, 10)))
     assert nd.data.shape == (10, 10)
     assert nd.data.size == 100
     assert nd.data.dtype == np.dtype(float)
 
+    # specific integers
+    nd = NDData(np.array([[1, 2, 3], [4, 5, 6]]))
+    assert nd.data.size == 6
+    assert nd.data.dtype == np.dtype(int)
 
-def test_nddata_data_properties():
+    # Tests to ensure that creating a new NDData object copies by *reference*.
+    a = np.ones((10, 10))
+    nd_ref = NDData(a)
+    a[0, 0] = 0
+    assert nd_ref.data[0, 0] == 0
+
+    # Except we choose copy=True
+    a = np.ones((10, 10))
+    nd_ref = NDData(a, copy=True)
+    a[0, 0] = 0
+    assert nd_ref.data[0, 0] != 0
+
+
+def test_nddata_init_data_maskedarray():
+    with NumpyRNGContext(456):
+        NDData(np.random.random((10, 10)),
+               mask=np.random.random((10, 10)) > 0.5)
+
+    # Another test (just copied here)
+    with NumpyRNGContext(12345):
+        a = np.random.randn(100)
+        marr = np.ma.masked_where(a > 0, a)
+    nd = NDData(marr)
+    # check that masks and data match
+    assert_array_equal(nd.mask, marr.mask)
+    assert_array_equal(nd.data, marr.data)
+    # check that they are both by reference
+    marr.mask[10] = ~marr.mask[10]
+    marr.data[11] = 123456789
+    assert_array_equal(nd.mask, marr.mask)
+    assert_array_equal(nd.data, marr.data)
+
+    # or not if we choose copy=True
+    nd = NDData(marr, copy=True)
+    marr.mask[10] = ~marr.mask[10]
+    marr.data[11] = 0
+    assert nd.mask[10] != marr.mask[10]
+    assert nd.data[11] != marr.data[11]
+
+
+@pytest.mark.parametrize('data', [np.array([1, 2, 3]), 5])
+def test_nddata_init_data_quantity(data):
+    # Test an array and a scalar because a scalar Quantity does not always
+    # behaves the same way as an array.
+    quantity = data * u.adu
+    ndd = NDData(quantity)
+    assert ndd.unit == quantity.unit
+    assert_array_equal(ndd.data, np.array(quantity.value))
+    if ndd.data.size > 1:
+        # check that if it is an array it is not copied
+        quantity.value[1] = 100
+        assert ndd.data[1] == quantity.value[1]
+
+        # or is copyied if we choose copy=True
+        ndd = NDData(quantity, copy=True)
+        quantity.value[1] = 5
+        assert ndd.data[1] != quantity.value[1]
+
+
+def test_nddata_init_data_maskedQuantity():
+    a = np.array([2, 3])
+    q = a * u.m
+    m = False
+    mq = np.ma.array(q, mask=m)
+    nd = NDData(mq)
+    assert_array_equal(nd.data, a)
+    # This test failed before the change in nddata init because the masked
+    # arrays data (which in fact was a quantity was directly saved)
+    assert nd.unit == u.m
+    assert not isinstance(nd.data, u.Quantity)
+    np.testing.assert_array_equal(nd.mask, np.array(m))
+
+
+def test_nddata_init_data_nddata():
+    nd1 = NDData(np.array([1]))
+    nd2 = NDData(nd1)
+    assert nd2.wcs == nd1.wcs
+    assert nd2.uncertainty == nd1.uncertainty
+    assert nd2.mask == nd1.mask
+    assert nd2.unit == nd1.unit
+    assert nd2.meta == nd1.meta
+
+    # Check that it is copied by reference
+    nd1 = NDData(np.ones((5, 5)))
+    nd2 = NDData(nd1)
+    assert nd1.data is nd2.data
+
+    # Check that it is really copied if copy=True
+    nd2 = NDData(nd1, copy=True)
+    nd1.data[2, 3] = 10
+    assert nd1.data[2, 3] != nd2.data[2, 3]
+
+    # Now let's see what happens if we have all explicitly set
+    nd1 = NDData(np.array([1]), mask=False, uncertainty=10, unit=u.s,
+                 meta={'dest': 'mordor'}, wcs=10)
+    nd2 = NDData(nd1)
+    assert nd2.data is nd1.data
+    assert nd2.wcs == nd1.wcs
+    assert nd2.uncertainty == nd1.uncertainty
+    assert nd2.mask == nd1.mask
+    assert nd2.unit == nd1.unit
+    assert nd2.meta == nd1.meta
+
+    # now what happens if we overwrite them all too
+    nd3 = NDData(nd1, mask=True, uncertainty=200, unit=u.km,
+                 meta={'observer': 'ME'}, wcs=4)
+    assert nd3.data is nd1.data
+    assert nd3.wcs != nd1.wcs
+    assert nd3.uncertainty != nd1.uncertainty
+    assert nd3.mask != nd1.mask
+    assert nd3.unit != nd1.unit
+    assert nd3.meta != nd1.meta
+
+
+def test_nddata_init_data_nddataSubclass():
+    # There might be some incompatible subclasses of NDData around.
+    bnd = BadNDDataSubclass(False, True, 3, 2, 'gollum', 100)
+    # Before changing the NDData init this would not have raised an error but
+    # would have lead to a compromised nddata instance
+    with pytest.raises(TypeError):
+        NDData(bnd)
+    # but if it has no actual incompatible attributes it passes
+    bnd_good = BadNDDataSubclass(np.array([1, 2]), True, 3, 2,
+                                 {'enemy': 'black knight'}, u.km)
+    nd = NDData(bnd_good)
+    assert nd.unit == bnd_good.unit
+    assert nd.meta == bnd_good.meta
+    assert nd.uncertainty == bnd_good.uncertainty
+    assert nd.mask == bnd_good.mask
+    assert nd.wcs == bnd_good.wcs
+    assert nd.data is bnd_good.data
+
+
+def test_nddata_init_data_fail():
     # First one is slicable but has no shape, so should fail.
     with pytest.raises(TypeError):
         NDData({'a': 'dict'})
@@ -94,6 +303,101 @@ def test_nddata_data_properties():
         NDData(Shape())
 
 
+def test_nddata_init_data_fakes():
+    ndd1 = NDData(FakeNumpyArray())
+    # First make sure that NDData isn't converting its data to a numpy array.
+    assert isinstance(ndd1.data, FakeNumpyArray)
+    # Make a new NDData initialized from an NDData
+    ndd2 = NDData(ndd1)
+    # Check that the data wasn't converted to numpy
+    assert isinstance(ndd2.data, FakeNumpyArray)
+
+
+# Specific parameters
+def test_param_uncertainty():
+    u = StdDevUncertainty(array=np.ones((5, 5)))
+    d = NDData(np.ones((5, 5)), uncertainty=u)
+    # Test that the parent_nddata is set.
+    assert d.uncertainty.parent_nddata is d
+    # Test conflicting uncertainties (other NDData)
+    u2 = StdDevUncertainty(array=np.ones((5, 5))*2)
+    d2 = NDData(d, uncertainty=u2)
+    assert d2.uncertainty is u2
+    assert d2.uncertainty.parent_nddata is d2
+
+
+def test_param_wcs():
+    # Since everything is allowed we only need to test something
+    nd = NDData([1], wcs=3)
+    assert nd.wcs == 3
+    # Test conflicting wcs (other NDData)
+    nd2 = NDData(nd, wcs=2)
+    assert nd2.wcs == 2
+
+
+def test_param_meta():
+    # everything dict-like is allowed
+    with pytest.raises(TypeError):
+        NDData([1], meta=3)
+    nd = NDData([1, 2, 3], meta={})
+    assert len(nd.meta) == 0
+    nd = NDData([1, 2, 3])
+    assert isinstance(nd.meta, OrderedDict)
+    assert len(nd.meta) == 0
+    # Test conflicting meta (other NDData)
+    nd2 = NDData(nd, meta={'image': 'sun'})
+    assert len(nd2.meta) == 1
+    nd3 = NDData(nd2, meta={'image': 'moon'})
+    assert len(nd3.meta) == 1
+    assert nd3.meta['image'] == 'moon'
+
+
+def test_param_mask():
+    # Since everything is allowed we only need to test something
+    nd = NDData([1], mask=False)
+    assert not nd.mask
+    # Test conflicting mask (other NDData)
+    nd2 = NDData(nd, mask=True)
+    assert nd2.mask
+    # (masked array)
+    nd3 = NDData(np.ma.array([1], mask=False), mask=True)
+    assert nd3.mask
+    # (masked quantity)
+    mq = np.ma.array(np.array([2, 3])*u.m, mask=False)
+    nd4 = NDData(mq, mask=True)
+    assert nd4.mask
+
+
+def test_param_unit():
+    with pytest.raises(ValueError):
+        NDData(np.ones((5, 5)), unit="NotAValidUnit")
+    NDData([1, 2, 3], unit='meter')
+    # Test conflicting units (quantity as data)
+    q = np.array([1, 2, 3]) * u.m
+    nd = NDData(q, unit='cm')
+    assert nd.unit != q.unit
+    assert nd.unit == u.cm
+    # (masked quantity)
+    mq = np.ma.array(np.array([2, 3])*u.m, mask=False)
+    nd2 = NDData(mq, unit=u.s)
+    assert nd2.unit == u.s
+    # (another NDData as data)
+    nd3 = NDData(nd, unit='km')
+    assert nd3.unit == u.km
+
+
+# Check that the meta descriptor is working as expected. The MetaBaseTest class
+# takes care of defining all the tests, and we simply have to define the class
+# and any minimal set of args to pass.
+from ...utils.tests.test_metadata import MetaBaseTest
+
+
+class TestMetaNDData(MetaBaseTest):
+    test_class = NDData
+    args = np.array([[1.]])
+
+
+# Representation tests
 def test_nddata_str():
     arr1d = NDData(np.array([1, 2, 3]))
     assert str(arr1d) == '[1 2 3]'
@@ -130,139 +434,14 @@ def test_nddata_repr():
                  [7, 8]]])"""[1:])
 
 
-def test_nddata_mask_valid():
-    with NumpyRNGContext(456):
-        NDData(np.random.random((10, 10)),
-               mask=np.random.random((10, 10)) > 0.5)
-
-
-def test_nddata_uncertainty_init():
-    u = StdDevUncertainty(array=np.ones((5, 5)))
-    d = NDData(np.ones((5, 5)), uncertainty=u)
-
-    # Expect a TypeError if the uncertainty is missing
-    # attribute uncertainty_type.
-    with pytest.raises(TypeError):
-        NDData(np.array([1]), uncertainty=5)
-
-    # Expect a TypeError if the uncertainty has attribute uncertainty_type
-    # but it is not a string.
-
-    class BadUncertainty(object):
-        def __init__(self):
-            self.uncertainty_type = 5
-
-    with pytest.raises(TypeError):
-        NDData(np.array([1]), uncertainty=BadUncertainty())
-
-
-def test_nddata_init_from_nddata_data_argument_only():
-    ndd1 = NDData(np.array([1]))
-    ndd2 = NDData(ndd1)
-    assert ndd2.wcs == ndd1.wcs
-    assert ndd2.uncertainty == ndd1.uncertainty
-    assert ndd2.mask == ndd1.mask
-    assert ndd2.unit == ndd1.unit
-    assert ndd2.meta == ndd1.meta
-
-
-def test_nddata_init_from_nddata_does_not_convert_data():
-    ndd1 = NDData(FakeNumpyArray())
-    # First make sure that NDData isn't converting its data to a numpy array.
-    assert isinstance(ndd1.data, FakeNumpyArray)
-    # Make a new NDData initialized from an NDData
-    ndd2 = NDData(ndd1)
-    # Check that the data wasn't converted to numpy
-    assert isinstance(ndd2.data, FakeNumpyArray)
-
-
-def test_nddata_copy_ref():
-    """
-    Tests to ensure that creating a new NDData object copies by *reference*.
-    """
-    a = np.ones((10, 10))
-    nd_ref = NDData(a)
-    a[0, 0] = 0
-    assert nd_ref.data[0, 0] == 0
-
-
-def test_nddata_conversion():
-    nd = NDData(np.array([[1, 2, 3], [4, 5, 6]]))
-    assert nd.data.size == 6
-    assert nd.data.dtype == np.dtype(int)
-
-
-@raises(ValueError)
-def test_invalid_unit():
-    d = NDData(np.ones((5, 5)), unit="NotAValidUnit")
-
-
+# Not supported features
 def test_slicing_not_supported():
     ndd = NDData(np.ones((5, 5)))
     with pytest.raises(TypeError):
         ndd[0]
 
 
-def test_initializing_from_nddata():
-    d1 = NDData(np.ones((5, 5)))
-    d2 = NDData(d1)
-
-    assert d1.data is d2.data
-
-
-def test_initializing_from_nduncertainty():
-    u1 = StdDevUncertainty(np.ones((5, 5)) * 3)
-    u2 = StdDevUncertainty(u1, copy=False)
-
-    assert u1.array is u2.array
-
-
-# Test an array and a scalar because a scalar Quantity does not always
-# behaves the same way as an array.
-@pytest.mark.parametrize('data', [np.array([1, 2, 3]), 5])
-def test_initializing_nddata_from_quantity(data):
-    # Until nddata and quantity are integrated initializing with a quantity
-    # should raise an error.
-    unit = u.adu
-    ndd = NDData(data * unit)
-    assert ndd.unit == unit
-    np.testing.assert_array_equal(ndd.data, np.array(data))
-
-
-def test_initializing_nddata_from_quantity_and_unit_raises_error():
-    # Should raise an error if a Quantity is provided for the data and
-    # an explicit unit is given.
-    with pytest.raises(ValueError):
-        NDData([1, 2, 3] * u.adu, unit=u.adu)
-
-
-def test_masked_array_input():
-
-    with NumpyRNGContext(12345):
-        a = np.random.randn(100)
-        marr = np.ma.masked_where(a > 0, a)
-
-    nd = NDData(marr)
-
-    # check that masks and data match
-    assert_array_equal(nd.mask, marr.mask)
-    assert_array_equal(nd.data, marr.data)
-
-    # check that they are both by reference
-    marr.mask[10] = ~marr.mask[10]
-    marr.data[11] = 123456789
-
-    assert_array_equal(nd.mask, marr.mask)
-    assert_array_equal(nd.data, marr.data)
-
-
-# Check that the meta descriptor is working as expected. The MetaBaseTest class
-# takes care of defining all the tests, and we simply have to define the class
-# and any minimal set of args to pass.
-
-from ...utils.tests.test_metadata import MetaBaseTest
-
-
-class TestMetaNDData(MetaBaseTest):
-    test_class = NDData
-    args = np.array([[1.]])
+def test_arithmetic_not_supported():
+    ndd = NDData(np.ones((5, 5)))
+    with pytest.raises(TypeError):
+        ndd + ndd

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..nddata_base import NDDataBase
-from ...tests.helper import pytest
+# from ...tests.helper import pytest
 
 
 class MinimalSubclass(NDDataBase):
@@ -32,17 +32,9 @@ class MinimalSubclass(NDDataBase):
     def meta(self):
         return super(MinimalSubclass, self).meta
 
-
-class MinimalUncertainty(object):
-    """
-    Define the minimum attributes acceptable as an uncertainty object.
-    """
-    def __init__(self, value):
-        self._uncertainty = value
-
     @property
-    def uncertainty_type(self):
-        return "totally and completely fake"
+    def uncertainty(self):
+        return super(MinimalSubclass, self).uncertainty
 
 
 def test_nddata_base_subclass():
@@ -52,9 +44,4 @@ def test_nddata_base_subclass():
     assert a.mask is None
     assert a.unit is None
     assert a.wcs is None
-    good_uncertainty = MinimalUncertainty(5)
-    a.uncertainty = good_uncertainty
-    assert a.uncertainty is good_uncertainty
-    bad_uncertainty = 5
-    with pytest.raises(TypeError):
-        a.uncertainty = bad_uncertainty
+    assert a.uncertainty is None

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..nddata_base import NDDataBase
-# from ...tests.helper import pytest
 
 
 class MinimalSubclass(NDDataBase):

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -64,7 +64,6 @@ The underlying Numpy array can be accessed via the ``data`` attribute::
 Values can be masked using the ``mask`` attribute::
 
      >>> ndd_masked = NDData(ndd, mask = ndd.data > 0.9)
-     INFO: Overwriting NDData's current mask with specified mask [astropy.nddata.nddata]
 
 A mask value of `True` indicates a value that should be ignored, while a mask
 value of `False` indicates a valid value.

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -74,7 +74,8 @@ Similar attributes are available to store:
 + generic meta-data, in ``meta``,
 + a unit for the data values, in ``unit`` and
 + an uncertainty for the data values, in ``uncertainty``. Note that the
-  ``uncertainty`` must have a string attribute called ``uncertainty_type``.
+  ``uncertainty`` must have a attribute called ``uncertainty_type`` otherwise
+  it will be converted to an `~astropy.nddata.UnknownUncertainty`.
 
 Note that a `~astropy.nddata.NDData` object is not sliceable::
 

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -21,12 +21,6 @@ datasets in astropy through:
   `~astropy.nddata` objects  in functions in astropy and affiliated packages.
 + General utility functions (:ref:`nddata_utils`) for array operations.
 
-.. warning::
-
-  `~astropy.nddata` has changed significantly in astropy 1.0. See the section
-  :ref:`nddata_transition` for more information. Some more changes were done in
-  astropy x.xx, see more details in :ref:`nddata_transition2`.
-
 Getting started
 ===============
 
@@ -132,81 +126,6 @@ of objects that support the NDData interface but need the freedom to define
 their own ways of storing data, unit, metadata and/or other properties. It
 should be used instead of `~astropy.nddata.NDData` as the starting point for
 any class for which the `~astropy.nddata.NDData` class is too restrictive.
-
-.. _nddata_transition:
-
-Transition to astropy 1.0
-=========================
-
-The nddata package underwent substantial revision as a result of `APE 7`_;
-please see that APE for an extensive discussion of the motivation and the
-changes.
-
-The most important changes are that:
-
-+ ``NDData`` does not provide a numpy-like interface; to use its data use the
-  ``data`` attribute instead.
-+ Slicing is no provided in the base `~astropy.nddata.NDData`.
-+ Arithmetic is no longer included in the base `~astropy.nddata.NDData` class.
-
-Code that only uses the metadata features of `~astropy.nddata.NDData` should
-not need to be modified.
-
-Code that uses the arithemtic methods that used to be included in
-`~astropy.nddata.NDData` and relied on it to behave like a numpy array should
-instead subclass `~astropy.nddata.NDDataArray`; that class is equivalent to
-the original `~astropy.nddata.NDData` class.
-
-.. _nddata_transition2:
-
-Transition to astropy x.xx
-==========================
-
-The implementation of `APE 7`_ where `~astropy.nddata.NDData` underwent a major
-revision had some bugs and minor shortcomings;
-So the interface was changed in some small ways and some bugs were fixed:
-
-`~astropy.nddata.NDDataBase`:
-
-+ `NDDataBase.uncertainty.getter`: is now abstract.
-+ `NDDataBase.uncertainty.setter`: is moved to `~astropy.nddata.NDData`.
-
-`~astropy.nddata.NDData`:
-
-+ ``NDData`` now implements the ``uncertainty`` getter and setter from the
-  former `~astropy.nddata.NDDataBase` with some minor modifications.
-
-+ ``NDData.uncertainty.setter``:
-
-  + wraps an ``uncertainty`` inside an `~astropy.nddata.UnknownUncertainty` if
-    no ``uncertainty_type`` attribute is present in the uncertainty.
-  + the uncertainty_type of the uncertainty must not be a string
-    anymore. But it is still recommended.
-  + did not set the ``parent_nddata`` of the ``uncertainty`` if the uncertainty
-    was a subclass of `~astropy.nddata.NDUncertainty`. This is now fixed.
-
-+ ``NDData.__init__``:
-
-  + got an additional optional parameter ``copy`` which is
-    by default False. If it is True all other parameters are copied before saving
-    them as attributes. If False the parameters are only copied if there is no
-    way of saving them as reference.
-  + the ``data`` parameter allows now also ``Masked_Quantity`` objects
-  + if the ``data`` is another instance or subclass of
-    `~astropy.nddata.NDData` all implicit properties are checked because
-    subclasses might implement another set of restrictions.
-  + if an implicit and explicit attribute is provided, the
-    explicit one is kept (without conversion) and a warning is issued. For
-    example if ``data`` is a `~astropy.units.Quantity` and also a ``unit`` is
-    given. The unit of the instance will be the ``unit`` parameter.
-  + allowed a ``data`` parameter with a ``mask`` without checking that it had a
-    ``data`` attribute.
-
-Not backwards-compatible changes:
-
-+ Subclasses of `~astropy.nddata.NDDataBase` need to implement an
-  ``uncertainty`` getter and setter. Subclasses of `~astropy.nddata.NDData`
-  are not affected.
 
 
 Using ``nddata``

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -24,7 +24,8 @@ datasets in astropy through:
 .. warning::
 
   `~astropy.nddata` has changed significantly in astropy 1.0. See the section
-  :ref:`nddata_transition` for more information.
+  :ref:`nddata_transition` for more information. Some more changes were done in
+  astropy x.xx, see more details in :ref:`nddata_transition2`.
 
 Getting started
 ===============
@@ -155,6 +156,57 @@ Code that uses the arithemtic methods that used to be included in
 `~astropy.nddata.NDData` and relied on it to behave like a numpy array should
 instead subclass `~astropy.nddata.NDDataArray`; that class is equivalent to
 the original `~astropy.nddata.NDData` class.
+
+.. _nddata_transition2:
+
+Transition to astropy x.xx
+==========================
+
+The implementation of `APE 7`_ where `~astropy.nddata.NDData` underwent a major
+revision had some bugs and minor shortcomings;
+So the interface was changed in some small ways and some bugs were fixed:
+
+`~astropy.nddata.NDDataBase`:
+
++ `NDDataBase.uncertainty.getter`: is now abstract.
++ `NDDataBase.uncertainty.setter`: is moved to `~astropy.nddata.NDData`.
+
+`~astropy.nddata.NDData`:
+
++ ``NDData`` now implements the ``uncertainty`` getter and setter from the
+  former `~astropy.nddata.NDDataBase` with some minor modifications.
+
++ ``NDData.uncertainty.setter``:
+
+  + wraps an ``uncertainty`` inside an `~astropy.nddata.UnknownUncertainty` if
+    no ``uncertainty_type`` attribute is present in the uncertainty.
+  + the uncertainty_type of the uncertainty must not be a string
+    anymore. But it is still recommended.
+  + did not set the ``parent_nddata`` of the ``uncertainty`` if the uncertainty
+    was a subclass of `~astropy.nddata.NDUncertainty`. This is now fixed.
+
++ ``NDData.__init__``:
+
+  + got an additional optional parameter ``copy`` which is
+    by default False. If it is True all other parameters are copied before saving
+    them as attributes. If False the parameters are only copied if there is no
+    way of saving them as reference.
+  + the ``data`` parameter allows now also ``Masked_Quantity`` objects
+  + if the ``data`` is another instance or subclass of
+    `~astropy.nddata.NDData` all implicit properties are checked because
+    subclasses might implement another set of restrictions.
+  + if an implicit and explicit attribute is provided, the
+    explicit one is kept (without conversion) and a warning is issued. For
+    example if ``data`` is a `~astropy.units.Quantity` and also a ``unit`` is
+    given. The unit of the instance will be the ``unit`` parameter.
+  + allowed a ``data`` parameter with a ``mask`` without checking that it had a
+    ``data`` attribute.
+
+Not backwards-compatible changes:
+
++ Subclasses of `~astropy.nddata.NDDataBase` need to implement an
+  ``uncertainty`` getter and setter. Subclasses of `~astropy.nddata.NDData`
+  are not affected.
 
 
 Using ``nddata``

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -67,7 +67,6 @@ Values can be masked using the ``mask`` attribute.  One straightforward way to
 provide a mask is to use a boolean numpy array::
 
      >>> ndd_masked = NDData(ndd, mask = ndd.data > 0.9)
-     INFO: Overwriting NDData's current mask with specified mask [astropy.nddata.nddata]
 
 Another is to simply initialize an `~astropy.nddata.NDData` object  with a
 masked numpy array::

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -13,7 +13,7 @@ array-like interface, and optional attributes:
 +  ``meta``, for metadata
 + ``unit`` for the ``data`` unit
 + ``uncertainty`` for the uncertainty of the data (which could be standard
-  deviation,variance, or something else),
+  deviation, variance or something else),
 + ``mask`` for the ``data``
 + ``wcs``, representing the relationship  between ``data`` and world
   coordinates.
@@ -106,7 +106,8 @@ Uncertainties
 
 `~astropy.nddata.NDData` objects have an ``uncertainty`` attribute that can be
 used to set the uncertainty on the data values. The ``uncertainty`` must have
-an attribute ``uncertainty_type`` which is a string.
+an attribute ``uncertainty_type`` otherwise it is wrapped inside an
+`~astropy.nddata.UnknownUncertainty`.
 
 While not a requirement, the following ``uncertainty_type`` strings
 are strongly recommended for common ways of specifying normal

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -155,6 +155,47 @@ At the moment the ``wcs`` attribute can be set to any object, though in the
 future it may be restricted to an `~astropy.wcs.WCS` object once a generalized
 WCS object is developed.
 
+Initialization with copy
+------------------------
+
+The default way to create an `~astropy.nddata.NDData` instance is to try saving
+the parameters as reference rather than as copy. Sometimes this is not possible
+because the internal mechanics doesn't allow for this. For example if the
+``data`` is a `list` then during initialization this is copied while converting
+to a `~numpy.ndarray`. But it is also possible to enforce copies
+during initialization by setting the ``copy`` parameter to ``True``::
+
+    >>> array = np.array([1, 2, 3, 4])
+    >>> ndd = NDData(array)
+    >>> ndd.data[2] = 10
+    >>> array[2]  # Original array is changed
+    10
+    >>> ndd2 = NDData(array, copy=True)
+    >>> ndd2.data[2] = 3
+    >>> array[2]  # Original array is not changed.
+    10
+
+Conflicting parameters
+----------------------
+
+It is possible to initialize `~astropy.nddata.NDData` with an explicit
+parameter in the initialization call and an implicit one in the ``data``
+parameter. If such a combination is detected a warning is
+issued and the explicit parameter is kept (without any attempt of conversion).
+
+For example with quantities::
+
+    >>> import astropy.units as u
+    >>> quantity = np.array([1, 2, 3, 4]) * u.m
+    >>> ndd = NDData(quantity, unit="cm")  # Explicit unit is cm and implicit is m, keep explicit.
+    INFO: Overwriting Quantity's current unit with specified unit [astropy.nddata.nddata]
+    >>> ndd.unit
+    Unit("cm")
+
+But this can affect the mask if the ``data`` parameter is a `~numpy.ma.MaskedArray`
+or even all attributes if the ``data`` is another `~astropy.nddata.NDData`
+instance.
+
 Converting to Numpy arrays
 --------------------------
 

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -45,7 +45,6 @@ can do::
     >>> ndd = NDData(array)
     >>> uncertainty = StdDevUncertainty(np.ones((12, 12, 12)) * 0.1)
     >>> ndd_uncertainty = NDData(ndd, uncertainty=uncertainty)
-    INFO: Overwriting NDData's current uncertainty being overwritten with specified uncertainty [astropy.nddata.nddata]
 
 New error classes should sub-class from `~astropy.nddata.NDUncertainty`, and
 should provide methods with the following API::

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -3,7 +3,7 @@ Subclassing
 
 There are a couple of choices to be made in subclassing from the nddata
 package. For the greatest flexibility, subclass from
-`~astropy.nddata.NDDataBase`, which places (almost) no restrictions on any of
+`~astropy.nddata.NDDataBase`, which places no restrictions on any of
 its attributes. In many cases, subclassing `~astropy.nddata.NDData` will work
 instead; it is more straightforward but places some minimal restrictions on
 how the data can be represented.
@@ -12,7 +12,7 @@ how the data can be represented.
 ----------------------------
 
 The class `~astropy.nddata.NDDataBase` is a metaclass -- when subclassing it,
-all properties of `~astropy.nddata.NDDataBase` except ``uncertainty`` *must*
+all properties of `~astropy.nddata.NDDataBase` *must*
 be overriden in the subclass. For an example of how to do this, see the source
 code for `astropy.nddata.NDData`.
 


### PR DESCRIPTION
This is the refactor of ``NDDataBase`` and ``NDData`` (from #4234). More comments will follow as soon as I get the splitted parts to work.

**edit 12/22/2015 to add checklist for completion:**

+ [x] Update documentation to reflect changes
+ [x] Remove restriction on type of `uncertainty_type` (ping list notifying about this)
+ [x] Always return the uncertainty object, not the data contained in that object, even if an `UnknownUncertainty` is created by `NDData`
