### PR TITLE
Fix missing AstropyDeprecationWarning import

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -22,6 +22,7 @@ from .verify import VerifyError, VerifyWarning
 from ...extern.six import string_types, iteritems
 from ...utils import lazyproperty, isiterable, indent
 from ...utils.compat import ignored
+from ...utils.exceptions import AstropyDeprecationWarning
 
 
 __all__ = ['Column', 'ColDefs', 'Delayed']


### PR DESCRIPTION
Missing `AstropyDeprecationWarning` in `astropy.io.fits.column`.
```
In [33]: coldefs = fits.ColDefs([c1], tbtype='BinTableHDU')
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-33-844778bb414c> in <module>()
----> 1 coldefs = fits.ColDefs([c1], tbtype='BinTableHDU')

/home/simon/lib/astropy/astropy/io/fits/column.py in __new__(cls, input, tbtype, ascii)
   1156                 'inferred from the formats of the supplied columns.  Use the '
   1157                 '``ascii=True`` argument to ensure that ASCII table columns '
-> 1158                 'are used.', AstropyDeprecationWarning)
   1159         else:
   1160             tbtype = 'BinTableHDU'  # The old default

NameError: global name 'AstropyDeprecationWarning' is not defined
```
I guess this `tbtype` arguments is not widely used ;-). The docstring says it was deprecated in Astropy 0.4, so maybe it is time to remove it ?