### PR TITLE
Replace "vvvv" and "^^^^" with unicode

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -53,7 +53,7 @@ class FunctionUnitBase(object):
     function_unit :  `~astropy.units.Unit` or `string`
         By default, the same as the function unit set by the subclass.
     """
-    # vvvvv the following four need to be set by subclasses
+    # ↓↓↓ the following four need to be set by subclasses
     # Make this a property so we can ensure subclasses define it.
     @abstractproperty
     def _default_function_unit(self):
@@ -88,7 +88,7 @@ class FunctionUnitBase(object):
         This method should be overridden by subclasses.  It is used to
         provide automatic transformations using an equivalency.
         """
-    # ^^^^^ the above four need to be set by subclasses
+    # ↑↑↑ the above four need to be set by subclasses
 
     # have priority over arrays, regular units, and regular quantities
     __array_priority__ = 30000
@@ -143,7 +143,7 @@ class FunctionUnitBase(object):
         return [(self, self.physical_unit,
                  self.to_physical, self.from_physical)]
 
-    # vvvv properties/methods required to behave like a unit
+    # ↓↓↓ properties/methods required to behave like a unit
     def decompose(self, bases=set()):
         """Copy the current unit with the physical unit decomposed.
 
@@ -536,7 +536,7 @@ class FunctionQuantity(Quantity):
         self._full_unit = unit
         return self
 
-    # vvvv properties not found in Quantity
+    # ↓↓↓ properties not found in Quantity
     @property
     def physical(self):
         """The physical quantity corresponding the function one."""
@@ -550,7 +550,7 @@ class FunctionQuantity(Quantity):
         """
         return self._new_view(self, self.unit.function_unit)
 
-    # vvvv properties overridden to point to different places
+    # ↓↓↓ properties overridden to point to different places
     @property
     def unit(self):
         """Function unit of the quantity, containing the physical unit.
@@ -568,7 +568,7 @@ class FunctionQuantity(Quantity):
         """
         return self.unit.equivalencies
 
-    # vvvv methods overridden to change the behaviour
+    # ↓↓↓ methods overridden to change the behaviour
     @property
     def si(self):
         """Return a copy with the physical unit in SI units."""
@@ -586,7 +586,7 @@ class FunctionQuantity(Quantity):
         """
         return self.__class__(self.physical.decompose(bases))
 
-    # vvvv methods overridden to add additional behaviour
+    # ↓↓↓ methods overridden to add additional behaviour
     def to(self, unit, equivalencies=[]):
         """Returns a new quantity with the specified units.
 
@@ -676,7 +676,7 @@ class FunctionQuantity(Quantity):
             view._unit = unit.function_unit
         return view
 
-    # vvvv methods overridden to change behaviour
+    # ↓↓↓ methods overridden to change behaviour
     def __mul__(self, other):
         if self.unit.physical_unit == dimensionless_unscaled:
             return self._function_view * other


### PR DESCRIPTION
This is a silly PR, but, alas...

For comments that reference code above or below, we could actually use arrows!