### PR TITLE
accept dict-like cards when creating io.fits.header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ New Features
 
   - File name could be passed as ``Path`` object. [#4606]
 
+  - Header allows a dictionary-like cards argument during creation. [#4663]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.votable``

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -86,7 +86,8 @@ class Header(object):
         Parameters
         ----------
         cards : A list of `Card` objects, optional
-            The cards to initialize the header with.
+            The cards to initialize the header with. Also allowed are other
+            `Header` (or `dict`-like) objects.
 
         txtfile : file path, file object or file-like object, optional
             Input ASCII header parameters file **(Deprecated)**
@@ -107,6 +108,8 @@ class Header(object):
 
         if isinstance(cards, Header):
             cards = cards.cards
+        elif isinstance(cards, dict):
+            cards = six.iteritems(cards)
 
         for card in cards:
             self.append(card, end=True)

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -5,6 +5,7 @@
 from __future__ import division, with_statement
 
 import warnings
+import collections
 
 from io import StringIO, BytesIO
 
@@ -22,6 +23,23 @@ from . import FitsTestCase
 from ..card import _pad
 from ..header import _pad_length
 from ..util import encode_ascii
+
+
+def test_init_with_dict():
+    dict1 = {'a': 11, 'b': 12, 'c': 13, 'd': 14, 'e': 15}
+    h1 = fits.Header(dict1)
+    for i in dict1:
+        assert dict1[i] == h1[i]
+
+
+def test_init_with_ordereddict():
+    # Create a list of tuples. Each tuple consisting of a letter and the number
+    list1 = [(i, j) for i, j in zip('abcdefghijklmnopqrstuvwxyz', range(26))]
+    # Create an ordered dictionary and a header from this dictionary
+    dict1 = collections.OrderedDict(list1)
+    h1 = fits.Header(dict1)
+    # Check that the order is preserved of the initial list
+    assert all(h1[val] == list1[i][1] for i, val in enumerate(h1))
 
 
 class TestOldApiHeaderFunctions(FitsTestCase):


### PR DESCRIPTION
From the discussion from #4648 .

This passes my local tests but there might be some subtil things I might be missing. Also if it's worth including (there were mixed opinions) I might need to add some more tests and maybe issue a warning (because it might be unsorted) if it get's a ``dict``-like cards object.

I've done some small tests with it and those examples will work:
```
import collections
from astropy.io import fits
dict1 = {'a':11, 'b':12, 'c':13, 'd':14, 'e':15}
dict2 = collections.OrderedDict({'a':11, 'b':12, 'c':13, 'd':14, 'e':15})
h1 = fits.Header(dict1)
h2 = fits.Header(dict2)

h1
B       =                   12                                                  
E       =                   15                                                  
D       =                   14                                                  
A       =                   11                                                  
C       =                   13    
```