### PR TITLE
better document SIP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -253,6 +253,11 @@ Bug Fixes
   - Fix use of the ``relax`` keyword in ``to_header`` when used to change the
     output precision. [#5164]
 
+  - ``wcs.to_header(relax=True)`` adds a "-SIP" suffix to ``CTYPE`` when SIP
+    distortion is present in the WCS object. [#5239]
+
+  - Improved log messages in ``to_header``. [#5239]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/wcs/__init__.py
+++ b/astropy/wcs/__init__.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-.. _wcslib: http://www.atnf.csiro.au/~mcalabre/WCS/
-.. _FITS WCS standard: http://fits.gsfc.nasa.gov/fits_wcs.html
+.. _wcslib: http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/index.html
 .. _distortion paper: http://www.atnf.csiro.au/people/mcalabre/WCS/dcs_20040422.pdf
 .. _SIP: http://irsa.ipac.caltech.edu/data/SPITZER/docs/files/spitzer/shupeADASS.pdf
+.. _FITS WCS standard: http://fits.gsfc.nasa.gov/fits_wcs.html
 
 `astropy.wcs` contains utilities for managing World Coordinate System
 (WCS) transformations in FITS files.  These transformations map the

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -984,8 +984,8 @@ def inconsistent_sip():
     ########## broken header ###########
     # Test that "-SIP" is added to CTYPE if relax=True and
     # "-SIP" was not in the original header
-    hdr['CTYPE1'] = 'RA---TAN'
     w = WCS(hdr)
+    w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
     newhdr = w.to_header(relax=True)
     assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
     del hdr['CTYPE2']

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -5,7 +5,7 @@
 World Coordinate System (`astropy.wcs`)
 ***************************************
 
-.. _FITS WCS standard: http://fits.gsfc.nasa.gov/fits_wcs.html
+.. _wcslib: http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/index.html
 .. _distortion paper: http://www.atnf.csiro.au/people/mcalabre/WCS/dcs_20040422.pdf
 .. _SIP: http://irsa.ipac.caltech.edu/data/SPITZER/docs/files/spitzer/shupeADASS.pdf
 
@@ -24,7 +24,7 @@ It performs three separate classes of WCS transformations:
   Calabretta's `wcslib`_.  (Also includes ``TPV`` and ``TPD``
   distortion, but not ``SIP``).
 
-- Simple Imaging Polynomial (`SIP`_) convention.
+- Simple Imaging Polynomial (`SIP`_) convention. (See :doc:`note about SIP in headers <note_sip>`.)
 
 - table lookup distortions as defined in the FITS WCS `distortion
   paper`_.
@@ -262,6 +262,7 @@ Other information
 
    relax
    history
+
 
 See Also
 ========

--- a/docs/wcs/note_sip.rst
+++ b/docs/wcs/note_sip.rst
@@ -1,0 +1,86 @@
+.. include:: references.rst
+.. doctest-skip-all
+.. _note_sip: :orphan:
+
+
+Note about SIP and WCS
+======================
+
+`astropy.wcs` supports the Simple Imaging Polynomial (`SIP`_) convention.
+The SIP distortion is defined in FITS headers by the presence of the
+SIP specific keywords **and** a ``-SIP`` suffix in ``CTYPE``, for example
+``RA---TAN-SIP``, ``DEC--TAN-SIP``.
+
+This has not been a strict convention in the past and the default in
+`astropy.wcs` is to always include the SIP distortion if the SIP coefficients
+are present, even if ``-SIP`` is not included in CTYPE.
+The presence of a ``-SIP`` suffix in CTYPE is not used as a trigger
+to initialize the SIP distortion.
+
+It is important that headers implement correctly the SIP convention.
+If the intention is to use the SIP distortion, a header should have
+the SIP coefficients and the ``-SIP`` suffix in CTYPE.
+
+`astropy.wcs` prints INFO messages when inconsistent headers are detected,
+for example when SIP coefficients are present but CTYPE is missing a ``-SIP`` suffix,
+see examples below.
+`astropy.wcs` will print a message about the inconsistent header
+but will create and use the SIP distortion and it will be used in
+calls to `~astropy.wcs.wcs.WCS.all_pix2world`. If this was not the intended use
+(e.g. it's a drizzled image and has no distortions) it is best to remove the SIP
+coefficients from the header. They can be removed temporarily from a WCS object by
+
+>>> wcsobj.sip = None
+
+In addition, if SIP is the only distortion in the header, the two methods,
+`~astropy.wcs.wcs.WCS.wcs_pix2world` and `~astropy.wcs.wcs.WCS.wcs_world2pix`,
+may be used to transform from pixels to world coordinate system while ommiting distortions.
+
+Another consequence of the inconsistent header is that if
+`~astropy.wcs.wcs.WCS.to_header()` is called with ``relax=True`` it will return a header
+with SIP coefficients and a ``-SIP`` suffix in CTYPE and will not reproduce the original header.
+
+**In conclusion, when astropy.wcs detects inconsistent headers, the recommendation
+is that the header is inspected and corrected to match the data.**
+
+Below is an example of a header with SIP coefficients when ``-SIP`` is missing from CTYPE.
+The data is drizzled, i.e. distortion free, so the intention is **not** to include the
+SIP distortion.
+
+>>> wcsobj = wcs.WCS(header)
+
+INFO::
+
+        Inconsistent SIP distortion information is present in the FITS header and the WCS object:
+        SIP coefficients were detected, but CTYPE is missing a "-SIP" suffix.
+        astropy.wcs is using the SIP distortion coefficients,
+        therefore the coordinates calculated here might be incorrect.
+
+        If you do not want to apply the SIP distortion coefficients,
+        please remove the SIP coefficients from the FITS header or the
+        WCS object.  As an example, if the image is already distortion-corrected
+        (e.g., drizzled) then distortion components should not apply and the SIP
+        coefficients should be removed.
+
+        While the SIP distortion coefficients are being applied here, if that was indeed the intent,
+        for consistency please append "-SIP" to the CTYPE in the FITS header or the WCS object.
+
+
+>>> hdr = wcsobj.to_header(relax=True)
+
+INFO::
+
+        Inconsistent SIP distortion information is present in the current WCS:
+        SIP coefficients were detected, but CTYPE is missing "-SIP" suffix,
+        therefore the current WCS is internally inconsistent.
+
+        Because relax has been set to True, the resulting output WCS will have
+        "-SIP" appended to CTYPE in order to make the header internally consistent.
+
+        However, this may produce incorrect astrometry in the output WCS, if
+        in fact the current WCS is already distortion-corrected.
+
+        Therefore, if current WCS is already distortion-corrected (eg, drizzled)
+        then SIP distortion components should not apply. In that case, for a WCS
+        that is already distortion-corrected, please remove the SIP coefficients
+        from the header.

--- a/docs/wcs/references.rst
+++ b/docs/wcs/references.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _wcslib: http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/index.html
 .. _distortion paper: http://www.atnf.csiro.au/people/mcalabre/WCS/dcs_20040422.pdf
 .. _SIP: http://irsa.ipac.caltech.edu/data/SPITZER/docs/files/spitzer/shupeADASS.pdf

--- a/docs/wcs/relax.rst
+++ b/docs/wcs/relax.rst
@@ -1,5 +1,3 @@
-.. include:: references.txt
-
 .. _relax:
 
 Relax constants


### PR DESCRIPTION
This PR attempts to better document the behavior of `astropy.wcs` in the presence of `SIP` distortion.
More specifically, if `astropy.wcs` detects inconsistent information in the headers (for example, SIP coefficients are present but the `CTYPE` keyword does not have a `-SIP` suffix) the `SIP` distortion object (similar to `wcslib`) is created and a log.INFO message is printed.

- The message printed in this case was clarified to give a better idea what one should do to use the WCS object without applying the distortion - important when the WCS object is passed to a function
and the user has no control over what WCS method is used to evaluate the transform.

Currently a second message is printed when `wcs.to_header(relax=False)` (the default value for `relax`) is called to inform the user that the `-SIP`suffix is stripped from `CTYPE` because `relax=False` returns a header without the SIP coefficients.

- This PR removes this log.info message as it turned out it is more confusing than clarifying. The code correctly removes all parts of the SIP distortion as was requested by `relax=False`.

A third message is printed when the WCS object was initialized with an inconsistent header as in case 1 and `wcs.to_header(relax=True)` is called. In this case since the SIP distortion object was created and it was requested to get  header with the SIP distortion, `astropy.wcs` adds a suffix `-SIP` to `CTYPE` and returns a complete set of SIP keywords (although the original header was inconsistent). This message is kept as it is, however a bug in the code was fixed to actually have this bahaviour.

This PR adds also a longer explanation of this behaviour to the WCS documentation.

Addresses concerns in #5145. The modified log message (case 1 above) explains how to create a WCS object without SIP (if this is the intended use).

