### PR TITLE
Change default ASCII reader numeric types to 64 bits on all platforms

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -953,8 +953,8 @@ class TableOutputter(BaseOutputter):
     Output the table as an astropy.table.Table object.
     """
 
-    default_converters = [convert_numpy(numpy.int),
-                          convert_numpy(numpy.float),
+    default_converters = [convert_numpy(numpy.int64),
+                          convert_numpy(numpy.float64),
                           convert_numpy(numpy.str)]
 
     def __call__(self, cols, meta):

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -84,7 +84,7 @@ cdef extern from "src/tokenizer.h":
     void delete_tokenizer(tokenizer_t *tokenizer)
     int skip_lines(tokenizer_t *self, int offset, int header)
     int tokenize(tokenizer_t *self, int end, int header, int num_cols)
-    long str_to_long(tokenizer_t *self, char *str)
+    long long str_to_long(tokenizer_t *self, char *str)
     double fast_str_to_double(tokenizer_t *self, char *str)
     double str_to_double(tokenizer_t *self, char *str)
     void start_iteration(tokenizer_t *self, int col)
@@ -580,9 +580,9 @@ cdef class CParser:
             num_rows = nrows
         # intialize ndarray
         cdef np.ndarray col = np.empty(num_rows, dtype=np.int_)
-        cdef long converted
+        cdef long long converted
         cdef int row = 0
-        cdef long *data = <long *> col.data # pointer to raw data
+        cdef long long *data = <long long *> col.data # pointer to raw data
         cdef char *field
         cdef char *empty_field = t.buf # memory address of designated empty buffer
         cdef bytes new_value
@@ -616,7 +616,7 @@ cdef class CParser:
                 else:
                     converted = str_to_long(t, field)
             else:
-                # convert the field to long (widest integer type)
+                # convert the field to long long (widest integer type)
                 converted = str_to_long(t, field)
 
             if t.code in (CONVERSION_ERROR, OVERFLOW_ERROR):

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -14,6 +14,7 @@ import re
 from collections import defaultdict, OrderedDict
 from textwrap import wrap
 from warnings import warn
+import numpy as np
 
 from ...extern import six
 from ...extern.six.moves import zip

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -79,7 +79,7 @@ void resize_col(tokenizer_t *self, int index)
 {
     // Temporarily store the position in output_cols[index] to
     // which col_ptrs[index] points
-    long diff = self->col_ptrs[index] - self->output_cols[index];
+    long long diff = self->col_ptrs[index] - self->output_cols[index];
 
     // Double the size of the column string
     self->output_cols[index] = (char *) realloc(self->output_cols[index], 2 *
@@ -621,10 +621,10 @@ static int ascii_strncasecmp(const char *str1, const char *str2, size_t n)
 }
 
 
-long str_to_long(tokenizer_t *self, char *str)
+long long str_to_long(tokenizer_t *self, char *str)
 {
     char *tmp;
-    long ret;
+    long long ret;
     errno = 0;
     ret = strtol(str, &tmp, 0);
 

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -99,7 +99,7 @@ void resize_col(tokenizer_t *self, int index);
 void resize_comments(tokenizer_t *self);
 int skip_lines(tokenizer_t *self, int offset, int header);
 int tokenize(tokenizer_t *self, int end, int header, int num_cols);
-long str_to_long(tokenizer_t *self, char *str);
+long long str_to_long(tokenizer_t *self, char *str);
 double str_to_double(tokenizer_t *self, char *str);
 double xstrtod(const char *str, char **endptr, char decimal,
                char sci, char tsep, int skip_trailing);

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -246,10 +246,10 @@ A B C D E
 4 2 -12 .4 six
 """
     table = read_basic(text, parallel=parallel)
-    assert_equal(table['A'].dtype.kind, 'f')
+    assert table['A'].dtype.type is np.float64
     assert table['B'].dtype.kind in ('S', 'U')
-    assert_equal(table['C'].dtype.kind, 'i')
-    assert_equal(table['D'].dtype.kind, 'f')
+    assert table['C'].dtype.type is np.int64
+    assert table['D'].dtype.type is np.float64
     assert table['E'].dtype.kind in ('S', 'U')
 
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -941,9 +941,9 @@ def test_ipac_abbrev():
              '  1    2    3       4     5   6    7     8    9   10  11  12 ']
     dat = ascii.read(lines, format='ipac')
     for name in dat.columns[0:8]:
-        assert dat[name].dtype.kind == 'f'
+        assert dat[name].dtype.type is np.float64
     for name in dat.columns[8:10]:
-        assert dat[name].dtype.kind == 'i'
+        assert dat[name].dtype.type is np.int64
     for name in dat.columns[10:12]:
         assert dat[name].dtype.kind in ('U', 'S')
 

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -10,6 +10,7 @@ except ImportError:
 import numpy as np
 
 from ... import ascii
+from ....tests.helper import pytest
 
 from .common import assert_equal, setup_function, teardown_function
 
@@ -40,18 +41,40 @@ def test_rdb_write_types():
 
 def test_ipac_read_types():
     table = r"""\
-|     ra   |    dec   |   sai   |-----v2---|    sptype        |
-|    real  |   float  |   l     |    real  |     char         |
-|    unit  |   unit   |   unit  |    unit  |     ergs         |
-|    null  |   null   |   null  |    null  |     -999         |
-   2.09708   2956        73765    2.06000   B8IVpMnHg
+|     ra   |    dec   |   sai   |   sai2  |-----v2---|    sptype        |
+|    real  |   float  |   l     |   int   |    real  |     char         |
+|    unit  |   unit   |   unit  |   unit  |    unit  |     ergs         |
+|    null  |   null   |   null  |   null  |    null  |     -999         |
+   2.09708   2956        73765     73765    2.06000   B8IVpMnHg
 """
     reader = ascii.get_reader(Reader=ascii.Ipac)
     dat = reader.read(table)
     types = [ascii.FloatType,
              ascii.FloatType,
              ascii.IntType,
+             ascii.IntType,
              ascii.FloatType,
              ascii.StrType]
-    for (col, expected_type) in zip(reader.cols, types):
+
+    for (col, expected_type, dat_col) in zip(reader.cols, types, dat.columns.values()):
         assert_equal(col.type, expected_type)
+
+        # Explicitly check that IPAC numeric types are 64-bits on all platforms (#4684).
+        if col.type is ascii.FloatType:
+            assert dat_col.dtype.type is np.float64
+        elif col.type is ascii.IntType:
+            assert dat_col.dtype.type is np.int64
+        else:
+            assert dat_col.dtype.kind in ('S', 'U')
+
+
+@pytest.mark.parametrize('fast_reader', [True, False, 'force'])
+def test_data_type(fast_reader):
+    """
+    Simple test that data type conversion is yielding int64, float64, and str
+    types by default.  On Windows np.int is 32 bit.
+    """
+    t = ascii.read(['a b c', '1 1.0 x'], format='basic', fast_reader=fast_reader, guess=False)
+    assert t['a'].dtype.type is np.int64
+    assert t['b'].dtype.type is np.float64
+    assert t['c'].dtype.kind in ('S', 'U')


### PR DESCRIPTION
#4684 raised the issue of how the different underlying type for `np.int` on Windows (`np.int32`) vs. other platforms (`np.int64`) can be a problem.  To solve that particular issue, and more generally ensure  consistent behavior for reading ASCII tables across platforms, this changes the default types to specifically choose the 64-bit version, e.g. `np.int64` instead of `np.int`.

This is going to be an API change for Windows users.  I think it should be acceptable, but comments otherwise are welcome.

Fixes #4684.
