### PR TITLE
New release instructions

### DIFF
--- a/astropy/utils/release.py
+++ b/astropy/utils/release.py
@@ -11,6 +11,12 @@ import io
 import os
 import re
 import sys
+import warnings
+
+from . import AstropyDeprecationWarning
+
+ZEST_DEPRECATION = AstropyDeprecationWarning('The zest.releaser machinery in '
+               'astropy is deprecated and may be removed in a future version.')
 
 
 def prereleaser_middle(data):
@@ -19,6 +25,7 @@ def prereleaser_middle(data):
     zest.releaser already does this normally but it's a little inflexible about
     the format.
     """
+    warnings.warn(ZEST_DEPRECATION)
     _update_setup_py_version(data['new_version'])
 
 
@@ -30,6 +37,7 @@ def releaser_middle(data):
     distributions.  This is supposedly a workaround for a bug in Python 2.4,
     but we don't care about Python 2.4.
     """
+    warnings.warn(ZEST_DEPRECATION)
     from zest.releaser.git import Git
     from zest.releaser.release import Releaser
 
@@ -235,6 +243,7 @@ def postreleaser_before(data):
     default: By default zest.releaser uses <version>.dev0.  We want just
     <version>.dev without the mysterious 0.
     """
+    warnings.warn(ZEST_DEPRECATION)
     data['dev_version_template'] = '%(new_version)s.dev'
     data['nothing_changed_yet'] = _NEW_CHANGELOG_TEMPLATE
 
@@ -244,6 +253,7 @@ def postreleaser_middle(data):
     postreleaser.middle hook to update the setup.py with the new version. See
     prereleaser_middle for more details.
     """
+    warnings.warn(ZEST_DEPRECATION)
     _update_setup_py_version(data['dev_version'])
 
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -31,8 +31,8 @@ packages that use the full bugfix/maintenance branch approach.)
    changes in the helpers.  See the section :ref:`helpers-release-info` for
    more on this.
 
-#. Make sure that Travis and any other continuous integration is passing for
-   the branch you're going to release.  You may also want to locally run the
+#. Make sure that the continuous integration services (E.g., Travis) are passing
+   for the branch you're going to release.  You may also want to locally run the
    tests in ``remote-data`` mode, as those are not necessarily run
    automatically::
 
@@ -482,12 +482,18 @@ to the beginning of the above procedure when this is required.
    updating the helpers to the commit described in the last step (i.e., the
    head of the astropy-helpers release branch).
 
-#. Wait for Travis to run to ensure that helpers build works with Astropy.
-   If it doesn't, back out the release and fix whatever the problem is before
-   trying again.
+#. Wait for the continuous integration services (E.g., Travis) to run to ensure
+   that helpers build works with Astropy.
 
-#. Assuming it does succeed, finish the release of the helpers by doing this in
-   the helpers repo::
+#. If the PR's tests fail, delete the release branch you just created in
+   astropy-helpers, fix whatever the problem is, and then re-run this procedure.
+   Note that you can re-use the PR into the astropy core repository (created in
+   the step just before this one) by updating the PR's astropy-helpers to point
+   to the release branch from *after* the fix - that way you don't need to make
+   another PR for the fixed version.
+
+#. Once they tests all succeed, finish the release of the helpers by doing this
+   in the helpers repo::
 
       git checkout master
       git merge --no-ff release-<version>

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -13,7 +13,7 @@ Release Procedure
 -----------------
 
 This is the standard release procedure for releasing Astropy (or affiliated
-packages that use the full bugfix/maintainence branch approach.)
+packages that use the full bugfix/maintenance branch approach.)
 
 #. (Optional) You may want to set up a clean environment to build the release.
    For more on setting up virtual environments, see :ref:`virtual_envs`, but
@@ -183,7 +183,7 @@ packages that use the full bugfix/maintainence branch approach.)
    this is to use ``git cherry-pick`` on the release commit from above, *but* if
    that method is used, be sure to amend that commit and not change the version
    in ``setup.py``. If you aren't sure how to do this, you might be better off
-   just copying-and-pasting the relevant parts of the maintainence branch's
+   just copying-and-pasting the relevant parts of the maintenance branch's
    ``CHANGES.rst`` into master.
 
 Modifications for a beta/release candidate release
@@ -211,7 +211,7 @@ As outlined in
 `APE2 <https://github.com/astropy/astropy-APEs/blob/master/APE2.rst>`_, astropy
 releases occur at regular intervals, but feature freezes occur well before the
 actual release.  Feature freezes are also the time when the master branch's
-development separates from the new major version's maintainence branch.  This
+development separates from the new major version's maintenance branch.  This
 allows new development for the next major version to continue while the
 soon-to-be-released version can focus on bug fixes and documentation updates.
 
@@ -478,7 +478,7 @@ to the beginning of the above procedure when this is required.
 
 #. Push the release branch to github.
 
-#. In astropy master (and/or the relevant maintainence branch), issue a PR
+#. In astropy master (and/or the relevant maintenance branch), issue a PR
    updating the helpers to the commit described in the last step (i.e., the
    head of the astropy-helpers release branch).
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -70,7 +70,7 @@ packages that use the full bugfix/maintainence branch approach.)
 
 #. Also update the ``CHANGES.rst`` file with a new section for the next version.
    You will likely want to use the ``add_to_changelog.py`` script in the
-   `astropy-tools`_ repository for this
+   `astropy-tools`_ repository for this.
 
 #. Add the changes to ``CHANGES.rst`` and ``setup.py``::
 
@@ -170,6 +170,77 @@ packages that use the full bugfix/maintainence branch approach.)
    https://github.com/astropy/astropy.github.com by changing the "current
    version" link and/or updating the list of older versions if this is an LTS
    bugfix or a new major version.
+
+   Modifications for a beta/release candidate release
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+   For major releases with a lot of changes, we do beta and/or release candiates
+   to have a chance to catch significant bugs before the true release.
+   If the release you are performing is this kind of pre-release, some
+   of the above steps need to be modified.
+
+   The primary modifications to the release procedure are:
+
+   * When entering the new version number, instead of just removing the
+     ``.dev``, enter "0.2b1" or "0.2rc1".  It is critical that you follow this
+     numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
+     is ordered "before" the main release by various automated tools, and also
+     tells PyPI that this is a "pre-release".
+   * Do not do step #20 or later, as those are tasks for an actual release.
+
+
+Performing a Feature Freeze/Branching new Major Versions
+--------------------------------------------------------
+
+As outlined in
+`APE2 <https://github.com/astropy/astropy-APEs/blob/master/APE2.rst>`_, astropy
+releases occur at regular intervals, but feature freezes occur well before the
+actual release.  Feature freezes are also the time when the master branch's
+development separates from the new major version's maintainence branch.  This
+allows new development for the next major version to continue while the
+soon-to-be-released version can focus on bug fixes and documentation updates.
+
+The procedure for this is straightforward:
+
+#. Make sure you're on master, and updated to the latest version from github::
+
+      $ git checkout master
+      $ git fetch origin
+      $ git reset --hard origin/master
+
+#. Create a new branch from master at the point you want the feature freeze to
+   occur::
+
+      $ git branch v<version>.x
+
+#. Update the ``CHANGES.rst`` file with a new section at the very top for the
+   next major version.  You will likely want to use the ``add_to_changelog.py``
+   script in the `astropy-tools`_ repository for this.
+
+#. Update the ``VERSION`` in ``setup.py`` to reflect the new major version. For
+   example, if you are about to issue a feature freeze for version ``1.2``, you
+   will want to set the new version to ``'1.3.dev'``.
+
+#. Add the changes to ``CHANGES.rst`` and ``setup.py``::
+
+      $ git add CHANGES.rst setup.py
+
+   and commit with message::
+
+      $ git commit -m "Next major version: <next_version>"
+
+#. Push all of these changes up to github::
+
+      $ git push origin v<version>.x:v<version>.x
+      $ git push origin master:master
+
+   .. note::
+
+      You may need to replace ``origin`` here with ``astropy`` or
+      whatever remote name you use for the main astropy repository.
+
+#. On the github issue tracker, add a new milestone for the next major version.
+
 
 Maintaining Bug Fix Releases
 ----------------------------

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -76,7 +76,7 @@ packages that use the full bugfix/maintenance branch approach.)
 
 #. Also update the ``CHANGES.rst`` file with a new section for the next version.
    You will likely want to use the ``add_to_changelog.py`` script in the
-   `astropy-tools`_ repository for this.
+   `astropy-tools repository`_ for this.
 
 #. Add the changes to ``CHANGES.rst`` and ``setup.py``::
 
@@ -145,14 +145,14 @@ packages that use the full bugfix/maintenance branch approach.)
    Do not enabled "Auto-hide old releases" as that may hide bugfix releases
    from older release lines that we may still want to make available.
 
-#. Push up all these changes to the astropy repository::
+#. Push up all these changes to the `astropy core repository`_::
 
       $ git push --tags upstream v<version>
 
    .. note::
 
       You may need to replace ``upstream`` here with ``astropy`` or
-      whatever remote name you use for the main astropy repository.
+      whatever remote name you use for the `astropy core repository`_.
 
 #. If this is a release of the current release (not an LTS), update the
    "stable" branch to point to the new release::
@@ -252,7 +252,7 @@ The procedure for this is straightforward:
    .. note::
 
       You may need to replace ``upstream`` here with ``astropy`` or
-      whatever remote name you use for the main astropy repository.
+      whatever remote name you use for the `astropy core repository`_.
 
 #. On the github issue tracker, add a new milestone for the next major version.
 
@@ -305,8 +305,8 @@ Most fixes are backported using the ``git cherry-pick`` command, which applies
 the diff from a single commit like a patch.  For the sake of example, say the
 current bug fix branch is 'v0.2.x', and that a bug was fixed in master in a
 commit ``abcd1234``.  In order to backport the fix, simply checkout the v0.2.x
-branch (it's also good to make sure it's in sync with the main Astropy
-repository) and cherry-pick the appropriate commit::
+branch (it's also good to make sure it's in sync with the
+`astropy core repository`_) and cherry-pick the appropriate commit::
 
     $ git checkout v0.2.x
     $ git pull upstream v0.2.x
@@ -363,12 +363,12 @@ As mentioned earlier in this section, in some cases a fix only applies to a bug
 fix release, and is not applicable in the mainline development.  In this case
 there are two choices:
 
-1. An Astropy developer with commit access to the main Astropy repository may
+1. An Astropy developer with commit access to the `astropy core repository`_ may
    check out the bug fix branch and commit and push your fix directly.
 
 2. **Preferable**: You may also make a pull request through GitHub against the
    bug fix branch rather than against master.  Normally when making a pull
-   request from a branch on your fork to the main Astropy repository GitHub
+   request from a branch on your fork to the `astropy core repository`_, GitHub
    compares your branch to Astropy's master.  If you look on the left-hand
    side of the pull request page, under "base repo: astropy/astropy" there is
    a drop-down list labeled "base branch: master".  You can click on this
@@ -469,47 +469,67 @@ A bit more initial effort is required for an Astropy release that has a
 corresponding astropy-helpers_ release.  The main reason for this more complex
 procedure is to allow the Astropy core to be tested against the new helpers
 before anything is released.  Hence the following procedure should be added
-to the beginning of the above procedure when this is required.
+to the beginning of the above procedure when this is required. This procedure
+applies both for regular release *and* release candidates are the same
+(except that version numbers have ``rc#`` at the end).
 
-.. note::
+#. In the `astropy-helpers repository`_, create a new (temporary) branch
+   "tmp-release-v<version>"::
 
-    This procedure applies both for regular release *and* release candidates.
-    The only change of the below for release candidates is that the branch in
-    astropy-helpers_ should be names "release-<version>rc#" instead of
-    "release-<version>".
+      $ cd /wherever/you/put/astropy/astropy_helpers
+      $ git branch tmp-release-v<version> <maintenance branch name>
 
-#. In the astropy-helpers_ repository, create a new release branch
-   "release-<version>".
+#. In that branch, create a release commit by updating the version info and
+   changelog as described in the release instructions above.
 
-#. Create the release commit (updating the version info and changelog) in that
-   branch.
+#. Push the branch you just created to the `astropy-helpers repository`_ on
+   github::
 
-#. Push the release branch to github.
+      $ git push upstream tmp-release-v<version>
 
-#. In astropy master (and/or the relevant maintenance branch), issue a PR
-   updating the helpers to the commit described in the last step (i.e., the
-   head of the astropy-helpers_ release branch).
+#. In astropy master (or the relevant maintenance branch for the release you
+   are doing), issue a PR updating the helpers to the commit described in the
+   last step (i.e., the commit at the head of the "tmp-release-v<version>"
+   branch you just created).  The easiest way to do this is::
 
-#. Wait for the continuous integration services (E.g., Travis) to run to ensure
-   that helpers build works with Astropy.
+      $ cd /wherever/you/put/astropy
+      $ cd astropy_helpers
+      $ git fetch upstream  # you probably did this already in the previous step
+      $ git checkout upstream/tmp-release-v<version>
+      $ cd ..
+      $ git add astropy_helpers
+      $ git commit -m "updated helpers to v<version>"
 
-#. If the PR's tests fail, delete the release branch you just created in
-   astropy-helpers, fix whatever the problem is, and then re-run this procedure.
-   Note that you can re-use the PR into the `astropy core repository`_ (created in
-   the step just before this one) by updating the PR's astropy-helpers_ to point
-   to the release branch from *after* the fix - that way you don't need to make
-   another PR for the fixed version.
+#. Wait for the continuous integration services (E.g., Travis) to run on the PR
+   to ensure the release commit of the helpers works with the to-be-released
+   version of Astropy.
 
-#. Once they tests all succeed, finish the release of the helpers by doing this
+#. If the PR's tests fail, fix whatever the problem is, and then re-do this
+   procedure. You'll need to either delete the previous "tmp-release-v<version>"
+   branch on the github `astropy-helpers repository`_ or use ``git push -f``
+   when you push up the replacement temporary release branch. You can re-use the
+   PR into the `astropy core repository`_ (created in the step just before this
+   one) by updating the ``astropy_helpers`` submodule to point to the new
+   "tmp-release-v<version>" from  *after* the fix - that way you don't need to
+   make another PR for the fixed version.
+
+#. Once the tests all succeed, finish the release of the helpers by doing this
    in the helpers repo::
 
-      git checkout master
-      git merge --no-ff release-<version>
-      git tag -s "v<version>" -m "Tagging v<version>"
+      $ git checkout <maintenance branch name>
+      $ git merge --no-ff tmp-release-v<version>
+      $ git tag -s "v<version>" -m "Tagging v<version>"
+      $ git push upstream --tags <maintenance branch name>
 
-   and then adding one more commit updating back to the next dev version.
+#. Update the changelog in master of the `astropy-helpers repository`_ to
+   reflect the release you just did.
 
-#. Merge the PR from the `astropy core repository`_
+#. Delete the temporary branch from github:
+
+      $ git push upstream :tmp-release-v<version>
+
+#. Merge the PR for the `astropy core repository`_ that updates the helpers, and
+   continue with the release process for the core as described above.
 
 This way the commit of the helpers that is tagged as the release is the same
 commit that the astropy_helpers submodule will be on when the PR to astropy
@@ -643,6 +663,6 @@ that for you.  You can delete this tag by doing::
 .. _astropy core repository: https://github.com/astropy/astropy
 .. _signed tags: http://git-scm.com/book/en/Git-Basics-Tagging#Signed-Tags
 .. _cython: http://www.cython.org/
-.. _astropy-tools: https://github.com/astropy/astropy-tools
+.. _astropy-tools repository: https://github.com/astropy/astropy-tools
 .. _Anaconda: http://conda.pydata.org/docs/
-.. _astropy-helpers: https://github.com/astropy/astropy-helpers
+.. _astropy-helpers repository: https://github.com/astropy/astropy-helpers

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -189,10 +189,10 @@ packages that use the full bugfix/maintenance branch approach.)
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   For major releases with a lot of changes, we do beta and/or release
-   candidates to have a chance to catch significant bugs before the true
-   release. If the release you are performing is this kind of pre-release, some
-   of the above steps need to be modified.
+   For major releases we do beta and/or release candidates to have a chance to
+   catch significant bugs before the true release. If the release you are
+   performing is this kind of pre-release, some of the above steps need to be
+   modified.
 
    The primary modifications to the release procedure are:
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -147,11 +147,11 @@ packages that use the full bugfix/maintenance branch approach.)
 
 #. Push up all these changes to the astropy repository::
 
-      $ git push --tags origin v<version>
+      $ git push --tags upstream v<version>
 
    .. note::
 
-      You may need to replace ``origin`` here with ``astropy`` or
+      You may need to replace ``upstream`` here with ``astropy`` or
       whatever remote name you use for the main astropy repository.
 
 #. If this is a release of the current release (not an LTS), update the
@@ -159,7 +159,7 @@ packages that use the full bugfix/maintenance branch approach.)
 
       $ git checkout stable
       $ git reset --hard v<version>
-      $ git push origin stable --force
+      $ git push upstream stable --force
 
 #. Update Readthedocs so that it builds docs for the corresponding github tag.
    Also verify that the ``stable`` Readthedocs version builds correctly for
@@ -220,8 +220,8 @@ The procedure for this is straightforward:
 #. Make sure you're on master, and updated to the latest version from github::
 
       $ git checkout master
-      $ git fetch origin
-      $ git reset --hard origin/master
+      $ git fetch upstream
+      $ git reset --hard upstream/master
 
 #. Create a new branch from master at the point you want the feature freeze to
    occur::
@@ -246,12 +246,12 @@ The procedure for this is straightforward:
 
 #. Push all of these changes up to github::
 
-      $ git push origin v<version>.x:v<version>.x
-      $ git push origin master:master
+      $ git push upstream v<version>.x:v<version>.x
+      $ git push upstream master:master
 
    .. note::
 
-      You may need to replace ``origin`` here with ``astropy`` or
+      You may need to replace ``upstream`` here with ``astropy`` or
       whatever remote name you use for the main astropy repository.
 
 #. On the github issue tracker, add a new milestone for the next major version.

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -32,9 +32,9 @@ packages that use the full bugfix/maintenance branch approach.)
    more on this.
 
 #. Make sure that the continuous integration services (E.g., Travis) are passing
-   for the branch you're going to release.  You may also want to locally run the
-   tests in ``remote-data`` mode, as those are not necessarily run
-   automatically::
+   for the `astropy core repository`_ branch you're going to release.  You may
+   also want to locally run the tests in ``remote-data`` mode, as those are not
+   necessarily run automatically::
 
       $ python setup.py test --remote-data
 
@@ -42,7 +42,7 @@ packages that use the full bugfix/maintenance branch approach.)
    tag you create for the release.  See :ref:`key-signing-info` for more on
    this.
 
-#. Obtain a *clean* version of the Astropy repository.  That is, one
+#. Obtain a *clean* version of the `astropy core repository`_.  That is, one
    where you don't have any intermediate build files.  Either use a fresh
    ``git clone`` or do ``git clean -dfx``.
 
@@ -495,7 +495,7 @@ to the beginning of the above procedure when this is required.
 
 #. If the PR's tests fail, delete the release branch you just created in
    astropy-helpers, fix whatever the problem is, and then re-run this procedure.
-   Note that you can re-use the PR into the astropy core repository (created in
+   Note that you can re-use the PR into the `astropy core repository`_ (created in
    the step just before this one) by updating the PR's astropy-helpers_ to point
    to the release branch from *after* the fix - that way you don't need to make
    another PR for the fixed version.
@@ -508,6 +508,8 @@ to the beginning of the above procedure when this is required.
       git tag -s "v<version>" -m "Tagging v<version>"
 
    and then adding one more commit updating back to the next dev version.
+
+#. Merge the PR from the `astropy core repository`_
 
 This way the commit of the helpers that is tagged as the release is the same
 commit that the astropy_helpers submodule will be on when the PR to astropy
@@ -638,6 +640,7 @@ that for you.  You can delete this tag by doing::
     $ git tag -d v0.1
 
 
+.. _astropy core repository: https://github.com/astropy/astropy
 .. _signed tags: http://git-scm.com/book/en/Git-Basics-Tagging#Signed-Tags
 .. _cython: http://www.cython.org/
 .. _astropy-tools: https://github.com/astropy/astropy-tools

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -31,7 +31,7 @@ packages that use the full bugfix/maintenance branch approach.)
    changes in the helpers.  See the section :ref:`helpers-release-info` for
    more on this.
 
-#. Make sure that the continuous integration services (E.g., Travis) are passing
+#. Make sure that the continuous integration services (e.g., Travis) are passing
    for the `astropy core repository`_ branch you're going to release.  You may
    also want to locally run the tests in ``remote-data`` mode, as those are not
    necessarily run automatically::
@@ -500,7 +500,7 @@ applies both for regular release *and* release candidates are the same
       $ git add astropy_helpers
       $ git commit -m "updated helpers to v<version>"
 
-#. Wait for the continuous integration services (E.g., Travis) to run on the PR
+#. Wait for the continuous integration services (e.g., Travis) to run on the PR
    to ensure the release commit of the helpers works with the to-be-released
    version of Astropy.
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -69,7 +69,7 @@ packages that use the full bugfix/maintenance branch approach.)
 #. Tag the commit with ``v<version>``, being certain to sign the tag with the
    ``-s`` option::
 
-      $ git tag -s v<version>
+      $ git tag -s v<version> -m "Tagging v<version>"
 
 #. Edit the ``VERSION`` in ``setup.py`` to be the next version number, but with
    a ``.dev`` suffix at the end (E.g., ``1.2.3.dev``).
@@ -84,7 +84,7 @@ packages that use the full bugfix/maintenance branch approach.)
 
    and commit with message::
 
-      $ git commit -m "Back to development: v<next_version>"
+      $ git commit -m "Back to development: v<next_version>.dev"
 
 #. Now go back and check out the tag of the released version with
    ``git checkout v<version>``.  For example::
@@ -115,18 +115,24 @@ packages that use the full bugfix/maintenance branch approach.)
 
       $ conda create -n astropy_release_test_v<verson> numpy
       $ source activate astropy_release_test_v<verson>
-      $ cd dist
-      $ mkdir test
-      $ pip install astropy-<version>.tar.gz
+      $ pip install dist/astropy-<version>.tar.gz
       $ python -c 'import astropy; astropy.test(remote_data=True)'
       $ source deactivate
-      $ cd <back to the source directory>
 
-   Assuming everything went smoothly with the last step, we are ready to proceed
-   with the release.  If not, you'll have to back up to before starting this
-   procedure and start over when things are fixed.
+#. If the tests do *not* pass, you'll have to fix whatever the problem is. First
+   you'll need to back out the release procedure by dropping the last two
+   commits and removing the tag you created::
 
-#. Register the release on PyPI with::
+      $ git reset --hard HEAD^^
+      $ git tag -d v<version>
+
+#. Once the tests are all passing, it's time to actually proceed with the
+   release! For safety's sake, you may want to clean the repo yet again
+   to make sure you didn't leave anything from the previous step::
+
+      $ git clean -dfx
+
+   Then register the release on PyPI with::
 
       $ python setup.py register
 
@@ -177,14 +183,14 @@ packages that use the full bugfix/maintenance branch approach.)
    version" link and/or updating the list of older versions if this is an LTS
    bugfix or a new major version.
 
-#. In the astropy *master* branch (not just the changelog), be sure to update
-   the ``CHANGES.rst`` to reflect the date of the release you just performed and
-   to include the new section of the changelog.  Often the easiest way to do
-   this is to use ``git cherry-pick`` on the release commit from above, *but* if
-   that method is used, be sure to amend that commit and not change the version
-   in ``setup.py``. If you aren't sure how to do this, you might be better off
-   just copying-and-pasting the relevant parts of the maintenance branch's
-   ``CHANGES.rst`` into master.
+#. In the astropy *master* branch (not just the maintenance branch), be sure to
+   update the ``CHANGES.rst`` to reflect the date of the release you just
+   performed and to include the new section of the changelog.  Often the easiest
+   way to do this is to use ``git cherry-pick`` on the release commit from
+   above. *But* if that method is used, be sure to amend that commit and not
+   change the version in ``setup.py``. If you aren't sure how to do this, you
+   might be better off just copying-and-pasting the relevant parts of the
+   maintenance branch's ``CHANGES.rst`` into master.
 
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -519,9 +525,10 @@ applies both for regular release *and* release candidates are the same
       $ git checkout <maintenance branch name>
       $ git merge --no-ff tmp-release-v<version>
       $ git tag -s "v<version>" -m "Tagging v<version>"
+      $ python setup.py build sdist register upload
       $ git push upstream --tags <maintenance branch name>
 
-#. Update the changelog in master of the `astropy-helpers repository`_ to
+#. Update the changelog in *master* of the `astropy-helpers repository`_ to
    reflect the release you just did.
 
 #. Delete the temporary branch from github:

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -62,7 +62,7 @@ packages that use the full bugfix/maintainence branch approach.)
 
       $ git add CHANGES.rst setup.py
 
-  and commit with message::
+   and commit with message::
 
       $ git commit -m "Preparing release v<version>"
 
@@ -186,8 +186,8 @@ packages that use the full bugfix/maintainence branch approach.)
    just copying-and-pasting the relevant parts of the maintainence branch's
    ``CHANGES.rst`` into master.
 
-   Modifications for a beta/release candidate release
-   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Modifications for a beta/release candidate release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
    For major releases with a lot of changes, we do beta and/or release candiates
    to have a chance to catch significant bugs before the true release.
@@ -201,7 +201,7 @@ packages that use the full bugfix/maintainence branch approach.)
      numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
      is ordered "before" the main release by various automated tools, and also
      tells PyPI that this is a "pre-release".
-   * Do not do step #20 or later, as those are tasks for an actual release.
+   * Do not do step #21 or later, as those are tasks for an actual release.
 
 
 Performing a Feature Freeze/Branching new Major Versions

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -51,19 +51,24 @@ packages that use the full bugfix/maintenance branch approach.)
 
       $ git checkout v1.2.x
 
-#. Edit the ``setup.py`` file by removing the ``".dev"`` at the end of the
-   ``VERSION`` string.
-
 #. Edit the ``CHANGES.rst`` file by changing the date for the version you are
    about to release from "unreleased" to today's date.  Also be sure to remove
-   any sections of the changelog for that version that have no entries.
+   any sections of the changelog for that version that have no entries.  Then
+   add and commit those changes with::
 
-#. Add the changes to ``CHANGES.rst`` and ``setup.py``::
+      <use your favorite editor on CHANGES.rst>
+      $ git add CHANGES.rst
+      $ git commit -m "Finalizing changelog for v<version>"
 
-      $ git add CHANGES.rst setup.py
 
-   and commit with message::
 
+
+#. Edit the ``setup.py`` file by removing the ``".dev"`` at the end of the
+   ``VERSION`` string, then add and commit that change as the final step prior
+   to release::
+
+      <use your favorite editor on setup.py>
+      $ git add setup.py
       $ git commit -m "Preparing release v<version>"
 
 #. Tag the commit with ``v<version>``, being certain to sign the tag with the
@@ -72,19 +77,19 @@ packages that use the full bugfix/maintenance branch approach.)
       $ git tag -s v<version> -m "Tagging v<version>"
 
 #. Edit the ``VERSION`` in ``setup.py`` to be the next version number, but with
-   a ``.dev`` suffix at the end (E.g., ``1.2.3.dev``).
+   a ``.dev`` suffix at the end (E.g., ``1.2.3.dev``).  Then add and commit::
+
+      <use your favorite editor on setup.py>
+      $ git add setup.py
+      $ git commit -m "Back to development: v<next_version>.dev"
 
 #. Also update the ``CHANGES.rst`` file with a new section for the next version.
    You will likely want to use the ``add_to_changelog.py`` script in the
-   `astropy-tools repository`_ for this.
+   `astropy-tools repository`_ for this.  Then add and commit::
 
-#. Add the changes to ``CHANGES.rst`` and ``setup.py``::
-
-      $ git add CHANGES.rst setup.py
-
-   and commit with message::
-
-      $ git commit -m "Back to development: v<next_version>.dev"
+      <use your favorite editor on CHANGES.rst>
+      $ git add CHANGES.rst
+      $ git commit -m "Add v<next_version> to the changelog"
 
 #. Now go back and check out the tag of the released version with
    ``git checkout v<version>``.  For example::
@@ -120,10 +125,10 @@ packages that use the full bugfix/maintenance branch approach.)
       $ source deactivate
 
 #. If the tests do *not* pass, you'll have to fix whatever the problem is. First
-   you'll need to back out the release procedure by dropping the last two
-   commits and removing the tag you created::
+   you'll need to back out the release procedure by dropping the commits you
+   made for release and removing the tag you created::
 
-      $ git reset --hard HEAD^^
+      $ git reset --hard HEAD^^^^ # you could also use the SHA hash of the commit before your first changelog edit
       $ git tag -d v<version>
 
 #. Once the tests are all passing, it's time to actually proceed with the
@@ -186,11 +191,10 @@ packages that use the full bugfix/maintenance branch approach.)
 #. In the astropy *master* branch (not just the maintenance branch), be sure to
    update the ``CHANGES.rst`` to reflect the date of the release you just
    performed and to include the new section of the changelog.  Often the easiest
-   way to do this is to use ``git cherry-pick`` on the release commit from
-   above. *But* if that method is used, be sure to amend that commit and not
-   change the version in ``setup.py``. If you aren't sure how to do this, you
-   might be better off just copying-and-pasting the relevant parts of the
-   maintenance branch's ``CHANGES.rst`` into master.
+   way to do this is to use ``git cherry-pick`` the changelog commit just before
+   the release commit from above. If you aren't sure how to do this, you might
+   be better off just copying-and-pasting the relevant parts of the maintenance
+   branch's ``CHANGES.rst`` into master.
 
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -234,21 +238,22 @@ The procedure for this is straightforward:
 
       $ git branch v<version>.x
 
-#. Update the ``CHANGES.rst`` file with a new section at the very top for the
-   next major version.  You will likely want to use the ``add_to_changelog.py``
-   script in the `astropy-tools`_ repository for this.
-
 #. Update the ``VERSION`` in ``setup.py`` to reflect the new major version. For
    example, if you are about to issue a feature freeze for version ``1.2``, you
-   will want to set the new version to ``'1.3.dev'``.
+   will want to set the new version to ``'1.3.dev'``. Then add and commit that::
 
-#. Add the changes to ``CHANGES.rst`` and ``setup.py``::
-
-      $ git add CHANGES.rst setup.py
-
-   and commit with message::
-
+      <use your favorite editor on setup.py>
+      $ git add setup.py
       $ git commit -m "Next major version: <next_version>"
+
+#. Update the ``CHANGES.rst`` file with a new section at the very top for the
+   next major version.  You will likely want to use the ``add_to_changelog.py``
+   script in the `astropy-tools`_ repository for this. The add and commit those
+   changes::
+
+      <use your favorite editor on CHANGES.rst>
+      $ git add CHANGES.rst
+      $ git commit -m "Add <next_version> to changelog"
 
 #. Push all of these changes up to github::
 
@@ -485,8 +490,8 @@ applies both for regular release *and* release candidates are the same
       $ cd /wherever/you/put/astropy/astropy_helpers
       $ git branch tmp-release-v<version> <maintenance branch name>
 
-#. In that branch, create a release commit by updating the version info and
-   changelog as described in the release instructions above.
+#. In that branch, create release commits by updating the changelog and then the
+   version info and as described in the release instructions above.
 
 #. Push the branch you just created to the `astropy-helpers repository`_ on
    github::
@@ -528,8 +533,9 @@ applies both for regular release *and* release candidates are the same
       $ python setup.py build sdist register upload
       $ git push upstream --tags <maintenance branch name>
 
-#. Update the changelog in *master* of the `astropy-helpers repository`_ to
-   reflect the release you just did.
+#. Update the changelog and version number in *master* of the
+   `astropy-helpers repository`_ to reflect the release you just did (detailed
+   instructions are above).
 
 #. Delete the temporary branch from github:
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -189,9 +189,9 @@ packages that use the full bugfix/maintenance branch approach.)
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   For major releases with a lot of changes, we do beta and/or release candiates
-   to have a chance to catch significant bugs before the true release.
-   If the release you are performing is this kind of pre-release, some
+   For major releases with a lot of changes, we do beta and/or release
+   candidates to have a chance to catch significant bugs before the true
+   release. If the release you are performing is this kind of pre-release, some
    of the above steps need to be modified.
 
    The primary modifications to the release procedure are:
@@ -467,13 +467,13 @@ Coordinating Astropy and astropy-helpers Releases
 
 A bit more initial effort is required for an Astropy release that has a
 corresponding astropy-helpers release.  The main reason for this more complex
-procedure is to allow the Astropy core to be tested aginst the new helpers
+procedure is to allow the Astropy core to be tested against the new helpers
 before anything is released.  Hence the following procedure should be added
 to the beginning of the above procedure when this is required.
 
 .. note::
 
-    This procedure applies both for regular relesease *and* release candidates.
+    This procedure applies both for regular release *and* release candidates.
     The only change of the below for release candidates is that the branch in
     astropy-helpers should be names "release-<version>rc#" instead of
     "release-<version>".

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -47,9 +47,9 @@ packages that use the full bugfix/maintenance branch approach.)
    ``git clone`` or do ``git clean -dfx``.
 
 #. Be sure you're on the branch appropriate for the version you're about to
-   release.  For example, if releasing version 0.2.2 make sure to::
+   release.  For example, if releasing version 1.2.2 make sure to::
 
-      $ git checkout v0.2.x
+      $ git checkout v1.2.x
 
 #. Edit the ``setup.py`` file by removing the ``".dev"`` at the end of the
    ``VERSION`` string.
@@ -72,7 +72,7 @@ packages that use the full bugfix/maintenance branch approach.)
       $ git tag -s v<version>
 
 #. Edit the ``VERSION`` in ``setup.py`` to be the next version number, but with
-   a ``.dev`` suffix at the end (E.g., ``0.2.3.dev``).
+   a ``.dev`` suffix at the end (E.g., ``1.2.3.dev``).
 
 #. Also update the ``CHANGES.rst`` file with a new section for the next version.
    You will likely want to use the ``add_to_changelog.py`` script in the
@@ -89,7 +89,7 @@ packages that use the full bugfix/maintenance branch approach.)
 #. Now go back and check out the tag of the released version with
    ``git checkout v<version>``.  For example::
 
-      $ git checkout v0.2.2
+      $ git checkout v1.2.2
 
    Don't forget to remove any non-commited files with::
 
@@ -138,8 +138,8 @@ packages that use the full bugfix/maintenance branch approach.)
 
 #. Go to https://pypi.python.org/pypi?:action=pkg_edit&name=astropy
    and ensure that only the most recent releases in each actively maintained
-   release line are *not* marked hidden.  For example, if v0.2.2 was
-   just released, v0.2.1 should be hidden.  This is so that users only find
+   release line are *not* marked hidden.  For example, if v1.2.2 was
+   just released, v1.2.1 should be hidden.  This is so that users only find
    the latest bugfix releases.
 
    Do not enabled "Auto-hide old releases" as that may hide bugfix releases
@@ -197,7 +197,7 @@ Modifications for a beta/release candidate release
    The primary modifications to the release procedure are:
 
    * When entering the new version number, instead of just removing the
-     ``.dev``, enter "0.2b1" or "0.2rc1".  It is critical that you follow this
+     ``.dev``, enter "1.2b1" or "1.2rc1".  It is critical that you follow this
      numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
      is ordered "before" the main release by various automated tools, and also
      tells PyPI that this is a "pre-release".
@@ -291,7 +291,7 @@ Issues are assigned to an Astropy release by way of the Milestone feature in
 the GitHub issue tracker.  At any given time there are at least two versions
 under development: The next major/minor version, and the next bug fix release.
 For example, at the time of writing there are two release milestones open:
-v0.2.2 and v0.3.0.  In this case, v0.2.2 is the next bug fix release and all
+v1.2.2 and v0.3.0.  In this case, v1.2.2 is the next bug fix release and all
 issues that should include fixes in that release should be assigned that
 milestone.  Any issues that implement new features would go into the v0.3.0
 milestone--this is any work that goes in the master branch that should not
@@ -303,13 +303,13 @@ Backporting fixes from master
 
 Most fixes are backported using the ``git cherry-pick`` command, which applies
 the diff from a single commit like a patch.  For the sake of example, say the
-current bug fix branch is 'v0.2.x', and that a bug was fixed in master in a
-commit ``abcd1234``.  In order to backport the fix, simply checkout the v0.2.x
+current bug fix branch is 'v1.2.x', and that a bug was fixed in master in a
+commit ``abcd1234``.  In order to backport the fix, simply checkout the v1.2.x
 branch (it's also good to make sure it's in sync with the
 `astropy core repository`_) and cherry-pick the appropriate commit::
 
-    $ git checkout v0.2.x
-    $ git pull upstream v0.2.x
+    $ git checkout v1.2.x
+    $ git pull upstream v1.2.x
     $ git cherry-pick abcd1234
 
 Sometimes a cherry-pick does not apply cleanly, since the bug fix branch
@@ -328,8 +328,8 @@ combined.  What this means is that it is only necessary to cherry-pick the
 merge commit (this requires adding the ``-m 1`` option to the cherry-pick
 command).  For example, if ``5678abcd`` is a merge commit::
 
-    $ git checkout v0.2.x
-    $ git pull upstream v0.2.x
+    $ git checkout v1.2.x
+    $ git pull upstream v1.2.x
     $ git cherry-pick -m 1 5678abcd
 
 In fact, because Astropy emphasizes a pull request-based workflow, this is the
@@ -372,7 +372,7 @@ there are two choices:
    compares your branch to Astropy's master.  If you look on the left-hand
    side of the pull request page, under "base repo: astropy/astropy" there is
    a drop-down list labeled "base branch: master".  You can click on this
-   drop-down and instead select the bug fix branch ("v0.2.x" for example). Then
+   drop-down and instead select the bug fix branch ("v1.2.x" for example). Then
    GitHub will instead compare your fix against that branch, and merge into
    that branch when the PR is accepted.
 
@@ -398,12 +398,12 @@ right version number).
 To aid in this process there is a `suggest_backports.py script in the astropy-tools repository <https://github.com/astropy/astropy-tools/blob/master/suggest_backports.py>`_.
 The script is not perfect and still needs a little work, but it will get most of
 the work done.  For example, if
-the current bug fix branch is called 'v0.2.x' run it like so::
+the current bug fix branch is called 'v1.2.x' run it like so::
 
-    $ suggest_backports.py astropy astropy v0.2.x -f backport.sh
+    $ suggest_backports.py astropy astropy v1.2.x -f backport.sh
 
 This will search GitHub for all issues assigned to the next bug fix release
-milestone that's associated with the given bug fix branch ('v0.2.2' for
+milestone that's associated with the given bug fix branch ('v1.2.2' for
 example), find the commits that fix those issues, and will generate a shell
 script called ``backport.sh`` containing all the ``git cherry-pick`` commands
 to backport all those fixes.
@@ -414,8 +414,8 @@ local clone of the Astropy repository::
 
     $ ./backport.sh
 
-This will checkout the appropriate bug fix branch ('v0.2.x' in this example),
-do a ``git pull upstream v0.2.x`` to make sure it's up to date, and then start
+This will checkout the appropriate bug fix branch ('v1.2.x' in this example),
+do a ``git pull upstream v1.2.x`` to make sure it's up to date, and then start
 doing cherry-picks into the bug fix branch.
 
 .. note::
@@ -456,8 +456,8 @@ Finally, not all issues assigned to a release milestone need to be fixed before
 making that release.  Usually, in the interest of getting a release with
 existing fixes out within some schedule, it's best to triage issues that won't
 be fixed soon to a new release milestone.  If the upcoming bug fix release is
-'v0.2.2', then go ahead and create a 'v0.2.3' milestone and reassign to it any
-issues that you don't expect to be fixed in time for 'v0.2.2'.
+'v1.2.2', then go ahead and create a 'v1.2.3' milestone and reassign to it any
+issues that you don't expect to be fixed in time for 'v1.2.2'.
 
 
 .. _helpers-release-info:

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -27,9 +27,10 @@ packages that use the full bugfix/maintenance branch approach.)
       $ pip install -r pip-requirements-dev  # any that might be left over
 
 #. Before doing a release of Astropy, you may need to do a release of
-   `astropy-helpers`_.  This is not always necessary if there are no significant
-   changes in the helpers.  See the section :ref:`helpers-release-info` for
-   more on this.
+   astropy-helpers.  This is not always necessary, as there are not always any
+   significant changes in the helpers.  See :ref:`helpers-release-info` for more
+   on this.
+
 
 #. Make sure that the continuous integration services (e.g., Travis) are passing
    for the `astropy core repository`_ branch you're going to release.  You may
@@ -248,7 +249,7 @@ The procedure for this is straightforward:
 
 #. Update the ``CHANGES.rst`` file with a new section at the very top for the
    next major version.  You will likely want to use the ``add_to_changelog.py``
-   script in the `astropy-tools`_ repository for this. The add and commit those
+   script in the `astropy-tools repository`_ for this. Then add and commit those
    changes::
 
       <use your favorite editor on CHANGES.rst>
@@ -477,7 +478,7 @@ Coordinating Astropy and astropy-helpers Releases
 -------------------------------------------------
 
 A bit more initial effort is required for an Astropy release that has a
-corresponding astropy-helpers_ release.  The main reason for this more complex
+corresponding astropy-helpers release.  The main reason for this more complex
 procedure is to allow the Astropy core to be tested against the new helpers
 before anything is released.  Hence the following procedure should be added
 to the beginning of the above procedure when this is required. This procedure

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -55,7 +55,8 @@ packages that use the full bugfix/maintainence branch approach.)
    ``VERSION`` string.
 
 #. Edit the ``CHANGES.rst`` file by changing the date for the version you are
-   about to release from "unreleased" to today's date.
+   about to release from "unreleased" to today's date.  Also be sure to remove
+   any sections of the changelog for that version that have no entries.
 
 #. Add the changes to ``CHANGES.rst`` and ``setup.py``::
 
@@ -63,7 +64,7 @@ packages that use the full bugfix/maintainence branch approach.)
 
   and commit with message::
 
-      $ git commit -m "Preparing release <version>"
+      $ git commit -m "Preparing release v<version>"
 
 #. Tag the commit with ``v<version>``, being certain to sign the tag with the
    ``-s`` option::
@@ -83,7 +84,7 @@ packages that use the full bugfix/maintainence branch approach.)
 
    and commit with message::
 
-      $ git commit -m "Back to development: <next_version>"
+      $ git commit -m "Back to development: v<next_version>"
 
 #. Now go back and check out the tag of the released version with
    ``git checkout v<version>``.  For example::

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -26,6 +26,11 @@ packages that use the full bugfix/maintainence branch approach.)
       $ conda uninstall astropy  # still keeps the dependencies
       $ pip install -r pip-requirements-dev  # any that might be left over
 
+#. Before doing a release of Astropy, you may need to do a release of
+   `astropy-helpers`_.  This is not always necessary if there are no significant
+   changes in the helpers.  See the section :ref:`helpers-release-info` for
+   more on this.
+
 #. Make sure that Travis and any other continuous integration is passing for
    the branch you're going to release.  You may also want to locally run the
    tests in ``remote-data`` mode, as those are not necessarily run
@@ -454,6 +459,46 @@ be fixed soon to a new release milestone.  If the upcoming bug fix release is
 issues that you don't expect to be fixed in time for 'v0.2.2'.
 
 
+.. _helpers-release-info:
+
+Coordinating Astropy and astropy-helpers Releases
+-------------------------------------------------
+
+A bit more initial effort is required for an Astropy release that has a
+corresponding astropy-helpers release.  The main reason for this more complex
+procedure is to allow the Astropy core to be tested aginst the new helpers
+before anything is released.  Hence the following procedure should be added
+to the beginning of the above procedure when this is required.
+
+#. In `astropy-helpers`, create a new release branch "release-<version>".
+
+#. Create the release commit (updating the version info and changelog) in that
+   branch.
+
+#. Push the release branch to github.
+
+#. In astropy master (and/or the relevant maintainence branch), issue a PR
+   updating the helpers to the commit described in the last step (i.e., the
+   head of the astropy-helpers release branch).
+
+#. Wait for Travis to run to ensure that helpers build works with Astropy.
+   If it doesn't, back out the release and fix whatever the problem is before
+   trying again.
+
+#. Assuming it does succeed, finish the release of the helpers by doing this in
+   the helpers repo::
+
+      git checkout master
+      git merge --no-ff release-<version>
+      git tag -s "v<version>" -m "Tagging v<version>"
+
+   and then adding one more commit updating back to the next dev version.
+
+This way the commit of the helpers that is tagged as the release is the same
+commit that the astropy_helpers submodule will be on when the PR to astropy
+testing the release gets merged.
+
+
 .. _key-signing-info:
 
 Creating a GPG Signing Key and a Signed Tag
@@ -582,3 +627,4 @@ that for you.  You can delete this tag by doing::
 .. _cython: http://www.cython.org/
 .. _astropy-tools: https://github.com/astropy/astropy-tools
 .. _Anaconda: http://conda.pydata.org/docs/
+.. _astropy-helpers: https://github.com/astropy/astropy-helpers

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -466,7 +466,7 @@ Coordinating Astropy and astropy-helpers Releases
 -------------------------------------------------
 
 A bit more initial effort is required for an Astropy release that has a
-corresponding astropy-helpers release.  The main reason for this more complex
+corresponding astropy-helpers_ release.  The main reason for this more complex
 procedure is to allow the Astropy core to be tested against the new helpers
 before anything is released.  Hence the following procedure should be added
 to the beginning of the above procedure when this is required.
@@ -475,10 +475,11 @@ to the beginning of the above procedure when this is required.
 
     This procedure applies both for regular release *and* release candidates.
     The only change of the below for release candidates is that the branch in
-    astropy-helpers should be names "release-<version>rc#" instead of
+    astropy-helpers_ should be names "release-<version>rc#" instead of
     "release-<version>".
 
-#. In `astropy-helpers`, create a new release branch "release-<version>".
+#. In the astropy-helpers_ repository, create a new release branch
+   "release-<version>".
 
 #. Create the release commit (updating the version info and changelog) in that
    branch.
@@ -487,7 +488,7 @@ to the beginning of the above procedure when this is required.
 
 #. In astropy master (and/or the relevant maintenance branch), issue a PR
    updating the helpers to the commit described in the last step (i.e., the
-   head of the astropy-helpers release branch).
+   head of the astropy-helpers_ release branch).
 
 #. Wait for the continuous integration services (E.g., Travis) to run to ensure
    that helpers build works with Astropy.
@@ -495,7 +496,7 @@ to the beginning of the above procedure when this is required.
 #. If the PR's tests fail, delete the release branch you just created in
    astropy-helpers, fix whatever the problem is, and then re-run this procedure.
    Note that you can re-use the PR into the astropy core repository (created in
-   the step just before this one) by updating the PR's astropy-helpers to point
+   the step just before this one) by updating the PR's astropy-helpers_ to point
    to the release branch from *after* the fix - that way you don't need to make
    another PR for the fixed version.
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -171,6 +171,15 @@ packages that use the full bugfix/maintainence branch approach.)
    version" link and/or updating the list of older versions if this is an LTS
    bugfix or a new major version.
 
+#. In the astropy *master* branch (not just the changelog), be sure to update
+   the ``CHANGES.rst`` to reflect the date of the release you just performed and
+   to include the new section of the changelog.  Often the easiest way to do
+   this is to use ``git cherry-pick`` on the release commit from above, *but* if
+   that method is used, be sure to amend that commit and not change the version
+   in ``setup.py``. If you aren't sure how to do this, you might be better off
+   just copying-and-pasting the relevant parts of the maintainence branch's
+   ``CHANGES.rst`` into master.
+
    Modifications for a beta/release candidate release
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -471,6 +471,13 @@ procedure is to allow the Astropy core to be tested aginst the new helpers
 before anything is released.  Hence the following procedure should be added
 to the beginning of the above procedure when this is required.
 
+.. note::
+
+    This procedure applies both for regular relesease *and* release candidates.
+    The only change of the below for release candidates is that the branch in
+    astropy-helpers should be names "release-<version>rc#" instead of
+    "release-<version>".
+
 #. In `astropy-helpers`, create a new release branch "release-<version>".
 
 #. Create the release commit (updating the version info and changelog) in that


### PR DESCRIPTION
This updates the releasing instructions to reflect the current procedure.  It also deprecates the `zest.releaser` machinery as it is no longer needed.

There's a matching astropy/astropy-tools#14 that implements the machinery to generate a new changelog, which should go in around the same time as this to make sure they are consistent.

cc @astrofrog