### PR TITLE
Fix two problems related to clear_download_cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1307,6 +1307,10 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - Fix two problems related to the download cache: clear_download_cache() does
+    not work in Python 2.7 and downloading in Python 2.7 and then Python 3
+    can result in an exception. [#4810]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1221,13 +1221,7 @@ def clear_download_cache(hashorurl=None):
     hashorurl : str or None
         If None, the whole cache is cleared.  Otherwise, either specifies a
         hash for the cached file that is supposed to be deleted, or a URL that
-        has previously been downloaded to the cache.
-
-    Raises
-    ------
-    OSEerror
-        If the requested filename is not present in the data directory.
-
+        should be removed from the cache if present.
     """
 
     try:
@@ -1270,9 +1264,10 @@ def clear_download_cache(hashorurl=None):
                     if os.path.exists(filepath):
                         # Make sure the filepath still actually exists (perhaps user removed it)
                         os.unlink(filepath)
-                else:
-                    msg = 'Could not find file or url {0}'
-                    raise OSError(msg.format(hashorurl))
+                # Otherwise could not find file or url, but no worries.
+                # Clearing download cache just makes sure that the file or url
+                # is no longer in the cache regardless of starting condition.
+
     finally:
         # the lock will be gone if rmtree was used above, but release otherwise
         if os.path.exists(os.path.join(dldir, 'lock')):

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1241,10 +1241,11 @@ def clear_download_cache(hashorurl=None):
     _acquire_download_cache_lock()
     try:
         if hashorurl is None:
+            # dldir includes both the download files and the urlmapfn.  This structure
+            # is required since we cannot know a priori the actual file name corresponding
+            # to the shelve map named urlmapfn.
             if os.path.exists(dldir):
                 shutil.rmtree(dldir)
-            if os.path.exists(urlmapfn):
-                os.unlink(urlmapfn)
         else:
             with _open_shelve(urlmapfn, True) as url2hash:
                 filepath = os.path.join(dldir, hashorurl)
@@ -1266,13 +1267,15 @@ def clear_download_cache(hashorurl=None):
                 elif hash_key in url2hash:
                     filepath = url2hash[hash_key]
                     del url2hash[hash_key]
-                    os.unlink(filepath)
+                    if os.path.exists(filepath):
+                        # Make sure the filepath still actually exists (perhaps user removed it)
+                        os.unlink(filepath)
                 else:
                     msg = 'Could not find file or url {0}'
                     raise OSError(msg.format(hashorurl))
     finally:
         # the lock will be gone if rmtree was used above, but release otherwise
-        if os.path.exists(os.path.join(_get_download_cache_locs()[0], 'lock')):
+        if os.path.exists(os.path.join(dldir, 'lock')):
             _release_download_cache_lock()
 
 
@@ -1289,12 +1292,18 @@ def _get_download_cache_locs():
     """
     from ..config.paths import get_cache_dir
 
-    datadir = os.path.join(get_cache_dir(), 'download')
-    shelveloc = os.path.join(get_cache_dir(), 'download_urlmap')
+    # datadir includes both the download files and the shelveloc.  This structure
+    # is required since we cannot know a priori the actual file name corresponding
+    # to the shelve map named shelveloc.  (The backend can vary and is allowed to
+    # do whatever it wants with the filename.  Filename munging can and does happen
+    # in practice).
+    py_version = 'py' + str(sys.version_info.major)
+    datadir = os.path.join(get_cache_dir(), 'download', py_version)
+    shelveloc = os.path.join(datadir, 'urlmap')
 
     if not os.path.exists(datadir):
         try:
-            os.mkdir(datadir)
+            os.makedirs(datadir)
         except OSError as e:
             if not os.path.exists(datadir):
                 raise

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1320,18 +1320,15 @@ def _get_download_cache_locs():
 
 def _open_shelve(shelffn, withclosing=False):
     """
-    opens a shelf in a way that is py3.x and py2.x compatible.  If
-    `withclosing` is  True, it will be opened with closing, allowing use like:
+    Opens a shelf file.  If `withclosing` is  True, it will be opened with closing,
+    allowing use like:
 
         with _open_shelve('somefile',True) as s:
             ...
     """
     import shelve
 
-    if six.PY2:
-        shelf = shelve.open(shelffn, protocol=2)
-    elif six.PY3:
-        shelf = shelve.open(shelffn + '.db', protocol=2)
+    shelf = shelve.open(shelffn, protocol=2)
 
     if withclosing:
         return contextlib.closing(shelf)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -90,6 +90,9 @@ def test_download_cache():
     fnout = download_file(TESTURL, cache=True)
     assert os.path.isfile(fnout)
 
+    # Clearing download cache succeeds even if the URL does not exist.
+    clear_download_cache('http://this_was_never_downloaded_before.com')
+
     # Make sure lockdir was released
     lockdir = os.path.join(download_dir, 'lock')
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -70,12 +70,28 @@ def test_download_cache():
 
     from ..data import download_file, clear_download_cache
 
+    download_dir = _get_download_cache_locs()[0]
+
+    # Download the test URL and make sure it exists, then clear just that
+    # URL and make sure it got deleted.
     fnout = download_file(TESTURL, cache=True)
+    assert os.path.isdir(download_dir)
     assert os.path.isfile(fnout)
     clear_download_cache(TESTURL)
-    assert not os.path.isfile(fnout)
+    assert not os.path.exists(fnout)
 
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+    # Test issues raised in #4427 with clear_download_cache() without a URL,
+    # followed by subsequent download.
+    fnout = download_file(TESTURL, cache=True)
+    assert os.path.isfile(fnout)
+    clear_download_cache()
+    assert not os.path.exists(fnout)
+    assert not os.path.exists(download_dir)
+    fnout = download_file(TESTURL, cache=True)
+    assert os.path.isfile(fnout)
+
+    # Make sure lockdir was released
+    lockdir = os.path.join(download_dir, 'lock')
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 


### PR DESCRIPTION
This fixes two problems:

- clear_download_cache() does not work in Python 2.7: fixes #4427
- Download cache shelve file is same on Python 2.7 and 3.5 => crash: fixes #4426

Unfortunately I don't know of any automated test that can verify that the second is fixed, but I have done this manually.

The download cache directory / file structure is changed from 
```
<root_cache_dir>/download/  <download files>
<root_cache_dir>/urlmap.db
```
to:
```
<root_cache_dir>/download/py2/  <download files>
<root_cache_dir>/download/py2/urlmap.db  # actual name depends on shelf backend
<root_cache_dir>/download/py3/  <download files>
<root_cache_dir>/download/py3/urlmap.db
```
The `2` or `3` is just `sys.version_info.major` (so this is Python 4 compatible).

cc: @eteq 