### PR TITLE
Add way to control HTML escaping in HTML writer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,8 @@ API changes
 
 - ``astropy.io.ascii``
 
+  - Add a way to control HTML escaping when writing a table as an HTML file. [#4423]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -329,7 +329,7 @@ class HTML(core.BaseReader):
         raw_html_cols = self.html.get('raw_html_cols', [])
         if isinstance(raw_html_cols, six.string_types):
             raw_html_cols = [raw_html_cols]  # Allow for a single string as input
-        cols_escaped = [col.name not in raw_html_cols for col in cols]
+        cols_escaped = [col.info.name not in raw_html_cols for col in cols]
 
         # Use XMLWriter to output HTML to lines
         w = writer.XMLWriter(ListWriter(lines))

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -265,15 +265,17 @@ class HTML(core.BaseReader):
             present, this parameter will be true by default.
 
         * raw_html_cols : column name or list of names with raw HTML content
-            This allows one to include raw HTML strings in the column output,
-            for instance to include link references in a table.  Normally
-            the HTML characters are escaped
+            This allows one to include raw HTML content in the column output,
+            for instance to include link references in a table.  This option
+            requires that the bleach package be installed.  Only whitelisted
+            tags are allowed through for security reasons (see the
+            raw_html_clean_kwargs arg).
 
         * raw_html_clean_kwargs : dict of keyword args controlling HTML cleaning
-            If the ``bleach`` package is installed then any raw HTML will be
-            cleaned to prevent unsafe HTML from ending up in the table output.
-            This is done by calling ``bleach.clean(data, **raw_html_clean_kwargs)``.
-            For details on the available options (e.g. tag whitelist) see:
+            Raw HTML will be cleaned to prevent unsafe HTML from ending up in
+            the table output.  This is done by calling ``bleach.clean(data,
+            **raw_html_clean_kwargs)``.  For details on the available options
+            (e.g. tag whitelist) see:
             http://bleach.readthedocs.org/en/latest/clean.html
 
         * parser : Specific HTML parsing library to use
@@ -405,7 +407,8 @@ class HTML(core.BaseReader):
                         with w.tag('tr'):
                             for el, col_escaped in izip(row, new_cols_escaped):
                                 # Potentially disable HTML escaping for column
-                                with w.xml_escaping(col_escaped, raw_html_clean_kwargs):
+                                method = ('escape_xml' if col_escaped else 'bleach_clean')
+                                with w.xml_cleaning_method(method, **raw_html_clean_kwargs):
                                     w.start('td')
                                     w.data(el.strip())
                                     w.end(indent=False)

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -14,6 +14,7 @@ from ....table import Table
 
 import numpy as np
 
+from .common import setup_function, teardown_function
 from ....tests.helper import pytest
 from ....extern.six.moves import cStringIO
 from ....utils.xml.writer import HAS_BLEACH

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -364,6 +364,64 @@ def test_multicolumn_write():
 
     col1 = [1, 2, 3]
     col2 = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]
+    col3 = [('a', 'a', 'a'), ('b', 'b', 'b'), ('c', 'c', 'c')]
+    table = Table([col1, col2, col3], names=('C1', 'C2', 'C3'))
+    expected = """\
+<html>
+ <head>
+  <meta charset="utf-8"/>
+  <meta content="text/html;charset=UTF-8" http-equiv="Content-type"/>
+ </head>
+ <body>
+  <table>
+   <thead>
+    <tr>
+     <th>C1</th>
+     <th colspan="2">C2</th>
+     <th colspan="3">C3</th>
+    </tr>
+   </thead>
+   <tr>
+    <td>1</td>
+    <td>1.0</td>
+    <td>1.0</td>
+    <td>a</td>
+    <td>a</td>
+    <td>a</td>
+   </tr>
+   <tr>
+    <td>2</td>
+    <td>2.0</td>
+    <td>2.0</td>
+    <td>b</td>
+    <td>b</td>
+    <td>b</td>
+   </tr>
+   <tr>
+    <td>3</td>
+    <td>3.0</td>
+    <td>3.0</td>
+    <td>c</td>
+    <td>c</td>
+    <td>c</td>
+   </tr>
+  </table>
+ </body>
+</html>
+    """
+    out = html.HTML().write(table)[0].strip()
+    assert out == expected.strip()
+
+@pytest.mark.skipif('not HAS_BLEACH')
+def test_multicolumn_write_escape():
+    """
+    Test to make sure that the HTML writer writes multimensional
+    columns (those with iterable elements) using the colspan
+    attribute of <th>.
+    """
+
+    col1 = [1, 2, 3]
+    col2 = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]
     col3 = [('<a></a>', '<a></a>', 'a'), ('<b></b>', 'b', 'b'), ('c', 'c', 'c')]
     table = Table([col1, col2, col3], names=('C1', 'C2', 'C3'))
     expected = """\
@@ -478,6 +536,7 @@ def test_multicolumn_read():
                               dtype=[('A', str_type, (2,)), ('B', '<f8')]))
     assert np.all(table == expected)
 
+@pytest.mark.skipif('not HAS_BLEACH')
 def test_raw_html_write():
     """
     Test that columns can contain raw HTML which is not escaped.

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from ....tests.helper import pytest
 from ....extern.six.moves import cStringIO
+from ....utils.xml.writer import HAS_BLEACH
 
 # Check to see if the BeautifulSoup dependency is present.
 try:

--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -7,6 +7,7 @@ from ...extern import six
 import io
 
 from ..xml import check, unescaper, writer
+from ...tests.helper import pytest
 
 
 def test_writer():
@@ -74,3 +75,37 @@ def test_escape_xml():
     s = writer.xml_escape(b'This & That')
     assert type(s) == bytes
     assert s == b'This &amp; That'
+
+
+@pytest.mark.skipif('writer.HAS_BLEACH')
+def test_escape_xml_without_bleach():
+    fh = io.StringIO()
+    w = writer.XMLWriter(fh)
+
+    with pytest.raises(ValueError) as err:
+        with w.xml_escaping(False):
+            pass
+    assert 'bleach package is required when HTML escaping is disabled' in str(err)
+
+
+@pytest.mark.skipif('not writer.HAS_BLEACH')
+def test_escape_xml_with_bleach():
+    fh = io.StringIO()
+    w = writer.XMLWriter(fh)
+
+    # Turn off XML escaping, but still sanitize unsafe tags like <script>
+    with w.xml_escaping(False):
+        w.start('td')
+        w.data('<script>x</script> <em>OK</em>')
+        w.end(indent=False)
+    assert fh.getvalue() == '<td>&lt;script&gt;x&lt;/script&gt; <em>OK</em></td>\n'
+
+    fh = io.StringIO()
+    w = writer.XMLWriter(fh)
+
+    # Default is True (all XML tags escaped)
+    with w.xml_escaping():
+        w.start('td')
+        w.data('<script>x</script> <em>OK</em>')
+        w.end(indent=False)
+    assert fh.getvalue() == '<td>&lt;script&gt;x&lt;/script&gt; &lt;em&gt;OK&lt;/em&gt;</td>\n'

--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -83,7 +83,7 @@ def test_escape_xml_without_bleach():
     w = writer.XMLWriter(fh)
 
     with pytest.raises(ValueError) as err:
-        with w.xml_escaping(False):
+        with w.xml_cleaning_method('bleach_clean'):
             pass
     assert 'bleach package is required when HTML escaping is disabled' in str(err)
 
@@ -94,7 +94,7 @@ def test_escape_xml_with_bleach():
     w = writer.XMLWriter(fh)
 
     # Turn off XML escaping, but still sanitize unsafe tags like <script>
-    with w.xml_escaping(False):
+    with w.xml_cleaning_method('bleach_clean'):
         w.start('td')
         w.data('<script>x</script> <em>OK</em>')
         w.end(indent=False)
@@ -104,7 +104,7 @@ def test_escape_xml_with_bleach():
     w = writer.XMLWriter(fh)
 
     # Default is True (all XML tags escaped)
-    with w.xml_escaping():
+    with w.xml_cleaning_method():
         w.start('td')
         w.data('<script>x</script> <em>OK</em>')
         w.end(indent=False)

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -11,6 +11,11 @@ from ...extern import six
 import contextlib
 import textwrap
 
+try:
+    import bleach
+    HAS_BLEACH = True
+except ImportError:
+    HAS_BLEACH = False
 
 try:
     from . import _iterparser
@@ -148,10 +153,15 @@ class XMLWriter:
         return len(self._tags)
 
     @contextlib.contextmanager
-    def xml_escaping(self, enabled=True):
+    def xml_escaping(self, enabled=True, clean_kwargs=None):
         current_xml_escape_cdata = self.xml_escape_cdata
         if not enabled:
-            self.xml_escape_cdata = lambda x: x
+            if HAS_BLEACH:
+                if clean_kwargs is None:
+                    clean_kwargs = {}
+                self.xml_escape_cdata = lambda x: bleach.clean(x, **clean_kwargs)
+            else:
+                self.xml_escape_cdata = lambda x: x
         yield
         self.xml_escape_cdata = current_xml_escape_cdata
 

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -153,9 +153,42 @@ class XMLWriter:
         return len(self._tags)
 
     @contextlib.contextmanager
-    def xml_escaping(self, enabled=True, clean_kwargs=None):
+    def xml_cleaning_method(self, method='escape_xml', **clean_kwargs):
+        """Context manager to control how XML data tags are cleaned (escaped) to
+        remove potentially unsafe characters or constructs.
+
+        The default (``method='escape_xml'``) applies brute-force escaping of
+        certain key XML characters like ``<``, ``>``, and ``&`` to ensure that
+        the output is not valid XML.
+
+        In order to explicitly allow certain XML tags (e.g. link reference or
+        emphasis tags), use ``method='bleach_clean'``.  This sanitizes the data
+        string using the ``clean`` function of the
+        `http://bleach.readthedocs.org/en/latest/clean.html <bleach>`_ package.
+        Any additional keyword arguments will be passed directly to the
+        ``clean`` function.
+
+        Example::
+
+          w = writer.XMLWriter(ListWriter(lines))
+          with w.xml_cleaning_method('bleach_clean'):
+              w.start('td')
+              w.data('<a href="http://google.com">google.com</a>')
+              w.end()
+
+        Parameters
+        ----------
+        method : str
+            Cleaning method.  Allowed values are "escape_xml" and
+            "bleach_clean".
+
+        **clean_kwargs : keyword args
+            Additional keyword args that are passed to the
+            bleach.clean() function.
+        """
         current_xml_escape_cdata = self.xml_escape_cdata
-        if not enabled:
+
+        if method == 'bleach_clean':
             if HAS_BLEACH:
                 if clean_kwargs is None:
                     clean_kwargs = {}
@@ -163,7 +196,11 @@ class XMLWriter:
             else:
                 raise ValueError('bleach package is required when HTML escaping is disabled.\n'
                                  'Use "pip install bleach".')
+        elif method != 'escape_xml':
+            raise ValueError('allowed values of method are "escape_xml" and "bleach_clean"')
+
         yield
+
         self.xml_escape_cdata = current_xml_escape_cdata
 
     @contextlib.contextmanager

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -148,6 +148,14 @@ class XMLWriter:
         return len(self._tags)
 
     @contextlib.contextmanager
+    def xml_escaping(self, enabled=True):
+        current_xml_escape_cdata = self.xml_escape_cdata
+        if not enabled:
+            self.xml_escape_cdata = lambda x: x
+        yield
+        self.xml_escape_cdata = current_xml_escape_cdata
+
+    @contextlib.contextmanager
     def tag(self, tag, attrib={}, **extra):
         """
         A convenience method for creating wrapper elements using the

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -161,7 +161,8 @@ class XMLWriter:
                     clean_kwargs = {}
                 self.xml_escape_cdata = lambda x: bleach.clean(x, **clean_kwargs)
             else:
-                self.xml_escape_cdata = lambda x: x
+                raise ValueError('bleach package is required when HTML escaping is disabled.\n'
+                                 'Use "pip install bleach".')
         yield
         self.xml_escape_cdata = current_xml_escape_cdata
 


### PR DESCRIPTION
Per discussion in #4006, this PR adds the `raw_html_cols` parameter to the `htmldict` input of the `io.ascii` HTML writer.  One can supply a single column name or a list of columns.

This *does not* have any understanding of tags like `<script>` etc that might be disallowed from being passed through as raw HTML.    Note that one has to specifically opt-in for each column, so this isn't something where one could read a FITS table from someone, display it naively, and have something bad happen.  But I appreciate taking security seriously.  @embray?   Is there an OTS way to detect and trap certain XML tags?