### PR TITLE
Enable calculation of barycentric velocities in get_body_barycentric

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New Features
   - Added an ``of_address`` classmethod to ``EarthLocation`` to enable fast creation of
     ``EarthLocation`` objects given an address by querying the Google maps API [#5154].
 
+  - In addition to positions, ``get_body_barycentric`` now also allows one to
+    calculate velocities for solar system bodies. [#5231]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,10 @@ New Features
   - Added an ``of_address`` classmethod to ``EarthLocation`` to enable fast creation of
     ``EarthLocation`` objects given an address by querying the Google maps API [#5154].
 
-  - In addition to positions, ``get_body_barycentric`` now also allows one to
-    calculate velocities for solar system bodies. [#5231]
+  - A new routine, ``get_body_barycentric_posvel`` has been added that allows
+    one to calculate positions as well as velocities for solar system bodies.
+    For JPL kernels, this roughly doubles the execution time, so if one requires
+    only the positions, one should use ``get_body_barycentric``. [#5231]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -173,7 +173,8 @@ def _get_kernel(value):
     return SPK.open(download_file(value, cache=True))
 
 
-def get_body_barycentric(body, time, ephemeris=None, get_velocity=False):
+def _get_body_barycentric_posvel(body, time, ephemeris=None,
+                                 get_velocity=True):
     """Calculate the barycentric position (and velocity) of a solar system body.
 
     Parameters
@@ -189,9 +190,6 @@ def get_body_barycentric(body, time, ephemeris=None, get_velocity=False):
         ``astropy.coordinates.solar_system_ephemeris.set``
     get_velocity : bool, optional
         Whether or not to calculate the velocity as well as the position.
-        Note that no velocity can be calculated with the built-in ephemeris for
-        the Moon, and that the execution time for most JPL ephemeris files
-        roughly doubles if the velocities are calculated as well.
 
     Returns
     -------
@@ -200,6 +198,11 @@ def get_body_barycentric(body, time, ephemeris=None, get_velocity=False):
 
     Notes
     -----
+    No velocity can be calculated with the built-in ephemeris for the Moon.
+
+    Whether or not velocities are calculated makes little difference for the
+    built-in ephemerides, but for most JPL ephemeris files, the execution time
+    roughly doubles.
     """
 
     if ephemeris is None:
@@ -296,6 +299,75 @@ def get_body_barycentric(body, time, ephemeris=None, get_velocity=False):
         return body_pos_bary, body_vel_bary
     else:
         return body_pos_bary
+
+def get_body_barycentric_posvel(body, time, ephemeris=None):
+    """Calculate the barycentric position and velocity of a solar system body.
+
+    Parameters
+    ----------
+    body : str or other
+        The solar system body for which to calculate positions.  Can also be a
+        kernel specifier (list of 2-tuples) if the ``ephemeris`` is a JPL
+        kernel.
+    time : `~astropy.time.Time`
+        Time of observation.
+    ephemeris : str, optional
+        Ephemeris to use.  By default, use the one set with
+        ``astropy.coordinates.solar_system_ephemeris.set``
+
+    Returns
+    -------
+    position, velocity : tuple of `~astropy.coordinates.CartesianRepresentation`
+        Tuple of barycentric (ICRS) position and velocity.
+
+    See also
+    --------
+    get_body_barycentric : to calculate position only.
+        This is faster by about a factor two for JPL kernels, but has no
+        speed advantage for the built-in ephemeris.
+
+    Notes
+    -----
+    The velocity cannot be calculated for the Moon.  To just get the position,
+    use :func:`~astropy.coordinates.get_body_barycentric`.
+
+    """
+    return _get_body_barycentric_posvel(body, time, ephemeris)
+
+
+get_body_barycentric_posvel.__doc__ += indent(_EPHEMERIS_NOTE)[4:]
+
+
+def get_body_barycentric(body, time, ephemeris=None):
+    """Calculate the barycentric position of a solar system body.
+
+    Parameters
+    ----------
+    body : str or other
+        The solar system body for which to calculate positions.  Can also be a
+        kernel specifier (list of 2-tuples) if the ``ephemeris`` is a JPL
+        kernel.
+    time : `~astropy.time.Time`
+        Time of observation.
+    ephemeris : str, optional
+        Ephemeris to use.  By default, use the one set with
+        ``astropy.coordinates.solar_system_ephemeris.set``
+
+    Returns
+    -------
+    position : `~astropy.coordinates.CartesianRepresentation`
+        Barycentric (ICRS) position of the body in cartesian coordinates
+
+    See also
+    --------
+    get_body_barycentric_posvel : to calculate both position and velocity.
+
+    Notes
+    -----
+    """
+    return _get_body_barycentric_posvel(body, time, ephemeris,
+                                        get_velocity=False)
+
 
 get_body_barycentric.__doc__ += indent(_EPHEMERIS_NOTE)[4:]
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -270,7 +270,7 @@ def get_body_barycentric(body, time, ephemeris=None, get_velocity=False):
             spk = kernel[pair]
             if spk.data_type == 3:
                 # Type 3 kernels contain both position and velocity.
-                posvel = kernel.compute(jd1, jd2)
+                posvel = spk.compute(jd1, jd2)
                 if get_velocity:
                     body_posvel_bary += posvel.reshape(body_posvel_bary.shape)
                 else:

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -53,7 +53,6 @@ PLAN94_BODY_NAME_TO_PLANET_INDEX = OrderedDict(
     (('mercury', 1),
      ('venus', 2),
      ('earth-moon-barycenter', 3),
-     ('moon', 301),
      ('mars', 4),
      ('jupiter', 5),
      ('saturn', 6),
@@ -74,7 +73,7 @@ If needed, the ephemeris file will be downloaded (and cached).
 
 One can check which bodies are covered by a given ephemeris using::
     >>> solar_system_ephemeris.bodies
-    ('earth', 'sun', 'mercury', 'venus', 'earth-moon-barycenter', 'moon', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune')
+    ('earth', 'sun', 'moon', 'mercury', 'venus', 'earth-moon-barycenter', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune')
 """[1:-1]
 
 
@@ -137,7 +136,7 @@ class solar_system_ephemeris(ScienceState):
         if cls._value is None:
             return None
         if cls._value.lower() == 'builtin':
-            return (('earth', 'sun') +
+            return (('earth', 'sun', 'moon') +
                     tuple(PLAN94_BODY_NAME_TO_PLANET_INDEX.keys()))
         else:
             return tuple(BODY_NAME_TO_KERNEL_SPEC.keys())

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -237,10 +237,12 @@ def get_body_barycentric(body, time, ephemeris=None, get_velocity=False):
                 body_pv_helio = erfa.plan94(jd1, jd2, body_index)
                 body_pv_bary = body_pv_helio + sun_pv_bary
 
-        body_posvel_bary = np.rollaxis(body_pv_bary, -1, 0)
-        body_pos_bary = u.Quantity(body_posvel_bary[..., 0], u.au, copy=False)
+        # Move coordinate components to front, as needed for
+        # CartesianRepresentation.
+        body_pv_bary = np.rollaxis(body_pv_bary, -1, 0)
+        body_pos_bary = u.Quantity(body_pv_bary[..., 0], u.au, copy=False)
         if get_velocity:
-            body_vel_bary = u.Quantity(body_posvel_bary[..., 1], u.au/u.day,
+            body_vel_bary = u.Quantity(body_pv_bary[..., 1], u.au/u.day,
                                        copy=False)
 
     else:

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -286,4 +286,4 @@ def test_of_address():
     loc = EarthLocation.of_address("New York, NY", get_height=True)
     assert quantity_allclose(loc.latitude, 40.7128*u.degree)
     assert quantity_allclose(loc.longitude, -74.0059*u.degree)
-    assert quantity_allclose(loc.height, 10.438659669*u.meter)
+    assert quantity_allclose(loc.height, 10.438659669*u.meter, atol=1.*u.cm)

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -13,7 +13,8 @@ from ..solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
                             _apparent_position_in_true_coordinates,
                             get_body_barycentric)
 from ..funcs import get_sun
-from ...tests.helper import pytest, assert_quantity_allclose, remote_data
+from ...tests.helper import (pytest, remote_data, assert_quantity_allclose,
+                             quantity_allclose)
 
 try:
     import jplephem  # pylint: disable=W0611
@@ -317,15 +318,40 @@ def test_earth_barycentric_velocity_rough():
     assert_quantity_allclose(ev.xyz, expected, atol=1.*u.km/u.s)
 
 
+def test_earth_barycentric_velocity_multi_d():
+    # Might as well test it with a multidimensional array too.
+    t = Time('2016-03-20T12:30:00') + np.arange(8.).reshape(2,2,2) * u.yr / 2.
+    ep, ev = get_body_barycentric('earth', t, get_velocity=True)
+    # note: assert_quantity_allclose doesn't like the shape mismatch.
+    # this is a problem with np.testing.assert_allclose.
+    assert quantity_allclose(np.rollaxis(ep.xyz, 0, ep.xyz.ndim),
+                             [[-1., 0., 0.], [+1., 0., 0.]]*u.AU,
+                             atol=0.06*u.AU)
+    expected = u.Quantity([0.*u.one,
+                           np.cos(23.5*u.deg),
+                           np.sin(23.5*u.deg)]) * ([[-30.], [30.]] * u.km / u.s)
+    assert quantity_allclose(np.rollaxis(ev.xyz, 0, ev.xyz.ndim),
+                             expected, atol=2.*u.km/u.s)
+
+
 @remote_data
 @pytest.mark.skipif('not HAS_JPLEPHEM')
 @pytest.mark.parametrize(('body', 'pos_tol', 'vel_tol'),
-                         (('mercury', 600.*u.km, 1.*u.km/u.s),
+                         (('mercury', 1000.*u.km, 1.*u.km/u.s),
                           ('jupiter', 100000.*u.km, 2.*u.km/u.s),
                           ('earth', 10*u.km, 10*u.mm/u.s)))
 def test_barycentric_velocity_consistency(body, pos_tol, vel_tol):
-    # Tolerances are about 1.5 times the rms listed for plan94 and epv00.
+    # Tolerances are about 1.5 times the rms listed for plan94 and epv00,
+    # except for Mercury (which nominally is 334 km rms)
     t = Time('2016-03-20T12:30:00')
+    ep, ev = get_body_barycentric(body, t, ephemeris='builtin',
+                                  get_velocity=True)
+    dp, dv = get_body_barycentric(body, t, ephemeris='de432s',
+                                  get_velocity=True)
+    assert_quantity_allclose(ep.xyz, dp.xyz, atol=pos_tol)
+    assert_quantity_allclose(ev.xyz, dv.xyz, atol=vel_tol)
+    # Might as well test it with a multidimensional array too.
+    t = Time('2016-03-20T12:30:00') + np.arange(8.).reshape(2,2,2) * u.yr / 2.
     ep, ev = get_body_barycentric(body, t, ephemeris='builtin',
                                   get_velocity=True)
     dp, dv = get_body_barycentric(body, t, ephemeris='de432s',

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import numpy as np
+
 from ...time import Time
 from ... import units as u
 from ...constants import c
@@ -8,7 +10,8 @@ from ..builtin_frames import GCRS
 from ..earth import EarthLocation
 from ..sky_coordinate import SkyCoord
 from ..solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
-                            _apparent_position_in_true_coordinates)
+                            _apparent_position_in_true_coordinates,
+                            get_body_barycentric)
 from ..funcs import get_sun
 from ...tests.helper import pytest, assert_quantity_allclose, remote_data
 
@@ -301,3 +304,31 @@ def test_get_moon_nonscalar_regression():
     times = Time(["2015-08-28 03:30", "2015-09-05 10:30"])
     # the following line will raise an Exception if the bug recurs.
     get_moon(times, ephemeris='builtin')
+
+
+def test_earth_barycentric_velocity_rough():
+    # Check that a time near the equinox gives roughly the right result.
+    ep, ev = get_body_barycentric('earth', Time('2016-03-20T12:30:00'),
+                                  get_velocity=True)
+    assert_quantity_allclose(ep.xyz, [-1., 0., 0.]*u.AU, atol=0.01*u.AU)
+    expected = u.Quantity([0.*u.one,
+                           np.cos(23.5*u.deg),
+                           np.sin(23.5*u.deg)]) * -30. * u.km / u.s
+    assert_quantity_allclose(ev.xyz, expected, atol=1.*u.km/u.s)
+
+
+@remote_data
+@pytest.mark.skipif('not HAS_JPLEPHEM')
+@pytest.mark.parametrize(('body', 'pos_tol', 'vel_tol'),
+                         (('mercury', 600.*u.km, 1.*u.km/u.s),
+                          ('jupiter', 100000.*u.km, 2.*u.km/u.s),
+                          ('earth', 10*u.km, 10*u.mm/u.s)))
+def test_barycentric_velocity_consistency(body, pos_tol, vel_tol):
+    # Tolerances are about 1.5 times the rms listed for plan94 and epv00.
+    t = Time('2016-03-20T12:30:00')
+    ep, ev = get_body_barycentric(body, t, ephemeris='builtin',
+                                  get_velocity=True)
+    dp, dv = get_body_barycentric(body, t, ephemeris='de432s',
+                                  get_velocity=True)
+    assert_quantity_allclose(ep.xyz, dp.xyz, atol=pos_tol)
+    assert_quantity_allclose(ev.xyz, dv.xyz, atol=vel_tol)

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -74,8 +74,8 @@ to the various functions:
       (150107535.1073409, -866789.11996916, -418963.55218495)>
   >>> get_body_barycentric('moon', t, ephemeris='builtin')
   ... # doctest: +FLOAT_CMP
-  <CartesianRepresentation (x, y, z) in AU
-    (1.00340677, -0.00579439, -0.00280071)>
+  <CartesianRepresentation (x, y, z) in km
+      (150107516.42468676, -866828.92708201, -418980.15909655)>
 
 For a list of the bodies for which positions can be calculated, do:
 
@@ -102,10 +102,10 @@ For a list of the bodies for which positions can be calculated, do:
   >>> solar_system_ephemeris.bodies
   ('earth',
    'sun',
+   'moon',
    'mercury',
    'venus',
    'earth-moon-barycenter',
-   'moon',
    'mars',
    'jupiter',
    'saturn',


### PR DESCRIPTION
This is a first step towards being able to compute barycentric corrections (#3544). It allows one to calculate barycentric velocities of solar system bodies, including the Earth, either based on builtin ephemerides or JPL ones.

Probably need some discussion on how exactly to implement getting a barycentric correction (in particular, should it be a method of `SkyCoord` or perhaps of `Time`, like `light_travel_time`).