### PR TITLE
fix double-definition of wcslib link in docs

### DIFF
--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -5,7 +5,6 @@
 World Coordinate System (`astropy.wcs`)
 ***************************************
 
-.. _wcslib: http://www.atnf.csiro.au/people/mcalabre/WCS/
 .. _FITS WCS standard: http://fits.gsfc.nasa.gov/fits_wcs.html
 .. _distortion paper: http://www.atnf.csiro.au/people/mcalabre/WCS/dcs_20040422.pdf
 .. _SIP: http://irsa.ipac.caltech.edu/data/SPITZER/docs/files/spitzer/shupeADASS.pdf

--- a/docs/wcs/references.txt
+++ b/docs/wcs/references.txt
@@ -1,4 +1,4 @@
-.. _wcslib: http://www.atnf.csiro.au/~mcalabre/WCS/
+.. _wcslib: http://www.atnf.csiro.au/people/~mcalabre/WCS/
 .. _distortion paper: http://www.atnf.csiro.au/people/mcalabre/WCS/dcs_20040422.pdf
 .. _SIP: http://irsa.ipac.caltech.edu/data/SPITZER/docs/files/spitzer/shupeADASS.pdf
 .. _ds9: http://hea-www.harvard.edu/RD/ds9/


### PR DESCRIPTION
In #4504, it appears that a definition of the ``.. _wcslib:`` doc link was added, but it was added in ``wcs/index.rst``.  But that link is *already* defined in ``wcs/references.txt``, so sphinx was giving major errors due to definition of the same links twice.  

I think this just slipped by Travis because there were other spurious errors in the sphinx build that probably led to this going un-tested.  But this PR gets the docs to build without errors again on my local machine.

@embray, I marked this as 1.0.9 as that's what #4504 is - that's right, isn't it?