### PR TITLE
Fix argument of `wcshdr_err_to_python_exc()`

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -378,7 +378,7 @@ PyWcsprm_init(
 
     if (status != 0) {
       free(colsel_ints);
-      wcshdr_err_to_python_exc(wcs->err);
+      wcshdr_err_to_python_exc(status);
       return -1;
     }
 
@@ -414,7 +414,7 @@ PyWcsprm_init(
     free(colsel_ints);
 
     if (status != 0) {
-      wcshdr_err_to_python_exc(wcs->err);
+      wcshdr_err_to_python_exc(status);
       return -1;
     }
 
@@ -613,7 +613,7 @@ PyWcsprm_find_all_wcs(
   Py_END_ALLOW_THREADS
 
   if (status != 0) {
-    wcshdr_err_to_python_exc(wcs->err);
+    wcshdr_err_to_python_exc(status);
     return NULL;
   }
 
@@ -648,7 +648,7 @@ PyWcsprm_find_all_wcs(
   Py_END_ALLOW_THREADS
 
   if (status != 0) {
-    wcshdr_err_to_python_exc(wcs->err);
+    wcshdr_err_to_python_exc(status);
     return NULL;
   }
 


### PR DESCRIPTION
The function takes the return value of `wcspih()`/`wcsbth()`, not the error code stored in the `wcs` structure. 

I also wonder whether a `wcsvfree(&nwcs, &wcs);` is needed in each block to avoid a memory leak.