### PR TITLE
Disable initial ordering in jsviewer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -399,6 +399,9 @@ Bug Fixes
   - Fixed bug when replacing a table column with a mixin column like
     Quantity or Time. [#4601]
 
+  - Disable initial ordering in jsviewer (``show_in_browser``,
+    ``show_in_notebook``) to respect the order from the Table. [#4628]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -41,6 +41,7 @@ require.config({{paths: {{
 require(["datatables"], function(){{
     console.log("$('#{tid}').dataTable()");
     $('#{tid}').dataTable({{
+        "order": [],
         "iDisplayLength": {display_length},
         "aLengthMenu": {display_length_menu},
         "pagingType": "full_numbers"
@@ -52,9 +53,10 @@ require(["datatables"], function(){{
 HTML_JS_SCRIPT = """
 $(document).ready(function() {{
     $('#{tid}').dataTable({{
-     "iDisplayLength": {display_length},
-     "aLengthMenu": {display_length_menu},
-     "pagingType": "full_numbers"
+        "order": [],
+        "iDisplayLength": {display_length},
+        "aLengthMenu": {display_length_menu},
+        "pagingType": "full_numbers"
     }});
 }} );
 """

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -34,9 +34,10 @@ table.dataTable {width: auto !important; margin: 0 !important;}
   <script>
 $(document).ready(function() {
     $('#%(table_id)s').dataTable({
-     "iDisplayLength": %(length)s,
-     "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
-     "pagingType": "full_numbers"
+        "order": [],
+        "iDisplayLength": %(length)s,
+        "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
+        "pagingType": "full_numbers"
     });
 } );  </script>
   <table class="%(table_class)s" id="%(table_id)s">


### PR DESCRIPTION
By default dataTables sort in ascending order with the first column, though it
seems more appropriate to keep the original table order.

Ref http://datatables.net/reference/option/order

Also ref #4404 which added an index column. When this column is present the
original order is respected, but then a useless sort is done by dataTables so it
is also a good idea to disable the initial sort.

cc @eteq @taldcroft 