### PR TITLE
Relaxed upper limit of Cone Search prediction time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,6 +149,8 @@ Bug fixes
 
 - ``astropy.vo``
 
+  - Fixed spurious failure for Cone Search prediction test. [#4382]
+
 - ``astropy.wcs``
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,7 +149,8 @@ Bug fixes
 
 - ``astropy.vo``
 
-  - Fixed spurious failure for Cone Search prediction test. [#4382]
+  - Relaxed expected accuracy of Cone Search prediction test to reduce spurious
+    failures. [#4382]
 
 - ``astropy.wcs``
 

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -179,7 +179,9 @@ class TestConeSearch(object):
             pedantic=self.pedantic, verbose=self.verbose)
 
         assert n_2 > 0 and n_2 <= n_1 * 1.5
-        assert t_2 > 0 and t_2 <= t_1 * 1.5
+
+        # Timer depends on network latency as well, so upper limit is very lax.
+        assert t_2 > 0 and t_2 <= t_1 * 10
 
     def test_prediction_neg_radius(self):
         with pytest.raises(ConeSearchError):


### PR DESCRIPTION
Relaxed upper limit of Cone Search prediction time. Added change log entry.

This *should* fix #4382, theoretically. c/c @eteq 