### PR TITLE
Fix AASTexData py2.6  incompatibility/performance boost

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -382,9 +382,6 @@ class AASTexData(LatexData):
     def start_line(self, lines):
         return find_latex_line(lines, self.data_start) + 1
 
-
-    _write_subre = re.compile(r'\s* \\ \\ \s* $', flags=re.VERBOSE)
-
     def write(self, lines):
         lines.append(self.data_start)
         lines_length_initial = len(lines)
@@ -392,7 +389,9 @@ class AASTexData(LatexData):
         # To remove extra space(s) and // appended which creates an extra new line
         # in the end.
         if len(lines) > lines_length_initial:
-            lines[-1] = re.sub(self._write_subre, '', lines[-1])
+            # we compile separately because py2.6 doesn't have a flags keyword in re.sub
+            re_final_line = re.compile(r'\s* \\ \\ \s* $', flags=re.VERBOSE)
+            lines[-1] = re.sub(re_final_line, '', lines[-1])
         lines.append(self.data_end)
         add_dictval_to_list(self.latex, 'tablefoot', lines)
         lines.append(r'\end{' + self.latex['tabletype'] + r'}')

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -382,6 +382,9 @@ class AASTexData(LatexData):
     def start_line(self, lines):
         return find_latex_line(lines, self.data_start) + 1
 
+
+    _write_subre = re.compile(r'\s* \\ \\ \s* $', flags=re.VERBOSE)
+
     def write(self, lines):
         lines.append(self.data_start)
         lines_length_initial = len(lines)
@@ -389,7 +392,7 @@ class AASTexData(LatexData):
         # To remove extra space(s) and // appended which creates an extra new line
         # in the end.
         if len(lines) > lines_length_initial:
-            lines[-1] = re.sub(r'\s* \\ \\ \s* $', '', lines[-1], flags=re.VERBOSE)
+            lines[-1] = re.sub(self._write_subre, '', lines[-1])
         lines.append(self.data_end)
         add_dictval_to_list(self.latex, 'tablefoot', lines)
         lines.append(r'\end{' + self.latex['tabletype'] + r'}')


### PR DESCRIPTION
This is a slight adjustment to the change introduced in #4561 .  It just pre-compiles the regex into an object that is then re-used in the ``re.sub`` call.  While this is probably a trivial improvement on it's own, it has a much more important effect when backported to v1.1.x and v1.0.x: it fixes a py2.6 incompatibility introcued in #4561.  It turns out that the ``flags`` keyword is not in ``re.sub`` in py2.6.  So this PR works around that by using the compiled regex instead of compiling it as part of the `re.sub` call.

In principal this could be put *only* in v1.0.x/v1.1.x... But I think it's better to put it in master, as it has no downside and might be a performance improvement.  Any opinions on that, @astrofrog or @taldcroft ?

(note that no changelog entry is needed because #4561 has not been in a release yet)