### PR TITLE
Replacing some lambda definitions with equivalent functions

### DIFF
--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -55,7 +55,7 @@ class SiteRegistry(Mapping):
         if site_name.lower() not in self._lowercase_names_to_locations:
             # If site name not found, find close matches and suggest them in error
             close_names = get_close_matches(site_name, self._lowercase_names_to_locations)
-            close_names = sorted(close_names, key=lambda x: len(x))
+            close_names = sorted(close_names, key=len)
 
             raise UnknownSiteException(site_name, "the 'names' attribute", close_names=close_names)
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -10,15 +10,18 @@ core.py:
 
 from __future__ import absolute_import, division, print_function
 
+import copy
+import csv
+import functools
+import itertools
+import operator
 import os
 import re
-import csv
-import itertools
-import functools
-import numpy
 import warnings
-import copy
+
 from collections import OrderedDict
+
+import numpy
 
 from ...extern import six
 from ...extern.six.moves import zip
@@ -1450,7 +1453,7 @@ def _get_writer(Writer, fast_writer, **kwargs):
             # Restore the default SplitterClass process_val method which strips
             # whitespace.  This may have been changed in the Writer
             # initialization (e.g. Rdb and Tab)
-            writer.data.splitter.process_val = lambda x: x.strip()
+            writer.data.splitter.process_val = operator.methodcaller('strip')
         else:
             writer.data.splitter.process_val = None
     if 'names' in kwargs:

--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -8,8 +8,9 @@ misc.py:
 
 from __future__ import absolute_import, division, print_function
 
-import itertools
 import collections
+import itertools
+import operator
 
 from ...extern.six.moves import zip, map, filter
 
@@ -17,7 +18,7 @@ from ...extern.six.moves import zip, map, filter
 def first_true_index(iterable, pred=None, default=None):
     """find the first index position for the which the callable pred returns True"""
     if pred is None:
-        func = lambda x: x[1]
+        func = operator.itemgetter(1)
     else:
         func = lambda x: pred(x[1])
     ii = next(filter(func, enumerate(iterable)), default)  # either index-item pair or default
@@ -27,7 +28,7 @@ def first_true_index(iterable, pred=None, default=None):
 def first_false_index(iterable, pred=None, default=None):
     """find the first index position for the which the callable pred returns False"""
     if pred is None:
-        func = lambda x: not x
+        func = operator.not_
     else:
         func = lambda x: not pred(x)
     return first_true_index(iterable, func, default)

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -55,6 +55,7 @@ explanation of all the different formats.
 """
 
 
+import operator
 import os
 import warnings
 
@@ -210,9 +211,9 @@ def getdata(filename, *args, **kwargs):
     # Change case of names if requested
     trans = None
     if lower:
-        trans = lambda s: s.lower()
+        trans = operator.methodcaller('lower')
     elif upper:
-        trans = lambda s: s.upper()
+        trans = operator.methodcaller('upper')
     if trans:
         if data.dtype.names is None:
             # this data does not have fields

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -12,8 +12,9 @@ import fnmatch
 import functools
 import glob
 import io
-import textwrap
+import operator
 import os.path
+import textwrap
 
 from collections import defaultdict
 from itertools import islice
@@ -23,7 +24,7 @@ import numpy as np
 from ... import __version__
 from ...extern import six
 from ...extern.six import u, string_types
-from ...extern.six.moves import zip, xrange, reduce
+from ...extern.six.moves import zip, xrange, reduce, map
 from ...utils import indent
 from ...utils.compat.funcsigs import signature
 from .card import Card, BLANK_CARD
@@ -575,11 +576,11 @@ class HeaderDiff(_BaseDiff):
 
         # Keywords common to each header but having different values (excluding
         # keywords in ignore_keywords)
-        self.diff_keyword_values = defaultdict(lambda: [])
+        self.diff_keyword_values = defaultdict(list)
 
         # Keywords common to each header but having different comments
         # (excluding keywords in ignore_keywords or in ignore_comments)
-        self.diff_keyword_comments = defaultdict(lambda: [])
+        self.diff_keyword_comments = defaultdict(list)
 
         if isinstance(a, string_types):
             a = Header.fromstring(a)
@@ -1039,7 +1040,7 @@ class TableDataDiff(_BaseDiff):
         colsa_set = set(colsa.values())
         colsb_set = set(colsb.values())
         self.common_columns = sorted(colsa_set.intersection(colsb_set),
-                                     key=lambda c: c.name)
+                                     key=operator.attrgetter('name'))
 
         self.common_column_names = set([col.name.lower()
                                         for col in self.common_columns])
@@ -1230,8 +1231,7 @@ def report_diff_values(fileobj, a, b, ind=0):
 
     if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
         diff_indices = np.where(a != b)
-        num_diffs = reduce(lambda x, y: x * y,
-                           (len(d) for d in diff_indices), 1)
+        num_diffs = reduce(operator.mul, map(len, diff_indices), 1)
         for idx in islice(zip(*diff_indices), 3):
             fileobj.write(indent(u('  at %r:\n') % list(idx), ind))
             report_diff_values(fileobj, a[idx], b[idx], ind=ind + 1)

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -2,14 +2,15 @@
 
 from __future__ import division, with_statement
 
+import bz2
+import gzip
 import mmap
+import operator
 import os
 import sys
 import tempfile
 import warnings
 import zipfile
-import bz2
-import gzip
 
 from functools import reduce
 
@@ -282,7 +283,7 @@ class _File(object):
             return np.ndarray(shape=shape, dtype=dtype, offset=offset,
                               buffer=self._mmap)
         else:
-            count = reduce(lambda x, y: x * y, shape)
+            count = reduce(operator.mul, shape)
             pos = self._file.tell()
             self._file.seek(offset)
             data = _array_from_file(self._file, dtype, count, '')

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1151,7 +1151,7 @@ class _ValidHDU(_BaseHDU, _Verify):
     def _verify(self, option='warn'):
         errs = _ErrList([], unit='Card')
 
-        is_valid = lambda v: v in [8, 16, 32, 64, -32, -64]
+        is_valid = BITPIX2DTYPE.__contains__
 
         # Verify location and value of mandatory keywords.
         # Do the first card here, instead of in the respective HDU classes, so

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -4,6 +4,7 @@ from __future__ import division  # confidence high
 
 import contextlib
 import csv
+import operator
 import os
 import re
 import sys
@@ -653,15 +654,16 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                                        num))
 
         # First delete
-        for idx, keyword, _, num in sorted(table_keywords,
-                                           key=lambda k: k[0], reverse=True):
+        rev_sorted_idx_0 = sorted(table_keywords, key=operator.itemgetter(0),
+                                  reverse=True)
+        for idx, keyword, _, num in rev_sorted_idx_0:
             if index is None or index == num:
                 del self._header[idx]
 
         # Now shift up remaining column keywords if only one column was cleared
         if index is not None:
-            for _, keyword, base_keyword, num in sorted(table_keywords,
-                                                        key=lambda k: k[3]):
+            sorted_idx_3 = sorted(table_keywords, key=operator.itemgetter(3))
+            for _, keyword, base_keyword, num in sorted_idx_3:
                 if num <= index:
                     continue
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -6,6 +6,7 @@ import gzip
 import itertools
 import io
 import mmap
+import operator
 import os
 import platform
 import signal
@@ -208,7 +209,7 @@ def itersubclasses(cls, _seen=None):
         subs = cls.__subclasses__()
     except TypeError:  # fails only when cls is type
         subs = cls.__subclasses__(cls)
-    for sub in sorted(subs, key=lambda s: s.__name__):
+    for sub in sorted(subs, key=operator.attrgetter('__name__')):
         if sub not in _seen:
             _seen.add(sub)
             yield sub

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 from __future__ import unicode_literals
 
+import operator
 import warnings
 
 from ...extern.six import next
@@ -96,7 +97,7 @@ class _Verify(object):
             # Don't print *unfixable* issues, but do print fixed issues; this
             # is probably not very useful but the option exists for
             # completeness
-            line_filter = lambda x: x[0]
+            line_filter = operator.itemgetter(0)
         else:
             line_filter = None
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -13,8 +13,10 @@ if six.PY2:
     import cmath
 
 import inspect
+import operator
 import textwrap
 import warnings
+
 import numpy as np
 
 from ..utils.decorators import lazyproperty, deprecated
@@ -1102,7 +1104,7 @@ class UnitBase(object):
                 cached_results[key] = results
                 return results
 
-        partial_results.sort(key=lambda x: x[0])
+        partial_results.sort(key=operator.itemgetter(0))
 
         # ...we have to recurse and try to further compose
         results = []
@@ -1120,7 +1122,7 @@ class UnitBase(object):
                     (len(subcomposed.bases), subcomposed, tunit))
 
         if len(results):
-            results.sort(key=lambda x: x[0])
+            results.sort(key=operator.itemgetter(0))
 
             min_length = results[0][0]
             subresults = set()

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -13,6 +13,7 @@ Handles the CDS string format for units
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import operator
 import os
 import re
 
@@ -346,7 +347,7 @@ class CDS(Base):
 
             pairs = list(zip(unit.bases, unit.powers))
             if len(pairs) > 0:
-                pairs.sort(key=lambda x: x[1], reverse=True)
+                pairs.sort(key=operator.itemgetter(1), reverse=True)
 
                 s += cls._format_unit_list(pairs)
 

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -12,6 +12,7 @@ import numpy as np
 
 import copy
 import keyword
+import operator
 
 from . import core, generic, utils
 
@@ -121,7 +122,7 @@ class Fits(generic.Generic):
 
             pairs = list(zip(unit.bases, unit.powers))
             if len(pairs):
-                pairs.sort(key=lambda x: x[1], reverse=True)
+                pairs.sort(key=operator.itemgetter(1), reverse=True)
                 parts.append(cls._format_unit_list(pairs))
 
             s = ' '.join(parts)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -10,6 +10,7 @@ from ...extern.six.moves import zip
 
 import copy
 import keyword
+import operator
 import re
 import warnings
 
@@ -213,7 +214,7 @@ class VOUnit(generic.Generic):
                 s += ' '.join(parts)
 
             pairs = list(zip(unit.bases, unit.powers))
-            pairs.sort(key=lambda x: x[1], reverse=True)
+            pairs.sort(key=operator.itemgetter(1), reverse=True)
 
             s += cls._format_unit_list(pairs)
         elif isinstance(unit, core.NamedUnit):


### PR DESCRIPTION
This PR replaces several `lambda` definitions if and only if there is an equivalent function available (for example in the `operator` module).