### PR TITLE
Removed raising of AssertionError from 'io.fits.fitsrec.__del__'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -395,6 +395,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Removed raising of ``AssertionError`` that could occur after closing or
+    deleting compressed image data. [#4690]
+    
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -631,7 +631,11 @@ class FITS_rec(np.recarray):
             raise AttributeError(exc.args[0])
 
     def __del__(self):
-        del self._coldefs
+        try:
+            del self._coldefs
+        except AttributeError as err:
+            pass
+
         if self.dtype.fields is not None:
             for col in self._col_weakrefs:
                 if col.array is not None:


### PR DESCRIPTION
`io.fits.fitsrec.__del__` does not print an array if it fails to delete `_coldefs`. The AssertionError is replaced with a if-statement that checks if `_coldefs` exists before trying to delete it. The bug in question is #4690.

With the example file given in #4690, this change prints:
`before close f`
`closed f`
That is, with no AssertionError being raised, there is no large output as shown in #4690.
