### PR TITLE
Make it clearer that table.unique is a function, not a method.

### DIFF
--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -882,8 +882,8 @@ Unique rows
 Sometimes it makes sense to use only rows with unique key columns or even
 fully unique rows from a table. This can be done using the above described
 :func:`~astropy.table.Table.group_by` method and ``groups`` attribute, or
-with the `~astropy.table.unique` convenience method. The
-`~astropy.table.unique` method returns with a sorted table containing the
+with the `~astropy.table.unique` convenience function. The
+`~astropy.table.unique` function returns with a sorted table containing the
 first row for each unique ``keys`` column value. If no ``keys`` is provided
 it returns with a sorted table containing all the fully unique rows.
 


### PR DESCRIPTION
I got confused by the doc sentence about [`table.unique`](http://astropy.readthedocs.org/en/latest/table/operations.html#unique-rows) whereas `unique` is not a method of the `Table` class: *This can be done using the above described group_by() method and groups attribute, or with the unique convenience method. The unique method returns ...*
This is a really small change but maybe it will prevent somebody else to spend 5 minutes looking for the `.unique()` method ;).
Also, as `unique` is presented as a shortcut for `group_by`, it should really be a method I think.