### PR TITLE
Travis: Remove Python 2.6 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
         - PIP_DEPENDENCIES=''
 
     matrix:
-        - PYTHON_VERSION=2.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
@@ -54,8 +53,6 @@ matrix:
 
         # Try all python versions with the latest numpy, but without the
         # optional dependencies
-        - os: linux
-          env: PYTHON_VERSION=2.6 SETUP_CMD='test --open-files'
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --open-files'
         - os: linux


### PR DESCRIPTION
Since there is likely to be more discussion in https://github.com/astropy/astropy/pull/4456 and https://github.com/astropy/astropy/pull/4225, I'm opening a super-simple PR to remove Python 2.6 since we know for sure this has to be done. We can then discuss details about Numpy versions etc in the other two PRs.

cc @mhvk @eteq