### PR TITLE
skip test_metadata_too_large if yaml is not installed

### DIFF
--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -15,6 +15,12 @@ except ImportError:
 else:
     HAS_H5PY = True
 
+try:
+    import yaml
+except ImportError:
+    HAS_YAML = False
+else:
+    HAS_YAML = True
 
 ALL_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64, np.int8,
               np.int16, np.int32, np.int64, np.float32, np.float64,
@@ -394,7 +400,7 @@ def test_preserve_serialized(tmpdir):
     assert t1.meta == t2.meta
 
 
-@pytest.mark.skipif('not HAS_H5PY')
+@pytest.mark.skipif('not HAS_H5PY' or 'not HAS_YAML')
 def test_metadata_too_large(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -400,7 +400,7 @@ def test_preserve_serialized(tmpdir):
     assert t1.meta == t2.meta
 
 
-@pytest.mark.skipif('not HAS_H5PY' or 'not HAS_YAML')
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
 def test_metadata_too_large(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
 


### PR DESCRIPTION
Does that suffice? #4528 
Or should the ``import yaml...`` go to the top of ``test_metadata_too_large``?