### PR TITLE
Make AstrometricFrame behave like other coordinate frames.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,8 +164,6 @@ New Features
   - Solar system and lunar ephemerides accessible via ``get_body``,
     ``get_body_barycentric`` and ``get_moon`` functions. [#4890]
 
-  - Added astrometric frames (i.e., a frame centered on a particular
-    point/object specified in another frame). [#4909]
   - Added astrometric frames (i.e., a frame centered on a particular 
     point/object specified in another frame). [#4909, #4941]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -166,6 +166,8 @@ New Features
 
   - Added astrometric frames (i.e., a frame centered on a particular
     point/object specified in another frame). [#4909]
+  - Added astrometric frames (i.e., a frame centered on a particular 
+    point/object specified in another frame). [#4909, #4941]
 
   - Added ``SkyCoord.spherical_offsets_to`` method. [#4338]
   - Recent Earth rotation (IERS) data are now auto-downloaded so that AltAz

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -36,7 +36,7 @@ from .cirs import CIRS
 from .itrs import ITRS
 from .hcrs import HCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
-from .astrometric import AstrometricICRS, AstrometricAltAz, make_astrometric_cls
+from .astrometric import AstrometricFrame
 # need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
 from . import fk4_fk5_transforms
@@ -52,7 +52,7 @@ __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS', 'HCRS',
            'PrecessedGeocentric', 'GeocentricTrueEcliptic',
            'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic',
-           'AstrometricICRS', 'AstrometricAltAz', 'make_astrometric_cls']
+           'AstrometricFrame']
 
 
 def _make_transform_graph_docs():

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -133,11 +133,11 @@ def make_astrometric_cls(framecls):
 
 class AstrometricFrame(BaseCoordinateFrame):
     """
-    A frame which is relative to some position on the sky. 
+    A frame which is relative to some position on the sky.
 
     Useful for calculating offsets and dithers in the frame of the sky relative
     to an arbitrary position. The resulting `AstrometricFrame` instance will be
-    specific to the base coordinate frame of the `origin`. 
+    specific to the base coordinate frame of the `origin`.
     See :ref:`astropy-astrometric-frames`
 
     Parameters

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -41,13 +41,13 @@ def make_astrometric_cls(framecls):
     just that class, as well as ensuring that only one example of such a class
     actually gets created in any given python session.
     """
-    
+
     if framecls in _astrometric_cache:
         return _astrometric_cache[framecls]
-        
+
     # the class of a class object is the metaclass
     framemeta = framecls.__class__
-    
+
     class AstrometricMeta(framemeta):
         """
         This metaclass renames the class to be "Astrometric<framecls>" and also
@@ -61,7 +61,7 @@ def make_astrometric_cls(framecls):
             res = super(AstrometricMeta, cls).__new__(cls, newname, bases, members)
             # now go through all the component names and make any spherical
             # lat/lon names be "d<lon>"/"d<lat>"
-            
+
             lists_done = []
             for nm, component_list in res._frame_specific_representation_info.items():
                 if nm in ('spherical', 'unitspherical'):
@@ -88,8 +88,8 @@ def make_astrometric_cls(framecls):
                     lists_done.append(component_list)
 
             return res
-        
-    
+
+
     # We need this to handle the intermediate metaclass correctly, otherwise we could
     # just subclass astrometric.
     class _Astrometric(six.with_metaclass(AstrometricMeta, framecls, AstrometricFrame)):
@@ -110,7 +110,7 @@ def make_astrometric_cls(framecls):
             the positive latitude (z) direction in the final frame.
 
         """
-        
+
 
     @frame_transform_graph.transform(FunctionTransform, _Astrometric, _Astrometric)
     def astrometric_to_astrometric(from_astrometric_coord, to_astrometric_frame):
@@ -165,10 +165,10 @@ class AstrometricFrame(BaseCoordinateFrame):
         the positive latitude (z) direction in the final frame.
 
     """
-    
+
     rotation = QuantityFrameAttribute(default=0, unit=u.deg)
     origin = CoordinateAttribute(default=None, frame=None)
-    
+
     def __new__(cls, *args, **kwargs):
         # We don't want to call this method if we've already set up
         # an astrometric frame for this class.
@@ -182,7 +182,7 @@ class AstrometricFrame(BaseCoordinateFrame):
                 origin_frame = origin_frame.frame
             newcls = make_astrometric_cls(origin_frame.__class__)
             return newcls.__new__(newcls, *args, **kwargs)
-            
+
         # http://stackoverflow.com/questions/19277399/why-does-object-new-work-differently-in-these-three-cases
         # See above for why this is necessary. Basically, because some child
         # may override __new__, we must override it here to never pass
@@ -190,4 +190,3 @@ class AstrometricFrame(BaseCoordinateFrame):
         if super(AstrometricFrame, cls).__new__ is object.__new__:
             return super(AstrometricFrame, cls).__new__(cls)
         return super(AstrometricFrame, cls).__new__(cls, *args, **kwargs)
-    

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -89,28 +89,12 @@ def make_astrometric_cls(framecls):
 
             return res
 
-
     # We need this to handle the intermediate metaclass correctly, otherwise we could
     # just subclass astrometric.
     class _Astrometric(six.with_metaclass(AstrometricMeta, framecls, AstrometricFrame)):
-        """
-        A frame which is relative to some position on the sky. Useful for
-        calculating offsets and dithers in the frame of the sky.
+        pass
 
-        Parameters
-        ----------
-        representation : `BaseRepresentation` or None
-            A representation object or None to have no data (or use the other keywords)
-        origin : `SkyCoord` or low-level coordinate object.
-            the coordinate which specifiy the origin of this frame.
-        rotation : Quantity with angle units
-            The final rotation of the frame about the ``origin``. The sign of
-            the rotation is the left-hand rule.  That is, an object at a
-            particular position angle in the un-rotated system will be sent to
-            the positive latitude (z) direction in the final frame.
-
-        """
-
+    _Astrometric.__doc__ = AstrometricFrame.__doc__
 
     @frame_transform_graph.transform(FunctionTransform, _Astrometric, _Astrometric)
     def astrometric_to_astrometric(from_astrometric_coord, to_astrometric_frame):
@@ -124,7 +108,7 @@ def make_astrometric_cls(framecls):
         return to_astrometric_frame.realize_frame(from_astrometric_coord.cartesian)
 
     @frame_transform_graph.transform(DynamicMatrixTransform, framecls, _Astrometric)
-    def icrs_to_astrometric(reference_frame, astrometric_frame):
+    def reference_to_astrometric(reference_frame, astrometric_frame):
         """Convert a reference coordinate to an Astrometric frame."""
 
         # Define rotation matricies along the position angle vector, and
@@ -137,7 +121,7 @@ def make_astrometric_cls(framecls):
         return R
 
     @frame_transform_graph.transform(DynamicMatrixTransform, _Astrometric, framecls)
-    def astrometric_to_icrs(astrometric_coord, reference_frame):
+    def astrometric_to_reference(astrometric_coord, reference_frame):
         """Convert an Astrometric frame coordinate to the reference frame"""
 
         # use the forward transform, but just invert it
@@ -149,15 +133,19 @@ def make_astrometric_cls(framecls):
 
 class AstrometricFrame(BaseCoordinateFrame):
     """
-    A frame which is relative to some position on the sky. Useful for
-    calculating offsets and dithers in the frame of the sky.
+    A frame which is relative to some position on the sky. 
+
+    Useful for calculating offsets and dithers in the frame of the sky relative
+    to an arbitrary position. The resulting `AstrometricFrame` instance will be
+    specific to the base coordinate frame of the `origin`. 
+    See :ref:`astropy-astrometric-frames`
 
     Parameters
     ----------
     representation : `BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
     origin : `SkyCoord` or low-level coordinate object.
-        the coordinate which specifiy the origin of this frame.
+        the coordinate which specifies the origin of this frame.
     rotation : Quantity with angle units
         The final rotation of the frame about the ``origin``. The sign of
         the rotation is the left-hand rule.  That is, an object at a

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -125,7 +125,7 @@ def make_astrometric_cls(framecls):
         """Convert an Astrometric frame coordinate to the reference frame"""
 
         # use the forward transform, but just invert it
-        R = icrs_to_astrometric(reference_frame, astrometric_coord)
+        R = reference_to_astrometric(reference_frame, astrometric_coord)
         return R.T  # this is the inverse because R is a rotation matrix
 
     _astrometric_cache[framecls] = _Astrometric

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -56,10 +56,12 @@ def make_astrometric_cls(framecls):
         """
         def __new__(cls, name, bases, members):
             newname = AstrometricFrame.__name__
+            members['origin'] = CoordinateAttribute(frame=framecls, default=None)
+            members['rotation'] = QuantityFrameAttribute(default=0, unit=u.deg)
             res = super(AstrometricMeta, cls).__new__(cls, newname, bases, members)
             # now go through all the component names and make any spherical
             # lat/lon names be "d<lon>"/"d<lat>"
-
+            
             lists_done = []
             for nm, component_list in res._frame_specific_representation_info.items():
                 if nm in ('spherical', 'unitspherical'):
@@ -108,9 +110,6 @@ def make_astrometric_cls(framecls):
             the positive latitude (z) direction in the final frame.
 
         """
-        
-        rotation = QuantityFrameAttribute(default=0, unit=u.deg)
-        origin = CoordinateAttribute(default=None, frame=framecls)
         
 
     @frame_transform_graph.transform(FunctionTransform, _Astrometric, _Astrometric)
@@ -178,11 +177,10 @@ class AstrometricFrame(BaseCoordinateFrame):
             try:
                 origin_frame = kwargs['origin']
             except KeyError:
-                raise TypeError("Can't initialize an AstrometricFrame without an Origin")
+                raise TypeError("Can't initialize an AstrometricFrame without origin= keyword.")
             if hasattr(origin_frame, 'frame'):
                 origin_frame = origin_frame.frame
             newcls = make_astrometric_cls(origin_frame.__class__)
-            print(newcls)
             return newcls.__new__(newcls, *args, **kwargs)
             
         # http://stackoverflow.com/questions/19277399/why-does-object-new-work-differently-in-these-three-cases

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -106,12 +106,11 @@ def make_astrometric_cls(framecls):
     def astrometric_to_astrometric(from_astrometric_coord, to_astrometric_frame):
         """Transform between two astrometric frames."""
 
-        # If both frames have on-sky positions, then the transform should happen relative to both origins.
-        if (from_astrometric_coord.origin is not None) and (to_astrometric_frame.origin is not None):
-            return from_astrometric_coord.transform_to(framecls).transform_to(to_astrometric_frame)
-
-        # Otherwise, the transform occurs just by setting the new origin.
-        return to_astrometric_frame.realize_frame(from_astrometric_coord.cartesian)
+        # This transform goes through the parent frames on each side.
+        # from_frame -> from_frame.origin -> to_frame.origin -> to_frame
+        intermediate_from = from_astrometric_coord.transform_to(from_astrometric_coord.origin)
+        intermediate_to = intermediate_from.transform_to(to_astrometric_frame.origin)
+        return intermediate_to.transform_to(to_astrometric_frame)
 
     @frame_transform_graph.transform(DynamicMatrixTransform, framecls, _Astrometric)
     def reference_to_astrometric(reference_frame, astrometric_frame):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -18,7 +18,7 @@ from ..utils.data_info import MixinInfo
 from .distances import Distance
 from .angles import Angle
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame, _get_repr_cls
-from .builtin_frames import ICRS, make_astrometric_cls
+from .builtin_frames import ICRS, AstrometricFrame
 from .representation import (BaseRepresentation, SphericalRepresentation,
                              UnitSphericalRepresentation)
 
@@ -1033,13 +1033,12 @@ class SkyCoord(object):
 
         Returns
         -------
-        astrframe: AstrometricFrame<subtype set by this object>
+        astrframe: AstrometricFrame
             An astrometric frame of the same type as this `SkyCoord` (e.g., if
             this object has an ICRS coordinate, the resulting frame is
-            AstrometricICRS)
+            AstrometricFrame with an ICRS origin)
         """
-        acls = make_astrometric_cls(self.frame.__class__)
-        return acls(origin=self)
+        return AstrometricFrame(origin=self)
 
     def get_constellation(self, short_name=False, constellation_list='iau'):
         """

--- a/astropy/coordinates/tests/test_astrometric_transformations.py
+++ b/astropy/coordinates/tests/test_astrometric_transformations.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ... import units as u
-from ..builtin_frames import ICRS, AstrometricICRS
+from ..builtin_frames import ICRS, AstrometricFrame
 from .. import SkyCoord
 from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
@@ -21,7 +21,7 @@ from ...tests.helper import (pytest, quantity_allclose as allclose,
     ])
 def test_astrometric(inradec, expecteddradec, tolsep, originradec=(45, 45)*u.deg):
     origin = ICRS(*originradec)
-    astrometric_frame = AstrometricICRS(origin=origin)
+    astrometric_frame = AstrometricFrame(origin=origin)
 
     skycoord = SkyCoord(*inradec, frame=ICRS)
     skycoord_inaf = skycoord.transform_to(astrometric_frame)
@@ -53,7 +53,7 @@ def test_astrometric_functional_ra():
         expected_xyz = expected.cartesian.xyz
 
         # actual transformation to the frame
-        astrometric_frame = AstrometricICRS(origin=ICRS(ra*u.deg, 0*u.deg))
+        astrometric_frame = AstrometricFrame(origin=ICRS(ra*u.deg, 0*u.deg))
         actual = icrs_coord.transform_to(astrometric_frame)
         actual_xyz = actual.cartesian.xyz
 
@@ -97,7 +97,7 @@ def test_astrometric_functional_dec():
         expected_xyz = expected.cartesian.xyz
 
         # actual transformation to the frame
-        astrometric_frame = AstrometricICRS(origin=ICRS(0*u.deg, dec*u.deg))
+        astrometric_frame = AstrometricFrame(origin=ICRS(0*u.deg, dec*u.deg))
         actual = icrs_coord.transform_to(astrometric_frame)
         actual_xyz = actual.cartesian.xyz
 
@@ -144,7 +144,7 @@ def test_astrometric_functional_ra_dec():
             expected_xyz = expected.cartesian.xyz
 
             # actual transformation to the frame
-            astrometric_frame = AstrometricICRS(origin=ICRS(ra*u.deg, dec*u.deg))
+            astrometric_frame = AstrometricFrame(origin=ICRS(ra*u.deg, dec*u.deg))
             actual = icrs_coord.transform_to(astrometric_frame)
             actual_xyz = actual.cartesian.xyz
 
@@ -182,7 +182,7 @@ def test_rotation(rotation, expecteddradec):
     origin = ICRS(45*u.deg, 45*u.deg)
     target = ICRS(45*u.deg, 46*u.deg)
 
-    aframe = AstrometricICRS(origin=origin, rotation=rotation)
+    aframe = AstrometricFrame(origin=origin, rotation=rotation)
     trans = target.transform_to(aframe)
 
     assert_allclose([trans.dra.wrap_at(180*u.deg), trans.ddec],

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -81,23 +81,17 @@ telescope operator to move from a bright star to a fainter target.)::
 To extend the concept of spherical offsets, `~astropy.coordinates` has
 machinery to create distinct frames that are centered on a specific point.
 These are known as "astrometric frames" (as they are a convenient way to create
-a locally "flat" frame on relatively small fields suitable for astrometry). One
-complication of astrometric frames is that they cannot be created in the same
-manner as other frames, because astrometric frames are generated on-the-fly
-given a particular "origin" frame. The 
-`~astropy.coordinates.make_astrometric_cls` function instead must be used to
-generate the class that creates such a frame::
+a locally "flat" frame on relatively small fields suitable for astrometry)::
 
-    >>> from astropy.coordinates import make_astrometric_cls, ICRS
-    >>> AstrometricICRS = make_astrometric_cls(ICRS)
+    >>> from astropy.coordinates import AstrometricFrame, ICRS
     >>> center = ICRS(10*u.deg, 45*u.deg)
-    >>> center.transform_to(AstrometricICRS(origin=center))  # doctest: +SKIP
-    <AstrometricICRS Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
+    >>> center.transform_to(AstrometricFrame(origin=center))  # doctest: +SKIP
+    <AstrometricFrame Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
         (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
         (0.0, 0.0)>
     >>> target = ICRS(11*u.deg, 46*u.deg)
-    >>> target.transform_to(AstrometricICRS(origin=center))  # doctest: +FLOAT_CMP
-    <AstrometricICRS Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
+    >>> target.transform_to(AstrometricFrame(origin=center))  # doctest: +FLOAT_CMP
+    <AstrometricFrame Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
         (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
         (0.69474685, 1.00428706)>
 
@@ -110,12 +104,12 @@ frame from an already-existing |SkyCoord|::
     >>> center = SkyCoord(10*u.deg, 45*u.deg)
     >>> aframe = center.astrometric_frame()
     >>> target.transform_to(aframe)  # doctest: +FLOAT_CMP
-    <AstrometricICRS Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
+    <AstrometricFrame Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
         (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
         (0.69474685, 1.00428706)>
     >>> other = SkyCoord(9*u.deg, 44*u.deg, frame='fk5')
     >>> other.transform_to(aframe)  # doctest: +FLOAT_CMP
-    <SkyCoord (AstrometricICRS: origin=<ICRS Coordinate: (ra, dec) in deg
+    <SkyCoord (AstrometricFrame: origin=<ICRS Coordinate: (ra, dec) in deg
         (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
         (359.28056055, -0.99556216)>
 

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -79,9 +79,11 @@ telescope operator to move from a bright star to a fainter target.)::
 ====================
 
 To extend the concept of spherical offsets, `~astropy.coordinates` has
-machinery to create distinct frames that are centered on a specific point.
+a frame class :class:`~astropy.coordinates.builtin_frames.astrometric.AstrometricFrame` 
+which creates distinct frames that are centered on a specific point.
 These are known as "astrometric frames" (as they are a convenient way to create
-a locally "flat" frame on relatively small fields suitable for astrometry)::
+a centered on an arbitrary position, suitable for computing positional offsets for
+astrometry)::
 
     >>> from astropy.coordinates import AstrometricFrame, ICRS
     >>> center = ICRS(10*u.deg, 45*u.deg)
@@ -98,7 +100,7 @@ a locally "flat" frame on relatively small fields suitable for astrometry)::
 
 
 Alternatively, the convenience method 
-`~astropy.coordinates.SkyCoord.astrometric_frame` let you create an astrometric
+:meth:`~astropy.coordinates.SkyCoord.astrometric_frame` lets you create an astrometric
 frame from an already-existing |SkyCoord|::
 
     >>> center = SkyCoord(10*u.deg, 45*u.deg)

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -88,13 +88,13 @@ astrometry)::
     >>> from astropy.coordinates import AstrometricFrame, ICRS
     >>> center = ICRS(10*u.deg, 45*u.deg)
     >>> center.transform_to(AstrometricFrame(origin=center))  # doctest: +SKIP
-    <AstrometricFrame Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
+    <AstrometricFrame Coordinate (rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
+        (10.0, 45.0)>): (dra, ddec) in deg
         (0.0, 0.0)>
     >>> target = ICRS(11*u.deg, 46*u.deg)
     >>> target.transform_to(AstrometricFrame(origin=center))  # doctest: +FLOAT_CMP
-    <AstrometricFrame Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
+    <AstrometricFrame Coordinate (rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
+        (10.0, 45.0)>): (dra, ddec) in deg
         (0.69474685, 1.00428706)>
 
 
@@ -106,13 +106,13 @@ frame from an already-existing |SkyCoord|::
     >>> center = SkyCoord(10*u.deg, 45*u.deg)
     >>> aframe = center.astrometric_frame()
     >>> target.transform_to(aframe)  # doctest: +FLOAT_CMP
-    <AstrometricFrame Coordinate (origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
+    <AstrometricFrame Coordinate (rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
+        (10.0, 45.0)>): (dra, ddec) in deg
         (0.69474685, 1.00428706)>
     >>> other = SkyCoord(9*u.deg, 44*u.deg, frame='fk5')
     >>> other.transform_to(aframe)  # doctest: +FLOAT_CMP
-    <SkyCoord (AstrometricFrame: origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>, rotation=0.0 deg): (dra, ddec) in deg
+    <SkyCoord (AstrometricFrame: rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
+        (10.0, 45.0)>): (dra, ddec) in deg
         (359.28056055, -0.99556216)>
 
 


### PR DESCRIPTION
This is a stub trying to make the AstrometricFrame behave like @taldcroft suggested in #4931.

Some things are still a little bit wonky:

- [x] Why can't I switch the inheritance order of ``AstrometricFrame`` and ``framecls`` (so that ``AstrometricFrame`` is first, which I think makes more sense in this case)? When I do this, the ``FrameMeta`` doesn't seem to pick up on the representation info from ``framecls``.
- [x] Is there a way to inherit the frame attributes from ``AstrometricFrame`` in ``_AstrometricFrame``
- [x] If there is a way to inherit the frame attributes, is there a way to just change the CoordinateAttribute's internal ``_frame`` variable? In this case, I think it would have to live on the class and not the descriptor, and the ``convert_input`` function on ``CoordinateFrame`` does not have access to the ``AstrometricFrame`` class, so maybe this is too complicated.
- [x] Should AstrometricFrame always be called AstrometricFrame, or should it incorporate the name of the base frame class?

- [x] Also, still needs some minor doc fixes and a changeling entry.