### PR TITLE
Make jsviewer table have a sortable index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         - NUMPY_VERSION=1.9
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautiful-soup'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautiful-soup ipython'
         - PIP_DEPENDENCIES=''
 
     matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,10 @@ New Features
 
 - ``astropy.table``
 
+  - ``Table.show_in_notebook`` and ``Table.show_in_browser(jsviewer=True)`` now
+    yield tables with an "idx" column, allowing easy identification of the index
+    of a row even when the table is re-sorted in the browser. [#4404]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -856,6 +856,14 @@ class Table(object):
             else:
                 print(line)
 
+    def _make_index_row_display_table(self, index_row_name='idx'):
+        if 'idx' not in self.columns:
+            idx_col = self.ColumnClass(name='idx', data=np.arange(len(self)))
+            return self.__class__([idx_col] + self.columns.values(),
+                                           copy=False)
+        else:
+            return self
+
     def show_in_notebook(self, tableid=None, css=None, display_length=50,
                          table_class='table table-striped table-bordered '
                          'table-condensed', show_row_index=True):
@@ -901,16 +909,10 @@ class Table(object):
 
         jsv = JSViewer(display_length=display_length)
 
-        has_row_index = 'idx' in self.colnames
-        try:
-            if show_row_index and not has_row_index:
-                self.add_column(self.ColumnClass(name='idx', data=range(len(self))), index=0)
-            html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
-                                    max_lines=-1, show_dtype=False,
-                                    tableclass=table_class)
-        finally:
-            if show_row_index and not has_row_index:
-                self.remove_column('idx')
+        display_table = self._make_index_row_display_table()
+        html = display_table._base_repr_(html=True, max_width=-1, tableid=tableid,
+                                         max_lines=-1, show_dtype=False,
+                                         tableclass=table_class)
 
         html += jsv.ipynb(tableid, css=css)
         return HTML(html)
@@ -975,18 +977,10 @@ class Table(object):
 
         with open(path, 'w') as tmp:
             if jsviewer:
-                has_row_index = 'idx' in self.colnames
-                try:
-                    if show_row_index and not has_row_index:
-                        self.add_column(self.ColumnClass(name='idx',
-                                                         data=range(len(self))),
-                                        index=0)
-                    self.write(tmp, format='jsviewer', css=css,
-                               max_lines=max_lines, jskwargs=jskwargs,
-                               table_id=tableid, table_class=table_class)
-                finally:
-                    if show_row_index and not has_row_index:
-                        self.remove_column('idx')
+                display_table = self._make_index_row_display_table()
+                display_table.write(tmp, format='jsviewer', css=css,
+                                    max_lines=max_lines, jskwargs=jskwargs,
+                                    table_id=tableid, table_class=table_class)
             else:
                 self.write(tmp, format='html')
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -858,7 +858,7 @@ class Table(object):
 
     def show_in_notebook(self, tableid=None, css=None, display_length=50,
                          table_class='table table-striped table-bordered '
-                         'table-condensed', add_row_index=True):
+                         'table-condensed', show_row_index=True):
         """Render the table in HTML and show it in the IPython notebook.
 
         Parameters
@@ -878,7 +878,7 @@ class Table(object):
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
         display_length : int, optional
             Number or rows to show. Default to 50.
-        add_row_index : bool
+        show_row_index : bool
             If True, a column named "row_index" will be added for display
             purposes.  This shows the index of the row in the table itself,
             even when the displayed table is re-sorted by another column.
@@ -903,13 +903,13 @@ class Table(object):
 
         has_row_index = 'row_index' in self.colnames
         try:
-            if add_row_index:
+            if show_row_index:
                 self.add_column(self.ColumnClass(name='row_index', data=range(len(self))), index=0)
             html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
                                     max_lines=-1, show_dtype=False,
                                     tableclass=table_class)
         finally:
-            if add_row_index and not has_row_index:
+            if show_row_index and not has_row_index:
                 self.remove_column('row_index')
 
         html += jsv.ipynb(tableid, css=css)
@@ -918,7 +918,7 @@ class Table(object):
     def show_in_browser(self, max_lines=5000, jsviewer=False,
                         browser='default', jskwargs={'use_local_files': True},
                         tableid=None, table_class="display compact",
-                        css=None, add_row_index=True):
+                        css=None, show_row_index=True):
 
         """Render the table in HTML and show it in a web browser.
 
@@ -952,7 +952,7 @@ class Table(object):
         css : string
             A valid CSS string declaring the formatting for the table. Default
             to ``astropy.table.jsviewer.DEFAULT_CSS``.
-        add_row_index : bool
+        show_row_index : bool
             If True, a column named "row_index" will be added for display
             purposes.  This shows the index of the row in the table itself,
             even when the displayed table is re-sorted by another column.
@@ -977,7 +977,7 @@ class Table(object):
             if jsviewer:
                 has_row_index = 'row_index' in self.colnames
                 try:
-                    if add_row_index:
+                    if show_row_index:
                         self.add_column(self.ColumnClass(name='row_index',
                                                          data=range(len(self))),
                                         index=0)
@@ -985,7 +985,7 @@ class Table(object):
                                max_lines=max_lines, jskwargs=jskwargs,
                                table_id=tableid, table_class=table_class)
                 finally:
-                    if add_row_index and not has_row_index:
+                    if show_row_index and not has_row_index:
                         self.remove_column('row_index')
             else:
                 self.write(tmp, format='html')

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -903,7 +903,7 @@ class Table(object):
 
         has_row_index = 'idx' in self.colnames
         try:
-            if show_row_index:
+            if show_row_index and not has_row_index:
                 self.add_column(self.ColumnClass(name='idx', data=range(len(self))), index=0)
             html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
                                     max_lines=-1, show_dtype=False,
@@ -977,7 +977,7 @@ class Table(object):
             if jsviewer:
                 has_row_index = 'idx' in self.colnames
                 try:
-                    if show_row_index:
+                    if show_row_index and not has_row_index:
                         self.add_column(self.ColumnClass(name='idx',
                                                          data=range(len(self))),
                                         index=0)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -908,8 +908,10 @@ class Table(object):
                                             np.random.randint(1, 1e6))
 
         jsv = JSViewer(display_length=display_length)
-
-        display_table = self._make_index_row_display_table()
+        if show_row_index:
+            display_table = self._make_index_row_display_table()
+        else:
+            display_table = self
         html = display_table._base_repr_(html=True, max_width=-1, tableid=tableid,
                                          max_lines=-1, show_dtype=False,
                                          tableclass=table_class)
@@ -977,7 +979,10 @@ class Table(object):
 
         with open(path, 'w') as tmp:
             if jsviewer:
-                display_table = self._make_index_row_display_table()
+                if show_row_index:
+                    display_table = self._make_index_row_display_table()
+                else:
+                    display_table = self
                 display_table.write(tmp, format='jsviewer', css=css,
                                     max_lines=max_lines, jskwargs=jskwargs,
                                     table_id=tableid, table_class=table_class)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -896,9 +896,17 @@ class Table(object):
                                             np.random.randint(1, 1e6))
 
         jsv = JSViewer(display_length=display_length)
-        html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
-                                max_lines=-1, show_dtype=False,
-                                tableclass=table_class)
+
+        has_row_index = 'row_index' in self.colnames
+        try:
+            self.add_column(self.ColumnClass(name='row_index', data=range(len(self))), index=0)
+            html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
+                                    max_lines=-1, show_dtype=False,
+                                    tableclass=table_class)
+        finally:
+            if not has_row_index:
+                self.remove_column('row_index')
+
         html += jsv.ipynb(tableid, css=css)
         return HTML(html)
 
@@ -958,9 +966,15 @@ class Table(object):
 
         with open(path, 'w') as tmp:
             if jsviewer:
-                self.write(tmp, format='jsviewer', css=css,
-                           max_lines=max_lines, jskwargs=jskwargs,
-                           table_id=tableid, table_class=table_class)
+                has_row_index = 'row_index' in self.colnames
+                try:
+                    self.add_column(self.ColumnClass(name='row_index', data=range(len(self))), index=0)
+                    self.write(tmp, format='jsviewer', css=css,
+                               max_lines=max_lines, jskwargs=jskwargs,
+                               table_id=tableid, table_class=table_class)
+                finally:
+                    if not has_row_index:
+                        self.remove_column('row_index')
             else:
                 self.write(tmp, format='html')
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -879,7 +879,7 @@ class Table(object):
         display_length : int, optional
             Number or rows to show. Default to 50.
         show_row_index : bool
-            If True, a column named "row_index" will be added for display
+            If True, a column named "idx" will be added for display
             purposes.  This shows the index of the row in the table itself,
             even when the displayed table is re-sorted by another column.
 
@@ -901,16 +901,16 @@ class Table(object):
 
         jsv = JSViewer(display_length=display_length)
 
-        has_row_index = 'row_index' in self.colnames
+        has_row_index = 'idx' in self.colnames
         try:
             if show_row_index:
-                self.add_column(self.ColumnClass(name='row_index', data=range(len(self))), index=0)
+                self.add_column(self.ColumnClass(name='idx', data=range(len(self))), index=0)
             html = self._base_repr_(html=True, max_width=-1, tableid=tableid,
                                     max_lines=-1, show_dtype=False,
                                     tableclass=table_class)
         finally:
             if show_row_index and not has_row_index:
-                self.remove_column('row_index')
+                self.remove_column('idx')
 
         html += jsv.ipynb(tableid, css=css)
         return HTML(html)
@@ -953,7 +953,7 @@ class Table(object):
             A valid CSS string declaring the formatting for the table. Default
             to ``astropy.table.jsviewer.DEFAULT_CSS``.
         show_row_index : bool
-            If True, a column named "row_index" will be added for display
+            If True, a column named "idx" will be added for display
             purposes.  This shows the index of the row in the table itself,
             even when the displayed table is re-sorted by another column.
         """
@@ -975,10 +975,10 @@ class Table(object):
 
         with open(path, 'w') as tmp:
             if jsviewer:
-                has_row_index = 'row_index' in self.colnames
+                has_row_index = 'idx' in self.colnames
                 try:
                     if show_row_index:
-                        self.add_column(self.ColumnClass(name='row_index',
+                        self.add_column(self.ColumnClass(name='idx',
                                                          data=range(len(self))),
                                         index=0)
                     self.write(tmp, format='jsviewer', css=css,
@@ -986,7 +986,7 @@ class Table(object):
                                table_id=tableid, table_class=table_class)
                 finally:
                     if show_row_index and not has_row_index:
-                        self.remove_column('row_index')
+                        self.remove_column('idx')
             else:
                 self.write(tmp, format='html')
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -857,8 +857,8 @@ class Table(object):
                 print(line)
 
     def _make_index_row_display_table(self, index_row_name='idx'):
-        if 'idx' not in self.columns:
-            idx_col = self.ColumnClass(name='idx', data=np.arange(len(self)))
+        if index_row_name not in self.columns:
+            idx_col = self.ColumnClass(name=index_row_name, data=np.arange(len(self)))
             return self.__class__([idx_col] + self.columns.values(),
                                            copy=False)
         else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -856,7 +856,7 @@ class Table(object):
             else:
                 print(line)
 
-    def _make_index_row_display_table(self, index_row_name='idx'):
+    def _make_index_row_display_table(self, index_row_name):
         if index_row_name not in self.columns:
             idx_col = self.ColumnClass(name=index_row_name, data=np.arange(len(self)))
             return self.__class__([idx_col] + self.columns.values(),
@@ -866,7 +866,7 @@ class Table(object):
 
     def show_in_notebook(self, tableid=None, css=None, display_length=50,
                          table_class='table table-striped table-bordered '
-                         'table-condensed', show_row_index=True):
+                         'table-condensed', show_row_index='idx'):
         """Render the table in HTML and show it in the IPython notebook.
 
         Parameters
@@ -886,10 +886,13 @@ class Table(object):
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
         display_length : int, optional
             Number or rows to show. Defaults to 50.
-        show_row_index : bool
-            If True (default), a column named "idx" will be added for display
-            purposes.  This shows the index of the row in the table itself,
-            even when the displayed table is re-sorted by another column.
+        show_row_index : str or False
+            If this does not evaulate to False, a column with the given name
+            will be added to the version of the table that gets displayed.
+            This new column shows the index of the row in the table itself,
+            even when the displayed table is re-sorted by another column. Note
+            that if a column with this name already exists, this option will be
+            ignored. Defaults to "idx".
 
         Notes
         -----
@@ -909,7 +912,7 @@ class Table(object):
 
         jsv = JSViewer(display_length=display_length)
         if show_row_index:
-            display_table = self._make_index_row_display_table()
+            display_table = self._make_index_row_display_table(show_row_index)
         else:
             display_table = self
         html = display_table._base_repr_(html=True, max_width=-1, tableid=tableid,
@@ -957,9 +960,12 @@ class Table(object):
             A valid CSS string declaring the formatting for the table. Defaults
             to ``astropy.table.jsviewer.DEFAULT_CSS``.
         show_row_index : bool
-            If True (default), a column named "idx" will be added for display
-            purposes.  This shows the index of the row in the table itself,
-            even when the displayed table is re-sorted by another column.
+            If this does not evaulate to False, a column with the given name
+            will be added to the version of the table that gets displayed.
+            This new column shows the index of the row in the table itself,
+            even when the displayed table is re-sorted by another column. Note
+            that if a column with this name already exists, this option will be
+            ignored. Defaults to "idx".
         """
 
         import os
@@ -980,7 +986,7 @@ class Table(object):
         with open(path, 'w') as tmp:
             if jsviewer:
                 if show_row_index:
-                    display_table = self._make_index_row_display_table()
+                    display_table = self._make_index_row_display_table(show_row_index)
                 else:
                     display_table = self
                 display_table.write(tmp, format='jsviewer', css=css,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -885,9 +885,9 @@ class Table(object):
             A valid CSS string declaring the formatting for the table. Default
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
         display_length : int, optional
-            Number or rows to show. Default to 50.
+            Number or rows to show. Defaults to 50.
         show_row_index : bool
-            If True, a column named "idx" will be added for display
+            If True (default), a column named "idx" will be added for display
             purposes.  This shows the index of the row in the table itself,
             even when the displayed table is re-sorted by another column.
 
@@ -943,7 +943,7 @@ class Table(object):
             "/Applications/Google Chrome.app" %s'`` for Chrome).  If
             ``'default'``, will use the system default browser.
         jskwargs : dict
-            Passed to the `astropy.table.JSViewer` init. Default to
+            Passed to the `astropy.table.JSViewer` init. Defaults to
             ``{'use_local_files': True}`` which means that the JavaScript
             libraries will be served from local copies.
         tableid : str or `None`
@@ -954,10 +954,10 @@ class Table(object):
             Default is "display compact", and other possible values can be
             found in http://www.datatables.net/manual/styling/classes
         css : string
-            A valid CSS string declaring the formatting for the table. Default
+            A valid CSS string declaring the formatting for the table. Defaults
             to ``astropy.table.jsviewer.DEFAULT_CSS``.
         show_row_index : bool
-            If True, a column named "idx" will be added for display
+            If True (default), a column named "idx" will be added for display
             purposes.  This shows the index of the row in the table itself,
             even when the displayed table is re-sorted by another column.
         """

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -1,7 +1,16 @@
 from os.path import abspath, dirname, join
+import textwrap
 
 from ..table import Table
 from ... import extern
+from ...tests.helper import pytest
+
+try:
+  import IPython
+except ImportError:
+  HAS_IPYTHON = False
+else:
+  HAS_IPYTHON = True
 
 EXTERN_DIR = abspath(dirname(extern.__file__))
 
@@ -122,3 +131,24 @@ def test_write_jsviewer_local(tmpdir):
     )
     with open(tmpfile) as f:
         assert f.read().strip() == ref.strip()
+
+
+@pytest.mark.skipif('not HAS_IPYTHON')
+def test_show_in_notebook():
+    t = Table()
+    t['a'] = [1, 2, 3, 4, 5]
+    t['b'] = ['b', 'c', 'a', 'd', 'e']
+
+    htmlstr_windx = t.show_in_notebook(show_row_index=True).data
+    htmlstr_woindx = t.show_in_notebook(show_row_index=False).data
+
+    assert (textwrap.dedent("""
+    <thead><tr><th>idx</th><th>a</th><th>b</th></tr></thead>
+    <tr><td>0</td><td>1</td><td>b</td></tr>
+    <tr><td>1</td><td>2</td><td>c</td></tr>
+    <tr><td>2</td><td>3</td><td>a</td></tr>
+    <tr><td>3</td><td>4</td><td>d</td></tr>
+    <tr><td>4</td><td>5</td><td>e</td></tr>
+    """).strip() in htmlstr_windx)
+
+    assert '<thead><tr><th>a</th><th>b</th></tr></thead>' in htmlstr_woindx

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -6,11 +6,11 @@ from ... import extern
 from ...tests.helper import pytest
 
 try:
-  import IPython
+    import IPython
 except ImportError:
-  HAS_IPYTHON = False
+    HAS_IPYTHON = False
 else:
-  HAS_IPYTHON = True
+    HAS_IPYTHON = True
 
 EXTERN_DIR = abspath(dirname(extern.__file__))
 

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -139,7 +139,8 @@ def test_show_in_notebook():
     t['a'] = [1, 2, 3, 4, 5]
     t['b'] = ['b', 'c', 'a', 'd', 'e']
 
-    htmlstr_windx = t.show_in_notebook(show_row_index=True).data
+    htmlstr_windx = t.show_in_notebook().data  # should default to 'idx'
+    htmlstr_windx_named = t.show_in_notebook(show_row_index='realidx').data
     htmlstr_woindx = t.show_in_notebook(show_row_index=False).data
 
     assert (textwrap.dedent("""
@@ -150,5 +151,8 @@ def test_show_in_notebook():
     <tr><td>3</td><td>4</td><td>d</td></tr>
     <tr><td>4</td><td>5</td><td>e</td></tr>
     """).strip() in htmlstr_windx)
+
+
+    assert '<thead><tr><th>realidx</th><th>a</th><th>b</th></tr></thead>' in htmlstr_windx_named
 
     assert '<thead><tr><th>a</th><th>b</th></tr></thead>' in htmlstr_woindx


### PR DESCRIPTION
I noticed something while playing around with the new `show_in_notebook` functionality: the jsviewer view into a table is *not* in the same order that the table is in in python.  This makes sense on reflection, because `DataTables` allows sorting, and seems to default to sorting on the first column.  But of course that's not always the "in-memory" order.

So this PR makes a simple modification to create a "fake" `row_index` column both with `show_in_notebook` and `show_inbrowser(jsviewer=True)`.  There are no tests or anything because I didn't want to spend too much time on it if others thing we don't want to do this.  It might also make more sense to actually implement this at a lower level, like where the HTML gets generated - this just adds in a column and then removes it immediately after the HTML is generated, but that feels a bit hacky.

@taldcroft @mhvk @saimn - what do you think?

(Screenshot below demonstrates how the notebook looks with and without this PR)
![prepost_virt_col](https://cloud.githubusercontent.com/assets/346587/11827323/36a4b78e-a359-11e5-8090-6396d4d1d74c.png)
