### PR TITLE
Allow string in Quantity constructor?

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,9 @@ New Features
   - The ``spectral_density`` equivalency now supports transformations of
     luminosity density. [#5151]
 
+  - ``Quantity`` now accepts strings consisting of a number and unit such
+    as '10 km/s'. [#5245]
+
 - ``astropy.utils``
 
   - Added a new decorator: ``deprecated_renamed_argument``. This can be used to

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1055,19 +1055,44 @@ def test_quantity_pickelability():
     assert q1.unit == q2.unit
 
 
-def test_quantity_from_string():
-    with pytest.raises(TypeError):
-        q = u.Quantity(u.m * "5")
-        # the reverse should also fail once #1408 is in
+def test_quantity_initialisation_from_string():
+    q = u.Quantity('1')
+    assert q.unit == u.dimensionless_unscaled
+    assert q.value == 1.
+    q = u.Quantity('1.5 m/s')
+    assert q.unit == u.m/u.s
+    assert q.value == 1.5
+    assert u.Unit(q) == u.Unit('1.5 m/s')
+    q = u.Quantity('.5 m')
+    assert q == u.Quantity(0.5, u.m)
+    q = u.Quantity('-1e1km')
+    assert q == u.Quantity(-10, u.km)
+    q = u.Quantity('-1e+1km')
+    assert q == u.Quantity(-10, u.km)
+    q = u.Quantity('+.5km')
+    assert q == u.Quantity(.5, u.km)
+    q = u.Quantity('+5e-1km')
+    assert q == u.Quantity(.5, u.km)
+    q = u.Quantity('5', u.m)
+    assert q == u.Quantity(5., u.m)
+    q = u.Quantity('5 km', u.m)
+    assert q.value == 5000.
+    assert q.unit == u.m
+    q = u.Quantity('5Em')
+    assert q == u.Quantity(5., u.Em)
 
     with pytest.raises(TypeError):
-        q = u.Quantity('5', u.m)
-
+        u.Quantity('')
     with pytest.raises(TypeError):
-        q = u.Quantity(['5'], u.m)
-
+        u.Quantity('m')
     with pytest.raises(TypeError):
-        q = u.Quantity(np.array(['5']), u.m)
+        u.Quantity(['5'])
+    with pytest.raises(TypeError):
+        u.Quantity(np.array(['5']))
+    with pytest.raises(ValueError):
+        u.Quantity('5E')
+    with pytest.raises(ValueError):
+        u.Quantity('5 foo')
 
 
 def test_unsupported():

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1086,6 +1086,14 @@ def test_quantity_initialisation_from_string():
     with pytest.raises(TypeError):
         u.Quantity('m')
     with pytest.raises(TypeError):
+        u.Quantity('1.2.3 deg')
+    with pytest.raises(TypeError):
+        u.Quantity('1+deg')
+    with pytest.raises(TypeError):
+        u.Quantity('1-2deg')
+    with pytest.raises(TypeError):
+        u.Quantity('1.2e-13.3m')
+    with pytest.raises(TypeError):
         u.Quantity(['5'])
     with pytest.raises(TypeError):
         u.Quantity(np.array(['5']))

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -11,7 +11,7 @@ associated with the number.
 Creating Quantity instances
 ---------------------------
 
-|quantity| objects are created through multiplication or division with
+|quantity| objects are created through multiplication with
 :class:`~astropy.units.Unit` objects. For example, to create a |quantity|
 to represent 15 m/s:
 
@@ -19,10 +19,16 @@ to represent 15 m/s:
     >>> 15 * u.m / u.s
     <Quantity 15.0 m / s>
 
-As another example:
+This extends as expected to division by a unit, or using Numpy arrays or Python
+sequences:
 
     >>> 1.25 / u.s
     <Quantity 1.25 1 / s>
+    >>> [1, 2, 3] * u.m
+    <Quantity [ 1., 2., 3.] m>
+    >>> import numpy as np
+    >>> np.array([1, 2, 3]) * u.m
+    <Quantity [ 1., 2., 3.] m>
 
 You can also create instances using the |quantity| constructor directly, by
 specifying a value and unit:
@@ -30,22 +36,16 @@ specifying a value and unit:
     >>> u.Quantity(15, u.m / u.s)
     <Quantity 15.0 m / s>
 
-|quantity| objects can also be created automatically from Numpy arrays
-or Python sequences:
-
-    >>> [1, 2, 3] * u.m
-    <Quantity [ 1., 2., 3.] m>
-    >>> import numpy as np
-    >>> np.array([1, 2, 3]) * u.m
-    <Quantity [ 1., 2., 3.] m>
-
-|quantity| objects can also be created from sequences of |quantity|
-objects, as long as all of their units are equivalent, and will
-automatically convert to Numpy arrays:
+The constructor gives a few more options.  In particular, it allows one to
+merge sequences of |quantity| objects (as long as all of their units are
+equivalent), and to parse simple strings (which may help, e.g., to parse
+configuration files, etc.):    
 
     >>> qlst = [60 * u.s, 1 * u.min]
     >>> u.Quantity(qlst, u.minute)
     <Quantity [ 1.,  1.] min>
+    >>> u.Quantity('15 m/s')
+    <Quantity 15.0 m / s>
 
 Finally, the current unit and value can be accessed via the
 `~astropy.units.quantity.Quantity.unit` and


### PR DESCRIPTION
I'd like to propose allowing Quantity scalar construction from a string.

IMO it would be nice if this worked:

```
>>> from astropy.units import Quantity
>>> Quantity('10 deg')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/units/quantity.py", line 264, in __new__
    raise TypeError("The value must be a valid Python or "
TypeError: The value must be a valid Python or Numpy numeric type.
```

Note that e.g. this works for other cases where it's unambiguous, so it's not a crazy idea:

```
>>> from astropy.coordinates import Angle
>>> Angle('10 deg')
<Angle 10.0 deg>
>>> from astropy.time import Time
>>> Time('2015-01-01')
<Time object: scale='utc' format='iso' value=2015-01-01 00:00:00.000>
```

Of course, when one constructs the quantity directly, it isn't needed, this is better:

```
>>> Quantity(10, 'deg')
<Quantity 10.0 deg>
```

The main use case I see is being able to do this

``` python
def speed(length='1 m', time='1 s'):
    length = Quantity(length)
    time = Quantity(time)
    return length / time
```

and call it like this, without having to import or construct quantities first:

```
speed(length='42 m', time='99 s')
```

There's many cases (100+ in Gammapy) where one wants to have quantities as parameters to functions / methods with default values. I didn't look around in Astropy much, just the first example I found:
http://docs.astropy.org/en/latest/api/astropy.coordinates.EarthLocation.html#astropy.coordinates.EarthLocation.from_geodetic
`height='0 m'` and only allowing quantity or string that parses unambiguously as Quantity would be better than `height=0`, no?
