### PR TITLE
NDUncertainty - Array Setter Method

### DIFF
--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -188,7 +188,7 @@ class NDUncertainty(object):
             array = deepcopy(array)
             unit = deepcopy(unit)
 
-        self._array = array
+        self.array = array
         self.parent_nddata = None  # no associated NDData - until it is set!
 
     @abstractproperty

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -188,7 +188,7 @@ class NDUncertainty(object):
             array = deepcopy(array)
             unit = deepcopy(unit)
 
-        self.array = array
+        self._array = array
         self.parent_nddata = None  # no associated NDData - until it is set!
 
     @abstractproperty
@@ -217,7 +217,9 @@ class NDUncertainty(object):
 
     @array.setter
     def array(self, value):
-        self._array = np.array(value, subok=False, copy=False)
+        if isinstance(value, (list, np.ndarray)):
+            value = np.array(value, subok=False, copy=False)
+        self._array = value
 
     @property
     def unit(self):

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -214,9 +214,13 @@ class NDUncertainty(object):
     @property
     def array(self):
         """
-        any type: the uncertainty's value.
+        `numpy.ndarray`: the uncertainty's value.
         """
         return self._array
+
+    @array.setter
+    def array(self, value):
+        self._array = np.array(value, subok=False, copy=False)
 
     @property
     def unit(self):

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -179,9 +179,6 @@ class NDUncertainty(object):
                 unit = array.unit
             array = array.value
 
-        elif isinstance(array, (list, np.ndarray)):
-            array = np.array(array, subok=False, copy=False)
-
         if unit is None:
             self._unit = None
         else:
@@ -191,7 +188,7 @@ class NDUncertainty(object):
             array = deepcopy(array)
             unit = deepcopy(unit)
 
-        self._array = array
+        self.array = array
         self.parent_nddata = None  # no associated NDData - until it is set!
 
     @abstractproperty


### PR DESCRIPTION
Before #4272 the ``StdDevUncertainty`` had an ``array.setter`` - but I forgot about it, when I moved it to ``NDUncertainty``. The failure was noticed in https://github.com/astropy/ccdproc/pull/287

But this is a slightly different setter than before. The version before compared the shape to the shape of the ``parent_nddata`` and it wasn't cast to a simple ``np.array``. I just thought this approach would be more senseable. Altough propagation will fail if the uncertainty has a not broadcastable shape.