### PR TITLE
Fix 4358 (replaces 4367)

### DIFF
--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -44,7 +44,7 @@ def gcrs_to_geoecliptic(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransform, GeocentricTrueEcliptic, GCRS)
 def geoecliptic_to_gcrs(from_coo, to_frame):
-    rmat = _ecliptic_rotation_matrix(to_frame.equinox)
+    rmat = _ecliptic_rotation_matrix(from_coo.equinox)
     newrepr = cartrepr_from_matmul(rmat, from_coo, transpose=True)
 
     if np.all(from_coo.equinox == to_frame.obstime):

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -73,13 +73,13 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     delta_bary_to_helio = pvh[..., 0, :] - pvb[..., 0, :]
 
     #first offset to heliocentric
-    heliocart = from_coo.cartesian.xyz + delta_bary_to_helio * u.au
+    heliocart = (from_coo.cartesian.xyz).T + delta_bary_to_helio * u.au
 
     # now compute the matrix to precess to the right orientation
     rmat = _ecliptic_rotation_matrix(to_frame.equinox)
 
     # it's not really ICRS because of the offset, but this is digestible by cartrepr_from_matmul
-    newrepr = cartrepr_from_matmul(rmat, ICRS(CartesianRepresentation(heliocart)))
+    newrepr = cartrepr_from_matmul(rmat, ICRS(CartesianRepresentation(heliocart.T)))
     return to_frame.realize_frame(newrepr)
 
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -93,6 +93,6 @@ def helioecliptic_to_icrs(from_coo, to_frame):
     # now offset back to barycentric, which is the correct center for ICRS
     pvh, pvb = erfa.epv00(*get_jd12(from_coo.equinox, 'tdb'))
     delta_bary_to_helio = pvh[..., 0, :] - pvb[..., 0, :]
-    newrepr = CartesianRepresentation(intermed_repr.cartesian.xyz - delta_bary_to_helio*u.au)
+    newrepr = CartesianRepresentation((intermed_repr.to_cartesian().xyz.T - delta_bary_to_helio*u.au).T)
 
     return to_frame.realize_frame(newrepr)

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -84,3 +84,15 @@ def test_arraytransforms():
 
     heliotoicrs = helio_arr.transform_to(ICRS)
     assert heliotoicrs.shape == test_icrs.shape
+
+def test_roundtrip_scalar():
+    icrs = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.au)
+
+    bary = test_icrs.transform_to(BarycentricTrueEcliptic)
+    helio = test_icrs.transform_to(HeliocentricTrueEcliptic)
+
+    bary_icrs = bary.transform_to(ICRS)
+    helio_icrs = helio.transform_to(ICRS)
+
+    assert quantity_allclose(bary_icrs.cartesian.xyz, icrs.cartesian.xyz)
+    assert quantity_allclose(helio_icrs.cartesian.xyz, icrs.cartesian.xyz)

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -67,15 +67,25 @@ def test_arraytransforms():
     (not testing for accuracy.)
     """
     ra = np.ones((3,), dtype=float) * u.deg
-    dec = np.zeros((3,), dtype=float) * u.deg
-    distance = np.ones((3, ), dtype=float) * u.au
+    dec = 2*np.ones((3,), dtype=float) * u.deg
+    distance = np.ones((3,), dtype=float) * u.au
 
     test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
 
     helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
-    assert len(helio_arr) == 3
-    #really, if hasn't thrown an exception, it passes
+    assert helio_arr.shape == ra.shape
 
     bary_arr = test_icrs.transform_to(BarycentricTrueEcliptic)
-    assert len(bary_arr) == 3
-    #really, if hasn't thrown an exception, it passes
+    assert bary_arr.shape == ra.shape
+
+    # now check that we also can go back the other way without problems
+
+    heliotoicrs = helio_arr.transform_to(ICRS)
+    assert quantity_allclose(ra, heliotoicrs.ra)
+    assert quantity_allclose(dec, heliotoicrs.dec)
+    assert quantity_allclose(distance, heliotoicrs.distance)
+
+    barytoicrs = bary_arr.transform_to(ICRS)
+    assert quantity_allclose(ra, barytoicrs.ra)
+    assert quantity_allclose(dec, barytoicrs.dec)
+    assert quantity_allclose(distance, barytoicrs.distance)

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -66,26 +66,21 @@ def test_arraytransforms():
     Test that transforms to/from ecliptic coordinates work on array coordinates
     (not testing for accuracy.)
     """
-    ra = np.ones((3,), dtype=float) * u.deg
-    dec = 2*np.ones((3,), dtype=float) * u.deg
-    distance = np.ones((3,), dtype=float) * u.au
+    ra = np.ones((4, ), dtype=float) * u.deg
+    dec = 2*np.ones((4, ), dtype=float) * u.deg
+    distance = np.ones((4, ), dtype=float) * u.au
 
     test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
-
-    helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
-    assert helio_arr.shape == ra.shape
 
     bary_arr = test_icrs.transform_to(BarycentricTrueEcliptic)
     assert bary_arr.shape == ra.shape
 
+    helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
+    assert helio_arr.shape == ra.shape
+
     # now check that we also can go back the other way without problems
+    barytoicrs = bary_arr.transform_to(ICRS)
+    assert barytoicrs.shape == test_icrs.shape
 
     heliotoicrs = helio_arr.transform_to(ICRS)
-    assert quantity_allclose(ra, heliotoicrs.ra)
-    assert quantity_allclose(dec, heliotoicrs.dec)
-    assert quantity_allclose(distance, heliotoicrs.distance)
-
-    barytoicrs = bary_arr.transform_to(ICRS)
-    assert quantity_allclose(ra, barytoicrs.ra)
-    assert quantity_allclose(dec, barytoicrs.dec)
-    assert quantity_allclose(distance, barytoicrs.distance)
+    assert heliotoicrs.shape == test_icrs.shape

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -87,12 +87,16 @@ def test_arraytransforms():
 
 def test_roundtrip_scalar():
     icrs = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.au)
+    gcrs = GCRS(icrs.cartesian)
 
-    bary = test_icrs.transform_to(BarycentricTrueEcliptic)
-    helio = test_icrs.transform_to(HeliocentricTrueEcliptic)
+    bary = icrs.transform_to(BarycentricTrueEcliptic)
+    helio = icrs.transform_to(HeliocentricTrueEcliptic)
+    geo = gcrs.transform_to(GeocentricTrueEcliptic)
 
     bary_icrs = bary.transform_to(ICRS)
     helio_icrs = helio.transform_to(ICRS)
+    geo_gcrs = geo.transform_to(GCRS)
 
     assert quantity_allclose(bary_icrs.cartesian.xyz, icrs.cartesian.xyz)
     assert quantity_allclose(helio_icrs.cartesian.xyz, icrs.cartesian.xyz)
+    assert quantity_allclose(geo_gcrs.cartesian.xyz, gcrs.cartesian.xyz)

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -59,3 +59,23 @@ def test_ecl_geo():
     gecl = gcrs.transform_to(GeocentricTrueEcliptic)
 
     assert quantity_allclose(gecl.distance, gcrs.distance)
+
+
+def test_arraytransforms():
+    """
+    Test that transforms to/from ecliptic coordinates work on array coordinates
+    (not testing for accuracy.)
+    """
+    ra = np.ones((3,), dtype=float) * u.deg
+    dec = np.zeros((3,), dtype=float) * u.deg
+    distance = np.ones((3, ), dtype=float) * u.au
+
+    test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
+
+    helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
+    assert len(helio_arr) == 3
+    #really, if hasn't thrown an exception, it passes
+
+    bary_arr = test_icrs.transform_to(BarycentricTrueEcliptic)
+    assert len(bary_arr) == 3
+    #really, if hasn't thrown an exception, it passes

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -71,6 +71,7 @@ def test_arraytransforms():
     distance = np.ones((4, ), dtype=float) * u.au
 
     test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
+    test_gcrs = GCRS(test_icrs.data)
 
     bary_arr = test_icrs.transform_to(BarycentricTrueEcliptic)
     assert bary_arr.shape == ra.shape
@@ -78,12 +79,18 @@ def test_arraytransforms():
     helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
     assert helio_arr.shape == ra.shape
 
-    # now check that we also can go back the other way without problems
-    barytoicrs = bary_arr.transform_to(ICRS)
-    assert barytoicrs.shape == test_icrs.shape
+    geo_arr = test_gcrs.transform_to(GeocentricTrueEcliptic)
+    assert geo_arr.shape == ra.shape
 
-    heliotoicrs = helio_arr.transform_to(ICRS)
-    assert heliotoicrs.shape == test_icrs.shape
+    # now check that we also can go back the other way without shape problems
+    bary_icrs = bary_arr.transform_to(ICRS)
+    assert bary_icrs.shape == test_icrs.shape
+
+    helio_icrs = helio_arr.transform_to(ICRS)
+    assert helio_icrs.shape == test_icrs.shape
+
+    geo_gcrs = geo_arr.transform_to(GCRS)
+    assert geo_gcrs.shape == test_gcrs.shape
 
 def test_roundtrip_scalar():
     icrs = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.au)

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -210,23 +210,3 @@ def test_obstime():
     # because the obstime is different
     assert icrs_50.ra.degree != icrs_75.ra.degree
     assert icrs_50.dec.degree != icrs_75.dec.degree
-
-
-def test_arraytransforms():
-    """
-    Test that transforms on arrays of coordinates function (not testing for
-    accuracy.)
-    """
-    ra = np.ones((3,), dtype=float) * u.deg
-    dec = np.zeros((3,), dtype=float) * u.deg
-    distance = np.ones((3, ), dtype=float) * u.au
-
-    test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
-
-    helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
-    assert len(helio_arr) == 3
-    #really, if hasn't thrown an exception, it passes
-
-    bary_arr = test_icrs.transform_to(BarycentricTrueEcliptic)
-    assert len(bary_arr) == 3
-    #really, if hasn't thrown an exception, it passes

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -11,7 +11,8 @@ from ..distances import Distance
 from .. import transformations as t
 from ..builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, \
                              Supergalactic, Galactocentric, CIRS, GCRS, AltAz, \
-                             ITRS, PrecessedGeocentric
+                             ITRS, PrecessedGeocentric, HeliocentricTrueEcliptic, \
+                             BarycentricTrueEcliptic
 from .. import representation as r
 from ..baseframe import frame_transform_graph
 from ...tests.helper import (pytest, quantity_allclose as allclose,
@@ -210,3 +211,22 @@ def test_obstime():
     assert icrs_50.ra.degree != icrs_75.ra.degree
     assert icrs_50.dec.degree != icrs_75.dec.degree
 
+
+def test_arraytransforms():
+    """
+    Test that transforms on arrays of coordinates function (not testing for
+    accuracy.)
+    """
+    ra = np.ones((3,), dtype=float) * u.deg
+    dec = np.zeros((3,), dtype=float) * u.deg
+    distance = np.ones((3, ), dtype=float) * u.au
+
+    test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
+
+    helio_arr = test_icrs.transform_to(HeliocentricTrueEcliptic)
+    assert len(helio_arr) == 3
+    #really, if hasn't thrown an exception, it passes
+
+    bary_arr = test_icrs.transform_to(BarycentricTrueEcliptic)
+    assert len(bary_arr) == 3
+    #really, if hasn't thrown an exception, it passes


### PR DESCRIPTION
This PR is a replacement for #4367 - it starts from #4367 and fixes it to work both ways (ICRS->Ecliptic *and* vice versa), as well as adding the `GeocentricTrueEcliptic` frame to the tests (and note that doing this revealed a typo bug which is also fixed).

So this closes #4367 and closes #4367