### PR TITLE
Add `keep` keyword to table.operations.unique()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,10 @@ API changes
 
 - ``astropy.table``
 
+  - ``operations.unique`` now has a ``keep`` parameter, which allows
+    one to select whether to keep the first or last row in a set of
+    duplicate rows, or to remove all rows that are duplicates. [#4632]
+
 - ``astropy.tests``
 
 - ``astropy.time``


### PR DESCRIPTION
The `keep` keyword allows one to specify whether to keep the first or
last row in a set of duplicate rows, or remove all duplicate rows
altogether (keep='none').