### PR TITLE
Angle hms construct UnitsError

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -50,6 +50,7 @@ class Angle(u.Quantity):
       Angle('-1h2m3s')
       Angle('-1h2.5m')
       Angle('-1:2.5', unit=u.deg)
+      Angle((10, 11, 12), unit='hourangle')  # (h, m, s)
       Angle((-1, 2, 3), unit=u.deg)  # (d, m, s)
       Angle(10.2345 * u.deg)
       Angle(Angle(10.2345 * u.deg))
@@ -88,7 +89,7 @@ class Angle(u.Quantity):
 
         if not isinstance(angle, u.Quantity):
             if unit is not None:
-                unit = cls._convert_unit_to_angle_unit(unit)
+                unit = cls._convert_unit_to_angle_unit(u.Unit(unit))
 
             if isinstance(angle, tuple):
                 angle = cls._tuple_to_float(angle, unit)

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -47,6 +47,8 @@ def test_create_angles():
     a10 = Angle(3.60827466667, unit=u.hour)
     a11 = Angle("3:36:29.7888000120", unit=u.hour)
     a12 = Angle((3, 36, 29.7888000120), unit=u.hour)  # *must* be a tuple
+    # Regression test for #5001
+    a13 = Angle((3, 36, 29.7888000120), unit='hour')
 
     Angle(0.944644098745, unit=u.radian)
 
@@ -58,11 +60,12 @@ def test_create_angles():
         Angle(54.12412, unit=u.m)
 
     with pytest.raises(ValueError):
-        a13 = Angle(12.34, unit="not a unit")
+        Angle(12.34, unit="not a unit")
 
     a14 = Angle("03h36m29.7888000120") # no trailing 's', but unambiguous
 
     a15 = Angle("5h4m3s") # single digits, no decimal
+    assert a15.unit == u.hourangle
 
     a16 = Angle("1 d")
     a17 = Angle("1 degree")
@@ -88,7 +91,7 @@ def test_create_angles():
     assert_allclose(a6.radian, a7.radian)
 
     assert_allclose(a10.degree, a11.degree)
-    assert a11 == a12 == a14
+    assert a11 == a12 == a13 == a14
     assert a21 == a22
     assert a23 == -a24
 


### PR DESCRIPTION
This way to create an Angle used to work with Astropy 1.1 (taking the tuple to mean hms format) but now errors with Astropy 1.2.dev15520 :
```python
>>> from astropy.coordinates import Angle
>>> angle = Angle((1, 2, 3), unit='hour')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/code/astropy/astropy/coordinates/angles.py", line 94, in __new__
    angle = cls._tuple_to_float(angle, unit)
  File "/Users/deil/code/astropy/astropy/coordinates/angles.py", line 141, in _tuple_to_float
    .format(angle, unit))
astropy.units.core.UnitsError: Can not parse '(1, 2, 3)' as unit 'hour'
```
These work with the dev version:
```python
>>> Angle((1, 2, 3), unit='hourangle')
<Angle 1.0341666666666667 hourangle>
>>> Angle('1 2 3 hour')
<Angle 1.0341666666666667 hourangle>
>>> Angle((1, 2, 3), unit='deg')
<Angle 1.0341666666666667 deg>
```

Looks like all of those treat the tuple as dms:
```
>>> 1 + 2/60 + 3/60/60
1.0341666666666667
```
According to the Angle docs, it's possible to create from an hms tuple (although it isn't said what unit one should pass to do that):
http://astropy.readthedocs.io/en/latest/api/astropy.coordinates.Angle.html#astropy.coordinates.Angle

Assuming dms for unit='hourangle'` or 'hour' in the unit string is a bug, no?

I didn't check if this was introduced in #4970 or where the change in behaviour originated.

cc @mhvk @eteq