### PR TITLE
make on-import warning tests pass even if done twice in the same session

### DIFF
--- a/astropy/utils/tests/test_argparse.py
+++ b/astropy/utils/tests/test_argparse.py
@@ -1,11 +1,19 @@
 from ...tests.helper import catch_warnings
 from ..exceptions import AstropyDeprecationWarning
+from ...extern.six.moves import reload_module
 
 
 def test_import_warning():
+    # this import *maybe* raises the warning too, but we force the matter below
+    from ..compat import argparse  # pylint: disable=W0611
 
     with catch_warnings() as w:
-        from ..compat import argparse  # pylint: disable=W0611
+        # this ensures the warning will be re-issues at reload.  Without this,
+        # the warning is missing if you invoke astropy.test twice in the same
+        # python session
+        if hasattr(argparse, '__warningregistry__'):
+            argparse.__warningregistry__.clear()
+        reload_module(argparse)
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning

--- a/astropy/utils/tests/test_fractions.py
+++ b/astropy/utils/tests/test_fractions.py
@@ -1,11 +1,19 @@
 from ...tests.helper import catch_warnings
 from ..exceptions import AstropyDeprecationWarning
+from ...extern.six.moves import reload_module
 
 
 def test_import_warning():
+    # this import *maybe* raises the warning too, but we force the matter below
+    from ..compat import fractions  # pylint: disable=W0611
 
     with catch_warnings() as w:
-        from ..compat import fractions  # pylint: disable=W0611
+        # this ensures the warning will be re-issues at reload.  Without this,
+        # the warning is missing if you invoke astropy.test twice in the same
+        # python session
+        if hasattr(fractions, '__warningregistry__'):
+            fractions.__warningregistry__.clear()
+        reload_module(fractions)
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning

--- a/astropy/utils/tests/test_gzip.py
+++ b/astropy/utils/tests/test_gzip.py
@@ -1,11 +1,19 @@
 from ...tests.helper import catch_warnings
 from ..exceptions import AstropyDeprecationWarning
+from ...extern.six.moves import reload_module
 
 
 def test_import_warning():
+    # this import *maybe* raises the warning too, but we force the matter below
+    from ..compat import gzip  # pylint: disable=W0611
 
     with catch_warnings() as w:
-        from ..compat import gzip  # pylint: disable=W0611
+        # this ensures the warning will be re-issues at reload.  Without this,
+        # the warning is missing if you invoke astropy.test twice in the same
+        # python session
+        if hasattr(gzip, '__warningregistry__'):
+            gzip.__warningregistry__.clear()
+        reload_module(gzip)
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning

--- a/astropy/utils/tests/test_subprocess.py
+++ b/astropy/utils/tests/test_subprocess.py
@@ -1,10 +1,19 @@
 from ...tests.helper import catch_warnings
 from ..exceptions import AstropyDeprecationWarning
+from ...extern.six.moves import reload_module
 
 
 def test_import_warning():
+    # this import *maybe* raises the warning too, but we force the matter below
+    from ..compat import subprocess  # pylint: disable=W0611
+
     with catch_warnings() as w:
-        from ..compat import subprocess
+        # this ensures the warning will be re-issues at reload.  Without this,
+        # the warning is missing if you invoke astropy.test twice in the same
+        # python session
+        if hasattr(subprocess, '__warningregistry__'):
+            subprocess.__warningregistry__.clear()
+        reload_module(subprocess)
 
     assert len(w) == 1
     assert w[0].category == AstropyDeprecationWarning


### PR DESCRIPTION
This is a follow-on to #4349 that should make it so that the tests all pass even when invoked twice in the same python session.  It's a bit hacky, but I don't really see any other solution.  Also not 100% sure how compliant it is with the various python versions... but Travis will answer that, at least.