### PR TITLE
Update testing for 1.2, moving to 3.5 by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,11 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
+        - PYTHON_VERSION=3.5
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautiful-soup ipython'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython'
         - PIP_DEPENDENCIES=''
 
     matrix:
@@ -41,8 +42,7 @@ matrix:
 
         # Try MacOS X
         - os: osx
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. WCSAxes is a dependency for the docs.
@@ -51,51 +51,45 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='wcsaxes --no-deps'
 
-        # Try all python versions with the latest numpy, but without the
-        # optional dependencies
+        # Try the full monty, with all optional dependencies on an appropriate
+        # 3.x build (noting the coverage) and on 2.7, both with latest numpy.
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.3 SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --open-files'
-
-        # Now try with all optional dependencies on 2.7 and an appropriate 3.x
-        # build (with latest numpy). We also note the code coverage on Python
-        # 2.7.
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage'
+          env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph'
                LC_CTYPE=C.ascii LC_ALL=C.ascii
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
         - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                LC_CTYPE=C.ascii LC_ALL=C.ascii
 
-        # Try older numpy versions without optional dependencies
+        # Try other python versions with the latest numpy that they support,
+        # but without the optional dependencies
+        - os: linux
+          env: PYTHON_VERSION=3.4 SETUP_CMD='test --open-files'
+        - os: linux
+          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.9 SETUP_CMD='test --open-files'
+        # Try older numpy versions on python 2.7, without optional dependencies
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test'
 
-        # Try developer version of Numpy without optional dependencies
+        # test with numpy development; we allow this one to fail below, since
+        # we want to know when there are problems, but not necessarily be unable
+        # to move forward ourselves.
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
+          env: NUMPY_VERSION=dev SETUP_CMD='test'
 
         # Do a PEP8 test
         - os: linux
-          env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
+          env: MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
 
     allow_failures:
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
+        - env: NUMPY_VERSION=dev SETUP_CMD='test'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
This is an alternative to #4225, in which I tried to make a mininal set and move to python 3. For this purpose, I made an explicit python 3.5 default, and removed the non-dependency tests on 2.7 and 3.5 (since those tests are already done with dependencies anyway). 

Now see if it actually passes...