### PR TITLE
Fix a bug in modeling.parameters affecting setters with 2 parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -219,6 +219,8 @@ Bug fixes
 - ``astropy.logger.py``
 
 - ``astropy.modeling``
+  - Fix a bug to allow instantiation of a modeling class having a parameter
+    with a custom setter that takes two parameters ``(value, model)`` [#4586]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -672,7 +672,7 @@ class Parameter(OrderedDescriptor):
                 if model is not None:
                     # Don't make a partial function unless we're tied to a
                     # specific model instance
-                    model_arg = inputs.args[1].name
+                    model_arg = inputs[1].name
                     wrapper = functools.partial(wrapper, **{model_arg: model})
             else:
                 raise TypeError("Parameter getter/setter must be a function "


### PR DESCRIPTION
Fixes a bug in modeling.parameters.Parameter due to which instantiation
of a model class with custom setters having two parameters (expecting
second parameter to be the model object) would fail. See issue https://github.com/astropy/astropy/issues/4586
for more details.