### PR TITLE
Move Virtual Observatory to "Connecting Up" section of docs.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,17 +84,17 @@ User Documentation
    io/ascii/index
    io/votable/index
    io/misc
+   vo/index
 
 **Astronomy computations and utilities**
 
 .. toctree::
    :maxdepth: 1
 
+   cosmology/index
    convolution/index
    visualization/index
-   cosmology/index
    stats/index
-   vo/index
 
 **Nuts and bolts of Astropy**
 


### PR DESCRIPTION
As noted in #4846, it is rather strange that `VO` is in the computations and utilities section of the documentation; it seems to make much more sense in "Connecting Up"

I also moved `cosmology` to be first in "computations" since it is much more mature than any of the other parts, and thus would seem to deserve prominence.