### PR TITLE
Fix a potentially uninitialized variable `io/fits/src/compressionmodule.c`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -886,6 +886,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed possible segfault during error handling in FITS tile
+    compression. [#4489]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -899,7 +899,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
     unsigned long long heapsize;
 
     fitsfile* fileptr;
-    FITSfile* Fptr;
+    FITSfile* Fptr = NULL;
     int status = 0;
 
     if (!PyArg_ParseTuple(args, "O:compression.compress_hdu", &hdu))
@@ -978,7 +978,9 @@ fail:
 cleanup:
     if (columns != NULL) {
         PyMem_Free(columns);
-        Fptr->tableptr = NULL;
+	if (Fptr != NULL) {
+	    Fptr->tableptr = NULL;
+	}
     }
 
     if (fileptr != NULL) {


### PR DESCRIPTION
If `open_from_hdu()` failed, a `goto fail` would execute this place without `Fptr` being initialized.