### PR TITLE
Allow aggregation over multiple columns at once

### DIFF
--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -328,9 +328,8 @@ class TableGroups(BaseGroups):
         else:
             return self._indices
 
-    def aggregate(self, func):
-        """
-        Aggregate each group in the Table into a single row by applying the reduction
+    def aggregate(self, func, use_table=False):
+        """Aggregate each group in the Table into a single row by applying the reduction
         function ``func`` to group values in each column.
 
         Parameters
@@ -338,30 +337,43 @@ class TableGroups(BaseGroups):
         func : function
             Function that reduces an array of values to a single value
 
+        use_table : bool
+            If use_table is True, the aggregating functions obtains a
+            sliced table instance instead, and should return a table
+            Row or an object that can be used
+
         Returns
         -------
         out : Table
             New table with the aggregated rows.
+
         """
 
         i0s, i1s = self.indices[:-1], self.indices[1:]
-        out_cols = []
+        out = []
         parent_table = self.parent_table
 
-        for col in six.itervalues(parent_table.columns):
-            # For key columns just pick off first in each group since they are identical
-            if col.info.name in self.key_colnames:
-                new_col = col.take(i0s)
-            else:
-                try:
-                    new_col = col.groups.aggregate(func)
-                except TypeError as err:
-                    warnings.warn(six.text_type(err), AstropyUserWarning)
-                    continue
+        if use_table:  # Pass the sliced table to ``func``
+            print('COLNAMES', parent_table.colnames)
+            for i0, i1 in izip(i0s, i1s):
+                row = func(parent_table[i0:i1][parent_table.colnames])
+                out.append(row.copy())
+        else:
+            for col in six.itervalues(parent_table.columns):
+                # For key columns just pick off first in each group
+                # since they are identical
+                if col.info.name in self.key_colnames:
+                    new_col = col.take(i0s)
+                else:
+                    try:
+                        new_col = col.groups.aggregate(func)
+                    except TypeError as err:
+                        warnings.warn(six.text_type(err), AstropyUserWarning)
+                        continue
 
-            out_cols.append(new_col)
+                out.append(new_col)
 
-        return parent_table.__class__(out_cols, meta=parent_table.meta)
+        return parent_table.__class__(out, meta=parent_table.meta)
 
     def filter(self, func):
         """

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -498,6 +498,31 @@ def test_table_aggregate_reduceat(T1):
                              '  2']
 
 
+def test_table_aggregate_multiple_columns(T1):
+    """Aggregate multiple columns at once"""
+    def average_weighted(table):
+        """Return a weighted average.
+        Column 'c' are the values, 'd' are the weights.
+        Take the first element of row 'a', since these are all the
+        same anyway.
+
+        """
+        result = {'a': table['a'][0],
+                  'c': (table['c'] * table['d']).sum() / table['d'].sum(),
+                  'd': table['d'].sum()}
+        return result
+
+    t1 = T1['a', 'c', 'd']
+    tg = t1.group_by('a')
+    tga = tg.groups.aggregate(average_weighted, use_table=True)
+    tga['c'].format = '.2f'
+    assert tga.pformat() == [' a   c    d ',
+                             '--- ---- ---',
+                             '  0 0.00   4',
+                             '  1 1.89  18',
+                             '  2 4.83   6']
+
+
 def test_column_aggregate(T1):
     """
     Aggregate a single table column


### PR DESCRIPTION
This provides an option to pass the row-sliced table to the
aggregating (user) function, instead of just a single column (the
slice is across aggregated rows). The function should accept a table,
and return a single row in the form of a dict. The dict should contain
the complete set of column names as keys.
