### PR TITLE
duplicate unit aliases (pixel, counts, photon and voxel)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1598,6 +1598,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Duplicates between long and short names are now removed in the ``names``
+    and ``aliases`` properties of units. [#5036]
+
 - ``astropy.utils``
 
   - Fix two problems related to the download cache: clear_download_cache() does

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1480,7 +1480,7 @@ class NamedUnit(UnitBase):
         elif isinstance(st, tuple):
             if not len(st) == 2:
                 raise ValueError("st must be string, list or 2-tuple")
-            self._names = st[0] + st[1]
+            self._names = st[0] + [n for n in st[1] if n not in st[0]]
             if not len(self._names):
                 raise ValueError("must provide at least one name")
             self._short_names = st[0][:]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -489,6 +489,13 @@ def test_no_as():
     assert hasattr(u, 'attosecond')
 
 
+def test_no_duplicates_in_names():
+    # Regression test for #5036
+    assert u.ct.names == ['ct', 'count']
+    assert u.ct.short_names == ['ct', 'count']
+    assert u.ct.long_names == ['count']
+    assert set(u.ph.names) == set(u.ph.short_names) | set(u.ph.long_names)
+
 def test_pickling():
     p = pickle.dumps(u.m)
     other = pickle.loads(p)


### PR DESCRIPTION
I just noticed that ``astropy.units.astrophys.pix`` ([link to documentation](http://docs.astropy.org/en/latest/units/index.html#module-astropy.units.astrophys)) has two aliases, both are ``pixel``. The same for ``counts``, ``photon`` and ``voxel``.

Was the original intention to accept the capitalized names?