### PR TITLE
added __repr__ to NDUncertainty.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,7 +171,7 @@ API changes
   - ``NDUncertainty``: Public methods ``propagate_add``, etc. are replaced by
     a general ``propagate`` method. [#4272]
 
-  - ``NDUncertainty``: implements a meaningful ``repr``. [#4787]
+  - ``NDUncertainty`` and subclasses: implement a representation (``__repr__``). [#4787]
 
   - ``StdDevUncertainty``: added an optional parameter ``copy`` which is False
     by default. [#4272]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,7 +171,7 @@ API changes
   - ``NDUncertainty``: Public methods ``propagate_add``, etc. are replaced by
     a general ``propagate`` method. [#4272]
 
-  - ``NDUncertainty``: Does implements a meaningful ``repr``. [#4787]
+  - ``NDUncertainty``: implements a meaningful ``repr``. [#4787]
 
   - ``StdDevUncertainty``: added an optional parameter ``copy`` which is False
     by default. [#4272]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,6 +171,8 @@ API changes
   - ``NDUncertainty``: Public methods ``propagate_add``, etc. are replaced by
     a general ``propagate`` method. [#4272]
 
+  - ``NDUncertainty``: Does implements a meaningful ``repr``. [#4787]
+
   - ``StdDevUncertainty``: added an optional parameter ``copy`` which is False
     by default. [#4272]
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -264,7 +264,11 @@ class NDUncertainty(object):
 
     def __repr__(self):
         prefix = self.__class__.__name__ + '('
-        body = np.array2string(self.array, separator=', ', prefix=prefix)
+        try:
+            body = np.array2string(self.array, separator=', ', prefix=prefix)
+        except AttributeError:
+            # In case it wasn't possible to use array2string
+            body = str(self.array)
         return ''.join([prefix, body, ')'])
 
     def __getitem__(self, item):

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -509,6 +509,12 @@ class StdDevUncertainty(NDUncertainty):
         >>> ndd.uncertainty
         StdDevUncertainty([ 0.2])
 
+    the uncertainty ``array`` can also be set directly::
+
+        >>> ndd.uncertainty.array = 2
+        >>> ndd.uncertainty
+        StdDevUncertainty(2)
+
     .. note::
         The unit will not be displayed.
     """

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -488,6 +488,23 @@ class StdDevUncertainty(NDUncertainty):
     Parameters
     ----------
     see `NDUncertainty`
+
+    Examples
+    --------
+    `StdDevUncertainty` should always be associated with an `NDData`-like
+    instance, either by creating it during initialization::
+
+        >>> from astropy.nddata import NDData, StdDevUncertainty
+        >>> ndd = NDData([1,2,3],
+        ...              uncertainty=StdDevUncertainty([0.1, 0.1, 0.1]))
+        >>> ndd.uncertainty
+        StdDevUncertainty([ 0.1,  0.1,  0.1])
+
+    or by setting it manually on the `NDData` instance::
+
+        >>> ndd.uncertainty = StdDevUncertainty([0.2], unit='m', copy=True)
+        >>> ndd.uncertainty
+        StdDevUncertainty([ 0.2], unit: m)
     """
 
     @property

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -265,8 +265,7 @@ class NDUncertainty(object):
     def __repr__(self):
         prefix = self.__class__.__name__ + '('
         body = np.array2string(self.array, separator=', ', prefix=prefix)
-        unit = ', unit: {0}'.format(self.unit) if self.unit else ''
-        return ''.join([prefix, body, unit, ')'])
+        return ''.join([prefix, body, ')'])
 
     def __getitem__(self, item):
         """
@@ -504,7 +503,10 @@ class StdDevUncertainty(NDUncertainty):
 
         >>> ndd.uncertainty = StdDevUncertainty([0.2], unit='m', copy=True)
         >>> ndd.uncertainty
-        StdDevUncertainty([ 0.2], unit: m)
+        StdDevUncertainty([ 0.2])
+
+    .. note::
+        The unit will not be displayed.
     """
 
     @property

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -262,6 +262,12 @@ class NDUncertainty(object):
     def parent_nddata(self, value):
         self._parent_nddata = value
 
+    def __repr__(self):
+        prefix = self.__class__.__name__ + '('
+        body = np.array2string(self.array, separator=', ', prefix=prefix)
+        unit = ', unit: {0}'.format(self.unit) if self.unit else ''
+        return ''.join([prefix, body, unit, ')'])
+
     def __getitem__(self, item):
         """
         Simple slicing is allowed and returns a reference *not* a copy. This


### PR DESCRIPTION
I think ``NDUncertainty`` (and subclasses) should have a basic `__repr__` method instead of displaying the Memory-Adress:
```
>>> ndd = NDData(np.array([[1,2,3],[2,3,4]])) # no specified unit
>>> ndd.uncertainty = np.ones((10,10))
INFO: Uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
>>> ndd.uncertainty
UnknownUncertainty([[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                    [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]])
```
----

I'm not sure if the unit should be displayed and I removed it again from the PR since `NDData` doesn't display it's unit. Also I've noticed some problems with the unit because it grabs the unit from the parent if no unit itself is set. This made it impossible viewing an uncertainty without unit and without parent.

Example with unit:
```
>>> ndd = NDData(np.array([[1,2,3],[2,3,4]]), unit='m')
>>> ndd.uncertainty = StdDevUncertainty(np.ones((10,10)))
>>> ndd.uncertainty
StdDevUncertainty([[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
                   [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]], unit: m)