### PR TITLE
Provide decorator for replaced parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,10 @@ New Features
 
 - ``astropy.utils``
 
+  - New decorator: replaced_argument. This can be used for functions
+    that have renamed a keyword, but still want to allow for use of
+    the older keyword.
+	
 - ``astropy.vo``
 
 - ``astropy.wcs``


### PR DESCRIPTION
The ``replaced_parameter`` decorator allows for the old use of a
function or method where a parameter has been deprecated and replaced
by one with a different name. The new parameter should otherwise
function the same.