### PR TITLE
Fix EarthLocation latex repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -616,9 +616,12 @@ Bug fixes
 
   - Ensure that ``angle_utilities.position_angle`` accepts floats, as stated
     in the docstring. [#3800]
-    
-  - Ensured that transformations for ``GCRS`` frames are correct for 
+
+  - Ensured that transformations for ``GCRS`` frames are correct for
     non-geocentric observers. [#4986]
+
+  - Fixed a problem with the ``EarthLocation._repr_latex_`` method that caused
+    errors when showing an ``EarthLocation`` in a Jupyter notebook. [#4542, #5049]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -185,6 +185,23 @@ class EarthLocation(u.Quantity):
         self._ellipsoid = ellipsoid
         return self.to(height.unit)
 
+    def _repr_latex_(self):
+        """
+        Generate a latex representation of this EarthLocation and its unit.
+
+        Customized from the base class because the base class doesn't play well
+        with structured arrays (and isn't really meant to).
+        """
+
+        tojoin = []
+        for component in 'xyz':
+            # assume the $$s are around all of them, and strip it... if that
+            # changes it might be necessary to start checking for that
+            element_latex = getattr(self, component)._repr_latex_()[1:-1]
+            tojoin.append('{}={}'.format(component, element_latex))
+        return '$' + ', '.join(tojoin) + '$'
+
+
     @classmethod
     def of_site(cls, site_name):
         """

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -257,3 +257,11 @@ def test_pickling():
     s = pickle.dumps(el)
     el2 = pickle.loads(s)
     assert el == el2
+
+def test_repr_latex():
+    """
+    Regression test for issue #4542
+    """
+
+    somelocation = EarthLocation(lon='149:3:57.9', lat='-31:16:37.3')
+    somelocation._repr_latex_()

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -270,6 +270,9 @@ def test_repr_latex():
     somelocation2 = EarthLocation(lon=[1,2]*u.deg, lat=[4,5]*u.deg)
     assert somelocation2._repr_latex_() == '$x=[6361734.7,~6350157.1] \\; \\mathrm{m}, y=[111044.49,~221752.37] \\; \\mathrm{m}, z=[441945.11,~552183.96] \\; \\mathrm{m}$'
 
-    somelocation_many = EarthLocation(lon=np.linspace(0,360,1000)*u.deg,
-                                      lat=np.linspace(0,90,1000)*u.deg)
-    assert somelocation_many._repr_latex_() == '$x=[6378137,~6378003,~6377601.1,~\\dots, 20123.415,~10062.317,~3.9186209 \\times 10^{-10}] \\; \\mathrm{m}, y=[0,~40114.818,~80227.754,~\\dots, -253.14478,~-63.287526,~0] \\; \\mathrm{m}, z=[0,~9961.6424,~19923.261,~\\dots, 6356720.7,~6356744.4,~6356752.3] \\; \\mathrm{m}$'
+    somelocation_many = EarthLocation(lon=np.linspace(0, 360, 1000)*u.deg,
+                                      lat=np.linspace(0, 90, 1000)*u.deg)
+    str_many = somelocation_many._repr_latex_()
+    assert str_many.startswith('$x=[')
+    assert str_many.endswith('\\mathrm{m}$')
+    assert str_many.count(',~\\dots,') == 3

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -260,8 +260,16 @@ def test_pickling():
 
 def test_repr_latex():
     """
-    Regression test for issue #4542
+    Regression test for issue #4542 + checks for new machinery fixing it
     """
 
     somelocation = EarthLocation(lon='149:3:57.9', lat='-31:16:37.3')
-    somelocation._repr_latex_()
+    assert somelocation._repr_latex_() == '$x=-4680035.7 \\; \\mathrm{m}, y=2804707.6 \\; \\mathrm{m}, z=-3292182.7 \\; \\mathrm{m}$'
+
+
+    somelocation2 = EarthLocation(lon=[1,2]*u.deg, lat=[4,5]*u.deg)
+    assert somelocation2._repr_latex_() == '$x=[6361734.7,~6350157.1] \\; \\mathrm{m}, y=[111044.49,~221752.37] \\; \\mathrm{m}, z=[441945.11,~552183.96] \\; \\mathrm{m}$'
+
+    somelocation_many = EarthLocation(lon=np.linspace(0,360,1000)*u.deg,
+                                      lat=np.linspace(0,90,1000)*u.deg)
+    assert somelocation_many._repr_latex_() == '$x=[6378137,~6378003,~6377601.1,~\\dots, 20123.415,~10062.317,~3.9186209 \\times 10^{-10}] \\; \\mathrm{m}, y=[0,~40114.818,~80227.754,~\\dots, -253.14478,~-63.287526,~0] \\; \\mathrm{m}, z=[0,~9961.6424,~19923.261,~\\dots, 6356720.7,~6356744.4,~6356752.3] \\; \\mathrm{m}$'

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -258,6 +258,7 @@ def test_pickling():
     el2 = pickle.loads(s)
     assert el == el2
 
+
 def test_repr_latex():
     """
     Regression test for issue #4542 + checks for new machinery fixing it
@@ -266,8 +267,7 @@ def test_repr_latex():
     somelocation = EarthLocation(lon='149:3:57.9', lat='-31:16:37.3')
     assert somelocation._repr_latex_() == '$x=-4680035.7 \\; \\mathrm{m}, y=2804707.6 \\; \\mathrm{m}, z=-3292182.7 \\; \\mathrm{m}$'
 
-
-    somelocation2 = EarthLocation(lon=[1,2]*u.deg, lat=[4,5]*u.deg)
+    somelocation2 = EarthLocation(lon=[1, 2]*u.deg, lat=[4, 5]*u.deg)
     assert somelocation2._repr_latex_() == '$x=[6361734.7,~6350157.1] \\; \\mathrm{m}, y=[111044.49,~221752.37] \\; \\mathrm{m}, z=[441945.11,~552183.96] \\; \\mathrm{m}$'
 
     somelocation_many = EarthLocation(lon=np.linspace(0, 360, 1000)*u.deg,


### PR DESCRIPTION
This fixes #4542 by making a custom `EarthLocation._repr_latex_` that handles the situation for just that class.

I thought about doing a more general fix in `Quantity._repr_latex_` for structured arrays of many sorts, but after thinking about it realized we probably don't want to typically do this anyway, so better to just special-case `EarthLocation`.

cc @mhvk 

This is a straightforward bug fix, so I've put it in for 1.2.0, but is not critical so if it doesn't seem ready by release time that's fine too and can be pushed to 1.2.1 (@astrofrog)