### PR TITLE
Remove use of np.matrix in coordinates, version 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,12 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - The use of ``np.matrix`` instances in the transformations has been
+    deprecated, since this class does not allow stacks of matrices.  As a
+    result, the semi-public functions ``angles.rotation_matrix`` and
+    ``angles.angle_axis`` are also deprecated, in favour of the new routines
+    with the same name in ``coordinates.matrix_utilities``. [#5104]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -17,7 +17,6 @@ from ..extern import six
 from . import angle_utilities as util
 from .. import units as u
 from ..utils import isiterable
-from ..utils.compat import NUMPY_LT_1_10
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
 
@@ -652,19 +651,6 @@ class Longitude(Angle):
         return obj
 
 #<----------------------------------Rotations--------------------------------->
-
-if NUMPY_LT_1_10:
-    def matmul(a, b, out=None):
-        if out is None:
-            kwargs = {}
-        else:
-            kwargs = {'out', out}
-        return np.einsum('...ij,...jk->...ik', a, b, **kwargs)
-
-else:
-    from numpy import matmul
-
-
 def rotation_matrix(angle, axis='z', unit=None):
     """
     Generate rotation matrices for rotation by some angle(s).

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -17,7 +17,7 @@ from ..extern import six
 from . import angle_utilities as util
 from .. import units as u
 from ..utils import isiterable
-
+from ..utils.compat import NUMPY_LT_1_10
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
 
@@ -652,6 +652,17 @@ class Longitude(Angle):
         return obj
 
 #<----------------------------------Rotations--------------------------------->
+
+if NUMPY_LT_1_10:
+    def matmul(a, b, out=None):
+        if out is None:
+            kwargs = {}
+        else:
+            kwargs = {'out', out}
+        return np.einsum('...ij,...jk->...ik', a, b, **kwargs)
+
+else:
+    from numpy import matmul
 
 
 def rotation_matrix(angle, axis='z', unit=None):

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -651,20 +651,36 @@ class Longitude(Angle):
         return obj
 
 #<----------------------------------Rotations--------------------------------->
+# The main routines have been moved to matrix_utilities.  The definitions here
+# are for backward compatibility.
+from . import matrix_utilities
+from ..utils.decorators import deprecated
+
+_DEPRECATION_MESSAGE="""
+Numpy matrix instances are no longer used to represent rotation matrices, since
+they do not allow one to represent stacks of matrices. Instead, plain arrays
+are used. Instead of %(func)s, use %(alternative)s.
+For matrix multiplication and tranposes, it is suggested to use
+:func:`~astropy.coordinates.matrix_utilities.matrix_product` and
+:func:`~astropy.coordinates.matrix_utilities.matrix_transpose`, respectively.
+"""
+@deprecated(since='1.3', message=_DEPRECATION_MESSAGE, alternative=':func:'
+            '`~astropy.coordinates.matrix_utilities.rotation_matrix`')
 def rotation_matrix(angle, axis='z', unit=None):
     """
-    Generate rotation matrices for rotation by some angle(s).
+    Generate a 3x3 cartesian rotation matrix in for rotation about
+    a particular axis.
 
     Parameters
     ----------
     angle : convertible to `Angle`
-        The amount of rotation the matrices should represent.
+        The amount of rotation this matrix should represent.
 
-    axis : str, or array-like
-        Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying the axis to
-        rotate about. If ``'x'``, ``'y'``, or ``'z'``, the rotation sense is
-        counterclockwise looking down the + axis (e.g. positive rotations obey
-        left-hand-rule).  If given as an array, the last dimension should be 3.
+    axis : str or 3-sequence
+        Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying an
+        axis to rotate about. If ``'x'``, ``'y'``, or ``'z'``, the
+        rotation sense is counterclockwise looking down the + axis
+        (e.g. positive rotations obey left-hand-rule).
 
     unit : UnitBase, optional
         If ``angle`` does not have associated units, they are in this
@@ -675,46 +691,15 @@ def rotation_matrix(angle, axis='z', unit=None):
     rmat: `numpy.matrix`
         A unitary rotation matrix.
     """
-    if unit is None:
-        unit = u.degree
-
-    angle = Angle(angle, unit=unit)
-
-    s = np.sin(angle)
-    c = np.cos(angle)
-
-    # use optimized implementations for x/y/z
-    try:
-        i = 'xyz'.index(axis)
-    except TypeError:
-        axis = np.asarray(axis)
-        axis = axis / np.sqrt((axis * axis).sum(axis=-1, keepdims=True))
-        R = (axis[..., np.newaxis] * axis[..., np.newaxis, :] *
-             (1. - c)[..., np.newaxis, np.newaxis])
-
-        for i in range(0, 3):
-            R[..., i, i] += c
-            a1 = (i + 1) % 3
-            a2 = (i + 2) % 3
-            R[..., a1, a2] += axis[..., i] * s
-            R[..., a2, a1] -= axis[..., i] * s
-
-    else:
-        a1 = (i + 1) % 3
-        a2 = (i + 2) % 3
-        R = np.zeros(angle.shape + (3, 3))
-        R[..., i, i] = 1.
-        R[..., a1, a1] = c
-        R[..., a1, a2] = s
-        R[..., a2, a1] = -s
-        R[..., a2, a2] = c
-
-    return R
+    return matrix_utilities.rotation_matrix(angle, axis, unit).view(np.matrix)
 
 
+@deprecated(since='1.3', message=_DEPRECATION_MESSAGE, alternative=':func:'
+            '`~astropy.coordinates.matrix_utilities.angle_axis`')
 def angle_axis(matrix):
     """
-    Angle of rotation and rotation axis for a given rotation matrix.
+    Computes the angle of rotation and the rotation axis for a given rotation
+    matrix.
 
     Parameters
     ----------
@@ -729,15 +714,5 @@ def angle_axis(matrix):
     axis : array (length 3)
         The (normalized) axis of rotation for this matrix.
     """
-    m = np.asanyarray(matrix)
-    if m.shape[-2:] != (3, 3):
-        raise ValueError('matrix is not 3x3')
-
-    axis = np.zeros(m.shape[:-1])
-    axis[..., 0] = m[..., 2, 1] - m[..., 1, 2]
-    axis[..., 1] = m[..., 0, 2] - m[..., 2, 0]
-    axis[..., 2] = m[..., 1, 0] - m[..., 0, 1]
-    r = np.sqrt((axis * axis).sum(-1, keepdims=True))
-    angle = np.arctan2(r[..., 0],
-                       m[..., 0, 0] + m[..., 1, 1] + m[..., 2, 2] - 1.)
-    return Angle(angle, u.radian), -axis / r
+    m = np.asmatrix(matrix)
+    return matrix_utilities.angle_axis(m.view(np.ndarray))

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 from ... import units as u
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform, DynamicMatrixTransform
-from ..angles import rotation_matrix
+from ..matrix_utilities import rotation_matrix
 from ..representation import CartesianRepresentation
 from ... import _erfa as erfa
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -9,14 +9,15 @@ from __future__ import (absolute_import, unicode_literals, division,
 from ... import units as u
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform, DynamicMatrixTransform
-from ..matrix_utilities import rotation_matrix
+from ..matrix_utilities import (rotation_matrix,
+                                matrix_product, matrix_transpose)
 from ..representation import CartesianRepresentation
 from ... import _erfa as erfa
 
 from .icrs import ICRS
 from .gcrs import GCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
-from .utils import get_jd12, matrix_product, matrix_transpose
+from .utils import get_jd12
 from ..errors import UnitsError
 
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -6,13 +6,10 @@ Contains the transformation functions for getting to/from ecliptic systems.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-import numpy as np
-
 from ... import units as u
-from ...utils.compat import NUMPY_LT_1_10
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform, DynamicMatrixTransform
-from ..angles import rotation_matrix
+from ..angles import rotation_matrix, matmul
 from ..representation import CartesianRepresentation
 from ... import _erfa as erfa
 
@@ -33,16 +30,7 @@ def _ecliptic_rotation_matrix(equinox):
     the dot product of the resulting matrices, finally combining
     into a new array.
     """
-    try:
-        rmat = np.array([rotation_matrix(this_obl, 'x') for this_obl in obl])
-        if NUMPY_LT_1_10:
-            result = np.einsum('...ij,...jk->...ik', rmat, rnpb)
-        else:
-            result = np.matmul(rmat, rnpb)
-    except:
-        # must be a scalar obliquity
-        result = np.asarray(np.dot(rotation_matrix(obl, 'x'), rnpb))
-    return result
+    return matmul(rotation_matrix(obl, 'x'), rnpb)
 
 
 @frame_transform_graph.transform(FunctionTransform, GCRS, GeocentricTrueEcliptic)

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -16,8 +16,7 @@ from ... import _erfa as erfa
 from .icrs import ICRS
 from .gcrs import GCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
-from .utils import (cartrepr_from_matmul, get_jd12,
-                    matrix_product, matrix_transpose)
+from .utils import get_jd12, matrix_product, matrix_transpose
 from ..errors import UnitsError
 
 
@@ -34,14 +33,14 @@ def gcrs_to_geoecliptic(gcrs_coo, to_frame):
     gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=to_frame.equinox))
 
     rmat = _ecliptic_rotation_matrix(to_frame.equinox)
-    newrepr = cartrepr_from_matmul(rmat, gcrs_coo2)
+    newrepr = gcrs_coo2.cartesian.transform(rmat)
     return to_frame.realize_frame(newrepr)
 
 
 @frame_transform_graph.transform(FunctionTransform, GeocentricTrueEcliptic, GCRS)
 def geoecliptic_to_gcrs(from_coo, gcrs_frame):
     rmat = _ecliptic_rotation_matrix(from_coo.equinox)
-    newrepr = cartrepr_from_matmul(rmat, from_coo, transpose=True)
+    newrepr = from_coo.cartesian.transform(matrix_transpose(rmat))
     gcrs = GCRS(newrepr, obstime=from_coo.equinox)
 
     # now do any needed offsets (no-op if same obstime and 0 pos/vel)
@@ -78,8 +77,7 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     # now compute the matrix to precess to the right orientation
     rmat = _ecliptic_rotation_matrix(to_frame.equinox)
 
-    # it's not really ICRS because of the offset, but this is digestible by cartrepr_from_matmul
-    newrepr = cartrepr_from_matmul(rmat, ICRS(CartesianRepresentation(heliocart.T)))
+    newrepr = CartesianRepresentation(heliocart.T).transform(rmat)
     return to_frame.realize_frame(newrepr)
 
 
@@ -90,7 +88,7 @@ def helioecliptic_to_icrs(from_coo, to_frame):
 
     # first un-precess from ecliptic to ICRS orientation
     rmat = _ecliptic_rotation_matrix(from_coo.equinox)
-    intermed_repr = cartrepr_from_matmul(rmat, from_coo, transpose=True)
+    intermed_repr = from_coo.cartesian.transform(matrix_transpose(rmat))
 
     # now offset back to barycentric, which is the correct center for ICRS
     pvh, pvb = erfa.epv00(*get_jd12(from_coo.equinox, 'tdb'))

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
-
+from ..angles import AstropyMatrix
 from .fk4 import FK4NoETerms
 from .fk5 import FK5
 from .utils import EQUINOX_B1950, EQUINOX_J2000
@@ -18,15 +18,17 @@ from .utils import EQUINOX_B1950, EQUINOX_J2000
 
 # FK5 to/from FK4 ------------------->
 # B1950->J2000 matrix from Murray 1989 A&A 218,325 eqn 28
-_B1950_TO_J2000_M = \
-    np.mat([[0.9999256794956877, -0.0111814832204662, -0.0048590038153592],
-            [0.0111814832391717,  0.9999374848933135, -0.0000271625947142],
-            [0.0048590037723143, -0.0000271702937440,  0.9999881946023742]])
+_B1950_TO_J2000_M = np.array(
+    [[0.9999256794956877, -0.0111814832204662, -0.0048590038153592],
+     [0.0111814832391717,  0.9999374848933135, -0.0000271625947142],
+     [0.0048590037723143, -0.0000271702937440,  0.9999881946023742]
+    ]).view(AstropyMatrix)
 
-_FK4_CORR = \
-    np.mat([[-0.0026455262, -1.1539918689, +2.1111346190],
-            [+1.1540628161, -0.0129042997, +0.0236021478],
-            [-2.1112979048, -0.0056024448, +0.0102587734]]) * 1.e-6
+_FK4_CORR = np.array(
+    [[-0.0026455262, -1.1539918689, +2.1111346190],
+     [+1.1540628161, -0.0129042997, +0.0236021478],
+     [-2.1112979048, -0.0056024448, +0.0102587734]
+    ]).view(AstropyMatrix) * 1.e-6
 
 def _fk4_B_matrix(obstime):
     """

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -7,9 +7,10 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import numpy as np
 
+from ..angles import matmul
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
-from ..angles import AstropyMatrix
+
 from .fk4 import FK4NoETerms
 from .fk5 import FK5
 from .utils import EQUINOX_B1950, EQUINOX_J2000
@@ -21,14 +22,12 @@ from .utils import EQUINOX_B1950, EQUINOX_J2000
 _B1950_TO_J2000_M = np.array(
     [[0.9999256794956877, -0.0111814832204662, -0.0048590038153592],
      [0.0111814832391717,  0.9999374848933135, -0.0000271625947142],
-     [0.0048590037723143, -0.0000271702937440,  0.9999881946023742]
-    ]).view(AstropyMatrix)
+     [0.0048590037723143, -0.0000271702937440,  0.9999881946023742]])
 
 _FK4_CORR = np.array(
     [[-0.0026455262, -1.1539918689, +2.1111346190],
      [+1.1540628161, -0.0129042997, +0.0236021478],
-     [-2.1112979048, -0.0056024448, +0.0102587734]
-    ]).view(AstropyMatrix) * 1.e-6
+     [-2.1112979048, -0.0056024448, +0.0102587734]]) * 1.e-6
 
 def _fk4_B_matrix(obstime):
     """
@@ -51,7 +50,7 @@ def fk4_no_e_to_fk5(fk4noecoord, fk5frame):
     pmat1 = fk4noecoord._precession_matrix(fk4noecoord.equinox, EQUINOX_B1950)
     pmat2 = fk5frame._precession_matrix(EQUINOX_J2000, fk5frame.equinox)
 
-    return pmat2 * B * pmat1
+    return matmul(matmul(pmat2, B), pmat1)
 
 
 # This transformation can't be static because the observation date is needed.
@@ -66,4 +65,4 @@ def fk5_to_fk4_no_e(fk5coord, fk4noeframe):
     pmat1 = fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
     pmat2 = fk4noeframe._precession_matrix(EQUINOX_B1950, fk4noeframe.equinox)
 
-    return pmat2 * B * pmat1
+    return matmul(matmul(pmat2, B), pmat1)

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -9,11 +9,12 @@ import numpy as np
 
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
+from ..matrix_utilities import matrix_product, matrix_transpose
+
 
 from .fk4 import FK4NoETerms
 from .fk5 import FK5
-from .utils import (EQUINOX_B1950, EQUINOX_J2000,
-                    matrix_product, matrix_transpose)
+from .utils import EQUINOX_B1950, EQUINOX_J2000
 
 
 # FK5 to/from FK4 ------------------->

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -3,13 +3,14 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix, matmul
+from ..angles import rotation_matrix
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 
 from .fk5 import FK5
 from .fk4 import FK4NoETerms
-from .utils import EQUINOX_B1950, EQUINOX_J2000
+from .utils import (EQUINOX_B1950, EQUINOX_J2000,
+                    matrix_product, matrix_transpose)
 from .galactic import Galactic
 
 
@@ -23,12 +24,12 @@ def fk5_to_gal(fk5coord, galframe):
     mat2 = rotation_matrix(90 - Galactic._ngp_J2000.dec.degree, 'y')
     mat3 = rotation_matrix(Galactic._ngp_J2000.ra.degree, 'z')
 
-    return matmul(matmul(matmul(mat1, mat2), mat3), pmat)
+    return matrix_product(mat1, mat2, mat3, pmat)
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, Galactic, FK5)
 def _gal_to_fk5(galcoord, fk5frame):
-    return fk5_to_gal(fk5frame, galcoord).T
+    return matrix_transpose(fk5_to_gal(fk5frame, galcoord))
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, FK4NoETerms, Galactic)
@@ -38,9 +39,9 @@ def fk4_to_gal(fk4coords, galframe):
     mat3 = rotation_matrix(Galactic._ngp_B1950.ra.degree, 'z')
     matprec = fk4coords._precession_matrix(fk4coords.equinox, EQUINOX_B1950)
 
-    return matmul(matmul(matmul(mat1, mat2), mat3), matprec)
+    return matrix_product(mat1, mat2, mat3, matprec)
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, Galactic, FK4NoETerms)
 def gal_to_fk4(galcoords, fk4frame):
-    return fk4_to_gal(fk4frame, galcoords).T
+    return matrix_transpose(fk4_to_gal(fk4frame, galcoords))

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -3,14 +3,14 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..matrix_utilities import rotation_matrix
+from ..matrix_utilities import (rotation_matrix,
+                                matrix_product, matrix_transpose)
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 
 from .fk5 import FK5
 from .fk4 import FK4NoETerms
-from .utils import (EQUINOX_B1950, EQUINOX_J2000,
-                    matrix_product, matrix_transpose)
+from .utils import EQUINOX_B1950, EQUINOX_J2000
 from .galactic import Galactic
 
 

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix
+from ..angles import rotation_matrix, matmul
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 
@@ -23,7 +23,7 @@ def fk5_to_gal(fk5coord, galframe):
     mat2 = rotation_matrix(90 - Galactic._ngp_J2000.dec.degree, 'y')
     mat3 = rotation_matrix(Galactic._ngp_J2000.ra.degree, 'z')
 
-    return mat1 * mat2 * mat3 * pmat
+    return matmul(matmul(matmul(mat1, mat2), mat3), pmat)
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, Galactic, FK5)
@@ -38,7 +38,7 @@ def fk4_to_gal(fk4coords, galframe):
     mat3 = rotation_matrix(Galactic._ngp_B1950.ra.degree, 'z')
     matprec = fk4coords._precession_matrix(fk4coords.equinox, EQUINOX_B1950)
 
-    return mat1 * mat2 * mat3 * matprec
+    return matmul(matmul(matmul(mat1, mat2), mat3), matprec)
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, Galactic, FK4NoETerms)

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix
+from ..matrix_utilities import rotation_matrix
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 import numpy as np
 
 from ... import units as u
-from ..angles import Angle
+from ..angles import Angle, rotation_matrix, matmul
 from ..representation import CartesianRepresentation, UnitSphericalRepresentation
 from ..baseframe import (BaseCoordinateFrame, FrameAttribute,
                          frame_transform_graph)
@@ -150,9 +150,6 @@ class Galactocentric(BaseCoordinateFrame):
 # ICRS to/from Galactocentric ----------------------->
 @frame_transform_graph.transform(FunctionTransform, ICRS, Galactocentric)
 def icrs_to_galactocentric(icrs_coord, galactocentric_frame):
-    from ..representation import CartesianRepresentation
-    from ..angles import rotation_matrix
-
     if isinstance(icrs_coord.data, UnitSphericalRepresentation):
         raise ConvertError("Transforming to a Galactocentric frame requires "
                            "a 3D coordinate, e.g. (angle, angle, distance) or"
@@ -163,13 +160,13 @@ def icrs_to_galactocentric(icrs_coord, galactocentric_frame):
     # define rotation matrix to align x(ICRS) with the vector to the Galactic center
     mat1 = rotation_matrix(-galactocentric_frame.galcen_dec, 'y')
     mat2 = rotation_matrix(galactocentric_frame.galcen_ra, 'z')
-    R1 = mat1 * mat2
+    R1 = matmul(mat1, mat2)
 
     # extra roll away from the Galactic x-z plane
     R2 = rotation_matrix(galactocentric_frame.get_roll0() - galactocentric_frame.roll, 'x')
 
     # construct transformation matrix
-    R = R2*R1
+    R = matmul(R2, R1)
 
     # some reshape hacks to handle ND arrays
     orig_shape = xyz.shape
@@ -188,9 +185,6 @@ def icrs_to_galactocentric(icrs_coord, galactocentric_frame):
 
 @frame_transform_graph.transform(FunctionTransform, Galactocentric, ICRS)
 def galactocentric_to_icrs(galactocentric_coord, icrs_frame):
-    from ..representation import CartesianRepresentation
-    from ..angles import rotation_matrix
-
     if isinstance(galactocentric_coord.data, UnitSphericalRepresentation):
         raise ConvertError("Transforming from a Galactocentric frame requires "
                            "a 3D coordinate, e.g. (angle, angle, distance) or"
@@ -212,13 +206,13 @@ def galactocentric_to_icrs(galactocentric_coord, icrs_frame):
     # define inverse rotation matrix that aligns x(ICRS) with the vector to the Galactic center
     mat1 = rotation_matrix(-galactocentric_coord.galcen_dec, 'y')
     mat2 = rotation_matrix(galactocentric_coord.galcen_ra, 'z')
-    R1 = mat1 * mat2
+    R1 = matmul(mat1, mat2)
 
     # extra roll away from the Galactic x-z plane
     R2 = rotation_matrix(galactocentric_coord.get_roll0() - galactocentric_coord.roll, 'x')
 
     # construct transformation matrix
-    R = R2*R1
+    R = matmul(R2, R1)
 
     # rotate into ICRS frame
     xyz = np.linalg.inv(R).dot(xyz.reshape(xyz.shape[0], np.prod(xyz.shape[1:]))).reshape(orig_shape)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ... import units as u
 from ..angles import Angle
-from ..matrix_utilities import rotation_matrix
+from ..matrix_utilities import rotation_matrix, matrix_product
 from ..representation import CartesianRepresentation, UnitSphericalRepresentation
 from ..baseframe import (BaseCoordinateFrame, FrameAttribute,
                          frame_transform_graph)
@@ -15,7 +15,6 @@ from ..transformations import FunctionTransform
 from ..errors import ConvertError
 
 from .icrs import ICRS
-from .utils import matrix_product
 
 # Measured by minimizing the difference between a plane of coordinates along
 #   l=0, b=[-90,90] and the Galactocentric x-z plane

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -6,7 +6,8 @@ from __future__ import (absolute_import, unicode_literals, division,
 import numpy as np
 
 from ... import units as u
-from ..angles import Angle, rotation_matrix
+from ..angles import Angle
+from ..matrix_utilities import rotation_matrix
 from ..representation import CartesianRepresentation, UnitSphericalRepresentation
 from ..baseframe import (BaseCoordinateFrame, FrameAttribute,
                          frame_transform_graph)

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -3,13 +3,14 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..matrix_utilities import rotation_matrix
+from ..matrix_utilities import (rotation_matrix,
+                                matrix_product, matrix_transpose)
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 
 from .fk5 import FK5
 from .icrs import ICRS
-from .utils import EQUINOX_J2000, matrix_product, matrix_transpose
+from .utils import EQUINOX_J2000
 
 
 def _icrs_to_fk5_matrix():

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -3,13 +3,13 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix, matmul
+from ..angles import rotation_matrix
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 
 from .fk5 import FK5
 from .icrs import ICRS
-from .utils import EQUINOX_J2000
+from .utils import EQUINOX_J2000, matrix_product, matrix_transpose
 
 
 def _icrs_to_fk5_matrix():
@@ -26,7 +26,7 @@ def _icrs_to_fk5_matrix():
     m2 = rotation_matrix(xi0, 'y')
     m3 = rotation_matrix(da0, 'z')
 
-    return matmul(matmul(m1, m2), m3)
+    return matrix_product(m1, m2, m3)
 # define this here because it only needs to be computed once
 _ICRS_TO_FK5_J2000_MAT = _icrs_to_fk5_matrix()
 
@@ -35,7 +35,7 @@ _ICRS_TO_FK5_J2000_MAT = _icrs_to_fk5_matrix()
 def icrs_to_fk5(icrscoord, fk5frame):
     # ICRS is by design very close to J2000 equinox
     pmat = fk5frame._precession_matrix(EQUINOX_J2000, fk5frame.equinox)
-    return matmul(pmat, _ICRS_TO_FK5_J2000_MAT)
+    return matrix_product(pmat, _ICRS_TO_FK5_J2000_MAT)
 
 
 # can't be static because the equinox is needed
@@ -43,4 +43,4 @@ def icrs_to_fk5(icrscoord, fk5frame):
 def fk5_to_icrs(fk5coord, icrsframe):
     # ICRS is by design very close to J2000 equinox
     pmat = fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
-    return matmul(_ICRS_TO_FK5_J2000_MAT.swapaxes(-2, -1), pmat)
+    return matrix_product(matrix_transpose(_ICRS_TO_FK5_J2000_MAT), pmat)

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix
+from ..matrix_utilities import rotation_matrix
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix
+from ..angles import rotation_matrix, matmul
 from ..baseframe import frame_transform_graph
 from ..transformations import DynamicMatrixTransform
 
@@ -26,7 +26,7 @@ def _icrs_to_fk5_matrix():
     m2 = rotation_matrix(xi0, 'y')
     m3 = rotation_matrix(da0, 'z')
 
-    return m1 * m2 * m3
+    return matmul(matmul(m1, m2), m3)
 # define this here because it only needs to be computed once
 _ICRS_TO_FK5_J2000_MAT = _icrs_to_fk5_matrix()
 
@@ -35,7 +35,7 @@ _ICRS_TO_FK5_J2000_MAT = _icrs_to_fk5_matrix()
 def icrs_to_fk5(icrscoord, fk5frame):
     # ICRS is by design very close to J2000 equinox
     pmat = fk5frame._precession_matrix(EQUINOX_J2000, fk5frame.equinox)
-    return pmat * _ICRS_TO_FK5_J2000_MAT
+    return matmul(pmat, _ICRS_TO_FK5_J2000_MAT)
 
 
 # can't be static because the equinox is needed
@@ -43,4 +43,4 @@ def icrs_to_fk5(icrscoord, fk5frame):
 def fk5_to_icrs(fk5coord, icrsframe):
     # ICRS is by design very close to J2000 equinox
     pmat = fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
-    return _ICRS_TO_FK5_J2000_MAT.T * pmat
+    return matmul(_ICRS_TO_FK5_J2000_MAT.swapaxes(-2, -1), pmat)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -12,12 +12,13 @@ import numpy as np
 
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform
+from ..matrix_utilities import matrix_transpose
 from ... import _erfa as erfa
 
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .utils import get_polar_motion, get_jd12, matrix_transpose
+from .utils import get_polar_motion, get_jd12
 
 # # first define helper functions
 def gcrs_to_cirs_mat(time):

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -12,13 +12,12 @@ import numpy as np
 
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform
-from .utils import cartrepr_from_matmul
 from ... import _erfa as erfa
 
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
-from .utils import get_polar_motion, get_jd12
+from .utils import get_polar_motion, get_jd12, matrix_transpose
 
 # # first define helper functions
 def gcrs_to_cirs_mat(time):
@@ -53,7 +52,7 @@ def gcrs_to_cirs(gcrs_coo, cirs_frame):
 
     #now get the pmatrix
     pmat = gcrs_to_cirs_mat(cirs_frame.obstime)
-    crepr = cartrepr_from_matmul(pmat, gcrs_coo2)
+    crepr = gcrs_coo2.cartesian.transform(pmat)
     return cirs_frame.realize_frame(crepr)
 
 
@@ -61,7 +60,7 @@ def gcrs_to_cirs(gcrs_coo, cirs_frame):
 def cirs_to_gcrs(cirs_coo, gcrs_frame):
     #compute the pmatrix, and then multiply by its transpose
     pmat = gcrs_to_cirs_mat(cirs_coo.obstime)
-    newrepr = cartrepr_from_matmul(pmat, cirs_coo, transpose=True)
+    newrepr = cirs_coo.cartesian.transform(matrix_transpose(pmat))
     gcrs = GCRS(newrepr, obstime=cirs_coo.obstime)
 
     #now do any needed offsets (no-op if same obstime and 0 pos/vel)
@@ -75,7 +74,7 @@ def cirs_to_itrs(cirs_coo, itrs_frame):
 
     #now get the pmatrix
     pmat = cirs_to_itrs_mat(itrs_frame.obstime)
-    crepr = cartrepr_from_matmul(pmat, cirs_coo2)
+    crepr = cirs_coo2.cartesian.transform(pmat)
     return itrs_frame.realize_frame(crepr)
 
 
@@ -83,7 +82,7 @@ def cirs_to_itrs(cirs_coo, itrs_frame):
 def itrs_to_cirs(itrs_coo, cirs_frame):
     #compute the pmatrix, and then multiply by its transpose
     pmat = cirs_to_itrs_mat(itrs_coo.obstime)
-    newrepr = cartrepr_from_matmul(pmat, itrs_coo, transpose=True)
+    newrepr = itrs_coo.cartesian.transform(matrix_transpose(pmat))
     cirs = CIRS(newrepr, obstime=itrs_coo.obstime)
 
     #now do any needed offsets (no-op if same obstime)
@@ -111,7 +110,7 @@ def gcrs_to_precessedgeo(from_coo, to_frame):
 
     # now precess to the requested equinox
     pmat = gcrs_precession_mat(to_frame.equinox)
-    crepr = cartrepr_from_matmul(pmat, gcrs_coo)
+    crepr = gcrs_coo.cartesian.transform(pmat)
     return to_frame.realize_frame(crepr)
 
 
@@ -119,7 +118,7 @@ def gcrs_to_precessedgeo(from_coo, to_frame):
 def precessedgeo_to_gcrs(from_coo, to_frame):
     # first un-precess
     pmat = gcrs_precession_mat(from_coo.equinox)
-    crepr = cartrepr_from_matmul(pmat, from_coo, transpose=True)
+    crepr = from_coo.cartesian.transform(matrix_transpose(pmat))
     gcrs_coo = GCRS(crepr, obstime=to_frame.obstime,
                            obsgeoloc=to_frame.obsgeoloc,
                            obsgeovel=to_frame.obsgeovel)

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -9,7 +9,7 @@ from ..transformations import DynamicMatrixTransform, FunctionTransform
 from ..baseframe import (CoordinateAttribute, QuantityFrameAttribute,
                          frame_transform_graph, RepresentationMapping,
                          BaseCoordinateFrame)
-from ..angles import rotation_matrix
+from ..matrix_utilities import rotation_matrix
 from .utils import matrix_product, matrix_transpose
 from ...utils.compat import namedtuple_asdict
 

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -9,7 +9,7 @@ from ..transformations import DynamicMatrixTransform, FunctionTransform
 from ..baseframe import (CoordinateAttribute, QuantityFrameAttribute,
                          frame_transform_graph, RepresentationMapping,
                          BaseCoordinateFrame)
-from ..angles import rotation_matrix
+from ..angles import rotation_matrix, matmul
 from ...utils.compat import namedtuple_asdict
 
 _skyoffset_cache = {}
@@ -129,7 +129,7 @@ def make_skyoffset_cls(framecls):
         mat1 = rotation_matrix(-skyoffset_frame.rotation, 'x')
         mat2 = rotation_matrix(-origin.lat, 'y')
         mat3 = rotation_matrix(origin.lon, 'z')
-        R = mat1 * mat2 * mat3
+        R = matmul(matmul(mat1, mat2), mat3)
         return R
 
     @frame_transform_graph.transform(DynamicMatrixTransform, _SkyOffsetFramecls, framecls)

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -9,8 +9,8 @@ from ..transformations import DynamicMatrixTransform, FunctionTransform
 from ..baseframe import (CoordinateAttribute, QuantityFrameAttribute,
                          frame_transform_graph, RepresentationMapping,
                          BaseCoordinateFrame)
-from ..matrix_utilities import rotation_matrix
-from .utils import matrix_product, matrix_transpose
+from ..matrix_utilities import (rotation_matrix,
+                                matrix_product, matrix_transpose)
 from ...utils.compat import namedtuple_asdict
 
 _skyoffset_cache = {}

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -9,7 +9,8 @@ from ..transformations import DynamicMatrixTransform, FunctionTransform
 from ..baseframe import (CoordinateAttribute, QuantityFrameAttribute,
                          frame_transform_graph, RepresentationMapping,
                          BaseCoordinateFrame)
-from ..angles import rotation_matrix, matmul
+from ..angles import rotation_matrix
+from .utils import matrix_product, matrix_transpose
 from ...utils.compat import namedtuple_asdict
 
 _skyoffset_cache = {}
@@ -129,8 +130,7 @@ def make_skyoffset_cls(framecls):
         mat1 = rotation_matrix(-skyoffset_frame.rotation, 'x')
         mat2 = rotation_matrix(-origin.lat, 'y')
         mat3 = rotation_matrix(origin.lon, 'z')
-        R = matmul(matmul(mat1, mat2), mat3)
-        return R
+        return matrix_product(mat1, mat2, mat3)
 
     @frame_transform_graph.transform(DynamicMatrixTransform, _SkyOffsetFramecls, framecls)
     def skyoffset_to_reference(skyoffset_coord, reference_frame):
@@ -138,7 +138,8 @@ def make_skyoffset_cls(framecls):
 
         # use the forward transform, but just invert it
         R = reference_to_skyoffset(reference_frame, skyoffset_coord)
-        return R.T  # this is the inverse because R is a rotation matrix
+        # transpose is the inverse because R is a rotation matrix
+        return matrix_transpose(R)
 
     _skyoffset_cache[framecls] = _SkyOffsetFramecls
     return _SkyOffsetFramecls

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -3,13 +3,13 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..matrix_utilities import rotation_matrix
+from ..matrix_utilities import (rotation_matrix,
+                                matrix_product, matrix_transpose)
 from ..baseframe import frame_transform_graph
 from ..transformations import StaticMatrixTransform
 
 from .galactic import Galactic
 from .supergalactic import Supergalactic
-from .utils import matrix_product, matrix_transpose
 
 
 @frame_transform_graph.transform(StaticMatrixTransform, Galactic, Supergalactic)

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix
+from ..matrix_utilities import rotation_matrix
 from ..baseframe import frame_transform_graph
 from ..transformations import StaticMatrixTransform
 

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix
+from ..angles import rotation_matrix, matmul
 from ..baseframe import frame_transform_graph
 from ..transformations import StaticMatrixTransform
 
@@ -16,7 +16,7 @@ def gal_to_supergal():
     mat1 = rotation_matrix(90, 'z')
     mat2 = rotation_matrix(90 - Supergalactic._nsgp_gal.b.degree, 'y')
     mat3 = rotation_matrix(Supergalactic._nsgp_gal.l.degree, 'z')
-    return mat1 * mat2 * mat3
+    return matmul(matmul(mat1, mat2), mat3)
 
 
 @frame_transform_graph.transform(StaticMatrixTransform, Supergalactic, Galactic)

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -3,12 +3,13 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from ..angles import rotation_matrix, matmul
+from ..angles import rotation_matrix
 from ..baseframe import frame_transform_graph
 from ..transformations import StaticMatrixTransform
 
 from .galactic import Galactic
 from .supergalactic import Supergalactic
+from .utils import matrix_product, matrix_transpose
 
 
 @frame_transform_graph.transform(StaticMatrixTransform, Galactic, Supergalactic)
@@ -16,9 +17,9 @@ def gal_to_supergal():
     mat1 = rotation_matrix(90, 'z')
     mat2 = rotation_matrix(90 - Supergalactic._nsgp_gal.b.degree, 'y')
     mat3 = rotation_matrix(Supergalactic._nsgp_gal.l.degree, 'z')
-    return matmul(matmul(mat1, mat2), mat3)
+    return matrix_product(mat1, mat2, mat3)
 
 
 @frame_transform_graph.transform(StaticMatrixTransform, Supergalactic, Galactic)
 def supergal_to_gal():
-    return gal_to_supergal().T
+    return matrix_transpose(gal_to_supergal())

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -8,8 +8,10 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 import warnings
+from functools import reduce
 
 import numpy as np
+from ...utils.compat.numpy import matmul
 
 from ... import units as u
 from ... import _erfa as erfa
@@ -32,6 +34,20 @@ PIOVER2 = np.pi / 2.
 
 # comes from the mean of the 1962-2014 IERS B data
 _DEFAULT_PM = (0.035, 0.29)*u.arcsec
+
+
+def matrix_product(*args):
+    """Matrix multiply all arguments together.
+
+    Arguments should have dimension 2 or larger, with larger dimensional
+    objects being interpreted as stacks of matrices.
+    """
+    return reduce(matmul, args)
+
+
+def matrix_transpose(m):
+    """Transpose a matrix or stack of matrices by swapping the last two axes."""
+    return m.swapaxes(-2, -1)
 
 
 def cartrepr_from_matmul(pmat, coo, transpose=False):

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -49,35 +49,6 @@ def matrix_transpose(m):
     return m.swapaxes(-2, -1)
 
 
-def cartrepr_from_matmul(pmat, coo, transpose=False):
-    """Transform a coordinate by matrix multiplication.
-
-    Parameters
-    ----------
-    pmat : `~numpy.ndarray`
-        If two-dimensional, a Matrix; if higher-dimensional, a stack of matrices
-        residing in the last two dimensions.  The higher dimensions will be
-        broadcast against ``coo``.
-    coo : coordinate or coordinate representation
-        Assumed to have a ``cartesian`` property that returns a
-        `~astropy.coordinates.CartesianRepresentation`.
-
-    Returns
-    -------
-    newcoo: `~astropy.coordinates.CartesianRepresentation`
-        The transformed representation of ``coo``.
-
-    Raises
-    ------
-    ValueError :
-        If the last two dimensions of ``pmat`` do not equal 3, 3.
-    """
-    if transpose:
-        pmat = matrix_transpose(pmat)
-
-    return coo.cartesian.transform(pmat)
-
-
 def get_polar_motion(time):
     """
     gets the two polar motion components in radians for use with apio13

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -7,8 +7,8 @@ the ``builtin_frames`` package.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-import warnings
 from functools import reduce
+import warnings
 
 import numpy as np
 from ...utils.compat.numpy import matmul

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -35,18 +35,31 @@ PIOVER2 = np.pi / 2.
 _DEFAULT_PM = (0.035, 0.29)*u.arcsec
 
 
-def matrix_product(*args):
+def matrix_product(*matrices):
     """Matrix multiply all arguments together.
 
     Arguments should have dimension 2 or larger. Larger dimensional objects
     are interpreted as stacks of matrices residing in the last two dimensions.
+
+    This function mostly exists for readability: using `~numpy.matmul`
+    directly, one would have ``matmul(matmul(m1, m2), m3)``, etc. For even
+    better readability, one might consider using `~numpy.matrix` for the
+    arguments (so that one could write ``m1 * m2 * m3``), but then it is not
+    possible to handle stacks of matrices. Once only python >=3.5 is supported,
+    this function can be replaced by ``m1 @ m2 @ m3``.
     """
-    return reduce(matmul, args)
+    return reduce(matmul, matrices)
 
 
-def matrix_transpose(m):
-    """Transpose a matrix or stack of matrices by swapping the last two axes."""
-    return m.swapaxes(-2, -1)
+def matrix_transpose(matrix):
+    """Transpose a matrix or stack of matrices by swapping the last two axes.
+
+    This function mostly exists for readability; seeing ``.swapaxes(-2, -1)``
+    it is not that obvious that one does a transpose.  Note that one cannot
+    use `~numpy.ndarray.T`, as this transposes all axes and thus does not
+    work for stacks of matrices.
+    """
+    return matrix.swapaxes(-2, -1)
 
 
 def get_polar_motion(time):

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -7,11 +7,9 @@ the ``builtin_frames`` package.
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-from functools import reduce
 import warnings
 
 import numpy as np
-from ...utils.compat.numpy import matmul
 
 from ... import units as u
 from ... import _erfa as erfa
@@ -33,33 +31,6 @@ PIOVER2 = np.pi / 2.
 
 # comes from the mean of the 1962-2014 IERS B data
 _DEFAULT_PM = (0.035, 0.29)*u.arcsec
-
-
-def matrix_product(*matrices):
-    """Matrix multiply all arguments together.
-
-    Arguments should have dimension 2 or larger. Larger dimensional objects
-    are interpreted as stacks of matrices residing in the last two dimensions.
-
-    This function mostly exists for readability: using `~numpy.matmul`
-    directly, one would have ``matmul(matmul(m1, m2), m3)``, etc. For even
-    better readability, one might consider using `~numpy.matrix` for the
-    arguments (so that one could write ``m1 * m2 * m3``), but then it is not
-    possible to handle stacks of matrices. Once only python >=3.5 is supported,
-    this function can be replaced by ``m1 @ m2 @ m3``.
-    """
-    return reduce(matmul, matrices)
-
-
-def matrix_transpose(matrix):
-    """Transpose a matrix or stack of matrices by swapping the last two axes.
-
-    This function mostly exists for readability; seeing ``.swapaxes(-2, -1)``
-    it is not that obvious that one does a transpose.  Note that one cannot
-    use `~numpy.ndarray.T`, as this transposes all axes and thus does not
-    work for stacks of matrices.
-    """
-    return matrix.swapaxes(-2, -1)
 
 
 def get_polar_motion(time):

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -15,8 +15,7 @@ import numpy as np
 
 from ..time import Time
 from .. import units as u
-from .matrix_utilities import rotation_matrix
-from .builtin_frames.utils import matrix_product, matrix_transpose
+from .matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 
 
 jd1950 = Time('B1950', scale='tai').jd

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -15,6 +15,9 @@ import numpy as np
 
 from ..time import Time
 from .. import units as u
+from .angles import rotation_matrix
+from .builtin_frames.utils import matrix_product, matrix_transpose
+
 
 jd1950 = Time('B1950', scale='tai').jd
 jd2000 = Time('J2000', scale='utc').jd
@@ -143,7 +146,8 @@ def precession_matrix_Capitaine(fromepoch, toepoch):
     ----------
     USNO Circular 179
     """
-    mat_fromto2000 = _precess_from_J2000_Capitaine(fromepoch.jyear).T
+    mat_fromto2000 = matrix_transpose(
+        _precess_from_J2000_Capitaine(fromepoch.jyear))
     mat_2000toto = _precess_from_J2000_Capitaine(toepoch.jyear)
 
     return np.dot(mat_2000toto, mat_fromto2000)
@@ -161,8 +165,6 @@ def _precess_from_J2000_Capitaine(epoch):
         The epoch as a Julian year number (e.g. J2000 is 2000.0)
 
     """
-    from .angles import rotation_matrix, matmul
-
     T = (epoch - 2000.0) / 100.0
     # from USNO circular
     pzeta = (-0.0000003173, -0.000005971, 0.01801828, 0.2988499, 2306.083227, 2.650545)
@@ -172,9 +174,9 @@ def _precess_from_J2000_Capitaine(epoch):
     z = np.polyval(pz, T) / 3600.0
     theta = np.polyval(ptheta, T) / 3600.0
 
-    return matmul(matmul(rotation_matrix(-z, 'z'),
-                         rotation_matrix(theta, 'y')),
-                  rotation_matrix(-zeta, 'z'))
+    return matrix_product(rotation_matrix(-z, 'z'),
+                          rotation_matrix(theta, 'y'),
+                          rotation_matrix(-zeta, 'z'))
 
 
 def _precession_matrix_besselian(epoch1, epoch2):
@@ -184,8 +186,6 @@ def _precession_matrix_besselian(epoch1, epoch2):
 
     ``epoch1`` and ``epoch2`` are in Besselian year numbers.
     """
-    from .angles import rotation_matrix, matmul
-
     # tropical years
     t1 = (epoch1 - 1850.0) / 1000.0
     t2 = (epoch2 - 1850.0) / 1000.0
@@ -209,9 +209,9 @@ def _precession_matrix_besselian(epoch1, epoch2):
     ptheta = (theta3, theta2, theta1, 0)
     theta = np.polyval(ptheta, dt) / 3600
 
-    return matmul(matmul(rotation_matrix(-z, 'z'),
-                         rotation_matrix(theta, 'y')),
-                  rotation_matrix(-zeta, 'z'))
+    return matrix_product(rotation_matrix(-z, 'z'),
+                          rotation_matrix(theta, 'y'),
+                          rotation_matrix(-zeta, 'z'))
 
 
 def _load_nutation_data(datastr, seriestype):
@@ -406,13 +406,9 @@ def nutation_matrix(epoch):
     Matrix converts from mean coordinate to true coordinate as
     r_true = M * r_mean
     """
-    from .angles import rotation_matrix, matmul
-
     # TODO: implement higher precision 2006/2000A model if requested/needed
     epsa, dpsi, deps = nutation_components2000B(epoch.jd)  # all in radians
 
-    rot1 = rotation_matrix(-(epsa + deps), 'x', False)
-    rot2 = rotation_matrix(-dpsi, 'z', False)
-    rot3 = rotation_matrix(epsa, 'x', False)
-
-    return matmul(matmul(rot1, rot2), rot3)
+    return matrix_product(rotation_matrix(-(epsa + deps), 'x', False),
+                          rotation_matrix(-dpsi, 'z', False),
+                          rotation_matrix(epsa, 'x', False))

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -161,7 +161,7 @@ def _precess_from_J2000_Capitaine(epoch):
         The epoch as a Julian year number (e.g. J2000 is 2000.0)
 
     """
-    from .angles import rotation_matrix
+    from .angles import rotation_matrix, matmul
 
     T = (epoch - 2000.0) / 100.0
     # from USNO circular
@@ -172,9 +172,9 @@ def _precess_from_J2000_Capitaine(epoch):
     z = np.polyval(pz, T) / 3600.0
     theta = np.polyval(ptheta, T) / 3600.0
 
-    return rotation_matrix(-z, 'z') *\
-           rotation_matrix(theta, 'y') *\
-           rotation_matrix(-zeta, 'z')
+    return matmul(matmul(rotation_matrix(-z, 'z'),
+                         rotation_matrix(theta, 'y')),
+                  rotation_matrix(-zeta, 'z'))
 
 
 def _precession_matrix_besselian(epoch1, epoch2):
@@ -184,7 +184,7 @@ def _precession_matrix_besselian(epoch1, epoch2):
 
     ``epoch1`` and ``epoch2`` are in Besselian year numbers.
     """
-    from .angles import rotation_matrix
+    from .angles import rotation_matrix, matmul
 
     # tropical years
     t1 = (epoch1 - 1850.0) / 1000.0
@@ -209,9 +209,9 @@ def _precession_matrix_besselian(epoch1, epoch2):
     ptheta = (theta3, theta2, theta1, 0)
     theta = np.polyval(ptheta, dt) / 3600
 
-    return rotation_matrix(-z, 'z') *\
-           rotation_matrix(theta, 'y') *\
-           rotation_matrix(-zeta, 'z')
+    return matmul(matmul(rotation_matrix(-z, 'z'),
+                         rotation_matrix(theta, 'y')),
+                  rotation_matrix(-zeta, 'z'))
 
 
 def _load_nutation_data(datastr, seriestype):
@@ -406,7 +406,7 @@ def nutation_matrix(epoch):
     Matrix converts from mean coordinate to true coordinate as
     r_true = M * r_mean
     """
-    from .angles import rotation_matrix
+    from .angles import rotation_matrix, matmul
 
     # TODO: implement higher precision 2006/2000A model if requested/needed
     epsa, dpsi, deps = nutation_components2000B(epoch.jd)  # all in radians
@@ -415,4 +415,4 @@ def nutation_matrix(epoch):
     rot2 = rotation_matrix(-dpsi, 'z', False)
     rot3 = rotation_matrix(epsa, 'x', False)
 
-    return rot1 * rot2 * rot3
+    return matmul(matmul(rot1, rot2), rot3)

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ..time import Time
 from .. import units as u
-from .angles import rotation_matrix
+from .matrix_utilities import rotation_matrix
 from .builtin_frames.utils import matrix_product, matrix_transpose
 
 

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+This module contains utililies used for constructing rotation matrices.
+"""
+import numpy as np
+
+from .. import units as u
+from .angles import Angle
+
+
+def rotation_matrix(angle, axis='z', unit=None):
+    """
+    Generate matrices for rotation by some angle around some axis.
+
+    Parameters
+    ----------
+    angle : convertible to `Angle`
+        The amount of rotation the matrices should represent.  Can be an array.
+    axis : str, or array-like
+        Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying the axis to
+        rotate about. If ``'x'``, ``'y'``, or ``'z'``, the rotation sense is
+        counterclockwise looking down the + axis (e.g. positive rotations obey
+        left-hand-rule).  If given as an array, the last dimension should be 3;
+        it will be broadcast against ``angle``.
+    unit : UnitBase, optional
+        If ``angle`` does not have associated units, they are in this
+        unit.  If neither are provided, it is assumed to be degrees.
+
+    Returns
+    -------
+    rmat: `numpy.matrix`
+        A unitary rotation matrix.
+    """
+    if unit is None:
+        unit = u.degree
+
+    angle = Angle(angle, unit=unit)
+
+    s = np.sin(angle)
+    c = np.cos(angle)
+
+    # use optimized implementations for x/y/z
+    try:
+        i = 'xyz'.index(axis)
+    except TypeError:
+        axis = np.asarray(axis)
+        axis = axis / np.sqrt((axis * axis).sum(axis=-1, keepdims=True))
+        R = (axis[..., np.newaxis] * axis[..., np.newaxis, :] *
+             (1. - c)[..., np.newaxis, np.newaxis])
+
+        for i in range(0, 3):
+            R[..., i, i] += c
+            a1 = (i + 1) % 3
+            a2 = (i + 2) % 3
+            R[..., a1, a2] += axis[..., i] * s
+            R[..., a2, a1] -= axis[..., i] * s
+
+    else:
+        a1 = (i + 1) % 3
+        a2 = (i + 2) % 3
+        R = np.zeros(angle.shape + (3, 3))
+        R[..., i, i] = 1.
+        R[..., a1, a1] = c
+        R[..., a1, a2] = s
+        R[..., a2, a1] = -s
+        R[..., a2, a2] = c
+
+    return R
+
+
+def angle_axis(matrix):
+    """
+    Angle of rotation and rotation axis for a given rotation matrix.
+
+    Parameters
+    ----------
+    matrix : array-like
+        A 3 x 3 unitary rotation matrix (or stack of matrices).
+
+    Returns
+    -------
+    angle : `Angle`
+        The angle of rotation.
+    axis : array
+        The (normalized) axis of rotation (with last dimension 3).
+    """
+    m = np.asanyarray(matrix)
+    if m.shape[-2:] != (3, 3):
+        raise ValueError('matrix is not 3x3')
+
+    axis = np.zeros(m.shape[:-1])
+    axis[..., 0] = m[..., 2, 1] - m[..., 1, 2]
+    axis[..., 1] = m[..., 0, 2] - m[..., 2, 0]
+    axis[..., 2] = m[..., 1, 0] - m[..., 0, 1]
+    r = np.sqrt((axis * axis).sum(-1, keepdims=True))
+    angle = np.arctan2(r[..., 0],
+                       m[..., 0, 0] + m[..., 1, 1] + m[..., 2, 2] - 1.)
+    return Angle(angle, u.radian), -axis / r

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -4,10 +4,39 @@
 """
 This module contains utililies used for constructing rotation matrices.
 """
+from functools import reduce
 import numpy as np
+from ..utils.compat.numpy import matmul
 
 from .. import units as u
 from .angles import Angle
+
+
+def matrix_product(*matrices):
+    """Matrix multiply all arguments together.
+
+    Arguments should have dimension 2 or larger. Larger dimensional objects
+    are interpreted as stacks of matrices residing in the last two dimensions.
+
+    This function mostly exists for readability: using `~numpy.matmul`
+    directly, one would have ``matmul(matmul(m1, m2), m3)``, etc. For even
+    better readability, one might consider using `~numpy.matrix` for the
+    arguments (so that one could write ``m1 * m2 * m3``), but then it is not
+    possible to handle stacks of matrices. Once only python >=3.5 is supported,
+    this function can be replaced by ``m1 @ m2 @ m3``.
+    """
+    return reduce(matmul, matrices)
+
+
+def matrix_transpose(matrix):
+    """Transpose a matrix or stack of matrices by swapping the last two axes.
+
+    This function mostly exists for readability; seeing ``.swapaxes(-2, -1)``
+    it is not that obvious that one does a transpose.  Note that one cannot
+    use `~numpy.ndarray.T`, as this transposes all axes and thus does not
+    work for stacks of matrices.
+    """
+    return matrix.swapaxes(-2, -1)
 
 
 def rotation_matrix(angle, axis='z', unit=None):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -368,7 +368,7 @@ class CartesianRepresentation(BaseRepresentation):
 
         We now create a rotation matrix around the z axis:
 
-            >>> from astropy.coordinates.angles import rotation_matrix
+            >>> from astropy.coordinates.matrix_utilities import rotation_matrix
             >>> rotation = rotation_matrix(30 * u.deg, axis='z')
 
         Finally, we can apply this transformation:

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -22,7 +22,7 @@ from ..constants import c as speed_of_light
 from .representation import CartesianRepresentation
 from .orbital_elements import calc_moon
 from .builtin_frames import GCRS, ICRS
-from .builtin_frames.utils import get_jd12, cartrepr_from_matmul
+from .builtin_frames.utils import get_jd12
 from .. import _erfa
 from ..extern import six
 
@@ -389,4 +389,5 @@ def _apparent_position_in_true_coordinates(skycoord):
     """
     jd1, jd2 = get_jd12(skycoord.obstime, 'tt')
     _, _, _, _, _, _, _, rbpn = _erfa.pn00a(jd1, jd2)
-    return SkyCoord(skycoord.frame.realize_frame(cartrepr_from_matmul(rbpn, skycoord)))
+    return SkyCoord(skycoord.frame.realize_frame(
+        skycoord.cartesian.transform(rbpn)))

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -835,7 +835,7 @@ def test_rotation_matrix():
     assert_allclose(rotation_matrix(-30*u.deg, 'z'),
                     rotation_matrix(-30*u.deg, [0, 0, 1]))
 
-    assert_allclose(np.dot(rotation_matrix(180*u.deg, [1, 1, 0]).A, [1, 0, 0]),
+    assert_allclose(np.dot(rotation_matrix(180*u.deg, [1, 1, 0]), [1, 0, 0]),
                     [0, 1, 0], atol=1e-12)
 
     #make sure it also works for very small angles

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -11,10 +11,11 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy.testing.utils import assert_allclose, assert_array_equal
 
-from ..angles import Longitude, Latitude, Angle
-from ...tests.helper import pytest
+from ..angles import Longitude, Latitude, Angle, rotation_matrix, angle_axis
+from ...tests.helper import pytest, catch_warnings
 from ... import units as u
 from ..errors import IllegalSecondError, IllegalMinuteError, IllegalHourError
+from ...utils.exceptions import AstropyDeprecationWarning
 
 
 def test_create_angles():
@@ -815,49 +816,6 @@ def test_mixed_string_and_quantity():
     assert_array_equal(a2.value, [1., 180., 3.])
     assert a2.unit == u.deg
 
-def test_rotation_matrix():
-    from ..angles import rotation_matrix
-
-    assert_array_equal(rotation_matrix(0*u.deg, 'x'), np.eye(3))
-
-    assert_allclose(rotation_matrix(90*u.deg, 'y'), [[ 0, 0,-1],
-                                                     [ 0, 1, 0],
-                                                     [ 1, 0, 0]], atol=1e-12)
-
-    assert_allclose(rotation_matrix(-90*u.deg, 'z'), [[ 0,-1, 0],
-                                                      [ 1, 0, 0],
-                                                      [ 0, 0, 1]], atol=1e-12)
-
-    assert_allclose(rotation_matrix(45*u.deg, 'x'),
-                    rotation_matrix(45*u.deg, [1, 0, 0]))
-    assert_allclose(rotation_matrix(125*u.deg, 'y'),
-                    rotation_matrix(125*u.deg, [0, 1, 0]))
-    assert_allclose(rotation_matrix(-30*u.deg, 'z'),
-                    rotation_matrix(-30*u.deg, [0, 0, 1]))
-
-    assert_allclose(np.dot(rotation_matrix(180*u.deg, [1, 1, 0]), [1, 0, 0]),
-                    [0, 1, 0], atol=1e-12)
-
-    #make sure it also works for very small angles
-    assert_allclose(rotation_matrix(0.000001*u.deg, 'x'),
-                    rotation_matrix(0.000001*u.deg, [1, 0, 0]))
-
-def test_angle_axis():
-    from ..angles import rotation_matrix, angle_axis
-
-    m1 = rotation_matrix(35*u.deg, 'x')
-    an1, ax1 = angle_axis(m1)
-
-    assert an1 - 35*u.deg < 1e-10*u.deg
-    assert_allclose(ax1, [1, 0, 0])
-
-
-    m2 = rotation_matrix(-89*u.deg, [1, 1, 0])
-    an2, ax2 = angle_axis(m2)
-
-    assert an2 - 89*u.deg < 1e-10*u.deg
-    assert_allclose(ax2, [-2**-0.5, -2**-0.5, 0])
-
 def test_array_angle_tostring():
     aobj = Angle([1, 2], u.deg)
     assert aobj.to_string().dtype.kind == 'U'
@@ -896,3 +854,20 @@ def test_repr_latex():
     # make sure the ... appears for large arrays
     bigarrangle = Angle(np.ones(50000)/50000., u.deg)
     assert '...' in bigarrangle._repr_latex_()
+
+
+def test_rotation_matrix_deprecation():
+    with catch_warnings(AstropyDeprecationWarning):
+        m = rotation_matrix(0.*u.deg, 'x')
+    assert isinstance(m, np.matrix)
+    assert_array_equal(m, np.eye(3))
+
+
+def test_angle_axis_deprecation():
+    m = np.matrix([[0., 1., 0,],
+                   [-1, 0., 0.],
+                   [0., 0., 1.]])
+    with catch_warnings(AstropyDeprecationWarning):
+        an1, ax1 = angle_axis(m)
+    assert_allclose(an1.to(u.deg).value, 90.)
+    assert_allclose(ax1, [0., 0., 1.])

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+from numpy.testing.utils import assert_allclose, assert_array_equal
+
+from ... import units as u
+from ..matrix_utilities import rotation_matrix, angle_axis
+
+
+def test_rotation_matrix():
+    assert_array_equal(rotation_matrix(0*u.deg, 'x'), np.eye(3))
+
+    assert_allclose(rotation_matrix(90*u.deg, 'y'), [[ 0, 0,-1],
+                                                     [ 0, 1, 0],
+                                                     [ 1, 0, 0]], atol=1e-12)
+
+    assert_allclose(rotation_matrix(-90*u.deg, 'z'), [[ 0,-1, 0],
+                                                      [ 1, 0, 0],
+                                                      [ 0, 0, 1]], atol=1e-12)
+
+    assert_allclose(rotation_matrix(45*u.deg, 'x'),
+                    rotation_matrix(45*u.deg, [1, 0, 0]))
+    assert_allclose(rotation_matrix(125*u.deg, 'y'),
+                    rotation_matrix(125*u.deg, [0, 1, 0]))
+    assert_allclose(rotation_matrix(-30*u.deg, 'z'),
+                    rotation_matrix(-30*u.deg, [0, 0, 1]))
+
+    assert_allclose(np.dot(rotation_matrix(180*u.deg, [1, 1, 0]), [1, 0, 0]),
+                    [0, 1, 0], atol=1e-12)
+
+    #make sure it also works for very small angles
+    assert_allclose(rotation_matrix(0.000001*u.deg, 'x'),
+                    rotation_matrix(0.000001*u.deg, [1, 0, 0]))
+
+
+def test_angle_axis():
+    m1 = rotation_matrix(35*u.deg, 'x')
+    an1, ax1 = angle_axis(m1)
+
+    assert an1 - 35*u.deg < 1e-10*u.deg
+    assert_allclose(ax1, [1, 0, 0])
+
+
+    m2 = rotation_matrix(-89*u.deg, [1, 1, 0])
+    an2, ax2 = angle_axis(m2)
+
+    assert an2 - 89*u.deg < 1e-10*u.deg
+    assert_allclose(ax2, [-2**-0.5, -2**-0.5, 0])

--- a/astropy/utils/compat/numpy/__init__.py
+++ b/astropy/utils/compat/numpy/__init__.py
@@ -8,3 +8,4 @@ in all supported NumPy versions.  See docs/utils/numpy.rst for details.
 from __future__ import division, absolute_import, unicode_literals
 
 from .lib.stride_tricks import broadcast_arrays, broadcast_to
+from .core.multiarray import matmul

--- a/astropy/utils/compat/numpy/core/multiarray.py
+++ b/astropy/utils/compat/numpy/core/multiarray.py
@@ -79,9 +79,9 @@ else:
                 return np.einsum('...ij,...jk->...ik', a, b, **kwargs)
 
             if b.ndim == 1:
-                return np.einsum('...ij,j->...i', a, b, **kwargs)
+                return np.einsum('...ij,...j->...i', a, b, **kwargs)
 
         elif a.ndim == 1 and b.ndim >= 2:
-            return np.einsum('i,...ik->...k', a, b, **kwargs)
+            return np.einsum('...i,...ik->...k', a, b, **kwargs)
 
         raise ValueError("Scalar operands are not allowed, use '*' instead.")

--- a/astropy/utils/compat/numpy/core/multiarray.py
+++ b/astropy/utils/compat/numpy/core/multiarray.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Licensed like numpy; see licenses/NUMPY_LICENSE.rst
+"""
+Replacement for matmul in 'numpy.core.multiarray'.
+
+Notes
+-----
+The pure python version here allows matrix multiplications for numpy <= 1.10
+"""
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+
+__all__ = ['matmul', 'GE1P10']
+
+
+def GE1P10(module=np):
+    return hasattr(module, 'matmul')
+
+
+if GE1P10():
+    from numpy import matmul
+
+else:
+    def matmul(a, b, out=None):
+        """Matrix product of two arrays.
+
+        The behavior depends on the arguments in the following way.
+
+        - If both arguments are 2-D they are multiplied like conventional
+          matrices.
+        - If either argument is N-D, N > 2, it is treated as a stack of
+          matrices residing in the last two indexes and broadcast accordingly.
+        - If the first argument is 1-D, it is promoted to a matrix by
+          prepending a 1 to its dimensions. After matrix multiplication
+          the prepended 1 is removed.
+        - If the second argument is 1-D, it is promoted to a matrix by
+          appending a 1 to its dimensions. After matrix multiplication
+          the appended 1 is removed.
+
+        Multiplication by a scalar is not allowed, use ``*`` instead. Note that
+        multiplying a stack of matrices with a vector will result in a stack of
+        vectors, but matmul will not recognize it as such.
+
+        ``matmul`` differs from ``dot`` in two important ways.
+
+        - Multiplication by scalars is not allowed.
+        - Stacks of matrices are broadcast together as if the matrices
+          were elements.
+
+        Parameters
+        ----------
+        a : array_like
+            First argument.
+        b : array_like
+            Second argument.
+        out : ndarray, optional
+            Output argument. This must have the exact kind that would be returned
+            if it was not used. In particular, it must have the right type, must be
+            C-contiguous, and its dtype must be the dtype that would be returned
+            for `dot(a,b)`. This is a performance feature. Therefore, if these
+            conditions are not met, an exception is raised, instead of attempting
+
+        Notes
+        -----
+        This routine mimicks ``matmul`` using ``einsum``.  See
+        http://docs.scipy.org/doc/numpy/reference/generated/numpy.matmul.html
+        """
+        a = np.asanyarray(a)
+        b = np.asanyarray(b)
+
+        if out is None:
+            kwargs = {}
+        else:
+            kwargs = {'out': out}
+
+        if a.ndim >= 2:
+            if b.ndim >= 2:
+                return np.einsum('...ij,...jk->...ik', a, b, **kwargs)
+
+            if b.ndim == 1:
+                return np.einsum('...ij,j->...i', a, b, **kwargs)
+
+        elif a.ndim == 1 and b.ndim >= 2:
+            return np.einsum('i,...ik->...k', a, b, **kwargs)
+
+        raise ValueError("Scalar operands are not allowed, use '*' instead.")

--- a/astropy/utils/compat/numpy/lib/stride_tricks.py
+++ b/astropy/utils/compat/numpy/lib/stride_tricks.py
@@ -17,6 +17,7 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 
 __all__ = ['broadcast_arrays', 'broadcast_to', 'GE1P10']
+__doctest_skip__ = ['*']
 
 
 def GE1P10(module=np):

--- a/astropy/utils/compat/numpy/tests/test_matmul.py
+++ b/astropy/utils/compat/numpy/tests/test_matmul.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Test matmul replacement.
+"""
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import numpy as np
+
+from astropy.tests.helper import pytest
+
+from ..core.multiarray import matmul, GE1P10
+
+
+def test_import():
+    """Check that what is imported from code is what we are testing."""
+    from ... import numpy as anp
+    assert anp.matmul is matmul
+
+
+def test_test_function():
+    """Test the test function
+
+    The possibly patched version of broadcast_arrays should always be OK
+    The numpy version may be, in which case we just use it, or it may not,
+    it which case we use the patched version.
+    """
+    from ... import numpy as anp
+    assert GE1P10(module=anp) is True
+    if GE1P10(module=np):
+        assert matmul is np.matmul
+    else:
+        assert not hasattr(np, 'matmul')
+
+
+def test_matmul():
+    a = np.arange(18).reshape(2, 3, 3)
+    # with another matrix
+    b1 = np.identity(3)
+    assert np.all(matmul(a, b1) == a)
+    b2 = 1. - b1
+    assert np.all(matmul(a[0], b2) == np.array([[3, 2, 1],
+                                                [9, 8, 7],
+                                                [15, 14, 13]]))
+    b3 = np.ones((4, 1, 3, 2))
+    out = np.zeros((4, 2, 3, 2))
+    res = matmul(a, b3, out=out)
+    assert res is out
+    with pytest.raises(ValueError):  # wrong shape
+        matmul(b3, a)
+    out2 = np.zeros((4, 1, 3, 2))
+    with pytest.raises(ValueError):
+        matmul(a, b3, out=out2)
+
+    # with a vector
+    b4 = np.ones((3,))
+    assert np.all(matmul(a, b4) == a.sum(-1))
+    out = np.zeros((a.shape[0], a.shape[2]))
+    res = matmul(b4, a, out=out)
+    assert res is out
+    assert np.all(out == a.sum(-2))
+
+    with pytest.raises(ValueError):
+        matmul(a, 1.)
+    with pytest.raises(ValueError):
+        matmul(1., a)
+    with pytest.raises(ValueError):
+        matmul(a, 1.)

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -55,7 +55,7 @@ plt.style.use(astropy_mpl_style)
 # Import the packages necessary for coordinates
 
 from astropy.coordinates import frame_transform_graph
-from astropy.coordinates.angles import rotation_matrix
+from astropy.coordinates.matrix_utilities import rotation_matrix
 import astropy.coordinates as coord
 import astropy.units as u
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ show-response = 1
 
 [pytest]
 minversion = 2.3.3
-norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat"
+norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
 doctest_norecursedirs = "astropy[\/]sphinx"
 open_files_ignore = "astropy.log" "/etc/hosts"


### PR DESCRIPTION
This is the second of two possible ways to remove the use of np.matrix in coordinates (see #5088).

In this PR, the matrices are replaced with normal arrays, and a new `matmul` function is defined that either just uses the numpy function of that name, or, for numpy <= 1.10, the equivalent `einsum`. With this implementation, in all the transformations, multiplication has to be replaced with `matmul`, so this affects a lot more files. To get general broadcasting to work, it will be necessary to also replace any `.T` on the rotation matrices with `.swapaxes(-2, -1)`.
