### PR TITLE
Adding backup url to fall back to if the main IERS_A link is unavailable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,9 @@ astropy.utils
   ``astropy.utils.compat.numpy`` module have been deprecated. Use the
   NumPy functions directly. [#6691]
 
+- Adding backup url to fall back to if the main IERS_A link is unavailable.
+  [#5195]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1006,7 +1006,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
             if cache:
                 # We don't need to acquire the lock here, since we are only
                 # reading
-                with _open_shelve(urlmapfn, True) as url2hash:
+                with shelve.open(urlmapfn) as url2hash:
                     if url_key in url2hash:
                         return url2hash[url_key]
 
@@ -1055,7 +1055,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
             if cache:
                 _acquire_download_cache_lock()
                 try:
-                    with _open_shelve(urlmapfn, True) as url2hash:
+                    with shelve.open(urlmapfn) as url2hash:
                         # We check now to see if another process has
                         # inadvertently written the file underneath us
                         # already

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -937,7 +937,8 @@ def check_free_space_in_dir(path, size):
                 path, human_file_size(size)))
 
 
-def download_file(remote_url, cache=False, show_progress=True, timeout=None):
+def download_file(remote_url, cache=False, show_progress=True, timeout=None,
+                  delimiter=','):
     """
     Accepts a URL, downloads and optionally caches the result
     returning the filename, with a name determined by the file's MD5
@@ -947,18 +948,23 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
     Parameters
     ----------
     remote_url : str
-        The URL of the file to download
+        The URL(s) of the file to download. Multiple alternative URLs can be
+        specified separated by the ``delimiter``. Only the first working URL
+        will be downloaded.
 
     cache : bool, optional
-        Whether to use the cache
+        Whether to use the cache.
 
     show_progress : bool, optional
         Whether to display a progress bar during the download (default
-        is `True`)
+        is `True`).
 
     timeout : float, optional
         The timeout, in seconds.  Otherwise, use
         `astropy.utils.data.Conf.remote_timeout`.
+
+    delimiter : str
+        The delimiter between urls in ``remote_url`` (default is ``','``).
 
     Returns
     -------
@@ -990,7 +996,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
     url_key = remote_url
 
-    url_key_list = url_key.split(',')
+    url_key_list = url_key.split(delimiter)
 
     # Going through the alternative URLs until the first one works
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -11,11 +11,6 @@ celestial-to-terrestrial coordinate transformations
 
 from warnings import warn
 
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
-
 import numpy as np
 
 from ... import config as _config
@@ -26,6 +21,7 @@ from ... import utils
 from ...utils.exceptions import AstropyWarning
 from ...tests import disable_internet
 from ...extern.six.moves.urllib.error import HTTPError
+from ...extern.six.moves.urllib.parse import urlparse
 
 __all__ = ['Conf', 'conf',
            'IERS', 'IERS_B', 'IERS_A', 'IERS_Auto',
@@ -102,7 +98,7 @@ class Conf(_config.ConfigNamespace):
 
     iers_auto_url_backup = _config.ConfigItem(
         IERS_A_URL_BACKUP,
-        'URL for auto-downloading IERS file data')
+        'Backup URL for auto-downloading IERS file data')
 
     remote_timeout = _config.ConfigItem(
         10.0,

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -33,9 +33,8 @@ __all__ = ['Conf', 'conf',
 
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
-IERS_A_URL = 'http://maia.usno.navy.mil/ser7/finals2000A.all'
+IERS_A_URL = 'http://maia.usno.navy.mil/ser7/finals2000A.all,https://datacenter.iers.org/eop/-/somos/5Rgv/latest/7'
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
-IERS_A_URL_BACKUP = 'https://datacenter.iers.org/eop/-/somos/5Rgv/latest/7'
 
 # IERS-B default file name, URL, and ReadMe with content description
 IERS_B_FILE = get_pkg_data_filename('data/eopc04_IAU2000.62-now')
@@ -95,10 +94,6 @@ class Conf(_config.ConfigNamespace):
     iers_auto_url = _config.ConfigItem(
         IERS_A_URL,
         'URL for auto-downloading IERS file data.')
-
-    iers_auto_url_backup = _config.ConfigItem(
-        IERS_A_URL_BACKUP,
-        'Backup URL for auto-downloading IERS file data')
 
     remote_timeout = _config.ConfigItem(
         10.0,
@@ -577,10 +572,6 @@ class IERS_Auto(IERS_A):
 
         try:
             filename = download_file(conf.iers_auto_url, cache=True)
-        except HTTPError:
-            global IERS_A_URL
-            IERS_A_URL = IERS_A_URL_BACKUP
-            filename = download_file(conf.iers_auto_url_backup, cache=True)
         except Exception as err:
             # Issue a warning here, perhaps user is offline.  An exception
             # will be raised downstream when actually trying to interpolate

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -10,6 +10,7 @@ celestial-to-terrestrial coordinate transformations
 """
 
 from warnings import warn
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -20,8 +21,6 @@ from ...utils.data import get_pkg_data_filename, clear_download_cache
 from ... import utils
 from ...utils.exceptions import AstropyWarning
 from ...tests import disable_internet
-from ...extern.six.moves.urllib.error import HTTPError
-from ...extern.six.moves.urllib.parse import urlparse
 
 __all__ = ['Conf', 'conf',
            'IERS', 'IERS_B', 'IERS_A', 'IERS_Auto',


### PR DESCRIPTION
This is to close #5194 by adding the `iers.org` address to fall back to when the main `maia.usno` page is unavailable.

I'm not sure how to test it, should I set the conf value for `iers_auto_url` something invalid that throws an `HTTPError`, and then check whether the global `IERS_A_URL` during the exception?

cc @mhvk @taldcroft 
