### PR TITLE
fix validate test to work with wcslib v >=5.13

### DIFF
--- a/astropy/wcs/tests/data/validate.5.13.txt
+++ b/astropy/wcs/tests/data/validate.5.13.txt
@@ -1,0 +1,16 @@
+HDU 1:
+  WCS key ' ':
+    - RADECSYS= 'ICRS ' / Astrometric system
+      the RADECSYS keyword is deprecated, use RADESYSa.
+    - The WCS transformation has more axes (2) than the image it is
+      associated with (0)
+    - Removed redundant SCAMP distortion parameters because SIP
+      parameters are also present
+
+HDU 2:
+  WCS key ' ':
+    - The WCS transformation has more axes (3) than the image it is
+      associated with (0)
+    - 'celfix' made the change 'In CUNIT3 : Mismatched units type
+      'length': have 'Hz', want 'm''.
+    - 'unitfix' made the change 'Changed units: 'HZ' -> 'Hz''.

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -424,8 +424,12 @@ def test_validate():
     with catch_warnings():
         results = wcs.validate(get_pkg_data_filename("data/validate.fits"))
         results_txt = repr(results)
-        if wcs._wcs.__version__[0] == '5':
-            filename = 'data/validate.5.0.txt'
+        version = wcs._wcs.__version__
+        if version[0] == '5':
+            if version >= '5.13':
+                filename = 'data/validate.5.13.txt'
+            else:
+                filename = 'data/validate.5.0.txt'
         else:
             filename = 'data/validate.txt'
         with open(get_pkg_data_filename(filename), "r") as fd:


### PR DESCRIPTION
This addresses #4535. 
In the test file `CUNIT3  = 'HZ      '`. wcslib converts it to `Hz` (without spaces) and issues a warning.
Before v 5.13 it used to report that `'HZ      '`  was converted to `'Hz'`, now it omits the trailing spaces in the original value and the warning says:
```
- 'unitfix' made the change 'Changed units: 'HZ' -> 'Hz''.
```
As a side question (perhaps @astrofrog knows as he originally reported the units problem in #36 )is `Hz` a valid unit if `CTYPE=AWAV ` as in the test file (`validate.fits`). The file triggers an `InvalidTransformError` because it expects units of length. I wonder if there are cases when `wcs.fix` catches real errors and turns them into warnings instead of raising them.