### PR TITLE
Be more specific regarding which exception to catch in data_utils.py

### DIFF
--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -114,7 +114,7 @@ def data_info_factory(names, funcs):
                     out = getattr(dat, func)()
                 else:
                     out = func(dat)
-            except:
+            except TypeError:
                 outs.append('--')
             else:
                 outs.append(str(out))


### PR DESCRIPTION
@taldcroft - while debugging an issue which ended up being due to https://github.com/numpy/numpy/pull/7312, I noticed that this line was catching *all* exceptions, and hiding the numpy-dev issue. I think the intent was this was to make sure that string columns and other non-numerical columns didn't cause crashes, so I thought maybe we could be more specific?