### PR TITLE
Check that CITATION file is well-formatted.

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -256,8 +256,9 @@ def _get_bibtex():
     import re
     if os.path.exists('CITATION'):
         with open('CITATION', 'r') as citation:
-            refcontents = re.findall(r'\{[^()]*\}', citation.read())[0]
-            bibtexreference = "@ARTICLE{0}".format(refcontents)
+            refs = re.findall(r'\{[^()]*\}', citation.read())
+            if len(refs) == 0: return ''
+            bibtexreference = "@ARTICLE{0}".format(refs[0])
         return bibtexreference
     else:
         return ''


### PR DESCRIPTION
In cases where astropy is imported in a directory that includes an ill-formatted CITATION file (or one that does not explicitly conform to the form that astropy expects) this was causing an import failure, as it expected at least one value to be returned.