### PR TITLE
Remove new line characters after last row of data in ascii.latex.AASTex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1121,6 +1121,9 @@ Bug Fixes
 
 - ``astropy.io.ascii``
 
+  - Fixed addition of new line characters after last row of data in
+    ascii.latex.AASTex. [#3888]
+
 - ``astropy.io.fits``
 
   - Fixed possible segfault during error handling in FITS tile

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -384,7 +384,12 @@ class AASTexData(LatexData):
 
     def write(self, lines):
         lines.append(self.data_start)
+        lines_length_initial = len(lines)
         core.BaseData.write(self, lines)
+        # To remove extra space and // appended which creates an extra new line
+        # in the end.
+        if len(lines) > lines_length_initial:
+            lines[-1] = lines[-1][:-3]
         lines.append(self.data_end)
         add_dictval_to_list(self.latex, 'tablefoot', lines)
         lines.append(r'\end{' + self.latex['tabletype'] + r'}')

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -386,10 +386,10 @@ class AASTexData(LatexData):
         lines.append(self.data_start)
         lines_length_initial = len(lines)
         core.BaseData.write(self, lines)
-        # To remove extra space and // appended which creates an extra new line
+        # To remove extra space(s) and // appended which creates an extra new line
         # in the end.
         if len(lines) > lines_length_initial:
-            lines[-1] = lines[-1][:-3]
+            lines[-1] = re.sub(r'\s* \\ \\ \s* $', '', lines[-1], flags=re.VERBOSE)
         lines.append(self.data_end)
         add_dictval_to_list(self.latex, 'tablefoot', lines)
         lines.append(r'\end{' + self.latex['tabletype'] + r'}')

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -98,7 +98,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 \\tablehead{\\colhead{ID} & \\colhead{XCENTER} & \\colhead{YCENTER} & \\colhead{MAG} & \\colhead{MERR} & \\colhead{MSKY} & \\colhead{NITER} & \\colhead{SHARPNESS} & \\colhead{CHI} & \\colhead{PIER} & \\colhead{PERROR}\\\\ \\colhead{ } & \\colhead{pixels} & \\colhead{pixels} & \\colhead{magnitudes} & \\colhead{magnitudes} & \\colhead{counts} & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{perrors}}
 \\startdata
 14 & 138.538 & 256.405 & 15.461 & 0.003 & 34.85955 & 4 & -0.032 & 0.802 & 0 & No_error \\\\
-18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error \\\\
+18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error
 \\enddata
 \\end{deluxetable}
 """
@@ -113,7 +113,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 \\tablehead{\\colhead{ID} & \\colhead{XCENTER} & \\colhead{YCENTER} & \\colhead{MAG} & \\colhead{MERR} & \\colhead{MSKY} & \\colhead{NITER} & \\colhead{SHARPNESS} & \\colhead{CHI} & \\colhead{PIER} & \\colhead{PERROR}\\\\ \\colhead{ } & \\colhead{[pixel]} & \\colhead{pixels} & \\colhead{[mag]} & \\colhead{magnitudes} & \\colhead{counts} & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{ } & \\colhead{perrors}}
 \\startdata
 14 & 138.538 & 256.405 & 15.461 & 0.003 & 34.85955 & 4 & -0.032 & 0.802 & 0 & No_error \\\\
-18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error \\\\
+18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error
 \\enddata
 \\end{deluxetable*}
 """
@@ -493,7 +493,7 @@ def test_latex_units():
 \\tablehead{\\colhead{date} & \\colhead{NUV exp.time}\\\\ \\colhead{ } & \\colhead{s}}
 \\startdata
 a & 1 \\\\
-b & 2 \\\\
+b & 2
 \\enddata
 \\end{table}
 '''.replace('\n', os.linesep)


### PR DESCRIPTION
For #3888. Also fixed ``AASTex`` tests in ``test_write.py`` to incorporate these changes.