### PR TITLE
Add sys pkg vers

### DIFF
--- a/cextern/erfa/README.rst
+++ b/cextern/erfa/README.rst
@@ -1,0 +1,88 @@
+This is the source code repository for ERFA (Essential Routines for
+Fundamental Astronomy).  ERFA is a C library containing key algorithms for
+astronomy, and is based on the `SOFA library <http://www.iausofa.org/>`_ published by the International
+Astronomical Union (IAU).
+
+ERFA is intended to replicate the functionality of SOFA (aside from possible
+bugfixes in ERFA that have not yet been included in SOFA), but is licensed
+under a three-clause BSD license to enable its compatibility with a wide
+range of open source licenses. Permission for this release has been
+obtained from the SOFA board, and is avilable in the ``LICENSE`` file included
+in this source distribution.
+
+Differences from SOFA
+---------------------
+
+This version of ERFA (v1.2.0) is based on SOFA version "20150209_a", with the
+differences outlined below.
+
+ERFA branding
+^^^^^^^^^^^^^
+
+All references to "SOFA" in the source code have been changed to ERFA, and
+functions have the prefix ``era`` instead of ``iau``.
+
+C macro prefixes
+^^^^^^^^^^^^^^^^
+
+All C macros used in ERFA are the same as their SOFA equivalents, but with an
+``ERFA_`` prefix to prevent namespace collisions.
+
+Bugfixes
+^^^^^^^^
+
+ERFA includes smaller changes that may or may not eventually make it into SOFA,
+addressing localized bugs or similar smaller issues:
+
+* Typos have been corrected in the documentation of atco13 and atio13 (see https://github.com/liberfa/erfa/issues/29).
+
+Note: Issues identified in ERFA should always be reported upstream to SOFA
+at sofa@ukho.gov.uk.
+
+Building and installing ERFA
+----------------------------
+
+To build and install a released version of ERFA in your OS's standard
+location, simply do::
+
+    ./configure
+    make
+    make install
+
+If you want to run the tests to make sure ERFA built correctly, before
+installing do::
+
+    make check
+
+
+For developers
+^^^^^^^^^^^^^^
+
+If you are using a developer version from github, you will need to first do
+``./bootstrap.sh`` before the above commands. This requires ``autoconf`` and
+``libtool``.
+
+If you wish to build against the ERFA static library without installing, you
+will find it in ``$ERFAROOT/src/.libs/liberfa.a`` after running ``make``.
+
+Creating a single-file version of the source code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Alternatively, if you wish to bundle the ERFA source code with a separate
+package, you can use the ``source_flattener.py`` script from the
+`erfa-fetch repository`_ to combine
+the ERFA source code into just two files: a ``erfa.c`` source file, and an
+``erfa.h`` include file.  You should run this script like this::
+
+    cd /path/to/erfa-source-code
+    python /path/to/erfa-fetch/source_flattener.py src -n erfa
+
+If possible, however, it is recommended that you provide an option to use any
+copy of the ERFA library that is already installed on the system.
+
+Travis build status
+-------------------
+.. image:: https://travis-ci.org/liberfa/erfa.png
+    :target: https://travis-ci.org/liberfa/erfa
+
+.. _erfa-fetch repository: https://github.com/liberfa/erfa-fetch

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Astropy also depends on other packages for optional features:
 
 - `matplotlib <http://matplotlib.org/>`_: To provide plotting functionality that `astropy.visualization` enhances.
 
-- `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To use `astropy.wcs` to define projections in Matplotlib. 
+- `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To use `astropy.wcs` to define projections in Matplotlib.
 
 - `pytz <http://pythonhosted.org/pytz/>`_: To specify and convert between timezones.
 
@@ -158,7 +158,7 @@ Prerequisites
 -------------
 
 You will need a compiler suite and the development headers for Python and
-Numpy in order to build Astropy. 
+Numpy in order to build Astropy.
 
 You will also need `Cython <http://cython.org/>`_ (v0.15 or later) and
 `jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed
@@ -169,16 +169,16 @@ not require Cython.)
 Prerequisites for Linux
 -----------------------
 
-On Linux, using the package manager for your distribution will usually be 
+On Linux, using the package manager for your distribution will usually be
 the easiest route. In order to build from source, you'll need the python development package
 for your distro.
 
 For Debian/Ubuntu::
-    
+
     sudo apt-get install python-dev
 
 For Fedora/RHEL::
-    
+
     sudo yum install python-devel
 
 Prerequisites for Mac OS X
@@ -187,7 +187,7 @@ Prerequisites for Mac OS X
 On MacOS X you will need the XCode command line tools which can be installed using
 
 For installing XCode command line tools::
-    
+
     xcode-select --install
 
 and follow the onscreen instructions to install the command line tools required.
@@ -304,6 +304,21 @@ the system `libexpat <http://www.libexpat.org/>`_, add the following to the
 
     [build]
     use_system_expat=1
+
+
+The C libraries currently bundled with Astropy include:
+
+- `wcslib <http://www.atnf.csiro.au/people/mcalabre/WCS/>`_ see
+  ``cextern/wcslib/README`` for the bundled version.
+
+- `cfitsio <http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html>`_ see
+  ``cextern/cfitsio/changes.txt`` for the bundled version.
+
+- `erfa <https://github.com/liberfa>`_ see ``cextern/erfa/README.rst`` for the
+  bundled version.
+
+- `expat <http://expat.sourceforge.net/>`_ see ``cextern/expat/README`` for the
+  bundled version.
 
 
 The required version of setuptools is not available


### PR DESCRIPTION
This is inspired by @mboquien, who wanted a clearer list of the C-bundled packages and their versions.

I realized as I was trying to make the version list that it would be extremely unlikely that we would actually remember to keep this up to date.  But all the bundled C libs (at least, after this PR), have a README or similar file with the version.  So this instead tells where to *find* what the version is.  Does that seem sufficient, @mboquien?