### PR TITLE
Fix conda install on travis-ci

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -x
 
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a
+
 # CONDA
 conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
 source activate test

--- a/.continuous-integration/travis/setup_environment_linux.sh
+++ b/.continuous-integration/travis/setup_environment_linux.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
 # Install conda
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/home/travis/miniconda/bin:$PATH
-conda update --yes conda
-
-# Installation of non-Python dependencies for documentation is now
-# in .travis.yml
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/.continuous-integration/travis/setup_environment_osx.sh
+++ b/.continuous-integration/travis/setup_environment_osx.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 # Install conda
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-MacOSX-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/Users/travis/miniconda/bin:$PATH
-conda update --yes conda
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh


### PR DESCRIPTION
Something changed on travis-ci or with conda (a few hours ago?) and now conda install is broken on travis-ci.

Here's an Astropy build that shows the issue (look at the full log to see the "conda not found" error)
https://travis-ci.org/astropy/astropy/jobs/89121856

This same change needs to be applied in all affiliated packages that copied the Astropy travis-ci setup scripts. E.g. here is the PR where I applied the fix in Gammapy: https://github.com/gammapy/gammapy/pull/378

At first I thought this was an issue with setuptools, but that was a red herring:
https://github.com/astropy/astropy-helpers/issues/202