### PR TITLE
Fixing LC_ALL env variable in the travis matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,12 @@ matrix:
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph'
-               LC_CTYPE=C.ascii LC_ALL=C.ascii
+               LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
         - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               LC_CTYPE=C.ascii LC_ALL=C.ascii
+               LC_CTYPE=C.ascii LC_ALL=C
 
         # Try older numpy versions without optional dependencies
         - os: linux


### PR DESCRIPTION
as it was never actually picked up and did anything in it's current form but somehow started to cause failures on python 2.7.
 (Long term warnings we never payed attention: ``/home/travis/build.sh: line 45: warning: setlocale: LC_ALL: cannot change locale (C.ascii): No such file or directory`` and ``bash: warning: setlocale: LC_ALL: cannot change locale (C.ascii)``). 

Actual test failure with python2.7:
```
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/test/bin/pip", line 6, in <module>
    sys.exit(pip.main())
  File "/home/travis/miniconda/envs/test/lib/python2.7/site-packages/pip/__init__.py", line 215, in main
    locale.setlocale(locale.LC_ALL, '')
  File "/home/travis/miniconda/envs/test/lib/python2.7/locale.py", line 579, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```
cc: @astrofrog 