### PR TITLE
Negative Ok0 in angular_diameter_distance_z1z2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,8 @@ New Features
 
   - ``angular_diameter_distance_z1z2`` now supports the computation of
     the angular diameter distance between a scalar and an array like
-    argument. [#4593]
+    argument [#4593] as well as cosmologies with negative curvature
+    [#4661].
   
 - ``astropy.io.ascii``
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1308,19 +1308,7 @@ class FLRW(Cosmology):
         ValueError
           If z2 is less than z1 or if z1 and z2 are arrays of different
           size
-        CosmologyError
-          If omega_k is < 0.
-
-        Notes
-        -----
-        This method only works for flat or open curvature
-        (omega_k >= 0).
         """
-
-        # does not work for negative curvature
-        Ok0 = self._Ok0
-        if Ok0 < 0:
-            raise CosmologyError('Ok0 must be >= 0 to use this method.')
 
         z1 = np.asanyarray(z1)
         z2 = np.asanyarray(z2)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1323,6 +1323,7 @@ class FLRW(Cosmology):
         dm2 = self.comoving_transverse_distance(z2).value
         dh_2 = self._hubble_distance.value ** 2
 
+        Ok0 = self._Ok0
         if Ok0 == 0:
             # Common case worth checking
             out = (dm2 - dm1) / (1. + z2)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1090,10 +1090,6 @@ def test_critical_density():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_angular_diameter_distance_z1z2():
 
-    with pytest.raises(core.CosmologyError):  # test neg Ok fail
-        tcos = core.LambdaCDM(H0=70.4, Om0=0.272, Ode0=0.8, Tcmb0=0.0)
-        tcos.angular_diameter_distance_z1z2(1, 2)
-
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     with pytest.raises(ValueError):  # test diff size z1, z2 fail
         tcos.angular_diameter_distance_z1z2([1, 2], [3, 4, 5])


### PR DESCRIPTION
Allow negative curvature in `angular_diameter_distance_z1z2` following my reasoning in #4661 