### PR TITLE
Prevent TypeError when FITS table column name is in unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ New Features
 
   - Allow trailing whitespace in the IPAC header lines. [#4758]
 
-  - Updated to filter out the default parser warning of BeautifulSoup. 
+  - Updated to filter out the default parser warning of BeautifulSoup.
     [#4551]
 
 - ``astropy.io.fits``
@@ -443,6 +443,9 @@ Bug Fixes
 - ``astropy.io.fits``
 
   - ``GroupsHDU.is_image`` property is now set to ``False``. [#4742]
+
+  - ``ColDefs.dtype`` no longer throws TypeError when column name is in
+    unicode. [#4805]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -19,7 +19,7 @@ from .util import (pairwise, _is_int, _convert_array, encode_ascii, cmp,
                    NotifierMixin)
 from .verify import VerifyError, VerifyWarning
 
-from ...extern.six import string_types, iteritems
+from ...extern.six import string_types, iteritems, PY2
 from ...utils import lazyproperty, isiterable, indent
 from ...utils.compat import ignored
 
@@ -1423,7 +1423,10 @@ class ColDefs(NotifierMixin):
                 else:
                     dt = np.dtype((dt.base, dim))
 
-            fields.append((name, dt))
+            if PY2:  # pragma: py2
+                fields.append((name.encode('utf-8'), dt))
+            else:  # pragma: py3
+                fields.append((name, dt))
 
         return nh.realign_dtype(np.dtype(fields), offsets)
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -141,7 +141,7 @@ class TestTableFunctions(FitsTestCase):
 
         # first, create individual column definitions
 
-        c1 = fits.Column(name='abc', format='3A', array=a1)
+        c1 = fits.Column(name=u'abc', format='3A', array=a1)
         c2 = fits.Column(name='def', format='E', array=r1)
         a3 = np.array([3, 4, 5], dtype='i2')
         c3 = fits.Column(name='xyz', format='I', array=a3)


### PR DESCRIPTION
Prevent `TypeError` when FITS table column name is in unicode. This fixes #4804.

With the current code (without this fix), using the modified test, expect to see one failure as follows:
```python
======================================= test session starts ========================================
platform linux2 -- Python 2.7.11, pytest-2.8.5, py-1.4.31, pluggy-0.3.1

Running tests with Astropy version 1.2.dev14953.
Running tests in .../astropy/io/fits.

Date: 2016-04-26T13:45:09

Platform: Linux-2.6.32-573.22.1.el6.x86_64-x86_64-with-redhat-6.7-Santiago

Executable: .../anaconda/bin/python

Full Python Version: 
2.7.11 |Anaconda 2.3.0 (64-bit)| (default, Dec  6 2015, 18:08:32) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]

encodings: sys: ascii, locale: UTF-8, filesystem: UTF-8, unicode bits: 20
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.10.4
Scipy: 0.16.1
Matplotlib: 1.5.1
h5py: 2.5.0
Pandas: 0.18.0

rootdir: .../astropy/io/fits, inifile: 
collected 485 items 

# blahblahblah
.../astropy/io/fits/tests/test_table.py .F.......................................................s.................
# blahblahblah

============================================= FAILURES =============================================
___________________________________ TestTableFunctions.test_open ___________________________________

self = <astropy.io.fits.tests.test_table.TestTableFunctions object at ...>

    def test_open(self):
        # open some existing FITS files:
        tt = fits.open(self.data('tb.fits'))
        fd = fits.open(self.data('test0.fits'))
    
        # create some local arrays
        a1 = chararray.array(['abc', 'def', 'xx'])
        r1 = np.array([11., 12., 13.], dtype=np.float32)
    
        # create a table from scratch, using a mixture of columns from existing
        # tables and locally created arrays:
    
        # first, create individual column definitions
    
        c1 = fits.Column(name=u'abc', format='3A', array=a1)
        ...
>       tbhdu = fits.BinTableHDU.from_columns(x)

.../astropy/io/fits/tests/test_table.py:167: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.../astropy/io/fits/hdu/table.py:126: in from_columns
    data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill)
.../astropy/io/fits/fitsrec.py:342: in from_columns
    raw_data = np.empty(columns.dtype.itemsize * nrows, dtype=np.uint8)
.../astropy/utils/decorators.py:498: in __get__
    val = self.fget(obj)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = ColDefs(
    name = u'abc'; format = '3A'
    name = 'def'; format = 'E'
    n...'; format = 'X'
    name = 't4'; format = 'J'
    name = 't5'; format = '11X'
)

    @lazyproperty
    def dtype(self):
        ...
>       return nh.realign_dtype(np.dtype(fields), offsets)
E       TypeError: data type not understood

.../astropy/io/fits/column.py:1429: TypeError
========================= 1 failed, 481 passed, 3 skipped in 22.27 seconds =========================
```