### PR TITLE
io.fits: allow limiting the number of read extensions

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -188,6 +188,7 @@ def getdata(filename, *args, **kwargs):
     data = hdu.data
     if data is None and extidx == 0:
         try:
+            hdulist, extidx = _getext(filename, mode, ext=1, *args, **kwargs)
             hdu = hdulist[1]
             data = hdu.data
         except IndexError:
@@ -753,7 +754,7 @@ def _getext(filename, mode, *args, **kwargs):
     elif extver and extname is None:
         raise TypeError('extver alone cannot specify an extension.')
 
-    hdulist = fitsopen(filename, mode=mode, **kwargs)
+    hdulist = fitsopen(filename, mode=mode, ext=ext, **kwargs)
 
     return hdulist, ext
 


### PR DESCRIPTION
In the convenience functions only read as many extensions as necessary
to satisfy the users request. This can greatly increase performance when
one is only interested in an early subset of extensions.
It adds the `ext` keyword to the fitsopen function so it will also be
accepted by the top level fits.open function, but this is an
implementational detail and not documented.

Closes gh-4589