### PR TITLE
Add the moon's track on the sky to the observing example (not ready yet)

### DIFF
--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -124,7 +124,7 @@ sunaltazs_July12_to_13 = get_sun(times_July12_to_13).transform_to(frame_July12_t
 # to get a precise location of the moon.
 
 from astropy.coordinates import get_moon
-moon_July12_to_13 = get_moon(times_July12_to_13, ephemeris='de432s')
+moon_July12_to_13 = get_moon(times_July12_to_13)
 moonaltazs_July12_to_13 = moon_July12_to_13.transform_to(frame_July12_to_13)
 
 ##############################################################################

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -117,6 +117,16 @@ times_July12_to_13 = midnight + delta_midnight
 frame_July12_to_13 = AltAz(obstime=times_July12_to_13, location=bear_mountain)
 sunaltazs_July12_to_13 = get_sun(times_July12_to_13).transform_to(frame_July12_to_13)
 
+
+##############################################################################
+# Do the same with `~astropy.coordinates.get_moon` to find when the moon is
+# up. Be aware that this will need to download a 10MB file from the internet
+# to get a precise location of the moon.
+
+from astropy.coordinates import get_moon
+moon_July12_to_13 = get_moon(times_July12_to_13, ephemeris='de432s')
+moonaltazs_July12_to_13 = moon_July12_to_13.transform_to(frame_July12_to_13)
+
 ##############################################################################
 # Find the alt,az coordinates of M33 at those same times:
 
@@ -127,6 +137,7 @@ m33altazs_July12_to_13 = m33.transform_to(frame_July12_to_13)
 # the Sun over that time:
 
 plt.plot(delta_midnight, sunaltazs_July12_to_13.alt, color='r', label='Sun')
+plt.plot(delta_midnight, moonaltazs_July12_to_13.alt, color=[0.75]*3, ls='--', label='Moon')
 plt.scatter(delta_midnight, m33altazs_July12_to_13.alt,
             c=m33altazs_July12_to_13.az, label='M33', lw=0, s=8,
             cmap='viridis')


### PR DESCRIPTION
This is a simple PR that just adds a line for the track of the moon to the observing example.

The reason I say it's not ready to merge yet is that, as it stands, this requires both a 10MB download and that `jplephem` be installed to build the docs.  We probably don't want to make people deal with that.  But #4963 is in, there'll be a "builtin" (i.e. approximation that requires no download) version of `get_moon`, and at that time this should be changed to use that and merged.
