### PR TITLE
Fix deepcopy/pickle of binary table columns with the X, P, or Q format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -323,6 +323,9 @@ Bug Fixes
   - Fixed possible segfault during error handling in FITS tile
     compression. [#4489]
 
+  - Fixed crash on pickling of binary table columns with the 'X', 'P', or
+    'Q' format. [#4514]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -1065,6 +1068,9 @@ Bug Fixes
 
   - Fixed possible segfault during error handling in FITS tile
     compression. [#4489]
+
+  - Fixed crash on pickling of binary table columns with the 'X', 'P', or
+    'Q' format. [#4514]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -322,6 +322,9 @@ class _FormatX(str):
         obj.repeat = repeat
         return obj
 
+    def __getnewargs__(self):
+        return (self.repeat,)
+
     @property
     def tform(self):
         return '%sX' % self.repeat
@@ -348,6 +351,9 @@ class _FormatP(str):
         obj.repeat = repeat
         obj.max = max
         return obj
+
+    def __getnewargs__(self):
+        return (self.dtype, self.repeat, self.max)
 
     @classmethod
     def from_tform(cls, format):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 from __future__ import division, with_statement, print_function
 
+import copy
+
 import numpy as np
 from numpy import char as chararray
 
@@ -2758,3 +2760,38 @@ class TestColumnFunctions(FitsTestCase):
         assert table.data.dtype.names == ('foo',)
         assert table.columns.names == ['foo']
         assert table.data.columns.names == ['foo']
+
+    def test_x_column_deepcopy(self):
+        """
+        Regression test for #XXX
+
+        Tests that columns with the X (bit array) format can be deep-copied.
+        """
+
+        c = fits.Column('xcol', format='5X', array=[1, 0, 0, 1, 0])
+        c2 = copy.deepcopy(c)
+        assert c2.name == c.name
+        assert c2.format == c.format
+        assert np.all(c2.array == c.array)
+
+    def test_p_column_deepcopy(self):
+        """
+        Regression test for #XXX
+
+        Tests that columns with the P/Q formats (variable length arrays) can be
+        deep-copied.
+        """
+
+        c = fits.Column('pcol', format='PJ', array=[[1, 2], [3, 4, 5]])
+        c2 = copy.deepcopy(c)
+        assert c2.name == c.name
+        assert c2.format == c.format
+        assert np.all(c2.array[0] == c.array[0])
+        assert np.all(c2.array[1] == c.array[1])
+
+        c3 = fits.Column('qcol', format='QJ', array=[[1, 2], [3, 4, 5]])
+        c4 = copy.deepcopy(c3)
+        assert c4.name == c3.name
+        assert c4.format == c3.format
+        assert np.all(c4.array[0] == c3.array[0])
+        assert np.all(c4.array[1] == c3.array[1])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2763,7 +2763,7 @@ class TestColumnFunctions(FitsTestCase):
 
     def test_x_column_deepcopy(self):
         """
-        Regression test for #XXX
+        Regression test for https://github.com/astropy/astropy/pull/4514
 
         Tests that columns with the X (bit array) format can be deep-copied.
         """
@@ -2776,7 +2776,7 @@ class TestColumnFunctions(FitsTestCase):
 
     def test_p_column_deepcopy(self):
         """
-        Regression test for #XXX
+        Regression test for https://github.com/astropy/astropy/pull/4514
 
         Tests that columns with the P/Q formats (variable length arrays) can be
         deep-copied.


### PR DESCRIPTION
Incidentally, I came across this bug in testing to see if #520 is still an issue.