### PR TITLE
Workaround py3.5 appveyor failures by using the previous VS build image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ matrix:
 platform:
     -x64
 
+os: Previous Visual Studio 2015
+
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"


### PR DESCRIPTION
This is a workaround for the current appveyor failures. Soon we will have something better https://github.com/appveyor/ci/issues/890#issuecomment-229529578, and possibly from within ci-helpers, but in the meantime it's better to be able to run and pass the tests.

