### PR TITLE
Fixes to sgr coordinates example

### DIFF
--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -134,18 +134,18 @@ def galactic_to_sgr(gal_coord, sgr_frame):
     l = np.atleast_1d(gal_coord.l.radian)
     b = np.atleast_1d(gal_coord.b.radian)
 
-    X = np.cos(b)*np.cos(l)
-    Y = np.cos(b)*np.sin(l)
-    Z = np.sin(b)
+    x = np.cos(b)*np.cos(l)
+    y = np.cos(b)*np.sin(l)
+    z = np.sin(b)
 
-    # Calculate X,Y,Z,distance in the Sgr system
-    Xs, Ys, Zs = SGR_MATRIX.dot(np.array([X, Y, Z]))
-    Zs = -Zs
+    # Calculate x,y,z,distance in the Sgr system
+    xs, ys, zs = SGR_MATRIX.dot(np.array([x, y, z]))
+    zs = -zs
 
     # Calculate the angular coordinates lambda,beta
-    Lambda = np.arctan2(Ys,Xs)*u.radian
+    Lambda = np.arctan2(ys,xs)*u.radian
     Lambda[Lambda < 0] = Lambda[Lambda < 0] + 2.*np.pi*u.radian
-    Beta = np.arcsin(Zs/np.sqrt(Xs*Xs+Ys*Ys+Zs*Zs))*u.radian
+    Beta = np.arcsin(zs/np.sqrt(xs*xs+ys*ys+zs*zs))*u.radian
 
     return Sagittarius(Lambda=Lambda, Beta=Beta,
                        distance=gal_coord.distance)
@@ -170,15 +170,15 @@ def sgr_to_galactic(sgr_coord, gal_frame):
     L = np.atleast_1d(sgr_coord.Lambda.radian)
     B = np.atleast_1d(sgr_coord.Beta.radian)
 
-    Xs = np.cos(B)*np.cos(L)
-    Ys = np.cos(B)*np.sin(L)
-    Zs = np.sin(B)
-    Zs = -Zs
+    xs = np.cos(B)*np.cos(L)
+    ys = np.cos(B)*np.sin(L)
+    zs = np.sin(B)
+    zs = -zs
 
-    X, Y, Z = SGR_MATRIX.T.dot(np.array([Xs, Ys, Zs]))
+    x, y, z = SGR_MATRIX.T.dot(np.array([xs, ys, zs]))
 
-    l = np.arctan2(Y,X)*u.radian
-    b = np.arcsin(Z/np.sqrt(X*X+Y*Y+Z*Z))*u.radian
+    l = np.arctan2(y, x)*u.radian
+    b = np.arcsin(z/np.sqrt(x*x + y*y + z*z))*u.radian
 
     l[l<=0] += 2*np.pi*u.radian
 

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -205,13 +205,15 @@ icrs = sgr.transform_to(coord.ICRS)
 ##############################################################################
 # Plot the points in both coordinate systems:
 
-fig,axes = plt.subplots(2, 1, figsize=(6,12),
-                        subplot_kw={'projection': 'aitoff'})
+fig, axes = plt.subplots(2, 1, figsize=(8, 10),
+                         subplot_kw={'projection': 'aitoff'})
 
 axes[0].set_title("Sagittarius")
-axes[0].scatter(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian)
+axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian,
+             linestyle='none', marker='.')
 
 axes[1].set_title("ICRS")
-axes[1].scatter(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian)
+axes[1].plot(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian,
+             linestyle='none', marker='.')
 
 plt.show()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -209,9 +209,9 @@ fig,axes = plt.subplots(2, 1, figsize=(6,12),
                         subplot_kw={'projection': 'aitoff'})
 
 axes[0].set_title("Sagittarius")
-axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian, linestyle='none')
+axes[0].scatter(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian)
 
 axes[1].set_title("ICRS")
-axes[1].plot(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian, linestyle='none')
+axes[1].scatter(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian)
 
 plt.show()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -55,7 +55,7 @@ plt.style.use(astropy_mpl_style)
 # Import the packages necessary for coordinates
 
 from astropy.coordinates import frame_transform_graph
-from astropy.coordinates.matrix_utilities import rotation_matrix
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 import astropy.coordinates as coord
 import astropy.units as u
 
@@ -118,7 +118,7 @@ SGR_PSI = np.radians(180+14.111534)
 D = rotation_matrix(SGR_PHI, "z", unit=u.radian)
 C = rotation_matrix(SGR_THETA, "x", unit=u.radian)
 B = rotation_matrix(SGR_PSI, "z", unit=u.radian)
-SGR_MATRIX = np.array(B.dot(C).dot(D))
+SGR_MATRIX = matrix_product(B, C, D)
 
 ##############################################################################
 # This is done at the module level, since it will be used by both the

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -139,7 +139,7 @@ def galactic_to_sgr(gal_coord, sgr_frame):
     z = np.sin(b)
 
     # Calculate x,y,z,distance in the Sgr system
-    xs, ys, zs = SGR_MATRIX.dot(np.array([x, y, z]))
+    xs, ys, zs = matrix_product(SGR_MATRIX, np.array([x, y, z]))
     zs = -zs
 
     # Calculate the angular coordinates lambda,beta
@@ -175,7 +175,7 @@ def sgr_to_galactic(sgr_coord, gal_frame):
     zs = np.sin(B)
     zs = -zs
 
-    x, y, z = SGR_MATRIX.T.dot(np.array([xs, ys, zs]))
+    x, y, z = matrix_product(SGR_MATRIX.T, np.array([xs, ys, zs]))
 
     l = np.arctan2(y, x)*u.radian
     b = np.arcsin(z/np.sqrt(x*x + y*y + z*z))*u.radian


### PR DESCRIPTION
This updates the Sgr coordinates example both for changes in #5104 and to actually show the plot that I think is intended.  To see the key difference, the current doc example looks like this:
![image](https://cloud.githubusercontent.com/assets/346587/17262325/19deaf42-561e-11e6-8c27-750a6e96c7fc.png)

vs after this PR it looks like:
![image](https://cloud.githubusercontent.com/assets/346587/17262318/0abf4864-561e-11e6-8451-0fdb6aecb70c.png)

I'm pretty sure the first one is just an oversight, but perhaps @adrn can clarify what was meant by that (the problem was a `linestyle='none'` in `plt.plot`)?

Also, @mhvk, does this look right re: use of #5104 new features?
