### PR TITLE
Limit included helpers stuff to what the helpers MANIFEST.in includes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,8 +30,25 @@ recursive-include astropy/sphinx/themes *
 prune docs/_build
 prune build
 
-recursive-include astropy_helpers *
-exclude astropy_helpers/.git
-exclude astropy_helpers/.gitignore
+
+# the next few stanzas are for astropy_helpers.  It's derived from the 
+# astropy_helpers/MANIFEST.in, but requires additional includes for the actual
+# package directory.  This is necessary because distutils automatically
+# includes a package's source files without them being in MANIFEST.in, but the
+# helpers are *not* included in this repo's setup function.
+
+include astropy_helpers/README.rst
+include astropy_helpers/CHANGES.rst
+include astropy_helpers/LICENSE.rst
+recursive-include astropy_helpers/licenses *
+
+include astropy_helpers/ez_setup.py
+include astropy_helpers/ah_bootstrap.py
+
+recursive-include astropy_helpers/astropy_helpers *.pyx *.pyx *.c *.h
+
+prune astropy_helpers/build
+prune astropy_helpers/astropy_helpers/tests
+
 
 global-exclude *.pyc *.o

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,9 +33,7 @@ prune build
 
 # the next few stanzas are for astropy_helpers.  It's derived from the 
 # astropy_helpers/MANIFEST.in, but requires additional includes for the actual
-# package directory.  This is necessary because distutils automatically
-# includes a package's source files without them being in MANIFEST.in, but the
-# helpers are *not* included in this repo's setup function.
+# package directory and egg-info.
 
 include astropy_helpers/README.rst
 include astropy_helpers/CHANGES.rst
@@ -46,6 +44,7 @@ include astropy_helpers/ez_setup.py
 include astropy_helpers/ah_bootstrap.py
 
 recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h
+recursive-include astropy_helpers/astropy_helpers.egg-info *
 
 prune astropy_helpers/build
 prune astropy_helpers/astropy_helpers/tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -45,7 +45,7 @@ recursive-include astropy_helpers/licenses *
 include astropy_helpers/ez_setup.py
 include astropy_helpers/ah_bootstrap.py
 
-recursive-include astropy_helpers/astropy_helpers *.pyx *.pyx *.c *.h
+recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h
 
 prune astropy_helpers/build
 prune astropy_helpers/astropy_helpers/tests


### PR DESCRIPTION
While running through the release, I noticed that the astropy_helpers that gets bundled with the release seemed to have a lot of spurious files that are not in a "normal" helpers release.  Inspection revealed that being due to the use of a ``recursive_include astropy_helpers`` in the astropy ``MANIFEST.in``, which grabbed a lot more than we actually need.

This PR fixes that by just copying over the MANIFEST.in from `astropy_helpers` (with the necessary prefix), which doesn't rely on a ``recursive_include`` for the whole helper directory.  Ideally we would instead use some sort of "import" of ``astropy_helpers/MANIFEST.in`` into ``astropy/MANIFEST.in``, so that we don't have to manually take care of any possible future changes to ``astropy_helpers/MANIFEST.in``.  I couldn't figure out a way to do that so just accepted this as better than nothing, but if anyone knows how to do that, I'm all ears.

This should also be ported to the package template once we're happy with it here.

Note that this is also the root cause of #4396 - if this were in that wouldn't have happened because the offending directory wouldn't have been in the build.

cc @astrofrog @embray @bsipocz