### PR TITLE
astropy tables with mixin columns cannot be pickled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -879,6 +879,8 @@ Bug Fixes
 
 - ``astropy.table``
 
+  - Fix a bug when pickling a Table with mixin columns (e.g. Time). [#4098]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -364,7 +364,9 @@ class Table(object):
             raise TypeError("masked property has not been set to True or False")
 
     def __getstate__(self):
-        return (self.columns.values(), self.meta)
+        columns = OrderedDict((key, col if isinstance(col, BaseColumn) else col_copy(col))
+                              for key, col in self.columns.items())
+        return (columns, self.meta)
 
     def __setstate__(self, state):
         columns, meta = state
@@ -2514,11 +2516,6 @@ class QTable(Table):
         a mixin column.
         """
         return has_info_class(col, MixinInfo)
-
-    def __getstate__(self):
-        columns = dict((key, col if isinstance(col, BaseColumn) else col_copy(col))
-                for key, col in self.columns.items())
-        return (columns, self.meta)
 
     def _convert_col_for_table(self, col):
         if (isinstance(col, Column) and getattr(col, 'unit', None) is not None):

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -54,39 +54,32 @@ def test_pickle_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
     b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',
                meta={'b': 1})
-    t = Table([a, b], meta={'a': 1})
-    ts = pickle.dumps(t)
-    tp = pickle.loads(ts)
 
-    assert np.all(tp['a'] == t['a'])
-    assert np.all(tp['b'] == t['b'])
-    assert tp['a'].attrs_equal(t['a'])
-    assert tp['b'].attrs_equal(t['b'])
-    assert tp.meta == t.meta
+    for table_class in Table, QTable:
+        t = table_class([a, b], meta={'a': 1, 'b': Quantity(10, unit='s')})
+        t['c'] = Quantity([1, 2], unit='m')
+        t['d'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+        t['e'] = SkyCoord([125.0,180.0]*deg, [-45.0,36.5]*deg)
 
-def test_pickle_qtable(protocol):
-    a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})
-    b = Column(data=[3.0, 4.0], name='b', format='%05d', description='col b', unit='cm',
-               meta={'b': 1})
-    t = QTable([a, b], meta={'a': 1, 'b':Quantity(10,unit='s')})
-    t['c'] = Quantity([1, 2], unit='m')
-    t['d'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
-    t['e'] = SkyCoord([125.0,180.0]*deg, [-45.0,36.5]*deg)
-    ts = pickle.dumps(t)
-    tp = pickle.loads(ts)
+        ts = pickle.dumps(t)
+        tp = pickle.loads(ts)
 
-    assert np.all(tp['a'] == t['a'])
-    assert np.all(tp['b'] == t['b'])
-    # test mixin columns
-    assert np.all(tp['c'] == t['c'])
-    assert np.all(tp['d'] == t['d'])
-    assert np.all(tp['e'].ra == t['e'].ra)
-    assert np.all(tp['e'].dec == t['e'].dec)
-    assert type(tp['c']) == type(t['c'])
-    assert type(tp['d']) == type(t['d'])
-    assert type(tp['e']) == type(t['e'])
-    assert tp.meta == t.meta
-    assert type(tp) == type(t)
+        assert tp.__class__ is table_class
+        assert np.all(tp['a'] == t['a'])
+        assert np.all(tp['b'] == t['b'])
+
+        # test mixin columns
+        assert np.all(tp['c'] == t['c'])
+        assert np.all(tp['d'] == t['d'])
+        assert np.all(tp['e'].ra == t['e'].ra)
+        assert np.all(tp['e'].dec == t['e'].dec)
+        assert type(tp['c']) == type(t['c'])
+        assert type(tp['d']) == type(t['d'])
+        assert type(tp['e']) == type(t['e'])
+        assert tp.meta == t.meta
+        assert type(tp) == type(t)
+
+        assert isinstance(tp['c'], Quantity if (table_class is QTable) else Column)
 
 def test_pickle_masked_table(protocol):
     a = Column(data=[1, 2], name='a', format='%05d', description='col a', unit='cm', meta={'a': 1})


### PR DESCRIPTION
[EDIT by @taldcroft] - the problem described below is already fixed, but later another issue pickling a table with mixin columns is described.  This issue now relates to that problem.

It seems if the shape of a column is multidimensional, then pickling does not work.  Here is a toy example given version 1.1.dev13184

```python
In [1]: from astropy.table import Table

In [2]: import cPickle as pickle

In [3]: a = zeros(3)

In [4]: t = Table([a], names=('a'))

In [5]: pickle.dump(t, open("table.pickle", "wb"))

In [6]: print t['a']
 a 
---
0.0
0.0
0.0

In [7]: a = zeros((3,2))

In [8]: t = Table([a], names=('a'))

In [9]: pickle.dump(t, open("table.pickle", "wb"))
---------------------------------------------------------------------------
PicklingError                             Traceback (most recent call last)
<ipython-input-9-563cc76ba7b1> in <module>()
----> 1 pickle.dump(t, open("table.pickle", "wb"))

PicklingError: Can't pickle <class 'astropy.table.column.Column'>: it's not the same object as astropy.table.column.Column

In [10]: print t['a']
  a [2]   
----------
0.0 .. 0.0
0.0 .. 0.0
0.0 .. 0.0

In [11]: a = [[0,1],[1,2],[2,3]]

In [12]: t = Table([a], names=('a'))

In [13]: pickle.dump(t, open("table.pickle", "wb"))
---------------------------------------------------------------------------
PicklingError                             Traceback (most recent call last)
<ipython-input-13-563cc76ba7b1> in <module>()
----> 1 pickle.dump(t, open("table.pickle", "wb"))

PicklingError: Can't pickle <class 'astropy.table.column.Column'>: it's not the same object as astropy.table.column.Column

In [14]: t['a']
Out[14]: 
<Column name='a' dtype='int64' shape=(2,) length=3>
0 .. 1
1 .. 2
2 .. 3
```