### PR TITLE
Fix bug writing space-delimited file when table has empty fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -869,6 +869,8 @@ Bug Fixes
 
 - ``astropy.io.ascii``
 
+  - Fix bug writing space-delimited file when table has empty fields. [#4417]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -952,13 +952,13 @@ cdef class FastWriter:
         if not hasattr(output, 'write'): # output is a filename
             output = open(output, 'w')
             opened_file = True # remember to close file afterwards
-        writer = csv.writer(output,
-                            delimiter=self.delimiter,
-                            doublequote=True,
-                            escapechar=None,
-                            quotechar=self.quotechar,
-                            quoting=csv.QUOTE_MINIMAL,
-                            lineterminator=os.linesep)
+        writer = core.CsvWriter(output,
+                                delimiter=self.delimiter,
+                                doublequote=True,
+                                escapechar=None,
+                                quotechar=self.quotechar,
+                                quoting=csv.QUOTE_MINIMAL,
+                                lineterminator=os.linesep)
         self._write_header(output, writer, header_output, output_types)
 
         # Split rows into N-sized chunks, since we don't want to

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -534,3 +534,19 @@ def test_byte_string_output(fast_writer):
     out = StringIO()
     ascii.write(t, out, fast_writer=fast_writer)
     assert out.getvalue().splitlines() == ['col0', 'Hello', 'World']
+
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_write_quoted_empty_field(fast_writer):
+    """
+    Test the fix for #4350 where byte strings were output with a
+    leading `b` on Py3.
+    """
+    t = table.Table([['Hello', ''], ['', '']], dtype=['S10', 'S10'])
+    out = StringIO()
+    ascii.write(t, out, fast_writer=fast_writer)
+    assert out.getvalue().splitlines() == ['col0 col1', 'Hello ""', '"" ""']
+
+    out = StringIO()
+    ascii.write(t, out, fast_writer=fast_writer, delimiter=',')
+    assert out.getvalue().splitlines() == ['col0,col1', 'Hello,', ',']


### PR DESCRIPTION
This fixes a fairly severe bug wherein a table that has empty (or entirely spaces) string values will not round-trip when written out in a space-delimited ASCII table.  The root cause is that `csv.writer` does not include a quoting option to handle this case, which is needed when reading back using `skipinitialspace=True`.  First noted in #4415, with simpler demonstration below.

This PR does constitute an interface change in that the file output will change.  However, the original file output is broken so I think this change is for the better.  I have successfully cherry-picked this commit onto v1.0.7 and v1.1, so this bug fix should be backported.

```
In [1]: from six.moves import cStringIO as StringIO
In [2]: out = StringIO()
In [3]: from astropy.table import Table
In [4]: t = Table([['hello'], [''], ['world']])
In [5]: t
Out[5]: 
<Table length=1>
 col0 col1  col2
 str5 str1  str5
----- ---- -----
hello      world

In [7]: t.write(out, format='ascii')
In [9]: print(out.getvalue())
col0 col1 col2
hello  world

In [10]: Table.read(out.getvalue(), format='ascii.basic', guess=False)
---------------------------------------------------------------------------
InconsistentTableError                    Traceback (most recent call last)

InconsistentTableError: Number of header columns (3) inconsistent with data columns (2) at data line 0
Header values: ['col0', 'col1', 'col2']
Data values: ['hello', 'world']
```

Closes #4415.