### PR TITLE
Add check_builtin_matches_remote to sites testing

### DIFF
--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -131,8 +131,15 @@ def test_non_EarthLocation():
     assert type(el2) is EarthLocation2
     assert el2.info.name == 'W. M. Keck Observatory'
 
-@remote_data
-def test_builtin_matches_remote(download_url=True):
+def check_builtin_matches_remote(download_url=True):
+    """
+    This function checks that the builtin sites registry is consistent with the
+    remote registry (or a registry at some other location).  
+
+    Note that current this is *not* run by the testing suite (because it 
+    doesn't start with "test", and is instead meant to be used as a check 
+    before merging changes in astropy-data)
+    """
     builtin_registry = EarthLocation._get_site_registry(force_builtin=True)
     dl_registry = EarthLocation._get_site_registry(force_download=download_url)
 

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -134,10 +134,10 @@ def test_non_EarthLocation():
 def check_builtin_matches_remote(download_url=True):
     """
     This function checks that the builtin sites registry is consistent with the
-    remote registry (or a registry at some other location).  
+    remote registry (or a registry at some other location).
 
-    Note that current this is *not* run by the testing suite (because it 
-    doesn't start with "test", and is instead meant to be used as a check 
+    Note that current this is *not* run by the testing suite (because it
+    doesn't start with "test", and is instead meant to be used as a check
     before merging changes in astropy-data)
     """
     builtin_registry = EarthLocation._get_site_registry(force_builtin=True)

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ...tests.helper import pytest, assert_quantity_allclose, remote_data
+from ...tests.helper import pytest, assert_quantity_allclose, remote_data, quantity_allclose
 from ... import units as u
 from .. import Longitude, Latitude, EarthLocation
 from ..sites import get_builtin_sites, get_downloaded_sites, SiteRegistry
@@ -130,3 +130,29 @@ def test_non_EarthLocation():
     el2 = EarthLocation2.of_site('keck')
     assert type(el2) is EarthLocation2
     assert el2.info.name == 'W. M. Keck Observatory'
+
+@remote_data
+def test_builtin_matches_remote(download_url=True):
+    builtin_registry = EarthLocation._get_site_registry(force_builtin=True)
+    dl_registry = EarthLocation._get_site_registry(force_download=download_url)
+
+    in_dl = {}
+    matches = {}
+    for name in builtin_registry.names:
+        in_dl[name] = name in dl_registry
+        if in_dl[name]:
+            matches[name] = quantity_allclose(builtin_registry[name], dl_registry[name])
+        else:
+            matches[name] = False
+
+    if not all(matches.values()):
+        # this makes sure we actually see which don't match
+        print("In builtin registry but not in download:")
+        for name in in_dl:
+            if not in_dl[name]:
+                print('    ', name)
+        print("In both but not the same value:")
+        for name in matches:
+            if not matches[name] and in_dl[name]:
+                print('    ', name, 'builtin:', builtin_registry[name], 'download:', dl_registry[name])
+        assert False, "Builtin and download registry aren't consistent - failures printed to stdout"


### PR DESCRIPTION
This PR adds a "test" to ``test_sites.py``.  It basically stems from a couple of PRs in astropy-data that add/alter existing sites.  It occurred to me that we don't want this to happen in a way that causes inconsistency between the remote and builtin sites.  After all, a user would likely be very surprised to find that ``EarthLocation.of_site('something')`` gives a different answer depending on whether their internet was on or not.

As it currently is implemented, it is not actually part of the testing suite, because it seems dangerous to have a test that depends on the remote site always being consistent.  Instead, this is meant to be used as a test by anyone who wants to update `astropy-data`.

(And I'm milestoning it 1.1 because that will make it a lot easier to tell people who've contributed sites to use their current copy of astropy, rather than making them upgrade or use the dev version or whatever.)