### PR TITLE
Remove errant changelog entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1222,8 +1222,6 @@ Bug Fixes
 
 - ``astropy.units``
 
-  - Fixed latex representation of function units. [#4563]
-
 - ``astropy.utils``
 
   - The ``zest.releaser`` hooks included in Astropy are now injected locally to


### PR DESCRIPTION
The fix in https://github.com/astropy/astropy/pull/4563 applies to only v1.1.2, not also v1.0.9.