### PR TITLE
Reraise an IOError for files that can't be opened.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,10 @@ Bug Fixes
 
 - ``astropy.io.registry``
 
+  - ``read`` now correctly raises an IOError if a file with an unknown
+    extension can't be found, instead of raising IORegistryError:
+    "Format could not be identified." [#4779]
+
 - ``astropy.io.votable``
 
 - ``astropy.modeling``

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -336,6 +336,8 @@ def read(cls, *args, **kwargs):
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary')
                         fileobj = ctx.__enter__()
+                    except IOError:
+                        raise
                     except Exception:
                         fileobj = None
                     else:


### PR DESCRIPTION
If a file can't be opened for reading, the registry read function
should not attempt to determine the format further, but raise the
corresponding exception.

If instead, the code proceeds to attempt to determine the format for
an unknown extension for a file that does not exist, it will fail
with, essentially, the incorrect error ("Format could not be
identified"). Confusingly then, if the file with the unknown extension
does exist, the format might very well be identified. An example would
a FITS file with the name test.fts.