### PR TITLE
allow Mapping-like data in Table.__init__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,9 @@ API Changes
 
 - ``astropy.table``
 
+  - Allow ``collections.Mapping``-like ``data`` attribute when initializing a
+    ``Table`` object (``dict``-like was already possible).
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,7 @@ API Changes
 - ``astropy.table``
 
   - Allow ``collections.Mapping``-like ``data`` attribute when initializing a
-    ``Table`` object (``dict``-like was already possible).
+    ``Table`` object (``dict``-like was already possible). [#5213]
 
 - ``astropy.time``
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -8,7 +8,7 @@ from .index import TableIndices, TableLoc, TableILoc
 
 import re
 import sys
-from collections import OrderedDict
+from collections import OrderedDict, Mapping
 
 from copy import deepcopy
 
@@ -317,7 +317,7 @@ class Table(object):
                     data = data[np.newaxis, :]
                 n_cols = data.shape[1]
 
-        elif isinstance(data, dict):
+        elif isinstance(data, Mapping):
             init_func = self._init_from_dict
             default_names = list(data)
             n_cols = len(default_names)

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -4,12 +4,22 @@
 
 from __future__ import print_function  # For print debugging with python 2 or 3
 
-from collections import OrderedDict
+from collections import OrderedDict, Mapping
+from ...extern import six
 
 import numpy as np
 
 from ...tests.helper import pytest
 from ...table import Column, TableColumns
+
+# Unfortunatly the python2 UserDict.UserDict is not a Mapping so it is not
+# possible to use "from six.moves import UserDict" but instead we have to use
+# IterableUserDict (which is a Mapping).
+# here.
+if six.PY2:
+    from UserDict import IterableUserDict as UserDict
+else:
+    from collections import UserDict
 
 
 class TestTableColumnsInit():
@@ -274,6 +284,17 @@ class TestInitFromDict(BaseInitFromDictLike):
         self.data = dict([('a', Column([1, 3], name='x')),
                           ('b', [2, 4]),
                           ('c', np.array([3, 5], dtype='i8'))])
+
+
+@pytest.mark.usefixtures('table_type')
+class TestInitFromMapping(BaseInitFromDictLike):
+
+    def _setup(self, table_type):
+        self.data = UserDict([('a', Column([1, 3], name='x')),
+                              ('b', [2, 4]),
+                              ('c', np.array([3, 5], dtype='i8'))])
+        assert isinstance(self.data, Mapping)
+        assert not isinstance(self.data, dict)
 
 
 @pytest.mark.usefixtures('table_type')

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -13,9 +13,8 @@ from ...tests.helper import pytest
 from ...table import Column, TableColumns
 
 # Unfortunatly the python2 UserDict.UserDict is not a Mapping so it is not
-# possible to use "from six.moves import UserDict" but instead we have to use
-# IterableUserDict (which is a Mapping).
-# here.
+# possible to use "from six.moves import UserDict". Instead we have to use
+# IterableUserDict (which is a Mapping) here.
 if six.PY2:
     from UserDict import IterableUserDict as UserDict
 else:


### PR DESCRIPTION
Closes #5212 

This PR allows any kind of `collections.Mapping` as `data` argument when creating a new `Table`.

However this doesn't change the behaviour if a list of mappings is given as `rows` argument (https://github.com/astropy/astropy/blob/master/astropy/table/table.py#L266).