### PR TITLE
Added subsampling to nddata.utils.extract_array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ New Features
 
 - ``astropy.nddata``
 
+    - Added ``subsampling`` to extract_array to allow for the extraction of
+    a subsampled patch centered on a set of coordinates.
+
 - ``astropy.stats``
 
 - ``astropy.sphinx``

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -18,6 +18,11 @@ try:
 except ImportError:
     HAS_SKIMAGE = False
 
+try:
+    import scipy
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
 
 test_positions = [(10.52, 3.12), (5.62, 12.97), (31.33, 31.77),
                   (0.46, 0.94), (20.45, 12.12), (42.24, 24.42)]
@@ -174,6 +179,98 @@ def test_extract_array_return_pos():
                                            mode='trim', return_position=True)
         assert new_pos == (expected, )
 
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_extract_array_subsample_default():
+    # Create an array to test subpixel extraction
+    test_result = np.array([
+        [ 4.33333333,  4.66666667,  5.        ,  5.33333333],
+        [ 4.66666667,  5.        ,  5.33333333,  5.66666667],
+        [ 5.        ,  5.33333333,  5.66666667,  6.        ]])
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    
+    result = extract_array(test_arr, (3,3),(1,3), subsampling=3)
+    assert result.shape==(9,9)
+    assert result[4,4]-test_arr[1,3]<10**-5
+    assert ~np.any(result[6:9,3:7]-test_result>10**-5)
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_extract_array_subsample_trim():
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    shape = (3,3)
+    pos = (0,1)
+    result = extract_array(test_arr, shape, pos, subsampling=3, 
+        mode='trim', return_slices=True, order=2)
+    subset, (large_slices, small_slices) = result
+    assert subset.shape==(5,8)
+    assert large_slices[0][0]<10**-5
+    assert (large_slices[0][1]-1.3333333333333)<10**-5
+    assert large_slices[1][0]<10**-5
+    assert (large_slices[1][1]-2.3333333333333)<10**-5
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_extract_array_subsample_partial():
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    shape = (3,3)
+    pos = (0,1)
+    result = extract_array(test_arr, shape, pos, subsampling=3, 
+        mode='partial', return_slices=True, order=2)
+    subset, (large_slices, small_slices) = result
+    assert subset.shape==(9,9)
+    assert (large_slices[0][0]-(-1.3333333333333))<10**-5
+    assert (large_slices[0][1]-1.3333333333333)<10**-5
+    assert (large_slices[1][0]-(-.333333333333))<10**-5
+    assert (large_slices[1][1]-2.3333333333333)<10**-5
+    assert np.sum(np.isnan(subset))==41
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_extract_array_subsample_mask():
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    shape = (3,3)
+    pos = (0,1)
+    result = extract_array(test_arr, shape, pos, subsampling=3, 
+        mode='mask', return_slices=True, order=2)
+    subset, (large_slices, small_slices) = result
+    assert subset.shape==(9,9)
+    assert (large_slices[0][0]-(-1.3333333333333))<10**-5
+    assert (large_slices[0][1]-1.3333333333333)<10**-5
+    assert (large_slices[1][0]-(-.333333333333))<10**-5
+    assert (large_slices[1][1]-2.3333333333333)<10**-5
+    assert np.sum(subset.mask)==41
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_extract_array_subsample_upper_bound():
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    shape = (5,5)
+    pos = (9,8)
+    result = extract_array(test_arr, shape, pos, subsampling=3, 
+        mode='mask', return_slices=True, order=2)
+    subset, (large_slices, small_slices) = result
+    assert subset.shape==(15,15)
+    assert (large_slices[0][0]-6.6666666666666)<10**-5
+    assert (large_slices[0][1]-11.3333333333333)<10**-5
+    assert (large_slices[1][0]-5.6666666666666)<10**-5
+    assert (large_slices[1][1]-10.3333333333333)<10**-5
+    assert np.sum(subset.mask)==155
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_extract_array_subsample_upper_bound_trim():
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    shape = (5,5)
+    pos = (9,8)
+    result = extract_array(test_arr, shape, pos, subsampling=3, 
+        mode='trim', return_slices=True, order=2)
+    subset, (large_slices, small_slices) = result
+    assert subset.shape==(7,10)
+    assert (large_slices[0][0]-6.6666666666666)<10**-5
+    assert (large_slices[0][1]-8.6666666666666)<10**-5
+    assert (large_slices[1][0]-5.6666666666666)<10**-5
+    assert (large_slices[1][1]-8.6666666666666)<10**-5
 
 def test_add_array_odd_shape():
     """

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -155,11 +155,14 @@ def overlap_slices(large_array_shape, small_array_shape, position,
 
 
 def extract_array(array_large, shape, position, mode='partial',
-                  fill_value=np.nan, return_position=False):
+                  fill_value=np.nan, return_position=False,
+                  subsampling=None, order=3, smoothing=0,
+                  return_slices=False):
     """
     Extract a smaller array of the given shape and position from a
-    larger array.
-
+    larger array. If a subsampling size is entered, the result will
+    be an array that subdivides each pixel using 
+    `~scipy.interpolate.RectBivariateSpline`. 
     Parameters
     ----------
     array_large : `~numpy.ndarray`
@@ -172,9 +175,9 @@ def extract_array(array_large, shape, position, mode='partial',
         large array.  The pixel coordinates should be in the same order
         as the array shape.  Integer positions are at the pixel centers
         (for 1D arrays, this can be a number).
-    mode : {'partial', 'trim', 'strict'}, optional
+    mode : {'partial', 'trim', 'strict', 'mask'}, optional
         The mode used for extracting the small array.  For the
-        ``'partial'`` and ``'trim'`` modes, a partial overlap of the
+        ``'partial'``,``'mask'``, and``'trim'`` modes, a partial overlap of the
         small array and the large array is sufficient.  For the
         ``'strict'`` mode, the small array has to be fully contained
         within the large array, otherwise an
@@ -185,6 +188,8 @@ def extract_array(array_large, shape, position, mode='partial',
         array will be filled with ``fill_value``.  In ``'trim'`` mode
         only the overlapping elements are returned, thus the resulting
         small array may be smaller than the requested ``shape``.
+        ``'mask'`` mode works the same as ``'partial'`` except entries
+        equal to ``fill_value`` will be masked.
     fill_value : number, optional
         If ``mode='partial'``, the value to fill pixels in the extracted
         small array that do not overlap with the input ``array_large``.
@@ -193,7 +198,20 @@ def extract_array(array_large, shape, position, mode='partial',
     return_position : boolean, optional
         If `True`, return the coordinates of ``position`` in the
         coordinate system of the returned array.
-
+    subsampling: int, optional
+        Number of subdivisions for each pixel. The default value is ``None``,
+        which does not subdivide the pixels.
+    order: int, optional
+        If ``subsampling is not None`` this is the order of the spline used to
+        interpolate the subdivided pixels (``kx`` and ``ky`` in 
+        `~scipy.interpolate.RectBivariateSpline`). The default is 3.
+    smoothing: number, optional
+        If ``subsampling is not None`` this is the positive smoothing factor
+        of the spline (``s`` in `~scipy.interpolate.RectBivariateSpline`). 
+        The default is 0.
+    return_indices: boolean, optional
+        If `True`, return the large and small indices or slices 
+        used to extract the array.
     Returns
     -------
     array_small : `~numpy.ndarray`
@@ -205,12 +223,15 @@ def extract_array(array_large, shape, position, mode='partial',
         ``new_position`` might actually be outside of the
         ``array_small``; ``array_small[new_position]`` might give wrong
         results if any element in ``new_position`` is negative.
-
+    slices: tuple
+        If ``return_slices`` is true, this tuple contains
+        (large_slices, small_slices). If ``subampling is None`` 
+        this is the result of `overlap_slices`, otherwise these are 
+        indices to the coordinates in the subsampled arrays.
     Examples
     --------
     We consider a large array with the shape 11x10, from which we extract
     a small array of shape 3x5:
-
     >>> import numpy as np
     >>> from astropy.nddata.utils import extract_array
     >>> large_array = np.arange(110).reshape((11, 10))
@@ -225,25 +246,100 @@ def extract_array(array_large, shape, position, mode='partial',
     if np.isscalar(position):
         position = (position, )
 
-    if mode not in ['partial', 'trim', 'strict']:
+    if mode not in ['partial', 'trim', 'strict', 'mask']:
         raise ValueError("Valid modes are 'partial', 'trim', and 'strict'.")
-    large_slices, small_slices = overlap_slices(array_large.shape,
-                                                shape, position, mode=mode)
-    extracted_array = array_large[large_slices]
-    if return_position:
-        new_position = [i - s.start for i, s in zip(position, large_slices)]
-    # Extracting on the edges is presumably a rare case, so treat special here
-    if (extracted_array.shape != shape) and (mode == 'partial'):
-        extracted_array = np.zeros(shape, dtype=array_large.dtype)
-        extracted_array[:] = fill_value
-        extracted_array[small_slices] = array_large[large_slices]
-        if return_position:
-            new_position = [i + s.start for i, s in zip(new_position,
-                                                        small_slices)]
-    if return_position:
-        return extracted_array, tuple(new_position)
+    if mode=='mask':
+        slice_mode = 'partial'
     else:
-        return extracted_array
+        slice_mode = mode
+    
+    # Extract the array
+    if subsampling is None:
+        large_slices, small_slices = overlap_slices(array_large.shape,
+                                                    shape, position, 
+                                                    mode=slice_mode)
+        extracted_array = array_large[large_slices]
+        if return_position:
+            new_position = [i - s.start for i, s in zip(position, large_slices)]
+        
+        # Extracting on the edges is presumably a rare case, 
+        # so treat special here
+        if (extracted_array.shape != shape) and (mode in ['partial','mask']):
+            extracted_array = np.zeros(shape, dtype=array_large.dtype)
+            extracted_array[:] = fill_value
+            extracted_array[small_slices] = array_large[large_slices]
+            if return_position:
+                new_position = [i + s.start for i, s in zip(new_position,
+                                                            small_slices)]
+    else:
+        # Subsample the array, centered on the position
+        try:
+            from scipy import interpolate
+        except ImportError:
+            raise ImportError(
+                "You must have scipy installed to use the subpixel method")
+        if len(array_large.shape)!=2:
+            raise ValueError("Subsampling only works with 2d arrays")
+        # Extract  slightly larger patch of the array to allow for 
+        # interpolation at the edges
+        large_slices, small_slices = overlap_slices(
+            array_large.shape, (shape[0]+2,shape[1]+2), position, 
+            mode=slice_mode)
+        extracted_array = array_large[large_slices]
+        # Create indices from the slices of the large array
+        x_indices = np.arange(array_large.shape[1])[large_slices[1]]
+        y_indices = np.arange(array_large.shape[0])[large_slices[0]]
+        # Build an interpolating function
+        data_func = interpolate.RectBivariateSpline(
+            y_indices, x_indices, 
+            extracted_array, kx=order, ky=order, s=smoothing)
+        # Get the positions in the subsampled array
+        scale = np.floor(subsampling/2.)/subsampling
+        xradius = .5*(shape[1]-1)
+        yradius = .5*(shape[0]-1)
+        sub_x = np.linspace(
+            position[1]-scale-xradius, 
+            position[1]+scale+xradius, 
+            shape[1]*subsampling)
+        sub_y = np.linspace(
+            position[0]-scale-yradius, 
+            position[0]+scale+yradius, 
+            shape[0]*subsampling)
+        extracted_array = data_func(sub_y, sub_x)
+        if mode in ['partial', 'mask']:
+            # Set values outside array_large to fill_value
+            extracted_array[:,sub_x<0] = fill_value
+            extracted_array[sub_y<0,:] = fill_value
+            extracted_array[:,sub_x>=array_large.shape[1]-1] = fill_value
+            extracted_array[sub_y>=array_large.shape[0]-1,:] = fill_value
+        else:
+            cuts = (sub_x>=0)&(sub_x<array_large.shape[1]-1)
+            extracted_array = extracted_array[:,cuts]
+            sub_x = sub_x[cuts]
+            cuts = (sub_y>=0)&(sub_y<array_large.shape[0]-1)
+            extracted_array = extracted_array[cuts,:]
+            sub_y = sub_y[cuts]
+        large_slices = (sub_y, sub_x)
+        small_slices = (np.arange(extracted_array.shape[0]),
+                        np.arange(extracted_array.shape[1]))
+        
+    # Only create a mask if there are any entries to mask
+    if mode=='mask' and (np.any(extracted_array==fill_value) or
+            np.any(np.isnan(extracted_array))):
+        extracted_array = np.ma.array(extracted_array)
+        if np.isnan(fill_value):
+            extracted_array.mask = np.isnan(extracted_array)
+        else:
+            extracted_array.mask = extracted_array==fill_value
+    # Create the result
+    result = [extracted_array]
+    if return_position:
+        result.append(tuple(new_position))
+    if return_slices:
+        result.append((large_slices, small_slices))
+    if len(result)==1:
+        result = result[0]
+    return result
 
 
 def add_array(array_large, array_small, position):

--- a/docs/nddata/utils.rst
+++ b/docs/nddata/utils.rst
@@ -342,6 +342,232 @@ position, and ``wcs`` object from above to create a cutout with size
     plt.imshow(cutout.data, origin='lower')
 
 
+Extracting a subset from a larger array
+---------------------------------------
+
+It is often necessary to extract a patch from a much larger ndarray and
+in some cases, a subsampled patch (for example when performing PSF
+photometry).
+
+First we create a test array::
+
+    >>> # Initialize the package and create a test array
+    >>> from astropy.nddata.utils import extract_array
+    >>> import numpy as np
+    >>> import matplotlib
+    >>> import matplotlib.pyplot as plt
+    >>> 
+    >>> x,y = np.indices((10,10), dtype=float)
+    >>> test_arr = x+y
+    >>> vmin = np.min(test_arr)
+    >>> vmax = np.max(test_arr)
+    >>> test_arr
+    >>> # Plot the array
+    >>> plt.imshow(test_arr, interpolation='none')
+    array([[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.],
+           [  1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.],
+           [  2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.],
+           [  3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.,  12.],
+           [  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.],
+           [  5.,   6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.],
+           [  6.,   7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.],
+           [  7.,   8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.],
+           [  8.,   9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.],
+           [  9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,  18.]])
+    
+.. plot::
+
+    from astropy.nddata.utils import extract_array
+    import numpy as np
+    import matplotlib
+    import matplotlib.pyplot as plt
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    vmin = np.min(test_arr)
+    vmax = np.max(test_arr)
+    plt.imshow(test_arr, interpolation='none')
+
+If the dataset is 2D, we can subdivide each pixel to create a subsampled image.
+We can also set ``return_slices=True`` to return the indices of the large array
+and the extracted array::
+
+    >>> shape = (3,3)
+    >>> position = 4,3
+    >>> subset, slices = extract_array(test_arr, shape, position, return_slices=True, subsampling=3)
+    >>> large_slices, small_slices = slices
+    >>> print(subset)
+    >>> print(large_slices)
+    >>> print(small_slices)
+    >>> plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax,
+    >>>     extent=[large_slices[1][0],large_slices[1][-1],
+                   large_slices[0][0],large_slices[0][-1]])
+    [[ 4.33333333  4.66666667  5.          5.33333333  5.66666667  6.
+       6.33333333  6.66666667  7.        ]
+     [ 4.66666667  5.          5.33333333  5.66666667  6.          6.33333333
+       6.66666667  7.          7.33333333]
+     [ 5.          5.33333333  5.66666667  6.          6.33333333  6.66666667
+       7.          7.33333333  7.66666667]
+     [ 5.33333333  5.66666667  6.          6.33333333  6.66666667  7.
+       7.33333333  7.66666667  8.        ]
+     [ 5.66666667  6.          6.33333333  6.66666667  7.          7.33333333
+       7.66666667  8.          8.33333333]
+     [ 6.          6.33333333  6.66666667  7.          7.33333333  7.66666667
+       8.          8.33333333  8.66666667]
+     [ 6.33333333  6.66666667  7.          7.33333333  7.66666667  8.
+       8.33333333  8.66666667  9.        ]
+     [ 6.66666667  7.          7.33333333  7.66666667  8.          8.33333333
+       8.66666667  9.          9.33333333]
+     [ 7.          7.33333333  7.66666667  8.          8.33333333  8.66666667
+       9.          9.33333333  9.66666667]]
+    (array([ 2.66666667,  3.        ,  3.33333333,  3.66666667,  4.        ,
+            4.33333333,  4.66666667,  5.        ,  5.33333333]), 
+     array([ 1.66666667,  2.        ,  2.33333333,  2.66666667,  3.        ,
+            3.33333333,  3.66666667,  4.        ,  4.33333333]))
+    (array([0, 1, 2, 3, 4, 5, 6, 7, 8]), array([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+    
+.. plot::
+
+    from astropy.nddata.utils import extract_array
+    import numpy as np
+    import matplotlib
+    import matplotlib.pyplot as plt
+    shape = (3,3)
+    position = (4,3)
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    vmin = np.min(test_arr)
+    vmax = np.max(test_arr)
+    subset, slices = extract_array(test_arr, shape, position, return_slices=True, subsampling=3)
+    large_slices, small_slices = slices
+    plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax,
+        extent=[large_slices[1][0],large_slices[1][-1],
+                large_slices[0][0],large_slices[0][-1]])
+
+Notice that although the x and y slices are [2,3,4] and [3,4,5] respectively, 
+since each subsampled pixel is at the center of the 9x9 subdivided pixel, the
+subsampled x and y indices range from 1.67 to 4.33 and 2.67 to 5.33 
+respectively.
+
+Edge Modes
+^^^^^^^^^^
+
+As with the regular array extraction, we can choose whether or not to trim the
+regions of the extracted array outside the bounds of the original array::
+
+    >>> subset, slices = extract_array(test_arr, shape, position, return_slices=True, 
+    >>>     subsampling=3, order=2, mode='trim')
+    >>> large_slices, small_slices = slices
+    >>> print(large_slices)
+    >>> print(small_slices)
+    >>> plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax,
+    >>>     extent=[large_slices[1][0],large_slices[1][-1],
+    >>>             large_slices[0][0],large_slices[0][-1]])
+    (array([ 0.        ,  0.33333333,  0.66666667,  1.        ,  1.33333333]), 
+     array([ 0.        ,  0.33333333,  0.66666667,  1.        ,  1.33333333,
+            1.66666667,  2.        ,  2.33333333]))
+    (array([0, 1, 2, 3, 4]), array([0, 1, 2, 3, 4, 5, 6, 7]))
+    
+.. plot::
+
+    from astropy.nddata.utils import extract_array
+    import numpy as np
+    import matplotlib
+    import matplotlib.pyplot as plt
+    shape = (3,3)
+    position = (0,1)
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    vmin = np.min(test_arr)
+    vmax = np.max(test_arr)
+    subset, slices = extract_array(test_arr, shape, position, return_slices=True, 
+        subsampling=3, order=2, mode='trim')
+    large_slices, small_slices = slices
+    plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax,
+        extent=[large_slices[1][0],large_slices[1][-1],
+               large_slices[0][0],large_slices[0][-1]])
+
+.. warning::
+
+    Notice that the preceding example changed the order of the interpolating
+    polynomial to 2. This is required because there are not enough entries
+    in the extracted array to fit a 3rd order polynomial. The best practice for
+    most cases is to use the same order for all patches you extract from an
+    image, so it is best to ignore patches close enough to the edges to 
+    prohibit them from interpolating with your chosen order.
+
+The default behavior is to return an extracted array with ``mode='partial'``
+and ``fill_value=np.nan`` to fill the regions of the extracted array outside
+the boundaries with ``NaN``::
+
+    >>> subset, slices = extract_array(test_arr, shape, position, return_slices=True, 
+    >>>     subsampling=3, order=2, mode='partial')
+    >>> large_slices, small_slices = slices
+    >>> print(large_slices)
+    >>> print(small_slices)
+    >>> plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax,
+    >>>     extent=[large_slices[1][0],large_slices[1][-1],
+                    large_slices[0][0],large_slices[0][-1]])
+    (array([-1.33333333, -1.        , -0.66666667, -0.33333333,  0.        ,
+            0.33333333,  0.66666667,  1.        ,  1.33333333]), 
+     array([-0.33333333,  0.        ,  0.33333333,  0.66666667,  1.        ,
+            1.33333333,  1.66666667,  2.        ,  2.33333333]))
+    (array([0, 1, 2, 3, 4, 5, 6, 7, 8]), array([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+
+.. plot::
+
+    from astropy.nddata.utils import extract_array
+    import numpy as np
+    import matplotlib
+    import matplotlib.pyplot as plt
+    shape = (3,3)
+    position = (0,1)
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    vmin = np.min(test_arr)
+    vmax = np.max(test_arr)
+    subset, slices = extract_array(test_arr, shape, position, return_slices=True, 
+        subsampling=3, order=2, mode='partial')
+    large_slices, small_slices = slices
+    plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax,
+        extent=[large_slices[1][0],large_slices[1][-1],
+               large_slices[0][0],large_slices[0][-1]])
+    
+Notice that since the pixel at index 0 is subdivided into [-.33, 0.0, .33],
+the lowest subsampled pixel is out of bounds and is clipped from the result.
+
+Masking Pixels
+^^^^^^^^^^^^^^
+
+Using ``mode='mask'`` is the same as partial except instead of filling the 
+array with a value, it creates a mask. This does not make a difference for 
+displaying the image but certain operations are easier with masked arrays::
+
+    >>> position = (9,8)
+    >>> shape=(5,5)
+    >>> subset = extract_array(test_arr, shape, position, mode='mask')
+    >>> print(subset)
+    >>> plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax)
+    [[13.0 14.0 15.0 16.0 --]
+     [14.0 15.0 16.0 17.0 --]
+     [15.0 16.0 17.0 18.0 --]
+     [-- -- -- -- --]
+     [-- -- -- -- --]]
+
+.. plot::
+
+    from astropy.nddata.utils import extract_array
+    import numpy as np
+    import matplotlib
+    import matplotlib.pyplot as plt
+    shape = (5,5)
+    position = (9,8)
+    x,y = np.indices((10,10), dtype=float)
+    test_arr = x+y
+    vmin = np.min(test_arr)
+    vmax = np.max(test_arr)
+    subset = extract_array(test_arr, shape, position, mode='mask')
+    plt.imshow(subset, interpolation='none', vmin=vmin, vmax=vmax)
+
 Reference/API
 =============
 

--- a/docs/nddata/utils.rst
+++ b/docs/nddata/utils.rst
@@ -349,6 +349,10 @@ It is often necessary to extract a patch from a much larger ndarray and
 in some cases, a subsampled patch (for example when performing PSF
 photometry).
 
+.. note::
+
+    The `~scipy` package is required to extract a subsampled patch.
+
 First we create a test array::
 
     >>> # Initialize the package and create a test array


### PR DESCRIPTION
PSF photometry and other image reduction can require one to extract a subsampled array. The extract_array function has been modified to allow users to subdivide each pixel by a specified number of subpixels using scipy.interpolate. An option has also been added to allow the function to return the indices to the subsampled pixels.

If the user does not specify any of the new parameters, the behavior of the function is the same as before the changes.
