### PR TITLE
Lazy loading of HDUs on fits.open

### DIFF
--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -46,6 +46,12 @@ class Conf(_config.ConfigNamespace):
         'FITS files. This generally provides better performance, especially '
         'for large files, but may affect performance in I/O-heavy '
         'applications.')
+    lazy_load_hdus = _config.ConfigItem(
+        True,
+        'If True, use lazy loading of HDUs when opening FITS files by '
+        'default; that is fits.open() will only seek for and read HDUs on '
+        'demand rather than reading all HDUs at once.  See the documentation '
+        'for fits.open() for more datails.')
     enable_uint = _config.ConfigItem(
         True,
         'If True, default to recognizing the convention for representing '

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -109,7 +109,14 @@ def getheader(filename, *args, **kwargs):
         hdu = hdulist[extidx]
         header = hdu.header
     finally:
-        hdulist.close(closed=closed)
+        # Use _close instead of close to close without loading any
+        # remaining HDUs for pre-lazy-loading backwards compatibility
+        # In other words, when the full HDUList is opened by a user they
+        # previously expected to be able to look at arbitrary HDUs even
+        # after the file was closed, but for getheader and other convenience
+        # functions this is irrelevant
+        hdulist._close(closed=closed)
+
     return header
 
 
@@ -205,7 +212,8 @@ def getdata(filename, *args, **kwargs):
         if header:
             hdr = hdu.header
     finally:
-        hdulist.close(closed=closed)
+        # _close instead of close; see note in getheader
+        hdulist._close(closed=closed)
 
     # Change case of names if requested
     trans = None
@@ -341,7 +349,8 @@ def setval(filename, keyword, *args, **kwargs):
             comment = None
         hdulist[extidx].header.set(keyword, value, comment, before, after)
     finally:
-        hdulist.close(closed=closed)
+        # _close instead of close; see note in getheader
+        hdulist._close(closed=closed)
 
 
 def delval(filename, keyword, *args, **kwargs):
@@ -379,7 +388,8 @@ def delval(filename, keyword, *args, **kwargs):
     try:
         del hdulist[extidx].header[keyword]
     finally:
-        hdulist.close(closed=closed)
+        # _close instead of close; see note in getheader
+        hdulist._close(closed=closed)
 
 
 def writeto(filename, data, header=None, output_verify='exception',
@@ -580,14 +590,15 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
                 # when writing the file.
                 hdu._output_checksum = checksum
             finally:
-                f.close(closed=closed)
+                # _close instead of close; see note in getheader
+                f._close(closed=closed)
         else:
             f = _File(filename, mode='append')
             try:
                 hdu._output_checksum = checksum
                 hdu._writeto(f)
             finally:
-                f.close()
+                f._close()
 
 
 def update(filename, data, *args, **kwargs):
@@ -646,7 +657,8 @@ def update(filename, data, *args, **kwargs):
     try:
         hdulist[_ext] = new_hdu
     finally:
-        hdulist.close(closed=closed)
+        # _close instead of close; see note in getheader
+        hdulist._close(closed=closed)
 
 
 def info(filename, output=None, **kwargs):
@@ -683,7 +695,8 @@ def info(filename, output=None, **kwargs):
         ret = f.info(output=output)
     finally:
         if closed:
-            f.close()
+            # _close instead of close; see note in getheader
+            f._close()
 
     return ret
 
@@ -747,7 +760,8 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
         f[ext].dump(datafile, cdfile, hfile, clobber)
     finally:
         if closed:
-            f.close()
+            # _close instead of close; see note in getheader
+            f._close()
 
 if isinstance(tabledump.__doc__, string_types):
     tabledump.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -259,37 +259,42 @@ class _File(object):
                 raise ValueError('size {} is too many bytes for a {} array of '
                                  '{}'.format(size, shape, dtype))
 
-        if self.memmap:
-            if self._mmap is None:
-                # Instantiate Memmap array of the file offset at 0
-                # (so we can return slices of it to offset anywhere else into
-                # the file)
-                memmap = Memmap(self._file,
-                                mode=MEMMAP_MODES[self.mode],
-                                dtype=np.uint8)
+        filepos = self._file.tell()
 
-                # Now we immediately discard the memmap array; we are really
-                # just using it as a factory function to instantiate the mmap
-                # object in a convenient way (may later do away with this
-                # usage)
-                self._mmap = memmap.base
+        try:
+            if self.memmap:
+                if self._mmap is None:
+                    # Instantiate Memmap array of the file offset at 0 (so we
+                    # can return slices of it to offset anywhere else into the
+                    # file)
+                    memmap = Memmap(self._file, mode=MEMMAP_MODES[self.mode],
+                                    dtype=np.uint8)
 
-                # Prevent dorking with self._memmap._mmap by memmap.__del__ in
-                # Numpy 1.6 (see
-                # https://github.com/numpy/numpy/commit/dcc355a0b179387eeba10c95baf2e1eb21d417c7)
-                memmap._mmap = None
-                del memmap
+                    # Now we immediately discard the memmap array; we are
+                    # really just using it as a factory function to instantiate
+                    # the mmap object in a convenient way (may later do away
+                    # with this usage)
+                    self._mmap = memmap.base
 
-            return np.ndarray(shape=shape, dtype=dtype, offset=offset,
-                              buffer=self._mmap)
-        else:
-            count = reduce(operator.mul, shape)
-            pos = self._file.tell()
-            self._file.seek(offset)
-            data = _array_from_file(self._file, dtype, count, '')
-            data.shape = shape
-            self._file.seek(pos)
-            return data
+                    # Prevent dorking with self._memmap._mmap by memmap.__del__
+                    # in Numpy 1.6 (see
+                    # https://github.com/numpy/numpy/commit/dcc355a0b179387eeba10c95baf2e1eb21d417c7)
+                    memmap._mmap = None
+                    del memmap
+
+                return np.ndarray(shape=shape, dtype=dtype, offset=offset,
+                                  buffer=self._mmap)
+            else:
+                count = reduce(operator.mul, shape)
+                self._file.seek(offset)
+                data = _array_from_file(self._file, dtype, count, '')
+                data.shape = shape
+                return data
+        finally:
+            # Make sure we leave the file in the position we found it; on
+            # some platforms (e.g. MSVCRT) mmaping a file handle can also
+            # reset its file pointer
+            self._file.seek(filepos)
 
     def writable(self):
         if self.readonly:

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -292,7 +292,7 @@ class _File(object):
                 return data
         finally:
             # Make sure we leave the file in the position we found it; on
-            # some platforms (e.g. MSVCRT) mmaping a file handle can also
+            # some platforms (e.g. Windows) mmaping a file handle can also
             # reset its file pointer
             self._file.seek(filepos)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -6,6 +6,7 @@ import gzip
 import os
 import shutil
 import sys
+import textwrap
 import warnings
 
 import numpy as np
@@ -212,6 +213,10 @@ class HDUList(list, _Verify):
             self._read_all = self._file.mode == 'ostream'
         else:
             self._read_all = False
+
+        # This is used for book-keeping for backwards compatibility of
+        # accessing unread HDUs after the file has been closed.
+        self._total_read = None
 
         if hdus is None:
             hdus = []
@@ -847,6 +852,35 @@ class HDUList(list, _Verify):
             When `True`, close the underlying file object.
         """
 
+        # If the underlying file object is not closed then we can still
+        # technically lazy-load HDUs
+
+        if closed:
+            # Get the actual current number of HDUs that have been loaded
+            total_read = list.__len__(self)
+
+            # Now read in any remaining HDUs
+            while self._read_next_hdu():
+                pass
+
+        try:
+            self._close(output_verify=output_verify, verbose=verbose,
+                        closed=closed)
+        finally:
+            # This will cause deprecation warnings on any future attempt
+            # to access HDUs that were not loaded before closing
+            if closed:
+                self._total_read = total_read
+
+    def _close(self, output_verify='exception', verbose=False, closed=True):
+        """
+        Internal implementation of close() that does not allow further
+        HDUs to be loaded.
+
+        The HDU pre-loading behavior of the explicit close() is currently
+        maintained only for backwards-compatibility.
+        """
+
         if self._file:
             if self._file.mode in ['append', 'update']:
                 self.flush(output_verify=output_verify, verbose=verbose)
@@ -974,17 +1008,45 @@ class HDUList(list, _Verify):
 
         return hdulist
 
-    def _try_while_unread_hdus(self, func, *args, **kwargs):
+    def _try_while_unread_hdus(self, func, index, *args, **kwargs):
         """
         Attempt an operation that accesses an HDU by index/name
         that can fail if not all HDUs have been read yet.  Keep
         reading HDUs until the operation succeeds or there are no
         more HDUs to read.
+
+        The first argument must always be the index of some HDU in the
+        HDUList, but additional arguments may be passed on.
         """
+
+        # TODO: This is a temporary hack for reporting the deprecation
+        # warning on the pre-lazy-loading behavior of allowing HDUs to
+        # be accessed after the file was closed.  It can be removed once
+        # the deprecation period has passed.
+        if self._file and self._file.closed and self._total_read is not None:
+            if index > self._total_read - 1:
+                warnings.warn(textwrap.dedent(
+                    """\
+                    Accessing an HDU after an HDUList is closed, where
+                    that HDU was no read while the HDUList was open
+                    is deprecated.  That is, you did something like:
+
+                        >>> hdulist.close()
+                        >>> print(hdulist[2].header)
+
+                    even though hdulist[2] had not been read yet.  Instead
+                    do:
+
+                        >>> print(hdulist[2].header)
+                        >>> hdulist.close()
+
+                    or open the file with lazy_load_hdus=False to read all
+                    the HDUs into memory immediately upon opening the file.
+                    """), AstropyDeprecationWarning)
 
         while True:
             try:
-                return func(*args, **kwargs)
+                return func(index, *args, **kwargs)
             except Exception:
                 if self._read_next_hdu():
                     continue

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -26,7 +26,7 @@ from ....extern.six.moves import range
 
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
-             cache=True, lazy_load_hdus=True, **kwargs):
+             cache=True, lazy_load_hdus=None, **kwargs):
     """Factory function to open a FITS file and return an `HDUList` object.
 
     Parameters
@@ -140,6 +140,11 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         memmap = None if conf.use_memmap else False
     else:
         memmap = bool(memmap)
+
+    if lazy_load_hdus is None:
+        lazy_load_hdus = conf.lazy_load_hdus
+    else:
+        lazy_load_hdus = bool(lazy_load_hdus)
 
     if 'uint16' in kwargs and 'uint' not in kwargs:
         kwargs['uint'] = kwargs['uint16']

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -247,6 +247,14 @@ class HDUList(list, _Verify):
 
         return super(HDUList, self).__len__()
 
+    def __repr__(self):
+        # In order to correctly repr an HDUList we need to load all the
+        # HDUs as well
+        while self._read_next_hdu():
+            pass
+
+        return super(HDUList, self).__repr__()
+
     def __iter__(self):
         idx = 0
         while True:
@@ -667,8 +675,6 @@ class HDUList(list, _Verify):
                 'Extension %s is out of bound or not found.' % index)
 
         return len(self) + index
-
-
 
     def readall(self):
         """

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1310,7 +1310,7 @@ class HDUList(list, _Verify):
             ffo.truncate(0)
             ffo.seek(0)
 
-            for hdu in self:
+            for hdu in hdulist:
                 hdu._writeto(ffo, inplace=True, copy=True)
 
             # Close the temporary file and delete it.

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -562,6 +562,14 @@ class HDUList(list, _Verify):
            form ``(key, ver)`` where ``ver`` is an ``EXTVER`` value that must
            match the HDU being searched for.
 
+           If the key is ambiguous (e.g. there are multiple 'SCI' extensions)
+           the first match is returned.  For a more precise match use the
+           ``(name, ver)`` pair.
+
+           If even the ``(name, ver)`` pair is ambiguous (it shouldn't be
+           but it's not impossible) the numeric index must be used to index
+           the duplicate HDU.
+
         Returns
         -------
         index : int
@@ -584,7 +592,6 @@ class HDUList(list, _Verify):
 
         _key = (_key.strip()).upper()
 
-        nfound = 0
         found = None
         for idx, hdu in enumerate(self):
             name = hdu.name
@@ -594,13 +601,10 @@ class HDUList(list, _Verify):
             if ((name == _key or (_key == 'PRIMARY' and idx == 0)) and
                 (_ver is None or _ver == hdu.ver)):
                 found = idx
-                nfound += 1
+                break
 
-        if (nfound == 0):
+        if (found is None):
             raise KeyError('Extension {} not found.'.format(repr(key)))
-        elif (nfound > 1):
-            raise KeyError('There are {} extensions of {}.'
-                          .format(nfound, repr(key)))
         else:
             return found
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -205,7 +205,13 @@ class HDUList(list, _Verify):
         # while it is being streamed to.  In the future that might be supported
         # but for now this is only used for the purpose of lazy-loading of
         # existing HDUs.
-        self._read_all = file is None
+        if file is None:
+            self._read_all = True
+        elif self._file is not None:
+            # Should never attempt to read HDUs in ostream mode
+            self._read_all = self._file.mode == 'ostream'
+        else:
+            self._read_all = False
 
         if hdus is None:
             hdus = []


### PR DESCRIPTION
This is something I've wanted to do a long time.  And while this isn't exactly how I had in mind to do it, it lays a lot of groundwork.  This is my alternative to #4634 

The idea here is that `fits.open()` currently immediately seeks through an entire FITS file, and finds all HDUs, as well as creates HDU objects and more importantly Header objects for them.  In a typical FITS file this overhead is negligible.  But for files containing hundreds of HDUs this can have a serious impact.  Further this can have a serious impact even when working with files of just a few HDUs, but when there are thousands of them that need to be looped over (and in particular when only the PRIMARY header is needed which is frequently the case).

This is an experimental attempt to add lazy-loading of HDUs, so HDUs are only read on demand.  For example if you open a file with `hdul = fits.open(filename)` and immediately do something like `hdul[3]` it read all HDUs up through the fourth one and then stop any further reading until necessary.

Of course some operations, most notably `len(hdul)` and `hdul.info()` necessitate reading the entire file.  But these are not the most common cases in scripts which is what this change really concerns itself with (as opposed to command-line interaction).

The biggest shortcoming to this patch as it stands is the issue I mentioned in #4634 regarding `hdulist.close()`.  Because `fits.open()` used to load all HDUs, and in particular their headers, I have no doubt that there is code in the wild that follows this sort of pattern:

```
>>> hdulist = fits.open(filename)
>>> # do some stuff
>>> hdulist.close()
>>> print(hdulist[3].header)
```

Because of the lazy-loading, `hdulist[3]` may not have been loaded yet before `hdulist.close()` was called, and so this will fail.  I'm of the opinion that it _should_ fail--you shouldn't `close()` the file object until you're actually done doing everything you're going to do with it.  But unfortunately PyFITS has played loose on this forever.

So currently, to maintain backwards compatibility, this patch ensures that all HDUs are loaded before the file is closed.  This is of course kills most benefit from lazy-loading.  But not in all cases!  In special cases like convenience functions (`getheader`, `getdata`, etc.) in which the user never has direct access to the `HDUList` object we can still take full advantage of lazy-loading.  Furthermore, attempts to access a previously not loaded HDU _after_ the file has been closed will result in a `DeprecationWarning`, with the aim of disallowing this usage in the long term, so that lazy-loading can be fully taken advantage of.
