### PR TITLE
Do not try to import IPython.kernel for ipython >= 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -885,6 +885,10 @@ Bug Fixes
 
 - ``astropy.utils``
 
+ - Fixed an issue where if ipython is installed but ipykernel is not
+   installed then importing astropy from the ipython console gave an
+   IPython.kernel deprecation warning. [#4279]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -31,19 +31,23 @@ except NameError:
     OutStream = None
     IPythonIOStream = None
 else:
+    from IPython import version_info
+    ipython_major_version = version_info[0]
+
     try:
         from ipykernel.iostream import OutStream
     except ImportError:
         try:
             from IPython.zmq.iostream import OutStream
         except ImportError:
-            try:
-                from IPython.kernel.zmq.iostream import OutStream
-            except ImportError:
+            if ipython_major_version < 4:
+                try:
+                    from IPython.kernel.zmq.iostream import OutStream
+                except ImportError:
+                    OutStream = None
+            else:
                 OutStream = None
 
-    from IPython import version_info
-    ipython_major_version = version_info[0]
 
     if OutStream is not None:
         from IPython.utils import io as ipyio


### PR DESCRIPTION
As reported by @keflavich (https://github.com/astropy/astropy/pull/4078#issuecomment-151397923), if `ipython` is installed but `ipykernel` is not installed then importing `astropy` from the `ipython` console gives a `IPython.kernel` deprecation warning (see #4078).  `ipykernel` is a required dependency for the `jupyter` notebook, but not for the `ipython` console.

In this PR an import of `IPython.kernel` will not be tried for `ipython >= 4`.  As a side effect, note that `OutStream` will now be `None` if using `ipython >= 4` and `ipykernel` is not installed.