### PR TITLE
numpycompat causes an error with Python 3 and a numpy library < 1.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -340,6 +340,8 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - Fixed crash on import on Python 3 with Numpy < 1.7. [#4510]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``
@@ -1076,6 +1078,8 @@ Bug Fixes
 - ``astropy.units``
 
 - ``astropy.utils``
+
+  - Fixed crash on import on Python 3 with Numpy < 1.7. [#4510]
 
 - ``astropy.vo``
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -59,7 +59,7 @@ def _register_patched_dtype_reduce():
 
     if NUMPY_LT_1_7:
         import numpy as np
-        import copy_reg
+        from ...extern.six.moves import copyreg
 
         # Originally this created an alternate constructor that fixed this
         # issue, and returned that constructor from the new reduce_dtype;
@@ -74,7 +74,7 @@ def _register_patched_dtype_reduce():
                 info = (info[0], args) + info[2:]
             return info
 
-        copy_reg.pickle(np.dtype, reduce_dtype)
+        copyreg.pickle(np.dtype, reduce_dtype)
 
 
 if not _ASTROPY_SETUP_:


### PR DESCRIPTION
There is a fix for a numpy bug in `utils.compat.numpycompat._register_patched_dtype_reduce()`
Since that fix involves importing `copy_reg`, this fix only works on Python 2: on Python 3 the module is named `copyreg`, and causes an `ImportError`.

I assume that most (or all) tests just install astropy with the most recent numpy version, hence this bug would not be discovered by Travis.

Admittedly, this is a rare case: I came across this trying to fix an astropy installation for a colleague, who is on a system with Python 3.2 (!) and likely an old-ish version of numpy as well. So support for such a rare case may not be warranted.

On the other hand, this is probably an easy and non-intrusive fix. I'd be happy to create a PR for this, though (as I'm not a `six` fan) would implement it as:

```
try:
    import copyreg
except ImportError:
    import copy_reg as copyreg
```

and adjust the code below as well.

If astropy dictates `six` should be used, just let me know. 
Provided of course it is felt that a bug fix for a rare case like this is wanted.
