### PR TITLE
Inputs and parameters to Modelling render function converted to float

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ New Features
 
 - ``astropy.modeling``
 
+  - Converted input and parameters of the render function to Float
+
 - ``astropy.nddata``
 
   - Added ``UnknownUncertainty`` as ``NDUncertainty`` subclass which cannot

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1132,6 +1132,7 @@ class Model(object):
                 bbox = [bbox]
 
         if coords is not None:
+            coords = np.asanyarray(coords, dtype=np.float)
             # Check dimensions match out and model
             assert len(coords) == ndim
             if out is not None:
@@ -1140,6 +1141,7 @@ class Model(object):
                 out = np.zeros(coords[0].shape)
 
         if out is not None:
+            out = np.asanyarray(out, dtype=np.float)
             try:
                 assert out.ndim == ndim
             except AssertionError:


### PR DESCRIPTION
Ensures that the input array and the parameter array to the `render` function are explicitly set to float, as defined in #4681