### PR TITLE
Expanded spectral_density equivalency for photlam <-> STmag/ABmag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ New Features
 
   - Added ``pixel_scale`` and ``plate_scale`` equivalencies. [#4987]
 
+  - Expanded ``spectral_density`` equivalency to convert between ``photlam``
+    and ``STmag``/``ABmag``. [#5012]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -12,6 +12,7 @@ from . import si
 from . import cgs
 from . import astrophys
 from .function import units as function_units
+from .function import logarithmic as log_units
 from . import dimensionless_unscaled
 from .core import UnitsError
 
@@ -122,6 +123,8 @@ def spectral_density(wav, factor=None):
     lafla = nufnu
     photlam = astrophys.photon / (si.cm ** 2 * si.s * si.AA)
     photnu = astrophys.photon / (si.cm ** 2 * si.s * si.Hz)
+    stmag = log_units.STmag
+    abmag = log_units.ABmag
 
     def converter(x):
         return x * (wav.to(si.AA, spectral()).value ** 2 / c_Aps)
@@ -169,6 +172,21 @@ def spectral_density(wav, factor=None):
     def iconverter_photnu_fla(x):
         return x * wav.to(si.AA, spectral()).value ** 3 / (hc * c_Aps)
 
+    def converter_photlam_stmag(x):
+        return (-2.5 * np.log10(hc * (x / wav.to(si.AA, spectral())).value)
+                - 21.1)
+
+    def iconverter_photlam_stmag(x):
+        return wav.to(si.AA, spectral()) * 10 ** (-0.4 * (x.value + 21.1)) / hc
+
+    def converter_photlam_abmag(x):
+        return (-2.5 * np.log10(h_cgs * (x * wav.to(si.AA, spectral())).value)
+                - 48.6)
+
+    def iconverter_photlam_abmag(x):
+        return (10 ** (-0.4 * (x.value + 48.6)) /
+                (h_cgs * wav.to(si.AA, spectral())))
+
     return [
         (fla, fnu, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
@@ -177,7 +195,9 @@ def spectral_density(wav, factor=None):
         (photlam, fnu, converter_photlam_fnu, iconverter_photlam_fnu),
         (photlam, photnu, converter_photlam_photnu, iconverter_photlam_photnu),
         (photnu, fnu, converter_photnu_fnu, iconverter_photnu_fnu),
-        (photnu, fla, converter_photnu_fla, iconverter_photnu_fla)
+        (photnu, fla, converter_photnu_fla, iconverter_photnu_fla),
+        (photlam, stmag, converter_photlam_stmag, iconverter_photlam_stmag),
+        (photlam, abmag, converter_photlam_abmag, iconverter_photlam_abmag)
     ]
 
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -345,6 +345,8 @@ def test_spectraldensity4():
     flux_flam = [3.9135e-14, 4.0209e-14, 3.9169e-14]
     flux_fnu = [3.20735792e-25, 3.29903646e-25, 3.21727226e-25]
     flux_jy = [3.20735792e-2, 3.29903646e-2, 3.21727226e-2]
+    flux_stmag = [12.41858665, 12.38919182, 12.41764379]
+    flux_abmag = [12.63463143, 12.60403221, 12.63128047]
 
     # PHOTLAM <--> FLAM
     assert_allclose(photlam.to(
@@ -381,6 +383,18 @@ def test_spectraldensity4():
         flam, flux_photnu, u.spectral_density(wave)), flux_flam, rtol=1e-6)
     assert_allclose(flam.to(
         photnu, flux_flam, u.spectral_density(wave)), flux_photnu, rtol=1e-6)
+
+    # PHOTLAM <--> STMAG
+    assert_allclose(photlam.to(
+        u.STmag, flux_photlam, u.spectral_density(wave)), flux_stmag, rtol=1e-6)
+    assert_allclose(u.STmag.to(
+        photlam, flux_stmag, u.spectral_density(wave)), flux_photlam, rtol=1e-6)
+
+    # PHOTLAM <--> ABMAG
+    assert_allclose(photlam.to(
+        u.ABmag, flux_photlam, u.spectral_density(wave)), flux_abmag, rtol=1e-6)
+    assert_allclose(u.ABmag.to(
+        photlam, flux_abmag, u.spectral_density(wave)), flux_photlam, rtol=1e-6)
 
 
 def test_equivalent_units():


### PR DESCRIPTION
Expanded `spectral_density()` equivalency for `photlam` conversion to/from `STmag` and `ABmag`. Without this, I have to use `flam` as a middle-person, which is inefficient.