### PR TITLE
sharedmethod for NDArithmetic methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,9 +72,10 @@ New Features
   - ``NDArithmeticMixin`` allows for arithmetic operations with anything that
     can be wrapped by the class. [#4272]
 
-  - ``NDArithmeticMixin`` provides methods for arithmetic operations where the
-    first operand is not an ``NDArithmeticMixin`` subclass via classmethods
-    called ``ic_add``, ``ic_subtract``, etc. [#4272]
+  - ``NDArithmeticMixin`` the methods add, subtract, multiply and divide now
+    support giving two operands and these methods are now classmethods. This
+    change allows evaluating the result when the first operand is not an
+    NDDataArithmeticMixin subclass. [#4272 + 4851]
 
 - ``astropy.stats``
 

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -145,11 +145,11 @@ class NDArithmeticMixin(object):
 
     Using it with two operand on an instance::
 
-        >>> ndd = NDDataWithMath(100)
-        >>> ndd.divide(1, 5)
+        >>> ndd = NDDataWithMath(5)
+        >>> ndd.divide(1, ndd)
         NDDataWithMath(0.2)
 
-    Using it with two operand on the class::
+    Using it as classmethod requires two operands::
 
         >>> NDDataWithMath.subtract(5, 4)
         NDDataWithMath(1)
@@ -535,6 +535,37 @@ class NDArithmeticMixin(object):
     @sharedmethod
     def _prepare_then_do_arithmetic(self_or_cls, operation, operand, operand2,
                                     **kwargs):
+        """Intermediate method called by public arithmetics (i.e. ``add``)
+        before the processing method (``_arithmetic``) is invoked.
+
+        .. warning::
+            Do not override this method in subclasses.
+
+        This method checks if it was called as instance or as class method and
+        then wraps the operands and the result from ``_arithmetics`` in the
+        appropriate subclass.
+
+        Parameters
+        ----------
+        self_or_cls : instance or class
+            ``sharedmethod`` behaves like a normal method if called on the
+            instance (then this parameter is ``self``) but like a classmethod
+            when called on the class (then this parameter is ``cls``).
+
+        operations : callable
+            The operation (normally a numpy-ufunc) that represents the
+            appropriate action.
+
+        operand, operand2, kwargs :
+            See for example ``add``.
+
+        Result
+        ------
+        result : `~astropy.nddata.NDData`-like
+            Depending how this method was called either ``self_or_cls``
+            (called on class) or ``self_or_cls.__class__`` (called on instance)
+            is the NDData-subclass that is used as wrapper for the result.
+        """
         # DO NOT OVERRIDE THIS METHOD IN SUBCLASSES.
 
         # TODO: Remove this in astropy 1.3 or 1.4:
@@ -571,7 +602,7 @@ class NDArithmeticMixin(object):
                 operand = self_or_cls
             else:
                 # Convert the first operand to the class of this method.
-                # This is important so that always the right _arithmetics is
+                # This is important so that always the correct _arithmetics is
                 # called later that method.
                 operand = cls(operand)
 

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -776,6 +776,44 @@ def test_arithmetics_mask_func():
         nd1.add(nd2, handle_mask=mask_sad_func, fun=1)
 
 
+@pytest.mark.parametrize('meth', ['add', 'subtract', 'divide', 'multiply'])
+def test_two_argument_useage(meth):
+    ndd1 = NDDataArithmetic(np.ones((3, 3)))
+    ndd2 = NDDataArithmetic(np.ones((3, 3)))
+
+    # Call add on the class (not the instance) and compare it with already
+    # tested useage:
+    ndd3 = getattr(NDDataArithmetic, meth)(ndd1, ndd2)
+    ndd4 = getattr(ndd1, meth)(ndd2)
+    np.testing.assert_array_equal(ndd3.data, ndd4.data)
+
+    # And the same done on an unrelated instance...
+    ndd3 = getattr(NDDataArithmetic(-100), meth)(ndd1, ndd2)
+    ndd4 = getattr(ndd1, meth)(ndd2)
+    np.testing.assert_array_equal(ndd3.data, ndd4.data)
+
+
+@pytest.mark.parametrize('meth', ['add', 'subtract', 'divide', 'multiply'])
+def test_two_argument_useage_non_nddata_first_arg(meth):
+    data1 = 50
+    data2 = 100
+
+    # Call add on the class (not the instance)
+    ndd3 = getattr(NDDataArithmetic, meth)(data1, data2)
+
+    # Compare it with the instance-useage and two identical NDData-like
+    # classes:
+    ndd1 = NDDataArithmetic(data1)
+    ndd2 = NDDataArithmetic(data2)
+    ndd4 = getattr(ndd1, meth)(ndd2)
+    np.testing.assert_array_equal(ndd3.data, ndd4.data)
+
+    # and check it's also working when called on an instance
+    ndd3 = getattr(NDDataArithmetic(-100), meth)(data1, data2)
+    ndd4 = getattr(ndd1, meth)(ndd2)
+    np.testing.assert_array_equal(ndd3.data, ndd4.data)
+
+
 def test_arithmetics_unknown_uncertainties():
     # Not giving any uncertainty class means it is saved as UnknownUncertainty
     ndd1 = NDDataArithmetic(np.ones((3, 3)),


### PR DESCRIPTION
This PR removes the "temporary" `ic_addition`, ... classmethods used in `NDArithmeticMixin` and will use `astropy.utils.sharedmethod` to allow using `add`, ... also on the class not only the instance. This lead to one new feature: Using it on the instance also allows using two operands that have nothing to do with the instance the method is called on.

Also to do this I needed to deprecate using the parameter `propagate_uncertainties` as positional parameter. It's only allowed to use it and all the other additional arguments as keyword argument.

I haven't included much narrative documentation (doctest and test cases do exist), this will be done (if this PR makes it in 1.2) together with the remainder of documentation mentioned in #4538.