### PR TITLE
Allow init from objects with __astropy_table__ method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,8 @@ New Features
     ``Table._repr_html_``) now use consistent table styles which can be set
     using the ``astropy.table.default_notebook_table_class`` configuration
     item. [#4886]
+  - Added interface to create ``Table`` directly from any "compatible" table
+    that has an ``__astropy_table__`` method.  [#4885]
 
 - ``astropy.tests``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,7 @@ New Features
     using the ``astropy.table.default_notebook_table_class`` configuration
     item. [#4886]
   - Added interface to create ``Table`` directly from any "compatible" table
+  - Added interface to create ``Table`` directly from any table-like object
     that has an ``__astropy_table__`` method.  [#4885]
 
 - ``astropy.tests``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -122,11 +122,12 @@ New Features
   - Allow to use a tuple of keys in ``Table.sort``.  [#4671]
 
   - Added ``itercols``; a way to iterate through columns of a table. [#3805]
+
   - ``Table.show_in_notebook`` and the default notebook display (i.e.,
     ``Table._repr_html_``) now use consistent table styles which can be set
     using the ``astropy.table.default_notebook_table_class`` configuration
     item. [#4886]
-  - Added interface to create ``Table`` directly from any "compatible" table
+
   - Added interface to create ``Table`` directly from any table-like object
     that has an ``__astropy_table__`` method.  [#4885]
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2585,12 +2585,6 @@ class QTable(Table):
         Additional keyword args when converting table-like object
 
     """
-    def __init__(self, data=None, masked=None, names=None, dtype=None,
-                 meta=None, copy=True, rows=None, copy_indices=True,
-                 **kwargs):
-        super(QTable, self).__init__(data, masked, names, dtype, meta,
-                                     copy, rows, copy_indices, **kwargs)
-
     def _add_as_mixin_column(self, col):
         """
         Determine if ``col`` should be added to the table directly as

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -150,7 +150,7 @@ class Table(object):
 
     Parameters
     ----------
-    data : numpy ndarray, dict, list, or Table, optional
+    data : numpy ndarray, dict, list, Table, or table-like object, optional
         Data to initialize table.
     masked : bool, optional
         Specify whether the table is masked.
@@ -166,6 +166,8 @@ class Table(object):
         Row-oriented data for table instead of ``data`` argument
     copy_indices : bool, optional
         Copy any indices in the input data (default=True)
+    **kwargs : dict, optional
+        Additional keyword args when converting table-like object
     """
 
     meta = MetaData()
@@ -238,7 +240,8 @@ class Table(object):
         return data
 
     def __init__(self, data=None, masked=None, names=None, dtype=None,
-                 meta=None, copy=True, rows=None, copy_indices=True):
+                 meta=None, copy=True, rows=None, copy_indices=True,
+                 **kwargs):
 
         # Set up a placeholder empty table
         self._set_masked(masked)
@@ -280,8 +283,11 @@ class Table(object):
             # self.__class__ and respects the `copy` arg.  The returned
             # Table object should NOT then be copied (though the meta
             # will be deep-copied anyway).
-            data = data.__astropy_table__(self.__class__, copy)
+            data = data.__astropy_table__(self.__class__, copy, **kwargs)
             copy = False
+        elif kwargs:
+            raise TypeError('__init__() got unexpected keyword argument {!r}'
+                            .format(list(kwargs.keys())[0]))
 
         if (isinstance(data, np.ndarray) and
                 data.shape == (0,) and
@@ -2559,7 +2565,7 @@ class QTable(Table):
 
     Parameters
     ----------
-    data : numpy ndarray, dict, list, or Table, optional
+    data : numpy ndarray, dict, list, Table, or table-like object, optional
         Data to initialize table.
     masked : bool, optional
         Specify whether the table is masked.
@@ -2573,12 +2579,17 @@ class QTable(Table):
         Copy the input data (default=True).
     rows : numpy ndarray, list of lists, optional
         Row-oriented data for table instead of ``data`` argument
+    copy_indices : bool, optional
+        Copy any indices in the input data (default=True)
+    **kwargs : dict, optional
+        Additional keyword args when converting table-like object
 
     """
     def __init__(self, data=None, masked=None, names=None, dtype=None,
-                 meta=None, copy=True, rows=None, copy_indices=True):
+                 meta=None, copy=True, rows=None, copy_indices=True,
+                 **kwargs):
         super(QTable, self).__init__(data, masked, names, dtype, meta,
-                                     copy, rows, copy_indices)
+                                     copy, rows, copy_indices, **kwargs)
 
     def _add_as_mixin_column(self, col):
         """

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -274,6 +274,15 @@ class Table(object):
 
         default_names = None
 
+        if hasattr(data, '__astropy_table__'):
+            # Data object implements the __astropy_table__ interface method.
+            # Calling that method returns an appropriate instance of
+            # self.__class__ and respects the `copy` arg.  The returned
+            # Table object should NOT then be copied (though the meta
+            # will be deep-copied anyway).
+            data = data.__astropy_table__(self.__class__, copy)
+            copy = False
+
         if (isinstance(data, np.ndarray) and
                 data.shape == (0,) and
                 not data.dtype.names):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1638,14 +1638,14 @@ class Test__Astropy_Table__():
             self.names = ['a', 'b', 'c']
             self.meta = OrderedDict([('a', 1), ('b', 2)])
 
-        def __astropy_table__(self, table_class, copy):
+        def __astropy_table__(self, cls, copy, **kwargs):
             a, b, c = self.columns
             c.info.name = 'c'
             cols = [table.Column(a, name='a'),
                     table.MaskedColumn(b, name='b'),
                     c]
             names = [col.info.name for col in cols]
-            return table_class(cols, names=names, copy=copy, meta=self.meta)
+            return cls(cols, names=names, copy=copy, meta=self.meta)
 
     def test_simple_1(self):
         """Make a SimpleTable and convert to Table, QTable with copy=False, True"""

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -987,7 +987,16 @@ list.
 
 As a simple example, imagine a dict-based table class.  (Note that |Table|
 already can be initialized from a dict-like object, so this is a bit contrived
-but does illustrate the principles involved.)
+but does illustrate the principles involved.)  Please note the method
+signature::
+
+  def __astropy_table__(self, cls, copy, **kwargs):
+
+Your class implementation of this should include the ``**kwargs`` keyword
+args catch.  This is not currently used, but in the future additional
+keywords could be added to the ``table = data.__astropy_table__(cls, copy)``
+call, so including ``**kwargs`` will prevent breakage.
+
 ::
 
   class DictTable(dict):
@@ -997,7 +1006,7 @@ but does illustrate the principles involved.)
       this a table.
       """
 
-      def __astropy_table__(self, cls, copy):
+      def __astropy_table__(self, cls, copy, **kwargs):
           """
           Return an astropy Table of type ``cls``.
 
@@ -1007,6 +1016,8 @@ but does illustrate the principles involved.)
                Astropy ``Table`` class or subclass
           copy : bool
                Copy input data (True) or return a reference (False)
+          **kwargs : dict
+               Additional keyword args, not currently used.
           """
           cols = list(self.values())
           names = list(self.keys())

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -527,10 +527,10 @@ for the ``data`` argument.
     correspond to the order of output columns.  If any row's keys do no match
     the rest of the rows, a ValueError will be thrown.
 
-**compatible table**
+**table-like object**
     If another table-like object has a `__astropy_table__` method then
     that object can be used to directly create a ``Table` object.  See
-    the `Compatible tables`_ section for details.
+    the `Table-like objects`_ section for details.
 
 **None**
     Initialize a zero-length table.  If ``names`` and optionally ``dtype``
@@ -966,47 +966,64 @@ To learn more about using standard `~astropy.table.Column` objects with defined
 units, see the :ref:`columns_with_units` section.
 
 
-Compatible tables
-^^^^^^^^^^^^^^^^^
+Table-like objects
+^^^^^^^^^^^^^^^^^^
 
 In order to improve interoperability between different table classes, an
-astropy |Table| object can be created directly from any other table
-object ``data`` that provides an ``__astropy_table__`` method.  In this case the
+astropy |Table| object can be created directly from any other table-like
+object that provides an ``__astropy_table__`` method.  In this case the
 ``__astropy_table__`` method will be called as follows::
 
-  table = data.__astropy_table__(cls, copy)
+  >>> data = SomeOtherTableClass({'a': [1, 2], 'b': [3, 4]})  # doctest: +SKIP
+  >>> t = QTable(data, copy=False, strict_copy=True)  # doctest: +SKIP
 
-where ``cls`` is the |Table| class or subclass that is being instantiated,
-and ``copy`` indicates whether a copy of the values in ``data`` should be
-provided.  If ``copy`` is ``False`` then the ``__astropy_table__`` method
-must ensure that the column data can actually be passed by reference
-into an astropy |Table|.  If not then an exception must be raised.  This
-is the case if the source ``data`` are not in an object that can be passed
-by reference into a numpy ``np.ndarray`` subclass, for instance a pure Python
-list.
+Internally the following call will be made to ask the ``data`` object
+to return a representation of itself as an astropy |Table|, respecting
+the ``copy`` preference of the original call to ``Table()``::
+
+  data.__astropy_table__(cls, copy, **kwargs)
+
+Here ``cls`` is the |Table| class or subclass that is being instantiated
+(|QTable| in this example), ``copy`` indicates whether a copy of the values in
+``data`` should be provided, and ``**kwargs`` are any extra keyword arguments
+which are not valid |Table| init keyword arguments.  In the example above,
+``strict_copy=True`` would end up in ``**kwargs`` and get passed to
+``__astropy_table__()``.
+
+If ``copy`` is ``True`` then the ``__astropy_table__`` method must ensure that
+a copy of the original data is returned.  If ``copy`` is ``False`` then a
+reference to the table data should returned if possible.  If it is not possible
+(e.g. the original data are in a Python list or must be other transformed in
+memory) then ``__astropy_table__`` method is free to either return a copy or
+else raise an exception.  This choice depends on the preference of the
+implementation.  The implementation might choose to allow an additional keyword
+argument (e.g. ``strict_copy`` which gets passed via ``**kwargs``) to control the
+behavior in this case.
 
 As a simple example, imagine a dict-based table class.  (Note that |Table|
 already can be initialized from a dict-like object, so this is a bit contrived
-but does illustrate the principles involved.)  Please note the method
-signature::
+but does illustrate the principles involved.)  Please pay attention to the
+method signature::
 
   def __astropy_table__(self, cls, copy, **kwargs):
 
-Your class implementation of this should include the ``**kwargs`` keyword
-args catch.  This is not currently used, but in the future additional
-keywords could be added to the ``table = data.__astropy_table__(cls, copy)``
-call, so including ``**kwargs`` will prevent breakage.
-
-::
+Your class implementation of this must use the ``**kwargs`` technique for
+catching keyword arguments at the end.  This is to ensure future compatibility
+in case additional keywords are added to the internal ``table =
+data.__astropy_table__(cls, copy)`` call.  Including ``**kwargs`` will prevent
+breakage in this case.  ::
 
   class DictTable(dict):
       """
       Trivial "table" class that just uses a dict to hold columns.
       This does not actually implement anything useful that makes
       this a table.
+
+      The non-standard ``strict_copy=False`` keyword arg here will be passed
+      via the **kwargs of Table __init__().
       """
 
-      def __astropy_table__(self, cls, copy, **kwargs):
+      def __astropy_table__(self, cls, copy, strict_copy=False, **kwargs):
           """
           Return an astropy Table of type ``cls``.
 
@@ -1016,16 +1033,24 @@ call, so including ``**kwargs`` will prevent breakage.
                Astropy ``Table`` class or subclass
           copy : bool
                Copy input data (True) or return a reference (False)
-          **kwargs : dict
-               Additional keyword args, not currently used.
+          strict_copy : bool, optional
+               Raise an exception if copy is False but reference is not
+               possible
+          **kwargs : dict, optional
+               Additional keyword args (ignored currently)
           """
+          if kwargs:
+              warnings.warn('unexpected keyword args {}'.format(kwargs))
+
           cols = list(self.values())
           names = list(self.keys())
 
-          # If returning a reference to existing data (copy=False), make sure
-          # that each column is a numpy ndarray.  If a column is a Python list or
-          # tuple then it must be copied for representation in an astropy Table.
-          if not copy:
+          # If returning a reference to existing data (copy=False) and
+          # strict_copy=True, make sure that each column is a numpy ndarray.
+          # If a column is a Python list or tuple then it must be copied for
+          # representation in an astropy Table.
+
+          if not copy and strict_copy:
               for name, col in zip(names, cols):
                   if not isinstance(col, np.ndarray):
                       raise ValueError('cannot have copy=False because column {} is '

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -528,8 +528,8 @@ for the ``data`` argument.
     the rest of the rows, a ValueError will be thrown.
 
 **table-like object**
-    If another table-like object has a `__astropy_table__` method then
-    that object can be used to directly create a ``Table` object.  See
+    If another table-like object has a ``__astropy_table__`` method then
+    that object can be used to directly create a ``Table`` object.  See
     the `Table-like objects`_ section for details.
 
 **None**

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -979,7 +979,7 @@ object that provides an ``__astropy_table__`` method.  In this case the
 
 Internally the following call will be made to ask the ``data`` object
 to return a representation of itself as an astropy |Table|, respecting
-the ``copy`` preference of the original call to ``Table()``::
+the ``copy`` preference of the original call to ``QTable()``::
 
   data.__astropy_table__(cls, copy, **kwargs)
 
@@ -993,7 +993,7 @@ which are not valid |Table| init keyword arguments.  In the example above,
 If ``copy`` is ``True`` then the ``__astropy_table__`` method must ensure that
 a copy of the original data is returned.  If ``copy`` is ``False`` then a
 reference to the table data should returned if possible.  If it is not possible
-(e.g. the original data are in a Python list or must be other transformed in
+(e.g. the original data are in a Python list or must be otherwise transformed in
 memory) then ``__astropy_table__`` method is free to either return a copy or
 else raise an exception.  This choice depends on the preference of the
 implementation.  The implementation might choose to allow an additional keyword


### PR DESCRIPTION
This is a second try at #4864.

This defines an interface method to allow an arbitrary object to initialize a `Table` subclass if it has an `__astropy_table__` method.

To do:

- [x] Documentation in Table narrative docs
- [x] Changelog

Supercedes and closes #4740.

cc: @astrofrog @TallJimbo @eteq @mhvk