### PR TITLE
Cannot do a deepcopy of an astropy.time.Time if delta_ut1_utc has been calculated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1566,6 +1566,9 @@ Bug Fixes
 
 - ``astropy.time``
 
+  - Ensure ``Time`` instances holding a single ``delta_ut1_utc`` can be copied,
+    flattened, etc. [#5225]
+
 - ``astropy.units``
 
   - Fixed bug in Ci definition. [#5106]

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -731,7 +731,7 @@ class Time(ShapedLikeNDArray):
         tm : Time object
             Copy of this object
         """
-        return self._apply(format=format, method='copy')
+        return self._apply('copy', format=format)
 
     def replicate(self, format=None, copy=False):
         """
@@ -762,18 +762,20 @@ class Time(ShapedLikeNDArray):
         tm : Time object
             Replica of this object
         """
-        return self._apply(format=format, method='copy' if copy else None)
+        return self._apply('copy' if copy else 'replicate', format=format)
 
-    def _apply(self, method=None, *args, **kwargs):
+    def _apply(self, method, *args, **kwargs):
         """Create a new time object, possibly applying a method to the arrays.
 
         Parameters
         ----------
-        method : str, optional
-            If given, the method is applied to the internal ``jd1`` and ``jd2``
-            arrays, as well as to possible ``location``, ``_delta_ut1_utc``,
-            and ``_delta_tdb_tt`` arrays, broadcasting the latter as required.
-            Example methods: ``copy``, ``__getitem__``, ``reshape``.
+        method : str
+            Can be 'replicate'  or the name of a relevant `~numpy.ndarray`
+            method. In the former case, a new time instance with unchanged
+            internal data is created, while in the latter the method is applied
+            to the internal ``jd1`` and ``jd2`` arrays, as well as to possible
+            ``location``, ``_delta_ut1_utc``, and ``_delta_tdb_tt`` arrays.
+            Example methods: 'copy', '__getitem__', 'reshape'.
         args : tuple
             Any positional arguments for ``method``.
         kwargs : dict
@@ -786,7 +788,7 @@ class Time(ShapedLikeNDArray):
             new_format = self.format
 
         jd1, jd2 = self._time.jd1, self._time.jd2
-        if method is not None:
+        if method != 'replicate':
             jd1 = getattr(jd1, method)(*args, **kwargs)
             jd2 = getattr(jd2, method)(*args, **kwargs)
 
@@ -803,15 +805,15 @@ class Time(ShapedLikeNDArray):
             # Apply the method to any value arrays (though skip if there is only
             # a single element and the method would return a view, since in
             # that case nothing would change).
-            if method is not None and val is not None and hasattr(val, method):
+            val_method = getattr(val, method, None)
+            if val_method:
                 if val.size > 1 or method == 'copy':
-                    val = getattr(val, method)(*args, **kwargs)
+                    val = val_method(*args, **kwargs)
                 elif method == 'flatten':
                     # flatten should copy also for a single element array, but
                     # we cannot use it directly for array scalars, since it
                     # always returns a one-dimensional array. So, just copy.
                     val = val.copy()
-
 
             setattr(tm, attr, val)
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -803,12 +803,15 @@ class Time(ShapedLikeNDArray):
             # Apply the method to any value arrays (though skip if there is only
             # a single element and the method would return a view, since in
             # that case nothing would change).
-            if method is not None and val is not None:
-                if method == 'copy' or method == 'flatten' and val.size == 1:
+            if method is not None and val is not None and hasattr(val, method):
+                if val.size > 1 or method == 'copy':
+                    val = getattr(val, method)(*args, **kwargs)
+                elif method == 'flatten':
+                    # flatten should copy also for a single element array, but
+                    # we cannot use it directly for array scalars, since it
+                    # always returns a one-dimensional array. So, just copy.
                     val = val.copy()
 
-                elif val.size > 1:
-                    val = getattr(val, method)(*args, **kwargs)
 
             setattr(tm, attr, val)
 

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -2,6 +2,7 @@
 
 # TEST_UNICODE_LITERALS
 import itertools
+import copy
 import numpy as np
 
 from .. import Time
@@ -359,3 +360,17 @@ class TestArithmetic():
         # Bit superfluous, but good to check.
         assert np.all(self.t0.sort(-1)[:, :, 0] == self.t0.min(-1))
         assert np.all(self.t0.sort(-1)[:, :, -1] == self.t0.max(-1))
+
+
+def test_regression():
+    # For #5225, where a time with a single-element delta_ut1_utc could not
+    # be copied, flattened, or ravelled. (For copy, it is in test_basic.)
+    t = Time(49580.0, scale='tai', format='mjd')
+    t_ut1 = t.ut1
+    t_ut1_copy = copy.deepcopy(t_ut1)
+    assert type(t_ut1_copy.delta_ut1_utc) is float
+    t_ut1_flatten = t_ut1.flatten()
+    assert type(t_ut1_flatten.delta_ut1_utc) is float
+    t_ut1_ravel = t_ut1.ravel()
+    assert type(t_ut1_ravel.delta_ut1_utc) is float
+    assert t_ut1_copy.delta_ut1_utc == t_ut1.delta_ut1_utc

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -873,6 +873,13 @@ class ShapedLikeNDArray(object):
 
     """
 
+    # Note to developers: if new methods are added here, be sure to check that
+    # they work properly with the classes that use this, such as Time and
+    # BaseRepresentation, i.e., look at their ``_apply`` methods and add
+    # relevant tests.  This is particularly important for methods that imply
+    # copies rather than views of data (see the special-case treatment of
+    # 'flatten' in Time).
+
     @abc.abstractproperty
     def shape(self):
         """The shape of the instance and underlying arrays."""


### PR DESCRIPTION
The following raises an exception that boils down to ```'float' object has no attribute 'copy'```

```
from astropy.time import Time
tt = Time(49580.0, scale='tai', format='mjd')
dd = tt.detla_ut1_utc

import copy
tt2 = copy.deepcopy(tt)
```

It is possible to do a ```deepcopy``` of ```tt``` if you do not call ```delt_ut1_utc```.