### PR TITLE
Inputs to render function are converted to float #4681

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,8 +179,9 @@ API changes
 - ``astropy.modeling``
 
   - Renamed ``Redshift`` model to ``RedshiftScaleFactor``. [#3672]
- - Inputs (``coords`` and ``out``) to ``render`` function in ``Model`` are
-   converted to float. [#4697]
+
+  - Inputs (``coords`` and ``out``) to ``render`` function in ``Model`` are
+    converted to float. [#4697]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,8 @@ API changes
 - ``astropy.modeling``
 
   - Renamed ``Redshift`` model to ``RedshiftScaleFactor``. [#3672]
+ - Inputs (``coords`` and ``out``) to ``render`` function in ``Model`` are
+   converted to float. [#4697]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1132,6 +1132,7 @@ class Model(object):
                 bbox = [bbox]
 
         if coords is not None:
+            coords = np.asanyarray(coords, dtype=float)
             # Check dimensions match out and model
             assert len(coords) == ndim
             if out is not None:
@@ -1140,6 +1141,7 @@ class Model(object):
                 out = np.zeros(coords[0].shape)
 
         if out is not None:
+            out = np.asanyarray(out, dtype=float)
             try:
                 assert out.ndim == ndim
             except AssertionError:


### PR DESCRIPTION
@eteq @patti `out` and `coords` are converted to float. Please suggest any changes. #4681 