### PR TITLE
Drop support for Numpy 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ matrix:
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test'
 
         # Try developer version of Numpy without optional dependencies
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,11 @@ matrix:
 
         # Try older numpy versions without optional dependencies
         - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10 SETUP_CMD='test'
+        - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test'
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test'
 
         # Try developer version of Numpy without optional dependencies
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.2 (unreleased)
 ----------------
 
+General
+^^^^^^^
+
+Astropy now requires a Numpy 1.8.0 or later.
+
 New Features
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 General
 ^^^^^^^
 
-Astropy now requires a Numpy 1.8.0 or later.
+Astropy now requires a Numpy 1.7.0 or later.
 
 New Features
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 General
 ^^^^^^^
 
-Astropy now requires a Numpy 1.7.0 or later.
+Astropy now requires Numpy 1.7.0 or later.
 
 New Features
 ^^^^^^^^^^^^

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -76,7 +76,7 @@ except ImportError:
     __githash__ = ''
 
 
-__minimum_numpy_version__ = '1.6.0'
+__minimum_numpy_version__ = '1.7.0'
 
 
 # The location of the online documentation for astropy

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -17,7 +17,6 @@ from ..extern import six
 from . import angle_utilities as util
 from .. import units as u
 from ..utils import isiterable
-from ..utils.compat import NUMPY_LT_1_7
 
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
@@ -370,18 +369,8 @@ class Angle(u.Quantity):
                 s = '${0}$'.format(s)
             return s
 
-        if NUMPY_LT_1_7 and not np.isscalar(values):  # pragma: no cover
-            format_ufunc = np.vectorize(do_format, otypes=[np.object])
-            # In Numpy 1.6, unicode output is broken.  vectorize always seems to
-            # yield U2 even if you tell it something else.  So we convert in
-            # a second step with 60 chars, on the theory that you'll never want
-            # better than what double-precision decimals give, which end up
-            # around that many characters.
-            result = format_ufunc(values).astype('U60')
-        else:
-            #for newer Numpy versions, this just works as you would expect
-            format_ufunc = np.vectorize(do_format, otypes=['U'])
-            result = format_ufunc(values)
+        format_ufunc = np.vectorize(do_format, otypes=['U'])
+        result = format_ufunc(values)
 
         if result.ndim == 0:
             result = result[()]
@@ -485,13 +474,8 @@ class Angle(u.Quantity):
         else:
             # Need to do a magic incantation to convert to str.  Regular str
             # or array2string causes all backslashes to get doubled.
-            if NUMPY_LT_1_7:
-                # Except that numpy 1.6 doesn't do formatter... so instead we
-                # just replace all double-backslashes with one.
-                return str(self.to_string(format='latex')).replace('\\\\', '\\')
-            else:
-                return np.array2string(self.to_string(format='latex'),
-                                       formatter={'str_kind': lambda x: x})
+            return np.array2string(self.to_string(format='latex'),
+                                   formatter={'str_kind': lambda x: x})
 
 
 class Latitude(Angle):

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -15,7 +15,6 @@ from ..angles import Longitude, Latitude, Angle
 from ...tests.helper import pytest
 from ... import units as u
 from ..errors import IllegalSecondError, IllegalMinuteError, IllegalHourError
-from ...utils.compat import NUMPY_LT_1_7
 
 
 def test_create_angles():
@@ -868,14 +867,6 @@ def test_repr_latex():
     # and array angles
     arrangle = Angle([1, 2.1], u.deg)
     rlarrangle = arrangle._repr_latex_()
-
-    if NUMPY_LT_1_7:
-        # numpy 1.6 gives weird latex output for unclear reasons.  We don't care
-        # that much though, so just xfail after making sure it isn't
-        # over-backslashing
-        assert '\\\\' not in rlscangle
-        assert '\\\\' not in rlarrangle
-        pytest.xfail('numpy 1.6 does not give correct to_string latex output')
 
     assert rlscangle == '$2^\circ06{}^\prime00{}^{\prime\prime}$'
     assert rlscangle.split('$')[1] in rlarrangle

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -26,7 +26,6 @@ from ...coordinates import Latitude, EarthLocation
 from ...time import Time
 from ...utils import minversion
 from ...utils.exceptions import AstropyDeprecationWarning
-from ...utils.compat import NUMPY_LT_1_7  # pylint: disable=W0611
 
 
 RA = 1.0 * u.deg
@@ -499,7 +498,6 @@ def test_repr():
     assert repr(sc_default) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
                                 '    (0.0, 1.0)>')
 
-@pytest.mark.skipif('NUMPY_LT_1_7')
 def test_repr_altaz():
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
     loc = EarthLocation(-2309223 * u.m, -3695529 * u.m, -4641767 * u.m)

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -13,7 +13,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from ..utils.compat import NUMPY_LT_1_7
 from ..extern.six.moves import xrange
 
 
@@ -703,10 +702,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0, conflevel
         background = np.asanyarray(background)
         if np.any(background < 0):
             raise ValueError('Background must be >= 0.')
-        if NUMPY_LT_1_7:
-            conf_interval = np.vectorize(_kraft_burrows_nousek)(n, background, conflevel)
-        else:
-            conf_interval = np.vectorize(_kraft_burrows_nousek, cache=True)(n, background, conflevel)
+        conf_interval = np.vectorize(_kraft_burrows_nousek, cache=True)(n, background, conflevel)
         conf_interval = np.vstack(conf_interval)
     else:
         raise ValueError("Invalid method for Poisson confidence intervals: %s" % interval)

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from .. import log
 # Note, in numpy <= 1.6, some classes do not properly represent themselves.
-from ..utils.compat import NUMPY_LT_1_6_1
 from ..utils.console import Getch, color_print, terminal_size, conf
 from ..utils.data_info import dtype_info_name
 
@@ -31,19 +30,6 @@ elif six.PY2:
 
 ### The first three functions are helpers for _auto_format_func
 
-
-def _use_val_tolist(format_func):
-    """Wrap format function to work with values converted to python equivalents.
-
-    In numpy <= 1.6, classes such as np.float32 do not properly represent
-    themselves as floats, and hence cannot easily be formatted; see
-    https://github.com/astropy/astropy/issues/148#issuecomment-3930809
-    Hence, we force the value to a python type using tolist()
-    (except for np.ma.masked, since np.ma.masked.tolist() is None).
-    """
-    return lambda format_, val: format_func(format_,
-                                            val if val is np.ma.masked
-                                            else val.tolist())
 
 def _use_str_for_masked_values(format_func):
     """Wrap format function to trap masked values.
@@ -78,8 +64,6 @@ def _auto_format_func(format_, val):
 
     if six.callable(format_):
         format_func = lambda format_, val: format_(val)
-        if NUMPY_LT_1_6_1:
-            format_func = _use_val_tolist(format_func)
         try:
             out = format_func(format_, val)
             if not isinstance(out, six.string_types):
@@ -109,9 +93,6 @@ def _auto_format_func(format_, val):
             return str(val)
 
         for format_func in _possible_string_format_functions(format_):
-            if NUMPY_LT_1_6_1:
-                format_func = _use_val_tolist(format_func)
-
             try:
                 # Does this string format method work?
                 out = format_func(format_, val)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -18,7 +18,7 @@ from numpy import ma
 from .. import log
 from ..io import registry as io_registry
 from ..units import Quantity
-from ..utils import isiterable, deprecated, minversion
+from ..utils import isiterable, deprecated
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo
@@ -30,11 +30,6 @@ from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 from .info import TableInfo
 from .index import Index, _IndexModeContext, get_index
-
-# Prior to Numpy 1.6.2, there was a bug (in Numpy) that caused
-# sorting of structured arrays containing Unicode columns to
-# silently fail.
-_BROKEN_UNICODE_TABLE_SORT = not minversion(np, '1.6.2')
 
 
 __doctest_skip__ = ['Table.read', 'Table.write',
@@ -2176,11 +2171,7 @@ class Table(object):
         else:
             data = self.as_array()
 
-        if _BROKEN_UNICODE_TABLE_SORT and keys is not None and any(
-                data.dtype[i].kind == 'U' for i in xrange(len(data.dtype))):
-            return np.lexsort([data[key] for key in keys[::-1]])
-        else:
-            return data.argsort(**kwargs)
+        return data.argsort(**kwargs)
 
     def sort(self, keys=None):
         '''

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -20,7 +20,6 @@ from .. import units as u, constants as const
 from .. import _erfa as erfa
 from ..units import UnitConversionError
 from ..utils.decorators import lazyproperty
-from ..utils.compat.numpycompat import NUMPY_LT_1_7
 from ..utils.compat.misc import override__dir__
 from ..utils.data_info import MixinInfo, data_info_factory
 from ..utils.compat.numpy import broadcast_to
@@ -1010,12 +1009,7 @@ class Time(object):
         """
         # first get the minimum at normal precision.
         jd = self.jd1 + self.jd2
-        if NUMPY_LT_1_7:
-            approx = jd.min(axis)
-            if axis is not None:
-                approx = np.expand_dims(approx, axis)
-        else:
-            approx = jd.min(axis, keepdims=True)
+        approx = jd.min(axis, keepdims=True)
 
         # Approx is very close to the true minimum, and by subtracting it at
         # full precision, all numbers near 0 can be represented correctly,
@@ -1037,12 +1031,7 @@ class Time(object):
         """
         # For procedure, see comment on argmin.
         jd = self.jd1 + self.jd2
-        if NUMPY_LT_1_7:
-            approx = jd.max(axis)
-            if axis is not None:
-                approx = np.expand_dims(approx, axis)
-        else:
-            approx = jd.max(axis, keepdims=True)
+        approx = jd.max(axis, keepdims=True)
 
         dt = (self.jd1 - approx) + self.jd2
         return dt.argmax(axis, out)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -18,7 +18,6 @@ from numpy.testing import (assert_allclose, assert_array_equal,
 
 from ...tests.helper import raises, pytest
 from ...utils import isiterable, minversion
-from ...utils.compat import NUMPY_LT_1_7
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
 from ...extern.six.moves import xrange
@@ -724,12 +723,6 @@ class TestQuantityDisplay(object):
         assert self.scalarfloatq._repr_latex_() == '$1.3 \\; \\mathrm{m}$'
         assert (q2scalar._repr_latex_() ==
                 '$1.5 \\times 10^{14} \\; \\mathrm{\\frac{m}{s}}$')
-
-        if NUMPY_LT_1_7:
-            with pytest.raises(NotImplementedError):
-                self.arrq._repr_latex_()
-            return  # all arrays should fail
-
         assert self.arrq._repr_latex_() == '$[1,~2.3,~8.9] \; \mathrm{m}$'
 
         qmed = np.arange(100)*u.m
@@ -1191,14 +1184,8 @@ def test_repr_array_of_quantity():
     """
 
     a = np.array([1 * u.m, 2 * u.s], dtype=object)
-    if NUMPY_LT_1_7:
-        # Numpy 1.6.x has some different defaults for how to display object
-        # arrays (it uses the str() of the objects instead of the repr()
-        assert repr(a) == 'array([1.0 m, 2.0 s], dtype=object)'
-        assert str(a) == '[1.0 m 2.0 s]'
-    else:
-        assert repr(a) == 'array([<Quantity 1.0 m>, <Quantity 2.0 s>], dtype=object)'
-        assert str(a) == '[<Quantity 1.0 m> <Quantity 2.0 s>]'
+    assert repr(a) == 'array([<Quantity 1.0 m>, <Quantity 2.0 s>], dtype=object)'
+    assert str(a) == '[<Quantity 1.0 m> <Quantity 2.0 s>]'
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ... import units as u
 from ...tests.helper import pytest
-from ...utils.compat import (NUMPY_LT_1_7, NUMPY_LT_1_8,
+from ...utils.compat import (NUMPY_LT_1_8,
                              NUMPY_LT_1_9_1, NUMPY_LT_1_10)
 
 
@@ -147,12 +147,6 @@ class TestQuantityStatsFuncs(object):
     # of the standard deviation; https://github.com/numpy/numpy/issues/5240
     @pytest.mark.xfail(NUMPY_LT_1_9_1, reason="Numpy 1.9.1 or later is required")
     def test_std_inplace(self):
-
-        # For Numpy < 1.7, the test segfaults.  Hence, the xfail decorator does
-        # not suffice: py.test will run the test anyway to see if it works.
-        if NUMPY_LT_1_7:
-            pytest.xfail()
-
         q1 = np.array([1., 2.]) * u.m
         qi = 1.5 * u.s
         np.std(q1, out=qi)
@@ -163,12 +157,6 @@ class TestQuantityStatsFuncs(object):
         assert np.var(q1) == 0.25 * u.m ** 2
 
     def test_var_inplace(self):
-
-        # For Numpy < 1.7, the test segfaults.  Hence, we cannot use the xfail
-        # decorator since py.test will run the test anyway to see if it works.
-        if NUMPY_LT_1_7:
-            pytest.xfail()
-
         q1 = np.array([1., 2.]) * u.m
         qi = 1.5 * u.s
         np.var(q1, out=qi)

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -9,14 +9,12 @@ from ...extern import six
 from ...utils import minversion
 
 
-__all__ = ['NUMPY_LT_1_6_1', 'NUMPY_LT_1_7', 'NUMPY_LT_1_8', 'NUMPY_LT_1_9',
-           'NUMPY_LT_1_9_1', 'NUMPY_LT_1_10', 'NUMPY_LT_1_11']
+__all__ = ['NUMPY_LT_1_8', 'NUMPY_LT_1_9', 'NUMPY_LT_1_9_1', 'NUMPY_LT_1_10',
+           'NUMPY_LT_1_11']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_6_1 = not minversion('numpy', '1.6.1')
-NUMPY_LT_1_7 = not minversion('numpy', '1.7.0')
 NUMPY_LT_1_8 = not minversion('numpy', '1.8.0')
 NUMPY_LT_1_9 = not minversion('numpy', '1.9.0')
 NUMPY_LT_1_9_1 = not minversion('numpy', '1.9.1')
@@ -47,37 +45,5 @@ def _monkeypatch_unicode_mask_fill_values():
         ma_core._check_fill_value = _check_fill_value
 
 
-def _register_patched_dtype_reduce():
-    """
-    Numpy < 1.7 has a bug when copying/pickling dtype objects with a
-    zero-width void type--i.e. ``np.dtype('V0')``.  Specifically, although
-    creating a void type is perfectly valid, it crashes when instantiating
-    a dtype using a format string of 'V0', which is what is normally returned
-    by dtype.__reduce__() for these dtypes.
-
-    See https://github.com/astropy/astropy/pull/3283#issuecomment-81667461
-    """
-
-    if NUMPY_LT_1_7:
-        import numpy as np
-        import copy_reg
-
-        # Originally this created an alternate constructor that fixed this
-        # issue, and returned that constructor from the new reduce_dtype;
-        # however that broke pickling since functions can't be pickled, so now
-        # we fix the issue directly within the custom __reduce__
-
-        def reduce_dtype(obj):
-            info = obj.__reduce__()
-            args = info[1]
-            if args[0] == 'V0':
-                args = ('V',) + args[1:]
-                info = (info[0], args) + info[2:]
-            return info
-
-        copy_reg.pickle(np.dtype, reduce_dtype)
-
-
 if not _ASTROPY_SETUP_:
     _monkeypatch_unicode_mask_fill_values()
-    _register_patched_dtype_reduce()

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -106,10 +106,7 @@ class AsymmetricPercentileInterval(BaseInterval):
         # If needed, limit the number of samples. We sample with replacement
         # since this is much faster.
         if self.n_samples is not None and values.size > self.n_samples:
-            try:
-                values = np.random.choice(values, self.n_samples)
-            except AttributeError:  # Numpy 1.6.x
-                values = values[np.random.randint(0, values.size, self.n_samples)]
+            values = np.random.choice(values, self.n_samples)
 
         # Filter out invalid values (inf, nan)
         values = values[np.isfinite(values)]

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -16,20 +16,6 @@
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>
 
-/* A few Numpy constants that don't have consistent (undeprecated) spellings
-   between Numpy 1.6 and the current version */
-#ifndef NPY_ARRAY_C_CONTIGUOUS
-#define NPY_ARRAY_C_CONTIGUOUS NPY_C_CONTIGUOUS
-#endif
-
-#ifndef NPY_ARRAY_WRITEABLE
-#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
-#endif
-
-#ifndef PyArray_SetBaseObject
-#define PyArray_SetBaseObject(arr, baseobj) ((arr)->base = (PyObject *)baseobj)
-#endif
-
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
 #else


### PR DESCRIPTION
Following #4225

+ Add Numpy 1.10 in Travis config as 1.11 is now the stable version
+ Remove compatibility code for Numpy 1.6 ~~and 1.7~~. (There are still a few things that could possibly be removed, but I wasn't sure)