### PR TITLE
Add whatsnew stats

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,8 @@
-Adam Ginsburg       <keflavich@gmail.com> 
-Adam Ginsburg       <keflavich@gmail.com> Adam Ginsburg <adam.g.ginsburg@gmail.com>
+Adam Ginsburg       <keflavich@gmail.com>
+Adam Ginsburg       <keflavich@gmail.com> Adam Ginsburg <adam.g.ginsburg@gmail.com> <keflavich@yahoo.com>
+Adele Plunkett      <aplunket@eso.org>
 Alex Conley         <alexander.conley@colorado.edu> Alexander Conley <alexander.conley@colorado.edu>
+Alex Conley         <alexander.conley@colorado.edu> Alexander Conley <alexanderconley@gmail.com>
 Alex Hagen          <mr.alex.hagen@gmail.com>
 Asish Panda         <asishrocks95@gmail.com>
 Axel Donath         <axel.donath@mpi-hd.mpg.de>
@@ -20,6 +22,7 @@ Dylan Gregersen     <gregersen.dylan@gmail.com>
 Emma Hogan          <ehogan@gemini.edu>
 Moataz Hisham       <mtzhisham@gmail.com>
 Erik M. Bray        <erik.m.bray@gmail.com> <embray@stsci.edu>
+Erik M. Bray        <erik.m.bray@gmail.com> <erik.bray@lri.fr>
 Erik M. Bray        <erik.m.bray@gmail.com> Erik Bray <erik.m.bray@gmail.com>
 Gerrit Schellenberger <gerrit@uni-bonn.de>
 Gustavo Bragança    <ga.braganca@gmail.com>
@@ -27,11 +30,15 @@ Hans Moritz Günther <moritz.guenther@gmx.de>
 Hans Moritz Günther <moritz.guenther@gmx.de> hamogu <hgunther@mit.edu>
 James Turner        <jturner@gemini.edu>
 Jeff Taylor         <jeff.c.taylor@gmail.com>
-Kacper Kowalik      <xarthisius@gentoo.org>
+Kacper Kowalik      <xarthisius.kk@gmail.com> Kacper Kowalik      <xarthisius@gentoo.org>
+Kacper Kowalik      <xarthisius.kk@gmail.com> Kacper Kowalik (Xarthisius) <xarthisius@gentoo.org>
+Kacper Kowalik      <xarthisius.kk@gmail.com> Kacper Kowalik (Xarthisius) <xarthisius.kk@gmail.com>
 Karan Grover        <karan@karan-HP-Pavilion-dm4-Notebook-PC.(none)>
+Karl Vyhmeister     <kvyh@users.noreply.github.com>
 Kirill Tchernyshyov <ktchernyshyov@pha.jhu.edu>
 Kelle Cruz          <kellecruz@gmail.com>
 Kevin Gullikson     <kevin.gullikson@gmail.com>
+Leonardo Ferreira <leonardo.ferreira.furg@gmail.com> [Leonardo Ferreira] <[leonardo.ferreira.furg@gmail.com]>
 Lisa Walter         <lisa@stsci.edu>
 Marten van Kerkwijk <mhvk@astro.utoronto.ca> <mhvk@swan.astro.utoronto.ca>
 Matt Davis          <jiffyclub.programatic@gmail.com>
@@ -41,7 +48,7 @@ Perry Greenfield    <perry@stsci.edu>
 Pritish Chakraborty <chakrabortypritish@gmail.com>
 Ryan Cooke          <ryancooke86@gmail.com>
 Shantanu Srivastava <shan_mbic@rediffmail.com>
-Simon Conseil       <contact@saimon.org>
+Simon Conseil       <contact@saimon.org> Simon Conseil <simon.conseil@univ-lyon1.fr>
 Simon Liedtke       <liedtke.simon@googlemail.com>
 Thomas Erben        <terben@astro.uni-bonn.de> <thomas@astro.uni-bonn.de>
 Thompson Le Blanc   <leblanc@stsci.edu>
@@ -49,11 +56,40 @@ Thompson Le Blanc   <leblanc@stsci.edu> astrocaribe <tlcommodore@gmail.com>
 Tom Aldcroft        <taldcroft@gmail.com> <aldcroft@dhcp-131-142-152-173.cfa.harvard.edu>
 Zach Edwards        <Zachary.Astro@Gmail.com>
 Jonathan Foster     <jonathan.bruce.foster@gmail.com>
-David Kirby         <dkirkby@uci.edu>
+David Kirkby         <dkirkby@uci.edu>
 Albert Y. Shih      <ayshih@gmail.com>
 Aleh Khvalko        <algerdnazgul@gmail.com>
-Elijah Bernstein-Cooper <ezbc@astro.wisc.edu>
+Elijah Bernstein-Cooper <e.bernsteincooper@gmail.com> <ezbc@astro.wisc.edu>
 Lingyi Hu           <hulingyi1995@yahoo.com.sg>
 Francesco Montesano <franz.bergesund@gmail.com>
 Daniel Lenz         <dlenz.bonn@gmail.com>
 Dan P. Cunningham   <dan.p.cunningham@gmail.com>
+Joseph Long         <josephoenix@gmail.com> <me@joseph-long.com>
+Brigitta Sipocz     <bsipocz@gmail.com> <b.sipocz@gmail.com>
+Rohit Patil         <rohit4change@yahoo.in> QuanTakeuchi <rohit4change@yahoo.in>
+Rohit Patil         <rohit4change@yahoo.in> QuanTakeuchi <Quan@Aries.(none)>
+Demitri Muna        <demitri.muna@gmail.com> Demitri Muna <github@demitri.com>
+Steve Crawford      <crawfordsm@gmail.com> Steven Crawford <crawfordsm@gmail.com>
+Anne Archibald      <peridot.faceted@gmail.com> Anne Archibald <archibald@astron.nl>
+Stuart Mumford      <stuart@mumford.me.uk> Stuart Mumford <stuart@cadair.com>
+Mihai Cara          <mihail.cara@gmail.com> Mihai Cara <mcara@itsd-osx22.home>
+Pey Lian Lim        <lim@stsci.edu> P. L. Lim <lim@stsci.edu>
+Jonathan Foster     <jonathan.bruce.foster@gmail.com> Jonathan Foster <jonathan.b.foster@yale.edu>
+Miguel de Val-Borro <miguel.deval@gmail.com> Miguel de Val-Borro <miguel@archlinux.net>
+Eric Depagne        <eric@depagne.org>
+Pratik Patel        <pratikpatel15133@gmail.com>
+Mavani Bhautik      <mavanibhautik@gmail.com>
+Aniketm Kulkarni    <kaniket21@gmail.com>
+Sara Ogaz           <ogaz@stsci.edu>
+Sourabh Cheedella   <cheedella.sourabh@gmail.com>
+Sudheesh Singanamalla <sudheesh1995@outlook.com>
+Amit Kumar          <dtu.amit@gmail.com>
+Jake VanderPlas     <jakevdp@gmail.com> Jake VanderPlas <jakevdp@uw.edu>
+Matthew Craig       <mattwcraig@gmail.com> Matt Craig <mattwcraig@gmail.com>
+Sergio Pascual      <sergio.pasra@gmail.com> Sergio Pascual <sergiopr@fis.ucm.es>
+Laura Watkins       <lauralwatkins@gmail.com> Laura L Watkins <lauralwatkins@gmail.com>
+Axel Donath         <axel.donath@mpi-hd.mpg.de> Axel Donath <donath@stud.uni-heidelberg.de>
+Zé Vinicius         <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
+Ole Streicher       <ole@aip.de> Ole Streicher <debian@liska.ath.cx>
+Alex Rudy           <alex.rudy@gmail.com> Alexander Rudy <alex.rudy@gmail.com>
+Leo Singer          <leo.singer@ligo.org> Leo Singer <leo.singer@nasa.gov>

--- a/.mailmap
+++ b/.mailmap
@@ -93,3 +93,4 @@ Zé Vinicius         <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
 Ole Streicher       <ole@aip.de> Ole Streicher <debian@liska.ath.cx>
 Alex Rudy           <alex.rudy@gmail.com> Alexander Rudy <alex.rudy@gmail.com>
 Leo Singer          <leo.singer@ligo.org> Leo Singer <leo.singer@nasa.gov>
+Anthony Horton      <anthony.horton@aao.gov.au>

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -30,6 +30,8 @@ Core Package Contributors
 * Daniel Bell
 * Elijah Bernstein-Cooper
 * Kristin Berry
+* Edward Betts
+* Mavani Bhautik
 * Francesco Biscani
 * Thompson Le Blanc
 * Christopher Bonnett
@@ -48,28 +50,33 @@ Core Package Contributors
 * Patti Carroll
 * Mabry Cervin
 * Pritish Chakraborty
+* Sourabh Cheedella
 * Alex Conley
 * Jean Connelly
 * Simon Conseil
 * Ryan Cooke
 * Yannick Copin
 * Matthew Craig
-* Steven Crawford
+* Steve Crawford
 * Neil Crighton
 * Robert Cross
 * Kelle Cruz
 * Dan P. Cunningham
 * Daniel Datsev
 * Matt Davis
+* James Dearman
 * Christoph Deil
 * Nadia Dencheva
+* Eric Depagne
 * Jörg Dietrich
 * Axel Donath
+* Bili Dong
 * Michael Droettboom
 * Zach Edwards
 * Jonathan Eisenhamer
 * Thomas Erben
 * Henry Ferguson
+* Leonardo Ferreira
 * Jonathan Foster
 * Ryan Fox
 * Lehman Garrison
@@ -94,9 +101,9 @@ Core Package Contributors
 * Anthony Horton
 * JC Hsu
 * Lingyi Hu
+* Joe Hunkeler
+* Anchit Jain
 * Eric Jeschke
-* Eric Depagne
-* Joseph Jon Booker
 * Sarah Kendrew
 * Marten van Kerkwijk
 * Wolfgang Kerzendorf
@@ -107,6 +114,8 @@ Core Package Contributors
 * Dominik Klaes
 * Kacper Kowalik
 * Roban Hultman Kramer
+* Aniket Kulkarni
+* Amit Kumar
 * Arne de Laat
 * Antony Lee
 * Daniel Lenz
@@ -115,6 +124,8 @@ Core Package Contributors
 * Stuart Littlefair
 * Joseph Long
 * Joe Lyman
+* Jerry Ma
+* Duncan Macleod
 * Curtis McCully
 * Vinayak Mehta
 * Aaron Meisner
@@ -126,10 +137,15 @@ Core Package Contributors
 * Stuart Mumford
 * Demitri Muna
 * Prasanth Nair
+* Stefan Nelson
 * Bogdan Nicula
+* Al Niessner
 * Joe Philip Ninan
 * Asra Nizami
 * Bryce Nordgren
+* Sigurd Næss
+* Sara Ogaz
+* Georgiana Ogrean
 * Miruna Oprescu
 * Carl Osterwisch
 * Luigi Paioro
@@ -137,14 +153,15 @@ Core Package Contributors
 * Madhura Parikh
 * Neil Parley
 * Sergio Pascual
+* Pratik Patel
 * Rohit Patil
 * David Perez-Suarez
 * Ray Plante
+* Adele Plunkett
 * Orion Poplawski
 * Adrian Price-Whelan
-* J\. Xavier Prochaska
+* J. Xavier Prochaska
 * David Pérez-Suárez
-* QuanTakeuchi
 * Tanuj Rastogi
 * Thomas Robitaille
 * Juan Luis Cano Rodríguez
@@ -154,29 +171,36 @@ Core Package Contributors
 * Eloy Salinas
 * Gerrit Schellenberger
 * Michael Seifert
+* Srikrishna Sekhar
 * David Shiga
 * Albert Y. Shih
 * David Shupe
 * Jonathan Sick
+* Simon
+* Sudheesh Singanamalla
 * Leo Singer
 * Brigitta Sipocz
+* Kevin Sooley
 * Shivan Sornarajah
 * Shantanu Srivastava
 * Ole Streicher
 * Matej Stuchlik
 * Bernardo Sulzbach
+* Vatsala Swaroop
 * James Taylor
 * Jeff Taylor
 * Kirill Tchernyshyov
+* Régis Terrier
 * Víctor Terrón
 * Scott Thomas
 * Erik Tollerud
 * James Turner
-* Jake VanderPlas
 * Miguel de Val-Borro
-* Jonathan Whitmore
-* Julien Woillez
+* Jake VanderPlas
+* Zé Vinicius
+* Karl Vyhmeister
 * Lisa Walter
+* Laura Watkins
 * Benjamin Alan Weaver
 * Jonathan Whitmore
 * Julien Woillez

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -26,8 +26,10 @@ packages that use the full bugfix/maintenance branch approach.)
    addresses.  Look for any mis-named entries or duplicates, and add them to the
    ``.mailmap`` file (matched to the appropriate canonical name/email address.)
    Once you have finished this, you can could the number of lines in
-   ``git shortlog -s`` to get the final contributor count (and also the names
-   to add to the Astropy web site at the end of the release).
+   ``git shortlog -s`` to get the final contributor count.  Also be sure to
+   use the names in that list to update the ``docs/credits.rst`` file. (The
+   ``author_lists.py`` script in the `astropy-tools repository`_ helps with
+   this.)
 
 #. (Optional) You may want to set up a clean environment to build the release.
    For more on setting up virtual environments, see :ref:`virtual_envs`, but
@@ -201,7 +203,8 @@ packages that use the full bugfix/maintenance branch approach.)
 #. Update the Astropy web site by editing the ``index.html`` page at
    https://github.com/astropy/astropy.github.com by changing the "current
    version" link and/or updating the list of older versions if this is an LTS
-   bugfix or a new major version.
+   bugfix or a new major version.  You may also need to update the contributor
+   list on the web site if you updated the ``docs/credits.rst`` at the outset.
 
 #. In the astropy *master* branch (not just the maintenance branch), be sure to
    update the ``CHANGES.rst`` to reflect the date of the release you just

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -15,6 +15,20 @@ Release Procedure
 This is the standard release procedure for releasing Astropy (or affiliated
 packages that use the full bugfix/maintenance branch approach.)
 
+#. (Only for major versions) Make sure to update the "What's new"
+   section with the stats on the number of issues, PRs, and contributors.  For
+   the first two, the `astropy-tools repository`_ script ``gh_issuereport.py``
+   can provide the numbers since the last major release.  For the final one, you
+   will likely need to update the Astropy ``.mailmap`` file, as there are often
+   contributors who are not careful about using the same e-mail address for
+   every commit.  The easiest way to do this is to run the command
+   ``git shortlog -n -s -e`` to see the list of all contributors and their email
+   addresses.  Look for any mis-named entries or duplicates, and add them to the
+   ``.mailmap`` file (matched to the appropriate canonical name/email address.)
+   Once you have finished this, you can could the number of lines in
+   ``git shortlog -s`` to get the final contributor count (and also the names
+   to add to the Astropy web site at the end of the release).
+
 #. (Optional) You may want to set up a clean environment to build the release.
    For more on setting up virtual environments, see :ref:`virtual_envs`, but
    for the sake of example we will assume you're using `Anaconda`_. This is not

--- a/docs/whatsnew/1.2.rst
+++ b/docs/whatsnew/1.2.rst
@@ -38,9 +38,9 @@ In addition to these major changes, Astropy 1.2 includes a large number of
 smaller improvements and bug fixes, which are described in the
 :ref:`changelog`. By the numbers:
 
-* ??? issues have been closed since v1.1
-* ??? pull requests have been merged since v1.1
-* ??? distinct people have contributed code
+* 615 issues have been closed since v1.1
+* 313 pull requests have been merged since v1.1
+* 191 distinct people have contributed code
 
 .. _whatsnew-1.2-lombscargle:
 


### PR DESCRIPTION
This updates the issue statistics for the 1.2 what's new page (and the corresponding ``mailmap`` entries).  It also includes another item in the release instructions describing the procedure that was followed to make this PR.

cc @astrofrog