### PR TITLE
Fix missing import in astropy.tests.runner

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -13,6 +13,7 @@ import warnings
 from ..config.paths import set_temp_config, set_temp_cache
 from ..extern import six
 from ..utils import wraps, find_current_module
+from ..utils.exceptions import AstropyWarning
 
 
 class TestRunner(object):


### PR DESCRIPTION
The bug is present in 1.1.2, but ``runner.py`` didn't exist in the 1.0.x series.