### PR TITLE
Move sphinx build to python3

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -4,6 +4,7 @@ channels:
   - astropy
 
 dependencies:
+  - python>=3
   - astropy-helpers
   - numpy
   - cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         # runs for a long time. The sphinx build also has some additional
         # dependencies.
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
+          env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='sphinx-gallery>=0.1.2 pillow wcsaxes --no-deps jplephem'
 


### PR DESCRIPTION
@bsipocz's #4556 made it possible to build the documentation well with python3. This is a reminder to consider moving the read-the-docs and travis sphinx builds to it. From @astrofrog's https://github.com/astropy/astropy/pull/4556#issuecomment-223653110

> I think we should do the switch to Python 3 on RTD **after** the release so that we can deal with things step by step. Note that RTD will not stop serving existing docs, so once we make the switch on RTD to Python 3, only new docs will need to be build-able. This suggests to me the following timeline:

* [X] Merge #4556 and keep Travis on Python 2.7
* [X] Go ahead with the 1.2 and 1.0.10 releases
* [X] Switch default travis build to python 3, but not yet the docs [#5155]
* [ ] Switch Travis and RTD to build the docs with Python 3. At this point, new ``latest`` builds will start building with Python 3, and future 1.2.x builds will also be fine since the 1.2.x branch includes the changes here.
* [ ] Backport any required changes for the docs to build to astropy-helpers 1.0.x, and release a new version of the helpers
* [ ] Update the 1.0.x branch of astropy core to the latest astropy-helpers and do whatever fixes are needed to get it building without errors on Python 3
* [ ] Carry out a new 1.0.x release, which will now build correctly on RTD
