### PR TITLE
Don't catch name resolve errors in test_database_specify

### DIFF
--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -154,10 +154,6 @@ def test_database_specify(name, db_dict):
 
     for db in db_dict.keys():
         with sesame_database.set(db):
-            try:
-                icrs = SkyCoord.from_name(name)
-            except NameResolveError:
-                ra, dec = db_dict[db]
-                icrs = SkyCoord(ra=float(ra)*u.degree, dec=float(dec)*u.degree)
+            icrs = SkyCoord.from_name(name)
 
         time.sleep(1)


### PR DESCRIPTION
While investigating some of the ``remote-data`` errors (a la #4896), I noticed that ``test_database_specify`` is doing something weird - it catches `NameResolveError`s and tries to replace them with a local/semi-local version.  But the ``except`` clause doesn't do this correctly and ends up just issuing a *different* error that has no information about the true error.  This PR corrects that by just not catching the error at all.

@adrn, can you shed some light on the original intent of this?  Is it out-of-date code from before ``remote_data`` was a thing, maybe?  If so, I think this is fine to remove.