### PR TITLE
Update RTD domain name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3381,7 +3381,7 @@ API Changes
     configuration items have moved, and some have been changed to science state
     values.  The old locations should continue to work until astropy 0.5, but
     deprecation warnings will be displayed.  See the `Configuration transition
-    <http://astropy.readthedocs.org/en/v0.4/config/config_0_4_transition.html>`_
+    <http://docs.astropy.org/en/v0.4/config/config_0_4_transition.html>`_
     docs for a detailed description of the changes and how to update existing
     code. [#2094]
 
@@ -4004,7 +4004,7 @@ Bug Fixes
 - ``astropy.io.fits``
 
   - Ported all bug fixes from PyFITS 3.2.1.  See the PyFITS changelog at
-    http://pyfits.readthedocs.org/en/v3.2.1/ [#2056]
+    http://pyfits.readthedocs.io/en/v3.2.1/ [#2056]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -282,7 +282,7 @@ class HTML(core.BaseReader):
             the table output.  This is done by calling ``bleach.clean(data,
             **raw_html_clean_kwargs)``.  For details on the available options
             (e.g. tag whitelist) see:
-            http://bleach.readthedocs.org/en/latest/clean.html
+            http://bleach.readthedocs.io/en/latest/clean.html
 
         * parser : Specific HTML parsing library to use
             If specified, this specifies which HTML parsing library

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -40,9 +40,12 @@ References
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import warnings
+
 import numpy as np
 
 from ..utils.compat.funcsigs import signature
+from ..utils.exceptions import AstropyUserWarning
 
 # TODO: implement other fitness functions from appendix B of Scargle 2012
 
@@ -417,12 +420,11 @@ class Events(FitnessFunc):
     """
     def __init__(self, p0=0.05, gamma=None, ncp_prior=None):
         if p0 is not None and gamma is None and ncp_prior is None:
-            import warnings
             warnings.warn('p0 does not seem to accurately represent the false '
                           'positive rate for event data. It is highly '
                           'recommended that you run random trials on signal-'
                           'free noise to calibrate ncp_prior to achieve a '
-                          'desired false positive rate.')
+                          'desired false positive rate.', AstropyUserWarning)
         super(Events, self).__init__(p0, gamma, ncp_prior)
 
     def fitness(self, N_k, T_k):
@@ -474,9 +476,8 @@ class RegularEvents(FitnessFunc):
 
         eps = 1E-8
         if np.any(N_over_M > 1 + eps):
-            import warnings
             warnings.warn('regular events: N/M > 1.  '
-                          'Is the time step correct?')
+                          'Is the time step correct?', AstropyUserWarning)
 
         one_m_NM = 1 - N_over_M
         N_over_M[N_over_M <= 0] = 1

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -164,7 +164,7 @@ class XMLWriter:
         In order to explicitly allow certain XML tags (e.g. link reference or
         emphasis tags), use ``method='bleach_clean'``.  This sanitizes the data
         string using the ``clean`` function of the
-        `http://bleach.readthedocs.org/en/latest/clean.html <bleach>`_ package.
+        `http://bleach.readthedocs.io/en/latest/clean.html <bleach>`_ package.
         Any additional keyword arguments will be passed directly to the
         ``clean`` function.
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2943,7 +2943,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             ...
 
         and this will generate a plot with the correct WCS coordinates on the
-        axes. See http://wcsaxes.readthedocs.org for more information.
+        axes. See http://wcsaxes.readthedocs.io for more information.
         """
 
         try:
@@ -2951,7 +2951,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         except ImportError:
             raise ImportError("Using WCS instances as Matplotlib projections "
                               "requires the WCSAxes package to be installed. "
-                              "See http://wcsaxes.readthedocs.org for more "
+                              "See http://wcsaxes.readthedocs.io for more "
                               "details.")
         else:
             return WCSAxes, {'wcs': self}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ del intersphinx_mapping['astropy']
 
 # add any custom intersphinx for astropy
 intersphinx_mapping['pytest'] = ('http://pytest.org/latest/', None)
-intersphinx_mapping['ipython'] = ('http://ipython.readthedocs.org/en/stable/', None)
+intersphinx_mapping['ipython'] = ('http://ipython.readthedocs.io/en/stable/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -216,8 +216,8 @@ To see the list of site names available, use
     you should find the appropriate reference and input the coordinates
     manually, or use more specialized functionality like that in the
     `astroquery <http://www.astropy.org/astroquery/>`_ or
-    `astroplan <http://astroplan.readthedocs.org/>`_ affiliated packages.
-    
+    `astroplan <http://astroplan.readthedocs.io/>`_ affiliated packages.
+
     Also note that these two methods retrieve data from the internet to
     determine the celestial or Earth coordinates. The online data may be
     updated, so if you need to guarantee that your scripts are reproducible

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -151,7 +151,7 @@ Enable PEP8 compliance testing with ``pep8=True`` in the call to
 Tox
 ---
 
-`Tox <http://tox.readthedocs.org>`_ is a sort of meta-test runner for Python.
+`Tox <http://tox.readthedocs.io>`_ is a sort of meta-test runner for Python.
 It installs a project into one or more virtualenvs (usually one for each Python
 version supported), build and installs the project into each virtualenv, and
 runs the projects tests (or any other build processes one might want to test).

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -299,7 +299,7 @@ If you are doing this because you have found a bug and are checking that it
 still exists in the development version, try running your code.
 
 Or, just for fun, try out one of the
-`new features <http://astropy.readthedocs.org/en/latest/changelog.html>`_ in
+`new features <http://docs.astropy.org/en/latest/changelog.html>`_ in
 the development version.
 
 Either way, once you are done, make sure you do the next step.

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -298,8 +298,7 @@ If you are going through this to ramp up to making more contributions to
 If you are doing this because you have found a bug and are checking that it
 still exists in the development version, try running your code.
 
-Or, just for fun, try out one of the
-`new features <http://docs.astropy.org/en/latest/changelog.html>`_ in
+Or, just for fun, try out one of the :ref:`new features <changelog>` in
 the development version.
 
 Either way, once you are done, make sure you do the next step.

--- a/docs/development/workflow/virtual_pythons.rst
+++ b/docs/development/workflow/virtual_pythons.rst
@@ -182,8 +182,8 @@ which the ``ENV`` is located; both also provide commands to make that a bit easi
 * `virtualenvwrapper`_: ``rmvirtualenv ENV``
 * `conda`_: ``conda remove --all -n ENV``
 
-.. _documentation for virtualenvwrapper: http://virtualenvwrapper.readthedocs.org/en/latest/install.html
-.. _virtualenvwrapper command documentation: http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html
+.. _documentation for virtualenvwrapper: http://virtualenvwrapper.readthedocs.io/en/latest/install.html
+.. _virtualenvwrapper command documentation: http://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html
 .. _documentation for the conda command: http://docs.continuum.io/conda/examples/create.html
 .. _blog post announcing anaconda environments: http://www.continuum.io/blog/conda
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Astropy also depends on other packages for optional features:
 
 - `matplotlib <http://matplotlib.org/>`_: To provide plotting functionality that `astropy.visualization` enhances.
 
-- `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_: To use `astropy.wcs` to define projections in Matplotlib.
+- `WCSAxes <http://wcsaxes.readthedocs.io/en/latest/>`_: To use `astropy.wcs` to define projections in Matplotlib.
 
 - `pytz <http://pythonhosted.org/pytz/>`_: To specify and convert between timezones.
 
@@ -395,7 +395,7 @@ packages:
       and most affiliated packages include this as a submodule in the source
       repository, so it does not need to be installed separately.)
 
-    - `WCSAxes <http://wcsaxes.readthedocs.org/en/latest/>`_
+    - `WCSAxes <http://wcsaxes.readthedocs.io/en/latest/>`_
 
 .. note::
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -893,8 +893,7 @@ If you desire the light travel time to the heliocentre instead then use::
 The method returns an |TimeDelta| object, which can be added to
 your times to give the arrival time of the photons at the barycentre or
 heliocentre.  Here, one should be careful with the timescales used; for more
-detailed information about timescales, see
-http://docs.astropy.org/en/stable/time/index.html#time-scale.
+detailed information about timescales, see :ref:`time-scale`.
 
 The heliocentre is not a fixed point, and therefore the gravity
 continually changes at the heliocentre. Thus, the use of a relativistic

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -175,7 +175,7 @@ yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:0
    initialization.  Furthermore, any specific realization information,
    such as ``UT(NIST)`` is stored only as long as the time scale is not changed.
 .. [#] `Rots et al. 2015, A&A 574:A36 <http://adsabs.harvard.edu/abs/2015A%26A...574A..36R>`_
-	  
+
 Changing format
 """""""""""""""
 
@@ -310,7 +310,7 @@ appropriate::
   >>> t[2]
   <Time object: scale='utc' format='mjd' value=300.0>
   >>> t = Time(np.arange(50000., 50003.)[:, np.newaxis],
-  ...          np.arange(0., 1., 0.5), format='mjd') 
+  ...          np.arange(0., 1., 0.5), format='mjd')
   >>> t
   <Time object: scale='utc' format='mjd' value=[[ 50000.   50000.5]
    [ 50001.   50001.5]
@@ -868,7 +868,7 @@ Barycentric and Heliocentric Light Travel Time Corrections
 ------------------------------------------------------------
 
 The arrival times of photons at an observatory are not particularly useful for
-accurate timing work, such as eclipse/transit timing of binaries or exoplanets. 
+accurate timing work, such as eclipse/transit timing of binaries or exoplanets.
 This is because the changing location of the observatory causes photons to
 arrive early or late. The solution is to calculate the time the photon would
 have arrived at a standard location; either the Solar system barycentre or the
@@ -881,27 +881,27 @@ calculate light travel times to the barycentre as follows::
     >>> from astropy import time, coordinates as coord, units as u
     >>> ip_peg = coord.SkyCoord("23:23:08.55", "+18:24:59.3",
     ...                         unit=(u.hourangle, u.deg), frame='icrs')
-    >>> greenwich = coord.EarthLocation.of_site('greenwich')  
+    >>> greenwich = coord.EarthLocation.of_site('greenwich')
     >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
-    ...                   scale='utc', location=greenwich)  
-    >>> ltt_bary = times.light_travel_time(ip_peg)  
-          
+    ...                   scale='utc', location=greenwich)
+    >>> ltt_bary = times.light_travel_time(ip_peg)
+
 If you desire the light travel time to the heliocentre instead then use::
-          
-    >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric') 
+
+    >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric')
 
 The method returns an |TimeDelta| object, which can be added to
 your times to give the arrival time of the photons at the barycentre or
 heliocentre.  Here, one should be careful with the timescales used; for more
 detailed information about timescales, see
-http://astropy.readthedocs.org/en/stable/time/index.html#time-scale.
+http://docs.astropy.org/en/stable/time/index.html#time-scale.
 
 The heliocentre is not a fixed point, and therefore the gravity
 continually changes at the heliocentre. Thus, the use of a relativistic
 timescale like TDB is not particularly appropriate, and, historically,
 times corrected to the heliocentre are given in the UTC timescale::
 
-    >>> times_heliocentre = times.utc + ltt_helio  
+    >>> times_heliocentre = times.utc + ltt_helio
 
 Corrections to the barycentre are more precise than the heliocentre,
 because the barycenter is a fixed point where gravity is constant. For
@@ -911,7 +911,7 @@ whose tick rate is related to the rate that a clock would tick at the
 barycentre. For this reason, barycentric corrected times normally use
 the TDB timescale::
 
-    >>> time_barycentre = times.tdb + ltt_bary 
+    >>> time_barycentre = times.tdb + ltt_bary
 
 Interaction with Time-like Quantities
 -------------------------------------

--- a/docs/vo/index.rst
+++ b/docs/vo/index.rst
@@ -22,10 +22,10 @@ Current services include:
 
 Other third-party Python packages and tools related to ``astropy.vo``:
 
-* `PyVO <http://pyvo.readthedocs.org/en/latest/>`__
+* `PyVO <http://pyvo.readthedocs.io/en/latest/>`__
   provides further functionality to discover
   and query VO services. Its user guide contains a
-  `good introduction <https://pyvo.readthedocs.org/en/latest/pyvo/vo.html>`__
+  `good introduction <https://pyvo.readthedocs.io/en/latest/pyvo/vo.html>`__
   to how the VO works.
 
 * `Astroquery <http://www.astropy.org/astroquery/>`__

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -229,10 +229,10 @@ area can be extracted with the utility function
 Matplotlib plots with correct WCS projection
 ============================================
 
-The `WCSAxes <http://wcsaxes.readthedocs.org>`_ affiliated package adds the
+The `WCSAxes <http://wcsaxes.readthedocs.io>`_ affiliated package adds the
 ability to use the :class:`~astropy.wcs.WCS` to define projections in
 Matplotlib. More information on installing and using WCSAxes can be found `here
-<http://wcsaxes.readthedocs.org>`__.
+<http://wcsaxes.readthedocs.io>`__.
 
 .. plot::
     :include-source:

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -243,7 +243,7 @@ Matplotlib. More information on installing and using WCSAxes can be found `here
     from astropy.utils.data import download_file
 
     fits_file = 'http://data.astropy.org/tutorials/FITS-images/HorseHead.fits'
-    image_file = download_file(fits_file, cache=True )
+    image_file = download_file(fits_file, cache=True)
     hdu = fits.open(image_file)[0]
     wcs = WCS(hdu.header)
 

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -348,9 +348,9 @@ Integration with WCSAxes
 The :class:`~astropy.wcs.WCS` class can now be used as a `Matplotlib
 <http://www.matplotlib.org>`_ projection to make plots of images with WCS
 coordinates overlaid, making use of the `WCSAxes
-<http://wcsaxes.readthedocs.org>`_ affiliated package behind the scenes. More
+<http://wcsaxes.readthedocs.io>`_ affiliated package behind the scenes. More
 information on using this functionality can be found in the `WCSAxes
-<http://wcsaxes.readthedocs.org>`_ documentation.
+<http://wcsaxes.readthedocs.io>`_ documentation.
 
 Deprecation and backward-incompatible changes
 ---------------------------------------------


### PR DESCRIPTION
Replaced `readthedocs.org` with `readthedocs.io`, as per recent RTD announcement for their domain name change. Point Astropy doc link to `astropy.org` instead of RTD.

This is just a simple search and replace. For better or worse, my Emacs also auto-remove unnecessary whitespace.