### PR TITLE
Allow base with dimensionless quantity as base for np.power.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1276,6 +1276,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Exponentation using a ``Quantity`` with a unit equivalent to dimensionless
+    as base and an ``array``-like exponent yields the correct result. [#4770]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -357,7 +357,7 @@ class Quantity(np.ndarray):
         # amount that depends on one of the input values, so we need to treat
         # this as a special case.
         # TODO: find a better way to deal with this case
-        if function is np.power and result_unit is not dimensionless_unscaled:
+        if function is np.power and result_unit != dimensionless_unscaled:
 
             if units[1] is None:
                 p = args[1]

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -306,9 +306,11 @@ class TestQuantityMathFuncs(object):
         assert res.unit == u.dimensionless_unscaled
         # The same holds for unit fractions that are scaled dimensionless.
         q2 = [2., 4.] * u.m / u.cm
-        res2 = np.power(q2, powers)
-        assert np.all(res2.value == q2.to(1).value ** powers)
-        assert res2.unit == u.dimensionless_unscaled
+        # Test also against different types of exponent
+        for cls in (list, tuple, np.array, np.ma.array, u.Quantity):
+            res2 = np.power(q2, cls(powers))
+            assert np.all(res2.value == q2.to(1).value ** powers)
+            assert res2.unit == u.dimensionless_unscaled
         # Though for single powers, we keep the composite unit.
         res3 = q2 ** 2
         assert np.all(res3.value == q2.value ** 2)

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -296,6 +296,18 @@ class TestQuantityMathFuncs(object):
     def test_power_array_array2(self):
         np.power([2., 4.] * u.m, [2., 4.])
 
+    def test_power_array_array3(self):
+        # Equivalent unit fractions are NOT considered dimensionless and raise
+        # a ValueError.
+        with raises(ValueError):
+            np.power([2., 4.] * u.m / u.cm, [2., 4.])
+
+        # But identical unit fractions are considered dimensionless and are
+        # allowed as base for np.power: #4764
+        res = np.power([2., 4.] * u.m / u.m, [2., 4.])
+        np.testing.assert_array_equal(res.value, np.array([4., 256.]))
+        assert res.unit == u.dimensionless_unscaled
+
     def test_power_invalid(self):
         with pytest.raises(TypeError) as exc:
             np.power(3., 4. * u.m)


### PR DESCRIPTION
Fixes #4764

The rationale for this change is explained in https://github.com/astropy/astropy/issues/4764#issuecomment-208371504.