### PR TITLE
Do not allow WCSes to be reverse-indexed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -706,6 +706,8 @@ Bug fixes
 
   - Made ``wcs.bounds_check`` call ``wcsprm_python2c``, which means it
     works even if ``wcs.set`` has not been called yet. [#4957].
+  - WCS objects can no longer be reverse-indexed, which was technically
+    permitted but incorrectly implemented previously [#4962]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2919,6 +2919,9 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         wcs_new = self.deepcopy()
         for i, iview in enumerate(view):
+            if iview.step < 0:
+                raise NotImplementedError("Reversing an axis is not "
+                                          "implemented.")
             if iview.step is not None and iview.start is None:
                 # Slice from "None" is equivalent to slice from 0 (but one
                 # might want to downsample, so allow slices with

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2919,7 +2919,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         wcs_new = self.deepcopy()
         for i, iview in enumerate(view):
-            if iview.step < 0:
+            if iview.step is not None and iview.step < 0:
                 raise NotImplementedError("Reversing an axis is not "
                                           "implemented.")
             if iview.step is not None and iview.start is None:


### PR DESCRIPTION
Addresses https://github.com/astropy/astropy/issues/4529

It would be nice to have access to this sort of functionality, but it requires having access to NAXIS to compute correctly (see https://github.com/astropy/astropy/issues/4669).