### PR TITLE
analytic_functions: Skip Tests on windows

### DIFF
--- a/astropy/analytic_functions/tests/test_blackbody.py
+++ b/astropy/analytic_functions/tests/test_blackbody.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
+from platform import system
 import warnings
 # THIRD-PARTY
 import numpy as np
@@ -26,7 +27,8 @@ else:
 __doctest_skip__ = ['*']
 
 
-@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
+@pytest.mark.skipif("system() == 'Windows' or os.environ.get('APPVEYOR')",
+                    reason="fails on Windows/AppVeyor")
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_blackbody_scipy():
     """Test Planck function.
@@ -47,7 +49,8 @@ def test_blackbody_scipy():
     np.testing.assert_allclose(intflux, ans.value, rtol=0.01)  # 1% accuracy
 
 
-@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
+@pytest.mark.skipif("system() == 'Windows' or os.environ.get('APPVEYOR')",
+                    reason="fails on Windows/AppVeyor")
 def test_blackbody_overflow():
     """Test Planck function with overflow."""
     photlam = u.photon / (u.cm**2 * u.s * u.AA)
@@ -69,7 +72,8 @@ def test_blackbody_overflow():
     assert flux.value == 0
 
 
-@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
+@pytest.mark.skipif("system() == 'Windows' or os.environ.get('APPVEYOR')",
+                    reason="fails on Windows/AppVeyor")
 def test_blackbody_synphot():
     """Test that it is consistent with IRAF SYNPHOT BBFUNC."""
     # Solid angle of solar radius at 1 kpc


### PR DESCRIPTION
I'm not really sure if that change makes sense. But the tests that are marked to ``xfail`` on AppVeyor are tried on windows - I'm not sure that's meant to be but I guess not. 

At least if I start the tests with ``python setup.py test`` and ``import astropy; astropy.test()`` the tests in ``analytic_functions`` fail (``F`` instead of ``x``) on my windows computer.

closes #4171