### PR TITLE
FastReader (with use_fast_converter=False) can fail on non-US locales

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
             - graphviz
             - texlive-latex-extra
             - dvipng
+            - language-pack-de
 env:
     global:
         # Set defaults to avoid repeating in most cases

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,9 @@ New Features
   - Added ``format_doc`` decorator which allows to replace and/or format the
     current docstring of an object. [#4242]
 
+  - Added a new context manager ``set_locale`` to temporarily set the
+    current locale. [#4363]
+
 - ``astropy.visualization``
 
 - ``astropy.vo``
@@ -251,6 +254,9 @@ Bug fixes
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
+
+  - Fix a problem where the fast reader (with use_fast_converter=False) can
+    fail on non-US locales. [#4363]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -8,6 +8,7 @@ from ...extern import six
 from ...table import Table
 from . import cparser
 from ...extern.six.moves import zip as izip
+from ...utils import set_locale
 
 @six.add_metaclass(core.MetaBaseReader)
 class FastBasic(object):
@@ -106,7 +107,9 @@ class FastBasic(object):
             try_float = {}
             try_string = {}
 
-        data, comments = self.engine.read(try_int, try_float, try_string)
+        with set_locale('C'):
+            data, comments = self.engine.read(try_int, try_float, try_string)
+
         meta = OrderedDict()
         if comments:
             meta['comments'] = comments

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -12,6 +12,15 @@ import numpy as np
 from .. import data, misc
 from ...tests.helper import remote_data
 from ...extern import six
+from ...tests.helper import pytest
+
+try:
+    locale.setlocale(locale.LC_ALL, 'en_US')
+    locale.setlocale(locale.LC_ALL, 'de_DE')
+except:
+    HAS_LOCALES = False
+else:
+    HAS_LOCALES = True
 
 
 def test_isiterable():
@@ -72,6 +81,7 @@ def test_inherit_docstrings():
         assert Subclass.__call__.__doc__ == "FOO"
 
 
+@pytest.mark.skipif('not HAS_LOCALES')
 def test_set_locale():
     date = datetime(2000, 10, 1, 0, 0, 0)
     day_mon = date.strftime('%a, %b')

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -4,6 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import json
 import os
+from datetime import datetime
+import locale
 
 import numpy as np
 
@@ -68,3 +70,21 @@ def test_inherit_docstrings():
     if Base.__call__.__doc__ is not None:
         # TODO: Maybe if __doc__ is None this test should be skipped instead?
         assert Subclass.__call__.__doc__ == "FOO"
+
+
+def test_set_locale():
+    date = datetime(2000, 10, 1, 0, 0, 0)
+    day_mon = date.strftime('%a, %b')
+
+    with misc.set_locale('en_US'):
+        assert date.strftime('%a, %b') == 'Sun, Oct'
+
+    with misc.set_locale('de_DE'):
+        assert date.strftime('%a, %b') == 'So, Okt'
+
+    # Back to original
+    assert date.strftime('%a, %b') == day_mon
+
+    current = locale.setlocale(locale.LC_ALL)
+    with misc.set_locale(current):
+        assert date.strftime('%a, %b') == day_mon


### PR DESCRIPTION
This is actually the issue that led me to discover #4362 (or perhaps vice-versa).

Because FastReader uses `strtod` it will no properly parse floats when the user's locale is set to one that uses commas instead of dots for decimal notation (e.g. fr_FR).  This isn't a problem with `use_fast_converter` since it's hard-coded to pass `'.'` to `xstrtod` as the decimal character.

This could be fixed either by temporarily changing the locale when going into the reader.  Or possibly by just detecting the locale setting and doing a find replace if necessary (I think this is more what WCSLIB does).