### PR TITLE
Add a note about reading a table that has unicode

### DIFF
--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -96,6 +96,12 @@ disable the fast engine::
 
    >>> data = ascii.read(lines, format='csv', fast_reader=False)
 
+.. Note::
+
+   Reading a table which contains non-ASCII (unicode) characters is not
+   supported in Python 2.  If you need this functionality then consider
+   using a newer version of Python.
+
 Writing Tables
 --------------
 


### PR DESCRIPTION
This is related to #3826.

It is written in a way that will still be correct when Python 4 is released (for @astrofrog).