### PR TITLE
Simplify code to generate coefficient names in PolynomialModel and _SIP1D

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -142,11 +142,7 @@ class PolynomialModel(PolynomialBase):
                 names.append('c{0}'.format(n))
         else:
             for i in range(self.degree + 1):
-                names.append('c{0}_{1}'.format(i, 0))
-            for i in range(1, self.degree + 1):
-                names.append('c{0}_{1}'.format(0, i))
-            for i in range(1, self.degree):
-                for j in range(1, self.degree):
+                for j in range(self.degree + 1):
                     if i + j < self.degree + 1:
                         names.append('c{0}_{1}'.format(i, j))
         return tuple(names)
@@ -979,13 +975,9 @@ class _SIP1D(PolynomialBase):
 
     def _generate_coeff_names(self, coeff_prefix):
         names = []
-        for i in range(2, self.order + 1):
-            names.append('{0}_{1}_{2}'.format(coeff_prefix, i, 0))
-        for i in range(2, self.order + 1):
-            names.append('{0}_{1}_{2}'.format(coeff_prefix, 0, i))
-        for i in range(1, self.order):
-            for j in range(1, self.order):
-                if i + j < self.order + 1:
+        for i in range(self.order + 1):
+            for j in range(self.order + 1):
+                if 1 < i + j < self.order + 1:
                     names.append('{0}_{1}_{2}'.format(coeff_prefix, i, j))
         return names
 


### PR DESCRIPTION
This is just a small change that I noticed could be done while I was working on other things in astropy.modeling. However, this was written near the end of a long flight, so should be double checked by someone who isn't jet-lagged :airplane: :tired_face:  

Milestoning as 1.2 since it does not change any behavior so there's no need to backport - it's just to make it easier to read in future.