### PR TITLE
Changing the remaining log.warn()s to log.warnings()

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -177,10 +177,10 @@ def _initialize_astropy():
         from .utils import _compiler
     except ImportError:
         if _is_astropy_source():
-            log.warn('You appear to be trying to import astropy from '
-                     'within a source checkout without building the '
-                     'extension modules first.  Attempting to (re)build '
-                     'extension modules:')
+            log.warning('You appear to be trying to import astropy from '
+                        'within a source checkout without building the '
+                        'extension modules first.  Attempting to (re)build '
+                        'extension modules:')
 
             try:
                 _rebuild_extensions()

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -136,16 +136,16 @@ def verify_checksums(filename):
     except UserWarning as w:
         remainder = '.. ' + ' '.join(str(w).split(' ')[1:]).strip()
         # if "Checksum" in str(w) or "Datasum" in str(w):
-        log.warn('BAD %r %s' % (filename, remainder))
+        log.warning('BAD %r %s' % (filename, remainder))
         return 1
     if not OPTIONS.ignore_missing:
         for i, hdu in enumerate(hdulist):
             if not hdu._checksum:
-                log.warn('MISSING %r .. Checksum not found in HDU #%d' %
+                log.warning('MISSING %r .. Checksum not found in HDU #%d' %
                          (filename, i))
                 return 1
             if not hdu._datasum:
-                log.warn('MISSING %r .. Datasum not found in HDU #%d' %
+                log.warning('MISSING %r .. Datasum not found in HDU #%d' %
                          (filename, i))
                 return 1
     if not errors:
@@ -160,7 +160,7 @@ def verify_compliance(filename):
     try:
         hdulist.verify('exception')
     except fits.VerifyError as exc:
-        log.warn('NONCOMPLIANT %r .. %s' %
+        log.warning('NONCOMPLIANT %r .. %s' %
                  (filename), str(exc).replace('\n', ' '))
         return 1
     return 0
@@ -216,5 +216,5 @@ def main():
     for filename in fits_files:
         errors += process_file(filename)
     if errors:
-        log.warn('%d errors' % errors)
+        log.warning('%d errors' % errors)
     return int(bool(errors))

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -144,9 +144,10 @@ errors should follow these rules:
   in favor of more specific exceptions (``IOError``, ``ValueError``,
   etc.).
 
-* For warnings, one should always use ``warnings.warn(message, warning_class)``. These get redirected to ``log.warn`` by default, but one
-  can still use the standard warning-catching mechanism and custom warning
-  classes. The warning class should be either
+* For warnings, one should always use ``warnings.warn(message,
+  warning_class)``. These get redirected to ``log.warning()`` by default,
+  but one can still use the standard warning-catching mechanism and custom
+  warning classes. The warning class should be either
   :class:`~astropy.utils.exceptions.AstropyUserWarning` or inherit from it.
 
 * For informational and debugging messages, one should always use


### PR DESCRIPTION
There are still a few ``log.warn()`` show up when one does a grep, but those are different as the given files import ``distutils.log``.

Also note that these are not changed to warnings.warn following @embray's comments from the original issue.