### PR TITLE
Quantities with specific types -> use in Angle, Distance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -198,6 +198,13 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Inplace operations on ``Angle`` and ``Distance`` instances now raise an
+    exception if the final unit is not equivalent to radian and meter, resp.
+    Similarly, views as ``Angle`` and ``Distance`` can now only be taken
+    from quantities with appropriate units, and views as ``Quantity`` can only
+    be taken from logarithmic quanties such as ``Magnitude`` if the physical
+    unit is dimensionless. [#5070]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -17,7 +17,7 @@ __all__ = ['Distance']
 __doctest_requires__ = {'*': ['scipy.integrate']}
 
 
-class Distance(u.Quantity):
+class Distance(u.SpecificTypeQuantity):
     """
     A one-dimensional distance.
 
@@ -87,6 +87,7 @@ class Distance(u.Quantity):
     >>> d7 = Distance(Distance(10 * u.Mpc))
     """
 
+    _equivalent_unit = u.m
     _include_easy_conversion_members = True
 
     def __new__(cls, value=None, unit=None, z=None, cosmology=None,
@@ -144,20 +145,11 @@ class Distance(u.Quantity):
             cls, value, unit, dtype=dtype, copy=copy, order=order,
             subok=subok, ndmin=ndmin)
 
-        if not distance.unit.is_equivalent(u.m):
-            raise u.UnitsError('Unit "{0}" is not a length type'.format(unit))
-
         if not allow_negative and np.any(distance.value < 0):
             raise ValueError("Distance must be >= 0.  Use the argument "
                              "'allow_negative=True' to allow negative values.")
 
         return distance
-
-    def __quantity_subclass__(self, unit):
-        if unit.is_equivalent(u.m):
-            return Distance, True
-        else:
-            return super(Distance, self).__quantity_subclass__(unit)[0], False
 
     @property
     def z(self):

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -119,6 +119,19 @@ def test_create_angles():
 
     assert a1 is not None
 
+
+def test_angle_from_view():
+    q = np.arange(3.) * u.deg
+    a = q.view(Angle)
+    assert type(a) is Angle
+    assert a.unit is q.unit
+    assert np.all(a == q)
+
+    q2 = np.arange(4) * u.m
+    with pytest.raises(u.UnitTypeError):
+        q2.view(Angle)
+
+
 def test_angle_ops():
     """
     Tests operations on Angle objects
@@ -161,6 +174,9 @@ def test_angle_ops():
 
     with pytest.raises(TypeError):
         a6 *= a5
+
+    with pytest.raises(TypeError):
+        a6 *= u.m
 
     with pytest.raises(TypeError):
         np.sin(a6, out=a6)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -27,9 +27,9 @@ from . import format as unit_format
 # TODO: Support function units, e.g. log(x), ln(x)
 
 __all__ = [
-    'UnitsError', 'UnitsWarning', 'UnitConversionError', 'UnitBase',
-    'NamedUnit', 'IrreducibleUnit', 'Unit', 'def_unit', 'CompositeUnit',
-    'PrefixUnit', 'UnrecognizedUnit', 'get_current_unit_registry',
+    'UnitsError', 'UnitsWarning', 'UnitConversionError', 'UnitTypeError',
+    'UnitBase', 'NamedUnit', 'IrreducibleUnit', 'Unit', 'CompositeUnit',
+    'PrefixUnit', 'UnrecognizedUnit', 'def_unit', 'get_current_unit_registry',
     'set_enabled_units', 'add_enabled_units',
     'set_enabled_equivalencies', 'add_enabled_equivalencies',
     'dimensionless_unscaled', 'one']
@@ -459,6 +459,11 @@ class UnitConversionError(UnitsError, ValueError):
     """
     Used specifically for errors related to converting between units or
     interpreting units in terms of other units.
+    """
+
+class UnitTypeError(UnitsError, TypeError):
+    """
+    Used specifically for errors in setting to units not allowed by a class.
     """
 
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -464,12 +464,15 @@ class UnitConversionError(UnitsError, ValueError):
 class UnitTypeError(UnitsError, TypeError):
     """
     Used specifically for errors in setting to units not allowed by a class.
+
+    E.g., would be raised if the unit of an `~astropy.coordinates.Angle`
+    instances were set to a non-angular unit.
     """
 
 
 class UnitsWarning(AstropyWarning):
     """
-    The base class for unit-specific exceptions.
+    The base class for unit-specific warnings.
     """
 
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -9,7 +9,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import numpy as np
 
 from ...extern import six
-from .. import (Unit, UnitBase, UnitsError,
+from .. import (Unit, UnitBase, UnitsError, UnitTypeError,
                 dimensionless_unscaled, Quantity, quantity_helper as qh)
 
 __all__ = ['FunctionUnitBase', 'FunctionQuantity']
@@ -489,10 +489,6 @@ class FunctionQuantity(Quantity):
     # Ensure priority over ndarray, regular Unit & Quantity, and FunctionUnit.
     __array_priority__ = 40000
 
-    # Store unit in different private property than is done by Quantity,
-    # to allow a Quantity view with just the function unit (stored in _unit)
-    _full_unit = None
-
     # Define functions that work on FunctionQuantity.
     _supported_ufuncs = SUPPORTED_UFUNCS
     _supported_functions = SUPPORTED_FUNCTIONS
@@ -528,13 +524,10 @@ class FunctionQuantity(Quantity):
             # convert to target unit
             value = unit.from_physical(value.to(unit.physical_unit).value)
 
-        # initialise Quantity
-        self = super(FunctionQuantity, cls).__new__(
-            cls, value, unit.function_unit, dtype=dtype, copy=copy,
-            order=order, subok=subok, ndmin=ndmin)
-        # set the full unit returned by self.unit
-        self._full_unit = unit
-        return self
+        # initialise!
+        return super(FunctionQuantity,
+                     cls).__new__(cls, value, unit, dtype=dtype, copy=copy,
+                                  order=order, subok=subok, ndmin=ndmin)
 
     # ↓↓↓ properties not found in Quantity
     @property
@@ -548,25 +541,7 @@ class FunctionQuantity(Quantity):
 
         Use `~astropy.units.quantity.Quantity.value` for just the value.
         """
-        return self._new_view(self, self.unit.function_unit)
-
-    # ↓↓↓ properties overridden to point to different places
-    @property
-    def unit(self):
-        """Function unit of the quantity, containing the physical unit.
-
-        Represented by a `~astropy.units.function.FunctionUnitBase` object.
-        """
-        return self._full_unit
-
-    @property
-    def equivalencies(self):
-        """Equivalencies applied by default during unit conversions.
-
-        Contains the list to convert between function and physical unit,
-        as set by the `~astropy.units.function.FunctionUnitBase` unit.
-        """
-        return self.unit.equivalencies
+        return self._new_view(unit=self.unit.function_unit)
 
     # ↓↓↓ methods overridden to change the behaviour
     @property
@@ -587,34 +562,6 @@ class FunctionQuantity(Quantity):
         return self.__class__(self.physical.decompose(bases))
 
     # ↓↓↓ methods overridden to add additional behaviour
-    def to(self, unit, equivalencies=[]):
-        """Returns a new quantity with the specified units.
-
-        Parameters
-        ----------
-        unit : `~astropy.units.UnitBase` instance, str
-            An object that represents the unit to convert to. Must be
-            an `~astropy.units.UnitBase` object or a string parseable
-            by the `~astropy.units` package.
-
-        equivalencies : list of equivalence pairs, optional
-            A list of equivalence pairs to try if the units are not
-            directly convertible.  See :ref:`unit_equivalencies`.
-            This list is in meant to treat only equivalencies between different
-            physical units; the build-in equivalency between the function
-            unit and the physical one is automatically taken into account.
-        """
-        result = super(FunctionQuantity, self).to(unit, equivalencies)
-        if isinstance(unit, FunctionUnitBase):
-            result._full_unit = unit
-        return result
-
-    def __array_finalize__(self, obj):
-        if isinstance(obj, FunctionQuantity):
-            self._full_unit = obj._full_unit
-
-        super(FunctionQuantity, self).__array_finalize__(obj)
-
     def __array_prepare__(self, obj, context=None):
         """Check that the ufunc can deal with a FunctionQuantity."""
 
@@ -635,33 +582,6 @@ class FunctionQuantity(Quantity):
 
         return super(FunctionQuantity, self).__array_prepare__(obj, context)
 
-    def __array_wrap__(self, obj, context=None):
-        """Reorder units properly after ufunc calculation."""
-
-        obj = super(FunctionQuantity, self).__array_wrap__(obj, context)
-
-        if isinstance(obj, FunctionQuantity):
-            obj._full_unit = obj._unit
-            obj._unit = obj._full_unit.function_unit
-            # Check for changes in the function unit (e.g., "mag" -> "2 mag").
-            if obj._unit != obj._full_unit._default_function_unit:
-                if obj._full_unit.physical_type != dimensionless_unscaled:
-                    raise UnitsError(
-                        "Unexpected production in "
-                        "FunctionQuantity.__array_wrap__ "
-                        "of a '{0}' instance with a physical dimension yet "
-                        "function_unit '{1}' when '{2}' was expected. "
-                        "Please alert the astropy developers."
-                        .format(obj.__class__.__name__, obj._unit,
-                                obj._full_unit._default_function_unit))
-
-                if not obj._unit.is_equivalent(
-                        obj._full_unit._default_function_unit):
-                    # For dimensionless, fall back to regular quantity.
-                    obj = self._new_view(obj, obj._unit)
-
-        return obj
-
     def __quantity_subclass__(self, unit):
         if isinstance(unit, FunctionUnitBase):
             return self.__class__, True
@@ -669,12 +589,20 @@ class FunctionQuantity(Quantity):
             return super(FunctionQuantity,
                          self).__quantity_subclass__(unit)[0], False
 
-    def _new_view(self, obj, unit=None):
-        view = super(FunctionQuantity, self)._new_view(obj, unit)
-        if unit is not None and isinstance(view, FunctionQuantity):
-            view._full_unit = unit
-            view._unit = unit.function_unit
-        return view
+    def _set_unit(self, unit):
+        if not isinstance(unit, self._unit_class):
+            # Have to take care of, e.g., (10*u.mag).view(u.Magnitude)
+            try:
+                # "or 'nonsense'" ensures `None` breaks, just in case.
+                unit = self._unit_class(function_unit=unit or 'nonsense')
+            except:
+                raise UnitTypeError(
+                    "{0} instances require {1} function units"
+                    .format(type(self).__name__, self._unit_class.__name__) +
+                    ", so cannot set it to '{0}'.".format(unit))
+
+        self._unit = unit
+        return self
 
     # ↓↓↓ methods overridden to change behaviour
     def __mul__(self, other):
@@ -741,10 +669,12 @@ class FunctionQuantity(Quantity):
             return super(FunctionQuantity,
                          self)._wrap_function(function, *args, **kwargs)
 
+        # For dimensionless, we can convert to regular quantities.
         if all(arg.unit.physical_unit == dimensionless_unscaled
                for arg in (self,) + args
                if (hasattr(arg, 'unit') and
                    hasattr(arg.unit, 'physical_unit'))):
+            args = tuple(getattr(arg, '_function_view', arg) for arg in args)
             return self._function_view._wrap_function(function, *args, **kwargs)
 
         raise TypeError("Cannot use method that uses function '{0}' with "

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -602,7 +602,6 @@ class FunctionQuantity(Quantity):
                     ", so cannot set it to '{0}'.".format(unit))
 
         self._unit = unit
-        return self
 
     # ↓↓↓ methods overridden to change behaviour
     def __mul__(self, other):

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -245,8 +245,7 @@ class LogQuantity(FunctionQuantity):
         # Do calculation in-place using _function_view of array.
         function_view = self._function_view
         function_view += getattr(other, '_function_view', other)
-        self._full_unit = new_unit
-        return self
+        return self._set_unit(new_unit)
 
     def __sub__(self, other):
         # Subtract function units, thus dividing physical units.
@@ -270,8 +269,7 @@ class LogQuantity(FunctionQuantity):
         # Do calculation in-place using _function_view of array.
         function_view = self._function_view
         function_view -= getattr(other, '_function_view', other)
-        self._full_unit = new_unit
-        return self
+        return self._set_unit(new_unit)
 
     # Could add __mul__ and __div__ and try interpreting other as a power,
     # but this seems just too error-prone.

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -245,7 +245,8 @@ class LogQuantity(FunctionQuantity):
         # Do calculation in-place using _function_view of array.
         function_view = self._function_view
         function_view += getattr(other, '_function_view', other)
-        return self._set_unit(new_unit)
+        self._set_unit(new_unit)
+        return self
 
     def __sub__(self, other):
         # Subtract function units, thus dividing physical units.
@@ -269,7 +270,8 @@ class LogQuantity(FunctionQuantity):
         # Do calculation in-place using _function_view of array.
         function_view = self._function_view
         function_view -= getattr(other, '_function_view', other)
-        return self._set_unit(new_unit)
+        self._set_unit(new_unit)
+        return self
 
     # Could add __mul__ and __div__ and try interpreting other as a power,
     # but this seems just too error-prone.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -638,6 +638,15 @@ class Quantity(np.ndarray):
         sets the unit, but subclasses can override it to check that, e.g.,
         a unit is consistent.  It should return ``self`` after modification.
         """
+        if not isinstance(unit, UnitBase):
+            # Trying to go through a string ensures that, e.g., Magnitudes with
+            # dimensionless physical unit become Quantity with units of mag.
+            unit = Unit(str(unit), parse_strict='silent')
+            if not isinstance(unit, UnitBase):
+                raise UnitTypeError(
+                    "{0} instances require {1} units, not {2} instances."
+                    .format(type(self).__name__, UnitBase, type(unit)))
+
         self._unit = unit
         return self
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -548,7 +548,8 @@ class Quantity(np.ndarray):
             if result_unit is None:  # return a plain array
                 return obj.view(np.ndarray)
             elif obj is self:  # all OK now, so set unit.
-                return obj._set_unit(result_unit)
+                obj._set_unit(result_unit)
+                return obj
             else:
                 return obj
 
@@ -648,7 +649,6 @@ class Quantity(np.ndarray):
                     .format(type(self).__name__, UnitBase, type(unit)))
 
         self._unit = unit
-        return self
 
     def __reduce__(self):
         # patch to pickle Quantity objects (ndarray subclasses), see
@@ -854,7 +854,8 @@ class Quantity(np.ndarray):
         """In-place multiplication between `Quantity` objects and others."""
 
         if isinstance(other, (UnitBase, six.string_types)):
-            return self._set_unit(other * self.unit)
+            self._set_unit(other * self.unit)
+            return self
 
         return super(Quantity, self).__imul__(other)
 
@@ -880,7 +881,8 @@ class Quantity(np.ndarray):
         """Inplace division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
-            return self._set_unit(self.unit / other)
+            self._set_unit(self.unit / other)
+            return self
 
         return super(Quantity, self).__itruediv__(other)
 
@@ -1334,7 +1336,8 @@ class Quantity(np.ndarray):
         if out is None:
             return self._new_view(value, unit)
         else:
-            return out._set_unit(unit)
+            out._set_unit(unit)
+            return out
 
     def clip(self, a_min, a_max, out=None):
         return self._wrap_function(np.clip, self._to_own_unit(a_min),
@@ -1503,4 +1506,4 @@ class SpecificTypeQuantity(Quantity):
                 (", but no unit was given." if unit is None else
                  ", so cannot set it to '{0}'.".format(unit)))
 
-        return super(SpecificTypeQuantity, self)._set_unit(unit)
+        super(SpecificTypeQuantity, self)._set_unit(unit)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1485,7 +1485,7 @@ class SpecificTypeQuantity(Quantity):
     _equivalent_unit = None
 
     # The default unit used for views.  Even with `None`, views of arrays
-    # without units are possible, but will have an uninitalized units.
+    # without units are possible, but will have an uninitalized unit.
     _unit = None
 
     # Default unit for initialization through the constructor.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -17,8 +17,8 @@ import numpy as np
 
 # AstroPy
 from ..extern import six
-from .core import (Unit, dimensionless_unscaled, UnitBase, UnitsError,
-                   get_current_unit_registry, UnitConversionError)
+from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
+                   UnitBase, UnitsError, UnitConversionError, UnitTypeError)
 from .format.latex import Latex
 from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_9
 from ..utils.compat.misc import override__dir__
@@ -27,7 +27,7 @@ from ..utils.data_info import ParentDtypeInfo
 from .. import config as _config
 
 
-__all__ = ["Quantity"]
+__all__ = ["Quantity", "SpecificTypeQuantity"]
 
 
 # We don't want to run doctests in the docstrings we inherit from Numpy
@@ -190,6 +190,13 @@ class Quantity(np.ndarray):
     # Constants can not initialize properly
     _equivalencies = []
 
+    # Default unit for initialization; can be overridden by subclasses,
+    # possibly to `None` to indicate there is no default unit.
+    _default_unit = dimensionless_unscaled
+
+    # Ensures views have an undefined unit.
+    _unit = None
+
     __array_priority__ = 10000
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, order=None,
@@ -237,7 +244,7 @@ class Quantity(np.ndarray):
             if value_unit is None:
                 # Default to dimensionless for no (initialized) unit attribute.
                 if unit is None:
-                    unit = dimensionless_unscaled
+                    unit = cls._default_unit
                 value_unit = unit  # signal below that no conversion is needed
             else:
                 try:
@@ -270,7 +277,7 @@ class Quantity(np.ndarray):
             value = value.astype(np.float)
 
         value = value.view(cls)
-        value._unit = value_unit
+        value._set_unit(value_unit)
         if unit is value_unit:
             return value
         else:
@@ -279,7 +286,11 @@ class Quantity(np.ndarray):
             return value.to(unit)
 
     def __array_finalize__(self, obj):
-        self._unit = getattr(obj, '_unit', None)
+        # If our unit is not set and obj has a valid one, use it.
+        if self._unit is None:
+            unit = getattr(obj, '_unit', None)
+            if unit is not None:
+                self._set_unit(unit)
 
         # Copy info if the original had `info` defined.  Because of the way the
         # DataInfo works, `'info' in obj.__dict__` is False until the
@@ -535,11 +546,11 @@ class Quantity(np.ndarray):
                     obj = self._new_view(out, result_unit)
 
             if result_unit is None:  # return a plain array
-                obj = obj.view(np.ndarray)
+                return obj.view(np.ndarray)
+            elif obj is self:  # all OK now, so set unit.
+                return obj._set_unit(result_unit)
             else:
-                obj._unit = result_unit
-
-        return obj
+                return obj
 
     def __deepcopy__(self, memo):
         # If we don't define this, ``copy.deepcopy(quantity)`` will
@@ -564,7 +575,7 @@ class Quantity(np.ndarray):
         """
         return Quantity, True
 
-    def _new_view(self, obj, unit=None):
+    def _new_view(self, obj=None, unit=None):
         """
         Create a Quantity view of obj, and set the unit
 
@@ -576,39 +587,59 @@ class Quantity(np.ndarray):
 
         Parameters
         ----------
-        obj : ndarray or scalar
+        obj : ndarray or scalar, optional
             The array to create a view of.  If obj is a numpy or python scalar,
-            it will be converted to an array scalar.
+            it will be converted to an array scalar.  By default, ``self``
+            is converted.
 
-        unit : `UnitBase`, or anything convertible to a :class:`~astropy.units.Unit`, or `None`
+        unit : `UnitBase`, or anything convertible to a :class:`~astropy.units.Unit`, optional
             The unit of the resulting object.  It is used to select a
-            subclass, and explicitly assigned to the view if not `None`.
-            If `None` (default), the unit is set by `__array_finalize__`
-            to self._unit.
+            subclass, and explicitly assigned to the view if given.
+            If not given, the subclass and unit will be that of ``self``.
 
         Returns
         -------
         view : Quantity subclass
         """
-        # python and numpy scalars cannot be viewed as arrays and thus not as
-        # Quantity either; turn them into zero-dimensional arrays
-        # (These are turned back into scalar in `.value`)
-        if not isinstance(obj, np.ndarray):
-            obj = np.array(obj)
-
+        # Determine the unit and quantity subclass that we need for the view.
         if unit is None:
-            subclass = self.__class__
+            unit = self.unit
+            quantity_subclass = self.__class__
         else:
             unit = Unit(unit)
-            subclass, subok = self.__quantity_subclass__(unit)
+            quantity_subclass, subok = self.__quantity_subclass__(unit)
             if subok:
-                subclass = self.__class__
+                quantity_subclass = self.__class__
 
-        view = obj.view(subclass)
+        # We only want to propagate information from ``self`` to our new view,
+        # so obj should be a regular array.  By using ``np.array``, we also
+        # convert python and numpy scalars, which cannot be viewed as arrays
+        # and thus not as Quantity either, to zero-dimensional arrays.
+        # (These are turned back into scalar in `.value`)
+        if obj is None:
+            obj = self.view(np.ndarray)
+        else:
+            obj = np.array(obj, copy=False)
+
+        # Take the view, set the unit, and update possible other properties
+        # such as ``info``, ``wrap_angle`` in `Longitude`, etc.
+        view = obj.view(quantity_subclass)
+        view._set_unit(unit)
         view.__array_finalize__(self)
-        if unit is not None:
-            view._unit = unit
         return view
+
+    def _set_unit(self, unit):
+        """Set the unit.
+
+        This is used anywhere the unit is set or modified, i.e., in the
+        initilizer, in ``__imul__`` and ``__itruediv__`` for in-place
+        multiplication and division by another unit, as well as in
+        ``__array_finalize__`` for wrapping up views.  For Quantity, it just
+        sets the unit, but subclasses can override it to check that, e.g.,
+        a unit is consistent.  It should return ``self`` after modification.
+        """
+        self._unit = unit
+        return self
 
     def __reduce__(self):
         # patch to pickle Quantity objects (ndarray subclasses), see
@@ -672,9 +703,6 @@ class Quantity(np.ndarray):
         """
 
         return self._unit
-
-    # this ensures that if we do a view, __repr__ and __str__ do not balk
-    _unit = None
 
     @property
     def equivalencies(self):
@@ -817,8 +845,7 @@ class Quantity(np.ndarray):
         """In-place multiplication between `Quantity` objects and others."""
 
         if isinstance(other, (UnitBase, six.string_types)):
-            self._unit = other * self.unit
-            return self
+            return self._set_unit(other * self.unit)
 
         return super(Quantity, self).__imul__(other)
 
@@ -844,8 +871,7 @@ class Quantity(np.ndarray):
         """Inplace division between `Quantity` objects and other objects."""
 
         if isinstance(other, (UnitBase, six.string_types)):
-            self._unit = self.unit / other
-            return self
+            return self._set_unit(self.unit / other)
 
         return super(Quantity, self).__itruediv__(other)
 
@@ -1288,7 +1314,6 @@ class Quantity(np.ndarray):
                 out.__quantity_subclass__(unit)[0] is type(out)):
                 # Set out to ndarray view to prevent calling __array_prepare__.
                 kwargs['out'] = out.view(np.ndarray)
-
             else:
                 ok_class =  (out.__quantity_subclass__(out, unit)[0]
                              if isinstance(out, Quantity) else Quantity)
@@ -1300,8 +1325,7 @@ class Quantity(np.ndarray):
         if out is None:
             return self._new_view(value, unit)
         else:
-            out._unit = unit
-            return out
+            return out._set_unit(unit)
 
     def clip(self, a_min, a_max, out=None):
         return self._wrap_function(np.clip, self._to_own_unit(a_min),
@@ -1430,3 +1454,44 @@ class Quantity(np.ndarray):
         """
         out_array = np.insert(self.value, obj, self._to_own_unit(values), axis)
         return self._new_view(out_array)
+
+
+class SpecificTypeQuantity(Quantity):
+    """Superclass for Quantities of specific physical type.
+
+    Subclasses of these work just like :class:`~astropy.units.Quantity`, except
+    that they are for specific physical types (and may have methods that are
+    only appropriate for that type).  Astropy examples are
+    :class:`~astropy.coordinates.Angle` and
+    :class:`~astropy.coordinates.Distance`
+
+    At a minimum, subclasses should set ``_equivalent_unit`` to the unit
+    associated with the physical type.
+    """
+    # The unit for the specific physical type.  Instances can only be created
+    # with units that are equivalent to this.
+    _equivalent_unit = None
+
+    # The default unit used for views.  Even with `None`, views of arrays
+    # without units are possible, but will have an uninitalized units.
+    _unit = None
+
+    # Default unit for initialization through the constructor.
+    _default_unit = None
+
+    def __quantity_subclass__(self, unit):
+        if unit.is_equivalent(self._equivalent_unit):
+            return type(self), True
+        else:
+            return super(SpecificTypeQuantity,
+                         self).__quantity_subclass__(unit)[0], False
+
+    def _set_unit(self, unit):
+        if unit is None or not unit.is_equivalent(self._equivalent_unit):
+            raise UnitTypeError(
+                "{0} instances require units equivalent to '{1}'"
+                .format(type(self).__name__, self._equivalent_unit) +
+                (", but no unit was given." if unit is None else
+                 ", so cannot set it to '{0}'.".format(unit)))
+
+        return super(SpecificTypeQuantity, self)._set_unit(unit)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -401,7 +401,7 @@ class Quantity(np.ndarray):
                                 .format(function.__name__, type(self)))
 
             if self.__quantity_subclass__(result_unit)[0] is not type(self):
-                raise TypeError(
+                raise UnitTypeError(
                     "Cannot store output with unit '{0}' from {1} function "
                     "in {2} instance.  Use {3} instance instead."
                     .format(result_unit, function.__name__, type(self),
@@ -1326,9 +1326,9 @@ class Quantity(np.ndarray):
             else:
                 ok_class =  (out.__quantity_subclass__(out, unit)[0]
                              if isinstance(out, Quantity) else Quantity)
-                raise TypeError("out cannot be assigned to a {0} instance; "
-                                "use a {1} instance instead.".format(
-                                    out.__class__, ok_class))
+                raise UnitTypeError("out cannot be assigned to a {0} instance; "
+                                    "use a {1} instance instead.".format(
+                                        out.__class__, ok_class))
 
         value = function(self.view(np.ndarray), *args, **kwargs)
         if out is None:

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -378,19 +378,35 @@ class TestLogQuantityCreation(object):
 
 
 class TestLogQuantityViews(object):
+    def setup(self):
+        self.lq = u.Magnitude(np.arange(10.) * u.Jy)
+        self.lq2 = u.Magnitude(np.arange(5.))
+
     def test_value_view(self):
-        lq = u.Magnitude(np.arange(10.) * u.Jy)
-        lq_value = lq.value
+        lq_value = self.lq.value
         assert type(lq_value) is np.ndarray
         lq_value[2] = -1.
-        assert np.all(lq.value == lq_value)
+        assert np.all(self.lq.value == lq_value)
 
-        lq_fv = lq._function_view
+    def test_function_view(self):
+        lq_fv = self.lq._function_view
         assert type(lq_fv) is u.Quantity
-        assert lq_fv.unit is lq.unit.function_unit
+        assert lq_fv.unit is self.lq.unit.function_unit
         lq_fv[3] = -2. * lq_fv.unit
-        assert np.all(lq.value == lq_fv.value)
-        assert np.all(lq.value == lq_value)
+        assert np.all(self.lq.value == lq_fv.value)
+
+    def test_quantity_view(self):
+        # Cannot view as Quantity, since the unit cannot be represented.
+        with pytest.raises(TypeError):
+            self.lq.view(u.Quantity)
+        # But a dimensionless one is fine.
+        q2 = self.lq2.view(u.Quantity)
+        assert q2.unit is u.mag
+        assert np.all(q2.value == self.lq2.value)
+        lq3 = q2.view(u.Magnitude)
+        assert type(lq3.unit) is u.MagUnit
+        assert lq3.unit.physical_unit == u.dimensionless_unscaled
+        assert np.all(lq3 == self.lq2)
 
 
 class TestLogQuantitySlicing(object):

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -54,9 +54,7 @@ Converting to different units
 -----------------------------
 
 Like |quantity| objects, logarithmic quantities can be converted to different
-units using the :meth:`~astropy.units.function.FunctionQuantity.to` method.
-Here, if the requested unit is not a logarithmic unit, the object will be
-automatically converted to its physical unit::
+units, be it another logarithmic unit or a physical one::
 
     >>> logg = 5. * u.dex(u.cm / u.s**2)
     >>> logg.to(u.m / u.s**2)


### PR DESCRIPTION
We have two `Quantity` subclasses that are for specific physical types, `Angle` and `Distance`. These are each set up such that if operations change the unit, they loose their type. Currently, this has some loop-holes, however (which led me to label this as a bug, since it is unintended):
```
In [5]: a = Angle(10., 'deg')

In [6]: a *= 'm'

In [7]: a
Out[7]: <Angle 10.0 deg m>

In [8]: (10. * u.m).view(Angle)
Out[8]: <Angle 10.0 m>
```
The first commit in this PR closes these loopholes by ensuring that all setting of units goes through a single `_set_unit` method, which checks that a given unit is consistent with the class. It also moves common code from `Angle` and `Distance` to a new `SpecificTypeQuantity` subclass

Note that I also use this to also define a `DimensionlessQuantity` class, whose main difference from other classes is that if one does `array.view(DimensionlessQuantity)` the unit will automatically be dimensionless (rather than unset). I can remove this if need be to keep this just a pure bug-fix PR.

The second commit uses the new `_set_unit` also for function quantities (magnitudes, etc.), which turns out to rather greatly simplify the code there. As part of this, it now also ensures that those can only be viewed as regular quantities if their physical dimension is dimensionless unscaled.

cc @eteq (as it touches coordinates) and @astrofrog.