### PR TITLE
Handle empty search matches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -343,6 +343,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Ensure that ``search_around_sky`` and ``search_around_3d`` return
+    integer type index arrays for empty (non) matches. [#4877]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -343,9 +343,6 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
-  - Ensure that ``search_around_sky`` and ``search_around_3d`` return
-    integer type index arrays for empty (non) matches. [#4877]
-
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -1718,6 +1715,13 @@ Bug Fixes
 
   - Fix bug where with cds units enabled it was no longer possible to initialize
     an ``Angle``. [#5483]
+
+  - Ensure that ``search_around_sky`` and ``search_around_3d`` return
+    integer type index arrays for empty (non) matches. [#4877]
+
+  - Return an empty set of matches for ``search_around_sky`` and
+    ``search_around_3d`` when one or both of the input coordinate
+    arrays is empty. [#4875]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -245,8 +245,8 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
         for match in matches:
             idxs1.append(i)
             idxs2.append(match)
-    idxs1 = np.array(idxs1)
-    idxs2 = np.array(idxs2)
+    idxs1 = np.array(idxs1, dtype=np.int)
+    idxs2 = np.array(idxs2, dtype=np.int)
 
     if idxs1.size == 0:
         d2ds = u.Quantity([], u.deg)
@@ -354,8 +354,8 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
         for match in matches:
             idxs1.append(i)
             idxs2.append(match)
-    idxs1 = np.array(idxs1)
-    idxs2 = np.array(idxs2)
+    idxs1 = np.array(idxs1, dtype=np.int)
+    idxs2 = np.array(idxs2, dtype=np.int)
 
     if idxs1.size == 0:
         d2ds = u.Quantity([], u.deg)

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -226,6 +226,12 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
                          '``coord1.separation_3d(coord2) < distlimit`` to find '
                          'the coordinates near a scalar coordinate.')
 
+    if len(coords1) == 0 or len(coords2) == 0:
+        # Empty array input: return empty match
+        return (np.array([], dtype=np.int), np.array([], dtype=np.int),
+                u.Quantity([], u.deg),
+                u.Quantity([], u.dimensionless_unscaled))
+
     kdt2 = _get_cartesian_kdtree(coords2, storekdtree)
     cunit = coords2.cartesian.x.unit
 
@@ -320,6 +326,12 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
                          'coordinates, not scalars.  Instead, use '
                          '``coord1.separation(coord2) < seplimit`` to find the '
                          'coordinates near a scalar coordinate.')
+
+    if len(coords1) == 0 or len(coords2) == 0:
+        # Empty array input: return empty match
+        return (np.array([], dtype=np.int), np.array([], dtype=np.int),
+                u.Quantity([], u.deg),
+                u.Quantity([], u.dimensionless_unscaled))
 
     # we convert coord1 to match coord2's frame.  We do it this way
     # so that if the conversion does happen, the KD tree of coord2 at least gets

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -157,6 +157,28 @@ def test_search_around():
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
 
+    # Test when one or both of the coordinate arrays is empty, #4875
+    empty = ICRS(ra=[] * u.degree, dec=[] * u.degree, distance=[] * u.kpc)
+    idx1, idx2, d2d, d3d = search_around_sky(empty, coo2, 1*u.arcsec)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+    idx1, idx2, d2d, d3d = search_around_sky(coo1, empty, 1*u.arcsec)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+    empty = ICRS(ra=[] * u.degree, dec=[] * u.degree, distance=[] * u.kpc)
+    idx1, idx2, d2d, d3d = search_around_sky(empty, empty[:], 1*u.arcsec)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+    idx1, idx2, d2d, d3d = search_around_3d(empty, coo2, 1*u.m)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+    idx1, idx2, d2d, d3d = search_around_3d(coo1, empty, 1*u.m)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+    idx1, idx2, d2d, d3d = search_around_3d(empty, empty[:], 1*u.m)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 @pytest.mark.skipif(str('OLDER_SCIPY'))

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -148,6 +148,15 @@ def test_search_around():
     assert list(zip(idx1_sm, idx2_sm)) == [(0, 1), (0, 2)]
     assert_allclose(d2d_sm, [2, 1]*u.deg)
 
+    # Test for the non-matches, #4877
+    coo1 = ICRS([4.1, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 5] * u.kpc)
+    idx1, idx2, d2d, d3d = search_around_sky(coo1, coo2, 1*u.arcsec)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+    idx1, idx2, d2d, d3d = search_around_3d(coo1, coo2, 1*u.m)
+    assert idx1.size == idx2.size == d2d.size == d3d.size == 0
+    assert idx1.dtype == idx2.dtype == np.int
+
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 @pytest.mark.skipif(str('OLDER_SCIPY'))


### PR DESCRIPTION
This fixes #4875 and #4877: empty matches or empty input coordinate lists to `search_around_*` are now handled properly.
