### PR TITLE
Numpy integer indexing

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1310,7 +1310,7 @@ class Model(object):
         n_models = kwargs.pop('n_models', None)
 
         if not (n_models is None or
-                    (isinstance(n_models, int) and n_models >=1)):
+                    (isinstance(n_models, (int, np.integer)) and n_models >=1)):
             raise ValueError(
                 "n_models must be either None (in which case it is "
                 "determined from the model_set_axis of the parameter initial "
@@ -1795,7 +1795,7 @@ class _CompoundModelMeta(_ModelMeta):
     def __getitem__(cls, index):
         index = cls._normalize_index(index)
 
-        if isinstance(index, int):
+        if isinstance(index, (int, np.integer)):
             return cls._get_submodels()[index]
         else:
             return cls._get_slice(index.start, index.stop)
@@ -2265,9 +2265,9 @@ class _CompoundModelMeta(_ModelMeta):
             start = index.start if index.start is not None else 0
             stop = (index.stop
                     if index.stop is not None else len(cls.submodel_names))
-            if isinstance(start, int):
+            if isinstance(start, (int, np.integer)):
                 start = check_for_negative_index(start)
-            if isinstance(stop, int):
+            if isinstance(stop, (int, np.integer)):
                 stop = check_for_negative_index(stop)
             if isinstance(start, six.string_types):
                 start = get_index_from_name(start)
@@ -2281,7 +2281,7 @@ class _CompoundModelMeta(_ModelMeta):
                 raise ValueError("Empty slice of a compound model.")
 
             return slice(start, stop)
-        elif isinstance(index, int):
+        elif isinstance(index, (int, np.integer)):
             if index >= len(cls.submodel_names):
                 raise IndexError(
                         "Model index {0} out of range.".format(index))

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -182,7 +182,7 @@ class BaseGroups(object):
     def __getitem__(self, item):
         parent = self.parent
 
-        if isinstance(item, int):
+        if isinstance(item, (int, np.integer)):
             i0, i1 = self.indices[item], self.indices[item + 1]
             out = parent[i0:i1]
             out.groups._keys = parent.groups.keys[item]

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -194,7 +194,7 @@ class Index(object):
         ----------
         row_specifier : int, list, ndarray, or slice
         '''
-        if isinstance(row_specifier, int):
+        if isinstance(row_specifier, (int, np.integer)):
             # single row
             return (row_specifier,)
         elif isinstance(row_specifier, (list, np.ndarray)):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -9,7 +9,6 @@ from .index import TableIndices, TableLoc, TableILoc
 import re
 import sys
 from collections import OrderedDict
-import numbers
 
 from copy import deepcopy
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -9,6 +9,7 @@ from .index import TableIndices, TableLoc, TableILoc
 import re
 import sys
 from collections import OrderedDict
+import numbers
 
 from copy import deepcopy
 
@@ -96,7 +97,7 @@ class TableColumns(OrderedDict):
         """
         if isinstance(item, six.string_types):
             return OrderedDict.__getitem__(self, item)
-        elif isinstance(item, int):
+        elif isinstance(item, (int, np.integer)):
             return self.values()[item]
         elif isinstance(item, tuple):
             return self.__class__([self[x] for x in item])


### PR DESCRIPTION
This is a replacement of #4745 (`modeling.core` has changed so it's easier to base this on the current one). The general failing use case this fixes is indexing a compound model or a table when the index is a numpy integer.

In #4745  @pllim has provided a list of modules containing `int)`  in other subpackages. Since this is very context dependent, based on my best understanding of the use cases I found only a few cases in `astropy.table` that may need to be modified. I'd like someone with better understanding of `table` to confirm/reject them. @taldcroft @mhvk 

I don't think this needs a Changelog entry. Setting milestone 1.3 (unless this can go in 1.2) and until 1.2.1 is available.
