### PR TITLE
Fix build_docs build path

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,11 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 
+[build_docs]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1


### PR DESCRIPTION
This adds a new section to `setup.cfg` for `build_docs` so that

    python setup.py build_sphinx

and

    python setup.py build_docs

build to the same location: `<root>/docs/_build/...`. Testing locally, this seems to be all it took. Not sure if this should be tested in some way -- thoughts?

Also, I'm not sold that we need two documentation build commands that do the same exact thing, but that can be discussed elsewhere...(I guess I should take it up with [robo-Erik](https://github.com/astropy/astropy/pull/4133#issuecomment-230601085)?)

Closes #4133 

cc @eteq @astrofrog 