### PR TITLE
Change loop variable name to avoid conflict with key= argument to function

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2510,15 +2510,15 @@ reduce these to 2 dimensions using the naxis kwarg.
             header = fits.Header()
 
         if do_sip and self.sip is not None:
-            for key, val in self._write_sip_kw().items():
-                header[key] = val
+            for kw, val in self._write_sip_kw().items():
+                header[kw] = val
 
         if display_warning:
             full_header = self.to_header(relax=True, key=key)
             missing_keys = []
-            for key, val in full_header.items():
-                if key not in header:
-                    missing_keys.append(key)
+            for kw, val in full_header.items():
+                if kw not in header:
+                    missing_keys.append(kw)
 
             if len(missing_keys):
                 warnings.warn(


### PR DESCRIPTION
I think that by luck this may actually never cause issues, but this should definitely be fixed anyway.