### PR TITLE
Quantity Support in Modeling [continued]

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1618,7 +1618,7 @@ class Model(object):
                 if value is None:
                     continue
                 else:
-                   params[param_name] = np.asanyarray(value, dtype=np.float)
+                    params[param_name] = np.asanyarray(value, dtype=np.float)
 
         if kwargs:
             # If any keyword arguments were left over at this point they are
@@ -1703,6 +1703,8 @@ class Model(object):
                 else:
                     unit = None
 
+            equivalencies = param_descr.equivalencies
+
             param_size = np.size(value)
             param_shape = np.shape(value)
 
@@ -1731,6 +1733,7 @@ class Model(object):
                 self._using_quantities = True
 
             param_metrics[name]['orig_unit'] = unit
+            param_metrics[name]['equivalencies'] = equivalencies
 
             total_size += param_size
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -703,7 +703,7 @@ class Model(object):
         """
 
         inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
-        parameters = self._param_sets(raw=True)
+        parameters = self._param_sets(raw=True, units=True)
 
         outputs = self.evaluate(*chain(inputs, parameters))
 
@@ -1630,7 +1630,7 @@ class Model(object):
                 "to the broadcasting rules.".format(param_a, shape_a,
                                                     param_b, shape_b))
 
-    def _param_sets(self, raw=False):
+    def _param_sets(self, raw=False, units=False):
         """
         Implementation of the Model.param_sets property.
 
@@ -1646,26 +1646,33 @@ class Model(object):
 
         param_metrics = self._param_metrics
         values = []
+        shapes = []
         for name in self.param_names:
+            param = getattr(self, name)
+
             if raw:
-                value = getattr(self, name)._raw_value
+                value = param._raw_value
             else:
-                value = getattr(self, name).value
+                value = param.value
 
             broadcast_shape = param_metrics[name].get('broadcast_shape')
             if broadcast_shape is not None:
                 value = value.reshape(broadcast_shape)
 
+            shapes.append(np.shape(value))
+
+            if len(self) == 1:
+                # Add a single param set axis to the parameter's value (thus
+                # converting scalars to shape (1,) array values) for
+                # consistenc
+                value = np.array([value])
+
+            if units and param.unit is not None:
+                value = Quantity(value, param.unit)
+
             values.append(value)
 
-        shapes = [np.shape(value) for value in values]
-
-        if len(self) == 1:
-            # Add a single param set axis to the parameter's value (thus
-            # converting scalars to shape (1,) array values) for consistency
-            values = [np.array([value]) for value in values]
-
-        if len(set(shapes)) != 1:
+        if len(set(shapes)) != 1 or units:
             # If the parameters are not all the same shape, converting to an
             # array is going to produce an object array
             # However the way Numpy creates object arrays is tricky in that it
@@ -1677,6 +1684,11 @@ class Model(object):
             psets = np.empty(len(values), dtype=object)
             psets[:] = values
             return psets
+
+        # TODO: Returning an array from this method may be entirely pointless
+        # for internal use--perhaps only the external param_sets method should
+        # return an array (and just for backwards compat--I would prefer to
+        # maybe deprecate that method)
 
         return np.array(values)
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1721,7 +1721,8 @@ class Model(object):
                             self.__class__.__name__, param_descr.unit, name))
             else:
                 if (param_descr.unit is not None and
-                        not unit.is_equivalent(param_descr.unit)):
+                        not unit.is_equivalent(param_descr.unit,
+                                               equivalencies=param_descr.equivalencies)):
                     raise InputParameterError(
                         "{0}.__init__() requires parameter {1!r} to be in "
                         "units equivalent to {2!r} (got {3!r})".format(

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -856,7 +856,7 @@ class Model(object):
 
         # The parallel to _prepare_output_units, though this one of course has
         # no knowledge of the outputs
-        inputs = self._prepare_input_units(inputs)
+        inputs, using_quantities = self._prepare_input_units(inputs)
 
         inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
         parameters = self._param_sets(raw=True, units=True)
@@ -873,7 +873,8 @@ class Model(object):
         # output units, so we would have to change the signature for
         # prepare_outputs to allow that.  So maybe having it here is fine for
         # now.
-        outputs = self._prepare_output_units(inputs, outputs)
+        if using_quantities:
+            outputs = self._prepare_output_units(inputs, outputs)
 
         if self.n_outputs == 1:
             return outputs[0]
@@ -1864,15 +1865,14 @@ class Model(object):
         return np.array(values)
 
     def _prepare_input_units(self, inputs):
-        for input_ in inputs:
-            if isinstance(input_, Quantity):
-                self._using_quantities = True
-                break
+        using_quantities = self._using_quantities
+        using_quantities |= any(isinstance(input_, Quantity)
+                                for input_ in inputs)
 
-        if not self._using_quantities:
-            return inputs
-        else:
-            return self._prepare_variable_units(inputs)
+        if using_quantities:
+            inputs = self._prepare_variable_units(inputs)
+
+        return inputs, using_quantities
 
     def _prepare_output_units(self, inputs, outputs):
         if not self._using_quantities:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -34,7 +34,9 @@ from ..utils import indent, isinstancemethod, metadata
 from ..extern import six
 from ..extern.six.moves import copyreg
 from ..table import Table
-from ..units import Quantity, Unit, UnitConversionError
+from ..units import (Quantity, Unit, UnitConversionError,
+                     dimensionless_unscaled)
+from ..units.quantity import _can_have_arbitrary_unit
 from ..utils import (deprecated, sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer)
 from ..utils.codegen import make_function_with_signature
@@ -820,6 +822,12 @@ class Model(object):
     # model hasn't completed initialization yet
     _n_models = 1
 
+    # Flag indicating whether units should be considered when evaluating this
+    # model.  This is enabled only if all of the model's parameters have units
+    _params_using_quantities = False
+    # This serves a similar purpose, but is reset between each __call__
+    _inputs_using_quantities = False
+
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
         meta = kwargs.pop('meta', None)
@@ -848,6 +856,10 @@ class Model(object):
         Evaluate this model using the given input(s) and the parameter values
         that were specified when the model was instantiated.
         """
+
+        # The parallel to _prepare_output_units, though this one of course has
+        # no knowledge of the outputs
+        inputs = self._prepare_input_units(inputs)
 
         inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
         parameters = self._param_sets(raw=True, units=True)
@@ -1691,6 +1703,9 @@ class Model(object):
 
             if isinstance(value, Quantity):
                 param_metrics[name]['orig_unit'] = value.unit
+                # A flag, for convenience, to track whether quantities were
+                # used in instantiating this model
+                self._params_using_quantities = True
             else:
                 param_metrics[name]['orig_unit'] = None
 
@@ -1851,6 +1866,29 @@ class Model(object):
 
         return np.array(values)
 
+    def _prepare_input_units(self, inputs):
+        self._inputs_using_quantities = False
+        for input_ in inputs:
+            if isinstance(input_, Quantity):
+                self._inputs_using_quantities = True
+                break
+
+        # If any parameters or inputs are using quantities, then all should;
+        # unit-less inputs are thus treated as dimensionless
+        if self._params_using_quantities or self._inputs_using_quantities:
+            converted_inputs = []
+            for input_ in inputs:
+                if (not isinstance(input_, Quantity) and
+                        not _can_have_arbitrary_unit(input_)):
+                    # We make a special case also for 0, since 0 may
+                    # be used in many quantity calculations without
+                    # penalty so long as it is not explicitly dimensionless
+                    input_ = input_ * dimensionless_unscaled
+                converted_inputs.append(input_)
+            return converted_inputs
+        else:
+            return inputs
+
     def _prepare_output_units(self, inputs, outputs):
         """
         Checks/converts units of model evaluation outputs using any directions
@@ -1861,7 +1899,9 @@ class Model(object):
         output_units = self.output_units
         output_unit_types = self.output_unit_types
 
-        if output_units is None and output_unit_types is None:
+        if ((output_units is None and output_unit_types is None)
+                or not (self._params_using_quantities or
+                        self._inputs_using_quantities)):
             # No output units specified, so we just return whatever we got
             return outputs
 
@@ -1870,6 +1910,12 @@ class Model(object):
 
         if self.n_outputs == 1 and not isinstance(output_unit_types, tuple):
             output_unit_types = (output_unit_types,)
+
+        # Make sure all inputs have units; this is specifically to
+        # address the case of 0 (without units) being an allowed input
+        inputs = [Quantity(input_, dimensionless_unscaled)
+                  if _can_have_arbitrary_unit(input_)
+                  else input_ for input_ in inputs]
 
         def to_unit(item):
             # Go from an element in the output_units or output_unit_types

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -511,11 +511,16 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
             # If *all* the parameters have default values we can make them
             # keyword arguments; otherwise they must all be positional
             # arguments
+            kwargs = []
             if all(p.default is not None
                    for p in six.itervalues(cls._parameters_)):
                 args = ('self',)
-                kwargs = [(name, cls._parameters_[name].default)
-                          for name in cls.param_names]
+                for param_name in cls.param_names:
+                    default = cls._parameters_[param_name].default
+                    unit = cls._parameters_[param_name].unit
+                    if unit is not None:
+                        default = Quantity(default, unit, copy=False)
+                    kwargs.append((param_name, default))
             else:
                 args = ('self',) + cls.param_names
                 kwargs = {}
@@ -1676,8 +1681,10 @@ class Model(object):
         total_size = 0
 
         for name in self.param_names:
+            param_descr = getattr(self, name)
+
             if params.get(name) is None:
-                default = getattr(self, name).default
+                default = param_descr.default
 
                 if default is None:
                     # No value was supplied for the parameter, and the
@@ -1688,8 +1695,13 @@ class Model(object):
                         "{1!r}".format(self.__class__.__name__, name))
 
                 value = params[name] = default
+                unit = param_descr.unit
             else:
                 value = params[name]
+                if isinstance(value, Quantity):
+                    unit = value.unit
+                else:
+                    unit = None
 
             param_size = np.size(value)
             param_shape = np.shape(value)
@@ -1699,13 +1711,26 @@ class Model(object):
             param_metrics[name]['slice'] = param_slice
             param_metrics[name]['shape'] = param_shape
 
-            if isinstance(value, Quantity):
-                param_metrics[name]['orig_unit'] = value.unit
+            if unit is None:
+                if param_descr.unit is not None:
+                    raise InputParameterError(
+                        "{0}.__init__() requires a Quantity with units "
+                        "equivalent to {1!r} for parameter {2!r}".format(
+                            self.__class__.__name__, param_descr.unit, name))
+            else:
+                if (param_descr.unit is not None and
+                        not unit.is_equivalent(param_descr.unit)):
+                    raise InputParameterError(
+                        "{0}.__init__() requires parameter {1!r} to be in "
+                        "units equivalent to {2!r} (got {3!r})".format(
+                            self.__class__.__name__, name, param_descr.unit,
+                            unit))
+
                 # A flag, for convenience, to track whether quantities were
                 # used in instantiating this model
                 self._using_quantities = True
-            else:
-                param_metrics[name]['orig_unit'] = None
+
+            param_metrics[name]['orig_unit'] = unit
 
             total_size += param_size
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -322,28 +322,29 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
                 continue
 
             attr = getattr(cls, attr_name)
-            n_vars = getattr(cls, 'n_{0}s'.format(var_type))
-
-            if n_vars == 1 and not isinstance(attr, tuple):
-                attr = (attr,)
-
-            if not isinstance(attr, tuple) or len(attr) != n_vars:
-                raise ModelDefinitionError(
-                    'If defined, the {0}.{1} attribute must be a tuple of '
-                    'length equal to the number of {2}s from this model '
-                    '({3}).  Only single-{2} models may forgo the tuple as a '
-                    'shortcut.  However, some entries in the tuple may be '
-                    'None.'.format(cls.__name__, attr_name, var_type, n_vars))
 
             # TODO: Validate the types of the items in the tuples as well
-            for unit_spec in attr:
+            def validate_unit_spec(unit_spec):
                 if isinstance(unit_spec, UnitBase):
                     # If any of the input_units or output_units are specific,
                     # concrete units this implies that units are *always*
                     # required for this model, so we implicitly force
                     # _using_quantities
                     cls._using_quantities = True
-                    break
+
+            if isinstance(attr, tuple):
+                n_vars = getattr(cls, 'n_{0}s'.format(var_type))
+                if len(attr) != n_vars:
+                    raise ModelDefinitionError(
+                        'If defined, the {0}.{1} attribute may be a tuple of '
+                        'length equal to the number of {2}s from this model '
+                        '({3}), or a single rule applying to all {2}s.'.format(
+                            cls.__name__, attr_name, var_type, n_vars))
+
+                for unit_spec in attr:
+                    validate_unit_spec(unit_spec)
+            else:
+                validate_unit_spec(attr)
 
     def _create_inverse_property(cls, members):
         inverse = members.get('inverse')
@@ -775,9 +776,9 @@ class Model(object):
            over the slope's unit, so that ``x.unit * intercept.unit ==
            slope.unit``.
 
-    For models with more than one input, this attribute must be a tuple with
-    one entry per output.  The above rules are then applied on a per-input
-    basis.
+    For models with more than one input, this attribute may be a tuple with
+    one entry per input.  The above rules are then applied on a per-input
+    basis.  Otherwise the same rule is applied over all inputs.
     """
 
     output_units = None
@@ -1881,20 +1882,20 @@ class Model(object):
 
     def _prepare_variable_units(self, inputs, outputs=None):
         if outputs is None:
-            units = self.input_units
+            unit_specs = self.input_units
             var_names = self.inputs
             n_vars = self.n_inputs
             vars_ = inputs
         else:
-            units = self.output_units
+            unit_specs = self.output_units
             var_names = self.outputs
             n_vars = self.n_outputs
             vars_ = outputs
 
-        if units is None:
-            units = (None,) * n_vars
-        elif not isinstance(units, tuple) and n_vars == 1:
-            units = (units,)
+        if unit_specs is None:
+            unit_specs = (None,) * n_vars
+        elif not isinstance(unit_specs, tuple):
+            unit_specs = (unit_specs,) * n_vars
 
         def to_unit(value, unit_spec):
             # Go from an element in the output_units attributes to an actual
@@ -1923,7 +1924,7 @@ class Model(object):
 
         converted = []
 
-        for var, var_name, var_unit in zip(vars_, var_names, units):
+        for var, var_name, unit_spec in zip(vars_, var_names, unit_specs):
             if outputs is None and not isinstance(var, Quantity):
                 # This check really only applies to inputs
                 if not _can_have_arbitrary_unit(var):
@@ -1937,11 +1938,11 @@ class Model(object):
                     converted.append(var)
                     continue
 
-            if var_unit is not None:
+            if unit_spec is not None:
                 # Just go ahead and try converting the input straight to the
                 # new unit; if this results in a conversion error that's fine;
                 # just raise it directly
-                unit = to_unit(var, var_unit)
+                unit = to_unit(var, unit_spec)
 
                 if (not isinstance(var, Quantity) and
                         _can_have_arbitrary_unit(var)):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2546,6 +2546,7 @@ class _CompoundModelMeta(_ModelMeta):
                 # a bound Parameter even if submodel is a Model instance (as
                 # opposed to a Model subclass)
                 new_param = orig_param.copy(name=param_name, default=default,
+                                            unit=orig_param.unit,
                                             **constraints)
 
             setattr(cls, param_name, new_param)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -43,13 +43,13 @@ from ..utils.codegen import make_function_with_signature
 from ..utils.compat import ignored
 from ..utils.compat.funcsigs import signature
 from ..utils.exceptions import AstropyDeprecationWarning
-from .utils import (array_repr_oneline, check_broadcast, combine_labels,
+from .utils import (check_broadcast, combine_labels,
                     make_binary_operator_eval, ExpressionTree,
                     IncompatibleShapeError, AliasDict, get_inputs_and_params,
                     _BoundingBox, format_unit_with_type)
 from ..nddata.utils import add_array, extract_array
 
-from .parameters import Parameter, InputParameterError
+from .parameters import Parameter, InputParameterError, param_repr_oneline
 
 
 __all__ = ['Model', 'FittableModel', 'Fittable1DModel', 'Fittable2DModel',
@@ -2005,7 +2005,7 @@ class Model(object):
 
         parts.extend(
             "{0}={1}".format(name,
-                             array_repr_oneline(getattr(self, name).value))
+                             param_repr_oneline(getattr(self, name)))
             for name in self.param_names)
 
         if self.name is not None:
@@ -2053,6 +2053,9 @@ class Model(object):
 
         if columns:
             param_table = Table(columns, names=self.param_names)
+            # Set units on the columns
+            for name in self.param_names:
+                param_table[name].unit = getattr(self, name).unit
             parts.append(indent(str(param_table), width=4))
 
         return '\n'.join(parts)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -34,7 +34,7 @@ from ..utils import indent, isinstancemethod, metadata
 from ..extern import six
 from ..extern.six.moves import copyreg
 from ..table import Table
-from ..units import Quantity
+from ..units import Quantity, Unit, UnitConversionError
 from ..utils import (deprecated, sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer)
 from ..utils.codegen import make_function_with_signature
@@ -112,6 +112,11 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         if '_is_dynamic' not in members:
             members['_is_dynamic'] = mcls._is_dynamic
 
+        # Prevent output_units, etc. from being treated as a method
+        for attr in ('output_units', 'output_unit_types'):
+            if attr in members and callable(members[attr]):
+                members[attr] = staticmethod(members[attr])
+
         return super(_ModelMeta, mcls).__new__(mcls, name, bases, members)
 
     def __init__(cls, name, bases, members):
@@ -132,6 +137,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         cls._create_bounding_box_property(members)
         cls._handle_backwards_compat(name, members)
         cls._handle_special_methods(members)
+        cls._check_output_units(members)
 
         if not inspect.isabstract(cls) and not name.startswith('_'):
             cls.registry.add(cls)
@@ -248,6 +254,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
 
         return new_cls
 
+
     def _create_inverse_property(cls, members):
         inverse = members.get('inverse')
         if inverse is None or cls.__bases__[0] is object:
@@ -255,6 +262,82 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
             # the Model base class, which implements the default getter and
             # setter for .inverse
             return
+
+    @classmethod
+    def _handle_parameters(mcls, name, members):
+        # Handle parameters
+        param_names = members.get('param_names', ())
+        parameters = {}
+        for key, value in members.items():
+            if not isinstance(value, Parameter):
+                continue
+            if not value.name:
+                # Name not explicitly given in the constructor; add the name
+                # automatically via the attribute name
+                value._name = key
+                value._attr = '_' + key
+            if value.name != key:
+                raise ModelDefinitionError(
+                    "Parameters must be defined with the same name as the "
+                    "class attribute they are assigned to.  Parameters may "
+                    "take their name from the class attribute automatically "
+                    "if the name argument is not given when initializing "
+                    "them.")
+            parameters[value.name] = value
+
+        # If no parameters were defined get out early--this is especially
+        # important for PolynomialModels which take a different approach to
+        # parameters, since they can have a variable number of them
+        if parameters:
+            mcls._check_parameters(name, members, param_names, parameters)
+
+        return parameters
+
+    @staticmethod
+    def _check_parameters(name, members, param_names, parameters):
+        # If param_names was declared explicitly we use only the parameters
+        # listed manually in param_names, but still check that all listed
+        # parameters were declared
+        if param_names and isiterable(param_names):
+            for param_name in param_names:
+                if param_name not in parameters:
+                    raise ModelDefinitionError(
+                        "Parameter {0!r} listed in {1}.param_names was not "
+                        "declared in the class body.".format(param_name, name))
+        else:
+            param_names = tuple(param.name for param in
+                                sorted(parameters.values(),
+                                       key=lambda p: p._order))
+            members['param_names'] = param_names
+            members['_param_orders'] = \
+                    dict((name, idx) for idx, name in enumerate(param_names))
+
+    def _check_output_units(cls, members):
+        """
+        Validates the output_units and output_unit_types attributes.
+        """
+
+        unit_attrs = []
+
+        for attr_name in ('output_units', 'output_unit_types'):
+            if attr_name in members and members[attr_name] is not None:
+                # Attribute not defined, or was defined on a base class, so we
+                # don't need to check it again (I don't think?)
+                attr = getattr(cls, attr_name)
+                if cls.n_outputs == 1 and not isinstance(attr, tuple):
+                    attr = (attr,)
+
+                if not isinstance(attr, tuple) or len(attr) != cls.n_outputs:
+                    raise ModelDefinitionError(
+                        'If defined, the {0}.{1} attribute must be a tuple '
+                        'of length equal to the number of outputs from this '
+                        'model ({2}).  Only single-output models may forgo '
+                        'the tuple as a shortcut.  However, some entries in '
+                        'the tuple may be None.'.format(cls.__name__,
+                                                        attr_name,
+                                                        cls.n_outputs))
+
+                # TODO: Validate the types of the items in the tuples as well
 
         if isinstance(inverse, property):
             # We allow the @property decorator to be omitted entirely from
@@ -651,6 +734,70 @@ class Model(object):
     outputs = ()
     """The name(s) of the output(s) of the model."""
 
+    output_units = None
+    """
+    This attribute specifies what units should be attached to a model's output
+    when being evaluated on inputs with units.  This can be defined in several
+    ways:
+
+        1. If this attribute is a `~astropy.units.Unit`, the output is
+           required to be in that unit.  This must be a specific unit--to
+           require only a compatible physical unit, use
+           `~astropy.modeling.Model.output_unit_types` instead (see below).
+           If the output is not in the specified unit, but is in a compatible
+           unit (including any active equivalencies) then the output will be
+           converted to the unit specified here.
+
+        2. If this attribute is a string, it must be the name of one of the
+           model's parameters, or one of the model's inputs.  In this case the
+           output units are taken from the units of that parameter or input.
+           The same semantics as in case 1. are then applied.  For example
+           ``output_units = 'amplitude'`` implies that the units of the output
+           should be the same as the units of the "amplitude" parameter.
+
+        3. This attribute may also be a callable (i.e. a function).  It is
+           called just before the output from the model is returned.  There
+           are two possibilities allowed for the signature of the callable:
+
+               a. It may take arguments with the same names as any of the
+                  model's inputs and/or parameters (not outputs, however).
+                  The corresponding parameters and inputs are passed in as
+                  arguments.  This allows in most cases for very terse,
+                  readable code.
+
+               b. For cases where just having the parameters and inputs is
+                  not sufficient, and more power/flexibility is needed a
+                  generic three argument call signature is allowed, consisting
+                  of:  The model instance itself, *all* inputs to the model as
+                  a `tuple`, and *all* outputs from the model as `tuple`.
+
+           In either case, this function must return a `~astropy.units.Unit`,
+           to which the output will be converted.
+
+    For models with more than one output, this attribute must be a tuple with
+    one entry per output.  The above rules are then applied on a per-output
+    basis.
+    """
+
+    output_unit_types = None
+    """
+    This attribute takes the same values as
+    `~astropy.modeling.Model.output_units`, but has different semantics.
+    Whereas the ``output_units`` *converts* the output to the specified units,
+    this attribute only ensures that the output units have a compatible type.
+    For example, ``output_units = u.km`` will *always* convert the output to
+    kilometers (as long as it is convertible to kilometers), whereas
+    ``output_unit_types = u.km`` will ensure that the output has units of
+    length, but otherwise performs no conversion.  This is useful for cases
+    where it is important to *validate* the type of the output, but it is not
+    the extra overhead of type conversion is not necessary.
+
+    It is an error to define both an output unit and an output unit type for a
+    single output.  However, both ``output_units`` and ``output_unit_types``
+    may be defined in the case of multiple outputs, where some outputs specify
+    a unit and others specify a unit type.
+    """
+
     standard_broadcasting = True
     fittable = False
     linear = True
@@ -710,7 +857,19 @@ class Model(object):
         if self.n_outputs == 1:
             outputs = (outputs,)
 
-        return self.prepare_outputs(format_info, *outputs, **kwargs)
+        outputs = self.prepare_outputs(format_info, *outputs, **kwargs)
+
+        # One might think this should go in prepare_outputs, except that
+        # for now we also allow the inputs to be factored into determing the
+        # output units, so we would have to change the signature for
+        # prepare_outputs to allow that.  So maybe having it here is fine for
+        # now.
+        outputs = self._prepare_output_units(inputs, outputs)
+
+        if self.n_outputs == 1:
+            return outputs[0]
+        else:
+            return outputs
 
     # *** Arithmetic operators for creating compound models ***
     __add__ =     _model_oper('+')
@@ -1691,6 +1850,85 @@ class Model(object):
         # maybe deprecate that method)
 
         return np.array(values)
+
+    def _prepare_output_units(self, inputs, outputs):
+        """
+        Checks/converts units of model evaluation outputs using any directions
+        from ``output_units`` and/or ``output_unit_types`` if they are
+        specified.
+        """
+
+        output_units = self.output_units
+        output_unit_types = self.output_unit_types
+
+        if output_units is None and output_unit_types is None:
+            # No output units specified, so we just return whatever we got
+            return outputs
+
+        if self.n_outputs == 1 and not isinstance(output_units, tuple):
+            output_units = (output_units,)
+
+        if self.n_outputs == 1 and not isinstance(output_unit_types, tuple):
+            output_unit_types = (output_unit_types,)
+
+        def to_unit(item):
+            # Go from an element in the output_units or output_unit_types
+            # attributes to an actual Unit object
+            if isinstance(item, Unit):
+                return item
+            elif isinstance(item, six.string_types):
+                # Take the unit from one of the parameter's or input's units
+                if item in self.inputs:
+                    return inputs[self.inputs.index(item)].unit
+                else:
+                    return getattr(self, item).unit
+                return getattr(self, item).unit
+            else:
+                # TODO: Move the call to _analyze_unit_converter to the
+                # validation code in the metaclass, rather than doing that
+                # on every call
+                # Must be a callable
+                item = _analyze_unit_converter(self, outputs, item)
+                return item(self, inputs, outputs)
+
+        # The output_units and output_unit_types should have already been
+        # validated, so now all that's left is to apply them
+        converted = []
+
+        for output, output_name, output_unit, output_unit_type in \
+                zip(outputs, self.outputs, output_units, output_unit_types):
+            if not isinstance(output, Quantity):
+                # TODO: We should probably avoid this loop altogether if the
+                # model is not being evaluated with quantities.  It might be
+                # nice if the model had a flag set somewhere specifying whether
+                # or not quantities are being used (based on the types of the
+                # parameters)
+                pass
+            elif output_unit is not None:
+                # Just go ahead and try converting the output straight to the
+                # new unit; if this results in a conversion error that's fine;
+                # just raise it directly
+                unit = to_unit(output_unit)
+                try:
+                    output = output.to(unit)
+                except UnitConversionError:
+                    raise UnitConversionError(
+                        "Units of output '{0}', {1} ({2}), could not be "
+                        "converted to required output units of {3} "
+                        "({4}).".format(output_name, output.unit,
+                                        output.unit.physical_type, unit,
+                                        unit.physical_type))
+            elif output_unit_type is not None:
+                unit = to_unit(output_unit_type)
+                if not output.unit.is_equivalent(unit):
+                    raise UnitConversionError(
+                        "Units of output '{0}' ({1}, {2}) are not compatible "
+                        "with the required physical type {3}.".format(
+                            output_name, output.unit,
+                            output.unit.physical_type, unit.physical_type))
+            converted.append(output)
+
+        return tuple(converted)
 
     def _format_repr(self, args=[], kwargs={}, defaults={}):
         """
@@ -2877,10 +3115,7 @@ def _prepare_outputs_single_model(model, outputs, format_info):
             else:
                 outputs[idx] = output.reshape(broadcast_shape)
 
-    if model.n_outputs == 1:
-        return outputs[0]
-    else:
-        return tuple(outputs)
+    return tuple(outputs)
 
 
 def _prepare_inputs_model_set(model, params, inputs, n_models, model_set_axis,
@@ -2959,10 +3194,7 @@ def _prepare_outputs_model_set(model, outputs, format_info):
             outputs[idx] = np.rollaxis(output, pivot,
                                        model.model_set_axis)
 
-    if model.n_outputs == 1:
-        return outputs[0]
-    else:
-        return tuple(outputs)
+    return tuple(outputs)
 
 
 def _validate_input_shapes(inputs, argnames, n_models, model_set_axis,
@@ -3020,6 +3252,58 @@ def _validate_input_shapes(inputs, argnames, n_models, model_set_axis,
 
     return input_broadcast
 
+
+def _analyze_unit_converter(model, output, converter):
+    """
+    This is to support the callable modes of output_units and
+    output_unit_types.  This allows a "magic" call signature that
+    specifies only the parameters and/or inputs needed to determine
+    the output units.
+
+    If all the arguments to the converter do not match either parameter
+    names or input names, then the default 3 argument signature will be
+    assumed.
+    """
+
+    argspec = inspect.getargspec(converter)
+
+    for argname in argspec.args:
+        if not (argname in model.param_names or argname in model.inputs):
+            if not len(argspec.args) == 3:
+                raise ModelDefinitionError(
+                    "Unit conversion/validation function for '{0}' does not "
+                    "have a compatible signature; it must either take three "
+                    "arguments (model, inputs, outputs) or have arguments "
+                    "with the same name as parameters and/or inputs to the "
+                    "model.  See the documentation for Model.output_units "
+                    "for more details.".format(output))
+
+            # Just use the converter as is
+            return converter
+    else:
+        # Return a wrapper that passes the correct arguments in to the
+        # converter
+        def wrapped_converter(model, inputs, outputs):
+            # Outputs is included for compatibility with the 3-argument
+            # signature, but is not used here
+            return _unit_converter_wrapper(model, inputs, converter,
+                                           argspec.args)
+
+        return wrapped_converter
+
+
+def _unit_converter_wrapper(model, inputs, converter, argnames):
+    """
+    Used in conjunction with _analyze_unit_converter.  This evaluates the
+    unit conversion callable with the correct inputs by evaluating its
+    signature.
+    """
+
+    args = (getattr(model, name) if name in model.param_names
+            else inputs[model.inputs.index(name)]
+            for name in argnames)
+
+    return converter(*args)
 
 copyreg.pickle(_ModelMeta, _ModelMeta.__reduce__)
 copyreg.pickle(_CompoundModelMeta, _CompoundModelMeta.__reduce__)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2784,6 +2784,14 @@ class _CompoundModel(Model):
         return super(_CompoundModel, self)._format_str(keywords=keywords)
 
     def __getattr__(self, attr):
+        # This __getattr__ is necessary, because _CompoundModelMeta creates
+        # Parameter descriptors *lazily*--they do not exist in the class
+        # __dict__ until one of them has been accessed.
+        # However, this is at odds with how Python looks up descriptors (see
+        # (https://docs.python.org/3/reference/datamodel.html#invoking-descriptors)
+        # which is to look directly in the class __dict__
+        # This workaround allows descriptors to work correctly when they are
+        # not initially found in the class __dict__
         value = getattr(self.__class__, attr)
         if hasattr(value, '__get__'):
             # Object is a descriptor, so we should really return the result of

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -34,7 +34,7 @@ from ..utils import indent, isinstancemethod, metadata
 from ..extern import six
 from ..extern.six.moves import copyreg
 from ..table import Table
-from ..units import (Quantity, Unit, UnitConversionError,
+from ..units import (Quantity, UnitBase, UnitConversionError,
                      dimensionless_unscaled)
 from ..units.quantity import _can_have_arbitrary_unit
 from ..utils import (deprecated, sharedmethod, find_current_module,
@@ -46,7 +46,7 @@ from ..utils.exceptions import AstropyDeprecationWarning
 from .utils import (array_repr_oneline, check_broadcast, combine_labels,
                     make_binary_operator_eval, ExpressionTree,
                     IncompatibleShapeError, AliasDict, get_inputs_and_params,
-                    _BoundingBox)
+                    _BoundingBox, format_unit_with_type)
 from ..nddata.utils import add_array, extract_array
 
 from .parameters import Parameter, InputParameterError
@@ -114,8 +114,9 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         if '_is_dynamic' not in members:
             members['_is_dynamic'] = mcls._is_dynamic
 
-        # Prevent output_units, etc. from being treated as a method
-        for attr in ('output_units', 'output_unit_types'):
+        # Prevent callable values for input_units or output_units from being
+        # treated as a method
+        for attr in ('input_units', 'output_units'):
             if attr in members and callable(members[attr]):
                 members[attr] = staticmethod(members[attr])
 
@@ -139,7 +140,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         cls._create_bounding_box_property(members)
         cls._handle_backwards_compat(name, members)
         cls._handle_special_methods(members)
-        cls._check_output_units(members)
+        cls._check_unit_specs(members)
 
         if not inspect.isabstract(cls) and not name.startswith('_'):
             cls.registry.add(cls)
@@ -256,15 +257,6 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
 
         return new_cls
 
-
-    def _create_inverse_property(cls, members):
-        inverse = members.get('inverse')
-        if inverse is None or cls.__bases__[0] is object:
-            # The latter clause is the prevent the below code from running on
-            # the Model base class, which implements the default getter and
-            # setter for .inverse
-            return
-
     @classmethod
     def _handle_parameters(mcls, name, members):
         # Handle parameters
@@ -314,32 +306,52 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
             members['_param_orders'] = \
                     dict((name, idx) for idx, name in enumerate(param_names))
 
-    def _check_output_units(cls, members):
+    def _check_unit_specs(cls, members):
         """
-        Validates the output_units and output_unit_types attributes.
+        Validates the input_units and output_units attributes.
         """
 
         unit_attrs = []
 
-        for attr_name in ('output_units', 'output_unit_types'):
-            if attr_name in members and members[attr_name] is not None:
+        for var_type in ('input', 'output'):
+            attr_name = var_type + '_units'
+
+            if not (attr_name in members and members[attr_name] is not None):
                 # Attribute not defined, or was defined on a base class, so we
                 # don't need to check it again (I don't think?)
-                attr = getattr(cls, attr_name)
-                if cls.n_outputs == 1 and not isinstance(attr, tuple):
-                    attr = (attr,)
+                continue
 
-                if not isinstance(attr, tuple) or len(attr) != cls.n_outputs:
-                    raise ModelDefinitionError(
-                        'If defined, the {0}.{1} attribute must be a tuple '
-                        'of length equal to the number of outputs from this '
-                        'model ({2}).  Only single-output models may forgo '
-                        'the tuple as a shortcut.  However, some entries in '
-                        'the tuple may be None.'.format(cls.__name__,
-                                                        attr_name,
-                                                        cls.n_outputs))
+            attr = getattr(cls, attr_name)
+            n_vars = getattr(cls, 'n_{0}s'.format(var_type))
 
-                # TODO: Validate the types of the items in the tuples as well
+            if n_vars == 1 and not isinstance(attr, tuple):
+                attr = (attr,)
+
+            if not isinstance(attr, tuple) or len(attr) != n_vars:
+                raise ModelDefinitionError(
+                    'If defined, the {0}.{1} attribute must be a tuple of '
+                    'length equal to the number of {2}s from this model '
+                    '({3}).  Only single-{2} models may forgo the tuple as a '
+                    'shortcut.  However, some entries in the tuple may be '
+                    'None.'.format(cls.__name__, attr_name, var_type, n_vars))
+
+            # TODO: Validate the types of the items in the tuples as well
+            for unit_spec in attr:
+                if isinstance(unit_spec, UnitBase):
+                    # If any of the input_units or output_units are specific,
+                    # concrete units this implies that units are *always*
+                    # required for this model, so we implicitly force
+                    # _using_quantities
+                    cls._using_quantities = True
+                    break
+
+    def _create_inverse_property(cls, members):
+        inverse = members.get('inverse')
+        if inverse is None or cls.__bases__[0] is object:
+            # The latter clause is the prevent the below code from running on
+            # the Model base class, which implements the default getter and
+            # setter for .inverse
+            return
 
         if isinstance(inverse, property):
             # We allow the @property decorator to be omitted entirely from
@@ -736,68 +748,53 @@ class Model(object):
     outputs = ()
     """The name(s) of the output(s) of the model."""
 
-    output_units = None
+    input_units = None
     """
-    This attribute specifies what units should be attached to a model's output
-    when being evaluated on inputs with units.  This can be defined in several
-    ways:
+    This attribute specifies what units should be attached to a model's inputs.
+    This can be defined in several ways:
 
-        1. If this attribute is a `~astropy.units.Unit`, the output is
-           required to be in that unit.  This must be a specific unit--to
-           require only a compatible physical unit, use
-           `~astropy.modeling.Model.output_unit_types` instead (see below).
-           If the output is not in the specified unit, but is in a compatible
-           unit (including any active equivalencies) then the output will be
-           converted to the unit specified here.
+        1. If this attribute is a `~astropy.units.Unit`, the input is
+           required to be in that unit or a compatible unit (up to any
+           active equivalencies).
 
         2. If this attribute is a string, it must be the name of one of the
-           model's parameters, or one of the model's inputs.  In this case the
-           output units are taken from the units of that parameter or input.
-           The same semantics as in case 1. are then applied.  For example
-           ``output_units = 'amplitude'`` implies that the units of the output
-           should be the same as the units of the "amplitude" parameter.
+           model's parameters, or one of the model's other inputs.  In this
+           case the input units are checked against the units of that parameter
+           or input.  The same semantics as in case 1. are then applied.  For
+           example ``input_units = 'mean'`` implies that the units of the input
+           should be the same as the units of the "mean" parameter.
 
-        3. This attribute may also be a callable (i.e. a function).  It is
-           called just before the output from the model is returned.  There
-           are two possibilities allowed for the signature of the callable:
+        3. This attribute may also be a callable (i.e. a function).  It may
+           take arguments with the same names as any of the model's inputs
+           and/or parameters just as in case 2.  The corresponding parameter
+           and/or input quantities are passed in to this functionas arguments.
+           The function must return a `~astropy.units.Unit`, against which
+           the input is checked.  For example,
+           ``lambda slope, intercept: intercept.unit / slope.unit`` implies
+           that the input's unit must be equivalent to the intercept's unit
+           over the slope's unit, so that ``x.unit * intercept.unit ==
+           slope.unit``.
 
-               a. It may take arguments with the same names as any of the
-                  model's inputs and/or parameters (not outputs, however).
-                  The corresponding parameters and inputs are passed in as
-                  arguments.  This allows in most cases for very terse,
-                  readable code.
-
-               b. For cases where just having the parameters and inputs is
-                  not sufficient, and more power/flexibility is needed a
-                  generic three argument call signature is allowed, consisting
-                  of:  The model instance itself, *all* inputs to the model as
-                  a `tuple`, and *all* outputs from the model as `tuple`.
-
-           In either case, this function must return a `~astropy.units.Unit`,
-           to which the output will be converted.
-
-    For models with more than one output, this attribute must be a tuple with
-    one entry per output.  The above rules are then applied on a per-output
+    For models with more than one input, this attribute must be a tuple with
+    one entry per output.  The above rules are then applied on a per-input
     basis.
     """
 
-    output_unit_types = None
+    output_units = None
     """
-    This attribute takes the same values as
-    `~astropy.modeling.Model.output_units`, but has different semantics.
-    Whereas the ``output_units`` *converts* the output to the specified units,
-    this attribute only ensures that the output units have a compatible type.
-    For example, ``output_units = u.km`` will *always* convert the output to
-    kilometers (as long as it is convertible to kilometers), whereas
-    ``output_unit_types = u.km`` will ensure that the output has units of
-    length, but otherwise performs no conversion.  This is useful for cases
-    where it is important to *validate* the type of the output, but it is not
-    the extra overhead of type conversion is not necessary.
+    This attribute specifies what units should be attached to a model's output
+    when being evaluated on inputs with units.  It takes the same values as
+    `~astropy.modeling.Model.input_units`, but has different semantics.
+    Whereas the ``input_units`` merely checks that an input has compatible
+    units with the specification, ``output_units`` always coverts an output to
+    the unit given by this specification.
 
-    It is an error to define both an output unit and an output unit type for a
-    single output.  However, both ``output_units`` and ``output_unit_types``
-    may be defined in the case of multiple outputs, where some outputs specify
-    a unit and others specify a unit type.
+    Specifying an ``output_units`` is not necessary, but is often a useful way
+    to specify what units a model should be converted to (for example by
+    outputting in the same units as the model's "amplitude" parameter) rather
+    than leaving users to manually perform unit conversion.  Otherwise the
+    exact output units may not be guaranteed, depending on what units the
+    inputs and parameters were converted to for efficient evaluation.
     """
 
     standard_broadcasting = True
@@ -823,10 +820,9 @@ class Model(object):
     _n_models = 1
 
     # Flag indicating whether units should be considered when evaluating this
-    # model.  This is enabled only if all of the model's parameters have units
-    _params_using_quantities = False
-    # This serves a similar purpose, but is reset between each __call__
-    _inputs_using_quantities = False
+    # model.  This is enabled only if any of the model's parameters or inputs
+    # have units, or if the outputs are forced to have a unit
+    _using_quantities = False
 
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
@@ -1683,7 +1679,7 @@ class Model(object):
 
                 if default is None:
                     # No value was supplied for the parameter, and the
-                    # parameter does not have a default--therefor the model is
+                    # parameter does not have a default--therefore the model is
                     # underspecified
                     raise TypeError(
                         "{0}.__init__() requires a value for parameter "
@@ -1705,7 +1701,7 @@ class Model(object):
                 param_metrics[name]['orig_unit'] = value.unit
                 # A flag, for convenience, to track whether quantities were
                 # used in instantiating this model
-                self._params_using_quantities = True
+                self._using_quantities = True
             else:
                 param_metrics[name]['orig_unit'] = None
 
@@ -1867,112 +1863,104 @@ class Model(object):
         return np.array(values)
 
     def _prepare_input_units(self, inputs):
-        self._inputs_using_quantities = False
         for input_ in inputs:
             if isinstance(input_, Quantity):
-                self._inputs_using_quantities = True
+                self._using_quantities = True
                 break
 
-        # If any parameters or inputs are using quantities, then all should;
-        # unit-less inputs are thus treated as dimensionless
-        if self._params_using_quantities or self._inputs_using_quantities:
-            converted_inputs = []
-            for input_ in inputs:
-                if (not isinstance(input_, Quantity) and
-                        not _can_have_arbitrary_unit(input_)):
-                    # We make a special case also for 0, since 0 may
-                    # be used in many quantity calculations without
-                    # penalty so long as it is not explicitly dimensionless
-                    input_ = input_ * dimensionless_unscaled
-                converted_inputs.append(input_)
-            return converted_inputs
-        else:
+        if not self._using_quantities:
             return inputs
+        else:
+            return self._prepare_variable_units(inputs)
 
     def _prepare_output_units(self, inputs, outputs):
-        """
-        Checks/converts units of model evaluation outputs using any directions
-        from ``output_units`` and/or ``output_unit_types`` if they are
-        specified.
-        """
-
-        output_units = self.output_units
-        output_unit_types = self.output_unit_types
-
-        if ((output_units is None and output_unit_types is None)
-                or not (self._params_using_quantities or
-                        self._inputs_using_quantities)):
-            # No output units specified, so we just return whatever we got
+        if not self._using_quantities:
             return outputs
+        else:
+            return self._prepare_variable_units(inputs, outputs)
 
-        if self.n_outputs == 1 and not isinstance(output_units, tuple):
-            output_units = (output_units,)
+    def _prepare_variable_units(self, inputs, outputs=None):
+        if outputs is None:
+            units = self.input_units
+            var_names = self.inputs
+            n_vars = self.n_inputs
+            vars_ = inputs
+        else:
+            units = self.output_units
+            var_names = self.outputs
+            n_vars = self.n_outputs
+            vars_ = outputs
 
-        if self.n_outputs == 1 and not isinstance(output_unit_types, tuple):
-            output_unit_types = (output_unit_types,)
+        if units is None:
+            units = (None,) * n_vars
+        elif not isinstance(units, tuple) and n_vars == 1:
+            units = (units,)
 
-        # Make sure all inputs have units; this is specifically to
-        # address the case of 0 (without units) being an allowed input
-        inputs = [Quantity(input_, dimensionless_unscaled)
-                  if _can_have_arbitrary_unit(input_)
-                  else input_ for input_ in inputs]
-
-        def to_unit(item):
-            # Go from an element in the output_units or output_unit_types
-            # attributes to an actual Unit object
-            if isinstance(item, Unit):
-                return item
-            elif isinstance(item, six.string_types):
+        def to_unit(value, unit_spec):
+            # Go from an element in the output_units attributes to an actual
+            # Unit object
+            if isinstance(unit_spec, UnitBase):
+                return unit_spec
+            elif isinstance(unit_spec, six.string_types):
                 # Take the unit from one of the parameter's or input's units
-                if item in self.inputs:
-                    return inputs[self.inputs.index(item)].unit
+                if unit_spec in self.inputs:
+                    input_ = inputs[self.inputs.index(unit_spec)]
+                    if (not isinstance(input_, Quantity) and
+                            _can_have_arbitrary_unit(input_)):
+                        # This will allow trivial conversion
+                        return value.unit
+                    else:
+                        return input_
                 else:
-                    return getattr(self, item).unit
-                return getattr(self, item).unit
+                    return getattr(self, unit_spec).unit
             else:
                 # TODO: Move the call to _analyze_unit_converter to the
                 # validation code in the metaclass, rather than doing that
                 # on every call
                 # Must be a callable
-                item = _analyze_unit_converter(self, outputs, item)
-                return item(self, inputs, outputs)
+                unit_spec = _analyze_unit_converter(self, inputs, unit_spec)
+                return unit_spec(self, inputs)
 
-        # The output_units and output_unit_types should have already been
-        # validated, so now all that's left is to apply them
         converted = []
 
-        for output, output_name, output_unit, output_unit_type in \
-                zip(outputs, self.outputs, output_units, output_unit_types):
-            if not isinstance(output, Quantity):
-                # TODO: We should probably avoid this loop altogether if the
-                # model is not being evaluated with quantities.  It might be
-                # nice if the model had a flag set somewhere specifying whether
-                # or not quantities are being used (based on the types of the
-                # parameters)
-                pass
-            elif output_unit is not None:
-                # Just go ahead and try converting the output straight to the
+        for var, var_name, var_unit in zip(vars_, var_names, units):
+            if outputs is None and not isinstance(var, Quantity):
+                # This check really only applies to inputs
+                if not _can_have_arbitrary_unit(var):
+                    # We make a special case also for 0, since 0 may
+                    # be used in many quantity calculations without
+                    # penalty so long as it is not explicitly dimensionless
+                    var = var * dimensionless_unscaled
+                else:
+                    # The input has "arbitrary" units, so there is no sense in
+                    # performing further checks on it.
+                    converted.append(var)
+                    continue
+
+            if var_unit is not None:
+                # Just go ahead and try converting the input straight to the
                 # new unit; if this results in a conversion error that's fine;
                 # just raise it directly
-                unit = to_unit(output_unit)
+                unit = to_unit(var, var_unit)
+
+                if (not isinstance(var, Quantity) and
+                        _can_have_arbitrary_unit(var)):
+                    # This supports the case of converting an output (such as
+                    # 0) that allows arbitrary units to the specified output
+                    # unit
+                    converted.append(Quantity(var, unit))
+                    continue
+
                 try:
-                    output = output.to(unit)
+                    var = var.to(unit)
                 except UnitConversionError:
                     raise UnitConversionError(
-                        "Units of output '{0}', {1} ({2}), could not be "
-                        "converted to required output units of {3} "
-                        "({4}).".format(output_name, output.unit,
-                                        output.unit.physical_type, unit,
-                                        unit.physical_type))
-            elif output_unit_type is not None:
-                unit = to_unit(output_unit_type)
-                if not output.unit.is_equivalent(unit):
-                    raise UnitConversionError(
-                        "Units of output '{0}' ({1}, {2}) are not compatible "
-                        "with the required physical type {3}.".format(
-                            output_name, output.unit,
-                            output.unit.physical_type, unit.physical_type))
-            converted.append(output)
+                        "Units of input '{0}', {1}, could not be converted "
+                        "to required input units of {2}".format(
+                            var_name, format_unit_with_type(var.unit),
+                            format_unit_with_type(unit)))
+
+            converted.append(var)
 
         return tuple(converted)
 
@@ -3299,37 +3287,27 @@ def _validate_input_shapes(inputs, argnames, n_models, model_set_axis,
     return input_broadcast
 
 
-def _analyze_unit_converter(model, output, converter):
+def _analyze_unit_converter(model, inputs, converter):
     """
-    This is to support the callable modes of output_units and
-    output_unit_types.  This allows a "magic" call signature that
-    specifies only the parameters and/or inputs needed to determine
-    the output units.
-
-    If all the arguments to the converter do not match either parameter
-    names or input names, then the default 3 argument signature will be
-    assumed.
+    This is to support the callable modes of input_units and output_units.
+    This allows a "magic" call signature that specifies only the parameters
+    and/or inputs needed to determine the output units.
     """
 
     argspec = inspect.getargspec(converter)
 
     for argname in argspec.args:
         if not (argname in model.param_names or argname in model.inputs):
-            if not len(argspec.args) == 3:
-                raise ModelDefinitionError(
-                    "Unit conversion/validation function for '{0}' does not "
-                    "have a compatible signature; it must either take three "
-                    "arguments (model, inputs, outputs) or have arguments "
-                    "with the same name as parameters and/or inputs to the "
-                    "model.  See the documentation for Model.output_units "
-                    "for more details.".format(output))
-
-            # Just use the converter as is
-            return converter
+            raise ModelDefinitionError(
+                "Unit conversion/validation function for '{0}' does not have "
+                "a compatible signature; it must have arguments with the "
+                "same names as parameters and/or inputs to the model.  See "
+                "the documentation for Model.output_units for more "
+                "details.".format(output))
     else:
         # Return a wrapper that passes the correct arguments in to the
         # converter
-        def wrapped_converter(model, inputs, outputs):
+        def wrapped_converter(model, inputs):
             # Outputs is included for compatibility with the 3-argument
             # signature, but is not used here
             return _unit_converter_wrapper(model, inputs, converter,
@@ -3345,9 +3323,17 @@ def _unit_converter_wrapper(model, inputs, converter, argnames):
     signature.
     """
 
-    args = (getattr(model, name) if name in model.param_names
-            else inputs[model.inputs.index(name)]
-            for name in argnames)
+    args = []
+
+    for name in argnames:
+        if name in model.param_names:
+            arg = getattr(model, name)
+        else:
+            arg = inputs[model.inputs.index(name)]
+            if not isinstance(arg, Quantity):
+                arg = Quantity(arg, dimensionless_unscaled)
+
+        args.append(arg)
 
     return converter(*args)
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2344,37 +2344,7 @@ class _CompoundModelMeta(_ModelMeta):
         else:
             modname = '__main__'
 
-        # TODO: These aren't the full rules for handling inputs and outputs, but
-        # this will handle most basic cases correctly
-        if operator == '|':
-            inputs = left.inputs
-            outputs = right.outputs
-
-            if left.n_outputs != right.n_inputs:
-                raise ModelDefinitionError(
-                    "Unsupported operands for |: {0} (n_inputs={1}, "
-                    "n_outputs={2}) and {3} (n_inputs={4}, n_outputs={5}); "
-                    "n_outputs for the left-hand model must match n_inputs "
-                    "for the right-hand model.".format(
-                        left.name, left.n_inputs, left.n_outputs, right.name,
-                        right.n_inputs, right.n_outputs))
-        elif operator == '&':
-            inputs = combine_labels(left.inputs, right.inputs)
-            outputs = combine_labels(left.outputs, right.outputs)
-        else:
-            # Without loss of generality
-            inputs = left.inputs
-            outputs = left.outputs
-
-            if (left.n_inputs != right.n_inputs or
-                    left.n_outputs != right.n_outputs):
-                raise ModelDefinitionError(
-                    "Unsupported operands for {0}: {1} (n_inputs={2}, "
-                    "n_outputs={3}) and {4} (n_inputs={5}, n_outputs={6}); "
-                    "models must have the same n_inputs and the same "
-                    "n_outputs for this operator".format(
-                        operator, left.name, left.n_inputs, left.n_outputs,
-                        right.name, right.n_inputs, right.n_outputs))
+        inputs, outputs = mcls._check_inputs_and_outputs(operator, left, right)
 
         if operator in ('|', '+', '-'):
             linear = left.linear and right.linear
@@ -2429,6 +2399,42 @@ class _CompoundModelMeta(_ModelMeta):
         # TODO: Remove this at the same time as removing
         # _ModelMeta._handle_backwards_compat
         return
+
+    @classmethod
+    def _check_inputs_and_outputs(mcls, operator, left, right):
+        # TODO: These aren't the full rules for handling inputs and outputs, but
+        # this will handle most basic cases correctly
+        if operator == '|':
+            inputs = left.inputs
+            outputs = right.outputs
+
+            if left.n_outputs != right.n_inputs:
+                raise ModelDefinitionError(
+                    "Unsupported operands for |: {0} (n_inputs={1}, "
+                    "n_outputs={2}) and {3} (n_inputs={4}, n_outputs={5}); "
+                    "n_outputs for the left-hand model must match n_inputs "
+                    "for the right-hand model.".format(
+                        left.name, left.n_inputs, left.n_outputs, right.name,
+                        right.n_inputs, right.n_outputs))
+        elif operator == '&':
+            inputs = combine_labels(left.inputs, right.inputs)
+            outputs = combine_labels(left.outputs, right.outputs)
+        else:
+            # Without loss of generality
+            inputs = left.inputs
+            outputs = left.outputs
+
+            if (left.n_inputs != right.n_inputs or
+                    left.n_outputs != right.n_outputs):
+                raise ModelDefinitionError(
+                    "Unsupported operands for {0}: {1} (n_inputs={2}, "
+                    "n_outputs={3}) and {4} (n_inputs={5}, n_outputs={6}); "
+                    "models must have the same n_inputs and the same "
+                    "n_outputs for this operator".format(
+                        operator, left.name, left.n_inputs, left.n_outputs,
+                        right.name, right.n_inputs, right.n_outputs))
+
+        return inputs, outputs
 
     @classmethod
     def _make_user_inverse(mcls, operator, left, right):

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -86,11 +86,15 @@ def unit_support(func):
 
     print("ICI")
     
-    def wrapper(self, model, x, y, *args, **kwargs):
+    def wrapper(self, model, x, y, z=None, *args, **kwargs):
         print("HERE")
         if isinstance(x, u.Quantity) or isinstance(y, u.Quantity):
-            model_new = func(self, model, x.value, y.value, *args, **kwargs)
-            return model_new.with_units_from_data(x, y)
+            if z is None:
+                model_new = func(self, model, x.value, y.value, *args, **kwargs)
+                return model_new.with_units_from_data(x, y)
+            else:
+                model_new = func(self, model, x.value, y.value, z=z.value, *args, **kwargs)
+                return model_new.with_units_from_data(x, y, z)
         else:
             func(self, model, x.value, y, *args, **kwargs)
         

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -38,12 +38,10 @@ from ..utils.exceptions import AstropyUserWarning
 from ..extern import six
 from .optimizers import (SLSQP, Simplex)
 from .statistic import (leastsquare)
-
+from .. import units as u
 
 __all__ = ['LinearLSQFitter', 'LevMarLSQFitter', 'SLSQPLSQFitter',
            'SimplexLSQFitter', 'JointFitter', 'Fitter']
-
-
 
 # Statistic functions implemented in `astropy.modeling.statistic.py
 STATISTICS = [leastsquare]
@@ -83,6 +81,20 @@ class _FitterMeta(abc.ABCMeta):
 
         return cls
 
+
+def unit_support(func):
+
+    print("ICI")
+    
+    def wrapper(self, model, x, y, *args, **kwargs):
+        print("HERE")
+        if isinstance(x, u.Quantity) or isinstance(y, u.Quantity):
+            model_new = func(self, model, x.value, y.value, *args, **kwargs)
+            return model_new.with_units_from_data(x, y)
+        else:
+            func(self, model, x.value, y, *args, **kwargs)
+        
+    return wrapper
 
 @six.add_metaclass(_FitterMeta)
 class Fitter(object):
@@ -212,6 +224,7 @@ class LinearLSQFitter(object):
             ynew = poly_map_domain(y, model.y_domain, model.y_window)
             return xnew, ynew
 
+    @unit_support
     def __call__(self, model, x, y, z=None, weights=None, rcond=None):
         """
         Fit data to this model.
@@ -238,6 +251,8 @@ class LinearLSQFitter(object):
         model_copy : `~astropy.modeling.FittableModel`
             a copy of the input model with parameters set by the fitter
         """
+
+        print("FINALLY IN FITTER")
 
         if not model.fittable:
             raise ValueError("Model must be a subclass of FittableModel")
@@ -407,6 +422,7 @@ class LevMarLSQFitter(object):
         else:
             return np.ravel(weights * (model(*args[2 : -1]) - meas))
 
+    @unit_support
     def __call__(self, model, x, y, z=None, weights=None,
                  maxiter=DEFAULT_MAXITER, acc=DEFAULT_ACC,
                  epsilon=DEFAULT_EPS, estimate_jacobian=False):
@@ -539,6 +555,7 @@ class SLSQPLSQFitter(Fitter):
         super(SLSQPLSQFitter, self).__init__(optimizer=SLSQP, statistic=leastsquare)
         self.fit_info = {}
 
+    @unit_support
     def __call__(self, model, x, y, z=None, weights=None, **kwargs):
         """
         Fit data to this model.

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -110,6 +110,8 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    output_units = 'amplitude'  # Output must have same units as amplitude
+
     def bounding_box(self, factor=5.5):
         """
         Tuple defining the default ``bounding_box`` limits,
@@ -208,6 +210,8 @@ class GaussianAbsorption1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     def bounding_box(self, factor=5.5):
         """
@@ -340,6 +344,8 @@ class Gaussian2D(Fittable2DModel):
     x_stddev = Parameter(default=1)
     y_stddev = Parameter(default=1)
     theta = Parameter(default=0)
+
+    output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
                  y_mean=y_mean.default, x_stddev=None, y_stddev=None,
@@ -496,6 +502,7 @@ class Shift(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+    output_units = 'x'
 
     offset = Parameter(default=0)
     fittable = True
@@ -523,6 +530,7 @@ class Scale(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+    output_units = lambda factor, x: factor.units * x.units
 
     factor = Parameter(default=1)
     linear = True
@@ -556,6 +564,8 @@ class RedshiftScaleFactor(Fittable1DModel):
     """
 
     z = Parameter(description='redshift', default=0)
+
+    output_units = 'x'
 
     @staticmethod
     def evaluate(x, z):
@@ -722,6 +732,8 @@ class Sine1D(Fittable1DModel):
     frequency = Parameter(default=1)
     phase = Parameter(default=0)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, frequency, phase):
         """One dimensional Sine model function"""
@@ -765,6 +777,9 @@ class Linear1D(Fittable1DModel):
 
     slope = Parameter(default=1)
     intercept = Parameter(default=0)
+
+    output_units = 'intercept'
+
     linear = True
 
     @staticmethod
@@ -838,6 +853,8 @@ class Lorentz1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     x_0 = Parameter(default=0)
     fwhm = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, amplitude, x_0, fwhm):
@@ -991,6 +1008,9 @@ class Const1D(Fittable1DModel):
     """
 
     amplitude = Parameter(default=1)
+
+    output_units = 'amplitude'
+
     linear = True
 
     @staticmethod
@@ -1037,6 +1057,9 @@ class Const2D(Fittable2DModel):
     """
 
     amplitude = Parameter(default=1)
+
+    output_units = 'amplitude'
+
     linear = True
 
     @staticmethod
@@ -1132,6 +1155,8 @@ class Ellipse2D(Fittable2DModel):
     b = Parameter(default=1)
     theta = Parameter(default=0)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, a, b, theta):
         """Two dimensional Ellipse model function."""
@@ -1200,6 +1225,8 @@ class Disk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     R_0 = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0):
         """Two dimensional Disk model function"""
@@ -1263,6 +1290,8 @@ class Ring2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     r_in = Parameter(default=1)
     width = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
                  y_0=y_0.default, r_in=r_in.default, width=width.default,
@@ -1372,6 +1401,8 @@ class Box1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     width = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, width):
         """One dimensional Box model function"""
@@ -1445,6 +1476,8 @@ class Box2D(Fittable2DModel):
     x_width = Parameter(default=1)
     y_width = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, x_width, y_width):
         """Two dimensional Box model function"""
@@ -1517,6 +1550,8 @@ class Trapezoid1D(Fittable1DModel):
     width = Parameter(default=1)
     slope = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, width, slope):
         """One dimensional Trapezoid model function"""
@@ -1577,6 +1612,8 @@ class TrapezoidDisk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     R_0 = Parameter(default=1)
     slope = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0, slope):
@@ -1656,6 +1693,8 @@ class MexicanHat1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     sigma = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, sigma):
         """One dimensional Mexican Hat model function"""
@@ -1699,6 +1738,8 @@ class MexicanHat2D(Fittable2DModel):
     x_0 = Parameter(default=0)
     y_0 = Parameter(default=0)
     sigma = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, sigma):
@@ -1755,6 +1796,7 @@ class AiryDisk2D(Fittable2DModel):
     x_0 = Parameter(default=0)
     y_0 = Parameter(default=0)
     radius = Parameter(default=1)
+    output_units = 'amplitude'
     _rz = None
     _j1 = None
 
@@ -1835,6 +1877,8 @@ class Moffat1D(Fittable1DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, gamma, alpha):
         """One dimensional Moffat model function"""
@@ -1890,6 +1934,8 @@ class Moffat2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, gamma, alpha):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -110,6 +110,7 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    input_units = 'mean'  # Input must have same units as mean
     output_units = 'amplitude'  # Output must have same units as amplitude
 
     def bounding_box(self, factor=5.5):
@@ -211,6 +212,7 @@ class GaussianAbsorption1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    input_units = 'mean'
     output_units = 'amplitude'
 
     def bounding_box(self, factor=5.5):
@@ -345,6 +347,7 @@ class Gaussian2D(Fittable2DModel):
     y_stddev = Parameter(default=1)
     theta = Parameter(default=0)
 
+    input_units = ('x_mean', 'y_mean')
     output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_mean=x_mean.default,
@@ -502,6 +505,10 @@ class Shift(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+
+    # Input must have compatible units with offset, but output is kept in the
+    # input units
+    input_units = 'offset'
     output_units = 'x'
 
     offset = Parameter(default=0)
@@ -530,6 +537,7 @@ class Scale(Model):
 
     inputs = ('x',)
     outputs = ('x',)
+
     output_units = lambda factor, x: factor.units * x.units
 
     factor = Parameter(default=1)
@@ -732,6 +740,7 @@ class Sine1D(Fittable1DModel):
     frequency = Parameter(default=1)
     phase = Parameter(default=0)
 
+    input_units = lambda frequency: 1 / frequency.unit
     output_units = 'amplitude'
 
     @staticmethod
@@ -778,6 +787,7 @@ class Linear1D(Fittable1DModel):
     slope = Parameter(default=1)
     intercept = Parameter(default=0)
 
+    input_units = lambda slope, intercept: intercept.unit / slope.unit
     output_units = 'intercept'
 
     linear = True
@@ -854,6 +864,7 @@ class Lorentz1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     fwhm = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1155,6 +1166,7 @@ class Ellipse2D(Fittable2DModel):
     b = Parameter(default=1)
     theta = Parameter(default=0)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1225,6 +1237,7 @@ class Disk2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     R_0 = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1291,6 +1304,7 @@ class Ring2D(Fittable2DModel):
     r_in = Parameter(default=1)
     width = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
@@ -1476,6 +1490,7 @@ class Box2D(Fittable2DModel):
     x_width = Parameter(default=1)
     y_width = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1550,6 +1565,7 @@ class Trapezoid1D(Fittable1DModel):
     width = Parameter(default=1)
     slope = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1613,6 +1629,7 @@ class TrapezoidDisk2D(Fittable2DModel):
     R_0 = Parameter(default=1)
     slope = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1693,6 +1710,7 @@ class MexicanHat1D(Fittable1DModel):
     x_0 = Parameter(default=0)
     sigma = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1739,6 +1757,7 @@ class MexicanHat2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     sigma = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod
@@ -1796,6 +1815,7 @@ class AiryDisk2D(Fittable2DModel):
     x_0 = Parameter(default=0)
     y_0 = Parameter(default=0)
     radius = Parameter(default=1)
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
     _rz = None
     _j1 = None
@@ -1877,6 +1897,7 @@ class Moffat1D(Fittable1DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -1935,6 +1956,7 @@ class Moffat2D(Fittable2DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    input_units = ('x_0', 'y_0')
     output_units = 'amplitude'
 
     @staticmethod

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -24,6 +24,13 @@ __all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
            'TrapezoidDisk2D', 'Ring2D', 'custom_model_1d', 'Voigt1D']
 
 
+def quantity_with_unit(parameter, unit):
+    if parameter.unit is None:
+        return parameter.value * unit
+    else:
+        return parameter.quantity.to(unit)
+
+
 class Gaussian1D(Fittable1DModel):
     """
     One dimensional Gaussian model.
@@ -110,8 +117,20 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
-    input_units = 'mean'  # Input must have same units as mean
-    output_units = 'amplitude'  # Output must have same units as amplitude
+    # input_units = 'mean'  # Input must have same units as mean
+    # output_units = 'amplitude'  # Output must have same units as amplitude
+
+    def with_units_from_data(self, x, y):
+        """
+        Return an instance of the model which has units for which the parameter
+        values are compatible with the data units.
+        """
+
+        amplitude = quantity_with_unit(self.amplitude, y.unit)
+        mean = quantity_with_unit(self.mean, y.unit)
+        stddev = quantity_with_unit(self.stddev, y.unit)
+
+        return Gaussian1D(amplitude=amplitude, mean=mean, stddev=stddev)
 
     def bounding_box(self, factor=5.5):
         """

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -21,6 +21,7 @@ from ..units import Quantity
 from ..utils import isiterable, OrderedDescriptor
 from ..utils.compat import ignored
 from ..extern import six
+from .utils import array_repr_oneline
 
 from .utils import get_inputs_and_params
 
@@ -845,3 +846,16 @@ class Parameter(OrderedDescriptor):
     __ge__ = _binary_comparison_operation(operator.ge)
     __neg__ = _unary_arithmetic_operation(operator.neg)
     __abs__ = _unary_arithmetic_operation(operator.abs)
+
+
+def param_repr_oneline(param):
+    """
+    Like array_repr_oneline but works on `Parameter` objects and supports
+    rendering parameters with units like quantities.
+    """
+
+    out = array_repr_oneline(param.value)
+    if param.unit is not None:
+        out = '{0} {1!s}'.format(out, param.unit)
+
+    return out

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -25,7 +25,7 @@ from .utils import array_repr_oneline
 
 from .utils import get_inputs_and_params
 
-__all__ = ['Parameter', 'InputParameterError']
+__all__ = ['Parameter', 'ParameterError', 'InputParameterError']
 
 
 class ParameterError(Exception):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -275,11 +275,28 @@ class Parameter(OrderedDescriptor):
         parameter = self.__class__.__new__(self.__class__)
         parameter.__dict__.update(self.__dict__)
         parameter._bind(obj)
+
         return parameter
 
     def __set__(self, obj, value):
 
         value = _tofloat(value)
+
+        # Check that units are compatible with default or units already set
+        param_unit = obj._param_metrics[self.name]['orig_unit']
+        if param_unit is None:
+            if isinstance(value, Quantity):
+                raise UnitsError("The '{0}' parameter should be given as a "
+                                 "unitless value".format(self._name))
+        else:
+            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit, equivalencies=self._equivalencies):
+                raise UnitsError("The '{0}' parameter should be given as a "
+                                 "Quantity with units equivalent to "
+                                 "{1}".format(self._name, param_unit))
+            else:
+                # We need to convert the value here since the units are dropped
+                # below when setting the parameter value with np.array.
+                value = value.to(param_unit, equivalencies=self._equivalencies)
 
         # Call the validator before the setter
         if self._validator is not None:
@@ -406,6 +423,12 @@ class Parameter(OrderedDescriptor):
 
         if self._setter is not None:
             val = self._setter(value)
+
+        if isinstance(value, Quantity):
+            raise TypeError("The .value property on parameters should be set to "
+                            "unitless values, not Quantity objects. To set a "
+                            "parameter to a quantity simply set the parameter "
+                            "directly without using .value")
 
         self._set_model_value(self._model, value)
 
@@ -779,21 +802,6 @@ class Parameter(OrderedDescriptor):
         # TODO: Maybe handle exception on invalid input shape
         param_metrics = model._param_metrics[self._name]
 
-        # Check that units are compatible with default or units already set
-        param_unit = param_metrics['orig_unit']
-        if param_unit is None:
-            if isinstance(value, Quantity):
-                raise UnitsError("The '{0}' parameter should be given as a "
-                                 "unitless value".format(self._name))
-        else:
-            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit, equivalencies=self._equivalencies):
-                raise UnitsError("The '{0}' parameter should be given as a "
-                                 "Quantity with units equivalent to "
-                                 "{1}".format(self._name, param_unit))
-            else:
-                # We need to convert the value here since the units are dropped
-                # below when setting the parameter value with np.array.
-                value = value.to(param_unit, equivalencies=self._equivalencies)
 
         param_slice = param_metrics['slice']
         param_shape = param_metrics['shape']

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -816,7 +816,12 @@ class Parameter(OrderedDescriptor):
 
     def __array__(self, dtype=None):
         # Make np.asarray(self) work a little more straightforwardly
-        return np.asarray(self.value, dtype=dtype)
+        arr = np.asarray(self.value, dtype=dtype)
+
+        if self.unit is not None:
+            arr = Quantity(arr, self.unit, copy=False)
+
+        return arr
 
     def __nonzero__(self):
         if self._model is None:

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -107,7 +107,7 @@ def _binary_comparison_operation(op):
         else:
             self_value = self.value
 
-        return op(self_value, val).all()
+        return np.all(op(self_value, val))
 
     return wrapper
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -284,19 +284,20 @@ class Parameter(OrderedDescriptor):
 
         # Check that units are compatible with default or units already set
         param_unit = obj._param_metrics[self.name]['orig_unit']
+        param_equiv = obj._param_metrics[self.name]['equivalencies']
         if param_unit is None:
             if isinstance(value, Quantity):
                 raise UnitsError("The '{0}' parameter should be given as a "
                                  "unitless value".format(self._name))
         else:
-            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit, equivalencies=self._equivalencies):
+            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit, equivalencies=param_equiv):
                 raise UnitsError("The '{0}' parameter should be given as a "
                                  "Quantity with units equivalent to "
                                  "{1}".format(self._name, param_unit))
             else:
                 # We need to convert the value here since the units are dropped
                 # below when setting the parameter value with np.array.
-                value = value.to(param_unit, equivalencies=self._equivalencies)
+                value = value.to(param_unit, equivalencies=param_equiv)
 
         # Call the validator before the setter
         if self._validator is not None:
@@ -475,6 +476,36 @@ class Parameter(OrderedDescriptor):
                              "{1}".format(unit, orig_unit))
 
         self._model._param_metrics[self.name]['orig_unit'] = unit
+
+    @property
+    def quantity(self):
+        """
+        This parameter, as a :class:`~astropy.units.Quantity` instance.
+        """
+        return self.value * self.unit
+
+    @quantity.setter
+    def quantity(self, quantity):
+        self.value = quantity.value
+        self.unit = quantity.unit
+
+    @property
+    def equivalencies(self):
+        """
+        The active equivalencies in this parameter
+        """
+        if self._model is None:
+            return self._equivalencies
+        else:
+            # orig_unit may be undefined early on in model instantiation
+            return self._model._param_metrics[self.name].get('equivalencies',
+                                                             self._equivalencies)
+
+    @equivalencies.setter
+    def equivalencies(self, value):
+        if self._model is None:
+            raise AttributeError('Cannot set equivalencies on a parameter definition')
+        self._model._param_metrics[self.name]['equivalencies'] = value
 
     @property
     def shape(self):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -210,16 +210,19 @@ class Parameter(OrderedDescriptor):
 
         self._name = name
         self.__doc__ = self._description = description.strip()
-        self._default = default
-        self._unit = unit
 
         # We only need to perform this check on unbound parameters
-        if (model is None and unit is not None and
-                isinstance(default, Quantity) and
-                not unit.is_equivalent(default.unit)):
-            raise ParameterDefinitionError(
-                "parameter default {0} does not have units equivalent to "
-                "the required unit {1}".format(default, unit))
+        if model is None and isinstance(default, Quantity):
+            if unit is not None and not unit.is_equivalent(default.unit):
+                raise ParameterDefinitionError(
+                    "parameter default {0} does not have units equivalent to "
+                    "the required unit {1}".format(default, unit))
+
+            unit = default.unit
+            default = default.value
+
+        self._default = default
+        self._unit = unit
 
         # NOTE: These are *default* constraints--on model instances constraints
         # are taken from the model if set, otherwise the defaults set here are
@@ -410,7 +413,9 @@ class Parameter(OrderedDescriptor):
         if self._model is None:
             return self._unit
         else:
-            return self._model._param_metrics[self.name]['orig_unit']
+            # orig_unit may be undefined early on in model instantiation
+            return self._model._param_metrics[self.name].get('orig_unit',
+                                                             self._unit)
 
     @unit.setter
     def unit(self, unit):
@@ -738,13 +743,15 @@ class Parameter(OrderedDescriptor):
 
         # Use the _param_metrics to extract the parameter value from the
         # _parameters array
-        param_slice = model._param_metrics[self._name]['slice']
-        param_shape = model._param_metrics[self._name]['shape']
+        param_metrics = model._param_metrics[self._name]
+        param_slice = param_metrics['slice']
+        param_shape = param_metrics['shape']
         value = model._parameters[param_slice]
         if param_shape:
             value = value.reshape(param_shape)
         else:
             value = value[0]
+
         return value
 
     def _set_model_value(self, model, value):
@@ -758,8 +765,9 @@ class Parameter(OrderedDescriptor):
         """
 
         # TODO: Maybe handle exception on invalid input shape
-        param_slice = model._param_metrics[self._name]['slice']
-        param_shape = model._param_metrics[self._name]['shape']
+        param_metrics = model._param_metrics[self._name]
+        param_slice = param_metrics['slice']
+        param_shape = param_metrics['shape']
         param_size = np.prod(param_shape)
 
         if np.size(value) != param_size:

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -166,6 +166,12 @@ class Parameter(OrderedDescriptor):
         parameter description
     default : float or array
         default value to use for this parameter
+    unit : `~astropy.units.Unit`
+        if specified, the parameter will be in these units, and when the
+        parameter is updated in future, it should be set to a
+        :`~astropy.units.Quantity` that has equivalent units.
+    equivalencies : list of equivalent pairs
+        equivalencies to apply when updating the parameter value
     getter : callable
         a function that wraps the raw (internal) value of the parameter
         when returning the value through the parameter proxy (eg. a
@@ -205,8 +211,8 @@ class Parameter(OrderedDescriptor):
     _name_attribute_ = '_name'
 
     def __init__(self, name='', description='', default=None, unit=None,
-                 getter=None, setter=None, fixed=False, tied=False, min=None,
-                 max=None, bounds=None, model=None):
+                 equivalencies=None, getter=None, setter=None, fixed=False,
+                 tied=False, min=None, max=None, bounds=None, model=None):
         super(Parameter, self).__init__()
 
         self._name = name
@@ -224,6 +230,7 @@ class Parameter(OrderedDescriptor):
 
         self._default = default
         self._unit = unit
+        self._equivalencies = equivalencies
 
         # NOTE: These are *default* constraints--on model instances constraints
         # are taken from the model if set, otherwise the defaults set here are
@@ -271,6 +278,7 @@ class Parameter(OrderedDescriptor):
         return parameter
 
     def __set__(self, obj, value):
+
         value = _tofloat(value)
 
         # Call the validator before the setter
@@ -775,14 +783,14 @@ class Parameter(OrderedDescriptor):
                 raise UnitsError("The '{0}' parameter should be given as a "
                                  "unitless value".format(self._name))
         else:
-            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit):
+            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit, equivalencies=self._equivalencies):
                 raise UnitsError("The '{0}' parameter should be given as a "
                                  "Quantity with units equivalent to "
                                  "{1}".format(self._name, param_unit))
             else:
                 # We need to convert the value here since the units are dropped
                 # below when setting the parameter value with np.array.
-                value = value.to(param_unit)
+                value = value.to(param_unit, equivalencies=self._equivalencies)
 
         param_slice = param_metrics['slice']
         param_shape = param_metrics['shape']

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -435,10 +435,10 @@ class Parameter(OrderedDescriptor):
         # placeholder.
         # Setting the unit on a bound parameter should only change the units
         # returned to the user when they access this parameter
-        # Try converting to the existing unit; if this fails the appropriate
-        # UnitError will be raised
-        # TODO: Do we want a more specific exception message for trying to
-        # convert a *parameter* to incompatible units?
+
+        # We now check that the new units are equivalent to the existing ones
+        # (including any equivalencies)
+
         orig_unit = self._model._param_metrics[self.name]['orig_unit']
 
         if orig_unit is None:
@@ -446,7 +446,10 @@ class Parameter(OrderedDescriptor):
                 'Cannot attach units to parameters that were not initially '
                 'specified with units')
 
-        orig_unit.to(unit)
+        if not orig_unit.is_equivalent(unit, equivalencies=self._equivalencies):
+            raise UnitsError("Cannot set parameter units to {0} since it is "
+                             "not equivalent with the original units of "
+                             "{1}".format(unit, orig_unit))
 
         self._model._param_metrics[self.name]['orig_unit'] = unit
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -17,7 +17,7 @@ import operator
 
 import numpy as np
 
-from ..units import Quantity
+from ..units import Quantity, UnitsError
 from ..utils import isiterable, OrderedDescriptor
 from ..utils.compat import ignored
 from ..extern import six
@@ -767,6 +767,23 @@ class Parameter(OrderedDescriptor):
 
         # TODO: Maybe handle exception on invalid input shape
         param_metrics = model._param_metrics[self._name]
+
+        # Check that units are compatible with default or units already set
+        param_unit = param_metrics['orig_unit']
+        if param_unit is None:
+            if isinstance(value, Quantity):
+                raise UnitsError("The '{0}' parameter should be given as a "
+                                 "unitless value".format(self._name))
+        else:
+            if not isinstance(value, Quantity) or not value.unit.is_equivalent(param_unit):
+                raise UnitsError("The '{0}' parameter should be given as a "
+                                 "Quantity with units equivalent to "
+                                 "{1}".format(self._name, param_unit))
+            else:
+                # We need to convert the value here since the units are dropped
+                # below when setting the parameter value with np.array.
+                value = value.to(param_unit)
+
         param_slice = param_metrics['slice']
         param_shape = param_metrics['shape']
         param_size = np.prod(param_shape)

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -211,7 +211,7 @@ class Parameter(OrderedDescriptor):
         self._name = name
         self.__doc__ = self._description = description.strip()
         self._default = default
-        self._default_unit = unit
+        self._unit = unit
 
         # We only need to perform this check on unbound parameters
         if (model is None and unit is not None and
@@ -325,8 +325,9 @@ class Parameter(OrderedDescriptor):
                 args += ', default={0}'.format(self._default)
         else:
             args += ', value={0}'.format(self.value)
-            if self.unit is not None:
-                args += ', unit={0}'.format(self.unit)
+
+        if self.unit is not None:
+            args += ', unit={0}'.format(self.unit)
 
         for cons in self.constraints:
             val = getattr(self, cons)
@@ -407,7 +408,7 @@ class Parameter(OrderedDescriptor):
         """
 
         if self._model is None:
-            return self._default_unit
+            return self._unit
         else:
             return self._model._param_metrics[self.name]['orig_unit']
 
@@ -656,9 +657,9 @@ class Parameter(OrderedDescriptor):
             else:
                 return types.MethodType(validator, self)
 
-    def copy(self, name=None, description=None, default=None, getter=None,
-             setter=None, fixed=False, tied=False, min=None, max=None,
-             bounds=None):
+    def copy(self, name=None, description=None, default=None, unit=None,
+             getter=None, setter=None, fixed=False, tied=False, min=None,
+             max=None, bounds=None):
         """
         Make a copy of this `Parameter`, overriding any of its core attributes
         in the process (or an exact copy).

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -98,7 +98,7 @@ class PolynomialModel(PolynomialBase):
             n_models=n_models, model_set_axis=model_set_axis, name=name,
             meta=meta, **params)
 
-    def with_units_from_data(self, x, y):
+    def with_units_from_data(self, x, y, z=None):
         """
         Return an instance of the model which has units for which the parameter
         values are compatible with the data units.
@@ -111,9 +111,14 @@ class PolynomialModel(PolynomialBase):
             for n in range(self._order):
                 name = 'c{0}'.format(n)
                 params[name] = quantity_with_unit(getattr(self, name),
-                                                  y.unit / x.unit ** (n))
+                                                  y.unit / x.unit ** n)
         else:
-            raise NotImplementedError()
+            for i in range(self._degree + 1):
+                for j in range(self._degree + 1):
+                    if i + j < self._degree + 1:
+                        name = 'c{0}_{1}'.format(i, j)
+                        params[name] = quantity_with_unit(getattr(self, name),
+                                                          z.unit / x.unit ** i / y.unit ** j)
 
         return self.__class__(**params)
 
@@ -160,13 +165,9 @@ class PolynomialModel(PolynomialBase):
             for n in range(self._order):
                 names.append('c{0}'.format(n))
         else:
-            for i in range(self.degree + 1):
-                names.append('c{0}_{1}'.format(i, 0))
-            for i in range(1, self.degree + 1):
-                names.append('c{0}_{1}'.format(0, i))
-            for i in range(1, self.degree):
-                for j in range(1, self.degree):
-                    if i + j < self.degree + 1:
+            for i in range(self._degree + 1):
+                for j in range(self._degree + 1):
+                    if i + j < self._degree + 1:
                         names.append('c{0}_{1}'.format(i, j))
         return tuple(names)
 

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -46,6 +46,8 @@ class PowerLaw1D(Fittable1DModel):
     x_0 = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha):
         """One dimensional power law model function"""
@@ -105,6 +107,8 @@ class BrokenPowerLaw1D(Fittable1DModel):
     alpha_1 = Parameter(default=1)
     alpha_2 = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_break, alpha_1, alpha_2):
         """One dimensional broken power law model function"""
@@ -161,6 +165,8 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
     alpha = Parameter(default=1)
     x_cutoff = Parameter(default=1)
 
+    output_units = 'amplitude'
+
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, x_cutoff):
         """One dimensional exponential cutoff power law model function"""
@@ -214,6 +220,8 @@ class LogParabola1D(Fittable1DModel):
     x_0 = Parameter(default=1)
     alpha = Parameter(default=1)
     beta = Parameter(default=0)
+
+    output_units = 'amplitude'
 
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, beta):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -46,6 +46,7 @@ class PowerLaw1D(Fittable1DModel):
     x_0 = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -107,6 +108,7 @@ class BrokenPowerLaw1D(Fittable1DModel):
     alpha_1 = Parameter(default=1)
     alpha_2 = Parameter(default=1)
 
+    input_units = 'x_break'
     output_units = 'amplitude'
 
     @staticmethod
@@ -165,6 +167,7 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
     alpha = Parameter(default=1)
     x_cutoff = Parameter(default=1)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod
@@ -221,6 +224,7 @@ class LogParabola1D(Fittable1DModel):
     alpha = Parameter(default=1)
     beta = Parameter(default=0)
 
+    input_units = 'x_0'
     output_units = 'amplitude'
 
     @staticmethod

--- a/astropy/modeling/tests/test_quantities.py
+++ b/astropy/modeling/tests/test_quantities.py
@@ -161,3 +161,17 @@ def test_output_units():
     assert m(0 * u.dimensionless_unscaled).unit == (1 / u.s)
     assert m(2 * u.dimensionless_unscaled).unit == (1 / u.s)
     assert m(2 * u.m).unit == (u.m / u.s)
+
+    class TestModelD(Fittable1DModel):
+        output_units = u.m
+
+        @staticmethod
+        def evaluate(x):
+            # This is a no-op model that just always forces the output to be in
+            # meters (if the input is a length)
+            return 2 * x
+
+    m = TestModelD()
+    assert m(0).unit is u.m
+    assert m(1 * u.m) == 2 * u.m
+    assert m(1 * u.km) == 2000 * u.m

--- a/astropy/modeling/tests/test_quantities.py
+++ b/astropy/modeling/tests/test_quantities.py
@@ -1,0 +1,107 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Tests specifically for models that use units and quantities."""
+
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from ..models import Gaussian1D
+from ... import units as u
+from ...units import UnitsError, Quantity
+from ...tests.helper import pytest
+
+
+def test_quantities_as_parameters():
+    """
+    Basic tests for initializing general models (that do not require units)
+    with parameters that have units attached.
+    """
+
+    g = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+    assert g.amplitude.value == 1.0
+    assert g.amplitude.unit is u.J
+    assert g.mean.value == 1.0
+    assert g.mean.unit is u.m
+    assert g.stddev.value == 0.1
+    assert g.stddev.unit is u.m
+
+
+def test_quantity_parameter_arithmetic():
+    """
+    Test that arithmetic operations with properties that have units return the
+    appropriate Quantities.
+    """
+
+    g = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    assert g.mean + (1 * u.m) == 2 * u.m
+    with pytest.raises(UnitsError):
+        g.mean + 1
+    assert (1 * u.m) + g.mean == 2 * u.m
+    with pytest.raises(UnitsError):
+        1 + g.mean
+    assert g.mean * 2 == (2 * u.m)
+    assert 2 * g.mean == (2 * u.m)
+    assert g.mean * (2 * u.m) == (2 * (u.m ** 2))
+    assert (2 * u.m) * g.mean == (2 * (u.m ** 2))
+
+    assert -g.mean == (-1 * u.m)
+    assert abs(-g.mean) == g.mean
+
+
+def test_quantity_parameter_comparison():
+    """
+    Basic test of comparison operations on properties with units.
+    """
+
+    g = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    assert g.mean == 1 * u.m
+    assert 1 * u.m == g.mean
+    assert g.mean != 1
+    assert 1 != g.mean
+
+    assert g.mean < 2 * u.m
+    assert 2 * u.m > g.mean
+    with pytest.raises(UnitsError):
+        g.mean < 2
+    with pytest.raises(UnitsError):
+        2 > g.mean
+
+    g = Gaussian1D([1, 2] * u.J, [1, 2] * u.m, [0.1, 0.2] * u.m)
+
+    assert g.mean == [1, 2] * u.m
+    assert np.all([1, 2] * u.m == g.mean)
+    assert g.mean != [1, 2]
+    assert np.all([1, 2] != g.mean)
+    with pytest.raises(UnitsError):
+        g.mean < [3, 4]
+    with pytest.raises(UnitsError):
+        [3, 4] > g.mean
+
+
+def test_basic_evaluate_with_quantities():
+    """
+    Test evaluation of a single model with Quantity parameters, that does
+    not explicitly require units.
+    """
+
+    g = Gaussian1D(1, 1, 0.1)
+    gq = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    assert isinstance(gq(0), Quantity)
+    assert gq(0).unit is u.J
+    assert g(0) == gq(0).value
+
+    # zero is allowed without explicit units, but other unitless quantities
+    # should be an exception
+    with pytest.raises(UnitsError):
+        gq(1)
+
+    assert gq(1 * u.m).value == g(1)
+
+    # Should get the same numeric result as if we multiplied by 1000
+    assert_allclose(gq(0.0005 * u.km).value, g(0.5))

--- a/astropy/modeling/tests/test_quantities.py
+++ b/astropy/modeling/tests/test_quantities.py
@@ -91,6 +91,33 @@ def test_parameter_unit_conversion_equivalencies():
     model.c = 3 * u.eV
 
 
+def test_init_equivalencies():
+    """
+    Check that equivalencies are taken into account when initializing a model
+    with quantities, if using a model where the parameters have specific
+    equivalencies defined.
+    """
+
+    class TestModel(Model):
+        a = Parameter(default=1.0, unit=u.m)
+        b = Parameter(default=1.0, unit=u.m, equivalencies=u.spectral())
+        @staticmethod
+        def evaluate(x, a):
+            return x
+
+    with pytest.raises(InputParameterError) as exc:
+        model = TestModel(a=2 * u.Hz)
+    assert exc.value.args[0] == ('TestModel.__init__() requires parameter \'a\' to '
+                                 'be in units equivalent to Unit("m") (got Unit("Hz"))')
+
+    model = TestModel(b=2 * u.Hz)
+
+    with pytest.raises(InputParameterError) as exc:
+        model = TestModel(b=2 * u.s)
+    assert exc.value.args[0] == ('TestModel.__init__() requires parameter \'b\' to '
+                                 'be in units equivalent to Unit("m") (got Unit("s"))')
+
+
 def test_parameter_unit_equivalency():
     """
     Test that we can set equivalencies on an existing model

--- a/astropy/modeling/tests/test_quantities.py
+++ b/astropy/modeling/tests/test_quantities.py
@@ -32,6 +32,37 @@ def test_quantities_as_parameters():
     assert g.stddev.unit is u.m
 
 
+def test_parameter_unit_immutable():
+    """
+    Check that units can't be changed once set
+    """
+
+    g = Gaussian1D(1 * u.J, 3, 0.1)
+
+    with pytest.raises(UnitsError) as exc:
+        g.amplitude = 2
+    assert exc.value.args[0] == "The 'amplitude' parameter should be given as a Quantity with units equivalent to J"
+
+    with pytest.raises(UnitsError) as exc:
+        g.amplitude = 2 * u.Jy
+    assert exc.value.args[0] == "The 'amplitude' parameter should be given as a Quantity with units equivalent to J"
+
+    with pytest.raises(UnitsError) as exc:
+        g.mean = 2 * u.Jy
+    assert exc.value.args[0] == "The 'mean' parameter should be given as a unitless value"
+
+
+def test_parameter_unit_conversion():
+    """
+    Check that units are converted on-the-fly if compatible
+    """
+
+    g = Gaussian1D(1 * u.Jy, 3, 0.1)
+    g.amplitude = 3000 * u.mJy
+    assert g.amplitude.value == 3
+    assert g.amplitude.unit is u.Jy
+
+
 def test_quantity_parameter_descriptors():
     """
     Test Model classes that specify units in their Parameter descriptors,

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -421,6 +421,9 @@ def test_input_units_instance_specific():
 
 @pytest.mark.xfail
 def test_input_units_equivalencies():
+    """
+    Test that input_equivalencies is recognized
+    """
 
     class TestModel(Fittable1DModel):
         input_units = u.m
@@ -441,9 +444,20 @@ def test_input_units_equivalencies():
     with u.set_enabled_equivalencies(u.spectral()):
         assert_quantity_allclose(result, 800 * u.GHz)
 
+    # And check that changing the equivalencies on-the-fly works
+    m.input_equivalencies = None
+    with pytest.raises(UnitsError) as exc:
+        m(400 * u.GHz)
+    assert exc.value.args[0] == ("Units of input 'x', GHz (frequency), could "
+                                 "not be converted to required input units of "
+                                 "m (length)")
+
 
 @pytest.mark.xfail
 def test_output_units_equivalencies():
+    """
+    Test that output_equivalencies is recognized
+    """
 
     class TestModel(Fittable1DModel):
         output_units = u.m
@@ -466,3 +480,11 @@ def test_output_units_equivalencies():
     # And we now check the actual accuracy of the result to be sure
     with u.set_enabled_equivalencies(u.spectral()):
         assert_quantity_allclose(result, 800 * u.GHz)
+
+    # And check that changing the equivalencies on-the-fly works
+    m.output_equivalencies = None
+    with pytest.raises(UnitsError) as exc:
+        m(400 * u.GHz)
+    assert exc.value.args[0] == ("Units of output 'y', GHz (frequency), could "
+                                 "not be converted to required output units of "
+                                 "m (length)")

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -1,0 +1,150 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Tests that relate to evaluating models with quantity parameters
+"""
+
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+from numpy.testing import assert_allclose
+
+
+from ..core import Fittable1DModel
+from ..parameters import Parameter
+from ..models import Gaussian1D
+from ... import units as u
+from ...units import UnitsError
+from ...tests.helper import pytest, assert_quantity_allclose
+
+
+@pytest.mark.xfail
+def test_evaluate_with_quantities():
+    """
+    Test evaluation of a single model with Quantity parameters that does
+    not explicitly require units.
+    """
+
+    # We create two models here - one with quantities, and one without. The one
+    # without is used to create the reference values for comparison.
+
+    g = Gaussian1D(1, 1, 0.1)
+    gq = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
+
+    # We first check that calling the Gaussian with quantities returns the
+    # expected result
+    assert_quantity_allclose(gq(1 * u.m), g(1) * u.J)
+
+    # Units have to be specified for the Gaussian with quantities - if not, an
+    # error is raised
+    with pytest.raises(UnitsError) as exc:
+        gq(1)
+    assert exc.value.args[0] == ("Units of input 'x', (dimensionless), could not be "
+                                 "converted to required input units of m (length)")
+
+    # However, zero is a special case
+    assert_quantity_allclose(gq(0), g(0) * u.J)
+
+    # We can also evaluate models with equivalent units
+    assert_allclose(gq(0.0005 * u.km).value, g(0.5))
+
+    # But not with incompatible units
+    with pytest.raises(UnitsError) as exc:
+        gq(3 * u.s)
+    assert exc.value.args[0] == ("Units of input 'x', s (time), could not be "
+                                 "converted to required input units of m (length)")
+
+    # We also can't evaluate the model without quantities with a quantity
+    with pytest.raises(UnitsError) as exc:
+        g(3 * u.m)
+    assert exc.value.args[0] == ("Input in m (length), could not be converted "
+                                 "to required to dimensionless input")
+
+
+@pytest.mark.xfail
+def test_evaluate_with_quantities_with_equivalencies():
+    """
+    We now make sure that equivalencies are correctly taken into account
+    """
+
+    g = Gaussian1D(1 * u.Jy, 10 * u.nm, 2 * u.nm)
+
+    # We haven't set the equivalencies yet, so this won't work
+    with pytest.raises(UnitsError) as exc:
+        g(30 * u.PHz)
+    assert exc.value.args[0] == ("Units of input 'x', PHz (frequency), could "
+                                 "not be converted to required input units of "
+                                 "nm (length)")
+
+    g.mean.equivalencies = u.spectral()
+    g.stddev.equivalencies = u.spectral()
+
+    # But it should now work
+    assert_quantity_allclose(g(30 * u.PHz), g(9.993081933333332 * u.nm))
+
+
+def test_evaluate_output_units():
+    """
+    Test multiple allowed settings for the output_units attribute
+    on a single-output model.
+    """
+
+    class TestModelA(Fittable1DModel):
+        a = Parameter()
+        output_units = 'a'
+
+        @staticmethod
+        def evaluate(x, a):
+            # For the sake of this test, the dimensions of x
+            # shouldn't matter, and the return value should be
+            # in the dimensions of the 'a' param
+            return (x / x) * a
+
+    m = TestModelA(a=1 * u.m)
+    assert m(0).unit is m.a.unit
+    assert m(1 * u.m).unit is m.a.unit
+    assert m(27 * u.s).unit is m.a.unit
+
+    class TestModelB(Fittable1DModel):
+        a = Parameter()
+        output_units = 'x'
+
+        @staticmethod
+        def evaluate(x, a):
+            # In this cfase only the input units should matter
+            return (a / a) * x
+
+    m = TestModelB(a=1 / u.s)
+    assert m(0).unit == u.dimensionless_unscaled
+    assert m(1 * u.m).unit is u.m
+
+    class TestModelC(Fittable1DModel):
+        a = Parameter()
+        output_units = lambda a, x: a.unit * x.unit
+
+        @staticmethod
+        def evaluate(x, a):
+            # In this case the output's units are some compound
+            # involving both the input and parameter's units
+            return a * x
+
+    m = TestModelC(a=1 / u.s)
+    assert m(0).unit == (1 / u.s)
+    assert m(2).unit == (1 / u.s)
+    assert m(0 * u.dimensionless_unscaled).unit == (1 / u.s)
+    assert m(2 * u.dimensionless_unscaled).unit == (1 / u.s)
+    assert m(2 * u.m).unit == (u.m / u.s)
+
+    class TestModelD(Fittable1DModel):
+        output_units = u.m
+
+        @staticmethod
+        def evaluate(x):
+            # This is a no-op model that just always forces the output to be in
+            # meters (if the input is a length)
+            return 2 * x
+
+    m = TestModelD()
+    assert m(0).unit is u.m
+    assert m(1 * u.m) == 2 * u.m
+    assert m(1 * u.km) == 2000 * u.m

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -52,6 +52,7 @@ def test_fitting_missing_data_units():
     assert exc.value.args[0] == ("Units of input 'y', (dimensionless), does not "
                                  "match required units for model output, Jy")
 
+
 @pytest.mark.xfail
 def test_fitting_missing_model_units():
     """
@@ -77,6 +78,7 @@ def test_fitting_missing_model_units():
     assert exc.value.args[0] == ("Units of input 'y', Jy, does not "
                                  "match required units for model output, "
                                  "(dimensionless)")
+
 
 @pytest.mark.xfail
 def test_fitting_incompatible_units():

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -7,7 +7,14 @@ Tests that relate to fitting models with quantity parameters
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
+import numpy as np
+
+from ..models import Gaussian1D
+from ... import units as u
+from ...units import UnitsError
+from ...tests.helper import pytest, assert_quantity_allclose
 from ...utils import NumpyRNGContext
+from .. import fitting
 
 
 # Fitting should be as intuitive as possible to the user. Essentially, models
@@ -29,7 +36,7 @@ def test_fitting_simple():
     y = y * u.Jy
 
     # Fit the data using a Gaussian with units
-    g_init = models.Gaussian1D(amplitude=1. * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
+    g_init = Gaussian1D(amplitude=1. * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
     fit_g = fitting.LevMarLSQFitter()
     g = fit_g(g_init, x, y)
 
@@ -45,16 +52,16 @@ def test_fitting_missing_data_units():
     """
     Raise an error if the model has units but the data doesn't
     """
-    g_init = models.Gaussian1D(amplitude=1. * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
+    g_init = Gaussian1D(amplitude=1. * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
     fit_g = fitting.LevMarLSQFitter()
 
     with pytest.raises(UnitsError) as exc:
-        g = fit_g(g_init, [1, 2, 3], [4, 5, 6])
+        fit_g(g_init, [1, 2, 3], [4, 5, 6])
     assert exc.value.args[0] == ("Units of input 'x', (dimensionless), does not "
                                  "match required units for model input, cm (length)")
 
     with pytest.raises(UnitsError) as exc:
-        g = fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6])
+        fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6])
     assert exc.value.args[0] == ("Units of input 'y', (dimensionless), does not "
                                  "match required units for model output, Jy")
 
@@ -67,20 +74,20 @@ def test_fitting_missing_model_units():
 
     # TODO: determine whether this breaks backward-compatibility.
 
-    g_init = models.Gaussian1D(amplitude=1., mean=3, stddev=2)
+    g_init = Gaussian1D(amplitude=1., mean=3, stddev=2)
     fit_g = fitting.LevMarLSQFitter()
 
     with pytest.raises(UnitsError) as exc:
-        g = fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6] * u.Jy)
+        fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6] * u.Jy)
     assert exc.value.args[0] == ("Units of input 'x', m (length), does not "
                                  "match required units for model input, "
                                  "(dimensionless)")
 
-    g_init = models.Gaussian1D(amplitude=1., mean=3 * u.m, stddev=2 * u.m)
+    g_init = Gaussian1D(amplitude=1., mean=3 * u.m, stddev=2 * u.m)
     fit_g = fitting.LevMarLSQFitter()
 
     with pytest.raises(UnitsError) as exc:
-        g = fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6] * u.Jy)
+        fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6] * u.Jy)
     assert exc.value.args[0] == ("Units of input 'y', Jy, does not "
                                  "match required units for model output, "
                                  "(dimensionless)")
@@ -92,11 +99,11 @@ def test_fitting_incompatible_units():
     Raise an error if the data and model have incompatible units
     """
 
-    g_init = models.Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
+    g_init = Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
     fit_g = fitting.LevMarLSQFitter()
 
     with pytest.raises(UnitsError) as exc:
-        g = fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
+        fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
     assert exc.value.args[0] == ("Units of input 'x', Hz (frequency), does not "
                                  "match required units for model input, "
                                  "m (length)")
@@ -110,7 +117,7 @@ def test_fitting_with_equivalencies():
 
     # A simple test with the spectral equivalency
 
-    g_init = models.Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
+    g_init = Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
     g_init.input_equivalencies = u.spectral()
 
     fit_g = fitting.LevMarLSQFitter()

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -10,6 +10,11 @@ from __future__ import (absolute_import, unicode_literals, division,
 from ...utils import NumpyRNGContext
 
 
+# Fitting should be as intuitive as possible to the user. Essentially, models
+# and fitting should work without units, but if one has units, the other should
+# have units too, and the resulting fitted parameters will also have units.
+
+
 @pytest.mark.xfail
 def test_fitting_simple():
 
@@ -28,7 +33,8 @@ def test_fitting_simple():
     fit_g = fitting.LevMarLSQFitter()
     g = fit_g(g_init, x, y)
 
-    # TODO: update actual numerical results, but these should be close
+    # TODO: update actual numerical results once implemented, but these should
+    # be close to the values below.
     assert_quantity_allclose(g.amplitude, 3 * u.Jy)
     assert_quantity_allclose(g.mean, 1.3 * u.m)
     assert_quantity_allclose(g.stddev, 0.8 * u.m)
@@ -59,7 +65,7 @@ def test_fitting_missing_model_units():
     Raise an error if the data has units but the model doesn't.
     """
 
-    # TODO: determine whether this breaks backward-compatibility
+    # TODO: determine whether this breaks backward-compatibility.
 
     g_init = models.Gaussian1D(amplitude=1., mean=3, stddev=2)
     fit_g = fitting.LevMarLSQFitter()
@@ -99,13 +105,32 @@ def test_fitting_incompatible_units():
 @pytest.mark.xfail
 def test_fitting_with_equivalencies():
     """
-    Raise an error if the data and model have incompatible units
+    Check that equivalencies are correctly taken into account in the fitting.
     """
+
+    # A simple test with the spectral equivalency
 
     g_init = models.Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
     g_init.input_equivalencies = u.spectral()
 
     fit_g = fitting.LevMarLSQFitter()
+
     g = fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
 
-    # TODO: check value of result
+    # TODO: numerical test of results
+
+    # A more complex test with an equivalency that depends on x values
+    g_init.output_equivalencies = u.brightness_temperature, (3e-5 * u.sr, 'x')
+
+    # Fit to data in Kelvin
+    g = fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.K)
+
+    # TODO: numerical test of results
+
+    # And we can also try with the spectral density equivalency
+    g_init.output_equivalencies = u.spectral_density, ('x',)
+
+    # Fit to data in Flambda = erg / cm^2 / s / micron
+    g = fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.erg / u.cm ** 2 / u.s / u.micron)
+
+    # TODO: numerical test of results

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -1,0 +1,109 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Tests that relate to fitting models with quantity parameters
+"""
+
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+from ...utils import NumpyRNGContext
+
+
+@pytest.mark.xfail
+def test_fitting_simple():
+
+    # Generate fake data
+    with NumpyRNGContext(12345):
+        x = np.linspace(-5., 5., 200)
+        y = 3 * np.exp(-0.5 * (x - 1.3)**2 / 0.8**2)
+        y += np.random.normal(0., 0.2, x.shape)
+
+    # Attach units to data
+    x = x * u.m
+    y = y * u.Jy
+
+    # Fit the data using a Gaussian with units
+    g_init = models.Gaussian1D(amplitude=1. * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
+    fit_g = fitting.LevMarLSQFitter()
+    g = fit_g(g_init, x, y)
+
+    # TODO: update actual numerical results, but these should be close
+    assert_quantity_allclose(g.amplitude, 3 * u.Jy)
+    assert_quantity_allclose(g.mean, 1.3 * u.m)
+    assert_quantity_allclose(g.stddev, 0.8 * u.m)
+
+
+@pytest.mark.xfail
+def test_fitting_missing_data_units():
+    """
+    Raise an error if the model has units but the data doesn't
+    """
+    g_init = models.Gaussian1D(amplitude=1. * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
+    fit_g = fitting.LevMarLSQFitter()
+
+    with pytest.raises(UnitsError) as exc:
+        g = fit_g(g_init, [1, 2, 3], [4, 5, 6])
+    assert exc.value.args[0] == ("Units of input 'x', (dimensionless), does not "
+                                 "match required units for model input, cm (length)")
+
+    with pytest.raises(UnitsError) as exc:
+        g = fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6])
+    assert exc.value.args[0] == ("Units of input 'y', (dimensionless), does not "
+                                 "match required units for model output, Jy")
+
+@pytest.mark.xfail
+def test_fitting_missing_model_units():
+    """
+    Raise an error if the data has units but the model doesn't.
+    """
+
+    # TODO: determine whether this breaks backward-compatibility
+
+    g_init = models.Gaussian1D(amplitude=1., mean=3, stddev=2)
+    fit_g = fitting.LevMarLSQFitter()
+
+    with pytest.raises(UnitsError) as exc:
+        g = fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6] * u.Jy)
+    assert exc.value.args[0] == ("Units of input 'x', m (length), does not "
+                                 "match required units for model input, "
+                                 "(dimensionless)")
+
+    g_init = models.Gaussian1D(amplitude=1., mean=3 * u.m, stddev=2 * u.m)
+    fit_g = fitting.LevMarLSQFitter()
+
+    with pytest.raises(UnitsError) as exc:
+        g = fit_g(g_init, [1, 2, 3] * u.m, [4, 5, 6] * u.Jy)
+    assert exc.value.args[0] == ("Units of input 'y', Jy, does not "
+                                 "match required units for model output, "
+                                 "(dimensionless)")
+
+@pytest.mark.xfail
+def test_fitting_incompatible_units():
+    """
+    Raise an error if the data and model have incompatible units
+    """
+
+    g_init = models.Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
+    fit_g = fitting.LevMarLSQFitter()
+
+    with pytest.raises(UnitsError) as exc:
+        g = fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
+    assert exc.value.args[0] == ("Units of input 'x', Hz (frequency), does not "
+                                 "match required units for model input, "
+                                 "m (length)")
+
+
+@pytest.mark.xfail
+def test_fitting_with_equivalencies():
+    """
+    Raise an error if the data and model have incompatible units
+    """
+
+    g_init = models.Gaussian1D(amplitude=1. * u.Jy, mean=3 * u.m, stddev=2 * u.cm)
+    g_init.input_equivalencies = u.spectral()
+
+    fit_g = fitting.LevMarLSQFitter()
+    g = fit_g(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
+
+    # TODO: check value of result

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -1,19 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""Tests specifically for models that use units and quantities."""
+"""
+Tests that relate to using quantities/units on parameters of models.
+"""
 
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 import numpy as np
-from numpy.testing import assert_allclose
 
-
-from ..core import Model, Fittable1DModel, ModelDefinitionError, InputParameterError
+from ..core import Model, Fittable1DModel, InputParameterError
 from ..parameters import Parameter, ParameterDefinitionError
 from ..models import Gaussian1D
 from ... import units as u
-from ...units import UnitsError, Quantity
+from ...units import UnitsError
 from ...tests.helper import pytest, assert_quantity_allclose
 
 class BaseTestModel(Fittable1DModel):
@@ -21,12 +21,6 @@ class BaseTestModel(Fittable1DModel):
     def evaluate(x, a):
         return x
 
-# Parameters
-# ----------
-#
-# The first set of tests below relate to using quantities/units on parameters of
-# models. The purpose of each test is described in the docstring and in comments
-# in the tests.
 
 def test_parameter_quantity():
     """
@@ -140,7 +134,7 @@ def test_parameter_equivalencies_used_in_init():
     model = TestModel(b=2 * u.Hz)
 
     with pytest.raises(InputParameterError) as exc:
-        model = TestModel(b=2 * u.s)
+        TestModel(b=2 * u.s)
     assert exc.value.args[0] == ('TestModel.__init__() requires parameter \'b\' to '
                                  'be in units equivalent to Unit("m") (got Unit("s"))')
 
@@ -399,144 +393,3 @@ def test_parameter_quantity_comparison():
                                  "dimensionless quantities when other argument "
                                  "is not a quantity (unless the latter is all "
                                  "zero/infinity/nan)")
-
-
-# Model evaluation
-# ----------------
-#
-# Now that we've checked that parameters deal properly with quantities, we can
-# move on to check that evaluating models with parameters that are quantities
-# works as expected.
-
-@pytest.mark.xfail
-def test_evaluate_with_quantities():
-    """
-    Test evaluation of a single model with Quantity parameters that does
-    not explicitly require units.
-    """
-
-    # We create two models here - one with quantities, and one without. The one
-    # without is used to create the reference values for comparison.
-
-    g = Gaussian1D(1, 1, 0.1)
-    gq = Gaussian1D(1 * u.J, 1 * u.m, 0.1 * u.m)
-
-    # We first check that calling the Gaussian with quantities returns the
-    # expected result
-    result = gq(1 * u.m)
-    assert_quantity_allclose(gq(1 * u.m), g(1) * u.J)
-
-    # Units have to be specified for the Gaussian with quantities - if not, an
-    # error is raised
-    with pytest.raises(UnitsError) as exc:
-        gq(1)
-    assert exc.value.args[0] == ("Units of input 'x', (dimensionless), could not be "
-                                 "converted to required input units of m (length)")
-
-    # However, zero is a special case
-    result = gq(0)
-    assert_quantity_allclose(gq(0), g(0) * u.J)
-
-    # We can also evaluate models with equivalent units
-    assert_allclose(gq(0.0005 * u.km).value, g(0.5))
-
-    # But not with incompatible units
-    with pytest.raises(UnitsError) as exc:
-        gq(3 * u.s)
-    assert exc.value.args[0] == ("Units of input 'x', s (time), could not be "
-                                 "converted to required input units of m (length)")
-
-    # We also can't evaluate the model without quantities with a quantity
-    with pytest.raises(UnitsError) as exc:
-        g(3 * u.m)
-    assert exc.value.args[0] == ("Input in m (length), could not be converted "
-                                 "to required to dimensionless input")
-
-
-@pytest.mark.xfail
-def test_evaluate_with_quantities_with_equivalencies():
-    """
-    We now make sure that equivalencies are correctly taken into account
-    """
-
-    g = Gaussian1D(1 * u.Jy, 10 * u.nm, 2 * u.nm)
-
-    # We haven't set the equivalencies yet, so this won't work
-    with pytest.raises(UnitsError) as exc:
-        g(30 * u.PHz)
-    assert exc.value.args[0] == ("Units of input 'x', PHz (frequency), could "
-                                 "not be converted to required input units of "
-                                 "nm (length)")
-
-    g.mean.equivalencies = u.spectral()
-    g.stddev.equivalencies = u.spectral()
-
-    # But it should now work
-    assert_quantity_allclose(g(30 * u.PHz), g(9.993081933333332 * u.nm))
-
-
-def test_evaluate_output_units():
-    """
-    Test multiple allowed settings for the output_units attribute
-    on a single-output model.
-    """
-
-    class TestModelA(Fittable1DModel):
-        a = Parameter()
-        output_units = 'a'
-
-        @staticmethod
-        def evaluate(x, a):
-            # For the sake of this test, the dimensions of x
-            # shouldn't matter, and the return value should be
-            # in the dimensions of the 'a' param
-            return (x / x) * a
-
-    m = TestModelA(a=1 * u.m)
-    assert m(0).unit is m.a.unit
-    assert m(1 * u.m).unit is m.a.unit
-    assert m(27 * u.s).unit is m.a.unit
-
-    class TestModelB(Fittable1DModel):
-        a = Parameter()
-        output_units = 'x'
-
-        @staticmethod
-        def evaluate(x, a):
-            # In this cfase only the input units should matter
-            return (a / a) * x
-
-    m = TestModelB(a=1 / u.s)
-    assert m(0).unit == u.dimensionless_unscaled
-    assert m(1 * u.m).unit is u.m
-
-    class TestModelC(Fittable1DModel):
-        a = Parameter()
-        output_units = lambda a, x: a.unit * x.unit
-
-        @staticmethod
-        def evaluate(x, a):
-            # In this case the output's units are some compound
-            # involving both the input and parameter's units
-            return a * x
-
-    m = TestModelC(a=1 / u.s)
-    assert m(0).unit == (1 / u.s)
-    assert m(2).unit == (1 / u.s)
-    assert m(0 * u.dimensionless_unscaled).unit == (1 / u.s)
-    assert m(2 * u.dimensionless_unscaled).unit == (1 / u.s)
-    assert m(2 * u.m).unit == (u.m / u.s)
-
-    class TestModelD(Fittable1DModel):
-        output_units = u.m
-
-        @staticmethod
-        def evaluate(x):
-            # This is a no-op model that just always forces the output to be in
-            # meters (if the input is a length)
-            return 2 * x
-
-    m = TestModelD()
-    assert m(0).unit is u.m
-    assert m(1 * u.m) == 2 * u.m
-    assert m(1 * u.km) == 2000 * u.m

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -16,6 +16,7 @@ from ..extern.six.moves import xrange, zip_longest
 
 from ..utils import isiterable
 from ..utils.compat.funcsigs import signature
+from ..units import dimensionless_unscaled
 
 
 __all__ = ['ExpressionTree', 'AliasDict', 'check_broadcast',
@@ -655,3 +656,14 @@ def get_inputs_and_params(func):
             params.append(param)
 
     return inputs, params
+
+
+def format_unit_with_type(unit):
+    """
+    Returns a string-formatted unit with its physical dimension in parentheses.
+    """
+
+    if unit == dimensionless_unscaled:
+        return '({0})'.format(unit.physical_type)
+    else:
+        return '{0} ({1})'.format(unit, unit.physical_type)


### PR DESCRIPTION
### Read me first!

This is a rebased continuation of @embray's https://github.com/astropy/astropy/pull/3852, and is still a work in progress, but I'll be pushing from time to time to make sure the CI doesn't break.

**At this stage please only review the tests, which show a proposed API - do not comment on implementation (which is incomplete)**

To-dos (some to-do list items are taken from @embray's list) - not all have to be done for this PR
- [ ] Support compound model/model arithmetic (check that units match/are equivalent)
- [ ] More sophisticated unit specs for parameters
- [ ] Ability to override `input_units`/`output_units` per instance
- [ ] Should we take into account all active equivalencies at model creation time?
- [ ] Implement more unit specs on built-in models
- [ ] Remove getter/setter attributes of `Parameter`? (see #3852)
- [ ] Implement @mhvk's comments from #3852
- [ ] Support for fitting
