### PR TITLE
Fix error message when accessing the component of a frame

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1037,9 +1037,18 @@ class BaseCoordinateFrame(object):
             raise AttributeError("'{0}' object has no attribute '{1}'"
                                  .format(self.__class__.__name__, attr))
 
-        rep = self.represent_as(self.representation, in_frame_units=True)
-        val = getattr(rep, self.representation_component_names[attr])
-        return val
+        if self._data is None:
+            if attr in self.representation_component_names.keys():
+                # this raises the "no data" error by design - doing it this way
+                # means we don't have to replicate the error message here
+                self.data
+            else:
+                raise AttributeError("'{0}' object has no attribute '{1}'"
+                                     .format(self.__class__.__name__, attr))
+        else:
+            rep = self.represent_as(self.representation, in_frame_units=True)
+            val = getattr(rep, self.representation_component_names[attr])
+            return val
 
     def __setattr__(self, attr, value):
         repr_attr_names = set()

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1036,15 +1036,16 @@ class BaseCoordinateFrame(object):
                 attr not in self.representation_component_names):
             raise AttributeError("'{0}' object has no attribute '{1}'"
                                  .format(self.__class__.__name__, attr))
+        elif self._data is None:
+            # The second clause of the ``or`` above means that
+            # ``attr in self.representation_component_names``, otherwise we
+            # would repeat that check here, because we only want to hit this
+            # clause when the user tried to access one of the representation's
+            # components
 
-        if self._data is None:
-            if attr in self.representation_component_names.keys():
-                # this raises the "no data" error by design - doing it this way
-                # means we don't have to replicate the error message here
-                self.data
-            else:
-                raise AttributeError("'{0}' object has no attribute '{1}'"
-                                     .format(self.__class__.__name__, attr))
+            self.data  # this raises the "no data" error by design - doing it
+            # this way means we don't have to replicate the error message here
+
         else:
             rep = self.represent_as(self.representation, in_frame_units=True)
             val = getattr(rep, self.representation_component_names[attr])

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -678,10 +678,21 @@ def test_getitem_representation():
 
 
 def test_component_error_useful():
+    """
+    Check that a data-less frame gives useful error messages about not having
+    data when the attributes asked for are possible coordinate components
+    """
     from ..builtin_frames import ICRS
 
     i = ICRS()
+
     with pytest.raises(ValueError) as excinfo:
         i.ra
-
     assert 'does not have associated data' in str(excinfo.value)
+
+    with pytest.raises(AttributeError) as excinfo1:
+        i.foobar
+    with pytest.raises(AttributeError) as excinfo2:
+        i.lon  # lon is *not* the component name despite being the underlying representation's name
+    assert "object has no attribute 'foobar'" in str(excinfo1.value)
+    assert "object has no attribute 'lon'" in str(excinfo2.value)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -531,8 +531,10 @@ def test_nodata_error():
     from ..builtin_frames import ICRS
 
     i = ICRS()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         i.data
+
+    assert 'does not have associated data' in str(excinfo.value)
 
 def test_len0_data():
     from ..builtin_frames import ICRS
@@ -673,3 +675,13 @@ def test_getitem_representation():
     c = ICRS([1, 1] * u.deg, [2, 2] * u.deg)
     c.representation = 'cartesian'
     assert c[0].representation is representation.CartesianRepresentation
+
+
+def test_component_error_useful():
+    from ..builtin_frames import ICRS
+
+    i = ICRS()
+    with pytest.raises(ValueError) as excinfo:
+        i.ra
+
+    assert 'does not have associated data' in str(excinfo.value)


### PR DESCRIPTION
I recently noticed the following behavior that I found surprising:
```
>>> c_wdata = ICRS(1*u.deg, 2*u.deg)
>>> c_wdata.ra
<Longitude 1.0 deg>
>>> c_nodata = ICRS()
>>> c_nodata.data
ValueError: The frame object "<ICRS Frame>" does not have associated data
>>> c_nodata.ra
AttributeError: 'ICRS' object has no attribute '_rep_cache'
```

I think it's pretty clear that in this context asking ``c.ra`` is a request for data, and the more useful error message is "this frame has no data" rather than an opaque error about not finding the representation cache.

So this PR fixes that by being a bit more careful in the base frame's `__getattr__` about asking for a representation.  So after this PR, the above changes to:
```
>>> c_nodata.ra
ValueError: The frame object "<ICRS Frame>" does not have associated data
```

I think this is more "correcting some possible confusion" than a bug, so I haven't labeled it as a bug, nor added a changelog entry (as it strikes me as more like "documentation").  But @adrn, @astrofrog, or @taldcroft, feel free to say otherwise if you think it should get a changelog entry.
