### PR TITLE
Fix img.scale for scaled integer data (fixes #4600)

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1404,7 +1404,10 @@ class CompImageHDU(BinTableHDU):
             if self._bscale != 1:
                 np.multiply(data, self._bscale, data)
             if self._bzero != 0:
-                data += self._bzero
+                if issubclass(data.dtype.type, np.floating):
+                    data += self._bzero
+                else:
+                    data += int(round(self._bzero))
 
             if zblank is not None:
                 data = np.where(blanks, np.nan, data)
@@ -1768,7 +1771,10 @@ class CompImageHDU(BinTableHDU):
 
         # Do the scaling
         if _zero != 0:
-            self.data += -_zero
+            if issubclass(self.data.dtype.type, np.floating):
+                self.data += -_zero
+            else:
+                self.data += int(round(-_zero))
             self.header['BZERO'] = _zero
         else:
             # Delete from both headers

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1407,7 +1407,7 @@ class CompImageHDU(BinTableHDU):
                 if issubclass(data.dtype.type, np.floating):
                     data += self._bzero
                 else:
-                    data += int(round(self._bzero))
+                    data += data.dtype.type(round(self._bzero))
 
             if zblank is not None:
                 data = np.where(blanks, np.nan, data)
@@ -1774,7 +1774,7 @@ class CompImageHDU(BinTableHDU):
             if issubclass(self.data.dtype.type, np.floating):
                 self.data += -_zero
             else:
-                self.data += int(round(-_zero))
+                self.data += self.data.dtype.type(round(-_zero))
             self.header['BZERO'] = _zero
         else:
             # Delete from both headers

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -514,7 +514,10 @@ class _ImageBaseHDU(_ValidHDU):
         # Do the scaling
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
-            self.data += -_zero
+            if issubclass(self.data.dtype.type, np.floating):
+                self.data += -_zero
+            else:
+                self.data += int(round(-_zero))
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -517,7 +517,7 @@ class _ImageBaseHDU(_ValidHDU):
             if issubclass(self.data.dtype.type, np.floating):
                 self.data += -_zero
             else:
-                self.data += int(round(-_zero))
+                self.data += self.data.dtype.type(round(-_zero))
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -992,6 +992,18 @@ class TestImageFunctions(FitsTestCase):
         hdul = fits.HDUList.fromstring(file_data)
         assert np.allclose(hdul[0].data, a)
 
+    def test_scale_bzero_with_int_data(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4600
+        """
+
+        a = np.arange(100, 200, dtype=np.int16)
+        hdu = fits.PrimaryHDU(data=a.copy())
+        bzero = 99.9
+        hdu.scale('int16', bzero=bzero)
+        a -= int(round(bzero))
+        assert np.allclose(hdu.data, a)
+
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1013,6 +1013,21 @@ class TestImageFunctions(FitsTestCase):
         a -= int(round(bzero))
         assert np.allclose(hdu.data, a)
 
+    def test_scale_back_uint_assignment(self):
+        """
+        Ensure fix for #4600 does not break assignment to data
+
+        Suggested by:
+        https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+        """
+
+        a = np.arange(100, 200, dtype=np.uint16)
+        fits.PrimaryHDU(a).writeto(self.temp('test.fits'))
+        with fits.open(self.temp('test.fits'), mode="update",
+                       scale_back=True) as (hdu,):
+            hdu.data[:] = 0
+            assert np.allclose(hdu.data, 0)
+
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):
@@ -1589,3 +1604,21 @@ class TestCompressedImage(FitsTestCase):
         hdu.scale('int16', bzero=bzero)
         a -= int(round(bzero))
         assert np.allclose(hdu.data, a)
+
+    def test_scale_back_compressed_uint_assignment(self):
+        """
+        Ensure fix for #4600 does not break assignment to data
+
+        Identical to test_scale_back_uint_assignment() but uses a compressed
+        image.
+
+        Suggested by:
+        https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+        """
+
+        a = np.arange(100, 200, dtype=np.uint16)
+        fits.CompImageHDU(a).writeto(self.temp('test.fits'))
+        with fits.open(self.temp('test.fits'), mode="update",
+                       scale_back=True) as hdul:
+            hdul[1].data[:] = 0
+            assert np.allclose(hdul[1].data, 0)

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -992,6 +992,15 @@ class TestImageFunctions(FitsTestCase):
         hdul = fits.HDUList.fromstring(file_data)
         assert np.allclose(hdul[0].data, a)
 
+    def test_set_data(self):
+        """
+        Test data assignment - issue #5087
+        """
+
+        im = fits.ImageHDU()
+        ar = np.arange(12)
+        im.data = ar
+
     def test_scale_bzero_with_int_data(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/4600
@@ -1566,11 +1575,17 @@ class TestCompressedImage(FitsTestCase):
             # technically it isn't invalid either :/
             assert hdul[1]._header.count('ZTENSION') == 2
 
+    def test_scale_bzero_with_compressed_int_data(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4600
 
-def test_set_data():
-    """
-    Test data assignment - issue #5087
-    """
-    im = fits.ImageHDU()
-    ar = np.arange(12)
-    im.data = ar
+        Identical to test_scale_bzero_with_int_data() but uses a compressed
+        image.
+        """
+
+        a = np.arange(100, 200, dtype=np.int16)
+        hdu = fits.CompImageHDU(data=a.copy())
+        bzero = 99.9
+        hdu.scale('int16', bzero=bzero)
+        a -= int(round(bzero))
+        assert np.allclose(hdu.data, a)


### PR DESCRIPTION
See issue #4600 for an explanation.
