### PR TITLE
Minor improvements to mechanics of example  gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ astropy/_erfa/core.pyx
 _build
 _generated
 docs/api
-docs/auto_examples
-docs/modules/generated/
+docs/generated
 
 # Packages/installer info
 *.egg

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,8 +38,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)
 	-rm -rf api
-	-rm -rf auto_examples/
-	-rm -rf modules/generated/*
+	-rm -rf generated
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -213,7 +213,6 @@ for line in open('nitpick-exceptions'):
 if six.PY2:
     nitpick_ignore.extend([('py:obj', six.u('bases'))])
 
-
 # -- Options for the Sphinx gallery -------------------------------------------
 
 try:
@@ -221,9 +220,10 @@ try:
     extensions += ["sphinx_gallery.gen_gallery"]
 
     sphinx_gallery_conf = {
+        'mod_example_dir': 'generated/modules', # path to store the module using example template
         'filename_pattern': '^((?!skip_).)*$', # execute all examples except those that start with "skip_"
         'examples_dirs': '..{}examples'.format(os.sep), # path to the examples scripts
-        'gallery_dirs': 'auto_examples', # path to save gallery generated examples
+        'gallery_dirs': 'generated/examples', # path to save gallery generated examples
         'reference_url': {
             'astropy': None,
             'matplotlib': 'http://matplotlib.org/',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -213,17 +213,26 @@ for line in open('nitpick-exceptions'):
 if six.PY2:
     nitpick_ignore.extend([('py:obj', six.u('bases'))])
 
+
 # -- Options for the Sphinx gallery -------------------------------------------
 
-extensions += ["sphinx_gallery.gen_gallery"]
+try:
+    import sphinx_gallery
+    extensions += ["sphinx_gallery.gen_gallery"]
 
-sphinx_gallery_conf = {
-    'filename_pattern': '^((?!skip_).)*$', # execute all examples except those that start with "skip_"
-    'examples_dirs': '..{}examples'.format(os.sep), # path to the examples scripts
-    'gallery_dirs': 'auto_examples', # path to save gallery generated examples
-    'reference_url': {
-        'astropy': None,
-        'matplotlib': 'http://matplotlib.org/',
-        'numpy': 'http://docs.scipy.org/doc/numpy/',
+    sphinx_gallery_conf = {
+        'filename_pattern': '^((?!skip_).)*$', # execute all examples except those that start with "skip_"
+        'examples_dirs': '..{}examples'.format(os.sep), # path to the examples scripts
+        'gallery_dirs': 'auto_examples', # path to save gallery generated examples
+        'reference_url': {
+            'astropy': None,
+            'matplotlib': 'http://matplotlib.org/',
+            'numpy': 'http://docs.scipy.org/doc/numpy/',
+        }
     }
-}
+except ImportError:
+    def setup(app):
+        app.warn('The sphinx_gallery extension is not installed, so the '
+                 'gallery will not be built.  You will probably see '
+                 'additional warnings about undefined references due '
+                 'to this.')

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -275,7 +275,7 @@ user-created frames.
 
 .. topic:: Examples:
 
-    See also :ref:`sphx_glr_auto_examples_coordinates_plot_sgr-coordinate-frame.py`
+    See also :ref:`sphx_glr_generated_examples_coordinates_plot_sgr-coordinate-frame.py`
     for a more annotated example of defining a new coordinate frame.
 
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -126,7 +126,7 @@ This form of `~astropy.coordinates.SkyCoord.transform_to` also makes it
 straightforward to convert from celestial coordinates to
 `~astropy.coordinates.AltAz` coordinates, allowing the use of |skycoord|
 as a tool for planning observations.  For a more complete example of
-this, see :ref:`sphx_glr_auto_examples_coordinates_plot_obs-planning.py`.
+this, see :ref:`sphx_glr_generated_examples_coordinates_plot_obs-planning.py`.
 
 Representation
 --------------
@@ -263,7 +263,7 @@ class.
 
 .. topic:: Examples:
 
-    See :ref:`sphx_glr_auto_examples_coordinates_plot_obs-planning.py` for an
+    See :ref:`sphx_glr_generated_examples_coordinates_plot_obs-planning.py` for an
     example of using the `~astropy.coordinates` functionality to prepare for an
     observing run.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ User Documentation
    overview
    install
    getting_started
-   Example gallery <auto_examples/index>
+   Example gallery <generated/examples/index>
 
 **Core data structures and transformations**
 

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -280,7 +280,7 @@ sections <data-sections>` for more details on using this interface.
 How can I create a very large FITS file from scratch?
 """""""""""""""""""""""""""""""""""""""""""""""""""""
 
-See :ref:`sphx_glr_auto_examples_io_skip_create-large-fits.py`.
+See :ref:`sphx_glr_generated_examples_io_skip_create-large-fits.py`.
 
 For creating very large tables, this method may also be used.  Though it can be
 difficult to determine ahead of time how many rows a table will need.  In
@@ -304,7 +304,7 @@ this FAQ might provide an example of how to do this.
 How do I create a multi-extension FITS file from scratch?
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-See :ref:`sphx_glr_auto_examples_io_create-mef.py`.
+See :ref:`sphx_glr_generated_examples_io_create-mef.py`.
 
 
 .. _fits-scaled-data-faq:

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -270,7 +270,7 @@ would with a dict::
 
 .. topic:: Examples:
 
-    See also :ref:`sphx_glr_auto_examples_io_modify-fits-header.py`.
+    See also :ref:`sphx_glr_generated_examples_io_modify-fits-header.py`.
 
 Working with Image Data
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -348,7 +348,7 @@ a new file, you can use the :meth:`HDUList.writeto` method (see below).
 
 .. topic:: Examples:
 
-    See also :ref:`sphx_glr_auto_examples_io_plot_fits-image.py`.
+    See also :ref:`sphx_glr_generated_examples_io_plot_fits-image.py`.
 
 Working With Table Data
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -463,7 +463,7 @@ and so on.
 
 .. topic:: Examples:
 
-    See also :ref:`sphx_glr_auto_examples_io_fits-tables.py`.
+    See also :ref:`sphx_glr_generated_examples_io_fits-tables.py`.
 
 Save File Changes
 ^^^^^^^^^^^^^^^^^
@@ -616,7 +616,7 @@ each class and method.
 
 .. topic:: Examples:
 
-    See also :ref:`sphx_glr_auto_examples_io_create-mef.py`.
+    See also :ref:`sphx_glr_generated_examples_io_create-mef.py`.
 
 Convenience Functions
 ---------------------

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -66,7 +66,7 @@ observations.  For example::
     60d32m28.4576s 133d45m36.4967s
 
 For a more detailed outline of this new functionality, see the
-:ref:`sphx_glr_auto_examples_coordinates_plot_obs-planning.py` and the
+:ref:`sphx_glr_generated_examples_coordinates_plot_obs-planning.py` and the
 `~astropy.coordinates.AltAz` documentation.
 
 To enable this functionality, `~astropy.coordinates` now also contains


### PR DESCRIPTION
This PR makes two changes to the new example gallery.

1. Inspired by @MSeifert04's https://github.com/astropy/astropy/pull/4915#issuecomment-219295103, the first commit makes it so that the docs still build even of the gallery extension doesn't exist.  Turns out this was easier than I feared.  The down side is that it leads to a bunch of additional warnings because the gallery extension generates a bunch of documents that are linked to elsewhere in the docs, and of course they don't exist if the extension is missing.  So there's a bunch of "broken link" warnings without the extension.  But this is still probably a  change that's worth doing to make quick doc-building a bit easier, do you agree @adrn?
2. The second commit re-arranges where the build products of the gallery extension land, so that they're all in ``docs/generated/<something>``.  I think this is more clear, and on top of that, it makes it easier to work cleanly with the ``-l`` argument of ``python setup.py build_sphinx``.  Will issue a PR against ``astropy_helpers`` shortly to close the loop on that.  Does this re-organization sound ok to you, @adrn ?