### PR TITLE
io.fits.fitsopen docstring newline and proper indentation for rendering issue

### DIFF
--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -95,7 +95,8 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
             when read.
 
         - **ignore_blank** : bool
-           If `True`, the BLANK keyword is ignored if present.
+
+            If `True`, the BLANK keyword is ignored if present.
 
         - **scale_back** : bool
 


### PR DESCRIPTION
There was a small rendering problem due to a missing blankline (or inproper indentation) in the [function documentation](http://docs.astropy.org/en/stable/io/fits/api/files.html#open).