### PR TITLE
Update tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = {py27,py33,py34,py35}-{base,all}
 
 [testenv]
 deps =
-    numpy
     Cython
     pytest-xdist
+    {py27,py33,py34,py35}-base: numpy
+    {py27,py33,py34,py35}-all: -rpip-requirements-dev
 commands = python setup.py test {posargs:--remote-data}
 sitepackages = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py27,py33,py34,py35
 
 [testenv]
 deps =
     numpy
     Cython
     pytest-xdist
-commands = python setup.py test {posargs}
+commands = python setup.py test {posargs:--remote-data}
 sitepackages = False


### PR DESCRIPTION
- Remove Python 2.6
- Add `--remote-data` by default (can be overridden with posargs)
- Add tox environments with all dependencies (using the recently added `pip-requirements-dev`)