### PR TITLE
Turn off syntax highlighting in one of the known issues

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -321,6 +321,7 @@ Displaying long docstrings that contain Unicode characters may fail on
 some platforms in the IPython console (prior to IPython version
 0.13.2)::
 
+    .. highlight:: none
     >>> import astropy.units as u
 
     >>> u.Angstrom?

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -321,11 +321,10 @@ Displaying long docstrings that contain Unicode characters may fail on
 some platforms in the IPython console (prior to IPython version
 0.13.2)::
 
-    .. highlight:: none
-    >>> import astropy.units as u
+    In [1]: import astropy.units as u
 
-    >>> u.Angstrom?
-    ERROR: UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in
+    In [2]: u.Angstrom?
+    Out[2]: ERROR: UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in
     position 184: ordinal not in range(128) [IPython.core.page]
 
 This can be worked around by changing the default encoding to ``utf-8``


### PR DESCRIPTION
Several recent doc builds have failed because the most recent release of sphinx made this change[1]:

> #1565: Sphinx will now emit a warning that highlighting was skipped if the syntax is incorrect for code-block, literalinclude and so on.

The known issue at https://github.com/astropy/astropy/blob/master/docs/known_issues.rst#L324 contains `u.Angstrom?` because the issue was in IPython. Because the question mark isn't standard python syntax, sphinx now generates a warning, which fails the test.

@eteq @astrofrog -- how should this be milestoned?

[1]: [Release 1.3.5 (released Jan 24, 2016)](http://www.sphinx-doc.org/en/stable/changes.html#release-1-3-5-released-jan-24-2016)