### PR TITLE
WIP: Prototype Table constructor from LSST afw table [skip ci]

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -293,6 +293,13 @@ class Table(object):
             else:
                 n_cols = len(data)
 
+        elif data.__class__.__module__.startswith('lsst.afw.table'):
+            # returned data is a list of astropy Column objects
+            # meta is an OrderedDict
+            data, meta, copy = data.as_astropy_cols_meta(copy)
+            init_func = self._init_from_list
+            n_cols = len(data)
+
         elif isinstance(data, np.ndarray):
             if data.dtype.names:
                 init_func = self._init_from_ndarray  # _struct


### PR DESCRIPTION
This defines a simple interface for instantiating an astropy Table or QTable object by extracting astropy Column objects and meta data from an LSST afw table.  The column extraction will be performed by an afw table method.