### PR TITLE
Add support for converting luminosity densities in spectral_density equivalency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New Features
 
   - Added ``pixel_scale`` and ``plate_scale`` equivalencies. [#4987]
 
+  - The ``spectral_density`` equivalency now supports transformations of
+    luminosity density. [#5151]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -117,18 +117,20 @@ def spectral_density(wav, factor=None):
     hc = c_Aps * h_cgs
 
     # flux density
-    fla = cgs.erg / si.angstrom / si.cm ** 2 / si.s
-    fnu = cgs.erg / si.Hz / si.cm ** 2 / si.s
-    nufnu = cgs.erg / si.cm ** 2 / si.s
-    lafla = nufnu
-    photlam = astrophys.photon / (si.cm ** 2 * si.s * si.AA)
-    photnu = astrophys.photon / (si.cm ** 2 * si.s * si.Hz)
+    f_la = cgs.erg / si.angstrom / si.cm ** 2 / si.s
+    f_nu = cgs.erg / si.Hz / si.cm ** 2 / si.s
+    nu_f_nu = cgs.erg / si.cm ** 2 / si.s
+    la_f_la = nu_f_nu
+    phot_f_la = astrophys.photon / (si.cm ** 2 * si.s * si.AA)
+    phot_f_nu = astrophys.photon / (si.cm ** 2 * si.s * si.Hz)
 
     # luminosity density
-    lnu = cgs.erg / si.s / si.Hz
-    lla = cgs.erg / si.s / si.angstrom
-    nulnu = cgs.erg / si.s
-    lalla = nulnu
+    L_nu = cgs.erg / si.s / si.Hz
+    L_la = cgs.erg / si.s / si.angstrom
+    nu_L_nu = cgs.erg / si.s
+    la_L_la = nu_L_nu
+    phot_L_la = astrophys.photon / (si.s * si.AA)
+    phot_L_nu = astrophys.photon / (si.s * si.Hz)
 
     def converter(x):
         return x * (wav.to(si.AA, spectral()).value ** 2 / c_Aps)
@@ -136,64 +138,63 @@ def spectral_density(wav, factor=None):
     def iconverter(x):
         return x / (wav.to(si.AA, spectral()).value ** 2 / c_Aps)
 
-    def converter_fnu_nufnu(x):
+    def converter_f_nu_to_nu_f_nu(x):
         return x * wav.to(si.Hz, spectral()).value
 
-    def iconverter_fnu_nufnu(x):
+    def iconverter_f_nu_to_nu_f_nu(x):
         return x / wav.to(si.Hz, spectral()).value
 
-    def converter_fla_lafla(x):
+    def converter_f_la_to_la_f_la(x):
         return x * wav.to(si.AA, spectral()).value
 
-    def iconverter_fla_lafla(x):
+    def iconverter_f_la_to_la_f_la(x):
         return x / wav.to(si.AA, spectral()).value
 
-    def converter_photlam_fla(x):
+    def converter_phot_f_la_to_f_la(x):
         return hc * x / wav.to(si.AA, spectral()).value
 
-    def iconverter_photlam_fla(x):
+    def iconverter_phot_f_la_to_f_la(x):
         return x * wav.to(si.AA, spectral()).value / hc
 
-    def converter_photlam_fnu(x):
+    def converter_phot_f_la_to_f_nu(x):
         return h_cgs * x * wav.to(si.AA, spectral()).value
 
-    def iconverter_photlam_fnu(x):
+    def iconverter_phot_f_la_to_f_nu(x):
         return x / (wav.to(si.AA, spectral()).value * h_cgs)
 
-    def converter_photlam_photnu(x):
+    def converter_phot_f_la_phot_f_nu(x):
         return x * wav.to(si.AA, spectral()).value ** 2 / c_Aps
 
-    def iconverter_photlam_photnu(x):
+    def iconverter_phot_f_la_phot_f_nu(x):
         return c_Aps * x / wav.to(si.AA, spectral()).value ** 2
 
-    converter_photnu_fnu = converter_photlam_fla
+    converter_phot_f_nu_to_f_nu = converter_phot_f_la_to_f_la
+    iconverter_phot_f_nu_to_f_nu = iconverter_phot_f_la_to_f_la
 
-    iconverter_photnu_fnu = iconverter_photlam_fla
-
-    def converter_photnu_fla(x):
+    def converter_phot_f_nu_to_f_la(x):
         return x * hc * c_Aps / wav.to(si.AA, spectral()).value ** 3
 
-    def iconverter_photnu_fla(x):
+    def iconverter_phot_f_nu_to_f_la(x):
         return x * wav.to(si.AA, spectral()).value ** 3 / (hc * c_Aps)
 
     # for luminosity density
-    converter_lnu_nulnu = converter_fnu_nufnu
-    converter_lla_lalla = converter_fla_lafla
-    iconverter_lnu_nulnu = iconverter_fnu_nufnu
-    iconverter_lla_lalla = iconverter_fla_lafla
+    converter_L_nu_to_nu_L_nu = converter_f_nu_to_nu_f_nu
+    converter_L_la_to_la_L_la = converter_f_la_to_la_f_la
+    iconverter_L_nu_to_nu_L_nu = iconverter_f_nu_to_nu_f_nu
+    iconverter_L_la_to_la_L_la = iconverter_f_la_to_la_f_la
 
     return [
-        (fla, fnu, converter, iconverter),
-        (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
-        (fla, lafla, converter_fla_lafla, iconverter_fla_lafla),
-        (photlam, fla, converter_photlam_fla, iconverter_photlam_fla),
-        (photlam, fnu, converter_photlam_fnu, iconverter_photlam_fnu),
-        (photlam, photnu, converter_photlam_photnu, iconverter_photlam_photnu),
-        (photnu, fnu, converter_photnu_fnu, iconverter_photnu_fnu),
-        (photnu, fla, converter_photnu_fla, iconverter_photnu_fla),
-        (lla, lnu, converter, iconverter), # luminosity
-        (lnu, nulnu, converter_lnu_nulnu, iconverter_lnu_nulnu),
-        (lla, lalla, converter_lla_lalla, iconverter_lla_lalla)
+        (f_la, f_nu, converter, iconverter),
+        (f_nu, nu_f_nu, converter_f_nu_to_nu_f_nu, iconverter_f_nu_to_nu_f_nu),
+        (f_la, la_f_la, converter_f_la_to_la_f_la, iconverter_f_la_to_la_f_la),
+        (phot_f_la, f_la, converter_phot_f_la_to_f_la, iconverter_phot_f_la_to_f_la),
+        (phot_f_la, f_nu, converter_phot_f_la_to_f_nu, iconverter_phot_f_la_to_f_nu),
+        (phot_f_la, phot_f_nu, converter_phot_f_la_phot_f_nu, iconverter_phot_f_la_phot_f_nu),
+        (phot_f_nu, f_nu, converter_phot_f_nu_to_f_nu, iconverter_phot_f_nu_to_f_nu),
+        (phot_f_nu, f_la, converter_phot_f_nu_to_f_la, iconverter_phot_f_nu_to_f_la),
+        (L_la, L_nu, converter, iconverter), # luminosity
+        (L_nu, nu_L_nu, converter_L_nu_to_nu_L_nu, iconverter_L_nu_to_nu_L_nu),
+        (L_la, la_L_la, converter_L_la_to_la_L_la, iconverter_L_la_to_la_L_la)
     ]
 
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -116,12 +116,19 @@ def spectral_density(wav, factor=None):
     h_cgs = _si.h.cgs.value  # erg * s
     hc = c_Aps * h_cgs
 
+    # flux density
     fla = cgs.erg / si.angstrom / si.cm ** 2 / si.s
     fnu = cgs.erg / si.Hz / si.cm ** 2 / si.s
     nufnu = cgs.erg / si.cm ** 2 / si.s
     lafla = nufnu
     photlam = astrophys.photon / (si.cm ** 2 * si.s * si.AA)
     photnu = astrophys.photon / (si.cm ** 2 * si.s * si.Hz)
+
+    # luminosity density
+    lnu = cgs.erg / si.s / si.Hz
+    lla = cgs.erg / si.s / si.angstrom
+    nulnu = cgs.erg / si.s
+    lalla = nulnu
 
     def converter(x):
         return x * (wav.to(si.AA, spectral()).value ** 2 / c_Aps)
@@ -177,7 +184,10 @@ def spectral_density(wav, factor=None):
         (photlam, fnu, converter_photlam_fnu, iconverter_photlam_fnu),
         (photlam, photnu, converter_photlam_photnu, iconverter_photlam_photnu),
         (photnu, fnu, converter_photnu_fnu, iconverter_photnu_fnu),
-        (photnu, fla, converter_photnu_fla, iconverter_photnu_fla)
+        (photnu, fla, converter_photnu_fla, iconverter_photnu_fla),
+        (lla, lnu, converter, iconverter), # luminosity
+        (lnu, nulnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
+        (lla, lalla, converter_fla_lafla, iconverter_fla_lafla)
     ]
 
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -179,11 +179,23 @@ def spectral_density(wav, factor=None):
 
     # for luminosity density
     converter_L_nu_to_nu_L_nu = converter_f_nu_to_nu_f_nu
-    converter_L_la_to_la_L_la = converter_f_la_to_la_f_la
     iconverter_L_nu_to_nu_L_nu = iconverter_f_nu_to_nu_f_nu
+    converter_L_la_to_la_L_la = converter_f_la_to_la_f_la
     iconverter_L_la_to_la_L_la = iconverter_f_la_to_la_f_la
 
+    converter_phot_L_la_to_L_la = converter_phot_f_la_to_f_la
+    iconverter_phot_L_la_to_L_la = iconverter_phot_f_la_to_f_la
+    converter_phot_L_la_to_L_nu = converter_phot_f_la_to_f_nu
+    iconverter_phot_L_la_to_L_nu = iconverter_phot_f_la_to_f_nu
+    converter_phot_L_la_phot_L_nu = converter_phot_f_la_phot_f_nu
+    iconverter_phot_L_la_phot_L_nu = iconverter_phot_f_la_phot_f_nu
+    converter_phot_L_nu_to_L_nu = converter_phot_f_nu_to_f_nu
+    iconverter_phot_L_nu_to_L_nu = iconverter_phot_f_nu_to_f_nu
+    converter_phot_L_nu_to_L_la = converter_phot_f_nu_to_f_la
+    iconverter_phot_L_nu_to_L_la = iconverter_phot_f_nu_to_f_la
+
     return [
+        # flux
         (f_la, f_nu, converter, iconverter),
         (f_nu, nu_f_nu, converter_f_nu_to_nu_f_nu, iconverter_f_nu_to_nu_f_nu),
         (f_la, la_f_la, converter_f_la_to_la_f_la, iconverter_f_la_to_la_f_la),
@@ -192,9 +204,15 @@ def spectral_density(wav, factor=None):
         (phot_f_la, phot_f_nu, converter_phot_f_la_phot_f_nu, iconverter_phot_f_la_phot_f_nu),
         (phot_f_nu, f_nu, converter_phot_f_nu_to_f_nu, iconverter_phot_f_nu_to_f_nu),
         (phot_f_nu, f_la, converter_phot_f_nu_to_f_la, iconverter_phot_f_nu_to_f_la),
-        (L_la, L_nu, converter, iconverter), # luminosity
+        # luminosity
+        (L_la, L_nu, converter, iconverter),
         (L_nu, nu_L_nu, converter_L_nu_to_nu_L_nu, iconverter_L_nu_to_nu_L_nu),
-        (L_la, la_L_la, converter_L_la_to_la_L_la, iconverter_L_la_to_la_L_la)
+        (L_la, la_L_la, converter_L_la_to_la_L_la, iconverter_L_la_to_la_L_la),
+        (phot_L_la, L_la, converter_phot_L_la_to_L_la, iconverter_phot_L_la_to_L_la),
+        (phot_L_la, L_nu, converter_phot_L_la_to_L_nu, iconverter_phot_L_la_to_L_nu),
+        (phot_L_la, phot_L_nu, converter_phot_L_la_phot_L_nu, iconverter_phot_L_la_phot_L_nu),
+        (phot_L_nu, L_nu, converter_phot_L_nu_to_L_nu, iconverter_phot_L_nu_to_L_nu),
+        (phot_L_nu, L_la, converter_phot_L_nu_to_L_la, iconverter_phot_L_nu_to_L_la),
     ]
 
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -176,6 +176,12 @@ def spectral_density(wav, factor=None):
     def iconverter_photnu_fla(x):
         return x * wav.to(si.AA, spectral()).value ** 3 / (hc * c_Aps)
 
+    # for luminosity density
+    converter_lnu_nulnu = converter_fnu_nufnu
+    converter_lla_lalla = converter_fla_lafla
+    iconverter_lnu_nulnu = iconverter_fnu_nufnu
+    iconverter_lla_lalla = iconverter_fla_lafla
+
     return [
         (fla, fnu, converter, iconverter),
         (fnu, nufnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
@@ -186,8 +192,8 @@ def spectral_density(wav, factor=None):
         (photnu, fnu, converter_photnu_fnu, iconverter_photnu_fnu),
         (photnu, fla, converter_photnu_fla, iconverter_photnu_fla),
         (lla, lnu, converter, iconverter), # luminosity
-        (lnu, nulnu, converter_fnu_nufnu, iconverter_fnu_nufnu),
-        (lla, lalla, converter_fla_lafla, iconverter_fla_lafla)
+        (lnu, nulnu, converter_lnu_nulnu, iconverter_lnu_nulnu),
+        (lla, lalla, converter_lla_lalla, iconverter_lla_lalla)
     ]
 
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -407,6 +407,49 @@ def test_spectraldensity4():
     assert_allclose(u.ABmag.to(
         photlam, flux_abmag, u.spectral_density(wave)), flux_photlam, rtol=1e-6)
 
+def test_spectraldensity5():
+    """ Test photon luminosity density conversions. """
+    L_la = u.erg / (u.s * u.AA)
+    L_nu = u.erg / (u.s * u.Hz)
+    phot_L_la = u.photon / (u.s * u.AA)
+    phot_L_nu = u.photon / (u.s * u.Hz)
+
+    wave = u.Quantity([4956.8, 4959.55, 4962.3], u.AA)
+    flux_phot_L_la = [9.7654e-3, 1.003896e-2, 9.78473e-3]
+    flux_phot_L_nu = [8.00335589e-14, 8.23668949e-14, 8.03700310e-14]
+    flux_L_la = [3.9135e-14, 4.0209e-14, 3.9169e-14]
+    flux_L_nu = [3.20735792e-25, 3.29903646e-25, 3.21727226e-25]
+
+    # PHOTLAM <--> FLAM
+    assert_allclose(phot_L_la.to(
+        L_la, flux_phot_L_la, u.spectral_density(wave)), flux_L_la, rtol=1e-6)
+    assert_allclose(L_la.to(
+        phot_L_la, flux_L_la, u.spectral_density(wave)), flux_phot_L_la, rtol=1e-6)
+
+    # PHOTLAM <--> FNU
+    assert_allclose(phot_L_la.to(
+        L_nu, flux_phot_L_la, u.spectral_density(wave)), flux_L_nu, rtol=1e-6)
+    assert_allclose(L_nu.to(
+        phot_L_la, flux_L_nu, u.spectral_density(wave)), flux_phot_L_la, rtol=1e-6)
+
+    # PHOTLAM <--> PHOTNU
+    assert_allclose(phot_L_la.to(
+        phot_L_nu, flux_phot_L_la, u.spectral_density(wave)), flux_phot_L_nu, rtol=1e-6)
+    assert_allclose(phot_L_nu.to(
+        phot_L_la, flux_phot_L_nu, u.spectral_density(wave)), flux_phot_L_la, rtol=1e-6)
+
+    # PHOTNU <--> FNU
+    assert_allclose(phot_L_nu.to(
+        L_nu, flux_phot_L_nu, u.spectral_density(wave)), flux_L_nu, rtol=1e-6)
+    assert_allclose(L_nu.to(
+        phot_L_nu, flux_L_nu, u.spectral_density(wave)), flux_phot_L_nu, rtol=1e-6)
+
+    # PHOTNU <--> FLAM
+    assert_allclose(phot_L_nu.to(
+        L_la, flux_phot_L_nu, u.spectral_density(wave)), flux_L_la, rtol=1e-6)
+    assert_allclose(L_la.to(
+        phot_L_nu, flux_L_la, u.spectral_density(wave)), flux_phot_L_nu, rtol=1e-6)
+
 
 def test_equivalent_units():
     from .. import imperial

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -291,11 +291,22 @@ def test_spectral4(in_val, in_unit):
 
 
 def test_spectraldensity2():
+    # flux density
     flambda = u.erg / u.angstrom / u.cm ** 2 / u.s
     fnu = u.erg / u.Hz / u.cm ** 2 / u.s
 
     a = flambda.to(fnu, 1, u.spectral_density(u.Quantity(3500, u.AA)))
     assert_allclose(a, 4.086160166177361e-12)
+
+    # luminosity density
+    llambda = u.erg / u.angstrom / u.s
+    lnu = u.erg / u.Hz / u.s
+
+    a = llambda.to(lnu, 1, u.spectral_density(u.Quantity(3500, u.AA)))
+    assert_allclose(a, 4.086160166177361e-12)
+
+    a = lnu.to(llambda, 1, u.spectral_density(u.Quantity(3500, u.AA)))
+    assert_allclose(a, 2.44728537142857e11)
 
 
 def test_spectraldensity3():

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -152,16 +152,16 @@ locations.  The function that handles these unit conversions is
 :func:`~astropy.units.equivalencies.spectral_density`. This function takes as
 its arguments the |quantity| for the spectral location. For example::
 
-    >>> (1.5 * u.Jy).to(u.erg / u.cm**2 / u.s / u.Hz,
-    ...                 equivalencies=u.spectral_density(3500 * u.AA))
-    <Quantity 1.5e-23 erg / (cm2 Hz s)>
-    >>> (1.5 * u.Jy).to(u.erg / u.cm**2 / u.s / u.micron,
+    >>> (1.5 * u.Jy).to(u.photon / u.cm**2 / u.s / u.Hz,
+    ...                 equivalencies=u.spectral_density(3500 * u.AA)) # doctest: +FLOAT_CMP
+    <Quantity 2.6429114293019694e-12 ph / (cm2 Hz s)>
+    >>> (1.5 * u.Jy).to(u.photon / u.cm**2 / u.s / u.micron,
     ...                 equivalencies=u.spectral_density(3500 * u.AA))  # doctest: +FLOAT_CMP
-    <Quantity 3.670928057142856e-08 erg / (cm2 micron s)>
-    >>> a = 1. * u.erg / u.s / u.angstrom
+    <Quantity 6467.9584789120845 ph / (cm2 micron s)>
+    >>> a = 1. * u.photon / u.s / u.angstrom
     >>> a.to(u.erg / u.s / u.Hz,
-    ...      equivalencies=u.spectral_density(5500 * u.AA))
-    <Quantity 1.00903138797441e-11 erg / (Hz s)>
+    ...      equivalencies=u.spectral_density(5500 * u.AA)) # doctest: +FLOAT_CMP
+    <Quantity 3.6443382634999996e-23 erg / (Hz s)>
 
 Brightness Temperature / Flux Density Equivalency
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -142,16 +142,15 @@ These three conventions are implemented in
     >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
     <Quantity -1895.4321928669085 km / s>
 
-Spectral Flux Density Units
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Spectral Flux / Luminosity Density Units
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There is also support for spectral flux density units. Their use is
-more complex, since it is necessary to also supply the location in the
-spectrum for which the conversions will be done, and the units of
-those spectral locations.  The function that handles these unit
-conversions is :func:`~astropy.units.equivalencies.spectral_density`. This
-function takes as its arguments the |quantity| for the spectral
-location. For example::
+There is also support for spectral flux and luminosity density units. Their use
+is more complex, since it is necessary to also supply the location in the
+spectrum for which the conversions will be done, and the units of those spectral
+locations.  The function that handles these unit conversions is
+:func:`~astropy.units.equivalencies.spectral_density`. This function takes as
+its arguments the |quantity| for the spectral location. For example::
 
     >>> (1.5 * u.Jy).to(u.erg / u.cm**2 / u.s / u.Hz,
     ...                 equivalencies=u.spectral_density(3500 * u.AA))
@@ -159,6 +158,10 @@ location. For example::
     >>> (1.5 * u.Jy).to(u.erg / u.cm**2 / u.s / u.micron,
     ...                 equivalencies=u.spectral_density(3500 * u.AA))  # doctest: +FLOAT_CMP
     <Quantity 3.670928057142856e-08 erg / (cm2 micron s)>
+    >>> a = 1. * u.erg / u.s / u.angstrom
+    >>> a.to(u.erg / u.s / u.Hz,
+    ...      equivalencies=u.spectral_density(5500 * u.AA))
+    <Quantity 1.00903138797441e-11 erg / (Hz s)>
 
 Brightness Temperature / Flux Density Equivalency
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR addresses #5032 to add support for transforming luminosity densities, e.g.,

```python
>>> a = 1*u.erg/u.s/u.Hz
>>> a.to(u.erg/u.s/u.AA, equivalencies=u.spectral_density(5000*u.AA))
<Quantity 119916983199.99998 erg / (Angstrom s)>
```

See in-line questions below.