### PR TITLE
Time value attribute incorrect when scale != epoch_scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -805,6 +805,9 @@ New Features
 
 - ``astropy.time``
 
+  - Fix incorrect ``value`` attribute for epoch formats like "unix"
+    when ``scale`` is different from the class ``epoch_scale``. [#4313]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -529,7 +529,7 @@ class Time(object):
     @property
     def value(self):
         """Time value(s) in current format"""
-        return self._shaped_like_input(self._time._to_value(self))
+        return self._shaped_like_input(self._time.to_value(parent=self))
 
     def sidereal_time(self, kind, longitude=None, model=None):
         """Calculate sidereal time.

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -529,7 +529,7 @@ class Time(object):
     @property
     def value(self):
         """Time value(s) in current format"""
-        return self._shaped_like_input(self._time.value)
+        return self._shaped_like_input(self._time.value(parent=self))
 
     def sidereal_time(self, kind, longitude=None, model=None):
         """Calculate sidereal time.
@@ -1048,8 +1048,6 @@ class Time(object):
 
         elif attr in self.FORMATS:
             tm = self.replicate(format=attr)
-            if hasattr(self.FORMATS[attr], 'epoch_scale'):
-                tm._set_scale(self.FORMATS[attr].epoch_scale)
             return tm.value
 
         elif attr in TIME_SCALES:  # allowed ones done above (self.SCALES)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -529,7 +529,7 @@ class Time(object):
     @property
     def value(self):
         """Time value(s) in current format"""
-        return self._shaped_like_input(self._time.value(parent=self))
+        return self._shaped_like_input(self._time._to_value(self))
 
     def sidereal_time(self, kind, longitude=None, model=None):
         """Calculate sidereal time.

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -198,12 +198,16 @@ class TimeFormat(object):
         """
         raise NotImplementedError
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         """
         Return time representation from internal jd1 and jd2.  Must be
         provided by derived classes.
         """
         raise NotImplementedError
+
+    @property
+    def value(self):
+        return self._to_value()
 
 
 class TimeJD(TimeFormat):
@@ -219,7 +223,7 @@ class TimeJD(TimeFormat):
         self._check_scale(self._scale)  # Validate scale.
         self.jd1, self.jd2 = day_frac(val1, val2)
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         return self.jd1 + self.jd2
 
 
@@ -240,7 +244,7 @@ class TimeMJD(TimeFormat):
         self.jd1, self.jd2 = day_frac(val1, val2)
         self.jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h)
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         return (self.jd1 - erfa.DJM0) + self.jd2
 
 
@@ -283,7 +287,7 @@ class TimeDecimalYear(TimeFormat):
 
         self.jd1, self.jd2 = day_frac(t_frac.jd1, t_frac.jd2)
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         scale = self.scale.upper().encode('ascii')
         iy_start, ims, ids, ihmsfs = erfa.d2dtf(scale, 0,  # precision=0
                                                 self.jd1, self.jd2)
@@ -366,7 +370,7 @@ class TimeFromEpoch(TimeFormat):
         self.jd1 = tm._time.jd1
         self.jd2 = tm._time.jd2
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         # Make sure that scale is the same as epoch scale so we can just
         # subtract the epoch and convert
         if self.scale != self.epoch_scale:
@@ -597,7 +601,7 @@ class TimeDatetime(TimeUnique):
                 out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
         return iterator.operands[-1]
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         return self.to_value()
 
 
@@ -763,7 +767,7 @@ class TimeString(TimeUnique):
         """
         return str_fmt.format(**kwargs)
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         # Select the first available subformat based on current
         # self.out_subfmt
         subfmts = self._select_subfmts(self.out_subfmt)
@@ -971,7 +975,7 @@ class TimeFITS(TimeString):
         else:
             return '{0}({1})'.format(time_str, self._scale.upper())
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         """Convert times to strings, using signed 5 digit if necessary."""
         if 'long' not in self.out_subfmt:
             # If we have times before year 0 or after year 9999, we can
@@ -979,7 +983,7 @@ class TimeFITS(TimeString):
             jd = self.jd1 + self.jd2
             if jd.min() < 1721425.5 or jd.max() >= 5373484.5:
                 self.out_subfmt = 'long' + self.out_subfmt
-        return super(TimeFITS, self).value()
+        return super(TimeFITS, self)._to_value(parent)
 
 
 class TimeEpochDate(TimeFormat):
@@ -992,7 +996,7 @@ class TimeEpochDate(TimeFormat):
         jd1, jd2 = epoch_to_jd(val1 + val2)
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         jd_to_epoch = getattr(erfa, self.jd_to_epoch)
         return jd_to_epoch(self.jd1, self.jd2)
 
@@ -1046,7 +1050,7 @@ class TimeEpochDateString(TimeString):
         epoch_to_jd = getattr(erfa, self.epoch_to_jd)
         self.jd1, self.jd2 = epoch_to_jd(iterator.operands[-1])
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         jd_to_epoch = getattr(erfa, self.jd_to_epoch)
         years = jd_to_epoch(self.jd1, self.jd2)
         # Use old-style format since it is a factor of 2 faster
@@ -1094,7 +1098,7 @@ class TimeDeltaFormat(TimeFormat):
         self._check_scale(self._scale)  # Validate scale.
         self.jd1, self.jd2 = day_frac(val1, val2, divisor=1./self.unit)
 
-    def value(self, parent=None):
+    def _to_value(self, parent):
         return (self.jd1 + self.jd2) / self.unit
 
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -661,11 +661,16 @@ class TestSubFormat():
         assert t2.value == '1998-01-01 00:00:00.000'
 
         # Value take from Chandra.Time.DateTime('2010:001:00:00:00').secs
-        t = Time(378691266.184, format='cxcsec', scale='utc')
+        t_cxcsec = 378691266.184
+        t = Time(t_cxcsec, format='cxcsec', scale='utc')
+        assert allclose_sec(t.value, t_cxcsec)
+        assert allclose_sec(t.cxcsec, t_cxcsec)
+        assert allclose_sec(t.tt.value, t_cxcsec)
+        assert allclose_sec(t.tt.cxcsec, t_cxcsec)
         assert t.yday == '2010:001:00:00:00.000'
         t = Time('2010:001:00:00:00.000', scale='utc')
-        assert allclose_sec(t.cxcsec, 378691266.184)
-        assert allclose_sec(t.tt.cxcsec, 378691266.184)
+        assert allclose_sec(t.cxcsec, t_cxcsec)
+        assert allclose_sec(t.tt.cxcsec, t_cxcsec)
 
         # Value from:
         #   d = datetime.datetime(2000, 1, 1)
@@ -930,7 +935,7 @@ def test_set_format_basic():
     """
     for format, value in (('jd', 2451577.5),
                           ('mjd', 51577.0),
-                          ('cxcsec', 65923200.0),
+                          ('cxcsec', 65923264.184),  # confirmed with Chandra.Time
                           ('datetime', datetime.datetime(2000, 2, 3, 0, 0)),
                           ('iso', '2000-02-03 00:00:00.000')):
         t = Time('+02000-02-03', format='fits')


### PR DESCRIPTION
For `TimeFromEpoch` subclasses there is a bug with the `value` attribute:
```
In [3]: x = Time(1, format='unix', scale='tt')  # epoch_scale is UTC

In [4]: x.value
Out[4]: 41.184082029998414

In [5]: x.unix
Out[5]: 0.9999999999921627
```
The problem is that the comment below in `TimeFormat.value` doesn't apply when accessing `Time.value` directly (it *is* correct when `Time.__getattr__` gets run for a format attribute):
```
    def value(self):
        # when we get here, getattr will already have ensured our scale
        # equals epoch scale, so we can just subtract the epoch and convert
        time_from_epoch = ((self.jd1 - self.epoch.jd1) +
                           (self.jd2 - self.epoch.jd2)) / self.unit
        return time_from_epoch
```
Options include patching `Time.value` to do the same munging that `Time.__getattr__` does, or fixing the `TimeFromEpoch.value` property.  The latter is conceptually nicer, but I think it requires that the contained `TimeFormat` object or `TimeFormat.value()` method has access to the parent `Time` object since scale transformations take place at that level.

It looks like it might be pretty clean to change the `TimeFormat.value` property into a normal method that takes an optional `parent` arg.  Since `Time._time` is not public this should be OK, and the footprint of this change actually looks quite small.

The `Time.__getattr__` munging definitely a hack since it requires that `Time` has specific knowledge about one kind of `TimeFormat` object:
```
        elif attr in self.FORMATS:
            tm = self.replicate(format=attr)
            if hasattr(self.FORMATS[attr], 'epoch_scale'):
                tm._set_scale(self.FORMATS[attr].epoch_scale)
            return tm.value
```

