### PR TITLE
Table sort with a tuple of keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ New Features
 
   - Added ``AttributeError`` when trying to set mask on non-masked table. [#3505]
 
+  - Allow to use a tuple of keys in ``Table.sort``.  [#4671]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2220,7 +2220,8 @@ class Table(object):
             if not self.indices:
                 raise ValueError("Table sort requires input keys or a table index")
             keys = [x.info.name for x in self.indices[0].columns]
-        if not isinstance(keys, (list, tuple)):
+
+        if isinstance(keys, six.string_types):
             keys = [keys]
 
         indexes = self.argsort(keys)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2220,7 +2220,7 @@ class Table(object):
             if not self.indices:
                 raise ValueError("Table sort requires input keys or a table index")
             keys = [x.info.name for x in self.indices[0].columns]
-        if type(keys) is not list:
+        if not isinstance(keys, (list, tuple)):
             keys = [keys]
 
         indexes = self.argsort(keys)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -959,6 +959,9 @@ class TestSort():
         t.sort(['b', 'a'])
         assert np.all(t['a'] == np.array([2, 1, 3, 1, 3, 2]))
         assert np.all(t['b'] == np.array([3, 4, 4, 5, 5, 6]))
+        t.sort(('a', 'b'))
+        assert np.all(t['a'] == np.array([1, 1, 2, 2, 3, 3]))
+        assert np.all(t['b'] == np.array([4, 5, 3, 6, 4, 5]))
 
     def test_multiple_with_bytes(self, table_types):
         t = table_types.Table()


### PR DESCRIPTION
Currently `Table.sort` works only with a list of keys, so I changed the test to include the possibility to pass a tuple:
```
t.sort(('a', 'b'))
```
This is a simple fix for a simple issue, but I wonder if it makes sense to support any kind of iterable (with `utils.isiterable`), or to do the same as `Table.argsort` (which is called by `sort`), i.e. changing the test to convert the argument to a list if it is a string (and btw it supports any iterable) ?

cc @taldcroft 