### PR TITLE
MetaData descriptor recognized as attribute (sphinx).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -272,7 +272,7 @@ API changes
 
   - ``NDData``: added an ``meta``-setter. It requires that the meta is
     dictionary-like (it also accepts Headers or ordered dictionaries and others)
-    or None. It will copy the given value before saving it. [#4509, #4469]
+    or None. [#4509, #4469, #4921]
 
   - ``NDArithmeticMixin``: The operand in arithmetic methods (``add``, ...)
     doesn't need to be a subclass of ``NDData``. It is sufficient if it can be
@@ -386,6 +386,9 @@ API changes
   - The astropy.utils.xml.unescaper module now also unescapes ``'%2F'`` to
     ``'/'`` and ``'&&'`` to ``'&'`` in a given URL. [#4699]
 
+  - The astropy.utils.metadata.MetaData descriptor has now two optional
+    parameters: doc and copy. [#4921]
+
 - ``astropy.visualization``
 
 - ``astropy.vo``
@@ -480,6 +483,9 @@ Bug fixes
 
   - Added ``format_doc`` decorator which allows to replace and/or format the
     current docstring of an object. [#4242]
+
+  - Attributes using the astropy.utils.metadata.MetaData descriptor are now
+    included in the sphinx documentation. [#4921]
 
 - ``astropy.visualization``
 

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -15,6 +15,8 @@ from ..utils.metadata import MetaData
 
 __all__ = ['NDData']
 
+_meta_doc = """`dict`-like : Additional meta information about the dataset."""
+
 
 class NDData(NDDataBase):
     """
@@ -76,11 +78,6 @@ class NDData(NDDataBase):
     TypeError
         In case ``data`` or ``meta`` don't meet the restrictions.
 
-    Attributes
-    ----------
-    meta : `dict`-like
-        Additional meta information about the dataset.
-
     Notes
     -----
     Each attribute can be accessed through the homonymous instance attribute:
@@ -114,14 +111,8 @@ class NDData(NDDataBase):
     """
 
     # Instead of a custom property use the MetaData descriptor also used for
-    # Tables. It will check if the meta is dict-like.
-    # TODO: reading the documentation from a descriptor using Sphinx isn't
-    # trivial so this attribute is documented in the class docstring but
-    # it would be better to define it here.
-    # TODO: Meta is copied when set, make sure this doesn't provide problems
-    # for affiliated packages. If it does alter the meta descriptor to take
-    # an optional parameter if it should be copied during setting.
-    meta = MetaData()
+    # Tables. It will check if the meta is dict-like or raise an exception.
+    meta = MetaData(doc=_meta_doc, copy=False)
 
     def __init__(self, data, uncertainty=None, mask=None, wcs=None,
                  meta=None, unit=None, copy=False):

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -362,10 +362,14 @@ class MetaData(object):
         Documentation for the attribute of the class.
         Default is ``""``.
 
+        .. versionadded:: 1.2
+
     copy : `bool`, optional
         If ``True`` the the value is deepcopied before setting, otherwise it
         is saved as reference.
         Default is ``True``.
+
+        .. versionadded:: 1.2
     """
     def __init__(self, doc="", copy=True):
         self.__doc__ = doc

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -354,10 +354,26 @@ class MetaData(object):
     """
     A descriptor for classes that have a ``meta`` property.
 
-    This can be set to any valid mapping.
+    This can be set to any valid `~collections.Mapping`.
+
+    Parameters
+    ----------
+    doc : `str`, optional
+        Documentation for the attribute of the class.
+        Default is ``""``.
+
+    copy : `bool`, optional
+        If ``True`` the the value is deepcopied before setting, otherwise it
+        is saved as reference.
+        Default is ``True``.
     """
+    def __init__(self, doc="", copy=True):
+        self.__doc__ = doc
+        self.copy = copy
 
     def __get__(self, instance, owner):
+        if instance is None:
+            return self
         if not hasattr(instance, '_meta'):
             instance._meta = OrderedDict()
         return instance._meta
@@ -367,6 +383,9 @@ class MetaData(object):
             instance._meta = OrderedDict()
         else:
             if isinstance(value, collections.Mapping):
-                instance._meta = deepcopy(value)
+                if self.copy:
+                    instance._meta = deepcopy(value)
+                else:
+                    instance._meta = value
             else:
                 raise TypeError("meta attribute must be dict-like")


### PR DESCRIPTION
This is primary a documentation fix but I've also added an optional parameter if the metadata is copied during set (which isn't a real bugfix, but ensures some backwards compatibility in nddata with regard to 1.1) even though @mwcraig did like the new functionality that meta is now copied while using the setter. (see #4509)

Some rendered images:

`astropy.nddata.NDData` (before):

![unbenannt2](https://cloud.githubusercontent.com/assets/14200878/15276153/1407acc8-1ae0-11e6-9d33-3958c5ea464d.png)

which was a bit inconsistent. With this PR it looks like this:
![unbenannt1](https://cloud.githubusercontent.com/assets/14200878/15276155/17eb6a96-1ae0-11e6-9452-99dc8b75b70f.png)

One other (unintentional) change is that the `meta` attribute is now also visible for `table`:
![unbenannt](https://cloud.githubusercontent.com/assets/14200878/15276154/1691d1c6-1ae0-11e6-894a-2001dfb37b7e.png)

but since there are some undocumented attributes I don't think it's severe. :smile:

This would need a Changelog alteration for NDData and probably a changelog entry for utils. Depending on the milestone - so they are not included (yet).