### PR TITLE
WIP: numpy integers are not int in  python3

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -24,6 +24,7 @@ import operator
 import sys
 import types
 import warnings
+import numbers
 
 from collections import defaultdict, OrderedDict
 from itertools import chain, islice
@@ -1872,7 +1873,7 @@ class _CompoundModelMeta(_ModelMeta):
     def __getitem__(cls, index):
         index = cls._normalize_index(index)
 
-        if isinstance(index, int):
+        if isinstance(index, numbers.Integral):
             return cls._get_submodels()[index]
         else:
             return cls._get_slice(index.start, index.stop)
@@ -2373,7 +2374,7 @@ class _CompoundModelMeta(_ModelMeta):
                 raise ValueError("Empty slice of a compound model.")
 
             return slice(start, stop)
-        elif isinstance(index, int):
+        elif isinstance(index, numbers.Integral):
             if index >= len(cls.submodel_names):
                 raise IndexError(
                         "Model index {0} out of range.".format(index))


### PR DESCRIPTION
There are a few places in `astropy.modeling` where numbers are checked that they are integers by comparing to python's `int` using `isinstance`. For example, when indexing compound models, `compound_model[index]`, `index` must be integer but the check for this is `isinstance(index, int)`. This works with numpy integers in python2 but not in python3. As there's a use case for using numpy integers for indexing, the check should be changed to `isinstance(index, numbers.Integral)`. This [numpy issue](https://github.com/numpy/numpy/issues/2951) gives a good explanation.

I need to check the modeling code for other places that may be a problem, that's why this is a `WIP`. I am curious if other subpackages have run into this issue. 