### PR TITLE
Fix find_api_page on py 3.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -905,6 +905,8 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - Fixed ``find_api_page`` to work correctly on python 3.x [#4378]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``


### PR DESCRIPTION
This closes #4378 by re-implementing the innards of `find_api_page` so that it doesn't use `HTTPResponse.readline`, which seems to be incompatible with `read`.

This should be backported to both v1.1.x and 1.0.x