### PR TITLE
FIX: #4550 Explicitly set BeautifulSoup parser to html.parser to avoid warning 

### DIFF
--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -18,6 +18,13 @@ from ...utils.xml import writer
 
 from copy import deepcopy
 
+try:
+  import lxml
+except ImportError:
+  lxml_installed = False
+else:
+  lxml_installed = True
+
 class SoupString(str):
     """
     Allows for strings to hold BeautifulSoup data.
@@ -83,7 +90,10 @@ class HTMLInputter(core.BaseInputter):
                                         'installed to read HTML tables')
 
         if 'parser' not in self.html:
-            soup = BeautifulSoup('\n'.join(lines))
+            if lxml_installed:
+              soup = BeautifulSoup('\n'.join(lines),"lxml")
+            else:
+              soup = BeautifulSoup('\n'.join(lines),"html.parser")
         else: # use a custom backend parser
             soup = BeautifulSoup('\n'.join(lines), self.html['parser'])
         tables = soup.find_all('table')

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -101,8 +101,8 @@ class Latex(base.Base):
         -------
         latex_string : str
             The value in exponential notation in a format suitable for LaTeX.
-        """
-        if np.isfinite(val):
+        """#np.any() and np.all() which to use depends on the val array
+        if np.any(np.isfinite(val)):   #np.isfinite returns a booleans of array type so np.any(np.ndarray) returns true if any vaues in np.ndarray is true
             m, ex = utils.split_mantissa_exponent(val)
 
             parts = []


### PR DESCRIPTION
@astrofrog  and @anchitjain1234  Using lxml if it's available is probably a good idea (similarly for html5lib). But it should be optional and otherwise fall back to html.parser.