### PR TITLE
Fix zscale when the image size is smaller than nsamples

### DIFF
--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -73,6 +73,12 @@ def test_zscale():
     np.testing.assert_allclose(vmin, 0, atol=0.1)
     np.testing.assert_allclose(vmax, 999, atol=0.1)
 
+    data = list(range(100))
+    interval = ZScaleInterval()
+    vmin, vmax = interval.get_limits(data)
+    np.testing.assert_allclose(vmin, 0, atol=0.1)
+    np.testing.assert_allclose(vmax, 99, atol=0.1)
+
 
 def test_integers():
 

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -54,7 +54,7 @@ def zscale(image, nsamples=1000, contrast=0.25, max_reject=0.5, min_npixels=5,
     # Sample the image
     image = np.asarray(image)
     image = image[np.isfinite(image)]
-    stride = int(image.size / nsamples)
+    stride = int(max(1.0, image.size / nsamples))
     samples = image[::stride][:nsamples]
     samples.sort()
 


### PR DESCRIPTION
When the image size is smaller than nsamples, the current code fails because it computes a stride to 0. The original code makes sure that stride is a least 1, but it seems I missed this. 
So this fix should go in 1.2 ...