### PR TITLE
minor bugfix in nddata to include a deleted import again.

### DIFF
--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from ...nduncertainty import (StdDevUncertainty, UnknownUncertainty,
                               IncompatibleUncertaintiesException)
 from ... import NDDataRef
+from ...nddata import NDData
 
 from ....units import UnitsError, Quantity
 from ....tests.helper import pytest


### PR DESCRIPTION
#4828 and #4797 didn't have merge conflicts but an important import got lost.

This PR adds it again so the tests don't fail.