### PR TITLE
Fix roll angle displayed in documentation of galactocentric frame

### DIFF
--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -62,7 +62,7 @@ of their :math:`y'` positions. We find:
 .. math::
 
    \begin{aligned}
-       \eta &= 148.5986320^\circ\\
+       \eta &= 58.5986320306^\circ\\
        \boldsymbol{R}_3 &=
        \begin{bmatrix}
          1 & 0 & 0\\


### PR DESCRIPTION
This just updates the doc page to reflect the value used in the code. This is a fix for #4841 