### PR TITLE
Improve render docs

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1074,7 +1074,8 @@ class Model(object):
 
     def render(self, out=None, coords=None):
         """
-        Evaluates a model on an input array.  I.e., "discretizes" the model.
+        Evaluate a model at fixed positions, respecting the ``bounding_box``.
+
         The key difference relative to evaluating the model directly is that
         this method is limited to a bounding box if the `Model.bounding_box`
         attribute is set.
@@ -1089,7 +1090,8 @@ class Model(object):
             to the ``out`` array. It should have the property that
             ``self(coords)`` yields the same shape as ``out``.  If ``out`` is
             not specified, ``coords`` will be used to determine the shape of the
-            returned array.
+            returned array. If this is not provided (or None), the model will be
+            evaluated on a grid determined by `Model.bounding_box`.
 
         Returns
         -------
@@ -1099,6 +1101,12 @@ class Model(object):
             If ``out`` and ``coords`` are both `None`, the returned array is
             limited to the `Model.bounding_box` limits. If
             `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be passed.
+
+        Raises
+        ------
+        ValueError
+            If ``coords`` are not given and the the `Model.bounding_box` of this
+            model is not set.
 
         Examples
         --------

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1074,22 +1074,28 @@ class Model(object):
 
     def render(self, out=None, coords=None):
         """
-        Evaluates a model on an input array. Evaluation is limited to
-        a bounding box if the `Model.bounding_box` attribute is set.
+        Evaluates a model on an input array.  I.e., "discretizes" the model.
+        The key difference relative to evaluating the model directly is that
+        this method is limited to a bounding box if the `Model.bounding_box`
+        attribute is set.
 
         Parameters
         ----------
         out : `numpy.ndarray`, optional
-            The array on which the model is to be evaluated.
+            An array that the evaluated model will be added to.  If this is not
+            given (or given as ``None``), a new array will be created.
         coords : array-like, optional
-            Coordinate arrays mapping to ``arr``, such that
-            ``arr[coords] == arr``.
+            An array to be used to translate from the model's input coordinates
+            to the ``out`` array. It should have the property that
+            ``self(coords)`` yields the same shape as ``out``.  If ``out`` is
+            not specified, ``coords`` will be used to determine the shape of the
+            returned array.
 
         Returns
         -------
         out : `numpy.ndarray`
-            The model evaluated on the input array if given, or else a new array from
-            ``coords``.
+            The model added to ``out`` if  ``out`` is not ``None``, or else a
+            new array from evaluating the model over ``coords``.
             If ``out`` and ``coords`` are both `None`, the returned array is
             limited to the `Model.bounding_box` limits. If
             `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be passed.
@@ -1134,7 +1140,6 @@ class Model(object):
                     'of dimensions.')
 
         if bbox is not None:
-
             # assures position is at center pixel, important when using add_array
             pd = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2))
                            for bb in bbox]).astype(int).T


### PR DESCRIPTION
This PR makes some changes to the docstring of the `Model.render` method.  I found the current in-master docstring to be a bit difficult to follow, so I'm hoping this will make things a bit clearer.

I'd appreciate if @patti and/or @cdeil could take a look at this and double-check I didn't say anything wrong (or if you think may change made it *less* clear I'm happy to here that and make changes appropriately!)