### PR TITLE
Loose identity test of a HCOMPRESSed image

### DIFF
--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1010,7 +1010,9 @@ class TestCompressedImage(FitsTestCase):
         hdu.writeto(self.temp('test.fits'))
 
         with fits.open(self.temp('test.fits')) as hdul:
-            assert (hdul['SCI'].data == cube).all()
+            # HCOMPRESSed images are allowed to deviate from the original by
+            # about 1/quantize_level of the RMS in each tile.
+            assert np.abs(hdul['SCI'].data - cube).max() < 1./15.
 
     def test_subtractive_dither_seed(self):
         """


### PR DESCRIPTION
HCOMPRESSed images are allowed to deviate from the original by about 1/quantize_level of the RMS in each tile. This patch changes the absolute identity test to a comparison with an accuracy up to the
mentioned level. 
This fixes #4647, if the cause I assume is correct. Someone with insight in `HCOMPRESS_1` and cfitsio should check this carefully, however so that no real problem is going to be hidden here.
