### PR TITLE
minor change during NDData init: call the existing mask setter

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -220,7 +220,7 @@ class NDData(NDDataBase):
 
         # Store the attributes
         self._data = data
-        self._mask = mask
+        self.mask = mask
         self._wcs = wcs
         self.meta = meta
         self._unit = unit


### PR DESCRIPTION
This PR contains a (more or less) trivial and hopefully not controversial subset of #4827.

The `NDData.__init__` will now call the `mask.setter` instead of directly saving it as `_mask`.