### PR TITLE
Fix misbehaving WCS locale test

### DIFF
--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -820,8 +820,10 @@ def test_locale():
     orig_locale = locale.getlocale(locale.LC_NUMERIC)[0]
 
     try:
-        locale.setlocale(locale.LC_NUMERIC, 'fr_FR')
-    except:
+        # str('fr_FR') because otherwise it will be a unicode string, which
+        # breaks setlocale on Python 2
+        locale.setlocale(locale.LC_NUMERIC, str('fr_FR'))
+    except locale.Error:
         pytest.xfail(
             "Can't set to 'fr_FR' locale, perhaps because it is not installed "
             "on this system")
@@ -830,7 +832,13 @@ def test_locale():
         w = _wcs.Wcsprm(header)
         assert re.search("[0-9]+,[0-9]*", w.to_header()) is None
     finally:
-        locale.setlocale(locale.LC_NUMERIC, orig_locale)
+        if orig_locale is None:
+            # reset to the default setting
+            locale.resetlocale(locale.LC_NUMERIC)
+        else:
+            # restore to whatever the previous value had been set to for
+            # whatever reason
+            locale.setlocale(locale.LC_NUMERIC, orig_locale)
 
 
 @raises(UnicodeEncodeError)


### PR DESCRIPTION
Turns out this was x-failing unconditionally on Python 2 ever since `from __future__ import unicode_literals` was added to the module it's in.  `locale.setlocale` breaks on Python 2 if given a unicode string.  But the try/except around it was too broad, hiding this error.

Meanwhile, on Python 3 the test was working but often not properly resetting the default `LC_NUMERIC`.  If this locale setting isn't set explicitly in the user's environment, `locale.getlocale(LC_NUMERIC`) can return `None`.  However, `locale.setlocale(..., None)` is just a no-op.  So `locale.setlocale(LC_NUMERIC, orig_locale)` does *not* reset the original setting if `orig_locale is None`.  This could later cause `io.ascii` tests to fail (it just happens that it wasn't in this case due to the order the tests are run).