### PR TITLE
Add function to convert a table to a single HDU

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ New Features
 
   - Header allows a dictionary-like cards argument during creation. [#4663]
 
+  - New function ``convenience.table_to_hdu``. [#4778]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -15,12 +15,10 @@ from ...extern import six
 from ...extern.six import string_types
 from ...table import Table
 from ...utils.exceptions import AstropyUserWarning
-from astropy.units.format.fits import UnitScaleError
-
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
-from . import FITS_rec
 from .hdu.hdulist import fitsopen as fits_open
 from .util import first
+from .convenience import table_to_hdu
 
 
 # FITS file signature as per RFC 4047
@@ -209,12 +207,7 @@ def write_table_fits(input, output, overwrite=False):
         Whether to overwrite any existing file without warning.
     """
 
-    # Tables with mixin columns are not supported
-    if input.has_mixin_columns:
-        mixin_names = [name for name, col in input.columns.items()
-                       if not isinstance(col, input.ColumnClass)]
-        raise ValueError('cannot write table with mixin column(s) {0} to FITS'
-                         .format(mixin_names))
+    table_hdu = table_to_hdu(input)
 
     # Check if output file already exists
     if isinstance(output, string_types) and os.path.exists(output):
@@ -223,80 +216,6 @@ def write_table_fits(input, output, overwrite=False):
         else:
             raise IOError("File exists: {0}".format(output))
 
-    # Create a new HDU object
-    if input.masked:
-        #float column's default mask value needs to be Nan
-        for column in six.itervalues(input.columns):
-            fill_value = column.get_fill_value()
-            if column.dtype.kind == 'f' and np.allclose(fill_value, 1e20):
-                column.set_fill_value(np.nan)
-
-        fits_rec = FITS_rec.from_columns(np.array(input.filled()))
-        table_hdu = BinTableHDU(fits_rec)
-        for col in table_hdu.columns:
-            # Binary FITS tables support TNULL *only* for integer data columns
-            # TODO: Determine a schema for handling non-integer masked columns
-            # in FITS (if at all possible)
-            int_formats = ('B', 'I', 'J', 'K')
-            if not (col.format in int_formats or
-                    col.format.p_format in int_formats):
-                continue
-
-            # The astype is necessary because if the string column is less
-            # than one character, the fill value will be N/A by default which
-            # is too long, and so no values will get masked.
-            fill_value = input[col.name].get_fill_value()
-
-            col.null = fill_value.astype(input[col.name].dtype)
-    else:
-        fits_rec = FITS_rec.from_columns(np.array(input.filled()))
-        table_hdu = BinTableHDU(fits_rec)
-
-    # Set units for output HDU
-    for col in table_hdu.columns:
-        unit = input[col.name].unit
-        if unit is not None:
-            try:
-                col.unit = unit.to_string(format='fits')
-            except UnitScaleError:
-                scale = unit.scale
-                raise UnitScaleError(
-                    "The column '{0}' could not be stored in FITS format "
-                    "because it has a scale '({1})' that "
-                    "is not recognized by the FITS standard. Either scale "
-                    "the data or change the units.".format(col.name, str(scale)))
-            except ValueError:
-                warnings.warn(
-                    "The unit '{0}' could not be saved to FITS format".format(
-                        unit.to_string()), AstropyUserWarning)
-
-    for key, value in input.meta.items():
-
-        if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:
-
-            warnings.warn(
-                "Meta-data keyword {0} will be ignored since it conflicts "
-                "with a FITS reserved keyword".format(key), AstropyUserWarning)
-
-        if isinstance(value, list):
-            for item in value:
-                try:
-                    table_hdu.header.append((key, item))
-                except ValueError:
-                    warnings.warn(
-                        "Attribute `{0}` of type {1} cannot be written to "
-                        "FITS files - skipping".format(key, type(value)),
-                        AstropyUserWarning)
-        else:
-            try:
-                table_hdu.header[key] = value
-            except ValueError:
-                warnings.warn(
-                    "Attribute `{0}` of type {1} cannot be written to FITS "
-                    "files - skipping".format(key, type(value)),
-                    AstropyUserWarning)
-
-    # Write out file
     table_hdu.writeto(output)
 
 io_registry.register_reader('fits', Table, read_table_fits)

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -56,6 +56,7 @@ explanation of all the different formats.
 
 
 import os
+import warnings
 
 import numpy as np
 
@@ -66,13 +67,17 @@ from .hdu.image import PrimaryHDU, ImageHDU
 from .hdu.table import BinTableHDU
 from .header import Header
 from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
+from .fitsrec import FITS_rec
+from ...units.format.fits import UnitScaleError
+from ...extern import six
 from ...extern.six import string_types
 from ...utils import deprecated
+from ...utils.exceptions import AstropyUserWarning
 
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
            'append', 'update', 'info', 'tdump', 'tcreate', 'tabledump',
-           'tableload']
+           'tableload', 'table_to_hdu']
 
 
 def getheader(filename, *args, **kwargs):
@@ -407,6 +412,103 @@ def writeto(filename, data, header=None, output_verify='exception',
         hdu = PrimaryHDU(data, header=header)
     hdu.writeto(filename, clobber=clobber, output_verify=output_verify,
                 checksum=checksum)
+
+
+def table_to_hdu(table):
+    """
+    Convert an astropy.table.Table object to a FITS BinTableHDU
+
+    Parameters
+    ----------
+    table : astropy.table.Table
+        The table to convert.
+
+    Returns
+    -------
+    table_hdu : astropy.io.fits.BinTableHDU
+        The FITS binary table HDU
+    """
+    # Avoid circular imports
+    from .connect import is_column_keyword, REMOVE_KEYWORDS
+
+    # Tables with mixin columns are not supported
+    if table.has_mixin_columns:
+        mixin_names = [name for name, col in table.columns.items()
+                       if not isinstance(col, table.ColumnClass)]
+        raise ValueError('cannot write table with mixin column(s) {0} to FITS'
+                         .format(mixin_names))
+
+    # Create a new HDU object
+    if table.masked:
+        #float column's default mask value needs to be Nan
+        for column in six.itervalues(table.columns):
+            fill_value = column.get_fill_value()
+            if column.dtype.kind == 'f' and np.allclose(fill_value, 1e20):
+                column.set_fill_value(np.nan)
+
+        fits_rec = FITS_rec.from_columns(np.array(table.filled()))
+        table_hdu = BinTableHDU(fits_rec)
+        for col in table_hdu.columns:
+            # Binary FITS tables support TNULL *only* for integer data columns
+            # TODO: Determine a schema for handling non-integer masked columns
+            # in FITS (if at all possible)
+            int_formats = ('B', 'I', 'J', 'K')
+            if not (col.format in int_formats or
+                    col.format.p_format in int_formats):
+                continue
+
+            # The astype is necessary because if the string column is less
+            # than one character, the fill value will be N/A by default which
+            # is too long, and so no values will get masked.
+            fill_value = table[col.name].get_fill_value()
+
+            col.null = fill_value.astype(table[col.name].dtype)
+    else:
+        fits_rec = FITS_rec.from_columns(np.array(table.filled()))
+        table_hdu = BinTableHDU(fits_rec)
+
+    # Set units for output HDU
+    for col in table_hdu.columns:
+        unit = table[col.name].unit
+        if unit is not None:
+            try:
+                col.unit = unit.to_string(format='fits')
+            except UnitScaleError:
+                scale = unit.scale
+                raise UnitScaleError(
+                    "The column '{0}' could not be stored in FITS format "
+                    "because it has a scale '({1})' that "
+                    "is not recognized by the FITS standard. Either scale "
+                    "the data or change the units.".format(col.name, str(scale)))
+            except ValueError:
+                warnings.warn(
+                    "The unit '{0}' could not be saved to FITS format".format(
+                        unit.to_string()), AstropyUserWarning)
+
+    for key, value in table.meta.items():
+        if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:
+            warnings.warn(
+                "Meta-data keyword {0} will be ignored since it conflicts "
+                "with a FITS reserved keyword".format(key), AstropyUserWarning)
+
+        if isinstance(value, list):
+            for item in value:
+                try:
+                    table_hdu.header.append((key, item))
+                except ValueError:
+                    warnings.warn(
+                        "Attribute `{0}` of type {1} cannot be written to "
+                        "FITS files - skipping".format(key, type(value)),
+                        AstropyUserWarning)
+        else:
+            try:
+                table_hdu.header[key] = value
+            except ValueError:
+                warnings.warn(
+                    "Attribute `{0}` of type {1} cannot be written to FITS "
+                    "files - skipping".format(key, type(value)),
+                    AstropyUserWarning)
+    return table_hdu
 
 
 def append(filename, data, header=None, checksum=False, verify=True, **kwargs):

--- a/docs/io/fits/api/tables.rst
+++ b/docs/io/fits/api/tables.rst
@@ -61,3 +61,7 @@ Table Functions
 :func:`tableload`
 """""""""""""""""
 .. autofunction:: tableload
+
+:func:`table_to_hdu`
+""""""""""""""""""""
+.. autofunction:: table_to_hdu

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -221,9 +221,12 @@ If the file already exists and you want to overwrite it, then set the
 
     >>> t.write('existing_table.fits', overwrite=True)
 
-At this time there is no support for appending an HDU to an existing file or
-writing multi-HDU files using the Table interface.  Instead one can use the
-lower-level :ref:`astropy.io.fits <astropy-io-fits>` interface.
+At this time there is no support for appending an HDU to an existing
+file or writing multi-HDU files using the Table interface. Instead one
+can use the convenience function
+:func:`~astropy.io.fits.table_to_hdu` to create a single
+binary table HDU and insert or append that to an existing
+:class:`~astropy.io.fits.HDUList`.
 
 Keywords
 """""""""


### PR DESCRIPTION
This is a convenience function to convert a table to a single HDU (`BinTableHDU`).

As the [current docs state](http://astropy.readthedocs.org/en/stable/io/unified.html#writing): 

> At this time there is no support for appending an HDU to an existing file or writing multi-HDU files using the Table interface. Instead one can use the lower-level `astropy.io.fits` interface.

In `astropy.io.fits` there is, however, no convenient function to convert a table to a single HDU (or at least, I couldn't find it; if it already exists, this PR is voided). Instead, one would have to craft it by hand, while this functionality is already in `write_table_fits`. So instead, I've taken all that functionality out of `write_table_fits` and move it into a new function `table_to_hdu`; `write_table_fits` simply calls `table_to_hdu`, wraps the result in a `HDUList` and writes that to disk.

A few notes:
- I wasn't sure where to put this functionality. I've put it in `io.fits.convenience`, but perhaps it should just live in `io.fits.connect` as well (in which case, `convenience.py` can be reverted to what it was before).
- I have not added unit tests. Most of that should logically be taken care of by unittests of `write_table_fits`, though one or two simple tests for just checking the interface of `table_to_hdu`. But I'd like to do that once I know which submodule the function should live in.
