### PR TITLE
fixed docscrape warning "unknown section Example"

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -736,11 +736,20 @@ class Table(object):
         """
         Iterate over the columns of this table.
 
-        Example
-        -----------
-        t = Table([[1], [2]])
-        for col in t.itercols():
-            print(col)
+        Examples
+        --------
+
+        To iterate over the columns of a table::
+
+            >>> t = Table([[1], [2]])
+            >>> for col in t.itercols():
+            ...     print(col)
+            col0
+            ----
+               1
+            col1
+            ----
+               2
 
         Using ``itercols()`` is similar to  ``for col in t.columns.values()``
         but is syntactically preferred.


### PR DESCRIPTION
Similar to  #4852 and maybe another reason to check if one could make this a sphinx-failure instead of only a printed (unnoticed) warning: https://github.com/astropy/astropy-helpers/issues/233
fixes this message:
```
reading sources... [ 51%] api/astropy.table.Table

/home/travis/build/astropy/astropy/astropy_helpers/astropy_helpers/sphinx/ext/docscrape.py:120: UserWarning: Unknown section Example

  warn("Unknown section %s" % key)
```