### PR TITLE
Delete scaling keywords from header when unsigned int data converted to another type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -627,6 +627,9 @@ Bug fixes
 
   - ``GroupsHDU.is_image`` property is now set to ``False``. [#4742]
 
+  - Ensure scaling keywords are removed from header when unsigned integer data
+    is converted to signed type. [#4974, #5053]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.votable``

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -627,6 +627,65 @@ class TestImageFunctions(FitsTestCase):
                 assert 'BZERO' in new_uint_hdu.header
                 assert new_uint_hdu.header['BZERO'] == (2 ** (int_size - 1))
 
+    @pytest.mark.parametrize(('from_file'), (False, True))
+    @pytest.mark.parametrize(('do_not_scale'), (False,))
+    def test_uint_header_keywords_removed_after_bitpix_change(self,
+                                                              from_file,
+                                                              do_not_scale):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4974
+
+        BZERO/BSCALE should be removed if data is converted to a floating
+        point type.
+
+        Currently excluding the case where do_not_scale_image_data=True
+        because it is not clear what the expectation should be.
+        """
+
+        arr = np.zeros(100, dtype='uint16')
+
+        if from_file:
+            # To generate the proper input file we always want to scale the
+            # data before writing it...otherwise when we open it will be
+            # regular (signed) int data.
+            tmp_uint = fits.PrimaryHDU(arr)
+            filename = 'unsigned_int.fits'
+            tmp_uint.writeto(self.temp(filename))
+            f = fits.open(self.temp(filename),
+                          do_not_scale_image_data=do_not_scale)
+
+            uint_hdu = f[0]
+            # Force a read before we close.
+            _ = uint_hdu.data
+        else:
+            uint_hdu = fits.PrimaryHDU(arr,
+                                       do_not_scale_image_data=do_not_scale)
+
+        # Make sure appropriate keywords are in the header. See
+        # https://github.com/astropy/astropy/pull/3916#issuecomment-122414532
+        # for discussion.
+        assert 'BSCALE' in uint_hdu.header
+        assert 'BZERO' in uint_hdu.header
+        assert uint_hdu.header['BSCALE'] == 1
+        assert uint_hdu.header['BZERO'] == 32768
+
+        # Convert data to floating point...
+        uint_hdu.data = uint_hdu.data * 1.0
+
+        # ...bitpix should be negative.
+        assert uint_hdu.header['BITPIX'] < 0
+
+        # BSCALE and BZERO should NOT be in header any more.
+        # assert 'BSCALE' not in uint_hdu.header
+        # assert 'BZERO' not in uint_hdu.header
+
+        # This is the main test...the data values should round trip
+        # as zero.
+        filename = 'test_uint_to_float.fits'
+        uint_hdu.writeto(self.temp(filename))
+        with fits.open(self.temp(filename)) as hdul:
+            assert (hdul[0].data == 0).all()
+
     def test_blanks(self):
         """Test image data with blank spots in it (which should show up as
         NaNs in the data array.

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -676,8 +676,8 @@ class TestImageFunctions(FitsTestCase):
         assert uint_hdu.header['BITPIX'] < 0
 
         # BSCALE and BZERO should NOT be in header any more.
-        # assert 'BSCALE' not in uint_hdu.header
-        # assert 'BZERO' not in uint_hdu.header
+        assert 'BSCALE' not in uint_hdu.header
+        assert 'BZERO' not in uint_hdu.header
 
         # This is the main test...the data values should round trip
         # as zero.


### PR DESCRIPTION
Ideally this would get into 1.2 (not necessary into the RC, but before the final release). It addresses #4974 but involved a fair bit of monkeying around with the internals of scaling.

@embray, if you could take a look that would be great.

Changelog as soon as I find out which section to put the entry in....