### PR TITLE
Fixing  links to make sphinx built pass with py3.5 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautiful-soup ipython mpmath'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
         - PIP_DEPENDENCIES=''
 
     matrix:

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -216,7 +216,7 @@ class EMConstant(Constant):
 
     @property
     def cgs(self):
-        """Overridden for EMConstant to raise a `~.exceptions.TypeError`
+        """Overridden for EMConstant to raise a `TypeError`
         emphasizing that there are multiple EM extensions to CGS.
         """
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -472,7 +472,7 @@ class Latitude(Angle):
       -90.0 * u.deg <= angle(s) <= +90.0 * u.deg
 
     Any attempt to set a value outside that range will result in a
-    `~.exceptions.ValueError`.
+    `ValueError`.
 
     The input angle(s) can be specified either as an array, list,
     scalar, tuple (see below), string,

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -593,7 +593,7 @@ class BaseCoordinateFrame(object):
     def data(self):
         """
         The coordinate data for this object.  If this frame has no data, an
-        `~.exceptions.ValueError` will be raised.  Use `has_data` to
+        `ValueError` will be raised.  Use `has_data` to
         check if data is present on this frame object.
         """
         if self._data is None:

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -269,7 +269,7 @@ class _AsciiColumnFormat(_BaseColumnFormat):
     Conversions between the two column formats can be performed using the
     ``to/from_binary`` methods on this class, or the ``to/from_ascii``
     methods on the `_ColumnFormat` class.  But again, not all conversions are
-    possible and may result in a `~.exceptions.ValueError`.
+    possible and may result in a `ValueError`.
     """
 
     def __new__(cls, format, strict=False):

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -155,14 +155,14 @@ class StreamingHDU(object):
         -----
         Only the amount of data specified in the header provided to the class
         constructor may be written to the stream.  If the provided data would
-        cause the stream to overflow, an `~.exceptions.IOError` exception is
+        cause the stream to overflow, an `IOError` exception is
         raised and the data is not written. Once sufficient data has been
         written to the stream to satisfy the amount specified in the header,
         the stream is padded to fill a complete FITS block and no more data
         will be accepted. An attempt to write more data after the stream has
-        been filled will raise an `~.exceptions.IOError` exception. If the
+        been filled will raise an `IOError` exception. If the
         dtype of the input data does not match what is expected by the header,
-        a `.exceptions.TypeError` exception is raised.
+        a `TypeError` exception is raised.
         """
 
         size = self._ffo.tell() - self._data_offset

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -426,7 +426,7 @@ class Header(object):
         endcard : bool, optional
             If True (the default) the header must end with an END card in order
             to be considered valid.  If an END card is not found an
-            `~.exceptions.IOError` is raised.
+            `IOError` is raised.
 
         padding : bool, optional
             If True (the default) the header will be required to be padded out
@@ -1559,7 +1559,7 @@ class Header(object):
         force : bool, optional
             When `True`, if the new keyword already exists in the header, force
             the creation of a duplicate keyword. Otherwise a
-            `~.exceptions.ValueError` is raised.
+            `ValueError` is raised.
         """
 
         oldkeyword = Card.normalize_keyword(oldkeyword)

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -19,7 +19,7 @@ def fnunpickle(fileorname, number=0, usecPickle=True):
 
     Parameters
     ----------
-    fileorname : str or `file`-like
+    fileorname : str or file-like
         The file name or file from which to unpickle objects. If a file object,
         it should have been opened in binary mode.
     number : int
@@ -87,7 +87,7 @@ def fnpickle(object, fileorname, usecPickle=True, protocol=None, append=False):
     ----------
     object
         The python object to pickle.
-    fileorname : str or `file`-like
+    fileorname : str or file-like
         The filename or file into which the `object` should be pickled. If a
         file object, it should have been opened in binary mode.
     usecPickle : bool

--- a/astropy/io/votable/xmlutil.py
+++ b/astropy/io/votable/xmlutil.py
@@ -55,7 +55,7 @@ _token_regex = r"(?![\r\l\t ])[^\r\l\t]*(?![\r\l\t ])"
 
 def check_token(token, attr_name, config=None, pos=None):
     """
-    Raises a `~.exceptions.ValueError` if *token* is not a valid XML token.
+    Raises a `ValueError` if *token* is not a valid XML token.
 
     As defined by XML Schema Part 2.
     """

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1199,7 +1199,7 @@ class Time(object):
             ``astropy.utils.iers``)
         return_status : bool
             Whether to return status values.  If `False` (default), iers
-            raises `~.exceptions.IndexError` if any time is out of the range
+            raises `IndexError` if any time is out of the range
             covered by the IERS table.
 
         Returns

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -23,7 +23,7 @@ class QuantityInput(object):
         the argument is not equivalent to the unit specified to the decorator
         or in the annotation.
         If the argument has no unit attribute, i.e. it is not a Quantity object, a
-        `~exceptions.ValueError` will be raised.
+        `ValueError` will be raised.
 
         Where an equivalency is specified in the decorator, the function will be
         executed with that equivalency in force.

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -90,7 +90,7 @@ def decompose_to_known_units(unit, func):
     func : callable
         This function will be called to determine if a given unit is
         "known".  If the unit is not known, this function should raise a
-        `~.exceptions.ValueError`.
+        `ValueError`.
 
     Returns
     -------

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -8,7 +8,7 @@ class HomogeneousList(list):
     """
     A subclass of list that contains only elements of a given type or
     types.  If an item that is not of the specified type is added to
-    the list, a `~.exceptions.TypeError` is raised.
+    the list, a `TypeError` is raised.
     """
     def __init__(self, types, values=[]):
         """

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -119,7 +119,7 @@ def _get_stdout(stderr=False):
 
 def isatty(file):
     """
-    Returns `True` if `file` is a tty.
+    Returns `True` if ``file`` is a tty.
 
     Most built-in Python file-like objects have an `isatty` member,
     but some user-defined types may not, so this assumes those are not
@@ -495,7 +495,7 @@ class ProgressBar(six.Iterator):
 
         file : writable file-like object, optional
             The file to write the progress bar to.  Defaults to
-            `sys.stdout`.  If `file` is not a tty (as determined by
+            `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any, or special case hacks
             to detect the IPython console), the progress bar will be
             completely silent.
@@ -696,7 +696,7 @@ class ProgressBar(six.Iterator):
 
         file : writeable file-like object, optional
             The file to write the progress bar to.  Defaults to
-            `sys.stdout`.  If `file` is not a tty (as determined by
+            `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any), the scrollbar will
             be completely silent.
 
@@ -762,7 +762,7 @@ class Spinner(object):
 
         file : writeable file-like object, optional
             The file to write the spinner to.  Defaults to
-            `sys.stdout`.  If `file` is not a tty (as determined by
+            `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any, or special case hacks
             to detect the IPython console), the spinner will be
             completely silent.
@@ -890,7 +890,7 @@ class ProgressBarOrSpinner(object):
 
         file : writable file-like object, optional
             The file to write the to.  Defaults to `sys.stdout`.  If
-            `file` is not a tty (as determined by calling its `isatty`
+            ``file`` is not a tty (as determined by calling its `isatty`
             member, if any), only ``msg`` will be displayed: the
             `ProgressBar` or `Spinner` will be silent.
         """

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -139,7 +139,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     encoding : str, optional
         When `None` (default), returns a file-like object with a
         ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (`unicode`) objects, using
+        on Python 3.x returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -148,7 +148,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         method returns `bytes` objects.
 
         When another string, it is the name of an encoding, and the
-        file-like object's ``read`` method will return `str` (`unicode`)
+        file-like object's ``read`` method will return `str` (``unicode``)
         objects, decoded from binary using the given encoding.
 
     cache : bool, optional
@@ -405,7 +405,7 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
     encoding : str, optional
         When `None` (default), returns a file-like object with a
         ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (`unicode`) objects, using
+        on Python 3.x returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -414,7 +414,7 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
         method returns `bytes` objects.
 
         When another string, it is the name of an encoding, and the
-        file-like object's ``read`` method will return `str` (`unicode`)
+        file-like object's ``read`` method will return `str` (``unicode``)
         objects, decoded from binary using the given encoding.
 
     cache : bool
@@ -637,7 +637,7 @@ def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):
     encoding : str, optional
         When `None` (default), returns a file-like object with a
         ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (`unicode`) objects, using
+        on Python 3.x returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -646,7 +646,7 @@ def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):
         method returns `bytes` objects.
 
         When another string, it is the name of an encoding, and the
-        file-like object's ``read`` method will return `str` (`unicode`)
+        file-like object's ``read`` method will return `str` (``unicode``)
         objects, decoded from binary using the given encoding.
 
     cache : bool
@@ -767,7 +767,7 @@ def get_pkg_data_fileobjs(datadir, package=None, pattern='*', encoding=None):
     encoding : str, optional
         When `None` (default), returns a file-like object with a
         ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (`unicode`) objects, using
+        on Python 3.x returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -776,7 +776,7 @@ def get_pkg_data_fileobjs(datadir, package=None, pattern='*', encoding=None):
         method returns `bytes` objects.
 
         When another string, it is the name of an encoding, and the
-        file-like object's ``read`` method will return `str` (`unicode`)
+        file-like object's ``read`` method will return `str` (``unicode``)
         objects, decoded from binary using the given encoding.
 
     Returns

--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -472,7 +472,7 @@ def conesearch_timer(*args, **kwargs):
 
 
 def _local_conversion(func, x):
-    """Try ``func(x)`` and replace `~.exceptions.ValueError` with
+    """Try ``func(x)`` and replace `ValueError` with
     ``ConeSearchError``."""
     try:
         y = func(x)

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -544,7 +544,7 @@ already set.
 Alternatively, if `~astropy.wcs.Wcsprm.mjdobs` is set and
 `~astropy.wcs.Wcsprm.dateobs` isn't, then `~astropy.wcs.Wcsprm.datfix`
 derives `~astropy.wcs.Wcsprm.dateobs` from it.  If both are set but
-disagree by more than half a day then `~.exceptions.ValueError` is raised.
+disagree by more than half a day then `ValueError` is raised.
 
 Returns
 -------

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -317,7 +317,7 @@ class WCS(WCSBase):
        two dimensional.  Therefore, if you try to create a WCS object
        where the core WCS has a different number of dimensions than 2
        and that object also contains a `distortion paper`_ lookup
-       table or `SIP`_ distortion, a `~.exceptions.ValueError`
+       table or `SIP`_ distortion, a `ValueError`
        exception will be raised.  To avoid this, consider using the
        *naxis* kwarg to select two dimensions from the core WCS.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ del intersphinx_mapping['astropy']
 # add any custom intersphinx for astropy
 intersphinx_mapping['pytest'] = ('http://pytest.org/latest/', None)
 intersphinx_mapping['ipython'] = ('http://ipython.readthedocs.io/en/stable/', None)
+intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -164,5 +164,5 @@ of being bounded so that::
   -90.0 * u.deg <= angle(s) <= +90.0 * u.deg
 
 Any attempt to set a value outside that range will result in a
-`~.exceptions.ValueError`.
+`ValueError`.
 

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -144,7 +144,7 @@ errors should follow these rules:
 * For errors/exceptions, one should always use ``raise`` with one of the
   built-in exception classes, or a custom exception class. The
   nondescript ``Exception`` class should be avoided as much as possible,
-  in favor of more specific exceptions (``IOError``, ``ValueError``,
+  in favor of more specific exceptions (`IOError`, `ValueError`,
   etc.).
 
 * For warnings, one should always use ``warnings.warn(message,
@@ -775,7 +775,7 @@ Catching of exceptions should always use this syntax::
 This avoids the old style syntax of ``except ImportError, e`` or
 ``except (ValueError,TypeError), e``, which is dangerous because it's easy to
 instead accidentally do something like ``except ValueError,TypeError``, which
-won't catch `~.exceptions.TypeError`.
+won't catch `TypeError`.
 
 
 Additional Resources

--- a/docs/development/workflow/git_edit_workflow_examples.rst
+++ b/docs/development/workflow/git_edit_workflow_examples.rst
@@ -415,7 +415,7 @@ the check for the scalar case.
 One could imagine two different desirable outcomes here:
 
 + ``len(scalar_coordinate)`` behaves just like ``len(scalar_angle)``, raising
-  a `~.exceptions.TypeError` for a scalar coordinate.
+  a `TypeError` for a scalar coordinate.
 + ``len(scalar_coordinate)`` returns 1 since there is one coordinate.
 
 If you encounter a case like this and are not sure what to do, ask. The best
@@ -427,7 +427,7 @@ you chose and why; instructions for that are below.
 Testing for an expected error
 +++++++++++++++++++++++++++++
 
-In this case I opted for raising a `~.exceptions.TypeError`, because
+In this case I opted for raising a `TypeError`, because
 the user needs to know that the coordinate they created is not going to
 behave like an array of one coordinate if they try to index it later on. It
 also provides an opportunity to demonstrate a test when the desired result

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -110,7 +110,7 @@ occurred and the path through the code that led to it.
 
 As Astropy is meant to be used as a piece in other software projects, some
 exceptions raised by Astropy are by design.  For example, one of the most
-common exceptions is a `~.exceptions.KeyError` when an attempt is made to read
+common exceptions is a `KeyError` when an attempt is made to read
 the value of a non-existent keyword in a header::
 
     >>> from astropy.io import fits

--- a/docs/io/fits/appendix/header_transition.rst
+++ b/docs/io/fits/appendix/header_transition.rst
@@ -202,7 +202,7 @@ surprises.  There are differences, however:
   as with a normal `dict`, ``header['NAXIS'] = 1`` will either update the NAXIS
   keyword if it already exists, or add a new NAXIS keyword with a value of
   ``1`` if it does not exist.  In the old interface this would return a
-  `~.exceptions.KeyError` if NAXIS did not exist, and the only way to add a new
+  `KeyError` if NAXIS did not exist, and the only way to add a new
   keyword was through the update() method.
 
   By default, new keywords added in this manner are added to the end of the
@@ -260,7 +260,7 @@ surprises.  There are differences, however:
   nothing.  For backwards-compatibility it is still okay to delete a
   non-existent keyword, but a warning will be raised.  In the future this
   *will* be changed so that trying to delete a non-existent keyword raises a
-  `~.exceptions.KeyError`.  This is for consistency with the behavior of Python dicts.  So
+  `KeyError`.  This is for consistency with the behavior of Python dicts.  So
   unless you know for certain that a keyword exists before deleting it, it's
   best to do something like::
 

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -169,7 +169,7 @@ to get the value of the keyword targname, which is a string 'NGC121'.
 Although keyword names are always in upper case inside the FITS file,
 specifying a keyword name with Astropy is case-insensitive, for the user's
 convenience. If the specified keyword name does not exist, it will raise a
-`~.exceptions.KeyError` exception.
+`KeyError` exception.
 
 We can also get the keyword value by indexing (a la Python lists)::
 


### PR DESCRIPTION
I made some changed to astropy-helpers that will allow to have sphinx builds with either python2 or python3 with all the links resolved.
This PR moves the build to use python 3.5, and also fix the remaining warnings and links.

This can be merged after astropy/ci-helpers#61 is merged and propagated back to here.

[Edit]: Closes #4968