### PR TITLE
Implementing astropy.utils.metadata.MetaData as descriptor for NDData.meta

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -4,9 +4,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import collections
-from collections import OrderedDict
-
 import numpy as np
 from copy import deepcopy
 
@@ -14,6 +11,7 @@ from .nddata_base import NDDataBase
 from .nduncertainty import NDUncertainty
 from .. import log
 from ..units import Unit, Quantity
+from ..utils.metadata import MetaData
 
 __all__ = ['NDData']
 
@@ -161,6 +159,8 @@ class NDData(NDDataBase):
     NDDataArray
     """
 
+    meta = MetaData()
+
     def __init__(self, data, uncertainty=None, mask=None, wcs=None,
                  meta=None, unit=None, copy=False):
 
@@ -252,12 +252,6 @@ class NDData(NDDataBase):
         if data.dtype == 'O':
             raise TypeError("Could not convert data to numpy array.")
 
-        # Check if meta is a dict and create an empty one if no meta was given
-        if meta is None:
-            meta = OrderedDict()
-        elif not isinstance(meta, collections.Mapping):
-            raise TypeError("Meta attribute must be dict-like")
-
         if unit is not None:
             unit = Unit(unit)
 
@@ -277,7 +271,7 @@ class NDData(NDDataBase):
         self._data = data
         self._mask = mask
         self._wcs = wcs
-        self._meta = meta
+        self.meta = meta
         self._unit = unit
         # Call the setter for uncertainty to further check the uncertainty
         self.uncertainty = uncertainty
@@ -324,13 +318,6 @@ class NDData(NDDataBase):
         any type : A world coordinate system (WCS) for the dataset, if any.
         """
         return self._wcs
-
-    @property
-    def meta(self):
-        """
-        `dict`-like : Meta information about the dataset, if any.
-        """
-        return self._meta
 
     @property
     def uncertainty(self):

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -110,7 +110,7 @@ def test_nddataarray_from_nddataarray():
     assert ndd2.data is ndd1.data
     assert ndd2.uncertainty is ndd1.uncertainty
     assert ndd2.flags is ndd1.flags
-    assert ndd2.meta is ndd1.meta
+    assert ndd2.meta == ndd1.meta
 
 
 # Test for issue #4137:
@@ -121,4 +121,4 @@ def test_nddataarray_from_nddata():
 
     assert ndd2.data is ndd1.data
     assert ndd2.uncertainty is ndd1.uncertainty
-    assert ndd2.meta is ndd1.meta
+    assert ndd2.meta == ndd1.meta


### PR DESCRIPTION
Fixes #4469

Although while implementing I noticed two differences to the current state of ``NDData.meta``:
- A setter is implemented (which wasn't there before)
- The setter automatically copies the meta that was given. Until now ``NDData`` only copied if specified or necessary.

@mwcraig - What do you think?