### PR TITLE
Safer use of jd1/jd2 times when using erfa

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -636,6 +636,11 @@ API changes
     units.  Furthermore, the ``ut1_utc`` method now returns a ``Quantity``
     instead of a float or an array (as did ``pm_xy`` already). [#3223]
 
+  -  ``astropy.utils.iers`` now throws an ``IERSRangeError``, a subclass
+     of ``IndexError``, rather than a raw ``IndexError``.  This allows more
+     fine-grained catching of situations where a ``Time`` is beyond the range
+     of the loaded IERS tables. [#4302]
+
 - ``astropy.visualization``
 
 - ``astropy.vo``
@@ -669,6 +674,9 @@ Bug fixes
 - ``astropy.convolution``
 
 - ``astropy.coordinates``
+
+  - Internally, ``coordinates`` now consistently uses the appropriate time
+    scales for using ERFA functions. [#4302]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -40,7 +40,8 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
     xp, yp = get_polar_motion(obstime)
 
     #first set up the astrometry context for CIRS<->AltAz
-    astrom = erfa.apio13(obstime.jd1, obstime.jd2,
+    obstime_utc = obstime if obstime.scale == 'utc' else obstime.utc
+    astrom = erfa.apio13(obstime_utc.jd1, obstime_utc.jd2,
                          get_dut1utc(obstime),
                          lon.to(u.radian).value, lat.to(u.radian).value,
                          height.to(u.m).value,
@@ -80,7 +81,8 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     xp, yp = get_polar_motion(altaz_coo.obstime)
 
     #first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
-    astrom = erfa.apio13(altaz_coo.obstime.jd1, altaz_coo.obstime.jd2,
+    aa_obstime_utc = altaz_coo.obstime if altaz_coo.obstime.scale == 'utc' else altaz_coo.obstime.utc
+    astrom = erfa.apio13(aa_obstime_utc.jd1, aa_obstime_utc.jd2,
                          get_dut1utc(altaz_coo.obstime),
                          lon.to(u.radian).value, lat.to(u.radian).value,
                          height.to(u.m).value,

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -18,7 +18,7 @@ from ... import _erfa as erfa
 
 from .cirs import CIRS
 from .altaz import AltAz
-from .utils import get_polar_motion, get_dut1utc, PIOVER2
+from .utils import get_polar_motion, get_dut1utc, get_jd12, PIOVER2
 
 
 @frame_transform_graph.transform(FunctionTransform, CIRS, AltAz)
@@ -40,8 +40,8 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
     xp, yp = get_polar_motion(obstime)
 
     #first set up the astrometry context for CIRS<->AltAz
-    obstime_utc = obstime if obstime.scale == 'utc' else obstime.utc
-    astrom = erfa.apio13(obstime_utc.jd1, obstime_utc.jd2,
+    jd1, jd2 = get_jd12(obstime, 'utc')
+    astrom = erfa.apio13(jd1, jd2,
                          get_dut1utc(obstime),
                          lon.to(u.radian).value, lat.to(u.radian).value,
                          height.to(u.m).value,
@@ -81,8 +81,8 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     xp, yp = get_polar_motion(altaz_coo.obstime)
 
     #first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
-    aa_obstime_utc = altaz_coo.obstime if altaz_coo.obstime.scale == 'utc' else altaz_coo.obstime.utc
-    astrom = erfa.apio13(aa_obstime_utc.jd1, aa_obstime_utc.jd2,
+    jd1, jd2 = get_jd12(altaz_coo.obstime, 'utc')
+    astrom = erfa.apio13(jd1, jd2,
                          get_dut1utc(altaz_coo.obstime),
                          lon.to(u.radian).value, lat.to(u.radian).value,
                          height.to(u.m).value,

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -26,7 +26,8 @@ from .cirs import CIRS
 @frame_transform_graph.transform(FunctionTransform, ICRS, CIRS)
 def icrs_to_cirs(icrs_coo, cirs_frame):
     #first set up the astrometry context for ICRS<->CIRS
-    astrom, eo = erfa.apci13(cirs_frame.obstime.jd1, cirs_frame.obstime.jd2)
+    cirs_obstime_tdb = cirs_frame.obstime if cirs_frame.obstime.scale == 'tdb' else cirs_frame.obstime.tdb
+    astrom, eo = erfa.apci13(cirs_obstime_tdb.jd1, cirs_obstime_tdb.jd2)
 
     if icrs_coo.data.get_name() == 'unitspherical'  or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -65,7 +66,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
-    astrom, eo = erfa.apci13(cirs_coo.obstime.jd1, cirs_coo.obstime.jd2)
+    cirs_obstime_tdb = cirs_coo.obstime if cirs_coo.obstime.scale == 'tdb' else cirs_coo.obstime.tdb
+    astrom, eo = erfa.apci13(cirs_obstime_tdb.jd1, cirs_obstime_tdb.jd2)
     i_ra, i_dec = erfa.aticq(cirs_ra, cirs_dec, astrom)
 
     if cirs_coo.data.get_name() == 'unitspherical'  or cirs_coo.data.to_cartesian().x.unit == u.one:
@@ -111,7 +113,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     #first set up the astrometry context for ICRS<->GCRS
     pv = np.array([gcrs_frame.obsgeoloc.value,
                    gcrs_frame.obsgeovel.value])
-    astrom = erfa.apcs13(gcrs_frame.obstime.jd1, gcrs_frame.obstime.jd2, pv)
+    gcrs_obstime_tdb = gcrs_frame.obstime if gcrs_frame.obstime.scale == 'tdb' else gcrs_frame.obstime.tdb
+    astrom = erfa.apcs13(gcrs_obstime_tdb.jd1, gcrs_obstime_tdb.jd2, pv)
 
     if icrs_coo.data.get_name() == 'unitspherical'  or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -153,7 +156,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     # coordinate direction
     pv = np.array([gcrs_coo.obsgeoloc.value,
                    gcrs_coo.obsgeovel.value])
-    astrom = erfa.apcs13(gcrs_coo.obstime.jd1, gcrs_coo.obstime.jd2, pv)
+    gcrs_obstime_tdb = gcrs_coo.obstime if gcrs_coo.obstime.scale == 'tdb' else gcrs_coo.obstime.tdb
+    astrom = erfa.apcs13(gcrs_obstime_tdb.jd1, gcrs_obstime_tdb.jd2, pv)
     i_ra, i_dec = erfa.aticq(gcrs_ra, gcrs_dec, astrom)
 
     if gcrs_coo.data.get_name() == 'unitspherical'  or gcrs_coo.data.to_cartesian().x.unit == u.one:

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -19,6 +19,7 @@ from ... import _erfa as erfa
 from .icrs import ICRS
 from .gcrs import GCRS
 from .cirs import CIRS
+from .utils import get_jd12
 
 
 #first the ICRS/CIRS related transforms
@@ -26,8 +27,7 @@ from .cirs import CIRS
 @frame_transform_graph.transform(FunctionTransform, ICRS, CIRS)
 def icrs_to_cirs(icrs_coo, cirs_frame):
     #first set up the astrometry context for ICRS<->CIRS
-    cirs_obstime_tdb = cirs_frame.obstime if cirs_frame.obstime.scale == 'tdb' else cirs_frame.obstime.tdb
-    astrom, eo = erfa.apci13(cirs_obstime_tdb.jd1, cirs_obstime_tdb.jd2)
+    astrom, eo = erfa.apci13(*get_jd12(cirs_frame.obstime, 'tdb'))
 
     if icrs_coo.data.get_name() == 'unitspherical'  or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -66,8 +66,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
-    cirs_obstime_tdb = cirs_coo.obstime if cirs_coo.obstime.scale == 'tdb' else cirs_coo.obstime.tdb
-    astrom, eo = erfa.apci13(cirs_obstime_tdb.jd1, cirs_obstime_tdb.jd2)
+    astrom, eo = erfa.apci13(*get_jd12(cirs_coo.obstime,'tdb'))
     i_ra, i_dec = erfa.aticq(cirs_ra, cirs_dec, astrom)
 
     if cirs_coo.data.get_name() == 'unitspherical'  or cirs_coo.data.to_cartesian().x.unit == u.one:
@@ -113,8 +112,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     #first set up the astrometry context for ICRS<->GCRS
     pv = np.array([gcrs_frame.obsgeoloc.value,
                    gcrs_frame.obsgeovel.value])
-    gcrs_obstime_tdb = gcrs_frame.obstime if gcrs_frame.obstime.scale == 'tdb' else gcrs_frame.obstime.tdb
-    astrom = erfa.apcs13(gcrs_obstime_tdb.jd1, gcrs_obstime_tdb.jd2, pv)
+    jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
+    astrom = erfa.apcs13(jd1, jd2, pv)
 
     if icrs_coo.data.get_name() == 'unitspherical'  or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -156,8 +155,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     # coordinate direction
     pv = np.array([gcrs_coo.obsgeoloc.value,
                    gcrs_coo.obsgeovel.value])
-    gcrs_obstime_tdb = gcrs_coo.obstime if gcrs_coo.obstime.scale == 'tdb' else gcrs_coo.obstime.tdb
-    astrom = erfa.apcs13(gcrs_obstime_tdb.jd1, gcrs_obstime_tdb.jd2, pv)
+    jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
+    astrom = erfa.apcs13(jd1, jd2, pv)
     i_ra, i_dec = erfa.aticq(gcrs_ra, gcrs_dec, astrom)
 
     if gcrs_coo.data.get_name() == 'unitspherical'  or gcrs_coo.data.to_cartesian().x.unit == u.one:

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -22,17 +22,18 @@ from .utils import get_polar_motion
 
 # # first define helper functions
 def gcrs_to_cirs_mat(time):
-    #felestial-to-intermediate matrix
-    return erfa.c2i06a(time.jd1, time.jd2)
+    #celestial-to-intermediate matrix
+    return erfa.c2i06a(time.tt.jd1, time.tt.jd2)
 
 def cirs_to_itrs_mat(time):
     #compute the polar motion p-matrix
     xp, yp = get_polar_motion(time)
-    sp = erfa.sp00(time.jd1, time.jd2)
+    sp = erfa.sp00(time.tt.jd1, time.tt.jd2)
     pmmat = erfa.pom00(xp, yp, sp)
 
     #now determine the Earth Rotation Angle for the input obstime
-    era = erfa.era00(time.jd1, time.jd2)
+    # this should be UT1 used here.
+    era = erfa.era00(time.ut1.jd1, time.ut1.jd2)
 
     #c2tcio expects a GCRS->CIRS matrix, but we just set that to an I-matrix
     #because we're already in CIRS

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -18,22 +18,35 @@ from ... import _erfa as erfa
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .utils import get_polar_motion
+from .utils import get_polar_motion, get_dut1utc
 
 # # first define helper functions
 def gcrs_to_cirs_mat(time):
     #celestial-to-intermediate matrix
-    return erfa.c2i06a(time.tt.jd1, time.tt.jd2)
+    if time.scale != 'tt':
+        time_tt = time.tt
+    else:
+        time_tt = time
+    return erfa.c2i06a(time_tt.jd1, time_tt.jd2)
 
 def cirs_to_itrs_mat(time):
     #compute the polar motion p-matrix
     xp, yp = get_polar_motion(time)
-    sp = erfa.sp00(time.tt.jd1, time.tt.jd2)
+    if time.scale != 'tt':
+        time_tt = time.tt
+    else:
+        time_tt = time    
+    sp = erfa.sp00(time_tt.jd1, time_tt.jd2)
     pmmat = erfa.pom00(xp, yp, sp)
 
     #now determine the Earth Rotation Angle for the input obstime
     # this should be UT1 used here.
-    era = erfa.era00(time.ut1.jd1, time.ut1.jd2)
+    if time.scale != 'ut1':
+        time.delta_ut1_utc = get_dut1utc(time)
+        time_ut1 = time.ut1    
+        era = erfa.era00(time_ut1.jd1, time_ut1.jd2)
+    else:
+        era = erfa.era00(time.jd1, time.jd2)
 
     #c2tcio expects a GCRS->CIRS matrix, but we just set that to an I-matrix
     #because we're already in CIRS

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -72,7 +72,7 @@ def get_polar_motion(time):
     gets the two polar motion components in radians for use with apio13
     """
     #get the polar motion from the IERS table
-    xp, yp, status = iers.IERS.open().pm_xy(time.jd1, time.jd2, return_status=True)
+    xp, yp, status = iers.IERS.open().pm_xy(time, return_status=True)
 
     wmsg = None
     if np.any(status == iers.TIME_BEFORE_IERS_RANGE):

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -107,3 +107,32 @@ def get_dut1utc(time):
         msg = e.args[0] + ' Assuming UT1-UTC=0 for coordinate transformations.' + _IERS_HINT
         warnings.warn(msg, AstropyWarning)
         return np.zeros(time.shape)
+
+def get_jd12(time, scale):
+    """
+    Gets ``jd1`` and ``jd2`` from a time object in a particular scale.
+
+    Parameters
+    ----------
+    time : `~astropy.time.Time`
+        The time to get the jds for
+    scale : str
+        The time scale to get the jds for
+
+    Returns
+    -------
+    jd1 : float
+    jd2 : float
+    """
+    if time.scale == scale:
+        newtime = time
+    elif time.scale == 'ut1' or scale == 'ut1':
+        olddt = time.delta_ut1_utc
+        time.delta_ut1_utc = get_dut1utc(time)
+        newtime = getattr(time, scale)
+        time.delta_ut1_utc =  olddt  # ensures no changes to the input `time`
+    else:
+        newtime = getattr(time, scale)
+
+    return newtime.jd1, newtime.jd2
+

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -147,7 +147,8 @@ def get_sun(time):
     250 km over the 1000-3000.
 
     """
-    earth_pv_helio, earth_pv_bary = erfa.epv00(time.jd1, time.jd2)
+    time_tdb = time if time.scale == 'tdb' else time.tdb
+    earth_pv_helio, earth_pv_bary = erfa.epv00(time_tdb.jd1, time_tdb.jd2)
 
     # We have to manually do aberration because we're outputting directly into
     # GCRS

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -20,6 +20,7 @@ from ..utils import isiterable, data
 from .sky_coordinate import SkyCoord
 from .builtin_frames import GCRS, PrecessedGeocentric
 from .representation import SphericalRepresentation, CartesianRepresentation
+from .builtin_frames.utils import get_jd12
 
 __all__ = ['cartesian_to_spherical', 'spherical_to_cartesian', 'get_sun',
            'concatenate', 'get_constellation']
@@ -147,8 +148,7 @@ def get_sun(time):
     250 km over the 1000-3000.
 
     """
-    time_tdb = time if time.scale == 'tdb' else time.tdb
-    earth_pv_helio, earth_pv_bary = erfa.epv00(time_tdb.jd1, time_tdb.jd2)
+    earth_pv_helio, earth_pv_bary = erfa.epv00(*get_jd12(time, 'tdb'))
 
     # We have to manually do aberration because we're outputting directly into
     # GCRS

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -107,11 +107,11 @@ def test_iau_fullstack(fullstack_icrs,  fullstack_fiducial_altaz,
     assert np.all(addecs < tol), 'largest Dec change is {0} mas, > {1}'.format(np.max(addecs.arcsec*1000), tol)
 
     # check that we're consistent with the ERFA alt/az result
-    xp, yp = u.Quantity(iers.IERS.open().pm_xy(fullstack_times.jd1, fullstack_times.jd2)).to(u.radian).value
+    xp, yp = u.Quantity(iers.IERS.open().pm_xy(fullstack_times.utc.jd1, fullstack_times.utc.jd2)).to(u.radian).value
     lon = fullstack_locations.geodetic[0].to(u.radian).value
     lat = fullstack_locations.geodetic[1].to(u.radian).value
     height = fullstack_locations.geodetic[2].to(u.m).value
-    astrom, eo = erfa.apco13(fullstack_times.jd1, fullstack_times.jd2,
+    astrom, eo = erfa.apco13(fullstack_times.utc.jd1, fullstack_times.utc.jd2,
                              fullstack_times.delta_ut1_utc,
                              lon, lat, height,
                              xp, yp,

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -10,6 +10,7 @@ from numpy import testing as npt
 from ... import units as u
 from ...time import Time
 from ..builtin_frames import ICRS, AltAz
+from ..builtin_frames.utils import get_jd12
 from .. import EarthLocation
 from .. import SkyCoord
 from ...tests.helper import pytest
@@ -107,11 +108,12 @@ def test_iau_fullstack(fullstack_icrs,  fullstack_fiducial_altaz,
     assert np.all(addecs < tol), 'largest Dec change is {0} mas, > {1}'.format(np.max(addecs.arcsec*1000), tol)
 
     # check that we're consistent with the ERFA alt/az result
-    xp, yp = u.Quantity(iers.IERS.open().pm_xy(fullstack_times.utc.jd1, fullstack_times.utc.jd2)).to(u.radian).value
+    xp, yp = u.Quantity(iers.IERS.open().pm_xy(fullstack_times)).to(u.radian).value
     lon = fullstack_locations.geodetic[0].to(u.radian).value
     lat = fullstack_locations.geodetic[1].to(u.radian).value
     height = fullstack_locations.geodetic[2].to(u.m).value
-    astrom, eo = erfa.apco13(fullstack_times.utc.jd1, fullstack_times.utc.jd2,
+    jd1, jd2 = get_jd12(fullstack_times, 'utc')
+    astrom, eo = erfa.apco13(jd1, jd2,
                              fullstack_times.delta_ut1_utc,
                              lon, lat, height,
                              xp, yp,

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -20,6 +20,7 @@ from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
 from ..._erfa import epv00
 
 from .utils import randomly_sample_sphere
+from ..builtin_frames.utils import get_jd12
 
 def test_icrs_cirs():
     """
@@ -401,7 +402,7 @@ def test_icrs_altaz_moonish(testframe):
     right AltAz distance
     """
     # we use epv00 instead of get_sun because get_sun includes aberration
-    earth_pv_helio, earth_pv_bary = epv00(testframe.obstime.tdb.jd1, testframe.obstime.tdb.jd2)
+    earth_pv_helio, earth_pv_bary = epv00(*get_jd12(testframe.obstime, 'tdb'))
     earth_icrs_xyz = earth_pv_bary[0]*u.au
     moonoffset = [0, 0, MOONDIST.value]*MOONDIST.unit
     moonish_icrs = ICRS(CartesianRepresentation(earth_icrs_xyz + moonoffset))

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -401,7 +401,7 @@ def test_icrs_altaz_moonish(testframe):
     right AltAz distance
     """
     # we use epv00 instead of get_sun because get_sun includes aberration
-    earth_pv_helio, earth_pv_bary = epv00(testframe.obstime.jd1, testframe.obstime.jd2)
+    earth_pv_helio, earth_pv_bary = epv00(testframe.obstime.tdb.jd1, testframe.obstime.tdb.jd2)
     earth_icrs_xyz = earth_pv_bary[0]*u.au
     moonoffset = [0, 0, MOONDIST.value]*MOONDIST.unit
     moonish_icrs = ICRS(CartesianRepresentation(earth_icrs_xyz + moonoffset))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -26,7 +26,7 @@ the default IERS B table is loaded as necessary in `Time`::
 But if one is dealing with very recent observations, this does not work::
 
     >>> t2 = Time.now()
-    >>> t2.ut1
+    >>> t2.ut1  # doctest: +SKIP
     Traceback (most recent call last):
     ...
     IERSRangeError: (some) times are outside of range covered by IERS table.

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -29,7 +29,7 @@ But if one is dealing with very recent observations, this does not work::
     >>> t2.ut1
     Traceback (most recent call last):
     ...
-    IndexError: (some) times are outside of range covered by IERS table.
+    IERSRangeError: (some) times are outside of range covered by IERS table.
 
 In this case, one needs to update the IERS B table or use IERS A instead
 (which also has predictions).  In future versions, this may become
@@ -67,7 +67,8 @@ __all__ = ['IERS', 'IERS_B', 'IERS_A',
            'FROM_IERS_B', 'FROM_IERS_A', 'FROM_IERS_A_PREDICTION',
            'TIME_BEFORE_IERS_RANGE', 'TIME_BEYOND_IERS_RANGE',
            'IERS_A_FILE', 'IERS_A_URL', 'IERS_A_README',
-           'IERS_B_FILE', 'IERS_B_URL', 'IERS_B_README']
+           'IERS_B_FILE', 'IERS_B_URL', 'IERS_B_README',
+           'IERSRangeError']
 
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
@@ -87,6 +88,11 @@ TIME_BEYOND_IERS_RANGE = -2
 
 MJD_ZERO = 2400000.5
 
+
+class IERSRangeError(IndexError):
+    """
+    Any error for when dates are outside of the valid range for IERS
+    """
 
 class IERS(QTable):
     """Generic IERS table class, defining interpolation functions.
@@ -184,7 +190,7 @@ class IERS(QTable):
             second part of two-part JD (default 0., ignored if jd1 is Time)
         return_status : bool
             Whether to return status values.  If False (default),
-            raise `IndexError` if any time is out of the range covered
+            raise `IERSRangeError` if any time is out of the range covered
             by the IERS table.
 
         Returns
@@ -213,7 +219,7 @@ class IERS(QTable):
             second part of two-part JD (default 0., ignored if jd1 is Time)
         return_status : bool
             Whether to return status values.  If False (default),
-            raise `IndexError` if any time is out of the range covered
+            raise `IERSRangeError` if any time is out of the range covered
             by the IERS table.
 
         Returns
@@ -281,7 +287,7 @@ class IERS(QTable):
         else:
             # Not returning status, so raise an exception for out-of-range
             if np.any(i1 != i):
-                raise IndexError('(some) times are outside of range covered '
+                raise IERSRangeError('(some) times are outside of range covered '
                                  'by IERS table.')
             return results[0] if len(results) == 1 else results
 


### PR DESCRIPTION
This was inspired by, subsumes, and closes #4290 (and it includes its commit history).

There, @StuartLittlefair pointed out (and fixed) the fact that the intermediate rotation transforms often expect tt, and most obstimes and such are given as utc.  This PR extends that further to the whole `coordinates` module where `erfa` is used, doing a transformation to whatever the appropriate scales when needed.

Note that in many cases (perhaps all here?) this is a small effect - e.g. the TT vs. TDB difference is unimportant for most coordinates, and just about all of these scale shifts are in the machine noise for secular things like the location of the Earth relative to the Sun (except maybe for some corner cases that I'm not aware of).  But this is definitely more "right" than it was before.

Two questions about this, though:
* @mhvk, I think you're probably best equipped to answer this: do you see anywhere here that a UT1-UTC operation might need additional information not already contained in the `Time` object? (I think this is a non-issue, but I just wanted to check to be sure...)
* There's at least one place where UT1-UTC is now needed when it wasn't before.  So this means users will get more of the DUT1 warnings.  I don't think this is really an issue (because it's a *real* problem, so it should be warned about), but it's something to at least consider.