### PR TITLE
SkyCoord/Baseframe shape changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,8 +70,10 @@ API Changes
 
 - ``astropy.coordinates``
 
-  - Representations can now be reshaped using methods named like the numpy ones
-    for ``ndarray`` (i.e., ``reshape``, ``swapaxes``, etc.) [#4123]
+  - ``SkyCoord``, ``ICRS``, and other coordinate objects, as well as the
+    underlying representations such as ``SphericalRepresentation`` and
+    ``CartesianRepresentation`` can now be reshaped using methods named like the
+    numpy ones for ``ndarray`` (``reshape``, ``swapaxes``, etc.) [#4123, #5254]
 
   - The ``obsgeoloc`` and ``obsgeovel`` attributes of ``GCRS`` and
     ``PrecessedGeocentric`` frames are now stored and returned as

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1230,7 +1230,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                           for attrnm in self.get_frame_attr_names()])
 
     def _apply(self, method, *args, **kwargs):
-        """Create a new time object, possibly applying a method to the arrays.
+        """Create a new coordinate object, applying a method to the arrays.
 
         Parameters
         ----------

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -12,7 +12,6 @@ from __future__ import (absolute_import, unicode_literals, division,
 import abc
 import copy
 import inspect
-import operator
 from collections import namedtuple, OrderedDict
 
 # Dependencies
@@ -673,7 +672,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         # empty arrays or data == 0
         if self._data is None:
             # No data: we still need to check that any non-scalar attributes
-            # have consistent shapes.
+            # have consistent shapes. Collect them for all attributes with
+            # size > 1 (which should be array-like and thus have a shape).
             shapes = {fnm: value.shape for fnm, value in values.items()
                       if getattr(value, 'size', 1) > 1}
             if shapes:
@@ -685,8 +685,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                             "non-scalar attributes with inconsistent "
                             "shapes: {0}".format(shapes))
 
+                    # Above, we checked that it is possible to broadcast all
+                    # shapes.  By getting and thus validating the attributes,
+                    # we verify that the attributes can in fact be broadcast.
                     for fnm in shapes:
-                        # validate new shape
                         getattr(self, fnm)
                 else:
                     self._no_data_shape = shapes.popitem()[1]

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -389,22 +389,20 @@ class QuantityFrameAttribute(FrameAttribute):
         ValueError
             If the input is not valid for this attribute.
         """
-        if np.all(value == 0) and self.unit is not None and self.unit is not None:
+        if np.all(value == 0) and self.unit is not None:
             return u.Quantity(np.zeros(self.shape), self.unit), True
         else:
-            converted = True
-            if not (hasattr(value, 'unit') ):
+            if not hasattr(value, 'unit'):
                 raise TypeError('Tried to set a QuantityFrameAttribute with '
                                 'something that does not have a unit.')
             oldvalue = value
-            value = u.Quantity(oldvalue, copy=False).to(self.unit)
+            value = u.Quantity(oldvalue, self.unit, copy=False)
             if self.shape is not None and value.shape != self.shape:
                 raise ValueError('The provided value has shape "{0}", but '
                                  'should have shape "{1}"'.format(value.shape,
                                                                   self.shape))
-            if (oldvalue.unit == value.unit and hasattr(oldvalue, 'value') and
-                np.all(oldvalue.value == value.value)):
-                converted = False
+            converted = not (oldvalue is value or
+                             np.may_share_memory(value, oldvalue))
             return value, converted
 
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -10,6 +10,7 @@ from .. import units as u
 from ..extern import six
 from ..extern.six.moves import urllib
 from ..utils.exceptions import AstropyUserWarning
+from ..utils.compat.numpy import broadcast_to
 from .angles import Longitude, Latitude
 from .builtin_frames import ITRS, GCRS
 from .representation import CartesianRepresentation
@@ -499,6 +500,11 @@ class EarthLocation(u.Quantity):
         itrs : `~astropy.coordinates.ITRS`
             The new object in the ITRS frame
         """
+        # Broadcast for a single position at multiple times, but don't attempt
+        # to be more general here.
+        if obstime and self.size == 1 and obstime.size > 1:
+            self = broadcast_to(self, obstime.shape, subok=True)
+
         return ITRS(x=self.x, y=self.y, z=self.z, obstime=obstime)
 
     itrs = property(get_itrs, doc="""An `~astropy.coordinates.ITRS` object  with

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -216,7 +216,7 @@ class EarthLocation(u.Quantity):
         # get geocentric coordinates. Have to give one-dimensional array.
         xyz = erfa.gd2gc(getattr(erfa, ellipsoid), _lon.ravel(),
                                  _lat.ravel(), _height.ravel())
-        self = xyz.view(cls._location_dtype, cls).reshape(lon.shape)
+        self = xyz.view(cls._location_dtype, cls).reshape(_lon.shape)
         self._unit = u.meter
         self._ellipsoid = ellipsoid
         return self.to(height.unit)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -119,7 +119,7 @@ class BaseRepresentation(ShapedLikeNDArray):
         return name
 
     def _apply(self, method, *args, **kwargs):
-        """Create a new coordinate object with ``method`` applied to the arrays.
+        """Create a new representation with ``method`` applied to the arrays.
 
         In typical usage, the method is any of the shape-changing methods for
         `~numpy.ndarray` (``reshape``, ``swapaxes``, etc.), as well as those
@@ -143,7 +143,7 @@ class BaseRepresentation(ShapedLikeNDArray):
             Any keyword arguments for ``method``.
         """
         if callable(method):
-            apply_method = functools.partial(method, *args, **kwargs)
+            apply_method = lambda array: method(array, *args, **kwargs)
         else:
             apply_method = operator.methodcaller(method, *args, **kwargs)
         return self.__class__( *[apply_method(getattr(self, component))

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -202,13 +202,8 @@ class TestHCRS():
         # corresponding HCRS positions
         self.sun_hcrs_t1 = HCRS(CartesianRepresentation([0.0, 0.0, 0.0] * u.km),
                                 obstime=self.t1)
-        self.sun_hcrs_tarr1 = HCRS(CartesianRepresentation([0.0, 0.0, 0.0] * u.km),
-                                   obstime=self.tarr)
         twod_rep = CartesianRepresentation([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]] * u.km)
-        self.sun_hcrs_tarr1 = HCRS(CartesianRepresentation([0.0, 0.0, 0.0] * u.km),
-                                   obstime=self.tarr)
-        self.sun_hcrs_tarr2 = HCRS(twod_rep,
-                                   obstime=self.tarr)
+        self.sun_hcrs_tarr = HCRS(twod_rep, obstime=self.tarr)
         self.tolerance = 5*u.km
 
     def test_from_hcrs(self):
@@ -217,13 +212,8 @@ class TestHCRS():
         separation = transformed.separation_3d(self.sun_icrs_scalar)
         assert_allclose(separation, 0*u.km, atol=self.tolerance)
 
-        # test scalar position and non-scalar time
-        transformed = self.sun_hcrs_tarr1.transform_to(ICRS())
-        separation = transformed.separation_3d(self.sun_icrs_arr)
-        assert_allclose(separation, 0*u.km, atol=self.tolerance)
-
         # test non-scalar positions and times
-        transformed = self.sun_hcrs_tarr2.transform_to(ICRS())
+        transformed = self.sun_hcrs_tarr.transform_to(ICRS())
         separation = transformed.separation_3d(self.sun_icrs_arr)
         assert_allclose(separation, 0*u.km, atol=self.tolerance)
 
@@ -234,7 +224,7 @@ class TestHCRS():
         assert_allclose(separation, 0*u.km, atol=self.tolerance)
         # nonscalar positions
         transformed = self.sun_icrs_arr.transform_to(HCRS(obstime=self.tarr))
-        separation = transformed.separation_3d(self.sun_hcrs_tarr1)
+        separation = transformed.separation_3d(self.sun_hcrs_tarr)
         assert_allclose(separation, 0*u.km, atol=self.tolerance)
 
 

--- a/astropy/coordinates/tests/test_frame_methods.py
+++ b/astropy/coordinates/tests/test_frame_methods.py
@@ -49,6 +49,10 @@ class TestManipulation():
                        obstime=self.obstime,
                        obsgeoloc=self.obsgeoloc,
                        obsgeovel=self.obsgeovel)
+        # For completeness, also some tests on an empty frame.
+        self.s3 = GCRS(obstime=self.obstime,
+                       obsgeoloc=self.obsgeoloc,
+                       obsgeovel=self.obsgeovel)
 
     def test_ravel(self):
         s0_ravel = self.s0.ravel()
@@ -79,6 +83,14 @@ class TestManipulation():
         assert np.all(s2_ravel.obsgeoloc == self.s2.obsgeoloc.ravel())
         assert not np.may_share_memory(s2_ravel.obsgeoloc.x,
                                        self.s2.obsgeoloc.x)
+        s3_ravel = self.s3.ravel()
+        assert s3_ravel.shape == (42,)  # cannot use .size on frame w/o data.
+        assert np.all(s3_ravel.obstime == self.s3.obstime.ravel())
+        assert not np.may_share_memory(s3_ravel.obstime.jd1,
+                                       self.s3.obstime.jd1)
+        assert np.all(s3_ravel.obsgeoloc == self.s3.obsgeoloc.ravel())
+        assert not np.may_share_memory(s3_ravel.obsgeoloc.x,
+                                       self.s3.obsgeoloc.x)
 
     def test_flatten(self):
         s0_flatten = self.s0.flatten()
@@ -194,6 +206,13 @@ class TestManipulation():
         assert np.all(s2_reshape.obsgeoloc ==
                       self.s2.obsgeoloc.reshape(3, 2, 7))
         assert np.may_share_memory(s2_reshape.obsgeoloc.x, self.s2.obsgeoloc.x)
+        s3_reshape = self.s3.reshape(3, 2, 7)
+        assert s3_reshape.shape == (3, 2, 7)
+        assert np.all(s3_reshape.obstime == self.s3.obstime.reshape(3, 2, 7))
+        assert np.may_share_memory(s3_reshape.obstime.jd1, self.s3.obstime.jd1)
+        assert np.all(s3_reshape.obsgeoloc ==
+                      self.s3.obsgeoloc.reshape(3, 2, 7))
+        assert np.may_share_memory(s3_reshape.obsgeoloc.x, self.s3.obsgeoloc.x)
 
     def test_squeeze(self):
         s0_squeeze = self.s0.reshape(3, 1, 2, 1, 7).squeeze()

--- a/astropy/coordinates/tests/test_frame_methods.py
+++ b/astropy/coordinates/tests/test_frame_methods.py
@@ -1,0 +1,169 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# TEST_UNICODE_LITERALS
+import numpy as np
+
+from ... import units as u
+from .. import Longitude, Latitude, EarthLocation
+# test on frame with most complicated frame attributes.
+from ..builtin_frames import ICRS, AltAz
+from ...time import Time
+from ...utils.compat.numpycompat import NUMPY_LT_1_9
+
+
+class TestManipulation():
+    """Manipulation of Frame shapes.
+
+    Checking that attributes are manipulated correctly.
+
+    Even more exhaustive tests are done in time.tests.test_methods
+    """
+
+    def setup(self):
+        lon = Longitude(np.arange(0, 24, 4), u.hourangle)
+        lat = Latitude(np.arange(-90, 91, 30), u.deg)
+        # With same-sized arrays, no attributes
+        self.s0 = ICRS(lon[:, np.newaxis] * np.ones(lat.shape),
+                       lat * np.ones(lon.shape)[:, np.newaxis])
+        self.obstime = Time('2012-01-01')
+        self.location = EarthLocation(20.*u.deg, lat, 100*u.m)
+        self.pressure = 1000 * u.hPa
+        self.temperature = np.random.uniform(
+            0., 20., size=(lon.size, lat.size)) * u.deg_C
+        self.s1 = AltAz(az=lon[:, np.newaxis], alt=lat,
+                        obstime=self.obstime,
+                        location=self.location,
+                        pressure=self.pressure,
+                        temperature=self.temperature)
+
+
+    def test_ravel(self):
+        s0_ravel = self.s0.ravel()
+        assert s0_ravel.shape == (self.s0.size,)
+        assert np.all(s0_ravel.data.lon == self.s0.data.lon.ravel())
+        assert np.may_share_memory(s0_ravel.data.lon, self.s0.data.lon)
+        assert np.may_share_memory(s0_ravel.data.lat, self.s0.data.lat)
+        # Since s1 lon, lat were broadcast, ravel needs to make a copy.
+        s1_ravel = self.s1.ravel()
+        assert s1_ravel.shape == (self.s1.size,)
+        assert np.all(s1_ravel.data.lon == self.s1.data.lon.ravel())
+        assert not np.may_share_memory(s1_ravel.data.lat, self.s1.data.lat)
+        assert s1_ravel.obstime == self.s1.obstime
+        assert np.all(s1_ravel.location == self.s1.location.ravel())
+        assert not np.may_share_memory(s1_ravel.location, self.s1.location)
+        assert np.all(s1_ravel.temperature == self.s1.temperature.ravel())
+        assert np.may_share_memory(s1_ravel.temperature, self.s1.temperature)
+        assert s1_ravel.pressure == self.s1.pressure
+
+    def test_flatten(self):
+        s0_flatten = self.s0.flatten()
+        assert s0_flatten.shape == (self.s0.size,)
+        assert np.all(s0_flatten.data.lon == self.s0.data.lon.flatten())
+        # Flatten always copies.
+        assert not np.may_share_memory(s0_flatten.data.lat, self.s0.data.lat)
+        s1_flatten = self.s1.flatten()
+        assert s1_flatten.shape == (self.s1.size,)
+        assert np.all(s1_flatten.data.lat == self.s1.data.lat.flatten())
+        assert not np.may_share_memory(s1_flatten.data.lon, self.s1.data.lat)
+        assert s1_flatten.obstime == self.s1.obstime
+        assert np.all(s1_flatten.location == self.s1.location.flatten())
+        assert not np.may_share_memory(s1_flatten.location, self.s1.location)
+        assert np.all(s1_flatten.temperature == self.s1.temperature.flatten())
+        assert not np.may_share_memory(s1_flatten.temperature,
+                                       self.s1.temperature)
+        assert s1_flatten.pressure == self.s1.pressure
+
+    def test_transpose(self):
+        s0_transpose = self.s0.transpose()
+        assert s0_transpose.shape == (7, 6)
+        assert np.all(s0_transpose.data.lon == self.s0.data.lon.transpose())
+        assert np.may_share_memory(s0_transpose.data.lat, self.s0.data.lat)
+        s1_transpose = self.s1.transpose()
+        assert s1_transpose.shape == (7, 6)
+        assert np.all(s1_transpose.data.lat == self.s1.data.lat.transpose())
+        assert np.may_share_memory(s1_transpose.data.lon, self.s1.data.lon)
+        assert s1_transpose.obstime == self.s1.obstime
+        assert np.all(s1_transpose.location == self.s1.location.transpose())
+        assert np.may_share_memory(s1_transpose.location, self.s1.location)
+        assert np.all(s1_transpose.temperature ==
+                      self.s1.temperature.transpose())
+        assert np.may_share_memory(s1_transpose.temperature,
+                                   self.s1.temperature)
+        assert s1_transpose.pressure == self.s1.pressure
+        # Only one check on T, since it just calls transpose anyway.
+        s1_T = self.s1.T
+        assert s1_T.shape == (7, 6)
+        assert np.all(s1_T.temperature == self.s1.temperature.T)
+        assert np.may_share_memory(s1_T.location, self.s1.location)
+
+    def test_diagonal(self):
+        s0_diagonal = self.s0.diagonal()
+        assert s0_diagonal.shape == (6,)
+        assert np.all(s0_diagonal.data.lat == self.s0.data.lat.diagonal())
+        if not NUMPY_LT_1_9:
+            assert np.may_share_memory(s0_diagonal.data.lat, self.s0.data.lat)
+
+    def test_swapaxes(self):
+        s1_swapaxes = self.s1.swapaxes(0, 1)
+        assert s1_swapaxes.shape == (7, 6)
+        assert np.all(s1_swapaxes.data.lat == self.s1.data.lat.swapaxes(0, 1))
+        assert np.may_share_memory(s1_swapaxes.data.lat, self.s1.data.lat)
+        assert s1_swapaxes.obstime == self.s1.obstime
+        assert np.all(s1_swapaxes.location == self.s1.location.swapaxes(0, 1))
+        assert s1_swapaxes.location.shape == (7, 6)
+        assert np.may_share_memory(s1_swapaxes.location, self.s1.location)
+        assert np.all(s1_swapaxes.temperature ==
+                      self.s1.temperature.swapaxes(0, 1))
+        assert np.may_share_memory(s1_swapaxes.temperature,
+                                   self.s1.temperature)
+        assert s1_swapaxes.pressure == self.s1.pressure
+
+    def test_reshape(self):
+        s0_reshape = self.s0.reshape(2, 3, 7)
+        assert s0_reshape.shape == (2, 3, 7)
+        assert np.all(s0_reshape.data.lon == self.s0.data.lon.reshape(2, 3, 7))
+        assert np.all(s0_reshape.data.lat == self.s0.data.lat.reshape(2, 3, 7))
+        assert np.may_share_memory(s0_reshape.data.lon, self.s0.data.lon)
+        assert np.may_share_memory(s0_reshape.data.lat, self.s0.data.lat)
+        s1_reshape = self.s1.reshape(3, 2, 7)
+        assert s1_reshape.shape == (3, 2, 7)
+        assert np.all(s1_reshape.data.lat == self.s1.data.lat.reshape(3, 2, 7))
+        assert np.may_share_memory(s1_reshape.data.lat, self.s1.data.lat)
+        assert s1_reshape.obstime == self.s1.obstime
+        assert np.all(s1_reshape.location == self.s1.location.reshape(3, 2, 7))
+        assert np.may_share_memory(s1_reshape.location, self.s1.location)
+        assert np.all(s1_reshape.temperature ==
+                      self.s1.temperature.reshape(3, 2, 7))
+        assert np.may_share_memory(s1_reshape.temperature,
+                                   self.s1.temperature)
+        assert s1_reshape.pressure == self.s1.pressure
+        # For reshape(3, 14), copying is necessary for lon, lat, location
+        s1_reshape2 = self.s1.reshape(3, 14)
+        assert s1_reshape2.shape == (3, 14)
+        assert np.all(s1_reshape2.data.lon == self.s1.data.lon.reshape(3, 14))
+        assert not np.may_share_memory(s1_reshape2.data.lon, self.s1.data.lon)
+        assert s1_reshape2.obstime == self.s1.obstime
+        assert np.all(s1_reshape2.location == self.s1.location.reshape(3, 14))
+        assert not np.may_share_memory(s1_reshape2.location, self.s1.location)
+        assert np.all(s1_reshape2.temperature ==
+                      self.s1.temperature.reshape(3, 14))
+        assert np.may_share_memory(s1_reshape2.temperature,
+                                   self.s1.temperature)
+        assert s1_reshape2.pressure == self.s1.pressure
+
+    def test_squeeze(self):
+        s0_squeeze = self.s0.reshape(3, 1, 2, 1, 7).squeeze()
+        assert s0_squeeze.shape == (3, 2, 7)
+        assert np.all(s0_squeeze.data.lat == self.s0.data.lat.reshape(3, 2, 7))
+        assert np.may_share_memory(s0_squeeze.data.lat, self.s0.data.lat)
+
+    def test_add_dimension(self):
+        s0_adddim = self.s0[:, np.newaxis, :]
+        assert s0_adddim.shape == (6, 1, 7)
+        assert np.all(s0_adddim.data.lon == self.s0.data.lon[:, np.newaxis, :])
+        assert np.may_share_memory(s0_adddim.data.lat, self.s0.data.lat)
+
+    def test_take(self):
+        s0_take = self.s0.take((5, 2))
+        assert s0_take.shape == (2,)
+        assert np.all(s0_take.data.lon == self.s0.data.lon.take((5, 2)))

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -374,8 +374,12 @@ def test_time_inputs():
         c = FK4(1 * u.deg, 2 * u.deg, obstime='hello')
     assert 'Invalid time input' in str(err)
 
-    #should work fine without a warning even with vector times not always working
-    FK4(1 * u.deg, 2 * u.deg, obstime=['J2000', 'J2001'])
+    # A vector time should work if the shapes match, but we don't automatically
+    # broadcast the basic data (just like time).
+    FK4([1, 2]* u.deg, [2, 3] * u.deg, obstime=['J2000', 'J2001'])
+    with pytest.raises(ValueError) as err:
+        FK4(1 * u.deg, 2 * u.deg, obstime=['J2000', 'J2001'])
+    assert 'shape' in str(err)
 
 
 def test_is_frame_attr_default():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -156,6 +156,19 @@ def test_create_nodata_frames():
     assert f4.obstime in (FK4.get_frame_attr_names()['obstime'],
                           FK4.get_frame_attr_names()['equinox'])
 
+def test_no_data_nonscalar_frames():
+    from ..builtin_frames import AltAz
+    from astropy.time import Time
+    a1 = AltAz(obstime=Time('2012-01-01') + np.arange(10.) * u.day,
+               temperature=np.ones((3, 1)) * u.deg_C)
+    assert a1.obstime.shape == (3, 10)
+    assert a1.temperature.shape == (3, 10)
+    assert a1.shape == (3, 10)
+    with pytest.raises(ValueError) as exc:
+        AltAz(obstime=Time('2012-01-01') + np.arange(10.) * u.day,
+              temperature=np.ones((3,)) * u.deg_C)
+    assert 'inconsistent shapes' in str(exc)
+
 
 def test_frame_repr():
     from ..builtin_frames import ICRS, FK5
@@ -338,6 +351,18 @@ def test_transform():
 
     assert_allclose(i1.ra, i2.ra)
     assert_allclose(i1.dec, i2.dec)
+
+
+def test_transform_to_nonscalar_nodata_frame():
+    # https://github.com/astropy/astropy/pull/5254#issuecomment-241592353
+    from ..builtin_frames import ICRS, FK5
+    from ...time import Time
+    times = Time('2016-08-23') + np.linspace(0,10,12)*u.day
+    coo1 = ICRS(ra=[[0.], [10.], [20.]]*u.deg,
+                dec=[[-30.], [30.], [60.]]*u.deg)
+    coo2 = coo1.transform_to(FK5(equinox=times))
+    assert coo2.shape == (3, 12)
+
 
 def test_sep():
     from ..builtin_frames import ICRS

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -7,6 +7,7 @@ from ... import units as u
 from .. import SphericalRepresentation, Longitude, Latitude
 from ...tests.helper import pytest
 from ...utils.compat.numpycompat import NUMPY_LT_1_9
+from ...utils.compat.numpy import broadcast_to as np_broadcast_to
 
 
 class TestManipulation():
@@ -159,3 +160,24 @@ class TestManipulation():
         s0_take = self.s0.take((5, 2))
         assert s0_take.shape == (2,)
         assert np.all(s0_take.lon == self.s0.lon.take((5, 2)))
+
+    def test_broadcast_to(self):
+        s0_broadcast = self.s0._apply(np_broadcast_to, shape=(3, 6, 7),
+                                      subok=True)
+        assert s0_broadcast.shape == (3, 6, 7)
+        assert np.all(s0_broadcast.lon == self.s0.lon)
+        assert np.all(s0_broadcast.lat == self.s0.lat)
+        assert np.all(s0_broadcast.distance == self.s0.distance)
+        assert np.may_share_memory(s0_broadcast.lon, self.s0.lon)
+        assert np.may_share_memory(s0_broadcast.lat, self.s0.lat)
+        assert np.may_share_memory(s0_broadcast.distance, self.s0.distance)
+        s1_broadcast = self.s1._apply(np_broadcast_to, shape=(3, 6, 7),
+                                      subok=True)
+        assert s1_broadcast.shape == (3, 6, 7)
+        assert np.all(s1_broadcast.lat == self.s1.lat)
+        assert np.all(s1_broadcast.lon == self.s1.lon)
+        assert np.all(s1_broadcast.distance == self.s1.distance)
+        assert s1_broadcast.distance.shape == (3, 6, 7)
+        assert np.may_share_memory(s1_broadcast.lat, self.s1.lat)
+        assert np.may_share_memory(s1_broadcast.lon, self.s1.lon)
+        assert np.may_share_memory(s1_broadcast.distance, self.s1.distance)

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -33,6 +33,7 @@ class TestManipulation():
 
     def test_ravel(self):
         s0_ravel = self.s0.ravel()
+        assert type(s0_ravel) is type(self.s0)
         assert s0_ravel.shape == (self.s0.size,)
         assert np.all(s0_ravel.lon == self.s0.lon.ravel())
         assert np.may_share_memory(s0_ravel.lon, self.s0.lon)
@@ -40,9 +41,18 @@ class TestManipulation():
         assert np.may_share_memory(s0_ravel.distance, self.s0.distance)
         # Since s1 was broadcast, ravel needs to make a copy.
         s1_ravel = self.s1.ravel()
+        assert type(s1_ravel) is type(self.s1)
         assert s1_ravel.shape == (self.s1.size,)
         assert np.all(s1_ravel.lon == self.s1.lon.ravel())
         assert not np.may_share_memory(s1_ravel.lat, self.s1.lat)
+
+    def test_copy(self):
+        s0_copy = self.s0.copy()
+        assert s0_copy.shape == self.s0.shape
+        assert np.all(s0_copy.lon == self.s0.lon)
+        assert np.all(s0_copy.lat == self.s0.lat)
+        # Check copy was made of internal data.
+        assert not np.may_share_memory(s0_copy.distance, self.s0.distance)
 
     def test_flatten(self):
         s0_flatten = self.s0.flatten()
@@ -162,8 +172,8 @@ class TestManipulation():
         assert np.all(s0_take.lon == self.s0.lon.take((5, 2)))
 
     def test_broadcast_to(self):
-        s0_broadcast = self.s0._apply(np_broadcast_to, shape=(3, 6, 7),
-                                      subok=True)
+        s0_broadcast = self.s0._apply(np_broadcast_to, (3, 6, 7), subok=True)
+        assert type(s0_broadcast) is type(self.s0)
         assert s0_broadcast.shape == (3, 6, 7)
         assert np.all(s0_broadcast.lon == self.s0.lon)
         assert np.all(s0_broadcast.lat == self.s0.lat)
@@ -181,3 +191,14 @@ class TestManipulation():
         assert np.may_share_memory(s1_broadcast.lat, self.s1.lat)
         assert np.may_share_memory(s1_broadcast.lon, self.s1.lon)
         assert np.may_share_memory(s1_broadcast.distance, self.s1.distance)
+
+        # A final test that "may_share_memory" equals "does_share_memory"
+        # Do this on a copy, to keep self.s0 unchanged.
+        sc = self.s0.copy()
+        assert not np.may_share_memory(sc.lon, self.s0.lon)
+        assert not np.may_share_memory(sc.lat, self.s0.lat)
+        sc_broadcast = sc._apply(np_broadcast_to, (3, 6, 7), subok=True)
+        assert np.may_share_memory(sc_broadcast.lon, sc.lon)
+        # Can only write to copy, not to broadcast version.
+        sc.lon[0, 0] = 22. * u.hourangle
+        assert np.all(sc_broadcast.lon[:, 0, 0] == 22. * u.hourangle)

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -82,7 +82,10 @@ class TestManipulation():
         assert np.all(s2_ravel.obstime == self.s2.obstime.ravel())
         assert not np.may_share_memory(s2_ravel.obstime.jd1,
                                        self.s2.obstime.jd1)
-        assert np.all(s2_ravel.obsgeoloc == self.s2.obsgeoloc.ravel())
+        # TODO: right now, we cannot compare CartesianRepresentation instances,
+        # so instead we compare the xyz quantities.  This can be made a direct
+        # comparison once CartesianRepresentation.__eq__ is implemented.
+        assert np.all(s2_ravel.obsgeoloc.xyz == self.s2.obsgeoloc.ravel().xyz)
         assert not np.may_share_memory(s2_ravel.obsgeoloc.x,
                                        self.s2.obsgeoloc.x)
         s3_ravel = self.s3.ravel()
@@ -90,7 +93,7 @@ class TestManipulation():
         assert np.all(s3_ravel.obstime == self.s3.obstime.ravel())
         assert not np.may_share_memory(s3_ravel.obstime.jd1,
                                        self.s3.obstime.jd1)
-        assert np.all(s3_ravel.obsgeoloc == self.s3.obsgeoloc.ravel())
+        assert np.all(s3_ravel.obsgeoloc.xyz == self.s3.obsgeoloc.ravel().xyz)
         assert not np.may_share_memory(s3_ravel.obsgeoloc.x,
                                        self.s3.obsgeoloc.x)
         sc_ravel = self.sc.ravel()
@@ -100,7 +103,7 @@ class TestManipulation():
         assert np.all(sc_ravel.obstime == self.sc.obstime.ravel())
         assert not np.may_share_memory(sc_ravel.obstime.jd1,
                                        self.sc.obstime.jd1)
-        assert np.all(sc_ravel.obsgeoloc == self.sc.obsgeoloc.ravel())
+        assert np.all(sc_ravel.obsgeoloc.xyz == self.sc.obsgeoloc.ravel().xyz)
         assert not np.may_share_memory(sc_ravel.obsgeoloc.x,
                                        self.sc.obsgeoloc.x)
 
@@ -215,15 +218,15 @@ class TestManipulation():
         assert np.may_share_memory(s2_reshape.data.lat, self.s2.data.lat)
         assert np.all(s2_reshape.obstime == self.s2.obstime.reshape(3, 2, 7))
         assert np.may_share_memory(s2_reshape.obstime.jd1, self.s2.obstime.jd1)
-        assert np.all(s2_reshape.obsgeoloc ==
-                      self.s2.obsgeoloc.reshape(3, 2, 7))
+        assert np.all(s2_reshape.obsgeoloc.xyz ==
+                      self.s2.obsgeoloc.reshape(3, 2, 7).xyz)
         assert np.may_share_memory(s2_reshape.obsgeoloc.x, self.s2.obsgeoloc.x)
         s3_reshape = self.s3.reshape(3, 2, 7)
         assert s3_reshape.shape == (3, 2, 7)
         assert np.all(s3_reshape.obstime == self.s3.obstime.reshape(3, 2, 7))
         assert np.may_share_memory(s3_reshape.obstime.jd1, self.s3.obstime.jd1)
-        assert np.all(s3_reshape.obsgeoloc ==
-                      self.s3.obsgeoloc.reshape(3, 2, 7))
+        assert np.all(s3_reshape.obsgeoloc.xyz ==
+                      self.s3.obsgeoloc.reshape(3, 2, 7).xyz)
         assert np.may_share_memory(s3_reshape.obsgeoloc.x, self.s3.obsgeoloc.x)
         sc_reshape = self.sc.reshape(3, 2, 7)
         assert sc_reshape.shape == (3, 2, 7)
@@ -231,8 +234,8 @@ class TestManipulation():
         assert np.may_share_memory(sc_reshape.data.lat, self.sc.data.lat)
         assert np.all(sc_reshape.obstime == self.sc.obstime.reshape(3, 2, 7))
         assert np.may_share_memory(sc_reshape.obstime.jd1, self.sc.obstime.jd1)
-        assert np.all(sc_reshape.obsgeoloc ==
-                      self.sc.obsgeoloc.reshape(3, 2, 7))
+        assert np.all(sc_reshape.obsgeoloc.xyz ==
+                      self.sc.obsgeoloc.reshape(3, 2, 7).xyz)
         assert np.may_share_memory(sc_reshape.obsgeoloc.x, self.sc.obsgeoloc.x)
         # For reshape(3, 14), the arrays all need to be copied.
         sc_reshape2 = self.sc.reshape(3, 14)
@@ -243,7 +246,8 @@ class TestManipulation():
         assert np.all(sc_reshape2.obstime == self.sc.obstime.reshape(3, 14))
         assert not np.may_share_memory(sc_reshape2.obstime.jd1,
                                        self.sc.obstime.jd1)
-        assert np.all(sc_reshape2.obsgeoloc == self.sc.obsgeoloc.reshape(3, 14))
+        assert np.all(sc_reshape2.obsgeoloc.xyz ==
+                      self.sc.obsgeoloc.reshape(3, 14).xyz)
         assert not np.may_share_memory(sc_reshape2.obsgeoloc.x,
                                        self.sc.obsgeoloc.x)
 

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from ... import units as u
-from .. import Longitude, Latitude, EarthLocation
+from .. import Longitude, Latitude, EarthLocation, SkyCoord
 # test on frame with most complicated frame attributes.
 from ..builtin_frames import ICRS, AltAz, GCRS
 from ...time import Time
@@ -53,6 +53,8 @@ class TestManipulation():
         self.s3 = GCRS(obstime=self.obstime,
                        obsgeoloc=self.obsgeoloc,
                        obsgeovel=self.obsgeovel)
+        # And make a SkyCoord
+        self.sc = SkyCoord(ra=lon[:, np.newaxis], dec=lat, frame=self.s3)
 
     def test_ravel(self):
         s0_ravel = self.s0.ravel()
@@ -91,6 +93,16 @@ class TestManipulation():
         assert np.all(s3_ravel.obsgeoloc == self.s3.obsgeoloc.ravel())
         assert not np.may_share_memory(s3_ravel.obsgeoloc.x,
                                        self.s3.obsgeoloc.x)
+        sc_ravel = self.sc.ravel()
+        assert sc_ravel.shape == (self.sc.size,)
+        assert np.all(sc_ravel.data.lon == self.sc.data.lon.ravel())
+        assert not np.may_share_memory(sc_ravel.data.lat, self.sc.data.lat)
+        assert np.all(sc_ravel.obstime == self.sc.obstime.ravel())
+        assert not np.may_share_memory(sc_ravel.obstime.jd1,
+                                       self.sc.obstime.jd1)
+        assert np.all(sc_ravel.obsgeoloc == self.sc.obsgeoloc.ravel())
+        assert not np.may_share_memory(sc_ravel.obsgeoloc.x,
+                                       self.sc.obsgeoloc.x)
 
     def test_flatten(self):
         s0_flatten = self.s0.flatten()
@@ -213,6 +225,27 @@ class TestManipulation():
         assert np.all(s3_reshape.obsgeoloc ==
                       self.s3.obsgeoloc.reshape(3, 2, 7))
         assert np.may_share_memory(s3_reshape.obsgeoloc.x, self.s3.obsgeoloc.x)
+        sc_reshape = self.sc.reshape(3, 2, 7)
+        assert sc_reshape.shape == (3, 2, 7)
+        assert np.all(sc_reshape.data.lon == self.sc.data.lon.reshape(3, 2, 7))
+        assert np.may_share_memory(sc_reshape.data.lat, self.sc.data.lat)
+        assert np.all(sc_reshape.obstime == self.sc.obstime.reshape(3, 2, 7))
+        assert np.may_share_memory(sc_reshape.obstime.jd1, self.sc.obstime.jd1)
+        assert np.all(sc_reshape.obsgeoloc ==
+                      self.sc.obsgeoloc.reshape(3, 2, 7))
+        assert np.may_share_memory(sc_reshape.obsgeoloc.x, self.sc.obsgeoloc.x)
+        # For reshape(3, 14), the arrays all need to be copied.
+        sc_reshape2 = self.sc.reshape(3, 14)
+        assert sc_reshape2.shape == (3, 14)
+        assert np.all(sc_reshape2.data.lon == self.sc.data.lon.reshape(3, 14))
+        assert not np.may_share_memory(sc_reshape2.data.lat,
+                                       self.sc.data.lat)
+        assert np.all(sc_reshape2.obstime == self.sc.obstime.reshape(3, 14))
+        assert not np.may_share_memory(sc_reshape2.obstime.jd1,
+                                       self.sc.obstime.jd1)
+        assert np.all(sc_reshape2.obsgeoloc == self.sc.obsgeoloc.reshape(3, 14))
+        assert not np.may_share_memory(sc_reshape2.obsgeoloc.x,
+                                       self.sc.obsgeoloc.x)
 
     def test_squeeze(self):
         s0_squeeze = self.s0.reshape(3, 1, 2, 1, 7).squeeze()

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -82,9 +82,9 @@ class TestManipulation():
         assert np.all(s2_ravel.obstime == self.s2.obstime.ravel())
         assert not np.may_share_memory(s2_ravel.obstime.jd1,
                                        self.s2.obstime.jd1)
-        # TODO: right now, we cannot compare CartesianRepresentation instances,
-        # so instead we compare the xyz quantities.  This can be made a direct
-        # comparison once CartesianRepresentation.__eq__ is implemented.
+        # CartesianRepresentation do not allow direct comparisons, as this is
+        # too tricky to get right in the face of rounding issues.  Here, though,
+        # it cannot be an issue, so we compare the xyz quantities.
         assert np.all(s2_ravel.obsgeoloc.xyz == self.s2.obsgeoloc.ravel().xyz)
         assert not np.may_share_memory(s2_ravel.obsgeoloc.x,
                                        self.s2.obsgeoloc.x)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -35,14 +35,15 @@ from ..extern import six
 from ..extern.six.moves import copyreg, zip
 from ..table import Table
 from ..utils import (sharedmethod, find_current_module,
+                     check_broadcast, IncompatibleShapeError,
                      InheritDocstrings, OrderedDescriptorContainer)
 from ..utils.codegen import make_function_with_signature
 from ..utils.compat import suppress
 from ..utils.compat.funcsigs import signature
 from ..utils.exceptions import AstropyDeprecationWarning
-from .utils import (array_repr_oneline, check_broadcast, combine_labels,
+from .utils import (array_repr_oneline, combine_labels,
                     make_binary_operator_eval, ExpressionTree,
-                    IncompatibleShapeError, AliasDict, get_inputs_and_params,
+                    AliasDict, get_inputs_and_params,
                     _BoundingBox)
 from ..nddata.utils import add_array, extract_array
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -12,8 +12,8 @@ import numpy as np
 from .core import FittableModel, Model
 from .functional_models import Shift
 from .parameters import Parameter
-from .utils import poly_map_domain, comb, check_broadcast
-from ..utils import indent
+from .utils import poly_map_domain, comb
+from ..utils import indent, check_broadcast
 from ..extern.six.moves import range
 
 

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -14,7 +14,7 @@ import numpy as np
 from ..extern import six
 from ..extern.six.moves import range, zip_longest, zip
 
-from ..utils import isiterable
+from ..utils import isiterable, check_broadcast
 from ..utils.compat.funcsigs import signature
 
 
@@ -446,60 +446,6 @@ def make_binary_operator_eval(oper, f, g):
     return lambda inputs, params: \
             tuple(oper(x, y) for x, y in zip(f(inputs, params),
                                              g(inputs, params)))
-
-
-class IncompatibleShapeError(ValueError):
-    def __init__(self, shape_a, shape_a_idx, shape_b, shape_b_idx):
-        super(IncompatibleShapeError, self).__init__(
-                shape_a, shape_a_idx, shape_b, shape_b_idx)
-
-
-def check_broadcast(*shapes):
-    """
-    Determines whether two or more Numpy arrays can be broadcast with each
-    other based on their shape tuple alone.
-
-    Parameters
-    ----------
-    *shapes : tuple
-        All shapes to include in the comparison.  If only one shape is given it
-        is passed through unmodified.  If no shapes are given returns an empty
-        `tuple`.
-
-    Returns
-    -------
-    broadcast : `tuple`
-        If all shapes are mutually broadcastable, returns a tuple of the full
-        broadcast shape.
-    """
-
-    if len(shapes) == 0:
-        return ()
-    elif len(shapes) == 1:
-        return shapes[0]
-
-    reversed_shapes = (reversed(shape) for shape in shapes)
-
-    full_shape = []
-
-    for dims in zip_longest(*reversed_shapes, fillvalue=1):
-        max_dim = 1
-        max_dim_idx = None
-        for idx, dim in enumerate(dims):
-            if dim == 1:
-                continue
-
-            if max_dim == 1:
-                # The first dimension of size greater than 1
-                max_dim = dim
-                max_dim_idx = idx
-            elif dim != max_dim:
-                raise IncompatibleShapeError(
-                    shapes[max_dim_idx], max_dim_idx, shapes[idx], idx)
-
-        full_shape.append(max_dim)
-
-    return tuple(full_shape[::-1])
 
 
 def poly_map_domain(oldx, domain, window):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -13,7 +13,6 @@ from __future__ import (absolute_import, division, print_function,
 import itertools
 import copy
 import operator
-import functools
 from datetime import datetime
 from collections import defaultdict
 
@@ -804,8 +803,7 @@ class Time(ShapedLikeNDArray):
             new_format = self.format
 
         if callable(method):
-            apply_method = functools.partial(method, *args, **kwargs)
-            method = str(apply_method)
+            apply_method = lambda array: method(array, *args, **kwargs)
         else:
             if method == 'replicate':
                 apply_method = None

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -12,6 +12,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import itertools
 import copy
+import operator
+import functools
 from datetime import datetime
 from collections import defaultdict
 
@@ -771,28 +773,49 @@ class Time(ShapedLikeNDArray):
 
         Parameters
         ----------
-        method : str
-            Can be 'replicate'  or the name of a relevant `~numpy.ndarray`
-            method. In the former case, a new time instance with unchanged
-            internal data is created, while in the latter the method is applied
-            to the internal ``jd1`` and ``jd2`` arrays, as well as to possible
-            ``location``, ``_delta_ut1_utc``, and ``_delta_tdb_tt`` arrays.
-            Example methods: 'copy', '__getitem__', 'reshape'.
+        method : str or callable
+            If string, can be 'replicate'  or the name of a relevant
+            `~numpy.ndarray` method. In the former case, a new time instance
+            with unchanged internal data is created, while in the latter the
+            method is applied to the internal ``jd1`` and ``jd2`` arrays, as
+            well as to possible ``location``, ``_delta_ut1_utc``, and
+            ``_delta_tdb_tt`` arrays.
+            If a callable, it is directly applied to the above arrays.
+            Examples: 'copy', '__getitem__', 'reshape', `~numpy.broadcast_to`.
         args : tuple
             Any positional arguments for ``method``.
         kwargs : dict
             Any keyword arguments for ``method``.  If the ``format`` keyword
             argument is present, this will be used as the Time format of the
             replica.
+
+        Examples
+        --------
+        Some ways this is used internally::
+
+            copy : ``_apply('copy')``
+            replicate : ``_apply('replicate')``
+            reshape : ``_apply('reshape', new_shape)``
+            index or slice : ``_apply('__getitem__', item)``
+            broadcast : ``_apply(np.broadcast, shape=new_shape)``
         """
         new_format = kwargs.pop('format', None)
         if new_format is None:
             new_format = self.format
 
+        if callable(method):
+            apply_method = functools.partial(method, *args, **kwargs)
+            method = str(apply_method)
+        else:
+            if method == 'replicate':
+                apply_method = None
+            else:
+                apply_method = operator.methodcaller(method, *args, **kwargs)
+
         jd1, jd2 = self._time.jd1, self._time.jd2
-        if method != 'replicate':
-            jd1 = getattr(jd1, method)(*args, **kwargs)
-            jd2 = getattr(jd2, method)(*args, **kwargs)
+        if apply_method:
+            jd1 = apply_method(jd1)
+            jd2 = apply_method(jd2)
 
         tm = super(Time, self.__class__).__new__(self.__class__)
         tm._time = TimeJD(jd1, jd2, self.scale, self.precision,
@@ -805,17 +828,17 @@ class Time(ShapedLikeNDArray):
             except AttributeError:
                 continue
 
-            if method != 'replicate' and getattr(val, 'size', 1) > 1:
+            if apply_method:
                 # Apply the method to any value arrays (though skip if there is
-                # onlya single element and the method would return a view,
+                # only a single element and the method would return a view,
                 # since in that case nothing would change).
-                val_method = getattr(val, method)
-                val = val_method(*args, **kwargs)
-            elif method == 'copy' or method == 'flatten':
-                # flatten should copy also for a single element array, but
-                # we cannot use it directly for array scalars, since it
-                # always returns a one-dimensional array. So, just copy.
-                val = copy.copy(val)
+                if getattr(val, 'size', 1) > 1:
+                    val = apply_method(val)
+                elif method == 'copy' or method == 'flatten':
+                    # flatten should copy also for a single element array, but
+                    # we cannot use it directly for array scalars, since it
+                    # always returns a one-dimensional array. So, just copy.
+                    val = copy.copy(val)
 
             setattr(tm, attr, val)
 

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -9,6 +9,7 @@ from .. import Time
 from ...tests.helper import pytest
 from ...utils.compat.numpycompat import NUMPY_LT_1_9
 
+
 class TestManipulation():
     """Manipulation of Time objects, ensuring attributes are done correctly."""
 
@@ -260,6 +261,25 @@ class TestManipulation():
         assert t2_take2.shape == (2,)
         assert np.all(t2_take2.jd1 == self.t2.jd1.take((5, 15)))
         assert t2_take2.location.shape == t2_take2.shape
+
+    def test_broadcast(self):
+        """Test using a callable method."""
+        t0_broadcast = self.t0._apply(np.broadcast_to, shape=(3, 10, 5))
+        assert t0_broadcast.shape == (3, 10, 5)
+        assert np.all(t0_broadcast.jd1 == self.t0.jd1)
+        assert np.may_share_memory(t0_broadcast.jd1, self.t0.jd1)
+        assert t0_broadcast.location is None
+        t1_broadcast = self.t1._apply(np.broadcast_to, shape=(3, 10, 5))
+        assert t1_broadcast.shape == (3, 10, 5)
+        assert np.all(t1_broadcast.jd1 == self.t1.jd1)
+        assert np.may_share_memory(t1_broadcast.jd1, self.t1.jd1)
+        assert t1_broadcast.location is self.t1.location
+        t2_broadcast = self.t2._apply(np.broadcast_to, shape=(3, 10, 5))
+        assert t2_broadcast.shape == (3, 10, 5)
+        assert np.all(t2_broadcast.jd1 == self.t2.jd1)
+        assert np.may_share_memory(t2_broadcast.jd1, self.t2.jd1)
+        assert t2_broadcast.location.shape == t2_broadcast.shape
+        assert np.may_share_memory(t2_broadcast.location, self.t2.location)
 
 
 class TestArithmetic():

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -8,6 +8,7 @@ import numpy as np
 from .. import Time
 from ...tests.helper import pytest
 from ...utils.compat.numpycompat import NUMPY_LT_1_9
+from ...utils.compat.numpy import broadcast_to as np_broadcast_to
 
 
 class TestManipulation():
@@ -264,17 +265,17 @@ class TestManipulation():
 
     def test_broadcast(self):
         """Test using a callable method."""
-        t0_broadcast = self.t0._apply(np.broadcast_to, shape=(3, 10, 5))
+        t0_broadcast = self.t0._apply(np_broadcast_to, shape=(3, 10, 5))
         assert t0_broadcast.shape == (3, 10, 5)
         assert np.all(t0_broadcast.jd1 == self.t0.jd1)
         assert np.may_share_memory(t0_broadcast.jd1, self.t0.jd1)
         assert t0_broadcast.location is None
-        t1_broadcast = self.t1._apply(np.broadcast_to, shape=(3, 10, 5))
+        t1_broadcast = self.t1._apply(np_broadcast_to, shape=(3, 10, 5))
         assert t1_broadcast.shape == (3, 10, 5)
         assert np.all(t1_broadcast.jd1 == self.t1.jd1)
         assert np.may_share_memory(t1_broadcast.jd1, self.t1.jd1)
         assert t1_broadcast.location is self.t1.location
-        t2_broadcast = self.t2._apply(np.broadcast_to, shape=(3, 10, 5))
+        t2_broadcast = self.t2._apply(np_broadcast_to, shape=(3, 10, 5))
         assert t2_broadcast.shape == (3, 10, 5)
         assert np.all(t2_broadcast.jd1 == self.t2.jd1)
         assert np.may_share_memory(t2_broadcast.jd1, self.t2.jd1)

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -923,10 +923,17 @@ class ShapedLikeNDArray(object):
         return self.shape == ()
 
     def __getitem__(self, item):
-        if self.isscalar:
+        if not self.shape:
             raise TypeError('scalar {0!r} object is not subscriptable.'.format(
                 self.__class__.__name__))
         return self._apply('__getitem__', item)
+
+    def copy(self, *args, **kwargs):
+        """Return an instance containing copies of the internal data.
+
+        Parameters are as for :meth:`~numpy.ndarray.copy`.
+        """
+        return self._apply('copy', *args, **kwargs)
 
     def reshape(self, *args, **kwargs):
         """Returns an instance containing the same data with a new shape.

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -98,3 +98,13 @@ def test_set_locale():
 
     with misc.set_locale(current):
         assert date.strftime('%a, %b') == day_mon
+
+
+def test_check_broadcast():
+    assert misc.check_broadcast((10, 1), (3,)) == (10, 3)
+    assert misc.check_broadcast((10, 1), (3,), (4, 1, 1, 3)) == (4, 1, 10, 3)
+    with pytest.raises(ValueError):
+        misc.check_broadcast((10, 2), (3,))
+
+    with pytest.raises(ValueError):
+        misc.check_broadcast((10, 1), (3,), (4, 1, 2, 3))

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -173,7 +173,7 @@ if it is preset, it can be accessed from the ``data`` attribute::
         (1.1, 2.2)>
 
 All of the above methods can also accept array data (in the form of
-class:`~astropy.unit.Quantity`, or other Python sequences) to create arrays of
+class:`~astropy.units.Quantity`, or other Python sequences) to create arrays of
 coordinates::
 
     >>> ICRS(ra=[1.5, 2.5]*u.deg, dec=[3.5, 4.5]*u.deg)

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -50,16 +50,21 @@ they store multiple coordinates in a single object.  When you're going
 to apply the same operation to many different coordinates (say, from a
 catalog), this is a better choice than a list of |skycoord| objects,
 because it will be *much* faster than applying the operation to each
-|skycoord| in a for loop.
-::
+|skycoord| in a for loop. Like the underlying `~numpy.ndarray` instances
+holding the data, |skycoord| objects can be sliced, reshaped, etc.::
 
-    >>> c = SkyCoord(ra=[10, 11]*u.degree, dec=[41, -5]*u.degree)
+    >>> c = SkyCoord(ra=[10, 11, 12, 13]*u.degree, dec=[41, -5, 42, 0]*u.degree)
     >>> c
     <SkyCoord (ICRS): (ra, dec) in deg
-        [(10.0, 41.0), (11.0, -5.0)]>
+        [(10.0, 41.0), (11.0, -5.0), (12.0, 42.0), (13.0, 0.0)]>
     >>> c[1]
     <SkyCoord (ICRS): (ra, dec) in deg
         (11.0, -5.0)>
+    >>> c.reshape(2, 2)
+    <SkyCoord (ICRS): (ra, dec) in deg
+        [[(10.0, 41.0), (11.0, -5.0)],
+         [(12.0, 42.0), (13.0, 0.0)]]>
+
 
 Coordinate access
 -----------------

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -83,24 +83,30 @@ removed, and the points are still located on a unit sphere:
         (0.424264068712, 0.707106781187, 0.565685424949)>
 
 
-Array values
-^^^^^^^^^^^^
+Array values and numpy array method analogs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Array `~astropy.units.Quantity` objects can also be passed to
-representations::
+Array `~astropy.units.Quantity` objects can also be passed to representations,
+and such representations can be sliced, reshaped, etc., using the same
+methods as are available to `~numpy.ndarray`::
 
   >>> import numpy as np
-  >>> x = np.random.random(100)
-  >>> y = np.random.random(100)
-  >>> z = np.random.random(100)
+  >>> x = np.linspace(0., 5., 6)
+  >>> y = np.linspace(10., 15., 6)
+  >>> z = np.linspace(20., 25., 6)
   >>> car_array = CartesianRepresentation(x * u.m, y * u.m, z * u.m)
-  >>> car_array  # doctest: +SKIP
+  >>> car_array
   <CartesianRepresentation (x, y, z) in m
-      [(0.7093..., 0.7788..., 0.3842...),
-       (0.8434..., 0.4543..., 0.9579...),
-       ...
-       (0.0179..., 0.8587..., 0.4916...),
-       (0.0207..., 0.3355..., 0.2799...)]>
+      [(0.0, 10.0, 20.0), (1.0, 11.0, 21.0), (2.0, 12.0, 22.0),
+       (3.0, 13.0, 23.0), (4.0, 14.0, 24.0), (5.0, 15.0, 25.0)]>
+  >>> car_array[2]
+  <CartesianRepresentation (x, y, z) in m
+      (2.0, 12.0, 22.0)>
+  >>> car_array.reshape(3, 2)
+  <CartesianRepresentation (x, y, z) in m
+      [[(0.0, 10.0, 20.0), (1.0, 11.0, 21.0)],
+       [(2.0, 12.0, 22.0), (3.0, 13.0, 23.0)],
+       [(4.0, 14.0, 24.0), (5.0, 15.0, 25.0)]]>
 
 .. _astropy-coordinates-create-repr:
 


### PR DESCRIPTION
Now that representations can change shape, etc. (#4123), it is time to move up to also allow this for frames ~~(~~ and ~~eventually~~ coordinates~~)~~.

For frames, one has to ensure that any frame attributes are reshaped if needed. To get this to work, before anything else, all attributes must have shapes that makes sense, i.e., do not carry extraneous information. Thus, this needs `obsgeloc` and `obsgeovel` not to be quantities with the extraneous dimension for x,y,z, but rather cartesian representations. Hence, this builds on #5253 ~~(could be #5207 too; will rebase on master once either is merged).~~ and now that that PR is merged, this is rebased on it.

At present, I assume that any attribute will either be a "scalar" or that it has a shape that equals (or, in case of quantities, can be broadcast to) the shape of the coordinates. I.e., I don't broadcast the shape of the coordinates to those of an attribute (as some of the tests assumed would be possible). I think this makes it too complicated (and we don't do this in `Time` either). The one exception I make is in `EarthLocation.get_itrs`, where it seems to make sense that a single position would be used with multiple times.

Questions for now, especially for @taldcroft and @eteq, are if I do the checks in the initializer and in `_apply` sensibly.

UPDATE: now also includes `SkyCoord`

UPDATE 2: with #5253 in, this is rebased and should thus be easier to review...