### PR TITLE
EarthLocation instances can't be pickled on python2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -670,8 +670,6 @@ Bug fixes
 
 - ``astropy.coordinates``
 
-  - Pickling of ``EarthLocation`` instances now also works on python3. [#4304]
-
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -860,6 +858,8 @@ Bug Fixes
 - ``astropy.convolution``
 
 - ``astropy.coordinates``
+
+  - Pickling of ``EarthLocation`` instances now also works on python3. [#4304]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -670,6 +670,8 @@ Bug fixes
 
 - ``astropy.coordinates``
 
+  - Pickling of ``EarthLocation`` instances now also works on python3. [#4304]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from warnings import warn
 

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 
 """Test initialization of angles not already covered by the API tests"""
 
+import pickle
 import numpy as np
 
 from ..earth import EarthLocation, ELLIPSOIDS
@@ -248,3 +249,11 @@ class TestInput():
             assert allclose_m14(location.z.value, self.z.value)
         else:
             assert not np.all(isclose_m14(location.z.value, self.z.value))
+
+
+def test_pickling():
+    """Regression test against #4304."""
+    el = EarthLocation(0.*u.m, 6000*u.km, 6000*u.km)
+    s = pickle.dumps(el)
+    el2 = pickle.loads(s)
+    assert el == el2


### PR DESCRIPTION
The title of the issue is self explanatory.  Note that this relates to #4098 as well, as if a column in a table has a location in it (i.e. for astropy Times with location set), then the column can't be pickled either.

Here are some simple examples:

```python
In [1]: import cPickle

In [2]: from astropy.time import Time

In [3]: from astropy.table import Table

In [4]: times = ['1999-01-01T00:00:00.123456789', '2010-01-01T00:00:00']

In [5]: t = Time(times, format='isot', scale='utc')

In [6]: cPickle.dump(t, open("test.pickle",'wb'))

In [7]: cPickle.load(open("test.pickle"))
Out[7]: <Time object: scale='utc' format='isot' value=['1999-01-01T00:00:00.123' '2010-01-01T00:00:00.000']>

In [8]: t2 = Time(times, format='isot', scale='utc', location=(-50.0, 40.0, 100))

In [9]: cPickle.dump(t2, open("test.pickle",'wb'))

In [10]: cPickle.load(open("test.pickle"))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-3f124c359ee8> in <module>()
----> 1 cPickle.load(open("test.pickle"))

ValueError: non-string names in Numpy dtype unpickling

In [11]: loc = t2[0].location

In [12]: loc
Out[12]: <EarthLocation (3145021.063533541, -3748090.1512505603, 4078049.850961345) m>

In [13]: cPickle.dump(loc, open("test.pickle",'wb'))

In [14]: cPickle.load(open("test.pickle"))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-14-3f124c359ee8> in <module>()
----> 1 cPickle.load(open("test.pickle"))

ValueError: non-string names in Numpy dtype unpickling
```
