### PR TITLE
Add a clarification to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,12 @@ include the following:
 - **Changelog entry**: whether you are fixing a bug or adding new
   functionality, you should add an entry to the ``CHANGES.rst`` file that
   includes if possible the issue number (if you are opening a pull request you
-  may not know this yet, but you can add it once the pull request is open). You
-  do not need to include a changelog entry for fixes to bugs introduced in the
-  developer version and which are not present in the stable releases.  In
+  may not know this yet, but you can add it once the pull request is open). If
+  you're not sure where to put the changelog entry, wait at least until a
+  maintainer has reviewed your PR and assigned it to a milestone.
+
+  You do not need to include a changelog entry for fixes to bugs introduced in
+  the developer version and which are not present in the stable releases.  In
   general you do not need to include a changelog entry for minor documentation
   or test updates.  Only user-visible changes (new features/API changes, fixed
   issues) need to be mentioned.  If in doubt ask the core maintainer reviewing


### PR DESCRIPTION
that a changelog entry shouldn't be added right away if you're not sure where to put it.  New contributors have been good lately about adding changelog entries, but they frequently don't put them in the right place (which is not always immediately determined--it depends on the issue and what versions it applies to). [skip ci]