### PR TITLE
Updating the Cython prerequisite to v0.19 in install.rst 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,6 +304,8 @@ Other Changes and Additions
 
 - Reduce Astropy's import time (``import astropy``) by almost a factor 2. [#4649]
 
+- Cython prerequisite for building changed to v0.19 in install.rst
+
 
 1.1.3 (unreleased)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,7 +304,7 @@ Other Changes and Additions
 
 - Reduce Astropy's import time (``import astropy``) by almost a factor 2. [#4649]
 
-- Cython prerequisite for building changed to v0.19 in install.rst
+- Cython prerequisite for building changed to v0.19 in install.rst [#4705]
 
 
 1.1.3 (unreleased)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -160,7 +160,7 @@ Prerequisites
 You will need a compiler suite and the development headers for Python and
 Numpy in order to build Astropy. 
 
-You will also need `Cython <http://cython.org/>`_ (v0.15 or later) and
+You will also need `Cython <http://cython.org/>`_ (v0.19 or later) and
 `jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed
 to build from source, unless you are installing a numbered release. (The
 releases packages have the necessary C files packaged with them, and hence do


### PR DESCRIPTION
resolving issue #4705 by changing the minimum version for building from v0.15 to v0.19 in docs/install.rst.