### PR TITLE
Support for Path objects in io packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,11 +20,17 @@ New Features
 
 - ``astropy.io.ascii``
 
+  - File name could be passed as ``Path`` object. [#4606]
+
 - ``astropy.io.fits``
+
+  - File name could be passed as ``Path`` object. [#4606]
 
 - ``astropy.io.misc``
 
 - ``astropy.io.votable``
+
+  - File name could be passed as ``Path`` object. [#4606]
 
 - ``astropy.logger.py``
 
@@ -71,6 +77,8 @@ New Features
     deprecated in 0.3.1, has been removed. [#4449]
 
 - ``astropy.utils``
+
+  - ``Path`` object could be passed to ``get_readable_fileobj``. [#4606]
 
   - Implemented a generic and extensible way of merging metadata. [#4459]
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -26,6 +26,12 @@ except ImportError:
 else:
     HAS_BZ2 = True
 
+try:
+    import pathlib
+except ImportError:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_convert_overflow(fast_reader):
@@ -1092,3 +1098,12 @@ def test_table_with_no_newline():
         t = ascii.read(table, **kwargs)
         assert t.colnames == ['a', 'b']
         assert len(t) == 0
+
+@pytest.mark.skipif('not HAS_PATHLIB')
+def test_path_object():
+    fpath = pathlib.Path('t/simple.txt')
+    data = ascii.read(fpath)
+
+    assert len(data) == 2
+    assert sorted(list(data.columns)) == ['test 1a', 'test2', 'test3', 'test4']
+    assert data['test2'][1] == 'hat2'

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -186,9 +186,9 @@ def read(table, guess=None, **kwargs):
 
     Parameters
     ----------
-    table : str, file-like, list
-        Input table as a file name, file-like object, list of strings, or
-        single newline-separated string.
+    table : str, file-like, list, pathlib.Path object
+        Input table as a file name, file-like object, list of strings,
+        single newline-separated string or pathlib.Path object .
     guess : bool
         Try to guess the table format (default= ``True``)
     format : str, `~astropy.io.ascii.BaseReader`

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -19,7 +19,7 @@ from numpy import memmap as Memmap
 from .util import (isreadable, iswritable, isfile, fileobj_open, fileobj_name,
                    fileobj_closed, fileobj_mode, _array_from_file,
                    _array_to_file, _write_string)
-from ...extern.six import b, string_types, PY3
+from ...extern.six import b, string_types
 from ...utils.data import download_file, _is_url
 from ...utils.decorators import classproperty
 from ...utils.exceptions import AstropyUserWarning
@@ -75,7 +75,7 @@ PKZIP_MAGIC = b('\x50\x4b\x03\x04')
 BZIP2_MAGIC = b('\x42\x5a')
 
 try:
-    from pathlib import Path
+    import pathlib
 except:
     HAS_PATHLIB = False
 else:
@@ -105,7 +105,7 @@ class _File(object):
         else:
             self.simulateonly = False
             # If fileobj is of type pathlib.Path
-            if PY3 and HAS_PATHLIB and isinstance(fileobj, Path):
+            if HAS_PATHLIB and isinstance(fileobj, pathlib.Path):
                 fileobj = str(fileobj)
 
         # Holds mmap instance for files that use mmap

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -19,7 +19,7 @@ from numpy import memmap as Memmap
 from .util import (isreadable, iswritable, isfile, fileobj_open, fileobj_name,
                    fileobj_closed, fileobj_mode, _array_from_file,
                    _array_to_file, _write_string)
-from ...extern.six import b, string_types
+from ...extern.six import b, string_types, PY3
 from ...utils.data import download_file, _is_url
 from ...utils.decorators import classproperty
 from ...utils.exceptions import AstropyUserWarning
@@ -74,6 +74,13 @@ GZIP_MAGIC = b('\x1f\x8b\x08')
 PKZIP_MAGIC = b('\x50\x4b\x03\x04')
 BZIP2_MAGIC = b('\x42\x5a')
 
+try:
+    from pathlib import Path
+except:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
+
 class _File(object):
     """
     Represents a FITS file on disk (or in some other file-like object).
@@ -97,6 +104,9 @@ class _File(object):
             return
         else:
             self.simulateonly = False
+            # If fileobj is of type pathlib.Path
+            if PY3 and HAS_PATHLIB and isinstance(fileobj, Path):
+                fileobj = str(fileobj)
 
         # Holds mmap instance for files that use mmap
         self._mmap = None

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -28,7 +28,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
     Parameters
     ----------
-    name : file path, file object or file-like object
+    name : file path, file object, file-like object or pathlib.Path object
         File to be opened.
 
     mode : str, optional

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -20,10 +20,18 @@ except ImportError:
 from ....io import fits
 from ....tests.helper import pytest, raises, catch_warnings, ignore_warnings
 from ....utils.exceptions import AstropyDeprecationWarning
+from ....utils.data import get_pkg_data_filename
 from . import FitsTestCase
 from ..convenience import _getext
 from ..diff import FITSDiff
 from ..file import _File, GZIP_MAGIC
+
+try:
+    import pathlib
+except ImportError:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
 
 
 class TestCore(FitsTestCase):
@@ -64,6 +72,22 @@ class TestCore(FitsTestCase):
 
         with fits.open(self.temp('test.fits')) as p:
             assert p[1].data[1]['foo'] == 60000.0
+
+    @pytest.mark.skipif('not HAS_PATHLIB')
+    def test_fits_file_path_object(self):
+        """
+        Testing when fits file is passed as pathlib.Path object #4412.
+        """
+        fpath = pathlib.Path(get_pkg_data_filename('data/tdim.fits'))
+        hdulist = fits.open(fpath)
+
+        assert hdulist[0].filebytes() == 2880
+        assert hdulist[1].filebytes() == 5760
+
+        hdulist2 = fits.open(self.data('tdim.fits'))
+
+        assert FITSDiff(hdulist2, hdulist).identical is True
+
 
     def test_add_del_columns(self):
         p = fits.ColDefs([])

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -26,11 +26,12 @@ _identifiers = OrderedDict()
 
 PATH_TYPES = six.string_types
 try:
-    from pathlib import Path
+    import pathlib
 except:
-    pass
+    HAS_PATHLIB = False
 else:
-    PATH_TYPES += (Path,)
+    HAS_PATHLIB = True
+    PATH_TYPES += (pathlib.Path,)
 
 
 def get_formats(data_class=None):
@@ -321,9 +322,9 @@ def read(cls, *args, **kwargs):
             if len(args):
                 if isinstance(args[0], PATH_TYPES):
                     from ..utils.data import get_readable_fileobj
-                    # For Py3 the path might be a pathlib.Path object, so coerce
-                    # to a regular string.
-                    if six.PY3:
+                    # path might be a pathlib.Path object if HAS_PATHLIB,
+                    # so coerce to a regular string.
+                    if HAS_PATHLIB and isinstance(args[0], pathlib.Path):
                         args = (str(args[0]),) + args[1:]
                     path = args[0]
                     try:
@@ -379,9 +380,9 @@ def write(data, *args, **kwargs):
         fileobj = None
         if len(args):
             if isinstance(args[0], PATH_TYPES):
-                # For Py3 the path might be a pathlib.Path object, so coerce
-                # to a regular string.
-                if six.PY3:
+                # path might be a pathlib.Path object if HAS_PATHLIB,
+                # so coerce to a regular string.
+                if HAS_PATHLIB and isinstance(args[0], pathlib.Path):
                     args = (str(args[0]),) + args[1:]
                 path = args[0]
                 fileobj = None

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -196,7 +196,8 @@ def validate(source, output=None, xmllint=False, filename=None):
     Parameters
     ----------
     source : str or readable file-like object
-        Path to a VOTABLE_ xml file.
+        Path to a VOTABLE_ xml file or pathlib.path
+        object having Path to a VOTABLE_ xml file.
 
     output : writable file-like object, optional
         Where to output the report.  Defaults to ``sys.stdout``.

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -13,6 +13,14 @@ import numpy as np
 from ....utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from ..table import parse, writeto
 from .. import tree
+from ....tests.helper import pytest
+
+try:
+    import pathlib
+except ImportError:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
 
 
 def test_table(tmpdir):
@@ -117,6 +125,17 @@ def test_table_read_with_unnamed_tables():
         t = Table.read(fd, format='votable')
 
     assert len(t) == 1
+
+@pytest.mark.skipif('not HAS_PATHLIB')
+def test_votable_path_object():
+    """
+    Testing when votable is passed as pathlib.Path object #4412.
+    """
+    fpath = pathlib.Path(get_pkg_data_filename('data/names.xml'))
+    table = parse(fpath).get_first_table().to_table()
+
+    assert len(table) == 1
+    assert int(table[0][3]) == 266
 
 
 def test_from_table_without_mask():

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -789,13 +789,20 @@ def test_build_from_scratch(tmpdir):
                                            (str('matrix'), str('?'), (2, 2))]))
 
 
-def test_validate():
+def test_validate(test_path_object=False):
+    """
+    test_path_object is needed for test below ``test_validate_path_object``
+    so that file could be passed as pathlib.Path object.
+    """
     output = io.StringIO()
+    fpath = get_pkg_data_filename('data/regression.xml')
+    if test_path_object:
+        fpath = pathlib.Path(fpath)
 
     # We can't test xmllint, because we can't rely on it being on the
     # user's machine.
     with catch_warnings():
-        result = validate(get_pkg_data_filename('data/regression.xml'),
+        result = validate(fpath,
                           output, xmllint=False)
 
     assert result == False
@@ -831,39 +838,8 @@ def test_validate():
 def test_validate_path_object():
     """
     Validating when source is passed as path object. (#4412)
-    Creating different method from ``test_validate`` so that it could be
-    skipped if ``pathlib`` isnt available without affecting ``test_validate``
     """
-    output = io.StringIO()
-    fpath = pathlib.Path(get_pkg_data_filename('data/regression.xml'))
-
-    with catch_warnings():
-        result = validate(fpath,
-                          output, xmllint=False)
-
-    assert result == False
-
-    output.seek(0)
-    output = output.readlines()
-
-    with io.open(
-        get_pkg_data_filename('data/validation.txt'),
-        'rt', encoding='utf-8') as fd:
-        truth = fd.readlines()
-
-    truth = truth[1:]
-    output = output[1:-1]
-
-    for line in difflib.unified_diff(truth, output):
-        if six.PY3:
-            sys.stdout.write(
-                line.replace('\\n', '\n'))
-        else:
-            sys.stdout.write(
-                line.encode('unicode_escape').
-                replace('\\n', '\n'))
-
-    assert truth == output
+    test_validate(test_path_object=True)
 
 
 def test_gzip_filehandles(tmpdir):

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -28,6 +28,12 @@ from .. import config as _config
 from ..utils.exceptions import AstropyWarning
 from ..utils.introspection import find_current_module, resolve_name
 
+try:
+    import pathlib
+except ImportError:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
 
 __all__ = [
     'Conf', 'conf', 'get_readable_fileobj', 'get_file_contents',
@@ -168,12 +174,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     # function to close it: doing so could result in a "double close"
     # and an "invalid file descriptor" exception.
     PATH_TYPES = six.string_types
-    try:
-        from pathlib import Path
-    except:
-        pass
-    else:
-        PATH_TYPES += (Path,)
+    if HAS_PATHLIB:
+        PATH_TYPES += (pathlib.Path,)
 
     close_fds = []
     delete_fds = []
@@ -184,8 +186,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
 
     # Get a file object to the content
     if isinstance(name_or_obj, PATH_TYPES):
-        # name_or_obj could be a Path object in Python 3
-        if six.PY3:
+        # name_or_obj could be a Path object if pathlib is available
+        if HAS_PATHLIB:
             name_or_obj = str(name_or_obj)
 
         is_url = _is_url(name_or_obj)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -106,7 +106,7 @@ def _is_inside(path, parent_path):
 def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                          show_progress=True, remote_timeout=None):
     """
-    Given a filename or a readable file-like object, return a context
+    Given a filename, pathlib.Path object or a readable file-like object, return a context
     manager that yields a readable file-like object.
 
     This supports passing filenames, URLs, and readable file-like objects,
@@ -167,6 +167,14 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     # passed in.  In that case it is not the responsibility of this
     # function to close it: doing so could result in a "double close"
     # and an "invalid file descriptor" exception.
+    PATH_TYPES = six.string_types
+    try:
+        from pathlib import Path
+    except:
+        pass
+    else:
+        PATH_TYPES += (Path,)
+
     close_fds = []
     delete_fds = []
 
@@ -175,7 +183,11 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         remote_timeout = conf.remote_timeout
 
     # Get a file object to the content
-    if isinstance(name_or_obj, six.string_types):
+    if isinstance(name_or_obj, PATH_TYPES):
+        # name_or_obj could be a Path object in Python 3
+        if six.PY3:
+            name_or_obj = str(name_or_obj)
+
         is_url = _is_url(name_or_obj)
         if is_url:
             name_or_obj = download_file(

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -42,6 +42,13 @@ except ImportError:
 else:
     HAS_XZ = True
 
+try:
+    import pathlib
+except ImportError:
+    HAS_PATHLIB = False
+else:
+    HAS_PATHLIB = True
+
 @remote_data
 def test_download_nocache():
     from ..data import download_file
@@ -396,3 +403,9 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
     # Assert that the temporary file was empty after get_readable_fileobj()
     # context manager finished running
     assert len(tempdir_listing) == 0
+
+@pytest.mark.skipif('not HAS_PATHLIB')
+def test_path_objects_get_readable_fileobj():
+    fpath = pathlib.Path(get_pkg_data_filename(os.path.join('data', 'local.dat')))
+    with get_readable_fileobj(fpath) as f:
+        assert f.read().rstrip() == 'This file is used in the test_local_data_* testing functions\nCONTENT'


### PR DESCRIPTION
For #4412.
Right now added support for ``io.ascii`` by modifying ``get_readable_fileobj`` in ``utils`` because ``io.ascii`` uses ``get_readable_fileobj`` to read.
I would also try to add support for Path objects in other io packages.