### PR TITLE
Implement a generic way of merging metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ New Features
 
 - ``astropy.utils``
 
+  - Implemented a generic and extensible way of merging metadata. [#4459]
+
 - ``astropy.visualization``
 
 - ``astropy.vo``

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -25,7 +25,8 @@ class MergeConflictWarning(AstropyWarning):
     pass
 
 
-MERGE_STRATEGY_CLASSES = []
+MERGE_STRATEGIES = []
+
 
 def common_dtype(arrs):
     """
@@ -67,7 +68,7 @@ def common_dtype(arrs):
 class MergeStrategyMeta(type):
     """
     Metaclass that registers MergeStrategy subclasses into the
-    MERGE_STRATEGY_CLASSES registry.
+    MERGE_STRATEGIES registry.
     """
 
     def __new__(mcls, name, bases, members):
@@ -92,24 +93,75 @@ class MergeStrategyMeta(type):
             if isinstance(types, tuple):
                 types = [types]
             for left, right in reversed(types):
-                MERGE_STRATEGY_CLASSES.insert(0, (left, right, cls))
+                MERGE_STRATEGIES.insert(0, (left, right, cls))
 
         return cls
 
 
 @six.add_metaclass(MergeStrategyMeta)
 class MergeStrategy(object):
-    # Set ``enabled = True`` to globally enable applying this merge strategy
+    """
+    Base class for defining a strategy for merging metadata from two
+    sources, left and right, into a single output.
+
+    The primary functionality for the class is the ``merge(cls, left, right)``
+    class method.  This takes ``left`` and ``right`` side arguments and
+    returns a single merged output.
+
+    The first class attribute is ``types``.  This is defined as a list of
+    (left_types, right_types) tuples that indicate for which input types the
+    merge strategy applies.  In determining whether to apply this merge
+    strategy to a pair of (left, right) objects, a test is done:
+    ``isinstance(left, left_types) and isinstance(right, right_types)``.  For
+    example::
+
+      types = [(np.ndarray, np.ndarray),  # Two ndarrays
+               (np.ndarray, (list, tuple)),  # ndarray and (list or tuple)
+               ((list, tuple), np.ndarray)]  # (list or tuple) and ndarray
+
+    As a convenience, ``types`` can be defined as a single two-tuple instead of
+    a list of two-tuples, e.g. ``types = (np.ndarray, np.ndarray)``.
+
+    The other class attribute is ``enabled``, which defaults to ``False`` in
+    the base class.  By defining a subclass of ``MergeStrategy`` the new merge
+    strategy is automatically registered to be available for use in
+    merging. However, by default the new merge strategy is *not enabled*.  This
+    prevents inadvertently changing the behavior of unrelated code that is
+    performing metadata merge operations.
+
+    In most cases (particularly in library code that others might use) it is
+    recommended to leave custom strategies disabled and use the
+    `~astropy.utils.metadata.enable_merge_strategy` context manager to locally
+    enable the desired strategies.  However, if one is confident that the
+    new strategy will not produce unexpected behavior, then one can globally
+    enable it by setting the ``enabled`` class attribute to ``True``.
+
+    Examples
+    --------
+    Here we define a custom merge strategy that takes an int or float on
+    the left and right sides and returns a list with the two values.
+
+      >>> from astropy.utils.metadata import MergeStrategy
+      >>> class MergeNumbersAsList(MergeStrategy):
+      ...     types = ((int, float), (int, float))  # (left_types, right_types)
+      ...
+      ...     @classmethod
+      ...     def merge(cls, left, right):
+      ...         return [left, right]
+
+    """
+    # Set ``enabled = True`` to globally enable applying this merge strategy.
+    # This is not generally recommended.
     enabled = False
 
+    # types = [(left_types, right_types), ...]
 
 class MergePlus(MergeStrategy):
     """
     Merge ``left`` and ``right`` objects using the plus operator.  This
     merge strategy is globally enabled by default.
     """
-    types = [(list, list),
-             (tuple, tuple)]
+    types = [(list, list), (tuple, tuple)]
     enabled = True
 
     @classmethod
@@ -148,6 +200,82 @@ def _not_equal(left, right):
         return True
 
 
+class _EnableMergeStrategies(object):
+    def __init__(self, *merge_strategies):
+        self.merge_strategies = merge_strategies
+        self.orig_enabled = {}
+        for left_type, right_type, merge_strategy in MERGE_STRATEGIES:
+            if issubclass(merge_strategy, merge_strategies):
+                self.orig_enabled[merge_strategy] = merge_strategy.enabled
+                merge_strategy.enabled = True
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, tb):
+        for merge_strategy, enabled in self.orig_enabled.items():
+            merge_strategy.enabled = enabled
+
+
+def enable_merge_strategies(*merge_strategies):
+    """
+    Context manager to temporarily enable one or more custom metadata merge
+    strategies.
+
+    Examples
+    --------
+    Here we define a custom merge strategy that takes an int or float on
+    the left and right sides and returns a list with the two values.
+
+      >>> from astropy.utils.metadata import MergeStrategy
+      >>> class MergeNumbersAsList(MergeStrategy):
+      ...     types = ((int, float),  # left side types
+      ...              (int, float))  # right side types
+      ...     @classmethod
+      ...     def merge(cls, left, right):
+      ...         return [left, right]
+
+    By defining this class the merge strategy is automatically registered to be
+    available for use in merging. However, by default new merge stratgies are
+    *not enabled*.  This prevents inadvertently changing the behavior of
+    unrelated code that is performing metadata merge operations.
+
+    In order to use the new merge strategy, use this context manager as in the
+    following example::
+
+      >>> from astropy.table import Table, vstack
+      >>> from astropy.utils.metadata import enable_merge_strategies
+      >>> t1 = Table([[1]], names=['a'])
+      >>> t2 = Table([[2]], names=['a'])
+      >>> t1.meta = {'m': 1}
+      >>> t2.meta = {'m': 2}
+      >>> with enable_merge_strategies(MergeNumbersAsList):
+      ...    t12 = vstack([t1, t2])
+      >>> t12.meta['m']
+      [1, 2]
+
+    One can supply further merge strategies as additional arguments to the
+    context manager.
+
+    As a convenience, the enabling operation is actually done by checking
+    whether the registered strategies are subclasses of the context manager
+    arguments.  This means one can define a related set of merge strategies and
+    then enable them all at once by enabling the base class.  As a trivial
+    example, *all* registered merge strategies can be enabled with::
+
+      >>> with enable_merge_strategies(MergeStrategy):
+      ...    t12 = vstack([t1, t2])
+
+    Parameters
+    ----------
+    merge_strategies: one or more `~astropy.utils.metadata.MergeStrategy` args
+        Merge strategies that will be enabled.
+
+    """
+
+    return _EnableMergeStrategies(*merge_strategies)
+
+
 def merge(left, right, merge_func=None, metadata_conflicts='warn'):
     """
     Merge the ``left`` and ``right`` metadata objects.
@@ -173,7 +301,7 @@ def merge(left, right, merge_func=None, metadata_conflicts='warn'):
         else:
             try:
                 if merge_func is None:
-                    for left_type, right_type, merge_cls in MERGE_STRATEGY_CLASSES:
+                    for left_type, right_type, merge_cls in MERGE_STRATEGIES:
                         if not merge_cls.enabled:
                             continue
                         if (isinstance(left[key], left_type) and

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This module contains helper functions for handling metadata.
+This module contains helper functions and classes for handling metadata.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -16,6 +16,10 @@ from copy import deepcopy
 import numpy as np
 from ..utils.exceptions import AstropyWarning
 
+
+__all__ = ['MergeConflictError', 'MergeConflictWarning', 'MERGE_STRATEGIES',
+           'common_dtype', 'MergePlus', 'MergeNpConcatenate', 'MergeStrategy',
+           'MergeStrategyMeta', 'enable_merge_strategies', 'merge', 'MetaData']
 
 class MergeConflictError(TypeError):
     pass
@@ -33,12 +37,12 @@ def common_dtype(arrs):
     Use numpy to find the common dtype for a list of ndarrays.
 
     Only allow arrays within the following fundamental numpy data types:
-    np.bool_, np.object_, np.number, np.character, np.void
+    ``np.bool``, ``np.object``, ``np.number``, ``np.character``, ``np.void``
 
     Parameters
     ----------
     arrs: list of ndarray objects
-
+        Arrays for which to find the common dtype
     """
     def dtype(arr):
         return getattr(arr, 'dtype', np.dtype('O'))
@@ -131,7 +135,7 @@ class MergeStrategy(object):
 
     In most cases (particularly in library code that others might use) it is
     recommended to leave custom strategies disabled and use the
-    `~astropy.utils.metadata.enable_merge_strategy` context manager to locally
+    `~astropy.utils.metadata.enable_merge_strategies` context manager to locally
     enable the desired strategies.  However, if one is confident that the
     new strategy will not produce unexpected behavior, then one can globally
     enable it by setting the ``enabled`` class attribute to ``True``.

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -141,22 +141,6 @@ class MergeNpConcatenate(MergeStrategy):
         return np.concatenate([left, right])
 
 
-def take_left(left, right):
-    return left
-
-
-def take_right(left, right):
-    return left
-
-
-def raise_error(left, right):
-    """
-    Raise a MergeConflictError if left and right sequences
-    are being merged.
-    """
-    raise MergeConflictError()
-
-
 def _both_isinstance(left, right, cls):
     return isinstance(left, cls) and isinstance(right, cls)
 

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -849,6 +849,12 @@ By default, a warning is emitted in the last case (both metadata values are not
 - ``'warn'`` - a warning is emitted, the value for the last table is picked
 - ``'error'`` - an exception is raised
 
+The default strategies for merging metadata can be augmented or customized by
+defining subclasses of the `~astropy.utils.metadata.MergeStrategy` base class.
+In most cases one also will use the
+`~astropy.utils.metadata.enable_merge_strategies` for enable the custom
+strategies. The linked documentation strings provide details.
+
 Merging column attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -34,19 +34,7 @@ Reference/API
 =============
 .. module:: astropy.utils
 
-.. automodapi:: astropy.utils.misc
-    :no-inheritance-diagram:
-
-.. automodapi:: astropy.utils.decorators
-    :no-inheritance-diagram:
-
 .. automodapi:: astropy.utils.codegen
-    :no-inheritance-diagram:
-
-.. automodapi:: astropy.utils.introspection
-    :no-inheritance-diagram:
-
-.. automodapi:: astropy.utils.exceptions
     :no-inheritance-diagram:
 
 .. automodapi:: astropy.utils.collections
@@ -55,10 +43,25 @@ Reference/API
 .. automodapi:: astropy.utils.console
     :no-inheritance-diagram:
 
-.. automodapi:: astropy.utils.timer
+.. automodapi:: astropy.utils.decorators
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.exceptions
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.introspection
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.metadata
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.misc
     :no-inheritance-diagram:
 
 .. automodapi:: astropy.utils.state
+    :no-inheritance-diagram:
+
+.. automodapi:: astropy.utils.timer
     :no-inheritance-diagram:
 
 


### PR DESCRIPTION
Inspired by #4455, this PR implements a completely new way of merging metadata.  It uses a class-based system to define discrete merge strategies for each pair of object types.  This is still conservative in the sense of being essentially a whitelist of allowed merging, so for example if you have a `list` and `list` then it can be merged with `left + right`.

This PR does make the merging somewhat less restrictive by now allowing an `ndarray` and `list, tuple` to be merged, resulting in an `ndarray`.  As shown in the tests, this allows custom strategies like merging two `int` objects into a list of `int`.

Since the registry of merge strategies is global, there is a way to disable strategies via the `enabled` class attribute.

I thought about (and partly implemented) as simpler system that just uses a registry of merge `functions`, but in the end decided it ends up being worth using the full class system.  I still have a dream of specialized FITS merging (like what happens in CIAO dmmerge), and in this case it would likely be very convenient to be able to subclass.

To do:

- [x] Docs
- [ ] Changelog
- [ ] Deprecate the `merge_func` argument to `merge`?