### PR TITLE
Quantity latex repr change to ensure EarthLocation can be done

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -620,6 +620,9 @@ Bug fixes
   - Ensured that transformations for ``GCRS`` frames are correct for 
     non-geocentric observers. [#4986]
 
+  - Fixed a problem with the ``Quantity._repr_latex_`` method causing errors
+    when showing an ``EarthLocation`` in a Jupyter notebook. [#4542, #5068]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -257,3 +257,11 @@ def test_pickling():
     s = pickle.dumps(el)
     el2 = pickle.loads(s)
     assert el == el2
+
+def test_repr_latex():
+    """
+    Regression test for issue #4542
+    """
+
+    somelocation = EarthLocation(lon='149:3:57.9', lat='-31:16:37.3')
+    somelocation._repr_latex_()

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -262,6 +262,7 @@ def test_repr_latex():
     """
     Regression test for issue #4542
     """
-
     somelocation = EarthLocation(lon='149:3:57.9', lat='-31:16:37.3')
     somelocation._repr_latex_()
+    somelocation2 = EarthLocation(lon=[1., 2.]*u.deg, lat=[-1., 9.]*u.deg)
+    somelocation2._repr_latex_()

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1031,17 +1031,17 @@ class Quantity(np.ndarray):
         # with array2string
         pops = np.get_printoptions()
         try:
-            formatter = {'all': Latex.format_exponential_notation,
-                         'str_kind': lambda x: x}
+            formatter = {'float_kind': Latex.format_exponential_notation}
             if conf.latex_array_threshold > -1:
                 np.set_printoptions(threshold=conf.latex_array_threshold,
                                     formatter=formatter)
 
             # the view is needed for the scalar case - value might be float
-            latex_value = np.array2string(self.view(np.ndarray),
-                                          style=Latex.format_exponential_notation,
-                                          max_line_width=np.inf,
-                                          separator=',~')
+            latex_value = np.array2string(
+                self.view(np.ndarray),
+                style=(Latex.format_exponential_notation
+                       if self.dtype.kind == 'f' else repr),
+                max_line_width=np.inf, separator=',~')
             latex_value = latex_value.replace('...', r'\dots')
         finally:
             np.set_printoptions(**pops)


### PR DESCRIPTION
This is a simpler alternative to #5049 which allows `EarthLocation._repr_latex_()` to work by not changing any exponentials. This mainly to avoid introducing a new representation which is different from both `Quantity` and  `CartesianRepresentation`.

As a side effect, it ensures complex numbers are now not mangled up (but exponentials are still in`e+??` form).