### PR TITLE
Make Table inherit primary_key attribute from its parent Table. Fix for [#4672]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1250,6 +1250,9 @@ Bug Fixes
 
 - ``astropy.table``
 
+  - Fixed bug where Tables created from existing Table objects were not
+    inheriting the ``primary_key`` attribute. [#4672]
+    
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -664,6 +664,7 @@ class Table(object):
         table = data  # data is really a Table, rename for clarity
         self.meta.clear()
         self.meta.update(deepcopy(table.meta))
+        self.primary_key = table.primary_key
         cols = list(table.columns.values())
 
         self._init_from_list(cols, names, dtype, n_cols, copy)
@@ -703,6 +704,7 @@ class Table(object):
         table = self.__class__(masked=self.masked)
         table.meta.clear()
         table.meta.update(deepcopy(self.meta))
+        table.primary_key = self.primary_key
         cols = self.columns.values()
 
         newcols = []

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1627,3 +1627,28 @@ def test_replace_column_qtable():
     assert t.colnames == ['a', 'b']
     assert t['a'].info.meta is None
     assert t['a'].info.format is None
+
+def test_primary_key_is_inherited():
+    """Test whether a new Table inherits the primary_key attribute from
+    its parent Table. Issue #4672"""
+
+    t = table.Table([(2, 3, 2, 1), (8, 7, 6, 5)], names=('a', 'b'))
+    t.add_index('a')
+    original_key = t.primary_key
+
+    # can't test if tuples are equal, so just check content
+    assert original_key[0] is 'a'
+
+    t2 = t[:]
+    t3 = t.copy()
+    t4 = table.Table(t)
+
+    # test whether the reference is the same in the following
+    assert original_key == t2.primary_key
+    assert original_key == t3.primary_key
+    assert original_key == t4.primary_key
+
+    # just test one element, assume rest are equal if assert passes
+    assert t.loc[1] == t2.loc[1]
+    assert t.loc[1] == t3.loc[1]
+    assert t.loc[1] == t4.loc[1]


### PR DESCRIPTION
This is a fix for issue #4672.

In the issue, running an example from the astropy docs for [Table indexing](http://astropy.readthedocs.org/en/latest/table/indexing.html) would run into an error. The error was a missing `primary_key` for the table in question. The error arises when a new Table is made from an existing one, either by slicing or reference, but the `primary_key` attribute is not transferred to the new Table. This PR fixes that.

I added one test for this case, but I couldn't figure out a way to test for `.loc` as @taldcroft suggested in the issue. I'm actually not that familiar with Tables or with writing test cases (this is my first attempt to do so), so any feedback would be appreciated.   