### PR TITLE
Eliminate hasattr from NDData

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -172,6 +172,8 @@ class NDData(NDDataBase):
             data = data.data
 
         else:
+            # data could be a masked array so we would need to seperate mask
+            # and data:
             try:
                 # This will raise an AttributeError if data has no mask
                 if data.mask is not None and mask is not None:


### PR DESCRIPTION
I recently read about `hasattr` being somewhat **not** recommended ([[1]](https://hynek.me/articles/hasattr/) and [[2]](https://news.ycombinator.com/item?id=10893226)) these might not affect `NDData`, I haven't thorougly checked...

I've edited those parts of `NDData` which use `hasattr`. The local tests were passing so I assume this is equivalent.

Only one minor change is a side-effect of this PR: If the input has a mask but _no_ data attribute it will use the mask of the input but keep the input as is. This will probably raise an error later on if someone really has something exotic that exactly meet these criteria.

This affects the dev branch so no changelog.

I've done some small benchmarks and it's +/- 1% (slightly slower most of the times) of the original performance for `NDData.__init__` except for maskedarrays which are slightly faster (~10%). But this is only a side-effect, this PR is not about Performance. Creating an `NDData`-object only takes approximatly 30-40 us so there is no need to speed this up.