### PR TITLE
Getting rid of "unknown section 'Note'" in sphinx builds

### DIFF
--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -143,8 +143,8 @@ def circvar(data, axis=None, weights=None):
        Circular Statistics (2001)'". 2015.
        <https://cran.r-project.org/web/packages/CircStats/CircStats.pdf>
 
-    Note
-    ----
+    Notes
+    -----
     The definition used here differs from the one in scipy.stats.circvar.
     Precisely, Scipy circvar uses an approximation based on the limit of small
     angles which approaches the linear variance.


### PR DESCRIPTION
In current sphinx builds there is a Warning:

```
reading sources... [ 48%] api/astropy.stats.circvar

/home/travis/build/astropy/astropy/astropy_helpers/astropy_helpers/sphinx/ext/docscrape.py:120: UserWarning: Unknown section Note

  warn("Unknown section %s" % key)
```

this PR renames the section title to ``Notes`` to avoid this Warning.

Also the ``Notes`` section should now be visible in the [documentation](http://astropy.readthedocs.io/en/latest/api/astropy.stats.circvar.html#astropy.stats.circvar)