### PR TITLE
lower precision for name resolve tests

### DIFF
--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -123,8 +123,11 @@ def test_names():
         icrs = SkyCoord(ra=float(ra)*u.degree, dec=float(dec)*u.degree)
 
     icrs_true = SkyCoord(ra="11h 22m 18.014s", dec="59d 04m 27.27s")
-    np.testing.assert_almost_equal(icrs.ra.degree, icrs_true.ra.degree, 3)
-    np.testing.assert_almost_equal(icrs.dec.degree, icrs_true.dec.degree, 3)
+
+    # use precsision of only 1 decimal here and below because the result can
+    # change due to Sesame server-side changes.
+    np.testing.assert_almost_equal(icrs.ra.degree, icrs_true.ra.degree, 1)
+    np.testing.assert_almost_equal(icrs.dec.degree, icrs_true.dec.degree, 1)
 
     try:
         icrs = get_icrs_coordinates("castor")
@@ -133,8 +136,8 @@ def test_names():
         icrs = SkyCoord(ra=float(ra)*u.degree, dec=float(dec)*u.degree)
 
     icrs_true = SkyCoord(ra="07h 34m 35.87s", dec="+31d 53m 17.8s")
-    np.testing.assert_almost_equal(icrs.ra.degree, icrs_true.ra.degree, 3)
-    np.testing.assert_almost_equal(icrs.dec.degree, icrs_true.dec.degree, 3)
+    np.testing.assert_almost_equal(icrs.ra.degree, icrs_true.ra.degree, 1)
+    np.testing.assert_almost_equal(icrs.dec.degree, icrs_true.dec.degree, 1)
 
 
 @remote_data


### PR DESCRIPTION
It turns out that some of the tests in `test_name_resolve.py` give slightly different answers depending on what SESAME server they connect to.  This was causing some intermittent test failures (when ``remote-data`` is on), and this PR just lowers the precision of the comparison to make this less of a concern.  It would still be a *very* strange error if the test worked but returned an object within .1 degrees but it wasn't the right one...