### PR TITLE
Fixed failed remote data tests due to presence of old config items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -175,7 +175,6 @@ Bug fixes
 
   - The astropy.utils.compat.fractions module has now been deprecated. Use the
     Python 'fractions' module directly instead. [#4463]
-  - Fixed configuration item using old format in test. [#4491]
 
 - ``astropy.visualization``
 
@@ -183,7 +182,6 @@ Bug fixes
 
   - Relaxed expected accuracy of Cone Search prediction test to reduce spurious
     failures. [#4382]
-  - Fixed configuration item using old format in the validator. [#4491]
 
 - ``astropy.wcs``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@ New Features
 - ``astropy.nddata``
 
 - ``astropy.stats``
- 
+
   - Added ``jackknife`` resampling method. [#3708]
 
   - Updated ``bootstrap`` to allow bootstrapping statistics with multiple
@@ -175,6 +175,7 @@ Bug fixes
 
   - The astropy.utils.compat.fractions module has now been deprecated. Use the
     Python 'fractions' module directly instead. [#4463]
+  - Fixed configuration item using old format in test. [#4491]
 
 - ``astropy.visualization``
 
@@ -182,6 +183,7 @@ Bug fixes
 
   - Relaxed expected accuracy of Cone Search prediction test to reduce spurious
     failures. [#4382]
+  - Fixed configuration item using old format in the validator. [#4491]
 
 - ``astropy.wcs``
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -227,7 +227,7 @@ def test_data_noastropy_fallback(monkeypatch):
     lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
 
     # better yet, set the configuration to make sure the temp files are deleted
-    data.DELETE_TEMPORARY_DOWNLOADS_AT_EXIT.set(True)
+    data.conf.delete_temporary_downloads_at_exit = True
 
     # make sure the config and cache directories are not searched
     monkeypatch.setenv(str('XDG_CONFIG_HOME'), 'foo')

--- a/astropy/vo/client/tests/test_vos_catalog.py
+++ b/astropy/vo/client/tests/test_vos_catalog.py
@@ -7,7 +7,8 @@
     `astropy.vo.client.tests.test_conesearch`.
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 # STDLIB
 import os
@@ -16,7 +17,8 @@ import tempfile
 
 # LOCAL
 from .. import vos_catalog
-from ..exceptions import VOSError, MissingCatalog, DuplicateCatalogName, DuplicateCatalogURL
+from ..exceptions import (VOSError, MissingCatalog, DuplicateCatalogName,
+                          DuplicateCatalogURL)
 from ....tests.helper import pytest, remote_data
 from ....utils.data import get_pkg_data_filename
 
@@ -204,10 +206,10 @@ def test_db_from_registry():
         but does not check for quality of data.
 
     """
-    from ...validator.validate import CS_MSTR_LIST
+    from ...validator import conf
 
     db = vos_catalog.VOSDatabase.from_registry(
-        CS_MSTR_LIST(), encoding='binary', show_progress=False)
+        conf.conesearch_master_list, encoding='binary', show_progress=False)
 
     # Should have over 9k catalogs; Update test if this changes.
     assert len(db) > 9000

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Common utilities for accessing VO simple services."""
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 from ...extern import six
 from ...extern.six.moves import urllib
 
@@ -16,12 +17,15 @@ from collections import defaultdict
 from copy import deepcopy
 
 # LOCAL
-from .exceptions import VOSError, MissingCatalog, DuplicateCatalogName, DuplicateCatalogURL, InvalidAccessURL
-from ...io.votable import parse_single_table, table, tree, conf
-
+from .exceptions import (VOSError, MissingCatalog, DuplicateCatalogName,
+                         DuplicateCatalogURL, InvalidAccessURL)
+from .. import conf as vo_conf
+from ...io.votable import parse_single_table, table, tree
+from ...io.votable import conf as votable_conf
 from ...io.votable.exceptions import vo_raise, vo_warn, E19, W24, W25
 from ...utils.console import color_print
 from ...utils.data import get_readable_fileobj
+from ...utils.data import conf as data_conf
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.misc import JsonCustomEncoder
 from ...utils.xml.unescaper import unescape_all
@@ -539,7 +543,7 @@ class VOSDatabase(VOSBase):
 
         """
         # Download registry as VO table
-        with conf.set_temp('remote_timeout', timeout):
+        with data_conf.set_temp('remote_timeout', timeout):
             with get_readable_fileobj(registry_url, **kwargs) as fd:
                 tab_all = parse_single_table(fd, pedantic=False)
 
@@ -628,10 +632,8 @@ def get_remote_catalog_db(dbname, cache=True, verbose=True):
         A database of VO services.
 
     """
-    from .. import conf
-
     return VOSDatabase.from_json(
-        urllib.parse.urljoin(conf.vos_baseurl, dbname + '.json'),
+        urllib.parse.urljoin(vo_conf.vos_baseurl, dbname + '.json'),
         encoding='utf8', cache=cache,
         show_progress=verbose)
 
@@ -843,7 +845,7 @@ def call_vo_service(service_type, catalog_db=None, pedantic=None,
                              verbose=verbose)
 
     if pedantic is None:  # pragma: no cover
-        pedantic = conf.pedantic
+        pedantic = votable_conf.pedantic
 
     for name, catalog in catalogs:
         if isinstance(catalog, six.string_types):

--- a/astropy/vo/validator/validate.py
+++ b/astropy/vo/validator/validate.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Validate VO Services."""
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 from ...extern import six
 
 # STDLIB
@@ -10,7 +11,8 @@ import warnings
 from collections import OrderedDict
 
 # LOCAL
-from .exceptions import ValidationMultiprocessingError, InvalidValidationAttribute
+from .exceptions import (ValidationMultiprocessingError,
+                         InvalidValidationAttribute)
 from ..client import vos_catalog
 from ..client.exceptions import VOSError
 from ...io import votable
@@ -122,12 +124,15 @@ def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         js_mstr = vos_catalog.VOSDatabase.from_registry(
-            CS_MSTR_LIST(), encoding='binary', show_progress=verbose)
+            conf.conesearch_master_list, encoding='binary',
+            show_progress=verbose)
 
     # Validate only a subset of the services.
     if url_list is not None:
         # Make sure URL is unique and fixed.
-        url_list = set(six.moves.map(unescape_all, [cur_url.encode('utf-8') if isinstance(cur_url, str) else cur_url for cur_url in url_list]))
+        url_list = set(six.moves.map(unescape_all,
+            [cur_url.encode('utf-8') if isinstance(cur_url, str) else cur_url
+             for cur_url in url_list]))
         uniq_rows = len(url_list)
         url_list_processed = []  # To track if given URL is valid in registry
         if verbose:


### PR DESCRIPTION
Fixed failed remote data tests due to presence of old configuration items. Cleaned up `conf` imports in `vo`. Minor PEP8 stuff in `vo`.

This is a follow up for #4446.

If there are no objections, I will merge by COB today because this holds up my work for Cone Search, which uses dev version of Astropy.