### PR TITLE
Hide numpy warnings for initial operations on unscaled quantity values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,10 @@ Bug Fixes
     be taken from logarithmic quanties such as ``Magnitude`` if the physical
     unit is dimensionless. [#5070]
 
+  - For inverse trig functions that operate on quantities, catch any warnings
+    that occur from evaluating the function on the unscaled quantity value
+    between __array_prepare__ and __array_wrap__. [#5153]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 # Standard library
 import numbers
 from fractions import Fraction
+import warnings
 
 import numpy as np
 
@@ -464,9 +465,19 @@ class Quantity(np.ndarray):
         # unit output will get (setting _unit could prematurely change input
         # if obj is self, which happens for in-place operations; see above)
         result._result_unit = result_unit
+
+        self._catch_warnings = warnings.catch_warnings()
+        self._catch_warnings.__enter__()
+        warnings.filterwarnings('ignore',
+                                message='invalid value encountered in',
+                                category=RuntimeWarning)
+
         return result
 
     def __array_wrap__(self, obj, context=None):
+        self._catch_warnings.__exit__()
+        del self._catch_warnings
+
         if context is None:
             # Methods like .squeeze() created a new `ndarray` and then call
             # __array_wrap__ to turn the array into self's subclass.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -478,9 +478,6 @@ class Quantity(np.ndarray):
         return result
 
     def __array_wrap__(self, obj, context=None):
-        if hasattr(self, '_catch_warnings'):
-            self._catch_warnings.__exit__()
-            del self._catch_warnings
 
         if context is None:
             # Methods like .squeeze() created a new `ndarray` and then call
@@ -501,6 +498,10 @@ class Quantity(np.ndarray):
 
                 converters = obj._converters
                 del obj._converters
+
+                if hasattr(self, '_catch_warnings'):
+                    self._catch_warnings.__exit__()
+                    del self._catch_warnings
 
                 # For in-place operations, input will get overwritten with
                 # junk. To avoid that, we hid it in a new object in

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -475,8 +475,9 @@ class Quantity(np.ndarray):
         return result
 
     def __array_wrap__(self, obj, context=None):
-        self._catch_warnings.__exit__()
-        del self._catch_warnings
+        if hasattr(self, '_catch_warnings'):
+            self._catch_warnings.__exit__()
+            del self._catch_warnings
 
         if context is None:
             # Methods like .squeeze() created a new `ndarray` and then call

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1,6 +1,8 @@
 # The purpose of these tests are to ensure that calling ufuncs with quantities
 # returns quantities with the right units, or raises exceptions.
 
+import warnings
+
 import numpy as np
 from numpy.testing.utils import assert_allclose
 
@@ -60,6 +62,14 @@ class TestQuantityTrigonometricFuncs(object):
             np.arcsin(3. * u.m)
         assert exc.value.args[0] == ("Can only apply 'arcsin' function to "
                                      "dimensionless quantities")
+
+    def test_arcsin_no_warning_on_unscaled_quantity(self):
+        a = 15 * u.kpc
+        b = 27 * u.pc
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            np.arcsin(b/a)
 
     def test_cos_scalar(self):
         q = np.cos(np.pi / 3. * u.radian)


### PR DESCRIPTION
This is an attempt to fix #3240.

Summarizing my understanding of the problem: numpy ufuncs will first operate directly on a quantity's value before it is scaled properly. This can cause a warning for things that are valid operations. For example, arcsin of the quantity `15 pc / kpc` -- arcsin(15) will throw a warning, but after scaling, arcsin(0.015) is fine. This PR silences warnings like this by utilizing the `warnings.catch_warnings` context manager to silence numpy Runtime warnings in between `__array_prepare__` and `__array_wrap__`. (I use the context manager to do this because it seems that temporarily catching a warning and then returning to the previous state is actually a nontrivial task, e.g., http://stackoverflow.com/questions/2390766/how-do-i-disable-and-then-re-enable-a-warning)

cc @mhvk 

Closes #3240