### PR TITLE
Fix bounds check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,10 @@ Bug Fixes
 
 - ``astropy.wcs``
 
+  - Worked around WCSlib bug which makes it impossible to set LATPOLE when
+    LONPOLE=90 when WCSTRIG_MACRO is enabled. Fixed by disabling WCSTRIG_MACRO.
+    According to comments in WCSlib, this could have a 20% performance impact.
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -193,7 +193,7 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
     cfg['include_dirs'].append('numpy')
     cfg['define_macros'].extend([
         ('ECHO', None),
-        ('WCSTRIG_MACRO', None),
+   #    ('WCSTRIG_MACRO', None),
         ('ASTROPY_WCS_BUILD', None),
         ('_GNU_SOURCE', None)])
 
@@ -260,6 +260,7 @@ def get_extensions():
         'flexed/wcspih.c',
         'flexed/wcsulex.c',
         'flexed/wcsutrn.c',
+        'wcstrig.c',
         'cel.c',
         'dis.c',
         'lin.c',

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -482,6 +482,7 @@ PyWcsprm_bounds_check(
       bounds |= 1;
   }
 
+  wcsprm_python2c(&self->x);
   wcsbchk(&self->x, bounds);
 
   Py_RETURN_NONE;

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -972,3 +972,15 @@ def inconsistent_sip():
     w = wcs.WCS()
     newhdr = w.to_header()
     assert('CTYPE1' not in newhdr)
+
+def test_lonpole_90_latpole():
+    """Tests the ability to set latpole when lonpole is 90"""
+    w = wcs.WCS(naxis=2)
+    w.wcs.ctype = ["RA---CAR","DEC--CAR"]
+    w.wcs.cdelt = [1,1]
+    w.wcs.crval = [0,0]
+    w.wcs.crpix = [1,1]
+    w.wcs.lonpole = 90
+    w.wcs.latpole =  0
+    w.wcs.set()
+    assert_allclose(w.wcs.latpole,0)


### PR DESCRIPTION
Make bounds_check work when no transformations have been performed first.

EDIT: Fixes #4957 