### PR TITLE
Refactor sky rotation classes to use the EulerAngleRotation class.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -207,6 +207,9 @@ API changes
   - Inputs (``coords`` and ``out``) to ``render`` function in ``Model`` are
     converted to float. [#4697]
 
+  - ``RotateNative2Celestial`` and ``RotateCelestial2Native`` are now
+    implemented as subclasses of ``EulerAngleRotation``. [#4881]
+
 - ``astropy.nddata``
 
   - ``NDData``: added an optional parameter ``copy``

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -55,7 +55,7 @@ class EulerAngleRotation(Model):
     theta = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
     psi = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
 
-    def __init__(self, phi, theta, psi, axes_order):
+    def __init__(self, phi, theta, psi, axes_order, **kwargs):
         self.axes = ['x', 'y', 'z']
         if len(axes_order) != 3:
             raise TypeError(
@@ -66,7 +66,7 @@ class EulerAngleRotation(Model):
             raise ValueError("Unrecognized axis label {0}; "
                              "should be one of {1} ".format(unrecognized, self.axes))
         self.axes_order = axes_order
-        super(EulerAngleRotation, self).__init__(phi=phi, theta=theta, psi=psi)
+        super(EulerAngleRotation, self).__init__(phi=phi, theta=theta, psi=psi, **kwargs)
 
     def _create_matrix(self, phi, theta, psi, axes_order):
         matrices = []
@@ -112,6 +112,13 @@ class EulerAngleRotation(Model):
         z = np.sin(delta)
         return np.array([x, y, z])
 
+    @staticmethod
+    def cartesian2spherical(x, y, z):
+        h = np.hypot(x, y)
+        alpha  = np.rad2deg(np.arctan2(y, x))
+        delta = np.rad2deg(np.arctan2(z, h))
+        return alpha, delta
+
     def inverse(self):
         return self.__class__(phi=-self.psi,
                               theta=-self.theta,
@@ -122,51 +129,49 @@ class EulerAngleRotation(Model):
         inp = self.spherical2cartesian(alpha, delta)
         matrix = self._create_matrix(phi, theta, psi, self.axes_order)
         result = np.dot(matrix, inp)
-        return (np.rad2deg(np.arctan2(result[1], result[0])),
-                np.rad2deg(np.arcsin(result[2])))
+        return self.cartesian2spherical(*result)
 
 
-class _SkyRotation(Model):
+class _SkyRotation(EulerAngleRotation):
     """
-    Base class for FITS WCS sky rotations.
-
-    Parameters
-    ----------
-    lon : float
-        Celestial longitude of the fiducial point.
-    lat : float
-        Celestial latitude of the fiducial point.
-    lon_pole : float
-        Longitude of the celestial pole in the native system.
+    Base class for RotateNative2Celestial and RotateCelestial2Native.
     """
 
-    lon = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
-    lat = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
-    lon_pole = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
+    def __init__(self, phi, theta, psi, **kwargs):
+        super(_SkyRotation, self).__init__(phi, theta, psi, 'zxz', **kwargs)
 
-    @staticmethod
-    def _rotate_zxz(phi_i, theta_i, lon, lat, lon_pole):
-        """
-        Defines a ZXZ rotation from initial coordinates phi_i, theta_i.
+    @property
+    def lon(self):
+        return self.phi
 
-        All inputs and outputs are in radians.
-        """
+    @lon.setter
+    def lon(self, val):
+        self.phi = val
 
-        cos_theta_i = np.cos(theta_i)
-        sin_theta_i = np.sin(theta_i)
-        cos_lat = np.cos(lat)
-        sin_lat = np.sin(lat)
-        delta = phi_i - lon_pole
-        cos_delta = np.cos(delta)
+    @property
+    def lat(self):
+        return self.theta
 
-        phi_f = lon + np.arctan2(-cos_theta_i * np.sin(delta),
-                                 sin_theta_i * cos_lat -
-                                 cos_theta_i * sin_lat * cos_delta)
+    @lat.setter
+    def lat(self, val):
+        self.theta = val
 
-        theta_f = np.arcsin(sin_theta_i * sin_lat +
-                            cos_theta_i * cos_lat * cos_delta)
+    @property
+    def lon_pole(self):
+        return self.psi
 
-        return phi_f, theta_f
+    @lon_pole.setter
+    def lon_pole(self, val):
+        self.psi = val
+
+    def evaluate(self, phi, theta, lon, lat, lon_pole):
+        alpha, delta = super(_SkyRotation, self).evaluate(phi, theta, lon, lat, lon_pole)
+        mask = alpha < 0
+        if isinstance(mask, np.ndarray):
+            alpha[mask] +=360
+        else:
+            alpha +=360
+        return alpha, delta
 
 
 class RotateNative2Celestial(_SkyRotation):
@@ -183,39 +188,27 @@ class RotateNative2Celestial(_SkyRotation):
         Longitude of the celestial pole in the native system.
     """
 
-    inputs = ('phi_N', 'theta_N')
-    outputs = ('alpha_C', 'delta_C')
+    # angles in degrees on the native sphere
+    inputs = ('phi', 'theta')
+    outputs = ('alpha', 'delta')
+
+    def __init__(self, lon, lat, lon_pole, **kwargs):
+        phi = lon_pole - 90
+        theta = - (90 - lat)
+        psi = -(90 + lon)
+        super(RotateNative2Celestial, self).__init__(phi, theta, psi, **kwargs)
 
     @property
     def inverse(self):
-        return RotateCelestial2Native(self.lon, self.lat, self.lon_pole)
-
-    @classmethod
-    def evaluate(cls, phi_N, theta_N, lon, lat, lon_pole):
-        """
-        Rotate native spherical coordinates into celestial coordinates.
-        """
-
-        phi_N = np.deg2rad(phi_N)
-        theta_N = np.deg2rad(theta_N)
-
-        alpha_C, delta_C = cls._rotate_zxz(phi_N, theta_N, lon, lat, lon_pole)
-
-        alpha_C = np.rad2deg(alpha_C)
-        delta_C = np.rad2deg(delta_C)
-
-        mask = alpha_C < 0
-        if isinstance(mask, np.ndarray):
-            alpha_C[mask] += 360
-        elif mask:
-            alpha_C += 360
-
-        return alpha_C, delta_C
+        lon = -(self.psi + 90)
+        lat = self.theta + 90
+        lon_pole = self.phi + 90
+        return RotateCelestial2Native(lon, lat, lon_pole)
 
 
 class RotateCelestial2Native(_SkyRotation):
     """
-    Transform from Celestial to Native to Spherical Coordinates.
+    Transform from Native to Celestial Spherical Coordinates.
 
     Parameters
     ----------
@@ -227,36 +220,24 @@ class RotateCelestial2Native(_SkyRotation):
         Longitude of the celestial pole in the native system.
     """
 
-    inputs = ('alpha_C', 'delta_C')
-    outputs = ('phi_N', 'theta_N')
+    # angles in degrees on the celestial sphere
+    inputs = ('alpha', 'delta')
+    # angles in degrees on the native sphere
+    outputs = ('phi', 'theta')
+
+
+    def __init__(self, lon, lat, lon_pole, **kwargs):
+        phi = (90 + lon)
+        theta =  (90 - lat)
+        psi = -(lon_pole - 90)
+        super(RotateCelestial2Native, self).__init__(phi, theta, psi, **kwargs)
 
     @property
     def inverse(self):
-        return RotateNative2Celestial(self.lon, self.lat, self.lon_pole)
-
-    @classmethod
-    def evaluate(cls, alpha_C, delta_C, lon, lat, lon_pole):
-        """
-        Rotate celestial coordinates into native spherical coordinates.
-
-        This is the inverse transformation of RotateNative2Celestial.
-        """
-
-        alpha_C = np.deg2rad(alpha_C)
-        delta_C = np.deg2rad(delta_C)
-
-        phi_N, theta_N = cls._rotate_zxz(alpha_C, delta_C, lon_pole, lat, lon)
-
-        phi_N = np.rad2deg(phi_N)
-        theta_N = np.rad2deg(theta_N)
-
-        mask = phi_N > 180
-        if isinstance(mask, np.ndarray):
-            phi_N[mask] -= 360
-        elif mask:
-            phi_N -= 360
-
-        return phi_N, theta_N
+        lon = -(self.psi + 90)
+        lat = self.theta + 90
+        lon_pole = self.phi + 90
+        return RotateCelestial2Native(lon, lat, lon_pole)
 
 
 class Rotation2D(Model):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -197,7 +197,7 @@ class RotateNative2Celestial(_SkyRotation):
 
     @property
     def lat(self):
-         return self.theta + 90
+        return self.theta + 90
 
     @lat.setter
     def lat(self, val):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -129,10 +129,19 @@ class EulerAngleRotation(Model):
                               axes_order=self.axes_order[::-1])
 
     def evaluate(self, alpha, delta, phi, theta, psi):
+        shape = None
+        if isinstance(alpha, np.ndarray) and alpha.ndim == 2:
+            alpha = alpha.flatten()
+            delta = delta.flatten()
+            shape = alpha.shape
         inp = self.spherical2cartesian(alpha, delta)
         matrix = self._create_matrix(phi, theta, psi, self.axes_order)
         result = np.dot(matrix, inp)
-        return self.cartesian2spherical(*result)
+        a, b = self.cartesian2spherical(*result)
+        if shape is not None:
+            a.shape = shape
+            b.shape = shape
+        return a, b
 
 
 class _SkyRotation(EulerAngleRotation):
@@ -180,18 +189,15 @@ class RotateNative2Celestial(_SkyRotation):
 
     @property
     def lon(self):
-        #return self.phi
         return - (self.psi + 90)
 
     @lon.setter
     def lon(self, val):
-        #self.phi = val
         self.psi = - (val + 90)
 
     @property
     def lat(self):
-        #return self.theta
-        return self.theta + 90
+         return self.theta + 90
 
     @lat.setter
     def lat(self, val):
@@ -216,7 +222,7 @@ class RotateNative2Celestial(_SkyRotation):
 
 class RotateCelestial2Native(_SkyRotation):
     """
-    Transform from Native to Celestial Spherical Coordinates.
+    Transform from Celestial to Native Spherical Coordinates.
 
     Parameters
     ----------

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -84,15 +84,6 @@ def test_inputless_model():
     assert np.all(m() == [[1, 2, 3], [4, 5, 6]])
 
 
-def test_Model_add_model():
-    m = models.Gaussian1D(1,2,3)
-    m.add_model(m, 'p')
-    m.add_model(m, 's')
-    with pytest.raises(InputParameterError):
-        m.add_model(m, 'q')
-        m.add_model(m, 42)
-
-
 def test_ParametericModel():
     with pytest.raises(TypeError):
         models.Gaussian1D(1, 2, 3, wrong=4)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -45,12 +45,8 @@ def test_Model_instance_repr_and_str():
 
 
 def test_Model_array_parameter():
-    m = NonFittableModel([[42, 43], [1,2]])
-    m = NonFittableModel([42, 43, 44, 45])
-
-    phi, theta, psi = 42, 43, 44
-    model = models.RotateNative2Celestial(phi, theta, psi)
-    assert_allclose(model.param_sets, [[42], [43], [44]])
+    model = models.Gaussian1D(4, 2, 1)
+    assert_allclose(model.param_sets, [[4], [2], [1]])
 
 
 def test_inputless_model():
@@ -86,6 +82,15 @@ def test_inputless_model():
     m = TestModel(a=[[1, 2, 3], [4, 5, 6]], model_set_axis=0)
     assert len(m) == 2
     assert np.all(m() == [[1, 2, 3], [4, 5, 6]])
+
+
+def test_Model_add_model():
+    m = models.Gaussian1D(1,2,3)
+    m.add_model(m, 'p')
+    m.add_model(m, 's')
+    with pytest.raises(InputParameterError):
+        m.add_model(m, 'q')
+        m.add_model(m, 42)
 
 
 def test_ParametericModel():

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -40,8 +40,8 @@ def test_against_wcslib(inp):
     radec = w.wcs_pix2world(inp[0], inp[1], 1)
     xy = w.wcs_world2pix(radec[0], radec[1], 1)
 
-    utils.assert_allclose(m(*inp), radec, atol=1e-13)
-    utils.assert_allclose(minv(*radec), xy, atol=1e-13)
+    utils.assert_allclose(m(*inp), radec, atol=1e-12)
+    utils.assert_allclose(minv(*radec), xy, atol=1e-12)
 
 
 @pytest.mark.parametrize(('inp'), [(0, 0), (40, -20.56), (21.5, 45.9)])

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -14,16 +14,7 @@ from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
 
 
-#class TestAgainstFits(object):
-    #def setup_class(self):
-        #hdr = fits.Header.fromfile(get_pkg_data_filename("data/sip.hdr"))
-        #self.w = wcs.WCS(hdr)
-
-        #self.w.wcs.crpix = [0, 0]
-        #self.w.wcs.pc = [[1, 0], [0, 1]]
-
-
-@pytest.mark.parametrize(('inp'), [(0, 0), (4000, -20.56), (-2001.5, 45.9), (0, 90), (0, -90)])
+@pytest.mark.parametrize(('inp'), [(0, 0), (4000, -20.56), (-2001.5, 45.9), (0, 90), (0, -90), (np.mgrid[:4, :6])])
 def test_against_wcslib(inp):
     w = wcs.WCS()
     crval = [ 202.4823228 , 47.17511893]


### PR DESCRIPTION
The sky rotation classes were implemented to as subclasses of `EulerAngleRotation`. This allows to avoid dealing with special cases and increases precision.
In response to spacetelescope/gwcs#50.

Not sure who's best to review or whom to assign it.
@philhodge @mcara @eteq 


