### PR TITLE
Remove deprecated compatibility layer in astropy.coordinates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ API changes
 
 - ``astropy.coordinates``
 
+  - Removed compatibility layer for pre-v0.4 API. [#4447]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -449,65 +449,6 @@ class BaseCoordinateFrame(object):
     frame_attributes = OrderedDict()
     # Default empty frame_attributes dict
 
-    # This __new__ provides for backward-compatibility with pre-0.4 API.
-    # TODO: remove in 1.0
-    def __new__(cls, *args, **kwargs):
-
-        # Only do backward-compatibility if frame is previously defined one
-        frame_name = cls.__name__.lower()
-        if frame_name not in ['altaz', 'fk4', 'fk4noeterms', 'fk5',
-                              'galactic', 'icrs']:
-            return super(BaseCoordinateFrame, cls).__new__(cls)
-
-        use_skycoord = False
-
-        for arg in args:
-            if not isinstance(arg, (u.Quantity, BaseRepresentation)):
-                msg = ('Initializing frame classes like "{0}" using string '
-                       'or other non-Quantity arguments is deprecated, and '
-                       'will be removed in the next version of Astropy.  '
-                       'Instead, you probably want to use the SkyCoord '
-                       'class with the "frame={1}" keyword, or if you '
-                       'really want to use the low-level frame classes, '
-                       'create it with an Angle or Quantity.')
-
-                warnings.warn(msg.format(cls.__name__,
-                                         cls.__name__.lower()),
-                              AstropyDeprecationWarning)
-                use_skycoord = True
-                break
-
-        if 'unit' in kwargs and not use_skycoord:
-            warnings.warn(
-                "Initializing frames using the ``unit`` argument is "
-                "now deprecated. Use SkyCoord or pass Quantity "
-                "instances to frames instead.", AstropyDeprecationWarning)
-            use_skycoord = True
-
-        if not use_skycoord:
-            representation = kwargs.get('representation',
-                                        cls._default_representation)
-            representation = _get_repr_cls(representation)
-
-            repr_info = cls._get_representation_info()
-
-            for key in repr_info[representation]['names']:
-                if key in kwargs:
-                    if not isinstance(kwargs[key], u.Quantity):
-                        warnings.warn(
-                            "Initializing frames using non-Quantity arguments "
-                            "is now deprecated. Use SkyCoord or pass Quantity "
-                            "instances instead.", AstropyDeprecationWarning)
-                        use_skycoord = True
-                        break
-
-        if use_skycoord:
-            kwargs['frame'] = frame_name
-            from .sky_coordinate import SkyCoord
-            return SkyCoord(*args, **kwargs)
-        else:
-            return super(BaseCoordinateFrame, cls).__new__(cls)
-
     def __init__(self, *args, **kwargs):
         self._attr_names_with_defaults = []
 

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ....tests.helper import quantity_allclose
 from .... import units as u
+from ... import SkyCoord
 from ...builtin_frames import FK5, ICRS, GCRS, GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 from ....constants import R_sun, R_earth
 
@@ -19,7 +20,7 @@ def test_against_pytpm_doc_example():
 
     Currently this is only testing against the example given in the pytpm docs
     """
-    fk5_in = FK5('12h22m54.899s', '15d49m20.57s', equinox='J2000')
+    fk5_in = SkyCoord('12h22m54.899s', '15d49m20.57s', frame=FK5(equinox='J2000'))
     pytpm_out = BarycentricTrueEcliptic(lon=178.78256462*u.deg,
                                         lat=16.7597002513*u.deg,
                                         equinox='J2000')

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -100,29 +100,28 @@ def test_array_coordinates_creation():
     """
     Test creating coordinates from arrays.
     """
-    from .. import Angle
-    from .. import ICRS, CartesianRepresentation
+    from .. import Angle, SkyCoord, CartesianRepresentation
 
-    c = ICRS(np.array([1, 2])*u.deg, np.array([3, 4])*u.deg)
+    c = SkyCoord(np.array([1, 2])*u.deg, np.array([3, 4])*u.deg)
     assert not c.ra.isscalar
 
     with pytest.raises(ValueError):
-        c = ICRS(np.array([1, 2])*u.deg, np.array([3, 4, 5])*u.deg)
+        c = SkyCoord(np.array([1, 2])*u.deg, np.array([3, 4, 5])*u.deg)
     with pytest.raises(ValueError):
-        c = ICRS(np.array([1, 2, 4, 5])*u.deg, np.array([[3, 4], [5, 6]])*u.deg)
+        c = SkyCoord(np.array([1, 2, 4, 5])*u.deg, np.array([[3, 4], [5, 6]])*u.deg)
 
     #make sure cartesian initialization also works
     cart = CartesianRepresentation(x=[1., 2.]*u.kpc, y=[3., 4.]*u.kpc, z=[5., 6.]*u.kpc)
-    c = ICRS(cart)
+    c = SkyCoord(cart)
 
     #also ensure strings can be arrays
-    c = ICRS(['1d0m0s', '2h02m00.3s'], ['3d', '4d'])
+    c = SkyCoord(['1d0m0s', '2h02m00.3s'], ['3d', '4d'])
 
     #but invalid strings cannot
     with pytest.raises(ValueError):
-        c = ICRS(Angle(['10m0s', '2h02m00.3s']), Angle(['3d', '4d']))
+        c = SkyCoord(Angle(['10m0s', '2h02m00.3s']), Angle(['3d', '4d']))
     with pytest.raises(ValueError):
-        c = ICRS(Angle(['1d0m0s', '2h02m00.3s']), Angle(['3x', '4d']))
+        c = SkyCoord(Angle(['1d0m0s', '2h02m00.3s']), Angle(['3x', '4d']))
 
 
 def test_array_coordinates_distances():

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -100,19 +100,19 @@ def test_array_coordinates_creation():
     """
     Test creating coordinates from arrays.
     """
-    from .. import Angle, SkyCoord, CartesianRepresentation
+    from .. import Angle, ICRS, SkyCoord, CartesianRepresentation
 
-    c = SkyCoord(np.array([1, 2])*u.deg, np.array([3, 4])*u.deg)
+    c = ICRS(np.array([1, 2])*u.deg, np.array([3, 4])*u.deg)
     assert not c.ra.isscalar
 
     with pytest.raises(ValueError):
-        c = SkyCoord(np.array([1, 2])*u.deg, np.array([3, 4, 5])*u.deg)
+        c = ICRS(np.array([1, 2])*u.deg, np.array([3, 4, 5])*u.deg)
     with pytest.raises(ValueError):
-        c = SkyCoord(np.array([1, 2, 4, 5])*u.deg, np.array([[3, 4], [5, 6]])*u.deg)
+        c = ICRS(np.array([1, 2, 4, 5])*u.deg, np.array([[3, 4], [5, 6]])*u.deg)
 
     #make sure cartesian initialization also works
     cart = CartesianRepresentation(x=[1., 2.]*u.kpc, y=[3., 4.]*u.kpc, z=[5., 6.]*u.kpc)
-    c = SkyCoord(cart)
+    c = ICRS(cart)
 
     #also ensure strings can be arrays
     c = SkyCoord(['1d0m0s', '2h02m00.3s'], ['3d', '4d'])

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -12,6 +12,7 @@ from .. import transformations as t
 from ..builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, \
                              Supergalactic, Galactocentric, CIRS, GCRS, AltAz, \
                              ITRS, PrecessedGeocentric
+from .. import SkyCoord
 from .. import representation as r
 from ..baseframe import frame_transform_graph
 from ...tests.helper import (pytest, quantity_allclose as allclose,
@@ -166,10 +167,10 @@ def test_supergalactic():
 
     # GRB 021219
     supergalactic = Supergalactic(sgl=29.91*u.degree, sgb=+73.72*u.degree)
-    icrs = ICRS('18h50m27s +31d57m17s')
+    icrs = SkyCoord('18h50m27s +31d57m17s')
     assert supergalactic.separation(icrs) < 0.005 * u.degree
 
     # GRB 030320
     supergalactic = Supergalactic(sgl=-174.44*u.degree, sgb=+46.17*u.degree)
-    icrs = ICRS('17h51m36s -25d18m52s')
+    icrs = SkyCoord('17h51m36s -25d18m52s')
     assert supergalactic.separation(icrs) < 0.005 * u.degree

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -51,7 +51,6 @@ coordinate object into the frame of another::
     <SkyCoord (FK5: equinox=J1980.000): (ra, dec) in deg
         (229.014693505, -1.05560349378)>
 
-
 Additionally, some coordinate frames (including `~astropy.coordinates.FK5`,
 `~astropy.coordinates.FK4`, and `~astropy.coordinates.FK4NoETerms`) support
 "self transformations", meaning the *type* of frame doesn't change, but the
@@ -60,7 +59,7 @@ to another in an equatorial frame. This is done by passing ``transform_to`` a
 frame class with the relevant attributes, as shown below. Note that these
 frames use a default equinox if you don't specify one::
 
-    >>> fk5c = FK5('02h31m49.09s', '+89d15m50.8s')
+    >>> fk5c = SkyCoord('02h31m49.09s', '+89d15m50.8s', frame=FK5)
     >>> fk5c.equinox
     <Time object: scale='utc' format='jyear_str' value=J2000.000>
     >>> fk5c  # doctest: +FLOAT_CMP
@@ -75,8 +74,8 @@ You can also specify the equinox when you create a coordinate using an
 `~astropy.time.Time` object::
 
     >>> from astropy.time import Time
-    >>> fk5c = FK5('02h31m49.09s', '+89d15m50.8s',
-    ...            equinox=Time('J1970', scale='utc'))
+    >>> fk5c = SkyCoord('02h31m49.09s', '+89d15m50.8s',
+    ...                 frame=FK5(equinox=Time('J1970', scale='utc')))
     >>> fk5_2000 = FK5(equinox=Time(2000, format='jyear', scale='utc'))
     >>> fk5c.transform_to(fk5_2000)  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=2000.0): (ra, dec) in deg


### PR DESCRIPTION
We had a note to remove these in 1.0. Now that 1.1 is out, I think it's definitely time to remove them.

cc @eteq @taldcroft 