### PR TITLE
Read colnames of LaTeX files with units as written by Astropy

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -321,6 +321,16 @@ class AASTexHeaderSplitter(LatexSplitter):
     This splitter expects the following LaTeX code **in a single line**:
 
         \tablehead{\colhead{col1} & ... & \colhead{coln}}
+
+    If the \tablehead defines multiple output lines separated by \\
+        only the first line is read
+        e.g., A table with units written by the astropy.io.ascii.latex
+        can be read back in, but without the units.
+
+        \tablehead{\colhead{col1} & ... & \colhead{coln}\\ \colhead{days} & ... & \colhead{mag}}
+
+        A \tablehead that spans several lines in the input file
+        will fail to read.
     '''
     def process_line(self, line):
         """extract column names from tablehead
@@ -332,6 +342,12 @@ class AASTexHeaderSplitter(LatexSplitter):
             line = line[1:-1]
         else:
             raise core.InconsistentTableError(r'\tablehead is missing {}')
+
+        # If '\\'' to separate lines then split to just first and replace with '}'
+        multiple_lines = line.split(r'\\')
+        if len(multiple_lines) >= 2:
+            line = multiple_lines[0]
+
         return line.replace(r'\colhead', '')
 
     def join(self, vals):


### PR DESCRIPTION
This is a partial solution to reading of LaTeX tables written by astropy.io.ascii.aastex that had units included.  This solution only reads out the colnames, it does not read the units.

It does this by spliting off first r'\' delimited section of tablehead to be AASTex colnames

It can read cases where the `\tablehead` is all one line (as is that produced by units-enabled astropy.io.ascii.aastex), but fails on cases where the `\tablehead` command is split over several lines in the table file (which was also previously true for the Latex and AASTeX readers).
