### PR TITLE
Add axis keyword to mad_std #4688

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ New Features
 
 - ``astropy.stats``
 
+  - Added ``axis`` keyword for ``mad_std`` function. [#4688]
+
   - Added Bayesian upper limits for Poisson count rates. [#4622]
   
   - Added ``circstats``; a module for computing circular statistics. [#3705]

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1087,7 +1087,7 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
 
     return boot
 
-def mad_std(data):
+def mad_std(data, axis=None):
     """
     Calculate a robust standard deviation using the `median absolute
     deviation (MAD)
@@ -1106,6 +1106,9 @@ def mad_std(data):
     ----------
     data : array-like
         Data array or object that can be converted to an array.
+    axis : int, optional
+        Axis along which the medians are computed. The default (axis=None)
+        is to compute the median along a flattened version of the array.
 
     Returns
     -------
@@ -1124,7 +1127,7 @@ def mad_std(data):
     """
 
     # NOTE: 1. / scipy.stats.norm.ppf(0.75) = 1.482602218505602
-    return median_absolute_deviation(data) * 1.482602218505602
+    return median_absolute_deviation(data, axis=axis) * 1.482602218505602
 
 
 def _scipy_kraft_burrows_nousek(N, B, CL):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -102,7 +102,6 @@ def test_median_absolute_deviation_masked():
     np.testing.assert_array_equal(funcs.median_absolute_deviation(array, axis=1).data, [0, 0])
 
 
-
 def test_median_absolute_deviation_quantity():
     # Based on the changes introduces in #4658
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -347,17 +347,15 @@ def test_mad_std():
         assert_allclose(funcs.mad_std(data), 2.0, rtol=0.05)
 
 def test_mad_std_with_axis():
-    with NumpyRNGContext(12345):
-        data = np.array([[1, 2, 3, 4],
-                         [4, 3, 2, 1]])
-        
-        #results follow data symmetry 
-        result_axis0 = np.array([ 2.22390333,  0.74130111,  0.74130111,  2.22390333])
-        result_axis1 = np.array([ 1.48260222,  1.48260222])
+    data = np.array([[1, 2, 3, 4],
+                     [4, 3, 2, 1]])
+    
+    #results follow data symmetry 
+    result_axis0 = np.array([2.22390333,  0.74130111,  0.74130111,  2.22390333])
+    result_axis1 = np.array([1.48260222,  1.48260222])
 
-        assert_allclose(funcs.mad_std(data, axis=0), result_axis0, rtol=0.05)  
-        assert_allclose(funcs.mad_std(data, axis=1), result_axis1, rtol=0.05)  
-
+    assert_allclose(funcs.mad_std(data, axis=0), result_axis0)  
+    assert_allclose(funcs.mad_std(data, axis=1), result_axis1) 
 
 
 def test_gaussian_fwhm_to_sigma():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -349,14 +349,11 @@ def test_mad_std():
 def test_mad_std_with_axis():
     data = np.array([[1, 2, 3, 4],
                      [4, 3, 2, 1]])
-    
-    #results follow data symmetry 
+    #results follow data symmetry
     result_axis0 = np.array([2.22390333,  0.74130111,  0.74130111,  2.22390333])
     result_axis1 = np.array([1.48260222,  1.48260222])
-
-    assert_allclose(funcs.mad_std(data, axis=0), result_axis0)  
-    assert_allclose(funcs.mad_std(data, axis=1), result_axis1) 
-
+    assert_allclose(funcs.mad_std(data, axis=0), result_axis0)
+    assert_allclose(funcs.mad_std(data, axis=1), result_axis1)
 
 def test_gaussian_fwhm_to_sigma():
     fwhm = (2.0 * np.sqrt(2.0 * np.log(2.0)))

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -102,6 +102,7 @@ def test_median_absolute_deviation_masked():
     np.testing.assert_array_equal(funcs.median_absolute_deviation(array, axis=1).data, [0, 0])
 
 
+
 def test_median_absolute_deviation_quantity():
     # Based on the changes introduces in #4658
 
@@ -345,6 +346,19 @@ def test_mad_std():
     with NumpyRNGContext(12345):
         data = normal(5, 2, size=(100, 100))
         assert_allclose(funcs.mad_std(data), 2.0, rtol=0.05)
+
+def test_mad_std_with_axis():
+    with NumpyRNGContext(12345):
+        data = np.array([[1, 2, 3, 4],
+                         [4, 3, 2, 1]])
+        
+        #results follow data symmetry 
+        result_axis0 = np.array([ 2.22390333,  0.74130111,  0.74130111,  2.22390333])
+        result_axis1 = np.array([ 1.48260222,  1.48260222])
+
+        assert_allclose(funcs.mad_std(data, axis=0), result_axis0, rtol=0.05)  
+        assert_allclose(funcs.mad_std(data, axis=1), result_axis1, rtol=0.05)  
+
 
 
 def test_gaussian_fwhm_to_sigma():


### PR DESCRIPTION
Fix to #4688. Add docstring info as well, I just used the same docstring information from **median_absolute_deviation** for the axis keyword, not sure if there's something specific to be added here. I left the example untouched as it's output matches the one you would expect from a flattened array.