### PR TITLE
PR #4539 backport to v1.0.x with Python 2.6 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,10 @@ Bug Fixes
   - Fixed memory / reference leak that could occur when copying a ``FITS_rec``
     object (the ``.data`` for table HDUs). [#520]
 
+  - Fixed a memory / reference leak in ``FITS_rec`` that occurred in a wide
+    range of cases, especially after writing FITS tables to a file, but in
+    other cases as well. [#4539]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -684,7 +684,7 @@ class Column(NotifierMixin):
         # the Column, but deletes all references to the underlying FITS_rec,
         # the .array attribute would suddenly start returning None instead of
         # the array data.  This problem is resolved on FITS_rec's end.  See the
-        # note in FITS_rec.__del__ for the rest of the story.
+        # note in the FITS_rec._coldefs property for the rest of the story.
 
         # If the Columns's array is not a reference to an existing FITS_rec,
         # then it is just stored in self.__dict__; otherwise check the

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -623,6 +623,72 @@ class Column(NotifierMixin):
 
     @property
     def array(self):
+        """
+        The Numpy `~numpy.ndarray` associated with this `Column`.
+
+        If the column was instantiated with an array passed to the ``array``
+        argument, this will return that array.  However, if the column is
+        later added to a table, such as via `BinTableHDU.from_columns` as
+        is typically the case, this attribute will be updated to reference
+        the associated field in the table, which may no longer be the same
+        array.
+        """
+
+        # Ideally the .array attribute never would have existed in the first
+        # place, or would have been internal-only.  This is a legacy of the
+        # older design from PyFITS that needs to have continued support, for
+        # now.
+
+        # One of the main problems with this design was that it created a
+        # reference cycle.  When the .array attribute was updated after
+        # creating a FITS_rec from the column (as explained in the docstring) a
+        # reference cycle was created.  This is because the code in BinTableHDU
+        # (and a few other places) does essentially the following:
+        #
+        # data._coldefs = columns  # The ColDefs object holding this Column
+        # for col in columns:
+        #     col.array = data.field(col.name)
+        #
+        # This way each columns .array attribute now points to the field in the
+        # table data.  It's actually a pretty confusing interface (since it
+        # replaces the array originally pointed to by .array), but it's the way
+        # things have been for a long, long time.
+        #
+        # However, this results, in *many* cases, in a reference cycle.
+        # Because the array returned by data.field(col.name), while sometimes
+        # an array that owns its own data, is usually like a slice of the
+        # original data.  It has the original FITS_rec as the array .base.
+        # This results in the following reference cycle (for the n-th column):
+        #
+        #    data -> data._coldefs -> data._coldefs[n] ->
+        #     data._coldefs[n].array -> data._coldefs[n].array.base -> data
+        #
+        # Because ndarray objects do not handled by Python's garbage collector
+        # the reference cycle cannot be broken.  Therefore the FITS_rec's
+        # refcount never goes to zero, its __del__ is never called, and its
+        # memory is never freed.  This didn't occur in *all* cases, but it did
+        # occur in many cases.
+        #
+        # To get around this, Column.array is no longer a simple attribute
+        # like it was previously.  Now each Column has a ._parent_fits_rec
+        # attribute which is a weakref to a FITS_rec object.  Code that
+        # previously assigned each col.array to field in a FITS_rec (as in
+        # the example a few paragraphs above) is still used, however now
+        # array.setter checks if a reference cycle will be created.  And if
+        # so, instead of saving directly to the Column's __dict__, it creates
+        # the ._prent_fits_rec weakref, and all lookups of the column's .array
+        # go through that instead.
+        #
+        # This alone does not fully solve the problem.  Because
+        # _parent_fits_rec is a weakref, if the user ever holds a reference to
+        # the Column, but deletes all references to the underlying FITS_rec,
+        # the .array attribute would suddenly start returning None instead of
+        # the array data.  This problem is resolved on FITS_rec's end.  See the
+        # note in FITS_rec.__del__ for the rest of the story.
+
+        # If the Columns's array is not a reference to an existing FITS_rec,
+        # then it is just stored in self.__dict__; otherwise check the
+        # _parent_fits_rec reference if it 's still available.
         if 'array' in self.__dict__:
             return self.__dict__['array']
         elif self._parent_fits_rec is not None:
@@ -634,6 +700,14 @@ class Column(NotifierMixin):
 
     @array.setter
     def array(self, array):
+        # The following looks over the bases of the given array to check if it
+        # has a ._coldefs attribute (i.e. is a FITS_rec) and that that _coldefs
+        # contains this Column itself, and would create a reference cycle if we
+        # stored the array directly in self.__dict__.
+        # In this case it instead sets up the _parent_fits_rec weakref to the
+        # underlying FITS_rec, so that array.getter can return arrays through
+        # self._parent_fits_rec().field(self.name), rather than storing a
+        # hard reference to the field like it used to.
         base = array
         while True:
             if (hasattr(base, '_coldefs') and
@@ -641,6 +715,11 @@ class Column(NotifierMixin):
                 for col in base._coldefs:
                     if col is self and self._parent_fits_rec is None:
                         self._parent_fits_rec = weakref.ref(base)
+
+                        # Just in case the user already set .array to their own
+                        # array.
+                        if 'array' in self.__dict__:
+                            del self.__dict__['array']
                         return
 
             if getattr(base, 'base', None) is not None:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -154,6 +154,9 @@ class TestMultipleHDU(object):
 
         self.hdus = HDUList([hdu1, hdu2, hdu3])
 
+    def teardown_class(self):
+        del self.hdus
+
     def setup_method(self, method):
         warnings.filterwarnings('always')
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 from __future__ import division, with_statement, print_function
 
+import contextlib
 import copy
 import gc
 
@@ -2365,23 +2366,6 @@ class TestTableFunctions(FitsTestCase):
     def test_reference_leak(self):
         """Regression test for https://github.com/astropy/astropy/pull/520"""
 
-        # There are still other leads created by reference cycles in FITS_rec
-        # that are not fixed by the fix to #520.  In particular, a known
-        # leak is created by:
-        # self._coldefs [ColDefs] -> ColDefs.columns[n].array [ndarray] ->
-        # ndarray.base [FITS_rec] -> self
-        #
-        # In other words, the columns list in the coldefs attribute of the
-        # FITS_rec, contains Column objects whose .array attributes are updated
-        # to point to fields in the original FITS_rec, creating a cycle.  This
-        # is an outstanding issue with the original design of pyfits, and may
-        # or may not be fixed, depending on how soon FITS_rec is deprecated.
-        #
-        # In the meantime, this test ensures that no *new* FITS_rec objects are
-        # left behind in this one use case, which *is* fixed by #520.  There
-        # are other cases that still create leaks though.
-        existing_fitsrecs = len(objgraph.by_type('FITS_rec'))
-
         def readfile(filename):
             with fits.open(filename) as hdul:
                 data = hdul[1].data.copy()
@@ -2389,15 +2373,71 @@ class TestTableFunctions(FitsTestCase):
             for colname in data.dtype.names:
                 data[colname]
 
-        readfile(self.data('memtest.fits'))
+        with _refcounting('FITS_rec'):
+            readfile(self.data('memtest.fits'))
 
-        # Shouldn't matter since ndarray and subclasses don't participate in
-        # garbage collection, but just in case...
-        gc.collect()
+    @pytest.mark.skipif(str('not HAVE_OBJGRAPH'))
+    def test_reference_leak(self, tmpdir):
+        """
+        Regression test for https://github.com/astropy/astropy/pull/4539
 
-        # Just make sure there aren't more FITS_rec objects remaining in memory
-        # than we started with.
-        assert len(objgraph.by_type('FITS_rec')) <= existing_fitsrecs
+        This actually re-runs a small set of tests that I found, during
+        careful testing, exhibited the reference leaks fixed by #4539, but
+        now with reference counting around each test to ensure that the
+        leaks are fixed.
+        """
+
+        from .test_core import TestCore
+        from .test_connect import TestMultipleHDU
+
+        t1 = TestCore()
+        t1.setup()
+        try:
+            with _refcounting('FITS_rec'):
+                t1.test_add_del_columns2()
+        finally:
+            t1.teardown()
+        del t1
+
+        t2 = self.__class__()
+        for test_name in ['test_recarray_to_bintablehdu',
+                          'test_numpy_ndarray_to_bintablehdu',
+                          'test_new_table_from_recarray',
+                          'test_new_fitsrec']:
+            t2.setup()
+            try:
+                with _refcounting('FITS_rec'):
+                    getattr(t2, test_name)()
+            finally:
+                t2.teardown()
+        del t2
+
+        t3 = TestMultipleHDU()
+        t3.setup_class()
+        try:
+            with _refcounting('FITS_rec'):
+                t3.test_read(tmpdir)
+        finally:
+            t3.teardown_class()
+        del t3
+
+
+@contextlib.contextmanager
+def _refcounting(type_):
+    """
+    Perform the body of a with statement with reference counting for the
+    given type (given by class name)--raises an assertion error if there
+    are more unfreed objects of the given type than when we entered the
+    with statement.
+    """
+
+    gc.collect()
+    refcount = len(objgraph.by_type(type_))
+    yield refcount
+    gc.collect()
+    assert len(objgraph.by_type(type_)) <= refcount, \
+            "More {0!r} objects still in memory than before."
+
 
 
 class TestVLATables(FitsTestCase):

--- a/astropy/utils/compat/_weakset_py2/__init__.py
+++ b/astropy/utils/compat/_weakset_py2/__init__.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2010 Michael Foord
+# E-mail: fuzzyman AT voidspace DOT org DOT uk
+
+# This software is licensed under the terms of the BSD license.
+# http://www.voidspace.org.uk/python/license.shtml
+
+from __future__ import with_statement
+
+from _weakref import ref
+
+__all__ = ['WeakSet']
+
+__version__ = '1.0.0'
+
+
+
+class _IterationGuard(object):
+    # This context manager registers itself in the current iterators of the
+    # weak container, such as to delay all removals until the context manager
+    # exits.
+    # This technique should be relatively thread-safe (since sets are).
+
+    def __init__(self, weakcontainer):
+        # Don't create cycles
+        self.weakcontainer = ref(weakcontainer)
+
+    def __enter__(self):
+        w = self.weakcontainer()
+        if w is not None:
+            w._iterating.add(self)
+        return self
+
+    def __exit__(self, e, t, b):
+        w = self.weakcontainer()
+        if w is not None:
+            s = w._iterating
+            s.remove(self)
+            if not s:
+                w._commit_removals()
+
+
+class WeakSet(object):
+    def __init__(self, data=None):
+        self.data = set()
+        def _remove(item, selfref=ref(self)):
+            self = selfref()
+            if self is not None:
+                if self._iterating:
+                    self._pending_removals.append(item)
+                else:
+                    self.data.discard(item)
+        self._remove = _remove
+        # A list of keys to be removed
+        self._pending_removals = []
+        self._iterating = set()
+        if data is not None:
+            self.update(data)
+
+    def _commit_removals(self):
+        l = self._pending_removals
+        discard = self.data.discard
+        while l:
+            discard(l.pop())
+
+    def __iter__(self):
+        with _IterationGuard(self):
+            for itemref in self.data:
+                item = itemref()
+                if item is not None:
+                    yield item
+
+    def __len__(self):
+        return sum(x() is not None for x in self.data)
+
+    def __contains__(self, item):
+        return ref(item) in self.data
+
+    def __reduce__(self):
+        return (self.__class__, (list(self),),
+                getattr(self, '__dict__', None))
+
+    __hash__ = None
+
+    def add(self, item):
+        if self._pending_removals:
+            self._commit_removals()
+        self.data.add(ref(item, self._remove))
+
+    def clear(self):
+        if self._pending_removals:
+            self._commit_removals()
+        self.data.clear()
+
+    def copy(self):
+        return self.__class__(self)
+
+    def pop(self):
+        if self._pending_removals:
+            self._commit_removals()
+        while True:
+            try:
+                itemref = self.data.pop()
+            except KeyError:
+                raise KeyError('pop from empty WeakSet')
+            item = itemref()
+            if item is not None:
+                return item
+
+    def remove(self, item):
+        if self._pending_removals:
+            self._commit_removals()
+        self.data.remove(ref(item))
+
+    def discard(self, item):
+        if self._pending_removals:
+            self._commit_removals()
+        self.data.discard(ref(item))
+
+    def update(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        if isinstance(other, self.__class__):
+            self.data.update(other.data)
+        else:
+            for element in other:
+                self.add(element)
+
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
+    # Helper functions for simple delegating methods.
+    def _apply(self, other, method):
+        if not isinstance(other, self.__class__):
+            other = self.__class__(other)
+        newdata = method(other.data)
+        newset = self.__class__()
+        newset.data = newdata
+        return newset
+
+    def difference(self, other):
+        return self._apply(other, self.data.difference)
+    __sub__ = difference
+
+    def difference_update(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        if self is other:
+            self.data.clear()
+        else:
+            self.data.difference_update(ref(item) for item in other)
+    def __isub__(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        if self is other:
+            self.data.clear()
+        else:
+            self.data.difference_update(ref(item) for item in other)
+        return self
+
+    def intersection(self, other):
+        return self._apply(other, self.data.intersection)
+    __and__ = intersection
+
+    def intersection_update(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        self.data.intersection_update(ref(item) for item in other)
+    def __iand__(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        self.data.intersection_update(ref(item) for item in other)
+        return self
+
+    def issubset(self, other):
+        return self.data.issubset(ref(item) for item in other)
+    __lt__ = issubset
+
+    def __le__(self, other):
+        return self.data <= set(ref(item) for item in other)
+
+    def issuperset(self, other):
+        return self.data.issuperset(ref(item) for item in other)
+    __gt__ = issuperset
+
+    def __ge__(self, other):
+        return self.data >= set(ref(item) for item in other)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.data == set(ref(item) for item in other)
+
+    def symmetric_difference(self, other):
+        return self._apply(other, self.data.symmetric_difference)
+    __xor__ = symmetric_difference
+
+    def symmetric_difference_update(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        if self is other:
+            self.data.clear()
+        else:
+            self.data.symmetric_difference_update(ref(item) for item in other)
+    def __ixor__(self, other):
+        if self._pending_removals:
+            self._commit_removals()
+        if self is other:
+            self.data.clear()
+        else:
+            self.data.symmetric_difference_update(ref(item) for item in other)
+        return self
+
+    def union(self, other):
+        return self._apply(other, self.data.union)
+    __or__ = union
+
+    def isdisjoint(self, other):
+        return len(self.intersection(other)) == 0

--- a/astropy/utils/compat/weakref.py
+++ b/astropy/utils/compat/weakref.py
@@ -1,0 +1,6 @@
+"""Support WeakSet on Python 2.6"""
+
+try:
+    from weakref import WeakSet
+except ImportError:
+    from ._weakset_py2 import WeakSet


### PR DESCRIPTION
This backports #4539 to the v1.0.x and v1.1.x branch (the latter can be done via cherry-pick).  This required some extra work to support Python 2.6, which is still supported on those branches.