### PR TITLE
Fix img.scale for scaled integer data (#4600, #4588) - alternative to #4602

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,10 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Avoid new exceptions with numpy >= 1.10 when using scaled integer data:
+    where BZERO has float type but integer value or where data is unsigned int.
+    [#4600, #4588, #4602, #4639]
+  
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -663,6 +663,12 @@ class CompImageHDU(BinTableHDU):
         self._orig_bscale = self._bscale
         self._orig_bitpix = self._bitpix
 
+        # If BZERO is consistent with being an integer, explicitly set it to
+        # integer type so that in-place operations on integer data arrays work
+        if self._bzero == int(self._bzero):
+            self._bzero = int(self._bzero)
+
+
     @classmethod
     def match_header(cls, header):
         card = header.cards[0]
@@ -1739,6 +1745,11 @@ class CompImageHDU(BinTableHDU):
         if type is None:
             type = BITPIX2DTYPE[self._bitpix]
         _type = getattr(np, type)
+
+        # If BZERO is consistent with being an integer, explicitly set it to
+        # integer type so that in-place operations on integer data arrays work
+        if bzero == int(bzero):
+            bzero = int(bzero)
 
         # Determine how to scale the data
         # bscale and bzero takes priority

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1779,7 +1779,7 @@ class CompImageHDU(BinTableHDU):
 
         # Do the scaling
         if _zero != 0:
-            self.data += -_zero
+            self.data -= _zero
             self.header['BZERO'] = _zero
         else:
             # Delete from both headers

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -129,6 +129,11 @@ class _ImageBaseHDU(_ValidHDU):
         self._orig_bzero = self._bzero
         self._orig_bscale = self._bscale
 
+        # If BZERO is consistent with being an integer, explicitly set it to
+        # integer type so that in-place operations on integer data arrays work
+        if self._bzero == int(self._bzero):
+            self._bzero = int(self._bzero)
+
         # Set the name attribute if it was provided (if this is an ImageHDU
         # this will result in setting the EXTNAME keyword of the header as
         # well)
@@ -483,6 +488,9 @@ class _ImageBaseHDU(_ValidHDU):
             type = BITPIX2DTYPE[self._bitpix]
         _type = getattr(np, type)
 
+        if bzero == int(bzero):
+            bzero = int(bzero)
+
         # Determine how to scale the data
         # bscale and bzero takes priority
         if (bscale != 1 or bzero != 0):
@@ -555,6 +563,12 @@ class _ImageBaseHDU(_ValidHDU):
         self._orig_bzero = self._bzero
         self._orig_bscale = self._bscale
         self._orig_blank = self._blank
+
+        # If BZERO is consistent with being an integer, explicitly set it to
+        # integer type so that in-place operations on integer data arrays work
+        if self._bzero == int(self._bzero):
+            self._bzero = int(self._bzero)
+
 
     def _verify(self, option='warn'):
         # update_header can fix some things that would otherwise cause

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -522,7 +522,7 @@ class _ImageBaseHDU(_ValidHDU):
         # Do the scaling
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
-            self.data += -_zero
+            self.data -= _zero
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -19,6 +19,7 @@ from .test_table import comparerecords
 
 from . import FitsTestCase
 
+NUMPY_LT_1P10 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 10]
 
 class TestImageFunctions(FitsTestCase):
     def test_constructor_name_arg(self):
@@ -1010,7 +1011,8 @@ class TestImageFunctions(FitsTestCase):
 
         hdu0 = fits.PrimaryHDU(data=a.copy())
         # Ensure this behaviour is preserved
-        pytest.raises(TypeError, hdu0.scale, 'int16', bzero=99.9)
+        if not NUMPY_LT_1P10:
+            pytest.raises(TypeError, hdu0.scale, 'int16', bzero=99.9)
 
         hdu1 = fits.PrimaryHDU(data=a.copy())
         hdu2 = fits.PrimaryHDU(data=a.copy())
@@ -1595,7 +1597,8 @@ class TestCompressedImage(FitsTestCase):
 
         hdu0 = fits.CompImageHDU(data=a.copy())
         # Ensure this behaviour is preserved
-        pytest.raises(TypeError, hdu0.scale, 'int16', bzero=99.9)
+        if not NUMPY_LT_1P10:
+            pytest.raises(TypeError, hdu0.scale, 'int16', bzero=99.9)
 
         hdu1 = fits.CompImageHDU(data=a.copy())
         hdu2 = fits.CompImageHDU(data=a.copy())

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1022,6 +1022,21 @@ class TestImageFunctions(FitsTestCase):
         hdu2.scale('int16', bzero=99)
         assert np.allclose(hdu1.data, hdu2.data)
 
+    def test_scale_back_uint_assignment(self):
+        """
+        Extend fix for #4600 to assignment to data
+
+        Suggested by:
+        https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+        """
+
+        a = np.arange(100, 200, dtype=np.uint16)
+        fits.PrimaryHDU(a).writeto(self.temp('test.fits'))
+        with fits.open(self.temp('test.fits'), mode="update",
+                       scale_back=True) as (hdu,):
+            hdu.data[:] = 0
+            assert np.allclose(hdu.data, 0)
+
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):
@@ -1607,3 +1622,21 @@ class TestCompressedImage(FitsTestCase):
         hdu1.scale('int16', bzero=99.0)
         hdu2.scale('int16', bzero=99)
         assert np.allclose(hdu1.data, hdu2.data)
+
+    def test_scale_back_compressed_uint_assignment(self):
+        """
+        Extend fix for #4600 to assignment to data
+
+        Identical to test_scale_back_uint_assignment() but uses a compressed
+        image.
+
+        Suggested by:
+        https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+        """
+
+        a = np.arange(100, 200, dtype=np.uint16)
+        fits.CompImageHDU(a).writeto(self.temp('test.fits'))
+        with fits.open(self.temp('test.fits'), mode="update",
+                       scale_back=True) as hdul:
+            hdul[1].data[:] = 0
+            assert np.allclose(hdul[1].data, 0)


### PR DESCRIPTION
Avoid exceptions in img.scale for scaled integer data and float BZERO,
and also for compressed scaled integer (e.g. uint) data.

The fix casts bzero to an integer type whenever that does not involve
a loss of precision (i.e. when bzero is a float type representation of
an integer).  An exception will still arise when using a non-integer
bzero while insisting on an integer data array, as the correct
behaviour is uncertain.  See #4602 for discussion.  The cast to
integer occurs after the original bzero is stored, so that checksum
tests still pass.

New regression tests are included.  All existing tests pass.
