### PR TITLE
Fix FITS convenience functions to actually close files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -429,6 +429,9 @@ Bug Fixes
 
   - ``GroupsHDU.is_image`` property is now set to ``False``. [#4742]
 
+  - Fix convenience functions (``getdata``, ``getheader``, ``append``,
+    ``update``) to close files. [#4786]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -1262,6 +1265,9 @@ Bug Fixes
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``
+
+  - Fix convenience functions (``getdata``, ``getheader``, ``append``,
+    ``update``) to close files. [#4786]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -102,7 +102,7 @@ def getheader(filename, *args, **kwargs):
     hdulist, extidx = _getext(filename, mode, *args, **kwargs)
     hdu = hdulist[extidx]
     header = hdu.header
-    hdulist.close(closed=closed)
+    hdulist.close(closed=not closed)
     return header
 
 
@@ -196,7 +196,7 @@ def getdata(filename, *args, **kwargs):
         raise IndexError('No data in this HDU.')
     if header:
         hdr = hdu.header
-    hdulist.close(closed=closed)
+    hdulist.close(closed=not closed)
 
     # Change case of names if requested
     trans = None
@@ -466,7 +466,7 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
             # Set a flag in the HDU so that only this HDU gets a checksum when
             # writing the file.
             hdu._output_checksum = checksum
-            f.close(closed=closed)
+            f.close(closed=not closed)
         else:
             f = _File(filename, mode='append')
             hdu._output_checksum = checksum
@@ -529,7 +529,7 @@ def update(filename, data, *args, **kwargs):
     hdulist, _ext = _getext(filename, 'update', *args, **kwargs)
     hdulist[_ext] = new_hdu
 
-    hdulist.close(closed=closed)
+    hdulist.close(closed=not closed)
 
 
 def info(filename, output=None, **kwargs):

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -1,0 +1,25 @@
+# Licensed under a 3-clause BSD style license - see PYFITS.rst
+
+from __future__ import division, with_statement
+
+import warnings
+
+from ....extern import six  # pylint: disable=W0611
+from ....io import fits
+from ....tests.helper import pytest, catch_warnings
+
+from . import FitsTestCase
+
+
+class TestConvenience(FitsTestCase):
+
+    @pytest.mark.skipif('six.PY2')
+    def test_resource_warning(self):
+        warnings.simplefilter('always', ResourceWarning)
+        with catch_warnings() as w:
+            data = fits.getdata(self.data('test0.fits'))
+            assert len(w) == 0
+
+        with catch_warnings() as w:
+            header = fits.getheader(self.data('test0.fits'))
+            assert len(w) == 0


### PR DESCRIPTION
Ref #2824 for an older bug report. On Python 3 `ResourceWarning` warnings were raised because the FITS convenience methods (`getdata`, `getheader`, `append`, `update`) were not closing files as they were supposed to.

According to @embray's comment (https://github.com/astropy/astropy/issues/2824#issuecomment-51381335) this could be due to some changes but I didn't find which one.

This was hidden because `ResourceWarning` are filtered by default (https://docs.python.org/3.4/library/warnings.html#default-warning-filters), but can be shown by unittest or in my case by nosetest. It seems that they are also hidden with py.test.