### PR TITLE
backwards compatibility patch: order of arguments in StdDevUncertainty.__init__

### DIFF
--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -155,7 +155,7 @@ class NDUncertainty(object):
        should fail.
     """
 
-    def __init__(self, array=None, unit=None, copy=True):
+    def __init__(self, array=None, copy=True, unit=None):
         if isinstance(array, NDUncertainty):
             # Given an NDUncertainty class or subclass check that the type
             # is the same.


### PR DESCRIPTION
Changed the order of arguments in ``__init__`` so that if anyone used copy as positional argument doesn't set the ``unit`` to ``True`` or ``False``.

See also https://github.com/astropy/astropy/pull/4876#discussion_r63205064