### PR TITLE
Remove deprecated support for tuples as fractional powers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ New Features
 
 - ``astropy.units``
 
+  - The option to use tuples to indicate fractional powers of units,
+    deprecated in 0.3.1, has been removed. [#4449]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1952,7 +1952,7 @@ class CompositeUnit(UnitBase):
                 if not isinstance(base, UnitBase):
                     raise TypeError(
                         "bases must be sequence of UnitBase instances")
-            powers = [validate_power(p, support_tuples=True) for p in powers]
+            powers = [validate_power(p) for p in powers]
 
         self._scale = scale
         self._bases = bases
@@ -2051,8 +2051,7 @@ class CompositeUnit(UnitBase):
         new_parts.sort(key=lambda x: (-x[1], getattr(x[0], 'name', '')))
 
         self._bases = [x[0] for x in new_parts]
-        self._powers = [validate_power(x[1], support_tuples=True)
-                        for x in new_parts]
+        self._powers = [validate_power(x[1]) for x in new_parts]
         self._scale = sanitize_scale(scale)
 
     def __copy__(self):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -111,7 +111,7 @@ def test_units_conversion():
 
 def test_units_manipulation():
     # Just do some manipulation and check it's happy
-    (u.kpc * u.yr) ** (1, 3) / u.Myr
+    (u.kpc * u.yr) ** Fraction(1, 3) / u.Myr
     (u.AA * u.erg) ** 9
 
 


### PR DESCRIPTION
It looks like the ``support_tuples`` option in ``validate_power`` is deprecated: https://github.com/astropy/astropy/blob/master/astropy/units/utils.py#L171

However, we actually make use of this in non-deprecated places:

https://github.com/astropy/astropy/blob/master/astropy/units/core.py#L1981

https://github.com/astropy/astropy/blob/master/astropy/units/core.py#L2080

Should the calls to ``validate_power`` be changed, or the argument un-deprecated?

cc @mhvk @mdboom