### PR TITLE
Enabling a frozen astropy

### DIFF
--- a/astropy/extern/six.py
+++ b/astropy/extern/six.py
@@ -4,7 +4,14 @@
 Handle loading six package from system or from the bundled copy
 """
 
-import imp
+try:
+    import importlib
+except ImportError:
+    importlib = None
+    import imp
+import io
+import sys
+
 from distutils.version import StrictVersion
 
 
@@ -34,15 +41,27 @@ def _find_module(name, path=None):
 
 def _import_six(search_path=_SIX_SEARCH_PATH):
     for mod_name in search_path:
-        try:
-            mod_info = _find_module(mod_name)
-        except ImportError:
-            continue
+        if importlib is not None:
+            try:
+                six_mod = importlib.import_module(mod_name)
+            except ImportError:
+                continue
+        else:
+            try:
+                mod_info = _find_module(mod_name)
+            except ImportError:
+                continue
+            else:
+                try:
+                    # Using __name__ causes the import to effectively overwrite
+                    # this shim.
+                    six_mod = imp.load_module(__name__, *mod_info)
+                finally:
+                    if mod_info[0] is not None:
+                        mod_info[0].close()
 
-        mod = imp.load_module(__name__, *mod_info)
-
         try:
-            if StrictVersion(mod.__version__) >= _SIX_MIN_VERSION:
+            if StrictVersion(six_mod.__version__) >= _SIX_MIN_VERSION:
                 break
         except (AttributeError, ValueError):
             # Attribute error if the six module isn't what it should be and
@@ -56,5 +75,26 @@ def _import_six(search_path=_SIX_SEARCH_PATH):
             "this warning consult the packager of your Astropy "
             "distribution.".format(_SIX_MIN_VERSION))
 
+    # Using importlib does not overwrite this shim, so do it ourselves.
+    this_module = sys.modules[__name__]
+    if not hasattr(this_module, '_importer'):
+        # Copy all main six attributes.
+        for name, value in six_mod.__dict__.items():
+            if name.startswith('__'):
+                continue
+            this_module.__dict__[name] = value
+
+        # Tell six's importer to accept this shim's name as its own.
+        importer = six_mod._importer
+        known_modules = list(importer.known_modules.items())
+        for name, mod in known_modules:
+            this_name = __name__ + name[len(mod_name):]
+            importer.known_modules[this_name] = mod
+
+        # Turn this shim into a package just like six does.
+        this_module.__path__ = []  # required for PEP 302 and PEP 451
+        this_module.__package__ = __name__  # see PEP 366
+        if this_module.__dict__.get('__spec__') is not None:
+            this_module.__spec__.submodule_search_locations = []  # PEP 451
 
 _import_six()


### PR DESCRIPTION
I need astropy to work in a frozen environment for www.astro.rug.nl/~breddels/vaex/ , for pyinstaller, py2app and py2exe. Some issues can be worked around, as demonstrated by this test packages:
https://github.com/maartenbreddels/frozen_astropy
But the astropy.extern.six modules really needed a change, since the imp modules doesn't play well with pyinstaller (and py2app and py2exe).
I changed this module to reflect what was done in vispy:
https://github.com/vispy/vispy/blob/master/vispy/ext/_bundled/six.py
