### PR TITLE
Fixed fit with Jacobian when weights are provided

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -255,6 +255,9 @@ Bug fixes
   - Refactored ``AiryDisk2D``, ``Sersic1D``, and ``Sersic2D`` models
     to be able to combine them as classes as well as instances. [#4720]
 
+  - Modified the "LevMarLSQFitter" class to use the weights in the
+    calculation of the Jacobian. [#4751]
+
 - ``astropy.nddata``
 
   - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -492,12 +492,15 @@ class LevMarLSQFitter(object):
         this function.
         """
 
+        if weights is None:
+            weights = 1.0
+
         if any(model.fixed.values()) or any(model.tied.values()):
 
             if z is None:
-                full_deriv = np.array(model.fit_deriv(x, *model.parameters))
+                full_deriv = np.ravel(weights) * np.array(model.fit_deriv(x, *model.parameters))
             else:
-                full_deriv = np.array(model.fit_deriv(x, y, *model.parameters))
+                full_deriv = (np.ravel(weights) * np.array(model.fit_deriv(x, y, *model.parameters)).T).T
 
             pars = [getattr(model, name) for name in model.param_names]
             fixed = [par.fixed for par in pars]
@@ -516,9 +519,9 @@ class LevMarLSQFitter(object):
             return [np.ravel(_) for _ in residues]
         else:
             if z is None:
-                return model.fit_deriv(x, *params)
+                return [np.ravel(_) for _ in np.ravel(weights) * np.array(model.fit_deriv(x, *params))]
             else:
-                return [np.ravel(_) for _ in model.fit_deriv(x, y, *params)]
+                return [np.ravel(_) for _ in (np.ravel(weights) * np.array(model.fit_deriv(x, y, *params)).T).T]
 
 
 class SLSQPLSQFitter(Fitter):

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -104,6 +104,18 @@ class TestICheb2D(object):
         assert_allclose(model.parameters, [0, 1, 2, 3, 4, 5, 6, 7, 8],
                         atol=10**-9)
 
+    @pytest.mark.skipif('not HAS_SCIPY')
+    def test_chebyshev2D_nonlinear_fitting_with_weights(self):
+        cheb2d = models.Chebyshev2D(2, 2)
+        cheb2d.parameters = np.arange(9)
+        z = cheb2d(self.x, self.y)
+        cheb2d.parameters = [0.1, .6, 1.8, 2.9, 3.7, 4.9, 6.7, 7.5, 8.9]
+        nlfitter = LevMarLSQFitter()
+        weights = np.ones_like(self.y)
+        model = nlfitter(cheb2d, self.x, self.y, z, weights=weights)
+        assert_allclose(model.parameters, [0, 1, 2, 3, 4, 5, 6, 7, 8],
+                        atol=10**-9)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestJointFitter(object):

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -252,6 +252,21 @@ class TestNonLinearFitters(object):
         emodel = efitter(g1e, self.xdata, self.ydata, estimate_jacobian=True)
         assert_allclose(model.parameters, emodel.parameters, rtol=10 ** (-3))
 
+    def test_estimated_vs_analytic_deriv_with_weights(self):
+        """
+        Runs `LevMarLSQFitter` with estimated and analytic derivatives of a
+        `Gaussian1D`.
+        """
+
+        weights = 1.0 / (self.ydata / 10.)
+
+        fitter = LevMarLSQFitter()
+        model = fitter(self.gauss, self.xdata, self.ydata, weights=weights)
+        g1e = models.Gaussian1D(100, 5.0, stddev=1)
+        efitter = LevMarLSQFitter()
+        emodel = efitter(g1e, self.xdata, self.ydata, weights=weights, estimate_jacobian=True)
+        assert_allclose(model.parameters, emodel.parameters, rtol=10 ** (-3))
+
     def test_with_optimize(self):
         """
         Tests results from `LevMarLSQFitter` against `scipy.optimize.leastsq`.


### PR DESCRIPTION
Currently, when weights are provided to LevMarLSQFitter, they are simply ignored in the derivative calculation. This PR adds a test that demonstrates the issue, and a fix. The second test is to check that weights are correctly multiplied in the 2D case (this seems to require special treatment because model.fit_deriv yields a 2D array that's transposed compared to the 1D case).