### PR TITLE
remove nonfunctional conesearch url

### DIFF
--- a/astropy/vo/validator/data/conesearch_urls.txt
+++ b/astropy/vo/validator/data/conesearch_urls.txt
@@ -1,4 +1,3 @@
-http://archive.noao.edu/nvo/usno.php?cat=a&amp;
 http://gsss.stsci.edu/webservices/vo/ConeSearch.aspx?CAT=GSC23&amp;
 http://irsa.ipac.caltech.edu/cgi-bin/Oasis/CatSearch/nph-catsearch?CAT=fp_psc&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/220&amp;


### PR DESCRIPTION
As mentioned in the #4701 NOAO cone search service is no longer functional and might be permanently offline, this removes its url from conesearch_urls as suggested in the issue.

Fixes #4701 
