### PR TITLE
Circstats issue3705

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,8 @@ New Features
 
   - Added Bayesian upper limits for Poisson count rates. [#4622]
   
+  - Added ``circstats``; a module for computing circular statistics. [#3705]
+
   - Added ``jackknife`` resampling method. [#3708]
 
   - Updated ``bootstrap`` to allow bootstrapping statistics with multiple

--- a/astropy/stats/__init__.py
+++ b/astropy/stats/__init__.py
@@ -14,5 +14,6 @@ astronomers' needs.
 from .funcs import *
 from .sigma_clipping import *
 from .jackknife import *
+from .circstats import *
 from .bayesian_blocks import *
 from .histogram import *

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -78,16 +78,16 @@ def circmean(data, w=None, axis=None):
     >>> import numpy as np
     >>> from astropy.stats.circstats import circmean
     >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
-    >>> circmean(data)
-    0.848704
+    >>> circmean(data) # doctest: +FLOAT_CMP
+    0.84870441244501904
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     return _angle(data,w,1,0.0,axis)
@@ -122,16 +122,16 @@ def circvar(data, w=None, axis=None):
     >>> import numpy as np
     >>> from astropy.stats.circstats import circvar
     >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
-    >>> circvar(data)
-    0.163563
+    >>> circvar(data) # doctest: +FLOAT_CMP
+    0.16356352748437508
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
     return 1.0 - _length(data,w,1,0.0,axis)
 
@@ -168,16 +168,16 @@ def circmoment(data, w=None, p=1, centered=False, axis=None):
     >>> import numpy as np
     >>> from astropy.stats.circstats import circmoment
     >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
-    >>> circmoment(data, p=2)
-    (1.588121, 0.480042)
+    >>> circmoment(data, p=2) # doctest: +FLOAT_CMP
+    (1.5881210029361645, 0.48004283892950717)
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     phi = 0.0
@@ -226,16 +226,16 @@ def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None,
     >>> beta = np.deg2rad(np.array([119, 162, 221, 259, 270, 29, 97, 292, 40,
     ...                             313, 94, 45, 47, 108, 221, 270, 119, 248,
     ...                             270, 45, 23]))
-    >>> circcorcoef(alpha, beta)
-    0.270464
+    >>> circcorrcoef(alpha, beta) # doctest: +FLOAT_CMP
+    0.27046488267488311
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     alpha = np.asarray(alpha)
@@ -292,16 +292,16 @@ def rayleightest(data, w=None, axis=None):
     ...                  3.0859854, 4.0566486, 2.3463984, 3.7370984, 5.6853310,
     ...                  5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
     ...                  3.5295258, 3.0162183, 3.2317242, 3.2778354, 3.1713455])
-    >>> rayleightest(data)
-    2.726928e-13
+    >>> rayleightest(data) # doctest: +FLOAT_CMP
+    2.726928722464598e-13
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     data = np.asarray(data)
@@ -346,16 +346,16 @@ def vtest(data, w=None, mu=0.0, axis=None):
     >>> from astropy.stats.circstats import vtest
     >>> data = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
     ...                  1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
-    >>> vtest(data)
-    0.987142
+    >>> vtest(data) # doctest: +FLOAT_CMP
+    0.98714203652055577
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     from scipy.stats import norm
@@ -411,16 +411,16 @@ def vonmisesmle(data, axis=None):
     >>> from astropy.stats.circstats import vonmisesmle
     >>> data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
     ...                  1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
-    >>> vonmisesmle(data)
-    (3.006514, 1.474132)
+    >>> vonmisesmle(data) # doctest: +FLOAT_CMP
+    (3.0065143178219063, 1.474132390391715)
 
     References
     ----------
-    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
-        Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
-        Circular Statistics (2001)'". 2015.
-        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    .. [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+       Series on Multivariate Analysis, Vol. 5, 2001.
+    .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+       Circular Statistics (2001)'". 2015.
+       <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     data = np.asarray(data)
@@ -460,17 +460,17 @@ def vonmisescrlb(data, axis=None):
     Examples
     --------
     >>> import numpy as np
-    >>> from astropy.stats.circstats import vonmisesmle
+    >>> from astropy.stats.circstats import vonmisescrlb
     >>> data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
     ...                  1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
-    >>> vonmisescrlb(data)
-    array([ 0.115040,  0.396398])
+    >>> vonmisescrlb(data) # docstest: +FLOAT_CMP
+    array([ 0.11504084,  0.39639812])
 
     References
     ----------
-    ..  [1] D. L. Dowe et. al.. "Bayesian Estimation of the von Mises
-        Concentration Parameter". Proceedings of the Fifteenth International
-        Workshop on Maximum Entropy and Bayesian Methods. doi=10.1.1.48.5719
+    .. [1] D. L. Dowe et. al.. "Bayesian Estimation of the von Mises
+       Concentration Parameter". Proceedings of the Fifteenth International
+       Workshop on Maximum Entropy and Bayesian Methods. doi=10.1.1.48.5719
     """
 
     n = np.size(data, axis)

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -13,7 +13,8 @@ are based on reference [1], which is also the basis for the R package
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-
+from astropy.units import Quantity
+from astropy import units as u
 
 __all__ = ['circmean', 'circvar', 'circmoment', 'circcorrcoef', 'rayleightest',
            'vtest', 'vonmisesmle']
@@ -30,7 +31,9 @@ def _components(data, deg=False, w=None, p=1, phi=0.0, axis=None):
                          % (w.shape, data.shape,))
 
     if deg:
-        data = np.deg2rad(data)
+        data = Quantity(data, u.deg)
+    else:
+        data = Quantity(data, u.rad)
 
     C = np.sum(w * np.cos(p * (data - phi)), axis)/np.sum(w, axis)
     S = np.sum(w * np.sin(p * (data - phi)), axis)/np.sum(w, axis)
@@ -91,9 +94,9 @@ def circmean(data, deg=False, w=None, axis=None):
     >>> data_deg = np.array([51, 67, 40, 109, 31, 358])
     >>> data_rad = np.deg2rad(data_deg)
     >>> circmean(data_rad) # doctest: +FLOAT_CMP
-    0.84870441244501904
+    <Quantity 0.848704412445019 rad>
     >>> circmean(data_deg, deg=True) # doctest: +FLOAT_CMP
-    48.627180887229891
+    <Quantity 48.62718088722989 deg>
     >>> from astropy import units as u
     >>> circmean(data_deg*u.deg, deg=True) # doctest: +FLOAT_CMP
     <Quantity 48.62718088722989 deg>
@@ -146,9 +149,9 @@ def circvar(data, deg=False, w=None, axis=None):
     >>> data_deg = np.array([51, 67, 40, 109, 31, 358])
     >>> data_rad = np.deg2rad(data_deg)
     >>> circvar(data_rad) # doctest: +FLOAT_CMP
-    0.16356352748437508
+    <Quantity 0.16356352748437508>
     >>> circvar(data_deg, deg=True) # doctest: +FLOAT_CMP
-    0.16356352748437508
+    <Quantity 0.16356352748437508>
     >>> from astropy import units as u
     >>> circvar(data_rad*u.rad) # doctest: +FLOAT_CMP
     <Quantity 0.16356352748437508>
@@ -206,9 +209,9 @@ def circmoment(data, deg=False, w=None, p=1.0, centered=False, axis=None):
     >>> data_deg = np.array([51, 67, 40, 109, 31, 358])
     >>> data_rad = np.deg2rad(data_deg)
     >>> circmoment(data_rad, p=2) # doctest: +FLOAT_CMP
-    (1.5881210029361645, 0.48004283892950717)
+    (<Quantity 1.5881210029361645 rad>, <Quantity 0.48004283892950717>)
     >>> circmoment(data_deg,deg=True,p=2) # doctest: +FLOAT_CMP
-    (90.992630824325644, 0.48004283892950717)
+    (<Quantity 90.99263082432564 deg>, <Quantity 0.48004283892950717>)
     >>> from astropy import units as u
     >>> circmoment(data_rad*u.rad,p=2) # doctest: +FLOAT_CMP
     (<Quantity 1.5881210029361645 rad>, <Quantity 0.48004283892950717>)
@@ -276,9 +279,9 @@ def circcorrcoef(alpha, beta, deg=False, w_alpha=None, w_beta=None,
     >>> alpha_rad = np.deg2rad(alpha_deg)
     >>> beta_rad = np.deg2rad(beta_deg)
     >>> circcorrcoef(alpha_rad, beta_rad) # doctest: +FLOAT_CMP
-    0.27046488267488311
+    <Quantity 0.2704648826748831>
     >>> circcorrcoef(alpha_deg, beta_deg, deg=True) # doctest: +FLOAT_CMP
-    0.27046488267488311
+    <Quantity 0.2704648826748831>
     >>> from astropy import units as u
     >>> circcorrcoef(alpha_rad*u.rad, beta_rad*u.rad) # doctest: +FLOAT_CMP
     <Quantity 0.2704648826748831>
@@ -298,11 +301,14 @@ def circcorrcoef(alpha, beta, deg=False, w_alpha=None, w_beta=None,
         raise ValueError("alpha and beta must be arrays of the same size")
 
     if deg:
-        alpha = np.deg2rad(alpha)
-        beta = np.deg2rad(beta)
+        alpha = Quantity(alpha, u.deg)
+        beta = Quantity(beta, u.deg)
+    else:
+        alpha = Quantity(alpha, u.rad)
+        beta = Quantity(beta, u.rad)
 
-    mu_a = circmean(alpha, False, w_alpha, ax_alpha)
-    mu_b = circmean(beta, False, w_beta, ax_beta)
+    mu_a = circmean(alpha, deg, w_alpha, ax_alpha)
+    mu_b = circmean(beta, deg, w_beta, ax_beta)
 
     sin_a = np.sin(alpha - mu_a)
     sin_b = np.sin(beta - mu_b)
@@ -362,9 +368,9 @@ def rayleightest(data, deg=False, w=None, axis=None):
     ...                      3.2778354, 3.1713455])
     >>> data_deg = np.rad2deg(data_rad)
     >>> rayleightest(data_rad) # doctest: +FLOAT_CMP
-    2.726928722464598e-13
+    <Quantity 2.726928722464598e-13>
     >>> rayleightest(data_deg, deg=True) # doctest: +FLOAT_CMP
-    2.726928722464598e-13
+    <Quantity 2.726928722464598e-13>
     >>> from astropy import units as u
     >>> rayleightest(data_rad*u.rad) # doctest: +FLOAT_CMP
     <Quantity 2.726928722464598e-13>
@@ -429,17 +435,14 @@ def vtest(data, deg=False, w=None, mu=0.0, axis=None):
     --------
     >>> import numpy as np
     >>> from astropy.stats import vtest
+    >>> from astropy import units as u
     >>> data_rad = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
-    ...                      1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
+    ...                      1.756324, 3.046718, 3.299150, 3.360557,
+    ...                      4.842499])*u.rad
     >>> data_deg = np.rad2deg(data_rad)
     >>> vtest(data_rad) # doctest: +FLOAT_CMP
-    0.98714203652055577
-    >>> vtest(data_deg, deg=True) # doctest +FLOAT_CMP
-    0.98714203652055577
-    >>> from astropy import units as u
-    >>> vtest(data_rad*u.rad) # doctest +FLOAT_CMP
     <Quantity 0.9871420365205558>
-    >>> vtest(data_deg*u.deg, deg=True) # doctest +FLOAT_CMP
+    >>> vtest(data_deg, deg=True) # doctest +FLOAT_CMP
     <Quantity 0.9871420365205558>
 
     References
@@ -461,10 +464,6 @@ def vtest(data, deg=False, w=None, mu=0.0, axis=None):
                          % (w.shape, data.shape,))
 
     n = np.size(data, axis=axis)
-
-    if deg:
-        data = np.deg2rad(data)
-        mu = np.deg2rad(mu)
 
     R0bar = np.sum(w*np.cos(data-mu), axis)/np.sum(w, axis)
     z = np.sqrt(2.0*n)*R0bar
@@ -521,9 +520,9 @@ def vonmisesmle(data, deg=False, axis=None):
     ...                      2.4672173, 2.8493644])
     >>> data_deg = np.rad2deg(data_rad)
     >>> vonmisesmle(data_rad) # doctest: +FLOAT_CMP
-    (3.0065143178219063, 1.474132390391715)
+    (<Quantity 3.0065143178219063 rad>, <Quantity 1.474132390391715>)
     >>> vonmisesmle(data_deg, deg=True) # doctest: +FLOAT_CMP
-    (172.26058145684905, 1.474132390391715)
+    (<Quantity 172.26058145684905 deg>, <Quantity 1.474132390391715>)
     >>> from astropy import units as u
     >>> vonmisesmle(data_rad*u.rad) # doctest: +FLOAT_CMP
     (<Quantity 3.0065143178219063 rad>, <Quantity 1.474132390391715>)
@@ -541,10 +540,13 @@ def vonmisesmle(data, deg=False, axis=None):
     mu = circmean(data, deg, axis=None)
 
     if deg:
-        data = np.deg2rad(data)
-        mu_rad = np.deg2rad(mu)
+        #data = np.deg2rad(data)
+        #mu_rad = np.deg2rad(mu)
+        data = Quantity(data, u.deg)
+        mu = Quantity(mu, u.deg)
     else:
-        mu_rad = mu
+        data = Quantity(data, u.rad)
+        mu = Quantity(mu, u.rad)
 
-    kappa = _A1inv(np.mean(np.cos(data - mu_rad), axis))
+    kappa = _A1inv(np.mean(np.cos(data - mu), axis))
     return mu, kappa

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -63,7 +63,7 @@ def circmean(data, axis=None, weights=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data : numpy.ndarray or Quantity
         Array of circular (directional) data.
     axis : int, optional
         Axis along which circular means are computed. The default is to compute
@@ -76,7 +76,7 @@ def circmean(data, axis=None, weights=None):
 
     Returns
     -------
-    circmean : Quantity
+    circmean : numpy.ndarray or Quantity
         Circular mean.
 
     Examples
@@ -108,7 +108,7 @@ def circvar(data, axis=None, weights=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data : numpy.ndarray or dimensionless Quantity
         Array of circular (directional) data.
     axis : int, optional
         Axis along which circular variances are computed. The default is to
@@ -121,7 +121,7 @@ def circvar(data, axis=None, weights=None):
 
     Returns
     -------
-    circvar : Quantity
+    circvar : numpy.ndarray or dimensionless Quantity
         Circular variance.
 
     Examples
@@ -157,7 +157,7 @@ def circmoment(data, p=1.0, centered=False, axis=None, weights=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data : numpy.ndarray or Quantity
         Array of circular (directional) data.
     p : float, optional
         Order of the circular moment.
@@ -175,7 +175,7 @@ def circmoment(data, p=1.0, centered=False, axis=None, weights=None):
 
     Returns
     -------
-    circmoment: Quantity
+    circmoment: numpy.ndarray or Quantity
         The first and second elements correspond to the direction and length of
         the ``p``-th circular moment, respectively.
 
@@ -212,9 +212,9 @@ def circcorrcoef(alpha, beta, axis=None, weights_alpha=None,
 
     Parameters
     ----------
-    alpha : numpy.ndarray
+    alpha : numpy.ndarray or Quantity
         Array of circular (directional) data.
-    beta : numpy.ndarray
+    beta : numpy.ndarray or Quantity
         Array of circular (directional) data.
     axis : int, optional
         Axis along which circular correlation coefficients are computed.
@@ -230,7 +230,7 @@ def circcorrcoef(alpha, beta, axis=None, weights_alpha=None,
 
     Returns
     -------
-    rho : Quantity
+    rho : numpy.ndarray or dimensionless Quantity
         Circular correlation coefficient.
 
     Examples
@@ -281,7 +281,7 @@ def rayleightest(data, axis=None, weights=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data : numpy.ndarray or Quantity
         Array of circular (directional) data.
     axis : int, optional
         Axis along which the Rayleigh test will be performed.
@@ -293,7 +293,7 @@ def rayleightest(data, axis=None, weights=None):
 
     Returns
     -------
-    p-value : float
+    p-value : float or dimensionless Quantity
         p-value.
 
     Examples
@@ -339,7 +339,7 @@ def vtest(data, mu=0.0, axis=None, weights=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data : numpy.ndarray or Quantity
         Array of circular (directional) data.
     mu : float, optional
         Mean angle. Assumed to be known.
@@ -353,7 +353,7 @@ def vtest(data, mu=0.0, axis=None, weights=None):
 
     Returns
     -------
-    p-value : float
+    p-value : float or dimensionless Quantity
         p-value.
 
     Examples
@@ -412,16 +412,16 @@ def vonmisesmle(data, axis=None):
 
     Parameters
     ----------
-    data : numpy.ndarray
+    data : numpy.ndarray or Quantity
         Array of circular (directional) data.
     axis : int, optional
         Axis along which the mle will be computed.
 
     Returns
     -------
-    mu : float
+    mu : float or Quantity
         the mean (aka location parameter).
-    kappa : float
+    kappa : float or dimensionless Quantity
         the concentration parameter.
 
     Examples

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -64,15 +64,16 @@ def circmean(data, axis=None, weights=None):
     Parameters
     ----------
     data : numpy.ndarray or Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     axis : int, optional
         Axis along which circular means are computed. The default is to compute
         the mean of the flattened array.
     weights : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a
-        weighting factor for each group such that sum(w,axis) equals the number
-        of observations. See [1], remark 1.4, page 22, for detailed
-        explanation.
+        In case of grouped data, the i-th element of ``weights`` represents a
+        weighting factor for each group such that ``sum(weights, axis)``
+        equals the number of observations. See [1], remark 1.4, page 22, for
+        detailed explanation.
 
     Returns
     -------
@@ -109,15 +110,16 @@ def circvar(data, axis=None, weights=None):
     Parameters
     ----------
     data : numpy.ndarray or dimensionless Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     axis : int, optional
         Axis along which circular variances are computed. The default is to
         compute the variance of the flattened array.
     weights : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a
-        weighting factor for each group such that sum(w,axis) equals the number
-        of observations. See [1], remark 1.4, page 22, for detailed
-        explanation.
+        In case of grouped data, the i-th element of ``weights`` represents a
+        weighting factor for each group such that ``sum(weights, axis)``
+        equals the number of observations. See [1], remark 1.4, page 22, for
+        detailed explanation.
 
     Returns
     -------
@@ -158,7 +160,8 @@ def circmoment(data, p=1.0, centered=False, axis=None, weights=None):
     Parameters
     ----------
     data : numpy.ndarray or Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     p : float, optional
         Order of the circular moment.
     centered : Boolean, optinal
@@ -168,10 +171,10 @@ def circmoment(data, p=1.0, centered=False, axis=None, weights=None):
         Axis along which circular moments are computed. The default is to
         compute the circular moment of the flattened array.
     weights : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a
-        weighting factor for each group such that sum(w,axis) equals the number
-        of observations. See [1], remark 1.4, page 22, for detailed
-        explanation.
+        In case of grouped data, the i-th element of ``weights`` represents a
+        weighting factor for each group such that ``sum(weights, axis)``
+        equals the number of observations. See [1], remark 1.4, page 22, for
+        detailed explanation.
 
     Returns
     -------
@@ -213,18 +216,20 @@ def circcorrcoef(alpha, beta, axis=None, weights_alpha=None,
     Parameters
     ----------
     alpha : numpy.ndarray or Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     beta : numpy.ndarray or Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     axis : int, optional
         Axis along which circular correlation coefficients are computed.
         The default is the compute the circular correlation coefficient of the
         flattened array.
     weights_alpha : numpy.ndarray, optional
         In case of grouped data, the i-th element of ``weights_alpha``
-        represents a weighting factor for each group such that sum(w,axis)
-        equals the number of observations. See [1], remark 1.4, page 22, for
-        detailed explanation.
+        represents a weighting factor for each group such that
+        ``sum(weights_alpha, axis)`` equals the number of observations.
+        See [1], remark 1.4, page 22, for detailed explanation.
     weights_beta : numpy.ndarray, optional
         See description of ``weights_alpha``.
 
@@ -282,7 +287,8 @@ def rayleightest(data, axis=None, weights=None):
     Parameters
     ----------
     data : numpy.ndarray or Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     axis : int, optional
         Axis along which the Rayleigh test will be performed.
     weights : numpy.ndarray, optional
@@ -340,16 +346,17 @@ def vtest(data, mu=0.0, axis=None, weights=None):
     Parameters
     ----------
     data : numpy.ndarray or Quantity
-        Array of circular (directional) data.
-    mu : float, optional
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
+    mu : float or Quantity, optional
         Mean angle. Assumed to be known.
     axis : int, optional
         Axis along which the V test will be performed.
     weights : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a
-        weighting factor for each group such that sum(w,axis) equals the number
-        of observations. See [1], remark 1.4, page 22, for detailed
-        explanation.
+        In case of grouped data, the i-th element of ``weights`` represents a
+        weighting factor for each group such that ``sum(weights, axis)``
+        equals the number of observations. See [1], remark 1.4, page 22, for
+        detailed explanation.
 
     Returns
     -------
@@ -413,7 +420,8 @@ def vonmisesmle(data, axis=None):
     Parameters
     ----------
     data : numpy.ndarray or Quantity
-        Array of circular (directional) data.
+        Array of circular (directional) data, which is assumed to be in
+        radians whenever ``data`` is ``numpy.ndarray``.
     axis : int, optional
         Axis along which the mle will be computed.
 

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -464,6 +464,13 @@ def vtest(data, deg=False, w=None, mu=0.0, axis=None):
                          % (w.shape, data.shape,))
 
     n = np.size(data, axis=axis)
+    
+    if deg:
+        data = Quantity(data, u.deg)
+        mu = Quantity(mu, u.deg)
+    else:
+        data = Quantity(data, u.rad)
+        mu = Quantity(mu, u.rad)
 
     R0bar = np.sum(w*np.cos(data-mu), axis)/np.sum(w, axis)
     z = np.sqrt(2.0*n)*R0bar
@@ -540,13 +547,9 @@ def vonmisesmle(data, deg=False, axis=None):
     mu = circmean(data, deg, axis=None)
 
     if deg:
-        #data = np.deg2rad(data)
-        #mu_rad = np.deg2rad(mu)
         data = Quantity(data, u.deg)
-        mu = Quantity(mu, u.deg)
     else:
         data = Quantity(data, u.rad)
-        mu = Quantity(mu, u.rad)
 
     kappa = _A1inv(np.mean(np.cos(data - mu), axis))
     return mu, kappa

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -380,7 +380,7 @@ def vtest(data, w=None, mu=0.0, axis=None):
 
     pz = norm.cdf(z)
     fz = norm.pdf(z)
-    
+
     # see reference [3]
     p_value = 1 - pz + fz*((3*z - z**3)/(16.0*n) + (15*z + 305*z**3 - 125*z**5
         + 9*z**7)/(4608.0*n*n))

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -17,7 +17,8 @@ import numpy as np
 
 __all__ = ['circmean','circvar', 'circmoment', 'circcorrcoef', 'rayleightest',
            'vtest', 'vonmisesmle', 'vonmisescrlb']
-__doctest_requires__ = {'vtest': ['scipy.stats']}
+__doctest_requires__ = {'vtest': ['scipy.stats'], 
+                        'vonmisescrlb': ['scipy.special']}
 
 
 def _components(data, w=None, p=1, phi=0.0, axis=None):
@@ -71,9 +72,17 @@ def circmean(data, w=None, axis=None):
     -------
     circmean : float
         Circular mean.
-    
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import circmean
+    >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    >>> circmean(data)
+    0.84870441244501904
+ 
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
@@ -107,9 +116,17 @@ def circvar(data, w=None, axis=None):
     -------
     circvar : float
         Circular variance.
-    
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import circvar
+    >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    >>> circvar(data)
+    0.16356352748437508
+ 
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
@@ -145,9 +162,17 @@ def circmoment(data, w=None, p=1, centered=False, axis=None):
     circmoment: np.ndarray
         The first are second elements correspond to the direction and length of
         the ``p``-th circular moment.
-    
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import circmoment
+    >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    >>> circmoment(data, p=2)
+    (1.5881210029361645, 0.48004283892950717)
+
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
@@ -190,9 +215,22 @@ def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None,
     -------
     rho : float
         Circular correlation coefficient
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import circcorcoef
+    >>> alpha = np.deg2rad(np.array([356, 97, 211, 232, 343, 292, 157, 302,
+    ...                              335, 302, 324, 85, 324, 340, 157, 238,
+    ...                              254, 146, 232, 122, 329]))
+    >>> beta = np.deg2rad(np.array([119, 162, 221, 259, 270, 29, 97, 292, 40,
+    ...                             313, 94, 45, 47, 108, 221, 270, 119, 248,
+    ...                             270, 45, 23]))
+    >>> circcorcoef(alpha, beta)
+    0.27046488267488311
     
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
@@ -217,10 +255,10 @@ def rayleightest(data, w=None, axis=None):
     This test is  used to indentify a non-uniform distribution, i.e. it is
     designed for detecting an unimodal deviation from uniformity. More
     precisely, it assumes the following hypotheses:
-        - H0 (null hypothesis): The population is distributed uniformly around
-        the circle.
-        - H1 (alternative hypothesis): The population is not distributed
-        uniformly around the circle.
+    - H0 (null hypothesis): The population is distributed uniformly around the
+    circle.
+    - H1 (alternative hypothesis): The population is not distributed uniformly
+    around the circle.
     Small p-values suggest to reject the null hypothesis.
 
     Parameters
@@ -234,12 +272,29 @@ def rayleightest(data, w=None, axis=None):
         explanation.
     axis : int, optional
         Axis along which the Rayleigh test will be performed.
- 
+
     Returns
     -------
     p-value : float
         p-value.
- 
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import rayleightest
+    >>> data = np.array([3.8955614, 3.1700932, 3.1804325, 2.7887885, 2.9513829,
+    ...                  3.1140079, 4.5052974, 3.7984484, 3.7510773, 2.9764646,
+    ...                  2.2100108, 2.9529469, 2.9722527, 3.5099678, 2.6844710,
+    ...                  4.5020762, 2.9285673, 2.2871037, 3.5805262, 3.4247286,
+    ...                  2.4355773, 3.7549614, 4.1346585, 2.8426607, 3.3291801,
+    ...                  2.5847791, 2.7217270, 3.4323084, 3.3058256, 3.2147845,
+    ...                  2.4918005, 3.4849414, 0.8249985, 3.4881397, 3.2070389,
+    ...                  3.0859854, 4.0566486, 2.3463984, 3.7370984, 5.6853310,
+    ...                  5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
+    ...                  3.5295258, 3.0162183, 3.2317242, 3.2778354, 3.1713455])
+    >>> rayleightest(data)
+    2.726928722464598e-13
+
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
@@ -253,15 +308,15 @@ def rayleightest(data, w=None, axis=None):
     n = np.size(data,axis=axis) 
     Rbar = _length(data,w,1,0.0,axis)
     z = n*Rbar*Rbar 
-    
+
     tmp = 1.0
     if(n < 50):
         tmp = 1.0 + (2.0*z - z*z)/(4.0*n) - (24.0*z - 132.0*z**2.0 +
                 76.0*z**3.0 - 9.0*z**4.0)/(288.0*n*n)
-    
+
     p_value = np.exp(-z)*tmp 
     return p_value
-    
+
 def vtest(data, w=None, mu=0.0, axis=None):
     """ Performs the Rayleigh test of uniformity where the alternative
     hypothesis H1 is assumed to have a known mean angle ``mu``.
@@ -284,9 +339,18 @@ def vtest(data, w=None, mu=0.0, axis=None):
     -------
     p-value : float
         p-value.
-    
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import vtest
+    >>> data = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
+    ...                  1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
+    >>> vtest(data)
+    0.98714203652055577
+
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
@@ -314,7 +378,7 @@ def vtest(data, w=None, mu=0.0, axis=None):
         + 9*z**7)/(4608.0*n*n))
     return p_value
 
-def _A1inv1(x):
+def _A1inv(x):
     # Approximation for _A1inv(x) according R Package 'CircStats'
     if(x >= 0 and x < 0.53):
         return 2.0*x + x*x*x + (5.0*x**5)/6.0
@@ -340,9 +404,18 @@ def vonmisesmle(data, axis=None):
         the mean (aka location parameter).
     kappa : float
         the concentration parameter.
-    
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import vonmisesmle
+    >>> data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
+    ...                  1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
+    >>> vonmisesmle(data)
+    (3.0065143178219063, 1.474132390391715)
+
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
@@ -352,7 +425,7 @@ def vonmisesmle(data, axis=None):
 
     data = np.asarray(data)
     mu = circmean(data, axis=None)
-    kappa = _A1inv1(np.mean(np.cos(data - mu), axis))
+    kappa = _A1inv(np.mean(np.cos(data - mu), axis))
     return mu, kappa
 
 def _A1(x):
@@ -384,8 +457,17 @@ def vonmisescrlb(data, axis=None):
         The first and second elements corresponds to the CRLB of the mean and
         the concentration parameter, respectively.
     
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.stats.circstats import vonmisesmle
+    >>> data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
+    ...                  1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
+    >>> vonmisescrlb(data)
+    array([ 0.11504084,  0.39639812])
+
     References
-    ---------
+    ----------
     ..  [1] D. L. Dowe et. al.. "Bayesian Estimation of the von Mises 
         Concentration Parameter". Proceedings of the Fifteenth International
         Workshop on Maximum Entropy and Bayesian Methods. doi=10.1.1.48.5719
@@ -395,5 +477,5 @@ def vonmisescrlb(data, axis=None):
     mu, kappa = vonmisesmle(data, axis)
 
     det = kappa*n*n*_A1(kappa)*_A1deriv(kappa)
-    crlb = np.array([n*_A1deriv(kappa), kappa*n*_A1(kappa)])/det
+    crlb = (n*_A1deriv(kappa), kappa*n*_A1(kappa))/det
     return crlb

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -17,7 +17,7 @@ import numpy as np
 
 __all__ = ['circmean','circvar', 'circmoment', 'circcorrcoef', 'rayleightest',
            'vtest', 'vonmisesmle', 'vonmisescrlb']
-__doctest_requires__ = {'vtest': ['scipy.stats'], 
+__doctest_requires__ = {'vtest': ['scipy.stats'],
                         'vonmisescrlb': ['scipy.special']}
 
 
@@ -25,13 +25,13 @@ def _components(data, w=None, p=1, phi=0.0, axis=None):
     # Utility function for computing the generalized rectangular components
     # of the circular data.
     data = np.asarray(data)
-   
+ 
     assert type(p) is int
     if w is None:
         w = np.ones(data.shape)
     else:
         assert w.shape == data.shape
-    
+
     C = np.sum(w*np.cos(p*(data-phi)), axis)/np.sum(w, axis)
     S = np.sum(w*np.sin(p*(data-phi)), axis)/np.sum(w, axis)
 
@@ -48,7 +48,7 @@ def _angle(data, w=None, p=1, phi=0.0, axis=None):
     return theta
 
 def _length(data, w=None, p=1, phi=0.0, axis=None):
-    # Utility function for computing the generalized sample length 
+    # Utility function for computing the generalized sample length
     C,S = _components(data,w,p,phi,axis)
     return np.hypot(S,C)
 
@@ -58,9 +58,9 @@ def circmean(data, w=None, axis=None):
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     w : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a 
+        In case of grouped data, the i-th element of ``w`` represents a
         weighting factor for each group such that sum(w,axis) equals the number
         of observations. See [1], remark 1.4, page 22, for detailed
         explanation.
@@ -79,13 +79,13 @@ def circmean(data, w=None, axis=None):
     >>> from astropy.stats.circstats import circmean
     >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
     >>> circmean(data)
-    0.84870441244501904
- 
+    0.848704
+
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
         Circular Statistics (2001)'". 2015.
         <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
@@ -95,23 +95,23 @@ def circmean(data, w=None, axis=None):
 def circvar(data, w=None, axis=None):
     """ Computes the circular variance of an array of circular data.
 
-    There are some concepts for defining measures of dispersion for circular 
+    There are some concepts for defining measures of dispersion for circular
     data. The variance implemented here is based on the definition given by [1]
     , which is also the same used by the R package 'CircStats'.
 
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     w : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a 
+        In case of grouped data, the i-th element of ``w`` represents a
         weighting factor for each group such that sum(w,axis) equals the number
         of observations. See [1], remark 1.4, page 22, for detailed
         explanation.
     axis : int, optional
-        Axis along which circular variances are computed. The default is to 
+        Axis along which circular variances are computed. The default is to
         compute the variance of the flattened array.
-   
+
     Returns
     -------
     circvar : float
@@ -123,8 +123,8 @@ def circvar(data, w=None, axis=None):
     >>> from astropy.stats.circstats import circvar
     >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
     >>> circvar(data)
-    0.16356352748437508
- 
+    0.163563
+
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
@@ -142,21 +142,21 @@ def circmoment(data, w=None, p=1, centered=False, axis=None):
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     w : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a 
+        In case of grouped data, the i-th element of ``w`` represents a
         weighting factor for each group such that sum(w,axis) equals the number
         of observations. See [1], remark 1.4, page 22, for detailed
         explanation.
     p : int, optional
-        Order of the circular moment. Must be integer valued. 
+        Order of the circular moment. Must be integer valued.
     centered : Boolean, optinal
-        If ``True``, central circular moments are computed. Default value is 
+        If ``True``, central circular moments are computed. Default value is
         ``False``.
     axis : int, optional
-        Axis along which circular moments are computed. The default is to 
+        Axis along which circular moments are computed. The default is to
         compute the circular moment of the flattened array.
-   
+
     Returns
     -------
     circmoment: np.ndarray
@@ -169,24 +169,24 @@ def circmoment(data, w=None, p=1, centered=False, axis=None):
     >>> from astropy.stats.circstats import circmoment
     >>> data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
     >>> circmoment(data, p=2)
-    (1.5881210029361645, 0.48004283892950717)
+    (1.588121, 0.480042)
 
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
         Circular Statistics (2001)'". 2015.
         <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
-    
+
     phi = 0.0
     if centered:
         phi = circmean(data,w,axis)
 
     return _angle(data,w,p,phi,axis), _length(data,w,p,phi,axis)
 
-def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None, 
+def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None,
                  ax_beta=None):
     """ Computes the circular correlation coefficient between two array of
     circular data.
@@ -194,19 +194,19 @@ def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None,
     Parameters
     ----------
     alpha : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     beta : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     w_alpha : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w_alpha`` represents a 
+        In case of grouped data, the i-th element of ``w_alpha`` represents a
         weighting factor for each group such that sum(w,axis) equals the number
         of observations. See [1], remark 1.4, page 22, for detailed
         explanation.
     w_beta : numpy.ndarray, optional
         See description of ``w_alpha``.
     ax_alpha : int, optional
-        Axis along which circular correlation coefficients are computed. 
-        The default is the compute the circular correlation coefficient of the 
+        Axis along which circular correlation coefficients are computed.
+        The default is the compute the circular correlation coefficient of the
         flattened array.
     ax_ beta : int, optional
         See description of ``ax_alpha``
@@ -219,7 +219,7 @@ def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from astropy.stats.circstats import circcorcoef
+    >>> from astropy.stats.circstats import circcorrcoef
     >>> alpha = np.deg2rad(np.array([356, 97, 211, 232, 343, 292, 157, 302,
     ...                              335, 302, 324, 85, 324, 340, 157, 238,
     ...                              254, 146, 232, 122, 329]))
@@ -227,13 +227,13 @@ def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None,
     ...                             313, 94, 45, 47, 108, 221, 270, 119, 248,
     ...                             270, 45, 23]))
     >>> circcorcoef(alpha, beta)
-    0.27046488267488311
-    
+    0.270464
+
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
         Circular Statistics (2001)'". 2015.
         <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
@@ -264,9 +264,9 @@ def rayleightest(data, w=None, axis=None):
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     w : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a 
+        In case of grouped data, the i-th element of ``w`` represents a
         weighting factor for each group such that sum(w,axis) equals the number
         of observations. See [1], remark 1.4, page 22, for detailed
         explanation.
@@ -293,40 +293,40 @@ def rayleightest(data, w=None, axis=None):
     ...                  5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
     ...                  3.5295258, 3.0162183, 3.2317242, 3.2778354, 3.1713455])
     >>> rayleightest(data)
-    2.726928722464598e-13
+    2.726928e-13
 
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
         Circular Statistics (2001)'". 2015.
         <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     data = np.asarray(data)
-    n = np.size(data,axis=axis) 
+    n = np.size(data,axis=axis)
     Rbar = _length(data,w,1,0.0,axis)
-    z = n*Rbar*Rbar 
+    z = n*Rbar*Rbar
 
     tmp = 1.0
     if(n < 50):
         tmp = 1.0 + (2.0*z - z*z)/(4.0*n) - (24.0*z - 132.0*z**2.0 +
                 76.0*z**3.0 - 9.0*z**4.0)/(288.0*n*n)
 
-    p_value = np.exp(-z)*tmp 
+    p_value = np.exp(-z)*tmp
     return p_value
 
 def vtest(data, w=None, mu=0.0, axis=None):
     """ Performs the Rayleigh test of uniformity where the alternative
     hypothesis H1 is assumed to have a known mean angle ``mu``.
-    
+
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians. 
+        Array of circular (directional) data measured in radians.
     w : numpy.ndarray, optional
-        In case of grouped data, the i-th element of ``w`` represents a 
+        In case of grouped data, the i-th element of ``w`` represents a
         weighting factor for each group such that sum(w,axis) equals the number
         of observations. See [1], remark 1.4, page 22, for detailed
         explanation.
@@ -334,7 +334,7 @@ def vtest(data, w=None, mu=0.0, axis=None):
         Assumed known mean angle.
     axis : int, optional
         Axis along which the V test will be performed.
-    
+
     Returns
     -------
     p-value : float
@@ -347,26 +347,26 @@ def vtest(data, w=None, mu=0.0, axis=None):
     >>> data = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
     ...                  1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
     >>> vtest(data)
-    0.98714203652055577
+    0.987142
 
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
         Circular Statistics (2001)'". 2015.
         <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
 
     from scipy.stats import norm
-    
+
     if w is None:
         w = np.ones(data.shape)
     else:
         assert w.shape == data.shape
 
     data = np.asarray(data)
-    n = np.size(data,axis=axis) 
+    n = np.size(data,axis=axis)
 
     R0bar = np.sum(w*np.cos(data-mu),axis)/np.sum(w, axis)
     z = np.sqrt(2.0*n)*R0bar
@@ -388,16 +388,16 @@ def _A1inv(x):
         return 1.0/(x*x*x - 4.0*x*x + 3.0*x)
 
 def vonmisesmle(data, axis=None):
-    """ Computes the Maximum Likelihood Estimator (MLE) for the parameters of 
-    the von Mises distribution. 
+    """ Computes the Maximum Likelihood Estimator (MLE) for the parameters of
+    the von Mises distribution.
 
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians.  
+        Array of circular (directional) data measured in radians.
     axis : int, optional
         Axis along which the mle will be computed.
-    
+
     Returns
     -------
     mu : float
@@ -412,13 +412,13 @@ def vonmisesmle(data, axis=None):
     >>> data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
     ...                  1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
     >>> vonmisesmle(data)
-    (3.0065143178219063, 1.474132390391715)
+    (3.006514, 1.474132)
 
     References
     ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
-    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
         Circular Statistics (2001)'". 2015.
         <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
     """
@@ -429,7 +429,7 @@ def vonmisesmle(data, axis=None):
     return mu, kappa
 
 def _A1(x):
-    # Utility function that computes the ratio between the modified Bessel 
+    # Utility function that computes the ratio between the modified Bessel
     # function of first kind of orders one and zero.
     import scipy.special as sps
     return sps.ive(1.0,x)/sps.ive(0.0,x)
@@ -439,24 +439,24 @@ def _A1deriv(x):
     return 1.0 - _A1(x)/x - _A1(x)*_A1(x)
 
 def vonmisescrlb(data, axis=None):
-    """ Computes the Cramer-Rao Lower Bound (CRLB) for the parameters of the 
+    """ Computes the Cramer-Rao Lower Bound (CRLB) for the parameters of the
     von Mises distribution.
-    
+
     Theoreticaly, the Maximum Likelihood Estimator attains the CRLB.
-    
+
     Parameters
     ----------
     data : numpy.ndarray
-        Array of circular (directional) data measured in radians.  
+        Array of circular (directional) data measured in radians.
     axis : int, optional
         Axis along which the mle will be computed.
-    
+
     Returns
     -------
     crlb : numpy.array
         The first and second elements corresponds to the CRLB of the mean and
         the concentration parameter, respectively.
-    
+
     Examples
     --------
     >>> import numpy as np
@@ -464,11 +464,11 @@ def vonmisescrlb(data, axis=None):
     >>> data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
     ...                  1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
     >>> vonmisescrlb(data)
-    array([ 0.11504084,  0.39639812])
+    array([ 0.115040,  0.396398])
 
     References
     ----------
-    ..  [1] D. L. Dowe et. al.. "Bayesian Estimation of the von Mises 
+    ..  [1] D. L. Dowe et. al.. "Bayesian Estimation of the von Mises
         Concentration Parameter". Proceedings of the Fifteenth International
         Workshop on Maximum Entropy and Bayesian Methods. doi=10.1.1.48.5719
     """

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -25,7 +25,7 @@ def _components(data, w=None, p=1, phi=0.0, axis=None):
     # Utility function for computing the generalized rectangular components
     # of the circular data.
     data = np.asarray(data)
- 
+
     assert type(p) is int
     if w is None:
         w = np.ones(data.shape)

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -39,11 +39,11 @@ def _components(data, w=None, p=1, phi=0.0, axis=None):
 def _angle(data, w=None, p=1, phi=0.0, axis=None):
     # Utility function for computing the generalized sample mean angle
     C, S = _components(data, w, p, phi, axis)
-    
+
     # theta will be an angle in the interval [-np.pi, np.pi)
     # [-180, 180)*u.deg in case data is a Quantity
     theta = np.arctan2(S, C)
-    
+
     if isinstance(data, Quantity):
         if data.unit == u'deg':
             theta = np.rad2deg(theta)
@@ -139,7 +139,7 @@ def circvar(data, w=None, axis=None):
     .. [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
        Circular Statistics (2001)'". 2015.
        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
-    
+
     Note
     ----
     The definition used here differs from the one in scipy.stats.circvar.

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -464,7 +464,7 @@ def vtest(data, deg=False, w=None, mu=0.0, axis=None):
                          % (w.shape, data.shape,))
 
     n = np.size(data, axis=axis)
-    
+
     if deg:
         data = Quantity(data, u.deg)
         mu = Quantity(mu, u.deg)

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -1,0 +1,410 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+This module contains simple functions for dealing with circular statistics, for
+instance, mean, variance, standard deviation, correlation coefficient, and so
+on. This module also cover tests of uniformity, e.g the Rayleigh and V0 tests.
+The Maximum Likelihood Estimator for the Von Mises distribution along with the
+Cramer-Rao Lower Bounds are also implemented. Almost all of the implementations
+are based on reference [1], which is also the basis for the R package
+'CircStats'.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import numpy as np
+
+
+__all__ = ['circmean','circvar', 'circmoment', 'circcorrcoef', 'rayleightest',
+           'vtest', 'vonmisesmle', 'vonmisescrlb']
+__doctest_requires__ = {'vtest': ['scipy.stats']}
+
+
+def _components(data, w=None, p=1, phi=0.0, axis=None):
+    # Utility function for computing the generalized rectangular components
+    # of the circular data.
+    data = np.asarray(data)
+   
+    assert type(p) is int
+    if w is None:
+        w = np.ones(data.shape)
+    else:
+        assert w.shape == data.shape
+    
+    C = np.sum(w*np.cos(p*(data-phi)), axis)/np.sum(w, axis)
+    S = np.sum(w*np.sin(p*(data-phi)), axis)/np.sum(w, axis)
+
+    return C,S
+
+def _angle(data, w=None, p=1, phi=0.0, axis=None):
+    # Utility function for computing the generalized sample mean angle
+    C,S = _components(data,w,p,phi,axis)
+    theta = np.arctan2(S,C)
+
+    mask = (S == .0)*(C == .0)
+    if mask.ndim > 0:
+        theta[mask] = np.nan
+    return theta
+
+def _length(data, w=None, p=1, phi=0.0, axis=None):
+    # Utility function for computing the generalized sample length 
+    C,S = _components(data,w,p,phi,axis)
+    return np.hypot(S,C)
+
+def circmean(data, w=None, axis=None):
+    """ Computes the circular mean angle of an array of circular data.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    w : numpy.ndarray, optional
+        In case of grouped data, the i-th element of ``w`` represents a 
+        weighting factor for each group such that sum(w,axis) equals the number
+        of observations. See [1], remark 1.4, page 22, for detailed
+        explanation.
+    axis : int, optional
+        Axis along which circular means are computed. The default is to compute
+        the mean of the flattened array.
+
+    Returns
+    -------
+    circmean : float
+        Circular mean.
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+
+    return _angle(data,w,1,0.0,axis)
+
+def circvar(data, w=None, axis=None):
+    """ Computes the circular variance of an array of circular data.
+
+    There are some concepts for defining measures of dispersion for circular 
+    data. The variance implemented here is based on the definition given by [1]
+    , which is also the same used by the R package 'CircStats'.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    w : numpy.ndarray, optional
+        In case of grouped data, the i-th element of ``w`` represents a 
+        weighting factor for each group such that sum(w,axis) equals the number
+        of observations. See [1], remark 1.4, page 22, for detailed
+        explanation.
+    axis : int, optional
+        Axis along which circular variances are computed. The default is to 
+        compute the variance of the flattened array.
+   
+    Returns
+    -------
+    circvar : float
+        Circular variance.
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+    return 1.0 - _length(data,w,1,0.0,axis)
+
+def circmoment(data, w=None, p=1, centered=False, axis=None):
+    """ Computes the ``p``-th trigonometric circular moment for an array
+    of circular data.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    w : numpy.ndarray, optional
+        In case of grouped data, the i-th element of ``w`` represents a 
+        weighting factor for each group such that sum(w,axis) equals the number
+        of observations. See [1], remark 1.4, page 22, for detailed
+        explanation.
+    p : int, optional
+        Order of the circular moment. Must be integer valued. 
+    centered : Boolean, optinal
+        If ``True``, central circular moments are computed. Default value is 
+        ``False``.
+    axis : int, optional
+        Axis along which circular moments are computed. The default is to 
+        compute the circular moment of the flattened array.
+   
+    Returns
+    -------
+    circmoment: np.ndarray
+        The first are second elements correspond to the direction and length of
+        the ``p``-th circular moment.
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+    
+    phi = 0.0
+    if centered:
+        phi = circmean(data,w,axis)
+
+    return _angle(data,w,p,phi,axis), _length(data,w,p,phi,axis)
+
+def circcorrcoef(alpha, beta, w_alpha=None, w_beta=None, ax_alpha=None, 
+                 ax_beta=None):
+    """ Computes the circular correlation coefficient between two array of
+    circular data.
+
+    Parameters
+    ----------
+    alpha : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    beta : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    w_alpha : numpy.ndarray, optional
+        In case of grouped data, the i-th element of ``w_alpha`` represents a 
+        weighting factor for each group such that sum(w,axis) equals the number
+        of observations. See [1], remark 1.4, page 22, for detailed
+        explanation.
+    w_beta : numpy.ndarray, optional
+        See description of ``w_alpha``.
+    ax_alpha : int, optional
+        Axis along which circular correlation coefficients are computed. 
+        The default is the compute the circular correlation coefficient of the 
+        flattened array.
+    ax_ beta : int, optional
+        See description of ``ax_alpha``
+
+    Returns
+    -------
+    rho : float
+        Circular correlation coefficient
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+
+    alpha = np.asarray(alpha)
+    beta = np.asarray(beta)
+
+    assert np.size(alpha, axis=ax_alpha) == np.size(beta, axis=ax_beta)
+
+    sin_a = np.sin(alpha - circmean(alpha,w_alpha,ax_alpha))
+    sin_b = np.sin(beta - circmean(beta,w_beta,ax_beta))
+    rho = np.sum(sin_a*sin_b)/np.sqrt(np.sum(sin_a*sin_a)*np.sum(sin_b*sin_b))
+
+    return rho
+
+def rayleightest(data, w=None, axis=None):
+    """ Performs the Rayleigh test of uniformity.
+
+    This test is  used to indentify a non-uniform distribution, i.e. it is
+    designed for detecting an unimodal deviation from uniformity. More
+    precisely, it assumes the following hypotheses:
+        - H0 (null hypothesis): The population is distributed uniformly around
+        the circle.
+        - H1 (alternative hypothesis): The population is not distributed
+        uniformly around the circle.
+    Small p-values suggest to reject the null hypothesis.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    w : numpy.ndarray, optional
+        In case of grouped data, the i-th element of ``w`` represents a 
+        weighting factor for each group such that sum(w,axis) equals the number
+        of observations. See [1], remark 1.4, page 22, for detailed
+        explanation.
+    axis : int, optional
+        Axis along which the Rayleigh test will be performed.
+    
+    Returns
+    -------
+    p-value : float
+        p-value.
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+
+    data = np.asarray(data)
+    n = np.size(data,axis=axis) 
+    Rbar = _length(data,w,1,0.0,axis)
+    z = n*Rbar*Rbar 
+    
+    tmp = 1.0
+    if(n < 50):
+        tmp = 1.0 + (2.0*z - z*z)/(4.0*n) - (24.0*z - 132.0*z**2.0 +
+                76.0*z**3.0 - 9.0*z**4.0)/(288.0*n*n)
+    
+    p_value = np.exp(-z)*tmp 
+    return p_value
+    
+def vtest(data, w=None, mu=0.0, axis=None):
+    """ Performs the Rayleigh test of uniformity where the alternative
+    hypothesis H1 is assumed to have a known mean angle ``mu``.
+    
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians. 
+    w : numpy.ndarray, optional
+        In case of grouped data, the i-th element of ``w`` represents a 
+        weighting factor for each group such that sum(w,axis) equals the number
+        of observations. See [1], remark 1.4, page 22, for detailed
+        explanation.
+    mu : float, optional
+        Assumed known mean angle.
+    axis : int, optional
+        Axis along which the V test will be performed.
+    
+    Returns
+    -------
+    p-value : float
+        p-value.
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+
+    from scipy.stats import norm
+    
+    if w is None:
+        w = np.ones(data.shape)
+    else:
+        assert w.shape == data.shape
+
+    data = np.asarray(data)
+    n = np.size(data,axis=axis) 
+
+    R0bar = np.sum(w*np.cos(data-mu),axis)/np.sum(w, axis)
+    z = np.sqrt(2.0*n)*R0bar
+
+    pz = norm.cdf(z)
+    fz = norm.pdf(z)
+
+    p_value = 1 - pz + fz*((3*z - z**3)/(16.0*n) + (15*z + 305*z**3 - 125*z**5
+        + 9*z**7)/(4608.0*n*n))
+    return p_value
+
+def _A1inv(x):
+    # Utility function used to compute the inverse of the ratio between the 
+    # modified Bessel function of first kind of orders one and zero.
+    import scipy.optimize as opt
+    import scipy.special as sps
+
+    invfunc = lambda y: x*sps.ive(0.0,y) - sps.ive(1.0,y)
+    kappa = opt.brentq(invfunc,0.0,100.0)
+    return kappa
+
+def _A1inv1(x):
+    # Approximation for _A1inv(x) according R Package 'CircStats'
+    if(x >= 0 and x < 0.53):
+        return 2.0*x + x*x*x + (5.0*x**5)/6.0
+    elif x < 0.85:
+        return -0.4 + 1.39*x + 0.43/(1.0 - x)
+    else:
+        return 1.0/(x*x*x - 4.0*x*x + 3.0*x)
+
+def vonmisesmle(data, axis=None):
+    """ Computes the Maximum Likelihood Estimator (MLE) for the parameters of 
+    the von Mises distribution. 
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians.  
+    axis : int, optional
+        Axis along which the mle will be computed.
+    
+    Returns
+    -------
+    mu : float
+        the mean (aka location parameter).
+    kappa : float
+        the concentration parameter.
+    
+    References
+    ---------
+    ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
+        Series on Multivariate Analysis, Vol. 5, 2001.
+    ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
+        Circular Statistics (2001)'". 2015.
+        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
+    """
+
+    data = np.asarray(data)
+    mu = circmean(data, axis=None)
+    kappa = _A1inv1(np.mean(np.cos(data - mu), axis))
+    return mu, kappa
+
+def _A1(x):
+    # Utility function that computes the ratio between the modified Bessel 
+    # function of first kind of orders one and zero.
+
+    import scipy.special as sps
+    return sps.ive(1.0,x)/sps.ive(0.0,x)
+
+def _A1deriv(x):
+    # Derivative of A1(x)
+    return 1.0 - A1(x)/x - A1(x)*A1(x)
+
+def vonmisescrlb(data, axis=None):
+    """ Computes the Cramer-Rao Lower Bound (CRLB) for the parameters of the 
+    von Mises distribution.
+    
+    Theoreticaly, the Maximum Likelihood Estimator attains the CRLB.
+    
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of circular (directional) data measured in radians.  
+    axis : int, optional
+        Axis along which the mle will be computed.
+    
+    Returns
+    -------
+    crlb : numpy.array
+        The first and second elements corresponds to the CRLB of the mean and
+        the concentration parameter, respectively.
+    
+    References
+    ---------
+    ..  [1] D. L. Dowe et. al.. "Bayesian Estimation of the von Mises 
+        Concentration Parameter". Proceedings of the Fifteenth International
+        Workshop on Maximum Entropy and Bayesian Methods. doi=10.1.1.48.5719
+    """
+
+    n = np.size(data, axis)
+    mu, kappa = vonmisesmle(data, axis)
+
+    det = kappa*n*n*_A1(kappa)*_A1deriv(kappa)
+    crlb = np.array([n*_A1deriv(kappa), kappa*n*_A1(kappa)])/det
+    return crlb

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -234,14 +234,14 @@ def rayleightest(data, w=None, axis=None):
         explanation.
     axis : int, optional
         Axis along which the Rayleigh test will be performed.
-    
+ 
     Returns
     -------
     p-value : float
         p-value.
-    
+ 
     References
-    ---------
+    ----------
     ..  [1] S. R. Jammalamadaka, A. SenGupta. "Topics in Circular Statistics".
         Series on Multivariate Analysis, Vol. 5, 2001.
     ..  [2] C. Agostinelli, U. Lund. "Circular Statistics from 'Topics in 
@@ -314,16 +314,6 @@ def vtest(data, w=None, mu=0.0, axis=None):
         + 9*z**7)/(4608.0*n*n))
     return p_value
 
-def _A1inv(x):
-    # Utility function used to compute the inverse of the ratio between the 
-    # modified Bessel function of first kind of orders one and zero.
-    import scipy.optimize as opt
-    import scipy.special as sps
-
-    invfunc = lambda y: x*sps.ive(0.0,y) - sps.ive(1.0,y)
-    kappa = opt.brentq(invfunc,0.0,100.0)
-    return kappa
-
 def _A1inv1(x):
     # Approximation for _A1inv(x) according R Package 'CircStats'
     if(x >= 0 and x < 0.53):
@@ -368,13 +358,12 @@ def vonmisesmle(data, axis=None):
 def _A1(x):
     # Utility function that computes the ratio between the modified Bessel 
     # function of first kind of orders one and zero.
-
     import scipy.special as sps
     return sps.ive(1.0,x)/sps.ive(0.0,x)
 
 def _A1deriv(x):
-    # Derivative of A1(x)
-    return 1.0 - A1(x)/x - A1(x)*A1(x)
+    # Derivative of _A1(x)
+    return 1.0 - _A1(x)/x - _A1(x)*_A1(x)
 
 def vonmisescrlb(data, axis=None):
     """ Computes the Cramer-Rao Lower Bound (CRLB) for the parameters of the 

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -25,226 +25,98 @@ def test__length():
     # Ref. [1] pages 6 and 125
     w = np.array([12, 1, 6, 1, 2, 1, 1])
     answer = 0.766282
-    # testing non-Quantity input
-    # testing input in degrees
-    data_deg = np.array([0, 3.6, 36, 72, 108, 169.2, 324])
-    assert_allclose(answer, _length(data_deg, deg=True, w=w), atol=1e-4)
-    # testing input in radians
-    data_rad = np.deg2rad(data_deg)
-    assert_allclose(answer, _length(data_rad, w=w), atol=1e-4)
-    # testing Quantity input
-    # testing input in radians
-    data_rad = data_rad*u.rad
-    assert_allclose(answer, _length(data_rad, w=w), atol=1e-4)
-    # testing input in degrees
-    data_deg = data_deg*u.deg
-    assert_allclose(answer, _length(data_deg, w=w), atol=1e-4)
+    data = np.array([0, 3.6, 36, 72, 108, 169.2, 324])*u.deg
+    assert_allclose(answer, _length(data, w=w), atol=1e-4)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
 def test_circmean():
     # testing against R CircStats package
     # Ref[1], page 23
-    # testing non-Quantity input
-    data_deg = np.array([51, 67, 40, 109, 31, 358])*u.deg
-    data_rad = np.deg2rad(data_deg)
-    # testing input in radians
-    answer_rad = 0.8487044*u.rad
-    assert_equal(answer_rad, np.around(circmean(data_rad), 7))
-    # testing input in degrees
-    answer_deg = np.around(np.rad2deg(answer_rad), 5)
-    assert_equal(answer_deg, np.around(circmean(data_deg, deg=True), 5))
+    data = np.array([51, 67, 40, 109, 31, 358])*u.deg
+    answer = 48.63*u.deg
+    assert_equal(answer, np.around(circmean(data), 2))
+
+
+def test_circmean_against_scipy():
     # testing against scipy.stats.circmean function
     data = np.random.uniform(-np.pi, np.pi, size=(100, 5))
     answer = scipy.stats.circmean(data, np.pi, -np.pi)
-    assert_equal(np.around(answer, 4)*u.rad, np.around(circmean(data), 4))
+    assert_equal(np.around(answer, 2), np.around(circmean(data), 2))
 
 
 def test_circvar():
     # testing against R CircStats package
     # Ref[1], page 23
+    data = np.array([51, 67, 40, 109, 31, 358])*u.deg
     answer = 0.1635635
-    # testing non-Quantity input
-    data_deg = np.array([51, 67, 40, 109, 31, 358])
-    data_rad = np.deg2rad(data_deg)
-    # testing input in radians
-    assert_allclose(answer, circvar(data_rad), atol=1e-4)
-    # testing input in degrees
-    assert_allclose(answer, circvar(data_deg, deg=True), atol=1e-4)
-    # testing with Quantity
-    # testing input in radians
-    data_rad = data_rad*u.rad
-    assert_allclose(answer, circvar(data_rad), atol=1e-4)
-    # testing input in degrees
-    data_deg = np.rad2deg(data_rad)
-    assert_allclose(answer, circvar(data_deg, deg=True), atol=1e-4)
+    assert_allclose(answer, circvar(data), atol=1e-4)
 
 
 def test_circmoment():
     # testing against R CircStats package
     # Ref[1], page 23
-    # testing non-Quantity input
-    data_deg = np.array([51, 67, 40, 109, 31, 358])
-    data_rad = np.deg2rad(data_deg)
+    data = np.array([51, 67, 40, 109, 31, 358])*u.deg
     # 2nd, 3rd, and 4th moments
-    answer_rad = np.array([1.588121, 1.963919, 2.685556])
-    # testing input in radians
-    data_rad = data_rad*u.rad
-    angles_answer_rad = answer_rad*u.rad
-    angles_result = (np.around(circmoment(data_rad, p=2)[0], 6),
-                     np.around(circmoment(data_rad, p=3)[0], 6),
-                     np.around(circmoment(data_rad, p=4)[0], 6))
-    assert_equal(angles_answer_rad[0], angles_result[0])
-    assert_equal(angles_answer_rad[1], angles_result[1])
-    assert_equal(angles_answer_rad[2], angles_result[2])
-    # testing input in degrees
-    data_deg = np.rad2deg(data_rad)
-    angles_answer_deg = np.around(np.rad2deg(angles_answer_rad), 4)
-    angles_result = (np.around(circmoment(data_deg, deg=True, p=2)[0], 4),
-                     np.around(circmoment(data_deg, deg=True, p=3)[0], 4),
-                     np.around(circmoment(data_deg, deg=True, p=4)[0], 4))
-    assert_equal(angles_answer_deg[0], angles_result[0])
-    assert_equal(angles_answer_deg[1], angles_result[1])
-    assert_equal(angles_answer_deg[2], angles_result[2])
+    # this is the answer given in Ref[1] in radians
+    answer = np.array([1.588121, 1.963919, 2.685556])
+    answer = np.around(np.rad2deg(answer)*u.deg, 4)
+
+    result = (np.around(circmoment(data, p=2)[0], 4),
+              np.around(circmoment(data, p=3)[0], 4),
+              np.around(circmoment(data, p=4)[0], 4))
+ 
+    assert_equal(answer[0], result[0])
+    assert_equal(answer[1], result[1])
+    assert_equal(answer[2], result[2])
     # testing lengths
     answer = np.array([0.4800428, 0.236541, 0.2255761])
-    assert_allclose(answer, (circmoment(data_rad, p=2)[1],
-                             circmoment(data_rad, p=3)[1],
-                             circmoment(data_rad, p=4)[1]), atol=1e-4)
-    assert_allclose(answer, (circmoment(data_deg, deg=True, p=2)[1],
-                             circmoment(data_deg, deg=True, p=3)[1],
-                             circmoment(data_deg, deg=True, p=4)[1]),
-                    atol=1e-4)
+    assert_allclose(answer, (circmoment(data, p=2)[1],
+                             circmoment(data, p=3)[1],
+                             circmoment(data, p=4)[1]), atol=1e-4)
 
 
 def test_circcorrcoef():
     # testing against R CircStats package
     # Ref[1], page 180
-    # testing non-Quantity
-    alpha_deg = np.array([356, 97, 211, 232, 343, 292, 157, 302, 335, 302, 324,
-                          85, 324, 340, 157, 238, 254, 146, 232, 122, 329])
-    beta_deg = np.array([119, 162, 221, 259, 270, 29, 97, 292, 40, 313, 94, 45,
-                         47, 108, 221, 270, 119, 248, 270, 45, 23])
-    alpha_rad = np.deg2rad(alpha_deg)
-    beta_rad = np.deg2rad(beta_deg)
+    alpha = np.array([356, 97, 211, 232, 343, 292, 157, 302, 335, 302, 324,
+                      85, 324, 340, 157, 238, 254, 146, 232, 122, 329])*u.deg
+    beta = np.array([119, 162, 221, 259, 270, 29, 97, 292, 40, 313, 94, 45,
+                     47, 108, 221, 270, 119, 248, 270, 45, 23])*u.deg
     answer = 0.2704648
-    # testing input in degrees
-    assert_allclose(answer, circcorrcoef(alpha_deg, beta_deg, deg=True),
-                    atol=1e-4)
-    # testing input in radians
-    assert_allclose(answer, circcorrcoef(alpha_rad, beta_rad), atol=1e-4)
-    # testing with Quantity
-    # testing input in degrees
-    alpha_deg = alpha_deg*u.deg
-    beta_deg = beta_deg*u.deg
-    assert_allclose(answer, circcorrcoef(alpha_deg, beta_deg, deg=True),
-                    atol=1e-4)
-    # testing input in radians
-    alpha_rad = alpha_rad*u.rad
-    beta_rad = beta_rad*u.rad
-    assert_allclose(answer, circcorrcoef(alpha_rad, beta_rad), atol=1e-4)
+    assert_allclose(answer, circcorrcoef(alpha, beta), atol=1e-4)
 
 
-def test_rayleightest1():
+def test_rayleightest():
     # testing against R CircStats package
-    data_rad = np.array([3.3192729, 3.0628233, 2.7219562, 3.8019564, 2.7290561,
-                         0.8840816, 3.7646373, 2.9782072, 3.3060406,
-                         2.9012014])
-    data_deg = np.rad2deg(data_rad)
+    data = np.array([190.18,  175.48,  155.95,  217.83, 156.36])*u.deg
     # answer was obtained through R CircStats function r.test(x)
-    answer = (0.0009917748, 0.774055)
-    # testing non-Quantity
-    # testing input in radians
-    result = (rayleightest(data_rad), _length(data_rad))
-    assert_allclose(answer[0], result[0], atol=1e-9)
+    answer = (0.00640418, 0.9202565)
+    result = (rayleightest(data), _length(data))
+    assert_allclose(answer[0], result[0], atol=1e-4)
     assert_allclose(answer[1], result[1], atol=1e-4)
-    # testing input in degrees
-    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
-    assert_allclose(answer[0], result[0], atol=1e-9)
-    assert_allclose(answer[1], result[1], atol=1e-4)
-    # testing with Quantity
-    # testing input in radians
-    data_rad = data_rad*u.rad
-    result = (rayleightest(data_rad), _length(data_rad))
-    assert_allclose(answer[0], result[0], atol=1e-9)
-    assert_allclose(answer[1], result[1], atol=1e-4)
-    # testing input in degrees
-    data_deg = data_deg*u.deg
-    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
-    assert_allclose(answer[0], result[0], atol=1e-9)
-    assert_allclose(answer[1], result[1], atol=1e-4)
-
-
-def test_rayleightest2():
-    # testing against R CircStats package
-    data_rad = np.array([3.8955614, 3.1700932, 3.1804325, 2.7887885, 2.9513829,
-                         3.1140079, 4.5052974, 3.7984484, 3.7510773, 2.9764646,
-                         2.2100108, 2.9529469, 2.9722527, 3.5099678, 2.6844710,
-                         4.5020762, 2.9285673, 2.2871037, 3.5805262, 3.4247286,
-                         2.4355773, 3.7549614, 4.1346585, 2.8426607, 3.3291801,
-                         2.5847791, 2.7217270, 3.4323084, 3.3058256, 3.2147845,
-                         2.4918005, 3.4849414, 0.8249985, 3.4881397, 3.2070389,
-                         3.0859854, 4.0566486, 2.3463984, 3.7370984, 5.6853310,
-                         5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
-                         3.5295258, 3.0162183, 3.2317242, 3.2778354,
-                         3.1713455])
-    data_deg = np.rad2deg(data_rad)
-    # answer was obtained through R CircStats function r.test(x)
-    answer = (2.726928e-13, 0.7606633)
-    # testing non-Quantity
-    # testing input in radians
-    result = (rayleightest(data_rad), _length(data_rad))
-    assert_allclose(answer[0], result[0], atol=1e-18)
-    assert_allclose(answer[1], result[1], atol=1e-5)
-    # testing input in degrees
-    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
-    assert_allclose(answer[0], result[0], atol=1e-18)
-    assert_allclose(answer[1], result[1], atol=1e-5)
-
-    # testing with Quantity
-    data_rad = data_rad*u.rad
-    data_deg = data_deg*u.deg
-    # testing input in radians
-    result = (rayleightest(data_rad), _length(data_rad))
-    assert_allclose(answer[0], result[0], atol=1e-18)
-    assert_allclose(answer[1], result[1], atol=1e-5)
-    # testing input in degrees
-    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
-    assert_allclose(answer[0], result[0], atol=1e-18)
-    assert_allclose(answer[1], result[1], atol=1e-5)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_vtest():
     # testing against R CircStats package
-    # testing non-Quantity
-    data_rad = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
-                         1.756324, 3.046718, 3.299150, 3.360557,
-                         4.842499])*u.rad
-    data_deg = np.rad2deg(data_rad)
+    data = np.array([190.18,  175.48,  155.95,  217.83, 156.36])*u.deg
     # answer was obtained through R CircStats function v0.test(x)
-    answer = 0.987142
-    # testing input in radians
-    assert_allclose(answer, vtest(data_rad), atol=1e-5)
-    # testing input in degrees
-    assert_allclose(answer, vtest(data_deg, deg=True), atol=1e-5)
+    answer = 0.9994725
+    assert_allclose(answer, vtest(data), atol=1e-5)
 
 
 def test_vonmisesmle():
     # testing against R CircStats package
     # testing non-Quantity
-    data_rad = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
-                         1.8136389, 4.1566039, 2.7806317, 2.4672173,
-                         2.8493644])*u.rad
-    data_deg = np.rad2deg(data_rad)
+    data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
+                     1.8136389, 4.1566039, 2.7806317, 2.4672173,
+                     2.8493644])
     # answer was obtained through R CircStats function vm.ml(x)
-    answer_rad = (3.006514*u.rad, 1.474132)
-    answer_deg = (np.around(np.rad2deg(3.006514), 4)*u.deg, 1.474132)
-    # testing input in radians
-    assert_equal(answer_rad[0], np.around(vonmisesmle(data_rad)[0], 6))
-    assert_allclose(answer_rad[1], vonmisesmle(data_rad)[1], atol=1e-5)
-    # testing input in derrees
-    assert_equal(answer_deg[0],
-                 np.around(vonmisesmle(data_deg, deg=True)[0], 4))
-    assert_allclose(answer_deg[1], vonmisesmle(data_deg, deg=True)[1],
-                    atol=1e-5)
+    answer = (3.006514, 1.474132)
+    assert_allclose(answer[0], vonmisesmle(data)[0], atol=1e-5)
+    assert_allclose(answer[1], vonmisesmle(data)[1], atol=1e-5)
+
+    # testing with Quantity
+    data = np.rad2deg(data)*u.deg
+    answer = np.rad2deg(3.006514)*u.deg
+    assert_equal(np.around(answer, 3), np.around(vonmisesmle(data)[0], 3))

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -111,7 +111,7 @@ def test_vtest():
     assert_allclose(answer, vtest(data), atol=1e-5)
 
 
-def test_vonmissesmle():
+def test_vonmisesmle():
     # testing against R CircStats package
     data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
                      1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -37,6 +37,7 @@ def test_circmean():
     assert_equal(answer, np.around(circmean(data), 2))
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_circmean_against_scipy():
     # testing against scipy.stats.circmean function
     data = np.random.uniform(-np.pi, np.pi, size=(100, 5))

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -46,27 +46,18 @@ def test_circmean():
     # testing against R CircStats package
     # Ref[1], page 23
     # testing non-Quantity input
-    data_deg = np.array([51, 67, 40, 109, 31, 358])
+    data_deg = np.array([51, 67, 40, 109, 31, 358])*u.deg
     data_rad = np.deg2rad(data_deg)
     # testing input in radians
-    answer_rad = 0.8487044
-    assert_allclose(answer_rad, circmean(data_rad), atol=1e-4)
-    # testing input in degrees
-    answer_deg = np.rad2deg(answer_rad)
-    assert_allclose(answer_deg, circmean(data_deg, deg=True), atol=1e-4)
-    # testing with Quantity
-    # testing input in radians
-    data_rad = data_rad*u.rad
-    answer_rad = answer_rad*u.rad
+    answer_rad = 0.8487044*u.rad
     assert_equal(answer_rad, np.around(circmean(data_rad), 7))
     # testing input in degrees
-    data_deg = np.rad2deg(data_rad)
     answer_deg = np.around(np.rad2deg(answer_rad), 5)
     assert_equal(answer_deg, np.around(circmean(data_deg, deg=True), 5))
     # testing against scipy.stats.circmean function
     data = np.random.uniform(-np.pi, np.pi, size=(100, 5))
     answer = scipy.stats.circmean(data, np.pi, -np.pi)
-    assert_allclose(answer, circmean(data), atol=1e-6)
+    assert_equal(np.around(answer, 4)*u.rad, np.around(circmean(data), 4))
 
 
 def test_circvar():
@@ -97,18 +88,6 @@ def test_circmoment():
     data_rad = np.deg2rad(data_deg)
     # 2nd, 3rd, and 4th moments
     answer_rad = np.array([1.588121, 1.963919, 2.685556])
-    # testing input in radians
-    assert_allclose(answer_rad, (circmoment(data_rad, p=2)[0],
-                                 circmoment(data_rad, p=3)[0],
-                                 circmoment(data_rad, p=4)[0]), atol=1e-4)
-    # testing input in degrees
-    answer_deg = np.rad2deg(answer_rad)
-    assert_allclose(answer_deg, (circmoment(data_deg, deg=True, p=2)[0],
-                                 circmoment(data_deg, deg=True, p=3)[0],
-                                 circmoment(data_deg, deg=True, p=4)[0]),
-                    atol=1e-4)
-    # testing with Quantity
-    # testing angles
     # testing input in radians
     data_rad = data_rad*u.rad
     angles_answer_rad = answer_rad*u.rad
@@ -240,17 +219,11 @@ def test_vtest():
     # testing against R CircStats package
     # testing non-Quantity
     data_rad = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
-                         1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
+                         1.756324, 3.046718, 3.299150, 3.360557,
+                         4.842499])*u.rad
     data_deg = np.rad2deg(data_rad)
     # answer was obtained through R CircStats function v0.test(x)
     answer = 0.987142
-    # testing input in radians
-    assert_allclose(answer, vtest(data_rad), atol=1e-5)
-    # testing input in degrees
-    assert_allclose(answer, vtest(data_deg, deg=True), atol=1e-5)
-    # testing with Quantity
-    data_rad = data_rad*u.rad
-    data_deg = data_deg*u.deg
     # testing input in radians
     assert_allclose(answer, vtest(data_rad), atol=1e-5)
     # testing input in degrees
@@ -262,18 +235,9 @@ def test_vonmisesmle():
     # testing non-Quantity
     data_rad = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
                          1.8136389, 4.1566039, 2.7806317, 2.4672173,
-                         2.8493644])
+                         2.8493644])*u.rad
     data_deg = np.rad2deg(data_rad)
     # answer was obtained through R CircStats function vm.ml(x)
-    answer_rad = (3.006514, 1.474132)
-    answer_deg = (np.rad2deg(3.006514), 1.474132)
-    # testing input in radians
-    assert_allclose(answer_rad, vonmisesmle(data_rad), atol=1e-5)
-    # testing input in degrees
-    assert_allclose(answer_deg, vonmisesmle(data_deg, deg=True), atol=1e-5)
-    # testing with Quantity
-    data_rad = data_rad*u.rad
-    data_deg = data_deg*u.deg
     answer_rad = (3.006514*u.rad, 1.474132)
     answer_deg = (np.around(np.rad2deg(3.006514), 4)*u.deg, 1.474132)
     # testing input in radians

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -6,6 +6,8 @@ import numpy as np
 from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
+from astropy import units as u
+
 try:
     import scipy.stats
 except ImportError:
@@ -18,86 +20,217 @@ from ..circstats import _length, circmean, circvar, circmoment, circcorrcoef
 from ..circstats import rayleightest, vtest, vonmisesmle
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
 def test__length():
     # testing against R CircStats package
     # Ref. [1] pages 6 and 125
-    data = np.deg2rad(np.array([0, 3.6, 36, 72, 108, 169.2, 324]))
     w = np.array([12, 1, 6, 1, 2, 1, 1])
     answer = 0.766282
+    # testing non-Quantity input
+    # testing input in degrees
+    data_deg = np.array([0, 3.6, 36, 72, 108, 169.2, 324])
+    assert_allclose(answer, _length(data_deg, deg=True, w=w), atol=1e-4)
+    # testing input in radians
+    data_rad = np.deg2rad(data_deg)
+    assert_allclose(answer, _length(data_rad, w=w), atol=1e-4)
+    # testing Quantity input
+    # testing input in radians
+    data_rad = data_rad*u.rad
+    assert_allclose(answer, _length(data_rad, w=w), atol=1e-4)
+    # testing input in degrees
+    data_deg = data_deg*u.deg
+    assert_allclose(answer, _length(data_deg, w=w), atol=1e-4)
 
-    assert_allclose(answer, _length(data, w), atol=1e-4)
 
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_circmean():
+    # testing against R CircStats package
+    # Ref[1], page 23
+    # testing non-Quantity input
+    data_deg = np.array([51, 67, 40, 109, 31, 358])
+    data_rad = np.deg2rad(data_deg)
+    # testing input in radians
+    answer_rad = 0.8487044
+    assert_allclose(answer_rad, circmean(data_rad), atol=1e-4)
+    # testing input in degrees
+    answer_deg = np.rad2deg(answer_rad)
+    assert_allclose(answer_deg, circmean(data_deg, deg=True), atol=1e-4)
+    # testing with Quantity
+    # testing input in radians
+    data_rad = data_rad*u.rad
+    answer_rad = answer_rad*u.rad
+    assert_equal(answer_rad, np.around(circmean(data_rad), 7))
+    # testing input in degrees
+    data_deg = np.rad2deg(data_rad)
+    answer_deg = np.around(np.rad2deg(answer_rad), 5)
+    assert_equal(answer_deg, np.around(circmean(data_deg, deg=True), 5))
     # testing against scipy.stats.circmean function
     data = np.random.uniform(-np.pi, np.pi, size=(100, 5))
     answer = scipy.stats.circmean(data, np.pi, -np.pi)
     assert_allclose(answer, circmean(data), atol=1e-6)
 
 
-def test_circmean():
-    # testing against R CircStats package
-    # Ref[1], page 23
-    data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
-    answer = 0.8487044
-    assert_allclose(answer, circmean(data), atol=1e-4)
-
-
 def test_circvar():
     # testing against R CircStats package
     # Ref[1], page 23
-    data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
     answer = 0.1635635
-    assert_allclose(answer, circvar(data), atol=1e-4)
+    # testing non-Quantity input
+    data_deg = np.array([51, 67, 40, 109, 31, 358])
+    data_rad = np.deg2rad(data_deg)
+    # testing input in radians
+    assert_allclose(answer, circvar(data_rad), atol=1e-4)
+    # testing input in degrees
+    assert_allclose(answer, circvar(data_deg, deg=True), atol=1e-4)
+    # testing with Quantity
+    # testing input in radians
+    data_rad = data_rad*u.rad
+    assert_allclose(answer, circvar(data_rad), atol=1e-4)
+    # testing input in degrees
+    data_deg = np.rad2deg(data_rad)
+    assert_allclose(answer, circvar(data_deg, deg=True), atol=1e-4)
 
 
 def test_circmoment():
     # testing against R CircStats package
     # Ref[1], page 23
-    data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    # testing non-Quantity input
+    data_deg = np.array([51, 67, 40, 109, 31, 358])
+    data_rad = np.deg2rad(data_deg)
     # 2nd, 3rd, and 4th moments
-    answer = np.array([[1.588121, 0.4800428], [1.963919, 0.236541],
-                       [2.685556, 0.2255761]])
-    assert_allclose(answer, (circmoment(data, p=2),
-                             circmoment(data, p=3),
-                             circmoment(data, p=4)), atol=1e-4)
+    answer_rad = np.array([1.588121, 1.963919, 2.685556])
+    # testing input in radians
+    assert_allclose(answer_rad, (circmoment(data_rad, p=2)[0],
+                                 circmoment(data_rad, p=3)[0],
+                                 circmoment(data_rad, p=4)[0]), atol=1e-4)
+    # testing input in degrees
+    answer_deg = np.rad2deg(answer_rad)
+    assert_allclose(answer_deg, (circmoment(data_deg, deg=True, p=2)[0],
+                                 circmoment(data_deg, deg=True, p=3)[0],
+                                 circmoment(data_deg, deg=True, p=4)[0]),
+                    atol=1e-4)
+    # testing with Quantity
+    # testing angles
+    # testing input in radians
+    data_rad = data_rad*u.rad
+    angles_answer_rad = answer_rad*u.rad
+    angles_result = (np.around(circmoment(data_rad, p=2)[0], 6),
+                     np.around(circmoment(data_rad, p=3)[0], 6),
+                     np.around(circmoment(data_rad, p=4)[0], 6))
+    assert_equal(angles_answer_rad[0], angles_result[0])
+    assert_equal(angles_answer_rad[1], angles_result[1])
+    assert_equal(angles_answer_rad[2], angles_result[2])
+    # testing input in degrees
+    data_deg = np.rad2deg(data_rad)
+    angles_answer_deg = np.around(np.rad2deg(angles_answer_rad), 4)
+    angles_result = (np.around(circmoment(data_deg, deg=True, p=2)[0], 4),
+                     np.around(circmoment(data_deg, deg=True, p=3)[0], 4),
+                     np.around(circmoment(data_deg, deg=True, p=4)[0], 4))
+    assert_equal(angles_answer_deg[0], angles_result[0])
+    assert_equal(angles_answer_deg[1], angles_result[1])
+    assert_equal(angles_answer_deg[2], angles_result[2])
+    # testing lengths
+    answer = np.array([0.4800428, 0.236541, 0.2255761])
+    assert_allclose(answer, (circmoment(data_rad, p=2)[1],
+                             circmoment(data_rad, p=3)[1],
+                             circmoment(data_rad, p=4)[1]), atol=1e-4)
+    assert_allclose(answer, (circmoment(data_deg, deg=True, p=2)[1],
+                             circmoment(data_deg, deg=True, p=3)[1],
+                             circmoment(data_deg, deg=True, p=4)[1]),
+                    atol=1e-4)
 
 
 def test_circcorrcoef():
     # testing against R CircStats package
     # Ref[1], page 180
-    alpha = np.deg2rad(np.array([356, 97, 211, 232, 343, 292, 157, 302, 335,
-                                 302, 324, 85, 324, 340, 157, 238, 254, 146,
-                                 232, 122, 329]))
-    beta = np.deg2rad(np.array([119, 162, 221, 259, 270, 29, 97, 292, 40, 313,
-                                94, 45, 47, 108, 221, 270, 119, 248, 270, 45,
-                                23]))
+    # testing non-Quantity
+    alpha_deg = np.array([356, 97, 211, 232, 343, 292, 157, 302, 335, 302, 324,
+                          85, 324, 340, 157, 238, 254, 146, 232, 122, 329])
+    beta_deg = np.array([119, 162, 221, 259, 270, 29, 97, 292, 40, 313, 94, 45,
+                         47, 108, 221, 270, 119, 248, 270, 45, 23])
+    alpha_rad = np.deg2rad(alpha_deg)
+    beta_rad = np.deg2rad(beta_deg)
     answer = 0.2704648
-    assert_allclose(answer, circcorrcoef(alpha, beta), atol=1e-4)
+    # testing input in degrees
+    assert_allclose(answer, circcorrcoef(alpha_deg, beta_deg, deg=True),
+                    atol=1e-4)
+    # testing input in radians
+    assert_allclose(answer, circcorrcoef(alpha_rad, beta_rad), atol=1e-4)
+    # testing with Quantity
+    # testing input in degrees
+    alpha_deg = alpha_deg*u.deg
+    beta_deg = beta_deg*u.deg
+    assert_allclose(answer, circcorrcoef(alpha_deg, beta_deg, deg=True),
+                    atol=1e-4)
+    # testing input in radians
+    alpha_rad = alpha_rad*u.rad
+    beta_rad = beta_rad*u.rad
+    assert_allclose(answer, circcorrcoef(alpha_rad, beta_rad), atol=1e-4)
 
 
-def test_rayleightest():
+def test_rayleightest1():
     # testing against R CircStats package
-    data = np.array([3.3192729, 3.0628233, 2.7219562, 3.8019564, 2.7290561,
-                     0.8840816, 3.7646373, 2.9782072, 3.3060406, 2.9012014])
+    data_rad = np.array([3.3192729, 3.0628233, 2.7219562, 3.8019564, 2.7290561,
+                         0.8840816, 3.7646373, 2.9782072, 3.3060406,
+                         2.9012014])
+    data_deg = np.rad2deg(data_rad)
     # answer was obtained through R CircStats function r.test(x)
     answer = (0.0009917748, 0.774055)
-    result = (rayleightest(data), _length(data))
+    # testing non-Quantity
+    # testing input in radians
+    result = (rayleightest(data_rad), _length(data_rad))
+    assert_allclose(answer[0], result[0], atol=1e-9)
+    assert_allclose(answer[1], result[1], atol=1e-4)
+    # testing input in degrees
+    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
+    assert_allclose(answer[0], result[0], atol=1e-9)
+    assert_allclose(answer[1], result[1], atol=1e-4)
+    # testing with Quantity
+    # testing input in radians
+    data_rad = data_rad*u.rad
+    result = (rayleightest(data_rad), _length(data_rad))
+    assert_allclose(answer[0], result[0], atol=1e-9)
+    assert_allclose(answer[1], result[1], atol=1e-4)
+    # testing input in degrees
+    data_deg = data_deg*u.deg
+    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
     assert_allclose(answer[0], result[0], atol=1e-9)
     assert_allclose(answer[1], result[1], atol=1e-4)
 
-    data = np.array([3.8955614, 3.1700932, 3.1804325, 2.7887885, 2.9513829,
-                     3.1140079, 4.5052974, 3.7984484, 3.7510773, 2.9764646,
-                     2.2100108, 2.9529469, 2.9722527, 3.5099678, 2.6844710,
-                     4.5020762, 2.9285673, 2.2871037, 3.5805262, 3.4247286,
-                     2.4355773, 3.7549614, 4.1346585, 2.8426607, 3.3291801,
-                     2.5847791, 2.7217270, 3.4323084, 3.3058256, 3.2147845,
-                     2.4918005, 3.4849414, 0.8249985, 3.4881397, 3.2070389,
-                     3.0859854, 4.0566486, 2.3463984, 3.7370984, 5.6853310,
-                     5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
-                     3.5295258, 3.0162183, 3.2317242, 3.2778354, 3.1713455])
+
+def test_rayleightest2():
+    # testing against R CircStats package
+    data_rad = np.array([3.8955614, 3.1700932, 3.1804325, 2.7887885, 2.9513829,
+                         3.1140079, 4.5052974, 3.7984484, 3.7510773, 2.9764646,
+                         2.2100108, 2.9529469, 2.9722527, 3.5099678, 2.6844710,
+                         4.5020762, 2.9285673, 2.2871037, 3.5805262, 3.4247286,
+                         2.4355773, 3.7549614, 4.1346585, 2.8426607, 3.3291801,
+                         2.5847791, 2.7217270, 3.4323084, 3.3058256, 3.2147845,
+                         2.4918005, 3.4849414, 0.8249985, 3.4881397, 3.2070389,
+                         3.0859854, 4.0566486, 2.3463984, 3.7370984, 5.6853310,
+                         5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
+                         3.5295258, 3.0162183, 3.2317242, 3.2778354,
+                         3.1713455])
+    data_deg = np.rad2deg(data_rad)
     # answer was obtained through R CircStats function r.test(x)
     answer = (2.726928e-13, 0.7606633)
-    result = (rayleightest(data), _length(data))
+    # testing non-Quantity
+    # testing input in radians
+    result = (rayleightest(data_rad), _length(data_rad))
+    assert_allclose(answer[0], result[0], atol=1e-18)
+    assert_allclose(answer[1], result[1], atol=1e-5)
+    # testing input in degrees
+    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
+    assert_allclose(answer[0], result[0], atol=1e-18)
+    assert_allclose(answer[1], result[1], atol=1e-5)
+
+    # testing with Quantity
+    data_rad = data_rad*u.rad
+    data_deg = data_deg*u.deg
+    # testing input in radians
+    result = (rayleightest(data_rad), _length(data_rad))
+    assert_allclose(answer[0], result[0], atol=1e-18)
+    assert_allclose(answer[1], result[1], atol=1e-5)
+    # testing input in degrees
+    result = (rayleightest(data_deg, deg=True), _length(data_deg, deg=True))
     assert_allclose(answer[0], result[0], atol=1e-18)
     assert_allclose(answer[1], result[1], atol=1e-5)
 
@@ -105,18 +238,49 @@ def test_rayleightest():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_vtest():
     # testing against R CircStats package
-    data = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
-                     1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
+    # testing non-Quantity
+    data_rad = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
+                         1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
+    data_deg = np.rad2deg(data_rad)
     # answer was obtained through R CircStats function v0.test(x)
     answer = 0.987142
-    assert_allclose(answer, vtest(data), atol=1e-5)
+    # testing input in radians
+    assert_allclose(answer, vtest(data_rad), atol=1e-5)
+    # testing input in degrees
+    assert_allclose(answer, vtest(data_deg, deg=True), atol=1e-5)
+    # testing with Quantity
+    data_rad = data_rad*u.rad
+    data_deg = data_deg*u.deg
+    # testing input in radians
+    assert_allclose(answer, vtest(data_rad), atol=1e-5)
+    # testing input in degrees
+    assert_allclose(answer, vtest(data_deg, deg=True), atol=1e-5)
 
 
 def test_vonmisesmle():
     # testing against R CircStats package
-    data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
-                     1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
+    # testing non-Quantity
+    data_rad = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
+                         1.8136389, 4.1566039, 2.7806317, 2.4672173,
+                         2.8493644])
+    data_deg = np.rad2deg(data_rad)
     # answer was obtained through R CircStats function vm.ml(x)
-    answer = (3.006514, 1.474132)
-    result = vonmisesmle(data)
-    assert_allclose(answer, result, atol=1e-5)
+    answer_rad = (3.006514, 1.474132)
+    answer_deg = (np.rad2deg(3.006514), 1.474132)
+    # testing input in radians
+    assert_allclose(answer_rad, vonmisesmle(data_rad), atol=1e-5)
+    # testing input in degrees
+    assert_allclose(answer_deg, vonmisesmle(data_deg, deg=True), atol=1e-5)
+    # testing with Quantity
+    data_rad = data_rad*u.rad
+    data_deg = data_deg*u.deg
+    answer_rad = (3.006514*u.rad, 1.474132)
+    answer_deg = (np.around(np.rad2deg(3.006514), 4)*u.deg, 1.474132)
+    # testing input in radians
+    assert_equal(answer_rad[0], np.around(vonmisesmle(data_rad)[0], 6))
+    assert_allclose(answer_rad[1], vonmisesmle(data_rad)[1], atol=1e-5)
+    # testing input in derrees
+    assert_equal(answer_deg[0],
+                 np.around(vonmisesmle(data_deg, deg=True)[0], 4))
+    assert_allclose(answer_deg[1], vonmisesmle(data_deg, deg=True)[1],
+                    atol=1e-5)

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -23,10 +23,10 @@ from ..circstats import rayleightest, vtest, vonmisesmle
 def test__length():
     # testing against R CircStats package
     # Ref. [1] pages 6 and 125
-    w = np.array([12, 1, 6, 1, 2, 1, 1])
+    weights = np.array([12, 1, 6, 1, 2, 1, 1])
     answer = 0.766282
     data = np.array([0, 3.6, 36, 72, 108, 169.2, 324])*u.deg
-    assert_allclose(answer, _length(data, w=w), atol=1e-4)
+    assert_allclose(answer, _length(data, weights=weights), atol=1e-4)
 
 
 def test_circmean():
@@ -65,7 +65,7 @@ def test_circmoment():
     result = (np.around(circmoment(data, p=2)[0], 4),
               np.around(circmoment(data, p=3)[0], 4),
               np.around(circmoment(data, p=4)[0], 4))
- 
+
     assert_equal(answer[0], result[0])
     assert_equal(answer[1], result[1])
     assert_equal(answer[2], result[2])

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -1,0 +1,121 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from numpy.testing import assert_equal
+from numpy.testing.utils import assert_allclose
+
+try:
+    import scipy.stats
+except ImportError:
+    HAS_SCIPY = False
+else:
+    HAS_SCIPY = True
+
+from ...tests.helper import pytest
+from ..circstats import _length, circmean, circvar, circmoment, circcorrcoef
+from ..circstats import rayleightest, vtest, vonmisesmle
+
+
+def test__length():
+    # testing against R CircStats package
+    # Ref. [1] pages 6 and 125
+    data = np.deg2rad(np.array([0, 3.6, 36, 72, 108, 169.2, 324]))
+    w = np.array([12, 1, 6, 1, 2, 1, 1])
+    answer = 0.766282
+
+    assert_allclose(answer, _length(data, w), atol=1e-4)
+
+    # testing against scipy.stats.circmean function
+    data = np.random.uniform(-np.pi, np.pi, size=(100, 5))
+    answer = scipy.stats.circmean(data, np.pi, -np.pi)
+    assert_allclose(answer, circmean(data), atol=1e-6)
+
+
+def test_circmean():
+    # testing against R CircStats package
+    # Ref[1], page 23
+    data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    answer = 0.8487044
+    assert_allclose(answer, circmean(data), atol=1e-4)
+
+
+def test_circvar():
+    # testing against R CircStats package
+    # Ref[1], page 23
+    data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    answer = 0.1635635
+    assert_allclose(answer, circvar(data), atol=1e-4)
+
+
+def test_circmoment():
+    # testing against R CircStats package
+    # Ref[1], page 23
+    data = np.deg2rad(np.array([51, 67, 40, 109, 31, 358]))
+    # 2nd, 3rd, and 4th moments
+    answer = np.array([[1.588121, 0.4800428], [1.963919, 0.236541],
+                       [2.685556, 0.2255761]])
+    assert_allclose(answer, (circmoment(data, p=2),
+                             circmoment(data, p=3),
+                             circmoment(data, p=4)), atol=1e-4)
+
+
+def test_circcorrcoef():
+    # testing against R CircStats package
+    # Ref[1], page 180
+    alpha = np.deg2rad(np.array([356, 97, 211, 232, 343, 292, 157, 302, 335,
+                                 302, 324, 85, 324, 340, 157, 238, 254, 146,
+                                 232, 122, 329]))
+    beta = np.deg2rad(np.array([119, 162, 221, 259, 270, 29, 97, 292, 40, 313,
+                                94, 45, 47, 108, 221, 270, 119, 248, 270, 45,
+                                23]))
+    answer = 0.2704648
+    assert_allclose(answer, circcorrcoef(alpha, beta), atol=1e-4)
+
+
+def test_rayleightest():
+    # testing against R CircStats package
+    data = np.array([3.3192729, 3.0628233, 2.7219562, 3.8019564, 2.7290561,
+                     0.8840816, 3.7646373, 2.9782072, 3.3060406, 2.9012014])
+    # answer was obtained through R CircStats function r.test(x)
+    answer = (0.0009917748, 0.774055)
+    result = (rayleightest(data), _length(data))
+    assert_allclose(answer[0], result[0], atol=1e-9)
+    assert_allclose(answer[1], result[1], atol=1e-4)
+
+    data = np.array([3.8955614, 3.1700932, 3.1804325, 2.7887885, 2.9513829,
+                     3.1140079, 4.5052974, 3.7984484, 3.7510773, 2.9764646,
+                     2.2100108, 2.9529469, 2.9722527, 3.5099678, 2.6844710,
+                     4.5020762, 2.9285673, 2.2871037, 3.5805262, 3.4247286,
+                     2.4355773, 3.7549614, 4.1346585, 2.8426607, 3.3291801,
+                     2.5847791, 2.7217270, 3.4323084, 3.3058256, 3.2147845,
+                     2.4918005, 3.4849414, 0.8249985, 3.4881397, 3.2070389,
+                     3.0859854, 4.0566486, 2.3463984, 3.7370984, 5.6853310,
+                     5.8108009, 3.3921987, 3.2166975, 3.6827617, 4.5055291,
+                     3.5295258, 3.0162183, 3.2317242, 3.2778354, 3.1713455])
+    # answer was obtained through R CircStats function r.test(x)
+    answer = (2.726928e-13, 0.7606633)
+    result = (rayleightest(data), _length(data))
+    assert_allclose(answer[0], result[0], atol=1e-18)
+    assert_allclose(answer[1], result[1], atol=1e-5)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_vtest():
+    # testing against R CircStats package
+    data = np.array([1.316075, 4.439193, 3.096231, 4.807068, 2.986021,
+                     1.756324, 3.046718, 3.299150, 3.360557, 4.842499])
+    # answer was obtained through R CircStats function v0.test(x)
+    answer = 0.987142
+    assert_allclose(answer, vtest(data), atol=1e-5)
+
+
+def test_vonmissesmle():
+    # testing against R CircStats package
+    data = np.array([3.3699057, 4.0411630, 0.5014477, 2.6223103, 3.7336524,
+                     1.8136389, 4.1566039, 2.7806317, 2.4672173, 2.8493644])
+    # answer was obtained through R CircStats function vm.ml(x)
+    answer = (3.006514, 1.474132)
+    result = vonmisesmle(data)
+    assert_allclose(answer, result, atol=1e-5)

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -18,6 +18,7 @@ from ..circstats import _length, circmean, circvar, circmoment, circcorrcoef
 from ..circstats import rayleightest, vtest, vonmisesmle
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test__length():
     # testing against R CircStats package
     # Ref. [1] pages 6 and 125


### PR DESCRIPTION
Hi,

Some circular statistical functions were implemented, as requested in issue #3705.

These functions are primarily based on those implemented in the R package [`CircStats`](https://cran.r-project.org/web/packages/CircStats/CircStats.pdf). Therefore, in most of the tests, results are compared with those obtained through similar functions presented in the aforementioned package.

Additionally, a function to compute the Cramér-Rao Lower Bounds for the von Mises distribution (which basically gives the uncertainties on estimating the parameters) was implemented. For this function, unfortunately, I could not find examples elsewhere in order to write a reliable enough test. Nonetheless, since the math envolved is simple and it only relies on the maximum likelihood estimation (which has been tested), I think this function is good.

I would be grateful for any comments.