### PR TITLE
Insertion of EntryPoints into modeling.fitters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,10 @@ matrix:
         - os: osx
           env: SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem'
+               if [[ $PYTHON_VERSION == 2.7 ]]; 
+               then PIP_DEPENDENCIES='jplephem mock';
+               else PIP_DEPENDENCIES='jplephem';
+               fi
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -74,8 +77,12 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem'
+               if [[ $PYTHON_VERSION == 2.7 ]]; 
+               then PIP_DEPENDENCIES='jplephem mock';
+               else PIP_DEPENDENCIES='jplephem'; 
+               fi
                LC_CTYPE=C.ascii LC_ALL=C
+
         - os: linux
           env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ New Features
   - Added a ``Tabular`` model. [#5105]
 
   - Added ``Hermite1D`` and ``Hermite2D`` polynomial models [#5242]
+  - Added the injection of EntryPoints into astropy.modeling.fitting if 
+    they inherit from Fitters class. [#5241]
 
 - ``astropy.nddata``
 
@@ -79,6 +81,7 @@ New Features
 - ``astropy.vo``
 
 - ``astropy.wcs``
+
 
 API Changes
 ^^^^^^^^^^^

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -44,6 +44,10 @@ Astropy also depends on other packages for optional features:
 
 - `objgraph <https://mg.pov.lt/objgraph/>`_: Used only in tests to test for reference leaks.
 
+- `setuptools <https://pythonhosted.org/setuptools/>`_: Used for discovery of entry points which are used to insert fitters into modeling.fitting
+
+- `mock <https://github.com/testing-cabal/mock>`_ (python <= 3.2) or `unittest.mock <https://docs.python.org/dev/library/unittest.mock.html>`_ (python > 3.3): 
+  Used for testing the entry point discovery functionality in `astropy.modeling.fitting`
 
 However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -163,3 +163,35 @@ bounds internally.
     ['fixed', 'tied', 'bounds']
     >>> fitting.SLSQPLSQFitter.supported_constraints
     ['bounds', 'eqcons', 'ineqcons', 'fixed', 'tied']
+
+Plugin Fitters
+--------------
+
+
+Fitters defined outside of astropy's core can be inserted into the
+`astropy.modeling.fitting` namespace through the use of entry points. 
+Entry points are references to importable objects. A tutorial on 
+defining entry points can be found in `setuptools' documentation 
+<http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_.
+Plugin fitters are required to extend from the `~astropy.modeling.fitting.Fitter` 
+base class. For the fitter to be discovered and inserted into 
+`astropy.modeling.fitting` the entry points must be inserted into 
+the `astropy.modeling` entry point group
+
+.. doctest-skip::
+
+    setup(
+          # ...
+          entry_points = {'astropy.modeling': 'PluginFitterName = fitter_module:PlugFitterClass'}
+    )
+
+This would allow users to import the ``PlugFitterName`` through `astropy.modeling.fitting` by
+
+.. doctest-skip::
+
+    from astropy.modeling.fitting import PlugFitterName
+
+One project which uses this functionality is `Saba <https://saba.readthedocs.io/>`_, 
+which insert its `SherpaFitter <http://saba.readthedocs.io/en/stable/api.html#saba.SherpaFitter>`_
+class and thus allows astropy users to use `Sherpa's <http://cxc.cfa.harvard.edu/contrib/sherpa/>`_
+fitting routine.

--- a/docs/modeling/new.rst
+++ b/docs/modeling/new.rst
@@ -327,6 +327,34 @@ necessary::
                                              ineqcons=self.ineqcons)
         return model_copy
 
+Defining a Plugin Fitter
+------------------------
+
+`astropy.modeling` includes a plugin mechanism which allows fitters 
+defined outside of astropy's core to be inserted into the 
+`astropy.modeling.fitting` namespace through the use of entry points. 
+Entry points are references to importable objects. A tutorial on defining
+entry points can be found in `setuptools' documentation <http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_.
+Plugin fitters must to extend from the `~astropy.modeling.fitting.Fitter` 
+base class. For the fitter to be discovered and inserted into 
+`astropy.modeling.fitting` the entry points must be inserted into 
+the `astropy.modeling` entry point group
+
+.. doctest-skip::
+
+    setup(
+          # ...
+          entry_points = {'astropy.modeling': 'PluginFitterName = fitter_module:PlugFitterClass'}
+    )
+
+This would allow users to import the ``PlugFitterName`` through `astropy.modeling.fitting` by
+
+.. doctest-skip::
+
+    from astropy.modeling.fitting import PlugFitterName
+
+One project which uses this functionality is `Saba <https://saba.readthedocs.io/>`_ 
+and be can be used as a reference. 
 
 Using a Custom Statistic Function
 =================================


### PR DESCRIPTION
This allows insertion of external references into the astropy.modeling.fitting namespace. This is required by the google summer of code [Saba project](https://github.com/nocturnalastro/saba) which allows the astropy users access to sherpa's fitting routines.  It would also be the mechanism for supporting other external back-end fitters such as emcee.