### PR TITLE
[WIP] fixed docstring inconsistencies in the nddata-like classes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,6 +159,16 @@ API changes
 
 - ``astropy.nddata``
 
+  - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,
+    which is now an abstractproperty. [#4270]
+
+  - ``NDData`` The ``uncertainty_type`` of the ``uncertainty`` is no longer
+    required to be a string, but it is still recommended. [#4270]
+
+  - ``NDData`` wraps the ``uncertainty`` inside an ``UnknownUncertainty``
+    if no ``uncertainty_type`` attribute is present in the uncertainty instead
+    of raising an Exception. [#4270]
+
   - ``NDData``: added an optional parameter ``copy``
     which is False by default. If it is True all other parameters are copied
     before saving them as attributes. If False the parameters are only copied
@@ -269,16 +279,6 @@ Bug fixes
     to be able to combine them as classes as well as instances. [#4720]
 
 - ``astropy.nddata``
-
-  - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,
-    which is now an abstractproperty. [#4270]
-
-  - ``NDData`` wraps the ``uncertainty`` inside an ``UnknownUncertainty``
-    if no ``uncertainty_type`` attribute is present in the uncertainty instead
-    of raising an Exception. [#4270]
-
-  - ``NDData`` The ``uncertainty_type`` of the ``uncertainty`` is no longer
-    required to be a string, but it is still recommended. [#4270]
 
   - ``NDData`` now sets the ``parent_nddata`` of the ``uncertainty`` if the
     uncertainty is ``NDUncertainty``-like. [#4152, #4270]

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -22,7 +22,7 @@ _arit_doc = """
 
     For the inverse operation or operations between different subclasses take a
     look at
-    :meth:`~astropy.nddata.NDArithmeticMixin.ic_{name}` .
+    :meth:`~astropy.nddata.NDArithmeticMixin.ic_{name}`.
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ _arit_doc = """
         was given otherwise it raises a ``ValueError`` if the comparison was
         not successful. Default is ``'first_found'``.
 
-    uncertainty_correlation : number or `~numpy.ndarray`, optional
+    uncertainty_correlation : number or `numpy.ndarray`, optional
         The correlation between the two operands is used for correct error
         propagation for correlated data as given in:
         https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
@@ -72,7 +72,7 @@ _arit_doc = """
     Returns
     -------
     result : `~astropy.nddata.NDData`-like
-        The resulting dataset
+        The resulting dataset.
 
     Notes
     -----
@@ -85,23 +85,23 @@ _arit_doc = """
     """
 
 _arit_cls_doc = """
-    Like :meth:`NDArithmeticMixin.{0}` you can {0} two operands.
+    Like :meth:`~NDArithmeticMixin.{0}` you can {0} two operands.
 
     This method is avaiable as classmethod in order to allow arithmetic
-    operations between arbitary objects as long as they are convertable to
+    operations between arbitary objects as long as they are convertible to
     the class that called the method. Therefore the name prefix ``ic_`` which
     stands for ``interclass`` operations.
 
     Parameters
     ----------
-    operand1 : `NDData`-like or convertable to `NDData`
+    operand1 : `NDData`-like or convertible to `NDData`
         the first operand in the operation.
 
-    operand2 : `NDData`-like or convertable to `NDData`
+    operand2 : `NDData`-like or convertible to `NDData`
         the second operand in the operation.
 
     kwargs :
-        see :meth:`NDArithmeticMixin.{0}`
+        see :meth:`NDArithmeticMixin.{0}`.
 
     Returns
     -------
@@ -113,10 +113,10 @@ _arit_cls_doc = """
 
 class NDArithmeticMixin(object):
     """
-    Mixin class to add arithmetic to an NDData object.
+    Mixin class to add arithmetic to an `NDData` object.
 
     When subclassing, be sure to list the superclasses in the correct order
-    so that the subclass sees NDData as the main superclass. See
+    so that the subclass sees `NDData` as the main superclass. See
     `~astropy.nddata.NDDataArray` for an example.
 
     Notes
@@ -217,22 +217,22 @@ class NDArithmeticMixin(object):
             `numpy.true_divide`.
 
         operand : `NDData` instance or something that can be converted to one.
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
         propagate_uncertainties : `bool` or ``None``, optional
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
         handle_mask : callable, ``'first_found'`` or ``None``, optional
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
         handle_meta : callable, ``'first_found'`` or ``None``, optional
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
         compare_wcs : callable, ``'first_found'`` or ``None``, optional
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
-        uncertainty_correlation : ``Number`` or `~numpy.ndarray`, optional
-            see :meth:`NDArithmeticMixin.add`
+        uncertainty_correlation : ``Number`` or `numpy.ndarray`, optional
+            see :meth:`NDArithmeticMixin.add`.
 
         kwargs :
             Any other parameter that should be passed to the
@@ -241,7 +241,7 @@ class NDArithmeticMixin(object):
 
         Returns
         -------
-        result : `~numpy.ndarray` or `~astropy.units.Quantity`
+        result : `numpy.ndarray` or `~astropy.units.Quantity`
             The resulting data as array (in case both operands were without
             unit) or as quantity if at least one had a unit.
 
@@ -329,7 +329,7 @@ class NDArithmeticMixin(object):
 
     def _arithmetic_data(self, operation, operand, **kwds):
         """
-        Calculate the resulting data
+        Calculate the resulting data.
 
         Parameters
         ----------
@@ -345,7 +345,7 @@ class NDArithmeticMixin(object):
 
         Returns
         -------
-        result_data : `~numpy.ndarray` or `~astropy.units.Quantity`
+        result_data : `numpy.ndarray` or `~astropy.units.Quantity`
             If both operands had no unit the resulting data is a simple numpy
             array, but if any of the operands had a unit the return is a
             Quantity.
@@ -380,10 +380,10 @@ class NDArithmeticMixin(object):
             The second operand wrapped in an instance of the same class as
             self.
 
-        result : `~astropy.units.Quantity` or `~numpy.ndarray`
+        result : `~astropy.units.Quantity` or `numpy.ndarray`
             The result of :meth:`NDArithmeticMixin._arithmetic_data`.
 
-        correlation : number or `~numpy.ndarray`
+        correlation : number or `numpy.ndarray`
             see :meth:`NDArithmeticMixin.add` parameter description.
 
         kwds :
@@ -456,7 +456,7 @@ class NDArithmeticMixin(object):
             self.
 
         handle_mask : callable
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
         kwds :
             Additional parameters given to ``handle_mask``.
@@ -543,7 +543,7 @@ class NDArithmeticMixin(object):
             self.
 
         handle_meta : callable
-            see :meth:`NDArithmeticMixin.add`
+            see :meth:`NDArithmeticMixin.add`.
 
         kwds :
             Additional parameters given to ``handle_meta``.

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -11,20 +11,21 @@ __all__ = ['NDIOMixin']
 
 class NDIOMixin(object):
     """
-    Mixin class to connect NDData to the astropy input/output registry.
+    Mixin class to connect `NDData` to the astropy input/output registry:
+    `astropy.io.registry`.
 
-    This mixin adds two methods to its subclasses, ``read`` and ``write``.
+    This mixin adds two methods to its subclasses, `read` and `write`.
     """
 
     @classmethod
     def read(cls, *args, **kwargs):
         """
         Read and parse gridded N-dimensional data and return as an
-        NDData-derived object.
+        `NDData`-derived object.
 
-        This function provides the NDDataBase interface to the astropy unified
-        I/O layer.  This allows easily reading a file in the supported data
-        formats.
+        This function provides the `NDDataBase` interface to the astropy
+        unified I/O layer. This allows easily reading a file in the supported
+        data formats.
         """
         return io_registry.read(cls, *args, **kwargs)
 
@@ -32,8 +33,8 @@ class NDIOMixin(object):
         """
         Write a gridded N-dimensional data object out in specified format.
 
-        This function provides the NDDataBase interface to the astropy unified
-        I/O layer.  This allows easily writing a file in the supported data
-        formats.
+        This function provides the `NDDataBase` interface to the astropy
+        unified I/O layer. This allows easily writing a file in the supported
+        data formats.
         """
         io_registry.write(self, *args, **kwargs)

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -141,7 +141,7 @@ def test_arithmetics_data_unit_identical(data1, data2):
 
 
 # Test with Data and unit and covers:
-# not identical not convertable units
+# not identical not convertible units
 # one with unit (which is not dimensionless) and one without
 @pytest.mark.parametrize(('data1', 'data2'), [
     (np.array(5) * u.s, np.array(10) * u.m),

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -20,7 +20,7 @@ __doctest_skip__ = ['NDData']
 
 class NDData(NDDataBase):
     """
-    A container for `~numpy.ndarray`-based datasets, using the
+    A container for `numpy.ndarray`-based datasets, using the
     `~astropy.nddata.NDDataBase` interface.
 
     The key distinction from raw `numpy.ndarray` is the presence of
@@ -31,36 +31,38 @@ class NDData(NDDataBase):
 
     Parameters
     -----------
-    data : `~numpy.ndarray`-like or `NDData`-like
+    data : `numpy.ndarray`-like or `NDData`-like
         The dataset.
 
     uncertainty : any type, optional
         Uncertainty in the dataset.
-        Should have an attribute
-        ``uncertainty_type`` that defines what kind of uncertainty is stored,
-        for example ``"std"`` for standard deviation or
-        ``"var"`` for variance. If the uncertainty has no such attribute the
-        uncertainty is stored inside an `UnknownUncertainty` .
-        A metaclass defining such an interface is
-        `~astropy.nddata.NDUncertainty` but isn't mandatory.
+        Should have an attribute ``uncertainty_type`` that defines what kind of
+        uncertainty is stored, for example ``"std"`` for standard deviation or
+        ``"var"`` for variance.
+        A metaclass defining such an interface is `NDUncertainty` but isn't
+        mandatory.
+        If the uncertainty has no such attribute the uncertainty is stored
+        inside an `UnknownUncertainty`.
         Defaults to ``None``.
 
     mask : any type, optional
         Mask for the dataset.
-        Masks should follow the ``numpy`` convention that valid data points are
-        marked by ``False`` and invalid ones with ``True``.
+        Masks should follow the ``numpy`` convention that **valid** data points
+        are marked by ``False`` and **invalid** ones with ``True``.
         Defaults to ``None``.
 
     wcs : any type, optional
-        A world coordinate system (WCS) for the dataset.
+        World coordinate system (WCS) for the dataset.
         Default is ``None``.
 
     meta : `dict`-like object, optional
         Meta information about the dataset. If no meta is provided an empty
         `collections.OrderedDict` is created.
+        Default is ``None``.
 
-    unit : `~astropy.units.Unit`-like or str, optional
-        Unit for the dataset.
+    unit : `~astropy.units.Unit`-like, optional
+        Unit for the dataset. Strings that can be converted to a
+        `~astropy.units.Unit` are allowed.
         Default is ``None``.
 
     copy : `bool`, optional
@@ -72,13 +74,13 @@ class NDData(NDDataBase):
 
     Raises
     ------
-    TypeError:
+    TypeError
         In case any parameter does not fulfill the classes restrictions.
 
     Notes
     -----
     Each attribute can be accessed through the homonymous instance attribute,
-    such as data in a `NDData` object can be accessed through the ``data``
+    such as ``data`` in a `NDData` object can be accessed through the `data`
     attribute.
 
     For example::
@@ -96,17 +98,16 @@ class NDData(NDDataBase):
         >>> import numpy as np
         >>> import astropy.units as u
         >>> q = np.array([1,2,3,4]) * u.m
-        >>> nd2 = NDData(q, unit=u.cm)  # doctest: +SKIP
-        INFO: Overwriting Quantity's current unit with specified
-        unit [astropy.nddata.nddata]
-        >>> nd2.data  # doctest: +SKIP
+        >>> nd2 = NDData(q, unit=u.cm)
+        INFO: Overwriting Quantity's current unit with specified unit \
+[astropy.nddata.nddata]
+        >>> nd2.data
         array([ 1.,  2.,  3.,  4.])
-        >>> nd2.unit  # doctest: +SKIP
+        >>> nd2.unit
         Unit("cm")
 
     See also
     --------
-
     NDIOMixin
     NDSlicingMixin
     NDArithmeticMixin
@@ -140,32 +141,32 @@ class NDData(NDDataBase):
             # other parameters.
             if (unit is not None and data.unit is not None and
                     unit != data.unit):
-                log.info("Overwriting NDData's current "
-                         "unit with specified unit")
+                log.info("overwriting NDData's current "
+                         "unit with specified unit.")
             elif data.unit is not None:
                 unit = data.unit
 
             if uncertainty is not None and data.uncertainty is not None:
-                log.info("Overwriting NDData's current "
-                         "uncertainty with specified uncertainty")
+                log.info("overwriting NDData's current "
+                         "uncertainty with specified uncertainty.")
             elif data.uncertainty is not None:
                 uncertainty = data.uncertainty
 
             if mask is not None and data.mask is not None:
-                log.info("Overwriting NDData's current "
-                         "mask with specified mask")
+                log.info("overwriting NDData's current "
+                         "mask with specified mask.")
             elif data.mask is not None:
                 mask = data.mask
 
             if wcs is not None and data.wcs is not None:
-                log.info("Overwriting NDData's current "
-                         "wcs with specified wcs")
+                log.info("overwriting NDData's current "
+                         "wcs with specified wcs.")
             elif data.wcs is not None:
                 wcs = data.wcs
 
             if meta is not None and data.meta is not None:
-                log.info("Overwriting NDData's current "
-                         "meta with specified meta")
+                log.info("overwriting NDData's current "
+                         "meta with specified meta.")
             elif data.meta is not None:
                 meta = data.meta
 
@@ -175,8 +176,8 @@ class NDData(NDDataBase):
             if hasattr(data, 'mask') and hasattr(data, 'data'):
                 # Seperating data and mask
                 if mask is not None:
-                    log.info("Overwriting Masked Objects's current "
-                             "mask with specified mask")
+                    log.info("overwriting Masked Objects's current "
+                             "mask with specified mask.")
                 else:
                     mask = data.mask
 
@@ -187,8 +188,8 @@ class NDData(NDDataBase):
 
             if isinstance(data, Quantity):
                 if unit is not None and unit != data.unit:
-                    log.info("Overwriting Quantity's current "
-                             "unit with specified unit")
+                    log.info("overwriting Quantity's current "
+                             "unit with specified unit.")
                 else:
                     unit = data.unit
                 data = data.value
@@ -204,7 +205,7 @@ class NDData(NDDataBase):
         # rather than an object (since numpy will convert a
         # non-numerical/non-string inputs to an array of objects).
         if data.dtype == 'O':
-            raise TypeError("Could not convert data to numpy array.")
+            raise TypeError("could not convert data to numpy array.")
 
         if unit is not None:
             unit = Unit(unit)
@@ -241,7 +242,7 @@ class NDData(NDDataBase):
     @property
     def data(self):
         """
-        `~numpy.ndarray`-like : The stored dataset.
+        `numpy.ndarray`-like : stored dataset.
         """
         return self._data
 
@@ -250,8 +251,8 @@ class NDData(NDDataBase):
         """
         any type : Mask for the dataset, if any.
 
-        Masks should follow the ``numpy`` convention that valid data points are
-        marked by ``False`` and invalid ones with ``True``.
+        Masks should follow the ``numpy`` convention that **valid** data points
+        are marked by ``False`` and **invalid** ones with ``True``.
         """
         return self._mask
 
@@ -269,7 +270,7 @@ class NDData(NDDataBase):
     @property
     def wcs(self):
         """
-        any type : A world coordinate system (WCS) for the dataset, if any.
+        any type : World coordinate system (WCS) for the dataset, if any.
         """
         return self._wcs
 
@@ -293,7 +294,7 @@ class NDData(NDDataBase):
             # If it does not match this requirement convert it to an unknown
             # uncertainty.
             if not hasattr(value, 'uncertainty_type'):
-                log.info('Uncertainty should have attribute uncertainty_type.')
+                log.info('uncertainty should have attribute uncertainty_type.')
                 value = UnknownUncertainty(value, copy=False)
 
             # If it is a subclass of NDUncertainty we must set the

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -15,8 +15,6 @@ from ..utils.metadata import MetaData
 
 __all__ = ['NDData']
 
-__doctest_skip__ = ['NDData']
-
 
 class NDData(NDDataBase):
     """
@@ -99,7 +97,7 @@ class NDData(NDDataBase):
         >>> import astropy.units as u
         >>> q = np.array([1,2,3,4]) * u.m
         >>> nd2 = NDData(q, unit=u.cm)
-        INFO: Overwriting Quantity's current unit with specified unit \
+        INFO: overwriting Quantity's current unit with specified unit. \
 [astropy.nddata.nddata]
         >>> nd2.data
         array([ 1.,  2.,  3.,  4.])

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -19,7 +19,7 @@ class NDDataBase(object):
 
     All properties and methods have to be overridden in subclasses. See
     `~astropy.nddata.NDData` for a subclass that defines this interface on
-    `~numpy.ndarray`-like based ``data``.
+    `numpy.ndarray`-like based ``data``.
     """
 
     @abstractmethod
@@ -53,7 +53,7 @@ class NDDataBase(object):
     @abstractproperty
     def wcs(self):
         """
-        A world coordinate system (WCS) for the dataset.
+        World coordinate system (WCS) for the dataset.
         """
         return None
 
@@ -72,7 +72,7 @@ class NDDataBase(object):
         Uncertainty in the dataset.
 
         Should have an attribute ``uncertainty_type`` that defines what kind of
-        uncertainty is stored, such as ``'std'`` for standard deviation or
-        ``'var'`` for variance.
+        uncertainty is stored, such as ``"std"`` for standard deviation or
+        ``"var"`` for variance.
         """
         return None

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -149,7 +149,7 @@ class NDUncertainty(object):
 
     6. If a ``unit`` is implicit (``data`` had a unit) or explicitly passed
        to the ``__init__`` one should be sure that this unit is identical or
-       convertable to the unit of the parent. Otherwise uncertainty propagation
+       convertible to the unit of the parent. Otherwise uncertainty propagation
        should fail.
     """
 
@@ -226,7 +226,7 @@ class NDUncertainty(object):
         """
         `~astropy.units.Unit` : The unit of the uncertainty.
 
-        Even though it is not enforced the unit should be convertable to the
+        Even though it is not enforced the unit should be convertible to the
         `parent_nddata` unit. Otherwise uncertainty propagation might give
         wrong results.
 
@@ -475,7 +475,7 @@ class StdDevUncertainty(NDUncertainty):
     This class implements uncertainty propagation for ``addition``,
     ``subtraction``, ``multiplication`` and ``division`` but only with other
     instances of `StdDevUncertainty`. The class can fully handle if the
-    uncertainty has a unit that differs from (but is convertable to) the
+    uncertainty has a unit that differs from (but is convertible to) the
     parents `NDData` unit but converts the unit of the propagated uncertainty
     to the unit of the resulting data. Also support for correlation is possible
     but that requires that the correlation is an input. It cannot handle

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -25,17 +25,17 @@ Propagate uncertainties for {operation}.
 Parameters
 ----------
 other_uncert : `{instance}`
-    The data for the uncertainty of b in a {operator} b
-result_data : `~numpy.ndarray` instance or `~astropy.units.Quantity`
+    The data for the uncertainty of b in a {operator} b.
+result_data : `numpy.ndarray` instance or `~astropy.units.Quantity`
     The data array that is the result of the {operation}.
-correlation: number or `~numpy.ndarray`
+correlation: number or `numpy.ndarray`
     Array or scalar representing the correlation. Must be 0 if the subclass
     does not support correlated uncertainties.
 
 Returns
 -------
 result_uncertainty : {instance} instance
-    The resulting uncertainty
+    The resulting uncertainty.
 
 Raises
 ------
@@ -73,18 +73,18 @@ class NDUncertainty(object):
 
     Parameters
     ----------
-    array: any type, optional
+    array : any type, optional
         The array or value (the parameter name is due to historical reasons) of
         the uncertainty.
-        `~numpy.ndarray`, `~astropy.units.Quantity` or `NDUncertainty`
+        `numpy.ndarray`, `~astropy.units.Quantity` or `NDUncertainty`
         subclasses are recommended.
-        If the `array` is `list`-like or `~numpy.ndarray`-like it will be cast
-        to a base `~numpy.ndarray`.
+        If the `array` is `list`-like or `numpy.ndarray`-like it will be cast
+        to a base `numpy.ndarray`.
         Default is ``None``.
 
-    unit: `~astropy.units.Unit` or str, optional
-        The unit of the uncertainty ``array``. If input is a string this will
-        be converted to an `~astropy.units.Unit`.
+    unit : `~astropy.units.Unit` or `str`, optional
+        The unit of the uncertainty ``array``. If the input is a string this
+        will be converted to an `~astropy.units.Unit`.
         Default is ``None``.
 
     copy : `bool`, optional
@@ -121,12 +121,12 @@ class NDUncertainty(object):
        - property ``uncertainty_type`` which should be a small string defining
          the kind of uncertainty. Recommened is ``std`` for standard deviation
          ``var`` for variance (following the ``numpy`` conventions).
-       - :meth:`_propagate_add` and similar ones which takes the
+       - ``_propagate_add`` and similar ones which takes the
          uncertainty of the other element and the resulting data (or quantity)
          and calculates the array (or quantity) which represents the resulting
          uncertainty.
        - Most of the time a subclasses will need to extend or override the
-         :meth:`NDUncertainty._convert_uncertainty`. This method is responsible
+         ``NDUncertainty._convert_uncertainty``. This method is responsible
          for checking that the other uncertainty has a class that can be used
          for uncertainty propagation. (`NDUncertainty` only checks that it is
          another instance or subclass of `NDUncertainty`). For subclasses that
@@ -163,8 +163,8 @@ class NDUncertainty(object):
             if (unit is not None and array.unit is not None and
                     unit != array.unit):
                 # TODO : Clarify it (see NDData.init for same problem)?
-                log.info("Overwriting Uncertainty's current "
-                         "unit with specified unit")
+                log.info("overwriting Uncertainty's current "
+                         "unit with specified unit.")
             elif array.unit is not None:
                 unit = array.unit
             array = array.array
@@ -173,8 +173,8 @@ class NDUncertainty(object):
             # Check if two units are given and take the explicit one then.
             if (unit is not None and array.unit is not None and
                     unit != array.unit):
-                log.info("Overwriting Quantity's current "
-                         "unit with specified unit")
+                log.info("overwriting Quantity's current "
+                         "unit with specified unit.")
             elif array.unit is not None:
                 unit = array.unit
             array = array.value
@@ -194,7 +194,7 @@ class NDUncertainty(object):
     @abstractproperty
     def uncertainty_type(self):
         """
-        `str`: Short description which kind of uncertainty is saved.
+        `str` : Short description which kind of uncertainty is saved.
 
         Defined as abstract property so subclasses *have* to override this
         and return a string.
@@ -204,14 +204,14 @@ class NDUncertainty(object):
     @property
     def supports_correlated(self):
         """
-        `bool`: Supports uncertainty propagation with correlated uncertainties?
+        `bool` : Supports uncertainty propagation with correlated uncertainties?
         """
         return False
 
     @property
     def array(self):
         """
-        `numpy.ndarray`: the uncertainty's value.
+        `numpy.ndarray` : the uncertainty's value.
         """
         return self._array
 
@@ -224,10 +224,10 @@ class NDUncertainty(object):
     @property
     def unit(self):
         """
-        `~astropy.units.Unit`: The unit of the uncertainty.
+        `~astropy.units.Unit` : The unit of the uncertainty.
 
         Even though it is not enforced the unit should be convertable to the
-        ``parent_nddata`` unit. Otherwise uncertainty propagation might give
+        `parent_nddata` unit. Otherwise uncertainty propagation might give
         wrong results.
 
         If the unit is not set the unit of the parent will be returned.
@@ -243,13 +243,13 @@ class NDUncertainty(object):
     @property
     def parent_nddata(self):
         """
-        `NDData` reference: The `NDData` whose uncertainty this is.
+        `NDData` : The `NDData` whose uncertainty this is.
 
         In case the reference is not set uncertainty propagation will not be
         possible since almost all kinds of propagation need the uncertain
         data besides the uncertainty.
         """
-        message = "Uncertainty is not associated with an NDData object"
+        message = "uncertainty is not associated with an NDData object."
         try:
             if self._parent_nddata is None:
                 raise MissingDataAssociationException(message)
@@ -275,32 +275,32 @@ class NDUncertainty(object):
 
         Parameters
         ----------
-        operation: callable
+        operation : callable
             The operation that is performed on the `NDData`. Supported are
             `numpy.add`, `numpy.subtract`, `numpy.multiply` and
             `numpy.true_divide`.
 
-        other_nddata: `NDData` instance
+        other_nddata : `NDData`
             The second NDData in the arithmetic operation.
 
-        result_data: `~numpy.ndarray` or `~astropy.units.Quantity`
+        result_data : `numpy.ndarray` or `~astropy.units.Quantity`
             The result of the arithmetic operations. This saves some duplicate
             calculations.
 
-        correlation: number or `~numpy.ndarray`
+        correlation : number or `numpy.ndarray`
             The correlation (rho) is defined between the uncertainties in
             sigma_AB = sigma_A * sigma_B * rho. A value of ``0`` means
             uncorrelated operands.
 
         Returns
         -------
-        resulting_uncertainty: `NDUncertainty` instance
+        resulting_uncertainty : `NDUncertainty` instance
             Another instance of the same `NDUncertainty` subclass containing
             the uncertainty of the result.
 
         Raises
         ------
-        ValueError:
+        ValueError
             If the ``operation`` is not supported or if correlation is not zero
             but the subclass does not support correlated uncertainties.
 
@@ -309,7 +309,7 @@ class NDUncertainty(object):
         This method at first tries to convert the ``uncertainty`` of the
         other operand to a `NDUncertainty` subclass that is useable for
         uncertainty propagation (this check and optional conversion is done
-        in :meth:`NDUncertainty._convert_uncertainty`) and then the
+        in ``NDUncertainty._convert_uncertainty``) and then the
         appropriate ``_propagate_*`` method for calculating the resulting
         uncertainty is invoked. Afterwards this function wraps it into
         another instance of `NDUncertainty` and returns it.
@@ -337,7 +337,7 @@ class NDUncertainty(object):
             result = self._propagate_divide(other_uncert, result_data,
                                             correlation)
         else:
-            raise ValueError('Unsupported operation')
+            raise ValueError('unsupported operation')
 
         return self.__class__(result, copy=False)
 
@@ -351,12 +351,12 @@ class NDUncertainty(object):
 
         Parameters
         ----------
-        other_uncert: `NDUncertainty` subclass
-            The other uncertainty
+        other_uncert : `NDUncertainty` subclass
+            The other uncertainty.
 
         Returns
         -------
-        other_uncert: `NDUncertainty` subclass
+        other_uncert : `NDUncertainty` subclass
             but converted to a compatible `NDUncertainty` subclass if
             possible and necessary.
 
@@ -409,20 +409,22 @@ class UnknownUncertainty(NDUncertainty):
 
     Parameters
     ----------
-    see `NDUncertainty`
+    args, kwargs :
+        see `NDUncertainty`
     """
 
     @property
     def supports_correlated(self):
         """
-        `False`: No uncertainty propagation is not possible for this class.
+        `False`
+            Uncertainty propagation is **not** possible for this class.
         """
         return False
 
     @property
     def uncertainty_type(self):
         """
-        `str`: ``'unknown'``
+        ``"unknown"``
             `UnknownUncertainty` implements any kind of unknown uncertainty
             type.
         """
@@ -437,16 +439,16 @@ class UnknownUncertainty(NDUncertainty):
 
         Parameters
         ----------
-        other_uncert: `NDUncertainty` subclass
-            The other uncertainty
+        other_uncert : `NDUncertainty` subclass
+            The other uncertainty.
 
         Raises
         ------
-        IncompatibleUncertaintiesException:
+        IncompatibleUncertaintiesException
             Always since we cannot propagate without knowing which kind of
             uncertainty is saved.
         """
-        msg = "Uncertainties of unknown type cannot be propagated."
+        msg = "uncertainties of unknown type cannot be propagated."
         raise IncompatibleUncertaintiesException(msg)
 
     def _propagate_add(self, other_uncert, result_data, correlation):
@@ -481,14 +483,16 @@ class StdDevUncertainty(NDUncertainty):
 
     Parameters
     ----------
-    see `NDUncertainty`
+    args, kwargs :
+        see `NDUncertainty`
     """
 
     @property
     def supports_correlated(self):
         """
-        `True`: `StdDevUncertainty` allows to propagate correlated
-        uncertainties.
+        `True`
+            `StdDevUncertainty` allows to propagate correlated
+            uncertainties.
 
         But only if the ``correlation`` is given, this class does not implement
         computing it by itself.
@@ -498,7 +502,7 @@ class StdDevUncertainty(NDUncertainty):
     @property
     def uncertainty_type(self):
         """
-        `str`: ``'std'``
+        ``"std"``
             `StdDevUncertainty` implements standard deviation.
         """
         return 'std'

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -156,7 +156,7 @@ def test_init_fake_with_somethingElse(UncertClass):
 
 
 def test_init_fake_with_StdDevUncertainty():
-    # Different instances of uncertainties are not directly convertable so this
+    # Different instances of uncertainties are not directly convertible so this
     # should fail
     uncert = np.arange(5).reshape(5, 1)
     std_uncert = StdDevUncertainty(uncert)

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -188,7 +188,7 @@ For example with quantities::
     >>> import astropy.units as u
     >>> quantity = np.array([1, 2, 3, 4]) * u.m
     >>> ndd = NDData(quantity, unit="cm")  # Explicit unit is cm and implicit is m, keep explicit.
-    INFO: Overwriting Quantity's current unit with specified unit [astropy.nddata.nddata]
+    INFO: overwriting Quantity's current unit with specified unit. [astropy.nddata.nddata]
     >>> ndd.unit
     Unit("cm")
 


### PR DESCRIPTION
Some links were broken and some parts of the docstrings didn't render correctly. I didn't skipped the tests to see if any sphinx-build-errors occur (I've removed docstring-skip because it didn't raise any problems locally).

# EDIT

I will use this PR to include the documentation for the NDData changes for astropy 1.2. This PR would likely create a lot of merge-conflicts if any of the other PRs is merged. So please don't merge this one.