### PR TITLE
Fix latex repr for function units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -400,6 +400,8 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - Fixed latex representation of function units. [#4563]
+
 - ``astropy.visualization``
 
   - Fixed ``fits2bitmap`` script to allow ext flag to contain extension
@@ -1156,6 +1158,8 @@ Bug Fixes
 - ``astropy.time``
 
 - ``astropy.units``
+
+  - Fixed latex representation of function units. [#4563]
 
 - ``astropy.utils``
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -98,8 +98,9 @@ class FunctionUnitBase(object):
             self._physical_unit = dimensionless_unscaled
         else:
             self._physical_unit = Unit(physical_unit)
-            if(not isinstance(self._physical_unit, UnitBase) or
-               self._physical_unit.is_equivalent(self._default_function_unit)):
+            if (not isinstance(self._physical_unit, UnitBase) or
+                self._physical_unit.is_equivalent(
+                    self._default_function_unit)):
                 raise ValueError("Unit {0} is not a physical unit."
                                  .format(self._physical_unit))
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -372,8 +372,13 @@ class FunctionUnitBase(object):
                              "supported.".format(format))
         self_str = self.function_unit.to_string(format)
         pu_str = self.physical_unit.to_string(format)
-        parens = '\left({0}\right)' if format == 'latex' else '({0})'
-        self_str += parens.format(pu_str if pu_str != '' else '1')
+        if pu_str == '':
+            pu_str = '1'
+        if format == 'latex':
+            self_str += r'$\mathrm{{\left( {0} \right)}}$'.format(
+                pu_str[1:-1])   # need to strip leading and trailing "$"
+        else:
+            self_str += '({0})'.format(pu_str)
         return self_str
 
     def __str__(self):

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -92,6 +92,12 @@ class TestLogUnitStrings(object):
         assert repr(lu3) == 'MagUnit("Jy", unit="2 mag")'
         assert lu3.to_string() == '2 mag(Jy)'
 
+        lu4 = u.mag(u.ct)
+        assert lu4.to_string('generic') == 'mag(ct)'
+        assert lu4.to_string('latex') == ('$\\mathrm{mag}$$\\mathrm{\\left( '
+                                          '\\mathrm{ct} \\right)}$')
+
+
 class TestLogUnitConversion(object):
     @pytest.mark.parametrize('lu_unit, physical_unit',
                              itertools.product(lu_units, pu_sample))


### PR DESCRIPTION
This PR fixes a bug in the latex represention in the juypter notebook of function units (e.g. mag, dex) where the left and right parentheses are not rendered in math mode.  For example, `u.mag(u.ct)` renders as `"mag\left(ctight)"`.