### PR TITLE
In mad_std function, allow `axis` keyword

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1007,7 +1007,7 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
 
     return boot
 
-def mad_std(data):
+def mad_std(data, axis=None):
     """
     Calculate a robust standard deviation using the `median absolute
     deviation (MAD)
@@ -1026,6 +1026,9 @@ def mad_std(data):
     ----------
     data : array-like
         Data array or object that can be converted to an array.
+    axis : int, optional
+        Axis along which the medians are computed. The default (axis=None)
+        is to compute the median along a flattened version of the array.
 
     Returns
     -------
@@ -1044,4 +1047,4 @@ def mad_std(data):
     """
 
     # NOTE: 1. / scipy.stats.norm.ppf(0.75) = 1.482602218505602
-    return median_absolute_deviation(data) * 1.482602218505602
+    return median_absolute_deviation(data, axis=axis) * 1.482602218505602


### PR DESCRIPTION
`median_absolute_deviation` accepts an `axis` keyword, so `mad_std` should too