### PR TITLE
Cleanup: remove unused imports

### DIFF
--- a/astropy/_erfa/setup_package.py
+++ b/astropy/_erfa/setup_package.py
@@ -62,7 +62,7 @@ def preprocess_source():
 
         # If jinja2 isn't present, then print a warning and use existing files
         try:
-            import jinja2
+            import jinja2  # pylint: disable=W0611
         except:
             log.warn("WARNING: jinja2 could not be imported, so the existing "
                      "ERFA core.py and core.c files will be used")

--- a/astropy/analytic_functions/tests/test_blackbody.py
+++ b/astropy/analytic_functions/tests/test_blackbody.py
@@ -3,7 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import warnings
 # THIRD-PARTY
 import numpy as np
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -122,7 +122,7 @@ def test_configitem_types():
 
     from ...tests.helper import pytest
 
-    from ..configuration import ConfigNamespace, ConfigItem, get_config
+    from ..configuration import ConfigNamespace, ConfigItem
 
     cio = ConfigItem(['op1', 'op2', 'op3'])
 
@@ -220,7 +220,7 @@ def test_config_noastropy_fallback(monkeypatch):
 
 def test_configitem_setters():
 
-    from ..configuration import ConfigNamespace, ConfigItem, get_config
+    from ..configuration import ConfigNamespace, ConfigItem
 
     class Conf(ConfigNamespace):
         tstnm12 = ConfigItem(42, 'this is another Description')

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -22,7 +22,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     '''
     Convolve an array with a kernel.
 
-    This routine differs from `scipy.ndimage.filters.convolve` because
+    This routine differs from `scipy.ndimage.convolve` because
     it includes a special treatment for ``NaN`` values. Rather than
     including ``NaN`` values in the array in the convolution calculation, which
     causes large ``NaN`` holes in the convolved array, ``NaN`` values are

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -540,7 +540,7 @@ class MexicanHat1DKernel(Kernel1D):
     This kernel is derived from a normalized Gaussian function, by
     computing the second derivative. This results in an amplitude
     at the kernels center of 1. / (sqrt(2 * pi) * width ** 3). The
-    normalization is the same as for `scipy.ndimage.filters.gaussian_laplace`,
+    normalization is the same as for `scipy.ndimage.gaussian_laplace`,
     except for a minus sign.
 
     Parameters
@@ -610,7 +610,7 @@ class MexicanHat2DKernel(Kernel2D):
     This kernel is derived from a normalized Gaussian function, by
     computing the second derivative. This results in an amplitude
     at the kernels center of 1. / (pi * width ** 4). The normalization
-    is the same as for `scipy.ndimage.filters.gaussian_laplace`, except
+    is the same as for `scipy.ndimage.gaussian_laplace`, except
     for a minus sign.
 
     Parameters

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -16,7 +16,7 @@ from ...modeling.tests.example_models import models_1D, models_2D
 from ...modeling.tests.test_models import create_model
 
 try:
-    import scipy
+    import scipy  # pylint: disable=W0611
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False

--- a/astropy/convolution/tests/test_pickle.py
+++ b/astropy/convolution/tests/test_pickle.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from ...extern.six.moves import cPickle
 from ... import convolution as conv
 from ...tests.helper import pytest, pickle_protocol, check_pickling_recovery
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -10,7 +10,6 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 # Standard library
 import inspect
-import warnings
 from copy import deepcopy
 from collections import namedtuple, OrderedDict
 
@@ -20,7 +19,6 @@ import numpy as np
 # Project
 from ..utils.compat.misc import override__dir__
 from ..extern import six
-from ..utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from .. import units as u
 from ..utils import OrderedDescriptor, OrderedDescriptorContainer
 from .transformations import TransformGraph

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -12,7 +12,7 @@ import numpy as np
 from ... import units as u
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform
-from ..representation import (SphericalRepresentation, CartesianRepresentation,
+from ..representation import (SphericalRepresentation,
                               UnitSphericalRepresentation)
 from ... import _erfa as erfa
 

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -18,7 +18,7 @@ from ... import _erfa as erfa
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .utils import get_polar_motion, get_dut1utc, get_jd12
+from .utils import get_polar_motion, get_jd12
 
 # # first define helper functions
 def gcrs_to_cirs_mat(time):

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -4,8 +4,7 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 from ..representation import CartesianRepresentation
-from ..baseframe import BaseCoordinateFrame, TimeFrameAttribute, frame_transform_graph
-from ..transformations import FunctionTransform
+from ..baseframe import BaseCoordinateFrame, TimeFrameAttribute
 from .utils import DEFAULT_OBSTIME
 
 

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 from ... import units as u
-from ..angles import Angle
 from ..representation import SphericalRepresentation
 from ..baseframe import BaseCoordinateFrame, RepresentationMapping
 from .galactic import Galactic

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -180,7 +180,6 @@ class Distance(u.Quantity):
         z : float
             The redshift of this distance given the provided ``cosmology``.
         """
-        from scipy import optimize
 
         if cosmology is None:
             from ..cosmology import default_cosmology

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -16,7 +16,6 @@ import re
 import socket
 
 # Astropy
-from ..extern import six
 from ..extern.six.moves import urllib
 from .. import units as u
 from .sky_coordinate import SkyCoord
@@ -113,7 +112,6 @@ def get_icrs_coordinates(name):
         The object's coordinates in the ICRS frame.
 
     """
-    from .. import conf
 
     database = sesame_database.get()
     # The web API just takes the first letter of the database name

--- a/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
+++ b/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ....tests.helper import pytest, catch_warnings
 from .... import units as u
-from ....time import Time, TimeDelta
+from ....time import Time
 from ...builtin_frames import AltAz
 from ... import EarthLocation
 from ... import Angle, SkyCoord

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 
 import numpy as np
 

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 
 import numpy as np
 

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 
 import numpy as np
 

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 
 import numpy as np
 

--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -9,7 +9,6 @@ Tests for the projected separation stuff
 """
 
 import numpy as np
-from numpy import testing as npt
 
 from ...tests.helper import pytest, assert_quantity_allclose as assert_allclose
 from ... import units as u

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -27,7 +27,7 @@ from ... import coordinates as coords
 from ..errors import *
 
 try:
-    import scipy
+    import scipy  # pylint: disable=W0611
 except ImportError:
     HAS_SCIPY = False
 else:

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -8,16 +8,11 @@ import numpy as np
 
 from ... import units as u
 from ..distances import Distance
-from .. import transformations as t
-from ..builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, \
-                             Supergalactic, Galactocentric, CIRS, GCRS, AltAz, \
-                             ITRS, PrecessedGeocentric
+from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
+                              Supergalactic, Galactocentric)
 from .. import SkyCoord
-from .. import representation as r
-from ..baseframe import frame_transform_graph
 from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
-from .utils import randomly_sample_sphere
 from ...time import Time
 
 # used below in the next parametrized test

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -10,7 +10,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ...extern import six
-from ...tests.helper import pytest
 
 from ..angles import Angle
 from ... import units as u

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -188,7 +188,6 @@ def test_converting_units():
     import re
     from ..baseframe import RepresentationMapping
     from ..builtin_frames import ICRS, FK5
-    from ..representation import SphericalRepresentation
 
     # this is a regular expression that with split (see below) removes what's
     # the decimal point  to fix rounding problems
@@ -364,7 +363,6 @@ def test_time_inputs():
     """
     from ...time import Time
     from ..builtin_frames import FK4
-    from ...utils.exceptions import AstropyWarning
 
     c = FK4(1 * u.deg, 2 * u.deg, equinox='J2001.5', obstime='2000-01-01 12:00:00')
     assert c.equinox == Time('J2001.5')

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -14,7 +14,7 @@ from ...tests.helper import (pytest,
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
                 PrecessedGeocentric, CartesianRepresentation,
-                SphericalRepresentation, UnitSphericalRepresentation)
+                SphericalRepresentation)
 
 
 from ..._erfa import epv00

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -6,7 +6,7 @@ import numpy as np
 
 #Can't test distances without scipy due to cosmology deps
 try:
-    import scipy
+    import scipy  # pylint: disable=W0611
     HAS_SCIPY = True
 except:
     HAS_SCIPY = False

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -16,7 +16,6 @@ from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS
 from ...time import Time
 
 from ...tests.helper import pytest, assert_quantity_allclose
-from .test_matching import HAS_SCIPY, OLDER_SCIPY
 
 
 def test_regression_3920():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -22,11 +22,12 @@ from ..representation import REPRESENTATION_CLASSES
 from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             SphericalRepresentation, CartesianRepresentation,
                             UnitSphericalRepresentation, AltAz)
-from ...coordinates import Latitude, Longitude, EarthLocation
+from ...coordinates import Latitude, EarthLocation
 from ...time import Time
 from ...utils import minversion
 from ...utils.exceptions import AstropyDeprecationWarning
-from ...utils.compat import NUMPY_LT_1_7
+from ...utils.compat import NUMPY_LT_1_7  # pylint: disable=W0611
+
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -7,17 +7,11 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ... import units as u
-from ..distances import Distance
 from .. import transformations as t
-from ..builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, \
-                             Supergalactic, Galactocentric, CIRS, GCRS, AltAz, \
-                             ITRS, PrecessedGeocentric, HeliocentricTrueEcliptic, \
-                             BarycentricTrueEcliptic
+from ..builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic
 from .. import representation as r
 from ..baseframe import frame_transform_graph
-from ...tests.helper import (pytest, quantity_allclose as allclose,
-                             assert_quantity_allclose as assert_allclose)
-from .utils import randomly_sample_sphere
+from ...tests.helper import assert_quantity_allclose as assert_allclose
 from ...time import Time
 
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -8,10 +8,8 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 import numpy as np
 
-from .core import default_cosmology as _default_cosmology
 from .core import CosmologyError
 from ..units import Quantity
-from ..utils import deprecated
 
 __all__ = ['z_at_value']
 

--- a/astropy/cosmology/tests/test_pickle.py
+++ b/astropy/cosmology/tests/test_pickle.py
@@ -1,10 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import numpy as np
 
 from ...tests.helper import pytest, pickle_protocol, check_pickling_recovery
-from ...extern.six.moves import cPickle
 from ... import cosmology as cosm
 
 originals = [cosm.FLRW]

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -4,11 +4,9 @@ from __future__ import absolute_import
 
 import os
 
-from distutils import version
 
 import numpy as np
 
-from ... import ascii
 
 __all__ = ['raises', 'assert_equal', 'assert_almost_equal',
            'assert_true', 'setup_function', 'teardown_function',

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ....tests.helper import pytest
 from ... import ascii
 from .common import (assert_equal, assert_almost_equal, has_isnan,
                      setup_function, teardown_function)

--- a/astropy/io/ascii/tests/test_compressed.py
+++ b/astropy/io/ascii/tests/test_compressed.py
@@ -10,7 +10,7 @@ ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 try:
-    import bz2
+    import bz2  # pylint: disable=W0611
 except ImportError:
     HAS_BZ2 = False
 else:
@@ -20,7 +20,7 @@ try:
     if sys.version_info >= (3,3,0):
         import lzma
     else:
-        from backports import lzma
+        from backports import lzma  # pylint: disable=W0611
 except ImportError:
     HAS_XZ = False
 else:

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -12,7 +12,7 @@ files = ['t/cds.dat', 't/ipac.dat', 't/daophot.dat', 't/latex1.tex',
 # Check to see if the BeautifulSoup dependency is present.
 
 try:
-    from bs4 import BeautifulSoup
+    from bs4 import BeautifulSoup  # pylint: disable=W0611
     HAS_BEAUTIFUL_SOUP = True
 except ImportError:
     HAS_BEAUTIFUL_SOUP = False

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -21,7 +21,7 @@ from ..ecsv import DELIMITERS
 from ... import ascii
 
 try:
-    import yaml
+    import yaml  # pylint: disable=W0611
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -15,8 +15,7 @@ from ....table import Table
 import numpy as np
 
 from ....tests.helper import pytest
-from .common import (raises, assert_equal, assert_almost_equal,
-                     assert_true, setup_function, teardown_function)
+from .common import setup_function, teardown_function
 
 # Check to see if the BeautifulSoup dependency is present.
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 
 import numpy as np
 
-from ....extern import six
 from ....extern.six.moves import cStringIO as StringIO
 from ....tests.helper import pytest
 from ... import ascii

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -20,7 +20,7 @@ from .. import core
 from ..ui import _probably_html, get_read_trace
 
 try:
-    import bz2
+    import bz2  # pylint: disable=W0611
 except ImportError:
     HAS_BZ2 = False
 else:
@@ -786,7 +786,7 @@ def get_testfiles(name=None):
     ]
 
     try:
-        import bs4
+        import bs4  # pylint: disable=W0611
         testfiles.append({'cols': ('Column 1', 'Column 2', 'Column 3'),
                           'name': 't/html.html',
                           'nrows': 3,

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -9,7 +9,6 @@ except ImportError:
 
 import numpy as np
 
-from ....tests.helper import pytest
 from ... import ascii
 
 from .common import assert_equal, setup_function, teardown_function

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -36,7 +36,7 @@ from ...extern import six
 _read_trace = []
 
 try:
-    import yaml
+    import yaml  # pylint: disable=W0611
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False

--- a/astropy/io/fits/_numpy_hacks.py
+++ b/astropy/io/fits/_numpy_hacks.py
@@ -5,7 +5,6 @@ relevant to FITS) or that otherwise require workarounds.
 """
 
 
-import numpy as np
 
 
 def realign_dtype(dtype, offsets):

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -20,7 +20,6 @@ from .util import (isreadable, iswritable, isfile, fileobj_open, fileobj_name,
                    fileobj_closed, fileobj_mode, _array_from_file,
                    _array_to_file, _write_string)
 from ...extern.six import b, string_types
-from ...extern.six.moves import urllib
 from ...utils.data import download_file, _is_url
 from ...utils.decorators import classproperty
 from ...utils.exceptions import AstropyUserWarning

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
-import contextlib
 import sys
 import warnings
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import warnings
 
 import numpy as np
@@ -9,7 +8,6 @@ from ... import fits
 from .. import HDUList, PrimaryHDU, BinTableHDU
 from ....table import Table
 from .... import units as u
-from .... import log
 from ....tests.helper import pytest, catch_warnings
 from astropy.units.format.fits import UnitScaleError
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -6,7 +6,6 @@ import bz2
 import io
 import mmap
 import os
-import shutil
 import warnings
 import zipfile
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -20,7 +20,7 @@ from ....utils.exceptions import AstropyDeprecationWarning
 
 from . import FitsTestCase
 from ..card import _pad
-from ..header import _pad_length, BLOCK_SIZE
+from ..header import _pad_length
 from ..util import encode_ascii
 
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -11,7 +11,6 @@ from ....extern.six.moves import range
 from ....extern.six.moves import cPickle as pickle
 from ....io import fits
 from ....tests.helper import pytest, catch_warnings, ignore_warnings
-from ....utils.compat.numpycompat import NUMPY_LT_1_10
 
 from ..column import Delayed, NUMPY2FITS
 from ..util import decode_ascii

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
-import os
 import platform
 
 import numpy as np

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -2,7 +2,6 @@
 
 from __future__ import division
 
-import errno
 import gzip
 import itertools
 import io

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import os
 
 import numpy as np
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -14,10 +14,7 @@ from ....extern.six.moves import xrange
 # STDLIB
 import difflib
 import io
-import os
-import shutil
 import sys
-import tempfile
 import gzip
 
 # THIRD-PARTY

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -28,11 +28,11 @@ from ...utils.misc import InheritDocstrings
 
 from . import converters
 from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
-    warn_unknown_attrs,
-    W06, W07, W08, W09, W10, W11, W12, W13, W15, W17, W18, W19, W20,
-    W21, W22, W26, W27, W28, W29, W32, W33, W35, W36, W37, W38, W40,
-    W41, W42, W43, W44, W45, W50, W52, W53, E06, E08, E09, E10, E11,
-    E12, E13, E14, E15, E16, E17, E18, E19, E20, E21)
+                         warn_unknown_attrs, W06, W07, W08, W09, W10, W11, W12,
+                         W13, W15, W17, W18, W19, W20, W21, W22, W26, W27, W28,
+                         W29, W32, W33, W35, W36, W37, W38, W40, W41, W42, W43,
+                         W44, W45, W50, W52, W53, E06, E08, E09, E10, E11, E12,
+                         E13, E15, E16, E17, E18, E19, E20, E21)
 from . import ucd as ucd_mod
 from . import util
 from . import xmlutil

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-import inspect
 
 import numpy as np
 
@@ -14,7 +13,6 @@ from .core import (Fittable1DModel, Fittable2DModel, Model,
 from .parameters import Parameter, InputParameterError
 from .utils import ellipse_extent
 from ..utils import deprecated
-from ..utils.compat.funcsigs import signature
 from ..extern import six
 
 from .utils import get_inputs_and_params

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -7,7 +7,7 @@ Creates a common namespace for all pre-defined models.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from .core import custom_model
+from .core import custom_model  # pylint: disable=W0611
 from .mappings import *
 from .projections import *
 from .rotations import *

--- a/astropy/modeling/setup_package.py
+++ b/astropy/modeling/setup_package.py
@@ -102,7 +102,7 @@ def preprocess_source():
 
         # If jinja2 isn't present, then print a warning and use existing files
         try:
-            import jinja2
+            import jinja2  # pylint: disable=W0611
         except:
             log.warn("WARNING: jinja2 could not be imported, so the existing "
                      "modeling _projections.c file will be used")

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -11,7 +11,7 @@ from .. import fitting
 from ...tests.helper import pytest
 
 try:
-    from scipy import optimize
+    from scipy import optimize  # pylint: disable=W0611
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -8,7 +8,6 @@ Compare the results of some models with other programs.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import types
 
 try:
     import cPickle as pickle
@@ -26,7 +25,6 @@ from ..core import FittableModel
 from ..polynomial import PolynomialBase
 from ...tests.helper import pytest
 
-from ...extern import six
 
 try:
     from scipy import optimize  # pylint: disable=W0611

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -13,7 +13,7 @@ from numpy.testing import utils
 
 from . import irafutil
 from .. import models, fitting
-from ..core import Model, FittableModel, ModelDefinitionError
+from ..core import Model, FittableModel
 from ..parameters import Parameter, InputParameterError
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest

--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 
 import numpy as np
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -13,7 +13,7 @@ from ...coordinates import SkyCoord
 from ... import units as u
 
 try:
-    import skimage
+    import skimage  # pylint: disable=W0611
     HAS_SKIMAGE = True
 except ImportError:
     HAS_SKIMAGE = False

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ...tests.helper import pytest
 from  numpy.testing import assert_allclose
-from .. import bayesian_blocks, Events, RegularEvents, PointMeasures
+from .. import bayesian_blocks, RegularEvents
 
 
 def test_single_change_point(rseed=0):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
 try:
-    import scipy
+    import scipy  # pylint: disable=W0611
 except ImportError:
     HAS_SCIPY = False
 else:

--- a/astropy/stats/tests/test_jackknife.py
+++ b/astropy/stats/tests/test_jackknife.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
 try:
-    import scipy
+    import scipy  # pylint: disable=W0611
 except ImportError:
     HAS_SCIPY = False
 else:

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -116,7 +116,6 @@ def column_group_by(column, keys):
     grouped_column : Column object with groups attr set accordingly
     """
     from .table import Table
-    from .column import Column
 
     if isinstance(keys, Table):
         keys = keys.as_array()

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -36,7 +36,7 @@ from copy import deepcopy
 import numpy as np
 
 from ..extern import six
-from .bst import BST, FastBST, FastRBT, MinValue, MaxValue
+from .bst import MinValue, MaxValue
 from .sorted_array import SortedArray
 from ..time import Time
 

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -8,7 +8,6 @@ import sys
 import os
 
 import numpy as np
-from ..extern import six
 from ..utils.data_info import DataInfo
 
 __all__ = ['table_info', 'TableInfo']

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
 import collections
 
 import numpy as np
-from numpy import ma
 
 from ..extern import six
 from ..utils import deprecated

--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from ..time import Time
 
 def _searchsorted(array, val, side='left'):
     '''

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -4,8 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from ..extern import six
 from ..extern.six.moves import zip as izip
 from ..extern.six.moves import range as xrange
-from .sorted_array import SortedArray
-from .index import QueryError, TableIndices, TableLoc, TableILoc
+from .index import TableIndices, TableLoc, TableILoc
 
 import re
 import sys

--- a/astropy/table/tests/test_bst.py
+++ b/astropy/table/tests/test_bst.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from ..bst import BST
 import pytest
-import random
-import math
 
 def get_tree(TreeType):
     b = TreeType([], [])

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -2,12 +2,10 @@
 import pytest
 import numpy as np
 from .test_table import SetupData
-from ..bst import BST, FastBST, FastRBT
+from ..bst import BST, FastRBT
 from ..sorted_array import SortedArray
-from ..table import Table, QTable, NdarrayMixin, Row
-from ...table import table_helpers
+from ..table import QTable, Row
 from ... import units as u
-from ...coordinates import SkyCoord
 from ...time import Time
 from ..column import BaseColumn
 

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -5,12 +5,9 @@
 """ Verify item access API in:
 https://github.com/astropy/astropy/wiki/Table-item-access-definition
 """
-from distutils import version
 import numpy as np
 
 from ...tests.helper import pytest
-from ... import table
-from .conftest import MaskedTable
 
 
 @pytest.mark.usefixtures('table_data')

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -6,7 +6,7 @@ from ... import extern
 from ...tests.helper import pytest
 
 try:
-    import IPython
+    import IPython  # pylint: disable=W0611
 except ImportError:
     HAS_IPYTHON = False
 else:

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -4,7 +4,6 @@
 
 """Test behavior related to masked tables"""
 
-from distutils import version
 import numpy as np
 import numpy.ma as ma
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -7,14 +7,14 @@ except ImportError:
     from io import StringIO
 
 try:
-    import h5py
+    import h5py  # pylint: disable=W0611
 except ImportError:
     HAS_H5PY = False
 else:
     HAS_H5PY = True
 
 try:
-    import yaml
+    import yaml  # pylint: disable=W0611
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -1,7 +1,6 @@
 from ...extern.six.moves import cPickle as pickle
 
 import numpy as np
-import pytest
 
 from ...table import Table, Column, MaskedColumn, QTable
 from ...units import Quantity, deg

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -23,7 +23,7 @@ try:
     with ignore_warnings(DeprecationWarning):
         # Ignore DeprecationWarning on pandas import in Python 3.5--see
         # https://github.com/astropy/astropy/issues/4380
-        import pandas
+        import pandas  # pylint: disable=W0611
 except ImportError:
     HAS_PANDAS = False
 else:

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -226,7 +226,7 @@ class AstropyTest(Command, object):
                 "--coverage can not be used with --parallel")
 
         try:
-            import coverage
+            import coverage  # pylint: disable=W0611
         except ImportError:
             raise ImportError(
                 "--coverage requires that the coverage package is "

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -22,7 +22,7 @@ try:
     # Import pkg_resources to prevent it from issuing warnings upon being
     # imported from within py.test.  See
     # https://github.com/astropy/astropy/pull/537 for a detailed explanation.
-    import pkg_resources
+    import pkg_resources  # pylint: disable=W0611
 except ImportError:
     pass
 
@@ -31,7 +31,7 @@ from ..utils.exceptions import (AstropyDeprecationWarning,
 
 
 # For backward-compatibility with affiliated packages
-from .runner import TestRunner
+from .runner import TestRunner  # pylint: disable=W0611
 
 __all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
            'treat_deprecations_as_exceptions', 'catch_warnings',
@@ -236,12 +236,12 @@ def treat_deprecations_as_exceptions():
     # before we turn the warnings into exceptions, we're golden.
     try:
         # A deprecated stdlib module used by py.test
-        import compiler
+        import compiler  # pylint: disable=W0611
     except ImportError:
         pass
 
     try:
-        import scipy
+        import scipy  # pylint: disable=W0611
     except ImportError:
         pass
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -26,9 +26,7 @@ try:
 except ImportError:
     pass
 
-from .. import test
-from ..utils.exceptions import (AstropyWarning,
-                                AstropyDeprecationWarning,
+from ..utils.exceptions import (AstropyDeprecationWarning,
                                 AstropyPendingDeprecationWarning)
 
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -26,12 +26,10 @@ import types
 from collections import OrderedDict
 
 from ..config.paths import set_temp_config, set_temp_cache
-from .helper import (
-    pytest, treat_deprecations_as_exceptions,
-    enable_deprecations_as_exceptions,
-    ignore_warnings)
+from .helper import pytest, treat_deprecations_as_exceptions, ignore_warnings
+from .helper import enable_deprecations_as_exceptions  # pylint: disable=W0611
 from .disable_internet import turn_off_internet, turn_on_internet
-from .output_checker import AstropyOutputChecker, FIX, FLOAT_CMP
+from .output_checker import AstropyOutputChecker, FIX
 from ..utils.argparse import writeable_directory
 from ..utils.introspection import resolve_name
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -182,7 +182,7 @@ class TestRunner(object):
 
         if pep8:
             try:
-                import pytest_pep8
+                import pytest_pep8  # pylint: disable=W0611
             except ImportError:
                 raise ImportError('PEP8 checking requires pytest-pep8 plugin: '
                                   'http://pypi.python.org/pypi/pytest-pep8')
@@ -201,7 +201,7 @@ class TestRunner(object):
                     "parallel testing.")
 
             try:
-                import psutil
+                import psutil  # pylint: disable=W0611
             except ImportError:
                 raise SystemError(
                     "open file detection requested, but psutil package "
@@ -213,7 +213,7 @@ class TestRunner(object):
 
         if parallel != 0:
             try:
-                import xdist
+                import xdist  # pylint: disable=W0611
             except ImportError:
                 raise ImportError(
                     'Parallel testing requires the pytest-xdist plugin '
@@ -243,7 +243,7 @@ class TestRunner(object):
         # This prevents cyclical import problems that make it
         # impossible to test packages that define Table types on their
         # own.
-        from ..table import Table
+        from ..table import Table  # pylint: disable=W0611
 
         # Have to use nested with statements for cross-Python support
         # Note, using these context managers here is superfluous if the

--- a/astropy/tests/tests/test_open_file_detection.py
+++ b/astropy/tests/tests/test_open_file_detection.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import sys
 
 from ...utils.data import get_pkg_data_filename
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -30,7 +30,7 @@ from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
                       TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
 # Import TimeFromEpoch to avoid breaking code that followed the old example of
 # making a custom timescale in the documentation.
-from .formats import TimeFromEpoch
+from .formats import TimeFromEpoch  # pylint: disable=W0611
 
 
 __all__ = ['Time', 'TimeDelta', 'TIME_SCALES', 'TIME_DELTA_SCALES',

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -13,7 +13,6 @@ Handles the CDS string format for units
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import keyword
 import os
 import re
 

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -4,7 +4,7 @@
 from functools import wraps
 from textwrap import dedent
 
-from ... import units as u
+from ... import units as u  # pylint: disable=W0611
 from ...extern import six
 from ...tests.helper import pytest
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from ... import units as u
 from ...tests.helper import pytest
-from ...utils.compat import NUMPY_LT_1_7, NUMPY_LT_1_8, NUMPY_LT_1_9_1
+from ...utils.compat import NUMPY_LT_1_7
+from ...utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_9_1  # pylint: disable=W0611
 
 
 class TestQuantityArrayCopy(object):

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -2,7 +2,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ... import units as u
-from ...extern import six
 from ...tests.helper import pytest
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.testing.utils import assert_allclose
 
 from ... import units as u
 from ...tests.helper import pytest

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -13,14 +13,12 @@ from __future__ import (absolute_import, division, print_function,
 import numbers
 import io
 import re
-import warnings
 from fractions import Fraction
 
 import numpy as np
 from numpy import finfo
 
 from ..extern import six
-from ..utils.exceptions import AstropyDeprecationWarning
 
 _float_finfo = finfo(float)
 # take float here to ensure comparison with another float is fast

--- a/astropy/utils/compat/subprocess.py
+++ b/astropy/utils/compat/subprocess.py
@@ -14,6 +14,6 @@ import subprocess
 
 # python2.7 and later provide a check_output method
 if not hasattr(subprocess, 'check_output'):
-    from ._subprocess_py2 import check_output
+    from ._subprocess_py2 import check_output  # pylint: disable=W0611
 
 from subprocess import *

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -1025,12 +1025,12 @@ class Getch(object):
 
 class _GetchUnix(object):
     def __init__(self):
-        import tty
-        import sys
+        import tty  # pylint: disable=W0611
+        import sys  # pylint: disable=W0611
 
         # import termios now or else you'll get the Unix
         # version on the Mac
-        import termios
+        import termios  # pylint: disable=W0611
 
     def __call__(self):
         import sys
@@ -1048,7 +1048,7 @@ class _GetchUnix(object):
 
 class _GetchWindows(object):
     def __init__(self):
-        import msvcrt
+        import msvcrt  # pylint: disable=W0611
 
     def __call__(self):
         import msvcrt

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -452,7 +452,6 @@ class BaseColumnInfo(DataInfo):
         col_len : int
             Length of original object
         '''
-        from ..table.index import Index
         from ..table.sorted_array import SortedArray
         if not getattr(self, '_copy_indices', True):
             # Necessary because MaskedArray will perform a shallow copy

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import functools
 import inspect
-import sys
 import textwrap
 import types
 import warnings

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, print_function,
 
 
 import inspect
-import sys
 import types
 
 from ..extern import six

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -15,7 +15,6 @@ import difflib
 import inspect
 import json
 import os
-import re
 import signal
 import sys
 import traceback

--- a/astropy/utils/state.py
+++ b/astropy/utils/state.py
@@ -2,12 +2,7 @@
 A simple class to manage a piece of global science state.  See
 :ref:`config-developer` for more details.
 """
-from contextlib import contextmanager
-import warnings
 
-from ..config import ConfigItem
-from .exceptions import AstropyDeprecationWarning
-from ..utils import find_current_module
 
 
 __all__ = ['ScienceState']

--- a/astropy/utils/tests/test_argparse.py
+++ b/astropy/utils/tests/test_argparse.py
@@ -5,7 +5,7 @@ from ..exceptions import AstropyDeprecationWarning
 def test_import_warning():
 
     with catch_warnings() as w:
-        from ..compat import argparse
+        from ..compat import argparse  # pylint: disable=W0611
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -6,7 +6,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ...extern import six
+from ...extern import six  # pylint: disable=W0611
 from ...extern.six import next
 from ...extern.six.moves import xrange
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -26,7 +26,7 @@ TESTURL = 'http://www.astropy.org'
 
 
 try:
-    import bz2
+    import bz2  # pylint: disable=W0611
 except ImportError:
     HAS_BZ2 = False
 else:
@@ -36,7 +36,7 @@ try:
     if sys.version_info >= (3,3,0):
         import lzma
     else:
-        from backports import lzma
+        from backports import lzma  # pylint: disable=W0611
 except ImportError:
     HAS_XZ = False
 else:

--- a/astropy/utils/tests/test_fractions.py
+++ b/astropy/utils/tests/test_fractions.py
@@ -5,7 +5,7 @@ from ..exceptions import AstropyDeprecationWarning
 def test_import_warning():
 
     with catch_warnings() as w:
-        from ..compat import fractions
+        from ..compat import fractions  # pylint: disable=W0611
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning

--- a/astropy/utils/tests/test_gzip.py
+++ b/astropy/utils/tests/test_gzip.py
@@ -5,7 +5,7 @@ from ..exceptions import AstropyDeprecationWarning
 def test_import_warning():
 
     with catch_warnings() as w:
-        from ..compat import gzip
+        from ..compat import gzip  # pylint: disable=W0611
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy import ma
 
 try:
-    import matplotlib
+    import matplotlib  # pylint: disable=W0611
     from matplotlib.colors import Normalize
 
     # On older versions of matplotlib Normalize is an old-style class

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -6,7 +6,7 @@ from ....tests.helper import pytest
 from ....io import fits
 
 try:
-    import matplotlib
+    import matplotlib  # pylint: disable=W0611
     HAS_MATPLOTLIB = True
     from ..fits2bitmap import fits2bitmap, main
 except:

--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -12,7 +12,7 @@ except ImportError:
     HAS_PLT = False
 
 try:
-    import scipy
+    import scipy  # pylint: disable=W0611
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -6,7 +6,7 @@ from numpy import ma
 from numpy.testing import assert_allclose
 
 try:
-    import matplotlib
+    import matplotlib  # pylint: disable=W0611
     HAS_MATPLOTLIB = True
 except:
     HAS_MATPLOTLIB = False

--- a/astropy/vo/samp/client.py
+++ b/astropy/vo/samp/client.py
@@ -22,7 +22,6 @@ from .constants import SSL_SUPPORT
 from .standard_profile import ThreadingXMLRPCServer
 
 if SSL_SUPPORT:
-    import ssl
     from .ssl_utils import SecureXMLRPCServer
 
 __all__ = ['SAMPClient']

--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -29,7 +29,6 @@ from .web_profile import WebProfileXMLRPCServer, web_profile_text_dialog
 from .constants import SSL_SUPPORT
 
 if SSL_SUPPORT:
-    import ssl
     from .ssl_utils import (SafeTransport, SecureXMLRPCServer,
                             get_ssl_version_name)
 

--- a/astropy/vo/samp/hub_proxy.py
+++ b/astropy/vo/samp/hub_proxy.py
@@ -14,7 +14,6 @@ from .lockfile_helpers import get_main_running_hub
 from .constants import SSL_SUPPORT
 
 if SSL_SUPPORT:
-    import ssl
     from .ssl_utils import SafeTransport
 
 

--- a/astropy/vo/samp/hub_script.py
+++ b/astropy/vo/samp/hub_script.py
@@ -11,7 +11,6 @@ import argparse
 from ... import log, __version__
 
 from .constants import SSL_SUPPORT
-from .errors import SAMPHubError
 from .hub import SAMPHubServer
 
 if SSL_SUPPORT:

--- a/astropy/vo/samp/tests/test_standard_profile.py
+++ b/astropy/vo/samp/tests/test_standard_profile.py
@@ -1,5 +1,3 @@
-import sys
-import time
 import tempfile
 
 from ....tests.helper import pytest
@@ -7,8 +5,7 @@ from ....utils.data import get_pkg_data_filename
 
 from ..hub import SAMPHubServer
 from ..integrated_client import SAMPIntegratedClient
-from ..constants import SAMP_STATUS_OK
-from ..errors import SAMPClientError, SAMPProxyError
+from ..errors import SAMPProxyError
 
 # By default, tests should not use the internet.
 from .. import conf

--- a/astropy/vo/samp/tests/test_web_profile.py
+++ b/astropy/vo/samp/tests/test_web_profile.py
@@ -6,23 +6,20 @@ parallel.
 """
 
 import os
-import time
 import threading
-import pickle
 import tempfile
 
 from ....extern import six
 from ....extern.six.moves.urllib.request import Request, urlopen
 from ....utils.data import get_readable_fileobj
 
-from .. import SAMPIntegratedClient, SAMPHubServer, SAMP_STATUS_OK
+from .. import SAMPIntegratedClient, SAMPHubServer
 from .web_profile_test_helpers import (AlwaysApproveWebProfileDialog,
                                        SAMPIntegratedWebClient)
 from ..web_profile import CROSS_DOMAIN, CLIENT_ACCESS_POLICY
 
 from .. import conf
 
-from .test_helpers import random_params, Receiver, assert_output, TEST_REPLY
 
 from .test_standard_profile import TestStandardProfile as BaseTestStandardProfile
 

--- a/astropy/vo/samp/utils.py
+++ b/astropy/vo/samp/utils.py
@@ -10,7 +10,6 @@ import inspect
 import traceback
 
 from ...extern.six.moves import queue
-from ...extern.six.moves.urllib.error import URLError
 from ...extern.six.moves.urllib.request import urlopen
 from ...extern.six.moves import xmlrpc_client as xmlrpc
 from ...extern.six import StringIO

--- a/astropy/vo/validator/tests/test_validate.py
+++ b/astropy/vo/validator/tests/test_validate.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # STDLIB
 import os
 import shutil
-import sys
 import tempfile
 
 # LOCAL

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -5,8 +5,7 @@ from ...utils.data import get_pkg_data_contents, get_pkg_data_filename
 from ...wcs import WCS
 from .. import utils
 from ..utils import proj_plane_pixel_scales, is_proj_plane_distorted, non_celestial_pixel_scales
-from ...tests.helper import pytest, catch_warnings
-from ...utils.exceptions import AstropyUserWarning
+from ...tests.helper import pytest
 from ... import units as u
 
 import numpy as np
@@ -212,8 +211,6 @@ def test_wcs_to_celestial_frame():
 
 def test_wcs_to_celestial_frame_extend():
 
-    from ...coordinates.builtin_frames import ICRS, FK5, FK4, Galactic
-    from ...time import Time
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ['XOFFSET', 'YOFFSET']

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -18,7 +18,7 @@ from numpy.testing import (
 
 from ...tests.helper import raises, catch_warnings, pytest
 from ... import wcs
-from .. import _wcs
+from .. import _wcs  # pylint: disable=W0611
 from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -2,9 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
-import warnings
 from .. import units as u
-from ..utils.exceptions import AstropyUserWarning
 
 __doctest_skip__ = ['wcs_to_celestial_frame']
 


### PR DESCRIPTION
This removes quite a few unused imports and adds ``# pylint: disable=W0611`` in cases where they are needed.

Pinging @pllim @eteq @aconley @nhmc @taldcroft @embray @crawfordsm @mhvk since it affects sub-packages you are maintainers for.