### PR TITLE
One failing io.fits test on Numpy 1.10.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -887,6 +887,11 @@ Bug Fixes
   - Fixed a regression that could cause writes of large FITS files to be
     truncated. [#4307]
 
+  - Astropy v1.0.6 included a fix (#4228) for an obscure case where the TDIM
+    of a table column is smaller than the repeat count of its data format.
+    This updates that fix in such a way that it works with Numpy 1.10 as well.
+    [#4266]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1827,7 +1827,6 @@ class TestTableFunctions(FitsTestCase):
             assert (h[1].data['strarray'].encode('ascii') == arrb).all()
             assert (h[1].data['intarray'] == arrc).all()
 
-    @pytest.mark.xfail('not NUMPY_LT_1_10')
     def test_mismatched_tform_and_tdim(self):
         """Normally the product of the dimensions listed in a TDIMn keyword
         must be less than or equal to the repeat count in the TFORMn keyword.
@@ -1850,8 +1849,12 @@ class TestTableFunctions(FitsTestCase):
         hdu.writeto(self.temp('test.fits'))
 
         with fits.open(self.temp('test.fits')) as h:
+            assert h[1].header['TFORM1'] == '20I'
+            assert h[1].header['TFORM2'] == '4I'
+            assert h[1].header['TDIM1'] == h[1].header['TDIM2'] == '(2,2)'
             assert (h[1].data['a'] == arra).all()
             assert (h[1].data['b'] == arrb).all()
+            assert h[1].data.itemsize == 48  # 16-bits times 24
 
         # If dims is more than the repeat count in the format specifier raise
         # an error


### PR DESCRIPTION
Not sure how, but I completely missed this somehow when I was finishing up testing for v1.0.6.  I don't have time to fix it right now so I've marked the test as xfail on Numpy 1.10 for now.  It's an obscure case that probably shouldn't affect any users.

See 06a53a1