### PR TITLE
Fast ASCII writer doesn't correctly handle bytes columns on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -892,6 +892,9 @@ Bug Fixes
     This updates that fix in such a way that it works with Numpy 1.10 as well.
     [#4266]
 
+  - Fix fast writer so bytestring column output is not prefixed by 'b' in
+    Python 3. [#4350]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -905,7 +905,11 @@ cdef class FastWriter:
 
         for col in six.itervalues(table.columns):
             if col.name in self.use_names: # iterate over included columns
-                if col.format is None:
+                # If col.format is None then don't use any formatter to improve
+                # speed.  However, if the column is a byte string and this
+                # is Py3, then use the default formatter (which in this case
+                # does val.decode('utf-8')) in order to avoid a leading 'b'.
+                if col.format is None and not (six.PY3 and col.dtype.kind == 'S'):
                     self.format_funcs.append(None)
                 else:
                     self.format_funcs.append(pprint._format_funcs.get(col.format,

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -522,3 +522,15 @@ def test_commented_header_comments(fast_writer):
         ascii.write(t, out, format='commented_header', comment=False,
                     fast_writer=fast_writer)
     assert "for the commented_header writer you must supply a string" in str(err.value)
+
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_byte_string_output(fast_writer):
+    """
+    Test the fix for #4350 where byte strings were output with a
+    leading `b` on Py3.
+    """
+    t = table.Table([['Hello', 'World']], dtype=['S10'])
+    out = StringIO()
+    ascii.write(t, out, fast_writer=fast_writer)
+    assert out.getvalue().splitlines() == ['col0', 'Hello', 'World']


### PR DESCRIPTION
In the process of updating #3086 I got stuck on this test:

https://github.com/astropy/astropy/blame/v1.1rc1/docs/io/ascii/write.rst#L79

On Python 3, the string column becomes bytes type, and outputs with the ugly `b''` formatting:

```
In [1]: import numpy as np

In [2]: from astropy.io import ascii

In [3]: data = np.array([(1, 2., 'Hello'), (2, 3., "World")], dtype=('i4,f4,a10'))

In [4]: ascii.write(data)
f0 f1 f2
1 2.0 b'Hello'
2 3.0 b'World'
```

This is only with the fast writer:

```
In [5]: ascii.write(data, fast_writer=False)
f0 f1 f2
1 2.0 Hello
2 3.0 World
```

It seems to have to do with the use of `csv.writer`, for which this is the default behavior for bytes values.  I see the normal writer has a workaround for this, but I don't know if or how that same workaround should be implemented for the fast writer (or if it should just do something else).