### PR TITLE
fix test_highlevel_api_remote to be robust against minor coord changes

### DIFF
--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -434,7 +434,15 @@ def test_highlevel_api():
 def test_highlevel_api_remote():
     m31icrs = coords.SkyCoord.from_name('M31', frame='icrs')
 
-    assert str(m31icrs) == '<SkyCoord (ICRS): (ra, dec) in deg\n    (10.6847083, 41.26875)>'
+    m31str = str(m31icrs)
+    assert m31str.startswith('<SkyCoord (ICRS): (ra, dec) in deg\n    (')
+    assert m31str.endswith(')>')
+    assert '10.68' in m31str
+    assert '41.26' in m31str
+    # The above is essentially a replacement of the below, but tweaked so that
+    # small/moderate changes in what `from_name` returns don't cause the tests
+    # to fail
+    #assert str(m31icrs) == '<SkyCoord (ICRS): (ra, dec) in deg\n    (10.6847083, 41.26875)>'
 
     m31fk4 = coords.SkyCoord.from_name('M31', frame='fk4')
 


### PR DESCRIPTION
While checking to make sure the ``--remote-data`` tests are still working, I noted that a test of `SkyCoord.from_name` was failing.  I'm not sure exactly what the origin of this is, but I suspect it's because of slightly different results coming back from Sesame.  So this just updates that test to be more robust for small changes in the location of M31 (after all, it's a big galaxy!)