### PR TITLE
Initialize indata pointer in compression_compress_hdu()

### DIFF
--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -891,7 +891,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
     void* outbuf;
     size_t outbufsize;
 
-    PyArrayObject* indata;
+    PyArrayObject* indata = NULL;
     PyArrayObject* tmp;
     npy_intp znaxis;
     int datatype;


### PR DESCRIPTION
The code of the function contains several `goto fail;` statements which jump over the initialization of the `indata` pointer, but then still call `Py_XDECREF(indata);` which then would be executed with an uninitialized pointer.
This was found on the Debian build warning
```
In file included from /usr/include/python2.7/Python.h:80:0,
                 from astropy/io/fits/src/compressionmodule.c:96:
astropy/io/fits/src/compressionmodule.c: In function 'compression_compress_hdu':
/usr/include/python2.7/object.h:773:12: warning: 'indata' may be used uninitialized in this function [-Wmaybe-uninitialized]
         if (_Py_DEC_REFTOTAL  _Py_REF_DEBUG_COMMA       \
            ^
astropy/io/fits/src/compressionmodule.c:894:20: note: 'indata' was declared here
     PyArrayObject* indata;
                    ^
```