### PR TITLE
Fix aastex lastline

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -51,7 +51,7 @@ def add_dictval_to_list(adict, key, alist):
 
 def find_latex_line(lines, latex):
     '''
-    Find the first line which matches a patters
+    Find the first line which matches a pattern
 
     Parameters
     ----------
@@ -75,7 +75,7 @@ def find_latex_line(lines, latex):
 
 
 class LatexSplitter(core.BaseSplitter):
-    '''Split LaTeX table date. Default delimiter is `&`.
+    '''Split LaTeX table data. Default delimiter is `&`.
     '''
     delimiter = '&'
 
@@ -386,7 +386,7 @@ class AASTexData(LatexData):
         lines.append(self.data_start)
         lines_length_initial = len(lines)
         core.BaseData.write(self, lines)
-        # To remove extra space(s) and // appended which creates an extra new line
+        # To remove extra space(s) and \\ appended which creates an extra new line
         # in the end.
         if len(lines) > lines_length_initial:
             # we compile separately because py2.6 doesn't have a flags keyword in re.sub

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -79,18 +79,7 @@ class LatexSplitter(core.BaseSplitter):
     '''
     delimiter = '&'
 
-    def process_line(self, line):
-        """Remove whitespace at the beginning or end of line. Also remove
-        \\ at end of line"""
-        line = line.split('%')[0]
-        line = line.strip()
-        if line[-2:] == r'\\':
-            line = line.strip(r'\\')
-        else:
-            raise core.InconsistentTableError(r'Lines in LaTeX table have to end with \\')
-        return line
-
-    def process_any_line(self, line, last_line=False):
+    def process_line(self, line, last_line=False):
         """Remove whitespace at the beginning or end of line. Also remove
         \\ at end of line"""
         line = line.split('%')[0]
@@ -100,16 +89,6 @@ class LatexSplitter(core.BaseSplitter):
         else:
             if not last_line:
                 raise core.InconsistentTableError(r'Lines in LaTeX table have to end with \\')
-        return line
-
-    def process_last_line(self, line):
-        """Remove whitespace at the beginning or end of line. Also remove
-        \\ at end of line"""
-        line = line.split('%')[0]
-        line = line.strip()
-        if line[-2:] == r'\\':
-            line = line.strip(r'\\')
-
         return line
 
     def process_val(self, val):
@@ -123,7 +102,7 @@ class LatexSplitter(core.BaseSplitter):
         '''Generator function that processes lines and last line specially.'''
         for x in lines[0:-1]:
             yield self.process_line(x)
-        yield self.process_last_line(lines[-1])
+        yield self.process_line(lines[-1], last_line=True)
 
     def __call__(self, lines):
         '''Treat the last line of a table specially because it's allowed to not end with \\.'''
@@ -361,7 +340,7 @@ class AASTexHeaderSplitter(LatexSplitter):
 
         \tablehead{\colhead{col1} & ... & \colhead{coln}}
     '''
-    def process_line(self, line):
+    def process_line(self, line, last_line=False):
         """extract column names from tablehead
         """
         line = line.split('%')[0]


### PR DESCRIPTION
Allow for last line to not have an ended `\\` by restructuring the LatexHeader line-by-line generator and write a special-case last_line option for processing the lines of a table.

The tests for this are part of the round-tripping testing of #5235.
