### PR TITLE
[ENH] New analytic integral property for models

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1476,13 +1476,13 @@ class Box1D(Fittable1DModel):
         return (self.x_0 - dx, self.x_0 + dx)
 
     @property
-    def integral(self):
-        """Integral for one dimensional Box model.
+    def primitive(self):
+        """Primitive for one dimensional Box model.
 
         Returns
         -------
         result : `Ramp1D`
-            Integration model.
+            Primitive integral (antiderivative) model.
 
         """
         return Ramp1D(amplitude=self.amplitude*self.width, x_0=self.x_0,

--- a/astropy/modeling/tests/test_integral.py
+++ b/astropy/modeling/tests/test_integral.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
-#import numpy as np
 from numpy.testing import assert_allclose
 
 from .. import models
@@ -20,7 +19,7 @@ def test_no_integral():
     """
     model = models.RedshiftScaleFactor()
     with pytest.raises(NotImplementedError):
-        x = model.integral
+        model.integral
 
 
 def test_Box1D():
@@ -35,7 +34,7 @@ def test_Box1D():
     bbox = model.bounding_box
     intg_model = model.integral
 
-    assert isinstance(intg_model, models.RampForBox1D)
+    assert isinstance(intg_model, models.Ramp1D)
 
     # Integrate over the whole range.
     y = intg_model(bbox)
@@ -46,14 +45,14 @@ def test_Box1D():
     assert_allclose(intg_model(6) - intg_model(0), 15)
     assert_allclose(intg_model(20) - intg_model(10), 0)
 
-    # User-defined integral ??? del ? set to None?
+    # User-defined integral
     model.integral = models.Const1D(100)
     assert model.has_user_integral
     assert model.integral(20) == 100
 
     model.integral = None
     with pytest.raises(NotImplementedError):
-        x = model.integral
+        model.integral
 
     del model.integral
     assert not model.has_user_integral
@@ -62,25 +61,5 @@ def test_Box1D():
     # n_models > 1
     model = models.Box1D(amplitude=[3, 3], x_0=[0, 4], width=[10, 5])
     assert_allclose(model.integral([0, 4]), [15, 7.5])
-
-
-def test_Box2D():
-    """Test Box2D integration."""
-    model = models.Box2D(
-        amplitude=3., x_0=0., x_width=10., y_0=4., y_width=5.)
-    bbox_y, bbox_x = model.bounding_box
-
-    with pytest.raises(ValueError):
-        x = model.integral(axis='z')
-
-    # Over X-axis
-    intg_model = model.integral
-    assert_allclose(intg_model(bbox_x[1]) - intg_model(bbox_x[0]), 30)
-    assert_allclose(intg_model(6) - intg_model(0), 15)
-    assert_allclose(intg_model(20) - intg_model(10), 0)
-
-    # Over Y-axis
-    intg_model = model.integral(axis='y')
-    assert_allclose(intg_model(bbox_y[1]) - intg_model(bbox_y[0]), 15)
-    assert_allclose(intg_model(4) - intg_model(-1), 7.5)
-    assert_allclose(intg_model(-9) - intg_model(-10), 0)
+    y = model.integral(model.bounding_box)
+    assert_allclose(y[1] - y[0], [30, 15])

--- a/astropy/modeling/tests/test_integral.py
+++ b/astropy/modeling/tests/test_integral.py
@@ -1,0 +1,86 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+#import numpy as np
+from numpy.testing import assert_allclose
+
+from .. import models
+from ...tests.helper import pytest
+
+
+def test_no_integral():
+    """Test that undefined integral raises appropriate exception.
+
+    .. note::
+
+        If the model being tested here has integral in the future, change
+        the model being tested to one without integral.
+
+    """
+    model = models.RedshiftScaleFactor()
+    with pytest.raises(NotImplementedError):
+        x = model.integral
+
+
+def test_Box1D():
+    """Test Box1D integration.
+
+    This tests most of the integral functionality.
+    Tests for other models can probably just test that the
+    integration is working properly for the "most popular" use case.
+
+    """
+    model = models.Box1D(amplitude=3., x_0=0., width=10.)
+    bbox = model.bounding_box
+    intg_model = model.integral
+
+    assert isinstance(intg_model, models.RampForBox1D)
+
+    # Integrate over the whole range.
+    y = intg_model(bbox)
+    intg_result = y[1] - y[0]
+    assert_allclose(intg_result, 30)
+
+    # Partial integration
+    assert_allclose(intg_model(6) - intg_model(0), 15)
+    assert_allclose(intg_model(20) - intg_model(10), 0)
+
+    # User-defined integral ??? del ? set to None?
+    model.integral = models.Const1D(100)
+    assert model.has_user_integral
+    assert model.integral(20) == 100
+
+    model.integral = None
+    with pytest.raises(NotImplementedError):
+        x = model.integral
+
+    del model.integral
+    assert not model.has_user_integral
+    assert model.integral(20) == 30
+
+    # n_models > 1
+    model = models.Box1D(amplitude=[3, 3], x_0=[0, 4], width=[10, 5])
+    assert_allclose(model.integral([0, 4]), [15, 7.5])
+
+
+def test_Box2D():
+    """Test Box2D integration."""
+    model = models.Box2D(
+        amplitude=3., x_0=0., x_width=10., y_0=4., y_width=5.)
+    bbox_y, bbox_x = model.bounding_box
+
+    with pytest.raises(ValueError):
+        x = model.integral(axis='z')
+
+    # Over X-axis
+    intg_model = model.integral
+    assert_allclose(intg_model(bbox_x[1]) - intg_model(bbox_x[0]), 30)
+    assert_allclose(intg_model(6) - intg_model(0), 15)
+    assert_allclose(intg_model(20) - intg_model(10), 0)
+
+    # Over Y-axis
+    intg_model = model.integral(axis='y')
+    assert_allclose(intg_model(bbox_y[1]) - intg_model(bbox_y[0]), 15)
+    assert_allclose(intg_model(4) - intg_model(-1), 7.5)
+    assert_allclose(intg_model(-9) - intg_model(-10), 0)

--- a/astropy/modeling/tests/test_integral.py
+++ b/astropy/modeling/tests/test_integral.py
@@ -8,58 +8,58 @@ from .. import models
 from ...tests.helper import pytest
 
 
-def test_no_integral():
-    """Test that undefined integral raises appropriate exception.
+def test_no_primitive():
+    """Test that undefined primitive raises appropriate exception.
 
     .. note::
 
-        If the model being tested here has integral in the future, change
-        the model being tested to one without integral.
+        If the model being tested here has primitive in the future, change
+        the model being tested to one without primitive.
 
     """
     model = models.RedshiftScaleFactor()
     with pytest.raises(NotImplementedError):
-        model.integral
+        model.primitive
+    with pytest.raises(NotImplementedError):
+        model.integrate(1, 100)
 
 
 def test_Box1D():
     """Test Box1D integration.
 
-    This tests most of the integral functionality.
+    This tests most of the primitive and integrate functionality.
     Tests for other models can probably just test that the
     integration is working properly for the "most popular" use case.
 
     """
     model = models.Box1D(amplitude=3., x_0=0., width=10.)
-    bbox = model.bounding_box
-    intg_model = model.integral
 
-    assert isinstance(intg_model, models.Ramp1D)
+    assert isinstance(model.primitive, models.Ramp1D)
 
     # Integrate over the whole range.
-    y = intg_model(bbox)
-    intg_result = y[1] - y[0]
-    assert_allclose(intg_result, 30)
+    assert_allclose(model.integrate(*model.bounding_box), 30)
 
     # Partial integration
-    assert_allclose(intg_model(6) - intg_model(0), 15)
-    assert_allclose(intg_model(20) - intg_model(10), 0)
+    assert_allclose(model.integrate(0, 6), 15)
+    assert_allclose(model.integrate(10, 20), 0)
 
-    # User-defined integral
-    model.integral = models.Const1D(100)
-    assert model.has_user_integral
-    assert model.integral(20) == 100
+    # User-defined primitive
+    model.primitive = models.Const1D(100)
+    assert model.has_user_primitive
+    assert_allclose(model.primitive(20), 100)
+    assert_allclose(model.integrate(0, 6), 0)
 
-    model.integral = None
+    # Disable primitive
+    model.primitive = None
     with pytest.raises(NotImplementedError):
-        model.integral
+        model.primitive
 
-    del model.integral
-    assert not model.has_user_integral
-    assert model.integral(20) == 30
+    # Restore default primitive
+    del model.primitive
+    assert not model.has_user_primitive
+    assert_allclose(model.primitive(20), 30)
 
     # n_models > 1
     model = models.Box1D(amplitude=[3, 3], x_0=[0, 4], width=[10, 5])
-    assert_allclose(model.integral([0, 4]), [15, 7.5])
-    y = model.integral(model.bounding_box)
-    assert_allclose(y[1] - y[0], [30, 15])
+    assert_allclose(model.primitive([0, 4]), [15, 7.5])
+    assert_allclose(model.integrate(*model.bounding_box), [30, 15])

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -12,7 +12,7 @@ from collections import deque, MutableMapping
 import numpy as np
 
 from ..extern import six
-from ..extern.six.moves import range, zip_longest, zip
+from ..extern.six.moves import range, zip
 
 from ..utils import isiterable, check_broadcast
 from ..utils.compat.funcsigs import signature
@@ -350,8 +350,8 @@ class AliasDict(MutableMapping):
         return repr(store_copy)
 
 
-class _Integral(object):
-    """Base class for models with custom integral templates.
+class _Primitive(object):
+    """Base class for models with custom primitive templates.
     This is similar concept as bounding box, except it does not return
     a tuple.
     """
@@ -359,9 +359,9 @@ class _Integral(object):
     _model = None
 
     def __new__(cls, _model=None):
-        self = super(_Integral, cls).__new__(cls)
+        self = super(_Primitive, cls).__new__(cls)
         if _model is not None:
-            # Bind this _Integral (most likely a subclass) to a Model
+            # Bind this _Primitive (most likely a subclass) to a Model
             # instance so that its __call__ can access the model
             self._model = _model
 
@@ -369,7 +369,7 @@ class _Integral(object):
 
     def __call__(self, *args, **kwargs):
         raise NotImplementedError(
-            "This integral is fixed by the model and does not have "
+            "This primitive is fixed by the model and does not have "
             "adjustable parameters.")
 
 

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -350,6 +350,29 @@ class AliasDict(MutableMapping):
         return repr(store_copy)
 
 
+class _Integral(object):
+    """Base class for models with custom integral templates.
+    This is similar concept as bounding box, except it does not return
+    a tuple.
+    """
+
+    _model = None
+
+    def __new__(cls, _model=None):
+        self = super(_Integral, cls).__new__(cls)
+        if _model is not None:
+            # Bind this _Integral (most likely a subclass) to a Model
+            # instance so that its __call__ can access the model
+            self._model = _model
+
+        return self
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "This integral is fixed by the model and does not have "
+            "adjustable parameters.")
+
+
 class _BoundingBox(tuple):
     """
     Base class for models with custom bounding box templates (methods that


### PR DESCRIPTION
This is a fully functional proof of concept for #5033.

Added new `integral` property to `modeling` core. Implemented analytic integral for `Box1D` and `Box2D`. Added relevant tests.

TODO:
- [x] Remove "ugly hack" for `Box2D` integral? Yes.
- [ ] Wait for Nadia's review.
- [ ] Wrap up review discussions.
- [ ] Add test for new ramp model by defining it in `modeling/tests/example_models.py`.
- [ ] Add change log entry.

c/c @mcara, @mhvk 
