### PR TITLE
sigma_clip expand the dimensions if axis is negative

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,8 @@ Bug Fixes
 
 - ``astropy.stats``
 
+  - Fixed broadcasting in ``sigma_clip`` when using negative ``axis``. [#4988]
+
 - ``astropy.table``
 
 - ``astropy.time``

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -173,7 +173,7 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
         min_value = max_value - std * sigma_lower
         max_value += std * sigma_upper
         if axis is not None:
-            if axis > 0:
+            if axis != 0:
                 min_value = np.expand_dims(min_value, axis=axis)
                 max_value = np.expand_dims(max_value, axis=axis)
         _filtered_data.mask |= _filtered_data > max_value

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -135,3 +135,10 @@ def test_invalid_sigma_clip():
     assert result.mask[2, 2]
     assert result.mask[3, 4]
     assert result.mask[1, 1]
+
+
+def test_sigmaclip_negative_axis():
+    """Test that dimensions are expanded correctly even if axis is negative."""
+    data = np.ones((3, 4))
+    # without correct expand_dims this would raise a ValueError
+    sigma_clip(data, axis=-1)


### PR DESCRIPTION
Negative axis parameters don't play well with the current version of `sigma_clip`:

```
from astropy.stats import sigma_clip
import numpy as np
sigma_clip(np.ones((3, 4)), axis=-1)
ValueError: operands could not be broadcast together with shapes (3,4) (3,) 
```
This PR fixes this issue by expanding the dimensions of the reduced center and standard deviation in all cases except when axis=0.

~~and I don't know why it has conflicts, I've created a new branch based on master just before I pushed it.~~