### PR TITLE
fix rotateCD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -226,7 +226,7 @@ Bug Fixes
   - Fix use of the ``relax`` keyword in ``to_header`` when used to change the
     output precision. [#5164]
 
-  - Fix rotateCD().
+  - Fix rotateCD(). [#5189]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -226,6 +226,8 @@ Bug Fixes
   - Fix use of the ``relax`` keyword in ``to_header`` when used to change the
     output precision. [#5164]
 
+  - Fix rotateCD().
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2678,7 +2678,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         _mrot = np.zeros(shape=(2, 2), dtype=np.double)
         _mrot[0] = (np.cos(_theta), np.sin(_theta))
         _mrot[1] = (-np.sin(_theta), np.cos(_theta))
-        new_cd = np.dot(self.wcs.cd, _mrot)
+        new_cd = np.dot(_mrot, self.wcs.cd)
         self.wcs.cd = new_cd
 
     def printwcs(self):


### PR DESCRIPTION
Closes #5175.

This fixes the problem with `rotateCD`.
On a related note, `rotateCD` is not the best name for this function as the same code applies to the PC matrix. Perhaps `rotate_wcs` is a better name.