### PR TITLE
Add new image normalization classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,18 @@ New Features
 
 - ``astropy.utils``
 
+- ``astropy.visualization``
+
+  - Added ``data`` and ``interval`` inputs to the ``ImageNormalize``
+    class. [#5206]
+
+  - Added a new ``mpl_norm`` convenience function. [#5206]
+
+  - Added a default stretch for the ``Normalization`` class. [#5206].
+
+  - Added a default ``vmin/vmax`` for the ``ManualInterval`` class.
+    [#5206].
+
 - ``astropy.vo``
 
 - ``astropy.wcs``
@@ -127,6 +139,10 @@ API Changes
 
   - Renamed ``ignored`` context manager in ``compat.misc`` to ``suppress``
     to be consistent with https://bugs.python.org/issue19266 . [#5003]
+
+- ``astropy.visualization``
+
+  - Deprecated the ``scale_image`` function. [#5206]
 
 - ``astropy.vo``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,7 +65,7 @@ New Features
   - Added ``data`` and ``interval`` inputs to the ``ImageNormalize``
     class. [#5206]
 
-  - Added a new ``mpl_norm`` convenience function. [#5206]
+  - Added a new ``simple_norm`` convenience function. [#5206]
 
   - Added a default stretch for the ``Normalization`` class. [#5206].
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -8,15 +8,18 @@ various criteria.
 from __future__ import division, print_function
 import abc
 import numpy as np
+from ..extern import six
+from ..utils.misc import InheritDocstrings
 from .transform import BaseTransform
 from .zscale import zscale
 
 
 __all__ = ['BaseInterval', 'ManualInterval', 'MinMaxInterval',
-           'PercentileInterval', 'AsymmetricPercentileInterval',
+           'AsymmetricPercentileInterval', 'PercentileInterval',
            'ZScaleInterval']
 
 
+@six.add_metaclass(InheritDocstrings)
 class BaseInterval(BaseTransform):
     """
     Base class for the interval classes, which, when called with an

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -56,18 +56,22 @@ class ManualInterval(BaseInterval):
 
     Parameters
     ----------
-    vmin : float
-        The minimum value in the scaling
-    vmax : float
-        The maximum value in the scaling
+    vmin : float, optional
+        The minimum value in the scaling.  Defaults to the image
+        minimum.
+    vmax : float, optional
+        The maximum value in the scaling.  Defaults to the image
+        maximum.
     """
 
-    def __init__(self, vmin, vmax):
+    def __init__(self, vmin=None, vmax=None):
         self.vmin = vmin
         self.vmax = vmax
 
     def get_limits(self, values):
-        return self.vmin, self.vmax
+        vmin = self.vmin or np.min(values)
+        vmax = self.vmax or np.max(values)
+        return vmin, vmax
 
 
 class MinMaxInterval(BaseInterval):

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -6,8 +6,10 @@ various criteria.
 """
 
 from __future__ import division, print_function
+
 import abc
 import numpy as np
+
 from ..extern import six
 from ..utils.misc import InheritDocstrings
 from .transform import BaseTransform
@@ -131,7 +133,7 @@ class AsymmetricPercentileInterval(BaseInterval):
     n_samples : int, optional
         Maximum number of values to use. If this is specified, and there
         are more values in the dataset as this, then values are randomly
-        sampled from the array (with replacement)
+        sampled from the array (with replacement).
     """
 
     def __init__(self, lower_percentile, upper_percentile, n_samples=None):
@@ -170,7 +172,7 @@ class PercentileInterval(AsymmetricPercentileInterval):
     n_samples : int, optional
         Maximum number of values to use. If this is specified, and there
         are more values in the dataset as this, then values are randomly
-        sampled from the array (with replacement)
+        sampled from the array (with replacement).
     """
 
     def __init__(self, percentile, n_samples=None):
@@ -193,22 +195,22 @@ class ZScaleInterval(BaseInterval):
         Input array.
     nsamples : int, optional
         Number of points in array to sample for determining scaling
-        factors.  Default to 1000.
+        factors.  Defaults to 1000.
     contrast : float, optional
         Scaling factor (between 0 and 1) for determining min and max.
         Larger values increase the difference between min and max values
-        used for display. Default to 0.25.
+        used for display. Defaults to 0.25.
     max_reject : float, optional
         If more than ``max_reject * npixels`` pixels are rejected, then
-        the returned values are the min and max of the data. Default to
+        the returned values are the min and max of the data. Defaults to
         0.5.
     min_npixels : int, optional
         If less than ``min_npixels`` pixels are rejected, then the
-        returned values are the min and max of the data. Default to 5.
+        returned values are the min and max of the data. Defaults to 5.
     krej : float, optional
-        Number of sigma used for the rejection. Default to 2.5.
+        Number of sigma used for the rejection. Defaults to 2.5.
     max_iterations : int, optional
-        Maximum number of iterations for the rejection. Default to 5.
+        Maximum number of iterations for the rejection. Defaults to 5.
     """
 
     def __init__(self, nsamples=1000, contrast=0.25, max_reject=0.5,

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -1,5 +1,6 @@
 """
-Normalization class for Matplotlib that can be used to produce colorbars.
+Normalization class for Matplotlib that can be used to produce
+colorbars.
 """
 
 from __future__ import division, print_function
@@ -8,7 +9,7 @@ from numpy import ma
 from .stretch import LinearStretch
 
 try:
-    import matplotlib  # pylint: disable=W0611
+    import matplotlib    # pylint: disable=W0611
     from matplotlib.colors import Normalize
 
     # On older versions of matplotlib Normalize is an old-style class
@@ -31,22 +32,44 @@ class ImageNormalize(Normalize):
 
     Parameters
     ----------
+    data : `~numpy.ndarray`, optional
+        The image array.  This input is used only if ``interval`` is
+        also input.  ``data`` and ``interval`` are used to compute the
+        vmin and/or vmax values only if ``vmin`` or ``vmax`` are not input.
+    interval : `~astropy.visualization.BaseInterval` subclass instance, optional
+        The interval object to apply to the input ``data`` to determine
+        the ``vmin`` and ``vmax`` values.  This input is used only if
+        ``data`` is also input.  ``data`` and ``interval`` are used to
+        compute the vmin and/or vmax values only if ``vmin`` or ``vmax``
+        are not input.
     vmin, vmax : float
-        The minimum and maximum levels to show for the data
-    stretch : :class:`~astropy.visualization.BaseStretch` instance
-        The stretch to use for the normalization
+        The minimum and maximum levels to show for the data.  The
+        ``vmin`` and ``vmax`` inputs override any calculated values from
+        the ``interval`` and ``data`` inputs.
+    stretch : `~astropy.visualization.BaseStretch` subclass instance, optional
+        The stretch object to apply to the data.  The default is
+        `~astropy.visualization.LinearStretch`.
     clip : bool, optional
-        Whether to clip the output values to the [0:1] range
+        If `True` (default), data values outside the [0:1] range are
+        clipped to the [0:1] range.
     """
 
-    def __init__(self, vmin=None, vmax=None, stretch=LinearStretch(),
-                 clip=False):
+    def __init__(self, data=None, interval=None, vmin=None, vmax=None,
+                 stretch=LinearStretch(), clip=False):
         # this super call checks for matplotlib
         super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
 
         self.vmin = vmin
         self.vmax = vmax
+        if data is not None and interval is not None:
+            _vmin, _vmax = interval.get_limits(data)
+            if self.vmin is None:
+                self.vmin = _vmin
+            if self.vmax is None:
+                self.vmax = _vmax
+
         self.stretch = stretch
+        self.interval = interval
         self.inverse_stretch = stretch.inverse
         self.clip = clip
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -4,15 +4,17 @@ colorbars.
 """
 
 from __future__ import division, print_function
+
 import numpy as np
 from numpy import ma
+
 from .interval import (PercentileInterval, AsymmetricPercentileInterval,
                        ManualInterval, MinMaxInterval)
 from .stretch import (LinearStretch, SqrtStretch, PowerStretch, LogStretch,
                       AsinhStretch)
 
 try:
-    import matplotlib    # pylint: disable=W0611
+    import matplotlib  # pylint: disable=W0611
     from matplotlib.colors import Normalize
 
     # On older versions of matplotlib Normalize is an old-style class
@@ -23,7 +25,7 @@ except ImportError:
     class Normalize(object):
         def __init__(self, *args, **kwargs):
             raise ImportError('matplotlib is required in order to use this '
-                              'class')
+                              'class.')
 
 
 __all__ = ['ImageNormalize', 'simple_norm']
@@ -38,7 +40,8 @@ class ImageNormalize(Normalize):
     data : `~numpy.ndarray`, optional
         The image array.  This input is used only if ``interval`` is
         also input.  ``data`` and ``interval`` are used to compute the
-        vmin and/or vmax values only if ``vmin`` or ``vmax`` are not input.
+        vmin and/or vmax values only if ``vmin`` or ``vmax`` are not
+        input.
     interval : `~astropy.visualization.BaseInterval` subclass instance, optional
         The interval object to apply to the input ``data`` to determine
         the ``vmin`` and ``vmax`` values.  This input is used only if
@@ -139,7 +142,7 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
     data : `~numpy.ndarray`
         The image array.
 
-    stretch : {{'linear', 'sqrt', 'power', log', 'asinh'}}, optional
+    stretch : {'linear', 'sqrt', 'power', log', 'asinh'}, optional
         The stretch function to apply to the image.  The default is
         'linear'.
 
@@ -150,7 +153,7 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
         For ``stretch='asinh'``, the value where the asinh curve
         transitions from linear to logarithmic behavior, expressed as a
         fraction of the normalized image.  Must be in the range between
-        0 and 1.
+        0 and 1.  The default is 0.1.
 
     min_cut : float, optional
         The pixel value of the minimum cut level.  Data values less than
@@ -214,7 +217,7 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
     elif stretch == 'asinh':
         stretch = AsinhStretch(asinh_a)
     else:
-        raise ValueError('Unknown stretch: {0}'.format(stretch))
+        raise ValueError('Unknown stretch: {0}.'.format(stretch))
 
     vmin, vmax = interval.get_limits(data)
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -26,7 +26,7 @@ except ImportError:
                               'class')
 
 
-__all__ = ['ImageNormalize', 'mpl_norm']
+__all__ = ['ImageNormalize', 'simple_norm']
 
 
 class ImageNormalize(Normalize):
@@ -121,15 +121,15 @@ class ImageNormalize(Normalize):
         return values_norm * (self.vmax - self.vmin) + self.vmin
 
 
-def mpl_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
-             max_cut=None, min_percent=None, max_percent=None, percent=None,
-             clip=True):
+def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
+                max_cut=None, min_percent=None, max_percent=None,
+                percent=None, clip=True):
     """
     Return a Normalization class that can be used for displaying images
     with Matplotlib.
 
     This function enables only a subset of image stretching functions
-    available in `astropy.visualization`.
+    available in `~astropy.visualization.mpl_normalize.ImageNormalize`.
 
     This function is used by the
     ``astropy.visualization.scripts.fits2bitmap`` script.

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -3,9 +3,9 @@ Normalization class for Matplotlib that can be used to produce colorbars.
 """
 
 from __future__ import division, print_function
-
 import numpy as np
 from numpy import ma
+from .stretch import LinearStretch
 
 try:
     import matplotlib  # pylint: disable=W0611
@@ -18,7 +18,8 @@ try:
 except ImportError:
     class Normalize(object):
         def __init__(self, *args, **kwargs):
-            raise ImportError("matplotlib is required in order to use this class")
+            raise ImportError('matplotlib is required in order to use this '
+                              'class')
 
 
 __all__ = ['ImageNormalize']
@@ -38,16 +39,18 @@ class ImageNormalize(Normalize):
         Whether to clip the output values to the [0:1] range
     """
 
-    def __init__(self, vmin=None, vmax=None, stretch=None, clip=False):
+    def __init__(self, vmin=None, vmax=None, stretch=LinearStretch(),
+                 clip=False):
+        # this super call checks for matplotlib
         super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
 
         self.vmin = vmin
         self.vmax = vmax
         self.stretch = stretch
         self.inverse_stretch = stretch.inverse
+        self.clip = clip
 
     def __call__(self, values, clip=None):
-
         if clip is None:
             clip = self.clip
 
@@ -72,7 +75,6 @@ class ImageNormalize(Normalize):
 
         # Normalize based on vmin and vmax
         np.subtract(values, self.vmin, out=values)
-
         np.true_divide(values, self.vmax - self.vmin, out=values)
 
         # Clip to the 0 to 1 range
@@ -86,7 +88,6 @@ class ImageNormalize(Normalize):
         return ma.array(values, mask=mask)
 
     def inverse(self, values):
-
         # Find unstretched values in range 0 to 1
         values_norm = self.inverse_stretch(values, clip=False)
 

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -5,17 +5,17 @@ from __future__ import (absolute_import, division, print_function,
 import os
 from ... import log
 from ...io.fits import getdata
-from ..ui import scale_image
+from ..mpl_normalize import mpl_norm
 
 
-def fits2bitmap(filename, ext=0, out_fn=None, scale='linear',
+def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
                 power=1.0, asinh_a=0.1, min_cut=None, max_cut=None,
                 min_percent=None, max_percent=None, percent=None,
                 cmap='Greys_r'):
     """
-    Create a bitmap file from a FITS image, applying a
-    scaling/stretching transform between minimum and maximum cut levels
-    and a matplotlib colormap.
+    Create a bitmap file from a FITS image, applying a stretching
+    transform between minimum and maximum cut levels and a matplotlib
+    colormap.
 
     Parameters
     ----------
@@ -28,25 +28,24 @@ def fits2bitmap(filename, ext=0, out_fn=None, scale='linear',
         The filename of the output bitmap image.  The type of bitmap
         is determined by the filename extension (e.g. '.jpg', '.png').
         The default is a PNG file with the same name as the FITS file.
-    scale : {{'linear', 'sqrt', 'power', log', 'asinh'}}
-        The scaling/stretch function to apply to the image.  The default
-        is 'linear'.
+    stretch : {{'linear', 'sqrt', 'power', log', 'asinh'}}
+        The stretching function to apply to the image.  The default is
+        'linear'.
     power : float, optional
-        The power index for ``scale='power'`` image scaling.  The
-        default is 1.0.
+        The power index for ``stretch='power'``.  The default is 1.0.
     asinh_a : float, optional
-        For ``scale='asinh'`` image scaling, the value where the asinh
-        curve transitions from linear to logarithmic behavior, expressed
-        as a fraction of the normalized image.  Must be in the range
-        between 0 and 1.
+        For ``stretch='asinh'``, the value where the asinh curve
+        transitions from linear to logarithmic behavior, expressed as a
+        fraction of the normalized image.  Must be in the range between
+        0 and 1.
     min_cut : float, optional
         The pixel value of the minimum cut level.  Data values less than
-        ``min_cut`` will set to ``min_cut`` before scaling the image.
+        ``min_cut`` will set to ``min_cut`` before stretching the image.
         The default is the image minimum.  ``min_cut`` overrides
         ``min_percent``.
     max_cut : float, optional
         The pixel value of the maximum cut level.  Data values greater
-        than ``min_cut`` will set to ``min_cut`` before scaling the
+        than ``min_cut`` will set to ``min_cut`` before stretching the
         image.  The default is the image maximum.  ``max_cut`` overrides
         ``max_percent``.
     min_percent : float, optional
@@ -71,7 +70,6 @@ def fits2bitmap(filename, ext=0, out_fn=None, scale='linear',
     import matplotlib.cm as cm
     import matplotlib.image as mimg
 
-
     # __main__ gives ext as a string
     try:
         ext = int(ext)
@@ -95,16 +93,15 @@ def fits2bitmap(filename, ext=0, out_fn=None, scale='linear',
         out_fn += '.png'
 
     if cmap not in cm.datad:
-        log.critical('{0} is not a valid matplotlib colormap '
-                     'name'.format(cmap))
+        log.critical('{0} is not a valid matplotlib colormap name'
+                     .format(cmap))
         return 1
 
-    image_scaled = scale_image(image, scale=scale, power=power,
-                               asinh_a=asinh_a, min_cut=min_cut,
-                               max_cut=max_cut, min_percent=min_percent,
-                               max_percent=max_percent, percent=percent)
+    norm = mpl_norm(image, stretch=stretch, power=power, asinh_a=asinh_a,
+                    min_cut=min_cut, max_cut=max_cut, min_percent=min_percent,
+                    max_percent=max_percent, percent=percent)
 
-    mimg.imsave(out_fn, image_scaled, cmap=cmap)
+    mimg.imsave(out_fn, norm(image), cmap=cmap)
     log.info('Saved file to {0}'.format(out_fn))
 
 
@@ -120,16 +117,16 @@ def main(args=None):
     parser.add_argument('-o', metavar='filename', type=str, default=None,
                         help='Filename for the output image (Default is a '
                         'PNG file with the same name as the FITS file).')
-    parser.add_argument('--scale', type=str, default='linear',
-                        help='Type of image scaling ("linear", "sqrt", '
+    parser.add_argument('--stretch', type=str, default='linear',
+                        help='Type of image stretching ("linear", "sqrt", '
                         '"power", "log", or "asinh") (Default is "linear").')
     parser.add_argument('--power', type=float, default=1.0,
-                        help='Power index for "power" scaling (Default is '
+                        help='Power index for "power" stretching (Default is '
                              '1.0).')
     parser.add_argument('--asinh_a', type=float, default=0.1,
                         help='The value in normalized image where the asinh '
                              'curve transitions from linear to logarithmic '
-                             'behavior (used only for "asinh" scaling) '
+                             'behavior (used only for "asinh" stretch) '
                              '(Default is 0.1).')
     parser.add_argument('--min_cut', type=float, default=None,
                         help='The pixel value of the minimum cut level '
@@ -156,7 +153,7 @@ def main(args=None):
 
     for filename in args.filename:
         fits2bitmap(filename, ext=args.ext, out_fn=args.o,
-                    scale=args.scale, min_cut=args.min_cut,
+                    stretch=args.stretch, min_cut=args.min_cut,
                     max_cut=args.max_cut, min_percent=args.min_percent,
                     max_percent=args.max_percent, percent=args.percent,
                     power=args.power, asinh_a=args.asinh_a, cmap=args.cmap)

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -37,7 +37,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
         For ``stretch='asinh'``, the value where the asinh curve
         transitions from linear to logarithmic behavior, expressed as a
         fraction of the normalized image.  Must be in the range between
-        0 and 1.
+        0 and 1.  The default is 0.1.
     min_cut : float, optional
         The pixel value of the minimum cut level.  Data values less than
         ``min_cut`` will set to ``min_cut`` before stretching the image.
@@ -93,7 +93,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
         out_fn += '.png'
 
     if cmap not in cm.datad:
-        log.critical('{0} is not a valid matplotlib colormap name'
+        log.critical('{0} is not a valid matplotlib colormap name.'
                      .format(cmap))
         return 1
 
@@ -103,7 +103,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
                        percent=percent)
 
     mimg.imsave(out_fn, norm(image), cmap=cmap)
-    log.info('Saved file to {0}'.format(out_fn))
+    log.info('Saved file to {0}.'.format(out_fn))
 
 
 def main(args=None):

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 from ... import log
 from ...io.fits import getdata
-from ..mpl_normalize import mpl_norm
+from ..mpl_normalize import simple_norm
 
 
 def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
@@ -97,9 +97,10 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
                      .format(cmap))
         return 1
 
-    norm = mpl_norm(image, stretch=stretch, power=power, asinh_a=asinh_a,
-                    min_cut=min_cut, max_cut=max_cut, min_percent=min_percent,
-                    max_percent=max_percent, percent=percent)
+    norm = simple_norm(image, stretch=stretch, power=power, asinh_a=asinh_a,
+                       min_cut=min_cut, max_cut=max_cut,
+                       min_percent=min_percent, max_percent=max_percent,
+                       percent=percent)
 
     mimg.imsave(out_fn, norm(image), cmap=cmap)
     log.info('Saved file to {0}'.format(out_fn))

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -76,9 +76,7 @@ class BaseStretch(BaseTransform):
 
     @property
     def inverse(self):
-        """
-        Return a stretch that performs the inverse operation.
-        """
+        """A stretch object that performs the inverse operation."""
 
 
 class LinearStretch(BaseStretch):
@@ -96,6 +94,7 @@ class LinearStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return LinearStretch()
 
 
@@ -116,6 +115,7 @@ class SqrtStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return PowerStretch(2)
 
 
@@ -145,6 +145,7 @@ class PowerStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return PowerStretch(1. / self.power)
 
 
@@ -179,6 +180,7 @@ class PowerDistStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return InvertedPowerDistStretch(a=self.exp)
 
 
@@ -214,6 +216,7 @@ class InvertedPowerDistStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return PowerDistStretch(a=self.exp)
 
 
@@ -232,6 +235,7 @@ class SquaredStretch(PowerStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return SqrtStretch()
 
 
@@ -264,6 +268,7 @@ class LogStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return InvertedLogStretch(self.exp)
 
 
@@ -296,6 +301,7 @@ class InvertedLogStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return LogStretch(self.exp)
 
 
@@ -331,6 +337,7 @@ class AsinhStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return SinhStretch(a=1. / np.arcsinh(1. / self.a))
 
 
@@ -362,6 +369,7 @@ class SinhStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return AsinhStretch(a=1. / np.sinh(1. / self.a))
 
 
@@ -399,6 +407,7 @@ class HistEqStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return InvertedHistEqStretch(self.data, values=self.values)
 
 
@@ -429,6 +438,7 @@ class InvertedHistEqStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return HistEqStretch(self.data, values=self.values)
 
 
@@ -473,6 +483,7 @@ class ContrastBiasStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return InvertedContrastBiasStretch(self.contrast, self.bias)
 
 
@@ -511,4 +522,5 @@ class InvertedContrastBiasStretch(BaseStretch):
 
     @property
     def inverse(self):
+        """A stretch object that performs the inverse operation."""
         return ContrastBiasStretch(self.contrast, self.bias)

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -6,7 +6,9 @@ another set of [0:1] values with a transformation
 """
 
 from __future__ import division, print_function
+
 import numpy as np
+
 from ..extern import six
 from ..utils.misc import InheritDocstrings
 from .transform import BaseTransform

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -6,20 +6,19 @@ another set of [0:1] values with a transformation
 """
 
 from __future__ import division, print_function
-
 import numpy as np
-
 from ..extern import six
 from ..utils.misc import InheritDocstrings
-
 from .transform import BaseTransform
+
 
 __all__ = ["BaseStretch", "LinearStretch", "SqrtStretch", "PowerStretch",
            "PowerDistStretch", "SquaredStretch", "LogStretch", "AsinhStretch",
            "SinhStretch", "HistEqStretch", "ContrastBiasStretch"]
 
 
-def logn(n, x, out=None):
+def _logn(n, x, out=None):
+    """Calculate the log base n of x."""
     # We define this because numpy.lib.scimath.logn doesn't support out=
     if out is None:
         return np.log(x) / np.log(n)
@@ -31,9 +30,10 @@ def logn(n, x, out=None):
 
 def _prepare(values, out=None, clip=True):
     """
-    Prepare the data by optionally clipping and copying, and return the array
-    that should be subsequently used for in-place calculations.
+    Prepare the data by optionally clipping and copying, and return the
+    array that should be subsequently used for in-place calculations.
     """
+
     if clip:
         return np.clip(values, 0., 1., out=out)
     else:
@@ -47,30 +47,30 @@ def _prepare(values, out=None, clip=True):
 @six.add_metaclass(InheritDocstrings)
 class BaseStretch(BaseTransform):
     """
-    Base class for the stretch classes, which, when called with an array of
-    values in the range [0:1], return an transformed array of values, also in
-    the range [0:1].
+    Base class for the stretch classes, which, when called with an array
+    of values in the range [0:1], return an transformed array of values,
+    also in the range [0:1].
     """
 
-    def __call__(self, values, out=None, clip=True):
+    def __call__(self, values, clip=True, out=None):
         """
         Transform values using this stretch.
 
         Parameters
         ----------
-        values : `~numpy.ndarray` or list
-            The input values, which should already be normalized to the [0:1]
-            range.
+        values : array-like
+            The input values, which should already be normalized to the
+            [0:1] range.
+        clip : bool, optional
+            If `True` (default), values outside the [0:1] range are
+            clipped to the [0:1] range.
         out : `~numpy.ndarray`, optional
             If specified, the output values will be placed in this array
             (typically used for in-place calculations).
-        clip : bool, optional
-            If `True` (default), values outside the [0:1] range are clipped to
-            the [0:1] range.
 
         Returns
         -------
-        new_values : `~numpy.ndarray`
+        result : `~numpy.ndarray`
             The transformed values.
         """
 
@@ -91,8 +91,7 @@ class LinearStretch(BaseStretch):
         y = x
     """
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         return _prepare(values, out=out, clip=clip)
 
     @property
@@ -110,12 +109,9 @@ class SqrtStretch(BaseStretch):
         y = \sqrt{x}
     """
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.sqrt(values, out=values)
-
         return values
 
     @property
@@ -131,18 +127,20 @@ class PowerStretch(BaseStretch):
 
     .. math::
         y = x^a
+
+    Parameters
+    ----------
+    a : float
+        The power index (see the above formula).
     """
 
     def __init__(self, a):
         super(PowerStretch, self).__init__()
         self.power = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.power(values, self.power, out=values)
-
         return values
 
     @property
@@ -158,6 +156,12 @@ class PowerDistStretch(BaseStretch):
 
     .. math::
         y = \frac{a^x - 1}{a - 1}
+
+    Parameters
+    ----------
+    a : float, optional
+        The ``a`` parameter used in the above formula.  Default is 1000.
+        ``a`` cannot be set to 1.
     """
 
     def __init__(self, a=1000.0):
@@ -166,14 +170,11 @@ class PowerDistStretch(BaseStretch):
         super(PowerDistStretch, self).__init__()
         self.exp = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.power(self.exp, values, out=values)
         np.subtract(values, 1, out=values)
         np.true_divide(values, self.exp - 1.0, out=values)
-
         return values
 
     @property
@@ -183,7 +184,19 @@ class PowerDistStretch(BaseStretch):
 
 class InvertedPowerDistStretch(BaseStretch):
     """
-    Inverse transformation for `~astropy.image.scaling.PowerDistStretch`.
+    Inverse transformation for
+    `~astropy.image.scaling.PowerDistStretch`.
+
+    The stretch is given by:
+
+    .. math::
+        y = \frac{\log(y (a-1) + 1)}{\log a}
+
+    Parameters
+    ----------
+    a : float, optional
+        The ``a`` parameter used in the above formula.  Default is 1000.
+        ``a`` cannot be set to 1.
     """
 
     def __init__(self, a=1000.0):
@@ -192,14 +205,11 @@ class InvertedPowerDistStretch(BaseStretch):
         super(InvertedPowerDistStretch, self).__init__()
         self.exp = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.multiply(values, self.exp - 1.0, out=values)
         np.add(values, 1, out=values)
-        logn(self.exp, values, out=values)
-
+        _logn(self.exp, values, out=values)
         return values
 
     @property
@@ -233,21 +243,23 @@ class LogStretch(BaseStretch):
 
     .. math::
         y = \frac{\log{(a x + 1)}}{\log{(a + 1)}}.
+
+    Parameters
+    ----------
+    a : float
+        The ``a`` parameter used in the above formula.  Default is 1000.
     """
 
     def __init__(self, a=1000.0):
         super(LogStretch, self).__init__()
         self.exp = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.multiply(values, self.exp, out=values)
         np.add(values, 1., out=values)
         np.log(values, out=values)
         np.true_divide(values, np.log(self.exp + 1.), out=values)
-
         return values
 
     @property
@@ -258,21 +270,28 @@ class LogStretch(BaseStretch):
 class InvertedLogStretch(BaseStretch):
     """
     Inverse transformation for `~astropy.image.scaling.LogStretch`.
+
+    The stretch is given by:
+
+    .. math::
+        y = \frac{e^{y} (a + 1) -1}{a}
+
+    Parameters
+    ----------
+    a : float, optional
+        The ``a`` parameter used in the above formula.  Default is 1000.
     """
 
     def __init__(self, a):
         super(InvertedLogStretch, self).__init__()
         self.exp = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.multiply(values, np.log(self.exp + 1.), out=values)
         np.exp(values, out=values)
         np.subtract(values, 1., out=values)
         np.true_divide(values, self.exp, out=values)
-
         return values
 
     @property
@@ -288,20 +307,26 @@ class AsinhStretch(BaseStretch):
 
     .. math::
         y = \frac{{\rm asinh}(x / a)}{{\rm asinh}(1 / a)}.
+
+    Parameters
+    ----------
+    a : float, optional
+        The ``a`` parameter used in the above formula.  The value of
+        this parameter is where the asinh curve transitions from linear
+        to logarithmic behavior, expressed as a fraction of the
+        normalized image.  Must be in the range between 0 and 1.
+        Default is 0.1
     """
 
     def __init__(self, a=0.1):
         super(AsinhStretch, self).__init__()
         self.a = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.true_divide(values, self.a, out=values)
         np.arcsinh(values, out=values)
         np.true_divide(values, np.arcsinh(1. / self.a), out=values)
-
         return values
 
     @property
@@ -317,20 +342,22 @@ class SinhStretch(BaseStretch):
 
     .. math::
         y = \frac{{\rm sinh}(x / a)}{{\rm sinh}(1 / a)}
+
+    Parameters
+    ----------
+    a : float, optional
+        The ``a`` parameter used in the above formula.  Default is 1/3.
     """
 
-    def __init__(self, a=1. / 3.):
+    def __init__(self, a=1./3.):
         super(SinhStretch, self).__init__()
         self.a = a
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         np.true_divide(values, self.a, out=values)
         np.sinh(values, out=values)
         np.true_divide(values, np.sinh(1. / self.a), out=values)
-
         return values
 
     @property
@@ -344,8 +371,11 @@ class HistEqStretch(BaseStretch):
 
     Parameters
     ----------
-    data : float
-        The data defining the equalization
+    data : array-like
+        The data defining the equalization.
+    values : array-like, optional
+        The input image values, which should already be normalized to
+        the [0:1] range.
     """
 
     def __init__(self, data, values=None):
@@ -362,12 +392,9 @@ class HistEqStretch(BaseStretch):
         else:
             self.values = values
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         values[:] = np.interp(values, self.data, self.values)
-
         return values
 
     @property
@@ -378,6 +405,14 @@ class HistEqStretch(BaseStretch):
 class InvertedHistEqStretch(BaseStretch):
     """
     Inverse transformation for `~astropy.image.scaling.HistEqStretch`.
+
+    Parameters
+    ----------
+    data : array-like
+        The data defining the equalization.
+    values : array-like, optional
+        The input image values, which should already be normalized to
+        the [0:1] range.
     """
 
     def __init__(self, data, values=None):
@@ -387,12 +422,9 @@ class InvertedHistEqStretch(BaseStretch):
         else:
             self.values = values
 
-    def __call__(self, values, out=None, clip=True):
-
+    def __call__(self, values, clip=True, out=None):
         values = _prepare(values, out=out, clip=clip)
-
         values[:] = np.interp(values, self.values, self.data)
-
         return values
 
     @property
@@ -410,6 +442,14 @@ class ContrastBiasStretch(BaseStretch):
         y = (x - {\\rm bias}) * {\\rm contrast} + 0.5
 
     and the output values are clipped to the [0:1] range.
+
+    Parameters
+    ----------
+    contrast : float
+        The contrast parameter (see the above formula).
+
+    bias : float
+        The bias parameter (see the above formula).
     """
 
     def __init__(self, contrast, bias):
@@ -417,10 +457,9 @@ class ContrastBiasStretch(BaseStretch):
         self.contrast = contrast
         self.bias = bias
 
-    def __call__(self, values, out=None, clip=True):
-
-        # As a special case here, we only clip *after* the transformation since
-        # it does not map [0:1] to [0:1]
+    def __call__(self, values, clip=True, out=None):
+        # As a special case here, we only clip *after* the
+        # transformation since it does not map [0:1] to [0:1]
         values = _prepare(values, out=out, clip=False)
 
         np.subtract(values, self.bias, out=values)
@@ -440,6 +479,16 @@ class ContrastBiasStretch(BaseStretch):
 class InvertedContrastBiasStretch(BaseStretch):
     """
     Inverse transformation for ContrastBiasStretch.
+
+    Parameters
+    ----------
+    contrast : float
+        The contrast parameter (see
+        `~astropy.visualization.ConstrastBiasStretch).
+
+    bias : float
+        The bias parameter (see
+        `~astropy.visualization.ConstrastBiasStretch).
     """
 
     def __init__(self, contrast, bias):
@@ -447,13 +496,10 @@ class InvertedContrastBiasStretch(BaseStretch):
         self.contrast = contrast
         self.bias = bias
 
-    def __call__(self, values, out=None, clip=True):
-
-        # As a special case here, we only clip *after* the transformation since
-        # it does not map [0:1] to [0:1]
-
+    def __call__(self, values, clip=True, out=None):
+        # As a special case here, we only clip *after* the
+        # transformation since it does not map [0:1] to [0:1]
         values = _prepare(values, out=out, clip=False)
-
         np.subtract(values, 0.5, out=values)
         np.true_divide(values, self.contrast, out=values)
         np.add(values, self.bias, out=values)

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -28,7 +28,7 @@ def _logn(n, x, out=None):
         return out
 
 
-def _prepare(values, out=None, clip=True):
+def _prepare(values, clip=True, out=None):
     """
     Prepare the data by optionally clipping and copying, and return the
     array that should be subsequently used for in-place calculations.
@@ -90,7 +90,7 @@ class LinearStretch(BaseStretch):
     """
 
     def __call__(self, values, clip=True, out=None):
-        return _prepare(values, out=out, clip=clip)
+        return _prepare(values, clip=clip, out=out)
 
     @property
     def inverse(self):
@@ -109,7 +109,7 @@ class SqrtStretch(BaseStretch):
     """
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.sqrt(values, out=values)
         return values
 
@@ -139,7 +139,7 @@ class PowerStretch(BaseStretch):
         self.power = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.power(values, self.power, out=values)
         return values
 
@@ -172,7 +172,7 @@ class PowerDistStretch(BaseStretch):
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.power(self.exp, values, out=values)
         np.subtract(values, 1, out=values)
         np.true_divide(values, self.exp - 1.0, out=values)
@@ -208,7 +208,7 @@ class InvertedPowerDistStretch(BaseStretch):
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.multiply(values, self.exp - 1.0, out=values)
         np.add(values, 1, out=values)
         _logn(self.exp, values, out=values)
@@ -259,7 +259,7 @@ class LogStretch(BaseStretch):
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.multiply(values, self.exp, out=values)
         np.add(values, 1., out=values)
         np.log(values, out=values)
@@ -292,7 +292,7 @@ class InvertedLogStretch(BaseStretch):
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.multiply(values, np.log(self.exp + 1.), out=values)
         np.exp(values, out=values)
         np.subtract(values, 1., out=values)
@@ -329,7 +329,7 @@ class AsinhStretch(BaseStretch):
         self.a = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.true_divide(values, self.a, out=values)
         np.arcsinh(values, out=values)
         np.true_divide(values, np.arcsinh(1. / self.a), out=values)
@@ -361,7 +361,7 @@ class SinhStretch(BaseStretch):
         self.a = a
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         np.true_divide(values, self.a, out=values)
         np.sinh(values, out=values)
         np.true_divide(values, np.sinh(1. / self.a), out=values)
@@ -401,7 +401,7 @@ class HistEqStretch(BaseStretch):
             self.values = values
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         values[:] = np.interp(values, self.data, self.values)
         return values
 
@@ -432,7 +432,7 @@ class InvertedHistEqStretch(BaseStretch):
             self.values = values
 
     def __call__(self, values, clip=True, out=None):
-        values = _prepare(values, out=out, clip=clip)
+        values = _prepare(values, clip=clip, out=out)
         values[:] = np.interp(values, self.values, self.data)
         return values
 
@@ -470,7 +470,7 @@ class ContrastBiasStretch(BaseStretch):
     def __call__(self, values, clip=True, out=None):
         # As a special case here, we only clip *after* the
         # transformation since it does not map [0:1] to [0:1]
-        values = _prepare(values, out=out, clip=False)
+        values = _prepare(values, clip=False, out=out)
 
         np.subtract(values, self.bias, out=values)
         np.multiply(values, self.contrast, out=values)
@@ -510,7 +510,7 @@ class InvertedContrastBiasStretch(BaseStretch):
     def __call__(self, values, clip=True, out=None):
         # As a special case here, we only clip *after* the
         # transformation since it does not map [0:1] to [0:1]
-        values = _prepare(values, out=out, clip=False)
+        values = _prepare(values, clip=False, out=out)
         np.subtract(values, 0.5, out=values)
         np.true_divide(values, self.contrast, out=values)
         np.add(values, self.bias, out=values)

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -59,14 +59,12 @@ class TestInterval(object):
 class TestIntervalList(TestInterval):
 
     # Make sure intervals work with lists
-
     data = np.linspace(-20., 60., 100).tolist()
 
 
 class TestInterval2D(TestInterval):
 
     # Make sure intervals work with 2d arrays
-
     data = np.linspace(-20., 60., 100).reshape(100, 1)
 
 
@@ -92,7 +90,6 @@ def test_zscale():
 
 
 def test_integers():
-
     # Need to make sure integers get cast to float
     interval = MinMaxInterval()
     values = interval([1, 3, 4, 5, 6])
@@ -102,7 +99,8 @@ def test_integers():
     out = np.zeros(5, dtype=int)
     with pytest.raises(TypeError) as exc:
         values = interval([1, 3, 4, 5, 6], out=out)
-    assert exc.value.args[0] == "Can only do in-place scaling for floating-point arrays"
+    assert exc.value.args[0] == ("Can only do in-place scaling for "
+                                 "floating-point arrays")
 
     # But integer input and floating point output is fine
     out = np.zeros(5, dtype=float)

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -19,6 +19,17 @@ class TestInterval(object):
         np.testing.assert_allclose(vmin, -10.)
         np.testing.assert_allclose(vmax, +15.)
 
+    def test_manual_defaults(self):
+        interval = ManualInterval(vmin=-10.)
+        vmin, vmax = interval.get_limits(self.data)
+        np.testing.assert_allclose(vmin, -10.)
+        np.testing.assert_allclose(vmax, np.max(self.data))
+
+        interval = ManualInterval(vmax=15.)
+        vmin, vmax = interval.get_limits(self.data)
+        np.testing.assert_allclose(vmin, np.min(self.data))
+        np.testing.assert_allclose(vmax, 15.)
+
     def test_minmax(self):
         interval = MinMaxInterval()
         vmin, vmax = interval.get_limits(self.data)

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -25,7 +25,7 @@ def test_normalize_error_message():
     with pytest.raises(ImportError) as exc:
         ImageNormalize()
     assert (exc.value.args[0] == "matplotlib is required in order to use "
-            "this class")
+            "this class.")
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import ma
 from numpy.testing import assert_allclose
 from ...tests.helper import pytest
-from ..mpl_normalize import ImageNormalize, mpl_norm
+from ..mpl_normalize import ImageNormalize, simple_norm
 from ..interval import ManualInterval
 from ..stretch import SqrtStretch
 
@@ -115,48 +115,48 @@ class TestImageScaling(object):
 
     def test_linear(self):
         """Test linear scaling."""
-        norm = mpl_norm(DATA2, stretch='linear')
+        norm = simple_norm(DATA2, stretch='linear')
         assert_allclose(norm(DATA2), DATA2SCL, atol=0, rtol=1.e-5)
 
     def test_sqrt(self):
         """Test sqrt scaling."""
-        norm = mpl_norm(DATA2, stretch='sqrt')
+        norm = simple_norm(DATA2, stretch='sqrt')
         assert_allclose(norm(DATA2), np.sqrt(DATA2SCL), atol=0, rtol=1.e-5)
 
     def test_power(self):
         """Test power scaling."""
         power = 3.0
-        norm = mpl_norm(DATA2, stretch='power', power=power)
+        norm = simple_norm(DATA2, stretch='power', power=power)
         assert_allclose(norm(DATA2), DATA2SCL ** power, atol=0, rtol=1.e-5)
 
     def test_log(self):
         """Test log10 scaling."""
-        norm = mpl_norm(DATA2, stretch='log')
+        norm = simple_norm(DATA2, stretch='log')
         ref = np.log10(1000 * DATA2SCL + 1.0) / np.log10(1001.0)
         assert_allclose(norm(DATA2), ref, atol=0, rtol=1.e-5)
 
     def test_asinh(self):
         """Test asinh scaling."""
         a = 0.1
-        norm = mpl_norm(DATA2, stretch='asinh', asinh_a=a)
+        norm = simple_norm(DATA2, stretch='asinh', asinh_a=a)
         ref = np.arcsinh(DATA2SCL / a) / np.arcsinh(1. / a)
         assert_allclose(norm(DATA2), ref, atol=0, rtol=1.e-5)
 
     def test_min(self):
         """Test linear scaling."""
-        norm = mpl_norm(DATA2, stretch='linear', min_cut=1.)
+        norm = simple_norm(DATA2, stretch='linear', min_cut=1.)
         assert_allclose(norm(DATA2), [0., 0., 1.], atol=0, rtol=1.e-5)
 
     def test_percent(self):
         """Test percent keywords."""
-        norm = mpl_norm(DATA2, stretch='linear', percent=99.)
+        norm = simple_norm(DATA2, stretch='linear', percent=99.)
         assert_allclose(norm(DATA2), DATA2SCL, atol=0, rtol=1.e-5)
 
-        norm2 = mpl_norm(DATA2, stretch='linear', min_percent=0.5,
+        norm2 = simple_norm(DATA2, stretch='linear', min_percent=0.5,
                          max_percent=99.5)
         assert_allclose(norm(DATA2), norm2(DATA2), atol=0, rtol=1.e-5)
 
     def test_invalid_stretch(self):
         """Test invalid stretch keyword."""
         with pytest.raises(ValueError):
-            mpl_norm(DATA2, stretch='invalid')
+            simple_norm(DATA2, stretch='invalid')

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -110,6 +110,7 @@ class TestNormalize(object):
         assert_allclose(output, norm2(mdata))
 
 
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
 class TestImageScaling(object):
 
     def test_linear(self):

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -5,6 +5,7 @@ from numpy import ma
 from numpy.testing import assert_allclose
 from ...tests.helper import pytest
 from ..mpl_normalize import ImageNormalize
+from ..interval import ManualInterval
 from ..stretch import SqrtStretch
 
 try:
@@ -31,52 +32,72 @@ class TestNormalize(object):
     def test_scalar(self):
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),
                               clip=True)
+        norm2 = ImageNormalize(data=6, interval=ManualInterval(2, 10),
+                               stretch=SqrtStretch(), clip=True)
         assert_allclose(norm(6), 0.70710678)
+        assert_allclose(norm(6), norm2(6))
 
     def test_clip(self):
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),
                               clip=True)
+        norm2 = ImageNormalize(DATA, interval=ManualInterval(2, 10),
+                               stretch=SqrtStretch(), clip=True)
         output = norm(DATA)
         expected = [0., 0.35355339, 0.70710678, 0.93541435, 1., 1.]
         assert_allclose(output, expected)
         assert_allclose(output.mask, [0, 0, 0, 0, 0, 0])
+        assert_allclose(output, norm2(DATA))
 
     def test_noclip(self):
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),
                               clip=False)
+        norm2 = ImageNormalize(DATA, interval=ManualInterval(2, 10),
+                               stretch=SqrtStretch(), clip=False)
         output = norm(DATA)
         expected = [np.nan, 0.35355339, 0.70710678, 0.93541435, 1.11803399,
                     1.27475488]
         assert_allclose(output, expected)
         assert_allclose(output.mask, [0, 0, 0, 0, 0, 0])
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
+        assert_allclose(output, norm2(DATA))
 
     def test_implicit_autoscale(self):
         norm = ImageNormalize(vmin=None, vmax=10., stretch=SqrtStretch(),
                               clip=False)
-        norm(DATA)
+        norm2 = ImageNormalize(DATA, interval=ManualInterval(None, 10),
+                               stretch=SqrtStretch(), clip=False)
+        output = norm(DATA)
         assert norm.vmin == np.min(DATA)
         assert norm.vmax == 10.
+        assert_allclose(output, norm2(DATA))
 
         norm = ImageNormalize(vmin=2., vmax=None, stretch=SqrtStretch(),
                               clip=False)
-        norm(DATA)
+        norm2 = ImageNormalize(DATA, interval=ManualInterval(2, None),
+                               stretch=SqrtStretch(), clip=False)
+        output = norm(DATA)
         assert norm.vmin == 2.
         assert norm.vmax == np.max(DATA)
+        assert_allclose(output, norm2(DATA))
 
     def test_masked_clip(self):
         mdata = ma.array(DATA, mask=[0, 0, 1, 0, 0, 0])
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),
                               clip=True)
+        norm2 = ImageNormalize(mdata, interval=ManualInterval(2, 10),
+                               stretch=SqrtStretch(), clip=True)
         output = norm(mdata)
         expected = [0., 0.35355339, 1., 0.93541435, 1., 1.]
         assert_allclose(output.filled(-10), expected)
         assert_allclose(output.mask, [0, 0, 0, 0, 0, 0])
+        assert_allclose(output, norm2(mdata))
 
     def test_masked_noclip(self):
         mdata = ma.array(DATA, mask=[0, 0, 1, 0, 0, 0])
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),
                               clip=False)
+        norm2 = ImageNormalize(mdata, interval=ManualInterval(2, 10),
+                               stretch=SqrtStretch(), clip=False)
         output = norm(mdata)
         expected = [np.nan, 0.35355339, -10, 0.93541435, 1.11803399,
                     1.27475488]
@@ -84,3 +105,4 @@ class TestNormalize(object):
         assert_allclose(output.mask, [0, 0, 1, 0, 0, 0])
 
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
+        assert_allclose(output, norm2(mdata))

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import ma
 from numpy.testing import assert_allclose
 from ...tests.helper import pytest
-from ..mpl_normalize import ImageNormalize
+from ..mpl_normalize import ImageNormalize, mpl_norm
 from ..interval import ManualInterval
 from ..stretch import SqrtStretch
 
@@ -16,6 +16,8 @@ except:
 
 
 DATA = np.linspace(0., 15., 6)
+DATA2 = np.arange(3)
+DATA2SCL = 0.5 * DATA2
 
 
 @pytest.mark.skipif('HAS_MATPLOTLIB')
@@ -106,3 +108,54 @@ class TestNormalize(object):
 
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
         assert_allclose(output, norm2(mdata))
+
+
+class TestImageScaling(object):
+
+    def test_linear(self):
+        """Test linear scaling."""
+        norm = mpl_norm(DATA2, stretch='linear')
+        assert_allclose(norm(DATA2), DATA2SCL, atol=0, rtol=1.e-5)
+
+    def test_sqrt(self):
+        """Test sqrt scaling."""
+        norm = mpl_norm(DATA2, stretch='sqrt')
+        assert_allclose(norm(DATA2), np.sqrt(DATA2SCL), atol=0, rtol=1.e-5)
+
+    def test_power(self):
+        """Test power scaling."""
+        power = 3.0
+        norm = mpl_norm(DATA2, stretch='power', power=power)
+        assert_allclose(norm(DATA2), DATA2SCL ** power, atol=0, rtol=1.e-5)
+
+    def test_log(self):
+        """Test log10 scaling."""
+        norm = mpl_norm(DATA2, stretch='log')
+        ref = np.log10(1000 * DATA2SCL + 1.0) / np.log10(1001.0)
+        assert_allclose(norm(DATA2), ref, atol=0, rtol=1.e-5)
+
+    def test_asinh(self):
+        """Test asinh scaling."""
+        a = 0.1
+        norm = mpl_norm(DATA2, stretch='asinh', asinh_a=a)
+        ref = np.arcsinh(DATA2SCL / a) / np.arcsinh(1. / a)
+        assert_allclose(norm(DATA2), ref, atol=0, rtol=1.e-5)
+
+    def test_min(self):
+        """Test linear scaling."""
+        norm = mpl_norm(DATA2, stretch='linear', min_cut=1.)
+        assert_allclose(norm(DATA2), [0., 0., 1.], atol=0, rtol=1.e-5)
+
+    def test_percent(self):
+        """Test percent keywords."""
+        norm = mpl_norm(DATA2, stretch='linear', percent=99.)
+        assert_allclose(norm(DATA2), DATA2SCL, atol=0, rtol=1.e-5)
+
+        norm2 = mpl_norm(DATA2, stretch='linear', min_percent=0.5,
+                         max_percent=99.5)
+        assert_allclose(norm(DATA2), norm2(DATA2), atol=0, rtol=1.e-5)
+
+    def test_invalid_stretch(self):
+        """Test invalid stretch keyword."""
+        with pytest.raises(ValueError):
+            mpl_norm(DATA2, stretch='invalid')

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-
 from ...tests.helper import pytest
-
 from ..stretch import (LinearStretch, SqrtStretch, PowerStretch,
                        PowerDistStretch, SquaredStretch, LogStretch,
                        AsinhStretch, SinhStretch, HistEqStretch,
@@ -21,39 +19,40 @@ RESULTS[PowerDistStretch()] = np.array([0., 0.004628, 0.030653, 0.177005, 1.])
 RESULTS[LogStretch()] = np.array([0., 0.799776, 0.899816, 0.958408, 1.])
 RESULTS[AsinhStretch()] = np.array([0., 0.549402, 0.77127, 0.904691, 1.])
 RESULTS[SinhStretch()] = np.array([0., 0.082085, 0.212548, 0.46828, 1.])
-RESULTS[ContrastBiasStretch(contrast=2., bias=0.4)] = np.array([-0.3, 0.2, 0.7, 1.2, 1.7])
+RESULTS[ContrastBiasStretch(contrast=2., bias=0.4)] = np.array([-0.3, 0.2,
+                                                                0.7, 1.2,
+                                                                1.7])
 RESULTS[HistEqStretch(DATA)] = DATA
 RESULTS[HistEqStretch(DATA[::-1])] = DATA
-RESULTS[HistEqStretch(DATA ** 0.5)] = np.array([0., 0.125, 0.25, 0.5674767, 1.])
+RESULTS[HistEqStretch(DATA ** 0.5)] = np.array([0., 0.125, 0.25, 0.5674767,
+                                                1.])
 
 
 class TestStretch(object):
 
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_no_clip(self, stretch):
-
         np.testing.assert_allclose(stretch(DATA, clip=False),
                                    RESULTS[stretch], atol=1.e-6)
 
-    @pytest.mark.parametrize('ndim', [2,3])
+    @pytest.mark.parametrize('ndim', [2, 3])
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_clip_ndimensional(self, stretch, ndim):
-
         new_shape = DATA.shape + (1,) * ndim
 
-        np.testing.assert_allclose(stretch(DATA.reshape(new_shape), clip=True).ravel(),
-                                   np.clip(RESULTS[stretch], 0., 1), atol=1.e-6)
-
+        np.testing.assert_allclose(stretch(DATA.reshape(new_shape),
+                                           clip=True).ravel(),
+                                   np.clip(RESULTS[stretch], 0., 1),
+                                   atol=1.e-6)
 
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_clip(self, stretch):
-
         np.testing.assert_allclose(stretch(DATA, clip=True),
-                                   np.clip(RESULTS[stretch], 0., 1), atol=1.e-6)
+                                   np.clip(RESULTS[stretch], 0., 1),
+                                   atol=1.e-6)
 
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_inplace(self, stretch):
-
         data_in = DATA.copy()
         result = np.zeros(DATA.shape)
         stretch(data_in, out=result, clip=False)
@@ -62,13 +61,11 @@ class TestStretch(object):
 
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_round_trip(self, stretch):
-
-        np.testing.assert_allclose(stretch.inverse(stretch(DATA, clip=False), clip=False),
-                                   DATA)
+        np.testing.assert_allclose(stretch.inverse(stretch(DATA, clip=False),
+                                                   clip=False), DATA)
 
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_inplace_roundtrip(self, stretch):
-
         result = np.zeros(DATA.shape)
         stretch(DATA, out=result, clip=False)
         stretch.inverse(result, out=result, clip=False)
@@ -76,7 +73,8 @@ class TestStretch(object):
 
     @pytest.mark.parametrize('stretch', RESULTS.keys())
     def test_double_inverse(self, stretch):
-        np.testing.assert_allclose(stretch.inverse.inverse(DATA), stretch(DATA), atol=1.e-6)
+        np.testing.assert_allclose(stretch.inverse.inverse(DATA),
+                                   stretch(DATA), atol=1.e-6)
 
     def test_inverted(self):
         stretch_1 = SqrtStretch().inverse
@@ -85,7 +83,6 @@ class TestStretch(object):
                                    stretch_2(DATA))
 
     def test_chaining(self):
-
         stretch_1 = SqrtStretch() + SqrtStretch()
         stretch_2 = PowerStretch(0.25)
         stretch_3 = PowerStretch(4.)
@@ -98,7 +95,6 @@ class TestStretch(object):
 
 
 def test_clip_invalid():
-
     stretch = SqrtStretch()
 
     values = stretch([-1., 0., 0.5, 1., 1.5])

--- a/astropy/visualization/tests/test_ui.py
+++ b/astropy/visualization/tests/test_ui.py
@@ -2,8 +2,9 @@
 
 import numpy as np
 from numpy.testing import assert_allclose
-
 from ..ui import scale_image
+from ...tests.helper import pytest
+
 
 DATA = np.array([0, 1., 2.])
 DATASCL = 0.5 * DATA
@@ -44,3 +45,17 @@ class TestImageScaling(object):
         """Test linear scaling."""
         img = scale_image(DATA, scale='linear', min_cut=1.)
         assert_allclose(img, [0., 0., 1.], atol=0, rtol=1.e-5)
+
+    def test_percent(self):
+        """Test percent keywords."""
+        img = scale_image(DATA, scale='linear', percent=99.)
+        assert_allclose(img, DATASCL, atol=0, rtol=1.e-5)
+
+        img2 = scale_image(DATA, scale='linear', min_percent=0.5,
+                           max_percent=99.5)
+        assert_allclose(img, img2, atol=0, rtol=1.e-5)
+
+    def test_invalid_stretch(self):
+        """Test invalid stretch keyword."""
+        with pytest.raises(ValueError):
+            scale_image(DATA, scale='invalid')

--- a/astropy/visualization/transform.py
+++ b/astropy/visualization/transform.py
@@ -2,6 +2,7 @@
 
 from __future__ import division, print_function
 
+
 __all__ = ['BaseTransform', 'CompositeTransform']
 
 

--- a/astropy/visualization/ui.py
+++ b/astropy/visualization/ui.py
@@ -12,7 +12,7 @@ __all__ = ['scale_image']
 
 
 @deprecated('1.3',
-            alternative='`~astropy.visualization.mpl_normalize.mpl_norm`')
+            alternative='`~astropy.visualization.mpl_normalize.simple_norm`')
 def scale_image(image, scale='linear', power=1.0, asinh_a=0.1, min_cut=None,
                 max_cut=None, min_percent=None, max_percent=None,
                 percent=None, clip=True):

--- a/astropy/visualization/ui.py
+++ b/astropy/visualization/ui.py
@@ -1,14 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-
 from .interval import (PercentileInterval, AsymmetricPercentileInterval,
                        ManualInterval, MinMaxInterval)
-
 from .stretch import (LinearStretch, SqrtStretch, PowerStretch, LogStretch,
                       AsinhStretch)
+from ..utils.decorators import deprecated
 
 
+__all__ = ['scale_image']
+
+
+@deprecated('1.3', alternative='`~astropy.visualization.mpl_normalize.ImgNorm`')
 def scale_image(image, scale='linear', power=1.0, asinh_a=0.1, min_cut=None,
                 max_cut=None, min_percent=None, max_percent=None,
                 percent=None, clip=True):

--- a/astropy/visualization/ui.py
+++ b/astropy/visualization/ui.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
+
 from .interval import (PercentileInterval, AsymmetricPercentileInterval,
                        ManualInterval, MinMaxInterval)
 from .stretch import (LinearStretch, SqrtStretch, PowerStretch, LogStretch,

--- a/astropy/visualization/ui.py
+++ b/astropy/visualization/ui.py
@@ -11,7 +11,8 @@ from ..utils.decorators import deprecated
 __all__ = ['scale_image']
 
 
-@deprecated('1.3', alternative='`~astropy.visualization.mpl_normalize.ImgNorm`')
+@deprecated('1.3',
+            alternative='`~astropy.visualization.mpl_normalize.mpl_norm`')
 def scale_image(image, scale='linear', power=1.0, asinh_a=0.1, min_cut=None,
                 max_cut=None, min_percent=None, max_percent=None,
                 percent=None, clip=True):

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -8,7 +8,6 @@ Zscale implementation based on the one from the STScI Numdisplay package.
 Original implementation from Numdisplay is BSD licensed:
 https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/lib/stsci/numdisplay/zscale.py?rev=19347
 https://trac.stsci.edu/ssb/stsci_python/browser/stsci_python/trunk/numdisplay/LICENSE.txt?rev=19347
-
 """
 
 from __future__ import absolute_import, division
@@ -16,6 +15,7 @@ from __future__ import absolute_import, division
 import numpy as np
 
 from ..extern.six.moves import range
+
 
 __all__ = ['zscale']
 
@@ -30,21 +30,21 @@ def zscale(image, nsamples=1000, contrast=0.25, max_reject=0.5, min_npixels=5,
         Input array.
     nsamples : int, optional
         Number of points in array to sample for determining scaling factors.
-        Default to 1000.
+        Defaults to 1000.
     contrast : float, optional
         Scaling factor (between 0 and 1) for determining min and max. Larger
         values increase the difference between min and max values used for
-        display. Default to 0.25.
+        display. Defaults to 0.25.
     max_reject : float, optional
         If more than ``max_reject * npixels`` pixels are rejected, then the
-        returned values are the min and max of the data. Default to 0.5.
+        returned values are the min and max of the data. Defaults to 0.5.
     min_npixels : int, optional
         If less than ``min_npixels`` pixels are rejected, then the
-        returned values are the min and max of the data. Default to 5.
+        returned values are the min and max of the data. Defaults to 5.
     krej : float, optional
-        Number of sigma used for the rejection. Default to 2.5.
+        Number of sigma used for the rejection. Defaults to 2.5.
     max_iterations : int, optional
-        Maximum number of iterations for the rejection. Default to 5.
+        Maximum number of iterations for the rejection. Defaults to 5.
 
     Returns
     -------

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -112,9 +112,11 @@ but this can be disabled::
 Combining transformations
 =========================
 
-Any stretches and intervals can be chained by using the ``+`` operator, which
-returns a new transformation. For example, to apply normalization based on a
-percentile value, followed by a square root stretch, you can do::
+Any intervals and stretches can be chained by using the ``+``
+operator, which returns a new transformation. When combining intervals
+and stretches, the stretch object must come before the interval
+object. For example, to apply normalization based on a percentile
+value, followed by a square root stretch, you can do::
 
     >>> transform = SqrtStretch() + PercentileInterval(90.)
     >>> transform([1, 3, 4, 5, 6])

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -211,7 +211,7 @@ also be the vmin and vmax limits, which you can determine from the
     fig.colorbar(im)
 
 Finally, we also provide a convenience
-:func:`~astropy.visualization.mpl_normalize.mpl_norm` function that
+:func:`~astropy.visualization.mpl_normalize.simple_norm` function that
 can be useful for quick interactive analysis (it is also used by the
 ``fits2bitmap`` command-line script).  However, it is not recommended
 to be used in scripted programs; it's better to use
@@ -223,15 +223,13 @@ to be used in scripted programs; it's better to use
 
     import numpy as np
     import matplotlib.pyplot as plt
-
-    from astropy.visualization import MinMaxInterval, SqrtStretch
-    from astropy.visualization.mpl_normalize import mpl_norm
+    from astropy.visualization.mpl_normalize import simple_norm
 
     # Generate a test image
     image = np.arange(65536).reshape((256, 256))
 
     # Create an ImageNormalize object
-    norm = mpl_norm(image, 'sqrt')
+    norm = simple_norm(image, 'sqrt')
 
     # Display the image
     fig = plt.figure()

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -2,9 +2,10 @@
 Image stretching and normalization
 **********************************
 
-The `astropy.visualization` module provides a framework for transforming values in
-images (and more generally any arrays), typically for the purpose of
-visualization. Two main types of transformations are provided:
+The `astropy.visualization` module provides a framework for
+transforming values in images (and more generally any arrays),
+typically for the purpose of visualization. Two main types of
+transformations are provided:
 
 * Normalization to the [0:1] range using lower and upper limits where
   :math:`x` represents the values in the original image:
@@ -13,55 +14,56 @@ visualization. Two main types of transformations are provided:
 
     y = \frac{x - v_{\rm min}}{v_{\rm max} - v_{\rm min}}
 
-* *Stretching* of values in the [0:1] range to the [0:1] range using a linear
-  or non-linear function:
+* *Stretching* of values in the [0:1] range to the [0:1] range using a
+  linear or non-linear function:
 
 .. math::
 
     z = f(y)
 
-In addition, classes are provided in order to identify lower and upper limits
-for a dataset based on specific algorithms (such as using percentiles).
+In addition, classes are provided in order to identify lower and upper
+limits for a dataset based on specific algorithms (such as using
+percentiles).
 
-Identifying lower and upper limits, as well as re-normalizing, is described in
-the `Intervals and Normalization`_ section, while stretching is described in
-the `Stretching`_ section.
+Identifying lower and upper limits, as well as re-normalizing, is
+described in the `Intervals and Normalization`_ section, while
+stretching is described in the `Stretching`_ section.
 
 
 Intervals and Normalization
 ===========================
 
-Several classes are provided for determining intervals and for normalizing values
-in this interval to the [0:1] range. One of the simplest examples is the
-:class:`~astropy.visualization.MinMaxInterval` which determines the limits of the
-values based on the minimum and maximum values in the array. The class is
-instantiated with no arguments::
-
+Several classes are provided for determining intervals and for
+normalizing values in this interval to the [0:1] range. One of the
+simplest examples is the
+:class:`~astropy.visualization.MinMaxInterval` which determines the
+limits of the values based on the minimum and maximum values in the
+array. The class is instantiated with no arguments::
 
     >>> from astropy.visualization import MinMaxInterval
     >>> interval = MinMaxInterval()
 
 and the limits can be determined by calling the
-:meth:`~astropy.visualization.MinMaxInterval.get_limits` method, which takes the
-array of values::
+:meth:`~astropy.visualization.MinMaxInterval.get_limits` method, which
+takes the array of values::
 
     >>> interval.get_limits([1, 3, 4, 5, 6])
     (1, 6)
 
-The ``interval`` instance can also be called like a function to actually
-normalize values to the range::
+The ``interval`` instance can also be called like a function to
+actually normalize values to the range::
 
     >>> interval([1, 3, 4, 5, 6])
     array([ 0. ,  0.4,  0.6,  0.8,  1. ])
 
-Other interval classes include :class:`~astropy.visualization.ManualInterval`,
+Other interval classes include
+:class:`~astropy.visualization.ManualInterval`,
 :class:`~astropy.visualization.PercentileInterval`,
 :class:`~astropy.visualization.AsymmetricPercentileInterval`, and
-:class:`~astropy.visualization.ZScaleInterval`. For these, values in the array
-can fall outside of the limits given by the interval.  A ``clip`` argument is
-provided to control the behavior of the normalization when values fall outside
-the limits::
-
+:class:`~astropy.visualization.ZScaleInterval`. For these, values in
+the array can fall outside of the limits given by the interval.  A
+``clip`` argument is provided to control the behavior of the
+normalization when values fall outside the limits::
 
     >>> from astropy.visualization import PercentileInterval
     >>> interval = PercentileInterval(50.)
@@ -72,23 +74,24 @@ the limits::
     >>> interval([1, 3, 4, 5, 6], clip=False)
     array([-1. ,  0. ,  0.5,  1. ,  1.5])
 
+
 Stretching
 ==========
 
-In addition to classes that can scale values to the [0:1] range, a number of
-classes are provide to 'stretch' the values using different functions. These
-map a [0:1] range onto a transformed [0:1] range. A simple example is the
-:class:`~astropy.visualization.SqrtStretch` class::
+In addition to classes that can scale values to the [0:1] range, a
+number of classes are provide to 'stretch' the values using different
+functions. These map a [0:1] range onto a transformed [0:1] range. A
+simple example is the :class:`~astropy.visualization.SqrtStretch`
+class::
 
     >>> from astropy.visualization import SqrtStretch
     >>> stretch = SqrtStretch()
     >>> stretch([0., 0.25, 0.5, 0.75, 1.])
     array([ 0.        ,  0.5       ,  0.70710678,  0.8660254 ,  1.        ])
 
-As for the intervals, values outside the [0:1] range can be treated differently
-depending on the ``clip`` argument. By default, output values are clipped to
-the [0:1] range::
-
+As for the intervals, values outside the [0:1] range can be treated
+differently depending on the ``clip`` argument. By default, output
+values are clipped to the [0:1] range::
 
     >>> stretch([-1., 0., 0.5, 1., 1.5])
     array([ 0.       ,  0.        ,  0.70710678,  1.        ,  1.        ])
@@ -109,6 +112,7 @@ but this can be disabled::
     our stretches and DS9 is that we have adjusted them so that the
     [0:1] range always maps exactly to the [0:1] range.
 
+
 Combining transformations
 =========================
 
@@ -122,41 +126,115 @@ value, followed by a square root stretch, you can do::
     >>> transform([1, 3, 4, 5, 6])
     array([ 0.        ,  0.60302269,  0.76870611,  0.90453403,  1.        ])
 
-As before, the combined transformation can also accept a ``clip`` argument
-(which is `True` by default).
+As before, the combined transformation can also accept a ``clip``
+argument (which is `True` by default).
 
 Matplotlib normalization
 ========================
 
-Matplotlib allows a custom normalization and stretch to be used when showing
-data, and requires a :class:`~matplotlib.colors.Normalize` object to be passed
-to e.g. :meth:`~matplotlib.axes.Axes.imshow`. The `astropy.visualization` module
-provides a class, :class:`~astropy.visualization.mpl_normalize.ImageNormalize`, which wraps the
-stretch functions from `Stretching`_ into an object Matplotlib understands. The
-:class:`~astropy.visualization.mpl_normalize.ImageNormalize` class takes the limits (which you
-can determine from the `Intervals and Normalization`_ classes) and the stretch
-instance:
+Matplotlib allows a custom normalization and stretch to be used when
+displaying data by passing a :class:`matplotlib.colors.Normalize`
+object, e.g. to :meth:`~matplotlib.axes.Axes.imshow`. The
+`astropy.visualization` module provides an
+:class:`~astropy.visualization.mpl_normalize.ImageNormalize` class
+that wraps the interval (see `Intervals and Normalization`_) and
+stretch (see `Stretching`_) objects into an object Matplotlib
+understands.
+
+The inputs to the
+:class:`~astropy.visualization.mpl_normalize.ImageNormalize` class are
+the data and the interval and stretch objects:
 
 .. plot::
-   :include-source:
-   :align: center
+    :include-source:
+    :align: center
 
     import numpy as np
     import matplotlib.pyplot as plt
 
-    from astropy.visualization import SqrtStretch
+    from astropy.visualization import MinMaxInterval, SqrtStretch
     from astropy.visualization.mpl_normalize import ImageNormalize
 
-    # Generate test image
+    # Generate a test image
     image = np.arange(65536).reshape((256, 256))
 
-    # Create normalizer object
-    norm = ImageNormalize(vmin=0., vmax=65536, stretch=SqrtStretch())
+    # Create an ImageNormalize object
+    norm = ImageNormalize(image, interval=MinMaxInterval(),
+                          stretch=SqrtStretch())
 
-    # Make the figure
+    # or equivalently using positional arguments
+    # norm = ImageNormalize(image, MinMaxInterval(), SqrtStretch())
+
+    # Display the image
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
     im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
 
 As shown above, the colorbar ticks are automatically adjusted.
+
+Also note that while the input image to
+:class:`~astropy.visualization.mpl_normalize.ImageNormalize` is
+typically the one to be displayed, a completely different image can be
+used to establish the normalization (e.g. if one wants to display
+several images with exactly the same normalization and stretch).
+
+The inputs to the
+:class:`~astropy.visualization.mpl_normalize.ImageNormalize` class can
+also be the vmin and vmax limits, which you can determine from the
+`Intervals and Normalization`_ classes, and the stretch object:
+
+.. plot::
+    :include-source:
+    :align: center
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from astropy.visualization import MinMaxInterval, SqrtStretch
+    from astropy.visualization.mpl_normalize import ImageNormalize
+
+    # Generate a test image
+    image = np.arange(65536).reshape((256, 256))
+
+    # Create interval object
+    interval = MinMaxInterval()
+    vmin, vmax = interval.get_limits(image)
+
+    # Create an ImageNormalize object using a SqrtStretch object
+    norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch())
+
+    # Display the image
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    im = ax.imshow(image, origin='lower', norm=norm)
+    fig.colorbar(im)
+
+Finally, we also provide a convenience
+:func:`~astropy.visualization.mpl_normalize.mpl_norm` function that
+can be useful for quick interactive analysis (it is also used by the
+``fits2bitmap`` command-line script).  However, it is not recommended
+to be used in scripted programs; it's better to use
+:class:`~astropy.visualization.mpl_normalize.ImageNormalize` directly:
+
+.. plot::
+    :include-source:
+    :align: center
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from astropy.visualization import MinMaxInterval, SqrtStretch
+    from astropy.visualization.mpl_normalize import mpl_norm
+
+    # Generate a test image
+    image = np.arange(65536).reshape((256, 256))
+
+    # Create an ImageNormalize object
+    norm = mpl_norm(image, 'sqrt')
+
+    # Display the image
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    im = ax.imshow(image, origin='lower', norm=norm)
+    fig.colorbar(im)

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -98,14 +98,16 @@ but this can be disabled::
     >>> stretch([-1., 0., 0.5, 1., 1.5], clip=False)
     array([        nan,  0.        ,  0.70710678,  1.        ,  1.22474487])
 
-.. note:: The stretch functions are similar but not always strictly identical
-          to those used in e.g. `DS9 <http://ds9.si.edu/site/Home.html>`_
-          (although they should have the same behavior). The equations for the
-          DS9 stretches can be found `here <http://ds9.si.edu/ref/how.html>`_
-          and can be compared to the equations for our stretches provided in
-          the `astropy.visualization` API section. The main difference between our
-          stretches and DS9 is that we have adjusted them so that the [0:1]
-          range always maps exactly to the [0:1] range.
+.. note::
+    The stretch functions are similar but not always strictly
+    identical to those used in e.g. `DS9
+    <http://ds9.si.edu/site/Home.html>`_ (although they should have
+    the same behavior). The equations for the DS9 stretches can be
+    found `here <http://ds9.si.edu/doc/ref/how.html>`_ and can be
+    compared to the equations for our stretches provided in the
+    `astropy.visualization` API section. The main difference between
+    our stretches and DS9 is that we have adjusted them so that the
+    [0:1] range always maps exactly to the [0:1] range.
 
 Combining transformations
 =========================


### PR DESCRIPTION
This PR contains the following changes to the `visualization` subpackage:

* ~~Adds a `Norm` class to generate a `matplotlib.colors.Normalize` object from an interval and a stretch instance.~~
* ~~Adds a convenience `ImgNorm` class for quick interactive analysis (and used by the `fits2bitmap` command-line script).  `ImgNorm` replaces the `scale_image` function.~~
* Deprecates the `scale_image` function (in favor of the `ImgNorm` class).
* Adds a default stretch for the existing `Normalization` class.
* Adds default `vmin/vmax` for the `ManualInterval` class.
* Adds missing API docs for existing interval and stretch classes.
* Adds addition tests for the visualization subpackage.
* Augments and updates the visualization narrative docs.

Examples
----------

With the existing `ImageNormalize` class one needs to input the `vmin/vmax` values, which is a bit cumbersome, e.g.:

```
interval = MinMaxInterval()
vmin, vmax = interval.get_limits(image)
norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch())
```

With the new ~~`Norm` class~~ inputs, one can simply do, e.g.:

```
norm = ImageNormalize(image, MinMaxInterval(), SqrtStretch())
```

And then the image is displayed with:
```
ax.imshow(image, origin='lower', norm=norm)
```

cc: @astrofrog 

