### PR TITLE
Add zscale interval based on Numdisplay's implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -129,6 +129,8 @@ New Features
 
 - ``astropy.visualization``
 
+  - Add zscale interval based on Numdisplay's implementation. [#4776]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -11,9 +11,11 @@ import abc
 import numpy as np
 
 from .transform import BaseTransform
+from .zscale import zscale
 
 __all__ = ['BaseInterval', 'ManualInterval', 'MinMaxInterval',
-           'PercentileInterval', 'AsymmetricPercentileInterval']
+           'PercentileInterval', 'AsymmetricPercentileInterval',
+           'ZScaleInterval']
 
 
 class BaseInterval(BaseTransform):
@@ -137,3 +139,28 @@ class PercentileInterval(AsymmetricPercentileInterval):
         lower_percentile = (100 - percentile) * 0.5
         upper_percentile = 100 - lower_percentile
         super(PercentileInterval, self).__init__(lower_percentile, upper_percentile, n_samples=n_samples)
+
+
+class ZScaleInterval(BaseInterval):
+    """
+    Interval based on IRAF's zscale.
+
+    http://iraf.net/forum/viewtopic.php?showtopic=134139
+
+    Parameters
+    ----------
+    nsamples : int
+        Number of points in array to sample for determining scaling factors.
+        (Default: 1000)
+    contrast : float
+        Scaling factor for determining min and max. Larger values increase the
+        difference between min and max values used for display. (Default: 0.25)
+
+    """
+
+    def __init__(self, nsamples=1000, contrast=0.25):
+        self.nsamples = nsamples
+        self.contrast = contrast
+
+    def get_limits(self, values):
+        return zscale(values, nsamples=self.nsamples, contrast=self.contrast)

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -149,12 +149,12 @@ class ZScaleInterval(BaseInterval):
 
     Parameters
     ----------
-    nsamples : int
+    nsamples : int, optional
         Number of points in array to sample for determining scaling factors.
-        (Default: 1000)
-    contrast : float
+        Default to 1000.
+    contrast : float, optional
         Scaling factor for determining min and max. Larger values increase the
-        difference between min and max values used for display. (Default: 0.25)
+        difference between min and max values used for display. Default to 0.25
 
     """
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -149,18 +149,38 @@ class ZScaleInterval(BaseInterval):
 
     Parameters
     ----------
+    image : array_like
+        Input array.
     nsamples : int, optional
         Number of points in array to sample for determining scaling factors.
         Default to 1000.
     contrast : float, optional
-        Scaling factor for determining min and max. Larger values increase the
-        difference between min and max values used for display. Default to 0.25
+        Scaling factor (between 0 and 1) for determining min and max. Larger
+        values increase the difference between min and max values used for
+        display. Default to 0.25.
+    max_reject : float, optional
+        If more than ``max_reject * npixels`` pixels are rejected, then the
+        returned values are the min and max of the data. Default to 0.5.
+    min_npixels : int, optional
+        If less than ``min_npixels`` pixels are rejected, then the
+        returned values are the min and max of the data. Default to 5.
+    krej : float, optional
+        Number of sigma used for the rejection. Default to 2.5.
+    max_iterations : int, optional
+        Maximum number of iterations for the rejection. Default to 5.
 
     """
 
-    def __init__(self, nsamples=1000, contrast=0.25):
+    def __init__(self, nsamples=1000, contrast=0.25, max_reject=0.5,
+                 min_npixels=5, krej=2.5, max_iterations=5):
         self.nsamples = nsamples
         self.contrast = contrast
+        self.max_reject = max_reject
+        self.min_npixels = min_npixels
+        self.krej = krej
+        self.max_iterations = max_iterations
 
     def get_limits(self, values):
-        return zscale(values, nsamples=self.nsamples, contrast=self.contrast)
+        return zscale(values, nsamples=self.nsamples, contrast=self.contrast,
+                      max_reject=self.max_reject, min_npixels=self.min_npixels,
+                      krej=self.krej, max_iterations=self.max_iterations)

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -6,7 +6,7 @@ from ...tests.helper import pytest
 from ...utils import NumpyRNGContext
 
 from ..interval import (ManualInterval, MinMaxInterval, PercentileInterval,
-                        AsymmetricPercentileInterval)
+                        AsymmetricPercentileInterval, ZScaleInterval)
 
 
 class TestInterval(object):
@@ -57,6 +57,12 @@ class TestInterval2D(TestInterval):
     # Make sure intervals work with 2d arrays
 
     data = np.linspace(-20., 60., 100).reshape(100, 1)
+
+    def test_zscale(self):
+        interval = ZScaleInterval()
+        vmin, vmax = interval.get_limits(self.data)
+        np.testing.assert_allclose(vmin, -20.)
+        np.testing.assert_allclose(vmax, +60.)
 
 
 def test_integers():

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -67,6 +67,12 @@ def test_zscale():
     np.testing.assert_allclose(vmin, -9.6, atol=0.1)
     np.testing.assert_allclose(vmax, 25.4, atol=0.1)
 
+    data = list(range(1000)) + [np.nan]
+    interval = ZScaleInterval()
+    vmin, vmax = interval.get_limits(data)
+    np.testing.assert_allclose(vmin, 0, atol=0.1)
+    np.testing.assert_allclose(vmax, 999, atol=0.1)
+
 
 def test_integers():
 

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -58,11 +58,14 @@ class TestInterval2D(TestInterval):
 
     data = np.linspace(-20., 60., 100).reshape(100, 1)
 
-    def test_zscale(self):
-        interval = ZScaleInterval()
-        vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -20.)
-        np.testing.assert_allclose(vmax, +60.)
+
+def test_zscale():
+    np.random.seed(42)
+    data = np.random.randn(100, 100) * 5 + 10
+    interval = ZScaleInterval()
+    vmin, vmax = interval.get_limits(data)
+    np.testing.assert_allclose(vmin, -9.6, atol=0.1)
+    np.testing.assert_allclose(vmax, 25.4, atol=0.1)
 
 
 def test_integers():

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -15,13 +15,9 @@ import numpy as np
 
 __all__ = ['zscale']
 
-MAX_REJECT = 0.5
-MIN_NPIXELS = 5
-KREJ = 2.5
-MAX_ITERATIONS = 5
 
-
-def zscale(image, nsamples=1000, contrast=0.25):
+def zscale(image, nsamples=1000, contrast=0.25, max_reject=0.5, min_npixels=5,
+           krej=2.5, max_iterations=5):
     """Implement IRAF zscale algorithm.
 
     Parameters
@@ -32,8 +28,19 @@ def zscale(image, nsamples=1000, contrast=0.25):
         Number of points in array to sample for determining scaling factors.
         Default to 1000.
     contrast : float, optional
-        Scaling factor for determining min and max. Larger values increase the
-        difference between min and max values used for display. Default to 0.25
+        Scaling factor (between 0 and 1) for determining min and max. Larger
+        values increase the difference between min and max values used for
+        display. Default to 0.25.
+    max_reject : float, optional
+        If more than ``max_reject * npixels`` pixels are rejected, then the
+        returned values are the min and max of the data. Default to 0.5.
+    min_npixels : int, optional
+        If less than ``min_npixels`` pixels are rejected, then the
+        returned values are the min and max of the data. Default to 5.
+    krej : float, optional
+        Number of sigma used for the rejection. Default to 2.5.
+    max_iterations : int, optional
+        Maximum number of iterations for the rejection. Default to 5.
 
     Returns
     -------
@@ -53,35 +60,20 @@ def zscale(image, nsamples=1000, contrast=0.25):
     zmax = samples[-1]
 
     # Fit a line to the sorted array of samples
-    minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
-    ngoodpix, zslope = zsc_fit_line(samples, KREJ, MAX_ITERATIONS)
-
-    if ngoodpix >= minpix:
-        if contrast > 0:
-            zslope = zslope / contrast
-        center_pixel = (npix - 1) // 2
-        median = np.median(samples)
-        zmin = max(zmin, median - (center_pixel - 1) * zslope)
-        zmax = min(zmax, median + (npix - center_pixel) * zslope)
-    return zmin, zmax
-
-
-def zsc_fit_line(samples, krej, maxiter):
-    npix = len(samples)
+    minpix = max(min_npixels, int(npix * max_reject))
     x = np.arange(npix)
-
     ngoodpix = npix
-    minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
     last_ngoodpix = npix + 1
 
+    # Bad pixels mask used in k-sigma clipping
+    badpix = np.zeros(npix, dtype=bool)
+
+    # Kernel used to dilate the bad pixels mask
     ngrow = max(1, int(npix * 0.01))
     kernel = np.ones(ngrow, dtype=bool)
 
-    # This is the mask used in k-sigma clipping
-    badpix = np.zeros(npix, dtype=bool)
-
-    for niter in range(maxiter):
-        if (ngoodpix >= last_ngoodpix) or (ngoodpix < minpix):
+    for niter in range(max_iterations):
+        if ngoodpix >= last_ngoodpix or ngoodpix < minpix:
             break
 
         fit = np.polyfit(x, samples, deg=1, w=(~badpix).astype(int))
@@ -103,4 +95,12 @@ def zsc_fit_line(samples, krej, maxiter):
         ngoodpix = np.sum(~badpix)
 
     slope, intercept = fit
-    return ngoodpix, slope
+
+    if ngoodpix >= minpix:
+        if contrast > 0:
+            slope = slope / contrast
+        center_pixel = (npix - 1) // 2
+        median = np.median(samples)
+        zmin = max(zmin, median - (center_pixel - 1) * slope)
+        zmax = min(zmax, median + (npix - center_pixel) * slope)
+    return zmin, zmax

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -8,10 +8,12 @@ https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/LI
 
 """
 
-from __future__ import division  # confidence high
+from __future__ import absolute_import, division
 
 import math
-import numpy
+import numpy as np
+
+__all__ = ['zscale']
 
 MAX_REJECT = 0.5
 MIN_NPIXELS = 5
@@ -87,7 +89,7 @@ def zsc_sample(image, maxpix):
 def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
     # First re-map indices from -1.0 to 1.0
     xscale = 2.0 / (npix - 1)
-    xnorm = numpy.arange(npix)
+    xnorm = np.arange(npix)
     xnorm = xnorm * xscale - 1.0
 
     ngoodpix = npix
@@ -95,7 +97,7 @@ def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
     last_ngoodpix = npix + 1
 
     # This is the mask used in k-sigma clipping.  0 is good, 1 is bad
-    badpix = numpy.zeros(npix, dtype="int32")
+    badpix = np.zeros(npix, dtype="int32")
 
     #
     #  Iterate
@@ -106,7 +108,7 @@ def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
             break
 
         # Accumulate sums to calculate straight line fit
-        goodpixels = numpy.where(badpix == GOOD_PIXEL)
+        goodpixels = np.where(badpix == GOOD_PIXEL)
         sumx = xnorm[goodpixels].sum()
         sumxx = (xnorm[goodpixels] * xnorm[goodpixels]).sum()
         sumxy = (xnorm[goodpixels] * samples[goodpixels]).sum()
@@ -130,17 +132,17 @@ def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
         # Detect and reject pixels further than k*sigma from the fitted line
         lcut = -threshold
         hcut = threshold
-        below = numpy.where(flat < lcut)
-        above = numpy.where(flat > hcut)
+        below = np.where(flat < lcut)
+        above = np.where(flat > hcut)
 
         badpix[below] = BAD_PIXEL
         badpix[above] = BAD_PIXEL
 
         # Convolve with a kernel of length ngrow
-        kernel = numpy.ones(ngrow, dtype="int32")
-        badpix = numpy.convolve(badpix, kernel, mode='same')
+        kernel = np.ones(ngrow, dtype="int32")
+        badpix = np.convolve(badpix, kernel, mode='same')
 
-        ngoodpix = len(numpy.where(badpix == GOOD_PIXEL)[0])
+        ngoodpix = len(np.where(badpix == GOOD_PIXEL)[0])
 
         niter += 1
 
@@ -157,7 +159,7 @@ def zsc_compute_sigma(flat, badpix, npix):
     # Ignore rejected pixels
 
     # Accumulate sum and sum of squares
-    goodpixels = numpy.where(badpix == GOOD_PIXEL)
+    goodpixels = np.where(badpix == GOOD_PIXEL)
     sumz = flat[goodpixels].sum()
     sumsq = (flat[goodpixels] * flat[goodpixels]).sum()
     ngoodpix = len(goodpixels[0])

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -21,7 +21,7 @@ KREJ = 2.5
 MAX_ITERATIONS = 5
 
 
-def zscale(image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
+def zscale(image, nsamples=1000, contrast=0.25):
     """Implement IRAF zscale algorithm
 
     Parameters
@@ -36,19 +36,13 @@ def zscale(image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
         Scaling factor for determining min and max. Larger values increase the
         difference between min and max values used for display.
 
-    bpmask : None
-        Not used at this time
-
-    zmask : None
-        Not used at this time
-
     Returns
     -------
     (z1, z2)
     """
 
     # Sample the image
-    samples = zsc_sample(image, nsamples, bpmask, zmask)
+    samples = zsc_sample(image, nsamples)
     npix = len(samples)
     samples.sort()
     zmin = samples[0]
@@ -78,11 +72,9 @@ def zscale(image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
     return z1, z2
 
 
-def zsc_sample(image, maxpix, bpmask=None, zmask=None):
-
+def zsc_sample(image, maxpix):
     # Figure out which pixels to use for the zscale algorithm
     # Returns the 1-d array samples
-    # Don't worry about the bad pixel mask or zmask for the moment
     # Sample in a square grid, and return the first maxpix in the sample
     nc = image.shape[0]
     nl = image.shape[1]
@@ -93,8 +85,6 @@ def zsc_sample(image, maxpix, bpmask=None, zmask=None):
 
 
 def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
-
-    #
     # First re-map indices from -1.0 to 1.0
     xscale = 2.0 / (npix - 1)
     xnorm = numpy.arange(npix)

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -53,8 +53,9 @@ def zscale(image, nsamples=1000, contrast=0.25, max_reject=0.5, min_npixels=5,
 
     # Sample the image
     image = np.asarray(image)
+    image = image[np.isfinite(image)]
     stride = int(image.size / nsamples)
-    samples = image.flatten()[::stride][:nsamples]
+    samples = image[::stride][:nsamples]
     samples.sort()
 
     npix = len(samples)

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -35,7 +35,7 @@ DAMAGE.
 
 """
 
-from __future__ import division # confidence high
+from __future__ import division  # confidence high
 
 import math
 import numpy
@@ -47,7 +47,8 @@ BAD_PIXEL = 1
 KREJ = 2.5
 MAX_ITERATIONS = 5
 
-def zscale (image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
+
+def zscale(image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
     """Implement IRAF zscale algorithm
 
     Parameters
@@ -74,14 +75,14 @@ def zscale (image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
     """
 
     # Sample the image
-    samples = zsc_sample (image, nsamples, bpmask, zmask)
+    samples = zsc_sample(image, nsamples, bpmask, zmask)
     npix = len(samples)
     samples.sort()
     zmin = samples[0]
     zmax = samples[-1]
     # For a zero-indexed array
     center_pixel = (npix - 1) // 2
-    if npix%2 == 1:
+    if npix % 2 == 1:
         median = samples[center_pixel]
     else:
         median = 0.5 * (samples[center_pixel] + samples[center_pixel + 1])
@@ -89,20 +90,22 @@ def zscale (image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
     #
     # Fit a line to the sorted array of samples
     minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
-    ngrow = max (1, int (npix * 0.01))
-    ngoodpix, zstart, zslope = zsc_fit_line (samples, npix, KREJ, ngrow,
-                                             MAX_ITERATIONS)
+    ngrow = max(1, int(npix * 0.01))
+    ngoodpix, zstart, zslope = zsc_fit_line(samples, npix, KREJ, ngrow,
+                                            MAX_ITERATIONS)
 
     if ngoodpix < minpix:
         z1 = zmin
         z2 = zmax
     else:
-        if contrast > 0: zslope = zslope / contrast
-        z1 = max (zmin, median - (center_pixel - 1) * zslope)
-        z2 = min (zmax, median + (npix - center_pixel) * zslope)
+        if contrast > 0:
+            zslope = zslope / contrast
+        z1 = max(zmin, median - (center_pixel - 1) * zslope)
+        z2 = min(zmax, median + (npix - center_pixel) * zslope)
     return z1, z2
 
-def zsc_sample (image, maxpix, bpmask=None, zmask=None):
+
+def zsc_sample(image, maxpix, bpmask=None, zmask=None):
 
     # Figure out which pixels to use for the zscale algorithm
     # Returns the 1-d array samples
@@ -110,12 +113,13 @@ def zsc_sample (image, maxpix, bpmask=None, zmask=None):
     # Sample in a square grid, and return the first maxpix in the sample
     nc = image.shape[0]
     nl = image.shape[1]
-    stride = max (1.0, math.sqrt((nc - 1) * (nl - 1) / float(maxpix)))
-    stride = int (stride)
-    samples = image[::stride,::stride].flatten()
+    stride = max(1.0, math.sqrt((nc - 1) * (nl - 1) / float(maxpix)))
+    stride = int(stride)
+    samples = image[::stride, ::stride].flatten()
     return samples[:maxpix]
 
-def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
+
+def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
 
     #
     # First re-map indices from -1.0 to 1.0
@@ -124,7 +128,7 @@ def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
     xnorm = xnorm * xscale - 1.0
 
     ngoodpix = npix
-    minpix = max (MIN_NPIXELS, int (npix*MAX_REJECT))
+    minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
     last_ngoodpix = npix + 1
 
     # This is the mask used in k-sigma clipping.  0 is good, 1 is bad
@@ -141,8 +145,8 @@ def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
         # Accumulate sums to calculate straight line fit
         goodpixels = numpy.where(badpix == GOOD_PIXEL)
         sumx = xnorm[goodpixels].sum()
-        sumxx = (xnorm[goodpixels]*xnorm[goodpixels]).sum()
-        sumxy = (xnorm[goodpixels]*samples[goodpixels]).sum()
+        sumxx = (xnorm[goodpixels] * xnorm[goodpixels]).sum()
+        sumxy = (xnorm[goodpixels] * samples[goodpixels]).sum()
         sumy = samples[goodpixels].sum()
         sum = len(goodpixels[0])
 
@@ -152,11 +156,11 @@ def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
         slope = (sum * sumxy - sumx * sumy) / delta
 
         # Subtract fitted line from the data array
-        fitted = xnorm*slope + intercept
+        fitted = xnorm * slope + intercept
         flat = samples - fitted
 
         # Compute the k-sigma rejection threshold
-        ngoodpix, mean, sigma = zsc_compute_sigma (flat, badpix, npix)
+        ngoodpix, mean, sigma = zsc_compute_sigma(flat, badpix, npix)
 
         threshold = sigma * krej
 
@@ -170,7 +174,7 @@ def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
         badpix[above] = BAD_PIXEL
 
         # Convolve with a kernel of length ngrow
-        kernel = numpy.ones(ngrow,dtype="int32")
+        kernel = numpy.ones(ngrow, dtype="int32")
         badpix = numpy.convolve(badpix, kernel, mode='same')
 
         ngoodpix = len(numpy.where(badpix == GOOD_PIXEL)[0])
@@ -183,7 +187,8 @@ def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
 
     return ngoodpix, zstart, zslope
 
-def zsc_compute_sigma (flat, badpix, npix):
+
+def zsc_compute_sigma(flat, badpix, npix):
 
     # Compute the rms deviation from the mean of a flattened array.
     # Ignore rejected pixels
@@ -191,7 +196,7 @@ def zsc_compute_sigma (flat, badpix, npix):
     # Accumulate sum and sum of squares
     goodpixels = numpy.where(badpix == GOOD_PIXEL)
     sumz = flat[goodpixels].sum()
-    sumsq = (flat[goodpixels]*flat[goodpixels]).sum()
+    sumsq = (flat[goodpixels] * flat[goodpixels]).sum()
     ngoodpix = len(goodpixels[0])
     if ngoodpix == 0:
         mean = None
@@ -201,10 +206,11 @@ def zsc_compute_sigma (flat, badpix, npix):
         sigma = None
     else:
         mean = sumz / ngoodpix
-        temp = sumsq / (ngoodpix - 1) - sumz*sumz / (ngoodpix * (ngoodpix - 1))
+        temp = sumsq / (ngoodpix - 1) - sumz * sumz / (ngoodpix *
+                                                       (ngoodpix - 1))
         if temp < 0:
             sigma = 0.0
         else:
-            sigma = math.sqrt (temp)
+            sigma = math.sqrt(temp)
 
     return ngoodpix, mean, sigma

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see NUMDISPLAY_LICENSE.rst
 
 """
-Zscale implementation from the STScI numdisplay package, BSD licensed.
+Zscale implementation based on the one from the STScI Numdisplay package.
 
+Original implementation from Numdisplay is BSD licensed:
 https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/lib/stsci/numdisplay/zscale.py?rev=19347
 https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/LICENSE.txt?rev=19347
 
@@ -21,26 +22,28 @@ MAX_ITERATIONS = 5
 
 
 def zscale(image, nsamples=1000, contrast=0.25):
-    """Implement IRAF zscale algorithm
+    """Implement IRAF zscale algorithm.
 
     Parameters
     ----------
-    image : arr
-        2-d numpy array
-
-    nsamples : int (Default: 1000)
-        Number of points in array to sample for determining scaling factors
-
-    contrast : float (Default: 0.25)
+    image : array_like
+        Input array.
+    nsamples : int, optional
+        Number of points in array to sample for determining scaling factors.
+        Default to 1000.
+    contrast : float, optional
         Scaling factor for determining min and max. Larger values increase the
-        difference between min and max values used for display.
+        difference between min and max values used for display. Default to 0.25
 
     Returns
     -------
-    (z1, z2)
+    zmin, zmax: float
+        Computed min and max values.
+
     """
 
     # Sample the image
+    image = np.asarray(image)
     stride = int(image.size / nsamples)
     samples = image.flatten()[::stride][:nsamples]
     samples.sort()

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -44,63 +44,43 @@ def zscale(image, nsamples=1000, contrast=0.25):
     """
 
     # Sample the image
-    samples = zsc_sample(image, nsamples)
-    npix = len(samples)
+    stride = int(image.size / nsamples)
+    samples = image.flatten()[::stride][:nsamples]
     samples.sort()
+
+    npix = len(samples)
     zmin = samples[0]
     zmax = samples[-1]
-    # For a zero-indexed array
-    center_pixel = (npix - 1) // 2
-    if npix % 2 == 1:
-        median = samples[center_pixel]
-    else:
-        median = 0.5 * (samples[center_pixel] + samples[center_pixel + 1])
 
-    #
     # Fit a line to the sorted array of samples
     minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
     ngrow = max(1, int(npix * 0.01))
     ngoodpix, zstart, zslope = zsc_fit_line(samples, npix, KREJ, ngrow,
                                             MAX_ITERATIONS)
 
-    if ngoodpix < minpix:
-        z1 = zmin
-        z2 = zmax
-    else:
+    if ngoodpix >= minpix:
         if contrast > 0:
             zslope = zslope / contrast
-        z1 = max(zmin, median - (center_pixel - 1) * zslope)
-        z2 = min(zmax, median + (npix - center_pixel) * zslope)
-    return z1, z2
-
-
-def zsc_sample(image, maxpix):
-    # Figure out which pixels to use for the zscale algorithm
-    # Returns the 1-d array samples
-    # Sample in a square grid, and return the first maxpix in the sample
-    nc = image.shape[0]
-    nl = image.shape[1]
-    stride = max(1.0, math.sqrt((nc - 1) * (nl - 1) / float(maxpix)))
-    stride = int(stride)
-    samples = image[::stride, ::stride].flatten()
-    return samples[:maxpix]
+        center_pixel = (npix - 1) // 2
+        median = np.median(samples)
+        zmin = max(zmin, median - (center_pixel - 1) * zslope)
+        zmax = min(zmax, median + (npix - center_pixel) * zslope)
+    return zmin, zmax
 
 
 def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
     # First re-map indices from -1.0 to 1.0
     xscale = 2.0 / (npix - 1)
-    xnorm = np.arange(npix)
-    xnorm = xnorm * xscale - 1.0
+    xnorm = np.linspace(-1, 1, npix)
 
     ngoodpix = npix
     minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
     last_ngoodpix = npix + 1
 
+    kernel = np.ones(ngrow, dtype="int32")
+
     # This is the mask used in k-sigma clipping.  0 is good, 1 is bad
     badpix = np.zeros(npix, dtype="int32")
-
-    #
-    #  Iterate
 
     for niter in range(maxiter):
 
@@ -125,57 +105,24 @@ def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
         flat = samples - fitted
 
         # Compute the k-sigma rejection threshold
-        ngoodpix, mean, sigma = zsc_compute_sigma(flat, badpix, npix)
-
+        sigma = flat[goodpixels].std()
         threshold = sigma * krej
 
         # Detect and reject pixels further than k*sigma from the fitted line
-        lcut = -threshold
-        hcut = threshold
-        below = np.where(flat < lcut)
-        above = np.where(flat > hcut)
+        below = np.where(flat < - threshold)
+        above = np.where(flat > threshold)
 
         badpix[below] = BAD_PIXEL
         badpix[above] = BAD_PIXEL
 
         # Convolve with a kernel of length ngrow
-        kernel = np.ones(ngrow, dtype="int32")
         badpix = np.convolve(badpix, kernel, mode='same')
 
+        last_ngoodpix = ngoodpix
         ngoodpix = len(np.where(badpix == GOOD_PIXEL)[0])
-
-        niter += 1
 
     # Transform the line coefficients back to the X range [0:npix-1]
     zstart = intercept - slope
     zslope = slope * xscale
 
     return ngoodpix, zstart, zslope
-
-
-def zsc_compute_sigma(flat, badpix, npix):
-
-    # Compute the rms deviation from the mean of a flattened array.
-    # Ignore rejected pixels
-
-    # Accumulate sum and sum of squares
-    goodpixels = np.where(badpix == GOOD_PIXEL)
-    sumz = flat[goodpixels].sum()
-    sumsq = (flat[goodpixels] * flat[goodpixels]).sum()
-    ngoodpix = len(goodpixels[0])
-    if ngoodpix == 0:
-        mean = None
-        sigma = None
-    elif ngoodpix == 1:
-        mean = sumz
-        sigma = None
-    else:
-        mean = sumz / ngoodpix
-        temp = sumsq / (ngoodpix - 1) - sumz * sumz / (ngoodpix *
-                                                       (ngoodpix - 1))
-        if temp < 0:
-            sigma = 0.0
-        else:
-            sigma = math.sqrt(temp)
-
-    return ngoodpix, mean, sigma

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -1,0 +1,210 @@
+"""
+Zscale implementation from the STScI numdisplay package, BSD licensed.
+
+https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/lib/stsci/numdisplay/zscale.py?rev=19347
+https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/LICENSE.txt?rev=19347
+
+Copyright (C) 2005 Association of Universities for Research in Astronomy (AURA)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    3. The name of AURA and its representatives may not be used to
+      endorse or promote products derived from this software without
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+"""
+
+from __future__ import division # confidence high
+
+import math
+import numpy
+
+MAX_REJECT = 0.5
+MIN_NPIXELS = 5
+GOOD_PIXEL = 0
+BAD_PIXEL = 1
+KREJ = 2.5
+MAX_ITERATIONS = 5
+
+def zscale (image, nsamples=1000, contrast=0.25, bpmask=None, zmask=None):
+    """Implement IRAF zscale algorithm
+
+    Parameters
+    ----------
+    image : arr
+        2-d numpy array
+
+    nsamples : int (Default: 1000)
+        Number of points in array to sample for determining scaling factors
+
+    contrast : float (Default: 0.25)
+        Scaling factor for determining min and max. Larger values increase the
+        difference between min and max values used for display.
+
+    bpmask : None
+        Not used at this time
+
+    zmask : None
+        Not used at this time
+
+    Returns
+    -------
+    (z1, z2)
+    """
+
+    # Sample the image
+    samples = zsc_sample (image, nsamples, bpmask, zmask)
+    npix = len(samples)
+    samples.sort()
+    zmin = samples[0]
+    zmax = samples[-1]
+    # For a zero-indexed array
+    center_pixel = (npix - 1) // 2
+    if npix%2 == 1:
+        median = samples[center_pixel]
+    else:
+        median = 0.5 * (samples[center_pixel] + samples[center_pixel + 1])
+
+    #
+    # Fit a line to the sorted array of samples
+    minpix = max(MIN_NPIXELS, int(npix * MAX_REJECT))
+    ngrow = max (1, int (npix * 0.01))
+    ngoodpix, zstart, zslope = zsc_fit_line (samples, npix, KREJ, ngrow,
+                                             MAX_ITERATIONS)
+
+    if ngoodpix < minpix:
+        z1 = zmin
+        z2 = zmax
+    else:
+        if contrast > 0: zslope = zslope / contrast
+        z1 = max (zmin, median - (center_pixel - 1) * zslope)
+        z2 = min (zmax, median + (npix - center_pixel) * zslope)
+    return z1, z2
+
+def zsc_sample (image, maxpix, bpmask=None, zmask=None):
+
+    # Figure out which pixels to use for the zscale algorithm
+    # Returns the 1-d array samples
+    # Don't worry about the bad pixel mask or zmask for the moment
+    # Sample in a square grid, and return the first maxpix in the sample
+    nc = image.shape[0]
+    nl = image.shape[1]
+    stride = max (1.0, math.sqrt((nc - 1) * (nl - 1) / float(maxpix)))
+    stride = int (stride)
+    samples = image[::stride,::stride].flatten()
+    return samples[:maxpix]
+
+def zsc_fit_line (samples, npix, krej, ngrow, maxiter):
+
+    #
+    # First re-map indices from -1.0 to 1.0
+    xscale = 2.0 / (npix - 1)
+    xnorm = numpy.arange(npix)
+    xnorm = xnorm * xscale - 1.0
+
+    ngoodpix = npix
+    minpix = max (MIN_NPIXELS, int (npix*MAX_REJECT))
+    last_ngoodpix = npix + 1
+
+    # This is the mask used in k-sigma clipping.  0 is good, 1 is bad
+    badpix = numpy.zeros(npix, dtype="int32")
+
+    #
+    #  Iterate
+
+    for niter in range(maxiter):
+
+        if (ngoodpix >= last_ngoodpix) or (ngoodpix < minpix):
+            break
+
+        # Accumulate sums to calculate straight line fit
+        goodpixels = numpy.where(badpix == GOOD_PIXEL)
+        sumx = xnorm[goodpixels].sum()
+        sumxx = (xnorm[goodpixels]*xnorm[goodpixels]).sum()
+        sumxy = (xnorm[goodpixels]*samples[goodpixels]).sum()
+        sumy = samples[goodpixels].sum()
+        sum = len(goodpixels[0])
+
+        delta = sum * sumxx - sumx * sumx
+        # Slope and intercept
+        intercept = (sumxx * sumy - sumx * sumxy) / delta
+        slope = (sum * sumxy - sumx * sumy) / delta
+
+        # Subtract fitted line from the data array
+        fitted = xnorm*slope + intercept
+        flat = samples - fitted
+
+        # Compute the k-sigma rejection threshold
+        ngoodpix, mean, sigma = zsc_compute_sigma (flat, badpix, npix)
+
+        threshold = sigma * krej
+
+        # Detect and reject pixels further than k*sigma from the fitted line
+        lcut = -threshold
+        hcut = threshold
+        below = numpy.where(flat < lcut)
+        above = numpy.where(flat > hcut)
+
+        badpix[below] = BAD_PIXEL
+        badpix[above] = BAD_PIXEL
+
+        # Convolve with a kernel of length ngrow
+        kernel = numpy.ones(ngrow,dtype="int32")
+        badpix = numpy.convolve(badpix, kernel, mode='same')
+
+        ngoodpix = len(numpy.where(badpix == GOOD_PIXEL)[0])
+
+        niter += 1
+
+    # Transform the line coefficients back to the X range [0:npix-1]
+    zstart = intercept - slope
+    zslope = slope * xscale
+
+    return ngoodpix, zstart, zslope
+
+def zsc_compute_sigma (flat, badpix, npix):
+
+    # Compute the rms deviation from the mean of a flattened array.
+    # Ignore rejected pixels
+
+    # Accumulate sum and sum of squares
+    goodpixels = numpy.where(badpix == GOOD_PIXEL)
+    sumz = flat[goodpixels].sum()
+    sumsq = (flat[goodpixels]*flat[goodpixels]).sum()
+    ngoodpix = len(goodpixels[0])
+    if ngoodpix == 0:
+        mean = None
+        sigma = None
+    elif ngoodpix == 1:
+        mean = sumz
+        sigma = None
+    else:
+        mean = sumz / ngoodpix
+        temp = sumsq / (ngoodpix - 1) - sumz*sumz / (ngoodpix * (ngoodpix - 1))
+        if temp < 0:
+            sigma = 0.0
+        else:
+            sigma = math.sqrt (temp)
+
+    return ngoodpix, mean, sigma

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -1,4 +1,6 @@
-# Licensed under a 3-clause BSD style license - see NUMDISPLAY_LICENSE.rst
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Adapted from code from the Numdisplay package (see NUMDISPLAY_LICENSE.rst)
 
 """
 Zscale implementation based on the one from the STScI Numdisplay package.

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -1,37 +1,10 @@
+# Licensed under a 3-clause BSD style license - see NUMDISPLAY_LICENSE.rst
+
 """
 Zscale implementation from the STScI numdisplay package, BSD licensed.
 
 https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/lib/stsci/numdisplay/zscale.py?rev=19347
 https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/LICENSE.txt?rev=19347
-
-Copyright (C) 2005 Association of Universities for Research in Astronomy (AURA)
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    1. Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    3. The name of AURA and its representatives may not be used to
-      endorse or promote products derived from this software without
-      specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
 
 """
 

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -55,11 +55,12 @@ normalize values to the range::
     array([ 0. ,  0.4,  0.6,  0.8,  1. ])
 
 Other interval classes include :class:`~astropy.visualization.ManualInterval`,
-:class:`~astropy.visualization.PercentileInterval`, and
-:class:`~astropy.visualization.AsymmetricPercentileInterval`. For these three,
-values in the array can fall outside of the limits given by the interval. A
-``clip`` argument is provided to control the behavior of the normalization when
-values fall outside the limits::
+:class:`~astropy.visualization.PercentileInterval`,
+:class:`~astropy.visualization.AsymmetricPercentileInterval`, and
+:class:`~astropy.visualization.ZScaleInterval`. For these, values in the array
+can fall outside of the limits given by the interval.  A ``clip`` argument is
+provided to control the behavior of the normalization when values fall outside
+the limits::
 
 
     >>> from astropy.visualization import PercentileInterval

--- a/licenses/NUMDISPLAY_LICENSE.rst
+++ b/licenses/NUMDISPLAY_LICENSE.rst
@@ -1,0 +1,29 @@
+Copyright (C) 2005 Association of Universities for Research in Astronomy (AURA)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    3. The name of AURA and its representatives may not be used to
+      endorse or promote products derived from this software without
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+


### PR DESCRIPTION
Ref #4773 
Currently this PR just add the zscale module from Numdisplay (BSD licensed), and provide an "interval" wrapper. Then a few questions before going on:

- The zscale implementation works only for 2D images. It seems easy to adapt, but then there may other way to improve / speedup this code. Do we want to stick with the original module, or just use it as a basis and modify it if it is useful ? As Numdisplay is not really actively developed, I think the second option is fine, but feedback is welcome before spending more time on this ;)

- What is the good way to mention the license of this external code ? Should I add a `licenses/NUMDISPLAY_LICENSE.rst` ?