### PR TITLE
FITS string columns can't be updated inplace on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -180,6 +180,9 @@ New Features
 
 - ``astropy.io.fits``
 
+  - Fixed an bug where updates to string columns in FITS tables were not saved
+    on Python 3. [#4452]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -967,6 +970,9 @@ Bug Fixes
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``
+
+  - Fixed an bug where updates to string columns in FITS tables were not saved
+    on Python 3. [#4452]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1237,10 +1237,10 @@ def _ascii_encode(inarray, out=None):
     the item that couldn't be encoded.
     """
 
-    inarray = inarray.flatten()
-    out_dtype = np.dtype('S{0}'.format(inarray.dtype.itemsize // 4))
+    out_dtype = np.dtype(('S{0}'.format(inarray.dtype.itemsize // 4),
+                         inarray.dtype.shape))
     if out is not None:
-        out = out.flatten().view(out_dtype)
+        out = out.view(out_dtype)
 
     op_dtypes = [inarray.dtype, out_dtype]
     op_flags = [['readonly'], ['writeonly', 'allocate']]
@@ -1253,6 +1253,8 @@ def _ascii_encode(inarray, out=None):
     except UnicodeEncodeError as exc:
         index = np.unravel_index(it.iterindex, inarray.shape)
         raise _UnicodeArrayEncodeError(*(exc.args + (index,)))
+
+    return it.operands[1]
 
 
 def _has_unicode_fields(array):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2308,6 +2308,49 @@ class TestTableFunctions(FitsTestCase):
         # its use in creating the "merged" table
         assert comparerecords(data1, fits.getdata(self.data('tb.fits')))
 
+    def test_update_string_column_inplace(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4452
+
+        Ensure that changes to values in a string column are saved when
+        a file is opened in ``mode='update'``.
+        """
+
+        data = np.array([('abc',)], dtype=[('a', 'S3')])
+        fits.writeto(self.temp('test.fits'), data)
+
+        with fits.open(self.temp('test.fits'), mode='update') as hdul:
+            hdul[1].data['a'][0] = 'XYZ'
+            assert hdul[1].data['a'][0] == 'XYZ'
+
+        with fits.open(self.temp('test.fits')) as hdul:
+            assert hdul[1].data['a'][0] == 'XYZ'
+
+        # Test update but with a non-trivial TDIMn
+        data = np.array([([['abc', 'def', 'geh'],
+                           ['ijk', 'lmn', 'opq']],)],
+                        dtype=[('a', ('S3', (2, 3)))])
+
+        fits.writeto(self.temp('test2.fits'), data)
+
+        expected = [['abc', 'def', 'geh'],
+                    ['ijk', 'XYZ', 'opq']]
+
+        with fits.open(self.temp('test2.fits'), mode='update') as hdul:
+            assert hdul[1].header['TDIM1'] == '(3,3,2)'
+            # Note: Previously I wrote data['a'][0][1, 1] to address
+            # the single row.  However, this is broken for chararray because
+            # data['a'][0] does *not* return a view of the original array--this
+            # is a bug in chararray though and not a bug in any FITS-specific
+            # code so we'll roll with it for now...
+            # (by the way the bug in question is fixed in newer Numpy versions)
+            hdul[1].data['a'][0, 1, 1] = 'XYZ'
+            assert np.all(hdul[1].data['a'][0] == expected)
+
+        with fits.open(self.temp('test2.fits')) as hdul:
+            assert hdul[1].header['TDIM1'] == '(3,3,2)'
+            assert np.all(hdul[1].data['a'][0] == expected)
+
 
 class TestVLATables(FitsTestCase):
     """Tests specific to tables containing variable-length arrays."""


### PR DESCRIPTION
Warren Hack pointed this bug out to me.  It can be reproduced fairly simply:

```python
In [1]: from astropy.io import fits

In [2]: import numpy as np

In [3]: r = np.array([('abc',)], dtype=[('a', 'S3')])

In [4]: fits.writeto('bug.fits', r)

In [5]: fits.getdata('bug.fits')
Out[5]: 
FITS_rec([('abc')], 
      dtype=(numpy.record, [('a', 'S3')]))

In [6]: with fits.open('bug.fits', mode='update') as f:
   ...:     f[1].data['a'][0] = 'XYZ'
   ...:     print(f[1].data)
   ...:     
[('XYZ')]

In [7]: fits.getdata('bug.fits')
Out[7]: 
FITS_rec([('abc')], 
      dtype=(numpy.record, [('a', 'S3')]))
```

This is a pretty critical bug since it can result in data loss, so I would like to get some patch releases out as soon as it's fixed.  I'm just mystified that none of the copious table tests caught it.

Incidentally, I believe I was previously aware of this issue.  It comes from the new [`_ascii_encode`](https://github.com/astropy/astropy/pull/4228/files#diff-703b4b625a97b7b26058e3e859bfe8d8R1225) function introduced in #4228, which is supposed to be able to update an array in-place.  However, right at the beginning of the function it calls `.flatten()` on the operands, which (to my surprise) *always* makes a copy (as opposed to a view).  This was in order to support a case where the input and output operands were different shapes.  This could happen in the case of supporting `TDIMn` keywords.  

This is actually what originally motivated me, as part of the same PR, to go ahead and change how `TDIMn` keywords are handled (in fdc1501454300c2db3d7d06063604e80f2a61fcb) such that the input and output arrays do *not* have different shapes.  That would allow me to fix `_ascii_encode` to not use `.flatten()`.  But it seems I forgot to actually go back and fix that--I became mostly focused on the `TDIMn` changes and forgot all about it.