### PR TITLE
Allow access to parent table in table aggregation function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ New Features
     yield tables with an "idx" column, allowing easy identification of the index
     of a row even when the table is re-sorted in the browser. [#4404]
 
+  - Enhance table and column aggregation to allow access to other table columns
+    and provide for additional arguments in ``aggregate`` that get passed
+    through to the aggregation function. [#4513]
+
 - ``astropy.tests``
 
 - ``astropy.time``


### PR DESCRIPTION
Currently the table aggregation function is passed only the slice of the single column being aggregated.  A column slice loses the reference to the parent table.  It can be useful to have access to the other table columns in some situations.

One way to accomplish this would be to allow the aggregation function to define three keyword parameters: `parent_table`, `i0`, `i1`.  The `ColumnGroups.aggregate()` method would be patched to inspect the function signature and provide those values if the function takes them.  For example:

```
def average_weighted(col, parent_table=None, i0=None, i1=None):
    """
    Return weighted average of ``col``.  This assumes the ``parent_table``
    has a column named ``weight``.  The args ``i0`` and ``i1`` represent
    the slice boundary for the current group being aggregated.
    """
    if parent_table is None:
        raise ValueError('this aggregation function requires astropy >= 1.2')
    if col.info.name == 'weight':
        value = col.sum()
    else:
        weight = parent_table['weight'][i0: i1]
        value = (col * weight).sum() / weight.sum()

    return value
```

While we're at it, it would be useful to allow for additional arbitrary `**kwargs` to be passed.  In this case one might like to specify the name of the `weight` column.  So the `aggregate` method would get a new `**kwargs` that would get passed through to the aggregation function as well.

```
def average_weighted(col, parent_table=None, i0=None, i1=None, weight_colname='weight'):
    """
    Return weighted average of ``col``.  This assumes the ``parent_table``
    has a column named ``weight``.  The args ``i0`` and ``i1`` represent
    the slice boundary for the current group being aggregated.
    """
    if parent_table is None:
        raise ValueError('this aggregation function requires astropy >= 1.2')
    if col.info.name == weight_colname:
        value = col.sum()
    else:
        weight = parent_table[weight_colname][i0: i1]
        value = (col * weight).sum() / weight.sum()

    return value

out = t.groups.aggregate(average_weighted, weight_colname='col_weights')
```
