### PR TITLE
Make ProgressBar work with IPython 4

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -26,6 +26,10 @@ except ImportError:
     _CAN_RESIZE_TERMINAL = False
 
 try:
+    from IPython import get_ipython
+except ImportError:
+    pass
+try:
     get_ipython()
 except NameError:
     OutStream = None


### PR DESCRIPTION
On IPython 4.0.0, ProgressBar does not work as an IPython widget. This command:

    astropy.utils.console.ProgressBar(10, ipython_widget=True)

produces this traceback:

    ---------------------------------------------------------------------------
    NameError                                 Traceback (most recent call last)
    <ipython-input-8-988ccc943b20> in <module>()
    ----> 1 astropy.utils.console.ProgressBar(10, ipython_widget=True)

    /Users/foobar/local/lib/python2.7/site-packages/astropy/utils/console.pyc in __init__(self, total_or_items, ipython_widget, file)
        497             # Import only if ipython_widget, i.e., widget in IPython
        498             # notebook
    --> 499             if ipython_major_version < 4:
        500                 from IPython.html import widgets
        501             else:

    NameError: global name 'ipython_major_version' is not defined

This patch addresses the issue by attempting to import `get_ipython` from `IPython`.