### PR TITLE
Saving large table FITS may lead to a truncated file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -873,6 +873,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed a regression that could cause writes of large FITS files to be
+    truncated. [#4307]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -14,8 +14,7 @@ from .. import conf
 from ..file import _File
 from ..header import Header, _pad_length
 from ..util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
-                    itersubclasses, decode_ascii,
-                    _get_array_mmap, _array_to_file, first)
+                    itersubclasses, decode_ascii, _get_array_mmap, first)
 from ..verify import _Verify, _ErrList
 
 from ....extern.six import string_types, add_metaclass
@@ -727,7 +726,7 @@ class _BaseHDU(object):
 
         raw = self._get_raw_data(self._data_size, 'ubyte', self._data_offset)
         if raw is not None:
-            _array_to_file(raw, fileobj)
+            fileobj.writearray(raw)
             return raw.nbytes
         else:
             return 0

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -864,19 +864,7 @@ def _write_string(f, s):
         # Workaround for StringIO/ndarray incompatibility
         s = s.data
 
-    written = 0
-    while written < len(s):
-        try:
-            n = f.write(s[written:])
-        except IOError as exc:
-            if exc.errno == errno.EINTR:
-                continue
-
-            raise
-
-        if n:
-            # n may be None if a non-blocking write fails
-            written += n
+    f.write(s)
 
 
 def _convert_array(array, dtype):

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -872,6 +872,8 @@ def _write_string(f, s):
             if exc.errno == errno.EINTR:
                 continue
 
+            raise
+
         if n:
             # n may be None if a non-blocking write fails
             written += n


### PR DESCRIPTION
While handling large catalogue FITS files, I sometimes encounter problems when saving them: the newly saved file is truncated whereas no error is raised at saving time. For instance, I have a 37 GiB file and if I open it and save it just after, this leads to a 2 GiB file.

I tried to write a script to generate a big FITS file and expose the bug. During this, I found that if read a big file and count the rows before saving it, the newly save file is OK.

Here is the script. Of course, you need a lot of memory and a lot of disk space to run it.

```python
import os

import numpy as np
from astropy.io import fits

# Let's generate a BIG fits file (~25 GiB).
print("> Generating a 500x13,000,000 random table FITS file.")
list_cols = []
for i in range(500):
    list_cols.append(
        fits.Column(
            name="{}".format(i),
            format='E',
            array=np.random.random(13000000)
        )
    )
cols = fits.ColDefs(list_cols)
hdu = fits.BinTableHDU.from_columns(cols)
hdu.writeto("bigfile.fits")
print("> bigfile.fits file saved.")

# If we count read the file and count the rows before saving it to another
# file, everything is OK.
print("> Read. Count rows. Save.")
hdu_list = fits.open("bigfile.fits")
print("bigfile.fits: {} rows".format(len(hdu_list[1].data)))
hdu_list.writeto("bigfile2.fits")
print("> bigfile2.fits saved.")

print("> Comparing the file sizes.")
print("bigfile.fits: {}".format(os.stat("bigfile.fits").st_size))
print("bigfile2.fits: {}".format(os.stat("bigfile2.fits").st_size))

print("Reading bigfile2.fits and counting the rows.")
hdu_list = fits.open("bigfile2.fits")
print("bigfile2.fits: {} rows".format(len(hdu_list[1].data)))

# If we read the file and right after save it to another file, the later is
# truncated.
print("> Read the file and save it to another file just after.")
hdu_list = fits.open("bigfile.fits")
hdu_list.writeto("bigfile3.fits")
print("> bigfile3.fits saved.")

print("> Comparing the file sizes.")
print("bigfile.fits: {}".format(os.stat("bigfile.fits").st_size))
print("bigfile3.fits: {}".format(os.stat("bigfile3.fits").st_size))

print("> Reading bigfile3.fits produce a warning.")
hdu_list = fits.open("bigfile3.fits")  # Produces a warning.
print("> Accessing the data raises an error.")
print("bigfile3.fits: {} rows".format(len(hdu_list[1].data)))  # Fails.
```

The output of the script is:
```
> Generating a 500x13,000,000 random table FITS file.
> bigfile.fits file saved.
> Read. Count rows. Save.
bigfile.fits: 13000000 rows
> bigfile2.fits saved.
> Comparing the file sizes.
bigfile.fits: 26000087040
bigfile2.fits: 26000087040
Reading bigfile2.fits and counting the rows.
bigfile2.fits: 13000000 rows
> Read the file and save it to another file just after.
> bigfile3.fits saved.
> Comparing the file sizes.
bigfile.fits: 26000087040
bigfile3.fits: 2147565952
> Reading bigfile3.fits produce a warning.
WARNING: File may have been truncated: actual file length (2147565952) is smaller than the expected size (26000087040) [astropy.io.fits.file]
> Accessing the data raises an error.
Traceback (most recent call last):
  File "/opt/anaconda3/lib/python3.4/site-packages/astropy/utils/decorators.py", line 339, in __get__
    return obj.__dict__[self._key]
KeyError: 'data'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "big_table_FITS_bug.py", line 52, in <module>
    print("bigfile3.fits: {} rows".format(len(hdu_list[1].data)))  # Fails.
  File "/opt/anaconda3/lib/python3.4/site-packages/astropy/utils/decorators.py", line 341, in __get__
    val = self._fget(obj)
  File "/opt/anaconda3/lib/python3.4/site-packages/astropy/io/fits/hdu/table.py", line 399, in data
    data = self._get_tbdata()
  File "/opt/anaconda3/lib/python3.4/site-packages/astropy/io/fits/hdu/table.py", line 168, in _get_tbdata
    self._data_offset)
  File "/opt/anaconda3/lib/python3.4/site-packages/astropy/io/fits/hdu/base.py", line 556, in _get_raw_data
    return self._file.readarray(offset=offset, dtype=code, shape=shape)
  File "/opt/anaconda3/lib/python3.4/site-packages/astropy/io/fits/file.py", line 271, in readarray
    buffer=self._mmap)
TypeError: buffer is too small for requested array
```

The main problem is that astropy does not raise an error when the saving leads to a truncated file. The second problem is that astropy should be able to handle large files.

I have no idea on how to debug this but I'm willing to help.

Yannick