### PR TITLE
Changed the order on which python version is checked.

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -34,7 +34,7 @@ def _find_home():
     # in py2.x but not in py3.x
     if six.PY2:
         decodepath = lambda pth: pth.decode(sys.getfilesystemencoding())
-    elif six.PY3:
+    else:
         decodepath = lambda pth: pth
 
     # First find the home directory - this is inspired by the scheme ipython

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1980,11 +1980,11 @@ class TestHeaderFunctions(FitsTestCase):
         """
 
         h = fits.Header()
-        if six.PY3:
+        if six.PY2:
+            pytest.raises(ValueError, h.set, 'TEST', str('ñ'))
+        else:
             pytest.raises(ValueError, h.set, 'TEST',
                           bytes('Hello', encoding='ascii'))
-        elif six.PY2:
-            pytest.raises(ValueError, h.set, 'TEST', str('ñ'))
 
     def test_header_strip_whitespace(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1706,10 +1706,10 @@ class TestTableFunctions(FitsTestCase):
 
         def test_dims_and_roundtrip(tbhdu):
             assert tbhdu.data['S'].shape == (5, 3, 2)
-            if six.PY3:
-                assert tbhdu.data['S'].dtype.str.endswith('U4')
-            else:
+            if six.PY2:
                 assert tbhdu.data['S'].dtype.str.endswith('S4')
+            else:
+                assert tbhdu.data['S'].dtype.str.endswith('U4')
 
             tbhdu.writeto(self.temp('test.fits'), clobber=True)
 
@@ -1717,10 +1717,10 @@ class TestTableFunctions(FitsTestCase):
                 tbhdu2 = hdul[1]
                 assert tbhdu2.header['TDIM1'] == '(4,2,3)'
                 assert tbhdu2.data['S'].shape == (5, 3, 2)
-                if six.PY3:
-                    assert tbhdu.data['S'].dtype.str.endswith('U4')
-                else:
+                if six.PY2:
                     assert tbhdu.data['S'].dtype.str.endswith('S4')
+                else:
+                    assert tbhdu.data['S'].dtype.str.endswith('U4')
                 assert np.all(tbhdu2.data['S'] == tbhdu.data['S'])
 
         test_dims_and_roundtrip(tbhdu1)

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -37,10 +37,10 @@ from ...utils import wraps
 from ...utils.compat import ignored
 from ...utils.exceptions import AstropyUserWarning
 
-if six.PY3:
-    cmp = lambda a, b: (a > b) - (a < b)
-elif six.PY2:
+if six.PY2:
     cmp = cmp
+else:
+    cmp = lambda a, b: (a > b) - (a < b)
 
 
 class NotifierMixin(object):
@@ -343,7 +343,18 @@ def iswritable(f):
     return True
 
 
-if six.PY3:
+if six.PY2:
+    def isfile(f):
+        """
+        Returns True if the given object represents an OS-level file (that is,
+        ``isinstance(f, file)``).
+
+        On Python 3 this also returns True if the given object is higher level
+        wrapper on top of a FileIO object, such as a TextIOWrapper.
+        """
+
+        return isinstance(f, file)
+else:
     def isfile(f):
         """
         Returns True if the given object represents an OS-level file (that is,
@@ -360,34 +371,9 @@ if six.PY3:
         elif hasattr(f, 'raw'):
             return isfile(f.raw)
         return False
-elif six.PY2:
-    def isfile(f):
-        """
-        Returns True if the given object represents an OS-level file (that is,
-        ``isinstance(f, file)``).
-
-        On Python 3 this also returns True if the given object is higher level
-        wrapper on top of a FileIO object, such as a TextIOWrapper.
-        """
-
-        return isinstance(f, file)
 
 
-if six.PY3:
-    def fileobj_open(filename, mode):
-        """
-        A wrapper around the `open()` builtin.
-
-        This exists because in Python 3, `open()` returns an
-        `io.BufferedReader` by default.  This is bad, because
-        `io.BufferedReader` doesn't support random access, which we need in
-        some cases.  In the Python 3 case (implemented in the py3compat module)
-        we must call open with buffering=0 to get a raw random-access file
-        reader.
-        """
-
-        return open(filename, mode, buffering=0)
-elif six.PY2:
+if six.PY2:
     def fileobj_open(filename, mode):
         """
         A wrapper around the `open()` builtin.
@@ -401,6 +387,20 @@ elif six.PY2:
         """
 
         return open(filename, mode)
+else:
+    def fileobj_open(filename, mode):
+        """
+        A wrapper around the `open()` builtin.
+
+        This exists because in Python 3, `open()` returns an
+        `io.BufferedReader` by default.  This is bad, because
+        `io.BufferedReader` doesn't support random access, which we need in
+        some cases.  In the Python 3 case (implemented in the py3compat module)
+        we must call open with buffering=0 to get a raw random-access file
+        reader.
+        """
+
+        return open(filename, mode, buffering=0)
 
 
 def fileobj_name(f):
@@ -662,16 +662,7 @@ def fileobj_is_binary(f):
         return True
 
 
-if six.PY3:
-    maketrans = str.maketrans
-
-    def translate(s, table, deletechars):
-        if deletechars:
-            table = table.copy()
-            for c in deletechars:
-                table[ord(c)] = None
-        return s.translate(table)
-elif six.PY2:
+if six.PY2:
     maketrans = string.maketrans
 
     def translate(s, table, deletechars):
@@ -689,6 +680,15 @@ elif six.PY2:
             for c in deletechars:
                 table[ord(c)] = None
             return s.translate(table)
+else:
+    maketrans = str.maketrans
+
+    def translate(s, table, deletechars):
+        if deletechars:
+            table = table.copy()
+            for c in deletechars:
+                table[ord(c)] = None
+        return s.translate(table)
 
 
 def fill(text, width, *args, **kwargs):

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -102,7 +102,7 @@ def bitarray_to_bool(data, length):
     """
     results = []
     for byte in data:
-        if not six.PY3:
+        if six.PY2:
             byte = ord(byte)
         for bit_no in range(7, -1, -1):
             bit = byte & (1 << bit_no)
@@ -1133,7 +1133,7 @@ class BooleanArray(NumericArray):
         result = []
         result_mask = []
         for char in data:
-            if not six.PY3:
+            if six.PY2:
                 char = ord(char)
             value, mask = binparse(char)
             result.append(value)

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -43,15 +43,15 @@ _empty_bytes = b''
 _zero_byte = b'\0'
 
 
-if six.PY3:
-    struct_unpack = _struct_unpack
-    struct_pack = _struct_pack
-else:
+if six.PY2:
     def struct_unpack(format, s):
         return _struct_unpack(format.encode('ascii'), s)
 
     def struct_pack(format, *args):
         return _struct_pack(format.encode('ascii'), *args)
+else:
+    struct_unpack = _struct_unpack
+    struct_pack = _struct_pack
 
 
 if sys.byteorder == 'little':

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -420,10 +420,10 @@ class W08(VOTableSpecWarning):
     make more sense.
     """
 
-    if six.PY3:
-        message_template = "'%s' must be a str or bytes object"
-    else:
+    if six.PY2:
         message_template = "'%s' must be a str or unicode object"
+    else:
+        message_template = "'%s' must be a str or bytes object"
     default_args = ('x',)
 
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -809,13 +809,13 @@ def test_validate():
     output = output[1:-1]
 
     for line in difflib.unified_diff(truth, output):
-        if six.PY3:
-            sys.stdout.write(
-                line.replace('\\n', '\n'))
-        else:
+        if six.PY2:
             sys.stdout.write(
                 line.encode('unicode_escape').
                 replace('\\n', '\n'))
+        else:
+            sys.stdout.write(
+                line.replace('\\n', '\n'))
 
     assert truth == output
 
@@ -887,10 +887,10 @@ def test_fileobj():
         if sys.platform == 'win32':
             fd()
         else:
-            if six.PY3:
-                assert isinstance(fd, io.FileIO)
-            elif six.PY2:
+            if six.PY2:
                 assert isinstance(fd, file)
+            else:
+                assert isinstance(fd, io.FileIO)
 
 
 def test_nonstandard_units():
@@ -986,13 +986,13 @@ def test_no_resource_check():
     output = output[1:-1]
 
     for line in difflib.unified_diff(truth, output):
-        if six.PY3:
-            sys.stdout.write(
-                line.replace('\\n', '\n'))
-        else:
+        if six.PY2:
             sys.stdout.write(
                 line.encode('unicode_escape').
                 replace('\\n', '\n'))
+        else:
+            sys.stdout.write(
+                line.replace('\\n', '\n'))
 
     assert truth == output
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2064,12 +2064,13 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
 
     def __bytes__(self):
         return bytes(self.to_table())
-    if six.PY2:
-        __str__ = __bytes__
 
     def __unicode__(self):
         return six.text_type(self.to_table())
-    if six.PY3:
+
+    if six.PY2:
+        __str__ = __bytes__
+    else:
         __str__ = __unicode__
 
     @property

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2223,17 +2223,17 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
 
             dtype = []
             for x in fields:
-                if six.PY3:
-                    if x._unique_name == x.ID:
-                        id = x.ID
-                    else:
-                        id = (x._unique_name, x.ID)
-                else:
+                if six.PY2:
                     if x._unique_name == x.ID:
                         id = x.ID.encode('utf-8')
                     else:
                         id = (x._unique_name.encode('utf-8'),
                               x.ID.encode('utf-8'))
+                else:
+                    if x._unique_name == x.ID:
+                        id = x.ID
+                    else:
+                        id = (x._unique_name, x.ID)
                 dtype.append((id, x.converter.format))
 
             array = np.recarray((nrows,), dtype=np.dtype(dtype))

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -104,11 +104,11 @@ class Result(object):
 
         r = None
         try:
-            if six.PY3:
+            if six.PY2:
+                r = urllib.request.urlopen(self.url, timeout=self.timeout)
+            else:
                 r = urllib.request.urlopen(
                     self.url.decode('ascii'), timeout=self.timeout)
-            elif six.PY2:
-                r = urllib.request.urlopen(self.url, timeout=self.timeout)
         except urllib.error.URLError as e:
             if hasattr(e, 'reason'):
                 reason = e.reason

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -438,7 +438,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
     __or__ =      _model_oper('|')
     __and__ =     _model_oper('&')
 
-    if not six.PY3:
+    if six.PY2:
         # The classic __div__ operator need only be implemented for Python 2
         # without from __future__ import division
         __div__ = _model_oper('/')
@@ -720,7 +720,7 @@ class Model(object):
     __or__ =      _model_oper('|')
     __and__ =     _model_oper('&')
 
-    if not six.PY3:
+    if six.PY2:
         __div__ = _model_oper('/')
 
     # *** Properties ***

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -179,11 +179,11 @@ def test_wrap_preserve_signature_docstring():
     if wrapped_function_6.__doc__ is not None:
         assert wrapped_function_6.__doc__.strip() == "An awesome function"
 
-    if six.PY3:
-        signature = inspect.formatargspec(
-            *inspect.getfullargspec(wrapped_function_6))
-    else:
+    if six.PY2:
         signature = inspect.formatargspec(
             *inspect.getargspec(wrapped_function_6))
+    else:
+        signature = inspect.formatargspec(
+            *inspect.getfullargspec(wrapped_function_6))
 
     assert signature == "(data, wcs=None, unit=None)"

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -753,13 +753,14 @@ class Column(BaseColumn):
 
         lines, outs = self._formatter._pformat_col(self)
         return '\n'.join(lines)
-    if six.PY3:
-        __str__ = __unicode__
 
     def __bytes__(self):
         return six.text_type(self).encode('utf-8')
+
     if six.PY2:
         __str__ = __bytes__
+    else:
+        __str__ = __unicode__
 
     # Set items using a view of the underlying data, as it gives an
     # order-of-magnitude speed-up. [#2994]

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -570,7 +570,7 @@ def fix_column_name(val):
         try:
             val = str(val)
         except UnicodeEncodeError:
-            if not six.PY3:
+            if six.PY2:
                 raise ValueError(
                     "Column names must not contain Unicode characters "
                     "on Python 2")

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -18,15 +18,15 @@ from ..utils.compat import NUMPY_LT_1_6_1
 from ..utils.console import Getch, color_print, terminal_size, conf
 from ..utils.data_info import dtype_info_name
 
-if six.PY3:
+if six.PY2:
+    _format_funcs = {None: lambda format_, val: text_type(val)}
+else:
     def default_format_func(format_, val):
         if isinstance(val, bytes):
             return val.decode('utf-8')
         else:
             return str(val)
     _format_funcs = {None: default_format_func}
-elif six.PY2:
-    _format_funcs = {None: lambda format_, val: text_type(val)}
 
 
 ### The first three functions are helpers for _auto_format_func

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2334,32 +2334,32 @@ class Table(object):
         return self.copy(False)
 
     def __lt__(self, other):
-        if six.PY3:
-            return super(Table, self).__lt__(other)
-        elif six.PY2:
+        if six.PY2:
             raise TypeError("unorderable types: Table() < {0}".
                             format(str(type(other))))
+        else:
+            return super(Table, self).__lt__(other)
 
     def __gt__(self, other):
-        if six.PY3:
-            return super(Table, self).__gt__(other)
-        elif six.PY2:
+        if six.PY2:
             raise TypeError("unorderable types: Table() > {0}".
                             format(str(type(other))))
+        else:
+            return super(Table, self).__gt__(other)
 
     def __le__(self, other):
-        if six.PY3:
-            return super(Table, self).__le__(other)
-        elif six.PY2:
+        if six.PY2:
             raise TypeError("unorderable types: Table() <= {0}".
                             format(str(type(other))))
+        else:
+            return super(Table, self).__le__(other)
 
     def __ge__(self, other):
-        if six.PY3:
-            return super(Table, self).__ge__(other)
-        else:
+        if six.PY2:
             raise TypeError("unorderable types: Table() >= {0}".
                             format(str(type(other))))
+        else:
+            return super(Table, self).__ge__(other)
 
     def __eq__(self, other):
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -119,10 +119,10 @@ class AstropyTest(Command, object):
             cmd_pre += pre
             cmd_post += post
 
-        if six.PY3:
-            set_flag = "import builtins; builtins._ASTROPY_TEST_ = True"
-        else:
+        if six.PY2:
             set_flag = "import __builtin__; __builtin__._ASTROPY_TEST_ = True"
+        else:
+            set_flag = "import builtins; builtins._ASTROPY_TEST_ = True"
 
         cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = ('
                '{1.package_name}.test('
@@ -243,10 +243,10 @@ class AstropyTest(Command, object):
         # as being specifically for Python 2 or Python 3
         with open(coveragerc, 'r') as fd:
             coveragerc_content = fd.read()
-        if six.PY3:
-            ignore_python_version = '2'
-        else:
+        if six.PY2:
             ignore_python_version = '3'
+        else:
+            ignore_python_version = '2'
         coveragerc_content = coveragerc_content.replace(
             "{ignore_python_version}", ignore_python_version).replace(
                 "{packagename}", self.package_name)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -46,19 +46,19 @@ if os.environ.get('ASTROPY_USE_SYSTEM_PYTEST') or '_pytest' in sys.modules:
 else:
     from ..extern import pytest as extern_pytest
 
-    if six.PY3:
+    if six.PY2:
+        exec("def do_exec_def(co, loc): exec co in loc\n")
+        extern_pytest.do_exec = do_exec_def
+
+        unpacked_sources = pickle.loads(
+            zlib.decompress(base64.decodestring(extern_pytest.sources)))
+    else:
         exec("def do_exec_def(co, loc): exec(co, loc)\n")
         extern_pytest.do_exec = do_exec_def
 
         unpacked_sources = extern_pytest.sources.encode("ascii")
         unpacked_sources = pickle.loads(
             zlib.decompress(base64.decodebytes(unpacked_sources)), encoding='utf-8')
-    elif six.PY2:
-        exec("def do_exec_def(co, loc): exec co in loc\n")
-        extern_pytest.do_exec = do_exec_def
-
-        unpacked_sources = pickle.loads(
-            zlib.decompress(base64.decodestring(extern_pytest.sources)))
 
     importer = extern_pytest.DictImporter(unpacked_sources)
     sys.meta_path.insert(0, importer)

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -616,7 +616,7 @@ def pytest_report_header(config):
     if opts:
         s += "Using Astropy options: {0}.\n".format(" ".join(opts))
 
-    if not six.PY3:
+    if six.PY2:
         s = s.encode(stdoutencoding, 'replace')
 
     return s

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -545,7 +545,7 @@ def pytest_report_header(config):
 
     if six.PY2:
         args = [x.decode('utf-8') for x in config.args]
-    elif six.PY3:
+    else:
         args = config.args
 
     # TESTED_VERSIONS can contain the affiliated package version, too
@@ -627,10 +627,10 @@ def pytest_pycollect_makemodule(path, parent):
     # from __future__ import unicode_literals
 
     # On Python 3, just do the regular thing that py.test does
-    if six.PY3:
-        return pytest.Module(path, parent)
-    elif six.PY2:
+    if six.PY2:
         return Pair(path, parent)
+    else:
+        return pytest.Module(path, parent)
 
 
 class Pair(pytest.File):

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -46,10 +46,10 @@ def test_imports():
         raise AttributeError('package to generate config items for does not '
                              'have __file__ or __path__')
 
-    if six.PY3:
-        excludes = _py2_packages
-    else:
+    if six.PY2:
         excludes = _py3_packages
+    else:
+        excludes = _py2_packages
 
     prefix = package.__name__ + '.'
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -342,7 +342,7 @@ def color_print(*args, **kwargs):
             # Some file objects support writing unicode sensibly on some Python
             # versions; if this fails try creating a writer using the locale's
             # preferred encoding. If that fails too give up.
-            if not six.PY3 and isinstance(msg, bytes):
+            if six.PY2 and isinstance(msg, bytes):
                 msg = _decode_preferred_encoding(msg)
 
             write = _write_with_fallback(msg, write, file)
@@ -351,7 +351,7 @@ def color_print(*args, **kwargs):
     else:
         for i in range(0, len(args), 2):
             msg = args[i]
-            if not six.PY3 and isinstance(msg, bytes):
+            if six.PY2 and isinstance(msg, bytes):
                 # Support decoding bytes to unicode on Python 2; use the
                 # preferred encoding for the locale (which is *sometimes*
                 # sensible)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -181,10 +181,10 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
             name_or_obj = download_file(
                 name_or_obj, cache=cache, show_progress=show_progress,
                 timeout=remote_timeout)
-        if six.PY3:
-            fileobj = io.FileIO(name_or_obj, 'r')
-        elif six.PY2:
+        if six.PY2:
             fileobj = open(name_or_obj, 'rb')
+        else:
+            fileobj = io.FileIO(name_or_obj, 'r')
         if is_url and not cache:
             delete_fds.append(fileobj)
         close_fds.append(fileobj)
@@ -283,10 +283,10 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     # io.TextIOWrapper so read will return unicode based on the
     # encoding parameter.
 
-    if six.PY3:
-        needs_textio_wrapper = encoding != 'binary'
-    elif six.PY2:
+    if six.PY2:
         needs_textio_wrapper = encoding != 'binary' and encoding is not None
+    else:
+        needs_textio_wrapper = encoding != 'binary'
 
     if needs_textio_wrapper:
         # A bz2.BZ2File can not be wrapped by a TextIOWrapper,
@@ -303,10 +303,10 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 tmp.write(data)
                 tmp.close()
                 delete_fds.append(tmp)
-                if six.PY3:
-                    fileobj = io.FileIO(tmp.name, 'r')
-                elif six.PY2:
+                if six.PY2:
                     fileobj = open(tmp.name, 'rb')
+                else:
+                    fileobj = io.FileIO(tmp.name, 'r')
                 close_fds.append(fileobj)
 
         # On Python 2.x, we need to first wrap the regular `file`
@@ -1307,7 +1307,7 @@ def _open_shelve(shelffn, withclosing=False):
 
     if six.PY2:
         shelf = shelve.open(shelffn, protocol=2)
-    elif six.PY3:
+    else:
         shelf = shelve.open(shelffn + '.db', protocol=2)
 
     if withclosing:

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -383,7 +383,10 @@ def isinstancemethod(cls, obj):
     return _isinstancemethod(cls, obj)
 
 
-if six.PY3:
+if six.PY2:
+    def _isinstancemethod(cls, obj):
+        return isinstance(obj, types.MethodType) and obj.im_class is cls
+else:
     def _isinstancemethod(cls, obj):
         if not isinstance(obj, types.FunctionType):
             return False
@@ -400,6 +403,3 @@ if six.PY3:
         # This shouldn't happen, though this is the most sensible response if
         # it does.
         raise AttributeError(name)
-else:
-    def _isinstancemethod(cls, obj):
-        return isinstance(obj, types.MethodType) and obj.im_class is cls

--- a/astropy/vo/samp/ssl_utils.py
+++ b/astropy/vo/samp/ssl_utils.py
@@ -8,10 +8,10 @@ import socket
 
 from ...extern import six
 
-if six.PY3:
-    from xmlrpc.server import SimpleXMLRPCRequestHandler
-else:
+if six.PY2:
     from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler
+else:
+    from xmlrpc.server import SimpleXMLRPCRequestHandler
 
 from ...extern.six.moves import xmlrpc_client as xmlrpc
 from .standard_profile import ThreadingXMLRPCServer

--- a/astropy/vo/samp/standard_profile.py
+++ b/astropy/vo/samp/standard_profile.py
@@ -11,11 +11,11 @@ from ...extern.six.moves import xmlrpc_client as xmlrpc
 from ...extern.six.moves import socketserver
 from ...extern import six
 
-if six.PY3:
-    from xmlrpc.server import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer
-else:
+if six.PY2:
     from SimpleXMLRPCServer import (SimpleXMLRPCRequestHandler,
                                     SimpleXMLRPCServer)
+else:
+    from xmlrpc.server import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer
 
 from .constants import SAMP_ICON
 from .errors import SAMPWarning

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -26,19 +26,19 @@ WCSVERSION = "5.10"
 def b(s):
     return s.encode('ascii')
 
-if six.PY3:
-    def string_escape(s):
-        s = s.decode('ascii').encode('ascii', 'backslashreplace')
-        s = s.replace(b'\n', b'\\n')
-        s = s.replace(b'\0', b'\\0')
-        return s.decode('ascii')
-elif six.PY2:
+if six.PY2:
     def string_escape(s):
         # string_escape has subtle differences with the escaping done in Python
         # 3 so correct for those too
         s = s.encode('string_escape')
         s = s.replace(r'\x00', r'\0')
         return s.replace(r"\'", "'")
+else:
+    def string_escape(s):
+        s = s.decode('ascii').encode('ascii', 'backslashreplace')
+        s = s.replace(b'\n', b'\\n')
+        s = s.replace(b'\0', b'\\0')
+        return s.decode('ascii')
 
 
 def determine_64_bit_int():


### PR DESCRIPTION
Following @astrofog suggestions on [his blog post about python4](http://astrofrog.github.io/blog/2016/01/12/stop-writing-python-4-incompatible-code/).
I've changed the instances where `six.PY3` and `six.PY2` are checked.

There are some places that needs to be updated where the check is:
`if not six.PY3` or `if six.PY3` only.  I imagine these should be changed for:
`if six.PY2` and some additional changes in the code.

To see the ones still missing:
```bash
find ./ -type f -iname '*.py' -exec grep -H 'six.PY3' {} \;
```
