### PR TITLE
Test stable numpy (1.10) in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautiful-soup ipython'
@@ -77,6 +77,8 @@ matrix:
                LC_CTYPE=C.ascii LC_ALL=C.ascii
 
         # Try older numpy versions without optional dependencies
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
         - os: linux

--- a/docs/coordinates/observing-example.rst
+++ b/docs/coordinates/observing-example.rst
@@ -130,8 +130,8 @@ azimuth::
 
     plt.plot(delta_midnight, sunaltazs.alt, color='y', label='Sun')
     plt.scatter(delta_midnight, m33altazs.alt, c=m33altazs.az, label='M33', lw=0, s=8)
-    plt.fill_between(delta_midnight, 0, 90, sunaltazs.alt < -0*u.deg, color='0.5', zorder=0)
-    plt.fill_between(delta_midnight, 0, 90, sunaltazs.alt < -18*u.deg, color='k', zorder=0)
+    plt.fill_between(delta_midnight.to(u.hr).value, 0, 90, sunaltazs.alt < -0*u.deg, color='0.5', zorder=0)
+    plt.fill_between(delta_midnight.to(u.hr).value, 0, 90, sunaltazs.alt < -18*u.deg, color='k', zorder=0)
     plt.colorbar().set_label('Azimuth [deg]')
     plt.legend(loc='upper left')
     plt.xlim(-12, 12)


### PR DESCRIPTION
Our travis test matrix is getting a bit out of data, and even with numpy 1.10 there are sphinx build errors, due to quantity/array interaction. These are solved in the first commit; the second moves the default numpy in travis tests to `stable`.