### PR TITLE
Fix gcrs transforms for non geocentric frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -503,6 +503,11 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Transformations between ``GCRS`` frames and other frames now properly handles
+    frames with non-zero ```obsgeoloc```. Previously this was in slight error for
+    nearby objects, leading to position errors of a few arcseconds for solar system
+    planets, to a degree for the Moon. 
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -24,6 +24,14 @@ from .hcrs import HCRS
 from .utils import get_jd12
 
 
+"""
+rotational velocity of Earth in radians per (UT1) second
+See Explanatory Supplement to the Astronomical Almanac, ed. P. Kenneth Seidelmann (1992),
+University Science Books.
+"""
+V_EARTH = u.Quantity([0, 0, 7.292115855306589e-5])*u.rad/u.s
+
+
 # helper function to find GCRS position and velocity of observatory
 def get_gcrs_posvel(time, frame):
     """
@@ -56,9 +64,7 @@ def get_gcrs_posvel(time, frame):
     vel_arr = obsgeovel.transform_to(geocentric_frame).cartesian.xyz.to(u.m/u.s).value
 
     # now add rotational velocity of GCRS frame w.r.t to ITRS
-    # rotation of earth
-    V = u.Quantity([0, 0, 7.292115855306589e-5])*u.rad/u.s
-    extra_rotation = np.cross(V, np.rollaxis(pos_arr, 0, pos_arr.ndim))
+    extra_rotation = np.cross(V_EARTH, np.rollaxis(pos_arr, 0, pos_arr.ndim))
     vel_arr += np.rollaxis(extra_rotation, -1, 0)
 
     pv = np.array([pos_arr, vel_arr])

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -25,7 +25,8 @@ from .utils import get_jd12
 
 
 """
-rotational velocity of Earth in radians per (UT1) second
+Rotational velocity of Earth. In UT1 seconds, this would be 2 pi / (24 * 3600),
+but we need the value in SI seconds.
 See Explanatory Supplement to the Astronomical Almanac, ed. P. Kenneth Seidelmann (1992),
 University Science Books.
 """

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -22,6 +22,7 @@ from ..._erfa import epv00
 from .utils import randomly_sample_sphere
 from ..builtin_frames.utils import get_jd12
 
+
 def test_icrs_cirs():
     """
     Check a few cases of ICRS<->CIRS for consistency.
@@ -127,6 +128,21 @@ def test_icrs_gcrs_dist_diff(gframe):
     assert not allclose(gcrswd.distance, icrs_coords[1].distance, rtol=1e-8,
                         atol=1e-10*u.pc)
 
+
+def test_non_geocentric_gcrs():
+    """
+    Test transformation to non-geocentric GCRS frames for nearby objects.
+    """
+    t = Time('1980-03-25 00:00')
+    gcrs_frame = GCRS(obstime=t,
+                      obsgeoloc=u.Quantity([-1463969.30185172,
+                                            -5166673.34223433,
+                                            3434985.71204565])*u.m)
+    icrs_coo = ICRS(ra=184.285*u.deg, dec=-1.8802*u.deg, distance=148101810.2*u.km)
+    gcrs_coo = icrs_coo.transform_to(gcrs_frame)
+    
+    expected = u.Quantity([-149099.43171337, 338254.76492942, 121819.91578453])*u.km
+    assert_allclose(gcrs_coo.cartesian.xyz, expected)
 
 def test_cirs_to_altaz():
     """

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -140,7 +140,7 @@ def test_non_geocentric_gcrs():
                                             3434985.71204565])*u.m)
     icrs_coo = ICRS(ra=184.285*u.deg, dec=-1.8802*u.deg, distance=148101810.2*u.km)
     gcrs_coo = icrs_coo.transform_to(gcrs_frame)
-    
+
     expected = u.Quantity([-149099.43171337, 338254.76492942, 121819.91578453])*u.km
     assert_allclose(gcrs_coo.cartesian.xyz, expected)
 


### PR DESCRIPTION
There was a bug when transforming to and from GCRS frames with non-geocentric coordinates (i.e those with non-zero values of ```obsgeoloc``` and ```obsgeovel```. This is because the ```erfa``` routine ```apcs13``` expects a position and velocity in GCRS coordinates.

Previously  ```obsgeoloc``` and ```obsgeovel``` were being passed naively, but these are defined in ITRS coordinates. I have added a helper routine ```get_gcrs_posvel``` to ```icrs_cirs_transforms``` to compute the proper pv array to supply to ```apcs13```.