### PR TITLE
4-6% speedup in "angular_separation" by using hypot ufunc

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -655,7 +655,7 @@ def angular_separation(lon1, lat1, lon2, lat2):
     num2 = clat1 * slat2 - slat1 * clat2 * cdlon
     denominator = slat1 * slat2 + clat1 * clat2 * cdlon
 
-    return np.arctan2(np.sqrt(num1 ** 2 + num2 ** 2), denominator)
+    return np.arctan2(np.hypot(num1,num2), denominator)
 
 
 def position_angle(lon1, lat1, lon2, lat2):


### PR DESCRIPTION
4-6% speedup observed in angular_separation computation by using ```numpy.hypot(x,y)``` instead of ```numpy.sqrt(x**2 + y**2)```