### PR TITLE
Keep "-SIP" in ctype when passed to wcslib

### DIFF
--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -813,7 +813,7 @@ def test_header_parse():
             'data/header_newlines.fits', encoding='binary') as test_file:
         hdulist = fits.open(test_file)
         w = wcs.WCS(hdulist[0].header)
-    assert w.wcs.ctype[0] == 'RA---TAN'
+    assert w.wcs.ctype[0] == 'RA---TAN-SIP'
 
 
 def test_locale():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -981,11 +981,11 @@ reduce these to 2 dimensions using the naxis kwarg.
         # Never pass SIP CTYPES or other information along to
         # wcslib
         for sel in [''] + [chr(i + ord('A')) for i in range(26)]:
-            for axis in ['1', '2']:
-                key = 'CTYPE{0}{1}'.format(axis, sel)
-                val = header.get(key)
-                if val is not None and val.endswith('-SIP'):
-                    header[key] = val[:-4]
+            #for axis in ['1', '2']:
+                #key = 'CTYPE{0}{1}'.format(axis, sel)
+                #val = header.get(key)
+                #if val is not None and val.endswith('-SIP'):
+                    #header[key] = val[:-4]
             for prefix in ('A', 'B', 'AP', 'BP'):
                 for i in range(20):
                     for j in range(20):

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -978,14 +978,9 @@ reduce these to 2 dimensions using the naxis kwarg.
         """
         Remove SIP information from a header.
         """
-        # Never pass SIP CTYPES or other information along to
-        # wcslib
+        # Never pass SIP coefficients to wcslib
+        # CTYPE must be passed with -SIP to wcslib
         for sel in [''] + [chr(i + ord('A')) for i in range(26)]:
-            #for axis in ['1', '2']:
-                #key = 'CTYPE{0}{1}'.format(axis, sel)
-                #val = header.get(key)
-                #if val is not None and val.endswith('-SIP'):
-                    #header[key] = val[:-4]
             for prefix in ('A', 'B', 'AP', 'BP'):
                 for i in range(20):
                     for j in range(20):


### PR DESCRIPTION
This is a fix for #4387. My understanding is that the presence of SIP coefficients in the header is the only thing that wcslib looks for in the header to determine whether to create a SIP distortion. It ignores `CTYPE` as well as `A_ORDER`, ...

`astropy.wcs` does SIP corrections in the wrapper, not in the core `wcslib`. So it must strip the coefficients from the header before passing it to `wcslib`. However, `CTYPE` should be kept unchanged.