### PR TITLE
Remove unnecessary test skip on appveyor

### DIFF
--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -47,7 +47,6 @@ def test_setitem_invalid_type(value):
     assert exc.value.args[0] == 'flags should be given as a Numpy array'
 
 
-@pytest.mark.skipif("os.environ.get('APPVEYOR')",  reason="fails on AppVeyor")
 def test_setitem_invalid_shape():
     f = FlagCollection(shape=(1, 2, 3))
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
This checks off one more box in the list of tests skipped on windows in #3242; seems it was actually fixed, except for removing the skip, in #2862.
