### PR TITLE
Convolution speedup

### DIFF
--- a/astropy/convolution/boundary_extend.pyx
+++ b/astropy/convolution/boundary_extend.pyx
@@ -114,12 +114,12 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                 if npy_isnan(f[i, j]):
                     top = 0.
                     bot = 0.
-                    iimin = i - wkx
-                    iimax = i + wkx + 1
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
@@ -142,12 +142,12 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
 
         # Now run the proper convolution
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                 if not npy_isnan(fixed[i, j]):
                     top = 0.
                     bot = 0.
-                    iimin = i - wkx
-                    iimax = i + wkx + 1
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
@@ -202,15 +202,15 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if npy_isnan(f[i, j, k]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
-                        jjmin = j - wky
-                        jjmax = j + wky + 1
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
@@ -237,15 +237,15 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
 
         # Now run the proper convolution
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if not npy_isnan(fixed[i, j, k]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
-                        jjmin = j - wky
-                        jjmax = j + wky + 1
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):

--- a/astropy/convolution/boundary_extend.pyx
+++ b/astropy/convolution/boundary_extend.pyx
@@ -123,13 +123,13 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
+                        iii = int_min(int_max(ii, 0), nx - 1)
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(jjmin, jjmax):
-                            iii = int_min(int_max(ii, 0), nx - 1)
                             jjj = int_min(int_max(jj, 0), ny - 1)
                             val = f[iii, jjj]
                             if not npy_isnan(val):
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j)]
+                                ker = g[iii2, <unsigned int>(wky + jj - j)]
                                 top += val * ker
                                 bot += ker
 
@@ -151,12 +151,12 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
+                        iii = int_min(int_max(ii, 0), nx - 1)
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(jjmin, jjmax):
-                            iii = int_min(int_max(ii, 0), nx - 1)
                             jjj = int_min(int_max(jj, 0), ny - 1)
                             val = fixed[iii, jjj]
-                            ker = g[<unsigned int>(wkx + ii - i),
-                                    <unsigned int>(wky + jj - j)]
+                            ker = g[iii2, <unsigned int>(wky + jj - j)]
                             if not npy_isnan(val):
                                 top += val * ker
                                 bot += ker
@@ -214,15 +214,16 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
+                            iii = int_min(int_max(ii, 0), nx - 1)
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
+                                jjj = int_min(int_max(jj, 0), ny - 1)
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(kkmin, kkmax):
-                                    iii = int_min(int_max(ii, 0), nx - 1)
-                                    jjj = int_min(int_max(jj, 0), ny - 1)
                                     kkk = int_min(int_max(kk, 0), nz - 1)
                                     val = f[iii, jjj, kkk]
                                     if not npy_isnan(val):
-                                        ker = g[<unsigned int>(wkx + ii - i),
-                                                <unsigned int>(wky + jj - j),
+                                        ker = g[iii2, jjj2,
                                                 <unsigned int>(wkz + kk - k)]
                                         top += val * ker
                                         bot += ker
@@ -248,14 +249,15 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
+                            iii = int_min(int_max(ii, 0), nx - 1)
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
+                                jjj = int_min(int_max(jj, 0), ny - 1)
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(kkmin, kkmax):
-                                    iii = int_min(int_max(ii, 0), nx - 1)
-                                    jjj = int_min(int_max(jj, 0), ny - 1)
                                     kkk = int_min(int_max(kk, 0), nz - 1)
                                     val = fixed[iii, jjj, kkk]
-                                    ker = g[<unsigned int>(wkx + ii - i),
-                                            <unsigned int>(wky + jj - j),
+                                    ker = g[iii2, jjj2,
                                             <unsigned int>(wkz + kk - k)]
                                     if not npy_isnan(val):
                                         top += val * ker

--- a/astropy/convolution/boundary_extend.pyx
+++ b/astropy/convolution/boundary_extend.pyx
@@ -102,7 +102,7 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
     cdef int wky = nky // 2
     cdef np.ndarray[DTYPE_t, ndim=2] fixed = np.empty([nx, ny], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=2] conv = np.empty([nx, ny], dtype=DTYPE)
-    cdef unsigned int i, j, iii, jjj
+    cdef unsigned int i, j, iii, jjj, iii2
     cdef int ii, jj
 
     cdef int iimin, iimax, jjmin, jjmax
@@ -190,7 +190,7 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
     cdef int wkz = nkz // 2
     cdef np.ndarray[DTYPE_t, ndim=3] fixed = np.empty([nx, ny, nz], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=3] conv = np.empty([nx, ny, nz], dtype=DTYPE)
-    cdef unsigned int i, j, k, iii, jjj, kkk
+    cdef unsigned int i, j, k, iii, jjj, kkk, iii2, jjj2
     cdef int ii, jj, kk
 
     cdef int iimin, iimax, jjmin, jjmax, kkmin, kkmax

--- a/astropy/convolution/boundary_fill.pyx
+++ b/astropy/convolution/boundary_fill.pyx
@@ -116,12 +116,12 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
         # Need a first pass to replace NaN values with value convolved
         # from neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                 if npy_isnan(f[i, j]):
                     top = 0.
                     bot = 0.
-                    iimin = i - wkx
-                    iimax = i + wkx + 1
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
@@ -144,12 +144,12 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
 
         # now run the proper convolution
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                     if not npy_isnan(fixed[i, j]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
                         jjmin = j - wky
                         jjmax = j + wky + 1
                         for ii in range(iimin, iimax):
@@ -206,15 +206,15 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if npy_isnan(f[i, j, k]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
-                        jjmin = j - wky
-                        jjmax = j + wky + 1
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
@@ -240,15 +240,15 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
 
         # Now run the proper convolution
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if not npy_isnan(fixed[i, j, k]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
-                        jjmin = j - wky
-                        jjmax = j + wky + 1
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):

--- a/astropy/convolution/boundary_fill.pyx
+++ b/astropy/convolution/boundary_fill.pyx
@@ -104,7 +104,7 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
     cdef int wky = nky // 2
     cdef np.ndarray[DTYPE_t, ndim=2] fixed = np.empty([nx, ny], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=2] conv = np.empty([nx, ny], dtype=DTYPE)
-    cdef unsigned int i, j, iii, jjj
+    cdef unsigned int i, j, iii, jjj, iii2
     cdef int ii, jj
 
     cdef int iimin, iimax, jjmin, jjmax
@@ -194,7 +194,7 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
     cdef int wkz = nkz // 2
     cdef np.ndarray[DTYPE_t, ndim=3] fixed = np.empty([nx, ny, nz], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=3] conv = np.empty([nx, ny, nz], dtype=DTYPE)
-    cdef unsigned int i, j, k, iii, jjj, kkk
+    cdef unsigned int i, j, k, iii, jjj, kkk, iii2, jjj2
     cdef int ii, jj, kk
 
     cdef int iimin, iimax, jjmin, jjmax, kkmin, kkmax

--- a/astropy/convolution/boundary_fill.pyx
+++ b/astropy/convolution/boundary_fill.pyx
@@ -125,14 +125,14 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(jjmin, jjmax):
                             if ii < 0 or ii > nx - 1 or jj < 0 or jj > ny - 1:
                                 val = fill_value
                             else:
                                 val = f[ii, jj]
                             if not npy_isnan(val):
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j)]
+                                ker = g[iii2, <unsigned int>(wky + jj - j)]
                                 top += val * ker
                                 bot += ker
                     if bot != 0.:
@@ -153,13 +153,13 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
                         jjmin = j - wky
                         jjmax = j + wky + 1
                         for ii in range(iimin, iimax):
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
                                 if ii < 0 or ii > nx - 1 or jj < 0 or jj > ny - 1:
                                     val = fill_value
                                 else:
                                     val = fixed[ii, jj]
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j)]
+                                ker = g[iii2, <unsigned int>(wky + jj - j)]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker
@@ -218,15 +218,16 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(kkmin, kkmax):
                                     if ii < 0 or ii > nx - 1 or jj < 0 or jj > ny - 1 or kk < 0 or kk > nz - 1:
                                         val = fill_value
                                     else:
                                         val = f[ii, jj, kk]
                                     if not npy_isnan(val):
-                                        ker = g[<unsigned int>(wkx + ii - i),
-                                                <unsigned int>(wky + jj - j),
+                                        ker = g[iii2, jjj2,
                                                 <unsigned int>(wkz + kk - k)]
                                         top += val * ker
                                         bot += ker
@@ -251,14 +252,15 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(kkmin, kkmax):
                                     if ii < 0 or ii > nx - 1 or jj < 0 or jj > ny - 1 or kk < 0 or kk > nz - 1:
                                         val = fill_value
                                     else:
                                         val = fixed[ii, jj, kk]
-                                    ker = g[<unsigned int>(wkx + ii - i),
-                                            <unsigned int>(wky + jj - j),
+                                    ker = g[iii2, jjj2,
                                             <unsigned int>(wkz + kk - k)]
                                     if not npy_isnan(val):
                                         top += val * ker

--- a/astropy/convolution/boundary_none.pyx
+++ b/astropy/convolution/boundary_none.pyx
@@ -116,11 +116,11 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
                     top = 0.
                     bot = 0.
                     for ii in range(i - wkx, i + wkx + 1):
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(j - wky, j + wky + 1):
                             val = f[ii, jj]
                             if not npy_isnan(val):
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j)]
+                                ker = g[iii2, <unsigned int>(wky + jj - j)]
                                 top += val * ker
                                 bot += ker
                     if bot != 0.:
@@ -137,10 +137,10 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
                     top = 0.
                     bot = 0.
                     for ii in range(i - wkx, i + wkx + 1):
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(j - wky, j + wky + 1):
                             val = fixed[ii, jj]
-                            ker = g[<unsigned int>(wkx + ii - i),
-                                    <unsigned int>(wky + jj - j)]
+                            ker = g[iii2, <unsigned int>(wky + jj - j)]
                             if not npy_isnan(val):
                                 top += val * ker
                                 bot += ker
@@ -196,12 +196,13 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
                         top = 0.
                         bot = 0.
                         for ii in range(i - wkx, i + wkx + 1):
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(j - wky, j + wky + 1):
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(k - wkz, k + wkz + 1):
                                     val = f[ii, jj, kk]
                                     if not npy_isnan(val):
-                                        ker = g[<unsigned int>(wkx + ii - i),
-                                                <unsigned int>(wky + jj - j),
+                                        ker = g[iii2, jjj2,
                                                 <unsigned int>(wkz + kk - k)]
                                         top += val * ker
                                         bot += ker
@@ -220,11 +221,12 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
                         top = 0.
                         bot = 0.
                         for ii in range(i - wkx, i + wkx + 1):
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(j - wky, j + wky + 1):
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(k - wkz, k + wkz + 1):
                                     val = fixed[ii, jj, kk]
-                                    ker = g[<unsigned int>(wkx + ii - i),
-                                            <unsigned int>(wky + jj - j),
+                                    ker = g[iii2, jjj2,
                                             <unsigned int>(wkz + kk - k)]
                                     if not npy_isnan(val):
                                         top += val * ker

--- a/astropy/convolution/boundary_none.pyx
+++ b/astropy/convolution/boundary_none.pyx
@@ -44,7 +44,9 @@ def convolve1d_boundary_none(np.ndarray[DTYPE_t, ndim=1] f,
             if npy_isnan(f[i]) and i >= wkx and i < nx - wkx:
                 top = 0.
                 bot = 0.
-                for ii in range(i - wkx, i + wkx + 1):
+                iimin = i - wkx
+                iimax = i + wkx + 1
+                for ii in range(iimin, iimax):
                     val = f[ii]
                     if not npy_isnan(val):
                         ker = g[<unsigned int>(wkx + ii - i)]
@@ -62,7 +64,9 @@ def convolve1d_boundary_none(np.ndarray[DTYPE_t, ndim=1] f,
             if not npy_isnan(fixed[i]):
                 top = 0.
                 bot = 0.
-                for ii in range(i - wkx, i + wkx + 1):
+                iimin = i - wkx
+                iimax = i + wkx + 1
+                for ii in range(iimin, iimax):
                     val = fixed[ii]
                     ker = g[<unsigned int>(wkx + ii - i)]
                     if not npy_isnan(val):
@@ -110,14 +114,18 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                 if npy_isnan(f[i, j]) and i >= wkx and i < nx - wkx \
                 and j >= wky and j < ny - wky:
                     top = 0.
                     bot = 0.
-                    for ii in range(i - wkx, i + wkx + 1):
+                    jjmin = j - wky
+                    jjmax = j + wky + 1
+                    for ii in range(iimin, iimax):
                         iii2 = <unsigned int>(wkx + ii - i)
-                        for jj in range(j - wky, j + wky + 1):
+                        for jj in range(jjmin, jjmax):
                             val = f[ii, jj]
                             if not npy_isnan(val):
                                 ker = g[iii2, <unsigned int>(wky + jj - j)]
@@ -132,13 +140,17 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
 
         # Now run the proper convolution
         for i in range(wkx, nx - wkx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(wky, ny - wky):
                 if not npy_isnan(fixed[i, j]):
                     top = 0.
                     bot = 0.
-                    for ii in range(i - wkx, i + wkx + 1):
+                    jjmin = j - wky
+                    jjmax = j + wky + 1
+                    for ii in range(iimin, iimax):
                         iii2 = <unsigned int>(wkx + ii - i)
-                        for jj in range(j - wky, j + wky + 1):
+                        for jj in range(jjmin, jjmax):
                             val = fixed[ii, jj]
                             ker = g[iii2, <unsigned int>(wky + jj - j)]
                             if not npy_isnan(val):
@@ -189,17 +201,23 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if npy_isnan(f[i, j, k]) and i >= wkx and i < nx - wkx \
                     and j >= wky and j < ny - wky and k >= wkz and k <= nz - wkz:
                         top = 0.
                         bot = 0.
-                        for ii in range(i - wkx, i + wkx + 1):
+                        kkmin = k - wkz
+                        kkmax = k + wkz + 1
+                        for ii in range(iimin, iimax):
                             iii2 = <unsigned int>(wkx + ii - i)
-                            for jj in range(j - wky, j + wky + 1):
+                            for jj in range(jjmin, jjmax):
                                 jjj2 = <unsigned int>(wky + jj - j)
-                                for kk in range(k - wkz, k + wkz + 1):
+                                for kk in range(kkmin, kkmax):
                                     val = f[ii, jj, kk]
                                     if not npy_isnan(val):
                                         ker = g[iii2, jjj2,
@@ -215,16 +233,22 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
 
         # Now run the proper convolution
         for i in range(wkx, nx - wkx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(wky, ny - wky):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(wkz, nz - wkz):
                     if not npy_isnan(fixed[i, j, k]):
                         top = 0.
                         bot = 0.
-                        for ii in range(i - wkx, i + wkx + 1):
+                        kkmin = k - wkz
+                        kkmax = k + wkz + 1
+                        for ii in range(iimin, iimax):
                             iii2 = <unsigned int>(wkx + ii - i)
-                            for jj in range(j - wky, j + wky + 1):
+                            for jj in range(jjmin, jjmax):
                                 jjj2 = <unsigned int>(wky + jj - j)
-                                for kk in range(k - wkz, k + wkz + 1):
+                                for kk in range(kkmin, kkmax):
                                     val = fixed[ii, jj, kk]
                                     ker = g[iii2, jjj2,
                                             <unsigned int>(wkz + kk - k)]

--- a/astropy/convolution/boundary_none.pyx
+++ b/astropy/convolution/boundary_none.pyx
@@ -103,7 +103,7 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
     cdef np.ndarray[DTYPE_t, ndim=2] fixed = np.zeros([nx, ny], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=2] conv = np.zeros([nx, ny], dtype=DTYPE)
 
-    cdef unsigned int i, j, ii, jj
+    cdef unsigned int i, j, ii, jj, iii2
 
     cdef int iimin, iimax, jjmin, jjmax
 
@@ -190,7 +190,7 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
     cdef np.ndarray[DTYPE_t, ndim=3] fixed = np.zeros([nx, ny, nz], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=3] conv = np.zeros([nx, ny, nz], dtype=DTYPE)
 
-    cdef unsigned int i, j, k, ii, jj, kk
+    cdef unsigned int i, j, k, ii, jj, kk, iii2, jjj2
 
     cdef int iimin, iimax, jjmin, jjmax, kkmin, kkmax
 

--- a/astropy/convolution/boundary_wrap.pyx
+++ b/astropy/convolution/boundary_wrap.pyx
@@ -120,13 +120,13 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
+                        iii = ii % nx
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(jjmin, jjmax):
-                            iii = ii % nx
                             jjj = jj % ny
                             val = f[iii, jjj]
                             if not npy_isnan(val):
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j)]
+                                ker = g[iii2, <unsigned int>(wky + jj - j)]
                                 top += val * ker
                                 bot += ker
 
@@ -148,12 +148,12 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
+                        iii = ii % nx
+                        iii2 = <unsigned int>(wkx + ii - i)
                         for jj in range(jjmin, jjmax):
-                            iii = ii % nx
                             jjj = jj % ny
                             val = fixed[iii, jjj]
-                            ker = g[<unsigned int>(wkx + ii - i),
-                                    <unsigned int>(wky + jj - j)]
+                            ker = g[iii2, <unsigned int>(wky + jj - j)]
                             if not npy_isnan(val):
                                 top += val * ker
                                 bot += ker
@@ -211,15 +211,16 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
+                            iii = ii % nx
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
+                                jjj = jj % ny
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(kkmin, kkmax):
-                                    iii = ii % nx
-                                    jjj = jj % ny
                                     kkk = kk % nz
                                     val = f[iii, jjj, kkk]
                                     if not npy_isnan(val):
-                                        ker = g[<unsigned int>(wkx + ii - i),
-                                                <unsigned int>(wky + jj - j),
+                                        ker = g[iii2, jjj2,
                                                 <unsigned int>(wkz + kk - k)]
                                         top += val * ker
                                         bot += ker
@@ -245,14 +246,15 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
+                            iii = ii % nx
+                            iii2 = <unsigned int>(wkx + ii - i)
                             for jj in range(jjmin, jjmax):
+                                jjj = jj % ny
+                                jjj2 = <unsigned int>(wky + jj - j)
                                 for kk in range(kkmin, kkmax):
-                                    iii = ii % nx
-                                    jjj = jj % ny
                                     kkk = kk % nz
                                     val = fixed[iii, jjj, kkk]
-                                    ker = g[<unsigned int>(wkx + ii - i),
-                                            <unsigned int>(wky + jj - j),
+                                    ker = g[iii2, jjj2,
                                             <unsigned int>(wkz + kk - k)]
                                     if not npy_isnan(val):
                                         top += val * ker

--- a/astropy/convolution/boundary_wrap.pyx
+++ b/astropy/convolution/boundary_wrap.pyx
@@ -111,12 +111,12 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                 if npy_isnan(f[i, j]):
                     top = 0.
                     bot = 0.
-                    iimin = i - wkx
-                    iimax = i + wkx + 1
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
@@ -139,12 +139,12 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
 
         # Now run the proper convolution
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
                 if not npy_isnan(fixed[i, j]):
                     top = 0.
                     bot = 0.
-                    iimin = i - wkx
-                    iimax = i + wkx + 1
                     jjmin = j - wky
                     jjmax = j + wky + 1
                     for ii in range(iimin, iimax):
@@ -199,15 +199,15 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
         # Need a first pass to replace NaN values with value convolved from
         # neighboring values
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if npy_isnan(f[i, j, k]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
-                        jjmin = j - wky
-                        jjmax = j + wky + 1
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):
@@ -234,15 +234,15 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
 
         # Now run the proper convolution
         for i in range(nx):
+            iimin = i - wkx
+            iimax = i + wkx + 1
             for j in range(ny):
+                jjmin = j - wky
+                jjmax = j + wky + 1
                 for k in range(nz):
                     if not npy_isnan(fixed[i, j, k]):
                         top = 0.
                         bot = 0.
-                        iimin = i - wkx
-                        iimax = i + wkx + 1
-                        jjmin = j - wky
-                        jjmax = j + wky + 1
                         kkmin = k - wkz
                         kkmax = k + wkz + 1
                         for ii in range(iimin, iimax):

--- a/astropy/convolution/boundary_wrap.pyx
+++ b/astropy/convolution/boundary_wrap.pyx
@@ -99,7 +99,7 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
     cdef int wky = nky // 2
     cdef np.ndarray[DTYPE_t, ndim=2] fixed = np.empty([nx, ny], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=2] conv = np.empty([nx, ny], dtype=DTYPE)
-    cdef unsigned int i, j, iii, jjj
+    cdef unsigned int i, j, iii, jjj, iii2
     cdef int ii, jj
 
     cdef int iimin, iimax, jjmin, jjmax
@@ -187,7 +187,7 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
     cdef int wkz = nkz // 2
     cdef np.ndarray[DTYPE_t, ndim=3] fixed = np.empty([nx, ny, nz], dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=3] conv = np.empty([nx, ny, nz], dtype=DTYPE)
-    cdef unsigned int i, j, k, iii, jjj, kkk
+    cdef unsigned int i, j, k, iii, jjj, kkk, iii2, jjj2
     cdef int ii, jj, kk
 
     cdef int iimin, iimax, jjmin, jjmax, kkmin, kkmax


### PR DESCRIPTION
Today I found out that convolution is slower than it needs to be.

Simply moving the calculations to outer loops resulted in a speedup of around 50% for large arrays and even more for large kernels. For a 1000x1000 array with a 13x13 kernel this decreased the total execution time on my computer from 4.8 seconds to 2.1 seconds. For a small array 10x10 with a 3x3 kernel the speedup was not visible (actually it took a bit longer: 194 microseconds to new version with 201 microseconds).

Actually I'm not too familiar with cython but probably defining types for the calculations I moved may further increase the execution time.

But it would be nice if anyone else could confirm the speedup since I've had a bit of trouble with cython and maybe the dev-installation compiled in a different way and that's the only thing visible.