### PR TITLE
Fix sigma_clipped_stats when no mask is used.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ New Features
 
   - Allow trailing whitespace in the IPAC header lines. [#4758]
 
-  - Updated to filter out the default parser warning of BeautifulSoup. 
+  - Updated to filter out the default parser warning of BeautifulSoup.
     [#4551]
 
 - ``astropy.io.fits``
@@ -459,7 +459,7 @@ Bug Fixes
 
 - ``astropy.stats``
 
-  - Fix ``sigma_clipped_stats`` to use the ``axis`` argument. [#4726]
+  - Fix ``sigma_clipped_stats`` to use the ``axis`` argument. [#4726, #4808]
 
 - ``astropy.table``
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -313,6 +313,6 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         # With Numpy 1.10 np.ma.median always return a MaskedArray, even with
         # one element. So for compatibility with previous versions, we take the
         # scalar value
-        median = median[0]
+        median = median.item()
 
     return mean, median, std

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -100,9 +100,15 @@ def test_sigma_clipped_stats():
     assert result == (1., 1., 0.)
 
     # test list data with mask_value
-    result2 = sigma_clipped_stats(data, mask_value=0.)
+    result = sigma_clipped_stats(data, mask_value=0.)
     assert isinstance(result[1], float)
-    assert result2 == (1., 1., 0.)
+    assert result == (1., 1., 0.)
+
+    # test without mask
+    data = [0, 2]
+    result = sigma_clipped_stats(data)
+    assert isinstance(result[1], float)
+    assert result == (1., 1., 1.)
 
     _data = np.arange(10)
     data = np.ma.MaskedArray([_data, _data, 10 * _data])


### PR DESCRIPTION
Fix #4726, cc @bsipocz @larrybradley 

With Numpy 1.10 the return value of `np.ma.median` with `axis=None` is not scalar as with previous versions, and its shape also depends on the mask:

- if nomask, it return a scalar array (`shape == ()`)
- if some values are masked, it returns a one-element array (`shape == (1,)`)

Instead of testing the shape, I used `.item` which by default works only for arrays with one element, so it seems appropriate here, but maybe there is a better way ?