### PR TITLE
Remove more Python 2.6 compatibility patches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,7 +214,7 @@ Bug fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Python 2.6 is no longer supported. [#4486]
 
 
 1.1.2 (unreleased)

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -10,6 +10,10 @@ from __future__ import absolute_import
 
 import sys
 import os
+from warnings import warn
+
+if sys.version_info[:2] < (2, 7):
+    warn("Astropy does not support Python 2.6 since v1.2")
 
 
 def _is_astropy_source(path=None):
@@ -154,13 +158,6 @@ test = TestRunner.make_test_runner_in(__path__[0])
 # configuration file with the defaults
 def _initialize_astropy():
     from . import config
-
-    from warnings import warn
-    from .utils.exceptions import AstropyDeprecationWarning
-
-    if sys.version_info[:2] < (2, 7):
-        warn("Python 2.6 will no longer be supported from Astropy v1.2.0 and "
-             "above", AstropyDeprecationWarning)
 
     def _rollback_import(message):
         log.error(message)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -520,23 +520,15 @@ class TestCartesianRepresentation(object):
         assert_allclose(s1.z.value, 3)
 
     def test_init_one_array_size_fail(self):
-
         with pytest.raises(ValueError) as exc:
             s1 = CartesianRepresentation(x=[1, 2, 3, 4] * u.pc)
-
-        # exception text differs on Python 2 and Python 3
-        if hasattr(exc.value, 'args'):
-            assert exc.value.args[0].startswith("too many values to unpack")
-        else:
-            #py 2.6 doesn't have `args`
-            assert exc.value == 'too many values to unpack'
+        assert exc.value.args[0].startswith("too many values to unpack")
 
     def test_init_one_array_yz_fail(self):
-
         with pytest.raises(ValueError) as exc:
             s1 = CartesianRepresentation(x=[1, 2, 3, 4] * u.pc, y=[1, 2] * u.pc)
-
-        assert exc.value.args[0] == "x, y, and z are required to instantiate CartesianRepresentation"
+        assert exc.value.args[0] == ("x, y, and z are required to instantiate "
+                                     "CartesianRepresentation")
 
     def test_init_array_nocopy(self):
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -482,8 +482,6 @@ def test_seps():
     assert sep3d == 1 * u.kpc
 
 def test_repr():
-    # Repr tests must use exact floating point vals because Python 2.6
-    # outputs values like 0.1 as 0.1000000000001.  No workaround found.
     sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame='icrs')
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -418,7 +418,7 @@ class AstropyLogger(Logger):
                 # your code here
         '''
 
-        fh = FileHandler(filename)
+        fh = logging.FileHandler(filename)
         if filter_level is not None:
             fh.setLevel(filter_level)
         if filter_origin is not None:
@@ -473,12 +473,6 @@ class AstropyLogger(Logger):
         yield lh.log_list
         self.removeHandler(lh)
 
-    def setLevel(self, level):
-        """
-        Set the logging level of this logger.
-        """
-        self.level = _checkLevel(level)
-
     def _set_defaults(self):
         '''
         Reset logger to its initial state
@@ -520,7 +514,7 @@ class AstropyLogger(Logger):
                 else:
                     log_file_path = os.path.expanduser(log_file_path)
 
-                fh = FileHandler(log_file_path)
+                fh = logging.FileHandler(log_file_path)
             except (IOError, OSError) as e:
                 warnings.warn(
                     'log file {0!r} could not be opened for writing: '
@@ -536,31 +530,6 @@ class AstropyLogger(Logger):
 
         if conf.log_exceptions:
             self.enable_exception_logging()
-
-
-# The following function is copied from the source code of Python 2.7 and 3.2.
-# This function is not included in Python 2.6 and 3.1, so we have to include it
-# here to provide uniform behavior across versions.
-def _checkLevel(level):
-    '''
-    '''
-    if isinstance(level, int):
-        rv = level
-    elif str(level) == level:
-        if sys.version_info[:2] >= (3, 4):
-            names = logging._nameToLevel
-        else:
-            names = logging._levelNames
-        if level not in names:
-            raise ValueError("Unknown level: %r" % level)
-        rv = names[level]
-    else:
-        raise TypeError("Level not an integer or a valid string: %r" % level)
-    return rv
-
-
-# We now have to be sure that we overload the setLevel in FileHandler, again
-# for compatibility with Python 2.6 and 3.1.
 
 
 class StreamHandler(logging.StreamHandler):
@@ -593,14 +562,6 @@ class StreamHandler(logging.StreamHandler):
         print(": " + record.message, file=stream)
 
 
-class FileHandler(logging.FileHandler):
-    def setLevel(self, level):
-        """
-        Set the logging level of this handler.
-        """
-        self.level = _checkLevel(level)
-
-
 class FilterOrigin(object):
     '''A filter for the record origin'''
     def __init__(self, origin):
@@ -619,9 +580,3 @@ class ListHandler(logging.Handler):
 
     def emit(self, record):
         self.log_list.append(record)
-
-    def setLevel(self, level):
-        """
-        Set the logging level of this handler.
-        """
-        self.level = _checkLevel(level)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1888,14 +1888,11 @@ class _CompoundModelMeta(_ModelMeta):
 
         return cls._format_cls_repr(keywords=keywords)
 
-    def __dir__(cls, *args):
+    def __dir__(cls):
         """
         Returns a list of attributes defined on a compound model, including
         all of its parameters.
         """
-
-        # The *args is to address a bug (?) on Python 2.6 where the dir()
-        # builtin calls __dir__ with an additional (unused) argument
 
         try:
             # Annoyingly, this will only work for Python 3.3+

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -16,7 +16,7 @@ from ..utils.decorators import deprecated
 
 from itertools import chain
 import collections
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 
 import numpy as np
 import numpy.ma as ma
@@ -32,17 +32,6 @@ DEPRECATION_MESSAGE = ('The %(func)s %(obj_type)s is deprecated and may '
 
 class TableMergeError(ValueError):
     pass
-
-
-def _counter(iterable):
-    """
-    Count instances of each unique value in ``iterable``.  Returns a dict
-    with the counts.  Would use collections.Counter but this isn't available in 2.6.
-    """
-    counts = collections.defaultdict(int)
-    for val in iterable:
-        counts[val] += 1
-    return counts
 
 
 def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name}',
@@ -88,7 +77,7 @@ def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name
             col_name_map[out_name][idx] = name
 
     # Check for duplicate output column names
-    col_name_count = _counter(col_name_list)
+    col_name_count = Counter(col_name_list)
     repeated_names = [name for name, count in six.iteritems(col_name_count) if count > 1]
     if repeated_names:
         raise TableMergeError('Merging column names resulted in duplicates: {0}.  '

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 import warnings
 import collections
 import itertools
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 
 import numpy as np
 from numpy import ma
@@ -380,17 +380,6 @@ def unique(input_table, keys=None, silent=False):
     return unique_table
 
 
-def _counter(iterable):
-    """
-    Count instances of each unique value in ``iterable``.  Returns a dict
-    with the counts.  Would use collections.Counter but this isn't available in 2.6.
-    """
-    counts = collections.defaultdict(int)
-    for val in iterable:
-        counts[val] += 1
-    return counts
-
-
 def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name}',
                      table_names=None):
     """
@@ -434,7 +423,7 @@ def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name
             col_name_map[out_name][idx] = name
 
     # Check for duplicate output column names
-    col_name_count = _counter(col_name_list)
+    col_name_count = Counter(col_name_list)
     repeated_names = [name for name, count in six.iteritems(col_name_count) if count > 1]
     if repeated_names:
         raise TableMergeError('Merging column names resulted in duplicates: {0}.  '

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -257,15 +257,6 @@ def treat_deprecations_as_exceptions():
         warnings.filterwarnings("error", ".*", AstropyDeprecationWarning)
         warnings.filterwarnings("error", ".*", AstropyPendingDeprecationWarning)
 
-    if sys.version_info[:2] == (2, 6):
-        # py.test's warning.showwarning does not include the line argument
-        # on Python 2.6, so we need to explicitly ignore this warning.
-        warnings.filterwarnings(
-            "ignore",
-            r"functions overriding warnings\.showwarning\(\) must support "
-            r"the 'line' argument",
-            DeprecationWarning)
-
     if sys.version_info[:2] >= (3, 4):
         # py.test reads files with the 'U' flag, which is now
         # deprecated in Python 3.4.

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -35,10 +35,9 @@ from .output_checker import AstropyOutputChecker, FIX, FLOAT_CMP
 from ..utils.argparse import writeable_directory
 from ..utils.introspection import resolve_name
 
-# Needed for Python 2.6 compatibility
 try:
     import importlib.machinery as importlib_machinery
-except ImportError:
+except ImportError:  # Python 2.7
     importlib_machinery = None
 
 # these pytest hooks allow us to mark tests and run the marked tests with

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -87,11 +87,10 @@ def _is_url(string):
         The string to test
     """
     url = urllib.parse.urlparse(string)
-    # url[0]==url.scheme, but url[0] is py 2.6-compat
-    # we can't just check that url[0] is not an empty string, because
+    # we can't just check that url.scheme is not an empty string, because
     # file paths in windows would return a non-empty scheme (e.g. e:\\
     # returns 'e').
-    return url[0].lower() in ['http', 'https', 'ftp', 'sftp', 'ssh', 'file']
+    return url.scheme.lower() in ['http', 'https', 'ftp', 'sftp', 'ssh', 'file']
 
 
 def _is_inside(path, parent_path):

--- a/astropy/vo/samp/standard_profile.py
+++ b/astropy/vo/samp/standard_profile.py
@@ -36,193 +36,104 @@ class SAMPSimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             self.end_headers()
             self.wfile.write(SAMP_ICON)
 
-    if sys.version_info[:2] >= (2, 7):
-        def do_POST(self):
-            """
-            Handles the HTTP POST request.
+    def do_POST(self):
+        """
+        Handles the HTTP POST request.
 
-            Attempts to interpret all HTTP POST requests as XML-RPC calls,
-            which are forwarded to the server's ``_dispatch`` method for
-            handling.
-            """
+        Attempts to interpret all HTTP POST requests as XML-RPC calls,
+        which are forwarded to the server's ``_dispatch`` method for
+        handling.
+        """
 
-            # Check that the path is legal
-            if not self.is_rpc_path_valid():
-                self.report_404()
-                return
+        # Check that the path is legal
+        if not self.is_rpc_path_valid():
+            self.report_404()
+            return
 
-            try:
-                # Get arguments by reading body of request.
-                # We read this in chunks to avoid straining
-                # socket.read(); around the 10 or 15Mb mark, some platforms
-                # begin to have problems (bug #792570).
-                max_chunk_size = 10 * 1024 * 1024
-                size_remaining = int(self.headers["content-length"])
-                L = []
-                while size_remaining:
-                    chunk_size = min(size_remaining, max_chunk_size)
-                    L.append(self.rfile.read(chunk_size))
-                    size_remaining -= len(L[-1])
-                data = b''.join(L)
+        try:
+            # Get arguments by reading body of request.
+            # We read this in chunks to avoid straining
+            # socket.read(); around the 10 or 15Mb mark, some platforms
+            # begin to have problems (bug #792570).
+            max_chunk_size = 10 * 1024 * 1024
+            size_remaining = int(self.headers["content-length"])
+            L = []
+            while size_remaining:
+                chunk_size = min(size_remaining, max_chunk_size)
+                L.append(self.rfile.read(chunk_size))
+                size_remaining -= len(L[-1])
+            data = b''.join(L)
 
-                params, method = xmlrpc.loads(data)
+            params, method = xmlrpc.loads(data)
 
-                if method == "samp.webhub.register":
-                    params = list(params)
-                    params.append(self.client_address)
-                    if 'Origin' in self.headers:
-                        params.append(self.headers.get('Origin'))
-                    else:
-                        params.append('unknown')
-                    params = tuple(params)
-                    data = xmlrpc.dumps(params, methodname=method)
+            if method == "samp.webhub.register":
+                params = list(params)
+                params.append(self.client_address)
+                if 'Origin' in self.headers:
+                    params.append(self.headers.get('Origin'))
+                else:
+                    params.append('unknown')
+                params = tuple(params)
+                data = xmlrpc.dumps(params, methodname=method)
 
-                elif method in ('samp.hub.notify', 'samp.hub.notifyAll',
-                                'samp.hub.call', 'samp.hub.callAll',
-                                'samp.hub.callAndWait'):
+            elif method in ('samp.hub.notify', 'samp.hub.notifyAll',
+                            'samp.hub.call', 'samp.hub.callAll',
+                            'samp.hub.callAndWait'):
 
-                    user = "unknown"
+                user = "unknown"
 
-                    if method == 'samp.hub.callAndWait':
-                        params[2]["host"] = self.address_string()
-                        params[2]["user"] = user
-                    else:
-                        params[-1]["host"] = self.address_string()
-                        params[-1]["user"] = user
+                if method == 'samp.hub.callAndWait':
+                    params[2]["host"] = self.address_string()
+                    params[2]["user"] = user
+                else:
+                    params[-1]["host"] = self.address_string()
+                    params[-1]["user"] = user
 
-                    data = xmlrpc.dumps(params, methodname=method)
+                data = xmlrpc.dumps(params, methodname=method)
 
-                data = self.decode_request_content(data)
-                if data is None:
-                    return  # response has been sent
+            data = self.decode_request_content(data)
+            if data is None:
+                return  # response has been sent
 
-                # In previous versions of SimpleXMLRPCServer, _dispatch
-                # could be overridden in this class, instead of in
-                # SimpleXMLRPCDispatcher. To maintain backwards compatibility,
-                # check to see if a subclass implements _dispatch and dispatch
-                # using that method if present.
-                response = self.server._marshaled_dispatch(
-                    data, getattr(self, '_dispatch', None), self.path
-                )
-            except Exception as e:
-                # This should only happen if the module is buggy
-                # internal error, report as HTTP server error
-                self.send_response(500)
+            # In previous versions of SimpleXMLRPCServer, _dispatch
+            # could be overridden in this class, instead of in
+            # SimpleXMLRPCDispatcher. To maintain backwards compatibility,
+            # check to see if a subclass implements _dispatch and dispatch
+            # using that method if present.
+            response = self.server._marshaled_dispatch(
+                data, getattr(self, '_dispatch', None), self.path
+            )
+        except Exception as e:
+            # This should only happen if the module is buggy
+            # internal error, report as HTTP server error
+            self.send_response(500)
 
-                # Send information about the exception if requested
-                if hasattr(self.server, '_send_traceback_header') and \
-                   self.server._send_traceback_header:
-                    self.send_header("X-exception", str(e))
-                    trace = traceback.format_exc()
-                    trace = str(trace.encode('ASCII', 'backslashreplace'), 'ASCII')
-                    self.send_header("X-traceback", trace)
+            # Send information about the exception if requested
+            if hasattr(self.server, '_send_traceback_header') and \
+               self.server._send_traceback_header:
+                self.send_header("X-exception", str(e))
+                trace = traceback.format_exc()
+                trace = str(trace.encode('ASCII', 'backslashreplace'), 'ASCII')
+                self.send_header("X-traceback", trace)
 
-                self.send_header("Content-length", "0")
-                self.end_headers()
-            else:
-                # got a valid XML RPC response
-                self.send_response(200)
-                self.send_header("Content-type", "text/xml")
-                if self.encode_threshold is not None:
-                    if len(response) > self.encode_threshold:
-                        q = self.accept_encodings().get("gzip", 0)
-                        if q:
-                            try:
-                                response = xmlrpc.gzip_encode(response)
-                                self.send_header("Content-Encoding", "gzip")
-                            except NotImplementedError:
-                                pass
-                self.send_header("Content-length", str(len(response)))
-                self.end_headers()
-                self.wfile.write(response)
-
-    else:
-
-        def do_POST(self):
-            """
-            Handles the HTTP POST request.
-
-            Attempts to interpret all HTTP POST requests as XML-RPC calls,
-            which are forwarded to the server's ``_dispatch`` method for
-            handling.
-            """
-
-            # Check that the path is legal
-            if not self.is_rpc_path_valid():
-                self.report_404()
-                return
-
-            try:
-                # Get arguments by reading body of request.
-                # We read this in chunks to avoid straining
-                # socket.read(); around the 10 or 15Mb mark, some platforms
-                # begin to have problems (bug #792570).
-                max_chunk_size = 10 * 1024 * 1024
-                size_remaining = int(self.headers["content-length"])
-                L = []
-                while size_remaining:
-                    chunk_size = min(size_remaining, max_chunk_size)
-                    L.append(self.rfile.read(chunk_size))
-                    size_remaining -= len(L[-1])
-                data = b''.join(L)
-
-                params, method = xmlrpc.loads(data)
-
-                if method == "samp.webhub.register":
-                    params = list(params)
-                    params.append(self.client_address)
-                    if 'Origin' in self.headers:
-                        params.append(self.headers.get('Origin'))
-                    else:
-                        params.append('unknown')
-                    params = tuple(params)
-                    data = xmlrpc.dumps(params, methodname=method)
-
-                elif method in ('samp.hub.notify', 'samp.hub.notifyAll',
-                                'samp.hub.call', 'samp.hub.callAll',
-                                'samp.hub.callAndWait'):
-
-                    user = "unknown"
-
-                    if method == 'samp.hub.callAndWait':
-                        params[2]["host"] = self.address_string()
-                        params[2]["user"] = user
-                    else:
-                        params[-1]["host"] = self.address_string()
-                        params[-1]["user"] = user
-
-                    data = xmlrpc.dumps(params, methodname=method)
-
-                # In previous versions of SimpleXMLRPCServer, _dispatch
-                # could be overridden in this class, instead of in
-                # SimpleXMLRPCDispatcher. To maintain backwards compatibility,
-                # check to see if a subclass implements _dispatch and dispatch
-                # using that method if present.
-                response = self.server._marshaled_dispatch(
-                    data, getattr(self, '_dispatch', None)
-                )
-            except Exception as e:  # This should only happen if the module is buggy
-                # internal error, report as HTTP server error
-                self.send_response(500)
-
-                # Send information about the exception if requested
-                if hasattr(self.server, '_send_traceback_header') and \
-                   self.server._send_traceback_header:
-                    self.send_header("X-exception", str(e))
-                    self.send_header("X-traceback", traceback.format_exc())
-
-                self.end_headers()
-            else:
-                # got a valid XML RPC response
-                self.send_response(200)
-                self.send_header("Content-Type", "text/xml")
-                self.send_header("Content-Length", str(len(response)))
-                self.end_headers()
-                self.wfile.write(response)
-
-                # shut down the connection
-                self.wfile.flush()
-                self.connection.shutdown(1)
+            self.send_header("Content-length", "0")
+            self.end_headers()
+        else:
+            # got a valid XML RPC response
+            self.send_response(200)
+            self.send_header("Content-type", "text/xml")
+            if self.encode_threshold is not None:
+                if len(response) > self.encode_threshold:
+                    q = self.accept_encodings().get("gzip", 0)
+                    if q:
+                        try:
+                            response = xmlrpc.gzip_encode(response)
+                            self.send_header("Content-Encoding", "gzip")
+                        except NotImplementedError:
+                            pass
+            self.send_header("Content-length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
 
 
 class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,9 @@ Astropy has the following strict requirements:
 
 - `Python <http://www.python.org/>`_ 2.7, 3.3, 3.4 or 3.5
 
-  - Prior to Astropy v1.0 Python 3.1 and 3.2 are also supported.
+  - Prior to Astropy v1.0, Python 3.1 and 3.2 were also supported
+
+  - Prior to Astropy v1.2, Python 2.6 was supported
 
 - `Numpy`_ |minimum_numpy_version| or later
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Astropy has the following strict requirements:
 
-- `Python <http://www.python.org/>`_ 2.6 (>=2.6.5), 2.7, 3.3, 3.4 or 3.5
+- `Python <http://www.python.org/>`_ 2.7, 3.3, 3.4 or 3.5
 
   - Prior to Astropy v1.0 Python 3.1 and 3.2 are also supported.
 


### PR DESCRIPTION
Some of the changes are easier to see if you ignore whitespace: https://github.com/astropy/astropy/pull/4486/files?w=0

cc @embray @eteq @taldcroft