### PR TITLE
Install dependencies via setup tools. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -345,7 +345,7 @@ New Features
     other than "docs". [#4748]
 
   - Install dependencies specified by the install_requires and tests_require
-    keywords via setuptools. [astropy-helpers #212]
+    keywords via setuptools. [#5092, astropy-helpers #212]
 
 - ``astropy.time``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -344,6 +344,9 @@ New Features
   - Enable test runner to obtain documentation source files from directory
     other than "docs". [#4748]
 
+  - Install dependencies specified by the install_requires and tests_require
+    keywords via setuptools. [astropy-helpers #212]
+
 - ``astropy.time``
 
   - Added caching of scale and format transformations for improved performance.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -344,8 +344,10 @@ New Features
   - Enable test runner to obtain documentation source files from directory
     other than "docs". [#4748]
 
-  - Install dependencies specified by the install_requires and tests_require
-    keywords via setuptools. [#5092, astropy-helpers #212]
+  - Install both runtime and test dependencies when running the
+    ./setup.py test command. These dependencies are specified by the
+    install_requires and tests_require keywords via setuptools.
+    [#5092, astropy-helpers #212]
 
 - ``astropy.time``
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -148,6 +148,7 @@ class AstropyTest(Command, object):
         """
         Run the tests!
         """
+        # Install the runtime and test dependencies.
         if self.distribution.install_requires:
             self.distribution.fetch_build_eggs(
                 self.distribution.install_requires)

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -148,6 +148,11 @@ class AstropyTest(Command, object):
         """
         Run the tests!
         """
+        if self.distribution.install_requires:
+            self.distribution.fetch_build_eggs(
+                self.distribution.install_requires)
+        if self.distribution.tests_require:
+            self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
         # Ensure there is a doc path
         if self.docs_path is None:


### PR DESCRIPTION
This change would automatically install dependencies specified by the install_requires and tests_require via setuptools. This implements to astropy/astropy-helpers#212

