### PR TITLE
Table pprint() to handle unicode in Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -625,6 +625,9 @@ Bug fixes
 
 - ``astropy.table``
 
+  - Fixed a bug where ``pprint()`` sometimes raises ``UnicodeDecodeError``
+    in Python 2. [#4946]
+
 - ``astropy.tests``
 
 - ``astropy.time``

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -18,18 +18,12 @@ from ..utils.data_info import dtype_info_name
 
 __all__ = []
 
-if six.PY2:  # pragma: py2
-    def default_format_func(format_, val):
-        if isinstance(val, bytes):
-            return val.decode('utf-8')
-        else:
-            return text_type(val)
-else:  # pragma: py3
-    def default_format_func(format_, val):
-        if isinstance(val, bytes):
-            return val.decode('utf-8')
-        else:
-            return str(val)
+
+def default_format_func(format_, val):
+    if isinstance(val, bytes):
+        return val.decode('utf-8')
+    else:
+        return text_type(val)
 
 
 _format_funcs = {None: default_format_func}

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -13,7 +13,6 @@ import re
 import numpy as np
 
 from .. import log
-# Note, in numpy <= 1.6, some classes do not properly represent themselves.
 from ..utils.console import Getch, color_print, terminal_size, conf
 from ..utils.data_info import dtype_info_name
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -17,15 +17,23 @@ from .. import log
 from ..utils.console import Getch, color_print, terminal_size, conf
 from ..utils.data_info import dtype_info_name
 
-if six.PY3:
+__all__ = []
+
+if six.PY2:  # pragma: py2
+    def default_format_func(format_, val):
+        if isinstance(val, bytes):
+            return val.decode('utf-8')
+        else:
+            return text_type(val)
+else:  # pragma: py3
     def default_format_func(format_, val):
         if isinstance(val, bytes):
             return val.decode('utf-8')
         else:
             return str(val)
-    _format_funcs = {None: default_format_func}
-elif six.PY2:
-    _format_funcs = {None: lambda format_, val: text_type(val)}
+
+
+_format_funcs = {None: default_format_func}
 
 
 ### The first three functions are helpers for _auto_format_func

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -539,7 +539,11 @@ def test_pprint_py3_bytes():
     t = table.Table(dat)
     s = t['col'].pformat()
     try:
-        assert s == ['col ', '----', ' val', u'bl\xe4h']
+        if s[2] == ' val':
+            assert s == ['col ', '----', ' val', u'bl\xe4h']
+        else:  # pragma: py2
+            # Either this or UnicodeDecodeError, depending on test env
+            pytest.xfail('Problem with decoding in one of the fixtures')
     except UnicodeDecodeError:  # pragma: py2
         # With unicode_literals in Python 2, 'val' becomes crazy or something
         pytest.xfail('Problem with decoding in one of the fixtures')

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -533,20 +533,11 @@ def test_pprint_py3_bytes():
     is printed correctly (without the "b" prefix like b'string').
     Also make sure special characters are printed in Python 2.
     """
-    val = 'val' if PY2 else bytes('val', encoding='utf-8')
+    val = str('val') if PY2 else bytes('val', encoding='utf-8')
     blah = u'bläh'.encode('utf-8') if PY2 else bytes('bläh', encoding='utf-8')
     dat = np.array([val, blah], dtype=[(str('col'), 'S10')])
     t = table.Table(dat)
-    s = t['col'].pformat()
-    try:
-        if s[2] == ' val':
-            assert s == ['col ', '----', ' val', u'bl\xe4h']
-        else:  # pragma: py2
-            # Either this or UnicodeDecodeError, depending on test env
-            pytest.xfail('Problem with decoding in one of the fixtures')
-    except UnicodeDecodeError:  # pragma: py2
-        # With unicode_literals in Python 2, 'val' becomes crazy or something
-        pytest.xfail('Problem with decoding in one of the fixtures')
+    assert t['col'].pformat() == ['col ', '----', ' val', u'bl\xe4h']
 
 
 def test_pprint_nameless_col():


### PR DESCRIPTION
This fixes #4944. That is, `pprint()` now handles unicode in Python 2 properly. Also expanded test to include special character and rearranged Python 2/3 logic to handle Python 4.

p.s. I optimistically milestoned this to 1.2. Feel free to remove milestone if it is not possible.

p.p.s. My Emacs also automatically removed trailing whitespace.

Example use case:
```python
In [1]: from astropy.table import Table, Column

In [2]: tab = Table()

In [3]: tab.add_column(Column(data=['blah','bläh'], name='ok'))

In [4]: tab.pprint()
 ok 
----
blah
bläh
```