### PR TITLE
Pixel scale and plate scale equivalencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ New Features
 
 - ``astropy.units``
 
+  - Added ``pixel_scale`` and ``plate_scale`` equivalencies. [#4987]
+
 - ``astropy.utils``
 
 - ``astropy.vo``
@@ -165,7 +167,7 @@ New Features
   - Solar system and lunar ephemerides accessible via ``get_body``,
     ``get_body_barycentric`` and ``get_moon`` functions. [#4890]
 
-  - Added astrometric frames (i.e., a frame centered on a particular 
+  - Added astrometric frames (i.e., a frame centered on a particular
     point/object specified in another frame). [#4909, #4941]
 
   - Added ``SkyCoord.spherical_offsets_to`` method. [#4338]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -19,7 +19,8 @@ from .core import UnitsError
 __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'doppler_optical', 'doppler_relativistic', 'mass_energy',
            'brightness_temperature', 'dimensionless_angles',
-           'logarithmic', 'temperature', 'temperature_energy']
+           'logarithmic', 'temperature', 'temperature_energy',
+           'pixel_scale', 'plate_scale']
 
 
 def dimensionless_angles():
@@ -481,11 +482,13 @@ def temperature():
         (si.K, deg_F, lambda x: (x - 273.15) * 1.8 + 32.0,
          lambda x: ((x - 32.0) / 1.8) + 273.15)]
 
+
 def temperature_energy():
     """Convert between Kelvin and keV(eV) to an equivalent amount."""
     return [
         (si.K, si.eV, lambda x: x / (_si.e.value / _si.k_B),
          lambda x: x * (_si.e.value / _si.k_B))]
+
 
 def assert_is_spectral_unit(value):
     try:

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -20,7 +20,7 @@ __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'doppler_optical', 'doppler_relativistic', 'mass_energy',
            'brightness_temperature', 'dimensionless_angles',
            'logarithmic', 'temperature', 'temperature_energy',
-           'pixel_scale', 'plate_scale']
+           'pixel_scale']
 
 
 def dimensionless_angles():
@@ -496,3 +496,23 @@ def assert_is_spectral_unit(value):
     except (AttributeError, UnitsError) as ex:
         raise UnitsError("The 'rest' value must be a spectral equivalent "
                          "(frequency, wavelength, or energy).")
+
+
+def pixel_scale(pixscale):
+    """
+    Convert between pixel distances (in units of ``pix``) and angular units.
+
+    Parameters
+    ----------
+    pixscale : `~astropy.units.Quantity`
+        The pixel scale either in units of angle/pixel or pixel/angle.
+    """
+    if pixscale.unit.is_equivalent(si.arcsec/astrophys.pix):
+        pixscale_val = pixscale.to(si.radian/astrophys.pix).value
+    elif pixscale.unit.is_equivalent(astrophys.pix/si.arcsec):
+        pixscale_val = (1/pixscale).to(si.radian/astrophys.pix).value
+    else:
+        raise UnitsError("The pixel scale must be in angle/pixel or "
+                         "pixel/angle")
+
+    return [(astrophys.pix, si.radian, lambda px: px*pixscale_val, lambda rad: rad/pixscale_val)]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -20,7 +20,7 @@ __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'doppler_optical', 'doppler_relativistic', 'mass_energy',
            'brightness_temperature', 'dimensionless_angles',
            'logarithmic', 'temperature', 'temperature_energy',
-           'pixel_scale']
+           'pixel_scale', 'plate_scale']
 
 
 def dimensionless_angles():
@@ -500,7 +500,8 @@ def assert_is_spectral_unit(value):
 
 def pixel_scale(pixscale):
     """
-    Convert between pixel distances (in units of ``pix``) and angular units.
+    Convert between pixel distances (in units of ``pix``) and angular units,
+    given a particular ``pixscale``.
 
     Parameters
     ----------
@@ -516,3 +517,24 @@ def pixel_scale(pixscale):
                          "pixel/angle")
 
     return [(astrophys.pix, si.radian, lambda px: px*pixscale_val, lambda rad: rad/pixscale_val)]
+
+
+def plate_scale(platescale):
+    """
+    Convert between lengths (to be interpreted as lengths in the focal plane)
+    and angular units with a specified ``platescale``.
+
+    Parameters
+    ----------
+    platescale : `~astropy.units.Quantity`
+        The pixel scale either in units of distance/pixel or distance/angle.
+    """
+    if platescale.unit.is_equivalent(si.arcsec/si.m):
+        platescale_val = platescale.to(si.radian/si.m).value
+    elif platescale.unit.is_equivalent(si.m/si.arcsec):
+        platescale_val = (1/platescale).to(si.radian/si.m).value
+    else:
+        raise UnitsError("The pixel scale must be in angle/distance or "
+                         "distance/angle")
+
+    return [(si.m, si.radian, lambda d: d*platescale_val, lambda rad: rad/platescale_val)]

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -14,7 +14,7 @@ from numpy.testing.utils import assert_allclose
 # LOCAL
 from ... import units as u
 from ... import constants
-from ...tests.helper import pytest
+from ...tests.helper import pytest, assert_quantity_allclose
 
 
 def test_dimensionless_angles():
@@ -566,3 +566,19 @@ def test_compose_equivalencies():
             break
     else:
         assert False, "Didn't find speed in compose results"
+
+def test_pixel_scale():
+    pix = 75*u.pix
+    asec = 30*u.arcsec
+
+    pixscale = 0.4*u.arcsec/u.pix
+    pixscale2 = 2.5*u.pix/u.arcsec
+
+    assert_quantity_allclose(pix.to(u.arcsec, u.pixel_scale(pixscale)), asec)
+    assert_quantity_allclose(pix.to(u.arcmin, u.pixel_scale(pixscale)), asec)
+
+    assert_quantity_allclose(pix.to(u.arcsec, u.pixel_scale(pixscale2)), asec)
+    assert_quantity_allclose(pix.to(u.arcmin, u.pixel_scale(pixscale2)), asec)
+
+    assert_quantity_allclose(asec.to(u.pix, u.pixel_scale(pixscale)), pix)
+    assert_quantity_allclose(asec.to(u.pix, u.pixel_scale(pixscale2)), pix)

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -567,6 +567,7 @@ def test_compose_equivalencies():
     else:
         assert False, "Didn't find speed in compose results"
 
+
 def test_pixel_scale():
     pix = 75*u.pix
     asec = 30*u.arcsec
@@ -582,3 +583,20 @@ def test_pixel_scale():
 
     assert_quantity_allclose(asec.to(u.pix, u.pixel_scale(pixscale)), pix)
     assert_quantity_allclose(asec.to(u.pix, u.pixel_scale(pixscale2)), pix)
+
+
+def test_plate_scale():
+    mm = 1.5*u.mm
+    asec = 30*u.arcsec
+
+    platescale = 20*u.arcsec/u.mm
+    platescale2 = 0.05*u.mm/u.arcsec
+
+    assert_quantity_allclose(mm.to(u.arcsec, u.plate_scale(platescale)), asec)
+    assert_quantity_allclose(mm.to(u.arcmin, u.plate_scale(platescale)), asec)
+
+    assert_quantity_allclose(mm.to(u.arcsec, u.plate_scale(platescale2)), asec)
+    assert_quantity_allclose(mm.to(u.arcmin, u.plate_scale(platescale2)), asec)
+
+    assert_quantity_allclose(asec.to(u.mm, u.plate_scale(platescale)), mm)
+    assert_quantity_allclose(asec.to(u.mm, u.plate_scale(platescale2)), mm)

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -171,7 +171,7 @@ only dependent on the aperture size.  See `Tools of Radio Astronomy
 <http://books.google.com/books?id=9KHw6R8rQEMC&pg=PA179&source=gbs_toc_r&cad=4#v=onepage&q&f=false>`__
 for details.
 
-.. note:: The brightness temperature mentioned here is the Rayleigh-Jeans 
+.. note:: The brightness temperature mentioned here is the Rayleigh-Jeans
           equivalent temperature, which results in a linear relation between
           flux and temperature. This is the convention that is most often used
           in relation to observations, but if you are interested in computing
@@ -222,6 +222,31 @@ observations at high-energy, be it for solar or X-ray astronomy. Example::
     >>> t_k = 1e6 * u.K
     >>> t_k.to(u.eV, equivalencies=u.temperature_energy())  # doctest: +FLOAT_CMP
     <Quantity 86.17332384960955 eV>
+
+
+Pixel and plate scale Equivalencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These equivalencies are for converting between angular scales and either linear
+scales in the focal plane or distances in units of the number of pixels.  For
+example, suppose you are working with cutouts from the Sloan Digital Sky Survey,
+which defaults to a pixel scale of 0.4 arcseconds per pixel, and want to know
+the true size of something that you measure to be 240 pixels across in the
+cutout image::
+
+    >>> import astropy.units as u
+    >>> sdss_pixelscale = u.pixel_scale(0.4*u.arcsec/u.pixel)
+    >>> (240*u.pixel).to(u.arcmin, sdss_pixelscale)  # doctest: +FLOAT_CMP
+    <Quantity 1.6 arcmin>
+
+Or maybe you are designing an instrument for a telescope that someone told you
+has a (inverse) plate  scale of 7.8 meters per radian (for your desired focus),
+and you want to know how big your pixels need to be to cover half an arcsecond::
+
+    >>> import astropy.units as u
+    >>> tel_platescale = u.plate_scale(7.8*u.m/u.radian)
+    >>> (0.5*u.arcsec).to(u.micron, tel_platescale)  # doctest: +FLOAT_CMP
+    <Quantity 18.9077335632719 micron>
 
 Writing new equivalencies
 -------------------------


### PR DESCRIPTION
This PR adds two equivalencies, intended for converting from angular scales to either focal plane lengths or pixels on detectors.  To see them in action check out the changes to ``equivalencies.rst``