### PR TITLE
numpy.linspace broken with Quantities

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -99,6 +99,14 @@ An easy solution is::
     array([False], dtype=bool)
 
 
+Quantities in np.linspace failure on numpy 1.10
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`~numpy.linspace` does not work correctly with quantities when using numpy
+1.10.0 to 1.10.5 due to a bug in numpy. The solution is to upgrade to numpy
+1.10.6 or later, in which the bug was fixed.
+
+
 Table sorting can silently fail on MacOS X or Windows with Python 3 and Numpy < 1.6.2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Numpy's linspace used to work nicely with quantities:

**Numpy 1.9.3**

```python
>>> np.linspace(-1 * u.m, 1 * u.m, 10)
<Quantity [-1.        ,-0.77777778,-0.55555556,-0.33333333,-0.11111111,
            0.11111111, 0.33333333, 0.55555556, 0.77777778, 1.        ] m>
```

**Numpy 1.10**

```
>>> np.linspace(-1 * u.m, 1 * u.m, 10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/miniconda3/envs/np110/lib/python2.7/site-packages/numpy/core/function_base.py", line 115, in linspace
    y[-1] = stop
ValueError: setting an array element with a sequence.
```

@mhvk - is this a bug in Astropy, or a bug introduced in Numpy?

A lot of user code might rely on this, so we should get a workaround out soon unless it has to be fixed in Numpy.