### PR TITLE
Iterative fitting with outlier removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ New Features
 
 - ``astropy.modeling``
 
+  - Add a class to combine astropy fitters and functions to remove outliers
+    e. g., sigma clip. [#4760]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -344,10 +344,10 @@ class LinearLSQFitter(object):
 class FittingWithOutlierRemoval(object):
     """
     This class combines an outlier removal technique with a fitting procedure.
-    Basically, given a number of iterations `niter`, outliers are removed in
-    and fitting is performed for each iteration.
+    Basically, given a number of iterations `niter`, outliers are removed and
+    fitting is performed for each iteration.
 
-    Attributes
+    Parameters
     ----------
     fitter : An Astropy fitter
         An instance of any Astropy fitter, i.e., LinearLSQFitter,
@@ -366,41 +366,8 @@ class FittingWithOutlierRemoval(object):
         self.niter = niter
         self.outlier_kwargs = outlier_kwargs
 
-    @property
-    def fitter(self):
-        return self._fitter
-
-    @fitter.setter
-    def fitter(self, fitter):
-        if isinstance(type(fitter), _FitterMeta):
-            self._fitter = fitter
-        else:
-            raise ValueError('fitter is expected to be an Astropy Fitter.')
-
-    @property
-    def outlier_func(self):
-        return self._outlier_func
-
-    @outlier_func.setter
-    def outlier_func(self, outlier_func):
-        if inspect.isfunction(outlier_func):
-            self._outlier_func = outlier_func
-        else:
-            raise ValueError('outlier_func is expected to be a callable.')
-
-    @property
-    def niter(self):
-        return self._niter
-
-    @niter.setter
-    def niter(self, niter):
-        if isinstance(niter, type(1)):
-            self._niter = niter
-        else:
-            raise ValueError('niter is expected to be an integer.')
-
     def __str__(self):
-        return ("Fitter: {0}\nOutlier function: {1}\nNum. of iterations: {2}" +
+        return ("Fitter: {0}\nOutlier function: {1}\nNum. of iterations: {2}"+
                 ("\nOutlier func. args.: {3}"))\
                 .format(self.fitter__class__.__name__,\
                         self.outlier_func.__name__, self.niter,\

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -344,8 +344,8 @@ class LinearLSQFitter(object):
 class FittingWithOutlierRemoval(object):
     """
     This class combines an outlier removal technique with a fitting procedure.
-    Basically, given a number of iterations `niter`, outliers are removed and
-    fitting is performed for each iteration.
+    Basically, given a number of iterations ``niter``, outliers are removed
+    and fitting is performed for each iteration.
 
     Parameters
     ----------

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -360,7 +360,7 @@ class FittingWithOutlierRemoval(object):
         Keyword arguments for outlier_func.
     """
 
-    def __init__(self, fitter, outlier_func, niter=3, **outlier_kwargs): 
+    def __init__(self, fitter, outlier_func, niter=3, **outlier_kwargs):
         self.fitter = fitter
         self.outlier_func = outlier_func
         self.niter = niter

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -414,19 +414,19 @@ class FittingWithOutlierRemoval(object):
             for n in range(self.niter):
                 filtered_data = self.outlier_func(filtered_data,
                                                   **self.outlier_kwargs)
-                fitted_model = self.fitter(fitted_model,\
-                               x[~filtered_data.mask],\
-                               filtered_data.data[~filtered_data.mask],\
+                fitted_model = self.fitter(fitted_model,
+                               x[~filtered_data.mask],
+                               filtered_data.data[~filtered_data.mask],
                                **kwargs)
         else:
             filtered_data = z
             for n in range(self.niter):
                 filtered_data = self.outlier_func(filtered_data,
                                                   **self.outlier_kwargs)
-                fitted_model = self.fitter(fitted_model,\
-                               x[~filtered_data.mask],\
-                               y[~filtered_data.mask],\
-                               filtered_data.data[~filtered_data.mask],\
+                fitted_model = self.fitter(fitted_model,
+                               x[~filtered_data.mask],
+                               y[~filtered_data.mask],
+                               filtered_data.data[~filtered_data.mask],
                                **kwargs)
         return filtered_data, fitted_model
 

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -22,6 +22,7 @@ from ...utils import NumpyRNGContext
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
 from .utils import ignore_non_integer_warning
+from ...stats import sigma_clip
 
 try:
     from scipy import optimize
@@ -405,6 +406,7 @@ class TestNonLinearFitters(object):
         assert_allclose(fmod.parameters, beta.A.ravel())
         assert_allclose(olscov, fitter.fit_info['param_cov'])
 
+
 @pytest.mark.skipif('not HAS_SCIPY')
 class Test1DFittingWithOutlierRemoval(object):
     def setup_class(self):
@@ -417,9 +419,7 @@ class Test1DFittingWithOutlierRemoval(object):
         self.y = func(self.model_params, self.x)
 
     def test_with_fitters_and_sigma_clip(self):
-        from astropy.stats import sigma_clip
         import scipy.stats as stats
-        from astropy.modeling import fitting
 
         np.random.seed(0)
         c = stats.bernoulli.rvs(0.25, size=self.x.shape)
@@ -428,19 +428,18 @@ class Test1DFittingWithOutlierRemoval(object):
 
         g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
         # test with Levenberg-Marquardt Least Squares fitter
-        fit = fitting.FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
-                                                niter=3, sigma=3.0)
+        fit = FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
+                                        niter=3, sigma=3.0)
         _, fitted_model = fit(g_init, self.x, self.y)
         assert_allclose(fitted_model.parameters, self.model_params, rtol=1e-1)
         # test with Sequential Least Squares Programming fitter
-        fit = fitting.FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip,
-                                                niter=3, sigma=3.0)
+        fit = FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip,
+                                        niter=3, sigma=3.0)
         _, fitted_model = fit(g_init, self.x, self.y)
         assert_allclose(fitted_model.parameters, self.model_params, rtol=1e-1)
         # test with Simplex LSQ fitter
-        fit = fitting.FittingWithOutlierRemoval(SimplexLSQFitter(),
-                                                sigma_clip, niter=3,
-                                                sigma=3.0)
+        fit = FittingWithOutlierRemoval(SimplexLSQFitter(), sigma_clip,
+                                        niter=3, sigma=3.0)
         _, fitted_model = fit(g_init, self.x, self.y)
         assert_allclose(fitted_model.parameters, self.model_params, atol=1e-1)
 
@@ -480,7 +479,6 @@ class Test2DFittingWithOutlierRemoval(object):
         return amplitude, x_mean, y_mean
 
     def test_with_fitters_and_sigma_clip(self):
-        from astropy.stats import sigma_clip
         import scipy.stats as stats
 
         np.random.seed(0)

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -463,16 +463,16 @@ class Test2DFittingWithOutlierRemoval(object):
         """computes the centroid of the data as the initial guess for the
         center position"""
 
-        wx = x*data
-        wy = y*data
+        wx = x * data
+        wy = y * data
         total_intensity = np.sum(data)
-        x_mean = np.sum(wx)/total_intensity
-        y_mean = np.sum(wy)/total_intensity
+        x_mean = np.sum(wx) / total_intensity
+        y_mean = np.sum(wy) / total_intensity
 
-        x_to_pixel = x[0].size/(x[x[0].size-1][x[0].size-1] - x[0][0])
-        y_to_pixel = y[0].size/(y[y[0].size-1][y[0].size-1] - y[0][0])
-        x_pos = np.around(x_mean*x_to_pixel + x[0].size/2.).astype(int)
-        y_pos = np.around(y_mean*y_to_pixel + y[0].size/2.).astype(int)
+        x_to_pixel = x[0].size / (x[x[0].size - 1][x[0].size - 1] - x[0][0])
+        y_to_pixel = y[0].size / (y[y[0].size - 1][y[0].size - 1] - y[0][0])
+        x_pos = np.around(x_mean * x_to_pixel + x[0].size / 2.).astype(int)
+        y_pos = np.around(y_mean * y_to_pixel + y[0].size / 2.).astype(int)
 
         amplitude = data[y_pos][x_pos]
 

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -11,6 +11,7 @@ import os.path
 import numpy as np
 
 from numpy import linalg
+from numpy.testing.utils import assert_raises
 from numpy.testing.utils import assert_allclose, assert_almost_equal
 
 from . import irafutil
@@ -403,3 +404,110 @@ class TestNonLinearFitters(object):
 
         assert_allclose(fmod.parameters, beta.A.ravel())
         assert_allclose(olscov, fitter.fit_info['param_cov'])
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class Test1DFittingWithOutlierRemoval(object):
+    def setup_class(self):
+        self.x = np.linspace(-5., 5., 200)
+        self.model_params = (3.0, 1.3, 0.8)
+
+        def func(p, x):
+            return p[0]*np.exp(-0.5*(x - p[1])**2/p[2]**2)
+
+        self.y = func(self.model_params, self.x)
+
+    def test_with_fitters_and_sigma_clip(self):
+        from astropy.stats import sigma_clip
+        import scipy.stats as stats
+        from astropy.modeling import fitting
+
+        np.random.seed(0)
+        c = stats.bernoulli.rvs(0.25, size=self.x.shape)
+        self.y += (np.random.normal(0., 0.2, self.x.shape) +
+                   c*np.random.normal(3.0, 5.0, self.x.shape))
+
+        g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
+        # test with Levenberg-Marquardt Least Squares fitter
+        fit = fitting.FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
+                                                niter=3, sigma=3.0)
+        _, fitted_model = fit(g_init, self.x, self.y)
+        assert_allclose(fitted_model.parameters, self.model_params, rtol=1e-1)
+        # test with Sequential Least Squares Programming fitter
+        fit = fitting.FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip,
+                                                niter=3, sigma=3.0)
+        _, fitted_model = fit(g_init, self.x, self.y)
+        assert_allclose(fitted_model.parameters, self.model_params, rtol=1e-1)
+        # test with Simplex LSQ fitter
+        fit = fitting.FittingWithOutlierRemoval(SimplexLSQFitter(),
+                                                sigma_clip, niter=3,
+                                                sigma=3.0)
+        _, fitted_model = fit(g_init, self.x, self.y)
+        assert_allclose(fitted_model.parameters, self.model_params, atol=1e-1)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class Test2DFittingWithOutlierRemoval(object):
+    def setup_class(self):
+        self.y, self.x = np.mgrid[-3:3:128j, -3:3:128j]
+        self.model_params = (3.0, 1.0, 0.0, 0.8, 0.8)
+
+        def Gaussian_2D(p, pos):
+            return p[0]*np.exp(-0.5*(pos[0] - p[2])**2 / p[4]**2 -
+                               0.5*(pos[1] - p[1])**2 / p[3]**2)
+
+        self.z = Gaussian_2D(self.model_params, np.array([self.y, self.x]))
+
+    def initial_guess(self, data, pos):
+        y = pos[0]
+        x = pos[1]
+
+        """computes the centroid of the data as the initial guess for the
+        center position"""
+
+        wx = x*data
+        wy = y*data
+        total_intensity = np.sum(data)
+        x_mean = np.sum(wx)/total_intensity
+        y_mean = np.sum(wy)/total_intensity
+
+        x_to_pixel = x[0].size/(x[x[0].size-1][x[0].size-1] - x[0][0])
+        y_to_pixel = y[0].size/(y[y[0].size-1][y[0].size-1] - y[0][0])
+        x_pos = np.around(x_mean*x_to_pixel + x[0].size/2.).astype(int)
+        y_pos = np.around(y_mean*y_to_pixel + y[0].size/2.).astype(int)
+
+        amplitude = data[y_pos][x_pos]
+
+        return amplitude, x_mean, y_mean
+
+    def test_with_fitters_and_sigma_clip(self):
+        from astropy.stats import sigma_clip
+        import scipy.stats as stats
+
+        np.random.seed(0)
+        c = stats.bernoulli.rvs(0.25, size=self.z.shape)
+        self.z += (np.random.normal(0., 0.2, self.z.shape) +
+                   c*np.random.normal(self.z, 2.0, self.z.shape))
+
+        guess = self.initial_guess(self.z, np.array([self.y, self.x]))
+        g2_init = models.Gaussian2D(amplitude=guess[0], x_mean=guess[1],
+                                    y_mean=guess[2], x_stddev=0.75,
+                                    y_stddev=1.25)
+
+        # test with Levenberg-Marquardt Least Squares fitter
+        fit = FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
+                                        niter=3, sigma=4.)
+        _, fitted_model = fit(g2_init, self.x, self.y, self.z)
+        assert_allclose(fitted_model.parameters[0:5], self.model_params,
+                        atol=1e-1)
+        # test with Sequential Least Squares Programming fitter
+        fit = FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip, niter=3,
+                                        sigma=4.)
+        _, fitted_model = fit(g2_init, self.x, self.y, self.z)
+        assert_allclose(fitted_model.parameters[0:5], self.model_params,
+                        atol=1e-1)
+        # test with Simplex LSQ fitter
+        fit = FittingWithOutlierRemoval(SimplexLSQFitter(), sigma_clip,
+                                        niter=3, sigma=4.)
+        _, fitted_model = fit(g2_init, self.x, self.y, self.z)
+        assert_allclose(fitted_model.parameters[0:5], self.model_params,
+                        atol=1e-1)

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -60,6 +60,46 @@ Fitting examples
           1.0 2.0 -5.86673908219e-16 3.61636197841e-17
           1.0 2.0 -5.86673908219e-16 3.61636197841e-17
 
+- Iterative fitting with sigma clipping:
+
+.. plot::
+    :include-source:
+    
+     import numpy as np
+     from astropy.stats import sigma_clip
+     from astropy.modeling import models, fitting
+     import scipy.stats as stats
+     from matplotlib import pyplot as plt
+     
+     # Generate fake data with outliers
+     np.random.seed(0)
+     x = np.linspace(-5., 5., 200)
+     y = 3 * np.exp(-0.5 * (x - 1.3)**2 / 0.8**2)
+     c = stats.bernoulli.rvs(0.35, size=x.shape)
+     y += (np.random.normal(0., 0.2, x.shape) +
+           c*np.random.normal(3.0, 5.0, x.shape))
+     g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
+
+     # initiliaze fitters
+     fit = fitting.LevMarLSQFitter()
+     or_fit = fitting.FittingWithOutlierRemoval(fit, sigma_clip,
+                                                niter=3, sigma=3.0)
+
+     # get fitted model and filtered data
+     filtered_data, or_fitted_model = or_fit(g_init, x, y)
+     fitted_model = fit(g_init, x, y)
+
+     # plot data and fitted models
+     plt.figure(figsize=(8,5))
+     plt.plot(x, y, 'gx', label="original data")
+     plt.plot(x, filtered_data, 'r+', label="filtered data")
+     plt.plot(x, fitted_model(x), 'g-',
+              label="model fitted w/ original data")
+     plt.plot(x, or_fitted_model(x), 'r--',
+              label="model fitted w/ filtered data")
+     plt.legend(loc=2, numpoints=1)
+      
+
 Fitters support constrained fitting.
 
 - All fitters support fixed (frozen) parameters through the ``fixed`` argument

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -80,7 +80,7 @@ Fitting examples
            c*np.random.normal(3.0, 5.0, x.shape))
      g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
 
-     # initiliaze fitters
+     # initialize fitters
      fit = fitting.LevMarLSQFitter()
      or_fit = fitting.FittingWithOutlierRemoval(fit, sigma_clip,
                                                 niter=3, sigma=3.0)


### PR DESCRIPTION
Hi all,

this PR addresses #4698.

The basic idea is (as stated by @pllim):
1. Create a model.
2. Attach a fitter to the model.
3. Fit with some data.
4. Reject some outliers with sigma clipping (or any other outlier removal procedure).
5. Redo fitting with clipped data.
6. Repeat 4-5 for a number of times (niter) until satisfied.

So, I would like to know what you guys think...

Can I go ahead and write some tests for the rest of the fitters and consider 2D case as well?

See the example below as a use case:
```
import numpy as np
from astropy.stats import sigma_clip
from astropy.modeling import models, fitting
import scipy.stats as stats
from matplotlib import pyplot as plt

np.random.seed(0)
x = np.linspace(-5., 5., 200)
y = 3 * np.exp(-0.5 * (x - 1.3)**2 / 0.8**2)
c = stats.bernoulli.rvs(0.25, size=x.shape)
y += np.random.normal(0., 0.2, x.shape) + c*np.random.normal(3.0, 5.0, x.shape)

g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
fit = fitting.FittingWithOutlierRemoval(fitting.LevMarLSQFitter(),
                                        sigma_clip, niter=3, sigma=3.0)
filtered_data, fitted_model = fit(g_init, x, y)

plt.figure()
plt.plot(x, y, 'gx', label="data")
plt.plot(x[~filtered_data.mask], filtered_data.data[~filtered_data.mask],
         'b+', label="filtered data")
plt.plot(x, fitted_model(x), '--', label="fitted model")
plt.legend(loc=2)
plt.show()
```
![figure_1](https://cloud.githubusercontent.com/assets/13077051/14273364/7e418a66-fae0-11e5-9f64-191021fd855f.png)

Thanks!
