### PR TITLE
Revert skipping doc tests that fail only on Windows Py 2.6

### DIFF
--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -123,7 +123,7 @@ the type of information to return.  The built-in ``option`` choices are
 (basic column statistics).  The ``option`` argument can also be a list
 of available options::
 
-  >>> t.info('stats')  # doctest: +SKIP
+  >>> t.info('stats')  # doctest: +FLOAT_CMP
   <Table length=5>
   name mean      std      min max
   ---- ---- ------------- --- ---
@@ -131,7 +131,7 @@ of available options::
      b  7.0 4.24264068712   1  13
      c  8.0 4.24264068712   2  14
 
-  >>> t.info(['attributes', 'stats'])  # doctest: +SKIP
+  >>> t.info(['attributes', 'stats'])  # doctest: +FLOAT_CMP
   <Table length=5>
   name dtype   unit   format       description        mean      std      min max
   ---- ----- -------- ------ ------------------------ ---- ------------- --- ---
@@ -152,7 +152,7 @@ but provides information about a single column::
   n_bad = 0
   length = 5
 
-  >>> t['a'].info('stats')  # doctest: +SKIP
+  >>> t['a'].info('stats')  # doctest: +FLOAT_CMP
   name = a
   mean = 6.0
   std = 4.24264068712


### PR DESCRIPTION
This reverts commit 8c850ef5b3a8d3572ae56091c3e54456ced5ffcb.

Closes #3853.
