### PR TITLE
Adding testing against numpy prerelease

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,10 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
 
+        # Try pre-release version of Numpy without optional dependencies
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test'
+
         # Do a PEP8 test
         - os: linux
           env: PYTHON_VERSION=2.7 MAIN_CMD='pep8 astropy --count' SETUP_CMD=''


### PR DESCRIPTION
Numpy pre-releases are now uploaded to pypi, so we can test against them as discussed on the mailing list and in https://github.com/astropy/ci-helpers/pull/59.

I've handled it as the other numpy versions (without optional dependencies, with python 2.7).