### PR TITLE
Fix #4718 - Make Scale and Shift models fittable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ New Features
 
 - ``astropy.modeling``
 
+  - Added the fittable=True attribute to the Scale and Shift models.
+
 - ``astropy.nddata``
 
   - Added ``UnknownUncertainty`` as ``NDUncertainty`` subclass which cannot

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ New Features
 
 - ``astropy.modeling``
 
-  - Added the fittable=True attribute to the Scale and Shift models.
+  - Added the fittable=True attribute to the Scale and Shift models with tests.
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ New Features
 
 - ``astropy.modeling``
 
-  - Added the fittable=True attribute to the Scale and Shift models with tests.
+  - Added the fittable=True attribute to the Scale and Shift models with tests. [#4718]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -464,6 +464,7 @@ class Shift(Model):
     outputs = ('x',)
 
     offset = Parameter(default=0)
+    fittable = True
 
     @property
     def inverse(self):
@@ -491,6 +492,7 @@ class Scale(Model):
 
     factor = Parameter(default=1)
     linear = True
+    fittable = True
 
     @property
     def inverse(self):

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -153,16 +153,6 @@ def test_Shift_inverse():
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
-def test_Scale_fittable():
-    m = models.Scale(1.2)
-    assert(m.fittable==True)
-
-
-def test_Shift_fittable():
-    m = models.Shift(1.2)
-    assert(m.fittable==True)
-
-
 @pytest.mark.skipif("not HAS_SCIPY")
 def test_Voigt1D():
     voi = models.Voigt1D(amplitude_L=-0.5, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -153,6 +153,16 @@ def test_Shift_inverse():
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
+def test_Scale_fittable():
+    m = models.Scale(1.2)
+    assert(m.fittable==True)
+
+
+def test_Shift_fittable():
+    m = models.Shift(1.2)
+    assert(m.fittable==True)
+
+
 @pytest.mark.skipif("not HAS_SCIPY")
 def test_Voigt1D():
     voi = models.Voigt1D(amplitude_L=-0.5, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)


### PR DESCRIPTION
Hope this fixes the issue. I have added the `fittable=True` attribute to the Scale and Shift models, made tests for them in test_functional_models.py and added a changelog entry in CHANGES.rst