### PR TITLE
Add function to remove duplicate rows in a Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ New Features
     yield tables with an "idx" column, allowing easy identification of the index
     of a row even when the table is re-sorted in the browser. [#4404]
 
+  - New function ``operations.remove_duplicate_rows``, which can delete *all*
+	duplicate rows (in contrast to ``operations.unique``). [#4617]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -21,7 +21,8 @@ conf = Conf()
 from .column import Column, MaskedColumn
 from .groups import TableGroups, ColumnGroups
 from .table import Table, QTable, TableColumns, Row, TableFormatter, NdarrayMixin
-from .operations import join, hstack, vstack, unique, TableMergeError
+from .operations import (join, hstack, vstack, unique, remove_duplicate_rows,
+                         TableMergeError)
 from .jsviewer import JSViewer
 from .bst import BST, FastBST, FastRBT
 from .sorted_array import SortedArray


### PR DESCRIPTION
This function is similar to table.operations.unique, except that it
can remove *all* duplicate rows, thus only keeping rows that never had
a duplicate in the input table. [#4617]
