### PR TITLE
Use custom exception for io.registry errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,10 @@ New Features
 
 - ``astropy.io.misc``
 
+- ``astropy.io.registry``
+
+  - Added custom ``IORegistryError`` [#4883]
+
 - ``astropy.io.votable``
 
   - File name could be passed as ``Path`` object. [#4606]

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -34,7 +34,7 @@ else:
     PATH_TYPES += (pathlib.Path,)
 
 
-class IORegistryError(ValueError):
+class IORegistryError(Exception):
     """Custom error for registry clashes
     """
     pass

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -14,7 +14,7 @@ from ..extern.six.moves import zip
 
 __all__ = ['register_reader', 'register_writer', 'register_identifier',
            'identify_format', 'get_reader', 'get_writer', 'read', 'write',
-           'get_formats']
+           'get_formats', 'IORegistryError']
 
 
 __doctest_skip__ = ['register_identifier']
@@ -32,6 +32,12 @@ except:
 else:
     HAS_PATHLIB = True
     PATH_TYPES += (pathlib.Path,)
+
+
+class IORegistryError(ValueError):
+    """Custom error for registry clashes
+    """
+    pass
 
 
 def get_formats(data_class=None):
@@ -164,9 +170,9 @@ def register_reader(data_format, data_class, function, force=False):
     if not (data_format, data_class) in _readers or force:
         _readers[(data_format, data_class)] = function
     else:
-        raise Exception("Reader for format '{0}' and class '{1}' is "
-                        'already defined'.format(data_format,
-                                                 data_class.__name__))
+        raise IORegistryError("Reader for format '{0}' and class '{1}' is "
+                              'already defined'.format(data_format,
+                                                       data_class.__name__))
 
     _update__doc__(data_class, 'read')
 
@@ -191,9 +197,9 @@ def register_writer(data_format, data_class, function, force=False):
     if not (data_format, data_class) in _writers or force:
         _writers[(data_format, data_class)] = function
     else:
-        raise Exception("Writer for format '{0}' and class '{1}' is "
-                        'already defined'.format(data_format,
-                                                 data_class.__name__))
+        raise IORegistryError("Writer for format '{0}' and class '{1}' is "
+                              'already defined'.format(data_format,
+                                                       data_class.__name__))
 
     _update__doc__(data_class, 'write')
 
@@ -247,9 +253,9 @@ def register_identifier(data_format, data_class, identifier, force=False):
     if not (data_format, data_class) in _identifiers or force:
         _identifiers[(data_format, data_class)] = identifier
     else:
-        raise Exception("Identifier for format '{0}' and class '{1}' is "
-                        'already defined'.format(data_format,
-                                                 data_class.__name__))
+        raise IORegistryError("Identifier for format '{0}' and class '{1}' is "
+                              'already defined'.format(data_format,
+                                                       data_class.__name__))
 
 
 def identify_format(origin, data_class_required, path, fileobj, args, kwargs):
@@ -282,10 +288,10 @@ def get_reader(data_format, data_class):
             return _readers[(reader_format, reader_class)]
     else:
         format_table_str = _get_format_table_str(data_class, 'Read')
-        raise Exception("No reader defined for format '{0}' and class '{1}'.\n"
-                        'The available formats are:\n'
-                        '{2}'
-                        .format(data_format, data_class.__name__, format_table_str))
+        raise IORegistryError(
+            "No reader defined for format '{0}' and class '{1}'.\nThe "
+            "available formats are:\n{2}".format(
+                data_format, data_class.__name__, format_table_str))
 
 
 def get_writer(data_format, data_class):
@@ -295,10 +301,10 @@ def get_writer(data_format, data_class):
             return _writers[(writer_format, writer_class)]
     else:
         format_table_str = _get_format_table_str(data_class, 'Write')
-        raise Exception("No writer defined for format '{0}' and class '{1}'.\n"
-                        'The available formats are:\n'
-                        '{2}'
-                        .format(data_format, data_class.__name__, format_table_str))
+        raise IORegistryError(
+            "No writer defined for format '{0}' and class '{1}'.\nThe "
+            "available formats are:\n{2}".format(
+                data_format, data_class.__name__, format_table_str))
 
 
 def read(cls, *args, **kwargs):
@@ -426,11 +432,11 @@ def _get_valid_format(mode, cls, path, fileobj, args, kwargs):
 
     if len(valid_formats) == 0:
         format_table_str = _get_format_table_str(cls, mode.capitalize())
-        raise Exception("Format could not be identified.\n"
+        raise IORegistryError("Format could not be identified.\n"
                         "The available formats are:\n"
                         "{0}".format(format_table_str))
     elif len(valid_formats) > 1:
-        raise Exception(
+        raise IORegistryError(
             "Format is ambiguous - options are: {0}".format(
                 ', '.join(sorted(valid_formats, key=lambda tup: tup[0]))))
 

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -47,14 +47,14 @@ def empty_identifier(*args, **kwargs):
 
 
 def test_get_reader_invalid():
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.get_reader('test', TestData)
     assert exc.value.args[0].startswith(
         "No reader defined for format 'test' and class 'TestData'")
 
 
 def test_get_writer_invalid():
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.get_writer('test', TestData)
     assert exc.value.args[0].startswith(
         "No writer defined for format 'test' and class 'TestData'")
@@ -81,21 +81,21 @@ def test_register_identifier():
 
 def test_register_reader_invalid():
     io_registry.register_reader('test', TestData, empty_reader)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_reader('test', TestData, empty_reader)
     assert exc.value.args[0] == "Reader for format 'test' and class 'TestData' is already defined"
 
 
 def test_register_writer_invalid():
     io_registry.register_writer('test', TestData, empty_writer)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_writer('test', TestData, empty_writer)
     assert exc.value.args[0] == "Writer for format 'test' and class 'TestData' is already defined"
 
 
 def test_register_identifier_invalid():
     io_registry.register_identifier('test', TestData, empty_identifier)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_identifier('test', TestData, empty_identifier)
     assert exc.value.args[0] == "Identifier for format 'test' and class 'TestData' is already defined"
 
@@ -116,13 +116,13 @@ def test_register_identifier_force():
 
 
 def test_read_noformat():
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read()
     assert exc.value.args[0].startswith("Format could not be identified.")
 
 
 def test_write_noformat():
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write()
     assert exc.value.args[0].startswith("Format could not be identified.")
 
@@ -130,7 +130,7 @@ def test_write_noformat():
 def test_read_noformat_arbitrary():
     """Test that all identifier functions can accept arbitary input"""
     _identifiers.update(_IDENTIFIERS_ORIGINAL)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(object())
     assert exc.value.args[0].startswith("Format could not be identified.")
 
@@ -142,7 +142,7 @@ def test_read_noformat_arbitrary_file(tmpdir):
     with open(testfile, 'w') as f:
         f.write("Hello world")
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         Table.read(testfile)
     assert exc.value.args[0].startswith("Format could not be identified.")
 
@@ -150,7 +150,7 @@ def test_read_noformat_arbitrary_file(tmpdir):
 def test_write_noformat_arbitrary():
     """Test that all identifier functions can accept arbitary input"""
     _identifiers.update(_IDENTIFIERS_ORIGINAL)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(object())
     assert exc.value.args[0].startswith("Format could not be identified.")
 
@@ -160,7 +160,7 @@ def test_write_noformat_arbitrary_file(tmpdir):
     _writers.update(_WRITERS_ORIGINAL)
     testfile = str(tmpdir.join('foo.example'))
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         Table().write(testfile)
     assert exc.value.args[0].startswith("Format could not be identified.")
 
@@ -168,7 +168,7 @@ def test_write_noformat_arbitrary_file(tmpdir):
 def test_read_toomanyformats():
     io_registry.register_identifier('test1', TestData, lambda o, *x, **y: True)
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: True)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read()
     assert exc.value.args[0] == "Format is ambiguous - options are: test1, test2"
 
@@ -176,20 +176,20 @@ def test_read_toomanyformats():
 def test_write_toomanyformats():
     io_registry.register_identifier('test1', TestData, lambda o, *x, **y: True)
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: True)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write()
     assert exc.value.args[0] == "Format is ambiguous - options are: test1, test2"
 
 
 def test_read_format_noreader():
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(format='test')
     assert exc.value.args[0].startswith(
         "No reader defined for format 'test' and class 'TestData'")
 
 
 def test_write_format_nowriter():
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(format='test')
     assert exc.value.args[0].startswith(
         "No writer defined for format 'test' and class 'TestData'")
@@ -208,12 +208,12 @@ def test_read_identifier():
     # the reader. The io_registry.get_reader will fail but the error message will
     # tell us if the identifier worked.
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read('abc')
     assert exc.value.args[0].startswith(
         "No reader defined for format 'test1' and class 'TestData'")
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read('bac')
     assert exc.value.args[0].startswith(
         "No reader defined for format 'test2' and class 'TestData'")
@@ -228,12 +228,12 @@ def test_write_identifier():
     # the reader. The io_registry.get_writer will fail but the error message will
     # tell us if the identifier worked.
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write('abc')
     assert exc.value.args[0].startswith(
         "No writer defined for format 'test1' and class 'TestData'")
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write('bac')
     assert exc.value.args[0].startswith(
         "No writer defined for format 'test2' and class 'TestData'")
@@ -250,12 +250,12 @@ def test_identifier_origin():
     TestData.read()
     TestData().write()
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(format='test2')
     assert exc.value.args[0].startswith(
         "No reader defined for format 'test2' and class 'TestData'")
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(format='test1')
     assert exc.value.args[0].startswith(
         "No writer defined for format 'test1' and class 'TestData'")


### PR DESCRIPTION
This PR fixes #4831 by replacing use of `Exception` with a new custom `IORegistryError` inherited from `ValueError`.