### PR TITLE
WCS: Add a test checking that CRVAL and CDELT do not get truncated

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -877,6 +877,23 @@ def test_no_truncate_crval():
     w.wcs.crval=[50,50,2.12345678e11]
     w.wcs.cdelt=[1e-3,1e-3,1e8]
     w.wcs.ctype=['RA---TAN','DEC--TAN','FREQ']
+    w.wcs.set()
+    for ii in range(3):
+        assert w.to_header()['CRVAL{0}'.format(ii+1)] == w.wcs.crval[ii]
+        assert w.to_header()['CDELT{0}'.format(ii+1)] == w.wcs.cdelt[ii]
+
+def test_no_truncate_crval_try2():
+    """
+    Regression test for https://github.com/astropy/astropy/issues/4612
+    """
+    w=wcs.WCS(naxis=3)
+    w.wcs.crval=[50,50,2.12345678e11]
+    w.wcs.cdelt=[1e-5,1e-5,1e5]
+    w.wcs.ctype=['RA---SIN','DEC--SIN','FREQ']
+    w.wcs.cunit=['deg', 'deg', 'Hz']
+    w.wcs.crpix=[1,1,1]
+    w.wcs.restfrq = 2.34e11
+    w.wcs.set()
     for ii in range(3):
         assert w.to_header()['CRVAL{0}'.format(ii+1)] == w.wcs.crval[ii]
         assert w.to_header()['CDELT{0}'.format(ii+1)] == w.wcs.cdelt[ii]

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -868,3 +868,15 @@ def test_sip_broken():
     hdr = get_pkg_data_contents("data/sip-broken.hdr")
 
     w = wcs.WCS(hdr)
+
+def test_no_truncate_crval():
+    """
+    Regression test for https://github.com/astropy/astropy/issues/4612
+    """
+    w=wcs.WCS(naxis=3)
+    w.wcs.crval=[50,50,2.12345678e11]
+    w.wcs.cdelt=[1e-3,1e-3,1e8]
+    w.wcs.ctype=['RA---TAN','DEC--TAN','FREQ']
+    for ii in range(3):
+        assert w.to_header()['CRVAL{0}'.format(ii+1)] == w.wcs.crval[ii]
+        assert w.to_header()['CDELT{0}'.format(ii+1)] == w.wcs.cdelt[ii]


### PR DESCRIPTION
Related to #4612 and #4613

WIP!  This seems to fail (1) in a different way than 4612 (CDELT instead of
CRVAL getting truncated) and (2) it still fails on master!  However, I need to
re-test with a clean build.