### PR TITLE
add ignore_nan option to median_absolute_deviation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -597,6 +597,10 @@ New Features
   - Added ``axis`` keyword to ``biweight_location`` and
     ``biweight_midvariance``. [#5127, #5158]
 
+  - ``median_absolute_deviation`` and ``mad_std`` have ``ignore_nan`` option
+    that will use ``np.ma.median`` with nans masked out or ``np.nanmedian``
+    instead of ``np.median`` when computing the median. [#5232]
+
 - ``astropy.table``
 
   - Allow renaming mixin columns. [#5469]


### PR DESCRIPTION
Simple PR: use `np.nanmedian` instead of `np.median` if `ignore_nan` is set.  I would favor it defaulting to `True`, but to avoid breaking backward compatibility I set it to `False`.  Feedback on that option would be helpful.
