### PR TITLE
Ensure in-place ptp works on Quantities.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -291,6 +291,8 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - In-place peak-to-peak calculations now work on ``Quantity``. [#4442]    
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -291,8 +291,6 @@ Bug Fixes
 
 - ``astropy.units``
 
-  - In-place peak-to-peak calculations now work on ``Quantity``. [#4442]    
-
 - ``astropy.utils``
 
 - ``astropy.vo``
@@ -987,6 +985,8 @@ Bug Fixes
 - ``astropy.time``
 
 - ``astropy.units``
+
+  - In-place peak-to-peak calculations now work on ``Quantity``. [#4442]
 
 - ``astropy.utils``
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1271,8 +1271,11 @@ class Quantity(np.ndarray):
             if unit is None:
                 unit = self.unit
 
-            if not (isinstance(out, Quantity) and
-                    out.__quantity_subclass__(unit)[0] is type(out)):
+            if(isinstance(out, Quantity) and
+               out.__quantity_subclass__(unit)[0] is type(out)):
+                kwargs['out'] = out.view(np.ndarray)
+
+            else:
                 ok_class =  (out.__quantity_subclass__(out, unit)[0]
                              if isinstance(out, Quantity) else Quantity)
                 raise TypeError("out cannot be assigned to a {0} instance; "

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -222,8 +222,9 @@ class Quantity(np.ndarray):
                             subok=True, ndmin=ndmin)
 
         # Maybe list/tuple of Quantity? short-circuit array for speed
-        if(not isinstance(value, np.ndarray) and isiterable(value) and
-           all(isinstance(v, Quantity) for v in value)):
+        if (not isinstance(value, np.ndarray) and isiterable(value) and
+            all(isinstance(v, Quantity) for v in value)):
+            # Convert all quantities to the same unit.
             if unit is None:
                 unit = value[0].unit
             value = [q.to(unit).value for q in value]
@@ -1271,8 +1272,9 @@ class Quantity(np.ndarray):
             if unit is None:
                 unit = self.unit
 
-            if(isinstance(out, Quantity) and
-               out.__quantity_subclass__(unit)[0] is type(out)):
+            if (isinstance(out, Quantity) and
+                out.__quantity_subclass__(unit)[0] is type(out)):
+                # Set out to ndarray view to prevent calling __array_prepare__.
                 kwargs['out'] = out.view(np.ndarray)
 
             else:

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -231,7 +231,6 @@ class TestQuantityStatsFuncs(object):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
         assert np.ptp(q1) == 5. * u.m
 
-    @pytest.mark.xfail
     def test_ptp_inplace(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
         qi = 1.5 * u.s


### PR DESCRIPTION
See title; addresses part of #1273 by ensuring that numpy functions called via quantity methods get numpy arrays to store output in.