### PR TITLE
Better interaction between function units and equivalencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -684,6 +684,9 @@ Bug fixes
   - Exponentation using a ``Quantity`` with a unit equivalent to dimensionless
     as base and an ``array``-like exponent yields the correct result. [#4770]
 
+  - Ensured that with ``spectral_density`` equivalency one could also convert
+    between ``photlam`` and ``STmag``/``ABmag``. [#5017]
+
 - ``astropy.utils``
 
   - The astropy.utils.compat.fractions module has now been deprecated. Use the

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -136,12 +136,12 @@ class FunctionUnitBase(object):
 
     @property
     def equivalencies(self):
-        """List of equivalencies between physical and function units.
+        """List of equivalencies between function and physical units.
 
         Uses the `from_physical` and `to_physical` methods.
         """
-        return [(self.physical_unit, self,
-                 self.from_physical, self.to_physical)]
+        return [(self, self.physical_unit,
+                 self.to_physical, self.from_physical)]
 
     # vvvv properties/methods required to behave like a unit
     def decompose(self, bases=set()):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -345,6 +345,8 @@ def test_spectraldensity4():
     flux_flam = [3.9135e-14, 4.0209e-14, 3.9169e-14]
     flux_fnu = [3.20735792e-25, 3.29903646e-25, 3.21727226e-25]
     flux_jy = [3.20735792e-2, 3.29903646e-2, 3.21727226e-2]
+    flux_stmag = [12.41858665, 12.38919182, 12.41764379]
+    flux_abmag = [12.63463143, 12.60403221, 12.63128047]
 
     # PHOTLAM <--> FLAM
     assert_allclose(photlam.to(
@@ -381,6 +383,18 @@ def test_spectraldensity4():
         flam, flux_photnu, u.spectral_density(wave)), flux_flam, rtol=1e-6)
     assert_allclose(flam.to(
         photnu, flux_flam, u.spectral_density(wave)), flux_photnu, rtol=1e-6)
+
+    # PHOTLAM <--> STMAG
+    assert_allclose(photlam.to(
+        u.STmag, flux_photlam, u.spectral_density(wave)), flux_stmag, rtol=1e-6)
+    assert_allclose(u.STmag.to(
+        photlam, flux_stmag, u.spectral_density(wave)), flux_photlam, rtol=1e-6)
+
+    # PHOTLAM <--> ABMAG
+    assert_allclose(photlam.to(
+        u.ABmag, flux_photlam, u.spectral_density(wave)), flux_abmag, rtol=1e-6)
+    assert_allclose(u.ABmag.to(
+        photlam, flux_abmag, u.spectral_density(wave)), flux_photlam, rtol=1e-6)
 
 
 def test_equivalent_units():

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -139,7 +139,7 @@ These three conventions are implemented in
 
     >>> restfreq = 115.27120 * u.GHz  # rest frequency of 12 CO 1-0 in GHz
     >>> freq_to_vel = u.doppler_radio(restfreq)
-    >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)
+    >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
     <Quantity -1895.4321928669085 km / s>
 
 Spectral Flux Density Units
@@ -297,7 +297,7 @@ but this example is illustrative::
     ... lambda x: (1-x/si.c.to('km/s').value) * restfreq )]
     >>> u.Hz.to(u.km / u.s, 116e9, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
     -1895.4321928669262
-    >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)
+    >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
     <Quantity -1895.4321928669262 km / s>
 
 Note that once this is defined for GHz and km/s, it will work for all other


### PR DESCRIPTION
An alternative solution to #5012 that ensures that magnitudes and other functional units can be converted to even if also an equivalency is needed. I think it is a better approach, being more general, but it does leave a few questions:

1. Would this be better implemented by letting non-units have the ability to convert `from` a unit (rather than just `to`)? Or perhaps have a `_get_converter` staticmethod that allows one to give the units in arbitrary order.
2. Would it be better to have a general ability to chain equivalencies (as is effectively done here).

My sense would be to leave these questions for the future (can raise a separate issue), and just merge this as this is simple and just extends what worked already in a logical fashion.

With this PR, the following works; @pllim - is this indeed good enough for you?
```
In [2]: t = 1.*u.erg/u.s/u.cm**2/u.AA

In [3]: u.add_enabled_equivalencies(u.spectral_density(5500*u.AA))
Out[3]: <astropy.units.core._UnitContext at 0x7f5caf5a3f60>

In [4]: t.to(u.ABmag)
Out[4]: <Quantity -21.109761690151405 mag(AB)>
```