### PR TITLE
Update astropy_helpers submodule to v1.1.1 release candidate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -300,7 +300,7 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Updated bundled astropy-helpers to v1.1.1. [#4413]
 
 
 1.1 (2015-12-11)


### PR DESCRIPTION
Note: If there any other astropy-helpers updates before the astropy v1.1.1 release, the changelog entry associated with this PR should be updated/replaced.