### PR TITLE
Handle unicode FITS BinTable column names on Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,8 +128,6 @@ Bug Fixes
   - Made TFORMx keyword check more flexible in test of compressed images to
     enable compatibility of the test with cfitsio 3.380. [#4646]
 
-  - Handle unicode FITS BinTable column names on Python 2 [#5204, #4805]
-
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -185,6 +183,8 @@ Bug Fixes
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``
+
+  - Handle unicode FITS BinTable column names on Python 2 [#5204, #4805]
 
 - ``astropy.io.misc``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,8 @@ Bug Fixes
   - Made TFORMx keyword check more flexible in test of compressed images to
     enable compatibility of the test with cfitsio 3.380. [#4646]
 
+  - Handle unicode FITS BinTable column names on Python 2 [#5204, #4805]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -19,7 +19,7 @@ from .util import (pairwise, _is_int, _convert_array, encode_ascii, cmp,
                    NotifierMixin)
 from .verify import VerifyError, VerifyWarning
 
-from ...extern.six import string_types, iteritems
+from ...extern.six import string_types, iteritems, PY2
 from ...utils import lazyproperty, isiterable, indent
 from ...utils.compat import suppress
 from ...utils.exceptions import AstropyDeprecationWarning
@@ -1428,6 +1428,12 @@ class ColDefs(NotifierMixin):
                     dt = np.dtype((dt.char + str(dim[-1]), dim[:-1]))
                 else:
                     dt = np.dtype((dt.base, dim))
+
+            # On Python 2, force the `name` to `str`
+            # because Numpy structured arrays can't handle unicode `name`
+            # See https://github.com/astropy/astropy/issues/5204
+            if PY2:  # pragma: py2
+                name = str(name)
 
             fields.append((name, dt))
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1503,6 +1503,15 @@ class TestTableFunctions(FitsTestCase):
             assert hdu.name == 'FOO'
             assert hdu.header['EXTNAME'] == 'FOO'
 
+    def test_unicode_colname(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/5204
+        "Handle unicode FITS BinTable column names on Python 2"
+        """
+        col = fits.Column(name=u'spam', format='E', array=[42.])
+        # This used to raise a TypeError, now it works
+        fits.BinTableHDU.from_columns([col])
+
     def test_bin_table_with_logical_array(self):
         c1 = fits.Column(name='flag', format='2L',
                          array=[[True, False], [False, True]])


### PR DESCRIPTION
The following example looks good, no?

```python
# Put this in a file: test.py
from __future__ import unicode_literals
from astropy.io import fits
col = fits.Column(name='spam', format='E', array=[42.])
hdu = fits.BinTableHDU.from_columns([col])
```

It follows the [Astropy coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html) that recommend using `from __future__ import unicode_literals` and it's a simplified version of the example from the docs how to create a `BinTable` (see [here](http://docs.astropy.org/en/latest/io/fits/index.html#creating-a-new-table-file)).

It works on Python 3, but on Python 2 it fails with a cryptic error message:
```
$ python2 test.py
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    hdu = fits.BinTableHDU.from_columns([col])
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/io/fits/hdu/table.py", line 126, in from_columns
    data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/io/fits/fitsrec.py", line 342, in from_columns
    raw_data = np.empty(columns.dtype.itemsize * nrows, dtype=np.uint8)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/utils/decorators.py", line 498, in __get__
    val = self.fget(obj)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/astropy/io/fits/column.py", line 1435, in dtype
    return nh.realign_dtype(np.dtype(fields), offsets)
TypeError: data type not understood
```
(This is with latest Astropy and Numpy, I think the error will be the same with all older versions of Astropy and Numpy.)

In Gammapy and Fermipy development, we encountered this issue this week (see https://github.com/gammapy/gammapy/pull/648#issuecomment-235850515 and https://github.com/fermiPy/fermipy/pull/63), cc @jjlk @woodmd

After a lot of head-scratching, I found the explanation of the issue and suggested workaround to force the column name to bytes on Python 2 only and use `name=str('spam')` here:
http://docs.astropy.org/en/latest/development/codeguide.html#not-so-fast-on-that-unicode-thing

I also found #4805 by @pllim where she got bitten by the same issue and proposed to do automatic conversion from unicode to bytes for dtype field names on Python 2 in `astropy.io.fits`:
https://github.com/numpy/numpy/issues/2407#issuecomment-195500248
That PR was closed without being merged after discussion with @saimn .

In https://github.com/numpy/numpy/issues/2407#issuecomment-195500248, @pv said that this change would probably even be welcome in Numpy itself.

Since we'll need to support Numpy versions without that fix for a long time, I'm +1 to implement that change in `astropy.io.fits`.

Does that sound like a good idea to everyone or is there someone against this change?

@saimn - I think your argument against #4805 was just about an issue with how the fix was implemented, and not against automatic conversion from unicode to bytes for dtype field names on Python 2 by encoding to ascii in principle?