### PR TITLE
Make GCRS transforms actually do something for GCRS frames with different ```obsgeoloc```

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -581,6 +581,9 @@ Bug fixes
 
   - Ensure that ``angle_utilities.position_angle`` accepts floats, as stated
     in the docstring. [#3800]
+    
+  - Ensured that transformations for ``GCRS`` frames are correct for 
+    non-geocentric observers. [#4986]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -43,7 +43,7 @@ def gcrs_to_geoecliptic(gcrs_coo, to_frame):
 def geoecliptic_to_gcrs(from_coo, gcrs_frame):
     rmat = _ecliptic_rotation_matrix(from_coo.equinox)
     newrepr = cartrepr_from_matmul(rmat, from_coo, transpose=True)
-    gcrs = GCRS(newrepr, obstime=from_coo.obstime)
+    gcrs = GCRS(newrepr, obstime=from_coo.equinox)
 
     #now do any needed offsets (no-op if same obstime and 0 pos/vel)
     return gcrs.transform_to(gcrs_frame)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -200,7 +200,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
 @frame_transform_graph.transform(FunctionTransform, GCRS, GCRS)
 def gcrs_to_gcrs(from_coo, to_frame):
-    if (np.all(from_coo.obstime == to_frame.obstime) 
+    if (np.all(from_coo.obstime == to_frame.obstime)
         and np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
         return to_frame.realize_frame(from_coo.data)
     else:

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -200,7 +200,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
 @frame_transform_graph.transform(FunctionTransform, GCRS, GCRS)
 def gcrs_to_gcrs(from_coo, to_frame):
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if (np.all(from_coo.obstime == to_frame.obstime) 
+        and np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
         return to_frame.realize_frame(from_coo.data)
     else:
         # like CIRS, we do this self-transform via ICRS

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -13,7 +13,7 @@ from ...tests.helper import (pytest,
                              assert_quantity_allclose as assert_allclose)
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
-                PrecessedGeocentric, CartesianRepresentation,
+                PrecessedGeocentric, CartesianRepresentation, SkyCoord,
                 SphericalRepresentation)
 
 
@@ -434,19 +434,19 @@ def test_gcrs_self_transform_closeby():
     frame onto the other.
     """
     t = Time("2014-12-25T07:00")
-    moon_geocentric = GCRS(318.10579159*u.deg,
-                           -11.65281165*u.deg,
-                           365042.64880308*u.km, obstime=t)
+    moon_geocentric = SkyCoord(GCRS(318.10579159*u.deg,
+                                    -11.65281165*u.deg,
+                                    365042.64880308*u.km, obstime=t))
 
     # this is the location of the Moon as seen from La Palma
     obsgeoloc = [-5592982.59658935, -63054.1948592, 3059763.90102216]*u.m
     obsgeovel = [4.59798494, -407.84677071, 0.]*u.m/u.s
-    moon_lapalma = GCRS(318.7048445*u.deg,
-                        -11.98761996*u.deg,
-                        369722.8231031*u.km,
-                        obstime=t,
-                        obsgeoloc=obsgeoloc,
-                        obsgeovel=obsgeovel)
+    moon_lapalma = SkyCoord(GCRS(318.7048445*u.deg,
+                                 -11.98761996*u.deg,
+                                 369722.8231031*u.km,
+                                 obstime=t,
+                                 obsgeoloc=obsgeoloc,
+                                 obsgeovel=obsgeovel))
 
     transformed = moon_geocentric.transform_to(moon_lapalma.frame)
     delta = transformed.separation_3d(moon_lapalma)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ... import units as u
-from ...tests.helper import (pytest,
+from ...tests.helper import (pytest, remote_data,
                              quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 from ...time import Time
@@ -412,7 +412,7 @@ def test_icrs_altaz_moonish(testframe):
     assert 1000*u.km < np.abs(moonaa.distance - MOONDIST).to(u.au) < 7000*u.km
 
 
-@pytest.remote_data
+@remote_data
 def test_gcrs_self_transform_closeby():
     """
     Tests GCRS self transform for objects which are nearby and thus

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -14,7 +14,7 @@ from ...tests.helper import (pytest,
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
                 PrecessedGeocentric, CartesianRepresentation,
-                SphericalRepresentation)
+                SphericalRepresentation, get_moon)
 
 
 from ..._erfa import epv00
@@ -410,3 +410,31 @@ def test_icrs_altaz_moonish(testframe):
 
     #now check that the distance change is similar to earth radius
     assert 1000*u.km < np.abs(moonaa.distance - MOONDIST).to(u.au) < 7000*u.km
+
+@remote_data
+def test_gcrs_self_transform_closeby():
+    """
+    Tests GCRS self transform for objects which are nearby and thus
+    have reasonable parallax.
+    
+    Create moon positions using JPL DE432s ephemeris (small download).
+    
+    The two lunar positions (one geocentric, one at a defined location)
+    are created via a transformation from ICRS to two different GCRS frames.
+    
+    We test that the GCRS-GCRS self transform can correctly map one GCRS
+    frame onto the other.
+    """
+    t = Time("2014-12-25T07:00")
+    moon_geocentric = get_moon(t, ephemeris='de432s')
+
+    # this is the location of La Palma
+    loc = EarthLocation(*(5327448.9957829,
+                          -1718665.73869569, 3051566.90295403)*u.m)
+    moon_lapalma = get_moon(t, ephemeris='de432s', location=loc)
+    
+    transformed = moon_geocentric.transform_to(moon_lapalma.frame)
+    delta = transformed.separation_3d(moon_lapalma)
+    assert_allclose(delta, 0.0*u.m, atol=1*u.m)
+    
+        

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -8,19 +8,20 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ... import units as u
-from ...tests.helper import (pytest, remote_data,
+from ...tests.helper import (pytest,
                              quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
                 PrecessedGeocentric, CartesianRepresentation,
-                SphericalRepresentation, get_moon)
+                SphericalRepresentation)
 
 
 from ..._erfa import epv00
 
 from .utils import randomly_sample_sphere
 from ..builtin_frames.utils import get_jd12
+
 
 def test_icrs_cirs():
     """
@@ -34,13 +35,13 @@ def test_icrs_cirs():
     iwd = ICRS(ra=ra, dec=dec, distance=dist*u.pc)
 
     cframe1 = CIRS()
-    cirsnod = inod.transform_to(cframe1)  #uses the default time
-    #first do a round-tripping test
+    cirsnod = inod.transform_to(cframe1)  # uses the default time
+    # first do a round-tripping test
     inod2 = cirsnod.transform_to(ICRS)
     assert_allclose(inod.ra, inod2.ra)
     assert_allclose(inod.dec, inod2.dec)
 
-    #now check that a different time yields different answers
+    # now check that a different time yields different answers
     cframe2 = CIRS(obstime=Time('J2005', scale='utc'))
     cirsnod2 = inod.transform_to(cframe2)
     assert not allclose(cirsnod.ra, cirsnod2.ra, rtol=1e-8)
@@ -53,7 +54,7 @@ def test_icrs_cirs():
     # and the distance should transform at least somehow
     assert not allclose(cirswd.distance, iwd.distance, rtol=1e-8)
 
-    #now check that the cirs self-transform works as expected
+    # now check that the cirs self-transform works as expected
     cirsnod3 = cirsnod.transform_to(cframe1)  # should be a no-op
     assert_allclose(cirsnod.ra, cirsnod3.ra)
     assert_allclose(cirsnod.dec, cirsnod3.dec)
@@ -71,25 +72,26 @@ ra, dec, dist = randomly_sample_sphere(200)
 icrs_coords = [ICRS(ra=ra, dec=dec), ICRS(ra=ra, dec=dec, distance=dist*u.pc)]
 gcrs_frames = [GCRS(), GCRS(obstime=Time('J2005', scale='utc'))]
 
+
 @pytest.mark.parametrize('icoo', icrs_coords)
 def test_icrs_gcrs(icoo):
     """
     Check ICRS<->GCRS for consistency
     """
-    gcrscoo = icoo.transform_to(gcrs_frames[0])  #uses the default time
-    #first do a round-tripping test
+    gcrscoo = icoo.transform_to(gcrs_frames[0])  # uses the default time
+    # first do a round-tripping test
     icoo2 = gcrscoo.transform_to(ICRS)
     assert_allclose(icoo.distance, icoo2.distance)
     assert_allclose(icoo.ra, icoo2.ra)
     assert_allclose(icoo.dec, icoo2.dec)
     assert isinstance(icoo2.data, icoo.data.__class__)
 
-    #now check that a different time yields different answers
+    # now check that a different time yields different answers
     gcrscoo2 = icoo.transform_to(gcrs_frames[1])
     assert not allclose(gcrscoo.ra, gcrscoo2.ra, rtol=1e-8, atol=1e-10*u.deg)
     assert not allclose(gcrscoo.dec, gcrscoo2.dec, rtol=1e-8, atol=1e-10*u.deg)
 
-    #now check that the cirs self-transform works as expected
+    # now check that the cirs self-transform works as expected
     gcrscoo3 = gcrscoo.transform_to(gcrs_frames[0])  # should be a no-op
     assert_allclose(gcrscoo.ra, gcrscoo3.ra)
     assert_allclose(gcrscoo.dec, gcrscoo3.dec)
@@ -102,7 +104,7 @@ def test_icrs_gcrs(icoo):
     assert_allclose(gcrscoo.ra, gcrscoo5.ra, rtol=1e-8, atol=1e-10*u.deg)
     assert_allclose(gcrscoo.dec, gcrscoo5.dec, rtol=1e-8, atol=1e-10*u.deg)
 
-    #also make sure that a GCRS with a different geoloc/geovel gets a different answer
+    # also make sure that a GCRS with a different geoloc/geovel gets a different answer
     # roughly a moon-like frame
     gframe3 = GCRS(obsgeoloc=[385000., 0, 0]*u.km, obsgeovel=[1, 0, 0]*u.km/u.s)
     gcrscoo6 = icoo.transform_to(gframe3)  # should be different
@@ -111,6 +113,7 @@ def test_icrs_gcrs(icoo):
     icooviag3 = gcrscoo6.transform_to(ICRS)  # and now back to the original
     assert_allclose(icoo.ra, icooviag3.ra)
     assert_allclose(icoo.dec, icooviag3.dec)
+
 
 @pytest.mark.parametrize('gframe', gcrs_frames)
 def test_icrs_gcrs_dist_diff(gframe):
@@ -146,7 +149,7 @@ def test_cirs_to_altaz():
     cirs2 = cirs.transform_to(altazframe).transform_to(cirs)
     cirs3 = cirscart.transform_to(altazframe).transform_to(cirs)
 
-    #check round-tripping
+    # check round-tripping
     assert_allclose(cirs.ra, cirs2.ra)
     assert_allclose(cirs.dec, cirs2.dec)
     assert_allclose(cirs.ra, cirs3.ra)
@@ -169,7 +172,7 @@ def test_gcrs_itrs():
     assert not allclose(gcrs.ra, gcrs6_2.ra)
     assert not allclose(gcrs.dec, gcrs6_2.dec)
 
-    #also try with the cartesian representation
+    # also try with the cartesian representation
     gcrsc = gcrs.realize_frame(gcrs.data)
     gcrsc.representation = CartesianRepresentation
     gcrsc2 = gcrsc.transform_to(ITRS).transform_to(gcrsc)
@@ -186,9 +189,9 @@ def test_cirs_itrs():
     cirs6 = CIRS(ra=ra, dec=dec, obstime='J2006')
 
     cirs2 = cirs.transform_to(ITRS).transform_to(cirs)
-    cirs6_2 = cirs6.transform_to(ITRS).transform_to(cirs) # different obstime
+    cirs6_2 = cirs6.transform_to(ITRS).transform_to(cirs)  # different obstime
 
-    #just check round-tripping
+    # just check round-tripping
     assert_allclose(cirs.ra, cirs2.ra)
     assert_allclose(cirs.dec, cirs2.dec)
     assert not allclose(cirs.ra, cirs6_2.ra)
@@ -212,7 +215,7 @@ def test_gcrs_cirs():
     assert not allclose(gcrs.ra, gcrs6_2.ra)
     assert not allclose(gcrs.dec, gcrs6_2.dec)
 
-    #now try explicit intermediate pathways and ensure they're all consistent
+    # now try explicit intermediate pathways and ensure they're all consistent
     gcrs3 = gcrs.transform_to(ITRS).transform_to(CIRS).transform_to(ITRS).transform_to(gcrs)
     assert_allclose(gcrs.ra, gcrs3.ra)
     assert_allclose(gcrs.dec, gcrs3.dec)
@@ -276,19 +279,20 @@ def test_precessed_geocentric():
 
 # shared by parametrized tests below.  Some use the whole AltAz, others use just obstime
 totest_frames = [AltAz(location=EarthLocation(-90*u.deg, 65*u.deg),
-                    obstime=Time('J2000')), #J2000 is often a default so this might work when others don't
-              AltAz(location=EarthLocation(120*u.deg, -35*u.deg),
-                    obstime=Time('J2000')),
-              AltAz(location=EarthLocation(-90*u.deg, 65*u.deg),
-                    obstime=Time('2014-01-01 00:00:00')),
-              AltAz(location=EarthLocation(-90*u.deg, 65*u.deg),
-                    obstime=Time('2014-08-01 08:00:00')),
-              AltAz(location=EarthLocation(120*u.deg, -35*u.deg),
-                    obstime=Time('2014-01-01 00:00:00'))
-              ]
+                       obstime=Time('J2000')),  # J2000 is often a default so this might work when others don't
+                 AltAz(location=EarthLocation(120*u.deg, -35*u.deg),
+                       obstime=Time('J2000')),
+                 AltAz(location=EarthLocation(-90*u.deg, 65*u.deg),
+                       obstime=Time('2014-01-01 00:00:00')),
+                 AltAz(location=EarthLocation(-90*u.deg, 65*u.deg),
+                       obstime=Time('2014-08-01 08:00:00')),
+                 AltAz(location=EarthLocation(120*u.deg, -35*u.deg),
+                       obstime=Time('2014-01-01 00:00:00'))
+                ]
 MOONDIST = 385000*u.km  # approximate moon semi-major orbit axis of moon
 MOONDIST_CART = CartesianRepresentation(3**-0.5*MOONDIST, 3**-0.5*MOONDIST, 3**-0.5*MOONDIST)
-EARTHECC = 0.017 + 0.005 # roughly earth orbital eccentricity, but with an added tolerance
+EARTHECC = 0.017 + 0.005  # roughly earth orbital eccentricity, but with an added tolerance
+
 
 @pytest.mark.parametrize('testframe', totest_frames)
 def test_gcrs_altaz_sunish(testframe):
@@ -316,10 +320,10 @@ def test_gcrs_altaz_moonish(testframe):
 
     moonaa = moon.transform_to(testframe)
 
-    #now check that the distance change is similar to earth radius
+    # now check that the distance change is similar to earth radius
     assert 1000*u.km < np.abs(moonaa.distance - moon.distance).to(u.au) < 7000*u.km
 
-    #also should add checks that the alt/az are different for different earth locations
+    # also should add checks that the alt/az are different for different earth locations
 
 
 @pytest.mark.parametrize('testframe', totest_frames)
@@ -339,6 +343,7 @@ def test_gcrs_altaz_bothroutes(testframe):
     assert_allclose(sunaa_viaicrs.cartesian.xyz, sunaa_viaitrs.cartesian.xyz)
     assert_allclose(moonaa_viaicrs.cartesian.xyz, moonaa_viaitrs.cartesian.xyz)
 
+
 @pytest.mark.parametrize('testframe', totest_frames)
 def test_cirs_altaz_moonish(testframe):
     """
@@ -350,9 +355,10 @@ def test_cirs_altaz_moonish(testframe):
     moonaa = moon.transform_to(testframe)
     assert 1000*u.km < np.abs(moonaa.distance - moon.distance).to(u.km) < 7000*u.km
 
-    #now check that it round-trips
+    # now check that it round-trips
     moon2 = moonaa.transform_to(moon)
     assert_allclose(moon.cartesian.xyz, moon2.cartesian.xyz)
+
 
 @pytest.mark.parametrize('testframe', totest_frames)
 def test_cirs_icrs_moonish(testframe):
@@ -365,6 +371,7 @@ def test_cirs_icrs_moonish(testframe):
 
     assert 0.97*u.au < moonicrs.distance < 1.03*u.au
 
+
 @pytest.mark.parametrize('testframe', totest_frames)
 def test_gcrs_icrs_moonish(testframe):
     """
@@ -375,6 +382,7 @@ def test_gcrs_icrs_moonish(testframe):
     moonicrs = moonish.transform_to(ICRS)
 
     assert 0.97*u.au < moonicrs.distance < 1.03*u.au
+
 
 @pytest.mark.parametrize('testframe', totest_frames)
 def test_icrs_gcrscirs_sunish(testframe):
@@ -408,17 +416,16 @@ def test_icrs_altaz_moonish(testframe):
     moonish_icrs = ICRS(CartesianRepresentation(earth_icrs_xyz + moonoffset))
     moonaa = moonish_icrs.transform_to(testframe)
 
-    #now check that the distance change is similar to earth radius
+    # now check that the distance change is similar to earth radius
     assert 1000*u.km < np.abs(moonaa.distance - MOONDIST).to(u.au) < 7000*u.km
 
 
-@remote_data
 def test_gcrs_self_transform_closeby():
     """
     Tests GCRS self transform for objects which are nearby and thus
     have reasonable parallax.
 
-    Create moon positions using JPL DE432s ephemeris (small download).
+    Moon positions were originall created using JPL DE432s ephemeris.
 
     The two lunar positions (one geocentric, one at a defined location)
     are created via a transformation from ICRS to two different GCRS frames.
@@ -427,12 +434,19 @@ def test_gcrs_self_transform_closeby():
     frame onto the other.
     """
     t = Time("2014-12-25T07:00")
-    moon_geocentric = get_moon(t, ephemeris='de432s')
+    moon_geocentric = GCRS(318.10579159*u.deg,
+                           -11.65281165*u.deg,
+                           365042.64880308*u.km, obstime=t)
 
-    # this is the location of La Palma
-    loc = EarthLocation(*(5327448.9957829,
-                          -1718665.73869569, 3051566.90295403)*u.m)
-    moon_lapalma = get_moon(t, ephemeris='de432s', location=loc)
+    # this is the location of the Moon as seen from La Palma
+    obsgeoloc = [-5592982.59658935, -63054.1948592, 3059763.90102216]*u.m
+    obsgeovel = [4.59798494, -407.84677071, 0.]*u.m/u.s
+    moon_lapalma = GCRS(318.7048445*u.deg,
+                        -11.98761996*u.deg,
+                        369722.8231031*u.km,
+                        obstime=t,
+                        obsgeoloc=obsgeoloc,
+                        obsgeovel=obsgeovel)
 
     transformed = moon_geocentric.transform_to(moon_lapalma.frame)
     delta = transformed.separation_3d(moon_lapalma)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -411,17 +411,18 @@ def test_icrs_altaz_moonish(testframe):
     #now check that the distance change is similar to earth radius
     assert 1000*u.km < np.abs(moonaa.distance - MOONDIST).to(u.au) < 7000*u.km
 
-@remote_data
+
+@pytest.remote_data
 def test_gcrs_self_transform_closeby():
     """
     Tests GCRS self transform for objects which are nearby and thus
     have reasonable parallax.
-    
+
     Create moon positions using JPL DE432s ephemeris (small download).
-    
+
     The two lunar positions (one geocentric, one at a defined location)
     are created via a transformation from ICRS to two different GCRS frames.
-    
+
     We test that the GCRS-GCRS self transform can correctly map one GCRS
     frame onto the other.
     """
@@ -432,9 +433,7 @@ def test_gcrs_self_transform_closeby():
     loc = EarthLocation(*(5327448.9957829,
                           -1718665.73869569, 3051566.90295403)*u.m)
     moon_lapalma = get_moon(t, ephemeris='de432s', location=loc)
-    
+
     transformed = moon_geocentric.transform_to(moon_lapalma.frame)
     delta = transformed.separation_3d(moon_lapalma)
     assert_allclose(delta, 0.0*u.m, atol=1*u.m)
-    
-        


### PR DESCRIPTION
This PR fixes #4964, which can be closed once this is merged.

Previously the GCRS self-transform did nothing if two GRCS frames had different ```obsgeoloc``` attributes. As a consequence, transforms to ```GeocentricTrueEcliptic```, and ```CIRS``` were only correct for geocentric observers. Since this is a parallax effect it is only significant for coordinates near Earth.