### PR TITLE
Remove duplicate or useless statements 

### DIFF
--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -15,14 +15,8 @@ from ....table import Table
 import numpy as np
 
 from ....tests.helper import pytest
-from ....extern.six.moves import zip as izip
 from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true, setup_function, teardown_function)
-
-try:
-    from itertools import izip
-except ImportError:
-    izip = zip
 
 # Check to see if the BeautifulSoup dependency is present.
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -262,12 +262,6 @@ def ignore_sigint(func):
     return wrapped
 
 
-def first(iterable):
-    """Returns the first element from an iterable."""
-
-    return next(iter(iterable))
-
-
 def pairwise(iterable):
     """Return the items of an iterable paired with its next item.
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.extern import six
-
 from ... import units as u
 from ...extern import six
 from ...tests.helper import pytest


### PR DESCRIPTION
`io.fits.util.first` was defined twice. I then looked quickly at the *F811 redefinition of unused ...* error, and found a few other things:
- Python 2.6 code in ah_bootstrap (cc @embray )
- duplicate imports

There is also a duplicate `test_find_by_hash` function in https://github.com/astropy/astropy/blob/master/astropy/utils/tests/test_data.py#L83: it seems that pytest runs both, but I could rename one of the two ?