### PR TITLE
Deprecate build_sphinx 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,13 @@ matrix:
         # runs for a long time. The sphinx build also has some additional
         # dependencies.
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
+          env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='sphinx-gallery>=0.1.2 pillow wcsaxes --no-deps jplephem'
 
         # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different 
-        # versions of Python, we can vary Python and Numpy versions at the same 
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -161,6 +161,9 @@ Other Changes and Additions
 - Initialization of ``Angle`` has been sped up for ``Quantity`` and ``Angle``
   input. [#4970]
 
+- To build the documentation, the ``build_sphinx`` command has been deprecated
+  in favor of ``build_docs``. [#5179]
+
 1.2.2 (unreleased)
 ------------------
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -151,7 +151,7 @@ class AstropyTest(Command, object):
 
         # Ensure there is a doc path
         if self.docs_path is None:
-            cfg_docs_dir = self.distribution.get_option_dict('build_sphinx').get('source_dir', None)
+            cfg_docs_dir = self.distribution.get_option_dict('build_docs').get('source_dir', None)
 
             # Some affiliated packages use this.
             # See astropy/package-template#157

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@
 # done. If the sys.path entry above is added, when the astropy.sphinx.conf
 # import occurs, it will import the *source* version of astropy instead of the
 # version installed (if invoked as "make html" or directly with sphinx), or the
-# version in the build directory (if "python setup.py build_sphinx" is used).
+# version in the build directory (if "python setup.py build_docs" is used).
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 


### PR DESCRIPTION
Closes #5157 

This PR should not be merged until (1) astropy/astropy-helpers#246 is merged, and (2) Astropy is updated to use a version of astropy-helpers that contains the code in that PR.