### PR TITLE
Fix RTD build

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - matplotlib
   - wcsaxes
   - scipy
-  - sphinx-gallery
   - pillow
-  - jplephem
+  - pip:
+    - sphinx-gallery
+    - jplephem


### PR DESCRIPTION
The initial impetus for this was to fix ReadTheDocs, which was broken some time in the freature freeze flurry yesterday.  The root cause is that the docs now require `sphinx-gallery` (and possibly `jplephem`), both of which are not on conda (which is used by RTD in our current setup to install dependencies).  

They *are* on pip, so this PR tries to solve the problem by ressurrecting the pip requirements file and using that *in addition to* the conda requirements.  The problem is... it doesn't seem to work.  If you check out [this build report](https://readthedocs.org/projects/eteq-astropy/builds/4002312/), you'll see that it's still refusing to use the pip requirements file, despite it being added to the RTD YAML file.  I think it was @astrofrog that first set this up, right?  Any ideas on how to fix this?

Another possible solution is to just put sphinx-gallery (and jplephem if needed) on the astropy conda channel.  Then the pip stuff is no longer necessary.  @mwcraig or @bsipocz, any thoughts on that?