### PR TITLE
 Fix sigma_clipped_stats to use the axis argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,7 +278,7 @@ Bug fixes
   - ``NDArithmeticMixin`` does provide correct resulting uncertainties for
     ``divide`` and ``multiply`` if only one uncertainty was set. [#4152, #4272]
 
- - ``astropy.stats``
+- ``astropy.stats``
 
 - ``astropy.table``
 
@@ -441,6 +441,8 @@ Bug Fixes
 - ``astropy.nddata``
 
 - ``astropy.stats``
+
+  - Fix ``sigma_clipped_stats`` to use the ``axis`` argument. [#4726]
 
 - ``astropy.table``
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -300,8 +300,19 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         data = np.ma.MaskedArray(data, mask)
     if mask_value is not None:
         data = np.ma.masked_values(data, mask_value)
+
     data_clip = sigma_clip(data, sigma=sigma, sigma_lower=sigma_lower,
                            sigma_upper=sigma_upper, iters=iters,
                            cenfunc=cenfunc, stdfunc=stdfunc, axis=axis)
-    goodvals = np.ma.compressed(data_clip)
-    return np.mean(goodvals), np.median(goodvals), np.std(goodvals)
+
+    mean = np.ma.mean(data_clip, axis=axis)
+    median = np.ma.median(data_clip, axis=axis)
+    std = np.ma.std(data_clip, axis=axis)
+
+    if axis is None and np.ma.isMaskedArray(median):
+        # With Numpy 1.10 np.ma.median always return a MaskedArray, even with
+        # one element. So for compatibility with previous versions, we take the
+        # scalar value
+        median = median[0]
+
+    return mean, median, std

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -95,16 +95,23 @@ def test_sigma_clipped_stats():
     data = [0, 1]
     mask = np.array([True, False])
     result = sigma_clipped_stats(data, mask=mask)
-    assert result[0] == 1.
-    assert result[1] == 1.
-    assert result[2] == 0.
+    # Check that the result of np.ma.median was converted to a scalar
+    assert isinstance(result[1], float)
+    assert result == (1., 1., 0.)
 
     # test list data with mask_value
     result2 = sigma_clipped_stats(data, mask_value=0.)
-    assert result2[0] == 1.
-    assert result2[1] == 1.
-    assert result2[2] == 0.
+    assert isinstance(result[1], float)
+    assert result2 == (1., 1., 0.)
 
+    _data = np.arange(10)
+    data = np.ma.MaskedArray([_data, _data, 10 * _data])
+    mean = sigma_clip(data, axis=0, sigma=1).mean(axis=0)
+    assert_equal(mean, _data)
+    mean, median, stddev = sigma_clipped_stats(data, axis=0, sigma=1)
+    assert_equal(mean, _data)
+    assert_equal(median, _data)
+    assert_equal(stddev, np.zeros_like(_data))
 
 def test_invalid_sigma_clip():
     """Test sigma_clip of data containing invalid values."""


### PR DESCRIPTION
The axis argument was added in #3792 and is passed correctly to `sigma_clip`, but
then mean, median and std did not use axis and were computed on the whole array.
This commit changes this to use axis to compute the statistics.

Also another minor annoyance is that, with Numpy 1.10, `np.ma.median` always
return a masked array, even when axis is None. This was not the case in previous
versions (and will probably be fixed in the future), and mean and std return
a scalar. So if it happens here, we take the first element of the array.

cc @larrybradley 