### PR TITLE
Coordinates allow initialisation without copies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,6 +192,9 @@ API changes
 
   - Removed compatibility layer for pre-v0.4 API. [#4447]
 
+  - Added ``copy`` keyword-only argument to allow initialisation without
+    copying the (possibly large) input coordinate arrays. [#4883]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -448,6 +448,7 @@ class BaseCoordinateFrame(object):
     # Default empty frame_attributes dict
 
     def __init__(self, *args, **kwargs):
+        copy = kwargs.pop('copy', True)
         self._attr_names_with_defaults = []
 
         if 'representation' in kwargs:
@@ -470,8 +471,6 @@ class BaseCoordinateFrame(object):
 
             # Validate input by getting the attribute here.
             getattr(self, fnm)
-
-        pref_rep = self.representation
 
         args = list(args)  # need to be able to pop them
         if (len(args) > 0) and (isinstance(args[0], BaseRepresentation) or
@@ -499,9 +498,10 @@ class BaseCoordinateFrame(object):
                     del repr_kwargs['distance']
                 if (issubclass(self.representation, SphericalRepresentation) and
                         'distance' not in repr_kwargs):
-                    representation_data = self.representation._unit_representation(**repr_kwargs)
+                    representation = self.representation._unit_representation
                 else:
-                    representation_data = self.representation(**repr_kwargs)
+                    representation = self.representation
+                representation_data = representation(copy=copy, **repr_kwargs)
 
         if len(args) > 0:
             raise TypeError(
@@ -729,7 +729,7 @@ class BaseCoordinateFrame(object):
                 for comp, new_attr_unit in zip(data.components, new_attrs['units']):
                     if new_attr_unit:
                         datakwargs[comp] = datakwargs[comp].to(new_attr_unit)
-                data = data.__class__(**datakwargs)
+                data = data.__class__(copy=False, **datakwargs)
 
             self._rep_cache[new_representation.__name__, in_frame_units] = data
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -436,6 +436,17 @@ class BaseCoordinateFrame(object):
         `~astropy.coordinates.RepresentationMapping` objects that tell what
         names and default units should be used on this frame for the components
         of that representation.
+
+    Parameters
+    ----------
+    representation : `BaseRepresentation` or None
+        A representation object or `None` to have no data (or use the other
+        arguments)
+    *args, **kwargs
+        Coordinates, with names that depend on the subclass.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     default_representation = None

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -60,6 +60,9 @@ class AltAz(BaseCoordinateFrame):
         ``representation`` must be None).
     distance : :class:`~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
 
     Notes
     -----

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -30,6 +30,9 @@ class CIRS(BaseCoordinateFrame):
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -48,6 +48,9 @@ class GeocentricTrueEcliptic(BaseCoordinateFrame):
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the geocenter.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
     default_representation = SphericalRepresentation
 
@@ -87,6 +90,9 @@ class BarycentricTrueEcliptic(BaseCoordinateFrame):
     r : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the sun's center.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
     default_representation = SphericalRepresentation
 
@@ -126,6 +132,9 @@ class HeliocentricTrueEcliptic(BaseCoordinateFrame):
     r : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object from the sun's center.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
     default_representation = SphericalRepresentation
 

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -41,6 +41,9 @@ class FK4(BaseCoordinateFrame):
     obstime : astropy.time.Time, optional, must be keyword
         The time this frame was observed.  If None, will be the same as
         ``equinox``.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
     frame_specific_representation_info = {
         'spherical': [RepresentationMapping('lon', 'ra'),
@@ -84,6 +87,9 @@ class FK4NoETerms(BaseCoordinateFrame):
     obstime : astropy.time.Time, optional, must be keyword
         The time this frame was observed.  If None, will be the same as
         ``equinox``.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
     frame_specific_representation_info = {
         'spherical': [RepresentationMapping('lon', 'ra'),

--- a/astropy/coordinates/builtin_frames/fk5.py
+++ b/astropy/coordinates/builtin_frames/fk5.py
@@ -34,6 +34,9 @@ class FK5(BaseCoordinateFrame):
         (``representation`` must be None).
     equinox : `~astropy.time.Time`, optional, must be keyword
         The equinox of this frame.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
     frame_specific_representation_info = {
         'spherical': [RepresentationMapping('lon', 'ra'),

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -29,6 +29,9 @@ class Galactic(BaseCoordinateFrame):
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -74,6 +74,9 @@ class Galactocentric(BaseCoordinateFrame):
         the final x-z plane will align with the Galactic coordinates x-z
         plane. Unless you really know what this means, you probably should
         not change this!
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
 
     Examples
     --------

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -53,6 +53,9 @@ class GCRS(BaseCoordinateFrame):
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {
@@ -109,6 +112,9 @@ class PrecessedGeocentric(BaseCoordinateFrame):
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -45,6 +45,9 @@ class HCRS(BaseCoordinateFrame):
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
         (``representation`` must be `None`).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -33,6 +33,9 @@ class ICRS(BaseCoordinateFrame):
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
         (``representation`` must be None).
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -27,6 +27,9 @@ class Supergalactic(BaseCoordinateFrame):
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -409,7 +409,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         y = u.one * np.cos(self.lat) * np.sin(self.lon)
         z = u.one * np.sin(self.lat)
 
-        return CartesianRepresentation(x=x, y=y, z=z)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -423,16 +423,19 @@ class UnitSphericalRepresentation(BaseRepresentation):
         lon = np.arctan2(cart.y, cart.x)
         lat = np.arctan2(cart.z, s)
 
-        return cls(lon=lon, lat=lat)
+        return cls(lon=lon, lat=lat, copy=False)
 
     def represent_as(self, other_class):
         # Take a short cut if the other class is a spherical representation
         if issubclass(other_class, PhysicsSphericalRepresentation):
-            return other_class(phi=self.lon, theta=90 * u.deg - self.lat, r=1.0)
+            return other_class(phi=self.lon, theta=90 * u.deg - self.lat, r=1.0,
+                               copy=False)
         elif issubclass(other_class, SphericalRepresentation):
-            return other_class(lon=self.lon, lat=self.lat, distance=1.0)
+            return other_class(lon=self.lon, lat=self.lat, distance=1.0,
+                               copy=False)
         else:
-            return super(UnitSphericalRepresentation, self).represent_as(other_class)
+            return super(UnitSphericalRepresentation,
+                         self).represent_as(other_class)
 
 
 class SphericalRepresentation(BaseRepresentation):
@@ -515,11 +518,12 @@ class SphericalRepresentation(BaseRepresentation):
         # Take a short cut if the other class is a spherical representation
         if issubclass(other_class, PhysicsSphericalRepresentation):
             return other_class(phi=self.lon, theta=90 * u.deg - self.lat,
-                               r=self.distance)
+                               r=self.distance, copy=False)
         elif issubclass(other_class, UnitSphericalRepresentation):
-            return other_class(lon=self.lon, lat=self.lat)
+            return other_class(lon=self.lon, lat=self.lat, copy=False)
         else:
-            return super(SphericalRepresentation, self).represent_as(other_class)
+            return super(SphericalRepresentation,
+                         self).represent_as(other_class)
 
     def to_cartesian(self):
         """
@@ -537,7 +541,7 @@ class SphericalRepresentation(BaseRepresentation):
         y = d * np.cos(self.lat) * np.sin(self.lon)
         z = d * np.sin(self.lat)
 
-        return CartesianRepresentation(x=x, y=y, z=z)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -552,7 +556,7 @@ class SphericalRepresentation(BaseRepresentation):
         lon = np.arctan2(cart.y, cart.x)
         lat = np.arctan2(cart.z, s)
 
-        return cls(lon=lon, lat=lat, distance=r)
+        return cls(lon=lon, lat=lat, distance=r, copy=False)
 
 
 class PhysicsSphericalRepresentation(BaseRepresentation):
@@ -666,7 +670,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         y = d * np.sin(self.theta) * np.sin(self.phi)
         z = d * np.cos(self.theta)
 
-        return CartesianRepresentation(x=x, y=y, z=z)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -681,7 +685,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         phi = np.arctan2(cart.y, cart.x)
         theta = np.arctan2(s, cart.z)
 
-        return cls(phi=phi, theta=theta, r=r)
+        return cls(phi=phi, theta=theta, r=r, copy=False)
 
 
 class CylindricalRepresentation(BaseRepresentation):
@@ -763,7 +767,7 @@ class CylindricalRepresentation(BaseRepresentation):
         phi = np.arctan2(cart.y, cart.x)
         z = cart.z
 
-        return cls(rho=rho, phi=phi, z=z)
+        return cls(rho=rho, phi=phi, z=z, copy=False)
 
     def to_cartesian(self):
         """
@@ -774,4 +778,4 @@ class CylindricalRepresentation(BaseRepresentation):
         y = self.rho * np.sin(self.phi)
         z = self.z
 
-        return CartesianRepresentation(x=x, y=y, z=z)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=False)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -159,8 +159,9 @@ class SkyCoord(object):
         Specifies the representation, e.g. 'spherical', 'cartesian', or
         'cylindrical'.  This affects the positional args and other keyword args
         which must correspond to the given representation.
-    copy: bool
-        If `True` (default), guarantees that a copy of any input is made.
+    copy: bool, optional
+        If `True` (default), a copy of any coordinate data is made.  This
+        argument can only be passed in as a keyword argument.
     **keyword_args
         Other keyword arguments as applicable for user-defined coordinate frames.
         Common options include:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -159,6 +159,8 @@ class SkyCoord(object):
         Specifies the representation, e.g. 'spherical', 'cartesian', or
         'cylindrical'.  This affects the positional args and other keyword args
         which must correspond to the given representation.
+    copy: bool
+        If `True` (default), guarantees that a copy of any input is made.
     **keyword_args
         Other keyword arguments as applicable for user-defined coordinate frames.
         Common options include:
@@ -188,6 +190,7 @@ class SkyCoord(object):
         # kwargs dict for initializing attributes for this object and for
         # creating the internal self._sky_coord_frame object
         args = list(args)  # Make it mutable
+        copy = kwargs.pop('copy', True)
         kwargs = self._parse_inputs(args, kwargs)
 
         # Set internal versions of object state attributes
@@ -204,7 +207,7 @@ class SkyCoord(object):
                 coord_kwargs[attr] = value
 
         # Finally make the internal coordinate object.
-        self._sky_coord_frame = frame.__class__(**coord_kwargs)
+        self._sky_coord_frame = frame.__class__(copy=copy, **coord_kwargs)
 
         if not self._sky_coord_frame.has_data:
             raise ValueError('Cannot create a SkyCoord without data')
@@ -1480,7 +1483,8 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
     try:
         for frame_attr_name, repr_attr_class, value, unit in zip(
                 frame_attr_names, repr_attr_classes, values, units):
-            valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
+            valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit,
+                                                            copy=False)
     except Exception as err:
         raise ValueError('Cannot parse first argument data "{0}" for attribute '
                          '{1}'.format(value, frame_attr_name), err)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -912,6 +912,22 @@ def test_unit_spherical_roundtrip():
     assert_allclose_quantity(s1.lat, s4.lat)
 
 
+def test_no_unnecessary_copies():
+
+    s1 = UnitSphericalRepresentation(lon=[10., 30.] * u.deg,
+                                     lat=[5., 6.] * u.arcmin)
+    s2 = s1.represent_as(UnitSphericalRepresentation)
+    assert s2 is s1
+    assert np.may_share_memory(s1.lon, s2.lon)
+    assert np.may_share_memory(s1.lat, s2.lat)
+    s3 = s1.represent_as(SphericalRepresentation)
+    assert np.may_share_memory(s1.lon, s3.lon)
+    assert np.may_share_memory(s1.lat, s3.lat)
+    s4 = s1.represent_as(CartesianRepresentation)
+    s5 = s4.represent_as(CylindricalRepresentation)
+    assert np.may_share_memory(s5.z, s4.z)
+
+
 def test_representation_repr():
     r1 = SphericalRepresentation(lon=1 * u.deg, lat=2.5 * u.deg, distance=1 * u.kpc)
     assert repr(r1) == ('<SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)\n'

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -899,6 +899,16 @@ def test_deepcopy():
     assert c5.representation == c4.representation
 
 
+def test_no_copy():
+    c1 = SkyCoord(np.arange(10.) * u.hourangle, np.arange(20., 30.) * u.deg)
+    c2 = SkyCoord(c1, copy=False)
+    # Note: c1.ra and c2.ra will *not* share memory, as these are recalculated
+    # to be in "preferred" units.  See discussion in #4883.
+    assert np.may_share_memory(c1.data.lon, c2.data.lon)
+    c3 = SkyCoord(c1, copy=True)
+    assert not np.may_share_memory(c1.data.lon, c3.data.lon)
+
+
 def test_immutable():
     c1 = SkyCoord(1 * u.deg, 2 * u.deg)
     with pytest.raises(AttributeError):

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -332,7 +332,8 @@ class TestCutout2D(object):
         wcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
                         [scale*np.sin(rho), scale*np.cos(rho)]]
         wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
-        wcs.wcs.crval = [self.position.ra.value, self.position.dec.value]
+        wcs.wcs.crval = [self.position.ra.to(u.deg).value,
+                         self.position.dec.to(u.deg).value]
         wcs.wcs.crpix = [3, 3]
         self.wcs = wcs
 

--- a/docs/nddata/utils.rst
+++ b/docs/nddata/utils.rst
@@ -245,7 +245,8 @@ your FITS header)::
     >>> wcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
     ...               [scale*np.sin(rho), scale*np.cos(rho)]]
     >>> wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
-    >>> wcs.wcs.crval = [position.ra.value, position.dec.value]
+    >>> wcs.wcs.crval = [position.ra.to(u.deg).value,
+    ...                  position.dec.to(u.deg).value]
     >>> wcs.wcs.crpix = [50, 100]
 
 Now let's create the cutout array using the


### PR DESCRIPTION
While working on my shape-changing PR, I noticed that when I do shape-changes that should not change the underlying data, nevertheless copies are made.  This PR addresses those inessential copies, in `representations` and `baseframe`. I hope the former are not controversial, but the latter do need some thought.

I noticed the effect of the latter in that when I create a `SkyCoord` and get, e.g., its right ascension, I get something that does not match my input units:
```
In [6]: t = SkyCoord(ra=np.arange(10) * u.hourangle, dec=np.arange(10) * u.deg)

In [7]: t.frame.data.lon
Out[7]: <Longitude [ 0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] hourangle>

In [8]: t.ra
Out[8]: <Longitude [   0.,  15.,  30.,  45.,  60.,  75.,  90., 105., 120., 135.] deg>
```
The reason for this is that the frame makes a new copy of the already existing representation and then also changes the units. 

I do *not* think this is a good idea, as it can lead to very surprising increases in memory usage for large arrays (and, more generally, I think that code should just return whatever the user put in, not think it "knows better").

Anyway, comments most welcome. I can also split the two commits if that ensures passage of the first one.

p.s.  Just in case: for representations, we currently just return self if one tries to represent something using the same representation. Hence, I do not think there can be any expectation that data is always copied.