### PR TITLE
Replace clobber parameter with overwrite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,9 +183,12 @@ API Changes
     - Removed ``startColumn`` and ``endColumn`` arguments to the ``FITS_record``
       constructor.
 
-  - FITS writers now accept an ``overwrite`` argument. If ``clobber``
-    is used, an ``AstropyDeprecationWarning`` is issued. If both are
-    used, a ``TypeError`` is raised. [#5171]
+  - The ``clobber`` argument in FITS writers has been renamed to
+    ``overwrite``. This change affects the following functions and
+    methods: ``tabledump``, ``writeto``, ``Header.tofile``,
+    ``Header.totextfile``, ``_BaseDiff.report``,
+    ``_BaseHDU.overwrite``, ``BinTableHDU.dump`` and
+    ``HDUList.writeto``. [#5171]
 
 - ``astropy.io.misc``
 
@@ -229,9 +232,8 @@ API Changes
 
 - ``astropy.vo``
 
-  - ``VOSDatabase.to_json()`` now accepts an ``overwrite`` argument.
-    If ``clobber`` is used, an ``AstropyDeprecationWarning`` is
-    issued. If both are used, a ``TypeError`` is raised. [#5171]
+  - The ``clobber`` argument in ``VOSDatabase.to_json()`` has been
+    renamed to ``overwrite``. [#5171]
 
 - ``astropy.wcs``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -229,6 +229,10 @@ API Changes
 
 - ``astropy.vo``
 
+  - ``VOSDatabase.to_json()`` now accepts an ``overwrite`` argument.
+    If ``clobber`` is used, an ``AstropyDeprecationWarning`` is
+    issued. If both are used, a ``TypeError`` is raised. [#5171]
+
 - ``astropy.wcs``
 
   - ``wcs.rotateCD()`` was deprecated without a replacement. [#5240]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,6 +183,10 @@ API Changes
     - Removed ``startColumn`` and ``endColumn`` arguments to the ``FITS_record``
       constructor.
 
+  - FITS writers now accept an ``overwrite`` argument. If ``clobber``
+    is used, an ``AstropyDeprecationWarning`` is issued. If both are
+    used, a ``TypeError`` is raised. [#5171]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -411,10 +411,12 @@ def writeto(filename, data, header=None, output_verify='exception',
         for more info.
 
     overwrite : bool, optional
-        If ``True``, overwrite the output file if exists.
+        If ``True``, overwrite the output file if it exists. Raises an
+        ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+        output file exists. Default is ``False``.
 
         .. versionchanged:: 1.3
-           ``overwrite`` replaces the deprecated ``clobber`` argument
+           ``overwrite`` replaces the deprecated ``clobber`` argument.
 
     checksum : bool, optional
         If `True`, adds both ``DATASUM`` and ``CHECKSUM`` cards to the
@@ -723,10 +725,12 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
         dumped.
 
     overwrite : bool, optional
-        If ``True``, overwrite the output file if exists.
+        If ``True``, overwrite the output file if it exists. Raises an
+        ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+        output file exists. Default is ``False``.
 
         .. versionchanged:: 1.3
-           ``overwrite`` replaces the deprecated ``clobber`` argument
+           ``overwrite`` replaces the deprecated ``clobber`` argument.
 
     Notes
     -----

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -73,6 +73,7 @@ from ...units.format.fits import UnitScaleError
 from ...extern import six
 from ...extern.six import string_types
 from ...utils.exceptions import AstropyUserWarning
+from ...utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
@@ -382,8 +383,9 @@ def delval(filename, keyword, *args, **kwargs):
         hdulist.close(closed=closed)
 
 
+@deprecated_renamed_argument('clobber', 'overwrite', '1.3')
 def writeto(filename, data, header=None, output_verify='exception',
-            clobber=False, checksum=False):
+            overwrite=False, checksum=False):
     """
     Create a new FITS file using the supplied data/header.
 
@@ -408,9 +410,8 @@ def writeto(filename, data, header=None, output_verify='exception',
         ``+warn``, or ``+exception" (e.g. ``"fix+warn"``).  See :ref:`verify`
         for more info.
 
-    clobber : bool, optional
-        If `True`, and if filename already exists, it will overwrite
-        the file.  Default is `False`.
+    overwrite : bool, optional
+        If ``True``, overwrite the output file if exists.
 
     checksum : bool, optional
         If `True`, adds both ``DATASUM`` and ``CHECKSUM`` cards to the
@@ -420,7 +421,7 @@ def writeto(filename, data, header=None, output_verify='exception',
     hdu = _makehdu(data, header)
     if hdu.is_image and not isinstance(hdu, PrimaryHDU):
         hdu = PrimaryHDU(data, header=header)
-    hdu.writeto(filename, clobber=clobber, output_verify=output_verify,
+    hdu.writeto(filename, overwrite=overwrite, output_verify=output_verify,
                 checksum=checksum)
 
 
@@ -688,8 +689,9 @@ def info(filename, output=None, **kwargs):
     return ret
 
 
+@deprecated_renamed_argument('clobber', 'overwrite', '1.3')
 def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
-              clobber=False):
+              overwrite=False):
     """
     Dump a table HDU to a file in ASCII format.  The table may be
     dumped in three separate files, one containing column definitions,
@@ -717,8 +719,8 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
         The number of the extension containing the table HDU to be
         dumped.
 
-    clobber : bool
-        Overwrite the output files if they exist.
+    overwrite : bool, optional
+        If ``True``, overwrite the output file if exists.
 
     Notes
     -----
@@ -744,7 +746,7 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
             datafile = root + '_' + repr(ext) + '.txt'
 
         # Dump the data from the HDU to the files
-        f[ext].dump(datafile, cdfile, hfile, clobber)
+        f[ext].dump(datafile, cdfile, hfile, overwrite)
     finally:
         if closed:
             f.close()

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -413,6 +413,9 @@ def writeto(filename, data, header=None, output_verify='exception',
     overwrite : bool, optional
         If ``True``, overwrite the output file if exists.
 
+        .. versionchanged:: 1.3
+           ``overwrite`` replaces the deprecated ``clobber`` argument
+
     checksum : bool, optional
         If `True`, adds both ``DATASUM`` and ``CHECKSUM`` cards to the
         headers of all HDU's written to the file.
@@ -721,6 +724,9 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
 
     overwrite : bool, optional
         If ``True``, overwrite the output file if exists.
+
+        .. versionchanged:: 1.3
+           ``overwrite`` replaces the deprecated ``clobber`` argument
 
     Notes
     -----

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -137,7 +137,8 @@ class _BaseDiff(object):
 
     @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
     def report(self, fileobj=None, indent=0, overwrite=False):
-        """Generates a text report on the differences (if any) between two
+        """
+        Generates a text report on the differences (if any) between two
         objects, and either returns it as a string or writes it to a file-like
         object.
 
@@ -153,10 +154,12 @@ class _BaseDiff(object):
             The number of 4 space tabs to indent the report.
 
         overwrite : bool, optional
-            If ``True``, overwrite the output file if exists.
+            If ``True``, overwrite the output file if it exists. Raises an
+            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+            output file exists. Default is ``False``.
 
             .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument
+               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         Returns
         -------

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -31,6 +31,7 @@ from ...utils import indent
 from ...utils.compat.funcsigs import signature
 from .card import Card, BLANK_CARD
 from .header import Header
+from ...utils.decorators import deprecated_renamed_argument
 # HDUList is used in one of the doctests
 from .hdu.hdulist import fitsopen  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
@@ -134,9 +135,9 @@ class _BaseDiff(object):
         return not any(getattr(self, attr) for attr in self.__dict__
                        if attr.startswith('diff_'))
 
-    def report(self, fileobj=None, indent=0, clobber=False):
-        """
-        Generates a text report on the differences (if any) between two
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def report(self, fileobj=None, indent=0, overwrite=False):
+        """Generates a text report on the differences (if any) between two
         objects, and either returns it as a string or writes it to a file-like
         object.
 
@@ -151,9 +152,8 @@ class _BaseDiff(object):
         indent : int
             The number of 4 space tabs to indent the report.
 
-        clobber : bool
-            Whether the report output should overwrite an existing file, when
-            fileobj is specified as a path.
+        overwrite : bool, optional
+            If ``True``, overwrite the output file if exists.
 
         Returns
         -------
@@ -164,9 +164,9 @@ class _BaseDiff(object):
         filepath = None
 
         if isinstance(fileobj, string_types):
-            if os.path.exists(fileobj) and not clobber:
+            if os.path.exists(fileobj) and not overwrite:
                 raise IOError("File {0} exists, aborting (pass in "
-                              "clobber=True to overwrite)".format(fileobj))
+                              "overwrite=True to overwrite)".format(fileobj))
             else:
                 filepath = fileobj
                 fileobj = open(filepath, 'w')

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -155,6 +155,9 @@ class _BaseDiff(object):
         overwrite : bool, optional
             If ``True``, overwrite the output file if exists.
 
+            .. versionchanged:: 1.3
+               ``overwrite`` replaces the deprecated ``clobber`` argument
+
         Returns
         -------
         report : str or None

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -25,6 +25,7 @@ from ...utils.data import download_file, _is_url
 from ...utils.decorators import classproperty, deprecated_renamed_argument
 from ...utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
+
 # Maps PyFITS-specific file mode names to the appropriate file modes to use
 # for the underlying raw files
 # TODO: This should probably renamed IO_FITS_MODES or something, but since it's

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -22,9 +22,8 @@ from .util import (isreadable, iswritable, isfile, fileobj_open, fileobj_name,
                    _array_to_file, _write_string)
 from ...extern.six import b, string_types
 from ...utils.data import download_file, _is_url
-from ...utils.decorators import classproperty
-from ...utils.exceptions import AstropyUserWarning
-
+from ...utils.decorators import classproperty, deprecated_renamed_argument
+from ...utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
 # Maps PyFITS-specific file mode names to the appropriate file modes to use
 # for the underlying raw files
@@ -87,7 +86,8 @@ class _File(object):
     Represents a FITS file on disk (or in some other file-like object).
     """
 
-    def __init__(self, fileobj=None, mode=None, memmap=None, clobber=False,
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def __init__(self, fileobj=None, mode=None, memmap=None, overwrite=False,
                  cache=True):
         self.strict_memmap = bool(memmap)
         memmap = True if memmap is None else memmap
@@ -146,11 +146,11 @@ class _File(object):
 
         # Initialize the internal self._file object
         if _is_random_access_file_backed(fileobj):
-            self._open_fileobj(fileobj, mode, clobber)
+            self._open_fileobj(fileobj, mode, overwrite)
         elif isinstance(fileobj, string_types):
-            self._open_filename(fileobj, mode, clobber)
+            self._open_filename(fileobj, mode, overwrite)
         else:
-            self._open_filelike(fileobj, mode, clobber)
+            self._open_filelike(fileobj, mode, overwrite)
 
         self.fileobj_mode = fileobj_mode(self._file)
 
@@ -375,8 +375,8 @@ class _File(object):
             self._mmap.close()
             self._mmap = None
 
-    def _overwrite_existing(self, clobber, fileobj, closed):
-        """Overwrite an existing file if ``clobber`` is ``True``, otherwise
+    def _overwrite_existing(self, overwrite, fileobj, closed):
+        """Overwrite an existing file if ``overwrite`` is ``True``, otherwise
         raise an IOError.  The exact behavior of this method depends on the
         _File object state and is only meant for use within the ``_open_*``
         internal methods.
@@ -385,7 +385,7 @@ class _File(object):
         # The file will be overwritten...
         if ((self.file_like and hasattr(fileobj, 'len') and fileobj.len > 0) or
             (os.path.exists(self.name) and os.path.getsize(self.name) != 0)):
-            if clobber:
+            if overwrite:
                 if self.file_like and hasattr(fileobj, 'truncate'):
                     fileobj.truncate(0)
                 else:
@@ -395,14 +395,14 @@ class _File(object):
             else:
                 raise IOError("File {!r} already exists.".format(self.name))
 
-    def _open_fileobj(self, fileobj, mode, clobber):
+    def _open_fileobj(self, fileobj, mode, overwrite):
         """Open a FITS file from a file object or a GzipFile object."""
 
         closed = fileobj_closed(fileobj)
         fmode = fileobj_mode(fileobj) or PYFITS_MODES[mode]
 
         if mode == 'ostream':
-            self._overwrite_existing(clobber, fileobj, closed)
+            self._overwrite_existing(overwrite, fileobj, closed)
 
         if not closed:
             # Although we have a specific mapping in PYFITS_MODES from our
@@ -429,7 +429,7 @@ class _File(object):
             # append mode the file pointer is at the end of the file
             self._file.seek(0)
 
-    def _open_filelike(self, fileobj, mode, clobber):
+    def _open_filelike(self, fileobj, mode, overwrite):
         """Open a FITS file from a file-like object, i.e. one that has
         read and/or write methods.
         """
@@ -455,7 +455,7 @@ class _File(object):
             self.mode = mode = 'ostream'
 
         if mode == 'ostream':
-            self._overwrite_existing(clobber, fileobj, False)
+            self._overwrite_existing(overwrite, fileobj, False)
 
         # Any "writeable" mode requires a write() method on the file object
         if (self.mode in ('update', 'append', 'ostream') and
@@ -468,11 +468,11 @@ class _File(object):
             raise IOError("File-like object does not have a 'read' "
                           "method, required for mode {!r}.".format(self.mode))
 
-    def _open_filename(self, filename, mode, clobber):
+    def _open_filename(self, filename, mode, overwrite):
         """Open a FITS file from a filename string."""
 
         if mode == 'ostream':
-            self._overwrite_existing(clobber, None, True)
+            self._overwrite_existing(overwrite, None, True)
 
         if os.path.exists(self.name):
             with fileobj_open(self.name, 'rb') as f:

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -336,7 +336,8 @@ class _BaseHDU(object):
     @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
     def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
-        """Write the HDU to a new file.  This is a convenience method to
+        """
+        Write the HDU to a new file. This is a convenience method to
         provide a user easier output interface if only one HDU needs
         to be written to a file.
 
@@ -354,12 +355,16 @@ class _BaseHDU(object):
             (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
 
         overwrite : bool, optional
-            If ``True``, overwrite the output file if exists.
+            If ``True``, overwrite the output file if it exists. Raises an
+            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+            output file exists. Default is ``False``.
+
+            .. versionchanged:: 1.3
+               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
             to the header of the HDU when written to the file.
-
         """
 
         from .hdulist import HDUList
@@ -1574,6 +1579,9 @@ class ExtensionHDU(_ValidHDU):
         Works similarly to the normal writeto(), but prepends a default
         `PrimaryHDU` are required by extension HDUs (which cannot stand on
         their own).
+
+        .. versionchanged:: 1.3
+           ``overwrite`` replaces the deprecated ``clobber`` argument.
         """
 
         from .hdulist import HDUList

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -23,6 +23,7 @@ from ....utils import lazyproperty
 from ....utils.compat import suppress
 from ....utils.compat.funcsigs import signature, Parameter
 from ....utils.exceptions import AstropyUserWarning
+from ....utils.decorators import deprecated_renamed_argument
 
 
 class _Delayed(object):
@@ -332,10 +333,10 @@ class _BaseHDU(object):
         fileobj.seek(hdu._data_offset + hdu._data_size, os.SEEK_SET)
         return hdu
 
-    def writeto(self, name, output_verify='exception', clobber=False,
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
-        """
-        Write the HDU to a new file.  This is a convenience method to
+        """Write the HDU to a new file.  This is a convenience method to
         provide a user easier output interface if only one HDU needs
         to be written to a file.
 
@@ -352,18 +353,19 @@ class _BaseHDU(object):
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
             (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
 
-        clobber : bool
-            Overwrite the output file if exists.
+        overwrite : bool, optional
+            If ``True``, overwrite the output file if exists.
 
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
             to the header of the HDU when written to the file.
+
         """
 
         from .hdulist import HDUList
 
         hdulist = HDUList([self])
-        hdulist.writeto(name, output_verify, clobber=clobber,
+        hdulist.writeto(name, output_verify, overwrite=overwrite,
                         checksum=checksum)
 
     @classmethod
@@ -1565,7 +1567,8 @@ class ExtensionHDU(_ValidHDU):
 
         raise NotImplementedError
 
-    def writeto(self, name, output_verify='exception', clobber=False,
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
         """
         Works similarly to the normal writeto(), but prepends a default
@@ -1577,7 +1580,7 @@ class ExtensionHDU(_ValidHDU):
         from .image import PrimaryHDU
 
         hdulist = HDUList([PrimaryHDU(), self])
-        hdulist.writeto(name, output_verify, clobber=clobber,
+        hdulist.writeto(name, output_verify, overwrite=overwrite,
                         checksum=checksum)
 
     def _verify(self, option='warn'):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -661,10 +661,12 @@ class HDUList(list, _Verify):
             (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
 
         overwrite : bool, optional
-            If ``True``, overwrite the output file if exists.
+            If ``True``, overwrite the output file if it exists. Raises an
+            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+            output file exists. Default is ``False``.
 
             .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument
+               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -663,6 +663,9 @@ class HDUList(list, _Verify):
         overwrite : bool, optional
             If ``True``, overwrite the output file if exists.
 
+            .. versionchanged:: 1.3
+               ``overwrite`` replaces the deprecated ``clobber`` argument
+
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
             to the headers of all HDU's written to the file.

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -20,6 +20,7 @@ from ..verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from ....extern.six import string_types
 from ....utils import indent
 from ....utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from ....utils.decorators import deprecated_renamed_argument
 from ....extern.six.moves import range
 
 
@@ -640,7 +641,8 @@ class HDUList(list, _Verify):
                 n = hdr['NAXIS']
                 hdr.set('EXTEND', True, after='NAXIS' + str(n))
 
-    def writeto(self, fileobj, output_verify='exception', clobber=False,
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def writeto(self, fileobj, output_verify='exception', overwrite=False,
                 checksum=False):
         """
         Write the `HDUList` to a new file.
@@ -658,8 +660,8 @@ class HDUList(list, _Verify):
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
             (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
 
-        clobber : bool
-            When `True`, overwrite the output file if exists.
+        overwrite : bool, optional
+            If ``True``, overwrite the output file if exists.
 
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
@@ -684,7 +686,7 @@ class HDUList(list, _Verify):
         # sensible mode to require is 'ostream'.  This can accept an open
         # file object that's open to write only, or in append/update modes
         # but only if the file doesn't exist.
-        fileobj = _File(fileobj, mode='ostream', clobber=clobber)
+        fileobj = _File(fileobj, mode='ostream', overwrite=overwrite)
         hdulist = self.fromfile(fileobj)
 
         for hdu in self:

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -992,6 +992,9 @@ class BinTableHDU(_TableBaseHDU):
         overwrite : bool, optional
             If ``True``, overwrite the output file if exists.
 
+            .. versionchanged:: 1.3
+               ``overwrite`` replaces the deprecated ``clobber`` argument
+
         Notes
         -----
         The primary use for the `dump` method is to allow viewing and editing

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -27,13 +27,13 @@ from ..column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
 from ..fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
 from ..header import Header, _pad_length
 from ..util import _is_int, _str_to_num
-
 from ....extern import six
 from ....extern.six import string_types
 from ....extern.six.moves import range, zip
 from ....utils import lazyproperty
 from ....utils.compat import suppress
 from ....utils.exceptions import AstropyUserWarning
+from ....utils.decorators import deprecated_renamed_argument
 
 
 class FITSTableDumpDialect(csv.excel):
@@ -967,7 +967,8 @@ class BinTableHDU(_TableBaseHDU):
           image.
       """)
 
-    def dump(self, datafile=None, cdfile=None, hfile=None, clobber=False):
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def dump(self, datafile=None, cdfile=None, hfile=None, overwrite=False):
         """
         Dump the table HDU to a file in ASCII format.  The table may be dumped
         in three separate files, one containing column definitions, one
@@ -988,8 +989,8 @@ class BinTableHDU(_TableBaseHDU):
             Output header parameters file.  The default is `None`,
             no header parameters output is produced.
 
-        clobber : bool
-            Overwrite the output files if they exist.
+        overwrite : bool, optional
+            If ``True``, overwrite the output file if exists.
 
         Notes
         -----
@@ -1006,7 +1007,7 @@ class BinTableHDU(_TableBaseHDU):
         for f in files:
             if isinstance(f, string_types):
                 if os.path.exists(f) and os.path.getsize(f) != 0:
-                    if clobber:
+                    if overwrite:
                         warnings.warn(
                             "Overwriting existing file '{}'.".format(f),
                             AstropyUserWarning)

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -27,6 +27,7 @@ from ..column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
 from ..fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
 from ..header import Header, _pad_length
 from ..util import _is_int, _str_to_num
+
 from ....extern import six
 from ....extern.six import string_types
 from ....extern.six.moves import range, zip
@@ -990,10 +991,12 @@ class BinTableHDU(_TableBaseHDU):
             no header parameters output is produced.
 
         overwrite : bool, optional
-            If ``True``, overwrite the output file if exists.
+            If ``True``, overwrite the output file if it exists. Raises an
+            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+            output file exists. Default is ``False``.
 
             .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument
+               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         Notes
         -----

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -694,10 +694,16 @@ class Header(object):
     @classmethod
     def fromtextfile(cls, fileobj, endcard=False):
         """
+        Read a header from a simple text file or file-like object.
+
         Equivalent to::
 
             >>> Header.fromfile(fileobj, sep='\\n', endcard=False,
             ...                 padding=False)
+
+        See Also
+        --------
+        fromfile
         """
 
         return cls.fromfile(fileobj, sep='\n', endcard=endcard, padding=False)
@@ -705,10 +711,19 @@ class Header(object):
     @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
     def totextfile(self, fileobj, endcard=False, overwrite=False):
         """
+        Write the header as text to a file or a file-like object.
+
         Equivalent to::
 
             >>> Header.tofile(fileobj, sep='\\n', endcard=False,
             ...               padding=False, overwrite=overwrite)
+
+        .. versionchanged:: 1.3
+           ``overwrite`` replaces the deprecated ``clobber`` argument.
+
+        See Also
+        --------
+        tofile
         """
 
         self.tofile(fileobj, sep='\n', endcard=endcard, padding=False,

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -659,6 +659,9 @@ class Header(object):
         overwrite : bool, optional
             If ``True``, overwrite the output file if exists.
 
+            .. versionchanged:: 1.3
+               ``overwrite`` replaces the deprecated ``clobber`` argument
+
         """
 
         close_file = fileobj_closed(fileobj)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -657,11 +657,12 @@ class Header(object):
             multiple of 2880 characters
 
         overwrite : bool, optional
-            If ``True``, overwrite the output file if exists.
+            If ``True``, overwrite the output file if it exists. Raises an
+            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
+            output file exists. Default is ``False``.
 
             .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument
-
+               ``overwrite`` replaces the deprecated ``clobber`` argument.
         """
 
         close_file = fileobj_closed(fileobj)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -17,6 +17,7 @@ from ...extern.six import string_types, itervalues, iteritems, next
 from ...extern.six.moves import zip, range, zip_longest
 from ...utils import isiterable
 from ...utils.exceptions import AstropyUserWarning
+from ...utils.decorators import deprecated_renamed_argument
 
 
 BLOCK_SIZE = 2880  # the FITS block size
@@ -626,8 +627,9 @@ class Header(object):
             s += ' ' * _pad_length(len(s))
         return s
 
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
     def tofile(self, fileobj, sep='', endcard=True, padding=True,
-               clobber=False):
+               overwrite=False):
         r"""
         Writes the header to file or file-like object.
 
@@ -654,14 +656,15 @@ class Header(object):
             If `True` (default) pads the string with spaces out to the next
             multiple of 2880 characters
 
-        clobber : bool, optional
-            If `True`, overwrites the output file if it already exists
+        overwrite : bool, optional
+            If ``True``, overwrite the output file if exists.
+
         """
 
         close_file = fileobj_closed(fileobj)
 
         if not isinstance(fileobj, _File):
-            fileobj = _File(fileobj, mode='ostream', clobber=clobber)
+            fileobj = _File(fileobj, mode='ostream', overwrite=overwrite)
 
         try:
             blocks = self.tostring(sep=sep, endcard=endcard, padding=padding)
@@ -696,16 +699,17 @@ class Header(object):
 
         return cls.fromfile(fileobj, sep='\n', endcard=endcard, padding=False)
 
-    def totextfile(self, fileobj, endcard=False, clobber=False):
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def totextfile(self, fileobj, endcard=False, overwrite=False):
         """
         Equivalent to::
 
             >>> Header.tofile(fileobj, sep='\\n', endcard=False,
-            ...               padding=False, clobber=clobber)
+            ...               padding=False, overwrite=overwrite)
         """
 
         self.tofile(fileobj, sep='\n', endcard=endcard, padding=False,
-                    clobber=clobber)
+                    overwrite=overwrite)
 
     def clear(self):
         """

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -176,8 +176,8 @@ def update(filename):
     hdulist = fits.open(filename, do_not_scale_image_data=True)
     try:
         output_verify = 'silentfix' if OPTIONS.compliance else 'ignore'
-        hdulist.writeto(filename, checksum=OPTIONS.checksum_kind, clobber=True,
-                        output_verify=output_verify)
+        hdulist.writeto(filename, checksum=OPTIONS.checksum_kind,
+                        overwrite=True, output_verify=output_verify)
     except fits.VerifyError:
         pass  # unfixable errors already noted during verification phase
     finally:

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -44,7 +44,7 @@ class TestChecksumFunctions(FitsTestCase):
     def test_image_create(self):
         n = np.arange(100, dtype=np.int64)
         hdu = fits.PrimaryHDU(n)
-        hdu.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+        hdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
         with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
             assert (hdu.data == hdul[0].data).all()
             assert 'CHECKSUM' in hdul[0].header
@@ -58,7 +58,7 @@ class TestChecksumFunctions(FitsTestCase):
 
     def test_nonstandard_checksum(self):
         hdu = fits.PrimaryHDU(np.arange(10.0 ** 6, dtype=np.float64))
-        hdu.writeto(self.temp('tmp.fits'), clobber=True,
+        hdu.writeto(self.temp('tmp.fits'), overwrite=True,
                     checksum='nonstandard')
         del hdu
         with fits.open(self.temp('tmp.fits'), checksum='nonstandard') as hdul:
@@ -75,7 +75,7 @@ class TestChecksumFunctions(FitsTestCase):
         with fits.open(self.data('scale.fits')) as hdul:
             orig_data = hdul[0].data.copy()
             hdul[0].scale('int16', 'old')
-            hdul.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+            hdul.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
             with fits.open(self.temp('tmp.fits'), checksum=True) as hdul1:
                 assert (hdul1[0].data == orig_data).all()
                 assert 'CHECKSUM' in hdul1[0].header
@@ -99,7 +99,7 @@ class TestChecksumFunctions(FitsTestCase):
 
         # Reopen the new file and save it back again with a checksum
         with fits.open(self.temp('rescaled.fits')) as hdul:
-            hdul.writeto(self.temp('rescaled2.fits'), clobber=True,
+            hdul.writeto(self.temp('rescaled2.fits'), overwrite=True,
                          checksum=True)
 
         # Now do like in the first writeto but use checksum immediately
@@ -131,7 +131,7 @@ class TestChecksumFunctions(FitsTestCase):
             ('8aCN8X9N8aAN8W9N', '1756785133'), ('UhqdUZnbUfnbUZnb', '0'),
             ('4cQJ5aN94aNG4aN9', '0')]
         with fits.open(self.data('o4sp040b0_raw.fits'), uint=True) as hdul:
-            hdul.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+            hdul.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
             with fits.open(self.temp('tmp.fits'), uint=True,
                            checksum=True) as hdul1:
                 for idx, (hdu_a, hdu_b) in enumerate(zip(hdul, hdul1)):
@@ -153,7 +153,7 @@ class TestChecksumFunctions(FitsTestCase):
         x = fits.hdu.groups.GroupData(imdata, parnames=[str('abc'), str('xyz')],
                                       pardata=[pdata1, pdata2], bitpix=-32)
         hdu = fits.GroupsHDU(x)
-        hdu.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+        hdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
         with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
             assert comparerecords(hdul[0].data, hdu.data)
             assert 'CHECKSUM' in hdul[0].header
@@ -168,7 +168,7 @@ class TestChecksumFunctions(FitsTestCase):
         col2 = fits.Column(name='V_mag', format='E', array=a2)
         cols = fits.ColDefs([col1, col2])
         tbhdu = fits.BinTableHDU.from_columns(cols)
-        tbhdu.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+        tbhdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
         with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
             assert comparerecords(tbhdu.data, hdul[1].data)
             assert 'CHECKSUM' in hdul[0].header
@@ -186,7 +186,7 @@ class TestChecksumFunctions(FitsTestCase):
                          'O'))
         c2 = fits.Column(name='xyz', format='2I', array=[[11, 3], [12, 4]])
         tbhdu = fits.BinTableHDU.from_columns([c1, c2])
-        tbhdu.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+        tbhdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
         with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
             assert comparerecords(tbhdu.data, hdul[1].data)
             assert 'CHECKSUM' in hdul[0].header
@@ -209,7 +209,7 @@ class TestChecksumFunctions(FitsTestCase):
         c3 = fits.Column(name='t1', format='I', array=[91, 92, 93])
         x = fits.ColDefs([c1, c2, c3])
         hdu = fits.TableHDU.from_columns(x)
-        hdu.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+        hdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
         with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
             assert comparerecords(hdu.data, hdul[1].data)
             assert 'CHECKSUM' in hdul[0].header
@@ -227,7 +227,7 @@ class TestChecksumFunctions(FitsTestCase):
 
     def test_compressed_image_data(self):
         with fits.open(self.data('comp.fits')) as h1:
-            h1.writeto(self.temp('tmp.fits'), clobber=True, checksum=True)
+            h1.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)
             with fits.open(self.temp('tmp.fits'), checksum=True) as h2:
                 assert np.all(h1[1].data == h2[1].data)
                 assert 'CHECKSUM' in h2[0].header
@@ -312,7 +312,7 @@ class TestChecksumFunctions(FitsTestCase):
 
     def test_append(self):
         hdul = fits.open(self.data('tb.fits'))
-        hdul.writeto(self.temp('tmp.fits'), clobber=True)
+        hdul.writeto(self.temp('tmp.fits'), overwrite=True)
         n = np.arange(100)
         fits.append(self.temp('tmp.fits'), n, checksum=True)
         hdul.close()
@@ -322,7 +322,7 @@ class TestChecksumFunctions(FitsTestCase):
 
     def test_writeto_convenience(self):
         n = np.arange(100)
-        fits.writeto(self.temp('tmp.fits'), n, clobber=True, checksum=True)
+        fits.writeto(self.temp('tmp.fits'), n, overwrite=True, checksum=True)
         hdul = fits.open(self.temp('tmp.fits'), checksum=True)
         self._check_checksums(hdul[0])
         hdul.close()
@@ -360,7 +360,7 @@ class TestChecksumFunctions(FitsTestCase):
     def test_datasum_only(self):
         n = np.arange(100, dtype='int16')
         hdu = fits.ImageHDU(n)
-        hdu.writeto(self.temp('tmp.fits'), clobber=True, checksum='datasum')
+        hdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum='datasum')
         with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
             if not (hasattr(hdul[0], '_datasum') and hdul[0]._datasum):
                 pytest.fail(msg='Missing DATASUM keyword')

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -140,7 +140,7 @@ class TestSingleTable(object):
     def test_read_from_fileobj(self, tmpdir):
         filename = str(tmpdir.join('test_read_from_fileobj.fits'))
         hdu = BinTableHDU(self.data)
-        hdu.writeto(filename, clobber=True)
+        hdu.writeto(filename, overwrite=True)
         with open(filename, 'rb') as f:
             t = Table.read(f)
         assert equal_data(t, self.data)

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -49,4 +49,4 @@ class TestConvenience(FitsTestCase):
         hdu = fits.table_to_hdu(table)
         assert isinstance(hdu, fits.BinTableHDU)
         filename = str(tmpdir.join('test_table_to_hdu.fits'))
-        hdu.writeto(filename, clobber=True)
+        hdu.writeto(filename, overwrite=True)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -70,7 +70,7 @@ class TestCore(FitsTestCase):
         l.append(p)
         l.append(t)
 
-        l.writeto(self.temp('test.fits'), clobber=True)
+        l.writeto(self.temp('test.fits'), overwrite=True)
 
         with fits.open(self.temp('test.fits')) as p:
             assert p[1].data[1]['foo'] == 60000.0
@@ -116,7 +116,7 @@ class TestCore(FitsTestCase):
         assert table.data.dtype.names == ('c2', 'c4', 'foo')
         assert table.columns.names == ['c2', 'c4', 'foo']
 
-        hdulist.writeto(self.temp('test.fits'), clobber=True)
+        hdulist.writeto(self.temp('test.fits'), overwrite=True)
         with ignore_warnings():
             # TODO: The warning raised by this test is actually indication of a
             # bug and should *not* be ignored. But as it is a known issue we
@@ -545,7 +545,7 @@ class TestConvenienceFunctions(FitsTestCase):
         data = np.zeros((100, 100))
         header = fits.Header()
         fits.writeto(self.temp('array.fits'), data, header=header,
-                     clobber=True)
+                     overwrite=True)
         hdul = fits.open(self.temp('array.fits'))
         assert len(hdul) == 1
         assert (data == hdul[0].data).all()
@@ -561,7 +561,7 @@ class TestConvenienceFunctions(FitsTestCase):
         header = fits.Header()
         header.set('CRPIX1', 1.)
         fits.writeto(self.temp('array.fits'), data, header=header,
-                     clobber=True, output_verify='silentfix')
+                     overwrite=True, output_verify='silentfix')
         hdul = fits.open(self.temp('array.fits'))
         assert len(hdul) == 1
         assert (data == hdul[0].data).all()

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -11,6 +11,7 @@ from ..diff import (FITSDiff, HeaderDiff, ImageDataDiff, TableDataDiff,
 from ..hdu import HDUList, PrimaryHDU, ImageHDU
 from ..hdu.table import BinTableHDU
 from ..header import Header
+
 from ....tests.helper import catch_warnings
 from ....utils.exceptions import AstropyDeprecationWarning
 from ....extern.six.moves import range

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -11,7 +11,8 @@ from ..diff import (FITSDiff, HeaderDiff, ImageDataDiff, TableDataDiff,
 from ..hdu import HDUList, PrimaryHDU, ImageHDU
 from ..hdu.table import BinTableHDU
 from ..header import Header
-
+from ....tests.helper import catch_warnings
+from ....utils.exceptions import AstropyDeprecationWarning
 from ....extern.six.moves import range
 from ....io import fits
 
@@ -623,7 +624,7 @@ class TestDiff(FitsTestCase):
         report_as_string = diffobj.report()
         assert open(outpath).read() == report_as_string
 
-    def test_file_output_clobber_safety(self):
+    def test_file_output_overwrite_safety(self):
         outpath = self.temp('diff_output.txt')
         ha = Header([('A', 1), ('B', 2), ('C', 3)])
         hb = ha.copy()
@@ -634,7 +635,7 @@ class TestDiff(FitsTestCase):
         with pytest.raises(IOError):
             diffobj.report(fileobj=outpath)
 
-    def test_file_output_clobber_success(self):
+    def test_file_output_overwrite_success(self):
         outpath = self.temp('diff_output.txt')
         ha = Header([('A', 1), ('B', 2), ('C', 3)])
         hb = ha.copy()
@@ -642,6 +643,23 @@ class TestDiff(FitsTestCase):
         diffobj = HeaderDiff(ha, hb)
         diffobj.report(fileobj=outpath)
         report_as_string = diffobj.report()
-        diffobj.report(fileobj=outpath, clobber=True)
-        assert open(outpath).read() == report_as_string, ("clobbered output "
+        diffobj.report(fileobj=outpath, overwrite=True)
+        assert open(outpath).read() == report_as_string, ("overwritten output "
             "file is not identical to report string")
+
+    def test_file_output_overwrite_vs_clobber(self):
+        """Verify uses of clobber and overwrite."""
+
+        outpath = self.temp('diff_output.txt')
+        ha = Header([('A', 1), ('B', 2), ('C', 3)])
+        hb = ha.copy()
+        hb['C'] = 4
+        diffobj = HeaderDiff(ha, hb)
+        diffobj.report(fileobj=outpath)
+        report_as_string = diffobj.report()
+        with catch_warnings(AstropyDeprecationWarning) as warning_lines:
+            diffobj.report(fileobj=outpath, clobber=True)
+            assert warning_lines[0].category == AstropyDeprecationWarning
+            assert (str(warning_lines[0].message) == '"clobber" was '
+                    'deprecated in version 1.3 and will be removed in a '
+                    'future version. Use argument "overwrite" instead.')

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1878,7 +1878,7 @@ class TestHeaderFunctions(FitsTestCase):
         while len(hdu.header) < 36:
             hdu.header.append()
         with ignore_warnings():
-            hdu.writeto(self.temp('test.fits'), clobber=True)
+            hdu.writeto(self.temp('test.fits'), overwrite=True)
 
         with fits.open(self.temp('test.fits')) as hdul:
             assert 'TESTKW' in hdul[0].header

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -801,7 +801,7 @@ class TestImageFunctions(FitsTestCase):
         hdul = fits.open(self.data('fixed-1890.fits'))
         orig_data = hdul[0].data
         with ignore_warnings():
-            hdul.writeto(self.temp('test_new.fits'), clobber=True)
+            hdul.writeto(self.temp('test_new.fits'), overwrite=True)
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
         assert (hdul[0].data == orig_data).all()
@@ -812,7 +812,7 @@ class TestImageFunctions(FitsTestCase):
         # https://aeon.stsci.edu/ssb/trac/pyfits/ticket/84
         hdul = fits.open(self.data('fixed-1890.fits'))
         with ignore_warnings():
-            hdul.writeto(self.temp('test_new.fits'), clobber=True)
+            hdul.writeto(self.temp('test_new.fits'), overwrite=True)
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
         assert (hdul[0].data == orig_data).all()
@@ -821,7 +821,7 @@ class TestImageFunctions(FitsTestCase):
         # Test opening/closing/reopening a scaled file in update mode
         hdul = fits.open(self.data('fixed-1890.fits'),
                          do_not_scale_image_data=True)
-        hdul.writeto(self.temp('test_new.fits'), clobber=True,
+        hdul.writeto(self.temp('test_new.fits'), overwrite=True,
                      output_verify='silentfix')
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
@@ -1028,7 +1028,7 @@ class TestCompressedImage(FitsTestCase):
                                  compressionType=compression_type,
                                  quantizeLevel=quantize_level)
         ofd.append(chdu)
-        ofd.writeto(self.temp('test_new.fits'), clobber=True)
+        ofd.writeto(self.temp('test_new.fits'), overwrite=True)
         ofd.close()
         with fits.open(self.temp('test_new.fits')) as fd:
             assert (fd[1].data == data).all()
@@ -1207,7 +1207,7 @@ class TestCompressedImage(FitsTestCase):
         hdul = fits.open(self.temp('fixed-1890-z.fits'))
         orig_data = hdul[1].data
         with ignore_warnings():
-            hdul.writeto(self.temp('test_new.fits'), clobber=True)
+            hdul.writeto(self.temp('test_new.fits'), overwrite=True)
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
         assert (hdul[1].data == orig_data).all()
@@ -1218,7 +1218,7 @@ class TestCompressedImage(FitsTestCase):
         # https://aeon.stsci.edu/ssb/trac/pyfits/ticket/84
         hdul = fits.open(self.temp('fixed-1890-z.fits'))
         with ignore_warnings():
-            hdul.writeto(self.temp('test_new.fits'), clobber=True)
+            hdul.writeto(self.temp('test_new.fits'), overwrite=True)
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
         assert (hdul[1].data == orig_data).all()
@@ -1227,7 +1227,7 @@ class TestCompressedImage(FitsTestCase):
         # Test opening/closing/reopening a scaled file in update mode
         hdul = fits.open(self.temp('fixed-1890-z.fits'),
                          do_not_scale_image_data=True)
-        hdul.writeto(self.temp('test_new.fits'), clobber=True,
+        hdul.writeto(self.temp('test_new.fits'), overwrite=True,
                      output_verify='silentfix')
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
@@ -1300,7 +1300,7 @@ class TestCompressedImage(FitsTestCase):
         chdu2 = fits.CompImageHDU(data=noise, compressionType='GZIP_1',
                                   quantizeLevel=0.0)  # No quantization
         with ignore_warnings():
-            chdu2.writeto(self.temp('test.fits'), clobber=True)
+            chdu2.writeto(self.temp('test.fits'), overwrite=True)
 
         with fits.open(self.temp('test.fits')) as h:
             assert (noise == h[1].data).all()

--- a/astropy/io/fits/tests/test_nonstandard.py
+++ b/astropy/io/fits/tests/test_nonstandard.py
@@ -50,7 +50,7 @@ class TestNonstandardHdus(FitsTestCase):
         # Just to be meta, let's append to the same hdulist that the fitshdu
         # encapuslates
         hdul_orig.append(fitshdu)
-        hdul_orig.writeto(self.temp('tmp.fits'), clobber=True)
+        hdul_orig.writeto(self.temp('tmp.fits'), overwrite=True)
         del hdul_orig[-1]
 
         hdul = fits.open(self.temp('tmp.fits'))

--- a/astropy/io/fits/tests/test_structured.py
+++ b/astropy/io/fits/tests/test_structured.py
@@ -80,7 +80,7 @@ class TestStructured(FitsTestCase):
         st = get_test_data()
 
         outfile = self.temp('test.fits')
-        fits.writeto(outfile, data1, clobber=True)
+        fits.writeto(outfile, data1, overwrite=True)
         fits.append(outfile, data2)
 
         fits.append(outfile, st)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -21,6 +21,7 @@ from ....extern.six.moves import cPickle as pickle
 from ....io import fits
 from ....tests.helper import pytest, catch_warnings, ignore_warnings
 from ....utils.exceptions import AstropyDeprecationWarning
+
 from ..column import Delayed, NUMPY2FITS
 from ..util import decode_ascii
 from ..verify import VerifyError

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -20,7 +20,7 @@ from ....extern.six.moves import range, zip
 from ....extern.six.moves import cPickle as pickle
 from ....io import fits
 from ....tests.helper import pytest, catch_warnings, ignore_warnings
-
+from ....utils.exceptions import AstropyDeprecationWarning
 from ..column import Delayed, NUMPY2FITS
 from ..util import decode_ascii
 from ..verify import VerifyError
@@ -199,7 +199,7 @@ class TestTableFunctions(FitsTestCase):
         # now we write out the newly created table HDU to a FITS file:
         fout = fits.HDUList(fits.PrimaryHDU())
         fout.append(tbhdu)
-        fout.writeto(self.temp('tableout1.fits'), clobber=True)
+        fout.writeto(self.temp('tableout1.fits'), overwrite=True)
 
         with fits.open(self.temp('tableout1.fits')) as f2:
             temp = f2[1].data.field(7)
@@ -289,7 +289,7 @@ class TestTableFunctions(FitsTestCase):
                 {'abc': (np.dtype('|S3'), 18),
                  'def': (np.dtype('|S15'), 2),
                  't1': (np.dtype('|S10'), 21)})
-        hdu.writeto(self.temp('toto.fits'), clobber=True)
+        hdu.writeto(self.temp('toto.fits'), overwrite=True)
         hdul = fits.open(self.temp('toto.fits'))
         assert comparerecords(hdu.data, hdul[1].data)
         hdul.close()
@@ -303,7 +303,7 @@ class TestTableFunctions(FitsTestCase):
         cols = fits.ColDefs([col])
         tbhdu = fits.BinTableHDU.from_columns(cols)
         tbhdu.name = "RFI"
-        tbhdu.writeto(self.temp('testendian.fits'), clobber=True)
+        tbhdu.writeto(self.temp('testendian.fits'), overwrite=True)
         hduL = fits.open(self.temp('testendian.fits'))
         rfiHDU = hduL['RFI']
         data = rfiHDU.data
@@ -331,7 +331,7 @@ class TestTableFunctions(FitsTestCase):
 
         # Double check that the array is converted to the correct byte-order
         # for FITS (big-endian).
-        tbhdu.writeto(self.temp('testendian.fits'), clobber=True)
+        tbhdu.writeto(self.temp('testendian.fits'), overwrite=True)
         with fits.open(self.temp('testendian.fits')) as hdul:
             assert (hdul[1].data['a'] == a2).all()
             assert (hdul[1].data['b'] == a2).all()
@@ -345,7 +345,7 @@ class TestTableFunctions(FitsTestCase):
             names='order,name,mag,Sp')
         hdu = fits.BinTableHDU(bright)
         assert comparerecords(hdu.data, bright)
-        hdu.writeto(self.temp('toto.fits'), clobber=True)
+        hdu.writeto(self.temp('toto.fits'), overwrite=True)
         hdul = fits.open(self.temp('toto.fits'))
         assert comparerecords(hdu.data, hdul[1].data)
         assert comparerecords(bright, hdul[1].data)
@@ -359,7 +359,7 @@ class TestTableFunctions(FitsTestCase):
                       (3, 'Rigil Kent', -0.1, 'G2V')], dtype=desc)
         hdu = fits.BinTableHDU(a)
         assert comparerecords(hdu.data, a.view(fits.FITS_rec))
-        hdu.writeto(self.temp('toto.fits'), clobber=True)
+        hdu.writeto(self.temp('toto.fits'), overwrite=True)
         hdul = fits.open(self.temp('toto.fits'))
         assert comparerecords(hdu.data, hdul[1].data)
         hdul.close()
@@ -430,7 +430,7 @@ class TestTableFunctions(FitsTestCase):
         assert hdu.data[1][3] == 'F0Ib'
 
         with ignore_warnings():
-            hdu.writeto(self.temp('toto.fits'), clobber=True)
+            hdu.writeto(self.temp('toto.fits'), overwrite=True)
 
         with fits.open(self.temp('toto.fits')) as hdul:
             assert (hdul[1].data.field(0) ==
@@ -450,7 +450,7 @@ class TestTableFunctions(FitsTestCase):
                            names='order,name,mag,Sp')
         assert comparerecords(hdu.data, tmp)
         with ignore_warnings():
-            hdu.writeto(self.temp('toto.fits'), clobber=True)
+            hdu.writeto(self.temp('toto.fits'), overwrite=True)
         with fits.open(self.temp('toto.fits')) as hdul:
             assert comparerecords(hdu.data, hdul[1].data)
 
@@ -808,7 +808,7 @@ class TestTableFunctions(FitsTestCase):
         for col in b.columns:
             col.null = NULLS[col.name]
 
-        b.writeto(self.temp('test.fits'), clobber=True)
+        b.writeto(self.temp('test.fits'), overwrite=True)
 
         with fits.open(self.temp('test.fits')) as hdul:
             header = hdul[1].header
@@ -1608,7 +1608,7 @@ class TestTableFunctions(FitsTestCase):
 
         ahdu = fits.TableHDU.from_columns([acol])
         with ignore_warnings():
-            ahdu.writeto(self.temp('newtable.fits'), clobber=True)
+            ahdu.writeto(self.temp('newtable.fits'), overwrite=True)
 
         with fits.open(self.temp('newtable.fits')) as hdul:
             assert (hdul[1].data.tostring().decode('raw-unicode-escape') ==
@@ -1619,7 +1619,7 @@ class TestTableFunctions(FitsTestCase):
 
         # Now serialize once more as a binary table; padding bytes should
         # revert to zeroes
-        ahdu.writeto(self.temp('newtable.fits'), clobber=True)
+        ahdu.writeto(self.temp('newtable.fits'), overwrite=True)
         with fits.open(self.temp('newtable.fits')) as hdul:
             assert hdul[1].data.tostring().decode('raw-unicode-escape') == s
             assert (hdul[1].data['MEMNAME'] == a).all()
@@ -1666,7 +1666,7 @@ class TestTableFunctions(FitsTestCase):
         data['x'] = 1, 2, 3
         data['s'] = 'ok'
         with ignore_warnings():
-            fits.writeto(self.temp('newtable.fits'), data, clobber=True)
+            fits.writeto(self.temp('newtable.fits'), data, overwrite=True)
 
         t = fits.getdata(self.temp('newtable.fits'))
 
@@ -1682,7 +1682,7 @@ class TestTableFunctions(FitsTestCase):
         del t
 
         with ignore_warnings():
-            fits.writeto(self.temp('newtable.fits'), data, clobber=True)
+            fits.writeto(self.temp('newtable.fits'), data, overwrite=True)
 
         t = fits.getdata(self.temp('newtable.fits'))
 
@@ -1721,7 +1721,7 @@ class TestTableFunctions(FitsTestCase):
             else:
                 assert tbhdu.data['S'].dtype.str.endswith('U4')
 
-            tbhdu.writeto(self.temp('test.fits'), clobber=True)
+            tbhdu.writeto(self.temp('test.fits'), overwrite=True)
 
             with fits.open(self.temp('test.fits')) as hdul:
                 tbhdu2 = hdul[1]
@@ -2216,7 +2216,7 @@ class TestTableFunctions(FitsTestCase):
             tbdata = hdul[1].data
             tbhdu = fits.TableHDU(data=tbdata)
             with ignore_warnings():
-                tbhdu.writeto(self.temp('test.fits'), clobber=True)
+                tbhdu.writeto(self.temp('test.fits'), overwrite=True)
             with fits.open(self.temp('test.fits')) as hdul2:
                 tbdata2 = hdul2[1].data
                 assert np.all(tbdata['c1'] == tbdata2['c1'])
@@ -2433,6 +2433,21 @@ class TestTableFunctions(FitsTestCase):
             t3.teardown_class()
         del t3
 
+    def test_dump_clobber_vs_overwrite(self):
+        with fits.open(self.data('table.fits')) as hdul:
+            tbhdu = hdul[1]
+            datafile = self.temp('data.txt')
+            cdfile = self.temp('coldefs.txt')
+            hfile = self.temp('header.txt')
+            tbhdu.dump(datafile, cdfile, hfile)
+            tbhdu.dump(datafile, cdfile, hfile, overwrite=True)
+            with catch_warnings(AstropyDeprecationWarning) as warning_lines:
+                tbhdu.dump(datafile, cdfile, hfile, clobber=True)
+                assert warning_lines[0].category == AstropyDeprecationWarning
+                assert (str(warning_lines[0].message) == '"clobber" was '
+                        'deprecated in version 1.3 and will be removed in a '
+                        'future version. Use argument "overwrite" instead.')
+
 
 @contextlib.contextmanager
 def _refcounting(type_):
@@ -2463,7 +2478,7 @@ class TestVLATables(FitsTestCase):
             pri_hdu = fits.PrimaryHDU()
             hdu_list = fits.HDUList([pri_hdu, tb_hdu])
             with ignore_warnings():
-                hdu_list.writeto(self.temp('toto.fits'), clobber=True)
+                hdu_list.writeto(self.temp('toto.fits'), overwrite=True)
 
             with fits.open(self.temp('toto.fits')) as toto:
                 q = toto[1].data.field('QUAL_SPE')
@@ -2503,7 +2518,7 @@ class TestVLATables(FitsTestCase):
             acol = fits.Column(name='testa', format=format_code, array=a)
             tbhdu = fits.BinTableHDU.from_columns([acol])
             with ignore_warnings():
-                tbhdu.writeto(self.temp('newtable.fits'), clobber=True)
+                tbhdu.writeto(self.temp('newtable.fits'), overwrite=True)
             with fits.open(self.temp('newtable.fits')) as tbhdu1:
                 assert tbhdu1[1].columns[0].format.endswith('D(2)')
                 for j in range(3):
@@ -2520,7 +2535,7 @@ class TestVLATables(FitsTestCase):
             acol = fits.Column(name='testa', format=format_code, array=a)
             tbhdu = fits.BinTableHDU.from_columns([acol])
             with ignore_warnings():
-                tbhdu.writeto(self.temp('newtable.fits'), clobber=True)
+                tbhdu.writeto(self.temp('newtable.fits'), overwrite=True)
 
             with fits.open(self.temp('newtable.fits')) as tbhdu1:
                 assert tbhdu1[1].columns[0].format.endswith('D(2)')
@@ -2538,7 +2553,7 @@ class TestVLATables(FitsTestCase):
             acol = fits.Column(name='testa', format=format_code, array=a)
             tbhdu = fits.BinTableHDU.from_columns([acol])
             with ignore_warnings():
-                tbhdu.writeto(self.temp('newtable.fits'), clobber=True)
+                tbhdu.writeto(self.temp('newtable.fits'), overwrite=True)
 
             with fits.open(self.temp('newtable.fits')) as hdul:
                 assert hdul[1].columns[0].format.endswith('A(3)')
@@ -2555,7 +2570,7 @@ class TestVLATables(FitsTestCase):
             acol = fits.Column(name='testa', format=format_code, array=a)
             tbhdu = fits.BinTableHDU.from_columns([acol])
             with ignore_warnings():
-                tbhdu.writeto(self.temp('newtable.fits'), clobber=True)
+                tbhdu.writeto(self.temp('newtable.fits'), overwrite=True)
 
             with fits.open(self.temp('newtable.fits')) as hdul:
                 assert hdul[1].columns[0].format.endswith('A(3)')
@@ -2576,7 +2591,7 @@ class TestVLATables(FitsTestCase):
             pri_hdu = fits.PrimaryHDU()
             hdu_list = fits.HDUList([pri_hdu, tb_hdu])
             with ignore_warnings():
-                hdu_list.writeto(self.temp('toto.fits'), clobber=True)
+                hdu_list.writeto(self.temp('toto.fits'), overwrite=True)
 
             data = fits.getdata(self.temp('toto.fits'))
 
@@ -2605,7 +2620,7 @@ class TestVLATables(FitsTestCase):
         t2 = fits.BinTableHDU.from_columns([c, c2])
 
         hdul = fits.HDUList([fits.PrimaryHDU(), t1, t2])
-        hdul.writeto(self.temp('test.fits'), clobber=True)
+        hdul.writeto(self.temp('test.fits'), overwrite=True)
 
         # Just test that the test file wrote out correctly
         with fits.open(self.temp('test.fits')) as h:

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -35,7 +35,7 @@ class TestUintFunctions(FitsTestCase):
             hdu.scale('int{0:d}'.format(bits), '', bzero=2 ** (bits-1))
 
             with ignore_warnings():
-                hdu.writeto(self.temp('tempfile.fits'), clobber=True)
+                hdu.writeto(self.temp('tempfile.fits'), overwrite=True)
 
             with fits.open(self.temp('tempfile.fits'), uint=True) as hdul:
                 assert hdul[hdu_number].data.dtype == self.utype_map[utype]
@@ -89,7 +89,7 @@ class TestUintFunctions(FitsTestCase):
             hdulist = fits.HDUList([hdu0,table])
 
             with ignore_warnings():
-                hdulist.writeto(self.temp('tempfile.fits'), clobber=True)
+                hdulist.writeto(self.temp('tempfile.fits'), overwrite=True)
 
             # Test write of unsigned int
             del hdulist
@@ -103,7 +103,7 @@ class TestUintFunctions(FitsTestCase):
             v = u.view(dtype=[(utype, self.utype_map[utype])])
 
             with ignore_warnings():
-                fits.writeto(self.temp('tempfile2.fits'), v, clobber=True)
+                fits.writeto(self.temp('tempfile2.fits'), v, overwrite=True)
 
             with fits.open(self.temp('tempfile2.fits'), uint=True) as hdulist3:
                 hdudata3 = hdulist3[1].data

--- a/astropy/vo/client/tests/test_vos_catalog.py
+++ b/astropy/vo/client/tests/test_vos_catalog.py
@@ -19,7 +19,8 @@ import tempfile
 from .. import vos_catalog
 from ..exceptions import (VOSError, MissingCatalog, DuplicateCatalogName,
                           DuplicateCatalogURL)
-from ....tests.helper import pytest, remote_data
+from ....tests.helper import pytest, remote_data, catch_warnings
+from ....utils.exceptions import AstropyDeprecationWarning
 from ....utils.data import get_pkg_data_filename
 
 
@@ -185,6 +186,13 @@ class TestWriteJson(object):
         outfile = os.path.join(self.outdir, 'test_1.json')
         db = vos_catalog.VOSDatabase.from_json(DB_FILE)
         db.to_json(outfile)
+        with catch_warnings(AstropyDeprecationWarning) as warning_lines:
+            db.to_json(outfile, clobber=True)
+            assert warning_lines[0].category == AstropyDeprecationWarning
+            assert (str(warning_lines[0].message) == '"clobber" was '
+                    'deprecated in version 1.3 and will be removed in a '
+                    'future version. Use argument "overwrite" instead.')
+        db.to_json(outfile, overwrite=True)
 
         # Read it back in
         db2 = vos_catalog.VOSDatabase.from_json(outfile)

--- a/astropy/vo/client/tests/test_vos_catalog.py
+++ b/astropy/vo/client/tests/test_vos_catalog.py
@@ -186,6 +186,9 @@ class TestWriteJson(object):
         outfile = os.path.join(self.outdir, 'test_1.json')
         db = vos_catalog.VOSDatabase.from_json(DB_FILE)
         db.to_json(outfile)
+        with pytest.raises(OSError) as exc:
+            db.to_json(outfile)
+        assert str(exc.value).endswith("test_1.json exists.")
         with catch_warnings(AstropyDeprecationWarning) as warning_lines:
             db.to_json(outfile, clobber=True)
             assert warning_lines[0].category == AstropyDeprecationWarning

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -426,7 +426,8 @@ class VOSDatabase(VOSBase):
 
     @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
     def to_json(self, filename, overwrite=False):
-        """Write database content to a JSON file.
+        """
+        Write database content to a JSON file.
 
         Parameters
         ----------
@@ -437,13 +438,12 @@ class VOSDatabase(VOSBase):
             If ``True``, overwrite the output file if it exists.
 
             .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument
+               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         Raises
         ------
         OSError
-            File exists.
-
+            If the file exists and ``overwrite`` is ``False``.
         """
         if os.path.exists(filename) and not overwrite:
             raise OSError('{0} exists.'.format(filename))

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -442,7 +442,7 @@ class VOSDatabase(VOSBase):
             File exists.
 
         """
-        if os.path.exists(filename) and not overwrite:  # pragma: no cover
+        if os.path.exists(filename) and not overwrite:
             raise OSError('{0} exists.'.format(filename))
 
         with open(filename, 'w') as fd:

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -29,6 +29,7 @@ from ...utils.data import conf as data_conf
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.misc import JsonCustomEncoder
 from ...utils.xml.unescaper import unescape_all
+from ...utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['VOSBase', 'VOSCatalog', 'VOSDatabase', 'get_remote_catalog_db',
@@ -423,7 +424,8 @@ class VOSDatabase(VOSBase):
 
         return db
 
-    def to_json(self, filename, clobber=False):
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def to_json(self, filename, overwrite=False):
         """Write database content to a JSON file.
 
         Parameters
@@ -431,8 +433,8 @@ class VOSDatabase(VOSBase):
         filename : str
             JSON file.
 
-        clobber : bool
-            Overwrite existing file?
+        overwrite : bool
+            If ``True``, overwrite the output file if it exists.
 
         Raises
         ------
@@ -440,7 +442,7 @@ class VOSDatabase(VOSBase):
             File exists.
 
         """
-        if os.path.exists(filename) and not clobber:  # pragma: no cover
+        if os.path.exists(filename) and not overwrite:  # pragma: no cover
             raise OSError('{0} exists.'.format(filename))
 
         with open(filename, 'w') as fd:

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -436,6 +436,9 @@ class VOSDatabase(VOSBase):
         overwrite : bool
             If ``True``, overwrite the output file if it exists.
 
+            .. versionchanged:: 1.3
+               ``overwrite`` replaces the deprecated ``clobber`` argument
+
         Raises
         ------
         OSError

--- a/astropy/vo/validator/validate.py
+++ b/astropy/vo/validator/validate.py
@@ -218,7 +218,7 @@ def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
     for key in db_file:
         n[key] = len(js_tree[key])
         n_tot += n[key]
-        js_tree[key].to_json(db_file[key], clobber=True)
+        js_tree[key].to_json(db_file[key], overwrite=True)
         if verbose:
             log.info('{0}: {1} catalog(s)'.format(key, n[key]))
 

--- a/examples/io/create-mef.py
+++ b/examples/io/create-mef.py
@@ -41,12 +41,12 @@ new_hdul.writeto('test.fits')
 #
 # Create a multi-extension FITS file with two empty IMAGE extensions (a
 # default PRIMARY HDU is prepended automatically if one is not specified;
-# we use ``clobber=True`` to overwrite the file if it already exists):
+# we use ``overwrite=True`` to overwrite the file if it already exists):
 
 hdu1 = fits.PrimaryHDU()
 hdu2 = fits.ImageHDU()
 new_hdul = fits.HDUList([hdu1, hdu2])
-new_hdul.writeto('test.fits', clobber=True)
+new_hdul.writeto('test.fits', overwrite=True)
 
 ##############################################################################
 # Finally, we'll remove the file we created:


### PR DESCRIPTION
`overwrite` can now be used instead of `clobber`. The `clobber`
parameter is deprecated, and an AstropyDeprecationWarning will be
issued if it is used instead of `overwrite`. If both happen to be
used, a ValueError is raised.
