### PR TITLE
Simple reader and writer for FITS files for NDIOMixin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ New Features
     currently avaiable mixins. This class does not implement additional
     attributes, methods or a numpy.ndarray-like interface like ``NDDataArray``.
 
+  - ``NDIOMixin`` and subclasses now support reading/writing fits files using
+    the ``read`` or ``write`` method with ``format='simple_fits'``. [#4799]
+
 - ``astropy.stats``
 
   - Added ``axis`` keyword for ``mad_std`` function. [#4688]

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -11,17 +11,21 @@ import numpy as np
 
 from .. import registry as io_registry
 from ... import units as u
+from ... import log
 from ...extern import six
 from ...extern.six import string_types
 from ...table import Table
 from ...utils.exceptions import AstropyUserWarning
 from astropy.units.format.fits import UnitScaleError
 
-from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
+from ...nddata import NDData, StdDevUncertainty, UnknownUncertainty, NDIOMixin
+from ...wcs import WCS
+
+from . import (HDUList, TableHDU, BinTableHDU, GroupsHDU, PrimaryHDU, ImageHDU,
+               Header)
 from . import FITS_rec
 from .hdu.hdulist import fitsopen as fits_open
 from .util import first
-
 
 # FITS file signature as per RFC 4047
 FITS_SIGNATURE = (b"\x53\x49\x4d\x50\x4c\x45\x20\x20\x3d\x20\x20\x20\x20\x20"
@@ -302,3 +306,200 @@ def write_table_fits(input, output, overwrite=False):
 io_registry.register_reader('fits', Table, read_table_fits)
 io_registry.register_writer('fits', Table, write_table_fits)
 io_registry.register_identifier('fits', Table, is_fits)
+
+
+def read_nddata_fits(filename, ext_data=0, ext_meta=0, ext_mask='mask',
+                     ext_uncert='uncert', kw_unit='bunit', dtype=None,
+                     **kwargs_for_open):
+    """
+    Read data from a FITS file and wrap the contents in a \
+    `~astropy.nddata.NDData`.
+
+    Parameters
+    ----------
+    filename : str and other types
+        see :func:`~astropy.io.fits.open` what possible types are allowed.
+
+    ext_data, ext_meta, ext_mask, ext_uncert : str or int, optional
+        Extensions from which to read ``data``, ``meta``, ``mask`` and
+        ``uncertainty``.
+        Default is ``0`` (data), ``0`` (meta), ``'mask'`` (mask) and
+        ``'uncert'`` (uncertainty).
+
+    kw_unit : str or None, optional
+        The header keyword which translates to the unit for the data. Set it
+        to ``None`` if parsing the unit results in a ValueError during reading.
+        Default is ``'bunit'``.
+
+    dtype : `numpy.dtype`-like or None, optional
+        If not ``None`` the data array is converted to this dtype before
+        returning. See `numpy.ndarray.astype` for more details.
+        Default is ``None``.
+
+    kwargs_for_open :
+        Additional keyword arguments that are passed to
+        :func:`~astropy.io.fits.open` (not all of them might be possible).
+    """
+
+    # Hardcoded values to get additional information about mask and uncertainty
+    kw_hdr_masktype = 'boolean mask'
+    kw_hdr_uncerttype = {
+        'standard deviation uncertainty': StdDevUncertainty,
+        'unknown uncertainty type': UnknownUncertainty}
+
+    with fits_open(filename, mode='readonly', **kwargs_for_open) as hdus:
+        # Read the data and meta from the specified extensions
+        data = hdus[ext_data].data
+        if dtype is not None:
+            data = data.astype(dtype)
+        meta = hdus[ext_meta].header
+
+        # Read the mask and uncertainty from the specified extensions but
+        # silently fail if the extension does not exist.
+        mask = None
+        if ext_mask in hdus:
+            mask = hdus[ext_mask].data
+            # Convert it to boolean array?
+            if kw_hdr_masktype in hdus[ext_mask].header.get('comment', []):
+                mask = mask.astype(bool)
+
+        uncertainty = None
+        if ext_uncert in hdus:
+            uncertainty = hdus[ext_uncert].data
+
+            hdr = hdus[ext_uncert].header
+            # Get the required class for the uncertainty
+            cls = (kw_hdr_uncerttype[kw] for kw in kw_hdr_uncerttype
+                   if kw in hdr.get('comment', []))
+            cls = next(cls, UnknownUncertainty)
+
+            # Get the unit for the uncertainty if present
+            unit_ = hdr[kw_unit].lower() if kw_unit in hdr else None
+
+            # Don't copy it here, if a copy is required do it when creating
+            # NDData.
+            uncertainty = cls(uncertainty, unit=unit_, copy=False)
+
+        # Load unit and wcs from header
+        unit = None
+        if kw_unit is not None and kw_unit in meta:
+            try:
+                unit = u.Unit(meta[kw_unit])
+            except ValueError as exc:
+                log.info(str(exc))
+                # TODO: Possibly convert it to lower-case and try it again.
+                # Could yield totally wrong results if the prefix "M" would be
+                # converted to "m".
+                # Possible way to do it:
+                # unit = u.Unit(meta[kw_unit].lower())
+        wcs = WCS(meta)
+
+    # Just create an NDData instance: This will be upcast to the appropriate
+    # class
+    return NDData(data, meta=meta, mask=mask, uncertainty=uncertainty,
+                  wcs=wcs, unit=unit, copy=False)
+
+
+def write_nddata_fits(ndd, filename, ext_mask='mask', ext_uncert='uncert',
+                      kw_unit='bunit', **kwargs_for_write):
+    """
+    Take an `~astropy.nddata.NDData`-like object and save it as FITS file.
+
+    Parameters
+    ----------
+    ndd : `astropy.nddata.NDData`-like
+        The data which is to be saved. Must not be given when this function
+        is called through the ``NDData.write``-method!
+
+    filename : str
+        The filename for the newly written file.
+
+    ext_mask, ext_uncert : str or int, optional
+        Extensions to which ``mask`` and ``uncertainty`` are written.
+        Default is ``'mask'`` (mask) and ``'uncert'`` (uncertainty).
+
+    kwargs_for_write :
+        Additional keyword arguments that are passed to
+        :func:`~astropy.io.fits.HDUList.writeto` (not all of them might be
+        possible).
+
+    Notes
+    -----
+    The ``data`` and ``meta`` are always written to the PrimaryHDU (extension
+    number ``0``).
+    """
+    # Comment card strings to allow roundtripping (must be identical to read!)
+    kw_hdr_masktype = 'boolean mask'
+    kw_hdr_uncerttype = {
+        StdDevUncertainty: 'standard deviation uncertainty',
+        UnknownUncertainty: 'unknown uncertainty type'}
+
+    # Copy or convert the meta to a FITS header
+    if isinstance(ndd.meta, Header):
+        header = ndd.meta.copy()
+    else:
+        header = Header(ndd.meta.items())
+
+    # Update the (copied) header (unit, wcs)
+    if ndd.unit is not None:
+        header[kw_unit] = ndd.unit.to_string()
+    elif kw_unit in header:
+        del header[kw_unit]
+
+    if ndd.wcs is not None:
+        try:
+            header.update(ndd.wcs.to_header())
+        except AttributeError:
+            # wcs has no to_header method
+            # FIXME: Implement this if other wcs objects should be allowed.
+            log.info("the wcs cannot be converted to header information.")
+
+    # Create a HDUList containing data
+    hdus = [PrimaryHDU(ndd.data, header=header)]
+
+    # And append mask to the HDUList (if present)
+    try:
+        # Convert mask to uint8 and set a keyword so that the opener knows
+        # that it was a boolean mask and can convert it back again.
+        if ndd.mask.dtype == 'bool':
+            hdr = Header()
+            hdr.add_comment(kw_hdr_masktype)
+            hdus.append(ImageHDU(ndd.mask.astype(np.uint8), header=hdr,
+                                 name=ext_mask))
+        else:
+            hdus.append(ImageHDU(ndd.mask, name=ext_mask))
+    except AttributeError:
+        # Either no mask or mask had no dtype
+        pass
+
+    # And append the uncertainty (if present)
+    try:
+        # We need to save the uncertainty_type and the unit of the uncertainty
+        # so that the uncertainty can be completly recovered.
+        hdr = Header()
+
+        # Save the class of the uncertainty
+        if ndd.uncertainty.__class__ in kw_hdr_uncerttype:
+            hdr.add_comment(kw_hdr_uncerttype[ndd.uncertainty.__class__])
+
+        # Save the unit of the uncertainty if it differs from the nddata
+        # TODO: This comparison only works correctly for StdDevUncertainty...
+        if ndd.uncertainty.unit != ndd.unit:
+            hdr[kw_unit] = ndd.uncertainty.unit.to_string()
+
+        hdus.append(ImageHDU(ndd.uncertainty.array, header=hdr,
+                             name=ext_uncert))
+    except AttributeError:
+        # Either no uncertainty or no uncertainty array, unit or
+        # uncertainty_type. Should not be possible because everything that
+        # doesn't look like an NDUUncertainty is converted to one.
+        pass
+
+    # Convert to HDUList and write it to the file.
+    with HDUList(hdus) as hdulist:
+        hdulist.writeto(filename, **kwargs_for_write)
+
+
+# TODO: Register reader and writer WITHOUT identifier (for now...)
+io_registry.register_reader('simple_fits', NDIOMixin, read_nddata_fits)
+io_registry.register_writer('simple_fits', NDIOMixin, write_nddata_fits)

--- a/astropy/io/fits/tests/test_connect_nddata.py
+++ b/astropy/io/fits/tests/test_connect_nddata.py
@@ -1,0 +1,314 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ....nddata import NDData, StdDevUncertainty, UnknownUncertainty, NDIOMixin
+from ..connect import write_nddata_fits, read_nddata_fits
+
+import numpy as np
+
+
+# Define minimal class that uses the I/O mixin
+class NDDataIO(NDIOMixin, NDData):
+    pass
+
+
+class TestIOFunctions(object):
+    counter = 0
+    filename = 'file{0}.fits'
+
+    def temp(self, tmpdir):
+        self.counter += 1
+        return str(tmpdir.join(self.filename.format(self.counter)))
+
+    def compare_nddata(self, ndd1, ndd2, compare_meta=True):
+        # Compare if the data is equal:
+        np.testing.assert_array_equal(ndd1.data, ndd2.data)
+        assert ndd1.data.dtype.kind == ndd1.data.dtype.kind
+
+        # Compare if mask is equal
+        if ndd1.mask is not None:
+            np.testing.assert_array_equal(ndd1.mask, ndd2.mask)
+            assert ndd1.mask.dtype.kind == ndd1.mask.dtype.kind
+        else:
+            assert ndd1.mask == ndd2.mask
+
+        # Compare if uncertainty is equal
+        if ndd1.uncertainty is not None:
+            assert ndd1.uncertainty.__class__ == ndd2.uncertainty.__class__
+            np.testing.assert_array_equal(ndd1.uncertainty.array,
+                                          ndd2.uncertainty.array)
+            assert ndd1.uncertainty.array.dtype.kind == ndd2.uncertainty.array.dtype.kind
+            assert ndd1.uncertainty.unit == ndd2.uncertainty.unit
+        else:
+            assert ndd1.uncertainty == ndd2.uncertainty
+
+        # Units equal?
+        assert ndd1.unit == ndd2.unit
+
+        # WCS equal?
+        if ndd1.wcs is not None:
+            assert ndd1.wcs.wcs.compare(ndd2.wcs.wcs)
+        else:
+            pass
+
+        # Compare meta only if comparison makes sense and only for those
+        # keywords that were present in the original (because WCS operations
+        # may alter/insert meta attributes).
+        if compare_meta:
+            assert all(ndd1.meta[key] == ndd2.meta[key] for key in ndd1.meta)
+
+    def test_nddata_write_read_data_only(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_data_only_with_dtype(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename, dtype=np.int32)
+
+        assert ndd2.data.dtype == np.int32
+
+    def test_nddata_write_read_mask_boolean(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)),
+                      mask=np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]], dtype=bool))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_mask_not_boolean(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)),
+                      mask=np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]]))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_uncertainty_unknown(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)),
+                      uncertainty=np.random.random((3, 3)))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_uncertainty_unknown_explicit(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)),
+                      uncertainty=UnknownUncertainty(np.random.random((3, 3))))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_uncertainty_stddev_explicit(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)),
+                      uncertainty=StdDevUncertainty(np.random.random((3, 3))))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_uncertainty_with_unit(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)),
+                      uncertainty=UnknownUncertainty(np.random.random((3, 3)), 'm'))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_uncertainty_with_same_unit(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)), unit='m',
+                      uncertainty=UnknownUncertainty(np.random.random((3, 3)), 'm'))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_unit(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)), unit='m')
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_unit_dimensionless(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)), unit='')
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_complex_unit(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)), unit='m^2 / s / kg')
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_unit_uppercase(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)))
+        ndd1.meta['BUNIT'] = 'ADU'
+        # ADU cannot be parsed but it can be parsed if it tries lowercase. We
+        # need to change 'kw_unit' during writing though otherwise it will be
+        # deleted.
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename, kw_unit='blub')
+        ndd2 = read_nddata_fits(filename)
+
+        # It couldn't be parsed so it will have no unit
+        # TODO: Catch info-message here
+        ndd3 = NDData(ndd1, unit=None)
+
+        self.compare_nddata(ndd3, ndd2)
+
+    def test_nddata_write_read_unit_deletes_keyword(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)))
+        ndd1.meta['BUNIT'] = 'adu'
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)  # this should delete BUNIT keyword!
+        ndd2 = read_nddata_fits(filename)
+
+        # Since we had no unit
+        ndd3 = NDData(ndd1, unit=None)
+        del ndd3.meta['BUNIT']
+
+        self.compare_nddata(ndd3, ndd2)
+
+    def test_nddata_write_read_meta(self, tmpdir):
+        meta = dict([(j, i) for i, j in enumerate('abcdefghijklmnopqrstuvwxyz')])
+        ndd1 = NDData(np.ones((3, 3)), meta=meta)
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        self.compare_nddata(ndd1, ndd2)
+
+    def test_nddata_write_read_wcs(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)))
+
+        # Write and read to generate basic wcs
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        # Need another round trip to compare "new" wcs
+        anotherfile = str(self.temp(tmpdir))
+        write_nddata_fits(ndd2, anotherfile)
+        ndd3 = read_nddata_fits(anotherfile)
+
+        self.compare_nddata(ndd1, ndd2)
+        self.compare_nddata(ndd2, ndd3)
+
+    def test_nddata_write_read_wcs_no_toheader(self, tmpdir):
+        ndd1 = NDData(np.ones((3, 3)), wcs=5)  # int has no "to_header"-method
+
+        # Write and read to generate basic wcs
+        filename = str(self.temp(tmpdir))
+        # Writing would fail if the missing method wasn't catched.
+        write_nddata_fits(ndd1, filename)
+
+    def test_nddata_write_read_wcs_slicing(self, tmpdir):
+        ndd1 = NDData(np.ones((10, 10)))
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        # Need another round trip to compare "new" wcs.
+        # Slice data and wcs to have something real to compare but keep header
+        # and see if it is updated correctly
+        ndd2tmp = NDData(ndd2.data[2:5, 4:8],
+                         wcs=ndd2.wcs[2:5, 4:8], meta=ndd2.meta)
+
+        anotherfile = str(self.temp(tmpdir))
+        write_nddata_fits(ndd2tmp, anotherfile)
+        ndd3 = read_nddata_fits(anotherfile)
+
+        self.compare_nddata(ndd1, ndd2)
+        self.compare_nddata(ndd2tmp, ndd3, False)
+
+        # Extra tests:
+        assert not ndd3.wcs.wcs.compare(ndd2.wcs.wcs)
+        assert ndd3.meta != ndd2.meta
+        assert ndd3.meta != ndd2tmp.meta
+        np.testing.assert_array_equal(ndd2.data[2:5, 4:8], ndd3.data)
+
+    def test_nddata_write_read_meta_wcs(self, tmpdir):
+        meta = dict([(j, i) for i, j in enumerate('abcdefghijklmnopqrstuvwxyz')])
+        ndd1 = NDData(np.ones((10, 10)), meta=meta)
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = read_nddata_fits(filename)
+
+        ndd2tmp = NDData(ndd2.data[2:5, 4:8],
+                         wcs=ndd2.wcs[2:5, 4:8], meta=ndd2.meta)
+
+        anotherfile = str(self.temp(tmpdir))
+        write_nddata_fits(ndd2tmp, anotherfile)
+        ndd3 = read_nddata_fits(anotherfile)
+
+        self.compare_nddata(ndd1, ndd2)
+        self.compare_nddata(ndd2tmp, ndd3, False)
+
+        # Extra tests:
+        np.testing.assert_array_equal(ndd2.data[2:5, 4:8], ndd3.data)
+        assert ndd3.wcs.wcs.compare(ndd2tmp.wcs.wcs)
+        assert not ndd3.wcs.wcs.compare(ndd2.wcs.wcs)
+        assert all(ndd1.meta[key] == ndd2.meta[key] for key in ndd1.meta)
+        assert all(ndd1.meta[key] == ndd3.meta[key] for key in ndd1.meta)
+
+    def test_ndiomixin_read(self, tmpdir):
+        data = np.ones((10, 10))
+        meta = dict([(j, i) for i, j in enumerate('abcdefghijklmnopqrstuvwxyz')])
+        unit = 'adu'
+        mask = np.random.random((10, 10)) > 0.5
+        uncertainty = UnknownUncertainty(np.ones((5, 5)))
+        ndd1 = NDData(data, uncertainty=uncertainty, unit=unit, meta=meta, mask=mask)
+
+        filename = str(self.temp(tmpdir))
+        write_nddata_fits(ndd1, filename)
+        ndd2 = NDDataIO.read(filename, format='simple_fits')
+
+        anotherfile = str(self.temp(tmpdir))
+        ndd2.write(anotherfile, format='simple_fits')
+        ndd3 = NDDataIO.read(anotherfile, format='simple_fits')
+
+        self.compare_nddata(ndd1, ndd2)
+        self.compare_nddata(ndd1, ndd3)
+
+        # Extra tests:
+        assert isinstance(ndd2, NDDataIO)
+        assert isinstance(ndd3, NDDataIO)
+
+    # TODO: Add one test for NDDataRef and NDDataArray!

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -8,7 +8,6 @@ import numpy as np
 from copy import deepcopy
 from .decorators import support_nddata
 from astropy.utils import lazyproperty
-from astropy.coordinates import SkyCoord
 from astropy.wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
 from astropy import units as u
 
@@ -611,6 +610,8 @@ class Cutout2D(object):
          [ nan   0.   1.]
          [ nan   4.   5.]]
         """
+        # FIXME: Lazy import because otherwise it creates cyclic imports.
+        from astropy.coordinates import SkyCoord
 
         if isinstance(position, SkyCoord):
             if wcs is None:


### PR DESCRIPTION
# Current status

This is inspired by #4756 and implements a simple reader and writer for `NDIOMixin` without auto-identification. So one has to use `format='simple_fits'`. This string may need some thinking over, this progressed somewhat from the original really simple fits reader without arguments.

It has the options to manipulate reader/writer to some extend:
- reader: HDUs which contain `data`, `meta`, `mask` and `uncertainty`
- reader: header keywords that indicate the `unit`
- writer: HDU _names_ for `mask` and `uncertainty`. Although `data` and `meta` are always the PrimaryHDU.
- writer: keyword that indicates the `unit`
  but some values are hardcoded:
- comment header card that indicates if the `mask` was `boolean`. Because FITS doesn't support writing boolean arrays.
- comment header card that saves the kind of uncertainty. Currently there are two useable uncertainties: `StdDevUncertainty` (standard deviation) and `UnknownUncertainty` (not a clue what kind). This probably requires some kind of registry if further reader/writer are added (if any).

Even though these are customizable the defaults can be used in a "self-consistent" way. So if you have a `NDData` object you can write/read it without bothering about these. Only reading some data from an externally created file should need using the arguments from the `reader`.

Another problem I encountered during this PR was the cyclic referencing between `NDData` and it's `uncertainty`. This was resolved by using a `weakref`. It made this PR probably a bit more messy than necessary.

Also I needed to make the `from astropy.coordinates import SkyCoord` lazy inside `astropy.nddata.utils.py` because sphinx complained about cyclic imports there.
# Old first post

Inspired by #4756 this PR adds a simple reader/writer for `NDIOMixin` for reading FITS files. Currently everything is hardcoded (therefore simple) but I think it's probably easy to extend.

The test setup was a bit messy, I'm very new with tempfiles and so one. These are just copy&pastes from other parts of astropy so there is probably room for improvement.

I didn't add any documentation (just yet) because this will get a bit messy with my other current PRs for `NDData` & associates.

Some context:
- The reader and writer should be self-consistent - so what the writer produces can be read by the reader.
- The reader cannot handle arbitary FITS files, I tried some files (images) and most pass. Only some require tweaking the reader (for example if there was a mask-extension but unreadable without IRAF) or the data was stored in another extension.
- I've submitted a very similar read/write to [`ccdproc`](https://github.com/astropy/ccdproc/pull/302) so I'm not sure if this is too much duplication. But they don't interfere with each other (or shouldn't).
- It should probably be put into `io.fits.connect.py` but since this is not really a reliable reader/writer I didn't want it to put it there (just yet).

But in general I didn't try to make them one-size-fits-all (sorry for that pun) but more or less a show-case implementation that does work in many cases without too much alteration.
