### PR TITLE
Added another redshift example in modeling

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -580,6 +580,7 @@ class RedshiftScaleFactor(Fittable1DModel):
 
 
 class Redshift(RedshiftScaleFactor):
+    """This is **deprecated**, use :class:`RedshiftScaleFactor`."""
     def __init__(self, *args):
         warnings.warn('The "Redshift" class is now deprecated -- use the '
                       '"RedshiftScaleFactor" class instead.',

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -423,6 +423,33 @@ example, to create the following compound model:
     plt.ylabel('Flux')
     plt.legend()
 
+If you wish to perform redshifting in the wavelength space instead of energy,
+and would also like to conserve flux, here is another way to do it using
+model *instances*:
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    from astropy.modeling.models import Redshift, Gaussian1D, Scale
+
+    x = np.linspace(1000, 5000, 1000)
+    g0 = Gaussian1D(1, 2000, 200)  # No redshift is same as redshift with z=0
+
+    plt.figure(figsize=(8, 5))
+    plt.plot(x, g0(x), 'g--', label='$z=0$')
+
+    for z in (0.2, 0.4, 0.6):
+        rs = Redshift(z).inverse  # Redshift in wavelength space
+        sc = Scale(1. / (1 + z))  # Rescale the flux to conserve energy
+        g = rs | g0 | sc
+        plt.plot(x, g(x), color=plt.cm.OrRd(z),
+                 label='$z={0}$'.format(z))
+
+    plt.xlabel('Wavelength')
+    plt.ylabel('Flux')
+    plt.legend()
+
 When working with models with multiple inputs and outputs the same idea
 applies.  If each input is thought of as a coordinate axis, then this defines a
 pipeline of transformations for the coordinates on each axis (though it does

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -411,7 +411,7 @@ example, to create the following compound model:
     x = np.linspace(0, 1.2, 100)
     g0 = RedshiftedGaussian(z_0=0)
 
-    plt.figure(figsize=(8, 3))
+    plt.figure(figsize=(8, 5))
     plt.plot(x, g0(x), 'g--', label='$z=0$')
 
     for z in (0.2, 0.4, 0.6):

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -431,7 +431,7 @@ model *instances*:
     :include-source:
 
     import numpy as np
-    from astropy.modeling.models import Redshift, Gaussian1D, Scale
+    from astropy.modeling.models import RedshiftScaleFactor, Gaussian1D, Scale
 
     x = np.linspace(1000, 5000, 1000)
     g0 = Gaussian1D(1, 2000, 200)  # No redshift is same as redshift with z=0
@@ -440,7 +440,7 @@ model *instances*:
     plt.plot(x, g0(x), 'g--', label='$z=0$')
 
     for z in (0.2, 0.4, 0.6):
-        rs = Redshift(z).inverse  # Redshift in wavelength space
+        rs = RedshiftScaleFactor(z).inverse  # Redshift in wavelength space
         sc = Scale(1. / (1 + z))  # Rescale the flux to conserve energy
         g = rs | g0 | sc
         plt.plot(x, g(x), color=plt.cm.OrRd(z),


### PR DESCRIPTION
This fixes #3391 (and also updated to reflect changes in #3672). I think this is okay to wait till 1.2 since it is kind of like adding a new feature but for documentation.

* Added another example that illustrate how to redshift in wavelength space and also conserve flux.
* Fixed the original redshift example plot not showing X label.

Here is a screenshot of the rendered doc (with old class name, which has been updated since, but you get the idea):

![screenshot](https://cloud.githubusercontent.com/assets/2090236/14854489/f518d70a-0c5d-11e6-9f75-e867d1ab837f.png)
