### PR TITLE
Allow for masked arrays inside median_absolute_deviation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1203,10 +1203,10 @@ Bug Fixes
 
   - the input for median_absolute_deviation will not be cast to plain numpy
     arrays when given subclasses of numpy arrays
-    (like Quantity, numpy.ma.MaskedArray, etc.)
+    (like Quantity, numpy.ma.MaskedArray, etc.) [#4658]
 
   - Fixed incorrect results when using median_absolute_deviation with masked
-    arrays.
+    arrays. [#4658]
 
 - ``astropy.table``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ New Features
   - ``angular_diameter_distance_z1z2`` now supports the computation of
     the angular diameter distance between a scalar and an array like
     argument. [#4593]
-  
+
 - ``astropy.io.ascii``
 
   - File name could be passed as ``Path`` object. [#4606]
@@ -415,6 +415,8 @@ Bug Fixes
 - ``astropy.nddata``
 
 - ``astropy.stats``
+
+  - Fixed wrong results when using median_absolute_deviation with masked arrays
 
 - ``astropy.table``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -416,8 +416,6 @@ Bug Fixes
 
 - ``astropy.stats``
 
-  - Fixed wrong results when using median_absolute_deviation with masked arrays
-
 - ``astropy.table``
 
   - Fixed bug when replacing a table column with a mixin column like
@@ -1202,6 +1200,13 @@ Bug Fixes
 - ``astropy.nddata``
 
 - ``astropy.stats``
+
+  - the input for median_absolute_deviation will not be cast to plain numpy
+    arrays when given subclasses of numpy arrays
+    (like Quantity, numpy.ma.MaskedArray, etc.)
+
+  - Fixed incorrect results when using median_absolute_deviation with masked
+    arrays.
 
 - ``astropy.table``
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -685,16 +685,12 @@ def median_absolute_deviation(a, axis=None):
     # See https://github.com/numpy/numpy/issues/7330 why using np.ma.median
     # for normal arrays should not be done (summary: np.ma.median always
     # returns an masked array even if the result should be scalar).
-    try:
-        if np.any(a.mask):
-            func = np.ma.median
-        else:
-            # Array has a mask but no value is masked so we can savely use
-            # np.median on it.
-            func = np.median
-    except AttributeError:
+    if isinstance(a, np.ma.MaskedArray):
+        func = np.ma.median
+    else:
         func = np.median
-        a = np.array(a, copy=False)
+
+    a = np.asanyarray(a)
 
     a_median = func(a, axis=axis)
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -684,7 +684,7 @@ def median_absolute_deviation(a, axis=None):
     # Check if the array has a mask and if so use np.ma.median
     # See https://github.com/numpy/numpy/issues/7330 why using np.ma.median
     # for normal arrays should not be done (summary: np.ma.median always
-    # returns an masked array even if the result should be scalar).
+    # returns an masked array even if the result should be scalar). (#4658)
     if isinstance(a, np.ma.MaskedArray):
         func = np.ma.median
     else:

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -60,6 +60,29 @@ def test_median_absolute_deviation():
                               [ 43.,  48.,  53.,  58.]])
 
 
+def test_median_absolute_deviation_masked():
+    # normal masked arrays without masked values are handled like normal
+    # numpy arrays
+    array = np.ma.array([1, 2, 3])
+    assert funcs.median_absolute_deviation(array) == 1
+
+    # masked numpy arrays return something different (rank 0 masked array)
+    # but one can still compare it without np.all!
+    array = np.ma.array([1, 4, 3], mask=[0, 1, 0])
+    assert funcs.median_absolute_deviation(array) == 1
+
+    # Multidimensional masked array
+    array = np.ma.array([[1, 4], [2, 2]], mask=[[1, 0], [0, 0]])
+    funcs.median_absolute_deviation(array)
+    assert funcs.median_absolute_deviation(array) == 0
+    # Just to compare it with the data without mask:
+    assert funcs.median_absolute_deviation(array.data) == 0.5
+
+    # And check if they are also broadcasted correctly
+    np.testing.assert_array_equal(funcs.median_absolute_deviation(array, axis=0).data, [0, 1])
+    np.testing.assert_array_equal(funcs.median_absolute_deviation(array, axis=1).data, [0, 0])
+
+
 def test_biweight_location():
     #need to seed the numpy RNG to make sure we don't get some amazingly flukey
     #random number that breaks one of the tests

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -62,6 +62,8 @@ def test_median_absolute_deviation():
 
 
 def test_median_absolute_deviation_masked():
+    # Based on the changes introduces in #4658
+
     # normal masked arrays without masked values are handled like normal
     # numpy arrays
     array = np.ma.array([1, 2, 3])
@@ -89,6 +91,8 @@ def test_median_absolute_deviation_masked():
 
 
 def test_median_absolute_deviation_quantity():
+    # Based on the changes introduces in #4658
+
     # Just a small test that this function accepts Quantities and returns a
     # quantity
     a = np.array([1, 16, 5]) * u.m

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -20,6 +20,7 @@ from ...tests.helper import pytest
 
 from .. import funcs
 from ...utils.misc import NumpyRNGContext
+from ... import units as u
 
 
 def test_median_absolute_deviation():
@@ -70,6 +71,10 @@ def test_median_absolute_deviation_masked():
     # but one can still compare it without np.all!
     array = np.ma.array([1, 4, 3], mask=[0, 1, 0])
     assert funcs.median_absolute_deviation(array) == 1
+    # Just cross check if that's identical to the function on the unmasked
+    # values only
+    assert funcs.median_absolute_deviation(array) == (
+            funcs.median_absolute_deviation(array[~array.mask]))
 
     # Multidimensional masked array
     array = np.ma.array([[1, 4], [2, 2]], mask=[[1, 0], [0, 0]])
@@ -81,6 +86,17 @@ def test_median_absolute_deviation_masked():
     # And check if they are also broadcasted correctly
     np.testing.assert_array_equal(funcs.median_absolute_deviation(array, axis=0).data, [0, 1])
     np.testing.assert_array_equal(funcs.median_absolute_deviation(array, axis=1).data, [0, 0])
+
+
+def test_median_absolute_deviation_quantity():
+    # Just a small test that this function accepts Quantities and returns a
+    # quantity
+    a = np.array([1, 16, 5]) * u.m
+    mad = funcs.median_absolute_deviation(a)
+    # Check for the correct unit and that the result is identical to the result
+    # without units.
+    assert mad.unit == a.unit
+    assert mad.value == funcs.median_absolute_deviation(a.value)
 
 
 def test_biweight_location():


### PR DESCRIPTION
Currently ``median_absolute_deviation`` ignores the mask when given masked arrays. I think that should be eventually fixed upstream (https://github.com/numpy/numpy/issues/7330) but I thought it might be worth it to include it here and later drop it again. I've noticed this problem during a recent PR for ``ccdproc`` (https://github.com/astropy/ccdproc/pull/311).

The problem is that ``np.median`` cannot handle masked-arrays:

```
from astropy.stats import median_absolute_deviation
array = np.ma.array([[1, 4], [2, 2]], mask=[[1, 0], [0, 0]])
median_absolute_deviation(array)
# Returns 0.5

# This is the same as if we just ignore the mask
median_absolute_deviation(array.data)
# Returns 0.5

# but using np.ma.median (realized within this PR) the result is correct:
median_absolute_deviation(array)
# Returns 0
```
This is also included as a test in the PR. I've assumed this is a Bugfix but depending on the point of view this could also be a new feature (or obsolete).