### PR TITLE
Add a new beam->angular area equivalency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -413,9 +413,9 @@ astropy.units
   ``bool(0 * u.dimensionless_unscaled)`` evaluates to ``True``. In the future,
   attempting to convert a ``Quantity`` to a ``bool`` will raise ``ValueError``.
   [#6580, #6590]
- - Modify the ``brightness_temperature`` equivalency to provide a surface
-   brightness equivalency instead of the awkward assumed-per-beam equivalency
-   that previously existed [#5173, #6663]
+- Modify the ``brightness_temperature`` equivalency to provide a surface
+  brightness equivalency instead of the awkward assumed-per-beam equivalency
+  that previously existed [#5173, #6663]
 
 - Support was added for a number of ``scipy.special`` functions. [#6852]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -413,6 +413,9 @@ astropy.units
   ``bool(0 * u.dimensionless_unscaled)`` evaluates to ``True``. In the future,
   attempting to convert a ``Quantity`` to a ``bool`` will raise ``ValueError``.
   [#6580, #6590]
+ - Modify the ``brightness_temperature`` equivalency to provide a surface
+   brightness equivalency instead of the awkward assumed-per-beam equivalency
+   that previously existed [#5173, #6663]
 
 - Support was added for a number of ``scipy.special`` functions. [#6852]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -413,6 +413,7 @@ astropy.units
   ``bool(0 * u.dimensionless_unscaled)`` evaluates to ``True``. In the future,
   attempting to convert a ``Quantity`` to a ``bool`` will raise ``ValueError``.
   [#6580, #6590]
+
 - Modify the ``brightness_temperature`` equivalency to provide a surface
   brightness equivalency instead of the awkward assumed-per-beam equivalency
   that previously existed [#5173, #6663]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -3,6 +3,7 @@
 
 # THIRD-PARTY
 import numpy as np
+import warnings
 
 # LOCAL
 from ..constants import si as _si
@@ -501,6 +502,16 @@ def brightness_temperature(disp, beam_area=None):
         >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz))
         <Quantity 130.19316407428414 K>
     """
+    if disp.unit.is_equivalent(si.sr):
+        if not beam_area.unit.is_equivalent(si.Hz):
+            raise ValueError("The inputs to `brightness_temperature` are "
+                             "frequency and angular area.")
+        warnings.warn("The inputs to `brightness_temperature` have changed. "
+                      "Frequency is now the first input, and angular area "
+                      "is the second, optional input.",
+                      DeprecationWarning)
+        disp, beam_area = beam_area, disp
+
     nu = disp.to(si.GHz, spectral())
 
     if beam_area is not None:

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -17,9 +17,10 @@ from .core import UnitsError, Unit
 
 __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'doppler_optical', 'doppler_relativistic', 'mass_energy',
-           'brightness_temperature', 'dimensionless_angles',
-           'logarithmic', 'temperature', 'temperature_energy', 'molar_mass_amu',
-           'pixel_scale', 'plate_scale']
+           'brightness_temperature', 'beam_angular_area',
+           'dimensionless_angles', 'logarithmic', 'temperature',
+           'temperature_energy', 'molar_mass_amu', 'pixel_scale',
+           'plate_scale']
 
 
 def dimensionless_angles():
@@ -544,8 +545,20 @@ def beam_angular_area(beam_area):
     """
     Convert between the `beam` unit, which is commonly used to express the area
     of a radio telescope resolution element, and an area on the sky.
+    It also allows for inverse-beam and inverse-steradian equivalency,
+    since those are more commonly used (e.g., Jy/sr <-> Jy/beam).
     """
-    return [(astrophys.beam, Unit(beam_area))]
+    beam_area_sr = beam_area.to(si.sr).value
+
+    def beam_to_sr(x):
+        return x * beam_area_sr
+
+    def sr_to_beam(x):
+        return x / beam_area_sr
+
+    return [(astrophys.beam, si.sr, beam_to_sr, sr_to_beam),
+            (astrophys.beam**-1, si.sr**-1, sr_to_beam, beam_to_sr),
+           ]
 
 def temperature():
     """Convert between Kelvin, Celsius, and Fahrenheit here because

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -478,7 +478,7 @@ def brightness_temperature(disp, beam_area=None):
         >>> beam_sigma = 50*u.arcsec
         >>> beam_area = 2*np.pi*(beam_sigma)**2
         >>> freq = 5*u.GHz
-        >>> equiv = u.brightness_temperature(beam_area, freq)
+        >>> equiv = u.brightness_temperature(freq, beam_area)
         >>> u.Jy.to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
         3.526294429423223
         >>> (1*u.Jy).to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
@@ -491,7 +491,7 @@ def brightness_temperature(disp, beam_area=None):
         >>> fwhm_to_sigma = 1./(8*np.log(2))**0.5
         >>> beam_area = 2.*np.pi*(bmaj*bmin*fwhm_to_sigma**2)
         >>> freq = 5*u.GHz
-        >>> equiv = u.brightness_temperature(beam_area, freq)
+        >>> equiv = u.brightness_temperature(freq, beam_area)
         >>> u.Jy.to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
         217.2658703625732
     """

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -507,6 +507,20 @@ def brightness_temperature(beam_area, disp):
 
     return [(astrophys.Jy, si.K, convert_Jy_to_K, convert_K_to_Jy)]
 
+def beam_angular_area(beam_area):
+    """
+    Convert between the `beam` unit, which is commonly used to express the area
+    of a radio telescope resolution element, and an area on the sky.
+    """
+    beam = beam_area.to(si.sr).value
+
+    def convert_beam_to_sr(x_beam):
+        return x_beam * beam
+
+    def convert_sr_to_beam(x_sr):
+        return x_sr / beam
+
+    return [(astrophys.beam, si.sr, convert_beam_to_sr, convert_sr_to_beam)]
 
 def temperature():
     """Convert between Kelvin, Celsius, and Fahrenheit here because

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -447,7 +447,7 @@ def mass_energy():
     ]
 
 
-def brightness_temperature(disp, beam_area=None):
+def brightness_temperature(frequency, beam_area=None):
     r"""
     Defines the conversion between Jy/sr and "brightness temperature",
     :math:`T_B`, in Kelvins.  The brightness temperature is a unit very
@@ -464,9 +464,13 @@ def brightness_temperature(disp, beam_area=None):
 
     Parameters
     ----------
-    disp : `~astropy.units.Quantity` with spectral units
-        The observed `spectral` equivalent `~astropy.units.Unit` (e.g.,
-        frequency or wavelength)
+    frequency : `~astropy.units.Quantity` with spectral units The observed
+        `spectral` equivalent `~astropy.units.Unit` (e.g., frequency or
+        wavelength).  The variable is named 'frequency' because it is more
+        commonly used in radio astronomy.
+        BACKWARD COMPATIBILITY NOTE: previous versions of the brightness
+        temperature equivalency used the keyword `disp`, which is no longer
+        supported.
     beam_area : angular area equivalent
         Beam area in angular units, i.e. steradian equivalent
 
@@ -500,7 +504,7 @@ def brightness_temperature(disp, beam_area=None):
         >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz)) # doctest: +FLOAT_CMP
         <Quantity 130.1931904778803 K>
     """
-    if disp.unit.is_equivalent(si.sr):
+    if frequency.unit.is_equivalent(si.sr):
         if not beam_area.unit.is_equivalent(si.Hz):
             raise ValueError("The inputs to `brightness_temperature` are "
                              "frequency and angular area.")
@@ -508,9 +512,9 @@ def brightness_temperature(disp, beam_area=None):
                       "Frequency is now the first input, and angular area "
                       "is the second, optional input.",
                       DeprecationWarning)
-        disp, beam_area = beam_area, disp
+        frequency, beam_area = beam_area, frequency
 
-    nu = disp.to(si.GHz, spectral())
+    nu = frequency.to(si.GHz, spectral())
 
     if beam_area is not None:
         beam = beam_area.to_value(si.sr)

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -497,7 +497,7 @@ def brightness_temperature(disp, beam_area=None):
     Any generic surface brightness:
 
         >>> surf_brightness = 1e6*u.MJy/u.sr
-        >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz))
+        >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz)) # doctest: +FLOAT_CMP
         <Quantity 130.1931904778803 K>
     """
     if disp.unit.is_equivalent(si.sr):

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -549,7 +549,9 @@ def beam_angular_area(beam_area):
     since those are more commonly used (e.g., Jy/sr <-> Jy/beam).
     """
     return [(astrophys.beam, Unit(beam_area)),
-            (astrophys.beam**-1, Unit(beam_area**-1))]
+            (astrophys.beam**-1, Unit(beam_area)**-1),
+            (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),
+           ]
 
 def temperature():
     """Convert between Kelvin, Celsius, and Fahrenheit here because

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -545,8 +545,13 @@ def beam_angular_area(beam_area):
     """
     Convert between the ``beam`` unit, which is commonly used to express the area
     of a radio telescope resolution element, and an area on the sky.
-    It also allows for inverse-beam and inverse-steradian equivalency,
-    since those are more commonly used (e.g., Jy/sr <-> Jy/beam).
+    This equivalency also supports direct conversion between ``Jy/beam`` and
+    ``Jy/steradian`` units, since that is a common operation.
+
+    Parameters
+    ----------
+    beam_area : angular area equivalent
+        The area of the beam in angular area units (e.g., steradians)
     """
     return [(astrophys.beam, Unit(beam_area)),
             (astrophys.beam**-1, Unit(beam_area)**-1),

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -465,12 +465,12 @@ def brightness_temperature(frequency, beam_area=None):
 
     Parameters
     ----------
-    frequency : `~astropy.units.Quantity` with spectral units The observed
-        `spectral` equivalent `~astropy.units.Unit` (e.g., frequency or
-        wavelength).  The variable is named 'frequency' because it is more
-        commonly used in radio astronomy.
+    frequency : `~astropy.units.Quantity` with spectral units
+        The observed ``spectral`` equivalent `~astropy.units.Unit` (e.g.,
+        frequency or wavelength).  The variable is named 'frequency' because it
+        is more commonly used in radio astronomy.
         BACKWARD COMPATIBILITY NOTE: previous versions of the brightness
-        temperature equivalency used the keyword `disp`, which is no longer
+        temperature equivalency used the keyword ``disp``, which is no longer
         supported.
     beam_area : angular area equivalent
         Beam area in angular units, i.e. steradian equivalent

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -12,7 +12,7 @@ from . import cgs
 from . import astrophys
 from .function import units as function_units
 from . import dimensionless_unscaled
-from .core import UnitsError
+from .core import UnitsError, Unit
 
 
 __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
@@ -523,7 +523,7 @@ def brightness_temperature(disp, beam_area=None):
             return (x_K * beam / factor)
 
         return [(astrophys.Jy, si.K, convert_Jy_to_K, convert_K_to_Jy),
-                (astrophys.Jy/astrophys.beam, si.K, convert_Jy_to_K, convert_K_to_Jy),
+                (astrophys.Jy/astrophys.beam, si.K, convert_Jy_to_K, convert_K_to_Jy)
                ]
     else:
         def convert_JySr_to_K(x_jysr):
@@ -534,22 +534,14 @@ def brightness_temperature(disp, beam_area=None):
             factor = (astrophys.Jy / (2 * _si.k_B * nu**2 / _si.c**2)).to(si.K).value
             return (x_K / factor) # multiplied by 1x for 1 steradian
 
-        return [(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr), ]
+        return [(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr)]
 
 def beam_angular_area(beam_area):
     """
     Convert between the `beam` unit, which is commonly used to express the area
     of a radio telescope resolution element, and an area on the sky.
     """
-    beam = beam_area.to(si.sr).value
-
-    def convert_beam_to_sr(x_beam):
-        return x_beam * beam
-
-    def convert_sr_to_beam(x_sr):
-        return x_sr / beam
-
-    return [(astrophys.beam, si.sr, convert_beam_to_sr, convert_sr_to_beam)]
+    return [(astrophys.beam, Unit(beam_area))]
 
 def temperature():
     """Convert between Kelvin, Celsius, and Fahrenheit here because

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -494,6 +494,12 @@ def brightness_temperature(disp, beam_area=None):
         >>> equiv = u.brightness_temperature(freq, beam_area)
         >>> u.Jy.to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
         217.2658703625732
+
+    Any generic surface brightness:
+
+        >>> surf_brightness = 1e6*u.MJy/u.sr
+        >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz))
+        <Quantity 130.19316407428414 K>
     """
     nu = disp.to(si.GHz, spectral())
 
@@ -519,7 +525,7 @@ def brightness_temperature(disp, beam_area=None):
             factor = (astrophys.Jy / (2 * _si.k_B * nu**2 / _si.c**2)).to(si.K).value
             return (x_K / factor) # multiplied by 1x for 1 steradian
 
-        return [(astrophys.Jy/u.sr, si.K, convert_JySr_to_K, convert_K_to_JySr), ]
+        return [(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr), ]
 
 def beam_angular_area(beam_area):
     """

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -479,11 +479,9 @@ def brightness_temperature(disp, beam_area=None):
         >>> beam_sigma = 50*u.arcsec
         >>> beam_area = 2*np.pi*(beam_sigma)**2
         >>> freq = 5*u.GHz
-        >>> equiv = u.brightness_temperature(freq, beam_area)
-        >>> u.Jy.to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
-        3.526294429423223
-        >>> (1*u.Jy).to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
-        <Quantity 3.526294429423223 K>
+        >>> equiv = u.brightness_temperature(freq)
+        >>> (1*u.Jy/beam_area).to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
+        <Quantity 3.526295144567176 K>
 
     VLA synthetic beam::
 
@@ -492,15 +490,15 @@ def brightness_temperature(disp, beam_area=None):
         >>> fwhm_to_sigma = 1./(8*np.log(2))**0.5
         >>> beam_area = 2.*np.pi*(bmaj*bmin*fwhm_to_sigma**2)
         >>> freq = 5*u.GHz
-        >>> equiv = u.brightness_temperature(freq, beam_area)
-        >>> u.Jy.to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
-        217.2658703625732
+        >>> equiv = u.brightness_temperature(freq)
+        >>> (u.Jy/beam_area).to(u.K, equivalencies=equiv)  # doctest: +FLOAT_CMP
+        <Quantity 217.2658703625732 K>
 
     Any generic surface brightness:
 
         >>> surf_brightness = 1e6*u.MJy/u.sr
         >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz))
-        <Quantity 130.19316407428414 K>
+        <Quantity 130.1931904778803 K>
     """
     if disp.unit.is_equivalent(si.sr):
         if not beam_area.unit.is_equivalent(si.Hz):

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -548,17 +548,8 @@ def beam_angular_area(beam_area):
     It also allows for inverse-beam and inverse-steradian equivalency,
     since those are more commonly used (e.g., Jy/sr <-> Jy/beam).
     """
-    beam_area_sr = beam_area.to(si.sr).value
-
-    def beam_to_sr(x):
-        return x * beam_area_sr
-
-    def sr_to_beam(x):
-        return x / beam_area_sr
-
-    return [(astrophys.beam, si.sr, beam_to_sr, sr_to_beam),
-            (astrophys.beam**-1, si.sr**-1, sr_to_beam, beam_to_sr),
-           ]
+    return [(astrophys.beam, Unit(beam_area)),
+            (astrophys.beam**-1, Unit(beam_area**-1))]
 
 def temperature():
     """Convert between Kelvin, Celsius, and Fahrenheit here because

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -543,7 +543,7 @@ def brightness_temperature(frequency, beam_area=None):
 
 def beam_angular_area(beam_area):
     """
-    Convert between the `beam` unit, which is commonly used to express the area
+    Convert between the ``beam`` unit, which is commonly used to express the area
     of a radio telescope resolution element, and an area on the sky.
     It also allows for inverse-beam and inverse-steradian equivalency,
     since those are more commonly used (e.g., Jy/sr <-> Jy/beam).

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -531,6 +531,12 @@ def test_beam():
     np.testing.assert_almost_equal(omega_B.to(u.sr).value * 5, new_beam.value)
     assert new_beam.unit.is_equivalent(u.sr)
 
+def test_surfacebrightness():
+    sb = 50*u.MJy/u.sr
+    k = sb.to(u.K, u.brightness_temperature(50*u.GHz))
+    np.testing.assert_almost_equal(k.value, 0.6509658203714207)
+    assert k.unit.is_equivalent(u.K)
+
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         phase = u.Quantity(1., u.cycle)

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -538,7 +538,7 @@ def test_swapped_args_brightness_temperature():
     """
     omega_B = np.pi * (50 * u.arcsec) ** 2
     nu = u.GHz * 5
-    tb = 7.05258885885 * u.K
+    tb = 7.052590289134352 * u.K
     # https://docs.pytest.org/en/latest/warnings.html#ensuring-function-triggers
     with warnings.catch_warnings():
         warnings.simplefilter('always')

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -540,8 +540,12 @@ def test_swapped_args_brightness_temperature():
             result = (1*u.Jy).to(u.K,
                                  equivalencies=u.brightness_temperature(omega_B,
                                                                         nu))
-    assert len(warning_list) == 1
+            roundtrip = result.to(u.Jy,
+                                  equivalencies=u.brightness_temperature(omega_B,
+                                                                         nu))
+    assert len(warning_list) == 2
     np.testing.assert_almost_equal(tb.value, result.value)
+    np.testing.assert_almost_equal(roundtrip.value, 1)
 
 def test_surfacebrightness():
     sb = 50*u.MJy/u.sr
@@ -550,10 +554,15 @@ def test_surfacebrightness():
     assert k.unit.is_equivalent(u.K)
 
 def test_beam():
-    omega_B = np.pi * (50 * u.arcsec) ** 2
+    # pick a beam area: 2 pi r^2 = area of a Gaussina with sigma=50 arcsec
+    omega_B = 2 * np.pi * (50 * u.arcsec) ** 2
     new_beam = (5*u.beam).to(u.sr, u.equivalencies.beam_angular_area(omega_B))
     np.testing.assert_almost_equal(omega_B.to(u.sr).value * 5, new_beam.value)
     assert new_beam.unit.is_equivalent(u.sr)
+
+    # make sure that it's still consistent with 5 beams
+    nbeams = new_beam.to(u.beam, u.equivalencies.beam_angular_area(omega_B))
+    np.testing.assert_almost_equal(nbeams.value, 5)
 
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -526,12 +526,6 @@ def test_brightness_temperature():
         1.0, tb.to_value(
             u.Jy, equivalencies=u.brightness_temperature(nu, beam_area=omega_B)))
 
-def test_beam():
-    omega_B = np.pi * (50 * u.arcsec) ** 2
-    new_beam = (5*u.beam).to(u.sr, u.equivalencies.beam_angular_area(omega_B))
-    np.testing.assert_almost_equal(omega_B.to(u.sr).value * 5, new_beam.value)
-    assert new_beam.unit.is_equivalent(u.sr)
-
 def test_swapped_args_brightness_temperature():
     """
     #5173 changes the order of arguments but accepts the old (deprecated) args
@@ -554,6 +548,12 @@ def test_surfacebrightness():
     k = sb.to(u.K, u.brightness_temperature(50*u.GHz))
     np.testing.assert_almost_equal(k.value, 0.650965, 5)
     assert k.unit.is_equivalent(u.K)
+
+def test_beam():
+    omega_B = np.pi * (50 * u.arcsec) ** 2
+    new_beam = (5*u.beam).to(u.sr, u.equivalencies.beam_angular_area(omega_B))
+    np.testing.assert_almost_equal(omega_B.to(u.sr).value * 5, new_beam.value)
+    assert new_beam.unit.is_equivalent(u.sr)
 
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -552,7 +552,7 @@ def test_swapped_args_brightness_temperature():
 def test_surfacebrightness():
     sb = 50*u.MJy/u.sr
     k = sb.to(u.K, u.brightness_temperature(50*u.GHz))
-    np.testing.assert_almost_equal(k.value, 0.6509658203714207)
+    np.testing.assert_almost_equal(k.value, 0.650965, 6)
     assert k.unit.is_equivalent(u.K)
 
 def test_equivalency_context():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -525,6 +525,11 @@ def test_brightness_temperature():
         1.0, tb.to_value(
             u.Jy, equivalencies=u.brightness_temperature(omega_B, nu)))
 
+def test_beam():
+    omega_B = np.pi * (50 * u.arcsec) ** 2
+    new_beam = (5*u.beam).to(u.sr, u.beam_angular_area(omega_B))
+    np.testing.assert_almost_equal(omega_B.value * 5, new_beam.value)
+    assert new_beam.is_equivalent(u.sr)
 
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -564,6 +564,18 @@ def test_beam():
     nbeams = new_beam.to(u.beam, u.equivalencies.beam_angular_area(omega_B))
     np.testing.assert_almost_equal(nbeams.value, 5)
 
+    # test inverse beam equivalency
+    # (this is just a sanity check that the equivalency is defined;
+    # it's not for testing numerical consistency)
+    new_inverse_beam = (5/u.beam).to(1/u.sr, u.equivalencies.beam_angular_area(omega_B))
+
+    # test practical case
+    # (this is by far the most important one)
+    flux_density = (5*u.Jy/u.beam).to(u.MJy/u.sr, u.equivalencies.beam_angular_area(omega_B))
+
+    np.testing.assert_almost_equal(flux_density.value, 13.5425483146382)
+
+
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         phase = u.Quantity(1., u.cycle)

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -552,7 +552,7 @@ def test_swapped_args_brightness_temperature():
 def test_surfacebrightness():
     sb = 50*u.MJy/u.sr
     k = sb.to(u.K, u.brightness_temperature(50*u.GHz))
-    np.testing.assert_almost_equal(k.value, 0.650965, 6)
+    np.testing.assert_almost_equal(k.value, 0.650965, 5)
     assert k.unit.is_equivalent(u.K)
 
 def test_equivalency_context():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -520,16 +520,16 @@ def test_brightness_temperature():
     tb = 7.052590289134352 * u.K
     np.testing.assert_almost_equal(
         tb.value, (1 * u.Jy).to_value(
-            u.K, equivalencies=u.brightness_temperature(omega_B, nu)))
+            u.K, equivalencies=u.brightness_temperature(nu, beam_area=omega_B)))
     np.testing.assert_almost_equal(
         1.0, tb.to_value(
-            u.Jy, equivalencies=u.brightness_temperature(omega_B, nu)))
+            u.Jy, equivalencies=u.brightness_temperature(nu, beam_area=omega_B)))
 
 def test_beam():
     omega_B = np.pi * (50 * u.arcsec) ** 2
-    new_beam = (5*u.beam).to(u.sr, u.beam_angular_area(omega_B))
-    np.testing.assert_almost_equal(omega_B.value * 5, new_beam.value)
-    assert new_beam.is_equivalent(u.sr)
+    new_beam = (5*u.beam).to(u.sr, u.equivalencies.beam_angular_area(omega_B))
+    np.testing.assert_almost_equal(omega_B.to(u.sr).value * 5, new_beam.value)
+    assert new_beam.unit.is_equivalent(u.sr)
 
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -5,6 +5,7 @@
 
 
 # THIRD-PARTY
+import warnings
 import pytest
 import numpy as np
 from numpy.testing.utils import assert_allclose
@@ -530,6 +531,23 @@ def test_beam():
     new_beam = (5*u.beam).to(u.sr, u.equivalencies.beam_angular_area(omega_B))
     np.testing.assert_almost_equal(omega_B.to(u.sr).value * 5, new_beam.value)
     assert new_beam.unit.is_equivalent(u.sr)
+
+def test_swapped_args_brightness_temperature():
+    """
+    #5173 changes the order of arguments but accepts the old (deprecated) args
+    """
+    omega_B = np.pi * (50 * u.arcsec) ** 2
+    nu = u.GHz * 5
+    tb = 7.05258885885 * u.K
+    # https://docs.pytest.org/en/latest/warnings.html#ensuring-function-triggers
+    with warnings.catch_warnings():
+        warnings.simplefilter('always')
+        with pytest.warns(DeprecationWarning) as warning_list:
+            result = (1*u.Jy).to(u.K,
+                                 equivalencies=u.brightness_temperature(omega_B,
+                                                                        nu))
+    assert len(warning_list) == 1
+    np.testing.assert_almost_equal(tb.value, result.value)
 
 def test_surfacebrightness():
     sb = 50*u.MJy/u.sr

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -245,7 +245,8 @@ with the `~astropy.units.equivalencies.beam_angular_area` equivalency::
     >>> fwhm_to_sigma = 1. / (8 * np.log(2))**0.5
     >>> beam_sigma = beam_fwhm * fwhm_to_sigma
     >>> omega_B = 2 * np.pi * beam_sigma**2
-    >>> (1*u.Jy/u.beam).to(u.Jy/u.sr, equivalencies=u.beam_angular_area(omega_B))
+    >>> (1*u.Jy/u.beam).to(u.MJy/u.sr, equivalencies=u.beam_angular_area(omega_B))  # doctest: +FLOAT_CMP
+    <Quantity 15.019166691021288 MJy / sr>
 
 
 Note that the `radio_beam <https://github.com/radio-astro-tools/radio-beam>`_ package

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -233,6 +233,23 @@ example converts the FWHM to sigma::
     >>> (u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
     <Quantity 19.553932298231704 K>
 
+Beam Equivalency
+----------------
+
+Radio data, especially from interferometers, is often produced in units of Jy/beam.
+Converting this number to a beam-independent value, e.g., Jy/sr, can be done
+with the `~astropy.units.equivalencies.beam_angular_area` equivalency::
+
+    >>> import numpy as np
+    >>> beam_fwhm = 50*u.arcsec
+    >>> fwhm_to_sigma = 1. / (8 * np.log(2))**0.5
+    >>> beam_sigma = beam_fwhm * fwhm_to_sigma
+    >>> omega_B = 2 * np.pi * beam_sigma**2
+    >>> (1*u.Jy/u.beam).to(u.Jy/u.sr, equivalencies=u.beam_angular_area(omega_B))
+
+
+Note that the `radio_beam <https://github.com/radio-astro-tools/radio-beam>`_ package
+deals with beam input/output and various operations more directly.
 
 Temperature Energy Equivalency
 ------------------------------

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -217,7 +217,7 @@ here is an example::
     >>> beam_sigma = 50*u.arcsec
     >>> omega_B = 2 * np.pi * beam_sigma**2
     >>> freq = 5 * u.GHz
-    >>> (u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
+    >>> (1*u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
     <Quantity 3.526295144567176 K>
 
 If you have beam full-width half-maxima (FWHM), which are often quoted and are
@@ -230,8 +230,34 @@ example converts the FWHM to sigma::
     >>> beam_sigma = beam_fwhm * fwhm_to_sigma
     >>> omega_B = 2 * np.pi * beam_sigma**2
     >>> freq = 5 * u.GHz
-    >>> (u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
+    >>> (1*u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
     <Quantity 19.553932298231704 K>
+
+You can also convert between Jy/beam and K by specifying the beam area::
+
+    >>> import numpy as np
+    >>> beam_fwhm = 50*u.arcsec
+    >>> fwhm_to_sigma = 1. / (8 * np.log(2))**0.5
+    >>> beam_sigma = beam_fwhm * fwhm_to_sigma
+    >>> omega_B = 2 * np.pi * beam_sigma**2
+    >>> freq = 5 * u.GHz
+    >>> (1*u.Jy/u.beam).to(u.K, u.brightness_temperature(freq, beam_area=omega_B))  # doctest: +FLOAT_CMP
+    <Quantity 19.553932298231704 K>
+
+Finally, there is an equivalency that allows you to convert from Jansky to Kelvin.
+In this case, the Jansky unit is *implicitly* Jansky/beam.  Because of the implicit
+assumed per beam unit, this approach is deprecated.::
+
+    >>> import numpy as np
+    >>> beam_fwhm = 50*u.arcsec
+    >>> fwhm_to_sigma = 1. / (8 * np.log(2))**0.5
+    >>> beam_sigma = beam_fwhm * fwhm_to_sigma
+    >>> omega_B = 2 * np.pi * beam_sigma**2
+    >>> freq = 5 * u.GHz
+    >>> # DEPRECATED
+    >>> (1*u.Jy).to(u.K, u.brightness_temperature(freq, beam_area=omega_B))  # doctest: +FLOAT_CMP
+    <Quantity 19.553932298231704 K>
+
 
 Beam Equivalency
 ----------------

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -188,14 +188,15 @@ its arguments the |quantity| for the spectral location. For example::
     ...      equivalencies=u.spectral_density(5500 * u.AA)) # doctest: +FLOAT_CMP
     <Quantity 3.6443382634999996e-23 erg / (Hz s)>
 
-Brightness Temperature / Flux Density Equivalency
--------------------------------------------------
+Brightness Temperature / Surface Brightness Equivalency
+-------------------------------------------------------
 
-There is an equivalency for brightness temperature and flux density.
-This equivalency is often referred to as "Antenna Gain" since, at a
-given frequency, telescope brightness sensitivity is unrelated to
-aperture size, but flux density sensitivity is, so this equivalency is
-only dependent on the aperture size.  See `Tools of Radio Astronomy
+There is an equivalency between surface brightness (flux density per area) and
+brightness temperature.  This equivalency is often referred to as "Antenna
+Gain" since, at a given frequency, telescope brightness sensitivity is
+unrelated to aperture size, but flux density sensitivity is, so this
+equivalency is only dependent on the aperture size.  See `Tools of Radio
+Astronomy
 <http://books.google.com/books?id=9KHw6R8rQEMC&pg=PA179&source=gbs_toc_r&cad=4#v=onepage&q&f=false>`__
 for details.
 
@@ -216,13 +217,8 @@ here is an example::
     >>> beam_sigma = 50*u.arcsec
     >>> omega_B = 2 * np.pi * beam_sigma**2
     >>> freq = 5 * u.GHz
-    >>> u.Jy.to(u.K, equivalencies=u.brightness_temperature(omega_B, freq))  # doctest: +FLOAT_CMP
-    3.526295144567176
-
-.. note:: Despite the Astropy unit on the left being shown as ``u.Jy``, this is
-          the conversion factor from Jy/beam to K (because ``u.beam`` cannot
-          currently be used as a meaningful unit since it depends on the
-          observations).
+    >>> (u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
+    <Quantity 3.526295144567176 K>
 
 If you have beam full-width half-maxima (FWHM), which are often quoted and are
 the values stored in the FITS header keywords BMAJ and BMIN, a more appropriate
@@ -234,8 +230,8 @@ example converts the FWHM to sigma::
     >>> beam_sigma = beam_fwhm * fwhm_to_sigma
     >>> omega_B = 2 * np.pi * beam_sigma**2
     >>> freq = 5 * u.GHz
-    >>> u.Jy.to(u.K, equivalencies=u.brightness_temperature(omega_B, freq))  # doctest: +FLOAT_CMP
-    19.553928332631582
+    >>> (u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
+    <Quantity 19.553932298231704 K>
 
 
 Temperature Energy Equivalency

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -233,7 +233,7 @@ example converts the FWHM to sigma::
     >>> (1*u.Jy/omega_B).to(u.K, equivalencies=u.brightness_temperature(freq))  # doctest: +FLOAT_CMP
     <Quantity 19.553932298231704 K>
 
-You can also convert between Jy/beam and K by specifying the beam area::
+You can also convert between ``Jy/beam`` and ``K`` by specifying the beam area::
 
     >>> import numpy as np
     >>> beam_fwhm = 50*u.arcsec
@@ -262,8 +262,8 @@ assumed per beam unit, this approach is deprecated.::
 Beam Equivalency
 ----------------
 
-Radio data, especially from interferometers, is often produced in units of Jy/beam.
-Converting this number to a beam-independent value, e.g., Jy/sr, can be done
+Radio data, especially from interferometers, is often produced in units of ``Jy/beam``.
+Converting this number to a beam-independent value, e.g., ``Jy/sr``, can be done
 with the `~astropy.units.equivalencies.beam_angular_area` equivalency::
 
     >>> import numpy as np


### PR DESCRIPTION
This will allow conversion from Jy/beam -> MJy/sr, for example.

There is a problem now, though: ideally, one should be able to do
`(5*u.Jy/u.beam).to(u.K, u.beam_angular_area(beam) + u.brightness_temperature(frequency))`,
but I think this is not possible at present because `brightness_temperature`
assumes the incoming unit is Jy and implicitly assumes only 1 beam.  Also, it
requires the beam to be input.  I think both equivalencies (Jy->K and Jy/beam -> K)
are useful, even though the latter is more technically correct.  Any suggestions on a new
name for the (Jy/beam -> K) equivalency?
