### PR TITLE
changed verify('fix') to verify('fix+warn') when printing fits cards

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,7 +118,7 @@ Bug Fixes
 
   - Converting a header card to a string now calls ``self.verify('warn')``
     instead of ``self.verify('fix')`` so headers with invalid keywords will
-    not raise a ``VerifyError`` on printing. [#887]
+    not raise a ``VerifyError`` on printing. [#887,#5054]
 
 - ``astropy.io.misc``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,7 +116,7 @@ Bug Fixes
   - Made TFORMx keyword check more flexible in test of compressed images to
     enable copatibility of the test with cfitsio 3.380. [#4646]
 
-  - Converting a header card to a string now calls ``self.verify('warn')``
+  - Converting a header card to a string now calls ``self.verify('fix+warn')``
     instead of ``self.verify('fix')`` so headers with invalid keywords will
     not raise a ``VerifyError`` on printing. [#887,#5054]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,10 @@ Bug Fixes
   - Made TFORMx keyword check more flexible in test of compressed images to
     enable copatibility of the test with cfitsio 3.380. [#4646]
 
+  - Converting a header card to a string now calls ``self.verify('warn')``
+    instead of ``self.verify('fix')`` so headers with invalid keywords will
+    not raise a ``VerifyError`` on printing. [#887]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -762,7 +762,7 @@ class Card(_Verify):
         """
 
         if self._image and not self._verified:
-            self.verify('fix')
+            self.verify('warn')
         if self._image is None or self._modified:
             self._image = self._format_image()
         return self._image

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -762,7 +762,7 @@ class Card(_Verify):
         """
 
         if self._image and not self._verified:
-            self.verify('warn')
+            self.verify('fix+warn')
         if self._image is None or self._modified:
             self._image = self._format_image()
         return self._image


### PR DESCRIPTION
Printing a fits header with an invalid keyword currently raises a `VerifyError` on the first try (see #887). This causes problems when headers are converted to strings inside of other functions, because those functions don't catch that error. For example, `astropy.wcs.WCS(hdr)` crashes when `hdr` has an invalid keyword, even if that keyword is unnecessary for the WCS object. (This is because `WCS` copies the header by converting to a string and back.) This pull request changes the `self.verify('fix')` call inside `self.image` for header cards to `self.verify('warn')` so that a warning is still shown but other higher-level functions will be able to continue.
