### PR TITLE
Warn when metadata is ignored when writing IPAC files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ New Features
 
   - Check for self-consistency of ECSV header column names. [#5463]
 
+  - Produce warnings when writing an IPAC table from an astropy table that
+    contains metadata not supported by the IPAC format [#4700]
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -491,7 +491,12 @@ class Ipac(basic.Basic):
                 except TypeError:
                     log.warn("Table metadata keyword {0} has been skipped.  "
                              "IPAC metadata must be in the form {{'keywords':"
-                             "{{'keyword': {{'value': value}} }}")
+                             "{{'keyword': {{'value': value}} }}".format(keyword))
+        ignored_keys = [key for key in table.meta if key not in ('keywords','comments')]
+        if any(ignored_keys)
+            log.warn("Table metadata keyword(s) {0} were not written.  "
+                     "IPAC metadata must be in the form {{'keywords':"
+                     "{{'keyword': {{'value': value}} }}".format(ignored_keys))
 
         # Usually, this is done in data.write, but since the header is written
         # first, we need that here.

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -15,6 +15,7 @@ from collections import defaultdict, OrderedDict
 from textwrap import wrap
 from warnings import warn
 
+from ... import log
 from ...extern import six
 from ...extern.six.moves import zip
 
@@ -488,7 +489,9 @@ class Ipac(basic.Basic):
                     lines.append('\\{0}={1!r}'.format(keyword.strip(), val))
                     # meta is not standardized: Catch some common Errors.
                 except TypeError:
-                    pass
+                    log.warn("Table metadata keyword {0} has been skipped.  "
+                             "IPAC metadata must be in the form {{'keywords':"
+                             "{{'keyword': {{'value': value}} }}")
 
         # Usually, this is done in data.write, but since the header is written
         # first, we need that here.

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -490,12 +490,15 @@ class Ipac(basic.Basic):
                 except TypeError:
                     warn("Table metadata keyword {0} has been skipped.  "
                          "IPAC metadata must be in the form {{'keywords':"
-                         "{{'keyword': {{'value': value}} }}".format(keyword))
+                         "{{'keyword': {{'value': value}} }}".format(keyword),
+                         AstropyUserWarning)
         ignored_keys = [key for key in table.meta if key not in ('keywords','comments')]
         if any(ignored_keys):
             warn("Table metadata keyword(s) {0} were not written.  "
                  "IPAC metadata must be in the form {{'keywords':"
-                 "{{'keyword': {{'value': value}} }}".format(ignored_keys))
+                 "{{'keyword': {{'value': value}} }}".format(ignored_keys),
+                 AstropyUserWarning
+                )
 
         # Usually, this is done in data.write, but since the header is written
         # first, we need that here.

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -15,7 +15,6 @@ from collections import defaultdict, OrderedDict
 from textwrap import wrap
 from warnings import warn
 
-from ... import log
 from ...extern import six
 from ...extern.six.moves import zip
 
@@ -489,14 +488,14 @@ class Ipac(basic.Basic):
                     lines.append('\\{0}={1!r}'.format(keyword.strip(), val))
                     # meta is not standardized: Catch some common Errors.
                 except TypeError:
-                    log.warn("Table metadata keyword {0} has been skipped.  "
-                             "IPAC metadata must be in the form {{'keywords':"
-                             "{{'keyword': {{'value': value}} }}".format(keyword))
+                    warn("Table metadata keyword {0} has been skipped.  "
+                         "IPAC metadata must be in the form {{'keywords':"
+                         "{{'keyword': {{'value': value}} }}".format(keyword))
         ignored_keys = [key for key in table.meta if key not in ('keywords','comments')]
-        if any(ignored_keys)
-            log.warn("Table metadata keyword(s) {0} were not written.  "
-                     "IPAC metadata must be in the form {{'keywords':"
-                     "{{'keyword': {{'value': value}} }}".format(ignored_keys))
+        if any(ignored_keys):
+            warn("Table metadata keyword(s) {0} were not written.  "
+                 "IPAC metadata must be in the form {{'keywords':"
+                 "{{'keyword': {{'value': value}} }}".format(ignored_keys))
 
         # Usually, this is done in data.write, but since the header is written
         # first, we need that here.

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -448,6 +448,20 @@ def test_write_no_data_ipac(fast_writer):
         check_write_table(test_def, data, fast_writer)
         check_write_table_via_table(test_def, data, fast_writer)
 
+def test_write_extra_meta_ipac():
+    """Write an IPAC table that contains no data but has extra metadata and
+    therefore should raise a warning, and check that the warning has been
+    raised"""
+    table = ascii.get_reader(Reader=ascii.Ipac)
+    data = table.read('t/no_data_ipac.dat')
+    data.meta['blah'] = 'extra'
+
+    with catch_warnings(AstropyWarning) as ASwarn:
+        out = StringIO()
+        data.write(out, format='ascii.ipac')
+    assert len(ASwarn) == 1
+
+
 @pytest.mark.parametrize("fast_writer", [True, False])
 def test_write_comments(fast_writer):
     """Write comments in output originally read by io.ascii."""

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -448,10 +448,10 @@ def test_write_no_data_ipac(fast_writer):
         check_write_table(test_def, data, fast_writer)
         check_write_table_via_table(test_def, data, fast_writer)
 
-def test_write_extra_meta_ipac():
-    """Write an IPAC table that contains no data but has extra metadata and
-    therefore should raise a warning, and check that the warning has been
-    raised"""
+def test_write_invalid_toplevel_meta_ipac():
+    """Write an IPAC table that contains no data but has invalid (incorrectly
+    specified) metadata stored in the top-level metadata and therefore should
+    raise a warning, and check that the warning has been raised"""
     table = ascii.get_reader(Reader=ascii.Ipac)
     data = table.read('t/no_data_ipac.dat')
     data.meta['blah'] = 'extra'
@@ -460,6 +460,34 @@ def test_write_extra_meta_ipac():
         out = StringIO()
         data.write(out, format='ascii.ipac')
     assert len(ASwarn) == 1
+    assert "were not written" in str(ASwarn[0].message)
+
+def test_write_invalid_keyword_meta_ipac():
+    """Write an IPAC table that contains no data but has invalid (incorrectly
+    specified) metadata stored appropriately in the ``keywords`` section
+    of the metadata but with invalid format and therefore should raise a
+    warning, and check that the warning has been raised"""
+    table = ascii.get_reader(Reader=ascii.Ipac)
+    data = table.read('t/no_data_ipac.dat')
+    data.meta['keywords']['blah'] = 'invalid'
+
+    with catch_warnings(AstropyWarning) as ASwarn:
+        out = StringIO()
+        data.write(out, format='ascii.ipac')
+    assert len(ASwarn) == 1
+    assert "has been skipped" in str(ASwarn[0].message)
+
+def test_write_valid_meta_ipac():
+    """Write an IPAC table that contains no data and has *correctly* specified
+    metadata.  No warnings should be issued"""
+    table = ascii.get_reader(Reader=ascii.Ipac)
+    data = table.read('t/no_data_ipac.dat')
+    data.meta['keywords']['blah'] = {'value': 'invalid'}
+
+    with catch_warnings(AstropyWarning) as ASwarn:
+        out = StringIO()
+        data.write(out, format='ascii.ipac')
+    assert len(ASwarn) == 0
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])


### PR DESCRIPTION
Currently, the IPAC writer will silently ignore metadata if it is not in the expected form, and the expected form is somewhat weird:

```
table.meta = {'keywords':
              {'keyword': {'value': value}, }
             }
```

This PR adds warnings if either level of the nested dictionary is incorrectly specified.
