### PR TITLE
Remove warning note of table 1.0 changes

### DIFF
--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -32,18 +32,6 @@ Currently `astropy.table` is used when reading an ASCII table using
 `astropy.io.ascii`.  Future releases of AstroPy are expected to use
 the |Table| class for other subpackages such as `astropy.io.votable` and `astropy.io.fits` .
 
-.. Note::
-
-   Starting with version 1.0 of astropy the internal implementation of the
-   |Table| class changed so that it no longer uses numpy structured arrays as
-   the core table data container.  Instead the table is stored as a collection
-   of individual column objects.  *For most users there is NO CHANGE to the
-   interface and behavior of |Table| objects.*
-
-   The page on :ref:`table_implementation_change` provides details about the
-   change.  This includes discussion of the table architecture, key differences,
-   and benefits of the change.
-
 Getting Started
 ===============
 


### PR DESCRIPTION
While working on some other table things I noticed that there's still a doc note about the changes in v1.0.  I think we can remove that now, as we are now two versions past that (usually our "deprecation window" standard).  The actual implementation notes will remain in the table of contents, but I think the note is now extraneous.

cc @taldcroft @astrofrog