### PR TITLE
Use list of keywords instead of generator (py3 fix)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -191,6 +191,24 @@ Other Changes and Additions
 - Nothing changed yet.
 
 
+1.1.2 (unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+- ``astropy.wcs``
+
+  - Fixed possible exception in handling of SIP headers that was introduced in
+    v1.1.1. [#4492]
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
 1.1.1 (unreleased)
 ------------------
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -130,11 +130,11 @@ else:
 # Additional relax bit flags
 WCSHDO_SIP = 0x10000
 
-# Regular expression defining SIP keyword
-# It matches keyword that starts with A, B, AP or B, followed by an underscore then
-# a number in range of 0-19, followed by an underscore and another number
-# in range of 0-19. Keyword optionally ends with a capital letter.
-SIP_KW = re.compile('''^(A|B|AP|BP)_(?:[0-9]|1[0-9])_(?:[0-9]|1[0-9])(|[A-Z])$''')
+# Regular expression defining SIP keyword It matches keyword that starts with A
+# or B, optionally followed by P, followed by an underscore then a number in
+# range of 0-19, followed by an underscore and another number in range of 0-19.
+# Keyword optionally ends with a capital letter.
+SIP_KW = re.compile('''^[AB]P?_1?[0-9]_1?[0-9][A-Z]?$''')
 
 def _parse_keysel(keysel):
     keysel_flags = 0

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -767,7 +767,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                     tables[i] = d_lookup
                 else:
                     warnings.warn('Polynomial distortion is not implemented.\n', AstropyUserWarning)
-                for key in list(header.keys()):
+                for key in list(header):
                     if key.startswith(dp + str('.')):
                         del header[key]
             else:
@@ -920,7 +920,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                     d_lookup = DistortionLookupTable(d_data, d_crpix, d_crval, d_cdelt)
                     tables[i] = d_lookup
 
-                    for key in list(header.keys()):
+                    for key in list(header):
                         if key.startswith(dp + str('.')):
                             del header[key]
                 else:
@@ -986,7 +986,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         """
         # Never pass SIP coefficients to wcslib
         # CTYPE must be passed with -SIP to wcslib
-        for key in (m.group() for m in map(SIP_KW.match, header.keys())
+        for key in (m.group() for m in map(SIP_KW.match, list(header))
                     if m is not None):
             del header[key]
 


### PR DESCRIPTION
On Python 3 header.keys() will iterate instead of return a list, and
we're modifying the dictionary inside the loop. See also:
https://github.com/spacetelescope/PyFITS/issues/74 https://github.com/astropy/astropy/commit/6d4552e450129a003842af9fafd7184b2c788fe8#commitcomment-15453711