### PR TITLE
io.registry: added fts and fts.gz to auto-identify for astropy.io.fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,9 @@ API Changes
 
 - ``astropy.io.registry``
 
+  - ``.fts`` and ``.fts.gz`` files will be automatically identified as
+    ``io.fits`` files if no explicit ``format`` is given.
+
 - ``astropy.io.votable``
 
 - ``astropy.modeling``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,7 +86,7 @@ API Changes
 - ``astropy.io.registry``
 
   - ``.fts`` and ``.fts.gz`` files will be automatically identified as
-    ``io.fits`` files if no explicit ``format`` is given.
+    ``io.fits`` files if no explicit ``format`` is given. [#5211]
 
 - ``astropy.io.votable``
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -70,7 +70,8 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
         fileobj.seek(pos)
         return sig == FITS_SIGNATURE
     elif filepath is not None:
-        if filepath.lower().endswith(('.fits', '.fits.gz', '.fit', '.fit.gz')):
+        if filepath.lower().endswith(('.fits', '.fits.gz', '.fit', '.fit.gz',
+                                      '.fts', '.fts.gz')):
             return True
     elif isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU)):
         return True

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -37,7 +37,7 @@ class TestSingleTable(object):
                              dtype=[(str('a'), int), (str('b'), str('U1')), (str('c'), float)])
 
     def test_simple(self, tmpdir):
-        filename = str(tmpdir.join('test_simple.fits'))
+        filename = str(tmpdir.join('test_simple.fts'))
         t1 = Table(self.data)
         t1.write(filename, overwrite=True)
         t2 = Table.read(filename)
@@ -45,7 +45,7 @@ class TestSingleTable(object):
 
     @pytest.mark.skipif('not HAS_PATHLIB')
     def test_simple_pathlib(self, tmpdir):
-        filename = pathlib.Path(str(tmpdir.join('test_simple.fits')))
+        filename = pathlib.Path(str(tmpdir.join('test_simple.fit')))
         t1 = Table(self.data)
         t1.write(filename, overwrite=True)
         t2 = Table.read(filename)


### PR DESCRIPTION
Currently only ``.fits`` and ``.fit`` are auto-identified ``io.fits`` file extensions. This PR adds - based on https://github.com/astropy/ccdproc/issues/355 - the ``.fts`` file extension.

I've changed some existing tests where auto-identification was used to test that it worked.