### PR TITLE
Make jsviewer in show_in_browser have local file option

### DIFF
--- a/astropy/extern/README.rst
+++ b/astropy/extern/README.rst
@@ -31,7 +31,6 @@ And for JavaScript:
 Notes for developers
 --------------------
 
-
 jQuery/DataTables
 ^^^^^^^^^^^^^^^^^
 the minified files are the ones that are used in the table viewer feature, but
@@ -96,7 +95,8 @@ configuration module::
 Third-party packagers can override the defaults for these configuration items
 (by modifying the configuration objects in ``astropy/table/jsviewer.py``, or
 provide astropy config files that include the overrides appropriate for the
-packaged version.
+packaged version.  They would *also* need to set the default
+``use_local_files`` option to ``False`` for these settings to be read.
 
 
 Other

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -858,7 +858,7 @@ class Table(object):
 
     def show_in_notebook(self, tableid=None, css=None, display_length=50,
                          table_class='table table-striped table-bordered '
-                         'table-condensed'):
+                         'table-condensed', use_local_files=False):
         """Render the table in HTML and show it in the IPython notebook.
 
         Parameters
@@ -878,7 +878,13 @@ class Table(object):
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
         display_length : int, optional
             Number or rows to show. Default to 50.
-
+        use_local_files : bool
+            If True, the JavaScript libraries will be served from local copies
+            provided with astropy. Otherwise, remote URLS will be used (set from
+            the configuration items in ``astropy.table.jsviewer.conf``). Note
+            that this defaults to False because some browsers don't allow
+            loading of local resources, so the local files cannot be used in the
+            notebook.
         """
 
         from .jsviewer import JSViewer
@@ -888,7 +894,7 @@ class Table(object):
             tableid = 'table{0}-{1}'.format(id(self),
                                             np.random.randint(1, 1e6))
 
-        jsv = JSViewer(use_local_files=False, display_length=display_length)
+        jsv = JSViewer(use_local_files=use_local_files, display_length=display_length)
         html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
                                 max_lines=-1, show_dtype=False,
                                 tableclass=table_class)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -858,7 +858,7 @@ class Table(object):
 
     def show_in_notebook(self, tableid=None, css=None, display_length=50,
                          table_class='table table-striped table-bordered '
-                         'table-condensed', use_local_files=False):
+                         'table-condensed'):
         """Render the table in HTML and show it in the IPython notebook.
 
         Parameters
@@ -878,13 +878,14 @@ class Table(object):
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
         display_length : int, optional
             Number or rows to show. Default to 50.
-        use_local_files : bool
-            If True, the JavaScript libraries will be served from local copies
-            provided with astropy. Otherwise, remote URLS will be used (set from
-            the configuration items in ``astropy.table.jsviewer.conf``). Note
-            that this defaults to False because some browsers don't allow
-            loading of local resources, so the local files cannot be used in the
-            notebook.
+
+        Notes
+        -----
+        Currently, unlike `show_in_browser` (with ``jsviewer=True``), this
+        method needs to access online javascript code repositories.  This is due
+        to modern browsers' limitations on accessing local files.  Hence, if you
+        call this method while offline (and don't have a cached version of
+        jquery and jquery.dataTables), you will not get the jsviewer features.
         """
 
         from .jsviewer import JSViewer
@@ -894,7 +895,7 @@ class Table(object):
             tableid = 'table{0}-{1}'.format(id(self),
                                             np.random.randint(1, 1e6))
 
-        jsv = JSViewer(use_local_files=use_local_files, display_length=display_length)
+        jsv = JSViewer(display_length=display_length)
         html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
                                 max_lines=-1, show_dtype=False,
                                 tableclass=table_class)


### PR DESCRIPTION
This adds a `use_local_files` option to the new `Table.show_in_notebook` method.  This makes it more consistent with `show_in_browser(jsviewer=True)`.  While in some sense a "new feature", I think it's more like a fix because otherwise it's really confusing that `show_in_notebook` is missing something that's in `show_in_Browser(jsviewer=True)`.

Unfortunately, it can't be fully consistent in the sence of *defaulting* to use the local files, because a lot of browsers restrict loading of local files as a security precaution. So this isn't as useful as we might like... But I think it's better to at least keep the option in there so that we can try it.  

It might be better down the road to be a bit smarter about first trying the remote and falling back on the local if possible, and use that for *both*.  But right now this seems better than just not having any local option at all in `show_in_notebook`.

(I'm also marking it as a change for 1.1.1, but it's pretty minor and `show_in_notebook` is new in 1.1.0 ... So if this looks good soon enough we can squeak it in for 1.1.0).

cc @saimn @taldcroft 