### PR TITLE
Fix a bug in modeling.parameters affecting setters with 2 parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -230,6 +230,9 @@ Bug fixes
 
 - ``astropy.modeling``
 
+  - Fix a bug to allow instantiation of a modeling class having a parameter
+    with a custom setter that takes two parameters ``(value, model)`` [#4586]
+
 - ``astropy.nddata``
 
   - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -230,9 +230,6 @@ Bug fixes
 
 - ``astropy.modeling``
 
-  - Fix a bug to allow instantiation of a modeling class having a parameter
-    with a custom setter that takes two parameters ``(value, model)`` [#4586]
-
 - ``astropy.nddata``
 
   - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,
@@ -1199,6 +1196,9 @@ Bug Fixes
 
   - Fixed display of compound model expressions and components when printing
     compound model instances. [#4414]
+
+  - Fix a bug to allow instantiation of a modeling class having a parameter
+    with a custom setter that takes two parameters ``(value, model)`` [#4586]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -672,7 +672,7 @@ class Parameter(OrderedDescriptor):
                 if model is not None:
                     # Don't make a partial function unless we're tied to a
                     # specific model instance
-                    model_arg = inputs.args[1].name
+                    model_arg = inputs[1].name
                     wrapper = functools.partial(wrapper, **{model_arg: model})
             else:
                 raise TypeError("Parameter getter/setter must be a function "

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -19,6 +19,36 @@ from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
 
 
+def setter1(val):
+    return val
+
+
+def setter2(val, model):
+    model.do_something(val)
+    return val * model.p
+
+
+class SetterModel(FittableModel):
+
+    inputs = ('x', 'y')
+    outputs = ('z',)
+
+    xc = Parameter(default=1, setter=setter1)
+    yc = Parameter(default=1, setter=setter2)
+
+    def __init__(self, xc, yc, p):
+        super(SetterModel, self).__init__()
+        self.p = p # p is a value intended to be used by the setter
+        self.xc = xc
+        self.yc = yc
+
+    def evaluate(self, x, y, xc, yc):
+        return ((x - xc)**2 + (y - yc)**2)
+
+    def do_something(self, v):
+        pass
+
+
 class TParModel(Model):
     """
     A toy model to test parameters machinery
@@ -582,3 +612,14 @@ def test_non_broadcasting_parameters():
     for args in itertools.permutations((a, b, c)):
         with pytest.raises(InputParameterError):
             TestModel(*args)
+
+
+def test_setter():
+    pars = np.random.rand(20).reshape((10,2))
+
+    model = SetterModel(-1, 3, np.pi)
+
+    for x, y in pars:
+        model.x = x
+        model.y = y
+        utils.assert_almost_equal(model(x, y), (x + 1)**2 + (y - np.pi * 3)**2)

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -37,8 +37,8 @@ class SetterModel(FittableModel):
     yc = Parameter(default=1, setter=setter2)
 
     def __init__(self, xc, yc, p):
-        super(SetterModel, self).__init__()
         self.p = p # p is a value intended to be used by the setter
+        super(SetterModel, self).__init__()
         self.xc = xc
         self.yc = yc
 


### PR DESCRIPTION
Fixes a bug in modeling.parameters.Parameter due to which instantiation
of a model class with custom setters having two parameters (expecting
second parameter to be the model object) would fail. See issue #4586
for more details.