### PR TITLE
deprecate rotateCD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,8 @@ API Changes
 
 - ``astropy.wcs``
 
+  - ``wcs.rotateCD()`` was deprecated without a replacement. [#5240]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -65,6 +65,7 @@ if _wcs is not None:
 
 from ..utils.compat import possible_filename
 from ..utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
+from ..utils.decorators import deprecated
 
 if _wcs is not None:
     assert _wcs._sanity_check(), \
@@ -2673,6 +2674,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             self._naxis1 = header.get('NAXIS1', 0)
             self._naxis2 = header.get('NAXIS2', 0)
 
+    @deprecated('1.3')
     def rotateCD(self, theta):
         _theta = np.deg2rad(theta)
         _mrot = np.zeros(shape=(2, 2), dtype=np.double)


### PR DESCRIPTION
As discussed in #5175 the `rotateCD` method is confusing and there's a consensus to deprecate it.
There's no evidence that this method is used by anyone. Is `1.3` a good time to remove it?
Are the changes here sufficient for the deprecation?

#5189 will be closed without merging.