### PR TITLE
Allow data as explicit parameter to NDDataArray

### DIFF
--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -81,12 +81,12 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         shape) onto ``data``.
     """
 
-    def __init__(self, *arg, **kwd):
+    def __init__(self, data, *args, **kwd):
         # Remove the flag argument from input.
         flags = kwd.pop('flags', None)
 
         # Initialize with the parent...
-        super(NDDataArray, self).__init__(*arg, **kwd)
+        super(NDDataArray, self).__init__(data, *args, **kwd)
 
         # ...then reset uncertainty to force it to go through the
         # setter logic below. In base NDData all that is done is to
@@ -98,7 +98,6 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
 
         # Initial flags because it is no longer handled in NDData
         # or NDDataBase.
-        data = arg[0]  # do this after parent __init__, to validate the args
         if isinstance(data, NDDataArray):
             if flags is None:
                 flags = data.flags

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -30,6 +30,27 @@ def test_nddata_simple():
     assert nd.dtype == np.dtype(float)
 
 
+def test_nddata_parameters():
+    # Test for issue 4620
+    nd = NDDataArray(data=np.zeros((10, 10)))
+    assert nd.shape == (10, 10)
+    assert nd.size == 100
+    assert nd.dtype == np.dtype(float)
+    # Change order; `data` has to be given explicitly here
+    nd = NDDataArray(meta={}, data=np.zeros((10, 10)))
+    assert nd.shape == (10, 10)
+    assert nd.size == 100
+    assert nd.dtype == np.dtype(float)
+    # Pass uncertainty as second implicit argument
+    data = np.zeros((10, 10))
+    uncertainty = StdDevUncertainty(0.1 + np.zeros_like(data))
+    nd = NDDataArray(data, uncertainty)
+    assert nd.shape == (10, 10)
+    assert nd.size == 100
+    assert nd.dtype == np.dtype(float)
+    assert nd.uncertainty == uncertainty
+
+
 def test_nddata_conversion():
     nd = NDDataArray(np.array([[1, 2, 3], [4, 5, 6]]))
     assert nd.size == 6


### PR DESCRIPTION
This is a possible fix for issue #4620 