### PR TITLE
Displaying Compound model expressions when printing compound model instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -150,8 +150,8 @@ Bug fixes
 
 - ``astropy.modeling``
 
-  - Displaying Compound model expressions when printing compound model instances
-    . [#4414]
+  - Fixed display of compound model expressions and components when printing
+    compound model instances. [#4414]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -150,6 +150,9 @@ Bug fixes
 
 - ``astropy.modeling``
 
+  - Displaying Compound model expressions when printing compound model instances
+    . [#4414]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1874,11 +1874,7 @@ class _CompoundModelMeta(_ModelMeta):
 
         raise AttributeError(attr)
 
-    def __repr__(cls):
-        if cls._tree is None:
-            # This case is mostly for debugging purposes
-            return cls._format_cls_repr()
-
+    def _get_expr_comp(cls):
         expression = cls._format_expression()
         components = '\n\n'.join('[{0}]: {1!r}'.format(idx, m)
                                  for idx, m in enumerate(cls._get_submodels()))
@@ -1887,7 +1883,14 @@ class _CompoundModelMeta(_ModelMeta):
             ('Components', '\n' + indent(components))
         ]
 
-        return cls._format_cls_repr(keywords=keywords)
+        return keywords
+
+    def __repr__(cls):
+        if cls._tree is None:
+            # This case is mostly for debugging purposes
+            return cls._format_cls_repr()
+
+        return cls._format_cls_repr(keywords=cls._get_expr_comp())
 
     def __dir__(cls, *args):
         """
@@ -2432,6 +2435,10 @@ class _CompoundModel(Model):
     col_fit_deriv = False
 
     _submodels = None
+
+    def __str__(self):
+        keywords=self._get_expr_comp()
+        return super(_CompoundModel,self)._format_str(keywords=keywords)
 
     def __getattr__(self, attr):
         value = getattr(self.__class__, attr)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1874,23 +1874,19 @@ class _CompoundModelMeta(_ModelMeta):
 
         raise AttributeError(attr)
 
-    def _get_expr_comp(cls):
-        expression = cls._format_expression()
-        components = '\n\n'.join('[{0}]: {1!r}'.format(idx, m)
-                                 for idx, m in enumerate(cls._get_submodels()))
-        keywords = [
-            ('Expression', expression),
-            ('Components', '\n' + indent(components))
-        ]
-
-        return keywords
-
     def __repr__(cls):
         if cls._tree is None:
             # This case is mostly for debugging purposes
             return cls._format_cls_repr()
 
-        return cls._format_cls_repr(keywords=cls._get_expr_comp())
+        expression = cls._format_expression()
+        components = cls._format_components()
+        keywords = [
+            ('Expression', expression),
+            ('Components', '\n' + indent(components))
+        ]
+
+        return cls._format_cls_repr(keywords=keywords)
 
     def __dir__(cls, *args):
         """
@@ -2304,6 +2300,10 @@ class _CompoundModelMeta(_ModelMeta):
         # albeit with more formatting options
         return cls._tree.format_expression(OPERATOR_PRECEDENCE)
 
+    def _format_components(cls):
+        return '\n\n'.join('[{0}]: {1!r}'.format(idx, m)
+                                 for idx, m in enumerate(cls._get_submodels()))
+
     def _normalize_index(cls, index):
         """
         Converts an index given to __getitem__ to either an integer, or
@@ -2437,8 +2437,13 @@ class _CompoundModel(Model):
     _submodels = None
 
     def __str__(self):
-        keywords=self._get_expr_comp()
-        return super(_CompoundModel,self)._format_str(keywords=keywords)
+        expression = self._format_expression()
+        components = self._format_components()
+        keywords = [
+            ('Expression', expression),
+            ('Components', '\n' + indent(components))
+        ]
+        return super(_CompoundModel, self)._format_str(keywords=keywords)
 
     def __getattr__(self, attr):
         value = getattr(self.__class__, attr)


### PR DESCRIPTION
Fix for #4414 .
Example
```
In [23]:  g1 = models.Gaussian1D(1, 0, 0.2)

In [24]:  g2 = models.Gaussian1D(2.5, 0.5, 0.1)

In [25]:  gg = g1 + g2

In [26]:  print(gg)
Model: CompoundModel0
Inputs: (u'x',)
Outputs: (u'y',)
Model set size: 1
Expression: [0] + [1]
Components: 
    [0]: <Gaussian1D(amplitude=1.0, mean=0.0, stddev=0.2)>

    [1]: <Gaussian1D(amplitude=2.5, mean=0.5, stddev=0.1)>
Parameters:
    amplitude_0 mean_0 stddev_0 amplitude_1 mean_1 stddev_1
    ----------- ------ -------- ----------- ------ --------
            1.0    0.0      0.2         2.5    0.5      0.1
```
