### PR TITLE
Modify Quantity documentation

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -135,7 +135,7 @@ class QuantityInfo(ParentDtypeInfo):
 
 @six.add_metaclass(InheritDocstrings)
 class Quantity(np.ndarray):
-    """ A `~astropy.units.Quantity` represents a number with some associated unit.
+    """A `~astropy.units.Quantity` represents a number with some associated unit.
 
     Parameters
     ----------
@@ -185,6 +185,12 @@ class Quantity(np.ndarray):
     TypeError
         If the unit provided is not either a :class:`~astropy.units.Unit`
         object or a parseable string unit.
+
+    Notes
+    -----
+    Quantities can also be created by multiplying a number or array with a
+    :class:`~astropy.unit.Unit`. See http://docs.astropy.org/en/latest/units/ 
+
     """
     # Need to set a class-level default for _equivalencies, or
     # Constants can not initialize properly

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -189,7 +189,7 @@ class Quantity(np.ndarray):
     Notes
     -----
     Quantities can also be created by multiplying a number or array with a
-    :class:`~astropy.unit.Unit`. See http://docs.astropy.org/en/latest/units/ 
+    :class:`~astropy.unit.Unit`. See http://docs.astropy.org/en/latest/units/
 
     """
     # Need to set a class-level default for _equivalencies, or

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -189,7 +189,7 @@ class Quantity(np.ndarray):
     Notes
     -----
     Quantities can also be created by multiplying a number or array with a
-    :class:`~astropy.unit.Unit`. See http://docs.astropy.org/en/latest/units/
+    :class:`~astropy.units.Unit`. See http://docs.astropy.org/en/latest/units/
 
     """
     # Need to set a class-level default for _equivalencies, or


### PR DESCRIPTION
To make it easier for new users I added a note how to easily create Quantity instances (which I copied from [http://docs.astropy.org/en/stable/units/index.html?highlight=quantity#module-astropy.units.quantity](http://docs.astropy.org/en/stable/units/index.html?highlight=quantity#module-astropy.units.quantity)).