### PR TITLE
Issues with updating parameters of combined models

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1881,7 +1881,7 @@ class _CompoundModelMeta(_ModelMeta):
 
         names = tuple(k[0] for k in names)
 
-        cls._submodels_names = names
+        cls._submodel_names = names
         return names
 
     @property

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -691,6 +691,10 @@ class Parameter(OrderedDescriptor):
 
         model._parameters[param_slice] = np.array(value).ravel()
 
+        if hasattr(model, '_submodels') and isinstance(model, types.InstanceType):
+            p_map = model._param_map[self._name]
+            setattr(model._submodels[p_map[0]], p_map[1], np.array(value).ravel())
+
     @staticmethod
     def _create_value_wrapper(wrapper, model):
         """Wraps a getter/setter function to support optionally passing in

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -691,7 +691,7 @@ class Parameter(OrderedDescriptor):
 
         model._parameters[param_slice] = np.array(value).ravel()
 
-        if hasattr(model, '_submodels') and isinstance(model, types.InstanceType):
+        if hasattr(model, '_submodels') and not isinstance(model._submodels[0], types.TypeType):
             p_map = model._param_map[self._name]
             setattr(model._submodels[p_map[0]], p_map[1], np.array(value).ravel())
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import inspect
 from copy import deepcopy
+import functools
 
 import numpy as np
 
@@ -838,3 +839,18 @@ def test_pickle_compound_fallback():
     gg = (Gaussian1D + Gaussian1D)()
     with pytest.raises(RuntimeError):
         pickle.dumps(gg)
+
+
+def test_update_parameters():
+    m = Gaussian1D(10,2,1) | Const1D(4)
+    m1 = Polynomial1D(1) | Scale(1)
+    pipe = [('d', m), ('f', m1), ('s', None)]
+
+    e = functools.reduce(lambda x,y: x | y, [t[1] for t in pipe[:-1]])
+    assert(e(1) == 0)
+    tr = pipe[1][1]
+    tr.c1_0 = 100
+    pipe[1] = (pipe[1][0], tr)
+
+    e = functools.reduce(lambda x, y: x | y, [t[1] for t in pipe[:-1]])
+    assert(e(1) == 400)


### PR DESCRIPTION
This is a fix for a subtle but critical bug in combining models.
When a parameter of a child model is updated the updated value does not propagate to the parameters of that child model and is not stored in the tree (although the corresponding parameter of the combined model is updated. Essentially there's a disconnect between the parameters of a combined model stored in the `parameters` array and the corresponding parameters in the `.tree` attribute. To a large extend this is the sensible thing to do. If the combined model is simply evaluated it works correctly because it uses its own parameters.  But there's one use case which doesn't work with this design. If an updated combined model is combined with another model then the tree is used to evaluate it and stale parameter value is used.

As an example of the problem:

```
Construct a model which basically evaluates to the value of Const1D.amplitude
m = Gaussian1D(10,2,1) | Const1D(4)
assert(m(1) == 4)
# Change hte amplitude and evaluate - this works
m.amplitude_1 = 100
assert(m(1) == 100)
# but it's broken when combined with another model
assert(models.Scale(1) | m)(1)==100
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
----> 1 assert(models.Scale(1) | m)(1) == 100
```

This PR provides a partial fix to the problem by updating the parameters in the underlying tree.
It's only a partial fix because it does not work for the case of getting a single model out of a combined model by indexing and updating it, i.e. this fix does not apply to 

```
m[1].amplitude = 100
```

Also one of the tests will fail with this solution. The reason is that `modeling` does not make copies of the input models but requires they are not changed if a parameter was changed. For example,

```
g = models.Gaussian1D(1, 2, 3, name='g')
p = models.Polynomial1D(1, name='p')
m = g + p
p.c0=100
# with master this works
assert(p.c0 == 0)
# now the result is
assert(p.c0 == 100)
```

This was achieved in the past by maintaining a disconnect between the parameters of the combined model and the parameters on the expression tree. It raises the question what i sthe correct and desired behaviour? Also should getting a model by indexing return a copy?

@astrofrog You've looked at modeling quite a bit. Any thoughts? Also @perrygreenfield 

Perhaps, now that we've had some real experience with combined models, we need to review the use cases.
