### PR TITLE
Allow trailing whitespace in the IPAC header lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ New Features
   - Check that columns in ``formats`` specifier exist in the output table
     when writing. [#4508]
 
+  - Allow trailing whitespace in the IPAC header lines. [#4758]
+
 - ``astropy.io.fits``
 
   - File name could be passed as ``Path`` object. [#4606]

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -85,9 +85,10 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
 
     def process_lines(self, lines):
         """Generator to yield IPAC header lines, i.e. those starting and ending with
-        delimiter character."""
+        delimiter character (with trailing whitespace stripped)"""
         delim = self.splitter.delimiter
         for line in lines:
+            line = line.rstrip()
             if line.startswith(delim) and line.endswith(delim):
                 yield line.strip(delim)
 

--- a/astropy/io/ascii/tests/t/ipac.dat
+++ b/astropy/io/ascii/tests/t/ipac.dat
@@ -4,7 +4,7 @@
 \key_continue = 'IPAC keywords '
 \key_continue = 'can continue across lines'
 \ This is an example of a valid comment
-|     ra   |    dec   |   sai   |-----v2---|    sptype        |
+|     ra   |    dec   |   sai   |-----v2---|    sptype        | 
 |    real  |   real   |   int   |    real  |     char         |
 |    unit  |   unit   |   unit  |    unit  |     ergs         |
 |    null  |   null   |   -999  |    null  |     -999         |


### PR DESCRIPTION
Partial fix for #4749.