### PR TITLE
Addressing #3805: allow iteration over columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,8 @@ New Features
 
   - Allow to use a tuple of keys in ``Table.sort``.  [#4671]
 
+  - Added ``itercols``; a way to iterate through columns of a table. [#3805]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -732,6 +732,22 @@ class Table(object):
 
         table.columns = columns
 
+    def itercols(self):
+        """
+        Iterate over the columns of this table.
+
+        Example
+        -----------
+        t = Table([[1], [2]])
+        for col in t.itercols():
+            print(col)
+
+        Using ``itercols()`` is similar to  ``for col in t.columns.values()``
+        but is syntactically preferred.
+        """
+        for colname in self.columns:
+            yield self[colname]
+
     def _base_repr_(self, html=False, descr_vals=None, max_width=None,
                     tableid=None, show_dtype=True, max_lines=None,
                     tableclass=None):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -19,6 +19,8 @@ from ... import table
 from ... import units as u
 from .conftest import MaskedTable
 
+from itertools import izip
+
 try:
     with ignore_warnings(DeprecationWarning):
         # Ignore DeprecationWarning on pandas import in Python 3.5--see
@@ -332,6 +334,13 @@ class TestColumnAccess():
         assert np.all(t['a'] == np.array([1, 2, 3]))
         with pytest.raises(KeyError):
             t['b']  # column does not exist
+
+    def test_itercols(self, table_types):
+        names = ['a', 'b', 'c']
+        t = table_types.Table([[1], [2], [3]], names=names)
+        for name, col in izip(names, t.itercols()):
+            assert name == col.name
+            assert isinstance(col, table_types.Column)
 
 
 @pytest.mark.usefixtures('table_types')

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -19,7 +19,7 @@ from ... import table
 from ... import units as u
 from .conftest import MaskedTable
 
-from itertools import izip
+from ...extern.six.moves import zip as izip
 
 try:
     with ignore_warnings(DeprecationWarning):


### PR DESCRIPTION
Created an itercols method to provide a simpler way to iterate over columns in a Table. Added a test for itercols, as well. 

edit: Closes #3805 