### PR TITLE
Add support for heliocentric coordinate frames and barycentric/heliocentric time corrections

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -34,6 +34,7 @@ from .altaz import AltAz
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
+from .heliocentric import Heliocentric
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 
 #need to import transformations so that they get registered in the graph
@@ -48,7 +49,7 @@ from . import ecliptic_transforms
 
 # we define an __all__ because otherwise the transformation modules get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
-           'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS',
+           'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS','Heliocentric',
            'PrecessedGeocentric', 'GeocentricTrueEcliptic',
            'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic']
 

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -37,7 +37,7 @@ from .itrs import ITRS
 from .hcrs import HCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 
-#need to import transformations so that they get registered in the graph
+# need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
 from . import fk4_fk5_transforms
 from . import galactic_transforms
@@ -49,9 +49,10 @@ from . import ecliptic_transforms
 
 # we define an __all__ because otherwise the transformation modules get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
-           'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS','HCRS',
+           'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS', 'HCRS',
            'PrecessedGeocentric', 'GeocentricTrueEcliptic',
            'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic']
+
 
 def _make_transform_graph_docs():
     """

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -34,7 +34,7 @@ from .altaz import AltAz
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .heliocentric import Heliocentric
+from .hcrs import HCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 
 #need to import transformations so that they get registered in the graph
@@ -49,7 +49,7 @@ from . import ecliptic_transforms
 
 # we define an __all__ because otherwise the transformation modules get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
-           'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS','Heliocentric',
+           'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS','HCRS',
            'PrecessedGeocentric', 'GeocentricTrueEcliptic',
            'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic']
 

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -8,10 +8,13 @@ from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
                          TimeFrameAttribute)
 from .utils import DEFAULT_OBSTIME
 
-class Heliocentric(BaseCoordinateFrame):
+class HCRS(BaseCoordinateFrame):
     """
-    A coordinate or frame in a Heliocentric system.
+    A coordinate or frame in a Heliocentric system, with axes aligned to ICRS.
 
+    The ICRS has an origin at the Barycenter and axes which are fixed with 
+    respect to space.
+    
     This coordinate system is distinct from ICRS mainly in that it is relative
     to the Sun's center-of-mass rather than the solar system Barycenter.
     In principle, therefore, this frame should include the effects of

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -8,13 +8,14 @@ from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
                          TimeFrameAttribute)
 from .utils import DEFAULT_OBSTIME
 
+
 class HCRS(BaseCoordinateFrame):
     """
     A coordinate or frame in a Heliocentric system, with axes aligned to ICRS.
 
-    The ICRS has an origin at the Barycenter and axes which are fixed with 
+    The ICRS has an origin at the Barycenter and axes which are fixed with
     respect to space.
-    
+
     This coordinate system is distinct from ICRS mainly in that it is relative
     to the Sun's center-of-mass rather than the solar system Barycenter.
     In principle, therefore, this frame should include the effects of
@@ -37,7 +38,7 @@ class HCRS(BaseCoordinateFrame):
         A representation or `None` to have no data (or use the other keywords)
     ra : `Angle`, optional, must be keyword
         Right ascension for this object (``dec`` must also be given and
-       ``representation`` must be `None`).
+        ``representation`` must be `None`).
     dec : `Angle`, optional, must be keyword
         Declination for this object (``ra`` must also be given and
         ``representation`` must be `None`).

--- a/astropy/coordinates/builtin_frames/heliocentric.py
+++ b/astropy/coordinates/builtin_frames/heliocentric.py
@@ -12,7 +12,7 @@ class Heliocentric(BaseCoordinateFrame):
     """
     A coordinate or frame in a Heliocentric system.
 
-    This coordinate system is distinct form ICRS mainly in that it is relative
+    This coordinate system is distinct from ICRS mainly in that it is relative
     to the Sun's center-of-mass rather than the solar system Barycenter.
     In principle, therefore, this frame should include the effects of
     abberation (unlike ICRS), but this is not done, since they are very small,

--- a/astropy/coordinates/builtin_frames/heliocentric.py
+++ b/astropy/coordinates/builtin_frames/heliocentric.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+from ..representation import SphericalRepresentation
+from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
+                         TimeFrameAttribute)
+from .utils import DEFAULT_OBSTIME, EQUINOX_J2000 
+
+class Heliocentric(BaseCoordinateFrame):
+    """
+    A coordinate or frame in a Heliocentric system.
+
+    This coordinate system is distinct form ICRS mainly in that it is relative 
+    to the Earth's center-of-mass rather than the solar system Barycenter.  
+    That means this frame should include the effects of abberation (unlike ICRS).
+    Abberation is currently not included, since it is of the order of 50 micro-arcseconds.
+
+    For more background on the ICRS and related coordinate transformations, see the
+    references provided in the  :ref:`astropy-coordinates-seealso` section of the
+    documentation.
+    
+    This frame has these frame attributes:
+
+    * ``obstime``
+        The time at which the observation is taken.  Used for determining the
+        position of the Sun.
+        
+    Parameters
+    ----------
+    representation : `BaseRepresentation` or None
+        A representation object or None to have no data (or use the other keywords)
+    ra : `Angle`, optional, must be keyword
+        The RA for this object (``dec`` must also be given and ``representation``
+        must be None).
+    dec : `Angle`, optional, must be keyword
+        The Declination for this object (``ra`` must also be given and
+        ``representation`` must be None).
+    distance : `~astropy.units.Quantity`, optional, must be keyword
+        The Distance for this object along the line-of-sight.
+        (``representation`` must be None).
+    """
+
+    frame_specific_representation_info = {
+        'spherical': [RepresentationMapping('lon', 'ra'),
+                      RepresentationMapping('lat', 'dec')]
+    }
+    frame_specific_representation_info['unitspherical'] = \
+        frame_specific_representation_info['spherical']
+
+    default_representation = SphericalRepresentation
+    obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)

--- a/astropy/coordinates/builtin_frames/heliocentric.py
+++ b/astropy/coordinates/builtin_frames/heliocentric.py
@@ -12,34 +12,35 @@ class Heliocentric(BaseCoordinateFrame):
     """
     A coordinate or frame in a Heliocentric system.
 
-    This coordinate system is distinct form ICRS mainly in that it is relative 
-    to the Sun's center-of-mass rather than the solar system Barycenter.  
-    That means this frame should include the effects of abberation (unlike ICRS).
-    Abberation is currently not included, since it is of the order of 8 milli-arcseconds.
+    This coordinate system is distinct form ICRS mainly in that it is relative
+    to the Sun's center-of-mass rather than the solar system Barycenter.
+    In principle, therefore, this frame should include the effects of
+    abberation (unlike ICRS), but this is not done, since they are very small,
+    of the order of 8 milli-arcseconds.
 
-    For more background on the ICRS and related coordinate transformations, see the
-    references provided in the  :ref:`astropy-coordinates-seealso` section of the
-    documentation.
-    
+    For more background on the ICRS and related coordinate transformations, see
+    the references provided in the :ref:`astropy-coordinates-seealso` section of
+    the documentation.
+
     This frame has these frame attributes:
 
     * ``obstime``
         The time at which the observation is taken.  Used for determining the
         position of the Sun.
-        
+
     Parameters
     ----------
     representation : `BaseRepresentation` or None
-        A representation object or None to have no data (or use the other keywords)
+        A representation or `None` to have no data (or use the other keywords)
     ra : `Angle`, optional, must be keyword
-        The RA for this object (``dec`` must also be given and ``representation``
-        must be None).
+        Right ascension for this object (``dec`` must also be given and
+       ``representation`` must be `None`).
     dec : `Angle`, optional, must be keyword
-        The Declination for this object (``ra`` must also be given and
-        ``representation`` must be None).
+        Declination for this object (``ra`` must also be given and
+        ``representation`` must be `None`).
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
-        (``representation`` must be None).
+        (``representation`` must be `None`).
     """
 
     frame_specific_representation_info = {
@@ -51,4 +52,3 @@ class Heliocentric(BaseCoordinateFrame):
 
     default_representation = SphericalRepresentation
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    

--- a/astropy/coordinates/builtin_frames/heliocentric.py
+++ b/astropy/coordinates/builtin_frames/heliocentric.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 from ..representation import SphericalRepresentation
 from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
                          TimeFrameAttribute)
-from .utils import DEFAULT_OBSTIME, EQUINOX_J2000 
+from .utils import DEFAULT_OBSTIME
 
 class Heliocentric(BaseCoordinateFrame):
     """
@@ -51,3 +51,4 @@ class Heliocentric(BaseCoordinateFrame):
 
     default_representation = SphericalRepresentation
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
+    

--- a/astropy/coordinates/builtin_frames/heliocentric.py
+++ b/astropy/coordinates/builtin_frames/heliocentric.py
@@ -13,9 +13,9 @@ class Heliocentric(BaseCoordinateFrame):
     A coordinate or frame in a Heliocentric system.
 
     This coordinate system is distinct form ICRS mainly in that it is relative 
-    to the Earth's center-of-mass rather than the solar system Barycenter.  
+    to the Sun's center-of-mass rather than the solar system Barycenter.  
     That means this frame should include the effects of abberation (unlike ICRS).
-    Abberation is currently not included, since it is of the order of 50 micro-arcseconds.
+    Abberation is currently not included, since it is of the order of 8 milli-arcseconds.
 
     For more background on the ICRS and related coordinate transformations, see the
     references provided in the  :ref:`astropy-coordinates-seealso` section of the

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -218,8 +218,10 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     # coordinate direction
     pv = np.array([gcrs_coo.obsgeoloc.value,
                    gcrs_coo.obsgeovel.value])
-    tdb = hcrs_frame.obstime.tdb
-    astrom = erfa.apcs13(tdb.jd1, tdb.jd2, pv)
+
+    jd1, jd2 = get_jd12(hcrs_frame.obstime, 'tdb')
+    astrom = erfa.apcs13(jd1, jd2, pv)
+
     i_ra, i_dec = erfa.aticq(gcrs_ra, gcrs_dec, astrom)
     
     # convert to Quantity objects

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -248,9 +248,13 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
                                               copy=False)
 
         newxyz = intermedrep.to_cartesian().xyz
+        # roll astrom['eh'] to the last axis and scale
+        eh = np.rollaxis(astrom['eh'], 0, astrom['eh'].ndim) * astrom['em'] * u.au
+        # roll astrom['eh'] back to the first axis
+        eh = np.rollaxis(eh, -1, 0)
+        
         # roll xyz to last axis and add the heliocentre position
-        newxyz = (np.rollaxis(newxyz, 0, newxyz.ndim) +
-                  astrom['eh'] * astrom['em'] * u.au)
+        newxyz = np.rollaxis(newxyz, 0, newxyz.ndim) + eh
         # roll xyz back to the first axis
         newxyz = np.rollaxis(newxyz, -1, 0)
         newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -44,7 +44,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # no parallax/PM. This ensures reversiblity and is more sensible for
         # inside solar system objects
         newxyz = intermedrep.to_cartesian().xyz
-        newxyz = np.rollaxis(newxyz,-1,0) -  astrom['eb']*u.au
+        newxyz = np.rollaxis(newxyz,0,newxyz.ndim) -  astrom['eb']*u.au
         # roll xyz back to the first axis
         newxyz  = np.rollaxis(newxyz,-1,0)
         newcart = CartesianRepresentation(newxyz)
@@ -90,7 +90,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
         newxyz = intermedrep.to_cartesian().xyz
         # roll xyz to last axis and add the barycentre position
-        newxyz = np.rollaxis(newxyz,-1,0) +  astrom['eb']*u.au
+        newxyz = np.rollaxis(newxyz,0,newxyz.ndim) +  astrom['eb']*u.au
         # roll xyz back to the first axis
         newxyz = np.rollaxis(newxyz,-1,0)
         newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)
@@ -137,7 +137,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # parallax/PM. This ensures reversiblity and is more sensible for
         # inside solar system objects
         newxyz = intermedrep.to_cartesian().xyz
-        newxyz = np.rollaxis(newxyz,-1,0) - astrom['eb']*u.au
+        newxyz = np.rollaxis(newxyz,0,newxyz.ndim) - astrom['eb']*u.au
         newxyz  = np.rollaxis(newxyz,-1,0)
         newcart = CartesianRepresentation(newxyz)
         
@@ -186,7 +186,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
         newxyz = intermedrep.to_cartesian().xyz
         # roll xyz to last axis and add the heliocentre position
-        newxyz = np.rollaxis(newxyz,-1,0) + astrom['eb']*u.au
+        newxyz = np.rollaxis(newxyz,0,newxyz.ndim) + astrom['eb']*u.au
         # roll xyz back to the first axis
         newxyz = np.rollaxis(newxyz,-1,0)
         newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)
@@ -242,7 +242,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
         newxyz = intermedrep.to_cartesian().xyz
         # roll xyz to last axis and add the heliocentre position
-        newxyz = np.rollaxis(newxyz,-1,0) +  astrom['eh']*astrom['em']*u.au
+        newxyz = np.rollaxis(newxyz,0,newxyz.ndim) +  astrom['eh']*astrom['em']*u.au
         # roll xyz back to the first axis
         newxyz = np.rollaxis(newxyz,-1,0)
         newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -22,14 +22,14 @@ from .cirs import CIRS
 from .hcrs import HCRS
 from .utils import get_jd12
 
-# First the ICRS/CIRS related transforms
 
+# First the ICRS/CIRS related transforms
 @frame_transform_graph.transform(FunctionTransform, ICRS, CIRS)
 def icrs_to_cirs(icrs_coo, cirs_frame):
-    #first set up the astrometry context for ICRS<->CIRS
+    # first set up the astrometry context for ICRS<->CIRS
     astrom, eo = erfa.apci13(*get_jd12(cirs_frame.obstime, 'tdb'))
 
-    if icrs_coo.data.get_name() == 'unitspherical'  or icrs_coo.data.to_cartesian().x.unit == u.one:
+    if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
         usrepr = icrs_coo.represent_as(UnitSphericalRepresentation)
         i_ra = usrepr.lon.to(u.radian).value
@@ -47,7 +47,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         newxyz = icrs_coo.cartesian.xyz
         newxyz = np.rollaxis(newxyz, 0, newxyz.ndim) - astrom['eb'] * u.au
         # roll xyz back to the first axis
-        newxyz  = np.rollaxis(newxyz, -1, 0)
+        newxyz = np.rollaxis(newxyz, -1, 0)
         newcart = CartesianRepresentation(newxyz)
 
         srepr = newcart.represent_as(SphericalRepresentation)
@@ -61,6 +61,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 
     return cirs_frame.realize_frame(newrep)
 
+
 @frame_transform_graph.transform(FunctionTransform, CIRS, ICRS)
 def cirs_to_icrs(cirs_coo, icrs_frame):
     srepr = cirs_coo.represent_as(UnitSphericalRepresentation)
@@ -69,10 +70,10 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
-    astrom, eo = erfa.apci13(*get_jd12(cirs_coo.obstime,'tdb'))
+    astrom, eo = erfa.apci13(*get_jd12(cirs_coo.obstime, 'tdb'))
     i_ra, i_dec = erfa.aticq(cirs_ra, cirs_dec, astrom)
 
-    if cirs_coo.data.get_name() == 'unitspherical'  or cirs_coo.data.to_cartesian().x.unit == u.one:
+    if cirs_coo.data.get_name() == 'unitspherical' or cirs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
@@ -98,6 +99,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
     return icrs_frame.realize_frame(newrep)
 
+
 @frame_transform_graph.transform(FunctionTransform, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
@@ -116,14 +118,14 @@ def cirs_to_cirs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
-    #first set up the astrometry context for ICRS<->GCRS
+    # first set up the astrometry context for ICRS<->GCRS
     pv = np.array([gcrs_frame.obsgeoloc.value,
                    gcrs_frame.obsgeovel.value])
 
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
 
-    if icrs_coo.data.get_name() == 'unitspherical'  or icrs_coo.data.to_cartesian().x.unit == u.one:
+    if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
         usrepr = icrs_coo.represent_as(UnitSphericalRepresentation)
         i_ra = usrepr.lon.to(u.radian).value
@@ -140,7 +142,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # inside solar system objects
         newxyz = icrs_coo.cartesian.xyz
         newxyz = np.rollaxis(newxyz, 0, newxyz.ndim) - astrom['eb'] * u.au
-        newxyz  = np.rollaxis(newxyz, -1, 0)
+        newxyz = np.rollaxis(newxyz, -1, 0)
         newcart = CartesianRepresentation(newxyz)
 
         srepr = newcart.represent_as(SphericalRepresentation)
@@ -170,7 +172,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
     i_ra, i_dec = erfa.aticq(gcrs_ra, gcrs_dec, astrom)
 
-    if gcrs_coo.data.get_name() == 'unitspherical'  or gcrs_coo.data.to_cartesian().x.unit == u.one:
+    if gcrs_coo.data.get_name() == 'unitspherical' or gcrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
@@ -232,7 +234,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     # convert to Quantity objects
     i_ra = u.Quantity(i_ra, u.radian, copy=False)
     i_dec = u.Quantity(i_dec, u.radian, copy=False)
-    if gcrs_coo.data.get_name() == 'unitspherical'  or gcrs_coo.data.to_cartesian().x.unit == u.one:
+    if gcrs_coo.data.get_name() == 'unitspherical' or gcrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(lat=i_dec, lon=i_ra, copy=False)
@@ -252,7 +254,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         eh = np.rollaxis(astrom['eh'], 0, astrom['eh'].ndim) * astrom['em'] * u.au
         # roll astrom['eh'] back to the first axis
         eh = np.rollaxis(eh, -1, 0)
-        
+
         # roll xyz to last axis and add the heliocentre position
         newxyz = np.rollaxis(newxyz, 0, newxyz.ndim) + eh
         # roll xyz back to the first axis

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -19,7 +19,7 @@ from ... import _erfa as erfa
 from .icrs import ICRS
 from .gcrs import GCRS
 from .cirs import CIRS
-from .heliocentric import Heliocentric
+from .hcrs import HCRS
 from .utils import get_jd12
 
 # First the ICRS/CIRS related transforms
@@ -205,7 +205,7 @@ def gcrs_to_gcrs(from_coo, to_frame):
         return from_coo.transform_to(ICRS).transform_to(to_frame)
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, Heliocentric)
+@frame_transform_graph.transform(FunctionTransform, GCRS, HCRS)
 def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     if np.any(gcrs_coo.obstime != hcrs_frame.obstime):
@@ -258,7 +258,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     return hcrs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransform, Heliocentric, Heliocentric)
+@frame_transform_graph.transform(FunctionTransform, HCRS, HCRS)
 def hcrs_to_hcrs(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -43,9 +43,12 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # astrometric coordinate direction and *then* run the ERFA transform for
         # no parallax/PM. This ensures reversiblity and is more sensible for
         # inside solar system objects
-        newxyz = icrs_coo.cartesian.xyz.T - astrom['eb']*u.au
-        newcart = CartesianRepresentation(newxyz.T)
-
+        newxyz = intermedrep.to_cartesian().xyz
+        newxyz = np.rollaxis(newxyz,-1,0) -  astrom['eb']*u.au
+        # roll xyz back to the first axis
+        newxyz  = np.rollaxis(newxyz,-1,0)
+        newcart = CartesianRepresentation(newxyz)
+        
         srepr = newcart.represent_as(SphericalRepresentation)
         i_ra = srepr.lon.to(u.radian).value
         i_dec = srepr.lat.to(u.radian).value
@@ -85,8 +88,12 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
                                               distance=cirs_coo.distance,
                                               copy=False)
 
-        newxyz = intermedrep.to_cartesian().xyz.T + astrom['eb']*u.au
-        newrep = CartesianRepresentation(newxyz.T).represent_as(SphericalRepresentation)
+        newxyz = intermedrep.to_cartesian().xyz
+        # roll xyz to last axis and add the barycentre position
+        newxyz = np.rollaxis(newxyz,-1,0) +  astrom['eb']*u.au
+        # roll xyz back to the first axis
+        newxyz = np.rollaxis(newxyz,-1,0)
+        newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)
 
     return icrs_frame.realize_frame(newrep)
 
@@ -102,7 +109,6 @@ def cirs_to_cirs(from_coo, to_frame):
         # is sort of glossed over in the current scheme because we are dropping
         # distances anyway.
         return from_coo.transform_to(ICRS).transform_to(to_frame)
-
 
 # Now the GCRS-related transforms to/from ICRS
 
@@ -130,9 +136,11 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # BCRS coordinate direction and *then* run the ERFA transform for no
         # parallax/PM. This ensures reversiblity and is more sensible for
         # inside solar system objects
-        newxyz = icrs_coo.cartesian.xyz.T - astrom['eb']*u.au
-        newcart = CartesianRepresentation(newxyz.T)
-
+        newxyz = intermedrep.to_cartesian().xyz
+        newxyz = np.rollaxis(newxyz,-1,0) - astrom['eb']*u.au
+        newxyz  = np.rollaxis(newxyz,-1,0)
+        newcart = CartesianRepresentation(newxyz)
+        
         srepr = newcart.represent_as(SphericalRepresentation)
         i_ra = srepr.lon.to(u.radian).value
         i_dec = srepr.lat.to(u.radian).value
@@ -176,11 +184,13 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
                                               distance=gcrs_coo.distance,
                                               copy=False)
 
-        newxyz = intermedrep.to_cartesian().xyz.T + astrom['eb']*u.au
-        newrep = CartesianRepresentation(newxyz.T).represent_as(SphericalRepresentation)
-
+        newxyz = intermedrep.to_cartesian().xyz
+        # roll xyz to last axis and add the heliocentre position
+        newxyz = np.rollaxis(newxyz,-1,0) + astrom['eb']*u.au
+        # roll xyz back to the first axis
+        newxyz = np.rollaxis(newxyz,-1,0)
+        newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)
     return icrs_frame.realize_frame(newrep)
-
 
 @frame_transform_graph.transform(FunctionTransform, GCRS, GCRS)
 def gcrs_to_gcrs(from_coo, to_frame):
@@ -211,26 +221,29 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     tdb = hcrs_frame.obstime.tdb
     astrom = erfa.apcs13(tdb.jd1, tdb.jd2, pv)
     i_ra, i_dec = erfa.aticq(gcrs_ra, gcrs_dec, astrom)
-
+    
+    # convert to Quantity objects
+    i_ra = u.Quantity(i_ra, u.radian, copy=False)
+    i_dec = u.Quantity(i_dec, u.radian, copy=False)
     if gcrs_coo.data.get_name() == 'unitspherical'  or gcrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
-        newrep = UnitSphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
-                                             lon=u.Quantity(i_ra, u.radian, copy=False),
-                                             copy=False)
+        newrep = UnitSphericalRepresentation(lat=i_dec,lon=i_ra,copy=False)
     else:
         # When there is a distance, apply the parallax/offset to the Heliocentre as the
         # last step - ensures round-tripping with the hcrs_to_gcrs transform
 
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the Heliocentre
-        intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
-                                              lon=u.Quantity(i_ra, u.radian, copy=False),
-                                              distance=gcrs_coo.distance,
+        intermedrep = SphericalRepresentation(lat=i_dec,lon=i_ra,distance=gcrs_coo.distance,
                                               copy=False)
 
-        newxyz = intermedrep.to_cartesian().xyz.T + astrom['eh']*astrom['em']*u.au
-        newrep = CartesianRepresentation(newxyz.T).represent_as(SphericalRepresentation)
+        newxyz = intermedrep.to_cartesian().xyz
+        # roll xyz to last axis and add the heliocentre position
+        newxyz = np.rollaxis(newxyz,-1,0) +  astrom['eh']*astrom['em']*u.au
+        # roll xyz back to the first axis
+        newxyz = np.rollaxis(newxyz,-1,0)
+        newrep = CartesianRepresentation(newxyz).represent_as(SphericalRepresentation)
 
     return hcrs_frame.realize_frame(newrep)
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -49,7 +49,7 @@ def cartrepr_from_matmul(pmat, coo, transpose=False):
     if pmat.shape[-2:] != (3, 3):
         raise ValueError("tried to do matrix multiplication with an array that "
                          "doesn't end in 3x3")
-    if coo.isscalar and pmat.shape[0] == 1:
+    if coo.isscalar and pmat.shape == (3,3):
         # a simpler path for scalar coordinates
         if transpose:
             pmat = pmat.T

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -49,7 +49,7 @@ def cartrepr_from_matmul(pmat, coo, transpose=False):
     if pmat.shape[-2:] != (3, 3):
         raise ValueError("tried to do matrix multiplication with an array that "
                          "doesn't end in 3x3")
-    if coo.isscalar:
+    if coo.isscalar and pmat.shape[0] == 1:
         # a simpler path for scalar coordinates
         if transpose:
             pmat = pmat.T

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -29,7 +29,7 @@ DEFAULT_OBSTIME = Time('J2000', scale='utc')
 
 PIOVER2 = np.pi / 2.
 
-#comes from the mean of the 1962-2014 IERS B data
+# comes from the mean of the 1962-2014 IERS B data
 _DEFAULT_PM = (0.035, 0.29)*u.arcsec
 
 _IERS_HINT = """
@@ -49,7 +49,7 @@ def cartrepr_from_matmul(pmat, coo, transpose=False):
     if pmat.shape[-2:] != (3, 3):
         raise ValueError("tried to do matrix multiplication with an array that "
                          "doesn't end in 3x3")
-    if coo.isscalar and pmat.shape == (3,3):
+    if coo.isscalar and pmat.shape == (3, 3):
         # a simpler path for scalar coordinates
         if transpose:
             pmat = pmat.T
@@ -71,15 +71,15 @@ def get_polar_motion(time):
     """
     gets the two polar motion components in radians for use with apio13
     """
-    #get the polar motion from the IERS table
+    # get the polar motion from the IERS table
     xp, yp, status = iers.IERS.open().pm_xy(time, return_status=True)
 
     wmsg = None
     if np.any(status == iers.TIME_BEFORE_IERS_RANGE):
         wmsg = ('Tried to get polar motions for times before IERS data is '
                 'valid. Defaulting to polar motion from the 50-yr mean for those.')
-        xp.ravel()[status.ravel()==iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[0]
-        yp.ravel()[status.ravel()==iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[1]
+        xp.ravel()[status.ravel() == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[0]
+        yp.ravel()[status.ravel() == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[1]
 
         warnings.warn(wmsg, AstropyWarning)
 
@@ -87,8 +87,8 @@ def get_polar_motion(time):
         wmsg = ('Tried to get polar motions for times after IERS data is '
                 'valid. Defaulting to polar motion from the 50-yr mean for those.' + _IERS_HINT)
 
-        xp.ravel()[status.ravel()==iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[0]
-        yp.ravel()[status.ravel()==iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[1]
+        xp.ravel()[status.ravel() == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[0]
+        yp.ravel()[status.ravel() == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[1]
 
         warnings.warn(wmsg, AstropyWarning)
 
@@ -106,6 +106,7 @@ def _warn_iers(ierserr):
     msg = '{0} Assuming UT1-UTC=0 for coordinate transformations.{1}'
     warnings.warn(msg.format(ierserr.args[0], _IERS_HINT), AstropyWarning)
 
+
 def get_dut1utc(time):
     """
     This function is used to get UT1-UTC in coordinates because normally it
@@ -117,6 +118,7 @@ def get_dut1utc(time):
     except iers.IERSRangeError as e:
         _warn_iers(e)
         return np.zeros(time.shape)
+
 
 def get_jd12(time, scale):
     """

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -11,7 +11,7 @@ from ..distances import Distance
 from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
                               Supergalactic, Galactocentric, HCRS)
 from .. import SkyCoord
-from ...tests.helper import (pytest, quantity_allclose as allclose,
+from ...tests.helper import (pytest, quantity_allclose as allclose, remote_data,
                              assert_quantity_allclose as assert_allclose)
 from .. import EarthLocation
 from ...time import Time
@@ -202,7 +202,7 @@ class TestHelioBarioCentric():
         self.wht_itrs = wht.get_itrs(obstime=self.obstime)
 
     def test_heliocentric(self):
-        helio = self.wht_itrs.transform_to(Heliocentric(obstime=self.obstime))
+        helio = self.wht_itrs.transform_to(HCRS(obstime=self.obstime))
         # Check it doesn't change from previous times.
         previous = [-1.02597256e+11, 9.71725820e+10, 4.21268419e+10] * u.m
         assert_allclose(helio.cartesian.xyz, previous)

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -172,7 +172,7 @@ def test_supergalactic():
     assert supergalactic.separation(icrs) < 0.005 * u.degree
     
 
-class TestHelioBarioCentric():
+class TestHelioBaryCentric():
     """
     Check GCRS<->Heliocentric and Barycentric coordinate conversions.
 

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -11,7 +11,7 @@ from ..distances import Distance
 from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
                               Supergalactic, Galactocentric, HCRS)
 from .. import SkyCoord
-from ...tests.helper import (pytest, quantity_allclose as allclose, remote_data,
+from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 from .. import EarthLocation
 from ...time import Time
@@ -171,24 +171,7 @@ def test_supergalactic():
     icrs = SkyCoord('17h51m36s -25d18m52s')
     assert supergalactic.separation(icrs) < 0.005 * u.degree
 
- 
-@remote_data    
-def test_heliocentric():
-    """
-    Check GCRS<->Heliocentric coordinate conversion for WHT observing site
-    """
-    wht = EarthLocation.of_site('lapalma')
-    t = Time("2013-02-02T23:00")
-    itrs = wht.get_itrs(obstime=t)
-    helio = itrs.transform_to(HCRS(obstime=t))
-    assert allclose(helio.cartesian.xyz,\
-        u.Quantity([ -1.02597256e+11,  9.71725820e+10,  4.21268419e+10],unit=u.m))
-        
-    # now we test against SLALIB answer, should agree to within 14km
-    helio_slalib = u.Quantity([-0.685820296, 0.6495585893, 0.2816005464],unit=u.au)
-    difference = np.linalg.norm((helio.cartesian.xyz-helio_slalib).to(u.km))
-    assert difference < 14.0
-    
+     
 
 class TestHelioBarioCentric():
     """

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -13,7 +13,6 @@ from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
 from .. import SkyCoord
 from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
-from .utils import randomly_sample_sphere
 from .. import EarthLocation
 from ...time import Time
 
@@ -171,7 +170,8 @@ def test_supergalactic():
     supergalactic = Supergalactic(sgl=-174.44*u.degree, sgb=+46.17*u.degree)
     icrs = SkyCoord('17h51m36s -25d18m52s')
     assert supergalactic.separation(icrs) < 0.005 * u.degree
-    
+ 
+@remote_data    
 def test_heliocentric():
     """
     Check GCRS<->Heliocentric coordinate conversion for WHT observing site
@@ -188,6 +188,7 @@ def test_heliocentric():
     difference = np.linalg.norm((helio.cartesian.xyz-helio_slalib).to(u.km))
     assert difference < 14.0
     
+@remote_data
 def test_barycentric():
     """
     Check GCRS<->ICRS coordinate conversion for WHT observing site

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -24,11 +24,12 @@ convert_precision = 1 * u.arcsec
 roundtrip_precision = 1e-4 * u.degree
 dist_precision = 1e-9 * u.kpc
 
-m31_params =[]
+m31_params = []
 for i in range(len(m31_sys)):
     for j in range(len(m31_sys)):
         if i < j:
             m31_params.append((m31_sys[i], m31_sys[j], m31_coo[i], m31_coo[j]))
+
 
 @pytest.mark.parametrize(('fromsys', 'tosys', 'fromcoo', 'tocoo'), m31_params)
 def test_m31_coord_transforms(fromsys, tosys, fromcoo, tocoo):
@@ -50,7 +51,7 @@ def test_m31_coord_transforms(fromsys, tosys, fromcoo, tocoo):
     assert m31_dist.unit == u.kpc
     assert (coo2.distance - m31_dist) < dist_precision
 
-    #check round-tripping
+    # check round-tripping
     coo1_2 = coo2.transform_to(fromsys)
     assert (coo1_2.spherical.lon - fromcoo[0]*u.deg) < roundtrip_precision
     assert (coo1_2.spherical.lat - fromcoo[1]*u.deg) < roundtrip_precision
@@ -97,8 +98,8 @@ def test_fk5_galactic():
 
 def test_galactocentric():
     # when z_sun=0, transformation should be very similar to Galactic
-    icrs_coord = ICRS(ra=np.linspace(0,360,10)*u.deg,
-                      dec=np.linspace(-90,90,10)*u.deg,
+    icrs_coord = ICRS(ra=np.linspace(0, 360, 10)*u.deg,
+                      dec=np.linspace(-90, 90, 10)*u.deg,
                       distance=1.*u.kpc)
 
     g_xyz = icrs_coord.transform_to(Galactic).cartesian.xyz
@@ -109,10 +110,10 @@ def test_galactocentric():
     assert allclose(diff[1:], 0*u.kpc, atol=1E-5*u.kpc)
 
     # generate some test coordinates
-    g = Galactic(l=[0,0,45,315]*u.deg, b=[-45,45,0,0]*u.deg,
+    g = Galactic(l=[0, 0, 45, 315]*u.deg, b=[-45, 45, 0, 0]*u.deg,
                  distance=[np.sqrt(2)]*4*u.kpc)
     xyz = g.transform_to(Galactocentric(galcen_distance=1.*u.kpc, z_sun=0.*u.pc)).cartesian.xyz
-    true_xyz = np.array([[0,0,-1.],[0,0,1],[0,1,0],[0,-1,0]]).T*u.kpc
+    true_xyz = np.array([[0, 0, -1.], [0, 0, 1], [0, 1, 0], [0, -1, 0]]).T*u.kpc
     assert allclose(xyz.to(u.kpc), true_xyz.to(u.kpc), atol=1E-5*u.kpc)
 
     # check that ND arrays work
@@ -123,12 +124,13 @@ def test_galactocentric():
     z = np.zeros_like(x)
 
     g1 = Galactocentric(x=x, y=y, z=z)
-    g2 = Galactocentric(x=x.reshape(100,1,1), y=y.reshape(100,1,1), z=z.reshape(100,1,1))
+    g2 = Galactocentric(x=x.reshape(100, 1, 1), y=y.reshape(100, 1, 1),
+                        z=z.reshape(100, 1, 1))
 
     g1t = g1.transform_to(Galactic)
     g2t = g2.transform_to(Galactic)
 
-    assert_allclose(g1t.cartesian.xyz, g2t.cartesian.xyz[:,:,0,0])
+    assert_allclose(g1t.cartesian.xyz, g2t.cartesian.xyz[:, :, 0, 0])
 
     # from Galactic to Galactocentric
     l = np.linspace(15, 30., 100) * u.deg
@@ -136,12 +138,14 @@ def test_galactocentric():
     d = np.ones_like(l.value) * u.kpc
 
     g1 = Galactic(l=l, b=b, distance=d)
-    g2 = Galactic(l=l.reshape(100,1,1), b=b.reshape(100,1,1), distance=d.reshape(100,1,1))
+    g2 = Galactic(l=l.reshape(100, 1, 1), b=b.reshape(100, 1, 1),
+                  distance=d.reshape(100, 1, 1))
 
     g1t = g1.transform_to(Galactocentric)
     g2t = g2.transform_to(Galactocentric)
 
-    np.testing.assert_almost_equal(g1t.cartesian.xyz.value, g2t.cartesian.xyz.value[:,:,0,0])
+    np.testing.assert_almost_equal(g1t.cartesian.xyz.value,
+                                   g2t.cartesian.xyz.value[:, :, 0, 0])
 
 
 def test_supergalactic():
@@ -170,7 +174,7 @@ def test_supergalactic():
     supergalactic = Supergalactic(sgl=-174.44*u.degree, sgb=+46.17*u.degree)
     icrs = SkyCoord('17h51m36s -25d18m52s')
     assert supergalactic.separation(icrs) < 0.005 * u.degree
-    
+
 
 class TestHelioBaryCentric():
     """
@@ -197,7 +201,7 @@ class TestHelioBaryCentric():
     def test_barycentric(self):
         gcrs = self.wht_itrs.transform_to(GCRS(obstime=self.obstime))
         bary = gcrs.transform_to(ICRS())
-        previous = [ -1.02758958e+11, 9.68331109e+10, 4.19720938e+10] * u.m
+        previous = [-1.02758958e+11, 9.68331109e+10, 4.19720938e+10] * u.m
         assert_allclose(bary.cartesian.xyz, previous)
 
         # And that it agrees with SLALIB answer to within 14km

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -9,7 +9,7 @@ import numpy as np
 from ... import units as u
 from ..distances import Distance
 from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
-                              Supergalactic, Galactocentric, HCRS)
+                              Supergalactic, Galactocentric, HCRS, GCRS)
 from .. import SkyCoord
 from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
@@ -170,8 +170,7 @@ def test_supergalactic():
     supergalactic = Supergalactic(sgl=-174.44*u.degree, sgb=+46.17*u.degree)
     icrs = SkyCoord('17h51m36s -25d18m52s')
     assert supergalactic.separation(icrs) < 0.005 * u.degree
-
-     
+    
 
 class TestHelioBarioCentric():
     """

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -13,7 +13,8 @@ from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
 from .. import SkyCoord
 from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
-from .. import Earthlocation
+from .utils import randomly_sample_sphere
+from .. import EarthLocation
 from ...time import Time
 
 # used below in the next parametrized test

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -588,7 +588,7 @@ class Time(object):
             location = self.location
 
         from ..coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
-                                   Heliocentric, ICRS, GCRS, EarthLocation, SkyCoord)
+                                   HCRS, ICRS, GCRS, EarthLocation, SkyCoord)
 
         if not isinstance(location, EarthLocation):
             raise ValueError("location must be an EarthLocation object")
@@ -603,7 +603,7 @@ class Time(object):
         itrs = location.get_itrs(obstime=self)
         if kind.lower() == 'heliocentric':
             # convert to heliocentric coordinates, aligned with ICRS
-            cpos = itrs.transform_to(Heliocentric(obstime=self)).cartesian.xyz
+            cpos = itrs.transform_to(HCRS(obstime=self)).cartesian.xyz
         else:
             # first we need to convert to GCRS coordinates with the correct
             # obstime, since ICRS coordinates have no frame time

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -568,23 +568,23 @@ class Time(object):
         at a standard location; either the Solar system barycentre or the heliocentre.
         
         Suppose you have a list of times in MJD form. Typically these will be in the UTC
-        timescale. First create an `~astropy.time.Time` object:
+        timescale. First create an `~astropy.time.Time` object::
         
-            from astropy import time, coordinates as coord, units as u
-            times = time.Time([56325.95833333, 56325.978254], format='mjd', scale='utc')
+            >>> from astropy import time, coordinates as coord, units as u
+            >>> times = time.Time([56325.95833333, 56325.978254], format='mjd', scale='utc')
             
         You should then set the ``'location'`` property of the time object to the location
         of the observatory:
         
-            times.location = coord.EarthLocation.of_site('lapalma')
+            >>> times.location = coord.EarthLocation.of_site('lapalma')
             
         This routine can then be used to calculate the light travel time to the
         heliocentre or barycentre, given the sky location of the photon's origin.
-        This should be supplied as a `~coordinates.SkyCoord` object:
+        This should be supplied as a `~coordinates.SkyCoord` object::
         
-            star = coord.SkyCoord("23:23:08.55","+18:24:59.3",unit=(u.deg,u.deg),frame='icrs')
-            ltt_bary  = times.ltt_correction(times,star,'barycentric')
-            ltt_helio = times.ltt_correction(times,star,'heliocentric')
+            >>> star = coord.SkyCoord("23:23:08.55","+18:24:59.3",unit=(u.deg,u.deg),frame='icrs')
+            >>> ltt_bary  = times.ltt_correction(times,star,'barycentric')
+            >>> ltt_helio = times.ltt_correction(times,star,'heliocentric')
             
         This function returns an `~astropy.time.TimeDelta` object, which can be added to
         your times to give the arrival time of the photons at the heliocentre or barycentre.
@@ -597,7 +597,7 @@ class Time(object):
         particularly appropriate. Historically in the astrophysical literature, times 
         corrected to the heliocentre are given in the UTC timescale:
         
-            times_heliocentre = times + ltt_helio
+            >>> times_heliocentre = times + ltt_helio
             
         Corrections to the barycentre are more precise than the heliocentre, because the 
         barycenter is a fixed point where gravity is constant. For maximum accuracy you
@@ -606,7 +606,7 @@ class Time(object):
         rate that a clock would tick at the barycentre. For this reason, barycentric 
         corrected times normally use the TDB timescale:
         
-            time_barycentre  = times.tdb + ltt_bary
+            >>> time_barycentre  = times.tdb + ltt_bary
         
         Parameters
         ---------------

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -590,17 +590,16 @@ class Time(object):
         from ..coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
                                    HCRS, ICRS, GCRS, EarthLocation, SkyCoord)
 
-        if not isinstance(location, EarthLocation):
-            raise ValueError("location must be an EarthLocation object")
-        if not isinstance(skycoord, SkyCoord):
-            raise ValueError("skycoord must be an SkyCoord object")
-
         # ensure sky location is ICRS compatible
         if not skycoord.is_transformable_to(ICRS()):
             raise ValueError("Given skycoord is not transformable to the ICRS")
 
         # get location of observatory in ITRS coordinates at this Time
-        itrs = location.get_itrs(obstime=self)
+        try:
+            itrs = location.get_itrs(obstime=self)
+        except:
+            raise ValueError("Supplied location does not have a valid `get_itrs` method")
+              
         if kind.lower() == 'heliocentric':
             # convert to heliocentric coordinates, aligned with ICRS
             cpos = itrs.transform_to(HCRS(obstime=self)).cartesian.xyz

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -574,55 +574,6 @@ class Time(object):
             The time offset between the barycentre or Heliocentre and Earth,
             in TDB seconds.  Should be added to the original time to get the
             time in the Solar system barycentre or the Heliocentre.
-
-        Examples
-        --------
-        The arrival times of photons at an observatory are not particularly
-        useful for accurate timing work, such as eclipse/transit timing of
-        binaries or exoplanets.  This is because the changing location of the
-        observatory causes photons to arrive early or late. The solution is to
-        calculate the time the photon would have arrived at a standard location;
-        either the Solar system barycentre or the heliocentre.
-
-        Suppose you observed IP Peg on La Palma and have a list of times in MJD
-        form, in the UTC timescale. You then create appropriate
-        `~astropy.time.Time` and `~astropy.coordinates.SkyCoord` objects and
-        calculate light travel times to the barycentre as follows::
-
-          >>> from astropy import time, coordinates as coord, units as u
-          >>> ip_peg = coord.SkyCoord("23:23:08.55", "+18:24:59.3",
-          ...                         unit=(u.hourangle, u.deg), frame='icrs')
-          >>> wht = coord.EarthLocation.of_site('lapalma')  # doctest: +REMOTE_DATA
-          >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
-          ...                   scale='utc', location=wht)  # doctest: +REMOTE_DATA
-          >>> ltt_bary = times.light_travel_time(ip_peg)  # doctest: +REMOTE_DATA
-          
-        If you desire the light travel time to the heliocentre instead then use::
-          
-          >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric')  # doctest: +REMOTE_DATA
-
-        The method returns an `~astropy.time.TimeDelta` object, which can be
-        added to your times to give the arrival time of the photons at the
-        barycentre or heliocentre.  Here, one should be careful with the
-        timescales used; for more detailed information about timescales, see
-        http://astropy.readthedocs.org/en/stable/time/index.html#time-scale.
-
-        The heliocentre is not a fixed point, and therefore the gravity
-        continually changes at the heliocentre. Thus, the use of a relativistic
-        timescale like TDB is not particularly appropriate, and, historically,
-        times corrected to the heliocentre are given in the UTC timescale:
-
-          >>> times_heliocentre = times.utc + ltt_helio  # doctest: +REMOTE_DATA
-
-        Corrections to the barycentre are more precise than the heliocentre,
-        because the barycenter is a fixed point where gravity is constant. For
-        maximum accuracy you want to have your barycentric corrected times in a
-        timescale that has always ticked at a uniform rate, and ideally one
-        whose tick rate is related to the rate that a clock would tick at the
-        barycentre. For this reason, barycentric corrected times normally use
-        the TDB timescale:
-
-          >>> time_barycentre = times.tdb + ltt_bary  # doctest: +REMOTE_DATA
         """
 
         if kind.lower() not in ('barycentric', 'heliocentric'):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -111,6 +111,7 @@ class TimeInfo(MixinInfo):
     # When Time has mean, std, min, max methods:
     # funcs = [lambda x: getattr(x, stat)() for stat_name in MixinInfo._stats])
 
+
 class Time(object):
     """
     Represent and manipulate times and dates for astronomy.
@@ -212,8 +213,8 @@ class Time(object):
             self._init_from_vals(val, val2, format, scale, copy,
                                  precision, in_subfmt, out_subfmt)
 
-        if self.location and (self.location.size > 1
-                              and self.location.shape != self.shape):
+        if self.location and (self.location.size > 1 and
+                              self.location.shape != self.shape):
             try:
                 # check the location can be broadcast to self's shape.
                 self.location = broadcast_to(self.location, self.shape,
@@ -599,7 +600,7 @@ class Time(object):
             itrs = location.get_itrs(obstime=self)
         except:
             raise ValueError("Supplied location does not have a valid `get_itrs` method")
-              
+
         if kind.lower() == 'heliocentric':
             # convert to heliocentric coordinates, aligned with ICRS
             cpos = itrs.transform_to(HCRS(obstime=self)).cartesian.xyz
@@ -611,15 +612,15 @@ class Time(object):
             cpos = gcrs_coo.transform_to(ICRS()).cartesian.xyz
 
         # get unit ICRS vector to star
-        spos  = (skycoord.icrs.represent_as(UnitSphericalRepresentation).
-                 represent_as(CartesianRepresentation).xyz)
+        spos = (skycoord.icrs.represent_as(UnitSphericalRepresentation).
+                represent_as(CartesianRepresentation).xyz)
 
         # Move X,Y,Z to last dimension, to enable possible broadcasting below.
         cpos = np.rollaxis(cpos, 0, cpos.ndim)
         spos = np.rollaxis(spos, 0, spos.ndim)
 
         # calculate light travel time correction
-        tcor_val  = (spos * cpos).sum(axis=-1) / const.c
+        tcor_val = (spos * cpos).sum(axis=-1) / const.c
         return TimeDelta(tcor_val, scale='tdb')
 
     def sidereal_time(self, kind, longitude=None, model=None):
@@ -760,10 +761,9 @@ class Time(object):
         # To avoid recalculating integer day + fraction, no longer just
         # instantiate a new class instance, but rather do the steps by hand.
         # This also avoids quite a bit of unnecessary work in __init__
-        ###  tm = self.__class__(self._time.jd1, self._time.jd2,
-        ###                      format='jd', scale=self.scale, copy=copy)
+        #  tm = self.__class__(self._time.jd1, self._time.jd2,
+        #                      format='jd', scale=self.scale, copy=copy)
         return self._replicate(format=format, method='copy' if copy else None)
-
 
     def _replicate(self, method=None, *args, **kwargs):
         """Replicate a time object, possibly applying a method to the arrays.
@@ -1522,7 +1522,6 @@ class Time(object):
         return tm._shaped_like_input(tm._time.to_value(timezone))
 
     to_datetime.__doc__ = TimeDatetime.to_value.__doc__
-
 
 
 class TimeDelta(Time):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -546,7 +546,7 @@ class Time(object):
         # the ``value`` attribute is cached.
         return getattr(self, self.format)
 
-    def ltt_correction(self, skycoord, kind='barycentric', location=None):
+    def light_travel_time(self, skycoord, kind='barycentric', location=None):
         """Light travel time correction to the barycentre or heliocentre.
 
         The frame transformations used to calculate the location of the solar
@@ -595,8 +595,11 @@ class Time(object):
           >>> wht = coord.EarthLocation.of_site('lapalma')  # doctest: +REMOTE_DATA
           >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
           ...                   scale='utc', location=wht)  # doctest: +REMOTE_DATA
-          >>> ltt_bary = times.ltt_correction(ip_peg, 'barycentric')  # doctest: +REMOTE_DATA
-          >>> ltt_helio = times.ltt_correction(ip_peg, 'heliocentric')  # doctest: +REMOTE_DATA
+          >>> ltt_bary = times.light_travel_time(ip_peg)  # doctest: +REMOTE_DATA
+          
+        If you desire the light travel time to the heliocentre instead then use::
+          
+          >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric')  # doctest: +REMOTE_DATA
 
         The method returns an `~astropy.time.TimeDelta` object, which can be
         added to your times to give the arrival time of the photons at the

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -17,5 +17,9 @@ def test_corrections():
     t.location = wht
     hval = t.heliocentric_correction(star)
     bval = t.barycentric_correction(star)
+    # test against values returned at time of initial creation
+    # these values agree to an independent SLALIB based implementation
+    # to 20 microseconds
     assert allclose(hval.sec,461.43037870502235)
     assert allclose(bval.sec,460.58538779827836)
+    

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -15,7 +15,7 @@ class TestHelioBaryCentric():
     """
     def setup(self):
         wht = EarthLocation(342.12*u.deg, 28.758333333333333*u.deg, 2327*u.m)
-        self.obstime  = Time("2013-02-02T23:00", location=wht)
+        self.obstime = Time("2013-02-02T23:00", location=wht)
         self.obstime2 = Time("2013-08-02T23:00", location=wht)
         self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"], location=wht)
         self.star = SkyCoord("08:08:08 +32:00:00", unit=(u.hour, u.degree),
@@ -32,7 +32,7 @@ class TestHelioBaryCentric():
         assert isinstance(bval, TimeDelta)
         assert bval.scale == 'tdb'
         assert abs(bval - 460.58538779827836 * u.s) < 1. * u.us
-        
+
     def test_arrays(self):
         bval1 = self.obstime.light_travel_time(self.star, 'barycentric')
         bval2 = self.obstime2.light_travel_time(self.star, 'barycentric')

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -37,5 +37,10 @@ class TestHelioBaryCentric():
         bval1 = self.obstime.light_travel_time(self.star, 'barycentric')
         bval2 = self.obstime2.light_travel_time(self.star, 'barycentric')
         bval_arr = self.obstimeArr.light_travel_time(self.star, 'barycentric')
+        hval1 = self.obstime.light_travel_time(self.star, 'heliocentric')
+        hval2 = self.obstime2.light_travel_time(self.star, 'heliocentric')
+        hval_arr = self.obstimeArr.light_travel_time(self.star, 'heliocentric')
+        assert hval_arr[0]-hval1 < 1. * u.us
+        assert hval_arr[1]-hval2 < 1. * u.us
         assert bval_arr[0]-bval1 < 1. * u.us
         assert bval_arr[1]-bval2 < 1. * u.us

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -4,7 +4,7 @@ from ...coordinates import EarthLocation, SkyCoord
 from .. import Time, TimeDelta
 
 
-class TestHelioBarioCentric():
+class TestHelioBaryCentric():
     """
     Verify time offsets to the solar system barycentre and the heliocentre.
     Uses the WHT observing site.
@@ -15,18 +15,27 @@ class TestHelioBarioCentric():
     """
     def setup(self):
         wht = EarthLocation(342.12*u.deg, 28.758333333333333*u.deg, 2327*u.m)
-        self.obstime = Time("2013-02-02T23:00", location=wht)
+        self.obstime  = Time("2013-02-02T23:00", location=wht)
+        self.obstime2 = Time("2013-08-02T23:00", location=wht)
+        self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"], location=wht)
         self.star = SkyCoord("08:08:08 +32:00:00", unit=(u.hour, u.degree),
                              frame='icrs')
 
     def test_heliocentric(self):
-        hval = self.obstime.ltt_correction(self.star, 'heliocentric')
+        hval = self.obstime.light_travel_time(self.star, 'heliocentric')
         assert isinstance(hval, TimeDelta)
         assert hval.scale == 'tdb'
         assert abs(hval - 461.43037870502235 * u.s) < 1. * u.us
 
     def test_barycentric(self):
-        bval = self.obstime.ltt_correction(self.star, 'barycentric')
+        bval = self.obstime.light_travel_time(self.star, 'barycentric')
         assert isinstance(bval, TimeDelta)
         assert bval.scale == 'tdb'
         assert abs(bval - 460.58538779827836 * u.s) < 1. * u.us
+        
+    def test_arrays(self):
+        bval1 = self.obstime.light_travel_time(self.star, 'barycentric')
+        bval2 = self.obstime2.light_travel_time(self.star, 'barycentric')
+        bval_arr = self.obstimeArr.light_travel_time(self.star, 'barycentric')
+        assert bval_arr[0]-bval1 < 1. * u.us
+        assert bval_arr[1]-bval2 < 1. * u.us

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -4,7 +4,7 @@ import itertools
 
 import numpy as np
 
-from ...tests.helper import (pytest, quantity_allclose as allclose, remote_data
+from ...tests.helper import (pytest, quantity_allclose as allclose, remote_data,
                              assert_quantity_allclose as assert_allclose)
 from .. import Time
 

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -1,0 +1,20 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import functools
+import itertools
+
+import numpy as np
+
+from ...tests.helper import (pytest, quantity_allclose as allclose,
+                             assert_quantity_allclose as assert_allclose)
+from .. import Time
+
+def test_corrections():
+    from .. import coordinates as coord, units as u
+    wht  = coord.EarthLocation.of_site('lapalma')
+    star = coord.SkyCoord("08:08:08 +32:00:00",distance=120*u.pc,unit=(u.hour,u.degree),frame='icrs')
+    t = Time("2013-02-02T23:00")
+    t.location = wht
+    hval = t.heliocentric_correction(star)
+    bval = t.barycentric_correction(star)
+    assert allclose(hval.sec,461.43037870502235)
+    assert allclose(bval.sec,460.58538779827836)

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -9,7 +9,7 @@ from ...tests.helper import (pytest, quantity_allclose as allclose,
 from .. import Time
 
 def test_corrections():
-    from .. import coordinates as coord, units as u
+    from ... import coordinates as coord, units as u
     wht  = coord.EarthLocation.of_site('lapalma')
     star = coord.SkyCoord("08:08:08 +32:00:00",distance=120*u.pc,unit=(u.hour,u.degree),frame='icrs')
     t = Time("2013-02-02T23:00")

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -4,10 +4,11 @@ import itertools
 
 import numpy as np
 
-from ...tests.helper import (pytest, quantity_allclose as allclose,
+from ...tests.helper import (pytest, quantity_allclose as allclose, remote_data
                              assert_quantity_allclose as assert_allclose)
 from .. import Time
 
+@remote_data
 def test_corrections():
     from ... import coordinates as coord, units as u
     wht  = coord.EarthLocation.of_site('lapalma')

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -874,16 +874,16 @@ arrive early or late. The solution is to calculate the time the photon would
 have arrived at a standard location; either the Solar system barycentre or the
 heliocentre.
 
-Suppose you observed IP Peg on La Palma and have a list of times in MJD form, in
+Suppose you observed IP Peg from Greenwich and have a list of times in MJD form, in
 the UTC timescale. You then create appropriate |Time| and |SkyCoord| objects and
 calculate light travel times to the barycentre as follows::
 
     >>> from astropy import time, coordinates as coord, units as u
     >>> ip_peg = coord.SkyCoord("23:23:08.55", "+18:24:59.3",
     ...                         unit=(u.hourangle, u.deg), frame='icrs')
-    >>> wht = coord.EarthLocation.of_site('lapalma')  
+    >>> greenwich = coord.EarthLocation.of_site('greenwich')  
     >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
-    ...                   scale='utc', location=wht)  
+    ...                   scale='utc', location=greenwich)  
     >>> ltt_bary = times.light_travel_time(ip_peg)  
           
 If you desire the light travel time to the heliocentre instead then use::


### PR DESCRIPTION
This pull request fixes #2244, fixes #4288, and adds tests for the GCRS<->ICRS transformations in #4268. The idea is that helper routines, similar to ```sidereal_time``` are now attached to each ```Time``` object. These helper routines, ```heliocentric_correction``` and ```barycentric_correction``` return ```TimeDelta``` objects, which can be added to a Time object to create a heliocentric or barycentric corrected time. 

An example usage


    from astropy import coordinates as coord, units as u
    from astropy.time import Time
 
    wht  = coord.EarthLocation.of_site('lap alma')
    star = coord.SkyCoord("08:08:08 +32:00:00",distance=120*u.pc,unit=(u.hour,u.degree),frame='icrs')
    t = Time("2013-02-02T23:00")
    t.location = wht
    hcor_val = t.heliocentric_correction(star)
    bcor_val = t.barycentric_correction(star)
    
    # the returned timedelta objects can be added to the original time
    hcor = t + hcor_val
    bcor = t + bcor_val
    print(' MJD (UTC)  = %.11f' % t.mjd)
    print(' MJD (TT)   = %.11f' % t.tt.mjd)
    print(' MJD (TDB)  = %.11f' % t.tdb.mjd)
    print('HMJD (UTC)  = %.11f' % hcor.utc.mjd)
    print('HMJD (TT)   = %.11f' % hcor.tt.mjd)
    print('HMJD (TDB)  = %.11f' % hcor.tdb.mjd)
    print('BMJD (UTC)  = %.11f' % bcor.utc.mjd)
    print('BMJD (TT)   = %.11f' % bcor.tt.mjd)
    print('BMJD (TDB)  = %.11f' % bcor.tdb.mjd)
    print("Correction to add to get time at heliocentre = {} seconds".format(hcor_val))
    print("Correction to add to get time at barycentre = {} seconds".format(bcor_val))