### PR TITLE
Expose Unit._represents to give access to a definition of a named unit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,7 @@ New Features
 
   - Added Earth radius (``R_earth``) and Jupiter radius (``R_jup``) to units.
     [#4818]
+
   - Added a ``represents`` property to allow access to the definition of a
     named unit (e.g., ``u.kpc.represents`` yields ``1000 pc``). [#4806]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,8 @@ New Features
 
   - Added Earth radius (``R_earth``) and Jupiter radius (``R_jup``) to units.
     [#4818]
+  - Added a ``represents`` property to allow access to the definition of a
+    named unit (e.g., ``u.kpc.represents`` yields ``1000 pc``). [#4806]
 
 - ``astropy.utils``
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1629,6 +1629,14 @@ class IrreducibleUnit(NamedUnit):
                 (self.__class__, list(self.names), self.name in registry),
                 self.__dict__)
 
+    @property
+    def represents(self):
+        """The unit that this named unit represents.
+
+        For an irreducible unit, that is always itself.
+        """
+        return self
+
     def decompose(self, bases=set()):
         if len(bases) and not self in bases:
             for base in bases:
@@ -1900,6 +1908,11 @@ class Unit(NamedUnit):
 
         NamedUnit.__init__(self, st, namespace=namespace, doc=doc,
                            format=format)
+
+    @property
+    def represents(self):
+        """The unit that this named unit represents."""
+        return self._represents
 
     def decompose(self, bases=set()):
         return self._represents.decompose(bases=bases)

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -101,6 +101,22 @@ def test_repr():
     assert repr(u.cm) == 'Unit("cm")'
 
 
+def test_represents():
+    assert u.m.represents is u.m
+    assert u.km.represents.scale == 1000.
+    assert u.km.represents.bases == [u.m]
+    assert u.Ry.scale == 1.0 and u.Ry.bases == [u.Ry]
+    assert_allclose(u.Ry.represents.scale, 13.605692518464949)
+    assert u.Ry.represents.bases == [u.eV]
+    bla = u.def_unit('bla', namespace=locals())
+    assert bla.represents is bla
+    blabla = u.def_unit('blabla', 10 * u.hr, namespace=locals())
+    assert blabla.represents.scale == 10.
+    assert blabla.represents.bases == [u.hr]
+    assert blabla.decompose().scale == 10 * 3600
+    assert blabla.decompose().bases == [u.s]
+
+
 def test_units_conversion():
     assert_allclose(u.kpc.to(u.Mpc), 0.001)
     assert_allclose(u.Mpc.to(u.kpc), 1000)

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -40,7 +40,10 @@ using the `~astropy.units.def_unit` function.  For example::
   >>> bakers_fortnight = u.def_unit('bakers_fortnight', 13 * u.day)
 
 The addition of a string gives the new unit a name that will show up
-when the unit is printed.
+when the unit is printed::
+
+  >>> 10. * bakers_fortnight
+  <Quantity 10.0 bakers_fortnight>
 
 Creating a new fundamental unit is simple::
 
@@ -50,8 +53,16 @@ Creating a new fundamental unit is simple::
   >>> guffaw = u.def_unit('guffaw', 3 * laugh)
   >>> rofl = u.def_unit('rofl', 4 * guffaw)
   >>> death_by_laughing = u.def_unit('death_by_laughing', 10 * rofl)
-  >>> rofl.to(titter, 1)
-  240.0
+  >>> (1. * rofl).to(titter)
+  <Quantity 240.0 titter>
+
+One can see the definition of a unit and its :ref:`decomposition <decomposing>`
+via::
+
+  >>> rofl.represents
+  Unit("4 guffaw")
+  >>> rofl.decompose()
+  Unit("240 titter")
 
 By default, custom units are not searched by methods such as
 `~astropy.units.core.UnitBase.find_equivalent_units`.  However, they

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -1,6 +1,8 @@
 Decomposing and composing units
 ===============================
 
+.. _decomposing:
+
 Reducing a unit to its irreducible parts
 ----------------------------------------
 
@@ -26,6 +28,11 @@ to decompose the Rydberg unit in terms of CGS units::
 
   >>> u.Ry.decompose(bases=u.cgs.bases)
   Unit("2.17987e-11 cm2 g / s2")
+
+Finally, if you just want to know how a unit was defined::
+
+  >>> u.Ry.represents
+  Unit("13.6057 eV")
 
 Automatically composing a unit into more complex units
 ------------------------------------------------------


### PR DESCRIPTION
Following comments in #3835, #4037, and #4110, this exposes the representation of a named unit via a new `represents` property.  It simply returns `self._represents` for named units, and `self` for irreducible ones.