### PR TITLE
Removing deprecated code from io.fits.header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,6 +208,13 @@ New Features
 
   - New function ``convenience.table_to_hdu`` to allow creating a FITS
     HDU object directly from an astropy ``Table``. [#4778]
+  - A new optional argument ``ignore_missing`` is added to ``astropy.io.fits.header.remove()``. When deleting keyword
+    from the header, ``ignore_missing`` is a boolean value specifying whether or not to raise ``KeyError`` when keyword is
+    not present in the header (``False`` by default). [#4445]
+
+  - A new optional argument ``all`` is added to ``astropy.io.fits.header.remove()``. When deleting keyword
+    from the header, ``all`` is a boolean value specifying whether or not to delete all instances of keyword in the header.
+    (``False`` by default). [#4445]
 
 - ``astropy.io.misc``
 
@@ -369,6 +376,11 @@ API changes
   - Add a way to control HTML escaping when writing a table as an HTML file. [#4423]
 
 - ``astropy.io.fits``
+
+  - Two optional boolean arguments ``ignore_missing`` and ``all`` were added to ``Header.remove``.
+    ``ignore_missing`` specifies whether or not to ignore ``KeyError`` when keyword is not
+    preset in the header. ``all`` specifies whether or not to delete all instances of keyword from
+    the header. [#4445]
 
 - ``astropy.io.misc``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,13 +208,9 @@ New Features
 
   - New function ``convenience.table_to_hdu`` to allow creating a FITS
     HDU object directly from an astropy ``Table``. [#4778]
-  - A new optional argument ``ignore_missing`` is added to ``astropy.io.fits.header.remove()``. When deleting keyword
-    from the header, ``ignore_missing`` is a boolean value specifying whether or not to raise ``KeyError`` when keyword is
-    not present in the header (``False`` by default). [#4445]
 
-  - A new optional argument ``all`` is added to ``astropy.io.fits.header.remove()``. When deleting keyword
-    from the header, ``all`` is a boolean value specifying whether or not to delete all instances of keyword in the header.
-    (``False`` by default). [#4445]
+  - A new optional arguments ``ignore_missing`` and ``remove_all`` are added
+    to ``astropy.io.fits.header.remove()``. [#5020]
 
 - ``astropy.io.misc``
 
@@ -368,7 +364,7 @@ API changes
     copying the (possibly large) input coordinate arrays. [#4883]
 
 - ``astropy.cosmology``
-  
+
   - Improve documentation of z validity range of cosmology objects [#4882]
 
 - ``astropy.io.ascii``
@@ -377,10 +373,8 @@ API changes
 
 - ``astropy.io.fits``
 
-  - Two optional boolean arguments ``ignore_missing`` and ``all`` were added to ``Header.remove``.
-    ``ignore_missing`` specifies whether or not to ignore ``KeyError`` when keyword is not
-    preset in the header. ``all`` specifies whether or not to delete all instances of keyword from
-    the header. [#4445]
+  - Two optional boolean arguments ``ignore_missing`` and ``remove_all`` are
+    added to ``Header.remove``. [#5020]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1518,7 +1518,7 @@ class Header(object):
 
         self._modified = True
 
-    def remove(self, keyword, ignore_missing=False, all=False):
+    def remove(self, keyword, ignore_missing=False, remove_all=False):
         """
         Removes the first instance of the given keyword from the header similar
         to `list.remove` if the Header object is treated as a list of keywords.
@@ -1526,13 +1526,13 @@ class Header(object):
         Parameters
         ----------
         keyword : str
-            The keyword of which to remove the first instance in the header
+            The keyword of which to remove the first instance in the header.
 
         ignore_missing : bool, optional
-            When True, ignores missing keywords.  Otherwise, if the keyword is not present
-            in the header a KeyError is raised.
+            When True, ignores missing keywords.  Otherwise, if the keyword
+            is not present in the header a KeyError is raised.
 
-        all : bool, optional
+        remove_all : bool, optional
             When True, all instances of keyword will be removed.
             Otherwise only the first instance of the given keyword is removed.
 
@@ -1540,7 +1540,7 @@ class Header(object):
         keyword = Card.normalize_keyword(keyword)
         if keyword in self._keyword_indices:
             del self[self._keyword_indices[keyword][0]]
-            if all:
+            if remove_all:
                 while keyword in self._keyword_indices:
                     del self[self._keyword_indices[keyword][0]]
         elif not ignore_missing:

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -4,10 +4,8 @@ from __future__ import division
 
 import collections
 import copy
-import inspect
 import itertools
 import re
-import sys
 import warnings
 
 from .card import Card, CardList, _pad, KEYWORD_LENGTH
@@ -224,21 +222,11 @@ class Header(object):
                 indices = self._rvkc_indices
 
             if key not in indices:
-                if _is_astropy_internal():
-                    # All internal code is designed to assume that this will
-                    # raise a KeyError, so go ahead and do so
-                    raise KeyError("Keyword '%s' not found." % key)
-                # Warn everyone else.
-                # TODO: Remove this warning and make KeyError the default after
-                # a couple versions (by 3.3, say)
-                warnings.warn(
-                    'Deletion of non-existent keyword %r: '
-                    'In a future Astropy version Header.__delitem__ may be '
-                    'changed so that this raises a KeyError just like a dict '
-                    'would. Please update your code so that KeyErrors are '
-                    'caught and handled when deleting non-existent keywords.' %
-                    key, AstropyDeprecationWarning)
-                return
+                # if keyword is not present raise KeyError.
+                # To delete keyword without caring if they were present,
+                # Header.remove(Keyword) can be used with optional argument ignore_missing as True
+                raise KeyError("Keyword '%s' not found." % key)
+
             for idx in reversed(indices[key]):
                 # Have to copy the indices list since it will be modified below
                 del self[idx]
@@ -1530,7 +1518,7 @@ class Header(object):
 
         self._modified = True
 
-    def remove(self, keyword):
+    def remove(self, keyword, ignore_missing=False, all=False):
         """
         Removes the first instance of the given keyword from the header similar
         to `list.remove` if the Header object is treated as a list of keywords.
@@ -1540,9 +1528,24 @@ class Header(object):
         keyword : str
             The keyword of which to remove the first instance in the header
 
-        """
+        ignore_missing : bool, optional
+            When True, ignores missing keywords.  Otherwise, if the keyword is not present
+            in the header a KeyError is raised.
 
-        del self[self.index(keyword)]
+        all : bool, optional
+            When True, all instances of keyword will be removed.
+            Otherwise only the first instance of the given keyword is removed.
+
+        """
+        keyword = Card.normalize_keyword(keyword)
+        if keyword in self._keyword_indices:
+            del self[self._keyword_indices[keyword][0]]
+            if all:
+                while keyword in self._keyword_indices:
+                    del self[self._keyword_indices[keyword][0]]
+        elif not ignore_missing:
+            raise KeyError("Keyword '%s' not found." % keyword)
+
 
     def rename_keyword(self, oldkeyword, newkeyword, force=False):
         """
@@ -2291,20 +2294,6 @@ class _HeaderCommentaryCards(_CardAccessor):
         # In this case, key/index errors should be raised; don't update
         # comments of nonexistent cards
         self._header[(self._keyword, item)] = value
-
-
-def _is_astropy_internal():
-    """
-    Returns True if the stack frame this is called from is in code internal to
-    the astropy package.
-
-    This is used in a few places where hacks are employed for backwards
-    compatibility with the old header API, but where we want to avoid using
-    those hacks internally.
-    """
-
-    calling_mod = inspect.getmodule(sys._getframe(2))
-    return calling_mod and calling_mod.__name__.startswith('astropy.')
 
 
 def _block_size(sep):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1410,17 +1410,19 @@ class TestHeaderFunctions(FitsTestCase):
         assert list(header) == ['A']
         assert 'C' not in header
 
-        # When keyword is not present in the header and ignore_missing is False, KeyError should be raised
+        # When keyword is not present in the header and ignore_missing is
+        # False, KeyError should be raised
         with pytest.raises(KeyError):
             header.remove('F')
 
-        # When keyword is not present and ignore_missing is True, KeyError will be ignored
+        # When keyword is not present and ignore_missing is True, KeyError
+        # will be ignored
         header.remove('F', ignore_missing=True)
         assert len(header) == 1
 
         # Test for removing all instances of a keyword
         header = fits.Header([('A', 'B'), ('C', 'D'), ('A', 'F')])
-        header.remove('A', all=True)
+        header.remove('A', remove_all=True)
         assert 'A' not in header
         assert len(header) == 1
         assert list(header) == ['C']

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1402,8 +1402,30 @@ class TestHeaderFunctions(FitsTestCase):
         assert list(header.keys())[-3] == 'TEST1'
 
     def test_remove(self):
-        # TODO: Test the Header.remove() method; add support for ignore_missing
-        pass
+        header = fits.Header([('A', 'B'), ('C', 'D')])
+
+        # When keyword is present in the header it should be removed.
+        header.remove('C')
+        assert len(header) == 1
+        assert list(header) == ['A']
+        assert 'C' not in header
+
+        # When keyword is not present in the header and ignore_missing is False, KeyError should be raised
+        with pytest.raises(KeyError):
+            header.remove('F')
+
+        # When keyword is not present and ignore_missing is True, KeyError will be ignored
+        header.remove('F', ignore_missing=True)
+        assert len(header) == 1
+
+        # Test for removing all instances of a keyword
+        header = fits.Header([('A', 'B'), ('C', 'D'), ('A', 'F')])
+        header.remove('A', all=True)
+        assert 'A' not in header
+        assert len(header) == 1
+        assert list(header) == ['C']
+        assert header[0] == 'D'
+
 
     def test_header_comments(self):
         header = fits.Header([('A', 'B', 'C'), ('DEF', 'G', 'H')])


### PR DESCRIPTION
This is a rebased ad squashed version of #4445 that was milestoned as 1.2. 
I believe @embray gave the green light pending the changelog entry back in Jan, thus it would be nice to get this in the release.

Closes #4445, closes #4429 and most probably #2594, too.

cc @eteq @astrofrog 