### PR TITLE
Make TFORMx keyword check more flexible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Made TFORMx keyword check more flexible in test of compressed images to
+    enable copatibility of the test with cfitsio 3.380. [#4646]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -4,6 +4,7 @@ from __future__ import division, with_statement
 
 import math
 import os
+import re
 import time
 import warnings
 
@@ -1265,8 +1266,8 @@ class TestCompressedImage(FitsTestCase):
 
         with fits.open(self.temp('test.fits'),
                        disable_image_compression=True) as h:
-            assert h[1].header['TFORM1'] == '1PB(30)'
-            assert h[1].header['TFORM2'] == '1PB(359)'
+            assert re.match(r'^1PB\(\d+\)$', h[1].header['TFORM1'])
+            assert re.match(r'^1PB\(\d+\)$', h[1].header['TFORM2'])
 
     def test_compression_update_header(self):
         """Regression test for


### PR DESCRIPTION
The maximal column length for compressed data in cfitsio changed between version 3370 and 3380. This patch replaces the check with a specific length by a general check of the correct syntax of the keywords.

This fixes #4646, if @embray raises the green flag.