### PR TITLE
Add CartesianFrameAttribute to coordinates for GCRS and PrecessedGeocentric frames

### DIFF
--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -6,7 +6,8 @@ from __future__ import (absolute_import, unicode_literals, division,
 from ... import units as u
 from ..representation import SphericalRepresentation
 from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
-                         TimeFrameAttribute, QuantityFrameAttribute)
+                         TimeFrameAttribute, QuantityFrameAttribute,
+                         CartesianFrameAttribute)
 from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
 
 
@@ -70,8 +71,8 @@ class GCRS(BaseCoordinateFrame):
     default_representation = SphericalRepresentation
 
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = QuantityFrameAttribute(default=0, unit=u.m, shape=(3,))
-    obsgeovel = QuantityFrameAttribute(default=0, unit=u.m/u.s, shape=(3,))
+    obsgeoloc = CartesianFrameAttribute(default=0, unit=u.m)
+    obsgeovel = CartesianFrameAttribute(default=0, unit=u.m/u.s)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like CIRS)
@@ -130,5 +131,5 @@ class PrecessedGeocentric(BaseCoordinateFrame):
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = QuantityFrameAttribute(default=0, unit=u.m, shape=(3,))
-    obsgeovel = QuantityFrameAttribute(default=0, unit=u.m/u.s, shape=(3,))
+    obsgeoloc = CartesianFrameAttribute(default=0, unit=u.m)
+    obsgeovel = CartesianFrameAttribute(default=0, unit=u.m/u.s)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -121,6 +121,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # first set up the astrometry context for ICRS<->GCRS
     pv = np.array([gcrs_frame.obsgeoloc.value,
                    gcrs_frame.obsgeovel.value])
+    if pv.ndim > 2:
+        pv = np.rollaxis(pv, -1, 0)
 
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
@@ -167,6 +169,9 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     # coordinate direction
     pv = np.array([gcrs_coo.obsgeoloc.value,
                    gcrs_coo.obsgeovel.value])
+    if pv.ndim > 2:
+        pv = np.rollaxis(pv, -1, 0)
+
     jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -13,7 +13,8 @@ import numpy as np
 
 from ... import units as u
 from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
-                GeocentricTrueEcliptic, Longitude, Latitude, GCRS)
+                GeocentricTrueEcliptic, Longitude, Latitude, GCRS, get_moon)
+from ..sites import get_builtin_sites
 from ...time import Time
 from ...utils import iers
 
@@ -225,3 +226,10 @@ def test_regression_4996():
 
     # this is intentionally not allclose - they should be *exactly* the same
     assert np.all(suncoo.ra.ravel() == suncoo2.ra.ravel())
+
+
+def test_regression_4926():
+    times = Time('2010-01-1') + np.arange(20)*u.day
+    green = get_builtin_sites()['greenwich']
+
+    get_moon(times, green)


### PR DESCRIPTION
This PR fixes #4926.

It was impossible to create ```GCRS``` frames and ```PrecessedGeocentric``` frames with ```obsgeoloc``` and ```obsgeovel``` frame attributes of shape (3, N).

I have created a new frame attribute to allow this as it seemed the easiest way to allow frame attributes with this property, without an API change. It was suggested to make the ```obsgeoloc``` and ```obsgeovel``` frame attributes ```CartesianRepresentation``` instances but this would have broken existing examples and required extensive code changes.

This PR also contains changes to the ICRS <-> GCRS transformation code, since that did not work for ```obsgeoloc``` and ```obsgeovel``` attributes with shapes other than (3,)

