### PR TITLE
Units issue with FK4 transforms with and without e terms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1541,6 +1541,10 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Fix errors in the implementation of the conversion to and from FK4 frames
+    without e-terms, which will have affected coordinates not on the unit
+    sphere (i.e., with distances). [#4293]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -143,7 +143,8 @@ def fk4_e_terms(equinox):
     equinox : Time object
         The equinox for which to compute the e-terms
     """
-    # Constant of aberration at J2000
+    # Constant of aberration at J2000; from Explanatory Supplement to the
+    # Astronomical Almanac (Seidelmann, 2005).
     k = 0.0056932  # in degrees (v_earth/c ~ 1e-4 rad ~ 0.0057 deg)
     k = np.radians(k)
 

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -144,11 +144,11 @@ def fk4_e_terms(equinox):
         The equinox for which to compute the e-terms
     """
     # Constant of aberration at J2000
-    k = 0.0056932
+    k = 0.0056932  # in degrees (v_earth/c ~ 1e-4 rad ~ 0.0057 deg)
+    k = np.radians(k)
 
     # Eccentricity of the Earth's orbit
     e = earth.eccentricity(equinox.jd)
-    e = np.radians(e)
 
     # Mean longitude of perigee of the solar orbit
     g = earth.mean_lon_of_perigee(equinox.jd)
@@ -170,7 +170,8 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     r = np.asarray(c.reshape((3, c.size // 3)))
 
     # Find distance (for re-normalization)
-    d_orig = np.sqrt(np.sum(r ** 2))
+    d_orig = np.sqrt(np.sum(r ** 2, axis=0))
+    r /= d_orig
 
     # Apply E-terms of aberration. Note that this depends on the equinox (not
     # the observing time/epoch) of the coordinates. See issue #1496 for a
@@ -179,10 +180,10 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     r = r - eterms_a.reshape(3, 1) + np.dot(eterms_a, r) * r
 
     # Find new distance (for re-normalization)
-    d_new = np.sqrt(np.sum(r ** 2))
+    d_new = np.sqrt(np.sum(r ** 2, axis=0))
 
     # Renormalize
-    r = r * d_orig / d_new
+    r *= d_orig / d_new
 
     subshape = c.shape[1:]
     x = r[0].reshape(subshape)
@@ -220,7 +221,8 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
     r = np.asarray(c.reshape((3, c.size // 3)))
 
     # Find distance (for re-normalization)
-    d_orig = np.sqrt(np.sum(r ** 2))
+    d_orig = np.sqrt(np.sum(r ** 2, axis=0))
+    r /= d_orig
 
     # Apply E-terms of aberration. Note that this depends on the equinox (not
     # the observing time/epoch) of the coordinates. See issue #1496 for a
@@ -231,10 +233,10 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
         r = (eterms_a.reshape(3, 1) + r0) / (1. + np.dot(eterms_a, r))
 
     # Find new distance (for re-normalization)
-    d_new = np.sqrt(np.sum(r ** 2))
+    d_new = np.sqrt(np.sum(r ** 2, axis=0))
 
     # Renormalize
-    r = r * d_orig / d_new
+    r *= d_orig / d_new
 
     subshape = c.shape[1:]
     x = r[0].reshape(subshape)

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -25,8 +25,7 @@ _asecperrad = u.radian.to(u.arcsec)
 
 def eccentricity(jd):
     """
-    Computes the eccentricity of the Earth's orbit at the requested Julian
-    Date.
+    Eccentricity of the Earth's orbit at the requested Julian Date.
 
     Parameters
     ----------
@@ -36,7 +35,7 @@ def eccentricity(jd):
     returns
     -------
     eccentricity : scalar or array
-        The eccentricity in degrees (or array of eccentricities)
+        The eccentricity (or array of eccentricities)
 
     References
     ----------


### PR DESCRIPTION
Mostly to @eteq: in the process of looking at trying to make coordinates fully shaped, I encountered the `fk4_to_fk4_no_e` transformation (and its inverse) and realised there surely is a units problem in https://github.com/astropy/astropy/blob/master/astropy/coordinates/builtin_frames/fk4.py#L173
```
r = r - eterms_a.reshape(3, 1) + np.dot(eterms_a, r) * r
```
Here, as written, `r` has units of length since it comes from `fk4coord.cartesian.xyz`, but `eterms_a` has units of degrees, since it just multiplies the constant of abberation `k` (which is given as a number that is in degrees, though it is the ratio of the speed of the earth to the speed of light, so is really a unit-less number), with eccentricity `e` (why converted to radians?) and some cosines and sines. I *think* what really should have happened here is to have `r` divided by `d_orig` so that it contains dimensionless direction cosines, but is this true?

My suggestion would be to write `fk4_e_terms` using units, and also use units throughout, so we're sure that what is being done is correct.

(Separately, the normalisation distances do not take into account the possibility of multiple coordinates, but that I can solve trivially if I understand how the above equation is supposed to work.)