### PR TITLE
[test] Trying astropy builds after deprecating build_sphinx in astropy_helpers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "astropy_helpers"]
 	path = astropy_helpers
-	url = https://github.com/astropy/astropy-helpers.git
+	url = https://github.com/adrn/astropy-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,13 @@ matrix:
         # runs for a long time. The sphinx build also has some additional
         # dependencies.
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
+          env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='sphinx-gallery>=0.1.2 pillow wcsaxes --no-deps jplephem'
 
         # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different 
-        # versions of Python, we can vary Python and Numpy versions at the same 
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
         - os: linux


### PR DESCRIPTION
Not meant to be merged! 

This moves astropy-helpers to the version in astropy/astropy-helpers#246 to see if it causes any sphinx build issues in Astropy core.

cc @eteq for the idea