### PR TITLE
Make sure we re-download the IERS table if the URL has changed.

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -519,6 +519,10 @@ class IERS_Auto(IERS_A):
     """
     iers_table = None
 
+    # Keep track of the URL used - if the URL changes, we need to re-download
+    # the file. This can occur for example in tests which change iers_auto_url.
+    _iers_url = None
+
     @classmethod
     def open(cls):
         """If the configuration setting ``astropy.utils.iers.conf.auto_download``
@@ -544,11 +548,13 @@ class IERS_Auto(IERS_A):
         if not conf.auto_download:
             cls.iers_table = IERS.open()
 
-        if cls.iers_table is not None:
+        # If the URL has changed, we need to redownload the file
+        if cls.iers_table is not None and conf.iers_auto_url == cls._iers_url:
             return cls.iers_table
 
         try:
             filename = download_file(conf.iers_auto_url, cache=True)
+            cls._iers_url = conf.iers_auto_url
         except Exception as err:
             # Issue a warning here, perhaps user is offline.  An exception
             # will be raised downstream when actually trying to interpolate


### PR DESCRIPTION
This is the solution to the issues reported in #5051 (took a few hours to figure out...). I'm surprised you didn't see the issue when running the tests (I don't see how they could pass before this PR).

The issue is that tests run before ``astropy.utils.iers`` cause the IERS file to be downloaded, which sets ``IERS_Auto.iers_table``. When you then later change the URL to a local file in ``test_iers.py``, it did not try and get the local file because ``cls.iers_table is not None`` and it was then using the real downloaded file instead of the local file. This also explains why the test did not fail when running just the IERS tests. With this PR, if the URL has changed, the file is retrieved again.

Another solution would be to simply not cache ``.iers_table`` and rely only on the ``download_file`` caching mechanism.

@taldcroft - can you review this and let me know what you think?

cc @pllim