### PR TITLE
included narrative documentation and updated docstrings in NDData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,23 +75,19 @@ New Features
 
 - ``astropy.nddata``
 
-  - Added ``UnknownUncertainty`` as ``NDUncertainty`` subclass which cannot
-    be used for error propagation. [#4272]
+  - ``UnknownUncertainty`` new subclass of ``NDUncertainty`` that can be used to
+    save uncertainties that cannot be used for error propagation. [#4272]
 
-  - ``StdDevUncertainty`` implements error propagation using it's ``unit`` and
-    a given ``correlation`` between the datasets. [#4272]
+  - ``NDArithmeticMixin``: ``add``, ``subtract``, ``multiply`` and ``divide``
+    can be used as classmethods but require that two operands are given. These
+    operands don't need to be NDData instances but they must be convertible to
+    NDData. This conversion is done internally. Using it on the instance does
+    not require (but also allows) two operands. [#4272, #4851]
 
-  - ``NDArithmeticMixin`` allows for arithmetic operations with anything that
-    can be wrapped by the class. [#4272]
-
-  - ``NDArithmeticMixin`` the methods add, subtract, multiply and divide now
-    support giving two operands and these methods are now classmethods. This
-    change allows evaluating the result when the first operand is not an
-    NDDataArithmeticMixin subclass. [#4272 + 4851]
-
-  - Added ``NDDataRef`` that implements ``NDData`` together with all
+  - ``NDDataRef`` new subclass that implements ``NDData`` together with all
     currently avaiable mixins. This class does not implement additional
     attributes, methods or a numpy.ndarray-like interface like ``NDDataArray``.
+    [#4797]
 
 - ``astropy.stats``
 
@@ -211,34 +207,123 @@ API changes
 
 - ``astropy.nddata``
 
-  - ``NDData``: added an optional parameter ``copy``
-    which is False by default. If it is True all other parameters are copied
-    before saving them as attributes. If False the parameters are only copied
-    if there is no way of saving them as reference. [#4270]
+  - ``NDDataBase`` does not set the private uncertainty property anymore. This
+    only affects you if you subclass ``NDDataBase`` directly. [#4270]
 
-  - ``NDData``: ``Masked_Quantity`` objects are allowed as ``data``
-    parameter. [#4270]
+  - ``NDDataBase``: the ``uncertainty``-setter is removed. A similar one is
+    added in ``NDData`` so this also only affects you if you subclassed
+    ``NDDataBase`` directly. [#4270]
 
-  - ``NDUncertainty``: Added ``array``, ``unit`` and ``copy`` as optional
-    parameters. [#4272]
+  - ``NDDataBase``: ``uncertainty``-getter returns ``None`` instead of the
+    private uncertainty and is now a abstract. This getter is moved to
+    ``NDData`` so it only affects direct subclasses of ``NDDataBase``. [#4270]
 
-  - ``NDUncertainty``: Public methods ``propagate_add``, etc. are replaced by
-    a general ``propagate`` method. [#4272]
+  - ``NDData`` accepts a Quantity-like data and an explictly given unit.
+    Before a ValueError was raised in this case. The final instance will use the
+    explicitly given unit-attribute but doesn't check if the units are
+    convertible and the data will not be scaled. [#4270]
 
-  - ``NDUncertainty`` and subclasses: implement a representation (``__repr__``). [#4787]
+  - ``NDData`` : the given mask, explicit or implicit if the data was masked,
+    will be saved by the setter. It will not be saved directly as the private
+    attribute. [#4879]
 
-  - ``StdDevUncertainty``: added an optional parameter ``copy`` which is False
-    by default. [#4272]
+  - ``NDData`` accepts an additional argument ``copy`` which will copy every
+    parameter before it is saved as attribute of the instance. [#4270]
 
-  - ``NDArithmeticMixin``: Added ``handle_mask``, ``handle_meta`` and
-    ``compare_wcs`` and ``uncertainty_correlation`` as optional parameters.
-    [#4272]
+  - ``NDData``: added an ``uncertainty.getter`` that returns the private
+    attibute. It is equivalent to the old ``NDDataBase.uncertainty``-getter.
+    [#4270]
 
-  - ``NDArithmeticMixin``: The optional ``propagate_uncertainties`` parameter
-    can also be ``None``. [#4272]
+  - ``NDData``: added an ``uncertainty.setter``. It is slightly modified with
+    respect to the old ``NDDataBase.uncertainty``-setter. The changes include:
 
-  - ``NDArithmeticMixin``: Does not compare the wcs for equality except if
-    ``compare_wcs`` is given as function that compares it. [#4272]
+    - if the uncertainty has no uncertainty_type an info message is printed
+      instead of a TypeError and the uncertainty is saved as
+      ``UnknownUncertainty`` except the uncertainty is None. [#4270]
+
+    - the requirement that the uncertainty_type of the uncertainty needs to be a
+      string was removed. [#4270]
+
+    - if the uncertainty is a subclass of NDUncertainty the parent_nddata
+      attribute will be set so the uncertainty knows to which data it belongs.
+      This is also a Bugfix. [#4152, #4270]
+
+  - ``NDData``: added a ``meta``-getter, which will set and return an empty
+    OrderedDict if no meta was previously set. [#4509, #4469]
+
+  - ``NDData``: added an ``meta``-setter. It requires that the meta is
+    dictionary-like (it also accepts Headers or ordered dictionaries and others)
+    or None. It will copy the given value before saving it. [#4509, #4469]
+
+  - ``NDArithmeticMixin``: The operand in arithmetic methods (``add``, ...)
+    doesn't need to be a subclass of ``NDData``. It is sufficient if it can be
+    converted to one. This conversion is done internally. [#4272]
+
+  - ``NDArithmeticMixin``: The arithmetic methods allow several new arguments to
+    control how or if different attributes of the class will be processed during
+    the operation. [#4272]
+
+  - ``NDArithmeticMixin``: Giving the parameter ``propagate_uncertainties`` as
+    positional keyword is deprecated and will be removed in the future. You now
+    need to specify it as keyword-parameter. Besides ``True`` and ``False`` also
+    ``None`` is now a valid value for this parameter. [#4272, #4851]
+
+  - ``NDArithmeticMixin``: The wcs attribute of the operands is not compared and
+    thus raises no ValueError if they differ, except if a ``compare_wcs``
+    parameter is specified. [#4272]
+
+  - ``NDArithmeticMixin``: The arithmetic operation was split from a general
+    ``_arithmetic`` method to different specialized private methods to allow
+    subclasses more control on how the attributes are processed without
+    overriding ``_arithmetic``. The ``_arithmetic`` method is now used to call
+    these other methods. [#4272]
+
+  - ``NDUncertainty``: ``support_correlated`` attribute is deprecated in favor of
+    ``supports_correlated`` which is a property. Also affects
+    ``StdDevUncertainty``. [#4272]
+
+  - ``NDUncertainty``: added the ``__init__`` that was previously implemented in
+    ``StdDevUncertainty`` and takes an additional ``unit`` parameter. [#4272]
+
+  - ``NDUncertainty``: added a ``unit`` property without setter that returns the
+    set unit or if not set the unit of the parent. [#4272]
+
+  - ``NDUncertainty``: included a ``parent_nddata`` property similar to the one
+    previously implemented in StdDevUncertainty. [#4272]
+
+  - ``NDUncertainty``: added an ``array`` property with setter. The setter will
+    convert the value to a plain numpy array if it is a list or a subclass of a
+    numpy array. [#4272]
+
+  - ``NDUncertainty``: ``propagate_multiply`` and similar were removed. Before
+    they were abstract properties and replaced by methods with the same name but
+    with a leading underscore. The entry point for propagation is a method
+    called ``propagate``. [#4272]
+
+  - ``NDUncertainty`` and subclasses: implement a representation (``__repr__``).
+    [#4787]
+
+  - ``StdDevUncertainty``: error propagation allows an explicitly given
+    correlation factor, which may be a scalar or an array which will be taken
+    into account during propagation.
+    This correlation must be determined manually and is not done by the
+    uncertainty! [#4272]
+
+  - ``StdDevUncertainty``: the ``array`` is converted to a plain numpy array
+    only if it's a list or a subclass of numpy.ndarray. Previously it was always
+    cast to a numpy array but also allowed subclasses. [#4272]
+
+  - ``StdDevUncertainty``: setting the ``parent_nddata`` does not compare if the
+    shape of it's array is identical to the parents data shape. [#4272]
+
+  - ``StdDevUncertainty``: the ``array.setter`` doesn't compare if the array has
+    the same shape as the parents data. [#4272]
+
+  - ``StdDevUncertainty``: deprecated ``support_correlated`` in favor of
+    ``supports_correlated``. [#4272, #4828]
+
+  - ``StdDevUncertainty``: deprecated ``propagate_add`` and similar methods in
+    favor of ``propagate``. [#4272, #4828]
 
 - ``astropy.stats``
 
@@ -341,24 +426,20 @@ Bug fixes
 
 - ``astropy.nddata``
 
-  - ``NDDataBase`` does not implement a setter or getter for ``uncertainty``,
-    which is now an abstractproperty. [#4270]
+  - ``NDData`` giving masked_Quantities as data-argument will use the
+    implicitly passed mask, unit and value. [#4270]
 
-  - ``NDData`` wraps the ``uncertainty`` inside an ``UnknownUncertainty``
-    if no ``uncertainty_type`` attribute is present in the uncertainty instead
-    of raising an Exception. [#4270]
+  - ``NDData`` using a subclass implementing ``NDData`` with
+    ``NDArithmeticMixin`` now allows error propagation. [#4270]
 
-  - ``NDData`` The ``uncertainty_type`` of the ``uncertainty`` is no longer
-    required to be a string, but it is still recommended. [#4270]
-
-  - ``NDData`` now sets the ``parent_nddata`` of the ``uncertainty`` if the
-    uncertainty is ``NDUncertainty``-like. [#4152, #4270]
-
-  - ``NDArithmeticMixin`` does provide correct resulting uncertainties for
-    ``divide`` and ``multiply`` if only one uncertainty was set. [#4152, #4272]
-
-  - Fixed memory leak that happened when uncertainty of NDDataArray was
+  - Fixed memory leak that happened when uncertainty of ``NDDataArray`` was
     set. [#4825, #4862]
+
+  - ``StdDevUncertainty``: During error propagation the unit of the uncertainty
+    is taken into account. [#4272]
+
+  - ``NDArithmeticMixin``: ``divide`` and ``multiply`` yield correct
+    uncertainties if only one uncertainty is set. [#4152, #4272]
 
 - ``astropy.stats``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,7 +215,7 @@ API changes
     ``NDDataBase`` directly. [#4270]
 
   - ``NDDataBase``: ``uncertainty``-getter returns ``None`` instead of the
-    private uncertainty and is now a abstract. This getter is moved to
+    private uncertainty and is now abstract. This getter is moved to
     ``NDData`` so it only affects direct subclasses of ``NDDataBase``. [#4270]
 
   - ``NDData`` accepts a Quantity-like data and an explictly given unit.

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -52,7 +52,7 @@ class NDData(NDDataBase):
         Default is ``None``.
 
     meta : `dict`-like object, optional
-        Additional meta informations about the dataset. If no meta is provided
+        Additional meta information about the dataset. If no meta is provided
         an empty `collections.OrderedDict` is created.
         Default is ``None``.
 
@@ -62,8 +62,9 @@ class NDData(NDDataBase):
         Default is ``None``.
 
     copy : `bool`, optional
-        Save the attributes as copy? ``True`` copies every attribute before
-        saving it while ``False`` tries to save every parameter as reference.
+        Indicates whether to save the arguments as copy. ``True`` copies
+        every attribute before saving it while ``False`` tries to save every
+        parameter as reference.
         Note however that it is not always possible to save the input as
         reference.
         Default is ``False``.
@@ -93,7 +94,7 @@ class NDData(NDDataBase):
 
     Given a conflicting implicit and an explicit parameter during
     initialization, for example the ``data`` is a `~astropy.units.Quantity` and
-    the unit parameter is not None. Then the implicit parameter is replaced
+    the unit parameter is not ``None``, then the implicit parameter is replaced
     (without conversion) by the explicit one and a warning is issued::
 
         >>> import numpy as np

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -86,8 +86,6 @@ class NDData(NDDataBase):
     ``data`` in a `NDData` object can be accessed through the `data`
     attribute::
 
-    For example::
-
         >>> from astropy.nddata import NDData
         >>> nd = NDData([1,2,3])
         >>> nd.data

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -54,7 +54,7 @@ class NDDataBase(object):
 
     @abstractproperty
     def meta(self):
-        """Additional meta informations about the dataset.
+        """Additional meta information about the dataset.
 
         Should be `dict`-like.
         """

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -13,13 +13,12 @@ __all__ = ['NDDataBase']
 
 @six.add_metaclass(ABCMeta)
 class NDDataBase(object):
-    """
-    Base metaclass that defines the interface for N-dimensional datasets with
-    associated meta informations used in ``astropy``.
+    """Base metaclass that defines the interface for N-dimensional datasets
+    with associated meta informations used in ``astropy``.
 
-    All properties and methods have to be overridden in subclasses. See
-    `~astropy.nddata.NDData` for a subclass that defines this interface on
-    `~numpy.ndarray`-like based ``data``.
+    All properties and ``__init__`` have to be overridden in subclasses. See
+    `NDData` for a subclass that defines this interface on `numpy.ndarray`-like
+    ``data``.
     """
 
     @abstractmethod
@@ -28,39 +27,34 @@ class NDDataBase(object):
 
     @abstractproperty
     def data(self):
-        """
-        The stored dataset.
+        """The stored dataset.
         """
         pass
 
     @abstractproperty
     def mask(self):
-        """
-        Mask for the dataset.
+        """Mask for the dataset.
 
-        Masks should follow the ``numpy`` convention that valid data points are
-        marked by ``False`` and invalid ones with ``True``.
+        Masks should follow the ``numpy`` convention that **valid** data points
+        are marked by ``False`` and **invalid** ones with ``True``.
         """
         return None
 
     @abstractproperty
     def unit(self):
-        """
-        Unit for the dataset.
+        """Unit for the dataset.
         """
         return None
 
     @abstractproperty
     def wcs(self):
-        """
-        A world coordinate system (WCS) for the dataset.
+        """World coordinate system (WCS) for the dataset.
         """
         return None
 
     @abstractproperty
     def meta(self):
-        """
-        Meta information about the dataset.
+        """Additional meta informations about the dataset.
 
         Should be `dict`-like.
         """
@@ -68,11 +62,10 @@ class NDDataBase(object):
 
     @abstractproperty
     def uncertainty(self):
-        """
-        Uncertainty in the dataset.
+        """Uncertainty in the dataset.
 
         Should have an attribute ``uncertainty_type`` that defines what kind of
-        uncertainty is stored, such as ``'std'`` for standard deviation or
-        ``'var'`` for variance.
+        uncertainty is stored, such as ``"std"`` for standard deviation or
+        ``"var"`` for variance.
         """
         return None

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -51,9 +51,10 @@ class NDUncertainty(object):
         Default is ``None``.
 
     copy : `bool`, optional
-        Save the ``array`` as copy? ``True`` copies it before saving, while
-        ``False`` tries to save every parameter as reference. Note however that
-        it is not always possible to save the input as reference.
+        Indicates whether to save the `array` as a copy. ``True`` copies it
+        before saving, while ``False`` tries to save every parameter as
+        reference. Note however that it is not always possible to save the
+        input as reference.
         Default is ``True``.
 
     Raises
@@ -374,7 +375,7 @@ class StdDevUncertainty(NDUncertainty):
     ``subtraction``, ``multiplication`` and ``division`` with other instances
     of `StdDevUncertainty`. The class can handle if the uncertainty has a
     unit that differs from (but is convertible to) the parents `NDData` unit.
-    But the unit of the resulting uncertainty will have the same unit as the
+    The unit of the resulting uncertainty will have the same unit as the
     resulting data. Also support for correlation is possible but requires the
     correlation as input. It cannot handle correlation determination itself.
 

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -157,7 +157,7 @@ def test_init_fake_with_somethingElse(UncertClass):
 
 
 def test_init_fake_with_StdDevUncertainty():
-    # Different instances of uncertainties are not directly convertable so this
+    # Different instances of uncertainties are not directly convertible so this
     # should fail
     uncert = np.arange(5).reshape(5, 1)
     std_uncert = StdDevUncertainty(uncert)

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -67,13 +67,8 @@ additional ``meta`` attributes:
     >>> ndd
     NDData([1, 2, 3, 4])
 
-the representation does not show additional attributes but these can be
-accessed like ``data`` above::
-
-    >>> ndd.uncertainty
-    StdDevUncertainty([ 1.        ,  1.41421356,  1.73205081,  2.        ])
-    >>> ndd.mask
-    array([False, False,  True,  True], dtype=bool)
+The representation only displays the ``data``; the other attributes need to be
+accessed directly, for example ``ndd.mask`` to access the mask.
 
 
 NDDataRef

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -50,8 +50,8 @@ and can be accessed again via the ``data`` attribute::
     >>> ndd2.data
     array([1, 2, 3, 4])
 
-and it supports additional properties like a ``unit`` or ``mask`` for the data,
-a ``wcs`` (world coordinate system) and ``uncertainty`` of the data and
+It also supports additional properties like a ``unit`` or ``mask`` for the
+data, a ``wcs`` (world coordinate system) and ``uncertainty`` of the data and
 additional ``meta`` attributes:
 
     >>> data = np.array([1,2,3,4])
@@ -92,17 +92,17 @@ Instances are created in the same way::
     >>> ndd
     NDDataRef([1, 2, 3, 4])
 
-But also support arithmetics (:ref:`nddata_arithmetic`) like addition::
+But also support arithmetic (:ref:`nddata_arithmetic`) like addition::
 
     >>> import astropy.units as u
     >>> ndd2 = ndd.add([4, 3, 2, 1] * u.erg / u.s)
     >>> ndd2
     NDDataRef([ 5.,  5.,  5.,  5.])
 
-because these operations have a wide range of options these are not avaible
-using pythons arithmetic operators like ``+``.
+Because these operations have a wide range of options these are not available
+using arithmetic operators like ``+``.
 
-Slicing or indexing (:ref:`nddata_slicing`) is possible (issueing warnings if
+Slicing or indexing (:ref:`nddata_slicing`) is possible (issuing warnings if
 some attribute cannot be sliced)::
 
     >>> ndd2 = NDDataRef(ndd2.data)  # because a scalar coordinate is not sliceable.

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -1,49 +1,406 @@
-Arithmetic mixin
-================
+.. _nddata_arithmetic:
 
-Overview
---------
+NDData Arithmetics
+==================
 
-The `~astropy.nddata.NDArithmeticMixin` adds methods for performing basic
-operations on `~astropy.nddata.NDData` objects:
-:meth:`~astropy.nddata.NDArithmeticMixin.add`,
-:meth:`~astropy.nddata.NDArithmeticMixin.subtract`,
-:meth:`~astropy.nddata.NDArithmeticMixin.multiply` and
-:meth:`~astropy.nddata.NDArithmeticMixin.divide`.
+Introduction
+------------
 
-The operations are permitted only if the two operands have the same WCS and
-shape and the units, if any, consistent with the operation performed.  The
-result is masked at a particular grid point if either of the operands is
-masked at that point.
+`~astropy.nddata.NDDataRef` implements the following arithmetic operations:
 
-The operations include a framework to propagate uncertainties that are based
-on the classes `~astropy.nddata.NDUncertainty`.
+- addition: :meth:`~astropy.nddata.NDArithmeticMixin.add`
+- subtraction: :meth:`~astropy.nddata.NDArithmeticMixin.subtract`
+- multiplication: :meth:`~astropy.nddata.NDArithmeticMixin.multiply`
+- division: :meth:`~astropy.nddata.NDArithmeticMixin.divide`
 
-.. warning:: Uncertainty propagation is still experimental, and does not take
-             into account correlated uncertainties.
+Usage basic arithmetic methods
+------------------------------
 
-Usage
------
+Using the standard arithmetic methods requires that the first operand
+is an `~astropy.nddata.NDDataRef` instance
 
-As with other mixins, using the arithmetic mixin starts with defining your own
-class::
+    >>> from astropy.nddata import NDDataRef
+    >>> import numpy as np
+    >>> ndd1 = NDDataRef([1, 2, 3, 4])
 
-    >>> from astropy.nddata import NDData, NDArithmeticMixin
-    >>> class MyNDDataArithmetic(NDArithmeticMixin, NDData): pass
+while the requirement for the second operand is simply: It must be convertible
+to the first operand. It can be a number::
 
-Then, create instances of this new object with your data the way you would
-with a plain `~astropy.nddata.NDData` object::
+    >>> ndd1.add(3)
+    NDDataRef([4, 5, 6, 7])
 
-    >>> ndd1 = MyNDDataArithmetic([1, 2])
-    >>> ndd2 = MyNDDataArithmetic([3, 4])
+or a `list`::
 
-The mixin adds methods on these instances for combining them::
+    >>> ndd1.subtract([1,1,1,1])
+    NDDataRef([0, 1, 2, 3])
 
-    >>> ndd1.add(ndd2)
-    MyNDDataArithmetic([4, 6])
-    >>> ndd2.multiply(ndd1)
-    MyNDDataArithmetic([3, 8])
+a `numpy.ndarray`::
 
-One important note: the order you list the mixins and `~astropy.nddata.NDData`
-matters; the base   class, `~astropy.nddata.NDData` should be on the far
-right.
+    >>> ndd1.multiply(np.arange(4, 8))
+    NDDataRef([ 4, 10, 18, 28])
+    >>> ndd1.divide(np.arange(1,13).reshape(3,4))  # a 3 x 4 numpy array
+    NDDataRef([[ 1.        ,  1.        ,  1.        ,  1.        ],
+               [ 0.2       ,  0.33333333,  0.42857143,  0.5       ],
+               [ 0.11111111,  0.2       ,  0.27272727,  0.33333333]])
+
+here broadcasting takes care of the different dimensions. Also several other
+classes are possible.
+
+Usage arithmetic classmethods
+-----------------------------
+
+Here both operands don't need to be `~astropy.nddata.NDDataRef`-like::
+
+    >>> NDDataRef.add(1, 3)
+    NDDataRef(4)
+
+or to wrap the result of an arithmetic operation between two Quantities::
+
+    >>> import astropy.units as u
+    >>> ndd = NDDataRef.multiply([1,2] * u.m, [10, 20] * u.cm)
+    >>> ndd
+    NDDataRef([ 10.,  40.])
+    >>> ndd.unit
+    Unit("cm m")
+
+or taking the inverse of a `~astropy.nddata.NDDataRef` object::
+
+    >>> NDDataRef.divide(1, ndd1)
+    NDDataRef([ 1.        ,  0.5       ,  0.33333333,  0.25      ])
+
+
+Possible operands
+^^^^^^^^^^^^^^^^^
+
+The possible types of input for operands are:
+
++ scalars of any type
++ lists containing numbers (or nested lists)
++ numpy arrays
++ numpy masked arrays
++ astropy quantities
++ other nddata classes or subclasses
+
+Advanced options
+----------------
+
+The normal python operators ``+``, ``-``, ... are not implemented because
+the methods provide several options how to proceed with the additional
+attributes.
+
+data, unit
+^^^^^^^^^^
+
+For ``data`` and ``unit`` there are no parameters. Every arithmetic
+operation let's the `astropy.units.Quantity`-framework evaluate the result
+or fail and abort the operation. For example if incompatible units are used.
+
+Adding two NDData objects with the same unit::
+
+    >>> ndd1 = NDDataRef([1,2,3,4,5], unit='m')
+    >>> ndd2 = NDDataRef([100,150,200,50,500], unit='m')
+
+    >>> ndd = ndd1.add(ndd2)
+    >>> ndd.data
+    array([ 101.,  152.,  203.,   54.,  505.])
+    >>> ndd.unit
+    Unit("m")
+
+works. Also if the units are compatible::
+
+    >>> ndd1 = NDDataRef(ndd1, unit='pc')
+    INFO: overwriting NDData's current unit with specified unit. [astropy.nddata.nddata]
+    >>> ndd2 = NDDataRef(ndd2, unit='lyr')
+    INFO: overwriting NDData's current unit with specified unit. [astropy.nddata.nddata]
+
+    >>> ndd = ndd1.subtract(ndd2)
+    >>> ndd.data
+    array([ -29.66013938,  -43.99020907,  -58.32027876,  -11.33006969,
+           -148.30069689])
+    >>> ndd.unit
+    Unit("pc")
+
+this will keep by default the unit of the first operand. However units will
+not be decomposed during division::
+
+    >>> ndd = ndd2.divide(ndd1)
+    >>> ndd.data
+    array([ 100.        ,   75.        ,   66.66666667,   12.5       ,  100.        ])
+    >>> ndd.unit
+    Unit("lyr / pc")
+
+mask
+^^^^
+
+The ``handle_mask`` parameter for the arithmetic operations implements what the
+resulting mask will be. There are several options.
+
+- ``None``, the result will have no ``mask``::
+
+      >>> ndd1 = NDDataRef(1, mask=True)
+      >>> ndd2 = NDDataRef(1, mask=False)
+      >>> ndd1.add(ndd2, handle_mask=None).mask is None
+      True
+
+- ``"first_found"`` or ``"ff"``, the result will have the mask of the first
+  operand or if that is None the mask of the second operand::
+
+      >>> ndd1 = NDDataRef(1, mask=True)
+      >>> ndd2 = NDDataRef(1, mask=False)
+      >>> ndd1.add(ndd2, handle_mask="first_found").mask
+      True
+      >>> ndd3 = NDDataRef(1)
+      >>> ndd3.add(ndd2, handle_mask="first_found").mask
+      False
+
+- a function (or an arbitary callable) that takes at least two arguments.
+  for example `numpy.logical_or` is the default::
+
+      >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
+      >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
+      >>> ndd1.add(ndd2).mask
+      array([ True, False,  True,  True], dtype=bool)
+
+  which will default to ``"first_found"`` in case only one ``mask`` is not None::
+
+      >>> ndd1 = NDDataRef(1)
+      >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
+      >>> ndd1.add(ndd2).mask
+      array([ True, False, False,  True], dtype=bool)
+
+  but also custom functions are possible::
+
+      >>> def take_alternating_values(mask1, mask2, start=0):
+      ...     result = np.zeros(mask1.shape, dtype=np.bool)
+      ...     result[start::2] = mask1[start::2]
+      ...     result[start+1::2] = mask2[start+1::2]
+      ...     return result
+
+  this function is obviously non-sense but let's see how it performs::
+
+      >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
+      >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
+      >>> ndd1.add(ndd2, handle_mask=take_alternating_values).mask
+      array([ True, False,  True,  True], dtype=bool)
+
+  and additional parameters can be given by prefixing them with ``mask_``
+  (which will be stripped before passing it to the function)::
+
+      >>> ndd1.add(ndd2, handle_mask=take_alternating_values, mask_start=1).mask
+      array([False, False, False, False], dtype=bool)
+      >>> ndd1.add(ndd2, handle_mask=take_alternating_values, mask_start=2).mask
+      array([False, False,  True,  True], dtype=bool)
+
+meta
+^^^^
+
+The ``handle_meta`` parameter for the arithmetic operations implements what the
+resulting meta will be. The options are the same as for the ``mask``:
+
+- If ``None`` the resulting ``meta`` will be an empty `collections.OrderedDict`.
+
+      >>> ndd1 = NDDataRef(1, meta={'object': 'sun'})
+      >>> ndd2 = NDDataRef(1, meta={'object': 'moon'})
+      >>> ndd1.add(ndd2, handle_meta=None).meta
+      OrderedDict()
+
+  For ``meta`` this is the default so you don't need to pass it in this case::
+
+      >>> ndd1.add(ndd2).meta
+      OrderedDict()
+
+- If ``"first_found"`` or ``"ff"`` the resulting meta will be the meta of the
+  first operand or if that contains no keys the meta of the second operand is
+  taken.
+
+      >>> ndd1 = NDDataRef(1, meta={'object': 'sun'})
+      >>> ndd2 = NDDataRef(1, meta={'object': 'moon'})
+      >>> ndd1.add(ndd2, handle_meta='ff').meta
+      {'object': 'sun'}
+
+- If it's a ``callable`` it must take at least two arguments. Both ``meta``
+  attributes will be passed to this function (even if one or both of them are
+  empty) and the callable evaluates the result's meta. For example just a
+  function that merges these two::
+
+      >>> # It's expected with arithmetics that the result is not a reference,
+      >>> # so we need to copy
+      >>> from copy import deepcopy
+
+      >>> def combine_meta(meta1, meta2):
+      ...     if not meta1:
+      ...         return deepcopy(meta2)
+      ...     elif not meta2:
+      ...         return deepcopy(meta1)
+      ...     else:
+      ...         meta_final = deepcopy(meta1)
+      ...         meta_final.update(meta2)
+      ...         return meta_final
+
+      >>> ndd1 = NDDataRef(1, meta={'time': 'today'})
+      >>> ndd2 = NDDataRef(1, meta={'object': 'moon'})
+      >>> ndd1.subtract(ndd2, handle_meta=combine_meta).meta # doctest: +SKIP
+      {'object': 'moon', 'time': 'today'}
+
+  Here again additional arguments for the function can be passed in using
+  the prefix ``meta_`` (which will be stripped away before passing it to this)
+  function. See the description for the mask-attribute for further details.
+
+wcs
+^^^
+
+The ``compare_wcs`` argument will determine what the result's ``wcs`` will be
+or if the operation should be forbidden. The possible values are identical to
+``mask`` and ``meta``:
+
+- If ``None`` the resulting ``wcs`` will be an empty ``None``.
+
+      >>> ndd1 = NDDataRef(1, wcs=0)
+      >>> ndd2 = NDDataRef(1, wcs=1)
+      >>> ndd1.add(ndd2, compare_wcs=None).wcs is None
+      True
+
+- If ``"first_found"`` or ``"ff"`` the resulting wcs will be the wcs of the
+  first operand or if that is None the meta of the second operand is
+  taken.
+
+      >>> ndd1 = NDDataRef(1, wcs=1)
+      >>> ndd2 = NDDataRef(1, wcs=0)
+      >>> ndd1.add(ndd2, compare_wcs='ff').wcs
+      1
+
+- If it's a ``callable`` it must take at least two arguments. Both ``wcs``
+  attributes will be passed to this function (even if one or both of them are
+  None) and the callable should return ``True`` if these wcs are identical
+  (enough) to allow the arithmetic operation or ``False`` if the arithmetic
+  operation should be aborted with a ``ValueError``. If ``True`` the ``wcs``
+  are identical and the first one is used for the result::
+
+      >>> def compare_wcs_scalar(wcs1, wcs2, allowed_deviation=0.1):
+      ...     if wcs1 is None and wcs2 is None:
+      ...         return True  # both have no WCS so they are identical
+      ...     if wcs1 is None or wcs2 is None:
+      ...         return False  # one has WCS, the other doesn't not possible
+      ...     else:
+      ...         return abs(wcs1 - wcs2) < allowed_deviation
+
+      >>> ndd1 = NDDataRef(1, wcs=1)
+      >>> ndd2 = NDDataRef(1, wcs=1)
+      >>> ndd1.subtract(ndd2, compare_wcs=compare_wcs_scalar).wcs
+      1
+
+  additional arguments can be passed in prefixing them with ``wcs_`` (this
+  prefix will be stripped away before passing it to the function)::
+
+      >>> ndd1 = NDDataRef(1, wcs=1)
+      >>> ndd2 = NDDataRef(1, wcs=2)
+      >>> ndd1.subtract(ndd2, compare_wcs=compare_wcs_scalar, wcs_allowed_deviation=2).wcs
+      1
+
+  If one is using `~astropy.wcs.WCS` objects a very handy function to use might
+  be::
+
+      >>> def wcs_compare(wcs1, wcs2, *args, **kwargs):
+      ...     return wcs1.wcs.compare(wcs2.wcs, *args, **kwargs)
+
+  see :meth:`astropy.wcs.Wcsprm.compare` for the arguments this comparison
+  allows.
+
+uncertainty
+^^^^^^^^^^^
+
+the ``propagate_uncertainties`` argument can be used to turn the propagation
+of uncertainties on or off.
+
+- If ``None`` the result will have no uncertainty::
+
+      >>> from astropy.nddata import StdDevUncertainty
+      >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty(0))
+      >>> ndd2 = NDDataRef(1, uncertainty=StdDevUncertainty(1))
+      >>> ndd1.add(ndd2, propagate_uncertainties=None).uncertainty is None
+      True
+
+- If ``False`` this is equivalent to ``"first_found"`` for ``meta``, ... and
+  the result will have the first found uncertainty.
+
+  .. note::
+      Setting ``propagate_uncertainties=False`` is not generally not
+      recommended.
+
+  but it's possible nevertheless::
+
+      >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty([0]))
+      >>> ndd2 = NDDataRef(1, uncertainty=StdDevUncertainty([1]))
+      >>> ndd1.add(ndd2, propagate_uncertainties=False).uncertainty
+      StdDevUncertainty([0])
+
+- If ``True`` both uncertainties must be ``NDUncertainty`` subclasses that
+  implement propagation. This is possible for
+  `~astropy.nddata.StdDevUncertainty`::
+
+      >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty([10]))
+      >>> ndd2 = NDDataRef(1, uncertainty=StdDevUncertainty([10]))
+      >>> ndd1.add(ndd2, propagate_uncertainties=True).uncertainty
+      StdDevUncertainty([ 14.14213562])
+
+uncertainty with correlation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+in case ``propagate_uncertainties`` is ``True`` you can give also an argument
+for ``uncertainty_correlation``. `~astropy.nddata.StdDevUncertainty` cannot
+keep track of it's correlations by itself but it can evaluate the correct
+resulting uncertainty if the correct ``correlation`` is given.
+
+For example without correlation subtracting a `~astropy.nddata.NDDataRef`
+instance from itself results in a non-zero uncertainty::
+
+    >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty([10]))
+    >>> ndd1.subtract(ndd1, propagate_uncertainties=True).uncertainty
+    StdDevUncertainty([ 14.14213562])
+
+but given a correlation of ``1`` because they clearly correlate gives the
+correct uncertainty of ``0``::
+
+    >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty([10]))
+    >>> ndd1.subtract(ndd1, propagate_uncertainties=True,
+    ...               uncertainty_correlation=1).uncertainty
+    StdDevUncertainty([ 0.])
+
+which would be consistent with the equivalent operation ``ndd1 * 0``::
+
+    >>> ndd1.multiply(0, propagate_uncertainties=True).uncertainty
+    StdDevUncertainty([0])
+
+The default (``0``) represents uncorrelated while ``1`` means correlated and
+``-1`` anti-correlated. If given a `numpy.ndarray` it should represent the
+element-wise correlation coefficient.
+
+.. warning::
+    The user needs to calculate or know the appropriate value or array manually
+    and pass it to ``uncertainty_correlation``. The implementation follows
+    general first order error propagation formulas, see for example:
+    `Wikipedia <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas>`_.
+
+You can also give element-wise correlations::
+
+    >>> ndd1 = NDDataRef([1,1,1,1], uncertainty=StdDevUncertainty([1,1,1,1]))
+    >>> ndd2 = NDDataRef([2,2,2,2], uncertainty=StdDevUncertainty([2,2,2,2]))
+    >>> ndd1.add(ndd2,uncertainty_correlation=np.array([1,0.5,0,-1])).uncertainty
+    StdDevUncertainty([ 3.        ,  2.64575131,  2.23606798,  1.        ])
+
+The correlation ``np.array([1, 0.5, 0, -1])`` would indicate that the first
+element is fully correlated, the second element partially correlates while
+element 3 is uncorrelated and 4 even anti-correlated.
+
+uncertainty with unit
+^^^^^^^^^^^^^^^^^^^^^
+
+`~astropy.nddata.StdDevUncertainty` implements correct error propagation even
+if the unit of the data differs from the unit of the uncertainty::
+
+    >>> ndd1 = NDDataRef([10], unit='m', uncertainty=StdDevUncertainty([10], unit='cm'))
+    >>> ndd2 = NDDataRef([20], unit='m', uncertainty=StdDevUncertainty([10]))
+    >>> ndd1.subtract(ndd2, propagate_uncertainties=True).uncertainty
+    StdDevUncertainty([ 10.00049999])
+
+but it needs to be convertible to the unit for the data.

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -1,7 +1,7 @@
 .. _nddata_arithmetic:
 
-NDData Arithmetics
-==================
+NDData Arithmetic
+=================
 
 Introduction
 ------------
@@ -13,7 +13,7 @@ Introduction
 - multiplication: :meth:`~astropy.nddata.NDArithmeticMixin.multiply`
 - division: :meth:`~astropy.nddata.NDArithmeticMixin.divide`
 
-Usage basic arithmetic methods
+Using basic arithmetic methods
 ------------------------------
 
 Using the standard arithmetic methods requires that the first operand
@@ -46,7 +46,7 @@ a `numpy.ndarray`::
 here broadcasting takes care of the different dimensions. Also several other
 classes are possible.
 
-Usage arithmetic classmethods
+Using arithmetic classmethods
 -----------------------------
 
 Here both operands don't need to be `~astropy.nddata.NDDataRef`-like::
@@ -92,10 +92,10 @@ data, unit
 ^^^^^^^^^^
 
 For ``data`` and ``unit`` there are no parameters. Every arithmetic
-operation let's the `astropy.units.Quantity`-framework evaluate the result
-or fail and abort the operation. For example if incompatible units are used.
+operation lets the `astropy.units.Quantity`-framework evaluate the result
+or fail and abort the operation.
 
-Adding two NDData objects with the same unit::
+Adding two NDData objects with the same unit works::
 
     >>> ndd1 = NDDataRef([1,2,3,4,5], unit='m')
     >>> ndd2 = NDDataRef([100,150,200,50,500], unit='m')
@@ -106,7 +106,7 @@ Adding two NDData objects with the same unit::
     >>> ndd.unit
     Unit("m")
 
-works. Also if the units are compatible::
+Adding two NDData objects with compatible units also works::
 
     >>> ndd1 = NDDataRef(ndd1, unit='pc')
     INFO: overwriting NDData's current unit with specified unit. [astropy.nddata.nddata]
@@ -154,21 +154,21 @@ resulting mask will be. There are several options.
       False
 
 - a function (or an arbitary callable) that takes at least two arguments.
-  for example `numpy.logical_or` is the default::
+  For example `numpy.logical_or` is the default::
 
       >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
       >>> ndd1.add(ndd2).mask
       array([ True, False,  True,  True], dtype=bool)
 
-  which will default to ``"first_found"`` in case only one ``mask`` is not None::
+  This defaults to ``"first_found"`` in case only one ``mask`` is not None::
 
       >>> ndd1 = NDDataRef(1)
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
       >>> ndd1.add(ndd2).mask
       array([ True, False, False,  True], dtype=bool)
 
-  but also custom functions are possible::
+  Custom functions are also possible::
 
       >>> def take_alternating_values(mask1, mask2, start=0):
       ...     result = np.zeros(mask1.shape, dtype=np.bool)
@@ -176,14 +176,14 @@ resulting mask will be. There are several options.
       ...     result[start+1::2] = mask2[start+1::2]
       ...     return result
 
-  this function is obviously non-sense but let's see how it performs::
+  This function is obviously non-sense but let's see how it performs::
 
       >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
       >>> ndd1.add(ndd2, handle_mask=take_alternating_values).mask
       array([ True, False,  True,  True], dtype=bool)
 
-  and additional parameters can be given by prefixing them with ``mask_``
+  Additional parameters can be given by prefixing them with ``mask_``
   (which will be stripped before passing it to the function)::
 
       >>> ndd1.add(ndd2, handle_mask=take_alternating_values, mask_start=1).mask
@@ -289,7 +289,7 @@ or if the operation should be forbidden. The possible values are identical to
       >>> ndd1.subtract(ndd2, compare_wcs=compare_wcs_scalar).wcs
       1
 
-  additional arguments can be passed in prefixing them with ``wcs_`` (this
+  Additional arguments can be passed in prefixing them with ``wcs_`` (this
   prefix will be stripped away before passing it to the function)::
 
       >>> ndd1 = NDDataRef(1, wcs=1)
@@ -309,7 +309,7 @@ or if the operation should be forbidden. The possible values are identical to
 uncertainty
 ^^^^^^^^^^^
 
-the ``propagate_uncertainties`` argument can be used to turn the propagation
+The ``propagate_uncertainties`` argument can be used to turn the propagation
 of uncertainties on or off.
 
 - If ``None`` the result will have no uncertainty::
@@ -320,19 +320,11 @@ of uncertainties on or off.
       >>> ndd1.add(ndd2, propagate_uncertainties=None).uncertainty is None
       True
 
-- If ``False`` this is equivalent to ``"first_found"`` for ``meta``, ... and
-  the result will have the first found uncertainty.
+- If ``False`` the result will have the first found uncertainty.
 
   .. note::
       Setting ``propagate_uncertainties=False`` is not generally not
       recommended.
-
-  but it's possible nevertheless::
-
-      >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty([0]))
-      >>> ndd2 = NDDataRef(1, uncertainty=StdDevUncertainty([1]))
-      >>> ndd1.add(ndd2, propagate_uncertainties=False).uncertainty
-      StdDevUncertainty([0])
 
 - If ``True`` both uncertainties must be ``NDUncertainty`` subclasses that
   implement propagation. This is possible for
@@ -346,10 +338,14 @@ of uncertainties on or off.
 uncertainty with correlation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-in case ``propagate_uncertainties`` is ``True`` you can give also an argument
+If ``propagate_uncertainties`` is ``True`` you can give also an argument
 for ``uncertainty_correlation``. `~astropy.nddata.StdDevUncertainty` cannot
 keep track of it's correlations by itself but it can evaluate the correct
 resulting uncertainty if the correct ``correlation`` is given.
+
+The default (``0``) represents uncorrelated while ``1`` means correlated and
+``-1`` anti-correlated. If given a `numpy.ndarray` it should represent the
+element-wise correlation coefficient.
 
 For example without correlation subtracting a `~astropy.nddata.NDDataRef`
 instance from itself results in a non-zero uncertainty::
@@ -358,7 +354,7 @@ instance from itself results in a non-zero uncertainty::
     >>> ndd1.subtract(ndd1, propagate_uncertainties=True).uncertainty
     StdDevUncertainty([ 14.14213562])
 
-but given a correlation of ``1`` because they clearly correlate gives the
+Given a correlation of ``1`` because they clearly correlate gives the
 correct uncertainty of ``0``::
 
     >>> ndd1 = NDDataRef(1, uncertainty=StdDevUncertainty([10]))
@@ -370,10 +366,6 @@ which would be consistent with the equivalent operation ``ndd1 * 0``::
 
     >>> ndd1.multiply(0, propagate_uncertainties=True).uncertainty
     StdDevUncertainty([0])
-
-The default (``0``) represents uncorrelated while ``1`` means correlated and
-``-1`` anti-correlated. If given a `numpy.ndarray` it should represent the
-element-wise correlation coefficient.
 
 .. warning::
     The user needs to calculate or know the appropriate value or array manually
@@ -390,7 +382,7 @@ You can also give element-wise correlations::
 
 The correlation ``np.array([1, 0.5, 0, -1])`` would indicate that the first
 element is fully correlated, the second element partially correlates while
-element 3 is uncorrelated and 4 even anti-correlated.
+element 3 is uncorrelated and 4 is anti-correlated.
 
 uncertainty with unit
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/nddata/mixins/ndio.rst
+++ b/docs/nddata/mixins/ndio.rst
@@ -1,3 +1,5 @@
+.. _nddata_io:
+
 I/O mixin
 =========
 

--- a/docs/nddata/mixins/ndslicing.rst
+++ b/docs/nddata/mixins/ndslicing.rst
@@ -1,3 +1,5 @@
+.. _nddata_slicing:
+
 Slicing mixin
 =============
 

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -66,7 +66,7 @@ numerical values::
     >>> ndd.data  # data will be a numpy-array:
     array([1, 2, 3, 4])
 
-even nested `list` or `tuple` are possible. But if these contain non-numerical
+Nested `list` or `tuple` are possible, but if these contain non-numerical
 values the conversion might fail.
 
 Besides input that is convertible to such an array you can use the ``data``
@@ -137,12 +137,12 @@ Mask
 
 The ``mask`` is being used to indicate if data points are valid or invalid.
 `~astropy.nddata.NDData` doesn't restrict this mask in any way but it is
-recommended to adapt the `numpy.ma.MaskedArray` convention that the mask:
+expected to follow the `numpy.ma.MaskedArray` convention that the mask:
 
 + returns ``True`` for data points that are considered **invalid**.
 + returns ``False`` for those points that are **valid**.
 
-one possibility is to create a mask by using numpys comparison operators::
+One possibility is to create a mask by using numpys comparison operators::
 
     >>> array = np.array([0, 1, 4, 0, 2])
 
@@ -188,15 +188,15 @@ The ``unit`` represents the unit of the data values. It is required to be
 Uncertainties
 -------------
 
-the ``uncertainty`` represents an arbitary representation of the error of the
+The ``uncertainty`` represents an arbitary representation of the error of the
 data values. To indicate which kind of uncertainty representation is used the
-``uncertainty`` should have itself an ``uncertainty_type`` property. If no such
+``uncertainty`` should have an ``uncertainty_type`` property. If no such
 property is found it will be wrapped inside a
 `~astropy.nddata.UnknownUncertainty`.
 
 The ``uncertainty_type`` should follow the `~astropy.nddata.StdDevUncertainty`
 convention that it returns a short string like ``"std"`` for an uncertainty
-given in standard deviation. But that's not an enforced requirement.
+given in standard deviation.
 
 Like the other properties the ``uncertainty`` can be set during
 initialization::
@@ -279,8 +279,8 @@ Initialization with copy
 ------------------------
 
 The default way to create an `~astropy.nddata.NDData` instance is to try saving
-the parameters as reference to the original rather than as copy. Sometimes this
-is not possible because the internal mechanics don't allow for this. For
+the parameters as references to the original rather than as copy. Sometimes
+this is not possible because the internal mechanics don't allow for this. For
 example if the ``data`` is a `list` then during initialization this is copied
 while converting to a `~numpy.ndarray`. But it is also possible to enforce
 copies during initialization by setting the ``copy`` parameter to ``True``::
@@ -347,16 +347,14 @@ Converting the ``data``  and ``unit`` to a Quantity::
 masked Quantity
 ^^^^^^^^^^^^^^^
 
-Converting the ``data``, ``mask``  and ``unit`` to a masked Quantity::
+Converting the ``data``, ``mask``  and ``unit`` to a masked Quantity requires
+NumPy version 1.9 or newer::
 
     >>> ma_quantity = np.ma.array(u.Quantity(ndd.data, unit=ndd.unit), mask=ndd.mask)  # doctest: +SKIP
     >>> ma_quantity  # doctest: +SKIP
     masked_Quantity(data = [-- 2.0 3.0 --] m,
                     mask = [ True False False  True],
               fill_value = 1e+20)
-
-.. warning::
-    This requires NumPy version 1.9 or newer.
 
 .. todo::
     Remove doctest skip as soon as NumPy 1.9 isn't supported anymore.

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -6,140 +6,247 @@ NDData
 Overview
 --------
 
-The `~astropy.nddata.NDData` class is a container for gridded N-dimensional
-data. It has a ``data`` attribute, which can be any object that presents an
-array-like interface, and optional attributes:
+:class:`~astropy.nddata.NDData` is based on `numpy.ndarray`-like ``data`` with
+additional meta attributes:
 
-+  ``meta``, for metadata
-+ ``unit`` for the ``data`` unit
-+ ``uncertainty`` for the uncertainty of the data (which could be standard
-  deviation, variance or something else),
-+ ``mask`` for the ``data``
-+ ``wcs``, representing the relationship  between ``data`` and world
-  coordinates.
++  ``meta``, for general metadata
++ ``unit``, representing the physical unit of the data
++ ``uncertainty`` for the uncertainty of the data
++ ``mask``, indicating invalid points in the data
++ ``wcs``, representing the relationship  between the data grid and world
+  coordinates
 
-Of these, only ``mask`` and  ``uncertainty`` may be changed after the NDData
-object is created.
+Each of these attributes can be set during initialization or directly on the
+instance. Only the ``data`` cannot be directly set after creating the instance.
 
-Initializing
-------------
+Data
+----
 
-An `~astropy.nddata.NDData` object can be instantiated by passing it an
-n-dimensional Numpy array::
+The data is the base of `~astropy.nddata.NDData` and required to be
+`numpy.ndarray`-like. It's the only property that is required to create an
+instance and it cannot be directly set on the instance.
+
+For example::
 
     >>> import numpy as np
     >>> from astropy.nddata import NDData
-    >>> array = np.zeros((12, 12, 12))  # a 3-dimensional array with all zeros
+    >>> array = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
     >>> ndd = NDData(array)
+    >>> ndd
+    NDData([[0, 1, 0],
+            [1, 0, 1],
+            [0, 1, 0]])
 
-Note that the data in ``ndd`` is a reference to the original ``array``, so
-changing the data in ``ndd`` will change the corresponding data in ``array``
-in most circumstances.
+and can be accessed by the ``data`` attribute::
 
-An `~astropy.nddata.NDData` object can also be instantiated by passing it an
-`~astropy.nddata.NDData` object:
+    >>> ndd.data
+    array([[0, 1, 0],
+           [1, 0, 1],
+           [0, 1, 0]])
 
-    >>> ndd1 = NDData(array)
-    >>> ndd2 = NDData(ndd1)
+as already mentioned it is not possible to set the data directly. So
+``ndd.data = np.arange(9)`` will raise an Exception. But the data can be
+modified in place::
 
-As above, the data in``ndd2`` is a reference to the data in ``ndd1``, so
-changes to one will affect the other.
+    >>> ndd.data[1,1] = 100
+    >>> ndd.data
+    array([[  0,   1,   0],
+           [  1, 100,   1],
+           [  0,   1,   0]])
 
-It can also be instantiated by passing in an object that can be converted to a
-numpy numerical array::
+Data during initialization
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    >>> ndd3 = NDData([1, 2, 3, 4])
+During initialization it is possible to provide data that it's not a
+`numpy.ndarray` but convertible to one. For example passing a `list` containing
+numerical values::
 
-The final way to instantiate an `~astropy.nddata.NDData` object is with a data
-object that presents a numpy array-like interface. If the object passed to the
-intializer has all three of the attributes ``shape``, ``__getitem__`` (so it
-is indexable) and ``__array__`` (so that it can act like a numpy array in
-expression) then the ``data`` attribute will be set to that object.
+    >>> alist = [1, 2, 3, 4]
+    >>> ndd = NDData(alist)
+    >>> ndd.data  # data will be a numpy-array:
+    array([1, 2, 3, 4])
+
+even nested `list` or `tuple` are possible. But if these contain non-numerical
+values the conversion might fail.
+
+Besides input that is convertible to such an array you can use the ``data``
+parameter to pass implicit additional information. For example if the data is
+another `~astropy.nddata.NDData`-object it implicitly uses it's properties::
+
+    >>> ndd = NDData(ndd, unit = 'm')
+    >>> ndd2 = NDData(ndd)
+    >>> ndd2.data  # It has the same data as ndd
+    array([1, 2, 3, 4])
+    >>> ndd2.unit  # but it also has the same unit as ndd
+    Unit("m")
+
+another possibility is to use a `~astropy.units.Quantity` as ``data``
+parameter::
+
+    >>> import astropy.units as u
+    >>> quantity = np.ones(3) * u.cm  # this will create a Quantity
+    >>> ndd3 = NDData(quantity)
+    >>> ndd3.data
+    array([ 1.,  1.,  1.])
+    >>> ndd3.unit
+    Unit("cm")
+
+or a `numpy.ma.MaskedArray`::
+
+    >>> masked_array = np.ma.array([5,10,15], mask=[False, True, False])
+    >>> ndd4 = NDData(masked_array)
+    >>> ndd4.data
+    array([ 5, 10, 15])
+    >>> ndd4.mask
+    array([False,  True, False], dtype=bool)
+
+or even a masked Quantity::
+
+    >>> masked_quantity = np.ma.array([1,2,3,4]*u.kg, mask=[True, False, True, False])
+    >>> ndd5 = NDData(masked_quantity)
+    >>> ndd5.data
+    array([ 1.,  2.,  3.,  4.])
+    >>> ndd5.mask
+    array([ True, False,  True, False], dtype=bool)
+    >>> ndd5.unit
+    Unit("kg")
+
+If such an implicitly passed property conflicts with an explicit parameter, the
+explicit parameter will be used and an info-message will be issued::
+
+    >>> quantity = np.ones(3) * u.cm
+    >>> ndd6 = NDData(quantity, unit='m')
+    INFO: overwriting Quantity's current unit with specified unit. [astropy.nddata.nddata]
+    >>> ndd6.data
+    array([ 1.,  1.,  1.])
+    >>> ndd6.unit
+    Unit("m")
+
+the unit of the `~astropy.units.Quantity` is being ignored and the unit is set
+to the explicitly passed one.
+
+It might be possible to pass other classes as ``data`` parameter as long as
+they have the properties ``shape``, ``dtype``, ``__getitem__`` and
+``__array__``.
 
 The purpose of this mechanism is to allow considerable flexibility in the
-objects used to store the data while providing a useful to default (numpy
-array).
+objects used to store the data while providing a useful default (numpy array).
 
 Mask
 ----
 
-Values can be masked using the ``mask`` attribute.  One straightforward way to
-provide a mask is to use a boolean numpy array::
+The ``mask`` is being used to indicate if data points are valid or invalid.
+`~astropy.nddata.NDData` doesn't restrict this mask in any way but it is
+recommended to adapt the `numpy.ma.MaskedArray` convention that the mask:
 
-     >>> ndd_masked = NDData(ndd, mask = ndd.data > 0.9)
++ returns ``True`` for data points that are considered **invalid**.
++ returns ``False`` for those points that are **valid**.
 
-Another is to simply initialize an `~astropy.nddata.NDData` object  with a
-masked numpy array::
+one possibility is to create a mask by using numpys comparison operators::
 
-    >>> masked_array = np.ma.array([1, 2, 3, 4], mask=[1, 0, 0, 1])
-    >>> ndd_masked = NDData(masked_array)
-    >>> ndd_masked.mask
-    array([ True, False, False,  True], dtype=bool)
+    >>> array = np.array([0, 1, 4, 0, 2])
 
-A mask value of `True` indicates a value that should be ignored, while a mask
-value of `False` indicates a valid value.
+    >>> mask = array == 0  # Mask points containing 0
+    >>> mask
+    array([ True, False, False,  True, False], dtype=bool)
 
-There is no requirement that the mask actually be a numpy array; for example,
-a function which evaluates a mask value as needed is acceptable as long as it
-follows the convention that `True` indicates a value that should be ignored.
+    >>> other_mask = array > 1  # Mask points with a value greater than 1
+    >>> other_mask
+    array([False, False,  True, False,  True], dtype=bool)
+
+and initialize the `~astropy.nddata.NDData` instance using the ``mask``
+parameter::
+
+    >>> ndd = NDData(array, mask=mask)
+    >>> ndd.mask
+    array([ True, False, False,  True, False], dtype=bool)
+
+or by replacing the mask::
+
+    >>> ndd.mask = other_mask
+    >>> ndd.mask
+    array([False, False,  True, False,  True], dtype=bool)
+
+but that it is a `numpy.ndarray` is not a requirement but probably the most
+intuitive option.
 
 Unit
 ----
 
-The unit of the data can be set by either explicitly providing an astropy unit
-when creating the ``NDData`` object::
+The ``unit`` represents the unit of the data values. It is required to be
+`~astropy.units.Unit`-like or a string that can be converted to such a
+`~astropy.units.Unit`::
 
     >>> import astropy.units as u
-    >>> ndd_unit = NDData([1, 2, 3, 4], unit="meter")
-    >>> ndd_unit.unit
+    >>> ndd = NDData([1, 2, 3, 4], unit="meter")  # using a string
+    >>> ndd.unit
     Unit("m")
 
-or by initializing with data that is an astropy `~astropy.units.Quantity`::
-
-    >>> q = [1, 2, 3, 4] * u.meter
-    >>> ndd_unit2 = NDData(q)
-    >>> ndd_unit2.unit
-    Unit("m")
+..note::
+    Setting the ``unit`` on an instance is not possible.
 
 Uncertainties
 -------------
 
-`~astropy.nddata.NDData` objects have an ``uncertainty`` attribute that can be
-used to set the uncertainty on the data values. The ``uncertainty`` must have
-an attribute ``uncertainty_type`` otherwise it is wrapped inside an
+the ``uncertainty`` represents an arbitary representation of the error of the
+data values. To indicate which kind of uncertainty representation is used the
+``uncertainty`` should have itself an ``uncertainty_type`` property. If no such
+property is found it will be wrapped inside a
 `~astropy.nddata.UnknownUncertainty`.
 
-While not a requirement, the following ``uncertainty_type`` strings
-are strongly recommended for common ways of specifying normal
-distributions:
+The ``uncertainty_type`` should follow the `~astropy.nddata.StdDevUncertainty`
+convention that it returns a short string like ``"std"`` for an uncertainty
+given in standard deviation. But that's not an enforced requirement.
 
-+ ``"std"``: if ``uncertainty`` stores the standard deviation/sigma
-  (either a single value or on a per-pixel basis).
-+ ``"var"``: if ``uncertainty`` stores the variance (either a single
-  value or on a per-pixel basis).
-+ ``"ivar"``: if ``uncertainty`` stores the inverse variance (either a
-  single value or on a per-pixel basis).
+Like the other properties the ``uncertainty`` can be set during
+initialization::
 
+    >>> from astropy.nddata import StdDevUncertainty
+    >>> array = np.array([10, 7, 12, 22])
+    >>> uncert = StdDevUncertainty(np.sqrt(array))
+    >>> ndd = NDData(array, uncertainty=uncert)
+    >>> ndd.uncertainty
+    StdDevUncertainty([ 3.16227766,  2.64575131,  3.46410162,  4.69041576])
 
-.. note:: For information on creating your own uncertainty classes,
-          see :doc:`subclassing`.
+or on the instance directly::
+
+    >>> other_uncert = StdDevUncertainty([2,2,2,2])
+    >>> ndd.uncertainty = other_uncert
+    >>> ndd.uncertainty
+    StdDevUncertainty([2, 2, 2, 2])
+
+but it will print an info message if there is no ``uncertainty_type``::
+
+    >>> ndd.uncertainty = np.array([5, 1, 2, 10])
+    INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
+    >>> ndd.uncertainty
+    UnknownUncertainty([ 5,  1,  2, 10])
+
+WCS
+---
+
+The ``wcs`` should contain a mapping from the gridded data to world
+coordinates. There are no restrictions placed on the property currently but it
+may be restricted to an `~astropy.wcs.WCS` object or a more generalized WCS
+object in the future.
+
+.. note::
+    Like the unit the wcs cannot be set on an instance.
 
 Meta-data
 ---------
 
-The :class:`~astropy.nddata.NDData` class includes a ``meta`` attribute that
-defaults to an empty ordered dictionary, and can be used to set overall meta-
-data for the dataset::
+The ``meta`` property contains all further meta information that don't fit
+any other property.
 
-    ndd.meta['exposure_time'] = 340.
-    ndd.meta['filter'] = 'J'
+If given it must be `dict`-like::
 
-Elements of the meta-data dictionary can be set to any valid Python object::
+    >>> ndd = NDData([1,2,3], meta={'observer': 'myself'})
+    >>> ndd.meta
+    {'observer': 'myself'}
 
-    ndd.meta['history'] = ['calibrated', 'aligned', 'flat-fielded']
-
-The metadata can be any python object that presents a dict-like interface. For
-example, a FITS header can be used as the metadata::
+`dict`-like means it must be a mapping from some keys to some values. This
+also includes `~astropy.io.fits.Header` objects::
 
     >>> from astropy.io import fits
     >>> header = fits.Header()
@@ -148,67 +255,108 @@ example, a FITS header can be used as the metadata::
     >>> ndd.meta['observer']
     'Edwin Hubble'
 
-WCS
----
+If the ``meta`` isn't provided or explicitly set to ``None`` it will default to
+an empty `collections.OrderedDict`::
 
-At the moment the ``wcs`` attribute can be set to any object, though in the
-future it may be restricted to an `~astropy.wcs.WCS` object once a generalized
-WCS object is developed.
+    >>> ndd.meta = None
+    >>> ndd.meta
+    OrderedDict()
+
+    >>> ndd = NDData([1,2,3])
+    >>> ndd.meta
+    OrderedDict()
+
+The ``meta`` object therefore supports adding or updating these values::
+
+    >>> ndd.meta['exposure_time'] = 340.
+    >>> ndd.meta['filter'] = 'J'
+
+Elements of the meta-data dictionary can be set to any valid Python object::
+
+    >>> ndd.meta['history'] = ['calibrated', 'aligned', 'flat-fielded']
 
 Initialization with copy
 ------------------------
 
 The default way to create an `~astropy.nddata.NDData` instance is to try saving
-the parameters as reference rather than as copy. Sometimes this is not possible
-because the internal mechanics doesn't allow for this. For example if the
-``data`` is a `list` then during initialization this is copied while converting
-to a `~numpy.ndarray`. But it is also possible to enforce copies
-during initialization by setting the ``copy`` parameter to ``True``::
+the parameters as reference to the original rather than as copy. Sometimes this
+is not possible because the internal mechanics don't allow for this. For
+example if the ``data`` is a `list` then during initialization this is copied
+while converting to a `~numpy.ndarray`. But it is also possible to enforce
+copies during initialization by setting the ``copy`` parameter to ``True``::
 
     >>> array = np.array([1, 2, 3, 4])
     >>> ndd = NDData(array)
     >>> ndd.data[2] = 10
-    >>> array[2]  # Original array is changed
+    >>> array[2]  # Original array has changed
     10
+
     >>> ndd2 = NDData(array, copy=True)
     >>> ndd2.data[2] = 3
-    >>> array[2]  # Original array is not changed.
+    >>> array[2]  # Original array hasn't changed.
     10
 
-Conflicting parameters
-----------------------
+.. note::
+    In some cases setting ``copy=True`` will copy the ``data`` twice. Known
+    cases are if the ``data`` is a `list` or `tuple`.
 
-It is possible to initialize `~astropy.nddata.NDData` with an explicit
-parameter in the initialization call and an implicit one in the ``data``
-parameter. If such a combination is detected a warning is
-issued and the explicit parameter is kept (without any attempt of conversion).
+Converting NDData to other classes
+----------------------------------
 
-For example with quantities::
+There is limited to support to convert a `~astropy.nddata.NDData` instance to
+other classes. In the process some properties might be lost.
 
-    >>> import astropy.units as u
-    >>> quantity = np.array([1, 2, 3, 4]) * u.m
-    >>> ndd = NDData(quantity, unit="cm")  # Explicit unit is cm and implicit is m, keep explicit.
-    INFO: Overwriting Quantity's current unit with specified unit [astropy.nddata.nddata]
-    >>> ndd.unit
-    Unit("cm")
+    >>> data = np.array([1, 2, 3, 4])
+    >>> mask = np.array([True, False, False, True])
+    >>> unit = 'm'
+    >>> ndd = NDData(data, mask=mask, unit=unit)
 
-But this can affect the mask if the ``data`` parameter is a `~numpy.ma.MaskedArray`
-or even all attributes if the ``data`` is another `~astropy.nddata.NDData`
-instance.
+`numpy.ndarray`
+^^^^^^^^^^^^^^^
 
-Converting to Numpy arrays
---------------------------
-
-Data should be accessed through the ``data`` attribute::
+Converting the ``data`` to an array::
 
     >>> array = np.asarray(ndd.data)
+    >>> array
+    array([1, 2, 3, 4])
 
-Though using ``np.asarray`` is not required it will ensure that an additional
-copy of the data is not made if the data is a numpy array.
+Though using ``np.asarray`` is not required in most cases it will ensure that
+the result is always a `numpy.ndarray`
 
-Note that if the data is masked you must explicitly construct a numpy masked
-array like this::
+`numpy.ma.MaskedArray`
+^^^^^^^^^^^^^^^^^^^^^^
 
-    >>> input_array = np.ma.array([1, 2, 3, 4], mask=[1, 0, 0, 1])
-    >>> ndd_masked = NDData(input_array)
-    >>> masked_array = np.ma.array(ndd_masked.data, mask=ndd_masked.mask)
+Converting the ``data``  and ``mask`` to a MaskedArray::
+
+
+    >>> masked_array = np.ma.array(ndd.data, mask=ndd.mask)
+    >>> masked_array
+    masked_array(data = [-- 2 3 --],
+                 mask = [ True False False  True],
+           fill_value = 999999)
+
+`~astropy.units.Quantity`
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Converting the ``data``  and ``unit`` to a Quantity::
+
+    >>> quantity = u.Quantity(ndd.data, unit=ndd.unit)
+    >>> quantity
+    <Quantity [ 1., 2., 3., 4.] m>
+
+masked Quantity
+^^^^^^^^^^^^^^^
+
+Converting the ``data``, ``mask``  and ``unit`` to a masked Quantity::
+
+    >>> ma_quantity = np.ma.array(u.Quantity(ndd.data, unit=ndd.unit), mask=ndd.mask)  # doctest: +SKIP
+    >>> ma_quantity  # doctest: +SKIP
+    masked_Quantity(data = [-- 2.0 3.0 --] m,
+                    mask = [ True False False  True],
+              fill_value = 1e+20)
+
+.. warning::
+    This requires NumPy version 1.9 or newer.
+
+.. todo::
+    Remove doctest skip as soon as NumPy 1.9 isn't supported anymore.

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -167,8 +167,9 @@ or by replacing the mask::
     >>> ndd.mask
     array([False, False,  True, False,  True], dtype=bool)
 
-but that it is a `numpy.ndarray` is not a requirement but probably the most
-intuitive option.
+There is no requirement that the mask actually be a numpy array; for example, a
+function which evaluates a mask value as needed is acceptable as long as it
+follows the convention that ``True`` indicates a value that should be ignored.
 
 Unit
 ----

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -1,20 +1,320 @@
+.. _nddata_subclassing:
+
 Subclassing
 ===========
 
-There are a couple of choices to be made in subclassing from the nddata
-package. For the greatest flexibility, subclass from
-`~astropy.nddata.NDDataBase`, which places no restrictions on any of
-its attributes. In many cases, subclassing `~astropy.nddata.NDData` will work
-instead; it is more straightforward but places some minimal restrictions on
-how the data can be represented.
+`~astropy.nddata.NDData`
+------------------------
+
+This class serves as the base for subclasses that use a `numpy.ndarray` (or
+something that presents a numpy-like interface) as the ``data`` attribute.
+
+.. note::
+  Each attribute is saved as attribute with one leading underscore. For example
+  the ``data`` is saved as ``_data`` and the ``mask`` as ``_mask``, and so on.
+
+Adding another property
+^^^^^^^^^^^^^^^^^^^^^^^
+
+    >>> from astropy.nddata import NDData
+
+    >>> class NDDataWithFlags(NDData):
+    ...     def __init__(self, *args, **kwargs):
+    ...         # Remove flags attribute if given and pass it to the setter.
+    ...         self.flags = kwargs.pop('flags') if 'flags' in kwargs else None
+    ...         super(NDDataWithFlags, self).__init__(*args, **kwargs)
+    ...
+    ...     @property
+    ...     def flags(self):
+    ...         return self._flags
+    ...
+    ...     @flags.setter
+    ...     def flags(self, value):
+    ...         self._flags = value
+
+    >>> ndd = NDDataWithFlags([1,2,3])
+    >>> ndd.flags is None
+    True
+
+    >>> ndd = NDDataWithFlags([1,2,3], flags=[0, 0.2, 0.3])
+    >>> ndd.flags
+    [0, 0.2, 0.3]
+
+.. note::
+  To simplify subclassing each setter (except for ``data``) is called during
+  ``__init__`` so putting restrictions on any attribute can be done inside
+  the setter and will also apply duing instance creation.
+
+Customize the setter for a property
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    >>> import numpy as np
+
+    >>> class NDDataMaskBoolNumpy(NDData):
+    ...
+    ...     @NDData.mask.setter
+    ...     def mask(self, value):
+    ...         # Convert mask to boolean numpy array.
+    ...         self._mask = np.array(value, dtype=np.bool_)
+
+    >>> ndd = NDDataMaskBoolNumpy([1,2,3])
+    >>> ndd.mask = True
+    >>> ndd.mask
+    array(True, dtype=bool)
+
+Extend the setter for a property
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``unit``, ``meta`` and ``uncertainty`` implement some additional logic in their
+setter so subclasses might define a call to the superclass and let the
+super property set the attribute afterwards::
+
+    >>> import numpy as np
+
+    >>> class NDDataUncertaintyShapeChecker(NDData):
+    ...
+    ...     @NDData.uncertainty.setter
+    ...     def uncertainty(self, value):
+    ...         value = np.asarray(value)
+    ...         if value.shape != self.data.shape:
+    ...             raise ValueError('uncertainty must have the same shape as the data.')
+    ...         # Call the setter of the super class in case it might contain some
+    ...         # important logic (only True for meta, unit and uncertainty)
+    ...         super(NDDataUncertaintyShapeChecker, self.__class__).uncertainty.fset(self, value)
+
+    >>> ndd = NDDataUncertaintyShapeChecker([1,2,3], uncertainty=[2,3,4])
+    INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
+    >>> ndd.uncertainty
+    UnknownUncertainty([2, 3, 4])
+
+Having a setter for the data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    >>> class NDDataWithDataSetter(NDData):
+    ...
+    ...     @NDData.data.setter
+    ...     def data(self, value):
+    ...         # Convert mask to numpy array
+    ...         self._data = np.asarray(value)
+
+    >>> ndd = NDDataWithDataSetter([1,2,3])
+    >>> ndd.data = [3,2,1]
+    >>> ndd.data
+    array([3, 2, 1])
+
+`~astropy.nddata.NDDataRef`
+---------------------------
+
+`~astropy.nddata.NDDataRef` itself inherits from `~astropy.nddata.NDData` so
+any of the possibilities there also apply to NDDataRef. But NDDataRef also
+inherits from the Mixins:
+
+- `~astropy.nddata.NDSlicingMixin`
+- `~astropy.nddata.NDArithmeticMixin`
+- `~astropy.nddata.NDIOMixin`
+
+which allow additional operations.
+
+
+Arithmetic on an existing property
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Customizing how an existing property is handled during arithmetics is possible
+with some arguments to the function calls like
+:meth:`~astropy.nddata.NDArithmeticMixin.add` but if it's possible to hardcode
+behaviour too. The actual operation on the attribute (except for ``unit``) is
+done in a method ``_arithmetic_*`` where ``*`` is the name of the property.
+
+For example to customize how the ``meta`` will be affected during arithmetics::
+
+    >>> from astropy.nddata import NDDataRef
+
+    >>> from copy import deepcopy
+    >>> class NDDataWithMetaArithmetics(NDDataRef):
+    ...
+    ...     def _arithmetic_meta(self, operation, operand, handle_mask, **kwds):
+    ...         # the function must take the arguments:
+    ...         # operation (numpy-ufunc like np.add, np.subtract, ...)
+    ...         # operand (the other NDData-like object, already wrapped as NDData)
+    ...         # handle_mask (see description for "add")
+    ...
+    ...         # The meta is dict like but we want the keywords exposure to change
+    ...         # Anticipate that one or both might have no meta and take the first one that has
+    ...         result_meta = deepcopy(self.meta) if self.meta else deepcopy(operand.meta)
+    ...         # Do the operation on the keyword if the keyword exists
+    ...         if result_meta and 'exposure' in result_meta:
+    ...             result_meta['exposure'] = operation(result_meta['exposure'], operand.data)
+    ...         return result_meta # return it
+
+To trigger this method the ``handle_meta`` argument must not be ``None``,
+``"ff"`` or ``"first_found"``::
+
+    >>> ndd = NDDataWithMetaArithmetics([1,2,3], meta={'exposure': 10})
+    >>> ndd2 = ndd.add(10, handle_meta='')
+    >>> ndd2.meta
+    {'exposure': 20}
+
+    >>> ndd3 = ndd.multiply(0.5, handle_meta='')
+    >>> ndd3.meta
+    {'exposure': 5.0}
+
+.. warning::
+  To use these internal `_arithmetic_*` methods there are some restrictions on
+  the attributes when calling the operation:
+
+  - ``mask``: ``handle_mask`` must not be ``None``, ``"ff"`` or ``"first_found"``.
+  - ``wcs``: ``compare_wcs`` argument with the same restrictions as mask.
+  - ``meta``: ``handle_meta`` argument with the same restrictions as mask.
+  - ``uncertainty``: ``propagate_uncertainties`` must be ``None`` or evaluate
+    to ``False``. ``arithmetic_uncertainty`` must also accepts different
+    arguments: ``operation, operand, result, correlation, **kwargs``
+
+
+Changing default argument for arithmetic operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the goal is to change the default value of an existing parameter for
+arithmetic methods. Maybe because explicitly specifying the parameter each
+time you're calling an arithmetic operation is too much effort you can easily
+change the default value of existing parameters by changing it in the method
+signature of ``_arithmetic``::
+
+    >>> from astropy.nddata import NDDataRef
+    >>> import numpy as np
+
+    >>> class NDDDiffAritDefaults(NDDataRef):
+    ...     def _arithmetic(self, *args, **kwargs):
+    ...         # Changing the default of handle_mask to None
+    ...         if 'handle_mask' not in kwargs:
+    ...             kwargs['handle_mask'] = None
+    ...         # Call the original with the updated kwargs
+    ...         return super(NDDDiffAritDefaults, self)._arithmetic(*args, **kwargs)
+
+    >>> ndd1 = NDDDiffAritDefaults(1, mask=False)
+    >>> ndd2 = NDDDiffAritDefaults(1, mask=True)
+    >>> ndd1.add(ndd2).mask is None  # it will be None
+    True
+
+    >>> # But giving other values is still possible:
+    >>> ndd1.add(ndd2, handle_mask=np.logical_or).mask
+    True
+
+    >>> ndd1.add(ndd2, handle_mask="ff").mask
+    False
+
+The parameter controlling how properties are handled are all keyword-only
+so using the ``*args, **kwargs`` approach allows only to alter one default
+without needing to care about the positional order of arguments. But using
+``def _arithmetic(self, *args, handle_mask=None, **kwargs)`` doesn't work
+for python 2.
+
+
+Arithmetic with an additional property
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This also requires overriding the ``_arithmetic`` method. Suppose we have a
+``flags`` attribute again::
+
+    >>> from copy import deepcopy
+    >>> import numpy as np
+
+    >>> class NDDataWithFlags(NDDataRef):
+    ...     def __init__(self, *args, **kwargs):
+    ...         # Remove flags attribute if given and pass it to the setter.
+    ...         self.flags = kwargs.pop('flags') if 'flags' in kwargs else None
+    ...         super(NDDataWithFlags, self).__init__(*args, **kwargs)
+    ...
+    ...     @property
+    ...     def flags(self):
+    ...         return self._flags
+    ...
+    ...     @flags.setter
+    ...     def flags(self, value):
+    ...         self._flags = value
+    ...
+    ...     def _arithmetic(self, operation, operand, *args, **kwargs):
+    ...         # take all args and kwargs to allow arithmetic on the other properties
+    ...         # to work like before.
+    ...
+    ...         # do the arithmetics on the flags (pop the relevant kwargs, if any!!!)
+    ...         if self.flags is not None and operand.flags is not None:
+    ...             result_flags = np.logical_or(self.flags, operand.flags)
+    ...             # np.logical_or is just a suggestion you can do what you want
+    ...         else:
+    ...             if self.flags is not None:
+    ...                 result_flags = deepcopy(self.flags)
+    ...             else:
+    ...                 result_flags = deepcopy(operand.flags)
+    ...
+    ...         # Let the superclass do all the other attributes note that
+    ...         # this returns the result and a dictionary containing other attributes
+    ...         result, kwargs = super(NDDataWithFlags, self)._arithmetic(operation, operand, *args, **kwargs)
+    ...         # The arguments for creating a new instance are saved in kwargs
+    ...         # so we need to add another keyword "flags" and add the processed flags
+    ...         kwargs['flags'] = result_flags
+    ...         return result, kwargs # these must be returned
+
+    >>> ndd1 = NDDataWithFlags([1,2,3], flags=np.array([1,0,1], dtype=bool))
+    >>> ndd2 = NDDataWithFlags([1,2,3], flags=np.array([0,0,1], dtype=bool))
+    >>> ndd3 = ndd1.add(ndd2)
+    >>> ndd3.flags
+    array([ True, False,  True], dtype=bool)
+
+Another arithmetic operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adding another possible operations is quite easy provided the ``data`` and
+``unit`` allow it within the framework of `~astropy.units.Quantity`.
+
+For example adding a power function::
+
+    >>> from astropy.nddata import NDDataRef
+    >>> import numpy as np
+    >>> from astropy.utils import sharedmethod
+
+    >>> class NDDataPower(NDDataRef):
+    ...     @sharedmethod # sharedmethod to allow it also as classmethod
+    ...     def pow(self, operand, operand2=None, **kwargs):
+    ...         # the uncertainty doesn't allow propagation so set it to None
+    ...         kwargs['propagate_uncertainties'] = None
+    ...         # Call the _prepare_then_do_arithmetic function with the
+    ...         # numpy.power ufunc.
+    ...         return self._prepare_then_do_arithmetic(np.power, operand,
+    ...                                                 operand2, **kwargs)
+
+This can be used like the other arithmetic methods like
+:meth:`~astropy.nddata.NDArithmeticMixin.add`. So it works when calling it
+on the class or the instance::
+
+    >>> ndd = NDDataPower([1,2,3])
+
+    >>> # using it on the instance with one operand
+    >>> ndd.pow(3)
+    NDDataPower([ 1,  8, 27])
+
+    >>> # using it on the instance with two operands
+    >>> ndd.pow([1,2,3], [3,4,5])
+    NDDataPower([  1,  16, 243])
+
+    >>> # or using it as classmethod
+    >>> NDDataPower.pow(6, [1,2,3])
+    NDDataPower([  6,  36, 216])
+
+To allow propagation also with ``uncertainty`` see subclassing
+`~astropy.nddata.NDUncertainty`.
+
+The ``_prepare_then_do_arithmetic`` implements the relevant checks if it was
+called on the class or the instance and if one or two operands were given and
+converts the operands, if necessary, to the appropriate classes. Overriding
+this ``_prepare_then_do_arithmetic`` in subclasses should be avoided if
+possible.
 
 `~astropy.nddata.NDDataBase`
 ----------------------------
 
 The class `~astropy.nddata.NDDataBase` is a metaclass -- when subclassing it,
-all properties of `~astropy.nddata.NDDataBase` *must*
-be overriden in the subclass. For an example of how to do this, see the source
-code for `astropy.nddata.NDData`.
+all properties of `~astropy.nddata.NDDataBase` *must* be overriden in the
+subclass.
 
 Subclassing from `~astropy.nddata.NDDataBase` gives you complete flexibility
 in how you implement data storage and the other properties. If your data is
@@ -22,79 +322,167 @@ stored in a numpy array (or something that behaves like a numpy array), it may
 be more straightforward to subclass `~astropy.nddata.NDData` instead of
 `~astropy.nddata.NDDataBase`.
 
-`~astropy.nddata.NDData`
-------------------------
+Implementing the NDDataBase interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This class serves as the base for subclasses that use a numpy array (or
-something that presents a numpy-like interface) as the ``data`` attribute.
+For example to create a readonly container::
 
-For an example of a class that includes mixins and subclasses
-`~astropy.nddata.NDData` to add additional functionality, see
-`~astropy.nddata.NDDataArray`.
+    >>> from astropy.nddata import NDDataBase
+
+    >>> class NDDataReadOnlyNoRestrictions(NDDataBase):
+    ...     def __init__(self, data, unit, mask, uncertainty, meta, wcs):
+    ...         self._data = data
+    ...         self._unit = unit
+    ...         self._mask = mask
+    ...         self._uncertainty = uncertainty
+    ...         self._meta = meta
+    ...         self._wcs = wcs
+    ...
+    ...     @property
+    ...     def data(self):
+    ...         return self._data
+    ...
+    ...     @property
+    ...     def unit(self):
+    ...         return self._unit
+    ...
+    ...     @property
+    ...     def mask(self):
+    ...         return self._mask
+    ...
+    ...     @property
+    ...     def uncertainty(self):
+    ...         return self._uncertainty
+    ...
+    ...     @property
+    ...     def meta(self):
+    ...         return self._meta
+    ...
+    ...     @property
+    ...     def wcs(self):
+    ...         return self._wcs
+
+    >>> # A meaningless test to show that creating this class is possible:
+    >>> NDDataReadOnlyNoRestrictions(1,2,3,4,5,6) is not None
+    True
+
+.. note::
+  Actually defining an ``__init__`` is not necessary and the properties could
+  return arbitary values but the properties **must** be defined.
 
 Subclassing `~astropy.nddata.NDUncertainty`
 -------------------------------------------
+.. warning::
+    The internal interface of NDUncertainty and subclasses is experimental and
+    might change in future versions.
 
-This is done by using classes to represent the uncertainties of a given type.
-For example, to set standard deviation uncertainties on the pixel values, you
-can do::
+Subclasses deriving from `~astropy.nddata.NDUncertainty` need to implement:
 
+- property ``uncertainty_type``, should return a string describing the
+  uncertainty for example ``"ivar"`` for inverse variance.
+- methods for propagation: `_propagate_*` where ``*`` is the name of the UFUNC
+  that is used on the ``NDData`` parent.
+
+Creating an uncertainty without propagation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`~astropy.nddata.UnknownUncertainty` is a minimal working implementation
+without error propagation. So let's create an uncertainty just storing
+systematic uncertainties::
+
+    >>> from astropy.nddata import NDUncertainty
+
+    >>> class SystematicUncertainty(NDUncertainty):
+    ...     @property
+    ...     def uncertainty_type(self):
+    ...         return 'systematic'
+    ...
+    ...     def _propagate_add(self, other_uncert, *args, **kwargs):
+    ...         return None
+    ...
+    ...     def _propagate_subtract(self, other_uncert, *args, **kwargs):
+    ...         return None
+    ...
+    ...     def _propagate_multiply(self, other_uncert, *args, **kwargs):
+    ...         return None
+    ...
+    ...     def _propagate_divide(self, other_uncert, *args, **kwargs):
+    ...         return None
+
+    >>> SystematicUncertainty([10])
+    SystematicUncertainty([10])
+
+Subclassing `~astropy.nddata.StdDevUncertainty`
+-----------------------------------------------
+
+Creating an variance uncertainty
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`~astropy.nddata.StdDevUncertainty` already implements propagation based
+on gaussian standard deviation so this could be the starting point of an
+uncertainty using these propagations:
+
+    >>> from astropy.nddata import StdDevUncertainty
     >>> import numpy as np
-    >>> from astropy.nddata import NDData, StdDevUncertainty
-    >>> array = np.zeros((12, 12, 12))  # a 3-dimensional array with all zeros
-    >>> ndd = NDData(array)
-    >>> uncertainty = StdDevUncertainty(np.ones((12, 12, 12)) * 0.1)
-    >>> ndd_uncertainty = NDData(ndd, uncertainty=uncertainty)
+    >>> import weakref
 
-New error classes should sub-class from `~astropy.nddata.NDUncertainty`, and
-should provide methods with the following API::
+    >>> class VarianceUncertainty(StdDevUncertainty):
+    ...     @property
+    ...     def uncertainty_type(self):
+    ...         return 'variance'
+    ...
+    ...     def _propagate_add(self, other_uncert, *args, **kwargs):
+    ...         # Neglect the unit assume that both are Variance uncertainties
+    ...         this = StdDevUncertainty(np.sqrt(self.array))
+    ...         other = StdDevUncertainty(np.sqrt(other_uncert.array))
+    ...
+    ...         # We need to set the parent_nddata attribute otherwise it will
+    ...         # fail for multiplication and division where the data
+    ...         # not only the uncertainty matters.
+    ...         this.parent_nddata = weakref.ref(self.parent_nddata)
+    ...         other.parent_nddata = weakref.ref(other_uncert.parent_nddata)
+    ...
+    ...         # Call propagation:
+    ...         result = this._propagate_add(other, *args, **kwargs)
+    ...
+    ...         # Return the square of it
+    ...         return np.square(result)
 
-   class MyUncertainty(NDUncertainty):
+    >>> from astropy.nddata import NDDataRef
 
-       def propagate_add(self, other_nddata, result_data):
-           ...
-           result_uncertainty = MyUncertainty(...)
-           return result_uncertainty
+    >>> ndd1 = NDDataRef([1,2,3], unit='m', uncertainty=VarianceUncertainty([1,4,9]))
+    >>> ndd2 = NDDataRef([1,2,3], unit='m', uncertainty=VarianceUncertainty([1,4,9]))
+    >>> ndd = ndd1.add(ndd2)
+    >>> ndd.uncertainty
+    VarianceUncertainty([  2.,   8.,  18.])
 
-       def propagate_subtract(self, other_nddata, result_data):
-           ...
-           result_uncertainty = MyUncertainty(...)
-           return result_uncertainty
+this approach certainly works if both are variance uncertainties, but if you
+want to allow that the second operand also can be a standard deviation one can
+override the ``_convert_uncertainty`` method as well::
 
-       def propagate_multiply(self, other_nddata, result_data):
-           ...
-           result_uncertainty = MyUncertainty(...)
-           return result_uncertainty
+    >>> class VarianceUncertainty2(VarianceUncertainty):
+    ...     def _convert_uncertainty(self, other_uncert):
+    ...         if isinstance(other_uncert, VarianceUncertainty):
+    ...             return other_uncert
+    ...         elif isinstance(other_uncert, StdDevUncertainty):
+    ...             converted = VarianceUncertainty(np.square(other_uncert.array))
+    ...             converted.parent_nddata = weakref.ref(other_uncert.parent_nddata)
+    ...             return converted
+    ...         raise ValueError('not compatible uncertainties.')
 
-       def propagate_divide(self, other_nddata, result_data):
-           ...
-           result_uncertainty = MyUncertainty(...)
-           return result_uncertainty
+    >>> ndd1 = NDDataRef([1,2,3], uncertainty=VarianceUncertainty2([1,4,9]))
+    >>> ndd2 = NDDataRef([1,2,3], uncertainty=StdDevUncertainty([1,2,3]))
+    >>> ndd = ndd1.add(ndd2)
+    >>> ndd.uncertainty
+    VarianceUncertainty2([  2.,   8.,  18.])
 
-All error sub-classes inherit an attribute ``self.parent_nddata`` that is
-automatically set to the parent `~astropy.nddata.NDData` object that they
-are attached to. The arguments passed to the error propagation methods are
-``other_nddata``, which is the `~astropy.nddata.NDData` object that is being
-combined with ``self.parent_nddata``, and ``result_data``, which is a Numpy
-array that contains the data array after the arithmetic operation. All these
-methods should return an error instance ``result_uncertainty``, and should not
-modify ``parent_nddata`` directly. For subtraction and division, the order of
-the operations is ``parent_nddata - other_nddata`` and ``parent_nddata /
-other_nddata``.
+.. warning::
+    This will only allow the **second** operand to have a
+    `~astropy.nddata.StdDevUncertainty` uncertainty. It will fail if the first
+    operand is standard deviation and the second operand a variance.
 
-To make it easier and clearer to code up the error propagation, you can use
-variables with more explicit names, e.g::
-
-   class MyUncertainty(NDUncertainty):
-
-       def propogate_add(self, other_nddata, result_data):
-
-           left_uncertainty = self.parent.uncertainty.array
-           right_uncertainty = other_nddata.uncertainty.array
-
-           ...
-
-Note that the above example assumes that the errors are stored in an ``array``
-attribute, but this does not have to be the case.
-
-For an example of a complete implementation, see `~astropy.nddata.StdDevUncertainty`.
+.. note::
+    Creating a variance uncertainty like this might require more work to
+    include proper treatement of the unit of the uncertainty! And of course
+    implementing also the ``_propagate_*`` for subtraction, division and
+    multiplication.


### PR DESCRIPTION
This is #4863 but only contains the relevant documentation changes. (I made it a seperate PR so it's easier to review and if some other PR will be merged I do have the documentation around).

I'm probably not too good writing explanations so I'd appreciate help proofreading this.

I'll include links to the rendered output as soon as I have the build ready:

- [nddata.index.rst](http://astropy-mseifer.readthedocs.io/en/nddata_narrative_docs/nddata/index.html)
- [nddata.nddata.rst](http://astropy-mseifer.readthedocs.io/en/nddata_narrative_docs/nddata/nddata.html)
- [nddata.mixins.index.rst and all pages linked there](http://astropy-mseifer.readthedocs.io/en/nddata_narrative_docs/nddata/mixins/index.html)
- [nddata.subclassing.rst](http://astropy-mseifer.readthedocs.io/en/nddata_narrative_docs/nddata/subclassing.html)

Edit: closes #4538 