### PR TITLE
Few optimizations for FITS tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -195,6 +195,10 @@ Other Changes and Additions
     ``angles.angle_axis`` are also deprecated, in favour of the new routines
     with the same name in ``coordinates.matrix_utilities``. [#5104]
 
+- ``astropy.io.fits``
+
+  - Performance improvements for tables with many columns. [#4985]
+
 - ``astropy.io.registry``
 
   - Reduced the time spent in the ``get_formats`` function. This also reduces

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1435,6 +1435,14 @@ class ColDefs(NotifierMixin):
         return nh.realign_dtype(np.dtype(fields), offsets)
 
     @lazyproperty
+    def names(self):
+        return [col.name for col in self.columns]
+
+    @lazyproperty
+    def formats(self):
+        return [col.format for col in self.columns]
+
+    @lazyproperty
     def _arrays(self):
         return [col.array for col in self.columns]
 
@@ -1515,6 +1523,11 @@ class ColDefs(NotifierMixin):
             if col is column:
                 break
 
+        if attr == 'name':
+            del self.names
+        elif attr == 'format':
+            del self.formats
+
         self._notify('column_attribute_changed', column, idx, attr, old_value,
                      new_value)
 
@@ -1530,6 +1543,8 @@ class ColDefs(NotifierMixin):
         del self.dtype
         del self._recformats
         del self._dims
+        del self.names
+        del self.formats
 
         self.columns.append(column)
 
@@ -1557,6 +1572,8 @@ class ColDefs(NotifierMixin):
         del self.dtype
         del self._recformats
         del self._dims
+        del self.names
+        del self.formats
 
         del self.columns[indx]
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -429,21 +429,21 @@ class ColumnAttribute(object):
         # determined from the KEYWORD_NAMES/ATTRIBUTES lists.  This could be
         # make more flexible in the future, for example, to support custom
         # column attributes.
-        self._attr = KEYWORD_TO_ATTRIBUTE[self._keyword]
+        self._attr = '_' + KEYWORD_TO_ATTRIBUTE[self._keyword]
 
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
         else:
-            return getattr(obj, '_' + self._attr)
+            return getattr(obj, self._attr)
 
     def __set__(self, obj, value):
         if self._validator is not None:
             self._validator(obj, value)
 
-        old_value = getattr(obj, '_' + self._attr, None)
-        setattr(obj, '_' + self._attr, value)
-        obj._notify('column_attribute_changed', obj, self._attr, old_value,
+        old_value = getattr(obj, self._attr, None)
+        setattr(obj, self._attr, value)
+        obj._notify('column_attribute_changed', obj, self._attr[1:], old_value,
                     value)
 
     def __call__(self, func):

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1693,7 +1693,6 @@ class _AsciiColDefs(ColDefs):
 
     @lazyproperty
     def dtype(self):
-        _itemsize = self.spans[-1] + self.starts[-1] - 1
         dtype = {}
 
         for j in range(len(self)):
@@ -1941,7 +1940,6 @@ def _makep(array, descr_output, format, nrows=None):
 
     if not nrows:
         nrows = len(array)
-    n = min(len(array), nrows)
 
     data_output = _VLF([None] * nrows, dtype=format.dtype)
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -82,16 +82,14 @@ ASCII_DEFAULT_WIDTHS= {'A': (1, 0), 'I': (10, 0), 'J': (15, 0),
                        'E': (15, 7), 'F': (16, 7), 'D': (25, 17)}
 
 
-
-
-# lists of column/field definition common names and keyword names, make
+# tuple of column/field definition common names and keyword names, make
 # sure to preserve the one-to-one correspondence when updating the list(s).
 # Use lists, instead of dictionaries so the names can be displayed in a
 # preferred order.
-KEYWORD_NAMES = ['TTYPE', 'TFORM', 'TUNIT', 'TNULL', 'TSCAL', 'TZERO',
-                 'TDISP', 'TBCOL', 'TDIM']
-KEYWORD_ATTRIBUTES = ['name', 'format', 'unit', 'null', 'bscale', 'bzero',
-                      'disp', 'start', 'dim']
+KEYWORD_NAMES = ('TTYPE', 'TFORM', 'TUNIT', 'TNULL', 'TSCAL', 'TZERO',
+                 'TDISP', 'TBCOL', 'TDIM')
+KEYWORD_ATTRIBUTES = ('name', 'format', 'unit', 'null', 'bscale', 'bzero',
+                      'disp', 'start', 'dim')
 """This is a list of the attributes that can be set on `Column` objects."""
 
 
@@ -1390,16 +1388,12 @@ class ColDefs(NotifierMixin):
 
         Implements for example self.units, self.formats, etc.
         """
-
         cname = name[:-1]
         if cname in KEYWORD_ATTRIBUTES and name[-1] == 's':
             attr = []
-            for col in self:
+            for col in self.columns:
                 val = getattr(col, cname)
-                if val is not None:
-                    attr.append(val)
-                else:
-                    attr.append('')
+                attr.append(val if val is not None else '')
             return attr
         raise AttributeError(name)
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -478,14 +478,12 @@ class _BaseHDU(object):
         header_offset = 0
 
         if isinstance(data, _File):
-            from_file = True
             if header is None:
                 header_offset = data.tell()
                 header = Header.fromfile(data, endcard=not ignore_missing_end)
             hdu_fileobj = data
             data_offset = data.tell()  # *after* reading the header
         else:
-            from_file = False
             try:
                 # Test that the given object supports the buffer interface by
                 # ensuring an ndarray can be created from it

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -43,6 +43,8 @@ if six.PY3:
 elif six.PY2:
     cmp = cmp
 
+all_integer_types = integer_types + (np.integer,)
+
 
 class NotifierMixin(object):
     """
@@ -917,7 +919,7 @@ def _is_pseudo_unsigned(dtype):
 
 
 def _is_int(val):
-    return isinstance(val, integer_types + (np.integer,))
+    return isinstance(val, all_integer_types)
 
 
 def _str_to_num(val):

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -38,10 +38,10 @@ from ...utils import wraps
 from ...utils.compat import suppress
 from ...utils.exceptions import AstropyUserWarning
 
-if six.PY3:
-    cmp = lambda a, b: (a > b) - (a < b)
-elif six.PY2:
+if six.PY2:
     cmp = cmp
+else:
+    cmp = lambda a, b: (a > b) - (a < b)
 
 all_integer_types = integer_types + (np.integer,)
 


### PR DESCRIPTION
I have FITS files with a lot of extensions, lot of tables with many columns (a few thousands sometimes ...) and it takes a significant time to load everything, so I tried to find some optimizations (btw snakeviz is very nice to look at profiling results !). 
The changes here could be seen a micro-optimizations, but they concern methods which are called many times, so it makes a difference in the end.

* Reference: Astropy 1.2.dev15480, Time to load my file : 2.8s
* Change on `_is_int` (ncalls=1621317). Time after : 2.64 s
* Change on `Coldefs.__getattr__` (ncalls=2673). Time after : 1.73s
* Change on `ColumnAttribute.__get__` (ncalls=1626425). Time after : 1.6s

Maybe @embray if you have some time ?