### PR TITLE
Fix Cone Search decoding and timeout test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,7 +301,8 @@ Bug fixes
     tables. [#4699]
 
   - VOSDatabase decodes byte-string to UTF-8 instead of ASCII to avoid
-    UnicodeDecodeError for some rare cases. [#4757]
+    UnicodeDecodeError for some rare cases. Fixed a Cone Search test that is
+    failing as a side-effect of #4699. [#4757]
 
 - ``astropy.wcs``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -300,6 +300,9 @@ Bug fixes
   - Cache option now properly caches both downloaded JSON database and XML VO
     tables. [#4699]
 
+  - VOSDatabase decodes byte-string to UTF-8 instead of ASCII to avoid
+    UnicodeDecodeError for some rare cases. [#4757]
+
 - ``astropy.wcs``
 
 Other Changes and Additions

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -100,7 +100,7 @@ class TestConeSearch(object):
             with data.conf.set_temp('remote_timeout', 0.001):
                 tab = conesearch.conesearch(
                     SCS_CENTER, SCS_RADIUS, pedantic=self.pedantic,
-                    verbose=self.verbose, catalog_db=self.url)
+                    verbose=self.verbose, catalog_db=self.url, cache=False)
         except VOSError as e:
             assert 'timed out' in str(e), 'test_timeout failed'
         else:

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -577,7 +577,7 @@ class VOSDatabase(VOSBase):
                     title_counter[cur_title] += 1  # Starts with 1
 
                     if isinstance(cur_title, bytes):  # pragma: py3
-                        cur_key = title_fmt.format(cur_title.decode('ascii'),
+                        cur_key = title_fmt.format(cur_title.decode('utf-8'),
                                                    title_counter[cur_title])
                     else:  # pragma: py2
                         cur_key = title_fmt.format(cur_title,


### PR DESCRIPTION
Several days ago, a new Cone Search service must have been added to the STScI database. It contains an entry that breaks `bytestring.decode('ascii')`. The solution is to use `bytestring.decode('utf-8')` instead.

Minimal VO table to reproduce the error is as follows (rename the `.txt` extension to `.xml`):
[VOTshort.txt](https://github.com/astropy/astropy/files/203092/VOTshort.txt)

Specifically, the offending line is its title, as illustrated below:
```python
>>> from astropy.vo.client import vos_catalog
>>> cur_title = b'DwarfArchives.org – Photometry, spectroscopy, and astrometry of L, T, and Y dwarfs'
>>> cur_title
'DwarfArchives.org \xe2\x80\x93 Photometry, spectroscopy, and astrometry of L, T, and Y dwarfs'
>>> cur_title.decode('ascii')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 18: ordinal not in range(128)
>>> cur_title.decode('utf-8')
 u'DwarfArchives.org \u2013 Photometry, spectroscopy, and astrometry of L, T, and Y dwarfs'
```

Also in this PR is a fix for `test_timeout()` that specifically tests that Cone Search reports timeouts appropriately. The test must have been broken by a fix to the caching system in #4699, although I am unsure how it wasn't caught back then.

As Cone Search is not a widely used feature (i.e., no one complains about it but me), I am okay with putting the fix to the next release instead of backporting.