### PR TITLE
Add support for Simple reStructuredText Tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ New Features
   - Updated to filter out the default parser warning of BeautifulSoup.
     [#4551]
 
+  - Added support for reading and writing reStructuredText simple tables
+    [#4812]
+
 - ``astropy.io.fits``
 
   - File name could be passed as ``Path`` object. [#4606]

--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -40,6 +40,7 @@ from .sextractor import SExtractor
 from .fixedwidth import (FixedWidth, FixedWidthNoHeader,
                          FixedWidthTwoLine, FixedWidthSplitter,
                          FixedWidthHeader, FixedWidthData)
+from .rst import RST
 from .ui import (set_guess, get_reader, read, get_writer, write, get_read_trace)
 
 from . import connect

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -141,7 +141,7 @@ class FixedWidthHeader(basic.BasicHeader):
                 if not set(line).issubset(charset):
                     raise InconsistentTableError('Characters in position line must be part of {0}'.format(charset))
                 vals, self.col_starts, col_ends = self.get_fixedwidth_params(line)
-                self.col_ends = [x - 1 for x in col_ends]
+                self.col_ends = [x - 1 if x is not None else None for x in col_ends]
 
             # Get the header column names and column positions
             line = self.get_line(lines, start_line)
@@ -187,7 +187,7 @@ class FixedWidthHeader(basic.BasicHeader):
         # been given, so figure out whichever wasn't given.
         if self.col_starts is not None and self.col_ends is not None:
             starts = list(self.col_starts)  # could be any iterable, e.g. np.array
-            ends = [x + 1 for x in self.col_ends]  # user supplies inclusive endpoint
+            ends = [x + 1 if x is not None else None for x in self.col_ends]  # user supplies inclusive endpoint
             if len(starts) != len(ends):
                 raise ValueError('Fixed width col_starts and col_ends must have the same length')
             vals = [line[start:end].strip() for start, end in zip(starts, ends)]

--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -1,0 +1,60 @@
+# Licensed under a 3-clause BSD style license
+"""
+:Author: Simon Gibbons (simongibbons@gmail.com)
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from .core import DefaultSplitter
+from .fixedwidth import (FixedWidth,
+                         FixedWidthData,
+                         FixedWidthHeader,
+                         FixedWidthTwoLineDataSplitter)
+
+class SimpleRSTHeader(FixedWidthHeader):
+    position_line = 0
+    start_line = 1
+    splitter_class = DefaultSplitter
+    position_char = '='
+
+    def get_fixedwidth_params(self, line):
+        vals, starts, ends = super(SimpleRSTHeader, self).get_fixedwidth_params(line)
+        # The right hand column can be unbounded
+        ends[-1] = None
+        return vals, starts, ends
+
+class SimpleRSTData(FixedWidthData):
+    start_line = 3
+    end_line = -1
+    splitter_class = FixedWidthTwoLineDataSplitter
+
+class RST(FixedWidth):
+    """
+    Read or write a `reStructuredText simple format table
+    <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables>`_.
+
+    Example::
+
+        ==== ===== ======
+        Col1  Col2  Col3
+        ==== ===== ======
+          1    2.3  Hello
+          2    4.5  Worlds
+        ==== ===== ======
+
+    Currently there is no support for reading tables which utilise continuation lines,
+    or for ones which define column spans through the use of an additional
+    line of dashes in the header.
+    """
+    _format_name = 'rst'
+    _description = 'reStructuredText simple table'
+    data_class = SimpleRSTData
+    header_class = SimpleRSTHeader
+
+    def __init__(self):
+        super(RST, self).__init__(delimiter_pad=None, bookend=False)
+
+    def write(self, lines):
+        lines = super(RST, self).write(lines)
+        lines = [lines[1]] + lines + [lines[1]]
+        return lines

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -1,0 +1,173 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+from ... import ascii
+from .common import (assert_equal, assert_almost_equal,
+                     setup_function, teardown_function)
+
+
+def assert_equal_splitlines(arg1, arg2):
+    assert_equal(arg1.splitlines(), arg2.splitlines())
+
+def test_read_normal():
+    """Normal SimpleRST Table"""
+    table = """
+# comment (with blank line above)
+======= =========
+   Col1      Col2
+======= =========
+   1.2    "hello"
+   2.4  's worlds
+======= =========
+"""
+    reader = ascii.get_reader(Reader=ascii.RST)
+    dat = reader.read(table)
+    assert_equal(dat.colnames, ['Col1', 'Col2'])
+    assert_almost_equal(dat[1][0], 2.4)
+    assert_equal(dat[0][1], '"hello"')
+    assert_equal(dat[1][1], "'s worlds")
+
+def test_read_normal_names():
+    """Normal SimpleRST Table with provided column names"""
+    table = """
+# comment (with blank line above)
+======= =========
+   Col1      Col2
+======= =========
+   1.2    "hello"
+   2.4  's worlds
+======= =========
+"""
+    reader = ascii.get_reader(Reader=ascii.RST,
+                                   names=('name1', 'name2'))
+    dat = reader.read(table)
+    assert_equal(dat.colnames, ['name1', 'name2'])
+    assert_almost_equal(dat[1][0], 2.4)
+
+def test_read_normal_names_include():
+    """Normal SimpleRST Table with provided column names"""
+    table = """
+# comment (with blank line above)
+=======  ========== ======
+   Col1     Col2      Col3
+=======  ========== ======
+   1.2     "hello"       3
+   2.4    's worlds      7
+=======  ========== ======
+"""
+    reader = ascii.get_reader(Reader=ascii.RST,
+                                   names=('name1', 'name2', 'name3'),
+                                   include_names=('name1', 'name3'))
+    dat = reader.read(table)
+    assert_equal(dat.colnames, ['name1', 'name3'])
+    assert_almost_equal(dat[1][0], 2.4)
+    assert_equal(dat[0][1], 3)
+
+def test_read_normal_exclude():
+    """Nice, typical SimpleRST table with col name excluded"""
+    table = """
+======= ==========
+  Col1     Col2
+======= ==========
+  1.2     "hello"
+  2.4    's worlds
+======= ==========
+"""
+    reader = ascii.get_reader(Reader=ascii.RST,
+                                   exclude_names=('Col1',))
+    dat = reader.read(table)
+    assert_equal(dat.colnames, ['Col2'])
+    assert_equal(dat[1][0], "'s worlds")
+
+def test_read_unbounded_right_column():
+    """The right hand column should be allowed to overflow"""
+    table = """
+# comment (with blank line above)
+===== ===== ====
+ Col1  Col2 Col3
+===== ===== ====
+ 1.2    2    Hello
+ 2.4     4   Worlds
+===== ===== ====
+"""
+    reader = ascii.get_reader(Reader=ascii.RST)
+    dat = reader.read(table)
+    assert_equal(dat[0][2], "Hello")
+    assert_equal(dat[1][2], "Worlds")
+
+def test_read_unbounded_right_column_header():
+    """The right hand column should be allowed to overflow"""
+    table = """
+# comment (with blank line above)
+===== ===== ====
+ Col1  Col2 Col3Long
+===== ===== ====
+ 1.2    2    Hello
+ 2.4     4   Worlds
+===== ===== ====
+"""
+    reader = ascii.get_reader(Reader=ascii.RST)
+    dat = reader.read(table)
+    assert_equal(dat.colnames[-1], "Col3Long")
+
+def test_read_right_indented_table():
+    """We should be able to read right indented tables correctly"""
+    table = """
+# comment (with blank line above)
+   ==== ==== ====
+   Col1 Col2 Col3
+   ==== ==== ====
+    3    3.4  foo
+    1    4.5  bar
+   ==== ==== ====
+"""
+    reader = ascii.get_reader(Reader=ascii.RST)
+    dat = reader.read(table)
+    assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
+    assert_equal(dat[0][2], "foo")
+    assert_equal(dat[1][0], 1)
+
+def test_trailing_spaces_in_row_definition():
+    """ Trailing spaces in the row definition column shouldn't matter"""
+    table = """
+# comment (with blank line above)
+   ==== ==== ====    
+   Col1 Col2 Col3
+   ==== ==== ====  
+    3    3.4  foo
+    1    4.5  bar
+   ==== ==== ====  
+"""  # nopep8
+    reader = ascii.get_reader(Reader=ascii.RST)
+    dat = reader.read(table)
+    assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
+    assert_equal(dat[0][2], "foo")
+    assert_equal(dat[1][0], 1)
+
+
+table = """\
+====== =========== ============ ===========
+  Col1    Col2        Col3        Col4
+====== =========== ============ ===========
+  1.2    "hello"      1           a
+  2.4   's worlds          2           2
+====== =========== ============ ===========
+"""
+dat = ascii.read(table, Reader=ascii.RST)
+
+def test_write_normal():
+    """Write a table as a normal SimpleRST Table"""
+    out = StringIO()
+    ascii.write(dat, out, Writer=ascii.RST)
+    assert_equal_splitlines(out.getvalue(), """\
+==== ========= ==== ====
+Col1      Col2 Col3 Col4
+==== ========= ==== ====
+ 1.2   "hello"    1    a
+ 2.4 's worlds    2    2
+==== ========= ==== ====
+""")

--- a/docs/io/ascii/extension_classes.rst
+++ b/docs/io/ascii/extension_classes.rst
@@ -24,6 +24,7 @@ well-defined but idiosyncratic formats.
 * :class:`~astropy.io.ascii.Latex`: LaTeX table with datavalue in the ``tabular`` environment
 * :class:`~astropy.io.ascii.NoHeader`: basic table with no header where columns are auto-named
 * :class:`~astropy.io.ascii.Rdb`: tab-separated values with an extra line after the column definition line
+* :class:`~astropy.io.ascii.RST`: `reStructuredText simple format table <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables>`_
 * :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <http://www.astromatic.net/software/sextractor>`_
 * :class:`~astropy.io.ascii.Tab`: tab-separated values
 * :class:`~astropy.io.ascii.Csv`: comma-separated values

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -205,6 +205,7 @@ the fast Cython/C engine for reading and writing.
 ``latex``                   Yes      :class:`~astropy.io.ascii.Latex`: LaTeX table
 ``no_header``               Yes  Yes :class:`~astropy.io.ascii.NoHeader`: Basic table with no headers
 ``rdb``                     Yes  Yes :class:`~astropy.io.ascii.Rdb`: Tab-separated with a type definition header line
+``rst``                     Yes      :class:`~astropy.io.ascii.RST`: reStructuredText simple format table
 ``sextractor``                       :class:`~astropy.io.ascii.SExtractor`: SExtractor format table
 ``tab``                     Yes  Yes :class:`~astropy.io.ascii.Tab`: Basic table with tab-separated values
 ========================= ===== ==== ============================================================================================


### PR DESCRIPTION
This is a first stab at getting an implementation for reading and writing [Simple RST tables](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables), as suggested in #4590 

Currently there is no real error checking in the code, and there is no support for an overflowing right hand column, these will be added in due course.