### PR TITLE
Quantity test failure on windows 

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -268,8 +268,11 @@ class TestQuantityMathFuncs(object):
 
     @pytest.mark.skipif("not hasattr(np, 'cbrt')")
     def test_cbrt_array(self):
-        assert np.all(np.cbrt(np.array([1., 8., 64.]) * u.m**3)
-                      == np.array([1., 2., 4.]) * u.m)
+        # Calculate cbrt on both sides since on Windows the cube root of 64
+        # does not exactly equal 4.  See 4388.
+        values = np.array([1., 8., 64.])
+        assert np.all(np.cbrt(values * u.m**3) ==
+                      np.cbrt(values) * u.m)
 
     def test_power_scalar(self):
         assert np.power(4. * u.m, 2.) == 16. * u.m ** 2


### PR DESCRIPTION
 One of the tests, `TestQuantityMathFuncs.test_cbrt_array`, in `astropy\units\tests\test_quantity_ufuncs.py` fails on Win 7/python 2.7

```
============================ test session starts =============================
platform win32 -- Python 2.7.11 -- py-1.4.30 -- pytest-2.7.3
rootdir: c:\users\mcraig\appdata\local\temp\astropy-test-1p64wn, inifile: setup.
cfg

Running tests with Astropy version 1.1.dev.
Running tests in lib.win-amd64-2.7\astropy\units docs\units.

Date: 2015-12-09T20:42:15

Platform: Windows-7-6.1.7601-SP1

Executable: C:\Users\mcraig\AppData\Local\Continuum\Miniconda2-clean\python.exe

Full Python Version:
2.7.11 |Continuum Analytics, Inc.| (default, Dec  7 2015, 14:10:42) [MSC v.1500
64 bit (AMD64)]

encodings: sys: ascii, locale: cp1252, filesystem: mbcs, unicode bits: 15
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.10.1
Scipy: not available
Matplotlib: not available
h5py: not available
Pandas: not available

[SNIP]

================================== FAILURES ==================================
___________________ TestQuantityMathFuncs.test_cbrt_array ____________________

self = <astropy.units.tests.test_quantity_ufuncs.TestQuantityMathFuncs object at
 0x000000000AD37898>

    @pytest.mark.skipif("not hasattr(np, 'cbrt')")
    def test_cbrt_array(self):
>       assert np.all(np.cbrt(np.array([1., 8., 64.]) * u.m**3)
                      == np.array([1., 2., 4.]) * u.m)
E       assert <function all at 0x00000000022C77B8>(<Quantity [ 1., 2., 4.] m> =
= <Quantity [ 1., 2., 4.] m>
E        +  where <function all at 0x00000000022C77B8> = np.all
E         Use -v to get the full diff)

astropy\units\tests\test_quantity_ufuncs.py:271: AssertionError
======= 1 failed, 2735 passed, 13 skipped, 5 xfailed in 65.03 seconds ========
```