### PR TITLE
Fix CompImageHDU's made from ImageHDUs with BSCALE/BZERO.

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -588,7 +588,11 @@ class _BaseHDU(object):
 
         if (self._has_data and self._standard and
                 _is_pseudo_unsigned(self.data.dtype)):
-            if 'GCOUNT' in self._header:
+            # CompImageHDUs need TFIELDS immediately after GCOUNT,
+            # so BSCALE has to go after TFIELDS if it exists.
+            if 'TFIELDS' in self._header:
+                self._header.set('BSCALE', 1, after='TFIELDS')
+            elif 'GCOUNT' in self._header:
                 self._header.set('BSCALE', 1, after='GCOUNT')
             else:
                 self._header.set('BSCALE', 1)

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -947,7 +947,8 @@ class CompImageHDU(BinTableHDU):
         # dimensions in the image data array.
         self._header.set('NAXIS1', cols.dtype.itemsize,
                          'width of table in bytes')
-        self._header.set('TFIELDS', ncols, 'number of fields in each row')
+        self._header.set('TFIELDS', ncols, 'number of fields in each row',
+                         after='GCOUNT')
         self._header.set('ZIMAGE', True, 'extension contains compressed image',
                          after=after)
         self._header.set('ZBITPIX', zbitpix,


### PR DESCRIPTION
If an existing ImageHDU containing BSCALE/BZERO is turned into a CompImageHDU,
the TFIELDS keyword don't get placed in the correct location (immediately
following GCOUNT), resulting in an invalid CompImageHDU. This fixes this behavior in the file I originally had trouble with, but I was not able to come up with a minimal example to turn into a proper test. It passes all the io.fits tests on my local copy, but it appears CompImageHDUs don't have good test coverage, so I can't promise this change is safe (though I believe it more closely matches the FITS standard, which is the important thing).

Said minimal example should look something like the below, but this doesn't actually produce the failure on the old code:

```python
from astropy.io import fits
import numpy as np

x = np.random.random((100, 100))*100

x0 = fits.PrimaryHDU()
x1 = fits.ImageHDU(x)
x2 = fits.ImageHDU(np.array(x-50, dtype=int), uint=True)
x2.header['BZERO'] = 32768
x2.header['BSCALE'] = 1
x3 = fits.ImageHDU(x*3)
x4 = fits.BinTableHDU()
hdus = fits.HDUList([x0, x1, x2, x3, x4])
hdus.writeto('3hdus.fits')

# fitsverify (based on cfitsio) should fail on this file, only seeing the first HDU.
data = fits.open('3hdus.fits')
for i in [1, 2, 3]:
    data[i] = fits.CompImageHDU(data=data[i].data, header=data[i].header)
data.writeto('3hdus_comp.fits')
```

For further details, see my recent emails to astropy and astropy-dev.