### PR TITLE
Specify required Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,5 +104,6 @@ setup(name=NAME,
       zip_safe=False,
       use_2to3=False,
       entry_points=entry_points,
+      python_requires='>=2.7',
       **package_info
 )


### PR DESCRIPTION
[PEP 345](https://www.python.org/dev/peps/pep-0345/) outlines version 1.2 of python package metadata, and this now supports the ability to specify requirements for the Python version. Recent versions of setuptools now support this. At the moment, this is not taken into account by pip because it isn't exposed by PyPI, but it will be soon (see https://github.com/pypa/pip/pull/3877). This will be very important once we drop support for Python 2 because we need to make sure that users don't install versions of Astropy that are only compatible with Python 3 when using Python 2.

In principle, this is already a problem because Python 2.6 users using pip will get Astropy 1.2 which is only compatible with Python 2.7+, but luckily the Python 2.6 user base is small.

@Carreau - is this the right way to set the metadata?