### PR TITLE
Extend wrapping of ERFA functions to AngleOps and SphericalCartesian

### DIFF
--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -22,7 +22,7 @@ ctype_to_dtype = {'double'     : "numpy.double",
                   'int'        : "numpy.intc",
                   'eraASTROM'  : "dt_eraASTROM",
                   'eraLDBODY'  : "dt_eraLDBODY",
-                  'char'       : "numpy.dtype('S16')",
+                  'char'       : "numpy.dtype('S1')",
                   'const char' : "numpy.dtype('S16')",
                   }
 
@@ -395,7 +395,7 @@ def main(srcdir, outfn, templateloc, verbose=True):
                                               erfa_h, flags=re.DOTALL|re.MULTILINE)
     for section, subsection, functions in section_subsection_functions:
         print_("{0}.{1}".format(section, subsection))
-        if section == "Astronomy":
+        if (section == "Astronomy") or (subsection == "AngleOps") or (subsection == "SphericalCartesian"):
             func_names = re.findall(' (\w+)\(.*?\);', functions, flags=re.DOTALL)
             for name in func_names:
                 print_("{0}.{1}.{2}...".format(section, subsection, name))

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -22,7 +22,7 @@ ctype_to_dtype = {'double'     : "numpy.double",
                   'int'        : "numpy.intc",
                   'eraASTROM'  : "dt_eraASTROM",
                   'eraLDBODY'  : "dt_eraLDBODY",
-                  'char'       : "numpy.dtype('U1')",
+                  'char'       : "numpy.dtype('S1')",
                   'const char' : "numpy.dtype('S16')",
                   }
 

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -22,7 +22,7 @@ ctype_to_dtype = {'double'     : "numpy.double",
                   'int'        : "numpy.intc",
                   'eraASTROM'  : "dt_eraASTROM",
                   'eraLDBODY'  : "dt_eraLDBODY",
-                  'char'       : "numpy.dtype('S1')",
+                  'char'       : "numpy.dtype('U1')",
                   'const char' : "numpy.dtype('S16')",
                   }
 

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -34,11 +34,11 @@ def test_erfa_wrapper():
     assert ihmsf.dtype == np.dtype('i4')
 
     sign, idmsf = erfa.a2af(6, -np.pi)
-    assert sign == '-'
+    assert sign == b'-'
     assert (idmsf == [180,0,0,0]).all()
 
     sign, ihmsf = erfa.a2tf(6, np.pi)
-    assert sign == '+'
+    assert sign == b'+'
     assert (ihmsf == [12,0,0,0]).all()
 
 

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -47,7 +47,7 @@ def test_angle_ops():
     rad = erfa.af2a('-', 180, 0, 0.0)
     np.testing.assert_allclose(rad, -np.pi)
 
-    rad = erfa.tf2a('+, 12, 0, 0.0)
+    rad = erfa.tf2a('+', 12, 0, 0.0)
     np.testing.assert_allclose(rad, -np.pi)
 
     rad = erfa.anp(3.*np.pi)

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -48,7 +48,7 @@ def test_angle_ops():
     np.testing.assert_allclose(rad, -np.pi)
 
     rad = erfa.tf2a('+', 12, 0, 0.0)
-    np.testing.assert_allclose(rad, -np.pi)
+    np.testing.assert_allclose(rad, np.pi)
 
     rad = erfa.anp(3.*np.pi)
     np.testing.assert_allclose(rad, np.pi)

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -79,7 +79,7 @@ def test_spherical_cartesian():
     np.testing.assert_allclose(theta, np.pi/2.0)
     np.testing.assert_allclose(phi, np.pi/4.0)
     np.testing.assert_allclose(r, 2.0)
-    np.testing.assert_allclose(td, np.sqrt(2.0)/2.0)
+    np.testing.assert_allclose(td, -np.sqrt(2.0)/2.0)
     np.testing.assert_allclose(pd, 0.0)
     np.testing.assert_allclose(rd, 0.0)
 

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -33,6 +33,14 @@ def test_erfa_wrapper():
     assert ihmsf.shape == (4,)
     assert ihmsf.dtype == np.dtype('i4')
 
+    sign, idmsf = erfa.a2af(6, -np.pi)
+    assert sign == '-'
+    assert (idmsf == [180,0,0,0]).all()
+
+    sign, ihmsf = erfa.a2tf(6, np.pi)
+    assert sign == '+'
+    assert (ihmsf == [12,0,0,0]).all()
+
 
 def test_errwarn_reporting(recwarn):
     """

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -90,7 +90,7 @@ def test_spherical_cartesian():
     np.testing.assert_allclose(c, [0.0, np.sqrt(2.0)/2.0, np.sqrt(2.0)/2.0], atol=1e-14)
 
     pv = erfa.s2pv(np.pi/2.0, np.pi/4.0, 2.0, np.sqrt(2.0)/2.0, 0.0, 0.0)
-    np.testing.assert_allclose(pv, [[0.0,np.sqrt(2.0),np.sqrt(2.0)],[1.0,0.0,0.0]], atol=1e-14)
+    np.testing.assert_allclose(pv, [[0.0,np.sqrt(2.0),np.sqrt(2.0)],[-1.0,0.0,0.0]], atol=1e-14)
 
 
 def test_errwarn_reporting(recwarn):

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -33,6 +33,9 @@ def test_erfa_wrapper():
     assert ihmsf.shape == (4,)
     assert ihmsf.dtype == np.dtype('i4')
 
+
+def test_angle_ops():
+
     sign, idmsf = erfa.a2af(6, -np.pi)
     assert sign == b'-'
     assert (idmsf == [180,0,0,0]).all()
@@ -40,6 +43,25 @@ def test_erfa_wrapper():
     sign, ihmsf = erfa.a2tf(6, np.pi)
     assert sign == b'+'
     assert (ihmsf == [12,0,0,0]).all()
+
+    rad = erfa.af2a('-', 180, 0, 0.0)
+    np.testing.assert_allclose(rad, -np.pi)
+
+    rad = erfa.tf2a('+, 12, 0, 0.0)
+    np.testing.assert_allclose(rad, -np.pi)
+
+    rad = erfa.anp(3.*np.pi)
+    np.testing.assert_allclose(rad, np.pi)
+
+    rad = erfa.anpm(3.*np.pi)
+    np.testing.assert_allclose(rad, -np.pi)
+
+    sign, ihmsf = erfa.d2tf(1, -1.5)
+    assert sign == b'-'
+    assert (ihmsf == [36,0,0,0]).all()
+
+    days = erfa.tf2d('+', 3, 0, 0.0)
+    np.testing.assert_allclose(days, 0.125)
 
 
 def test_errwarn_reporting(recwarn):

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -64,6 +64,35 @@ def test_angle_ops():
     np.testing.assert_allclose(days, 0.125)
 
 
+def test_spherical_cartesian():
+
+    theta, phi = erfa.c2s([0.0,np.sqrt(2.0),np.sqrt(2.0)])
+    np.testing.assert_allclose(theta, np.pi/2.0)
+    np.testing.assert_allclose(phi, np.pi/4.0)
+
+    theta, phi, r = erfa.p2s([0.0,np.sqrt(2.0),np.sqrt(2.0)])
+    np.testing.assert_allclose(theta, np.pi/2.0)
+    np.testing.assert_allclose(phi, np.pi/4.0)
+    np.testing.assert_allclose(r, 2.0)
+
+    theta, phi, r, td, pd, rd = erfa.pv2s([[0.0,np.sqrt(2.0),np.sqrt(2.0)],[1.0,0.0,0.0]])
+    np.testing.assert_allclose(theta, np.pi/2.0)
+    np.testing.assert_allclose(phi, np.pi/4.0)
+    np.testing.assert_allclose(r, 2.0)
+    np.testing.assert_allclose(td, np.sqrt(2.0)/2.0)
+    np.testing.assert_allclose(pd, 0.0)
+    np.testing.assert_allclose(rd, 0.0)
+
+    c = erfa.s2c(np.pi/2.0, np.pi/4.0)
+    np.testing.assert_allclose(c, [0.0, np.sqrt(2.0)/2.0, np.sqrt(2.0)/2.0], atol=1e-14)
+
+    c = erfa.s2p(np.pi/2.0, np.pi/4.0, 1.0)
+    np.testing.assert_allclose(c, [0.0, np.sqrt(2.0)/2.0, np.sqrt(2.0)/2.0], atol=1e-14)
+
+    pv = erfa.s2pv(np.pi/2.0, np.pi/4.0, 2.0, np.sqrt(2.0)/2.0, 0.0, 0.0)
+    np.testing.assert_allclose(pv, [[0.0,np.sqrt(2.0),np.sqrt(2.0)],[1.0,0.0,0.0]], atol=1e-14)
+
+
 def test_errwarn_reporting(recwarn):
     """
     Test that the ERFA error reporting mechanism works as it should


### PR DESCRIPTION
One small step closer to making a full fledge ERFA available to python, somewhat related to #3123.