### PR TITLE
Fix formatting example in documentation

### DIFF
--- a/docs/coordinates/formatting.rst
+++ b/docs/coordinates/formatting.rst
@@ -29,7 +29,7 @@ more).  For example::
 You can also use python's `format` string method to create more complex
 string expressions, such as IAU-style coordinates or even full sentences::
 
-  >>> 'SDSS J{0}{1}'.format(c.ra.to_string(sep='', precision=2, pad=True), c.dec.to_string(sep='', precision=2, alwayssign=True, pad=True))
-  'SDSS J1874221.31+122328.03'
-  >>> 'The galaxy M87, at an RA of {0.ra.deg:.1f} and Dec of {0.dec.deg:.1f} degrees, has an impressive jet.'.format(c)
-  'The galaxy M87, at an RA of 187.7 and Dec of 12.4 degrees, has an impressive jet.'
+  >>> 'SDSS J{0}{1}'.format(c.ra.to_string(unit=u.hourangle, sep='', precision=2, pad=True), c.dec.to_string(sep='', precision=2, alwayssign=True, pad=True))
+  'SDSS J123049.42+122328.03'
+  >>> 'The galaxy M87, at an RA of {0.ra.hour:.2f} hours and Dec of {0.dec.deg:.1f} degrees, has an impressive jet.'.format(c)
+  'The galaxy M87, at an RA of 12.51 hours and Dec of 12.4 degrees, has an impressive jet.'


### PR DESCRIPTION
As noted in the issue #4767, the formatted RA should be in hours.