### PR TITLE
Updating image.py for safer datatype conversion

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -439,7 +439,8 @@ class _ImageBaseHDU(_ValidHDU):
         # Do the scaling
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
-            self.data = self.data - _zero
+#            self.data = self.data - _zero
+            self.data+=-zero
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -439,8 +439,8 @@ class _ImageBaseHDU(_ValidHDU):
         # Do the scaling
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
-#            self.data = self.data - _zero
-            self.data+=-_zero
+            #have to explcitly cast _zero to prevent numpy from complaining, consider explicit type assertions for signed vs unsigned
+            self.data+=-zero.astype(self.data.dtype)
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -436,15 +436,10 @@ class _ImageBaseHDU(_ValidHDU):
                         nbytes = 8 * _type().itemsize
                         _scale = (max - min) / (2.0 ** nbytes - 2)
 
-        #convert the data
-        if self.data.dtype.type != _type:
-            self.data = np.array(np.around(self.data), dtype=_type)
-
         # Do the scaling
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
-            # not sure if this deal with unsigned destination data types correctly
-            self.data += self.data.dtype.type(-_zero)
+            self.data += -_zero
             self._header['BZERO'] = _zero
         else:
             try:
@@ -461,12 +456,15 @@ class _ImageBaseHDU(_ValidHDU):
             except KeyError:
                 pass
 
+        # Set blanks
         if blank is not None and issubclass(_type, np.integer):
             # TODO: Perhaps check that the requested BLANK value fits in the
             # integer type being scaled to?
             self.data[np.isnan(self.data)] = blank
             self._header['BLANK'] = blank
 
+        if self.data.dtype.type != _type:
+            self.data = np.array(np.around(self.data), dtype=_type)
 
         # Update the BITPIX Card to match the data
         self._bitpix = DTYPE2BITPIX[self.data.dtype.name]

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -440,7 +440,7 @@ class _ImageBaseHDU(_ValidHDU):
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
             #have to explcitly cast _zero to prevent numpy from complaining, consider explicit type assertions for signed vs unsigned
-            self.data+=-zero.astype(self.data.dtype)
+            self.data+=-_zero.astype(self.data.dtype)
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -440,7 +440,7 @@ class _ImageBaseHDU(_ValidHDU):
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
             #have to explcitly cast _zero to prevent numpy from complaining, consider explicit type assertions for signed vs unsigned
-            np.add(self.data, -_zero, out=self.data), casting='unsafe')
+            np.add(self.data, -_zero, out=self.data, casting='unsafe')
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -439,7 +439,7 @@ class _ImageBaseHDU(_ValidHDU):
         # Do the scaling
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
-            self.data += -_zero
+            self.data = self.data - _zero
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -440,7 +440,7 @@ class _ImageBaseHDU(_ValidHDU):
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
             #have to explcitly cast _zero to prevent numpy from complaining, consider explicit type assertions for signed vs unsigned
-            self.data+=-_zero.astype(self.data.dtype)
+            np.add(self.data, -_zero, out=self.data), casting='unsafe')
             self._header['BZERO'] = _zero
         else:
             try:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -440,7 +440,7 @@ class _ImageBaseHDU(_ValidHDU):
         if _zero != 0:
             # 0.9.6.3 to avoid out of range error for BZERO = +32768
 #            self.data = self.data - _zero
-            self.data+=-zero
+            self.data+=-_zero
             self._header['BZERO'] = _zero
         else:
             try:


### PR DESCRIPTION
(apologies, I created a new pull request from [4772](https://github.com/astropy/astropy/pull/4772)
as I couldn't figure out who to rebase the old one as I made it from editing the sourcefile on github..my github-fu is unfortunately weak, I've adjusted the latest comment from that pull request below)

My solution indeed may not be correct after tracing through the code(though it appears to work). The error is triggered from lxnstack when opens a canon raw CR2 file and tries to convert it to FITS with astropy.

I put the the longer trace below, lnxnstack fills 'data' with type 'uint16' and then eventually applies 'scale' with a destination data type of 'int16'. The add happens before the conversion of 'data' to the new type. The conversion should happen before zeroing and scaling, the zero should be constructed to be the same type as 'data'. 

I think this change fixes the problem more correctly than the existing version.

```
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/lxnstack/utils.py", line 1953, in imwrite_fits
outbits)
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/lxnstack/utils.py", line 1983, in _get_fits_hdl
hdu.scale('int16', bzero=32768)
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/io/fits/hdu/image.py", line 384, in scale
bzero=bzero, blank=None)
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/io/fits/hdu/image.py", line 443, in _scale_internal
self.data += -_zero
TypeError: Cannot cast ufunc add output from dtype('int32') to dtype('uint16') with casting rule 'same_kind'
```