### PR TITLE
Minimal fix for NDArithmeticMixin matching WCS check with astropy.wcs.WCS objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,9 @@ Bug fixes
   - ``NDData`` now sets the ``parent_nddata`` of the ``uncertainty`` if the
     uncertainty is ``NDUncertainty``-like. [#4152, #4270]
 
+  - ``NDArithmeticMixin`` check for matching WCS now works with 
+    ``astropy.wcs.WCS`` objects [#4499] 
+
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,10 +189,7 @@ Bug fixes
   - ``NDData`` now sets the ``parent_nddata`` of the ``uncertainty`` if the
     uncertainty is ``NDUncertainty``-like. [#4152, #4270]
 
-  - ``NDArithmeticMixin`` check for matching WCS now works with 
-    ``astropy.wcs.WCS`` objects [#4499] 
-
-- ``astropy.stats``
+ - ``astropy.stats``
 
 - ``astropy.table``
 
@@ -848,6 +845,9 @@ New Features
 - ``astropy.modeling``
 
 - ``astropy.nddata``
+
+ - ``NDArithmeticMixin`` check for matching WCS now works with 
+    ``astropy.wcs.WCS`` objects [#4499]
 
 - ``astropy.stats``
 

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -13,6 +13,8 @@ from ... import log
 from ...extern.six import string_types
 from ..nduncertainty import IncompatibleUncertaintiesException
 
+from ...wcs import WCS
+
 __all__ = ['NDArithmeticMixin']
 
 
@@ -59,8 +61,15 @@ class NDArithmeticMixin(object):
 
         from .. import conf
 
-        if self.wcs != operand.wcs:
-            raise ValueError("WCS properties do not match")
+        if isinstance(self.wcs, WCS):
+            # If an astropy.wcs.WCS object is present need to
+            # use astropy._wcs.Wcsprm.compare to check
+            # equivalence of WCS not __eq__ (#4499)
+            if not self.wcs.wcs.compare(operand.wcs.wcs):
+                raise ValueError("WCS properties do not match")
+        else:
+            if self.wcs != operand.wcs:
+                raise ValueError("WCS properties do not match")
 
         # get a sensible placeholder if .unit is None
         self_unit = self.unit or dimensionless_unscaled

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -16,6 +16,7 @@ from ....tests.helper import pytest
 from .... import units as u
 from ....utils import NumpyRNGContext
 
+from ....wcs import WCS
 
 class FakeUncertainty(NDUncertainty):
 
@@ -261,10 +262,22 @@ def test_nddata_subtract():
     d3 = d1.subtract(d2)
     assert np.all(d3.data == -1.)
 
+def test_nddata_subtract_with_wcs():
+    # Test arithmetic with identical WCS present #4499
+    w1 = WCS()
+    w2 = w1.deepcopy()
+    d1 = NDDataArray(np.ones((5, 5)), wcs=w1)
+    d2 = NDDataArray(np.ones((5, 5)) * 2., wcs=w2)
+    d3 = d1.subtract(d2)
+    assert np.all(d3.data == -1.)
 
 def test_nddata_subtract_mismatch_wcs():
-    d1 = NDDataArray(np.ones((5, 5)), wcs=1.)
-    d2 = NDDataArray(np.ones((5, 5)) * 2., wcs=2.)
+    # Test using actual WCS objects #4499
+    w1 = WCS()
+    w2 = w1.deepcopy()
+    w2.wcs.crpix = np.array((1.0,0.0))
+    d1 = NDDataArray(np.ones((5, 5)), wcs=w1)
+    d2 = NDDataArray(np.ones((5, 5)) * 2., wcs=w2)
     with pytest.raises(ValueError) as exc:
         d1.subtract(d2)
     assert exc.value.args[0] == "WCS properties do not match"


### PR DESCRIPTION
Minimal change to `NDArithmeticMixin._arithmetic` so that the check for matching WCS works correctly when `wcs.WCS` objects are present. Uses `astropy._wcs.Wcsprm.compare` to test for equivalence instead of `__eq__`.  Fixes #4499 , fixes astropy/ccdproc#283