### PR TITLE
Bugfix for issue 2594

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@ New Features
 - ``astropy.nddata``
 
 - ``astropy.stats``
- 
+
   - Added ``jackknife`` resampling method. [#3708]
 
   - Updated ``bootstrap`` to allow bootstrapping statistics with multiple
@@ -2389,6 +2389,10 @@ Bug Fixes
     returns an ``OrderedDict`` instead of just a ``dict``. [#2845]
 
 - ``astropy.io.fits``
+
+  - Fixed a crash when Delete of a non-existent CompImageHDU header keyword
+    raises KeyError and Fixed a crash when Delete of a non-existent ImageHDU
+    header keyword raises warning. [#2594]
 
   - Fixed a crash when reading scaled float data out of a FITS file that was
     loaded from a string (using ``HDUList.fromfile``) rather than from a file.

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -159,10 +159,10 @@ class CompImageHeader(Header):
         else:
             keyword, index = key, None
 
-        if key not in self:
-            raise KeyError("Keyword %r not found." % key)
+        # if key exist in self then call headerfile  __delitem__  method
+        if key in self:
+            super(CompImageHeader, self).__delitem__(key)
 
-        super(CompImageHeader, self).__delitem__(key)
 
         remapped_keyword = self._remap_keyword(keyword)
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -225,17 +225,7 @@ class Header(object):
                     # All internal code is designed to assume that this will
                     # raise a KeyError, so go ahead and do so
                     raise KeyError("Keyword '%s' not found." % key)
-                # Warn everyone else.
-                # TODO: Remove this warning and make KeyError the default after
-                # a couple versions (by 3.3, say)
-                warnings.warn(
-                    'Deletion of non-existent keyword %r: '
-                    'In a future Astropy version Header.__delitem__ may be '
-                    'changed so that this raises a KeyError just like a dict '
-                    'would. Please update your code so that KeyErrors are '
-                    'caught and handled when deleting non-existent keywords.' %
-                    key, AstropyDeprecationWarning)
-                return
+
             for idx in reversed(indices[key]):
                 # Have to copy the indices list since it will be modified below
                 del self[idx]


### PR DESCRIPTION
Fixed a crash when Delete of a non-existent CompImageHDU header keyword raises KeyError and Fixed a crash when Delete of a non-existent ImageHDU header keyword raises warning.

Fixes #2594.