### PR TITLE
Fix to CompImageHDU from 5118 with regression test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,10 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fixed a bug that caused TFIELDS to not be in the correct position in
+    compressed image HDU headers under certain circumstances, which created
+    invalid FITS files. [#5118, #5125]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -588,7 +588,11 @@ class _BaseHDU(object):
 
         if (self._has_data and self._standard and
                 _is_pseudo_unsigned(self.data.dtype)):
-            if 'GCOUNT' in self._header:
+            # CompImageHDUs need TFIELDS immediately after GCOUNT,
+            # so BSCALE has to go after TFIELDS if it exists.
+            if 'TFIELDS' in self._header:
+                self._header.set('BSCALE', 1, after='TFIELDS')
+            elif 'GCOUNT' in self._header:
                 self._header.set('BSCALE', 1, after='GCOUNT')
             else:
                 self._header.set('BSCALE', 1)

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -947,7 +947,8 @@ class CompImageHDU(BinTableHDU):
         # dimensions in the image data array.
         self._header.set('NAXIS1', cols.dtype.itemsize,
                          'width of table in bytes')
-        self._header.set('TFIELDS', ncols, 'number of fields in each row')
+        self._header.set('TFIELDS', ncols, 'number of fields in each row',
+                         after='GCOUNT')
         self._header.set('ZIMAGE', True, 'extension contains compressed image',
                          after=after)
         self._header.set('ZBITPIX', zbitpix,


### PR DESCRIPTION
I managed to reproduce the failure that #5118 fixes, so I'm starting by adding a regression test to make sure it fails, then I'll cherry-pick the fix from #5118. I think the data passed to ``CompImageHDU`` had to be integer so that the BSCALE and BZERO still applied.

cc @parejkoj @eteq @embray

EDIT: Closes #5118 