### PR TITLE
include NDSlicingMixin in narrative docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,9 @@ API changes
     overriding ``_arithmetic``. The ``_arithmetic`` method is now used to call
     these other methods. [#4272]
 
+  - ``NDSlicingMixin``: If the attempt at slicing the mask, wcs or uncertainty
+    fails with a ``TypeError`` a Warning is issued instead of the TypeError. [#4271]
+
   - ``NDUncertainty``: ``support_correlated`` attribute is deprecated in favor of
     ``supports_correlated`` which is a property. Also affects
     ``StdDevUncertainty``. [#4272]

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -41,6 +41,7 @@ _arit_doc = """
         .. versionchanged:: 1.2
             This parameter must be given as keyword-parameter. Using it as
             positional parameter is deprecated.
+            ``None`` was added as valid parameter value.
 
     handle_mask : callable, ``'first_found'`` or ``None``, optional
         If ``None`` the result will have no mask. If ``'first_found'`` the
@@ -49,12 +50,16 @@ _arit_doc = """
         create the results ``mask`` and if necessary provide a copy.
         Default is `numpy.logical_or`.
 
+        .. versionadded:: 1.2
+
     handle_meta : callable, ``'first_found'`` or ``None``, optional
         If ``None`` the result will have no meta. If ``'first_found'`` the
         result will have a copied version of the first operand that has a
         (not empty) meta. If it is a callable then the specified callable must
         create the results ``meta`` and if necessary provide a copy.
         Default is ``None``.
+
+        .. versionadded:: 1.2
 
     compare_wcs : callable, ``'first_found'`` or ``None``, optional
         If ``None`` the result will have no wcs and no comparison between
@@ -65,11 +70,15 @@ _arit_doc = """
         was given otherwise it raises a ``ValueError`` if the comparison was
         not successful. Default is ``'first_found'``.
 
+        .. versionadded:: 1.2
+
     uncertainty_correlation : number or `~numpy.ndarray`, optional
         The correlation between the two operands is used for correct error
         propagation for correlated data as given in:
         https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
         Default is 0.
+
+        .. versionadded:: 1.2
 
 
     kwargs :

--- a/astropy/nddata/mixins/ndslicing.py
+++ b/astropy/nddata/mixins/ndslicing.py
@@ -10,72 +10,47 @@ __all__ = ['NDSlicingMixin']
 
 
 class NDSlicingMixin(object):
-    """
-    Mixin to provide slicing on objects using the `~astropy.nddata.NDData`
+    """Mixin to provide slicing on objects using the `NDData`
     interface.
 
-    The most common cases of the properties of `~astropy.nddata.NDData` are
-    covered, i.e. if uncertainty, mask and wcs are ``None`` or unsliceable.
-
-    TODO: Move Notes to nddata/subclassing.rst except maybe point 2. (mwcraig)
-
-    Notes
-    -----
-    1. When subclassing, be sure to list the superclasses in the correct order
-       so that the subclass sees NDData as the main superclass. See
-       `~astropy.nddata.NDDataArray` for an example.
-
-    2. The ``meta`` and ``unit`` are simply taken from the original, no attempt
-       is made to slice them.
-
-    3. Some advice about extending this Mixin in subclasses:
-
-       - if the ``data`` is not a `~numpy.ndarray` or should not be sliceable
-         you may be better off not using this Mixin.
-       - if you have defined an additional property that needs to be sliced
-         extend :meth:`NDSlicingMixin._slice`. Probably the best way to do this
-         is to first call ``kwarg = super(subclass, self)._slice(item)`` in
-         there and then just afterwards add the other sliced properties to the
-         ``kwarg``-dict. Since this kwarg is used to initialize a new
-         instance of the class you need to match the key to the name of the
-         parameter. For example if you use a property called ``flags`` you need
-         to add a new line ``kwargs['flags'] = ...`` to :meth:`_slice`.
-         *BUT* the ``__init__`` has to accept a flags parameter otherwise
-         this will fail.
-       - if you have a property that does not match the criterias above you may
-         need to extend or override some method here. For example you want a
-         custom made ``uncertainty`` class that does not subclass from
-         `NDUncertainty` or `~numpy.ndarray` to be sliced. The best way to do
-         this would be to extend ``_slice_uncertainty(self, item)`` which
-         takes the ``slice`` as ``item`` parameter and returns what the
-         sliced uncertainty should be. The current uncertainty is avaiable
-         using ``self._uncertainty``. Be careful since this can be also
-         ``None`` if there is no uncertainty set.
+    The ``data``, ``mask``, ``uncertainty`` and ``wcs`` will be sliced, if
+    set and sliceable. The ``unit`` and ``meta`` will be untouched. The return
+    will be a reference and not a copy, if possible.
 
     Examples
     --------
-
-    You need to make NDData the last superclass like this::
+    Using this Mixin with `~astropy.nddata.NDData`:
 
         >>> from astropy.nddata import NDData, NDSlicingMixin
-        >>> class NDDataSliceable(NDSlicingMixin, NDData): pass
+        >>> class NDDataSliceable(NDSlicingMixin, NDData):
+        ...     pass
 
-    Then you can slice it::
+    Slicing an instance containing data::
 
         >>> nd = NDDataSliceable([1,2,3,4,5])
         >>> nd[1:3]
         NDDataSliceable([2, 3])
-        >>> import numpy as np # Mask has to be a numpy array to be sliceable
+
+    Also the other attributes are sliced for example the ``mask``::
+
+        >>> import numpy as np
         >>> mask = np.array([True, False, True, True, False])
         >>> nd2 = NDDataSliceable(nd, mask=mask)
         >>> nd2[1:3].mask
         array([False,  True], dtype=bool)
-        >>> # But be aware that the slicing only returns references not copies
+
+    Be aware that changing values of the sliced instance will change the values
+    of the original::
+
         >>> nd3 = nd2[1:3]
         >>> nd3.data[0] = 100
         >>> nd2
         NDDataSliceable([  1, 100,   3,   4,   5])
 
+    See also
+    --------
+    NDDataRef
+    NDDataArray
     """
     def __getitem__(self, item):
         # Abort slicing if the data is a single scalar.
@@ -87,25 +62,26 @@ class NDSlicingMixin(object):
         return self.__class__(**kwargs)
 
     def _slice(self, item):
-        """
-        Collects the sliced attributes and passes them back as ``kwargs``.
+        """Collects the sliced attributes and passes them back as `dict`.
 
         It passes uncertainty, mask and wcs to their appropriate ``_slice_*``
         method, while ``meta`` and ``unit`` are simply taken from the original.
         The data is assumed to be sliceable and is sliced directly.
 
-        When possible the return is *not* a copy of the data but a reference.
+        When possible the return should *not* be a copy of the data but a
+        reference.
 
         Parameters
         ----------
-        item: slice
+        item : slice
             The slice passed to ``__getitem__``.
 
         Returns
         -------
-        kwargs: `dict`
+        dict :
             Containing all the attributes after slicing - ready to
-            feed them into the ``self.__class__.__init__()`` in __getitem__.
+            use them to create ``self.__class__.__init__(**kwargs)`` in
+            ``__getitem__``.
         """
         kwargs = {}
         kwargs['data'] = self.data[item]

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -79,7 +79,7 @@ class NDData(NDDataBase):
     Attributes
     ----------
     meta : `dict`-like
-        Additional meta informations about the dataset.
+        Additional meta information about the dataset.
 
     Notes
     -----

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -100,10 +100,11 @@ using arithmetic operators like ``+``.
 Slicing or indexing (:ref:`nddata_slicing`) is possible (issuing warnings if
 some attribute cannot be sliced)::
 
-    >>> ndd2 = NDDataRef(ndd2.data)  # because a scalar coordinate is not sliceable.
     >>> ndd2[2:]  # discard the first two elements
+    INFO: wcs cannot be sliced. [astropy.nddata.mixins.ndslicing]
     NDDataRef([ 5.,  5.])
     >>> ndd2[1]   # get the second element
+    INFO: wcs cannot be sliced. [astropy.nddata.mixins.ndslicing]
     NDDataRef(5.0)
 
 

--- a/docs/nddata/mixins/ndslicing.rst
+++ b/docs/nddata/mixins/ndslicing.rst
@@ -1,24 +1,141 @@
 .. _nddata_slicing:
 
-Slicing mixin
-=============
+Slicing and Indexing NDData
+===========================
 
-The slicing mixin adds the ability to index an `~astropy.nddata.NDData` object
-in a manner similar to a numpy array. Slicing returns a new
-`~astropy.nddata.NDData` object with the shape indicated by the slice.
+Introduction
+------------
 
-The first step in creating an `~astropy.nddata.NDData`-based object with
-slicing is to create a new class::
+This page only deals with peculiarities applying to
+`~astropy.nddata.NDData`-like classes. For a tutorial about slicing/indexing see the
+`python documentation <https://docs.python.org/tutorial/introduction.html#lists>`_
+and `numpy documentation <http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_.
 
-    >>> from astropy.nddata import NDData, NDSlicingMixin
-    >>> class MyNDDataWithSlicing(NDSlicingMixin, NDData): pass
+.. warning::
+    `~astropy.nddata.NDData` and `~astropy.nddata.NDDataRef` enforce almost no
+    restrictions on the properties so it might happen that some **valid but
+    unusual** combination of properties always results in an IndexError or
+    incorrect results. In this case see :ref:`nddata_subclassing` on how to
+    customize slicing for a particular property.
 
-Then, initialize the new object the same way you would initialize a plain
-`~astropy.nddata.NDData` object::
 
-    >>> sliceable_ndd = MyNDDataWithSlicing([1, 2, 3, 4])
-    >>> sliceable_ndd[1:3]
-    MyNDDataWithSlicing([2, 3])
+Slicing NDDataRef
+-----------------
 
-One important note: the order you list the mixins and `~astropy.nddata.NDData`
-matters; the base class, `~astropy.nddata.NDData` should be on the far right.
+Unlike `~astropy.nddata.NDData` the class `~astropy.nddata.NDDataRef`
+implements slicing or indexing. The result will be wrapped inside the same
+class as the sliced object.
+
+Getting one element::
+
+    >>> import numpy as np
+    >>> from astropy.nddata import NDDataRef
+
+    >>> data = np.array([1, 2, 3, 4])
+    >>> ndd = NDDataRef(data)
+    >>> ndd[1]
+    NDDataRef(2)
+
+Getting a sliced portion of the original::
+
+    >>> ndd[1:3]  # Get element 1 (inclusive) to 3 (exclusive)
+    NDDataRef([2, 3])
+
+This will return a reference (and as such **not a copy**) of the original
+properties so changing a slice will affect the original::
+
+    >>> ndd_sliced = ndd[1:3]
+    >>> ndd_sliced.data[0] = 5
+    >>> ndd_sliced
+    NDDataRef([5, 3])
+    >>> ndd
+    NDDataRef([1, 5, 3, 4])
+
+except you indexed only one element (for example ``ndd_sliced = ndd[1]``). Then
+the element is a scalar and changes will not propagate to the original.
+
+Slicing NDDataRef including attributes
+--------------------------------------
+
+In case a ``wcs``, ``mask`` or ``uncertainty`` is present this attribute will
+be sliced too::
+
+    >>> from astropy.nddata import StdDevUncertainty
+    >>> data = np.array([1, 2, 3, 4])
+    >>> mask = data > 2
+    >>> uncertainty = StdDevUncertainty(np.sqrt(data))
+    >>> wcs = np.ones(4)
+    >>> ndd = NDDataRef(data, mask=mask, uncertainty=uncertainty, wcs=wcs)
+    >>> ndd_sliced = ndd[1:3]
+
+    >>> ndd_sliced.data
+    array([2, 3])
+
+    >>> ndd_sliced.mask
+    array([False,  True], dtype=bool)
+
+    >>> ndd_sliced.uncertainty
+    StdDevUncertainty([ 1.41421356,  1.73205081])
+
+    >>> ndd_sliced.wcs
+    array([ 1.,  1.])
+
+but ``unit`` and ``meta`` will be unaffected.
+
+If any of the attributes is set but doesn't implement slicing an info will be
+printed and the property will be kept as is::
+
+    >>> data = np.array([1, 2, 3, 4])
+    >>> mask = False
+    >>> uncertainty = StdDevUncertainty(0)
+    >>> wcs = {'a': 5}
+    >>> ndd = NDDataRef(data, mask=mask, uncertainty=uncertainty, wcs=wcs)
+    >>> ndd_sliced = ndd[1:3]
+    INFO: uncertainty cannot be sliced. [astropy.nddata.mixins.ndslicing]
+    INFO: mask cannot be sliced. [astropy.nddata.mixins.ndslicing]
+    INFO: wcs cannot be sliced. [astropy.nddata.mixins.ndslicing]
+
+    >>> ndd_sliced.mask
+    False
+
+Example: Remove masked data
+---------------------------
+
+.. warning::
+    If you are using a `~astropy.wcs.WCS` object as ``wcs`` this will **NOT**
+    be possible. But you could work around it, i.e. set it to ``None`` before
+    slicing.
+
+By convention the ``mask`` attribute indicates if a point is valid or invalid.
+So we are able to get all valid data points by slicing with the mask::
+
+    >>> data = np.array([[1,2,3],[4,5,6],[7,8,9]])
+    >>> mask = np.array([[0,1,0],[1,1,1],[0,0,1]], dtype=bool)
+    >>> uncertainty = StdDevUncertainty(np.sqrt(data))
+    >>> ndd = NDDataRef(data, mask=mask, uncertainty=uncertainty)
+    >>> # don't forget that ~ or you'll get the invalid points
+    >>> ndd_sliced = ndd[~ndd.mask]
+    >>> ndd_sliced
+    NDDataRef([1, 3, 7, 8])
+
+    >>> ndd_sliced.mask
+    array([False, False, False, False], dtype=bool)
+
+    >>> ndd_sliced.uncertainty
+    StdDevUncertainty([ 1.        ,  1.73205081,  2.64575131,  2.82842712])
+
+or all invalid points::
+
+    >>> ndd_sliced = ndd[ndd.mask] # without the ~ now!
+    >>> ndd_sliced
+    NDDataRef([2, 4, 5, 6, 9])
+
+    >>> ndd_sliced.mask
+    array([ True,  True,  True,  True,  True], dtype=bool)
+
+    >>> ndd_sliced.uncertainty
+    StdDevUncertainty([ 1.41421356,  2.        ,  2.23606798,  2.44948974,  3.        ])
+
+.. note::
+    The result of this kind of indexing (boolean indexing) will always be
+    one-dimensional!


### PR DESCRIPTION
fixes #4905

Documentation builds avaiable:

- [ndslicing.rst](http://astropy-mseifer.readthedocs.io/en/nddata_slicing_documentation/nddata/mixins/ndslicing.html)
- this example in [subclassing.rst](http://astropy-mseifer.readthedocs.io/en/nddata_slicing_documentation/nddata/subclassing.html#slicing-an-existing-property) and the following.

Some unrelated changes are included but only documentation-related. Fixing some open ends I've encountered.