### PR TITLE
Fix for issue #4867 (io.ascii.read handling of empty units)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -449,7 +449,7 @@ Bug fixes
     fail on non-US locales. [#4363]
 
   - Fix astropy.io.ascii.read handling of units for IPAC formatted files.
-    Columns with no unit are treated as unitless not dimensionless.
+    Columns with no unit are treated as unitless not dimensionless. [#4867]
 
 - ``astropy.io.fits``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -448,6 +448,9 @@ Bug fixes
   - Fix a problem where the fast reader (with use_fast_converter=False) can
     fail on non-US locales. [#4363]
 
+  - Fix astropy.io.ascii.read handling of units for IPAC formatted files.
+    Columns with no unit are treated as unitless not dimensionless.
+
 - ``astropy.io.fits``
 
 - ``astropy.io.misc``

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -193,7 +193,7 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
                 col.raw_type = header_vals[1][i].strip(' -')
                 col.type = self.get_col_type(col)
             if len(header_vals) > 2:
-                col.unit = header_vals[2][i].strip()  # Can't strip dashes here
+                col.unit = header_vals[2][i].strip() or None  # Can't strip dashes here
             if len(header_vals) > 3:
                 # The IPAC null value corresponds to the io.ascii bad_value.
                 # In this case there isn't a fill_value defined, so just put

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1185,6 +1185,5 @@ def test_no_units_for_char_columns():
     t1 = Table([["A"]], names="B")
     out = StringIO()
     ascii.write(t1, out, format="ipac")
-    out.seek(0)
-    t2 = ascii.read(out, format="ipac", guess=False)
+    t2 = ascii.read(out.getvalue(), format="ipac", guess=False)
     assert t2["B"].unit == None

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1177,3 +1177,14 @@ def test_non_C_locale_with_fast_reader():
         raise
     finally:
         locale.setlocale(locale.LC_ALL, current)
+
+
+def test_no_units_for_char_columns():
+    '''Test that a char column of a Table is assigned no unit and not
+    a dimensionless unit.'''
+    t1 = Table([["A"]], names="B")
+    out = StringIO()
+    ascii.write(t1, out, format="ipac")
+    out.seek(0)
+    t2 = ascii.read(out, format="ipac", guess=False)
+    assert t2["B"].unit == None

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -20,7 +20,7 @@ from ... import table
 from ... import units as u
 from .conftest import MaskedTable
 
-from ...extern.six.moves import zip as izip
+from ...extern.six.moves import zip as izip, cStringIO as StringIO
 
 try:
     with ignore_warnings(DeprecationWarning):
@@ -1736,3 +1736,15 @@ def test_primary_key_is_inherited():
     assert t.loc[1] == t2.loc[1]
     assert t.loc[1] == t3.loc[1]
     assert t.loc[1] == t4.loc[1]
+
+
+def test_qtable_read_for_ipac_table_with_char_columns():
+    '''Test that a char column of a QTable is assigned no unit and not
+    a dimensionless unit, otherwise conversion of reader output to
+    QTable fails.'''
+    t1 = table.QTable([["A"]], names="B")
+    out = StringIO()
+    t1.write(out, format="ascii.ipac")
+    out.seek(0)
+    t2 = table.QTable.read(out, format="ascii.ipac", guess=False)
+    assert t2["B"].unit == None

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1745,6 +1745,5 @@ def test_qtable_read_for_ipac_table_with_char_columns():
     t1 = table.QTable([["A"]], names="B")
     out = StringIO()
     t1.write(out, format="ascii.ipac")
-    out.seek(0)
-    t2 = table.QTable.read(out, format="ascii.ipac", guess=False)
+    t2 = table.QTable.read(out.getvalue(), format="ascii.ipac", guess=False)
     assert t2["B"].unit == None


### PR DESCRIPTION
Implemented fix suggested by @taldcroft for issue #4867 and added regression tests.

In IPAC tables, both no unit and a dimensionless unit appear as an empty string in the table header. So, when reading in an IPAC table, there is inherent ambiguity in the unit of a numerical column for which the unit header is blank. The [IPAC table format definition](http://exoplanetarchive.ipac.caltech.edu/docs/ddgen/ipac_tbl.html#unit) states:

> If there is no unit string the table is treated as unitless.

So this fix also assumes that any numerical column with no unit is unitless (as well as string columns).
