### PR TITLE
Fix memory-leak in NDData with uncertainty.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,6 +314,9 @@ Bug fixes
   - ``NDArithmeticMixin`` does provide correct resulting uncertainties for
     ``divide`` and ``multiply`` if only one uncertainty was set. [#4152, #4272]
 
+  - Fixed memory leak that happened when uncertainty of NDDataArray was
+    set. [#4825, #4862]
+
 - ``astropy.stats``
 
 - ``astropy.table``

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -299,5 +299,13 @@ class NDData(NDDataBase):
             # If it is a subclass of NDUncertainty we must set the
             # parent_nddata attribute. (#4152)
             if isinstance(value, NDUncertainty):
+                # In case the uncertainty already has a parent create a new
+                # instance because we need to assume that we don't want to
+                # steal the uncertainty from another NDData object
+                if value._parent_nddata is not None:
+                    value = value.__class__(value, copy=False)
+                # Then link it to this NDData instance (internally this needs
+                # to be saved as weakref but that's done by NDUncertainty
+                # setter).
                 value.parent_nddata = self
         self._uncertainty = value

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -239,7 +239,7 @@ def test_nddata_init_data_nddata():
     nd2 = NDData(nd1)
     assert nd2.data is nd1.data
     assert nd2.wcs == nd1.wcs
-    assert nd2.uncertainty == nd1.uncertainty
+    assert nd2.uncertainty.array == nd1.uncertainty.array
     assert nd2.mask == nd1.mask
     assert nd2.unit == nd1.unit
     assert nd2.meta == nd1.meta
@@ -249,7 +249,7 @@ def test_nddata_init_data_nddata():
                  meta={'observer': 'ME'}, wcs=4)
     assert nd3.data is nd1.data
     assert nd3.wcs != nd1.wcs
-    assert nd3.uncertainty != nd1.uncertainty
+    assert nd3.uncertainty.array != nd1.uncertainty.array
     assert nd3.mask != nd1.mask
     assert nd3.unit != nd1.unit
     assert nd3.meta != nd1.meta

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_array_equal
 from ..nduncertainty import (StdDevUncertainty, NDUncertainty,
                              IncompatibleUncertaintiesException,
                              UnknownUncertainty)
+from ..nddata import NDData
 from ...tests.helper import pytest
 from ... import units as u
 
@@ -180,3 +181,49 @@ def test_uncertainty_correlated():
     assert not fake_uncert.supports_correlated
     std_uncert = StdDevUncertainty([10, 2])
     assert std_uncert.supports_correlated
+
+
+def test_for_leak_with_uncertainty():
+    # Regression test for memory leak because of cyclic references between
+    # NDData and uncertainty
+    from collections import defaultdict
+    from gc import get_objects
+
+    def test_leak(func, specific_objects=None):
+        """Function based on gc.get_objects to determine if any object or
+        a specific object leaks.
+
+        It requires a function to be given and if any objects survive the
+        function scope it's considered a leak (so don't return anything).
+        """
+        before = defaultdict(int)
+        for i in get_objects():
+            before[type(i)] += 1
+
+        func()
+
+        after = defaultdict(int)
+        for i in get_objects():
+            after[type(i)] += 1
+
+        if specific_objects is None:
+            assert all(after[k] - before[k] == 0 for k in after)
+        else:
+            assert after[specific_objects] - before[specific_objects] == 0
+
+    def non_leaker():
+        NDData(np.ones(100))
+
+    def leaker():
+        NDData(np.ones(100), uncertainty=StdDevUncertainty(np.ones(100)))
+
+    test_leak(non_leaker, NDData)
+    test_leak(leaker, NDData)
+
+
+def test_for_stolen_uncertainty():
+    # Sharing uncertainties should not overwrite the parent_nddata attribute
+    ndd1 = NDData(1, uncertainty=1)
+    ndd2 = NDData(2, uncertainty=ndd1.uncertainty)
+    # parent_nddata.data should be the original data.
+    assert ndd1.uncertainty.parent_nddata.data == ndd1.data

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -225,5 +225,5 @@ def test_for_stolen_uncertainty():
     # Sharing uncertainties should not overwrite the parent_nddata attribute
     ndd1 = NDData(1, uncertainty=1)
     ndd2 = NDData(2, uncertainty=ndd1.uncertainty)
-    # parent_nddata.data should be the original data.
+    # uncertainty.parent_nddata.data should be the original data!
     assert ndd1.uncertainty.parent_nddata.data == ndd1.data


### PR DESCRIPTION
Fixes only parts of the issue: #4825 

also included a small fix that prevents that uncertainties are stolen if assigned as an uncertainty for another NDData object. The initial commit only contains the test cases (the failed fork-build with these tests can be inspected [here](https://travis-ci.org/MSeifert04/astropy/builds/129279059). The second provides the fixes. Unfortunatly these are entangled to some extend since the fix of the one requires the other one.