### PR TITLE
Added a way to create 1D Gaussian models using FWHM

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -36,6 +36,8 @@ class Gaussian1D(Fittable1DModel):
         Mean of the Gaussian.
     stddev : float
         Standard deviation of the Gaussian.
+        This can also be indirectly set via ``fwhm`` keyword;
+        If both are given, ``fwhm`` overrides ``stddev``.
 
     Notes
     -----
@@ -110,6 +112,14 @@ class Gaussian1D(Fittable1DModel):
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
 
+    def __init__(self, *args, **kwargs):
+        fwhm = kwargs.pop('fwhm', None)
+        super(Gaussian1D, self).__init__(*args, **kwargs)
+
+        if fwhm is not None:
+            from ..stats.funcs import gaussian_fwhm_to_sigma
+            self.stddev = fwhm * gaussian_fwhm_to_sigma
+
     def bounding_box(self, factor=5.5):
         """
         Tuple defining the default ``bounding_box`` limits,
@@ -173,6 +183,8 @@ class GaussianAbsorption1D(Fittable1DModel):
         Mean of the gaussian.
     stddev : float
         Standard deviation of the gaussian.
+        This can also be indirectly set via ``fwhm`` keyword;
+        If both are given, ``fwhm`` overrides ``stddev``.
 
     Notes
     -----
@@ -208,6 +220,14 @@ class GaussianAbsorption1D(Fittable1DModel):
     amplitude = Parameter(default=1)
     mean = Parameter(default=0)
     stddev = Parameter(default=1)
+
+    def __init__(self, *args, **kwargs):
+        fwhm = kwargs.pop('fwhm', None)
+        super(GaussianAbsorption1D, self).__init__(*args, **kwargs)
+
+        if fwhm is not None:
+            from ..stats.funcs import gaussian_fwhm_to_sigma
+            self.stddev = fwhm * gaussian_fwhm_to_sigma
 
     def bounding_box(self, factor=5.5):
         """

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -37,6 +37,13 @@ def test_GaussianAbsorption1D():
     assert g_ab.bounding_box == g_em.bounding_box
 
 
+def test_Gaussian1D_fwhm():
+    """Test 1D Gaussian models defined using FWHM instead of STDDEV."""
+    g_em = models.Gaussian1D(amplitude=0.8, mean=3000, fwhm=100)
+    g_ab = models.GaussianAbsorption1D(amplitude=0.8, mean=3000, fwhm=100)
+    assert_allclose([g_em.stddev, g_ab.stddev], 42.466090014400955)
+
+
 def test_Gaussian2D():
     """
     Test rotated elliptical Gaussian2D model.


### PR DESCRIPTION
I see this as an expansion of #2085 to have 1D Gaussian models (namely `Gaussian1D` and `GaussianAbsorption1D`) accept FWHM values as well as STDDEV. Instead of making FWHM another Parameter, which will complicate things, this simply use it during init to set/override STDDEV. Hacky (maybe) but simple.
#### TODO:
- [ ] Add change log when milestone is decided.
- [ ] Enable Travis CI testing (skipped to avoid competing resources with v1.2 stuff).
