### PR TITLE
Renamed ignored to suppress

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,9 @@ API Changes
 
 - ``astropy.utils``
 
+  - Renamed ``ignored`` context manager in ``compat.misc`` to ``suppress``
+    to be consistent with https://bugs.python.org/issue19266 . [#5003]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from ..utils.compat import ignored
+from ..utils.compat import suppress
 from ..utils.compat.funcsigs import signature
 from ..extern import six
 
@@ -690,7 +690,7 @@ class FunctionTransform(CoordinateTransform):
         if not six.callable(func):
             raise TypeError('func must be callable')
 
-        with ignored(TypeError):
+        with suppress(TypeError):
             sig = signature(func)
             kinds = [x.kind for x in sig.parameters.values()]
             if (len(x for x in kinds if x == sig.POSITIONAL_ONLY) != 2

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -18,7 +18,7 @@ import os
 from . import core
 from . import fixedwidth
 
-from ...utils.compat import ignored
+from ...utils.compat import suppress
 
 
 __doctest_skip__ = ['*']
@@ -299,7 +299,7 @@ class Cds(core.BaseReader):
         if self.data.start_line == 'guess':
             # Replicate the first part of BaseReader.read up to the point where
             # the table lines are initially read in.
-            with ignored(TypeError):
+            with suppress(TypeError):
                 # For strings only
                 if os.linesep not in table + '':
                     self.data.table_name = os.path.basename(table)
@@ -315,7 +315,7 @@ class Cds(core.BaseReader):
             # could be a file.
             for data_start in range(len(lines)):
                 self.data.start_line = data_start
-                with ignored(Exception):
+                with suppress(Exception):
                     table = super(Cds, self).read(lines)
                     return table
         else:

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -26,7 +26,7 @@ from ...extern.six.moves import cStringIO as StringIO
 from ...utils.exceptions import AstropyWarning
 
 from ...table import Table
-from ...utils.compat import ignored
+from ...utils.compat import suppress
 from ...utils.data import get_readable_fileobj
 from . import connect
 
@@ -746,7 +746,7 @@ class BaseData(object):
                     col.fill_values = {}
 
             # if input is only one <fill_spec>, then make it a list
-            with ignored(TypeError):
+            with suppress(TypeError):
                 self.fill_values[0] + ''
                 self.fill_values = [self.fill_values]
 
@@ -1019,7 +1019,7 @@ class MetaBaseReader(type):
 
 
 def _is_number(x):
-    with ignored(ValueError):
+    with suppress(ValueError):
         x = float(x)
         return True
     return False
@@ -1132,7 +1132,7 @@ class BaseReader(object):
         # If ``table`` is a file then store the name in the ``data``
         # attribute. The ``table`` is a "file" if it is a string
         # without the new line specific to the OS.
-        with ignored(TypeError):
+        with suppress(TypeError):
             # Strings only
             if os.linesep not in table + '':
                 self.data.table_name = os.path.basename(table)

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -21,9 +21,8 @@ from .verify import VerifyError, VerifyWarning
 
 from ...extern.six import string_types, iteritems
 from ...utils import lazyproperty, isiterable, indent
-from ...utils.compat import ignored
+from ...utils.compat import suppress
 from ...utils.exceptions import AstropyDeprecationWarning
-
 
 __all__ = ['Column', 'ColDefs', 'Delayed']
 
@@ -813,7 +812,7 @@ class Column(NotifierMixin):
             return format, format.recformat
 
         if format in NUMPY2FITS:
-            with ignored(VerifyError):
+            with suppress(VerifyError):
                 # legit recarray format?
                 recformat = format
                 format = cls.from_recformat(format)
@@ -1048,7 +1047,7 @@ class Column(NotifierMixin):
             # "optional" codes), but it is also strictly a valid ASCII
             # table format, then assume an ASCII table column was being
             # requested (the more likely case, after all).
-            with ignored(VerifyError):
+            with suppress(VerifyError):
                 format = _AsciiColumnFormat(format, strict=True)
 
             # A safe guess which reflects the existing behavior of previous

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -18,7 +18,7 @@ from .util import decode_ascii, encode_ascii
 from ...extern.six import string_types
 from ...extern.six.moves import xrange
 from ...utils import lazyproperty
-from ...utils.compat import ignored
+from ...utils.compat import suppress
 from ...utils.exceptions import AstropyDeprecationWarning
 
 
@@ -217,7 +217,7 @@ class FITS_rec(np.recarray):
         for attrs in ['_converted', '_heapoffset', '_heapsize', '_nfields',
                       '_gap', '_uint', 'parnames', '_coldefs']:
 
-            with ignored(AttributeError):
+            with suppress(AttributeError):
                 # _coldefs can be Delayed, and file objects cannot be
                 # picked, it needs to be deepcopied first
                 if attrs == '_coldefs':
@@ -977,7 +977,7 @@ class FITS_rec(np.recarray):
         elif _bool and field.dtype != bool:
             field = np.equal(field, ord('T'))
         elif _str:
-            with ignored(UnicodeDecodeError):
+            with suppress(UnicodeDecodeError):
                 field = decode_ascii(field)
 
         if dim:

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -19,7 +19,7 @@ from ..verify import _Verify, _ErrList
 
 from ....extern.six import string_types, add_metaclass
 from ....utils import lazyproperty, deprecated
-from ....utils.compat import ignored
+from ....utils.compat import suppress
 from ....utils.compat.funcsigs import signature, Parameter
 from ....utils.exceptions import AstropyUserWarning
 
@@ -642,13 +642,13 @@ class _BaseHDU(object):
         if (self._has_data and self._standard and
                 _is_pseudo_unsigned(self.data.dtype)):
             for keyword in ('BSCALE', 'BZERO'):
-                with ignored(KeyError):
+                with suppress(KeyError):
                     del self._header[keyword]
 
     def _writeheader(self, fileobj):
         offset = 0
         if not fileobj.simulateonly:
-            with ignored(AttributeError, IOError):
+            with suppress(AttributeError, IOError):
                 offset = fileobj.tell()
 
             self._header.tofile(fileobj)

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -22,7 +22,7 @@ from ..util import (_is_pseudo_unsigned, _unsigned_zero, _is_int,
 
 from ....extern.six import string_types, iteritems
 from ....utils import lazyproperty, deprecated
-from ....utils.compat import ignored
+from ....utils.compat import suppress
 from ....utils.exceptions import (AstropyPendingDeprecationWarning,
                                   AstropyUserWarning)
 
@@ -331,7 +331,7 @@ class CompImageHeader(Header):
 
         is_naxisn = False
         if keyword[:5] == 'NAXIS':
-            with ignored(ValueError):
+            with suppress(ValueError):
                 index = int(keyword[5:])
                 is_naxisn = index > 0
 
@@ -355,7 +355,7 @@ class CompImageHeader(Header):
         keyword, repeat = self._keyword_from_index(idx)
         remapped_insert_keyword = self._remap_keyword(keyword)
 
-        with ignored(IndexError, KeyError):
+        with suppress(IndexError, KeyError):
             idx = self._table_header._cardindex((remapped_insert_keyword,
                                                  repeat))
 
@@ -1773,7 +1773,7 @@ class CompImageHDU(BinTableHDU):
         else:
             # Delete from both headers
             for header in (self.header, self._header):
-                with ignored(KeyError):
+                with suppress(KeyError):
                     del header['BZERO']
 
         if _scale != 1:
@@ -1781,7 +1781,7 @@ class CompImageHDU(BinTableHDU):
             self.header['BSCALE'] = _scale
         else:
             for header in (self.header, self._header):
-                with ignored(KeyError):
+                with suppress(KeyError):
                     del header['BSCALE']
 
         if self.data.dtype.type != _type:
@@ -1910,7 +1910,7 @@ class CompImageHDU(BinTableHDU):
                 # Make sure to delete from both the image header and the table
                 # header; later this will be streamlined
                 for header in (self.header, self._header):
-                    with ignored(KeyError):
+                    with suppress(KeyError):
                         del header[keyword]
                         # Since _update_header_scale_info can, currently, be
                         # called *after* _prewriteto(), replace these with

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -31,7 +31,7 @@ from ....extern import six
 from ....extern.six import string_types
 from ....extern.six.moves import xrange as range
 from ....utils import deprecated, lazyproperty
-from ....utils.compat import ignored
+from ....utils.compat import suppress
 from ....utils.exceptions import AstropyUserWarning
 
 
@@ -355,7 +355,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 self.columns = self.data._coldefs
                 self.update()
 
-                with ignored(TypeError, AttributeError):
+                with suppress(TypeError, AttributeError):
                     # Make the ndarrays in the Column objects of the ColDefs
                     # object of the HDU reference the same ndarray as the HDU's
                     # FITS_rec object.
@@ -444,7 +444,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
             self.columns = self.data.columns
             self.update()
 
-            with ignored(TypeError, AttributeError):
+            with suppress(TypeError, AttributeError):
                 # Make the ndarrays in the Column objects of the ColDefs
                 # object of the HDU reference the same ndarray as the HDU's
                 # FITS_rec object.

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -34,7 +34,7 @@ from ...extern.six import (string_types, integer_types, text_type,
                            binary_type, next)
 from ...extern.six.moves import zip
 from ...utils import wraps
-from ...utils.compat import ignored
+from ...utils.compat import suppress
 from ...utils.exceptions import AstropyUserWarning
 
 if six.PY3:
@@ -112,7 +112,7 @@ class NotifierMixin(object):
         if self._listeners is None:
             return
 
-        with ignored(KeyError):
+        with suppress(KeyError):
             del self._listeners[id(listener)]
 
     def _notify(self, notification, *args, **kwargs):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -37,7 +37,7 @@ from ..table import Table
 from ..utils import (sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer)
 from ..utils.codegen import make_function_with_signature
-from ..utils.compat import ignored
+from ..utils.compat import suppress
 from ..utils.compat.funcsigs import signature
 from ..utils.exceptions import AstropyDeprecationWarning
 from .utils import (array_repr_oneline, check_broadcast, combine_labels,
@@ -1849,7 +1849,7 @@ class _CompoundModelMeta(_ModelMeta):
 
         if isinstance(rv, tuple):
             # Delete _evaluate from the members dict
-            with ignored(KeyError):
+            with suppress(KeyError):
                 del rv[1][2]['_evaluate']
 
         return rv

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -7,11 +7,10 @@ be accessed from there.
 
 Includes the following fixes:
 
-* The `contextlib.ignored` context manager, which is only available in Python
+* The `contextlib.suppress` context manager, which is only available in Python
   3.4 or greater.
 
 """
-
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ...extern import six
@@ -19,8 +18,9 @@ from ...extern import six
 import functools
 import sys
 
+from ..decorators import deprecated
 
-__all__ = ['invalidate_caches', 'override__dir__', 'ignored',
+__all__ = ['invalidate_caches', 'override__dir__', 'suppress',
            'possible_filename', 'namedtuple_asdict']
 
 
@@ -97,6 +97,7 @@ try:
     from contextlib import ignored
 except ImportError:
     from contextlib import contextmanager
+    @deprecated('1.3', alternative='suppress')
     @contextmanager
     def ignored(*exceptions):
         """A context manager for ignoring exceptions.  Equivalent to::
@@ -113,7 +114,32 @@ except ImportError:
             ...     os.remove('file-that-does-not-exist')
 
         """
+        try:
+            yield
+        except exceptions:
+            pass
 
+
+try:
+    from contextlib import suppress
+except ImportError:
+    from contextlib import contextmanager
+    @contextmanager
+    def suppress(*exceptions):
+        """A context manager for ignoring exceptions.  Equivalent to::
+
+            try:
+                <body>
+            except exceptions:
+                pass
+
+        Example::
+
+            >>> import os
+            >>> with suppress(OSError):
+            ...     os.remove('file-that-does-not-exist')
+
+        """
         try:
             yield
         except exceptions:

--- a/astropy/vo/samp/lockfile_helpers.py
+++ b/astropy/vo/samp/lockfile_helpers.py
@@ -20,7 +20,7 @@ from ...extern import six
 
 from ... import log
 
-from ...utils.compat import ignored
+from ...utils.compat import suppress
 from ...utils.data import get_readable_fileobj
 
 from .constants import SSL_SUPPORT
@@ -263,7 +263,7 @@ def remove_garbage_lock_files():
     if not hub_is_running:
         # If lockfilename belongs to a dead hub, then it is deleted
         if os.path.isfile(lockfilename):
-            with ignored(OSError):
+            with suppress(OSError):
                 os.remove(lockfilename)
 
     # HUB MULTIPLE INSTANCE MODE
@@ -278,5 +278,5 @@ def remove_garbage_lock_files():
                 if not hub_is_running:
                     # If lockfilename belongs to a dead hub, then it is deleted
                     if os.path.isfile(lockfilename):
-                        with ignored(OSError):
+                        with suppress(OSError):
                             os.remove(lockfilename)


### PR DESCRIPTION
As suggested by @embray in [this comment](https://github.com/astropy/astropy/pull/4977#issuecomment-222103333), I replaced `ignored` context manager with `suppress` to be consistent with renaming in Python 3 itself (see https://bugs.python.org/issue19266).