### PR TITLE
Some fixes to Quantity docs

### DIFF
--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -106,7 +106,7 @@ the quantity:
     [...]
 
 .. plot::
-    
+
     from astropy import units as u
     from astropy.visualization import quantity_support
     quantity_support()
@@ -124,7 +124,7 @@ though the second line is given in ``cm``:
     [...]
 
 .. plot::
-    
+
     from astropy import units as u
     from astropy.visualization import quantity_support
     quantity_support()
@@ -164,7 +164,7 @@ To make sure unit support is turned off afterward, you can use
     with quantity_support():
         plt.figure(figsize=(5,3))
         plt.plot([1, 2, 3] * u.m)
-    
+
 Arithmetic
 ----------
 
@@ -192,7 +192,7 @@ resulting object **has units of the object on the left**:
     >>> 13.5 * u.km - 1100.1 * u.m  # doctest: +FLOAT_CMP
     <Quantity 12.3999 km>
 
-Addition and subtraction is not supported between |quantity| objects and basic
+Addition and subtraction are not supported between |quantity| objects and basic
 numeric types:
 
     >>> 13.5 * u.km + 19.412  # doctest: +IGNORE_EXCEPTION_DETAIL
@@ -207,7 +207,7 @@ except for dimensionless quantities (see `Dimensionless quantities`_).
 Multiplication and Division
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Multiplication and division is supported between |quantity| objects with any
+Multiplication and division are supported between |quantity| objects with any
 units, and with numeric types. For these operations between objects with
 equivalent units, the **resulting object has composite units**:
 


### PR DESCRIPTION
...to prevent the `.. doctest-requires:: matplotlib` directives from showing up in the docs.