### PR TITLE
Table init from objects with __astropy_table__ method

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -273,6 +273,14 @@ class Table(object):
 
         default_names = None
 
+        if hasattr(data, '__astropy_table__'):
+            # This method indicates that the ``data`` object can provide the
+            # objects needed to initialize an astropy Table.  The returned
+            # ``data`` object must be a list of Column-compatible or
+            # mixin-column objects.
+            data, meta, copy = data.__astropy_table__(copy)
+            self.meta.update(meta)
+
         if (isinstance(data, np.ndarray) and
                 data.shape == (0,) and
                 not data.dtype.names):


### PR DESCRIPTION
This defines an interface method to allow an arbitrary object to initialize a `Table` subclass if it has an `__astropy_table__` method.

To do:

- [ ] Documentation in Table narrative docs
- [ ] Changelog

Supercedes and closes #4740.

cc: @astrofrog @TallJimbo @eteq