### PR TITLE
Added metadata to compound model

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1754,6 +1754,8 @@ BINARY_OPERATORS = {
     '&': _join_operator
 }
 
+# This is for joining metadata in a compound model.
+METADATA_OPERATORS = defaultdict(lambda: metadata.merge)
 
 _ORDER_OF_OPERATORS = [('|',), ('&',), ('+', '-'), ('*', '/'), ('**',)]
 OPERATOR_PRECEDENCE = {}
@@ -2465,6 +2467,20 @@ class _CompoundModel(Model):
     @sharedmethod
     def _get_submodels(self):
         return self.__class__._get_submodels()
+
+    @staticmethod
+    def _model_meta_getter(idx, model):
+        if isinstance(model, Model):
+            meta = model.meta
+        else:  # Already metadata (last step of ExpressionTree operation)
+            meta = model
+        return meta
+
+    @property
+    def meta(self):
+        """Merged metadata from individual models."""
+        return self._tree.evaluate(METADATA_OPERATORS,
+                                   getter=self.__class__._model_meta_getter)
 
 
 def custom_model(*args, **kwargs):

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -13,6 +13,7 @@ from numpy.testing.utils import (assert_allclose, assert_array_equal,
 
 from ...extern.six.moves import cPickle as pickle
 from ...tests.helper import pytest
+from ...utils.metadata import MergeConflictWarning
 
 from ..core import Model, ModelDefinitionError
 from ..parameters import Parameter
@@ -838,3 +839,15 @@ def test_pickle_compound_fallback():
     gg = (Gaussian1D + Gaussian1D)()
     with pytest.raises(RuntimeError):
         pickle.dumps(gg)
+
+
+def test_meta():
+    """Test combining metadata from individual models."""
+    m1 = Const1D(meta={'key1': 'foo'})
+    m2 = Const1D(meta={'key1': 'bar', 'key2': 2})
+    m = m1 + m2
+
+    with pytest.warns(MergeConflictWarning):
+        meta = m.meta
+
+    assert meta == m2.meta


### PR DESCRIPTION
Added `meta` property to compound model. This extends the functionality from #2189.

Currently, it uses the default merging strategy. If flexibility is needed, this can be turned into a method instead to accept optional keywords. In that case, `METADATA_OPERATORS` will have to be moved to inside the method and constructed on-the-fly using `partial` to pass in the options.
##### TODO
- [ ] Revisit logic to let user have more control of what is actually merged.
- [ ] Maybe init metadata instead of on-the-fly merging?
- [ ] Add a change log (when milestone is determined).
- [ ] Enable Travis CI testing when ready to merge (to avoid competing resources with x.x release).
