### PR TITLE
Avoiding to compile parts of statements with preprocessor conditionals.

### DIFF
--- a/cextern/expat/lib/xmlparse.c
+++ b/cextern/expat/lib/xmlparse.c
@@ -4187,11 +4187,11 @@ doProlog(XML_Parser parser,
         doctypeSysid = externalSubsetName;
 #endif /* XML_DTD */
       }
-	  int xmlError = !dtd->standalone;
+      int xmlError = !dtd->standalone;
 #ifdef XML_DTD
       xmlError = xmlError && !paramEntityParsing;
 #endif /* XML_DTD */  
-	  xmlError = xmlError && notStandaloneHandler
+      xmlError = xmlError && notStandaloneHandler
           && !notStandaloneHandler(handlerArg);
       if (xmlError)
         return XML_ERROR_NOT_STANDALONE;

--- a/cextern/expat/lib/xmlparse.c
+++ b/cextern/expat/lib/xmlparse.c
@@ -4180,13 +4180,13 @@ doProlog(XML_Parser parser,
           return XML_ERROR_NO_MEMORY;
         poolFinish(&tempPool);
         handleDefault = XML_FALSE;
-      }
+      } else {
 #ifdef XML_DTD
-      else
         /* use externalSubsetName to make doctypeSysid non-NULL
            for the case where no startDoctypeDeclHandler is set */
         doctypeSysid = externalSubsetName;
 #endif /* XML_DTD */
+      }
 	  int xmlError = !dtd->standalone;
 #ifdef XML_DTD
       xmlError = xmlError && !paramEntityParsing;

--- a/cextern/expat/lib/xmlparse.c
+++ b/cextern/expat/lib/xmlparse.c
@@ -4187,12 +4187,13 @@ doProlog(XML_Parser parser,
            for the case where no startDoctypeDeclHandler is set */
         doctypeSysid = externalSubsetName;
 #endif /* XML_DTD */
-      if (!dtd->standalone
+	  int xmlError = !dtd->standalone;
 #ifdef XML_DTD
-          && !paramEntityParsing
-#endif /* XML_DTD */
-          && notStandaloneHandler
-          && !notStandaloneHandler(handlerArg))
+      xmlError = xmlError && !paramEntityParsing;
+#endif /* XML_DTD */  
+	  xmlError = xmlError && notStandaloneHandler
+          && !notStandaloneHandler(handlerArg);
+      if (xmlError)
         return XML_ERROR_NOT_STANDALONE;
 #ifndef XML_DTD
       break;

--- a/cextern/expat/xmlwf/xmlwf.c
+++ b/cextern/expat/xmlwf/xmlwf.c
@@ -606,11 +606,11 @@ showVersion(XML_Char *prog)
   XML_Char ch;
   const XML_Feature *features = XML_GetFeatureList();
   while ((ch = *s) != 0) {
-    if (ch == '/'
+    int isSpecialCharacter = (ch == '/');
 #if (defined(WIN32) || defined(__WATCOMC__))
-        || ch == '\\'
+    isSpecialCharacter = isSpecialCharacter || (ch == '\\');
 #endif
-        )
+    if (isSpecialCharacter)
       prog = s + 1;
     ++s;
   }


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness. Furthermore, I found that the astropy uses this type of directives only in a few places, which makes possible to remove all.