### PR TITLE
Appveyor: changing VS version to be Update 2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ matrix:
 platform:
     -x64
 
-os: Previous Visual Studio 2015
+os: Visual Studio 2015 Update 2
 
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"


### PR DESCRIPTION
This PR removes the workaround that relied on a temporary appveyor solution. We should stick to using Update 2 at least until a new update is out that solves the issues with Update 3.

@mwcraig - Could you please merge this once the tests pass?