### PR TITLE
Remove unnecessary sort when defining __all__

### DIFF
--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -9,12 +9,12 @@ from .utils import KernelSizeError
 from ..modeling import models
 from ..modeling.core import Fittable1DModel, Fittable2DModel
 
-__all__ = sorted(['Gaussian1DKernel', 'Gaussian2DKernel', 'CustomKernel',
-                  'Box1DKernel', 'Box2DKernel', 'Tophat2DKernel',
-                  'Trapezoid1DKernel', 'MexicanHat1DKernel',
-                  'MexicanHat2DKernel', 'AiryDisk2DKernel',
-                  'Moffat2DKernel', 'Model1DKernel', 'Model2DKernel',
-                  'TrapezoidDisk2DKernel', 'Ring2DKernel'])
+
+__all__ = ['Gaussian1DKernel', 'Gaussian2DKernel', 'CustomKernel',
+           'Box1DKernel', 'Box2DKernel', 'Tophat2DKernel',
+           'Trapezoid1DKernel', 'MexicanHat1DKernel', 'MexicanHat2DKernel',
+           'AiryDisk2DKernel', 'Moffat2DKernel', 'Model1DKernel',
+           'Model2DKernel', 'TrapezoidDisk2DKernel', 'Ring2DKernel']
 
 
 def _round_up_to_odd_integer(value):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -14,14 +14,12 @@ from ..extern import six
 from .utils import get_inputs_and_params
 
 
-__all__ = sorted([
-    'AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D',
-    'Box2D', 'Const1D', 'Const2D', 'Ellipse2D', 'Disk2D',
-    'Gaussian1D', 'GaussianAbsorption1D', 'Gaussian2D', 'Linear1D',
-    'Lorentz1D', 'MexicanHat1D', 'MexicanHat2D', 'Redshift', 'Scale',
-    'Sersic1D', 'Sersic2D', 'Shift', 'Sine1D', 'Trapezoid1D', 'TrapezoidDisk2D',
-    'Ring2D', 'custom_model_1d', 'Voigt1D'
-])
+__all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
+           'Const2D', 'Ellipse2D', 'Disk2D', 'Gaussian1D',
+           'GaussianAbsorption1D', 'Gaussian2D', 'Linear1D', 'Lorentz1D',
+           'MexicanHat1D', 'MexicanHat2D', 'Redshift', 'Scale', 'Sersic1D',
+           'Sersic2D', 'Shift', 'Sine1D', 'Trapezoid1D', 'TrapezoidDisk2D',
+           'Ring2D', 'custom_model_1d', 'Voigt1D']
 
 
 class Gaussian1D(Fittable1DModel):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -13,8 +13,8 @@ from .core import Fittable1DModel
 from .parameters import Parameter
 
 
-__all__ = sorted(['PowerLaw1D', 'BrokenPowerLaw1D',
-                  'ExponentialCutoffPowerLaw1D', 'LogParabola1D'])
+__all__ = ['PowerLaw1D', 'BrokenPowerLaw1D', 'ExponentialCutoffPowerLaw1D',
+           'LogParabola1D']
 
 
 class PowerLaw1D(Fittable1DModel):


### PR DESCRIPTION
It is unnecessary to sort the entries in `__all__`.  I think this is a holdover from when the entries were not automatically sorted in the docs.