### PR TITLE
Table.read for Path objects and FITS files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,9 @@ New Features
 
 - ``astropy.io.registry``
 
+  - Allow ``pathlib.Path`` objects (available in Python 3.4 and later) for
+    specifying the file name in registry read / write functions. [#4405]
+
 - ``astropy.io.votable``
 
 - ``astropy.modeling``

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -15,6 +15,13 @@ from astropy.units.format.fits import UnitScaleError
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
+try:
+    import pathlib
+except ImportError:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
+
 
 def equal_data(a, b):
     for name in a.dtype.names:
@@ -33,6 +40,14 @@ class TestSingleTable(object):
 
     def test_simple(self, tmpdir):
         filename = str(tmpdir.join('test_simple.fits'))
+        t1 = Table(self.data)
+        t1.write(filename, overwrite=True)
+        t2 = Table.read(filename)
+        assert equal_data(t1, t2)
+
+    @pytest.mark.skipif('not HAS_PATHLIB')
+    def test_simple_pathlib(self, tmpdir):
+        filename = pathlib.Path(str(tmpdir.join('test_simple.fits')))
         t1 = Table(self.data)
         t1.write(filename, overwrite=True)
         t2 = Table.read(filename)

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -24,6 +24,14 @@ _readers = OrderedDict()
 _writers = OrderedDict()
 _identifiers = OrderedDict()
 
+PATH_TYPES = six.string_types
+try:
+    from pathlib import Path
+except:
+    pass
+else:
+    PATH_TYPES += (Path,)
+
 
 def get_formats(data_class=None):
     """
@@ -311,8 +319,12 @@ def read(cls, *args, **kwargs):
             fileobj = None
 
             if len(args):
-                if isinstance(args[0], six.string_types):
+                if isinstance(args[0], PATH_TYPES):
                     from ..utils.data import get_readable_fileobj
+                    # For Py3 the path might be a pathlib.Path object, so coerce
+                    # to a regular string.
+                    if six.PY3:
+                        args = (str(args[0]),) + args[1:]
                     path = args[0]
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary')
@@ -366,7 +378,11 @@ def write(data, *args, **kwargs):
         path = None
         fileobj = None
         if len(args):
-            if isinstance(args[0], six.string_types):
+            if isinstance(args[0], PATH_TYPES):
+                # For Py3 the path might be a pathlib.Path object, so coerce
+                # to a regular string.
+                if six.PY3:
+                    args = (str(args[0]),) + args[1:]
                 path = args[0]
                 fileobj = None
             elif hasattr(args[0], 'read'):


### PR DESCRIPTION
I got this error message (see also #4165):
```
  File "code/hgps/figures/hgps_associations_image/hgps_associations_image.py", line 54, in draw_snrs
    table = Table.read(filename, format='fits')
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/table/table.py", line 2261, in read
    return io_registry.read(cls, *args, **kwargs)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/registry.py", line 332, in read
    data = reader(*args, **kwargs)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/connect.py", line 137, in read_table_fits
    hdulist = fits_open(input)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/hdu/hdulist.py", line 138, in fitsopen
    return HDUList.fromfile(name, mode, memmap, save_backup, cache, **kwargs)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/hdu/hdulist.py", line 280, in fromfile
    save_backup=save_backup, cache=cache, **kwargs)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/hdu/hdulist.py", line 801, in _readfrom
    ffo = _File(fileobj, mode=mode, memmap=memmap, cache=cache)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/file.py", line 143, in __init__
    self._open_filelike(fileobj, mode, clobber)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/file.py", line 455, in _open_filelike
    % self.mode)
OSError: File-like object does not have a 'write' method, required for mode 'ostream'.
```

The reason is that I used a `pathlib.Path` object, which doesn't work for filenames with Astropy.

I don't know if it would be desirable to make Astropy table and fits work with pathlib.Path objects in addition to filename strings.

But I noticed this, which maybe could be considered a bug?
```python
from astropy.table import Table
from pathlib import Path

table = Table()
table['a'] = [1, 2, 3]

filename = Path('table_fits_test.fits.gz')
table.write(filename, format='fits', overwrite=True)
table = Table.read(filename, format='fits')
table.pprint()
```
```
$ python table_fits_test.py 
Traceback (most recent call last):
  File "table_fits_test.py", line 8, in <module>
    table.write(filename, format='fits', overwrite=True)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/table/table.py", line 2278, in write
    io_registry.write(self, *args, **kwargs)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/registry.py", line 380, in write
    writer(data, *args, **kwargs)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/connect.py", line 300, in write_table_fits
    table_hdu.writeto(output)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/hdu/base.py", line 1765, in writeto
    checksum=checksum)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/hdu/hdulist.py", line 685, in writeto
    fileobj = _File(fileobj, mode='ostream', clobber=clobber)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/file.py", line 143, in __init__
    self._open_filelike(fileobj, mode, clobber)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/file.py", line 448, in _open_filelike
    self._overwrite_existing(clobber, fileobj, False)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.1.dev14232-py3.4-macosx-10.11-x86_64.egg/astropy/io/fits/file.py", line 386, in _overwrite_existing
    raise IOError("File %r already exists." % self.name)
OSError: File 'table_fits_test.fits.gz' already exists.
```
The `overwrite=True` argument to `Table.write` is not recognised in this case!?
Can this behaviour or the error messages when `pathlib.Path` objects are passed be improved?
