### PR TITLE
Minor docs extension for affiliated packages

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -133,7 +133,9 @@ Starting a new package
 
    You can also uncomment the line ``enable_deprecations_as_exceptions()`` if
    you want deprecation warnings to make tests fail. There are also
-   options to customize the information to be printed when running the tests.
+   options to customize the information to be printed when running the
+   tests. The package template has comments in the ``conftest.py`` file that
+   indicate what they are.
 
 #. If you are interested in accurate coverage test results, copy over the
    ``coveragerc`` and the ``setup_package.py`` files to your repository (the

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -132,7 +132,8 @@ Starting a new package
     git add <packagename>/conftest.py
 
    You can also uncomment the line ``enable_deprecations_as_exceptions()`` if
-   you want deprecation warnings to make tests fail.
+   you want deprecation warnings to make tests fail. There are also
+   options to customize the information to be printed when running the tests.
 
 #. If you are interested in accurate coverage test results, copy over the
    ``coveragerc`` and the ``setup_package.py`` files to your repository (the


### PR DESCRIPTION
Mention the option that test headers can be customized in conftest.py for affiliated packages