### PR TITLE
Add ability to read urlopen object in fitsopen

### DIFF
--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -118,6 +118,8 @@ class _File(object):
             mode not in ('ostream', 'append') and
             _is_url(fileobj)): # This is an URL.
                 self.name = download_file(fileobj, cache=cache)
+        if hasattr(fileobj, 'geturl'):
+            self.name = download_file(fileobj.geturl(), cache=cache)
         else:
             self.name = fileobj_name(fileobj)
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -114,12 +114,13 @@ class _File(object):
         if mode not in PYFITS_MODES:
             raise ValueError("Mode '%s' not recognized" % mode)
 
+        if hasattr(fileobj, 'geturl'):
+            fileobj = fileobj.geturl()
+
         if (isinstance(fileobj, string_types) and
             mode not in ('ostream', 'append') and
             _is_url(fileobj)): # This is an URL.
                 self.name = download_file(fileobj, cache=cache)
-        if hasattr(fileobj, 'geturl'):
-            self.name = download_file(fileobj.geturl(), cache=cache)
         else:
             self.name = fileobj_name(fileobj)
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1010,6 +1010,21 @@ class TestFileFunctions(FitsTestCase):
         with fits.open(self.temp(filename)) as hdul:
             assert np.all(hdul[0].data == hdu.data)
 
+    def test_open_urlopen(self):
+        """
+        Test reading a urlopen object
+
+        Regression test for https://github.com/astropy/astropy/issues/4165
+        """
+
+        from ....extern.six.moves import urllib
+        from urllib2 import urlopen
+
+        testurl = "file:" + urllib.request.pathname2url(self.data('test0.fits'))
+        f = urlopen(testurl)
+        open_file = fits.open(f)
+        assert len(open_file) == 5
+
     def _test_write_string_bytes_io(self, fileobj):
         """
         Implemented for both test_write_stringio and test_write_bytesio.


### PR DESCRIPTION
This pull request fixes #4165 by explicitly checking for a urlopen object. 
I'm not sure if this needs a test though? 
