### PR TITLE
Make magnitude zero points available on demand.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,11 @@ New Features
 
   - Added ``pixel_scale`` and ``plate_scale`` equivalencies. [#4987]
 
+  - Magnitude zero points used to define ``STmag``, ``ABmag``, ``M_bol`` and
+    ``m_bol`` are now collected in ``astropy.units.magnitude_zero_points``.
+    They are not enabled as regular units by default, but can be included
+    using ``astropy.units.magnitude_zero_points.enable()``. [#5030]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -30,6 +30,7 @@ from .equivalencies import *
 
 from .function.core import *
 from .function.logarithmic import *
+from .function import magnitude_zero_points
 
 del bases
 

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -4,9 +4,8 @@ from __future__ import (absolute_import, unicode_literals,
                         division, print_function)
 import numpy as np
 
-from .. import (CompositeUnit, Unit, UnitsError, dimensionless_unscaled,
-                si, astrophys)
-from ...constants import L_bol0
+from .. import CompositeUnit, UnitsError, dimensionless_unscaled
+from . import magnitude_zero_points as mag0
 from .core import FunctionUnitBase, FunctionQuantity
 from .units import dex, dB, mag
 
@@ -120,6 +119,11 @@ class MagUnit(LogUnit):
         By default, this is ``mag``, but this allows one to use an equivalent
         unit such as ``2 mag``.
     """
+    def __init__(self, *args, **kwargs):
+        # Ensure we recognize magnitude zero points here.
+        with mag0.enable():
+            super(MagUnit, self).__init__(*args, **kwargs)
+
     @property
     def _default_function_unit(self):
         return mag
@@ -317,30 +321,16 @@ dB._function_unit_class = DecibelUnit
 mag._function_unit_class = MagUnit
 
 
-AB0 = Unit('AB', 10.**(-0.4*48.6) * 1.e-3 * si.W / si.m**2 / si.Hz,
-           doc="AB magnitude zero flux density.")
-
-ST0 = Unit('ST', 10.**(-0.4*21.1) * 1.e-3 * si.W / si.m**2 / si.AA,
-           doc="ST magnitude zero flux density.")
-
-Bol0 = Unit('Bol', L_bol0, doc="Luminosity corresponding to "
-            "absolute bolometric magnitude zero")
-
-bol0 = Unit('bol', L_bol0 / (4 * np.pi * (10.*astrophys.pc)**2),
-            doc="Irradiance corresponding to apparent bolometric magnitude "
-            "zero")
-
-
-STmag = MagUnit(ST0)
+STmag = MagUnit(mag0.ST)
 STmag.__doc__ = "ST magnitude: STmag=-21.1 corresponds to 1 erg/s/cm2/A"
 
-ABmag = MagUnit(AB0)
+ABmag = MagUnit(mag0.AB)
 ABmag.__doc__ = "AB magnitude: ABmag=-48.6 corresponds to 1 erg/s/cm2/Hz"
 
-M_bol = MagUnit(Bol0)
+M_bol = MagUnit(mag0.Bol)
 M_bol.__doc__ = ("Absolute bolometric magnitude: M_bol=0 corresponds to "
-                 "L_bol0={0}".format(Bol0.si))
+                 "L_bol0={0}".format(mag0.Bol.si))
 
-m_bol = MagUnit(bol0)
+m_bol = MagUnit(mag0.bol)
 m_bol.__doc__ = ("Apparent bolometric magnitude: m_bol=0 corresponds to "
-                 "f_bol0={0}".format(bol0.si))
+                 "f_bol0={0}".format(mag0.bol.si))

--- a/astropy/units/function/magnitude_zero_points.py
+++ b/astropy/units/function/magnitude_zero_points.py
@@ -16,6 +16,8 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as _numpy
 from ..core import UnitBase, def_unit
 
+# One cannot import L_bol0 directly, or the order of imports of units and
+# constants starts to matter on python2. [#5121]
 from ...constants import si as _si
 from .. import si, astrophys
 
@@ -24,7 +26,7 @@ _ns = globals()
 
 def_unit(['Bol', 'L_bol'], _si.L_bol0, namespace=_ns, prefixes=False,
          doc="Luminosity corresponding to absolute bolometric magnitude zero")
-def_unit(['bol', 'f_bol'], L_bol / (4 * _numpy.pi * (10.*astrophys.pc)**2),
+def_unit(['bol', 'f_bol'], _si.L_bol0 / (4 * _numpy.pi * (10.*astrophys.pc)**2),
          namespace=_ns, prefixes=False, doc="Irradiance corresponding to "
          "appparent bolometric magnitude zero")
 def_unit(['AB'], 10.**(-0.4*48.6) * 1.e-3 * si.W / si.m**2 / si.Hz,

--- a/astropy/units/function/magnitude_zero_points.py
+++ b/astropy/units/function/magnitude_zero_points.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+This package defines magnitude zero points.  By default, they are used to
+define corresponding magnitudes, but not enabled as regular physical units.
+To enable them, do::
+
+    >>> from astropy.units import magnitude_zero_points
+    >>> magnitude_zero_points.enable()  # doctest: +SKIP
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as _numpy
+from ..core import UnitBase, def_unit
+
+from ...constants import si as _si
+from .. import si, astrophys
+
+
+_ns = globals()
+
+def_unit(['Bol', 'L_bol'], _si.L_bol0, namespace=_ns, prefixes=False,
+         doc="Luminosity corresponding to absolute bolometric magnitude zero")
+def_unit(['bol', 'f_bol'], L_bol / (4 * _numpy.pi * (10.*astrophys.pc)**2),
+         namespace=_ns, prefixes=False, doc="Irradiance corresponding to "
+         "appparent bolometric magnitude zero")
+def_unit(['AB'], 10.**(-0.4*48.6) * 1.e-3 * si.W / si.m**2 / si.Hz,
+         namespace=_ns, prefixes=False,
+         doc="AB magnitude zero flux density.")
+def_unit(['ST'], 10.**(-0.4*21.1) * 1.e-3 * si.W / si.m**2 / si.AA,
+         namespace=_ns, prefixes=False,
+         doc="ST magnitude zero flux density.")
+
+###########################################################################
+# CLEANUP
+
+del UnitBase
+del def_unit
+del si
+del astrophys
+
+###########################################################################
+# DOCSTRING
+
+# This generates a docstring for this module that describes all of the
+# standard units defined here.
+from ..utils import generate_unit_summary as _generate_unit_summary
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())
+
+
+def enable():
+    """
+    Enable magnitude zero point units so they appear in results of
+    `~astropy.units.UnitBase.find_equivalent_units` and
+    `~astropy.units.UnitBase.compose`.
+
+    This may be used with the ``with`` statement to enable these
+    units only temporarily.
+    """
+    # Local import to avoid cyclical import
+    from ..core import add_enabled_units
+    # Local import to avoid polluting namespace
+    import inspect
+    return add_enabled_units(inspect.getmodule(enable))

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -81,6 +81,22 @@ def test_predefined_magnitudes():
                              c.L_bol0/(4.*np.pi*(10.*c.pc)**2))
 
 
+def test_predefined_reinitialisation():
+    assert u.mag('ST') == u.STmag
+    assert u.mag('AB') == u.ABmag
+    assert u.mag('Bol') == u.M_bol
+    assert u.mag('bol') == u.m_bol
+
+
+def test_predefined_string_roundtrip():
+    """Ensure roundtripping; see #5015"""
+    with u.magnitude_zero_points.enable():
+        assert u.Unit(u.STmag.to_string()) == u.STmag
+        assert u.Unit(u.ABmag.to_string()) == u.ABmag
+        assert u.Unit(u.M_bol.to_string()) == u.M_bol
+        assert u.Unit(u.m_bol.to_string()) == u.m_bol
+
+
 class TestLogUnitStrings(object):
 
     def test_str(self):

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -121,9 +121,10 @@ Here, ``ST`` is a short-hand for the ST zero-point flux::
     >>> (-21.1 * u.STmag).to(u.erg/u.s/u.cm**2/u.AA)  # doctest: +FLOAT_CMP
     <Quantity 1. erg / (Angstrom cm2 s)>
 
-.. note:: only ST [H+95]_ and AB [OG83]_ magnitudes are implemented at
-	  present, as these are defined in terms of flux densities, i.e.,
-          do not depend on the filter the measurement was made with.
+.. note:: at present, only magnitudes defined in terms of luminosity or flux
+	  are implemented, since those that do not depend on the filter the
+          measurement was made with.  They include absolute and apparent
+          bolometric [M+15]_, ST [H+95]_ and AB [OG83]_ magnitudes.
 
 Now applying the calibration, we find (note the proper change in units)::
 
@@ -158,19 +159,17 @@ to be raised to some power), and |quantity| objects, unlike logarithmic
 quantities, allow units like ``mag / d``.
 
 Note that one can take the automatic unit conversion quite far (perhaps too
-far, but it is fun).  For instance, suppose we also knew the absolute
-magnitude, then we can define the appropriate corresponding luminosity and
-absolute magnitude and calculate the distance modulus::
+far, but it is fun).  For instance, suppose we also knew the bolometric
+correction and absolute bolometric magnitude, then we can calculate the
+distance modulus::
 
-    >>> ST0abs = u.Unit('STabs', u.STmag.physical_unit * 4.*np.pi*(10.*u.pc)**2)
-    >>> STabsmag = u.mag(ST0abs)
-    >>> M_V = 5.76 * STabsmag
-    >>> M_B = M_V + B_V0
-    >>> DM = V[0] - A_V - M_V
-    >>> M_V, M_B, DM  # doctest: +FLOAT_CMP
-    (<Magnitude 5.76 mag(STabs)>,
-     <Magnitude 5.56 mag(STabs)>,
-     <Magnitude 10.000000000000002 mag(ST / STabs)>)
+    >>> BC_V = -0.3 * (u.m_bol - u.STmag)
+    >>> M_bol = 5.46 * u.M_bol
+    >>> DM = V[0] - A_V + BC_V - M_bol
+    >>> BC_V, M_bol, DM  # doctest: +FLOAT_CMP
+    (<Magnitude -0.3 mag(bol / ST)>,
+     <Magnitude 5.46 mag(Bol)>,
+     <Magnitude 10.0 mag(bol / Bol)>)
 
 With a proper equivalency, we can also convert to distance without remembering
 the 5-5log rule::
@@ -179,7 +178,7 @@ the 5-5log rule::
     ...                            lambda x: 1./(4.*np.pi*x**2),
     ...                            lambda x: np.sqrt(1./(4.*np.pi*x)))]
     >>> DM.to(u.pc, equivalencies=radius_and_inverse_area)  # doctest: +FLOAT_CMP
-    <Quantity 1000.0000000000009 pc>
+    <Quantity 1000.0 pc>
 
 Numpy functions
 ---------------
@@ -218,7 +217,8 @@ supported as logarithmic units.  For instance::
     <Decibel 80.0 dB(mW)>
 
 
-
+.. [M+15] Mamajek et al., 2015, `arXiv:1510.06262
+	  <http://adsabs.harvard.edu/abs/2015arXiv151006262M>`_
 .. [H+95] E.g., Holtzman et al., 1995, `PASP 107, 1065
           <http://adsabs.harvard.edu/abs/1995PASP..107.1065H>`_
 .. [OG83] Oke, J.B., & Gunn, J. E., 1983, `ApJ 266, 713


### PR DESCRIPTION
In #5015, @pllim noted that special magnitudes like `STmag` do not roundtrip via `Unit(STmag.to_string())`. This is because the underlying reference fluxes for magnitude 0 are not normally exposed. This PR exposes those, though they are still not enabled by default, since it is not obvious that one would pollute the namespace with, e.g., `u.ST`. But they are included by default if one defines a magnitude, and can be added to the enabled units on demand.  With this PR:
```
In [1]: import astropy.units as u

In [2]: u.mag('ST')  # did not work before
Out[2]: Unit("mag(ST)")

In [3]: u.magnitude_zero_points.enable()
Out[3]: <astropy.units.core._UnitContext at 0x7f4b2dd0dd30>

In [4]: u.Unit('mag(ST)')  # only works with above (can be a context)
Out[4]: Unit("mag(ST)")
```