### PR TITLE
Test runner to handle docs path more gracefully

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -151,12 +151,16 @@ class AstropyTest(Command, object):
 
         # Ensure there is a doc path
         if self.docs_path is None:
-            if os.path.exists('docs'):
-                self.docs_path = os.path.abspath('docs')
+            cfg_docs_dir = self.distribution.get_option_dict('build_sphinx').get('source_dir', None)
+
             # Some affiliated packages use this.
             # See astropy/package-template#157
-            elif os.path.exists('doc'):
-                self.docs_path = os.path.abspath('doc')
+            if cfg_docs_dir is not None and os.path.exists(cfg_docs_dir[1]):
+                self.docs_path = os.path.abspath(cfg_docs_dir[1])
+
+            # fall back on a default path of "docs"
+            elif os.path.exists('docs'):
+                self.docs_path = os.path.abspath('docs')
 
         # Build a testing install of the package
         self._build_temp_install()

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -153,6 +153,10 @@ class AstropyTest(Command, object):
         if self.docs_path is None:
             if os.path.exists('docs'):
                 self.docs_path = os.path.abspath('docs')
+            # Some affiliated packages use this.
+            # See astropy/package-template#157
+            elif os.path.exists('doc'):
+                self.docs_path = os.path.abspath('doc')
 
         # Build a testing install of the package
         self._build_temp_install()
@@ -209,10 +213,14 @@ class AstropyTest(Command, object):
         self.testing_path = os.path.join(self.tmp_dir, os.path.basename(new_path))
         shutil.copytree(new_path, self.testing_path)
 
-        new_docs_path = os.path.join(self.tmp_dir,
-                                     os.path.basename(self.docs_path))
-        shutil.copytree(self.docs_path, new_docs_path)
-        self.docs_path = new_docs_path
+        # Ideally, docs_path is set properly in run(), but if it is still
+        # not set here, do not pretend it is, otherwise bad things happen.
+        # See astropy/package-template#157
+        if self.docs_path is not None:
+            new_docs_path = os.path.join(self.tmp_dir,
+                                         os.path.basename(self.docs_path))
+            shutil.copytree(self.docs_path, new_docs_path)
+            self.docs_path = new_docs_path
 
         shutil.copy('setup.cfg', self.tmp_dir)
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -159,7 +159,7 @@ class AstropyTest(Command, object):
                 self.docs_path = os.path.abspath(cfg_docs_dir[1])
 
             # fall back on a default path of "docs"
-            elif os.path.exists('docs'):
+            elif os.path.exists('docs'):  # pragma: no cover
                 self.docs_path = os.path.abspath('docs')
 
         # Build a testing install of the package


### PR DESCRIPTION
This addressed astropy/package-template#157 and fixes failing test in ejeschke/ginga#313 . Unless someone else can give me a way to set `docs_path` without this fix. I plan to merge this by the end of the week if I don't hear otherwise.