### PR TITLE
fits convenience functions close open file objects

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -105,9 +105,11 @@ def getheader(filename, *args, **kwargs):
 
     mode, closed = _get_file_mode(filename)
     hdulist, extidx = _getext(filename, mode, *args, **kwargs)
-    hdu = hdulist[extidx]
-    header = hdu.header
-    hdulist.close(closed=not closed)
+    try:
+        hdu = hdulist[extidx]
+        header = hdu.header
+    finally:
+        hdulist.close(closed=closed)
     return header
 
 
@@ -189,19 +191,21 @@ def getdata(filename, *args, **kwargs):
     view = kwargs.pop('view', None)
 
     hdulist, extidx = _getext(filename, mode, *args, **kwargs)
-    hdu = hdulist[extidx]
-    data = hdu.data
-    if data is None and extidx == 0:
-        try:
-            hdu = hdulist[1]
-            data = hdu.data
-        except IndexError:
+    try:
+        hdu = hdulist[extidx]
+        data = hdu.data
+        if data is None and extidx == 0:
+            try:
+                hdu = hdulist[1]
+                data = hdu.data
+            except IndexError:
+                raise IndexError('No data in this HDU.')
+        if data is None:
             raise IndexError('No data in this HDU.')
-    if data is None:
-        raise IndexError('No data in this HDU.')
-    if header:
-        hdr = hdu.header
-    hdulist.close(closed=not closed)
+        if header:
+            hdr = hdu.header
+    finally:
+        hdulist.close(closed=closed)
 
     # Change case of names if requested
     trans = None
@@ -330,11 +334,14 @@ def setval(filename, keyword, *args, **kwargs):
     after = kwargs.pop('after', None)
     savecomment = kwargs.pop('savecomment', False)
 
+    closed = fileobj_closed(filename)
     hdulist, extidx = _getext(filename, 'update', *args, **kwargs)
-    if keyword in hdulist[extidx].header and savecomment:
-        comment = None
-    hdulist[extidx].header.set(keyword, value, comment, before, after)
-    hdulist.close()
+    try:
+        if keyword in hdulist[extidx].header and savecomment:
+            comment = None
+        hdulist[extidx].header.set(keyword, value, comment, before, after)
+    finally:
+        hdulist.close(closed=closed)
 
 
 def delval(filename, keyword, *args, **kwargs):
@@ -367,9 +374,12 @@ def delval(filename, keyword, *args, **kwargs):
     if 'do_not_scale_image_data' not in kwargs:
         kwargs['do_not_scale_image_data'] = True
 
+    closed = fileobj_closed(filename)
     hdulist, extidx = _getext(filename, 'update', *args, **kwargs)
-    del hdulist[extidx].header[keyword]
-    hdulist.close()
+    try:
+        del hdulist[extidx].header[keyword]
+    finally:
+        hdulist.close(closed=closed)
 
 
 def writeto(filename, data, header=None, output_verify='exception',
@@ -563,17 +573,21 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
 
         if verify or not closed:
             f = fitsopen(filename, mode='append')
-            f.append(hdu)
+            try:
+                f.append(hdu)
 
-            # Set a flag in the HDU so that only this HDU gets a checksum when
-            # writing the file.
-            hdu._output_checksum = checksum
-            f.close(closed=not closed)
+                # Set a flag in the HDU so that only this HDU gets a checksum
+                # when writing the file.
+                hdu._output_checksum = checksum
+            finally:
+                f.close(closed=closed)
         else:
             f = _File(filename, mode='append')
-            hdu._output_checksum = checksum
-            hdu._writeto(f)
-            f.close()
+            try:
+                hdu._output_checksum = checksum
+                hdu._writeto(f)
+            finally:
+               f.close()
 
 
 def update(filename, data, *args, **kwargs):
@@ -629,9 +643,10 @@ def update(filename, data, *args, **kwargs):
     closed = fileobj_closed(filename)
 
     hdulist, _ext = _getext(filename, 'update', *args, **kwargs)
-    hdulist[_ext] = new_hdu
-
-    hdulist.close(closed=not closed)
+    try:
+        hdulist[_ext] = new_hdu
+    finally:
+        hdulist.close(closed=closed)
 
 
 def info(filename, output=None, **kwargs):
@@ -664,10 +679,11 @@ def info(filename, output=None, **kwargs):
         kwargs['ignore_missing_end'] = True
 
     f = fitsopen(filename, mode=mode, **kwargs)
-    ret = f.info(output=output)
-
-    if closed:
-        f.close()
+    try:
+        ret = f.info(output=output)
+    finally:
+        if closed:
+            f.close()
 
     return ret
 
@@ -720,18 +736,18 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
     f = fitsopen(filename, mode=mode)
 
     # Create the default data file name if one was not provided
+    try:
+        if not datafile:
+            # TODO: Really need to provide a better way to access the name of
+            # any files underlying an HDU
+            root, tail = os.path.splitext(f._HDUList__file.name)
+            datafile = root + '_' + repr(ext) + '.txt'
 
-    if not datafile:
-        # TODO: Really need to provide a better way to access the name of any
-        # files underlying an HDU
-        root, tail = os.path.splitext(f._HDUList__file.name)
-        datafile = root + '_' + repr(ext) + '.txt'
-
-    # Dump the data from the HDU to the files
-    f[ext].dump(datafile, cdfile, hfile, clobber)
-
-    if closed:
-        f.close()
+        # Dump the data from the HDU to the files
+        f[ext].dump(datafile, cdfile, hfile, clobber)
+    finally:
+        if closed:
+            f.close()
 
 if isinstance(tabledump.__doc__, string_types):
     tabledump.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -27,6 +27,22 @@ class TestConvenience(FitsTestCase):
             header = fits.getheader(self.data('test0.fits'))
             assert len(w) == 0
 
+    def test_fileobj_not_closed(self):
+        """
+        Tests that file-like objects are not closed after being passed
+        to convenenience functions.
+
+        Regression test for https://github.com/astropy/astropy/issues/5063
+        """
+
+        f = open(self.data('test0.fits'), 'rb')
+        data = fits.getdata(f)
+        assert not f.closed
+
+        f.seek(0)
+        header = fits.getheader(f)
+        assert not f.closed
+
     def test_table_to_hdu(self, tmpdir):
         table = Table([[1, 2, 3], ['a', 'b', 'c'], [2.3, 4.5, 6.7]],
                       names=['a', 'b', 'c'], dtype=['i', 'U1', 'f'])

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -433,9 +433,15 @@ def fileobj_name(f):
 
 def fileobj_closed(f):
     """
-    Returns True if the given file-like object is closed or if f is not a
-    file-like object.
+    Returns True if the given file-like object is closed or if f is a string
+    (and assumed to be a pathname).
+
+    Returns False for all other types of objects, under the assumption that
+    they are file-like objects with no sense of a 'closed' state.
     """
+
+    if isinstance(f, string_types):
+        return True
 
     if hasattr(f, 'closed'):
         return f.closed

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -19,8 +19,6 @@ to represent 15 m/s:
     >>> 15 * u.m / u.s
     <Quantity 15.0 m / s>
 
-.. note:: |quantity| objects are converted to float by default.
-
 As another example:
 
     >>> 1.25 / u.s
@@ -58,6 +56,11 @@ Finally, the current unit and value can be accessed via the
     Unit("m / s")
     >>> q.value
     2.5
+
+.. note:: |quantity| objects are converted to float by default.  Furthermore,
+	  any data passed in are copied, which for large arrays may not be
+	  optimal.  One can instead obtain a `~numpy.ndarray.view` by
+	  passing ``copy=False`` to |quantity|.
 
 Converting to different units
 -----------------------------


### PR DESCRIPTION
This is actually a pretty bad bug, but I marked it "Priority-low" since I don't think it's come up much before.  I feel like I've heard of this bug before actually, but I couldn't find an open ticket for it.

The issue is that the "convenience" functions in `astropy.io.fits` like `getheader`, `getdata`, and the like, when passed an *open* file object they close that file object when they're done with it.  They should not be assuming that it's safe for them to close the given file object (that's kind of the point of passing around file objects).

By contrast, when passed a filename, they open the file and then close it when they're done with it, correctly.  This is probably the far more common use case which is why this hasn't come up before.