### PR TITLE
Fix py 3.4.x failures by expanding namedtuple_asdict workaround

### DIFF
--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -147,10 +147,12 @@ except ImportError:
 
 
 # For unclear reasons, the `_asdict` method of namedtuple produces an empty
-# dictionary if the namedtuple is a subclass of another namedtuple... But *onlt*
-# in py 3.3.  >3.4 or 2.7 seem to work just fine.  So we provide this for
-# compatibility as long as 3.3 is supported.
-if sys.version_info[:2] == (3, 3):
+# dictionary if the namedtuple is a subclass of another namedtuple... But
+# *only* in py 3.3.  >3.4 or 2.7 seem to work just fine.  So we provide this
+# for compatibility as long as 3.3 is supported.
+# Furthermore, in python 3.4.x except for 3.4.4, `_asdict` produces only a
+# *partial* dictionary.  So we work around that case too.
+if sys.version_info[0] == 3 and sys.version_info[:3] < (3, 4, 4):
     def namedtuple_asdict(namedtuple):
         """
         The same as ``namedtuple._adict()``, but fixed to work even when


### PR DESCRIPTION
This is PR fixes #5079 .  The root cause there is that apparently py 3.4.x (except for 3.4.4) have a bug in the `namedtuple._asdict()` method that causes it to not return a fully-populated dictionary *if* you subclass `namedtuple`.  This is similar but subtly different from the bugs in the 3.3.x series: there, `_asdict()` yielded an *empty* dictionary, not a populated but incorrect one.  `namedtuple._asdict()` is used by some of the new  machinery for the sky offset frames, so that's why #5079 causes a bunch of errors there. 

At any rate, because of the 3.3.x bug, there's already a workaround (introduced in #4909), so all this PR does is expand that to include python 3.x versions < 3.4.3 rather than only the 3.3.x series as it did before.

Travis won't really test this because it's only in 3.4.3 and not 3.4.4 (which is the 3.4.x version travis checks).  I've got the tests passing locally in 3.4.3, but as a sanity check, @matthew-brett or @bsipocz, can you double-check me to make sure this fixes #5079 for you?