### PR TITLE
Add Imperial slug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,8 @@ New Features
   - The option to use tuples to indicate fractional powers of units,
     deprecated in 0.3.1, has been removed. [#4449]
 
+  - Added slug to imperial units. [#4670]
+
 - ``astropy.utils``
 
   - ``Path`` object could be passed to ``get_readable_fileobj``. [#4606]

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -73,6 +73,8 @@ def_unit(['st', 'stone'], 14 * lb, namespace=_ns,
          doc="International avoirdupois stone: mass")
 def_unit(['ton'], 2000 * lb, namespace=_ns,
          doc="International avoirdupois ton: mass")
+def_unit(['slug'], 32.174049 * lb, namespace=_ns,
+         doc="slug: mass")
 
 
 ###########################################################################
@@ -85,7 +87,7 @@ def_unit(['kn', 'kt', 'knot', 'NMPH'], nmi / si.h, namespace=_ns,
 ###########################################################################
 # FORCE
 
-def_unit('lbf', 32.174049 * lb * ft * si.s**-2, namespace=_ns,
+def_unit('lbf', slug * ft * si.s**-2, namespace=_ns,
          doc="Pound: force")
 def_unit(['kip', 'kilopound'], 1000 * lbf, namespace=_ns,
          doc="Kilopound: force")

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -390,7 +390,8 @@ def test_equivalent_units():
         units_set = set(units)
         match = set(
             [u.M_e, u.M_p, u.g, u.kg, u.solMass, u.t, u.u, u.M_earth,
-             u.M_jup, imperial.oz, imperial.lb, imperial.st, imperial.ton])
+             u.M_jup, imperial.oz, imperial.lb, imperial.st, imperial.ton, 
+             imperial.slug])
         assert units_set == match
 
     r = repr(units)

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -390,7 +390,7 @@ def test_equivalent_units():
         units_set = set(units)
         match = set(
             [u.M_e, u.M_p, u.g, u.kg, u.solMass, u.t, u.u, u.M_earth,
-             u.M_jup, imperial.oz, imperial.lb, imperial.st, imperial.ton, 
+             u.M_jup, imperial.oz, imperial.lb, imperial.st, imperial.ton,
              imperial.slug])
         assert units_set == match
 


### PR DESCRIPTION
Greetings from the aerospace industry.

Believe it or not, the slug is a useful engineering unit of mass that (in combination with the pound-force, foot, and second) yields a coherent system of units (RE: PR [3409](https://github.com/astropy/astropy/pull/3409#issuecomment-74017113)). Essentially F=ma without any pesky gravitational constants. Since the imperial system persists in these parts (unfortunately), including this unit in astropy.units.imperial should facilitate wider adoption of this excellent library.

In order to minimize the diff and reduce the proliferation of magic numbers, I also redefined the pound-force in terms of the slug.