### PR TITLE
Avoid anonymous exception catching

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -165,6 +165,12 @@ def terminal_size(file=None):
         if width > 10:
             width -= 1
         return (lines, width)
+    except KeyboardInterrupt:
+        # anonymous exception catching will catch - and therefore prevent -
+        # keyboard interrupts, which means users can't manually break out of
+        # loops.  Catching and raising KeyboardInterrupts allows all other
+        # exceptions to pass into the next clause below
+        raise
     except:
         try:
             # see if POSIX standard variables will work


### PR DESCRIPTION
When running loops with ProgressBar, catching anonymous exceptions with a block like

```
    try:
        ...
    except:
        ...
```

catches, and therefore prevents the use of, `KeyboardInterrupt`s.  This PR
catches and _raises_ `KeyboardInterrupt`s.

There are many other cases in astropy where anonymous exception catching is
used; probably all of these cases should be modified to reraise
`KeyboardInterrupt`s, but I would like to put that off til after we handle this
issue as this one is urgent for my present work.
