### PR TITLE
Include runtime errors in PEP8 checks and fix for various PEP8 statement errors

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -693,7 +693,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
 
     # Don't install template files for dev versions, or we'll end up
     # spamming `~/.astropy/config`.
-    if not 'dev' in version and cfgfn is not None:
+    if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
             get_config_dir(), '{0}.{1}.cfg'.format(pkg, version))
         needs_template = not path.exists(template_path)

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -1011,6 +1011,6 @@ class CustomKernel(Kernel):
         # Check if array is bool
         ones = self._array == 1.
         zeros = self._array == 0
-        self._is_bool = np.all(np.logical_or(ones, zeros))
+        self._is_bool = bool(np.all(np.logical_or(ones, zeros)))
 
         self._truncation = 0.0

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -201,7 +201,7 @@ class TestKernels(object):
         """
         gauss = Gaussian1DKernel(3)
         gauss_new = number * gauss
-        assert isinstance(gauss_new, Gaussian1DKernel)
+        assert type(gauss_new) is Gaussian1DKernel
 
     @pytest.mark.parametrize(('number'), NUMS)
     def test_rmultiply_scalar_type(self, number):
@@ -210,7 +210,7 @@ class TestKernels(object):
         """
         gauss = Gaussian1DKernel(3)
         gauss_new = gauss * number
-        assert isinstance(gauss_new, Gaussian1DKernel)
+        assert type(gauss_new) is Gaussian1DKernel
 
     def test_multiply_kernel1d(self):
         """Test that multiplying two 1D kernels raises an exception."""
@@ -292,7 +292,7 @@ class TestKernels(object):
         Check if CustomKernel works with lists.
         """
         custom = CustomKernel([1, 1, 1, 1, 1])
-        assert custom.is_bool
+        assert custom.is_bool is True
 
     def test_custom_2D_kernel_list(self):
         """
@@ -301,7 +301,7 @@ class TestKernels(object):
         custom = CustomKernel([[1, 1, 1],
                                [1, 1, 1],
                                [1, 1, 1]])
-        assert custom.is_bool
+        assert custom.is_bool is True
 
     def test_custom_1D_kernel_zerosum(self):
         """

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -201,7 +201,7 @@ class TestKernels(object):
         """
         gauss = Gaussian1DKernel(3)
         gauss_new = number * gauss
-        assert type(gauss_new) == Gaussian1DKernel
+        assert isinstance(gauss_new, Gaussian1DKernel)
 
     @pytest.mark.parametrize(('number'), NUMS)
     def test_rmultiply_scalar_type(self, number):
@@ -210,7 +210,7 @@ class TestKernels(object):
         """
         gauss = Gaussian1DKernel(3)
         gauss_new = gauss * number
-        assert type(gauss_new) == Gaussian1DKernel
+        assert isinstance(gauss_new, Gaussian1DKernel)
 
     def test_multiply_kernel1d(self):
         """Test that multiplying two 1D kernels raises an exception."""
@@ -292,7 +292,7 @@ class TestKernels(object):
         Check if CustomKernel works with lists.
         """
         custom = CustomKernel([1, 1, 1, 1, 1])
-        assert custom.is_bool == True
+        assert custom.is_bool
 
     def test_custom_2D_kernel_list(self):
         """
@@ -301,7 +301,7 @@ class TestKernels(object):
         custom = CustomKernel([[1, 1, 1],
                                [1, 1, 1],
                                [1, 1, 1]])
-        assert custom.is_bool == True
+        assert custom.is_bool
 
     def test_custom_1D_kernel_zerosum(self):
         """

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -694,7 +694,7 @@ class FunctionTransform(CoordinateTransform):
             sig = signature(func)
             kinds = [x.kind for x in sig.parameters.values()]
             if (len(x for x in kinds if x == sig.POSITIONAL_ONLY) != 2
-                and not sig.VAR_POSITIONAL in kinds):
+                and sig.VAR_POSITIONAL not in kinds):
                 raise ValueError('provided function does not accept two arguments')
 
         self.func = func

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -278,13 +278,13 @@ class DaophotInputter(core.ContinuationLinesInputter):
     def process_lines(self, lines):
 
         markers, block, header = self.search_multiline(lines)
-        self.data.is_multiline = not markers is None
+        self.data.is_multiline = markers is not None
         self.data.markers = markers
         self.data.first_block = block
         # set the header lines returned by the search as a attribute of the header
         self.data.header.lines = header
 
-        if not markers is None:
+        if markers is not None:
             lines = lines[markers[0]:]
 
         continuation_char = self.continuation_char

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -127,7 +127,7 @@ class LatexHeader(core.BaseHeader):
         return units
 
     def write(self, lines):
-        if not 'col_align' in self.latex:
+        if 'col_align' not in self.latex:
             self.latex['col_align'] = len(self.cols) * 'c'
         if 'tablealign' in self.latex:
             align = '[' + self.latex['tablealign'] + ']'
@@ -352,7 +352,7 @@ class AASTexHeader(LatexHeader):
         return find_latex_line(lines, r'\tablehead')
 
     def write(self, lines):
-        if not 'col_align' in self.latex:
+        if 'col_align' not in self.latex:
             self.latex['col_align'] = len(self.cols) * 'c'
         if 'tablealign' in self.latex:
             align = '[' + self.latex['tablealign'] + ']'

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1186,4 +1186,4 @@ def test_no_units_for_char_columns():
     out = StringIO()
     ascii.write(t1, out, format="ipac")
     t2 = ascii.read(out.getvalue(), format="ipac", guess=False)
-    assert t2["B"].unit == None
+    assert t2["B"].unit is None

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -377,7 +377,7 @@ def check_write_table(test_def, table, fast_writer):
     try:
         ascii.write(table, out, fast_writer=fast_writer, **test_def['kwargs'])
     except ValueError as e: # if format doesn't have a fast writer, ignore
-        if not 'not in the list of formats with fast writers' in str(e):
+        if 'not in the list of formats with fast writers' not in str(e):
             raise e
         return
     print('Expected:\n%s' % test_def['out'])
@@ -399,7 +399,7 @@ def check_write_table_via_table(test_def, table, fast_writer):
     try:
         table.write(out, format=format,  fast_writer=fast_writer, **test_def['kwargs'])
     except ValueError as e: # if format doesn't have a fast writer, ignore
-        if not 'not in the list of formats with fast writers' in str(e):
+        if 'not in the list of formats with fast writers' not in str(e):
             raise e
         return
     print('Expected:\n%s' % test_def['out'])

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1101,7 +1101,7 @@ class Column(NotifierMixin):
             elif 'L' in format:
                 # boolean needs to be scaled back to storage values ('T', 'F')
                 if array.dtype == np.dtype('bool'):
-                    return np.where(array == False, ord('F'), ord('T'))
+                    return np.where(array is False, ord('F'), ord('T'))
                 else:
                     return np.where(array == 0, ord('F'), ord('T'))
             elif 'X' in format:

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1101,7 +1101,7 @@ class Column(NotifierMixin):
             elif 'L' in format:
                 # boolean needs to be scaled back to storage values ('T', 'F')
                 if array.dtype == np.dtype('bool'):
-                    return np.where(array is False, ord('F'), ord('T'))
+                    return np.where(array == np.bool(False), ord('F'), ord('T'))
                 else:
                     return np.where(array == 0, ord('F'), ord('T'))
             elif 'X' in format:

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1101,7 +1101,7 @@ class Column(NotifierMixin):
             elif 'L' in format:
                 # boolean needs to be scaled back to storage values ('T', 'F')
                 if array.dtype == np.dtype('bool'):
-                    return np.where(array == np.bool(False), ord('F'), ord('T'))
+                    return np.where(array == np.False_, ord('F'), ord('T'))
                 else:
                     return np.where(array == 0, ord('F'), ord('T'))
             elif 'X' in format:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -660,7 +660,7 @@ def info(filename, output=None, **kwargs):
 
     mode, closed = _get_file_mode(filename, default='readonly')
     # Set the default value for the ignore_missing_end parameter
-    if not 'ignore_missing_end' in kwargs:
+    if 'ignore_missing_end' not in kwargs:
         kwargs['ignore_missing_end'] = True
 
     f = fitsopen(filename, mode=mode, **kwargs)

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -419,7 +419,7 @@ class FITS_rec(np.recarray):
                 data._cache_field(name, converted)
                 # TODO: Maybe this step isn't necessary at all if _scale_back
                 # will handle it?
-                inarr = np.where(inarr == False, ord('F'), ord('T'))
+                inarr = np.where(inarr is False, ord('F'), ord('T'))
             elif (columns[idx]._physical_values and
                     columns[idx]._pseudo_unsigned_ints):
                 # Temporary hack...

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -419,7 +419,7 @@ class FITS_rec(np.recarray):
                 data._cache_field(name, converted)
                 # TODO: Maybe this step isn't necessary at all if _scale_back
                 # will handle it?
-                inarr = np.where(inarr == np.bool(False), ord('F'), ord('T'))
+                inarr = np.where(inarr == np.False_, ord('F'), ord('T'))
             elif (columns[idx]._physical_values and
                     columns[idx]._pseudo_unsigned_ints):
                 # Temporary hack...

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -419,7 +419,7 @@ class FITS_rec(np.recarray):
                 data._cache_field(name, converted)
                 # TODO: Maybe this step isn't necessary at all if _scale_back
                 # will handle it?
-                inarr = np.where(inarr is False, ord('F'), ord('T'))
+                inarr = np.where(inarr == np.bool(False), ord('F'), ord('T'))
             elif (columns[idx]._physical_values and
                     columns[idx]._pseudo_unsigned_ints):
                 # Temporary hack...

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -230,7 +230,7 @@ class _BaseHDU(object):
             ('XTENSION' in self._header and
              (self._header['XTENSION'] == 'IMAGE' or
               (self._header['XTENSION'] == 'BINTABLE' and
-               'ZIMAGE' in self._header and self._header['ZIMAGE'] == True))))
+               'ZIMAGE' in self._header and self._header['ZIMAGE']))))
 
     @property
     def _data_loaded(self):
@@ -888,7 +888,7 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         # The check that 'GROUPS' is missing is a bit redundant, since the
         # match_header for GroupsHDU will always be called before this one.
         if card.keyword == 'SIMPLE':
-            if 'GROUPS' not in header and card.value == False:
+            if 'GROUPS' not in header and card.value is False:
                 return True
             else:
                 raise InvalidHDUException

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -230,7 +230,7 @@ class _BaseHDU(object):
             ('XTENSION' in self._header and
              (self._header['XTENSION'] == 'IMAGE' or
               (self._header['XTENSION'] == 'BINTABLE' and
-               'ZIMAGE' in self._header and self._header['ZIMAGE']))))
+               'ZIMAGE' in self._header and self._header['ZIMAGE'] is True))))
 
     @property
     def _data_loaded(self):

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -676,7 +676,7 @@ class CompImageHDU(BinTableHDU):
         if xtension not in ('BINTABLE', 'A3DTABLE'):
             return False
 
-        if 'ZIMAGE' not in header or header['ZIMAGE'] is not True:
+        if 'ZIMAGE' not in header or not header['ZIMAGE']:
             return False
 
         if COMPRESSION_SUPPORTED and COMPRESSION_ENABLED:

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -676,7 +676,7 @@ class CompImageHDU(BinTableHDU):
         if xtension not in ('BINTABLE', 'A3DTABLE'):
             return False
 
-        if 'ZIMAGE' not in header or header['ZIMAGE'] != True:
+        if 'ZIMAGE' not in header or header['ZIMAGE'] is not True:
             return False
 
         if COMPRESSION_SUPPORTED and COMPRESSION_ENABLED:
@@ -781,7 +781,7 @@ class CompImageHDU(BinTableHDU):
             huge_hdu = False
 
         # Update the extension name in the table header
-        if not name and not 'EXTNAME' in self._header:
+        if not name and 'EXTNAME' not in self._header:
             name = 'COMPRESSED_IMAGE'
 
         if name:
@@ -1083,7 +1083,7 @@ class CompImageHDU(BinTableHDU):
             if tile_size and len(tile_size) >= idx + 1:
                 ts = tile_size[idx]
             else:
-                if not ztile in self._header:
+                if ztile not in self._header:
                     # Default tile size
                     if not idx:
                         ts = self._image_header['NAXIS1']

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -279,7 +279,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     def match_header(cls, header):
         keyword = header.cards[0].keyword
         return (keyword == 'SIMPLE' and 'GROUPS' in header and
-                header['GROUPS'])
+                header['GROUPS'] is True)
 
     @lazyproperty
     def data(self):
@@ -507,7 +507,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
         self.req_cards('GCOUNT', pos, _is_int, 1, option, errs)
         self.req_cards('PCOUNT', pos, _is_int, 0, option, errs)
-        self.req_cards('GROUPS', pos, lambda v: (v), True, option,
+        self.req_cards('GROUPS', pos, lambda v: (v is True), True, option,
                        errs)
         return errs
 

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -279,7 +279,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     def match_header(cls, header):
         keyword = header.cards[0].keyword
         return (keyword == 'SIMPLE' and 'GROUPS' in header and
-                header['GROUPS'] == True)
+                header['GROUPS'])
 
     @lazyproperty
     def data(self):
@@ -507,7 +507,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
         self.req_cards('GCOUNT', pos, _is_int, 1, option, errs)
         self.req_cards('PCOUNT', pos, _is_int, 0, option, errs)
-        self.req_cards('GROUPS', pos, lambda v: (v == True), True, option,
+        self.req_cards('GROUPS', pos, lambda v: (v), True, option,
                        errs)
         return errs
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -630,7 +630,7 @@ class HDUList(list, _Verify):
         hdr = self[0].header
 
         if 'EXTEND' in hdr:
-            if len(self) > 1 and hdr['EXTEND'] == False:
+            if len(self) > 1 and hdr['EXTEND'] is False:
                 hdr['EXTEND'] = True
         elif len(self) > 1:
             if hdr['NAXIS'] == 0:

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -630,7 +630,7 @@ class HDUList(list, _Verify):
         hdr = self[0].header
 
         if 'EXTEND' in hdr:
-            if len(self) > 1 and hdr['EXTEND'] is False:
+            if len(self) > 1 and not hdr['EXTEND']:
                 hdr['EXTEND'] = True
         elif len(self) > 1:
             if hdr['NAXIS'] == 0:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -928,8 +928,8 @@ class PrimaryHDU(_ImageBaseHDU):
     def match_header(cls, header):
         card = header.cards[0]
         return (card.keyword == 'SIMPLE' and
-                ('GROUPS' not in header or header['GROUPS'] is not True) and
-                card.value is True)
+                ('GROUPS' not in header or not header['GROUPS']) and
+                card.value)
 
     def update_header(self):
         super(PrimaryHDU, self).update_header()

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -928,8 +928,8 @@ class PrimaryHDU(_ImageBaseHDU):
     def match_header(cls, header):
         card = header.cards[0]
         return (card.keyword == 'SIMPLE' and
-                ('GROUPS' not in header or header['GROUPS'] != True) and
-                card.value == True)
+                ('GROUPS' not in header or header['GROUPS'] is not True) and
+                card.value is True)
 
     def update_header(self):
         super(PrimaryHDU, self).update_header()

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -277,7 +277,7 @@ def test_bool_column(tmpdir):
     """
 
     arr = np.ones(5, dtype=bool)
-    arr[::2] is False
+    arr[::2] == np.False_
 
     t = Table([arr])
     t.write(str(tmpdir.join('test.fits')), overwrite=True)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -277,7 +277,7 @@ def test_bool_column(tmpdir):
     """
 
     arr = np.ones(5, dtype=bool)
-    arr[::2] == False
+    arr[::2] is False
 
     t = Table([arr])
     t.write(str(tmpdir.join('test.fits')), overwrite=True)

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -519,7 +519,7 @@ class TestDiff(FitsTestCase):
         assert hdudiff.diff_extvers == ()
         assert hdudiff.diff_extension_types == ()
         assert hdudiff.diff_headers.identical
-        assert not hdudiff.diff_data is None
+        assert hdudiff.diff_data is not None
 
         datadiff = hdudiff.diff_data
         assert isinstance(datadiff, ImageDataDiff)

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -27,7 +27,7 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_valid_hdu_size(self):
         t1 = fits.open(self.data('tb.fits'))
-        assert isinstance(t1[1].size, type(1))
+        assert t1[1].size is type(1)
 
     def test_hdu_get_size(self):
         with catch_warnings() as w:

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -27,7 +27,7 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_valid_hdu_size(self):
         t1 = fits.open(self.data('tb.fits'))
-        assert type(t1[1].size) == type(1)
+        assert isinstance(t1[1].size, type(1))
 
     def test_hdu_get_size(self):
         with catch_warnings() as w:

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -27,7 +27,7 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_valid_hdu_size(self):
         t1 = fits.open(self.data('tb.fits'))
-        assert t1[1].size is type(1)
+        assert type(t1[1].size) is type(1)  # nopep8
 
     def test_hdu_get_size(self):
         with catch_warnings() as w:

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -431,7 +431,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdul.verify('silentfix')
 
         assert 'EXTEND' in hdul[0].header
-        assert hdul[0].header['EXTEND']
+        assert hdul[0].header['EXTEND'] is True
 
     def test_new_hdulist_extend_keyword(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/114
@@ -446,7 +446,7 @@ class TestHDUListFunctions(FitsTestCase):
         image = fits.HDUList([hdu, sci])
         image.writeto(self.temp('temp.fits'))
         assert 'EXTEND' in hdu.header
-        assert hdu.header['EXTEND']
+        assert hdu.header['EXTEND'] is True
 
     def test_replace_memmaped_array(self):
         # Copy the original before we modify it

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -431,7 +431,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdul.verify('silentfix')
 
         assert 'EXTEND' in hdul[0].header
-        assert hdul[0].header['EXTEND'] == True
+        assert hdul[0].header['EXTEND']
 
     def test_new_hdulist_extend_keyword(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/114
@@ -446,7 +446,7 @@ class TestHDUListFunctions(FitsTestCase):
         image = fits.HDUList([hdu, sci])
         image.writeto(self.temp('temp.fits'))
         assert 'EXTEND' in hdu.header
-        assert hdu.header['EXTEND'] == True
+        assert hdu.header['EXTEND']
 
     def test_replace_memmaped_array(self):
         # Copy the original before we modify it

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -198,7 +198,7 @@ class TestOldApiHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h.update('FOO', True)
         h.update('BAR', False)
-        assert h['FOO']
+        assert h['FOO'] is True
         assert h['BAR'] is False
         assert h.ascard['FOO'].cardimage == fooimg
         assert h.ascard['BAR'].cardimage == barimg
@@ -206,7 +206,7 @@ class TestOldApiHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h.update('FOO', np.bool_(True))
         h.update('BAR', np.bool_(False))
-        assert h['FOO']
+        assert h['FOO'] is True
         assert h['BAR'] is False
         assert h.ascard['FOO'].cardimage == fooimg
         assert h.ascard['BAR'].cardimage == barimg
@@ -214,7 +214,7 @@ class TestOldApiHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h.ascard.append(fits.Card.fromstring(fooimg))
         h.ascard.append(fits.Card.fromstring(barimg))
-        assert h['FOO']
+        assert h['FOO'] is True
         assert h['BAR'] is False
         assert h.ascard['FOO'].cardimage == fooimg
         assert h.ascard['BAR'].cardimage == barimg
@@ -1816,7 +1816,7 @@ class TestHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h['FOO'] = True
         h['BAR'] = False
-        assert h['FOO']
+        assert h['FOO'] is True
         assert h['BAR'] is False
         assert str(h.cards['FOO']) == fooimg
         assert str(h.cards['BAR']) == barimg
@@ -1824,7 +1824,7 @@ class TestHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h['FOO'] = np.bool_(True)
         h['BAR'] = np.bool_(False)
-        assert h['FOO']
+        assert h['FOO'] is True
         assert h['BAR'] is False
         assert str(h.cards['FOO']) == fooimg
         assert str(h.cards['BAR']) == barimg
@@ -1832,7 +1832,7 @@ class TestHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h.append(fits.Card.fromstring(fooimg))
         h.append(fits.Card.fromstring(barimg))
-        assert h['FOO']
+        assert h['FOO'] is True
         assert h['BAR'] is False
         assert str(h.cards['FOO']) == fooimg
         assert str(h.cards['BAR']) == barimg

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -198,24 +198,24 @@ class TestOldApiHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h.update('FOO', True)
         h.update('BAR', False)
-        assert h['FOO'] == True
-        assert h['BAR'] == False
+        assert h['FOO']
+        assert h['BAR'] is False
         assert h.ascard['FOO'].cardimage == fooimg
         assert h.ascard['BAR'].cardimage == barimg
 
         h = fits.Header()
         h.update('FOO', np.bool_(True))
         h.update('BAR', np.bool_(False))
-        assert h['FOO'] == True
-        assert h['BAR'] == False
+        assert h['FOO']
+        assert h['BAR'] is False
         assert h.ascard['FOO'].cardimage == fooimg
         assert h.ascard['BAR'].cardimage == barimg
 
         h = fits.Header()
         h.ascard.append(fits.Card.fromstring(fooimg))
         h.ascard.append(fits.Card.fromstring(barimg))
-        assert h['FOO'] == True
-        assert h['BAR'] == False
+        assert h['FOO']
+        assert h['BAR'] is False
         assert h.ascard['FOO'].cardimage == fooimg
         assert h.ascard['BAR'].cardimage == barimg
 
@@ -270,7 +270,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(c) == _pad("ABC     =                    T")
 
         c = fits.Card.fromstring('ABC     = F')
-        assert c.value == False
+        assert c.value is False
 
     def test_long_integer_value_card(self):
         """Test Card constructor with long integer value"""
@@ -1816,24 +1816,24 @@ class TestHeaderFunctions(FitsTestCase):
         h = fits.Header()
         h['FOO'] = True
         h['BAR'] = False
-        assert h['FOO'] == True
-        assert h['BAR'] == False
+        assert h['FOO']
+        assert h['BAR'] is False
         assert str(h.cards['FOO']) == fooimg
         assert str(h.cards['BAR']) == barimg
 
         h = fits.Header()
         h['FOO'] = np.bool_(True)
         h['BAR'] = np.bool_(False)
-        assert h['FOO'] == True
-        assert h['BAR'] == False
+        assert h['FOO']
+        assert h['BAR'] is False
         assert str(h.cards['FOO']) == fooimg
         assert str(h.cards['BAR']) == barimg
 
         h = fits.Header()
         h.append(fits.Card.fromstring(fooimg))
         h.append(fits.Card.fromstring(barimg))
-        assert h['FOO'] == True
-        assert h['BAR'] == False
+        assert h['FOO']
+        assert h['BAR'] is False
         assert str(h.cards['FOO']) == fooimg
         assert str(h.cards['BAR']) == barimg
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -75,7 +75,7 @@ def comparerecords(a, b):
             fielda = decode_ascii(fielda)
         if fieldb.dtype.char == 'S':
             fieldb = decode_ascii(fieldb)
-        if (type(fielda) != type(fieldb) and not
+        if (not isinstance(fielda, type(fieldb)) and not
             (issubclass(type(fielda), type(fieldb)) or
              issubclass(type(fieldb), type(fielda)))):
             print("type(fielda): ", type(fielda), " fielda: ", fielda)
@@ -976,7 +976,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0] == True
+        assert tbhdu.columns.columns[4].array[0]
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33
@@ -987,7 +987,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
         assert (tbhdu.columns.columns[3].array[3] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[3] == True
+        assert tbhdu.columns.columns[4].array[3]
 
     def test_assign_multiple_rows_to_table(self):
         counts = np.array([312, 334, 308, 317])
@@ -1038,7 +1038,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[0] == ''
         assert (tbhdu2.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[0] == True
+        assert tbhdu2.columns.columns[4].array[0]
 
         assert tbhdu2.data[4][1] == 112
         assert tbhdu2.data._coldefs._arrays[1][4] == 112
@@ -1049,14 +1049,14 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[4] == False
+        assert tbhdu2.columns.columns[4].array[4] is False
 
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[8] == False
+        assert tbhdu2.columns.columns[4].array[8] is False
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])
@@ -2214,7 +2214,7 @@ class TestTableFunctions(FitsTestCase):
                 assert np.all(tbdata['c3'] == tbdata2['c3'])
                 # c4 is a boolean column in the original table; we want ASCII
                 # columns to convert these to columns of 'T'/'F' strings
-                assert np.all(np.where(tbdata['c4'] == True, 'T', 'F') ==
+                assert np.all(np.where(tbdata['c4'], 'T', 'F') ==
                               tbdata2['c4'])
 
     def test_pickle(self):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -76,8 +76,7 @@ def comparerecords(a, b):
         if fieldb.dtype.char == 'S':
             fieldb = decode_ascii(fieldb)
         if (not isinstance(fielda, type(fieldb)) and not
-            (issubclass(type(fielda), type(fieldb)) or
-             issubclass(type(fieldb), type(fielda)))):
+            isinstance(fieldb, type(fielda))):
             print("type(fielda): ", type(fielda), " fielda: ", fielda)
             print("type(fieldb): ", type(fieldb), " fieldb: ", fieldb)
             print('field {0} type differs'.format(i))
@@ -976,7 +975,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0]
+        assert tbhdu.columns.columns[4].array[0] is True
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33
@@ -1049,13 +1048,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert bool(tbhdu2.columns.columns[4].array[4]) is False
+        assert not tbhdu2.columns.columns[4].array[4]
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert bool(tbhdu2.columns.columns[4].array[8]) is False
+        assert not tbhdu2.columns.columns[4].array[8]
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -986,7 +986,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
         assert (tbhdu.columns.columns[3].array[3] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[3]
+        assert tbhdu.columns.columns[4].array[3] == True  # nopep8
 
     def test_assign_multiple_rows_to_table(self):
         counts = np.array([312, 334, 308, 317])
@@ -1037,7 +1037,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[0] == ''
         assert (tbhdu2.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[0]
+        assert tbhdu2.columns.columns[4].array[0] == True  # nopep8
 
         assert tbhdu2.data[4][1] == 112
         assert tbhdu2.data._coldefs._arrays[1][4] == 112
@@ -1048,13 +1048,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert not tbhdu2.columns.columns[4].array[4]
+        assert tbhdu2.columns.columns[4].array[4] == False  # nopep8
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert not tbhdu2.columns.columns[4].array[8]
+        assert tbhdu2.columns.columns[4].array[8] == False  #nopep8
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1049,14 +1049,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[4] is False
-
+        assert bool(tbhdu2.columns.columns[4].array[4]) is False
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[8] is False
+        assert bool(tbhdu2.columns.columns[4].array[8]) is False
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -975,7 +975,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0] is True
+        assert tbhdu.columns.columns[4].array[0] == True  # nopep8
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -805,7 +805,7 @@ def test_validate(test_path_object=False):
         result = validate(fpath,
                           output, xmllint=False)
 
-    assert result == False
+    assert result is False
 
     output.seek(0)
     output = output.readlines()
@@ -990,7 +990,7 @@ def test_no_resource_check():
         result = validate(get_pkg_data_filename('data/no_resource.xml'),
                           output, xmllint=False)
 
-    assert result == False
+    assert result is False
 
     output.seek(0)
     output = output.readlines()

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1112,7 +1112,7 @@ class Values(Element, _IDProperty):
         column.meta['values'] = meta
 
     def from_table_column(self, column):
-        if not 'values' in column.meta:
+        if 'values' not in column.meta:
             return
 
         meta = column.meta['values']
@@ -2828,7 +2828,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     for i, converter in fields_basic:
                         try:
                             chunk = converter(array_row[i], array_mask[i])
-                            assert type(chunk) == type(b'')
+                            assert isinstance(chunk, type(b''))
                         except Exception as e:
                             vo_reraise(e,
                                        additional="(in row %d, col '%s')" %
@@ -3429,7 +3429,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
             in each `Table` object as it was created or read in.  See
             :ref:`votable-serialization`.
         """
-        if write_null_values != False:
+        if write_null_values:
             warnings.warn(
                 "write_null_values has been deprecated and has no effect",
                 AstropyDeprecationWarning)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2828,7 +2828,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     for i, converter in fields_basic:
                         try:
                             chunk = converter(array_row[i], array_mask[i])
-                            assert isinstance(chunk, type(b''))
+                            assert type(chunk) == six.binary_type
                         except Exception as e:
                             vo_reraise(e,
                                        additional="(in row %d, col '%s')" %

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -900,7 +900,7 @@ def _fitter_to_model_params(model, fps):
     # better to change this at some point
     if has_tied:
         for idx, name in enumerate(model.param_names):
-            if model.tied[name] != False:
+            if model.tied[name]:
                 value = model.tied[name](model)
                 slice_ = param_metrics[name]['slice']
                 model.parameters[slice_] = value

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -145,8 +145,8 @@ class SLSQP(Optimization):
         # set the values of constraints to match the requirements of fmin_slsqp
         model = fargs[0]
         pars = [getattr(model, name) for name in model.param_names]
-        bounds = [par.bounds for par in pars if par.fixed != True and
-                  par.tied == False]
+        bounds = [par.bounds for par in pars if par.fixed is not True and
+                  par.tied is False]
         bounds = np.asarray(bounds)
         for i in bounds:
             if i[0] is None:

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -145,8 +145,7 @@ class SLSQP(Optimization):
         # set the values of constraints to match the requirements of fmin_slsqp
         model = fargs[0]
         pars = [getattr(model, name) for name in model.param_names]
-        bounds = [par.bounds for par in pars if par.fixed is not True and
-                  par.tied is False]
+        bounds = [par.bounds for par in pars if not (par.fixed or par.tied)]
         bounds = np.asarray(bounds)
         for i in bounds:
             if i[0] is None:

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -261,7 +261,7 @@ def test_set_tied_2():
 
     gauss = models.Gaussian1D(amplitude=20, mean=2, stddev=1,
                               tied={'amplitude': tie_amplitude})
-    assert gauss.amplitude.tied != False
+    assert gauss.amplitude.tied
 
 
 def test_unset_fixed():

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -1,4 +1,4 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Licensedf under a 3-clause BSD style license - see LICENSE.rst
 """
 Tests models.parameters
 """
@@ -85,23 +85,23 @@ def test_parameter_properties():
     with pytest.raises(AttributeError):
         p.name = 'beta'
 
-    assert p.fixed == False
+    assert p.fixed is False
     p.fixed = True
-    assert p.fixed == True
+    assert p.fixed
 
-    assert p.tied == False
+    assert p.tied is False
     p.tied = lambda _: 0
 
     p.tied = False
-    assert p.tied == False
+    assert p.tied is False
 
-    assert p.min == None
+    assert p.min is None
     p.min = 42
     assert p.min == 42
     p.min = None
-    assert p.min == None
+    assert p.min is None
 
-    assert p.max == None
+    assert p.max is None
     # TODO: shouldn't setting a max < min give an error?
     p.max = 41
     assert p.max == 41

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -1,4 +1,4 @@
-# Licensedf under a 3-clause BSD style license - see LICENSE.rst
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Tests models.parameters
 """
@@ -87,7 +87,7 @@ def test_parameter_properties():
 
     assert p.fixed is False
     p.fixed = True
-    assert p.fixed
+    assert p.fixed is True
 
     assert p.tied is False
     p.tied = lambda _: 0

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -132,6 +132,6 @@ def test_invalid_sigma_clip():
     # Pre #4051 if data contains any NaN or infs sigma_clip returns the mask
     # containing `False` only or TypeError if data also contains a masked value.
 
-    assert result.mask[2, 2] == True
-    assert result.mask[3, 4] == True
-    assert result.mask[1, 1] == True
+    assert result.mask[2, 2]
+    assert result.mask[3, 4]
+    assert result.mask[1, 1]

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -371,7 +371,7 @@ class Table(object):
         init_func(data, names, dtype, n_cols, copy)
 
         # Whatever happens above, the masked property should be set to a boolean
-        if type(self.masked) != bool:
+        if not isinstance(self.masked, bool):
             raise TypeError("masked property has not been set to True or False")
 
     def __getstate__(self):
@@ -687,7 +687,7 @@ class Table(object):
         MaskedColumn if the table is masked.  Table subclasses like QTable
         override this method.
         """
-        if isinstance(col, Column) and not col.__class__ is self.ColumnClass:
+        if isinstance(col, Column) and col.__class__ is not self.ColumnClass:
             col = self.ColumnClass(col)  # copy attributes and reference data
         return col
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -371,7 +371,7 @@ class Table(object):
         init_func(data, names, dtype, n_cols, copy)
 
         # Whatever happens above, the masked property should be set to a boolean
-        if not isinstance(self.masked, bool):
+        if type(self.masked) is not bool:
             raise TypeError("masked property has not been set to True or False")
 
     def __getstate__(self):
@@ -687,7 +687,7 @@ class Table(object):
         MaskedColumn if the table is masked.  Table subclasses like QTable
         override this method.
         """
-        if isinstance(col, Column) and col.__class__ is not self.ColumnClass:
+        if col.__class__ is not self.ColumnClass and isinstance(col, Column):
             col = self.ColumnClass(col)  # copy attributes and reference data
         return col
 

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -72,11 +72,11 @@ def test_pickle_table(protocol):
         assert np.all(tp['d'] == t['d'])
         assert np.all(tp['e'].ra == t['e'].ra)
         assert np.all(tp['e'].dec == t['e'].dec)
-        assert type(tp['c']) == type(t['c'])
-        assert type(tp['d']) == type(t['d'])
-        assert type(tp['e']) == type(t['e'])
+        assert isinstance(tp['c'], type(t['c']))
+        assert isinstance(tp['d'], type(t['d']))
+        assert isinstance(tp['e'], type(t['e']))
         assert tp.meta == t.meta
-        assert type(tp) == type(t)
+        assert isinstance(tp, type(t))
 
         assert isinstance(tp['c'], Quantity if (table_class is QTable) else Column)
 

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -72,11 +72,11 @@ def test_pickle_table(protocol):
         assert np.all(tp['d'] == t['d'])
         assert np.all(tp['e'].ra == t['e'].ra)
         assert np.all(tp['e'].dec == t['e'].dec)
-        assert isinstance(tp['c'], type(t['c']))
-        assert isinstance(tp['d'], type(t['d']))
-        assert isinstance(tp['e'], type(t['e']))
+        assert type(tp['c']) is type(t['c'])  # nopep8
+        assert type(tp['d']) is type(t['d'])  # nopep8
+        assert type(tp['e']) is type(t['e'])  # nopep8
         assert tp.meta == t.meta
-        assert isinstance(tp, type(t))
+        assert type(tp) is type(t)
 
         assert isinstance(tp['c'], Quantity if (table_class is QTable) else Column)
 

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -128,13 +128,13 @@ class TestRow():
         np_data = np.array(d)
         if table_types.Table is not MaskedTable:
             assert np.all(np_data == d.as_void())
-        assert not np_data is d.as_void()
+        assert np_data is not d.as_void()
         assert d.colnames == list(np_data.dtype.names)
 
         np_data = np.array(d, copy=False)
         if table_types.Table is not MaskedTable:
             assert np.all(np_data == d.as_void())
-        assert not np_data is d.as_void()
+        assert np_data is not d.as_void()
         assert d.colnames == list(np_data.dtype.names)
 
         with pytest.raises(ValueError):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -263,7 +263,7 @@ class TestNewFromColumns():
         t = table_types.Table(cols)
         assert np.all(t['a'].data == np.array([1, 2, 3]))
         assert np.all(t['b'].data == np.array([4, 5, 6], dtype=np.float32))
-        assert type(t['b'][1]) == np.float32
+        assert isinstance(t['b'][1], np.float32)
 
     def test_from_np_array(self, table_types):
         cols = [table_types.Column(name='a', data=np.array([1, 2, 3], dtype=np.int64),
@@ -272,8 +272,8 @@ class TestNewFromColumns():
         t = table_types.Table(cols)
         assert np.all(t['a'] == np.array([1, 2, 3], dtype=np.float64))
         assert np.all(t['b'] == np.array([4, 5, 6], dtype=np.float32))
-        assert type(t['a'][1]) == np.float64
-        assert type(t['b'][1]) == np.float32
+        assert isinstance(t['a'][1], np.float64)
+        assert isinstance(t['b'][1], np.float32)
 
     def test_size_mismatch(self, table_types):
         cols = [table_types.Column(name='a', data=[1, 2, 3]),
@@ -1097,7 +1097,7 @@ class TestConvertNumpyArray():
         np_data = np.array(d)
         if table_types.Table is not MaskedTable:
             assert np.all(np_data == d.as_array())
-        assert not np_data is d.as_array()
+        assert np_data is not d.as_array()
         assert d.colnames == list(np_data.dtype.names)
 
         np_data = np.array(d, copy=False)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -263,7 +263,7 @@ class TestNewFromColumns():
         t = table_types.Table(cols)
         assert np.all(t['a'].data == np.array([1, 2, 3]))
         assert np.all(t['b'].data == np.array([4, 5, 6], dtype=np.float32))
-        assert isinstance(t['b'][1], np.float32)
+        assert type(t['b'][1]) is np.float32
 
     def test_from_np_array(self, table_types):
         cols = [table_types.Column(name='a', data=np.array([1, 2, 3], dtype=np.int64),
@@ -272,8 +272,8 @@ class TestNewFromColumns():
         t = table_types.Table(cols)
         assert np.all(t['a'] == np.array([1, 2, 3], dtype=np.float64))
         assert np.all(t['b'] == np.array([4, 5, 6], dtype=np.float32))
-        assert isinstance(t['a'][1], np.float64)
-        assert isinstance(t['b'][1], np.float32)
+        assert type(t['a'][1]) is np.float64
+        assert type(t['b'][1]) is np.float32
 
     def test_size_mismatch(self, table_types):
         cols = [table_types.Column(name='a', data=[1, 2, 3]),

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1746,4 +1746,4 @@ def test_qtable_read_for_ipac_table_with_char_columns():
     out = StringIO()
     t1.write(out, format="ascii.ipac")
     t2 = table.QTable.read(out.getvalue(), format="ascii.ipac", guess=False)
-    assert t2["B"].unit == None
+    assert t2["B"].unit is None

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -30,8 +30,8 @@ class TestTimeComparisons():
                 op(t1, None)
             assert str(err).endswith("Unsupported operand type(s) for {0}: 'Time' and 'NoneType'"
                                      .format(op_str))
-        assert (t1 == None) is False
-        assert (t1 != None) is True
+        assert (t1 is None) is False
+        assert (t1 is not None) is True
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -31,8 +31,8 @@ class TestTimeComparisons():
                                      .format(op_str))
         # Keep == and != as they are specifically meant to test Time.__eq__
         # and Time.__ne__
-        assert (t1 == None) is False  # pylint: disable=C0121
-        assert (t1 != None) is True  # pylint: disable=C0121
+        assert (t1 == None) is False  # nopep8
+        assert (t1 != None) is True  # nopep8
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -1,4 +1,3 @@
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import operator
 
@@ -30,8 +29,10 @@ class TestTimeComparisons():
                 op(t1, None)
             assert str(err).endswith("Unsupported operand type(s) for {0}: 'Time' and 'NoneType'"
                                      .format(op_str))
-        assert (t1 is None) is False
-        assert (t1 is not None) is True
+        # Keep == and != as they are specifically meant to test Time.__eq__
+        # and Time.__ne__
+        assert (t1 == None) is False  # pylint: disable=C0121
+        assert (t1 != None) is True  # pylint: disable=C0121
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1638,7 +1638,7 @@ class IrreducibleUnit(NamedUnit):
         return self
 
     def decompose(self, bases=set()):
-        if len(bases) and not self in bases:
+        if len(bases) and self not in bases:
             for base in bases:
                 try:
                     scale = self._to(base)

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -683,8 +683,8 @@ def test_compare_with_none():
     # Ensure that equality comparisons with `None` work, and don't
     # raise exceptions.  We are deliberately not using `is None` here
     # because that doesn't trigger the bug.  See #3108.
-    assert not (u.m is None)
-    assert u.m is not None
+    assert not (u.m == None)  # nopep8
+    assert u.m != None  # nopep8
 
 
 def test_validate_power_detect_fraction():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -655,7 +655,7 @@ def test_fractional_powers():
     assert x.powers[0].denominator == 7
 
     x = u.cm ** Fraction(1, 2) * u.cm ** Fraction(2, 3)
-    assert type(x.powers[0]) == Fraction
+    assert isinstance(x.powers[0], Fraction)
     assert x.powers[0] == Fraction(7, 6)
 
 
@@ -683,13 +683,13 @@ def test_compare_with_none():
     # Ensure that equality comparisons with `None` work, and don't
     # raise exceptions.  We are deliberately not using `is None` here
     # because that doesn't trigger the bug.  See #3108.
-    assert not (u.m == None)
-    assert u.m != None
+    assert not (u.m is None)
+    assert u.m is not None
 
 
 def test_validate_power_detect_fraction():
     frac = utils.validate_power(1.1666666666666665)
-    assert type(frac) == Fraction
+    assert isinstance(frac, Fraction)
     assert frac.numerator == 7
     assert frac.denominator == 6
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -123,7 +123,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         # functools.wraps on it, but we normally don't care.
         # This crazy way to get the type of a wrapper descriptor is
         # straight out of the Python 3.3 inspect module docs.
-        if type(func) != type(str.__dict__['__add__']):
+        if not isinstance(func, type(str.__dict__['__add__'])):
             deprecated_func = functools.wraps(func)(deprecated_func)
 
         deprecated_func.__doc__ = deprecate_doc(
@@ -181,7 +181,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             name = get_function(obj).__name__
 
         altmessage = ''
-        if not message or type(message) == type(deprecate):
+        if not message or isinstance(message, type(deprecate)):
             if pending:
                 message = ('The %(func)s %(obj_type)s will be deprecated in a '
                            'future version.')
@@ -203,7 +203,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         else:
             return deprecate_function(obj, message)
 
-    if type(message) == type(deprecate):
+    if isinstance(message, type(deprecate)):
         return deprecate(message)
 
     return deprecate

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -123,7 +123,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         # functools.wraps on it, but we normally don't care.
         # This crazy way to get the type of a wrapper descriptor is
         # straight out of the Python 3.3 inspect module docs.
-        if not isinstance(func, type(str.__dict__['__add__'])):
+        if type(func) != type(str.__dict__['__add__']):  # nopep8
             deprecated_func = functools.wraps(func)(deprecated_func)
 
         deprecated_func.__doc__ = deprecate_doc(
@@ -181,7 +181,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             name = get_function(obj).__name__
 
         altmessage = ''
-        if not message or isinstance(message, type(deprecate)):
+        if not message or type(message) is type(deprecate):
             if pending:
                 message = ('The %(func)s %(obj_type)s will be deprecated in a '
                            'future version.')
@@ -203,7 +203,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         else:
             return deprecate_function(obj, message)
 
-    if isinstance(message, type(deprecate)):
+    if type(message) is type(deprecate):
         return deprecate(message)
 
     return deprecate

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -123,7 +123,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         # functools.wraps on it, but we normally don't care.
         # This crazy way to get the type of a wrapper descriptor is
         # straight out of the Python 3.3 inspect module docs.
-        if type(func) != type(str.__dict__['__add__']):  # nopep8
+        if type(func) is not type(str.__dict__['__add__']):  # nopep8
             deprecated_func = functools.wraps(func)(deprecated_func)
 
         deprecated_func.__doc__ = deprecate_doc(

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -247,7 +247,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
 
         # intersphinx version line, project name, and project version
         ivers, proj, vers, compr  = headerlines
-        if not 'The remainder of this file is compressed using zlib' in compr:
+        if 'The remainder of this file is compressed using zlib' not in compr:
             raise ValueError('The file downloaded from {0} does not seem to be'
                              'the usal Sphinx objects.inv format.  Maybe it '
                              'has changed?'.format(baseurl + 'objects.inv'))

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -175,7 +175,7 @@ class VOSDatabase(VOSBase):
 
     """
     def __init__(self, tree):
-        if not 'catalogs' in tree:
+        if 'catalogs' not in tree:
             raise VOSError("Invalid VO service catalog database")
 
         super(VOSDatabase, self).__init__(tree)

--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -930,7 +930,7 @@ class SAMPHubServer(object):
             for mtype in mtypes:
 
                 if mtype in self._mtype2ids:
-                    if not private_key in self._mtype2ids[mtype]:
+                    if private_key not in self._mtype2ids[mtype]:
                         self._mtype2ids[mtype].append(private_key)
                 else:
                     self._mtype2ids[mtype] = [private_key]
@@ -1098,7 +1098,7 @@ class SAMPHubServer(object):
         self._update_last_activity_time(private_key)
 
         if private_key in self._private_keys:
-            if not "samp.mtype" in message:
+            if "samp.mtype" not in message:
                 raise SAMPProxyError(3, "samp.mtype keyword is missing")
             recipient_ids = self._notify_all_(private_key, message)
             return recipient_ids
@@ -1170,7 +1170,7 @@ class SAMPHubServer(object):
         self._update_last_activity_time(private_key)
 
         if private_key in self._private_keys:
-            if not "samp.mtype" in message:
+            if "samp.mtype" not in message:
                 raise SAMPProxyError(3, "samp.mtype keyword is missing in "
                                         "message tagged as %s" % msg_tag)
 

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -51,7 +51,7 @@ def test_cd():
     w = _wcs.Wcsprm()
     w.cd = [[1, 0], [0, 1]]
     assert w.cd.dtype == np.float
-    assert w.has_cd()
+    assert w.has_cd() is True
     assert_array_equal(w.cd, [[1, 0], [0, 1]])
     del w.cd
     assert w.has_cd() is False
@@ -68,7 +68,7 @@ def test_cd_missing():
 def test_cd_missing2():
     w = _wcs.Wcsprm()
     w.cd = [[1, 0], [0, 1]]
-    assert w.has_cd()
+    assert w.has_cd() is True
     del w.cd
     assert w.has_cd() is False
     w.cd
@@ -179,7 +179,7 @@ def test_crota():
     w = _wcs.Wcsprm()
     w.crota = [1, 0]
     assert w.crota.dtype == np.float
-    assert w.has_crota()
+    assert w.has_crota() is True
     assert_array_equal(w.crota, [1, 0])
     del w.crota
     assert w.has_crota() is False
@@ -196,7 +196,7 @@ def test_crota_missing():
 def test_crota_missing2():
     w = _wcs.Wcsprm()
     w.crota = [1, 0]
-    assert w.has_crota()
+    assert w.has_crota() is True
     del w.crota
     assert w.has_crota() is False
     w.crota

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -51,16 +51,16 @@ def test_cd():
     w = _wcs.Wcsprm()
     w.cd = [[1, 0], [0, 1]]
     assert w.cd.dtype == np.float
-    assert w.has_cd() == True
+    assert w.has_cd()
     assert_array_equal(w.cd, [[1, 0], [0, 1]])
     del w.cd
-    assert w.has_cd() == False
+    assert w.has_cd() is False
 
 
 @raises(AttributeError)
 def test_cd_missing():
     w = _wcs.Wcsprm()
-    assert w.has_cd() == False
+    assert w.has_cd() is False
     w.cd
 
 
@@ -68,9 +68,9 @@ def test_cd_missing():
 def test_cd_missing2():
     w = _wcs.Wcsprm()
     w.cd = [[1, 0], [0, 1]]
-    assert w.has_cd() == True
+    assert w.has_cd()
     del w.cd
-    assert w.has_cd() == False
+    assert w.has_cd() is False
     w.cd
 
 
@@ -179,16 +179,16 @@ def test_crota():
     w = _wcs.Wcsprm()
     w.crota = [1, 0]
     assert w.crota.dtype == np.float
-    assert w.has_crota() == True
+    assert w.has_crota()
     assert_array_equal(w.crota, [1, 0])
     del w.crota
-    assert w.has_crota() == False
+    assert w.has_crota() is False
 
 
 @raises(AttributeError)
 def test_crota_missing():
     w = _wcs.Wcsprm()
-    assert w.has_crota() == False
+    assert w.has_crota() is False
     w.crota
 
 
@@ -196,9 +196,9 @@ def test_crota_missing():
 def test_crota_missing2():
     w = _wcs.Wcsprm()
     w.crota = [1, 0]
-    assert w.has_crota() == True
+    assert w.has_crota()
     del w.crota
-    assert w.has_crota() == False
+    assert w.has_crota() is False
     w.crota
 
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -698,7 +698,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             raise ValueError(
                     "Image size could not be determined.")
 
-        if center == True:
+        if center:
             corners = np.array([[1, 1],
                                 [1, naxis2],
                                 [naxis1, naxis2],

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,14 +35,9 @@ auto_use = True
 # E111 - 4 spaces per indentation level
 # E112 - 4 spaces per indentation level
 # E113 - 4 spaces per indentation level
-# E711 - comparison to None should be 'if cond is None:'
-# E712 - comparison to True should be 'if cond is True:' or 'if cond:'
-# E713 - test for membership should be 'not in'
-# E714 - test for object identity should be 'is not'
-# E721 - do not compare types, use 'isinstance()'
 # E901 - SyntaxError or IndentationError
 # E902 - IOError
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E711,E712,E713,E714,E721,E901,E902
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
 exclude = extern,sphinx,*parsetab.py
 
 [zest.releaser]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,14 @@ auto_use = True
 # E111 - 4 spaces per indentation level
 # E112 - 4 spaces per indentation level
 # E113 - 4 spaces per indentation level
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113
+# E711 - comparison to None should be 'if cond is None:'
+# E712 - comparison to True should be 'if cond is True:' or 'if cond:'
+# E713 - test for membership should be 'not in'
+# E714 - test for object identity should be 'is not'
+# E721 - do not compare types, use 'isinstance()'
+# E901 - SyntaxError or IndentationError
+# E902 - IOError
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E711,E712,E713,E714,E721,E901,E902
 exclude = extern,sphinx,*parsetab.py
 
 [zest.releaser]


### PR DESCRIPTION
[Edited]:

Fixes are for the followings, while only including the last two in ``setup.cfg``:

```
E711 - comparison to None should be 'if cond is None:'
E712 - comparison to True should be 'if cond is True:' or 'if cond:'
E713 - test for membership should be 'not in'
E714 - test for object identity should be 'is not'
E721 - do not compare types, use 'isinstance()'
E901 - SyntaxError or IndentationError
E902 - IOError
```