### PR TITLE
Catch TypeError during FITS_rec deletion

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -632,16 +632,15 @@ class FITS_rec(np.recarray):
 
     def __del__(self):
         try:
-            try:
-                del self._coldefs
-            except AttributeError as err:  # pragma: no cover
-                pass
+            del self._coldefs
 
             if self.dtype.fields is not None:
                 for col in self._col_weakrefs:
                     if col.array is not None:
                         col.array = col.array.copy()
-        except TypeError:
+
+        # See issues #4690 and #4912
+        except (AttributeError, TypeError):  # pragma: no cover
             pass
 
     @property

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -632,14 +632,17 @@ class FITS_rec(np.recarray):
 
     def __del__(self):
         try:
-            del self._coldefs
-        except AttributeError as err:  # pragma: no cover
-            pass
+            try:
+                del self._coldefs
+            except AttributeError as err:  # pragma: no cover
+                pass
 
-        if self.dtype.fields is not None:
-            for col in self._col_weakrefs:
-                if col.array is not None:
-                    col.array = col.array.copy()
+            if self.dtype.fields is not None:
+                for col in self._col_weakrefs:
+                    if col.array is not None:
+                        col.array = col.array.copy()
+        except TypeError:
+            pass
 
     @property
     def names(self):


### PR DESCRIPTION
Fixes #4912 as per [this comment](https://github.com/astropy/astropy/issues/4912#issuecomment-221191001) by @embray. I was at a stage where I could reproduce the problem consistently (running `test_spectrum.py` for spacetelescope/stsynphot_refactor#16. I find that this makes those pesky messages disappear at least for my case.

@weaverba137, can you please give this a spin?

See also: #4690, #4694, #4948