### PR TITLE
Fixed indentation problem with author name

### DIFF
--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -142,7 +142,7 @@ Core Package Contributors
 * Ray Plante
 * Orion Poplawski
 * Adrian Price-Whelan
-* J. Xavier Prochaska
+* J\. Xavier Prochaska
 * David Pérez-Suárez
 * QuanTakeuchi
 * Tanuj Rastogi


### PR DESCRIPTION
Fixed indentation problem when first author name is "J.", as mentioned in #4683.