### PR TITLE
Sky offset frames added to whatsnew

### DIFF
--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -124,6 +124,22 @@ frame from an already-existing |SkyCoord|::
     ``SkyOffsetFrame(origin=ICRS(...)).__class__ is SkyOffsetFrame`` will
     *not* be ``True``, as it would be for most classes.
 
+This same frame is also useful as a tool for defining frames that are relative
+to a specific known object, useful for hierarchical physical systems like galaxy
+groups.  For example, objects around M31 are sometimes shown in a coordinate
+frame aligned with standard ICRA RA/Dec, but on M31::
+
+    >>> m31 = SkyCoord(10.6847083*u.deg, 41.26875*u.deg, frame='icrs')
+    >>> ngc147 = SkyCoord(8.3005*u.deg, 48.5087389*u.deg, frame='icrs')
+    >>> ngc147_inm31 = ngc147.transform_to(m31.skyoffset_frame())
+    >>> xi, eta = ngc147_inm31.lon, ngc147_inm31.lat
+    >>> xi  # doctest: +FLOAT_CMP
+    <Longitude -1.5920694752086249 deg>
+    >>> eta  # doctest: +FLOAT_CMP
+    <Latitude 7.261837574183891 deg>
+
+
+
 .. _astropy-coordinates-matching:
 
 Matching Catalogs

--- a/docs/whatsnew/1.2.rst
+++ b/docs/whatsnew/1.2.rst
@@ -44,10 +44,17 @@ The :class:`~astropy.time.Time` class has gained a new method
 (or heliocentric) corrections. For more details, see
 :ref:`time-light-travel-time`.
 
-Astrometric coordinate frames
------------------------------
+Sky offset coordinate frames
+----------------------------
 
-
+:mod:`~astropy.coordinates` now includes support for coordinate frames that are
+rotated in the sky to be centered on a particular object.  This sort of frame is
+variously known as "FOV coordinates", "offset coordinates", or "astrometric". It
+makes it easier to compute offsets from a particular reference object, and
+define coordinate frames that for heirarchical systems like groups or clusters
+of galaxies.  It also enables the new
+:meth:`~astropy.coordinates.SkyCoord.spherical_offsets_to` method. For more
+details, see :ref:`astropy-skyoffset-frames`.
 
 Lomb-scargle periodograms
 -------------------------

--- a/docs/whatsnew/1.2.rst
+++ b/docs/whatsnew/1.2.rst
@@ -35,8 +35,9 @@ coordinate frames, allowing easy conversion to apparent (e.g. ``AltAz``)
 positions or barycentric values.  The positions can be calculated using either
 using built-in approximations or more precise values that depend on downloading
 JPL-provided ephemeris models derived from n-body simulations (the latter
-requires the additional dependency of the ``jplephem`` package). For more
-details, see :ref:`astropy-coordinates-solarsystem`.
+requires the additional dependency of the
+`jplephem <https://pypi.python.org/pypi/jplephem>`_ package). For more details,
+see :ref:`astropy-coordinates-solarsystem`.
 
 Barycentric light-travel time corrections
 -----------------------------------------

--- a/docs/whatsnew/1.2.rst
+++ b/docs/whatsnew/1.2.rst
@@ -29,12 +29,14 @@ smaller improvements and bug fixes, which are described in the
 Solar system ephemerides
 ------------------------
 
-Positions of the major solar-system bodies, including the moon, can now be
-calculated.  These integrate with the coordinates subpackage, allowing use of
-apparent (e.g. ``AltAz``) positions or barycentric values.  These can be
-calculated using either using built-in approximations or more precisely
-using JPL ephemeris models (the latter requiring the ``jplephem`` package).
-For more details, see :ref:`astropy-coordinates-solarsystem`.
+:mod:`~astropy.coordinates` can now calculate the positions of the major
+solar system bodies (as well as the moon).  These integrate fully all the
+coordinate frames, allowing easy conversion to apparent (e.g. ``AltAz``)
+positions or barycentric values.  The positions can be calculated using either
+using built-in approximations or more precise values that depend on downloading
+JPL-provided ephemeris models derived from n-body simulations (the latter
+requires the additional dependency of the ``jplephem`` package). For more
+details, see :ref:`astropy-coordinates-solarsystem`.
 
 Barycentric light-travel time corrections
 -----------------------------------------


### PR DESCRIPTION
This PR's main purpose is to populate the "what's new in 1.2" section that was labeled "Astrometric coordinate frames" (renamed since that was drafted to sky offset frames).

It also adjusts the "Solar system ephemerides" section to be worded a bit more consistently, and adds an additional example to the sky offset frame docs (inspired by a bit of motivation that is described  in the "what's new")