### PR TITLE
Changing pep8 tool to pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ matrix:
                PIP_DEPENDENCIES='sphinx-gallery>=0.1.2 pillow wcsaxes --no-deps jplephem'
 
         # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different 
-        # versions of Python, we can vary Python and Numpy versions at the same 
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
         - os: linux
@@ -92,9 +92,9 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
-        # Do a PEP8 test
+        # Do a PEP8 test with pycodestyle
         - os: linux
-          env: MAIN_CMD='pep8 astropy --count' SETUP_CMD=''
+          env: MAIN_CMD='pycodestyle astropy --count' SETUP_CMD=''
 
     allow_failures:
       - env: NUMPY_VERSION=dev SETUP_CMD='test'

--- a/docs/development/codeguide_emacs.rst
+++ b/docs/development/codeguide_emacs.rst
@@ -4,7 +4,7 @@
 
 .. _flymake: http://www.emacswiki.org/emacs/FlyMake
 .. _pyflakes: http://pypi.python.org/pypi/pyflakes
-.. _pep8: http://pypi.python.org/pypi/pep8
+.. _pycodestyle: http://pypi.python.org/pypi/pycodestyle
 .. include:: workflow/known_projects.inc
 
 The Astropy coding guidelines are listed in :doc:`codeguide`. This
@@ -14,7 +14,7 @@ be configured in several different ways. So instead of providing a drop
 in configuration file, only the individual configurations are presented
 below.
 
-For this setup we will need flymake_, pyflakes_ and the pep8_ Python
+For this setup we will need flymake_, pyflakes_ and the pycodestyle_ Python
 script, in addition to ``python-mode``.
 
 Flymake comes with Emacs 23. The rest can be obtained from their websites,
@@ -118,7 +118,7 @@ red. When cursor is on such a line a message is displayed in the
 mini-buffer. When mouse pointer is on such a line a "tool tip" message
 is also shown.
 
-For flymake to work with `pep8`_ and `pyflakes`_, create an
+For flymake to work with `pycodestyle`_ and `pyflakes`_, create an
 executable file named `pychecker`_ with the following contents. This
 file must be in the system path.
 
@@ -127,7 +127,7 @@ file must be in the system path.
   #!/bin/bash
 
   pyflakes "$1"
-  pep8 --ignore=E221,E701,E202 --repeat "$1"
+  pycodestyle --ignore=E221,E701,E202 --repeat "$1"
   true
 
 Also download `flymake-cursor.el

--- a/docs/development/docrules.rst
+++ b/docs/development/docrules.rst
@@ -30,7 +30,7 @@ Use a code checker:
 
  * `pylint <http://www.logilab.org/857>`_
  * `pyflakes <http://pypi.python.org/pypi/pyflakes>`_
- * `pep8.py <https://github.com/jcrocholl/pep8>`_
+ * `pycodestyle <https://github.com/PyCQA/pycodestyle>`_
 
 The following import conventions are used throughout the Astropy source
 and documentation::

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ bitmap = static/wininst_background.bmp
 [ah_bootstrap]
 auto_use = True
 
-[pycodestyle]
+[pep8]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
 # W291 - trailing whitespace

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ bitmap = static/wininst_background.bmp
 [ah_bootstrap]
 auto_use = True
 
-[pep8]
+[pycodestyle]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
 # W291 - trailing whitespace


### PR DESCRIPTION
They had recently changed the name, and however there is a cooling down deprecation period, it's worth changing this now (rather than getting the warnings).

We also use ``pytest-pep8``, but it's not yet updated.
