### PR TITLE
Solar system epherides doc update and kernel URL setting option

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -43,20 +43,34 @@ BODY_NAME_TO_KERNEL_SPEC = OrderedDict(
 SOLAR_SYSTEM_BODIES = tuple(BODY_NAME_TO_KERNEL_SPEC.keys())
 
 
-def _download_spk_file(url=('http://naif.jpl.nasa.gov/pub/naif/'
-                            'generic_kernels/spk/planets/de430.bsp'),
-                       show_progress=True):
+def set_kernel_url(url='http://naif.jpl.nasa.gov/pub/naif/generic_kernels'
+                       '/spk/planets/de430.bsp'):
     """
-    Get the Satellite Planet Kernel (SPK) file from NASA JPL.
+    Choose the URL to use for downloading a download the Satellite Planet
+    Kernel (SPK) file with ephemerides.  The download will *not* occur when
+    this function is called, but rather whenever the first time is that the
+    kernel actually needs to be used.
 
-    Download the file from the JPL webpage once and subsequently access a
-    cached copy. The default is the file de430.bsp.
+    Parameters
+    ----------
+    url : str
+        A url to an SPK file to use.
 
-    This file is ~120 MB, and covers years ~1550-2650 CE [1]_.
+    Notes
+    -----
+    The default Satellite Planet Kernel (SPK) file from NASA JPL (DE430) is
+    ~120MB, and covers years ~1550-2650 CE [1]_.
 
     .. [1] http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/aareadme_de430-de431.txt
+
     """
-    return download_file(url, cache=True, show_progress=show_progress)
+    global KERNEL, KERNEL_URL
+
+    KERNEL_URL = url
+    KERNEL = None
+
+# set the default kernel off the bat
+set_kernel_url()
 
 
 def _get_kernel(*args, **kwargs):
@@ -64,7 +78,7 @@ def _get_kernel(*args, **kwargs):
     Try importing jplephem, download/retrieve from cache the Satellite Planet
     Kernel.
     """
-    global KERNEL
+    global KERNEL, KERNEL_URL
 
     try:
         from jplephem.spk import SPK
@@ -74,7 +88,7 @@ def _get_kernel(*args, **kwargs):
                           "(https://pypi.python.org/pypi/jplephem)")
 
     if KERNEL is None:
-        KERNEL = SPK.open(_download_spk_file())
+        KERNEL = SPK.open(download_file(KERNEL_URL, cache=True))
     return KERNEL
 
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -11,14 +11,17 @@ from collections import OrderedDict
 import numpy as np
 from .sky_coordinate import SkyCoord
 from ..utils.data import download_file
+from ..utils.state import ScienceState
 from .. import units as u
 from ..constants import c as speed_of_light
 from .representation import CartesianRepresentation
 from .builtin_frames import GCRS, ICRS
 from .builtin_frames.utils import get_jd12, cartrepr_from_matmul
 from .. import _erfa
+from ..extern import six
 
-__all__ = ["get_body", "get_moon", "get_body_barycentric", "SOLAR_SYSTEM_BODIES"]
+__all__ = ["get_body", "get_moon", "get_body_barycentric",
+           "SOLAR_SYSTEM_BODIES", "kernel_url"]
 
 KERNEL = None
 
@@ -42,19 +45,19 @@ BODY_NAME_TO_KERNEL_SPEC = OrderedDict(
                                       )
 SOLAR_SYSTEM_BODIES = tuple(BODY_NAME_TO_KERNEL_SPEC.keys())
 
+_JPL_EPHEM_NOTE = """
+    This calculation uses JPL Ephemeris SPK filesto calculate the body's
+    location, defaulting to DE430.  It will be downloaded the first time this
+    function is used and cached from then on.  To change this, set
+    ``kernel_url`` as described in the coordinate documentation.
+"""[1:-1]
 
-def set_kernel_url(url='http://naif.jpl.nasa.gov/pub/naif/generic_kernels'
-                       '/spk/planets/de430.bsp'):
+class kernel_url(ScienceState):
     """
-    Choose the URL to use for downloading a download the Satellite Planet
+    The URL to use for downloading a download the Satellite Planet
     Kernel (SPK) file with ephemerides.  The download will *not* occur when
-    this function is called, but rather whenever the first time is that the
+    this state is set, but rather whenever the first time is that the
     kernel actually needs to be used.
-
-    Parameters
-    ----------
-    url : str
-        A url to an SPK file to use.
 
     Notes
     -----
@@ -62,15 +65,19 @@ def set_kernel_url(url='http://naif.jpl.nasa.gov/pub/naif/generic_kernels'
     ~120MB, and covers years ~1550-2650 CE [1]_.
 
     .. [1] http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/aareadme_de430-de431.txt
-
     """
-    global KERNEL, KERNEL_URL
+    _value = ('http://naif.jpl.nasa.gov/pub/naif/generic_kernels'
+               '/spk/planets/de430.bsp')
 
-    KERNEL_URL = url
-    KERNEL = None
-
-# set the default kernel off the bat
-set_kernel_url()
+    @classmethod
+    def validate(cls, value):
+        try:
+            six.moves.urllib.parse.urlparse(value)
+        except:
+            raise ValueError('{} could not be parsed as a URL'.format(value))
+        global KERNEL
+        KERNEL = None
+        return value
 
 
 def _get_kernel(*args, **kwargs):
@@ -78,7 +85,7 @@ def _get_kernel(*args, **kwargs):
     Try importing jplephem, download/retrieve from cache the Satellite Planet
     Kernel.
     """
-    global KERNEL, KERNEL_URL
+    global KERNEL
 
     try:
         from jplephem.spk import SPK
@@ -88,7 +95,7 @@ def _get_kernel(*args, **kwargs):
                           "(https://pypi.python.org/pypi/jplephem)")
 
     if KERNEL is None:
-        KERNEL = SPK.open(download_file(KERNEL_URL, cache=True))
+        KERNEL = SPK.open(download_file(kernel_url.get(), cache=True))
     return KERNEL
 
 
@@ -117,16 +124,14 @@ def get_body_barycentric(time, body):
 
     Notes
     -----
-
-    """
-    # lookup chain
-    chain = BODY_NAME_TO_KERNEL_SPEC[body.lower()]
+    """ +_JPL_EPHEM_NOTE
 
     kernel = _get_kernel()
+    kernelspec_chain = BODY_NAME_TO_KERNEL_SPEC[body.lower()]
 
     jd1, jd2 = get_jd12(time, 'tdb')
 
-    cartesian_position_body = sum([kernel[pair].compute(jd1, jd2) for pair in chain])
+    cartesian_position_body = sum([kernel[pair].compute(jd1, jd2) for pair in kernelspec_chain])
 
     barycen_to_body_vector = u.Quantity(cartesian_position_body, unit=u.km)
     return CartesianRepresentation(barycen_to_body_vector)
@@ -164,10 +169,6 @@ def _get_earth_body_vector(time, body, earth_time=None):
 
     earth_distance : `~astropy.units.Quantity`
         Distance between Earth and body.
-
-    Notes
-    -----
-
     """
     earth_time = earth_time if earth_time is not None else time
     earth_loc = get_body_barycentric(earth_time, 'earth')
@@ -240,7 +241,10 @@ def get_body(time, body, location=None):
     -------
     skycoord : `~astropy.coordinates.SkyCoord`
         Coordinate for the body
-    """
+
+    Notes
+    -----
+    """ +_JPL_EPHEM_NOTE
     cartrep = _get_apparent_body_position(time, body)
     icrs = ICRS(cartrep)
     if location is not None:
@@ -271,7 +275,12 @@ def get_moon(time, location=None):
     -------
     skycoord : `~astropy.coordinates.SkyCoord`
         Coordinate for the Moon
-    """
+
+
+
+    Notes
+    -----
+    """ +_JPL_EPHEM_NOTE
     return get_body(time, body='moon', location=location)
 
 

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -7,7 +7,8 @@ from ...constants import c
 from ..builtin_frames import GCRS
 from ..earth import EarthLocation
 from ..sky_coordinate import SkyCoord
-from ..solar_system import get_body, get_moon, _apparent_position_in_true_coordinates
+from ..solar_system import (get_body, get_moon, kernel_url,
+                            _apparent_position_in_true_coordinates)
 from ...tests.helper import pytest, assert_quantity_allclose, remote_data
 
 try:
@@ -204,3 +205,14 @@ def test_positions_distances_kittpeak_2016():
 
     assert_quantity_allclose(distances_astropy, distances_horizons,
                              atol=distance_tolerance)
+
+def test_kernel_change():
+    t = Time('2016-01-1 00:00')
+    de430_pluto = get_body(t, 'pluto')
+
+    #dr432 is convenient because it's relatively small - ~10MB
+    with kernel_url.set('http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk'
+                        '/planets/de432s.bsp'):
+        de432_pluto = get_body(t, 'pluto')
+
+

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -206,6 +206,8 @@ def test_positions_distances_kittpeak_2016():
     assert_quantity_allclose(distances_astropy, distances_horizons,
                              atol=distance_tolerance)
 
+@remote_data
+@pytest.mark.skipif(str('not HAS_JPLEPHEM'))
 def test_kernel_change():
     t = Time('2016-01-1 00:00')
     de430_pluto = get_body(t, 'pluto')

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -53,3 +53,13 @@ For a list of the bodies for which positions can be calculated, do::
     method, but instead uses a polynomial model for the location of the sun
     (as this requires no special download). So it is not safe to assume that
     ``get_body(time, 'sun')`` and ``get_sun(time)`` will give the same result.
+
+You can also change the SPK kernel (the file used to actually locate the 
+planets), although this interface should be considered preliminary (and hence 
+is not yet considered part of the public API)::
+
+    >>> from astropy import coordinates
+    >>> coordinates.solar_system.set_kernel_url('http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de432s.bsp')
+    >>> coordinates.get_body(t,'pluto')
+    <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 0.  0.  0.] m, obsgeovel=[ 0.  0.  0.] m / s): (ra, dec, distance) in (deg, deg, km)
+    (281.52508175, -20.60080214, 4865115955.7188015)>

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -6,11 +6,16 @@ Solar System Ephemerides
 ------------------------
 
 `astropy.coordinates` can calculate the |SkyCoord| of some of the major
-solar system objects. This functionality requires the 
-`jplephem <https://pypi.python.org/pypi/jplephem>`_ package
-to be installed. Coordinates are calculated using the JPL DE430 ephemeris file. 
-The ephemeris file provides predictions valid for years between 1550 and 2650. 
-The file is 115 MB and will be downloaded the first time, but cached after that.
+solar system objects. Coordinates are calculated using the JPL DE430 
+ephemerides. These ephemerides provide predictions valid roughly for years 
+between 1550 and 2650. The file is 115 MB and will need to be downloaded 
+the first time you use this functionality, but will be cached after that.
+
+.. note::
+    This functionality requires that the 
+    `jplephem <https://pypi.python.org/pypi/jplephem>`_ package
+    is installed. This is most easily acheived via ``pip install jplephem``,
+    although whatever package management system you use might have it as well.
 
 Three functions are provided; :meth:`~astropy.coordinates.get_body`, 
 :meth:`~astropy.coordinates.get_moon` and 
@@ -19,7 +24,7 @@ two functions return |SkyCoord| objects in the `~astropy.coordinates.GCRS` frame
 whilst the latter returns a `~astropy.coordinates.CartesianRepresentation` of the barycentric position
 of a body (i.e in the `~astropy.coordinates.ICRS` frame).
 
-The methods are used as follows::
+Here are some examples of these functions in use::
 
     >>> from astropy.time import Time
     >>> from astropy.coordinates import get_moon, get_body
@@ -36,10 +41,15 @@ The methods are used as follows::
     <CartesianRepresentation (x, y, z) in km
     (150107535.26352832, -866789.03506676, -418963.52113854)>
        
-The bodies for which positions can be calculated can be listed::
+For a list of the bodies for which positions can be calculated, do::
 
     >>> from astropy.coordinates import SOLAR_SYSTEM_BODIES
     >>> SOLAR_SYSTEM_BODIES
     ('sun', 'mercury', 'venus', 'earth-moon-barycenter', 'earth', 'moon', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune', 'pluto')
 
-
+.. note ::
+    While the sun is included in the these ephemerides, it is important to
+    recognize that `~astropy.coordinates.get_sun` does *not* use this
+    method, but instead uses a polynomial model for the location of the sun
+    (as this requires no special download). So it is not safe to assume that
+    ``get_body(time, 'sun')`` and ``get_sun(time)`` will give the same result.

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -33,10 +33,10 @@ Here are some examples of these functions in use::
     >>> loc = EarthLocation.of_site('greenwich')
     >>> get_moon(t, loc) # doctest: +REMOTE_DATA
     <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 3949481.69039034  -550931.90976401  4961151.73716876] m, obsgeovel=[  40.17459314  288.00078055   -0.        ] m / s): (ra, dec, distance) in (deg, deg, km)
-    (165.51839027, 2.32901144, 407226.55887392)>
+        (165.51840736, 2.32900633, 407226.68749637)>
     >>> get_body(t, 'jupiter', loc) # doctest: +REMOTE_DATA
     <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 3949481.69039034  -550931.90976401  4961151.73716876] m, obsgeovel=[  40.17459314  288.00078055   -0.        ] m / s): (ra, dec, distance) in (deg, deg, km)
-    (136.90234741, 17.03160607, 889196019.26282585)>
+        (136.90234741, 17.03160607, 889196019.26282585)>
     >>> get_body_barycentric(t, 'moon') # doctest: +REMOTE_DATA
     <CartesianRepresentation (x, y, z) in km
     (150107535.26352832, -866789.03506676, -418963.52113854)>
@@ -59,7 +59,7 @@ planets), although this interface should be considered preliminary (and hence
 is not yet considered part of the public API)::
 
     >>> from astropy import coordinates
-    >>> coordinates.solar_system.set_kernel_url('http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de432s.bsp')
-    >>> coordinates.get_body(t,'pluto')
+    >>> with coordinates.solar_system.kernel_url.set('http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de432s.bsp'):
+    ...     coordinates.get_body(t,'pluto') # doctest: +REMOTE_DATA
     <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 0.  0.  0.] m, obsgeovel=[ 0.  0.  0.] m / s): (ra, dec, distance) in (deg, deg, km)
-    (281.52508175, -20.60080214, 4865115955.7188015)>
+        (281.52508175, -20.60080214, 4865115955.7188015)>


### PR DESCRIPTION
This implements a couple of the things I mentioned in #4890 (but were not really worth holding up the merge there).  Specifically, it clarifies some of the documentation about this functionality, and it also adds a way to choose a specific URL to get the kernel from.

One mildly questionable bit - it seemed most natural to have it live in this module and not be outside visible, especially given that this is rather experimental.  But if someone things this function should be public, I can certainly do that.  It just seems a bit narrow for that.