### PR TITLE
Revert HAS_SCIPY/OLDER_SCIPY import removal in coordinates test_regression

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -16,6 +16,7 @@ from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS
 from ...time import Time
 
 from ...tests.helper import pytest, assert_quantity_allclose
+from .test_matching import HAS_SCIPY, OLDER_SCIPY
 
 
 def test_regression_3920():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -113,8 +113,8 @@ def test_regression_4033():
     assert_quantity_allclose(alb_wdistaa.separation(deaa), 22.2862*u.deg, rtol=1e-3)
 
 
-@pytest.mark.skipif(str(not HAS_SCIPY))
-@pytest.mark.skipif(str(OLDER_SCIPY))
+@pytest.mark.skipif(not HAS_SCIPY, reason='No Scipy')
+@pytest.mark.skipif(OLDER_SCIPY, reason='Scipy too old')
 def test_regression_4082():
     """
     Issue: https://github.com/astropy/astropy/issues/4082

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -16,7 +16,7 @@ from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS
 from ...time import Time
 
 from ...tests.helper import pytest, assert_quantity_allclose
-from .test_matching import HAS_SCIPY, OLDER_SCIPY
+from .test_matching import HAS_SCIPY, OLDER_SCIPY  # pylint: disable=W0611
 
 
 def test_regression_3920():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -16,7 +16,7 @@ from .. import AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS
 from ...time import Time
 
 from ...tests.helper import pytest, assert_quantity_allclose
-from .test_matching import HAS_SCIPY, OLDER_SCIPY  # pylint: disable=W0611
+from .test_matching import HAS_SCIPY, OLDER_SCIPY
 
 
 def test_regression_3920():
@@ -113,8 +113,8 @@ def test_regression_4033():
     assert_quantity_allclose(alb_wdistaa.separation(deaa), 22.2862*u.deg, rtol=1e-3)
 
 
-@pytest.mark.skipif(str('not HAS_SCIPY'))
-@pytest.mark.skipif(str('OLDER_SCIPY'))
+@pytest.mark.skipif(str(not HAS_SCIPY))
+@pytest.mark.skipif(str(OLDER_SCIPY))
 def test_regression_4082():
     """
     Issue: https://github.com/astropy/astropy/issues/4082


### PR DESCRIPTION
This is a small tweak to #4526 .  That removed the ``from .test_matching import HAS_SCIPY, OLDER_SCIPY`` import from ``coordinates/tests/test_regression.py``.  It appears sensible because those aren't used in the *code* exactly, but they are used in a `skipif` on one of the tests in that file.  So this just brings the import back. 

The weird thing to me is that the tests *currently* pass if you invoke the whole suite, or even just with ``-P coordinates``.  But if you do ``-t astropy/coordinates/tests/test_regression.py``, the test errors because, understandably, it can't find ``HAS_SCIPY`` or ``OLDER_SCIPY``.  So somehow those get injected to the namespace that `skipif` uses even if it's not in the root of the module it's called in.  Regardless, though, it seems clearer to be explicit, and that allows the ``-t`` mode to work, so I think this should go back in.

cc @astrofrog @mhvk re:#4526