### PR TITLE
Remove use of np.matrxi in coordinates, version 1

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -672,19 +672,18 @@ class Longitude(Angle):
 
 def rotation_matrix(angle, axis='z', unit=None):
     """
-    Generate a 3x3 cartesian rotation matrix in for rotation about
-    a particular axis.
+    Generate rotation matrices for rotation by some angle(s).
 
     Parameters
     ----------
     angle : convertible to `Angle`
-        The amount of rotation this matrix should represent.
+        The amount of rotation the matrices should represent.
 
-    axis : str or 3-sequence
-        Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying an
-        axis to rotate about. If ``'x'``, ``'y'``, or ``'z'``, the
-        rotation sense is counterclockwise looking down the + axis
-        (e.g. positive rotations obey left-hand-rule).
+    axis : str, or array-like
+        Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying the axis to
+        rotate about. If ``'x'``, ``'y'``, or ``'z'``, the rotation sense is
+        counterclockwise looking down the + axis (e.g. positive rotations obey
+        left-hand-rule).  If given as an array, the last dimension should be 3.
 
     unit : UnitBase, optional
         If ``angle`` does not have associated units, they are in this
@@ -704,35 +703,37 @@ def rotation_matrix(angle, axis='z', unit=None):
     c = np.cos(angle)
 
     # use optimized implementations for x/y/z
-    if axis == 'z':
-        return np.matrix(((c, s, 0),
-                          (-s, c, 0),
-                          (0, 0, 1)))
-    elif axis == 'y':
-        return np.matrix(((c, 0, -s),
-                          (0, 1, 0),
-                          (s, 0, c)))
-    elif axis == 'x':
-        return np.matrix(((1, 0, 0),
-                          (0, c, s),
-                          (0, -s, c)))
-    else:
+    try:
+        i = 'xyz'.index(axis)
+    except TypeError:
         axis = np.asarray(axis)
-        axis = axis / np.sqrt((axis * axis).sum())
+        axis = axis / np.sqrt((axis * axis).sum(axis=-1, keepdims=True))
+        R = (axis[..., np.newaxis] * axis[..., np.newaxis, :] *
+             (1. - c)[..., np.newaxis, np.newaxis])
 
-        R = np.diag((c, c, c))
-        R += np.outer(axis, axis) * (1. - c)
-        axis *= s
-        R += np.array([[0., axis[2], -axis[1]],
-                       [-axis[2], 0., axis[0]],
-                       [axis[1], -axis[0], 0.]])
-        return R.view(np.matrix)
+        for i in range(0, 3):
+            R[..., i, i] += c
+            a1 = (i + 1) % 3
+            a2 = (i + 2) % 3
+            R[..., a1, a2] += axis[..., i] * s
+            R[..., a2, a1] -= axis[..., i] * s
+
+    else:
+        a1 = (i + 1) % 3
+        a2 = (i + 2) % 3
+        R = np.zeros(angle.shape + (3, 3))
+        R[..., i, i] = 1.
+        R[..., a1, a1] = c
+        R[..., a1, a2] = s
+        R[..., a2, a1] = -s
+        R[..., a2, a2] = c
+
+    return R
 
 
 def angle_axis(matrix):
     """
-    Computes the angle of rotation and the rotation axis for a given rotation
-    matrix.
+    Angle of rotation and rotation axis for a given rotation matrix.
 
     Parameters
     ----------
@@ -747,12 +748,15 @@ def angle_axis(matrix):
     axis : array (length 3)
         The (normalized) axis of rotation for this matrix.
     """
-    m = np.asmatrix(matrix)
-    if m.shape != (3, 3):
+    m = np.asanyarray(matrix)
+    if m.shape[-2:] != (3, 3):
         raise ValueError('matrix is not 3x3')
 
-    axis = np.array((m[2, 1] - m[1, 2], m[0, 2] - m[2, 0], m[1, 0] - m[0, 1]))
-    r = np.sqrt((axis * axis).sum())
-    angle = np.arctan2(r, np.trace(m) - 1)
-
+    axis = np.zeros(m.shape[:-1])
+    axis[..., 0] = m[..., 2, 1] - m[..., 1, 2]
+    axis[..., 1] = m[..., 0, 2] - m[..., 2, 0]
+    axis[..., 2] = m[..., 1, 0] - m[..., 0, 1]
+    r = np.sqrt((axis * axis).sum(-1, keepdims=True))
+    angle = np.arctan2(r[..., 0],
+                       m[..., 0, 0] + m[..., 1, 1] + m[..., 2, 2] - 1.)
     return Angle(angle, u.radian), -axis / r

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -17,7 +17,7 @@ from ..extern import six
 from . import angle_utilities as util
 from .. import units as u
 from ..utils import isiterable
-
+from ..utils.compat import NUMPY_LT_1_10
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
 
@@ -669,6 +669,29 @@ class Longitude(Angle):
 
 #<----------------------------------Rotations--------------------------------->
 
+if NUMPY_LT_1_10:
+    def matmul(a, b, out=None):
+        if out is None:
+            kwargs = {}
+        else:
+            kwargs = {'out', out}
+        return np.einsum('...ij,...jk->...ik', a, b, **kwargs)
+
+else:
+    from numpy import matmul
+
+
+class AstropyMatrix(np.ndarray):
+    def __mul__(self, other):
+        if isinstance(other, AstropyMatrix):
+            return matmul(self, other)
+        else:
+            return super(AstropyMatrix, self).__mul__(other)
+
+    @property
+    def T(self):
+        return self.swapaxes(-2, -1)
+
 
 def rotation_matrix(angle, axis='z', unit=None):
     """
@@ -728,7 +751,7 @@ def rotation_matrix(angle, axis='z', unit=None):
         R[..., a2, a1] = -s
         R[..., a2, a2] = c
 
-    return R
+    return R.view(AstropyMatrix)
 
 
 def angle_axis(matrix):

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -6,13 +6,10 @@ Contains the transformation functions for getting to/from ecliptic systems.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-import numpy as np
-
 from ... import units as u
-from ...utils.compat import NUMPY_LT_1_10
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform, DynamicMatrixTransform
-from ..angles import rotation_matrix
+from ..angles import rotation_matrix, matmul
 from ..representation import CartesianRepresentation
 from ... import _erfa as erfa
 
@@ -33,16 +30,7 @@ def _ecliptic_rotation_matrix(equinox):
     the dot product of the resulting matrices, finally combining
     into a new array.
     """
-    try:
-        rmat = np.array([rotation_matrix(this_obl, 'x') for this_obl in obl])
-        if NUMPY_LT_1_10:
-            result = np.einsum('...ij,...jk->...ik', rmat, rnpb)
-        else:
-            result = np.matmul(rmat, rnpb)
-    except:
-        # must be a scalar obliquity
-        result = np.asarray(np.dot(rotation_matrix(obl, 'x'), rnpb))
-    return result
+    return matmul(rotation_matrix(obl, 'x'), rnpb)
 
 
 @frame_transform_graph.transform(FunctionTransform, GCRS, GeocentricTrueEcliptic)

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
-
+from ..angles import AstropyMatrix
 from .fk4 import FK4NoETerms
 from .fk5 import FK5
 from .utils import EQUINOX_B1950, EQUINOX_J2000
@@ -18,15 +18,17 @@ from .utils import EQUINOX_B1950, EQUINOX_J2000
 
 # FK5 to/from FK4 ------------------->
 # B1950->J2000 matrix from Murray 1989 A&A 218,325 eqn 28
-_B1950_TO_J2000_M = \
-    np.mat([[0.9999256794956877, -0.0111814832204662, -0.0048590038153592],
-            [0.0111814832391717,  0.9999374848933135, -0.0000271625947142],
-            [0.0048590037723143, -0.0000271702937440,  0.9999881946023742]])
+_B1950_TO_J2000_M = np.array(
+    [[0.9999256794956877, -0.0111814832204662, -0.0048590038153592],
+     [0.0111814832391717,  0.9999374848933135, -0.0000271625947142],
+     [0.0048590037723143, -0.0000271702937440,  0.9999881946023742]
+    ]).view(AstropyMatrix)
 
-_FK4_CORR = \
-    np.mat([[-0.0026455262, -1.1539918689, +2.1111346190],
-            [+1.1540628161, -0.0129042997, +0.0236021478],
-            [-2.1112979048, -0.0056024448, +0.0102587734]]) * 1.e-6
+_FK4_CORR = np.array(
+    [[-0.0026455262, -1.1539918689, +2.1111346190],
+     [+1.1540628161, -0.0129042997, +0.0236021478],
+     [-2.1112979048, -0.0056024448, +0.0102587734]
+    ]).view(AstropyMatrix) * 1.e-6
 
 def _fk4_B_matrix(obstime):
     """

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -819,7 +819,7 @@ def test_rotation_matrix():
     assert_allclose(rotation_matrix(-30*u.deg, 'z'),
                     rotation_matrix(-30*u.deg, [0, 0, 1]))
 
-    assert_allclose(np.dot(rotation_matrix(180*u.deg, [1, 1, 0]).A, [1, 0, 0]),
+    assert_allclose(np.dot(rotation_matrix(180*u.deg, [1, 1, 0]), [1, 0, 0]),
                     [0, 1, 0], atol=1e-12)
 
     #make sure it also works for very small angles


### PR DESCRIPTION
This is the first of two possible ways to remove the use of `np.matrix` in `coordinates` (see #5088).

In this PR, the matrices are replaced with a new `AstropyMatrix` class, which still overrides `*` to do matrix multiplication if the other object is a `AstropyMatrix` as well. It also defines `.T` to just transpose the last two axes. With that, there are minimal changes to the transformations proper, and it should be reasonably straightforward to get general broadcasting to work (but not yet tried...).