### PR TITLE
Allow scalar/iterable combinations in angular_diameter_distance_z1z2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New Features
 
 - ``astropy.cosmology``
 
+  - ``angular_diameter_distance_z1z2`` now supports the computation of
+    the angular diameter distance between a scalar and an array like
+    argument. [#4593]
+  
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1305,6 +1305,8 @@ class FLRW(Cosmology):
 
         Raises
         ------
+        ValueError
+          If z2 is less than z1
         CosmologyError
           If omega_k is < 0.
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1322,14 +1322,12 @@ class FLRW(Cosmology):
         if Ok0 < 0:
             raise CosmologyError('Ok0 must be >= 0 to use this method.')
 
-        z1 = np.array(z1)
-        z2 = np.array(z2)
-        # Not elegant but try: np.broadcast(z1, z2) doubles the runtime.
-        if z1.size != z2.size and z1.size != 1 and z2.size !=1:
-            raise ValueError('z1 and z2 must have compatible sizes.')
-
-        if np.any(z1 > z2):
-                raise ValueError('z2 must greater than z1')
+        try:
+            any_z1_gt_z2 = np.any(z1 > z2)
+        except ValueError:
+            raise ValueError('z1 and z2 must have compatible shape')
+        if any_z1_gt_z2:
+            raise ValueError('z2 must be greater than z1')
 
         dm1 = self.comoving_transverse_distance(z1).value
         dm2 = self.comoving_transverse_distance(z2).value

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1322,6 +1322,8 @@ class FLRW(Cosmology):
         if Ok0 < 0:
             raise CosmologyError('Ok0 must be >= 0 to use this method.')
 
+        z1 = np.asanyarray(z1)
+        z2 = np.asanyarray(z2)
         try:
             any_z1_gt_z2 = np.any(z1 > z2)
         except ValueError:

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1322,18 +1322,14 @@ class FLRW(Cosmology):
         if Ok0 < 0:
             raise CosmologyError('Ok0 must be >= 0 to use this method.')
 
-        outscalar = False
-        if not isiterable(z1) and not isiterable(z2):
-            outscalar = True
-
-        z1 = np.atleast_1d(z1)
-        z2 = np.atleast_1d(z2)
-
+        z1 = np.array(z1)
+        z2 = np.array(z2)
+        # Not elegant but try: np.broadcast(z1, z2) doubles the runtime.
         if z1.size != z2.size and z1.size != 1 and z2.size !=1:
-            raise ValueError('z1 and z2 must be the same size.')
+            raise ValueError('z1 and z2 must have compatible sizes.')
 
-        if (z1 > z2).any():
-            raise ValueError('z2 must greater than z1')
+        if np.any(z1 > z2):
+                raise ValueError('z2 must greater than z1')
 
         dm1 = self.comoving_transverse_distance(z1).value
         dm2 = self.comoving_transverse_distance(z2).value
@@ -1346,9 +1342,6 @@ class FLRW(Cosmology):
             out = ((dm2 * np.sqrt(1. + Ok0 * dm1 ** 2 / dh_2) -
                     dm1 * np.sqrt(1. + Ok0 * dm2 ** 2 / dh_2)) /
                    (1. + z2))
-
-        if outscalar:
-            return u.Quantity(out[0], u.Mpc)
 
         return u.Quantity(out, u.Mpc)
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1306,7 +1306,8 @@ class FLRW(Cosmology):
         Raises
         ------
         ValueError
-          If z2 is less than z1
+          If z2 is less than z1 or if z1 and z2 are arrays of different
+          size
         CosmologyError
           If omega_k is < 0.
 
@@ -1328,7 +1329,7 @@ class FLRW(Cosmology):
         z1 = np.atleast_1d(z1)
         z2 = np.atleast_1d(z2)
 
-        if z1.size != z2.size:
+        if z1.size != z2.size and z1.size != 1 and z2.size !=1:
             raise ValueError('z1 and z2 must be the same size.')
 
         if (z1 > z2).any():

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1113,6 +1113,16 @@ def test_angular_diameter_distance_z1z2():
     assert allclose(tcos.angular_diameter_distance_z1z2(z1, z2),
                     results)
 
+    z1 = 0.1
+    z2 = 0.1, 0.2, 0.5, 1.1, 2
+    results = (0.,
+               332.09893173,
+               986.35635069,
+               1508.37010062,
+               1621.07937976) * u.Mpc
+    assert allclose(tcos.angular_diameter_distance_z1z2(0.1, z2),
+                    results)
+
     # Non-flat (positive Ocurv) test
     tcos = core.LambdaCDM(H0=70.4, Om0=0.2, Ode0=0.5, Tcmb0=0.0)
     assert allclose(tcos.angular_diameter_distance_z1z2(1, 2),


### PR DESCRIPTION
A common use case in gravitational lensing is to compute the angular diameter distance between one lens and many background galaxies. This PR allows such scalar/iterable combinations in angular_diameter_distance and speeds up resulting code because the distance to the lens does not have to be recomputed for every lens-source pair:

```
In [1]: from astropy import cosmology

In [2]: cosmo = cosmology.FlatLambdaCDM(70, 0.3)

In [3]: z1 = 0.3

In [4]: z2 = np.random.uniform(0.5, 1, 5000)

In [5]: # Old version

In [6]: %timeit -n5 cosmo.angular_diameter_distance_z1z2(np.repeat(z1, z2.size), z2)
5 loops, best of 3: 154 ms per loop

In [7]: 

In [7]: # New version

In [8]: %timeit -n5 cosmo.angular_diameter_distance_z1z2(z1, z2)
5 loops, best of 3: 75.9 ms per loop

In [9]: 

In [9]: res1 = cosmo.angular_diameter_distance_z1z2(np.repeat(z1, z2.size), z2)

In [10]: res2 = cosmo.angular_diameter_distance_z1z2(z1, z2)

In [11]: np.allclose(res1.value, res2.value)
Out[11]: True

```