### PR TITLE
Ignore RuntimeWarning issued by blackbody toplevel code

### DIFF
--- a/astropy/analytic_functions/blackbody.py
+++ b/astropy/analytic_functions/blackbody.py
@@ -27,7 +27,9 @@ FLAM = u.erg / (u.cm**2 * u.s * u.AA)
 # NaN instead of INF like it should (it should only return NaN on a
 # NaN input
 # See https://github.com/astropy/astropy/issues/4171
-_has_buggy_expm1 = np.isnan(np.expm1(1000))
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', RuntimeWarning)
+    _has_buggy_expm1 = np.isnan(np.expm1(1000))
 
 
 def blackbody_nu(in_x, temperature):


### PR DESCRIPTION
Ignore `RuntimeWarning` that is always issued when trying to catch another known bug.

`np.expm1(1000)` introduced in #4393 obviously is going to issue a warning. This PR suppresses that warning because it is unnecessary.

Currently, user will :scream: seeing this warning even before any actual calculations are done:
```python
>>> from astropy.analytic_functions import blackbody
.../blackbody.py:30: RuntimeWarning: overflow encountered in expm1
  _has_buggy_expm1 = np.isnan(np.expm1(1000))
```

With the fix:
```python
>>> from astropy.analytic_functions import blackbody
# No unnecessary warning!
```

This does not really affect anything, so I am not sure if it needs a change log.