### PR TITLE
Removing 3.4 build from appveyor matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,6 @@ environment:
 
         - PYTHON_VERSION: "2.7"
           NUMPY_VERSION: "stable"
-        - PYTHON_VERSION: "3.4"
-          NUMPY_VERSION: "stable"
         - PYTHON_VERSION: "3.5"
           NUMPY_VERSION: "stable"
 


### PR DESCRIPTION
Keeping two python3 build knowing that one of them is failing turned out to be a luxury, and now we ended up having a ~half day long backlog on appveyor. ~~I suggest to remove the failing 3.5 build for the time being, and when it's fixed replace the 3.4 as planned in #4450.~~

~~The build was allowed to fail as there are known issues reported in #4332.~~

This PR changed, and now removes 3.4 from the matrix since #4792 solved the issues.

