### PR TITLE
correct a typo

### DIFF
--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -293,9 +293,9 @@ file that has multiple datasets, use *both* the ``overwrite=True`` and
 
 If the metadata of the table cannot be written directly to the HDF5 file 
 (e.g. dictionaries), or if you want to preserve the units and description
-of tables and columns, use using ``serialized_meta=True``::
+of tables and columns, use using ``serialize_meta=True``::
 
-    >>> t.write('observations.hdf5', path='updated_data', serialized_meta=True)
+    >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True)
  
 Finally, when writing to HDF5 files, the ``compression=`` argument can be
 used to ensure that the data is compressed on disk::


### PR DESCRIPTION
The keyword argument in `t.write` should be `serialize_meta` instead of `serialized_meta`.