### PR TITLE
Fix format conversion in the fast writer with plain format strings ('.2f')

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1131,6 +1131,7 @@ Bug Fixes
 
   - Fixed reading of Latex tables where the ``\tabular`` tag is in the first
     line. [#4595]
+  - Fix use of plain format strings with the fast writer. [#4517]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -912,8 +912,8 @@ cdef class FastWriter:
                 if col.format is None and not (six.PY3 and col.dtype.kind == 'S'):
                     self.format_funcs.append(None)
                 else:
-                    self.format_funcs.append(pprint._format_funcs.get(col.format,
-                                                            auto_format_func))
+                    self.format_funcs.append(pprint._format_funcs.get(
+                        col.format, pprint._auto_format_func))
                 # col is a numpy.ndarray, so we convert it to
                 # an ordinary list because csv.writer will call
                 # np.array_str() on each numpy value, which is
@@ -1048,38 +1048,3 @@ def get_fill_values(fill_values, read=True):
         return (fill_values, fill_empty)
     else:
         return fill_values # cache for empty values doesn't matter for writing
-
-def auto_format_func(format_, val):
-    """
-    Mimics pprint._auto_format_func for non-numpy values.
-    """
-    if six.callable(format_):
-        format_func = lambda format_, val: format_(val)
-        try:
-            out = format_func(format_, val)
-            if not isinstance(out, six.string_types):
-                raise ValueError('Format function for value {0} returned {1} instead of string type'
-                                 .format(val, type(val)))
-        except Exception as err:
-            raise ValueError('Format function for value {0} failed: {1}'
-                             .format(val, err))
-    else:
-        try:
-            # Convert val to Python object with tolist().  See
-            # https://github.com/astropy/astropy/issues/148#issuecomment-3930809
-            out = format_.format(val)
-            # Require that the format statement actually did something
-            if out == format_:
-                raise ValueError
-            format_func = lambda format_, val: format_.format(val)
-        except:  # Not sure what exceptions might be raised
-            try:
-                out = format_ % val
-                if out == format_:
-                    raise ValueError
-                format_func = lambda format_, val: format_ % val
-            except:
-                raise ValueError('Unable to parse format string {0}'
-                                 .format(format_))
-    pprint._format_funcs[format_] = format_func
-    return out

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -469,6 +469,17 @@ def test_write_comments(fast_writer):
     assert out.getvalue().splitlines() == expected
 
 @pytest.mark.parametrize("fast_writer", [True, False])
+@pytest.mark.parametrize("fmt", ['%0.1f', '.1f', '0.1f', '{:0.1f}'])
+def test_write_format(fast_writer, fmt):
+    """Check different formats for a column."""
+    data = ascii.read('#c1\n  # c2\t\na,b,c\n#  c3\n1.11,2.22,3.33')
+    out = StringIO()
+    expected = ['# c1', '# c2', '# c3', 'a b c', '1.1 2.22 3.33']
+    data['a'].format = fmt
+    ascii.write(data, out, format='basic', fast_writer=fast_writer)
+    assert out.getvalue().splitlines() == expected
+
+@pytest.mark.parametrize("fast_writer", [True, False])
 def test_strip_names(fast_writer):
     """Names should be stripped of whitespace by default."""
     data = table.Table([[1], [2], [3]], names=(' A', 'B ', ' C '))


### PR DESCRIPTION
Plain format strings (`'.2f'`) were not supported by the fast writer, whereas it is by the basic writer: http://docs.astropy.org/en/latest/table/construct_table.html#format-specifier

With the fast writer I get this error:
```
astropy/io/ascii/cparser.pyx in astropy.io.ascii.cparser.FastWriter.write (astropy/io/ascii/cparser.c:18549)()

astropy/io/ascii/cparser.pyx in astropy.io.ascii.cparser.auto_format_func (astropy/io/ascii/cparser.c:20888)()

ValueError: Unable to parse format string .1f
```

The basic writer use `astropy.table.pprint._auto_format_func` to try the different formatting syntaxes. And the fast writer was reimplementing this in `cparser.pyx` (`auto_format_func`). The comment on these function is not so clear about why the function is duplicated (*Mimics pprint._auto_format_func for non-numpy values.*), and the function does less than `astropy.table.pprint._auto_format_func` so this commit just use this function. But maybe there is a good reason for this duplication ?

cc @taldcroft 

