### PR TITLE
(WIP) Fix in-place updates to binary table columns of unsigned ints

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -304,45 +304,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 if isinstance(data, self._data_type):
                     self.data = data
                 else:
-                    # Just doing a view on the input data screws up unsigned
-                    # columns, so treat those more carefully.
-                    # TODO: I need to read this code a little more closely
-                    # again, but I think it can be simplified quite a bit with
-                    # the use of some appropriate utility functions
-                    update_coldefs = {}
-                    if 'u' in [data.dtype[k].kind for k in data.dtype.names]:
-                        self._uint = True
-                        bzeros = {2: np.uint16(2**15), 4: np.uint32(2**31),
-                                  8: np.uint64(2**63)}
-
-                        new_dtype = [
-                            (k, data.dtype[k].kind.replace('u', 'i') +
-                            str(data.dtype[k].itemsize))
-                            for k in data.dtype.names]
-
-                        new_data = np.zeros(data.shape, dtype=new_dtype)
-
-                        for k in data.dtype.fields:
-                            dtype = data.dtype[k]
-                            if dtype.kind == 'u':
-                                new_data[k] = data[k] - bzeros[dtype.itemsize]
-                                update_coldefs[k] = bzeros[dtype.itemsize]
-                            else:
-                                new_data[k] = data[k]
-                        self.data = new_data.view(self._data_type)
-                        # Uck...
-                        self.data._uint = True
-                    else:
-                        self.data = data.view(self._data_type)
-                    for k in update_coldefs:
-                        indx = _get_index(self.data.names, k)
-                        self.data._coldefs[indx].bzero = update_coldefs[k]
-                        # This is so bad that we have to update this in
-                        # duplicate...
-                        self.data._coldefs.bzeros[indx] = update_coldefs[k]
-                        # More uck...
-                        self.data._coldefs[indx]._physical_values = False
-                        self.data._coldefs[indx]._pseudo_unsigned_ints = True
+                    self.data = self._data_type.from_columns(data)
 
                 # TODO: Too much of the code in this class uses header keywords
                 # in making calculations related to the data size.  This is

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2419,6 +2419,35 @@ class TestTableFunctions(FitsTestCase):
             t3.teardown_class()
         del t3
 
+    def test_pseudo_unsigned_ints(self):
+        """
+        Tests updating a table column containing pseudo-unsigned ints.
+        """
+
+        data = np.array([1, 2, 3], dtype=np.uint32)
+        col = fits.Column(name='A', format='1J', bzero=2**31, array=data)
+        thdu = fits.BinTableHDU.from_columns([col])
+        thdu.writeto(self.temp('test.fits'))
+
+        # Test that the file wrote out correctly
+        with fits.open(self.temp('test.fits'), uint=True) as hdul:
+            hdu = hdul[1]
+            assert 'TZERO1' in hdu.header
+            assert hdu.header['TZERO1'] == 2**31
+            assert hdu.data['A'].dtype == np.dtype('uint32')
+            assert np.all(hdu.data['A'] == data)
+
+            # Test updating the unsigned int data
+            hdu.data['A'] = 99
+            hdu.writeto(self.temp('test2.fits'))
+
+        with fits.open(self.temp('test2.fits'), uint=True) as hdul:
+            hdu = hdul[1]
+            assert 'TZERO1' in hdu.header
+            assert hdu.header['TZERO1'] == 2**31
+            assert hdu.data['A'].dtype == np.dtype('uint32')
+            assert np.all(hdu.data['A'] == [99, 2, 3])
+
 
 @contextlib.contextmanager
 def _refcounting(type_):
@@ -2435,7 +2464,6 @@ def _refcounting(type_):
     gc.collect()
     assert len(objgraph.by_type(type_)) <= refcount, \
             "More {0!r} objects still in memory than before."
-
 
 
 class TestVLATables(FitsTestCase):


### PR DESCRIPTION
This is a work-in-progress fix to the issue reported on Stack Overflow here: http://stackoverflow.com/questions/35921060/updating-pyfits-bin-table-data#35921060

I believe this might also be the same issue as #3921, but as the use case in that issue is _slightly_ different I'm not 100% sure (nevertheless it still relates to updating unsigned int data in a table).

Right now this PR only contains the regression test, and some preliminary code cleanup that I realized was possible.  I haven't had time to complete the fix yet.  But if someone else wants to look into it I can point you in the right direction.
