### PR TITLE
Current convolve documentation contains a mistake. [skip ci]

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -24,9 +24,10 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
 
     This routine differs from `scipy.ndimage.filters.convolve` because
     it includes a special treatment for ``NaN`` values. Rather than
-    including ``NaN``s in the convolution calculation, which causes large
-    ``NaN`` holes in the convolved image, ``NaN`` values are replaced with
-    interpolated values using the kernel as an interpolation function.
+    including ``NaN`` values in the array in the convolution calculation, which
+    causes large ``NaN`` holes in the convolved array, ``NaN`` values are
+    replaced with interpolated values using the kernel as an interpolation
+    function.
 
     Parameters
     ----------


### PR DESCRIPTION
http://docs.astropy.org/en/stable/api/astropy.convolution.convolve.html#astropy.convolution.convolve

seems like the trailing "s" in "``NaN``s" was wrong. Also replaced ``image`` by ``array`` (since it is 1D, 2D and 3D)