### PR TITLE
Resolve v1.2 ImportError when a constant is imported before the units package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,9 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Change how bolometric luminosity constant is imported to ensure it remains
+    possible to import ``constants`` and ``units`` in any order. [#5121]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -6,7 +6,9 @@ import numpy as np
 
 from .. import (CompositeUnit, Unit, UnitsError, dimensionless_unscaled,
                 si, astrophys)
-from ...constants import L_bol0
+# Cannot import L_bol0 directly, or the order of imports of units and constants
+# starts to matter on python2. [#5121]
+from ...constants import si as _si
 from .core import FunctionUnitBase, FunctionQuantity
 from .units import dex, dB, mag
 
@@ -323,10 +325,10 @@ AB0 = Unit('AB', 10.**(-0.4*48.6) * 1.e-3 * si.W / si.m**2 / si.Hz,
 ST0 = Unit('ST', 10.**(-0.4*21.1) * 1.e-3 * si.W / si.m**2 / si.AA,
            doc="ST magnitude zero flux density.")
 
-Bol0 = Unit('Bol', L_bol0, doc="Luminosity corresponding to "
+Bol0 = Unit('Bol', _si.L_bol0, doc="Luminosity corresponding to "
             "absolute bolometric magnitude zero")
 
-bol0 = Unit('bol', L_bol0 / (4 * np.pi * (10.*astrophys.pc)**2),
+bol0 = Unit('bol', _si.L_bol0 / (4 * np.pi * (10.*astrophys.pc)**2),
             doc="Irradiance corresponding to apparent bolometric magnitude "
             "zero")
 


### PR DESCRIPTION
I am getting a strange `ImportError` with `astropy` v1.2: 
the following lines
```
from astropy.constants import G
import astropy.units as u
```
give
```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    import astropy.units as u
  File "....../lib/python3.4/site-packages/astropy/units/__init__.py", line 18, in <module>
    from . import si
ImportError: cannot import name 'si'
```
whereas importing `astropy.units` first gives no error. The issue is absent in previous versions of `astropy`.