### PR TITLE
Issue a log.info message with inconsistent SIP representation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -264,6 +264,8 @@ API changes
 
   - WCS objects can now be initialized with an ImageHDU or
     PrimaryHDU object. [#4493]
+  - astropy.wcs now issues an INFO message when the header has SIP coefficients but 
+    "-SIP" is missing from CTYPE. [#4814]
 
 Bug fixes
 ^^^^^^^^^
@@ -357,6 +359,9 @@ Bug fixes
     failing as a side-effect of #4699. [#4757]
 
 - ``astropy.wcs``
+
+  - astropy.wcs.to_header removes "-SIP" from CTYPE when SIP coefficients 
+    are not written out, i.e. ``relax`` is either ``False`` or ``None``. [#4814]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -264,8 +264,10 @@ API changes
 
   - WCS objects can now be initialized with an ImageHDU or
     PrimaryHDU object. [#4493]
-  - astropy.wcs now issues an INFO message when the header has SIP coefficients but 
+
+  - astropy.wcs now issues an INFO message when the header has SIP coefficients but
     "-SIP" is missing from CTYPE. [#4814]
+
 
 Bug fixes
 ^^^^^^^^^
@@ -360,8 +362,10 @@ Bug fixes
 
 - ``astropy.wcs``
 
-  - astropy.wcs.to_header removes "-SIP" from CTYPE when SIP coefficients 
-    are not written out, i.e. ``relax`` is either ``False`` or ``None``. [#4814]
+  - astropy.wcs.to_header removes "-SIP" from CTYPE when SIP coefficients
+    are not written out, i.e. ``relax`` is either ``False`` or ``None``.
+    astropy.wcs.to_header appends "-SIP" to CTYPE when SIP coefficients
+    are written out, i.e. ``relax=True``. [#4814]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -941,9 +941,11 @@ def inconsistent_sip():
     # CTYPE should not include "-SIP" if relax is None
     assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
     newhdr = w.to_header(relax=False)
+    assert('A_0_2' not in newhdr)
     # CTYPE should not include "-SIP" if relax is False
     assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
     newhdr = w.to_header(key="C")
+    assert('A_0_2' not in newhdr)
     # Test writing header with a different key
     assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
     newhdr = w.to_header(key=" ")
@@ -953,6 +955,7 @@ def inconsistent_sip():
     # "-SIP" was in the original header
     newhdr = w.to_header(relax=True)
     assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    assert('A_0_2' in newhdr)
     # Test that SIP coefficients are aslo written out.
     wtest = WCS(newhdr)
     assert wtest.sip is not None

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -929,3 +929,26 @@ def test_passing_ImageHDU():
     wcs_hdu = wcs.WCS(hdulist[1])
     wcs_header = wcs.WCS(hdulist[1].header)
     assert wcs_hdu.wcs.compare(wcs_header.wcs)
+
+
+def inconsistent_sip():
+    """
+    Test for #4814
+    """
+    hdr = get_pkg_data_contents("data/sip-broken.hdr")
+    w = wcs.WCS(hdr)
+    newhdr = w.to_header(relax=None)
+    # CTYPE should not include "-SIP" if relax is None
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    newhdr = w.to_header(relax=False)
+    # CTYPE should not include "-SIP" if relax is False
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    newhdr = w.to_header(key="C")
+    # Test writing header with a different key
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    newhdr = w.to_header(key=" ")
+    # Test writing a primary WCS to header
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    # Test that "-SIP" is kept into CTYPE if relax=True
+    newhdr = w.to_header(relax=True)
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -949,6 +949,18 @@ def inconsistent_sip():
     newhdr = w.to_header(key=" ")
     # Test writing a primary WCS to header
     assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
-    # Test that "-SIP" is kept into CTYPE if relax=True
+    # Test that "-SIP" is kept into CTYPE if relax=True and
+    # "-SIP" was in the original header
     newhdr = w.to_header(relax=True)
     assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    # Test that SIP coefficients are aslo written out.
+    wtest = WCS(newhdr)
+    assert wtest.sip is not None
+    ########## broken header ###########
+    # Test that "-SIP" is added to CTYPE if relax=True and
+    # "-SIP" was not in the original header
+    hdr['CTYPE1'] = 'RA---TAN'
+    w = WCS(hdr)
+    newhdr = w.to_header(relax=True)
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -966,4 +966,3 @@ def inconsistent_sip():
     w = WCS(hdr)
     newhdr = w.to_header(relax=True)
     assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
-

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2499,6 +2499,7 @@ reduce these to 2 dimensions using the naxis kwarg.
           8. Keyword order may be changed.
 
         """
+        # default precision for numerical WCS keywords
         precision = WCSHDO_P14
         display_warning = False
         if relax is None:
@@ -2528,25 +2529,16 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         if do_sip and self.sip is not None:
             if self.wcs is not None and any([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]):
-                message = """
-                Inconsistent SIP distortion information:
-
-                SIP coefficients were detected, but CTYPE is missing "-SIP" suffix,
-                therefore the header will be incorrect.
-
-                If distortion should be included in the header please add "-SIP" to CTYPE.
-
-                If distortion should not be included please remove the SIP coefficients.
-
-                """
-                log.info(message)
+                self._fix_ctype(header, add_sip=True)
 
             for kw, val in self._write_sip_kw().items():
                 header[kw] = val
 
+
         if not do_sip and self.wcs is not None and any(self.wcs.ctype):
-            # this is called when relax is True
-            header = self._fix_ctype(header)
+            # This is called when relax is not False or WCSHDO_SIP
+            # The default case of ``relax=None`` is handled further in the code.
+            header = self._fix_ctype(header, add_sip=False)
 
         if display_warning:
             full_header = self.to_header(relax=True, key=key)
@@ -2561,27 +2553,74 @@ reduce these to 2 dimensions using the naxis kwarg.
                     "Use the ``relax`` kwarg to control this.".format(
                         ', '.join(missing_keys)),
                     AstropyWarning)
-            # called when relax is None
-            # This is different than the case of ``relax=False`` and ``to_header()`` is called twice.
+            # called when ``relax=None``
+            # This is different from the case of ``relax=False``.
             if any(self.wcs.ctype):
-                header = self._fix_ctype(header)
-        # finally reset the key, must be called after ``_fix_ctype``
+                header = self._fix_ctype(header, add_sip=False, log_message=False)
+        # Finally reset the key. This must be called after ``_fix_ctype``.
         if key is not None:
             self.wcs.alt = orig_key
         return header
 
-    def _fix_ctype(self, header):
+    def _fix_ctype(self, header, add_sip=True, log_message=True):
         """
-        Remove "-SIP" from CTYPE when writing out a header with relax=False.
-        This needs to be done outside ``to_header`` because ``to_header`` runs
-        twice when ``relax=False`` and the second time ``relax`` is set to ``True``
-        to display the missing keywords.
+        Parameters
+        ----------
+        header : `~astropy.io.fits.Header`
+            FITS header.
+        add_sip : bool
+            Flag indicating whether "-SIP" should be added or removed from CTYPE keywords.
+
+            Remove "-SIP" from CTYPE when writing out a header with relax=False.
+            This needs to be done outside ``to_header`` because ``to_header`` runs
+            twice when ``relax=False`` and the second time ``relax`` is set to ``True``
+            to display the missing keywords.
+
+            If the user requested SIP distortion to be written out add "-SIP" to
+            CTYPE if it is missing.
         """
+
+        _strip_sip_from_ctype = """
+        Warning: to_header() was invoked without ``relax=True``: stripping all SIP
+        coefficients from output header, and stripping "-SIP" from output CTYPE
+        if it was originally present.
+
+        Therefore astrometry obtained for output image may be different from
+        original image because SIP is no longer present.
+
+        Please inspect the headers of input and output images to verify, and
+        modify the headers if necessary.
+        """
+
+        _add_sip_to_ctype = """
+        Inconsistent SIP distortion information is present in the current WCS:
+        SIP coefficients were detected, but CTYPE is missing "-SIP" suffix,
+        therefore the current WCS is internally inconsistent.
+
+        Because relax has been set to True, the resulting output WCS will have
+        "-SIP" appended to CTYPE in order to make the header internally consistent.
+
+        However, this may produce incorrect astrometry in the output WCS, if
+        in fact the current WCS is already distortion-corrected.
+
+        Therefore, if current WCS is already distortion-corrected (eg, drizzled)
+        then SIP distortion components should not apply. In that case, for a WCS
+        that is already distortion-corrected, please do not set relax=True.
+
+        """
+        if log_message:
+            if add_sip:
+                log.info(_add_sip_to_ctype)
+            else:
+                log.info(_strip_sip_from_ctype)
         for i in range(1, self.naxis+1):
             # strip() must be called here to cover the case of alt key= " "
             kw = 'CTYPE{0}{1}'.format(i, self.wcs.alt).strip()
-            val = header[kw].strip("-SIP")
-            header[kw] = header['CTYPE{0}{1}'.format(i, self.wcs.alt)].strip("-SIP")
+            if add_sip:
+                val = header[kw].strip("-SIP") + "-SIP"
+            else:
+                val = header[kw].strip("-SIP")
+            header[kw] = val
         return header
 
     def to_header_string(self, relax=None):


### PR DESCRIPTION
This is a follow up on #4803. While I prefer issuing a `Warning`, warnings are issued once per session and it is easy to miss the problem in subsequent calls to `wcs.WCS`. To avoid this I implemented it as a `log.info` message. However, I can convert it to a warning message if that's desired.

So please, suggest better wording or let me know if you think `log.info` is too intrusive and I'll change it to a warning. 

_Update on what this PR implements:_

- If SIP coefficients are in the header but `CTYPE` **is missing** " -SIP" a log.info message is printed when the header is read in. The WCS includes SIP distortion.
- If SIP coefficients are in the WCS but `CTYPE` **is missing** "-SIP" a log.info message is printed when `wcs.to_header(relax=True)` is called and "-SIP" is appended to CTYPE.
- If SIP coefficients are in the WCS and `-SIP` **is in** `CTYPE`, "-SIP" is stripped from `CTYPE` when `wcs.to_header()` is called with `relax=None` or `relax=False`. 

