### PR TITLE
Adding NUMPY_LT_1_10_4 to utils.compat

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from ... import units as u
 from ...tests.helper import pytest
-from ...utils.compat import (NUMPY_LT_1_8,
-                             NUMPY_LT_1_9_1, NUMPY_LT_1_10)
+from ...utils.compat import (NUMPY_LT_1_8, NUMPY_LT_1_9_1,
+                             NUMPY_LT_1_10, NUMPY_LT_1_10_4)
 
 
 class TestQuantityArrayCopy(object):
@@ -359,7 +359,8 @@ class TestQuantityStatsFuncs(object):
         assert q3.value == np.dot(q1.value, q2.value)
         assert q3.unit == u.m * u.s
 
-    @pytest.mark.xfail(NUMPY_LT_1_10, reason="Numpy 1.10 or later is required")
+    @pytest.mark.xfail(NUMPY_LT_1_10_4,
+                       reason="Numpy 1.10.4 or later is required")
     def test_trace_func(self):
 
         q = np.array([[1.,2.],[3.,4.]]) * u.m

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,7 @@ from ...utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_8', 'NUMPY_LT_1_9', 'NUMPY_LT_1_9_1', 'NUMPY_LT_1_10',
-           'NUMPY_LT_1_11']
+           'NUMPY_LT_1_10_4', 'NUMPY_LT_1_11']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -19,6 +19,7 @@ NUMPY_LT_1_8 = not minversion('numpy', '1.8.0')
 NUMPY_LT_1_9 = not minversion('numpy', '1.9.0')
 NUMPY_LT_1_9_1 = not minversion('numpy', '1.9.1')
 NUMPY_LT_1_10 = not minversion('numpy', '1.10.0')
+NUMPY_LT_1_10_4 = not minversion('numpy', '1.10.4')
 NUMPY_LT_1_11 = not minversion('numpy', '1.11.0')
 
 


### PR DESCRIPTION
to be able to xfail the test in units that require np >=v1.10.4

fixes #5077

cc @mhvk 