### PR TITLE
included missing "self" in UnknownUncertainty method definition

### DIFF
--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -428,7 +428,7 @@ class UnknownUncertainty(NDUncertainty):
         """
         return 'unknown'
 
-    def _convert_uncertainty(other_uncert):
+    def _convert_uncertainty(self, other_uncert):
         """
         Checks that the uncertainties are compatible for propagation.
 


### PR DESCRIPTION
I forgot a `self` in one of the methods: I found it and placed in the right spot and included a test for it.