### PR TITLE
Renamed function argument - deprecate decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,7 +205,7 @@ Bug Fixes
 
   - New decorator: ``deprecated_renamed_argument``. This can be used when
     renaming a function argument, but still want to allow for use of
-    the older parameter name.
+    the older parameter name. [#5214]
 
 - ``astropy.vo``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,10 @@ New Features
 
 - ``astropy.utils``
 
+  - Added a new decorator: ``deprecated_renamed_argument``. This can be used to
+    rename a function argument, while it still allows for the use of the older
+    argument name. [#5214]
+
 - ``astropy.visualization``
 
   - Added ``data`` and ``interval`` inputs to the ``ImageNormalize``
@@ -202,10 +206,6 @@ Bug Fixes
 - ``astropy.units``
 
 - ``astropy.utils``
-
-  - New decorator: ``deprecated_renamed_argument``. This can be used when
-    renaming a function argument, but still want to allow for use of
-    the older parameter name. [#5214]
 
 - ``astropy.vo``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,6 +203,10 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - New decorator: ``deprecated_renamed_argument``. This can be used when
+    renaming a function argument, but still want to allow for use of
+    the older parameter name.
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -7,9 +7,11 @@ from __future__ import print_function
 
 import functools
 import inspect
+import itertools
 import textwrap
 import types
 import warnings
+from distutils.version import LooseVersion
 
 from .codegen import make_function_with_signature
 from .exceptions import (AstropyDeprecationWarning, AstropyUserWarning,
@@ -18,9 +20,9 @@ from ..extern import six
 from ..extern.six.moves import zip
 
 
-__all__ = ['deprecated', 'deprecated_attribute', 'classproperty',
-           'lazyproperty', 'sharedmethod', 'wraps',
-           'format_doc', 'deprecated_renamed_argument']
+__all__ = ['classproperty', 'deprecated', 'deprecated_attribute',
+           'deprecated_renamed_argument', 'format_doc',
+           'lazyproperty', 'sharedmethod', 'wraps']
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,
@@ -285,16 +287,16 @@ def deprecated_renamed_argument(old_name, new_name, since,
 
     Parameters
     ----------
-    old_name : str
+    old_name : str or list/tuple thereof
         The old name of the argument.
 
-    new_name : str
+    new_name : str or list/tuple thereof
         The new name of the argument.
 
-    since : str or number
+    since : str or number or list/tuple thereof
         The release at which the old argument became deprecated.
 
-    arg_in_kwargs : bool, optional
+    arg_in_kwargs : bool or list/tuple thereof, optional
         If the argument is not a named argument (for example it
         was meant to be consumed by ``**kwargs``) set this to
         ``True``.  Otherwise the decorator will throw an Exception
@@ -302,11 +304,17 @@ def deprecated_renamed_argument(old_name, new_name, since,
         the decorated function.
         Default is ``False``.
 
-    relax : bool, optional
+    relax : bool or list/tuple thereof, optional
         If ``False`` a ``TypeError`` is raised if both ``new_name`` and
         ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
         and a Warning is issued.
         Default is ``False``.
+
+    .. warning::
+        If ``old_name`` is a list or tuple the ``new_name`` and ``since`` must
+        also be a list or tuple with the same number of entries. ``relax`` and
+        ``arg_in_kwarg`` can be a single bool (applied to all) or also a
+        list/tuple with the same number of entries like ``new_name``, etc.
 
     Raises
     ------
@@ -363,85 +371,149 @@ def deprecated_renamed_argument(old_name, new_name, since,
 
         >>> test(sig=2)
         2
+
+    It is also possible to replace multiple arguments. The ``old_name``,
+    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
+    same number of entries::
+
+        >>> @deprecated_renamed_argument(['a', 'b'], ['alpha', 'beta'],
+        ...                              ['1.0', 1.2])
+        ... def test(alpha, beta):
+        ...     return alpha, beta
+
+        >>> test(a=2, b=3)
+        (2, 3)
+
+    In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
+    is applied to all renamed arguments) or must also be a `tuple` or `list`
+    with values for each of the arguments.
+
+    .. warning::
+        This decorator needs to access the original signature of the decorated
+        function. Therefore this decorator must be the **first** decorator on
+        any function if it needs to work for Python before version 3.4.
     """
+    cls_iter = (list, tuple)
+    if isinstance(old_name, cls_iter):
+        n = len(old_name)
+        # Assume that new_name and since are correct (tuple/list with the
+        # appropriate length) in the spirit of the "consenting adults". But the
+        # optional parameters may not be set, so if these are not iterables
+        # wrap them.
+        if not isinstance(arg_in_kwargs, cls_iter):
+            arg_in_kwargs = [arg_in_kwargs] * n
+        if not isinstance(relax, cls_iter):
+            relax = [relax] * n
+    else:
+        # To allow a uniform approach later on, wrap all arguments in lists.
+        n = 1
+        old_name = [old_name]
+        new_name = [new_name]
+        since = [since]
+        arg_in_kwargs = [arg_in_kwargs]
+        relax = [relax]
+
     def decorator(function):
         # Lazy import to avoid cyclic imports
         from .compat.funcsigs import signature
 
-        # Named arguments of the function
+        # The named arguments of the function.
         arguments = signature(function).parameters
+        keys = list(arguments.keys())
+        position = [None] * n
 
-        # Determine the position of the argument.
-        if new_name in arguments:
-            param = arguments[new_name]
-            # There are several possibilities now:
+        for i in range(n):
+            # Determine the position of the argument.
+            if new_name[i] in arguments:
+                param = arguments[new_name[i]]
+                # There are several possibilities now:
 
-            # 1.) Positional or keyword argument
-            if param.kind == param.POSITIONAL_OR_KEYWORD:
-                position = list(arguments.keys()).index(new_name)
+                # 1.) Positional or keyword argument:
+                if param.kind == param.POSITIONAL_OR_KEYWORD:
+                    position[i] = keys.index(new_name[i])
 
-            # 2.) Keyword only argument (Python 3 only)
-            elif param.kind == param.KEYWORD_ONLY:
-                # These cannot be specified by position
-                position = None
+                # 2.) Keyword only argument (Python 3 only):
+                elif param.kind == param.KEYWORD_ONLY:
+                    # These cannot be specified by position.
+                    position[i] = None
 
-            # 3.) positional-only argument, varargs, varkwargs or some unknown
-            #     type
+                # 3.) positional-only argument, varargs, varkwargs or some
+                #     unknown type:
+                else:
+                    raise TypeError('cannot replace argument "{0}" of kind {1}'
+                                    '.'.format(new_name[i], repr(param.kind)))
+
+            # In case the argument is not found in the list of arguments
+            # the only remaining possibility is that it should be catched
+            # by some kind of **kwargs argument.
+            # This case has to be explicitly specified, otherwise throw
+            # an exception!
+            elif arg_in_kwargs[i]:
+                position[i] = None
             else:
-                raise TypeError('cannot replace argument "{0}" of kind {1}.'
-                                ''.format(new_name, repr(param.kind)))
-
-        # In case the argument is not found in the list of arguments
-        # the only remaining possibility is that it should be catched
-        # by some kind of **kwargs argument.
-        # This case has to be explicitly specified, otherwise throw
-        # an exception!
-        elif arg_in_kwargs:
-            position = None
-        else:
-            raise TypeError('"{0}" was not specified in the function '
-                            'signature. If it was meant to be part of '
-                            '"**kwargs" then set "arg_in_kwargs" to "True".'
-                            ''.format(new_name))
+                raise TypeError('"{}" was not specified in the function '
+                                'signature. If it was meant to be part of '
+                                '"**kwargs" then set "arg_in_kwargs" to "True"'
+                                '.'.format(new_name[i]))
 
         if function.__doc__:
-            function.__doc__ += ("\n.. versionchanged:: {0}"
-                                 "\n   ``{1}`` replaces the deprecated "
-                                 "``{2}`` argument.\n"
-                                 "".format(since, new_name, old_name))
+            # Remove indentation of the original documentation so it will be
+            # correctly rendered.
+            doc = [textwrap.dedent(function.__doc__).strip('\n')]
+
+            # Append the deprecation messages ordered by their "since".
+            def item2(x):
+                return LooseVersion(str(x[2]))
+
+            # Add the "versionchanged" directive to the docstring of the
+            # function, but in _sorted_ order and _grouped_ by version.
+            # Note that groupby only groups successive identical elements so
+            # the sorting is required.
+            sorted_zipped = sorted(zip(old_name, new_name, since), key=item2)
+            for k, vals in itertools.groupby(sorted_zipped, key=item2):
+                doc.append("\n.. versionchanged:: {}".format(k))
+                for old, new, _ in vals:
+                    doc.append("   ``{}`` replaces the deprecated "
+                               "``{}`` argument.".format(new, old))
+
+            function.__doc__ = '\n'.join(doc)
 
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            # The only way to have oldkeyword inside the function is
-            # that it is passed as kwarg because the oldkeyword
-            # parameter was renamed to newkeyword
-            if old_name in kwargs:
-                value = kwargs.pop(old_name)
-                warnings.warn('"{0}" was deprecated in version {1} '
-                              'and will be removed in a future version. '
-                              'Use argument "{2}" instead.'
-                              ''.format(old_name, since, new_name),
-                              AstropyDeprecationWarning)
+            for i in range(n):
+                # The only way to have oldkeyword inside the function is
+                # that it is passed as kwarg because the oldkeyword
+                # parameter was renamed to newkeyword.
+                if old_name[i] in kwargs:
+                    value = kwargs.pop(old_name[i])
+                    warnings.warn('"{0}" was deprecated in version {1} '
+                                  'and will be removed in a future version. '
+                                  'Use argument "{2}" instead.'
+                                  ''.format(old_name[i], since[i],
+                                            new_name[i]),
+                                  AstropyDeprecationWarning)
 
-                # Check if the newkeyword was given as well
-                newarg_in_args = position is not None and len(args) > position
-                newarg_in_kwargs = new_name in kwargs
+                    # Check if the newkeyword was given as well.
+                    newarg_in_args = (position[i] is not None and
+                                      len(args) > position[i])
+                    newarg_in_kwargs = new_name[i] in kwargs
 
-                if newarg_in_args or newarg_in_kwargs:
-                    # If both are given print a Warning if relax is True or
-                    # raise an Exception is relax is False.
-                    if relax:
-                        warnings.warn('"{0}" and "{1}" keywords were set. '
-                                      'Using the value of "{1}".'
-                                      ''.format(old_name, new_name),
-                                      AstropyUserWarning)
+                    if newarg_in_args or newarg_in_kwargs:
+                        # If both are given print a Warning if relax is True or
+                        # raise an Exception is relax is False.
+                        if relax[i]:
+                            warnings.warn('"{0}" and "{1}" keywords were set. '
+                                          'Using the value of "{1}".'
+                                          ''.format(old_name[i], new_name[i]),
+                                          AstropyUserWarning)
+                        else:
+                            raise TypeError('cannot specify both "{}" and "{}"'
+                                            '.'.format(old_name[i],
+                                                       new_name[i]))
                     else:
-                        raise TypeError('cannot specify both "{}" and "{}".'
-                                        ''.format(old_name, new_name))
-                else:
-                    # If the new argument isn't specified use pass the old one
-                    # with the name of the new argument to the function.
-                    kwargs[new_name] = value
+                        # If the new argument isn't specified just pass the old
+                        # one with the name of the new argument to the function
+                        kwargs[new_name[i]] = value
             return function(*args, **kwargs)
 
         return wrapper

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -404,6 +404,12 @@ def deprecated_renamed_argument(old_name, new_name, since,
                             '"**kwargs" then set "arg_in_kwargs" to "True".'
                             ''.format(new_name))
 
+        if function.__doc__:
+            function.__doc__ += ("\n.. versionchanged:: {0}"
+                                 "\n   ``{1}`` replaces the deprecated "
+                                 "``{2}`` argument.\n"
+                                 "".format(since, new_name, old_name))
+
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             # The only way to have oldkeyword inside the function is

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -268,8 +268,7 @@ def test_deprecated_argument():
         def test3(self, overwrite):
             return overwrite
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3',
-                                 relax=False)
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', relax=False)
     def test1(overwrite):
         return overwrite
 
@@ -324,8 +323,7 @@ def test_deprecated_argument_in_kwargs():
 
 
 def test_deprecated_argument_relaxed():
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3',
-                                 relax=True)
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', relax=True)
     def test(overwrite):
         return overwrite
 
@@ -350,6 +348,20 @@ def test_deprecated_argument_relaxed():
     with catch_warnings(AstropyUserWarning) as w:
         assert test(1, clobber=2) == 1
     assert len(w) == 1
+
+
+def test_deprecated_argument_docstring():
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def test1(overwrite):
+        """Some docstring."""
+        return overwrite
+
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    def test2(overwrite):
+        return overwrite
+
+    assert '.. versionchanged:: 1.3' in test1.__doc__
+    assert not test2.__doc__
 
 
 def test_deprecated_argument_not_allowed_use():


### PR DESCRIPTION
This is a follow up on #5208 which was conceived in #5171.

I hope I did not mess up the commit history when trying to add @evertrol as author. (thanks @bsipocz and @pllim)