### PR TITLE
included an NDDataRef (NDData with all Mixins) class as alternative to NDDataArray.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,10 @@ New Features
     first operand is not an ``NDArithmeticMixin`` subclass via classmethods
     called ``ic_add``, ``ic_subtract``, etc. [#4272]
 
+  - Added ``NDDataAllMixins`` that implements ``NDData`` together with all
+    currently avaiable mixins. This class does not implement additional
+    attributes, methods or a numpy.ndarray-like interface like ``NDDataArray``.
+
 - ``astropy.stats``
 
   - Added ``axis`` keyword for ``mad_std`` function. [#4688]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,7 +76,7 @@ New Features
     first operand is not an ``NDArithmeticMixin`` subclass via classmethods
     called ``ic_add``, ``ic_subtract``, etc. [#4272]
 
-  - Added ``NDDataAllMixins`` that implements ``NDData`` together with all
+  - Added ``NDDataRef`` that implements ``NDData`` together with all
     currently avaiable mixins. This class does not implement additional
     attributes, methods or a numpy.ndarray-like interface like ``NDDataArray``.
 

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -10,6 +10,7 @@ be easily provided by a single array.
 
 from .nddata import *
 from .nddata_base import *
+from .nddata_withmixins import *
 from .nduncertainty import *
 from .flag_collection import *
 

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -8,18 +8,16 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from ... import NDData, NDArithmeticMixin
 from ...nduncertainty import (StdDevUncertainty, UnknownUncertainty,
                               IncompatibleUncertaintiesException)
+from ... import NDDataAllMixins
 from ....units import UnitsError, Quantity
 from ....tests.helper import pytest
 from .... import units as u
 
 
-# Just add the Mixin to NDData
-class NDDataArithmetic(NDArithmeticMixin, NDData):
-
-    pass
+# Alias NDDataAllMixins in case this will be renamed ... :-)
+NDDataArithmetic = NDDataAllMixins
 
 
 class StdDevUncertaintyUncorrelated(StdDevUncertainty):

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -10,14 +10,15 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from ...nduncertainty import (StdDevUncertainty, UnknownUncertainty,
                               IncompatibleUncertaintiesException)
-from ... import NDDataAllMixins
+from ... import NDDataRef
+
 from ....units import UnitsError, Quantity
 from ....tests.helper import pytest
 from .... import units as u
 
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)
-NDDataArithmetic = NDDataAllMixins
+NDDataArithmetic = NDDataRef
 
 
 class StdDevUncertaintyUncorrelated(StdDevUncertainty):

--- a/astropy/nddata/mixins/tests/test_ndio.py
+++ b/astropy/nddata/mixins/tests/test_ndio.py
@@ -1,13 +1,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ...nddata import NDData
-from ...mixins.ndio import NDIOMixin
+from ... import NDData, NDIOMixin, NDDataAllMixins
 
 
-# Define minimal class that uses the I/O mixin
-class NDDataIO(NDIOMixin, NDData):
-    pass
+# Alias NDDataAllMixins in case this will be renamed ... :-)
+NDDataIO = NDDataAllMixins
 
 
 def test_simple_write_read(tmpdir):

--- a/astropy/nddata/mixins/tests/test_ndio.py
+++ b/astropy/nddata/mixins/tests/test_ndio.py
@@ -1,11 +1,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ... import NDData, NDIOMixin, NDDataAllMixins
+from ... import NDData, NDIOMixin, NDDataRef
 
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)
-NDDataIO = NDDataAllMixins
+NDDataIO = NDDataRef
 
 
 def test_simple_write_read(tmpdir):

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -106,7 +106,7 @@ class NDData(NDDataBase):
 
     See also
     --------
-    NDDataAllMixins
+    NDDataRef
     NDDataArray
     """
 

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -106,10 +106,7 @@ class NDData(NDDataBase):
 
     See also
     --------
-
-    NDIOMixin
-    NDSlicingMixin
-    NDArithmeticMixin
+    NDDataAllMixins
     NDDataArray
     """
 

--- a/astropy/nddata/nddata_withmixins.py
+++ b/astropy/nddata/nddata_withmixins.py
@@ -1,0 +1,67 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+This module implements a class based on NDData with all Mixins.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .nddata import NDData
+
+from .mixins.ndslicing import NDSlicingMixin
+from .mixins.ndarithmetic import NDArithmeticMixin
+from .mixins.ndio import NDIOMixin
+
+__all__ = ['NDDataAllMixins']
+
+
+class NDDataAllMixins(NDArithmeticMixin, NDIOMixin, NDSlicingMixin, NDData):
+    """Implements `NDData` with all Mixins.
+
+    This class implements a `NDData`-like container that supports reading and
+    writing as implemented in the ``astropy.io.registry`` and also slicing
+    (indexing) and simple arithmetics (add, subtract, divide and multiply).
+
+    Notes
+    -----
+    A key distinction from `NDDataArray` is that this class does not attempt
+    to provide anything that was not defined in any of the parent classes.
+
+    See also
+    --------
+    NDData
+    NDArithmeticMixin
+    NDSlicingMixin
+    NDIOMixin
+
+    Examples
+    --------
+    Simple arithmetics::
+
+        >>> from astropy.nddata import NDDataAllMixins, StdDevUncertainty
+        >>> import numpy as np
+
+        >>> data = np.ones((3,3))
+        >>> ndd1 = NDDataAllMixins(data, uncertainty=StdDevUncertainty(data))
+        >>> ndd2 = NDDataAllMixins(data, uncertainty=StdDevUncertainty(data))
+
+        >>> ndd3 = ndd1.add(ndd2)
+        >>> ndd3.data
+        array([[ 2.,  2.,  2.],
+               [ 2.,  2.,  2.],
+               [ 2.,  2.,  2.]])
+        >>> ndd3.uncertainty.array
+        array([[ 1.41421356,  1.41421356,  1.41421356],
+               [ 1.41421356,  1.41421356,  1.41421356],
+               [ 1.41421356,  1.41421356,  1.41421356]])
+
+    Slicing (Indexing)::
+
+        >>> ndd4 = ndd3[1,:]
+        >>> ndd4.data
+        array([ 2.,  2.,  2.])
+        >>> ndd4.uncertainty.array
+        array([ 1.41421356,  1.41421356,  1.41421356])
+    """
+    pass

--- a/astropy/nddata/nddata_withmixins.py
+++ b/astropy/nddata/nddata_withmixins.py
@@ -13,10 +13,10 @@ from .mixins.ndslicing import NDSlicingMixin
 from .mixins.ndarithmetic import NDArithmeticMixin
 from .mixins.ndio import NDIOMixin
 
-__all__ = ['NDDataAllMixins']
+__all__ = ['NDDataRef']
 
 
-class NDDataAllMixins(NDArithmeticMixin, NDIOMixin, NDSlicingMixin, NDData):
+class NDDataRef(NDArithmeticMixin, NDIOMixin, NDSlicingMixin, NDData):
     """Implements `NDData` with all Mixins.
 
     This class implements a `NDData`-like container that supports reading and
@@ -40,12 +40,12 @@ class NDDataAllMixins(NDArithmeticMixin, NDIOMixin, NDSlicingMixin, NDData):
     The mixins allow operation that are not possible with `NDData` or
     `NDDataBase`, i.e. simple arithmetics::
 
-        >>> from astropy.nddata import NDDataAllMixins, StdDevUncertainty
+        >>> from astropy.nddata import NDDataRef, StdDevUncertainty
         >>> import numpy as np
 
         >>> data = np.ones((3,3), dtype=np.float)
-        >>> ndd1 = NDDataAllMixins(data, uncertainty=StdDevUncertainty(data))
-        >>> ndd2 = NDDataAllMixins(data, uncertainty=StdDevUncertainty(data))
+        >>> ndd1 = NDDataRef(data, uncertainty=StdDevUncertainty(data))
+        >>> ndd2 = NDDataRef(data, uncertainty=StdDevUncertainty(data))
 
         >>> ndd3 = ndd1.add(ndd2)
         >>> ndd3.data

--- a/astropy/nddata/nddata_withmixins.py
+++ b/astropy/nddata/nddata_withmixins.py
@@ -37,12 +37,13 @@ class NDDataAllMixins(NDArithmeticMixin, NDIOMixin, NDSlicingMixin, NDData):
 
     Examples
     --------
-    Simple arithmetics::
+    The mixins allow operation that are not possible with `NDData` or
+    `NDDataBase`, i.e. simple arithmetics::
 
         >>> from astropy.nddata import NDDataAllMixins, StdDevUncertainty
         >>> import numpy as np
 
-        >>> data = np.ones((3,3))
+        >>> data = np.ones((3,3), dtype=np.float)
         >>> ndd1 = NDDataAllMixins(data, uncertainty=StdDevUncertainty(data))
         >>> ndd2 = NDDataAllMixins(data, uncertainty=StdDevUncertainty(data))
 
@@ -56,12 +57,18 @@ class NDDataAllMixins(NDArithmeticMixin, NDIOMixin, NDSlicingMixin, NDData):
                [ 1.41421356,  1.41421356,  1.41421356],
                [ 1.41421356,  1.41421356,  1.41421356]])
 
-    Slicing (Indexing)::
+    see `NDArithmeticMixin` for a complete list of all supported arithmetic
+    operations.
+
+    But also slicing (indexing) is possible::
 
         >>> ndd4 = ndd3[1,:]
         >>> ndd4.data
         array([ 2.,  2.,  2.])
         >>> ndd4.uncertainty.array
         array([ 1.41421356,  1.41421356,  1.41421356])
+
+    See `NDSlicingMixin` for a description how slicing works (which attributes)
+    are sliced.
     """
     pass


### PR DESCRIPTION
The `NDDataAllMixins`-class (horrible name but I haven't figured out a better name) is an alternative to the compatibility class `NDDataArray`. It's nothing special it's an empty class that could serve for demonstration purposes in the documentation and as an useable implementation of `NDData`+Mixins for user that don't want to subclass themself.

I've changed the tests for the Mixins to use this class. But I really don't like the name.

Rationale for this class:

`NDDataArray` was kept as compatibility class during APE7 (see [Transition to astropy 1.0](https://astropy.readthedocs.org/en/v1.0.9/nddata/index.html#transition-to-astropy-1-0)). It provides all Mixins too but with a `numpy.ndarray`-like interface.

In my opinion `NDDataArray` would need a lot of work to make it recommendable. The `ndarray`-like-ness is a bit of a curse because it only keeps the `data` and `mask` (see [https://github.com/astropy/astropy/blob/master/astropy/nddata/compat.py#L237](sourcecode)) but throws away everything else. This gives unexpected results when using UFUNCS:

```
from astropy.nddata import NDDataArray, NDDataAllMixins
import numpy as np
ndd1 = NDDataAllMixins(np.ones((3,3)), 
                       meta={'cool': True}, 
                       mask=np.random.random((3,3))>0.5,
                       uncertainty=StdDevUncertainty(np.ones((3,3))),
                       unit='m')
ndd2 = NDDataArray(ndd1, copy=True)
np.sin(ndd2)
masked_array(data =
 [[0.8414709848078965 -- --]
 [0.8414709848078965 -- --]
 [0.8414709848078965 -- 0.8414709848078965]],
             mask =
 [[False  True  True]
 [False  True  True]
 [False  True False]],
       fill_value = 1e+20)
```
While it just simple doesn't work with `NDDataAllMixins`:
```
np.sin(ndd1)
AttributeError: 'NDDataAllMixins' object has no attribute 'sin'
```

So instead of telling people to subclass `NDData` and `NDArithmeticMixin` or `NDData` and `NDIOMixin` or `NDData` and `NDSlicingMixin` one could just describe `NDDataAllMixins` which has all these Mixins implemented without promoting `NDDataArray` (which also puts more restrictions on the implementation than `NDData` does).

Long story short:
The reason is because I want to rewrite parts of the `nddata`-package documentation:
- NDDataAllMixins as _the class_ the users probably want to use (Getting started and explaining the Mixins)
- NDData if the user wants just the container (no arithmetics, slicing or io-interface)
- NDDataBase if the user wants the abstract meta-container because NDData is too restricted for his use-case.
- don't mention `NDDataArray` that's just for compatibility with pre-astropy 1.0 code as far as I see it.