### PR TITLE
add missing check to ensure zest entry points aren't global

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -417,7 +417,7 @@ Bug Fixes
 
   - Fixed latex representation of function units. [#4563]
 
-  - The `zest.releaser` hooks included in Astropy are now  entirely local to
+  - The ``zest.releaser`` hooks included in Astropy are now  entirely local to
     Astropy, rather than one of them being global. [#4650]
 
 - ``astropy.visualization``
@@ -1199,7 +1199,7 @@ Bug Fixes
 
 - ``astropy.utils``
 
-  - The `zest.releaser` hooks included in Astropy are now  entirely local to
+  - The ``zest.releaser`` hooks included in Astropy are now  entirely local to
     Astropy, rather than one of them being global. [#4650]
 
 - ``astropy.vo``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -417,8 +417,8 @@ Bug Fixes
 
   - Fixed latex representation of function units. [#4563]
 
-  - The ``zest.releaser`` hooks included in Astropy are now  entirely local to
-    Astropy, rather than one of them being global. [#4650]
+  - The ``zest.releaser`` hooks included in Astropy are now injected locally to
+    Astropy, rather than being global. [#4650]
 
 - ``astropy.visualization``
 
@@ -1199,8 +1199,8 @@ Bug Fixes
 
 - ``astropy.utils``
 
-  - The ``zest.releaser`` hooks included in Astropy are now  entirely local to
-    Astropy, rather than one of them being global. [#4650]
+  - The ``zest.releaser`` hooks included in Astropy are now injected locally to
+    Astropy, rather than being global. [#4650]
 
 - ``astropy.vo``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -417,6 +417,9 @@ Bug Fixes
 
   - Fixed latex representation of function units. [#4563]
 
+  - The `zest.releaser` hooks included in Astropy are now  entirely local to
+    Astropy, rather than one of them being global. [#4650]
+
 - ``astropy.visualization``
 
   - Fixed ``fits2bitmap`` script to allow ext flag to contain extension
@@ -1195,6 +1198,9 @@ Bug Fixes
   - Fixed latex representation of function units. [#4563]
 
 - ``astropy.utils``
+
+  - The `zest.releaser` hooks included in Astropy are now  entirely local to
+    Astropy, rather than one of them being global. [#4650]
 
 - ``astropy.vo``
 

--- a/astropy/utils/release.py
+++ b/astropy/utils/release.py
@@ -19,10 +19,6 @@ def prereleaser_middle(data):
     zest.releaser already does this normally but it's a little inflexible about
     the format.
     """
-
-    if data['name'] != 'astropy':
-        return
-
     _update_setup_py_version(data['new_version'])
 
 
@@ -34,10 +30,6 @@ def releaser_middle(data):
     distributions.  This is supposedly a workaround for a bug in Python 2.4,
     but we don't care about Python 2.4.
     """
-
-    if data['name'] != 'astropy':
-        return
-
     from zest.releaser.git import Git
     from zest.releaser.release import Releaser
 
@@ -243,10 +235,6 @@ def postreleaser_before(data):
     default: By default zest.releaser uses <version>.dev0.  We want just
     <version>.dev without the mysterious 0.
     """
-
-    if data['name'] != 'astropy':
-        return
-
     data['dev_version_template'] = '%(new_version)s.dev'
     data['nothing_changed_yet'] = _NEW_CHANGELOG_TEMPLATE
 
@@ -256,10 +244,6 @@ def postreleaser_middle(data):
     postreleaser.middle hook to update the setup.py with the new version. See
     prereleaser_middle for more details.
     """
-
-    if data['name'] != 'astropy':
-        return
-
     _update_setup_py_version(data['dev_version'])
 
 

--- a/astropy/utils/release.py
+++ b/astropy/utils/release.py
@@ -257,6 +257,9 @@ def postreleaser_middle(data):
     prereleaser_middle for more details.
     """
 
+    if data['name'] != 'astropy':
+        return
+
     _update_setup_py_version(data['dev_version'])
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,9 @@ auto_use = True
 # E113 - 4 spaces per indentation level
 select = E101,W191,W291,W292,W293,W391,E111,E112,E113
 exclude = extern,sphinx,*parsetab.py
+
+[zest.releaser]
+prereleaser.middle = astropy.utils.release.prereleaser_middle
+releaser.middle = astropy.utils.release.releaser_middle
+postreleaser.before = astropy.utils.release.postreleaser_before
+postreleaser.middle = astropy.utils.release.postreleaser_middle

--- a/setup.py
+++ b/setup.py
@@ -50,16 +50,8 @@ package_info = get_package_info()
 # Add the project-global data
 package_info['package_data'].setdefault('astropy', []).append('data/*')
 
-# Currently the only entry points installed by Astropy are hooks to
-# zest.releaser for doing Astropy's releases
+# Add any necessary entry points
 entry_points = {}
-for hook in [('prereleaser', 'middle'), ('releaser', 'middle'),
-             ('postreleaser', 'before'), ('postreleaser', 'middle')]:
-    hook_ep = 'zest.releaser.' + '.'.join(hook)
-    hook_name = 'astropy.release.' + '.'.join(hook)
-    hook_func = 'astropy.utils.release:' + '_'.join(hook)
-    entry_points[hook_ep] = ['%s = %s' % (hook_name, hook_func)]
-
 # Command-line scripts
 entry_points['console_scripts'] = [
     'fits2bitmap = astropy.visualization.scripts.fits2bitmap:main',


### PR DESCRIPTION
This closes #4633 by adding the ``if data['name'] != 'astropy': return`` bit into the one zest.releaser hook that was missing it.

Turns out that all the other entry points *do* have that bit.  But It looks like it was just an oversight that this one doesn't.  @embray, if you get a chance, can you confirm?