### PR TITLE
Update equivalencies.py

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -450,11 +450,11 @@ def brightness_temperature(beam_area, disp):
         >>> bmaj = 15*u.arcsec
         >>> bmin = 15*u.arcsec
         >>> fwhm_to_sigma = 1./(8*np.log(2))**0.5
-        >>> beam_area = 2.*np.pi*(bmaj*bmin/fwhm_to_sigma**2)
+        >>> beam_area = 2.*np.pi*(bmaj*bmin*fwhm_to_sigma**2)
         >>> freq = 5*u.GHz
         >>> equiv = u.brightness_temperature(beam_area, freq)
         >>> u.Jy.to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
-        7.065788175060084
+        217.2658703625732
     """
     beam = beam_area.to(si.sr).value
     nu = disp.to(si.GHz, spectral())


### PR DESCRIPTION
Multiply instead of divide in the equation for beam area (`beam_area = 2.*np.pi*(bmaj*bmin*fwhm_to_sigma**2)`), because of the way `fwhm_to_sigma` is defined with `(8*np.log(2))**0.5` already in the denominator.  

I think this is consistent with the equations shown on this page: https://www.cv.nrao.edu/course/astr534/Interferometers2.html  But, you can ignore this if I have made a mistake or wrong assumption.