### PR TITLE
Update non_celestial_pixel_scales docs

### DIFF
--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -322,18 +322,18 @@ def _is_cd_orthogonal(cd, maxerr):
 
 def non_celestial_pixel_scales(inwcs):
     """
-    For a non-celestial WCS, e.g. one with mixed spectral and spatial axes, it
-    is still sometimes possible to define a pixel scale.
+    Calculate the pixel scale along each axis of a non-celestial WCS,
+    for example one with mixed spectral and spatial axes.
 
     Parameters
     ----------
     inwcs : `~astropy.wcs.WCS`
-        The world coordinate system object
+        The world coordinate system object.
 
     Returns
     -------
     scale : `numpy.ndarray`
-        The pixel scale along each axis
+        The pixel scale along each axis.
     """
 
     if inwcs.is_celestial:


### PR DESCRIPTION
The one-line description in the original docs was truncated after the "e.g." (apparently the one-liners get truncatated after ". [space]").  See here near the bottom of the page: http://docs.astropy.org/en/stable/wcs/index.html

This PR rewords the doc.