### PR TITLE
OSX 10.6 build compatibility

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -39,7 +39,7 @@ def _get_compression_extension():
                     '-Wno-uninitialized', '-Wno-format',
                     '-Wno-strict-prototypes', '-Wno-unused', '-Wno-comments',
                     '-Wno-switch', '-Wno-strict-aliasing', '-Wno-return-type',
-                    '-Wno-address', '-Wno-unused-result'
+                    '-Wno-address'
                 ])
 
         cfitsio_path = os.path.join('cextern', 'cfitsio')

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -244,8 +244,7 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
                 '-Wno-strict-prototypes',
                 '-Wno-unused-function',
                 '-Wno-unused-value',
-                '-Wno-uninitialized',
-                '-Wno-unused-but-set-variable'])
+                '-Wno-uninitialized'])
 
 
 


### PR DESCRIPTION
Apple GCC 4.2.1 has neither `no-unused-result` or `no-unused-but-set-variable` compiler flags. The presence of these are causing our nightly builds to fail.
