### PR TITLE
Speed up use of compound model classes

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1805,7 +1805,6 @@ class _CompoundModelMeta(_ModelMeta):
         # an attribute on a concrete compound model class and should just raise
         # the AttributeError
         if cls._tree is not None and attr in cls.param_names:
-            cls._init_param_descriptors()
             return getattr(cls, attr)
 
         raise AttributeError(attr)
@@ -1857,37 +1856,32 @@ class _CompoundModelMeta(_ModelMeta):
 
     @property
     def submodel_names(cls):
-        if cls._submodel_names is not None:
-            return cls._submodel_names
+        if cls._submodel_names is None:
+            seen = {}
+            names = []
+            for idx, submodel in enumerate(cls._get_submodels()):
+                name = submodel.name
+                if name is None:
+                    names.append(name)
+                elif name in seen:
+                    names.append('{0}_{1}'.format(name, idx))
+                    if seen[name] >= 0:
+                        jdx = seen[name]
+                        names[jdx] = '{0}_{1}'.format(names[jdx], jdx)
+                        seen[name] = -1
+                else:
+                    names.append(name)
+                    seen[name] = idx
+            cls._submodel_names = names
 
-        by_name = defaultdict(list)
-
-        for idx, submodel in enumerate(cls._get_submodels()):
-            # Keep track of the original sort order of the submodels
-            by_name[submodel.name].append(idx)
-
-        names = []
-        for basename, indices in six.iteritems(by_name):
-            if len(indices) == 1:
-                # There is only one model with this name, so it doesn't need an
-                # index appended to its name
-                names.append((basename, indices[0]))
-            else:
-                for idx in indices:
-                    names.append(('{0}_{1}'.format(basename, idx), idx))
-
-        # Sort according to the models' original sort orders
-        names.sort(key=lambda k: k[1])
-
-        names = tuple(k[0] for k in names)
-
-        cls._submodels_names = names
-        return names
+        return cls._submodel_names
 
     @property
     def param_names(cls):
         if cls._param_names is None:
             cls._init_param_names()
+            if isinstance(cls, (_CompoundModelMeta, _CompoundModel)):
+                cls._init_param_descriptors()
 
         return cls._param_names
 


### PR DESCRIPTION
This change was motivated by problems with complex wcs
models. Profiling showed that initialization code was being run too
often and, in particular, too much time was spent in
submodel_names. There are two changes:

The call to _init_param_descriptors was moved from __getattr__ to
param_names and in that method, only called once for each
class. Having the call in **getattr** meant that the initialization
code was run each time an atttribute was accessed, clearly an
error. Method param_names seemed the best place to move it to, as the
functionality was related.

Since submodel_names was a hotspot in the code, it seemed worth the
time to optimize it. The original code updated the names in random
(hash) order and then sorted. The new code updates them in their
original order, doing away for the need for a sort. Also, cases where
the name is None are handled as a specially. There is no valued to
building names like None_1, None_2, and so on. After rewriting I
noticed the caching of the submodel names was incorrect, so I also
changed that.
