### PR TITLE
Fix typo from 4042

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -214,7 +214,7 @@ class EarthLocation(u.Quantity):
         if cls is el.__class__:
             return el
         else:
-            neweel = cls.from_geodetic(*el.to_geodetic())
+            newel = cls.from_geodetic(*el.to_geodetic())
             newel.info.name = el.info.name
             return newel
 

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -114,7 +114,6 @@ def test_registry():
     loc2 = reg['sIte a']
     assert loc2 is loc
 
-@remote_data
 def test_non_EarthLocation():
     """
     A regression test for a typo bug pointed out at the bottom of
@@ -122,6 +121,11 @@ def test_non_EarthLocation():
     """
     class EarthLocation2(EarthLocation):
         pass
+
+    # This lets keeps us from needing to do remote_data
+    # note that this does *not* mess up the registry for EarthLocation because
+    # registry is cached on a per-class basis
+    EarthLocation2._get_site_registry(force_builtin=True)
 
     el2 = EarthLocation2.of_site('keck')
     assert type(el2) is EarthLocation2

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -113,3 +113,14 @@ def test_registry():
 
     loc2 = reg['sIte a']
     assert loc2 is loc
+
+@remote_data
+def test_non_EarthLocation():
+    """
+    A regression test for a typo bug pointed out at the bottom of
+    https://github.com/astropy/astropy/pull/4042
+    """
+    class EarthLocation2(EarthLocation):
+        pass
+
+    EarthLocation2.of_site('keck')

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -123,4 +123,6 @@ def test_non_EarthLocation():
     class EarthLocation2(EarthLocation):
         pass
 
-    EarthLocation2.of_site('keck')
+    el2 = EarthLocation2.of_site('keck')
+    assert type(el2) is EarthLocation2
+    assert el2.info.name == 'W. M. Keck Observatory'


### PR DESCRIPTION
This addresses [a comment](https://github.com/astropy/astropy/pull/4042#discussion_r42800440) by @mhvk in #4042 pointing out a typo from that PR.  It fixes the typo and adds a regression test to ensure that part of the code gets tested.

Note that it's a remote_data test so Travis won't check it, but I did it locally and it passes.