### PR TITLE
Implemented more setter for NDData and NDUncertainty attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -167,6 +167,10 @@ API changes
 
 - ``astropy.nddata``
 
+  - ``NDData`` implements setter for meta, unit and wcs. Using the setter for
+    unit will issue a warning that the other attributes (especially the data)
+    are not scaled.
+
   - ``NDData``: added an optional parameter ``copy``
     which is False by default. If it is True all other parameters are copied
     before saving them as attributes. If False the parameters are only copied
@@ -180,6 +184,9 @@ API changes
 
   - ``NDUncertainty``: Public methods ``propagate_add``, etc. are replaced by
     a general ``propagate`` method. [#4272]
+
+  - ``NDUncertainty``: added setter for unit. This will simply replace the unit
+    without affecting (scaling or converting) the uncertainty values.
 
   - ``StdDevUncertainty``: added an optional parameter ``copy`` which is False
     by default. [#4272]

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -179,16 +179,12 @@ class NDUncertainty(object):
                 unit = array.unit
             array = array.value
 
-        if unit is None:
-            self._unit = None
-        else:
-            self._unit = Unit(unit)
-
         if copy:
             array = deepcopy(array)
             unit = deepcopy(unit)
 
         self.array = array
+        self.unit = unit
         self.parent_nddata = None  # no associated NDData - until it is set!
 
     @abstractproperty
@@ -231,6 +227,13 @@ class NDUncertainty(object):
         wrong results.
 
         If the unit is not set the unit of the parent will be returned.
+
+        .. warning::
+
+          Setting or overwriting the unit manually will not check if the new
+          unit is compatible or convertible to the old unit. Neither will this
+          scale or otherwise affect the saved uncertainty. Appropriate
+          conversion of these values must be done manually.
         """
         if self._unit is None:
             if (self._parent_nddata is None or
@@ -239,6 +242,14 @@ class NDUncertainty(object):
             else:
                 return self.parent_nddata.unit
         return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        # Simply replace the unit without scaling
+        if value is None:
+            self._unit = None
+        else:
+            self._unit = Unit(value)
 
     @property
     def parent_nddata(self):


### PR DESCRIPTION
- NDData: Setter for unit and wcs.
- NDUncertainty: Setter for unit.
- both classes use the appropriate setters in their init.

With including the `meta`-descriptor only unit, wcs and data had no setter. This PR includes these and since the `__init__` now uses them these are already covered by the tests. None of the internal logic changed (except for unnecessary copies during `__init__`).

This PR doesn't apply the `NDDataArray` INFO message when overwriting the `unit` but includes a warning-message in the docs.

FYI: The `data` still has no setter but that's ok since one can alter the data in-place and you need to supply at least some data to initialize `NDData`. Also it might be strange to duplicate the logic depending on the type of data that is used in `__init__` inside the setter. Or only have it during init and not inside the setter.
