### PR TITLE
Set is_image = False for GroupsHDU

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -409,6 +409,8 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - ``is_image`` property is now set to ``False``. [#4742]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -357,6 +357,10 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         return 0
 
     @property
+    def is_image(self):
+        return False
+
+    @property
     def size(self):
         """
         Returns the size (in bytes) of the HDU's data part.


### PR DESCRIPTION
There was previously no is_image property for the GroupsHDU class and this
was causing the fits differ to fail. This should fix that.