### PR TITLE
Implement caching for Time scale and format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New Features
 
 - ``astropy.time``
 
+  - Added caching of scale and format transformations for improved performance.
+    [#4422]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -196,7 +196,7 @@ class Time(object):
         else:
             self.location = None
 
-        if isinstance(val, self.__class__):
+        if isinstance(val, Time):
             # Update _time formatting parameters if explicitly specified
             if precision is not None:
                 self._time.precision = precision
@@ -1505,7 +1505,7 @@ class TimeDelta(Time):
     """Dict of time delta formats."""
 
     def __init__(self, val, val2=None, format=None, scale=None, copy=False):
-        if isinstance(val, self.__class__):
+        if isinstance(val, TimeDelta):
             if scale is not None:
                 self._set_scale(scale)
         else:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1073,3 +1073,4 @@ def test_cache():
     # Clear the cache
     del t.cache
     assert not hasattr(t, '_cache')
+    assert not t.cache

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -217,22 +217,10 @@ class TestBasic():
         # Uses initial class-defined precision=3
         assert t.iso == '2010-01-01 00:00:00.000'
 
-        # Set global precision = 5  XXX this uses private var, FIX THIS
-        Time._precision = 5
-        assert t.iso == '2010-01-01 00:00:00.00000'
-
         # Set instance precision to 9
         t.precision = 9
         assert t.iso == '2010-01-01 00:00:00.000000000'
         assert t.tai.utc.iso == '2010-01-01 00:00:00.000000000'
-
-        # Restore global to original default of 3, instance is still at 9
-        Time._precision = 3
-        assert t.iso == '2010-01-01 00:00:00.000000000'
-
-        # Make a new time instance and confirm precision = 3
-        t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
-        assert t.iso == '2010-01-01 00:00:00.000'
 
     def test_transforms(self):
         """Transform from UTC to all supported time scales (TAI, TCB, TCG,
@@ -750,6 +738,12 @@ class TestCopyReplicate():
         # This is not allowed publicly, but here we hack the internal time
         # and location values to show that t and t2 are sharing references.
         t2._time.jd1 += 100.0
+
+        # Need to delete the cached yday attributes (only an issue because
+        # of the internal _time hack).
+        del t.cache
+        del t2.cache
+
         assert t.yday == t2.yday
         assert t.yday != t_yday  # prove that it changed
         t2_loc_x_view = t2.location.x
@@ -769,6 +763,12 @@ class TestCopyReplicate():
         # This is not allowed publicly, but here we hack the internal time
         # and location values to show that t and t2 are not sharing references.
         t2._time.jd1 += 100.0
+
+        # Need to delete the cached yday attributes (only an issue because
+        # of the internal _time hack).
+        del t.cache
+        del t2.cache
+
         assert t.yday != t2.yday
         assert t.yday == t_yday  # prove that it did not change
         t2_loc_x_view = t2.location.x
@@ -1051,3 +1051,25 @@ def test_to_datetime_pytz():
     for dt, tz_dt in zip(time.datetime, tz_aware_datetime):
         assert tz.tzname(dt) == tz_dt.tzname()
     assert np.all(time == forced_to_astropy_time)
+
+def test_cache():
+    t = Time('2010-09-03 00:00:00')
+    t2 = Time('2010-09-03 00:00:00')
+
+    # Time starts out with no _cache attribute
+    assert not hasattr(t, '_cache')
+
+    # Access the iso format and confirm that the cached version is as expected
+    t.iso
+    assert t.cache['format']['iso'] == t2.iso
+
+    # Access the TAI scale and confirm that the cached version is as expected
+    t.tai
+    assert t.cache['scale']['tai'] == t2.tai
+
+    # New Time object after scale transform does not have a cache yet
+    assert not hasattr(t.tt, '_cache')
+
+    # Clear the cache
+    del t.cache
+    assert not hasattr(t, '_cache')

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -644,6 +644,35 @@ process of changing the time scale therefore begins by making a copy of the
 original object and then converting the internal time values in the copy to the
 new time scale.  The new |Time| object is returned by the attribute access.
 
+Caching
+^^^^^^^
+
+The computations for transforming to different time scales or formats can be
+time-consuming for large arrays.  In order to avoid repeated computations, each
+|Time| or |TimeDelta| instance caches such transformations internally::
+
+  >>> t = Time(np.arange(1e6), format='unix', scale='utc')  # doctest: +SKIP
+
+  >>> time x = t.tt  # doctest: +SKIP
+  CPU times: user 263 ms, sys: 4.02 ms, total: 267 ms
+  Wall time: 267 ms
+
+  >>> time x = t.tt  # doctest: +SKIP
+  CPU times: user 28 µs, sys: 9 µs, total: 37 µs
+  Wall time: 32.9 µs
+
+Actions such as changing the output precision or sub-format will clear
+the cache.  In order to explicitly clear the internal cache do::
+
+  >>> del t.cache  # doctest: +SKIP
+
+  >>> time x = t.tt  # doctest: +SKIP
+  CPU times: user 263 ms, sys: 4.02 ms, total: 267 ms
+  Wall time: 267 ms
+
+Since these objects are immutable (cannot be changed internally), this should
+not normally be required.
+
 Transformation offsets
 """"""""""""""""""""""
 


### PR DESCRIPTION
This implements caching to resolve #4309.  The footprint got a little bigger than I had hoped, in part because I expanded the scope to include format caching as well.  Because if this I want to get some review before going ahead with doc updates.  

The changes in `__add__` and `__sub__` highlight the subtle problems that can come along with caching.  Basically you need to be careful when messing around with `_time` internals.

Parts of the precision testing were taken out because they relied on changing the internal time object state in a way that is not allowed in normal use.
