### PR TITLE
make sure ImageHDU.data is settable.

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -246,7 +246,7 @@ class _ImageBaseHDU(_ValidHDU):
 
     @data.setter
     def data(self, data):
-        if 'data' in self.__dict__:
+        if 'data' in self.__dict__ and self.__dict__['data'] is not None:
             if self.__dict__['data'] is data:
                 return
             else:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1553,3 +1553,12 @@ class TestCompressedImage(FitsTestCase):
             # There's no good reason to have a duplicate keyword, but
             # technically it isn't invalid either :/
             assert hdul[1]._header.count('ZTENSION') == 2
+
+
+def test_set_data():
+    """
+    Test data assignment - issue #5087
+    """
+    im = fits.ImageHDU()
+    ar = np.arange(12)
+    im.data = ar


### PR DESCRIPTION
This is a fix for #5087 - ensures that `ImageHDU.data` is settable when it started as `None`.
I am setting the `Affects-release` label since this needs to be fixed on the 1.2 branch.

@mwcraig Is this the right place to make the check?

Edit: closes #5087 