### PR TITLE
Refactor sky rotations to have the same interface as the other models

### DIFF
--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -10,8 +10,8 @@ WCS Paper II to rotate to/from a native sphere and the celestial sphere.
 The implementation uses `EulerAngleRotation`. The model parameters are
 three angles: the longitude (``lon``) and latitude (``lat``) of the fiducial point
 in the celestial system (``CRVAL`` keywords in FITS), and the longitude of the celestial
-pole in the native system (``lon_pole``). The Euler angles are ``lon+90``, ``90 - lat``
-and ``-(lon_pole - 90)``.
+pole in the native system (``lon_pole``). The Euler angles are ``lon+90``, ``90-lat``
+and ``-(lon_pole-90)``.
 
 
 References
@@ -34,7 +34,82 @@ __all__ = ['RotateCelestial2Native', 'RotateNative2Celestial', 'Rotation2D',
            'EulerAngleRotation']
 
 
-class EulerAngleRotation(Model):
+class _EulerRotation(object):
+    """
+    Base class which does the actual computation.
+    """
+    def _create_matrix(self, phi, theta, psi, axes_order):
+        matrices = []
+        for angle, axis in zip([phi, theta, psi], axes_order):
+            matrix = np.zeros((3, 3), dtype=np.float)
+            if axis == 'x':
+                mat = self.rotation_matrix_from_angle(angle)
+                matrix[0, 0] = 1
+                matrix[1:, 1:] = mat
+            elif axis == 'y':
+                mat = self.rotation_matrix_from_angle(-angle)
+                matrix[1, 1] = 1
+                matrix[0, 0] = mat[0, 0]
+                matrix[0, 2] = mat[0, 1]
+                matrix[2, 0] = mat[1, 0]
+                matrix[2, 2] = mat[1, 1]
+            elif axis == 'z':
+                mat = self.rotation_matrix_from_angle(angle)
+                matrix[2, 2] = 1
+                matrix[:2, :2] = mat
+            else:
+                raise ValueError("Expected axes_order to be a combination of characters"
+                                 "'x', 'y' and 'z', got {0}".format(
+                                     set(axes_order).difference(self.axes)))
+            matrices.append(matrix)
+        return np.dot(matrices[2], np.dot(matrices[1], matrices[0]))
+
+    @staticmethod
+    def spherical2cartesian(alpha, delta):
+        alpha = np.deg2rad(alpha)
+        delta = np.deg2rad(delta)
+        x = np.cos(alpha) * np.cos(delta)
+        y = np.cos(delta) * np.sin(alpha)
+        z = np.sin(delta)
+        return np.array([x, y, z])
+
+    @staticmethod
+    def cartesian2spherical(x, y, z):
+        h = np.hypot(x, y)
+        alpha  = np.rad2deg(np.arctan2(y, x))
+        delta = np.rad2deg(np.arctan2(z, h))
+        return alpha, delta
+
+    @staticmethod
+    def rotation_matrix_from_angle(angle):
+        """
+        Clockwise rotation matrix.
+
+        Parameters
+        ----------
+        angle : float
+            Rotation angle in radians.
+        """
+        return np.array([[math.cos(angle), math.sin(angle)],
+                         [-math.sin(angle), math.cos(angle)]])
+
+    def evaluate(self, alpha, delta, phi, theta, psi, axes_order):
+        shape = None
+        if isinstance(alpha, np.ndarray) and alpha.ndim == 2:
+            alpha = alpha.flatten()
+            delta = delta.flatten()
+            shape = alpha.shape
+        inp = self.spherical2cartesian(alpha, delta)
+        matrix = self._create_matrix(phi, theta, psi, axes_order)
+        result = np.dot(matrix, inp)
+        a, b = self.cartesian2spherical(*result)
+        if shape is not None:
+            a.shape = shape
+            b.shape = shape
+        return a, b
+
+
+class EulerAngleRotation(_EulerRotation, Model):
     """
     Implements Euler angle intrinsic rotations.
 
@@ -71,57 +146,6 @@ class EulerAngleRotation(Model):
         self.axes_order = axes_order
         super(EulerAngleRotation, self).__init__(phi=phi, theta=theta, psi=psi, **kwargs)
 
-    def _create_matrix(self, phi, theta, psi, axes_order):
-        matrices = []
-        for angle, axis in zip([phi, theta, psi], axes_order):
-            matrix = np.zeros((3, 3), dtype=np.float)
-            if axis == 'x':
-                mat = self._rotation_matrix_from_angle(angle)
-                matrix[0, 0] = 1
-                matrix[1:, 1:] = mat
-            elif axis == 'y':
-                mat = self._rotation_matrix_from_angle(-angle)
-                matrix[1, 1] = 1
-                matrix[0, 0] = mat[0, 0]
-                matrix[0, 2] = mat[0, 1]
-                matrix[2, 0] = mat[1, 0]
-                matrix[2, 2] = mat[1, 1]
-            elif axis == 'z':
-                mat = self._rotation_matrix_from_angle(angle)
-                matrix[2, 2] = 1
-                matrix[:2, :2] = mat
-            else:
-                raise ValueError("Expected axes_order to be a combination of characters"
-                                 "'x', 'y' and 'z', got {0}".format(
-                                     set(axes_order).difference(self.axes)))
-            matrices.append(matrix)
-        return np.dot(matrices[2], np.dot(matrices[1], matrices[0]))
-
-
-    def _rotation_matrix_from_angle(self, angle):
-        """
-        Clockwise rotation matrix.
-        """
-        return np.array([[math.cos(angle), math.sin(angle)],
-                         [-math.sin(angle), math.cos(angle)]])
-
-    @staticmethod
-    def spherical2cartesian(alpha, delta):
-        alpha = np.deg2rad(alpha)
-        delta = np.deg2rad(delta)
-
-        x = np.cos(alpha) * np.cos(delta)
-        y = np.cos(delta) * np.sin(alpha)
-        z = np.sin(delta)
-        return np.array([x, y, z])
-
-    @staticmethod
-    def cartesian2spherical(x, y, z):
-        h = np.hypot(x, y)
-        alpha  = np.rad2deg(np.arctan2(y, x))
-        delta = np.rad2deg(np.arctan2(z, h))
-        return alpha, delta
-
     def inverse(self):
         return self.__class__(phi=-self.psi,
                               theta=-self.theta,
@@ -144,16 +168,22 @@ class EulerAngleRotation(Model):
         return a, b
 
 
-class _SkyRotation(EulerAngleRotation):
+class _SkyRotation(_EulerRotation, Model):
     """
     Base class for RotateNative2Celestial and RotateCelestial2Native.
     """
 
-    def __init__(self, phi, theta, psi, **kwargs):
-        super(_SkyRotation, self).__init__(phi, theta, psi, 'zxz', **kwargs)
+    lon = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
+    lat = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
+    lon_pole = Parameter(default=0, getter=np.rad2deg, setter=np.deg2rad)
 
-    def evaluate(self, phi, theta, lon, lat, lon_pole):
-        alpha, delta = super(_SkyRotation, self).evaluate(phi, theta, lon, lat, lon_pole)
+    def __init__(self, lon, lat, lon_pole, **kwargs):
+        super(_SkyRotation, self).__init__(lon, lat, lon_pole, **kwargs)
+        self.axes_order = 'zxz'
+
+    def _evaluate(self, phi, theta, lon, lat, lon_pole):
+        alpha, delta = super(_SkyRotation, self).evaluate(phi, theta, lon, lat,
+                                                          lon_pole, self.axes_order)
         mask = alpha < 0
         if isinstance(mask, np.ndarray):
             alpha[mask] +=360
@@ -177,47 +207,25 @@ class RotateNative2Celestial(_SkyRotation):
     """
 
     # angles in degrees on the native sphere
-    inputs = ('phi', 'theta')
-    outputs = ('alpha', 'delta')
+    inputs = ('phi_N', 'theta_N')
+    outputs = ('alpha_C', 'delta_C')
 
     def __init__(self, lon, lat, lon_pole, **kwargs):
+        super(RotateNative2Celestial, self).__init__(lon, lat, lon_pole, **kwargs)
+
+    def evaluate(self, phi_N, theta_N, lon, lat, lon_pole):
         # Convert to Euler angles
-        phi = lon_pole - 90
-        theta = - (90 - lat)
-        psi = -(90 + lon)
-        super(RotateNative2Celestial, self).__init__(phi, theta, psi, **kwargs)
-
-    @property
-    def lon(self):
-        return - (self.psi + 90)
-
-    @lon.setter
-    def lon(self, val):
-        self.psi = - (val + 90)
-
-    @property
-    def lat(self):
-        return self.theta + 90
-
-    @lat.setter
-    def lat(self, val):
-        self.theta = val - 90
-
-    @property
-    def lon_pole(self):
-        return self.phi + 90
-
-    @lon_pole.setter
-    def lon_pole(self, val):
-        self.phi = val - 90
+        phi = lon_pole - np.pi / 2
+        theta = - (np.pi / 2 - lat)
+        psi = -(np.pi / 2 + lon)
+        alpha_C, delta_C = super(RotateNative2Celestial, self)._evaluate(phi_N, theta_N,
+                                                                         phi, theta, psi)
+        return alpha_C, delta_C
 
     @property
     def inverse(self):
         # convert to angles on the celestial sphere
-        lon = -(self.psi + 90)
-        lat = self.theta + 90
-        lon_pole = self.phi + 90
-        return RotateCelestial2Native(lon, lat, lon_pole)
+        return RotateCelestial2Native(self.lon, self.lat, self.lon_pole)
 
 
 class RotateCelestial2Native(_SkyRotation):
@@ -235,49 +243,26 @@ class RotateCelestial2Native(_SkyRotation):
     """
 
     # angles in degrees on the celestial sphere
-    inputs = ('alpha', 'delta')
+    inputs = ('alpha_C', 'delta_C')
     # angles in degrees on the native sphere
-    outputs = ('phi', 'theta')
+    outputs = ('phi_N', 'theta_N')
 
 
     def __init__(self, lon, lat, lon_pole, **kwargs):
+        super(RotateCelestial2Native, self).__init__(lon, lat, lon_pole, **kwargs)
+
+    def evaluate(self, alpha_C, delta_C, lon, lat, lon_pole):
         # Convert to Euler angles
-        phi = (90 + lon)
-        theta =  (90 - lat)
-        psi = -(lon_pole - 90)
-        super(RotateCelestial2Native, self).__init__(phi, theta, psi, **kwargs)
-
-    @property
-    def lon(self):
-        return self.phi - 90
-
-    @lon.setter
-    def lon(self, val):
-        self.phi = val + 90
-
-    @property
-    def lat(self):
-        return 90 - self.theta
-
-    @lat.setter
-    def lat(self, val):
-        self.theta = 90 - val
-
-    @property
-    def lon_pole(self):
-        return 90 - self.psi
-
-    @lon_pole.setter
-    def lon_pole(self, val):
-        self.psi = 90 - val
+        phi = (np.pi / 2 + lon)
+        theta =  (np.pi / 2 - lat)
+        psi = -(lon_pole - np.pi / 2)
+        phi_N, theta_N = super(RotateCelestial2Native, self)._evaluate(alpha_C, delta_C,
+                                                                       phi, theta, psi)
+        return phi_N, theta_N
 
     @property
     def inverse(self):
-        # convert to angles on the celestial sphere
-        lon = -(self.psi + 90)
-        lat = self.theta + 90
-        lon_pole = self.phi + 90
-        return RotateCelestial2Native(lon, lat, lon_pole)
+        return RotateNative2Celestial(self.lon, self.lat, self.lon_pole)
 
 
 class Rotation2D(Model):

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -44,23 +44,6 @@ def test_roundtrip_sky_rotaion(inp):
     utils.assert_allclose(c2n.inverse(*c2n(*inp)), inp, atol=1e-13)
 
 
-def test_skyrot_parameters():
-    # Because parameters are converted to Euler angles
-    # test the sky rotation angles are correctly set.
-    n2c = models.RotateNative2Celestial(2, 4, 6)
-    c2n = models.RotateCelestial2Native(1, 3, 5)
-    assert n2c.lon == 2
-    assert n2c.lat == 4
-    assert n2c.lon_pole == 6
-    assert c2n.lon == 1
-    assert c2n.lat == 3
-    assert c2n.lon_pole == 5
-    n2c.lon +=1
-    assert n2c.lon == 3
-    c2n.lat -=1
-    assert c2n.lat == 2
-
-
 def test_native_celestial_lat90():
     n2c = models.RotateNative2Celestial(1, 90, 0)
     alpha, delta = n2c(1, 1)


### PR DESCRIPTION
This addresses the concerns @mcara raised in #4932. It's unfortunate but I did not see this solution when I checked it in last Friday. There're no  computational changes in this implementation.
Computing the Euler angles rotation is pulled into a separate class used as a mixin in the three 3D rotation classes. This allows each one of them to have its parameters as instances of `modeling.Parameter` and makes the user interface consistent with the other models in `modeling`. This is a user interface issue and I think it's better to release this version with 1.2 instead of what's currently there.

So I'm setting the milestone to 1.2 and can also port it to the 1.2 branch if I'm told to.