### PR TITLE
Fix AiryDisk2D, Sersic1D, and Sersic2D models so they can be used in compound models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,6 +250,9 @@ Bug fixes
 
 - ``astropy.modeling``
 
+  - Refactored ``AiryDisk2D``, ``Sersic1D``, and ``Sersic2D`` models
+    to be able to combine them as classes as well as instances. [#4720]
+
 - ``astropy.nddata``
 
   - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,
@@ -416,6 +419,9 @@ Bug Fixes
 - ``astropy.io.votable``
 
 - ``astropy.modeling``
+
+  - Refactored ``AiryDisk2D``, ``Sersic1D``, and ``Sersic2D`` models
+    to be able to combine them as classes as well as instances. [#4720]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1600,19 +1600,6 @@ class AiryDisk2D(Fittable2DModel):
         super(AiryDisk2D, self).__init__(
             amplitude=amplitude, x_0=x_0, y_0=y_0, radius=radius, **kwargs)
 
-    # TODO: Why does this particular model have its own special __deepcopy__
-    # and __copy__?  If it has anything to do with the use of the j_1 function
-    # that should be reworked.
-    def __deepcopy__(self, memo):
-        new_model = self.__class__(self.amplitude.value, self.x_0.value,
-                                   self.y_0.value, self.radius.value)
-        return new_model
-
-    def __copy__(self):
-        new_model = self.__class__(self.amplitude.value, self.x_0.value,
-                                   self.y_0.value, self.radius.value)
-        return new_model
-
     @classmethod
     def evaluate(cls, x, y, amplitude, x_0, y_0, radius):
         """Two dimensional Airy model function"""

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -610,23 +610,18 @@ class Sersic1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     r_eff = Parameter(default=1)
     n = Parameter(default=4)
-    _gammaincinv = None
 
-    def __init__(self, amplitude=amplitude.default, r_eff=r_eff.default,
-                 n=n.default, **kwargs):
+    @staticmethod
+    def evaluate(r, amplitude, r_eff, n):
+        """One dimensional Sersic profile function."""
+
         try:
             from scipy.special import gammaincinv
-            self.__class__._gammaincinv = gammaincinv
         except ValueError:
-            raise ImportError("Sersic1D model requires scipy > 0.11.")
+            raise ImportError('Sersic1D model requires scipy > 0.11.')
 
-        super(Sersic1D, self).__init__(
-            amplitude=amplitude, r_eff=r_eff, n=n, **kwargs)
-
-    @classmethod
-    def evaluate(cls, r, amplitude, r_eff, n):
-        """One dimensional Sersic profile function."""
-        return amplitude * np.exp(-cls._gammaincinv(2 * n, 0.5) * ((r / r_eff) ** (1 / n) - 1))
+        return (amplitude * np.exp(
+            -gammaincinv(2 * n, 0.5) * ((r / r_eff) ** (1 / n) - 1)))
 
 
 class Sine1D(Fittable1DModel):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -4,17 +4,13 @@
 
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
-
-
 import numpy as np
-
 from .core import (Fittable1DModel, Fittable2DModel, Model,
                    ModelDefinitionError, custom_model)
 from .parameters import Parameter, InputParameterError
 from .utils import ellipse_extent
 from ..utils import deprecated
 from ..extern import six
-
 from .utils import get_inputs_and_params
 
 
@@ -1795,26 +1791,17 @@ class Sersic2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     ellip = Parameter(default=0)
     theta = Parameter(default=0)
-    _gammaincinv = None
 
-    def __init__(self, amplitude=amplitude.default, r_eff=r_eff.default,
-                 n=n.default, x_0=x_0.default, y_0=y_0.default, ellip=ellip.default,
-                 theta=theta.default, **kwargs):
-        try:
-            from scipy.special import gammaincinv
-            self.__class__._gammaincinv = gammaincinv
-        except ValueError:
-            raise ImportError("Sersic2D model requires scipy > 0.11.")
-
-        super(Sersic2D, self).__init__(
-            amplitude=amplitude, r_eff=r_eff, n=n, x_0=x_0, y_0=y_0,
-            ellip=ellip, theta=theta, **kwargs)
-
-    @classmethod
-    def evaluate(cls, x, y, amplitude, r_eff, n, x_0, y_0, ellip, theta):
+    @staticmethod
+    def evaluate(x, y, amplitude, r_eff, n, x_0, y_0, ellip, theta):
         """Two dimensional Sersic profile function."""
 
-        bn = cls._gammaincinv(2. * n, 0.5)
+        try:
+            from scipy.special import gammaincinv
+        except ValueError:
+            raise ImportError('Sersic2D model requires scipy > 0.11.')
+
+        bn = gammaincinv(2. * n, 0.5)
         a, b = r_eff, (1 - ellip) * r_eff
         cos_theta, sin_theta = np.cos(theta), np.sin(theta)
         x_maj = (x - x_0) * cos_theta + (y - y_0) * sin_theta

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -166,7 +166,7 @@ def test_Voigt1D():
 
 @pytest.mark.skipif("not HAS_SCIPY")
 def test_compound_models_with_class_variables():
-    models_2d = [models.AiryDisk2D]
+    models_2d = [models.AiryDisk2D, models.Sersic2D]
     models_1d = [models.Sersic1D]
 
     for model_2d in models_2d:

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -167,9 +167,18 @@ def test_Voigt1D():
 @pytest.mark.skipif("not HAS_SCIPY")
 def test_compound_models_with_class_variables():
     models_2d = [models.AiryDisk2D]
+    models_1d = [models.Sersic1D]
+
     for model_2d in models_2d:
         class CompoundModel2D(models.Const2D + model_2d):
             pass
         x, y = np.mgrid[:10, :10]
         f = CompoundModel2D()(x, y)
         assert f.shape == (10, 10)
+
+    for model_1d in models_1d:
+        class CompoundModel1D(models.Const1D + model_1d):
+            pass
+        x = np.arange(10)
+        f = CompoundModel1D()(x)
+        assert f.shape == (10,)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -162,3 +162,14 @@ def test_Voigt1D():
     fitter = fitting.LevMarLSQFitter()
     voi_fit = fitter(voi_init, xarr, yarr)
     assert_allclose(voi_fit.param_sets, voi.param_sets)
+
+
+@pytest.mark.skipif("not HAS_SCIPY")
+def test_compound_models_with_class_variables():
+    models_2d = [models.AiryDisk2D]
+    for model_2d in models_2d:
+        class CompoundModel2D(models.Const2D + model_2d):
+            pass
+        x, y = np.mgrid[:10, :10]
+        f = CompoundModel2D()(x, y)
+        assert f.shape == (10, 10)


### PR DESCRIPTION
As reported on the mailing list, compound models using `AiryDisk2D` fail because of a special function (Bessel function) and constant that are defined in the model.  Moving these definitions from the `__init__` method to class variables fixes the problem (and the `__init__` method is no longer needed).

The `Sersic1D` and `Sersic2D` models (which also define a special function in the models) were fixed in the same manner.

@nden I also removed the `AiryDisk2D` special `__deepcopy__` and `__copy__` methods that you apparently wrote.  I don't think they are still needed (e.g. fitting seems to work without them).

I've added a change log entry for both `1.2` and `1.1.3`.