### PR TITLE
Add CartesianRepresentationFrameAttribute to GCRS and PrecessedGeocentric frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -167,6 +167,51 @@ Other Changes and Additions
 1.2.2 (unreleased)
 ------------------
 
+API Changes
+^^^^^^^^^^^
+
+- ``astropy.config``
+
+- ``astropy.constants``
+
+- ``astropy.convolution``
+
+- ``astropy.coordinates``
+
+  - The ``obsgeoloc`` and ``obsgeovel`` attributes of ``GCRS`` and ``PrecessedGeocentric``
+    frames are now stored and returned as ``CartesianRepresentation`` objects, rather than
+    ``Quantity`` objects.
+
+- ``astropy.cosmology``
+
+- ``astropy.io.ascii``
+
+- ``astropy.io.fits``
+
+- ``astropy.io.misc``
+
+- ``astropy.io.registry``
+
+- ``astropy.io.votable``
+
+- ``astropy.modeling``
+
+- ``astropy.nddata``
+
+- ``astropy.stats``
+
+- ``astropy.table``
+
+- ``astropy.time``
+
+- ``astropy.units``
+
+- ``astropy.utils``
+
+- ``astropy.vo``
+
+- ``astropy.wcs``
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -178,8 +223,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
-  - Changed obsgeoloc and obsgeovel frame attributes to CartesianRepresentation. Fixes creation of
-    GCRS frames representing a location on Earth with multiple obstimes. [#5207]
+  - GCRS frames representing a location on Earth with multiple obstimes are now allowed. This means that
+   the solar system routines ``get_body``, ``get_moon`` and ``get_sun`` now work with non-scalar times and
+   a none geocentric observer. [#5207]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -224,8 +224,8 @@ Bug Fixes
 - ``astropy.coordinates``
 
   - GCRS frames representing a location on Earth with multiple obstimes are now allowed. This means that
-   the solar system routines ``get_body``, ``get_moon`` and ``get_sun`` now work with non-scalar times and
-   a none geocentric observer. [#5207]
+    the solar system routines ``get_body``, ``get_moon`` and ``get_sun`` now work with non-scalar times and
+    a none geocentric observer. [#5207]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,6 +178,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Changed obsgeoloc and obsgeovel frame attributes to CartesianRepresentation. Fixes creation of
+    GCRS frames representing a location on Earth with multiple obstimes. [#5207]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -217,7 +220,7 @@ Bug Fixes
 
   - Conversion from quantities to logarithmic units now correctly causes a
     logarithmic quantity such as ``Magnitude`` to be returned. [#5183]
-  
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -320,21 +320,19 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
             return CartesianRepresentation(np.zeros(3) * self.unit), True
         else:
             converted = True
-            # it may already by an appropriate CartesianRepresentation
-            if hasattr(value, 'xyz') and value.xyz.unit == self.unit:
-                converted = False
-                return value
-
             # if it's a CartesianRepresentation, get the xyz Quantity
             value = getattr(value, 'xyz', value)
-            if not (hasattr(value, 'unit')):
+            if not (hasattr(value, 'unit') ):
                 raise TypeError('Tried to set a CartesianRepresentationFrameAttribute with '
                                 'something that does not have a unit.')
             oldvalue = value
             value = u.Quantity(oldvalue, self.unit, copy=False)
+            if (oldvalue.unit == value.unit and hasattr(oldvalue, 'value') and
+                np.all(oldvalue.value == value.value)):
+                converted = False
 
             # now try and make a CartesianRepresentation. Aim to be flexible
-            cartrep = CartesianRepresentation(value, copy=False)
+            cartrep = CartesianRepresentation(value)
             return cartrep, converted
 
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -332,11 +332,7 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
                 converted = False
 
             # now try and make a CartesianRepresentation. Aim to be flexible
-            try:
-                cartrep = CartesianRepresentation(value)
-            except:
-                value = value.swapaxes(0,-1)
-                cartrep = CartesianRepresentation(value)
+            cartrep = CartesianRepresentation(value)
             return cartrep, converted
 
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -326,7 +326,7 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
                 raise TypeError('Tried to set a CartesianRepresentationFrameAttribute with '
                                 'something that does not have a unit.')
             oldvalue = value
-            value = u.Quantity(oldvalue, copy=False).to(self.unit)
+            value = u.Quantity(oldvalue, self.unit, copy=False)
             if (oldvalue.unit == value.unit and hasattr(oldvalue, 'value') and
                 np.all(oldvalue.value == value.value)):
                 converted = False

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -996,7 +996,7 @@ class BaseCoordinateFrame(object):
         """
         if self.__class__ == other.__class__:
             for frame_attr_name in self.get_frame_attr_names():
-                if getattr(self, frame_attr_name) != getattr(other, frame_attr_name):
+                if np.any(getattr(self, frame_attr_name) != getattr(other, frame_attr_name)):
                     return False
             return True
         elif not isinstance(other, BaseCoordinateFrame):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -298,7 +298,7 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
     def convert_input(self, value):
         """
         Checks that the input is a CartesianRepresentation with the correct unit, or
-        the special value ``0``.
+        the special value ``[0, 0, 0]``.
 
         Parameters
         ----------
@@ -316,7 +316,8 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
         ValueError
             If the input is not valid for this attribute.
         """
-        if np.all(value == 0) and self.unit is not None:
+        if (isinstance(value, list) and np.all([v == 0 for v in value]) and
+                len(value) == 3 and self.unit is not None):
             return CartesianRepresentation(np.zeros(3) * self.unit), True
         else:
             # is it a CartesianRepresentation with correct unit?

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -332,7 +332,7 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
                 converted = False
 
             # now try and make a CartesianRepresentation. Aim to be flexible
-            cartrep = CartesianRepresentation(value)
+            cartrep = CartesianRepresentation(value, copy=False)
             return cartrep, converted
 
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -328,7 +328,7 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
             # if it's a CartesianRepresentation, get the xyz Quantity
             value = getattr(value, 'xyz', value)
             if not (hasattr(value, 'unit')):
-                raise TypeError('Tried to set a CartesianRepresentationFrameAttribute with '
+                raise TypeError('tried to set a CartesianRepresentationFrameAttribute with '
                                 'something that does not have a unit.')
 
             value = value.to(self.unit)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -320,19 +320,21 @@ class CartesianRepresentationFrameAttribute(FrameAttribute):
             return CartesianRepresentation(np.zeros(3) * self.unit), True
         else:
             converted = True
+            # it may already by an appropriate CartesianRepresentation
+            if hasattr(value, 'xyz') and value.xyz.unit == self.unit:
+                converted = False
+                return value
+
             # if it's a CartesianRepresentation, get the xyz Quantity
             value = getattr(value, 'xyz', value)
-            if not (hasattr(value, 'unit') ):
+            if not (hasattr(value, 'unit')):
                 raise TypeError('Tried to set a CartesianRepresentationFrameAttribute with '
                                 'something that does not have a unit.')
             oldvalue = value
             value = u.Quantity(oldvalue, self.unit, copy=False)
-            if (oldvalue.unit == value.unit and hasattr(oldvalue, 'value') and
-                np.all(oldvalue.value == value.value)):
-                converted = False
 
             # now try and make a CartesianRepresentation. Aim to be flexible
-            cartrep = CartesianRepresentation(value)
+            cartrep = CartesianRepresentation(value, copy=False)
             return cartrep, converted
 
 

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -34,13 +34,13 @@ class GCRS(BaseCoordinateFrame):
         position of the Earth.
     * ``obsgeoloc``
         The position of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
-        Defaults to 0,  meaning "true" GCRS.
+        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
+        Defaults to 0, meaning "true" GCRS.
     * ``obsgeovel``
         The velocity of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
+        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity units.
         Defaults to 0, meaning "true" GCRS.
 
     Parameters
@@ -95,14 +95,14 @@ class PrecessedGeocentric(BaseCoordinateFrame):
         position of the Earth.
     * ``obsgeoloc``
         The position of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
-        Defaults to 0,  meaning "true" GCRS.
+        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
+        Defaults to 0, meaning "true" Geocentric.
     * ``obsgeovel``
         The velocity of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
-        Defaults to 0, meaning "true" GCRS.
+        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity units.
+        Defaults to 0, meaning "true" Geocentric.
 
     Parameters
     ----------

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -34,14 +34,14 @@ class GCRS(BaseCoordinateFrame):
         position of the Earth.
     * ``obsgeoloc``
         The position of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        oriented the same as BCRS/ICRS. Either [0, 0, 0], `~astropy.coordinates.CartesianRepresentation`,
         or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to 0, meaning "true" GCRS.
+        Defaults to [0, 0, 0], meaning "true" GCRS.
     * ``obsgeovel``
         The velocity of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        oriented the same as BCRS/ICRS. Either [0, 0, 0], `~astropy.coordinates.CartesianRepresentation`,
         or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity units.
-        Defaults to 0, meaning "true" GCRS.
+        Defaults to [0, 0, 0], meaning "true" GCRS.
 
     Parameters
     ----------
@@ -71,8 +71,8 @@ class GCRS(BaseCoordinateFrame):
     default_representation = SphericalRepresentation
 
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationFrameAttribute(default=0, unit=u.m)
-    obsgeovel = CartesianRepresentationFrameAttribute(default=0, unit=u.m/u.s)
+    obsgeoloc = CartesianRepresentationFrameAttribute(default=[0, 0, 0], unit=u.m)
+    obsgeovel = CartesianRepresentationFrameAttribute(default=[0, 0, 0], unit=u.m/u.s)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like CIRS)
@@ -95,14 +95,14 @@ class PrecessedGeocentric(BaseCoordinateFrame):
         position of the Earth.
     * ``obsgeoloc``
         The position of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
+        oriented the same as BCRS/ICRS. Either [0, 0, 0], `~astropy.coordinates.CartesianRepresentation`,
         or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to 0, meaning "true" Geocentric.
+        Defaults to [0, 0, 0], meaning "true" Geocentric.
     * ``obsgeovel``
         The velocity of the observer relative to the center-of-mass of the Earth,
         oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
         or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity units.
-        Defaults to 0, meaning "true" Geocentric.
+        Defaults to [0, 0, 0], meaning "true" Geocentric.
 
     Parameters
     ----------
@@ -133,5 +133,5 @@ class PrecessedGeocentric(BaseCoordinateFrame):
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationFrameAttribute(default=0, unit=u.m)
-    obsgeovel = CartesianRepresentationFrameAttribute(default=0, unit=u.m/u.s)
+    obsgeoloc = CartesianRepresentationFrameAttribute(default=[0, 0, 0], unit=u.m)
+    obsgeovel = CartesianRepresentationFrameAttribute(default=[0, 0, 0], unit=u.m/u.s)

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -6,7 +6,8 @@ from __future__ import (absolute_import, unicode_literals, division,
 from ... import units as u
 from ..representation import SphericalRepresentation
 from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
-                         TimeFrameAttribute, QuantityFrameAttribute)
+                         TimeFrameAttribute, QuantityFrameAttribute,
+                         CartesianRepresentationFrameAttribute)
 from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
 
 
@@ -32,14 +33,14 @@ class GCRS(BaseCoordinateFrame):
         The time at which the observation is taken.  Used for determining the
         position of the Earth.
     * ``obsgeoloc``
-        Vector giving the position of the observer relative to the
-        center-of-mass of the Earth, oriented the same as BCRS/ICRS.
-        The leading dimension of this vector needs to be 3.
+        The position of the observer relative to the center-of-mass of the Earth,
+        oriented the same as BCRS/ICRS.
+        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
         Defaults to 0,  meaning "true" GCRS.
     * ``obsgeovel``
-        Vector giving the velocity of the observer relative to the
-        center-of-mass of the Earth, oriented the same as BCRS/ICRS.
-        The leading dimension of this vector needs to be 3.
+        The velocity of the observer relative to the center-of-mass of the Earth,
+        oriented the same as BCRS/ICRS.
+        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
         Defaults to 0, meaning "true" GCRS.
 
     Parameters
@@ -70,8 +71,8 @@ class GCRS(BaseCoordinateFrame):
     default_representation = SphericalRepresentation
 
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = QuantityFrameAttribute(default=0, unit=u.m, shape=(3,))
-    obsgeovel = QuantityFrameAttribute(default=0, unit=u.m/u.s, shape=(3,))
+    obsgeoloc = CartesianRepresentationFrameAttribute(default=0, unit=u.m)
+    obsgeovel = CartesianRepresentationFrameAttribute(default=0, unit=u.m/u.s)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like CIRS)
@@ -93,12 +94,14 @@ class PrecessedGeocentric(BaseCoordinateFrame):
         The time at which the observation is taken.  Used for determining the
         position of the Earth.
     * ``obsgeoloc``
-        3-vector giving the position of the observer relative to the
-        center-of-mass of the Earth, oriented the same as BCRS/ICRS.
+        The position of the observer relative to the center-of-mass of the Earth,
+        oriented the same as BCRS/ICRS.
+        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
         Defaults to 0,  meaning "true" GCRS.
     * ``obsgeovel``
-        3-vector giving the velocity of the observer relative to the
-        center-of-mass of the Earth, oriented the same as BCRS/ICRS.
+        The velocity of the observer relative to the center-of-mass of the Earth,
+        oriented the same as BCRS/ICRS.
+        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
         Defaults to 0, meaning "true" GCRS.
 
     Parameters
@@ -130,5 +133,5 @@ class PrecessedGeocentric(BaseCoordinateFrame):
 
     equinox = TimeFrameAttribute(default=EQUINOX_J2000)
     obstime = TimeFrameAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = QuantityFrameAttribute(default=0, unit=u.m, shape=(3,))
-    obsgeovel = QuantityFrameAttribute(default=0, unit=u.m/u.s, shape=(3,))
+    obsgeoloc = CartesianRepresentationFrameAttribute(default=0, unit=u.m)
+    obsgeovel = CartesianRepresentationFrameAttribute(default=0, unit=u.m/u.s)

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -35,12 +35,12 @@ class GCRS(BaseCoordinateFrame):
     * ``obsgeoloc``
         The position of the observer relative to the center-of-mass of the Earth,
         oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
+        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
         Defaults to 0,  meaning "true" GCRS.
     * ``obsgeovel``
         The velocity of the observer relative to the center-of-mass of the Earth,
         oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
+        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
         Defaults to 0, meaning "true" GCRS.
 
     Parameters
@@ -96,12 +96,12 @@ class PrecessedGeocentric(BaseCoordinateFrame):
     * ``obsgeoloc``
         The position of the observer relative to the center-of-mass of the Earth,
         oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
+        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
         Defaults to 0,  meaning "true" GCRS.
     * ``obsgeovel``
         The velocity of the observer relative to the center-of-mass of the Earth,
         oriented the same as BCRS/ICRS.
-        Either 0, a CartesianRepresentation, or a Quantity of shape (..., 3) or (3, ...)
+        Either 0, a CartesianRepresentation, or a Quantity of shape (3, ...)
         Defaults to 0, meaning "true" GCRS.
 
     Parameters

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -119,10 +119,10 @@ def cirs_to_cirs(from_coo, to_frame):
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # first set up the astrometry context for ICRS<->GCRS
-    pv = np.array([gcrs_frame.obsgeoloc.xyz.value,
-                   gcrs_frame.obsgeovel.xyz.value])
-    if pv.ndim > 2:
-        pv = np.rollaxis(pv, -1, 0)
+    loc = gcrs_frame.obsgeoloc.xyz.value
+    vel = gcrs_frame.obsgeovel.xyz.value
+    pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
+                   np.rollaxis(vel, 0, vel.ndim)), axis=-2)
 
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
@@ -167,10 +167,10 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
-    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
-                   gcrs_coo.obsgeovel.xyz.value])
-    if pv.ndim > 2:
-        pv = np.rollaxis(pv, -1, 0)
+    loc = gcrs_frame.obsgeoloc.xyz.value
+    vel = gcrs_frame.obsgeovel.xyz.value
+    pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
+                   np.rollaxis(vel, 0, vel.ndim)), axis=-2)
 
     jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
@@ -229,10 +229,10 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
-    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
-                   gcrs_coo.obsgeovel.xyz.value])
-    if pv.ndim > 2:
-        pv = np.rollaxis(pv, -1, 0)
+    loc = gcrs_frame.obsgeoloc.xyz.value
+    vel = gcrs_frame.obsgeovel.xyz.value
+    pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
+                   np.rollaxis(vel, 0, vel.ndim)), axis=-2)
 
     jd1, jd2 = get_jd12(hcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -119,10 +119,11 @@ def cirs_to_cirs(from_coo, to_frame):
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # first set up the astrometry context for ICRS<->GCRS
-    loc = gcrs_frame.obsgeoloc.xyz.value
-    vel = gcrs_frame.obsgeovel.xyz.value
-    pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
-                   np.rollaxis(vel, 0, vel.ndim)), axis=-2)
+    pv = np.array([gcrs_frame.obsgeoloc.xyz.value,
+                   gcrs_frame.obsgeovel.xyz.value])
+    # roll axes 0 and 1 to end
+    if pv.ndim > 2:
+            pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
 
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
@@ -167,10 +168,11 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
-    loc = gcrs_coo.obsgeoloc.xyz.value
-    vel = gcrs_coo.obsgeovel.xyz.value
-    pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
-                   np.rollaxis(vel, 0, vel.ndim)), axis=-2)
+    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
+                   gcrs_coo.obsgeovel.xyz.value])
+    # roll axes 0 and 1 to end
+    if pv.ndim > 2:
+            pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
 
     jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
@@ -229,10 +231,11 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
-    loc = gcrs_coo.obsgeoloc.xyz.value
-    vel = gcrs_coo.obsgeovel.xyz.value
-    pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
-                   np.rollaxis(vel, 0, vel.ndim)), axis=-2)
+    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
+                   gcrs_coo.obsgeovel.xyz.value])
+    # roll axes 0 and 1 to end
+    if pv.ndim > 2:
+            pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
 
     jd1, jd2 = get_jd12(hcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -167,8 +167,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
-    loc = gcrs_frame.obsgeoloc.xyz.value
-    vel = gcrs_frame.obsgeovel.xyz.value
+    loc = gcrs_coo.obsgeoloc.xyz.value
+    vel = gcrs_coo.obsgeovel.xyz.value
     pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
                    np.rollaxis(vel, 0, vel.ndim)), axis=-2)
 
@@ -229,8 +229,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
-    loc = gcrs_frame.obsgeoloc.xyz.value
-    vel = gcrs_frame.obsgeovel.xyz.value
+    loc = gcrs_coo.obsgeoloc.xyz.value
+    vel = gcrs_coo.obsgeovel.xyz.value
     pv = np.stack((np.rollaxis(loc, 0, loc.ndim),
                    np.rollaxis(vel, 0, vel.ndim)), axis=-2)
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -119,8 +119,10 @@ def cirs_to_cirs(from_coo, to_frame):
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # first set up the astrometry context for ICRS<->GCRS
-    pv = np.array([gcrs_frame.obsgeoloc.value,
-                   gcrs_frame.obsgeovel.value])
+    pv = np.array([gcrs_frame.obsgeoloc.xyz.value,
+                   gcrs_frame.obsgeovel.xyz.value])
+    if pv.ndim > 2:
+        pv = np.rollaxis(pv, -1, 0)
 
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
@@ -165,8 +167,11 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
-    pv = np.array([gcrs_coo.obsgeoloc.value,
-                   gcrs_coo.obsgeovel.value])
+    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
+                   gcrs_coo.obsgeovel.xyz.value])
+    if pv.ndim > 2:
+        pv = np.rollaxis(pv, -1, 0)
+
     jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)
 
@@ -224,8 +229,10 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
-    pv = np.array([gcrs_coo.obsgeoloc.value,
-                   gcrs_coo.obsgeovel.value])
+    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
+                   gcrs_coo.obsgeovel.xyz.value])
+    if pv.ndim > 2:
+        pv = np.rollaxis(pv, -1, 0)
 
     jd1, jd2 = get_jd12(hcrs_frame.obstime, 'tdb')
     astrom = erfa.apcs13(jd1, jd2, pv)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -223,6 +223,21 @@ class BaseRepresentation(ShapedLikeNDArray):
                            for component in self.components]))
         return unitstr
 
+    def __eq__(self, other):
+        """
+        Check for equality with another representation.
+        """
+        try:
+            return np.all([getattr(self, component) == getattr(other, component)
+                           for component in self.components])
+        except:
+            try:
+                newrep = other.represent_as(self.__class__)
+                return np.all([getattr(self, component) == getattr(newrep, component)
+                               for component in self.components])
+            except:
+                return False
+
     def __str__(self):
         return '{0} {1:s}'.format(self._values, self._unitstr)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -238,6 +238,9 @@ class BaseRepresentation(ShapedLikeNDArray):
             except:
                 return False
 
+    def __ne__(self, other):
+        return not self == other
+
     def __str__(self):
         return '{0} {1:s}'.format(self._values, self._unitstr)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -228,18 +228,18 @@ class BaseRepresentation(ShapedLikeNDArray):
         Check for equality with another representation.
         """
         try:
-            return np.all([getattr(self, component) == getattr(other, component)
-                           for component in self.components])
+            return np.array([getattr(self, component) == getattr(other, component)
+                             for component in self.components])
         except:
             try:
                 newrep = other.represent_as(self.__class__)
-                return np.all([getattr(self, component) == getattr(newrep, component)
-                               for component in self.components])
+                return np.array([getattr(self, component) == getattr(newrep, component)
+                                 for component in self.components])
             except:
                 return False
 
     def __ne__(self, other):
-        return not self == other
+        return ~(self == other)
 
     def __str__(self):
         return '{0} {1:s}'.format(self._values, self._unitstr)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -465,7 +465,7 @@ def test_representation():
     icrs.representation = representation.CylindricalRepresentation
 
     assert icrs.representation == representation.CylindricalRepresentation
-    assert icrs.data == data
+    assert all(icrs.data == data)
 
     # Testing setter input using text argument for spherical.
     icrs.representation = 'spherical'
@@ -474,7 +474,7 @@ def test_representation():
     assert icrs_spher.lat == icrs.dec
     assert icrs_spher.lon == icrs.ra
     assert icrs_spher.distance == icrs.distance
-    assert icrs.data == data
+    assert all(icrs.data == data)
 
     # Testing that an ICRS object in SphericalRepresentation must not have cartesian attributes.
     for attr in ('x', 'y', 'z'):
@@ -486,7 +486,7 @@ def test_representation():
     icrs.representation = 'cylindrical'
 
     assert icrs.representation is representation.CylindricalRepresentation
-    assert icrs.data == data
+    assert all(icrs.data == data)
 
     with pytest.raises(ValueError) as err:
         icrs.representation = 'WRONG'

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -453,7 +453,7 @@ def test_representation():
     assert icrs_cart.x == icrs.x
     assert icrs_cart.y == icrs.y
     assert icrs_cart.z == icrs.z
-    assert icrs.data == data
+    assert all(icrs.data == data)
 
     # Testing that an ICRS object in CartesianRepresentation must not have spherical attributes.
     for attr in ('ra', 'dec', 'distance'):

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from ... import units as u
 from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
-                GeocentricTrueEcliptic, Longitude, Latitude, GCRS)
+                GeocentricTrueEcliptic, Longitude, Latitude, GCRS, get_moon)
 from ...time import Time
 from ...utils import iers
 
@@ -225,3 +225,10 @@ def test_regression_4996():
 
     # this is intentionally not allclose - they should be *exactly* the same
     assert np.all(suncoo.ra.ravel() == suncoo2.ra.ravel())
+
+
+ def test_regression_4926():
+     times = Time('2010-01-1') + np.arange(20)*u.day
+     green = get_builtin_sites()['greenwich']
+
+     get_moon(times, green)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -227,8 +227,8 @@ def test_regression_4996():
     assert np.all(suncoo.ra.ravel() == suncoo2.ra.ravel())
 
 
- def test_regression_4926():
-     times = Time('2010-01-1') + np.arange(20)*u.day
-     green = get_builtin_sites()['greenwich']
+def test_regression_4926():
+    times = Time('2010-01-1') + np.arange(20)*u.day
+    green = get_builtin_sites()['greenwich']
 
-     get_moon(times, green)
+    get_moon(times, green)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -14,6 +14,7 @@ import numpy as np
 from ... import units as u
 from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
                 GeocentricTrueEcliptic, Longitude, Latitude, GCRS, get_moon)
+from ..sites import get_builtin_sites
 from ...time import Time
 from ...utils import iers
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ... import units as u
-from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
+from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, HCRS, CIRS, ITRS,
                 GeocentricTrueEcliptic, Longitude, Latitude, GCRS, get_moon)
 from ..sites import get_builtin_sites
 from ...time import Time
@@ -231,5 +231,12 @@ def test_regression_4996():
 def test_regression_4926():
     times = Time('2010-01-1') + np.arange(20)*u.day
     green = get_builtin_sites()['greenwich']
+    # this is the regression test
+    moon = get_moon(times, green)
 
-    get_moon(times, green)
+    # this is an additional test to make sure the GCRS->ICRS transform works for complex shapes
+    moon.transform_to(ICRS())
+
+    # and some others to increase coverage of transforms
+    moon.transform_to(HCRS(obstime="J2000"))
+    moon.transform_to(HCRS(obstime=times))

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -31,15 +31,15 @@ Here is an example of using these functions with built-in ephemerides, i.e.,
 without the need to download a large ephemerides file::
 
   >>> from astropy.time import Time
-  >>> from astropy.coordinates import solar_system_ephemeris, EarthLocation  
+  >>> from astropy.coordinates import solar_system_ephemeris, EarthLocation
   >>> from astropy.coordinates import get_body_barycentric, get_body, get_moon
   >>> t = Time("2014-09-22 23:22")
   >>> loc = EarthLocation.of_site('greenwich') # doctest: +REMOTE_DATA
   >>> with solar_system_ephemeris.set('builtin'):
   ...     jup = get_body('jupiter', t, loc) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
   >>> jup  # doctest: +FLOAT_CMP +REMOTE_DATA
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 3949481.6898847   -550931.9118969   4961151.73733443] m, obsgeovel=[  40.1745933   288.00078051   -0.        ] m / s): (ra, dec, distance) in (deg, deg, AU)
-      (136.91116201, 17.02935408, 5.94386022)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.689878457, -550931.9118835592, 4961151.737334465) m, obsgeovel=(40.174593298404744, 288.00078051005755, -0.0) m / s): (ra, dec, distance) in (deg, deg, AU)
+    (136.91116201, 17.02935408, 5.94386022)>
 
 Above, we used ``solar_system_ephemeris`` as a context, which sets the default
 ephemeris while in the ``with`` clause, and resets it at the end.
@@ -54,11 +54,11 @@ downloaded and cached when the ephemeris is set):
   >>> solar_system_ephemeris.set('de432s') # doctest: +REMOTE_DATA, +IGNORE_OUTPUT
   <ScienceState solar_system_ephemeris: 'de432s'>
   >>> get_body('jupiter', t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 3949481.6898847   -550931.9118969   4961151.73733443] m, obsgeovel=[  40.1745933   288.00078051   -0.        ] m / s): (ra, dec, distance) in (deg, deg, km)
-      (136.90234781, 17.03160686, 889196019.15383542)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.689878457, -550931.9118835592, 4961151.737334465) m, obsgeovel=(40.174593298404744, 288.00078051005755, -0.0) m / s): (ra, dec, distance) in (deg, deg, km)
+    (136.90234781, 17.03160686, 889196019.15383542)>
   >>> get_moon(t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=[ 3949481.6898847   -550931.9118969   4961151.73733443] m, obsgeovel=[  40.1745933   288.00078051   -0.        ] m / s): (ra, dec, distance) in (deg, deg, km)
-      (165.51840735, 2.32900633, 407226.68749643)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.689878457, -550931.9118835592, 4961151.737334465) m, obsgeovel=(40.174593298404744, 288.00078051005755, -0.0) m / s): (ra, dec, distance) in (deg, deg, km)
+    (165.51840735, 2.32900633, 407226.68749643)>
   >>> get_body_barycentric('moon', t) # doctest: +REMOTE_DATA, +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
       (150107535.1073409, -866789.11996916, -418963.55218495)>
@@ -79,7 +79,7 @@ to the various functions:
 
 For a list of the bodies for which positions can be calculated, do:
 
-.. note that we skip the next test if jplephem is not installed because if 
+.. note that we skip the next test if jplephem is not installed because if
 .. jplephem was not installed, we didn't change the science state higher up
 
 .. doctest-requires:: jplephem


### PR DESCRIPTION
This PR fixes #4926, and is a replacement for #5196.

As @mhvk mentioned on the latter PR, it would be much more logical for the ```obsgeoloc``` and ```obsgeovel``` attributes to be ```CartesianRepresentations```. 

I was initially reluctant, but I realised that you can be flexible about what types of values initialise these attributes so that (3, ...) or (..., 3) shaped ```Quantities``` are allowed, as well as ```CartesianRepresentations``` themselves. This means the code changes are minimal, and anyone who sets these attributes in their code will find their code still works. 

