### PR TITLE
Correct `cast ufunc add` TypeError when opening compressed files

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1404,7 +1404,7 @@ class CompImageHDU(BinTableHDU):
             if self._bscale != 1:
                 np.multiply(data, self._bscale, data)
             if self._bzero != 0:
-                data += self._bzero
+                data += new_dtype.type(self._bzero)
 
             if zblank is not None:
                 data = np.where(blanks, np.nan, data)


### PR DESCRIPTION
This is a partial fix for #4588. It forces the `BZERO` value to be of the same type of the compressed image data.