### PR TITLE
allow also "ff" instead of "first_found" for arithmetics with nddata

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -82,6 +82,8 @@ _arit_doc = """
     defined as ``kwargs`` and must start with ``"wcs_"`` (for wcs callable) or
     ``"meta_"`` (for meta callable). This startstring is removed before the
     callable is called.
+
+    ``"first_found"`` can also be abbreviated with ``"ff"``.
     """
 
 _arit_cls_doc = """
@@ -275,7 +277,7 @@ class NDArithmeticMixin(object):
         # First check that the WCS allows the arithmetic operation
         if compare_wcs is None:
             kwargs['wcs'] = None
-        elif compare_wcs == 'first_found':
+        elif compare_wcs in ['ff', 'first_found']:
             if self.wcs is None:
                 kwargs['wcs'] = deepcopy(operand.wcs)
             else:
@@ -303,7 +305,7 @@ class NDArithmeticMixin(object):
 
         if handle_mask is None:
             kwargs['mask'] = None
-        elif handle_mask == 'first_found':
+        elif handle_mask in ['ff', 'first_found']:
             if self.mask is None:
                 kwargs['mask'] = deepcopy(operand.mask)
             else:
@@ -315,7 +317,7 @@ class NDArithmeticMixin(object):
 
         if handle_meta is None:
             kwargs['meta'] = None
-        elif handle_meta == 'first_found':
+        elif handle_meta in ['ff', 'first_found']:
             if not self.meta:
                 kwargs['meta'] = deepcopy(operand.meta)
             else:

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -631,7 +631,9 @@ def test_arithmetics_stddevuncertainty_with_units(uncert1, uncert2):
     assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
 
 
-def test_arithmetics_handle_switches():
+# Test abbreviation and long name for taking the first found meta, mask, wcs
+@pytest.mark.parametrize(('use_abbreviation'), ['ff', 'first_found'])
+def test_arithmetics_handle_switches(use_abbreviation):
     meta1 = {'a': 1}
     meta2 = {'b': 2}
     mask1 = True
@@ -659,8 +661,8 @@ def test_arithmetics_handle_switches():
 
     # Only second has attributes and False is chosen
     nd_ = nd3.add(nd2, propagate_uncertainties=False,
-                  handle_meta='first_found', handle_mask='first_found',
-                  compare_wcs='first_found')
+                  handle_meta=use_abbreviation, handle_mask=use_abbreviation,
+                  compare_wcs=use_abbreviation)
     assert nd_.wcs == wcs2
     assert nd_.meta == meta2
     assert nd_.mask == mask2
@@ -668,8 +670,8 @@ def test_arithmetics_handle_switches():
 
     # Only first has attributes and False is chosen
     nd_ = nd1.add(nd3, propagate_uncertainties=False,
-                  handle_meta='first_found', handle_mask='first_found',
-                  compare_wcs='first_found')
+                  handle_meta=use_abbreviation, handle_mask=use_abbreviation,
+                  compare_wcs=use_abbreviation)
     assert nd_.wcs == wcs1
     assert nd_.meta == meta1
     assert nd_.mask == mask1


### PR DESCRIPTION
With the refactoring of `NDDataArithmeticMixin` a parameter can have the value `"first_found"`. I've been using it quite regularly now and I sometimes make a spelling mistake or use `"firstfound"` and it crashes.

Since this only affects the dev-version I've included another possibility: To use an abbreviation `"ff"` (for FirstFound). The additional costs of checking if it is in a list instead for checking string equality is nearly negligable (in the order of 20-50ns).