### PR TITLE
Moved cartesian transformation code to CartesianRepresentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ New Features
 
 - ``astropy.coordinates``
 
+  - ``CartesianRepresentation`` now includes a transform() method that can take
+    a 3x3 matrix to transform coordinates.
+
 - ``astropy.cosmology``
 
   - ``angular_diameter_distance_z1z2`` now supports the computation of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - ``astropy.coordinates``
 
   - ``CartesianRepresentation`` now includes a transform() method that can take
-    a 3x3 matrix to transform coordinates.
+    a 3x3 matrix to transform coordinates. [#4860]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -339,14 +339,10 @@ class CartesianRepresentation(BaseRepresentation):
         # Do the transformation
         vec_new = np.dot(np.asarray(matrix), vec)
 
-        # Reshape to preserve the original shape
-        subshape = xyz.shape[1:]
-        x = vec_new[0].reshape(subshape)
-        y = vec_new[1].reshape(subshape)
-        z = vec_new[2].reshape(subshape)
+        # Restore the original shape
+        vec_new = vec_new.reshape(xyz.shape)
 
-        # Make a new representation and return
-        return CartesianRepresentation(x, y, z)
+        return self.__class__(*vec_new)
 
 
 class UnitSphericalRepresentation(BaseRepresentation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -290,6 +290,40 @@ class CartesianRepresentation(BaseRepresentation):
     def to_cartesian(self):
         return self
 
+    def transform(self, matrix):
+        """
+        Transform the cartesian coordinates using a 3x3 matrix.
+
+        This returns a new representation and does not modify the original one.
+
+        Parameters
+        ----------
+        matrix : `~numpy.ndarray`
+            A 3x3 transformation matrix, such as a rotation matrix.
+        """
+
+        # TODO: since this is likely to be a widely used function in coordinate
+        # transforms, it should be optimized (for example in Cython).
+
+        # Get xyz once since it's an expensive operation
+        xyz = self.xyz
+
+        # Since the underlying data can be n-dimensional, reshape to a
+        # 2-dimensional (3, N) array.
+        vec = xyz.reshape((3, xyz.size // 3))
+
+        # Do the transformation
+        vec_new = np.dot(np.asarray(matrix), vec)
+
+        # Reshape to preserve the original shape
+        subshape = xyz.shape[1:]
+        x = vec_new[0].reshape(subshape)
+        y = vec_new[1].reshape(subshape)
+        z = vec_new[2].reshape(subshape)
+
+        # Make a new representation and return
+        return CartesianRepresentation(x, y, z)
+
 
 class UnitSphericalRepresentation(BaseRepresentation):
     """

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -300,6 +300,30 @@ class CartesianRepresentation(BaseRepresentation):
         ----------
         matrix : `~numpy.ndarray`
             A 3x3 transformation matrix, such as a rotation matrix.
+
+        Examples
+        --------
+
+        We can start off by creating a cartesian representation object:
+
+            >>> from astropy import units as u
+            >>> from astropy.coordinates import CartesianRepresentation
+            >>> rep = CartesianRepresentation([1, 2] * u.pc,
+            ...                               [2, 3] * u.pc,
+            ...                               [3, 4] * u.pc)
+
+        We now create a rotation matrix around the z axis:
+
+            >>> from astropy.coordinates.angles import rotation_matrix
+            >>> rotation = rotation_matrix(30 * u.deg, axis='z')
+
+        Finally, we can apply this transformation:
+
+            >>> rep_new = rep.transform(rotation)
+            >>> rep_new.xyz  # doctest: +FLOAT_CMP
+            <Quantity [[ 1.8660254 , 3.23205081],
+                       [ 1.23205081, 1.59807621],
+                       [ 3.        , 4.        ]] pc>
         """
 
         # TODO: since this is likely to be a widely used function in coordinate

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -656,6 +656,19 @@ class TestCartesianRepresentation(object):
             s_slc = s[0]
 
 
+    def test_transform(self):
+
+        s1 = CartesianRepresentation(x=[1,2] * u.kpc, y=[3,4] * u.kpc, z=[5,6] * u.kpc)
+
+        matrix = np.array([[1,2,3], [4,5,6], [7,8,9]])
+
+        s2 = s1.transform(matrix)
+
+        assert_allclose(s2.x.value, [1 * 1 + 2 * 3 + 3 * 5, 1 * 2 + 2 * 4 + 3 * 6])
+        assert_allclose(s2.y.value, [4 * 1 + 5 * 3 + 6 * 5, 4 * 2 + 5 * 4 + 6 * 6])
+        assert_allclose(s2.z.value, [7 * 1 + 8 * 3 + 9 * 5, 7 * 2 + 8 * 4 + 9 * 6])
+
+
 class TestCylindricalRepresentation(object):
 
     def test_empty_init(self):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -668,6 +668,10 @@ class TestCartesianRepresentation(object):
         assert_allclose(s2.y.value, [4 * 1 + 5 * 3 + 6 * 5, 4 * 2 + 5 * 4 + 6 * 6])
         assert_allclose(s2.z.value, [7 * 1 + 8 * 3 + 9 * 5, 7 * 2 + 8 * 4 + 9 * 6])
 
+        assert s2.x.unit is u.kpc
+        assert s2.y.unit is u.kpc
+        assert s2.z.unit is u.kpc
+
 
 class TestCylindricalRepresentation(object):
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -818,18 +818,15 @@ class DynamicMatrixTransform(CoordinateTransform):
             priority=priority, register_graph=register_graph)
 
     def __call__(self, fromcoord, toframe):
+
         from .representation import CartesianRepresentation, \
                                     UnitSphericalRepresentation
 
-        xyz = fromcoord.represent_as(CartesianRepresentation).xyz
-        v = xyz.reshape((3, xyz.size // 3))
-        v2 = np.dot(np.asarray(self.matrix_func(fromcoord, toframe)), v)
-        subshape = xyz.shape[1:]
-        x = v2[0].reshape(subshape)
-        y = v2[1].reshape(subshape)
-        z = v2[2].reshape(subshape)
+        transform_matrix = self.matrix_func(fromcoord, toframe)
 
-        newrep = CartesianRepresentation(x, y, z)
+        rep = fromcoord.represent_as(CartesianRepresentation)
+        newrep = rep.transform(transform_matrix)
+
         if issubclass(fromcoord.data.__class__, UnitSphericalRepresentation):
             #need to special-case this because otherwise the new class will
             #think it has a valid distance


### PR DESCRIPTION
I found that for another project (WCSAxes) I wanted to use the representation classes and wanted to be able to apply arbitrary transforms - the code to do this was already in astropy but not in a place where it could easily be used, so this adds a new ``transform`` method to ``CartesianRepresentation``.

@eteq - I'd like to include this in 1.2 if possible, could you review and let me know what you think?