### PR TITLE
Reduce import time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -260,6 +260,7 @@ Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Python 2.6 is no longer supported. [#4486]
+- Reduce Astropy's import time (``import astropy``) by almost a factor 2. [#4649]
 
 
 1.1.2 (unreleased)

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -550,6 +550,8 @@ class StreamHandler(logging.StreamHandler):
         if record.levelno < logging.DEBUG or not _conf.use_color:
             print(record.levelname, end='', file=stream)
         else:
+            # Import utils.console only if necessary and at the latest because
+            # the import takes a significant time [#4649]
             from .utils.console import color_print
             if record.levelno < logging.INFO:
                 color_print(record.levelname, 'magenta', end='', file=stream)

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -14,7 +14,6 @@ from . import config as _config
 from . import conf as _conf
 from .extern.six import PY3, text_type
 from .utils import find_current_module
-from .utils.console import color_print
 from .utils.exceptions import AstropyWarning, AstropyUserWarning
 
 __all__ = ['Conf', 'conf', 'log', 'AstropyLogger', 'LoggingError']
@@ -550,14 +549,16 @@ class StreamHandler(logging.StreamHandler):
 
         if record.levelno < logging.DEBUG or not _conf.use_color:
             print(record.levelname, end='', file=stream)
-        elif(record.levelno < logging.INFO):
-            color_print(record.levelname, 'magenta', end='', file=stream)
-        elif(record.levelno < logging.WARN):
-            color_print(record.levelname, 'green', end='', file=stream)
-        elif(record.levelno < logging.ERROR):
-            color_print(record.levelname, 'brown', end='', file=stream)
         else:
-            color_print(record.levelname, 'red', end='', file=stream)
+            from .utils.console import color_print
+            if record.levelno < logging.INFO:
+                color_print(record.levelname, 'magenta', end='', file=stream)
+            elif record.levelno < logging.WARN:
+                color_print(record.levelname, 'green', end='', file=stream)
+            elif record.levelno < logging.ERROR:
+                color_print(record.levelname, 'brown', end='', file=stream)
+            else:
+                color_print(record.levelname, 'red', end='', file=stream)
         record.message = "{0} [{1:s}]".format(record.msg, record.origin)
         print(": " + record.message, file=stream)
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -438,6 +438,8 @@ def human_file_size(size):
         A human-friendly representation of the size of the file
     """
     if hasattr(size, 'unit'):
+        # Import units only if necessary because the import takes a
+        # significant time [#4649]
         from .. import units as u
         size = size.to(u.byte).value
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -74,7 +74,6 @@ else:
 from ..extern import six
 from ..extern.six.moves import range
 from .. import conf
-from .. import units as u
 
 from .misc import isiterable
 
@@ -439,6 +438,7 @@ def human_file_size(size):
         A human-friendly representation of the size of the file
     """
     if hasattr(size, 'unit'):
+        from .. import units as u
         size = size.to(u.byte).value
 
     suffixes = ' kMGTPEZY'


### PR DESCRIPTION
Ref  #4598

- Avoid to import `utils.console` in the logger setup. The import will be done when the first logging message is printed.
- I also moved the units import in `utils.console` to a local one. With the previous change it is useless, but I think it may still be useful on some cases or for command-line scripts (when Spinner or ProgressBar are used).

With these changes, the import time goes down from ~480ms to ~250ms on my laptop. The remaining time is mostly in developer specific stuff (subprocess call to get the git hash for the version string), so the import time will be even better for released package.
