### PR TITLE
Add of_address classmethod to EarthLocation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ New Features
 
 - ``astropy.coordinates``
 
-  - Added a ``from_address`` classmethod to ``EarthLocation`` to enable fast creation of
+  - Added an ``of_address`` classmethod to ``EarthLocation`` to enable fast creation of
     ``EarthLocation`` objects given an address by querying the Google maps API [#5154].
 
 - ``astropy.cosmology``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ New Features
 
 - ``astropy.coordinates``
 
+  - Added a ``from_address`` classmethod to ``EarthLocation`` to enable fast creation of
+    ``EarthLocation`` objects given an address by querying the Google maps API [#5154].
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -2,14 +2,20 @@
 from __future__ import absolute_import, division, print_function
 
 from warnings import warn
+import socket
+import json
 
 import numpy as np
 from .. import units as u
 from ..extern import six
+from ..extern.six.moves import urllib
 from ..utils.exceptions import AstropyUserWarning
 from . import Longitude, Latitude
 from .builtin_frames import ITRS, GCRS
 from .errors import UnknownSiteException
+from ..utils import data
+
+from .name_resolve import NameResolveError
 
 try:
     # Not guaranteed available at setup time.
@@ -233,6 +239,80 @@ class EarthLocation(u.Quantity):
             newel = cls.from_geodetic(*el.to_geodetic())
             newel.info.name = el.info.name
             return newel
+
+    @classmethod
+    def from_address(cls, address):
+        """
+        Return an object of this class for a given address by querying the Google
+        maps geocoding API.
+
+        This is intended as a quick convenience function to get fast access to
+        locations. In the background, this just issues a query to the Google maps
+        geocoding API. It is not meant to be abused! Google uses IP-based query
+        limiting and will ban your IP if you send more than a few thousand queries
+        per hour. See the Google maps geocoding documentation for more information:
+        https://developers.google.com/maps/documentation/geocoding/intro
+
+        .. warning::
+            If the query returns more than one location (e.g., searching on
+            ``address='springfield'``), this function will use the _first_ returned
+            location.
+
+        Parameters
+        ----------
+        address : str
+            The address to get the location for. As per the Google maps API, this
+            can be a fully specified street address (e.g., 123 Main St., New York,
+            NY) or a city name (e.g., Danbury, CT), or etc.
+
+        Returns
+        -------
+        location : This class (a `~astropy.coordinates.EarthLocation` or subclass)
+            The location of the input address.
+
+        See Also
+        --------
+        https://developers.google.com/maps/documentation/geocoding/intro
+
+        """
+
+        pars = urllib.parse.urlencode({'address': address})
+        url = "https://maps.googleapis.com/maps/api/geocode/json?{0}".format(pars)
+
+        # common error message
+        err_str = ("Unable to retrieve coordinates for address '{address}'; {{msg}}"
+                   .format(address=address))
+
+        try:
+            # Retrieve JSON response from Google maps API
+            resp = urllib.request.urlopen(url, timeout=data.conf.remote_timeout)
+            resp_data = json.loads(resp.read().decode('utf8'))
+
+        except urllib.error.URLError as e:
+            # This catches a timeout error, see:
+            #   http://stackoverflow.com/questions/2712524/handling-urllib2s-timeout-python
+            if isinstance(e.reason, socket.timeout):
+                raise NameResolveError(err_str.format(msg="connection timed out"))
+            else:
+                raise NameResolveError(err_str.format(msg=e.reason))
+
+        except socket.timeout:
+            # There are some cases where urllib2 does not catch socket.timeout
+            # especially while receiving response data on an already previously
+            # working request
+            raise NameResolveError(err_str.format(msg="connection timed out"))
+
+        results = resp_data.get('results', [])
+
+        if len(results) == 0:
+            raise NameResolveError(err_str.format(msg="no results returned"))
+
+        if resp_data.get('status', None) != 'OK':
+            raise NameResolveError(err_str.format(msg="unknown failure with Google maps API"))
+
+        loc = results[0]['geometry']['location']
+        return cls.from_geodetic(lon=loc['lng']*u.degree,
+                                 lat=loc['lat']*u.degree)
 
     @classmethod
     def get_site_names(cls):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -283,7 +283,7 @@ class EarthLocation(u.Quantity):
 
         .. warning::
             If the query returns more than one location (e.g., searching on
-            ``address='springfield'``), this function will use the _first_ returned
+            ``address='springfield'``), this function will use the **first** returned
             location.
 
         Parameters

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -279,8 +279,7 @@ class EarthLocation(u.Quantity):
         locations. In the background, this just issues a query to the Google maps
         geocoding API. It is not meant to be abused! Google uses IP-based query
         limiting and will ban your IP if you send more than a few thousand queries
-        per hour. See the Google maps geocoding documentation for more information:
-        https://developers.google.com/maps/documentation/geocoding/intro
+        per hour [1]_.
 
         .. warning::
             If the query returns more than one location (e.g., searching on
@@ -295,17 +294,17 @@ class EarthLocation(u.Quantity):
             NY) or a city name (e.g., Danbury, CT), or etc.
         get_height : bool (optional)
             Use the retrieved location to perform a second query to the Google maps
-            elevation API to retrieve the height of the input address.
+            elevation API to retrieve the height of the input address [2]_.
 
         Returns
         -------
         location : This class (a `~astropy.coordinates.EarthLocation` or subclass)
             The location of the input address.
 
-        See Also
-        --------
-        https://developers.google.com/maps/documentation/geocoding/intro
-        https://developers.google.com/maps/documentation/elevation/intro
+        References
+        ----------
+        .. [1] https://developers.google.com/maps/documentation/geocoding/intro
+        .. [2] https://developers.google.com/maps/documentation/elevation/intro
 
         """
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -270,7 +270,7 @@ class EarthLocation(u.Quantity):
             return newel
 
     @classmethod
-    def from_address(cls, address, get_height=False):
+    def of_address(cls, address, get_height=False):
         """
         Return an object of this class for a given address by querying the Google
         maps geocoding API.

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -68,7 +68,7 @@ def _get_json_result(url, err_str):
 
     results = resp_data.get('results', [])
 
-    if len(results) == 0:
+    if not results:
         raise NameResolveError(err_str.format(msg="no results returned"))
 
     if resp_data.get('status', None) != 'OK':

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -13,8 +13,9 @@ import numpy as np
 
 from ..earth import EarthLocation, ELLIPSOIDS
 from ..angles import Longitude, Latitude
-from ...tests.helper import pytest, quantity_allclose
+from ...tests.helper import pytest, quantity_allclose, remote_data
 from ... import units as u
+from ..name_resolve import NameResolveError
 
 def allclose_m14(a, b, rtol=1.e-14, atol=None):
     if atol is None:
@@ -266,3 +267,13 @@ def test_repr_latex():
     somelocation._repr_latex_()
     somelocation2 = EarthLocation(lon=[1., 2.]*u.deg, lat=[-1., 9.]*u.deg)
     somelocation2._repr_latex_()
+
+
+@remote_data
+def test_from_address():
+    with pytest.raises(NameResolveError):
+        EarthLocation.from_address("lkjasdflkja")
+
+    loc = EarthLocation.from_address("New York, NY")
+    quantity_allclose(loc.latitude, 40.7128*u.degree)
+    quantity_allclose(loc.longitude, -74.0059*u.degree)

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -271,9 +271,18 @@ def test_repr_latex():
 
 @remote_data
 def test_from_address():
+    # no match
     with pytest.raises(NameResolveError):
         EarthLocation.from_address("lkjasdflkja")
 
+    # just a location
     loc = EarthLocation.from_address("New York, NY")
-    quantity_allclose(loc.latitude, 40.7128*u.degree)
-    quantity_allclose(loc.longitude, -74.0059*u.degree)
+    assert quantity_allclose(loc.latitude, 40.7128*u.degree)
+    assert quantity_allclose(loc.longitude, -74.0059*u.degree)
+    assert np.allclose(loc.height.value, 0.)
+
+    # a location and height
+    loc = EarthLocation.from_address("New York, NY", get_height=True)
+    assert quantity_allclose(loc.latitude, 40.7128*u.degree)
+    assert quantity_allclose(loc.longitude, -74.0059*u.degree)
+    assert quantity_allclose(loc.height, 10.438659669*u.meter)

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -206,7 +206,7 @@ for a particular named object::
         (83.82208, -5.39111)>
 
 For sites (primarily observatories) on the Earth, `astropy.coordinates` provides
-a similar quick way to get an `~astropy.coordinates.EarthLocation`::
+a quick way to get an `~astropy.coordinates.EarthLocation`::
 
     >>> from astropy.coordinates import EarthLocation
     >>> EarthLocation.of_site('Apache Point Observatory')  # doctest: +REMOTE_DATA +FLOAT_CMP
@@ -215,16 +215,32 @@ a similar quick way to get an `~astropy.coordinates.EarthLocation`::
 To see the list of site names available, use
 :func:`astropy.coordinates.EarthLocation.get_site_names`.
 
-.. note::
-    `~astropy.coordinates.SkyCoord.from_name` and
-    `~astropy.coordinates.EarthLocation.of_site` are for convenience, and hence
-    are by design rather simple. If you need precise coordinates for an object
-    you should find the appropriate reference and input the coordinates
-    manually, or use more specialized functionality like that in the
-    `astroquery <http://www.astropy.org/astroquery/>`_ or
-    `astroplan <http://astroplan.readthedocs.io/>`_ affiliated packages.
+For arbitrary Earth addresses (e.g., not observatory sites), use the
+`~astropy.coordinates.EarthLocation.of_address` classmethod. Any address passed
+to this function uses Google maps to retrieve the latitude and longitude and can
+also (optionally) query Google maps to get the height of the location. As with
+Google maps, this works with fully specified addresses, location names, city
+names, and etc.::
 
-    Also note that these two methods retrieve data from the internet to
+    >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO')  # doctest: +REMOTE_DATA +FLOAT_CMP
+    <EarthLocation (-26727.247396719715, -4997012.160946069, 3950268.2727357596) m>
+    >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO',
+    ...                          get_height=True)  # doctest: +REMOTE_DATA +FLOAT_CMP
+    <EarthLocation (-26727.890243898288, -4997132.349722762, 3950363.9254298285) m>
+    >>> EarthLocation.of_address('Danbury, CT')  # doctest: +REMOTE_DATA +FLOAT_CMP
+    <EarthLocation (1364606.6451165068, -4593292.942827304, 4195415.936951392) m>
+
+.. note::
+    `~astropy.coordinates.SkyCoord.from_name`,
+    `~astropy.coordinates.EarthLocation.of_site`, and
+    `~astropy.coordinates.EarthLocation.of_address` are for convenience, and
+    hence are by design rather simple. If you need precise coordinates for an
+    object you should find the appropriate reference and input the coordinates
+    manually, or use more specialized functionality like that in the `astroquery
+    <http://www.astropy.org/astroquery/>`_ or `astroplan
+    <http://astroplan.readthedocs.io/>`_ affiliated packages.
+
+    Also note that these methods retrieve data from the internet to
     determine the celestial or Earth coordinates. The online data may be
     updated, so if you need to guarantee that your scripts are reproducible
     in the long term, see the :doc:`remote_methods` section.


### PR DESCRIPTION
In the same vein as `SkyCoord.from_name()`, this PR implements a `from_address()` classmethod on `EarthLocation` that queries the Google maps API to get a latitude and longitude for a specified address. As with Google maps, the address can be a fully specified address (e.g., 123 Main St., New York, NY), or a city (e.g., Danbury), or a country, etc. etc...

cc @eteq @bmorris3 