### PR TITLE
use six.moves versions for map/range/zip (when used)

### DIFF
--- a/astropy/constants/tests/test_pickle.py
+++ b/astropy/constants/tests/test_pickle.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ... import constants as const
 from ...tests.helper import pytest, pickle_protocol, check_pickling_recovery
+from ...extern.six.moves import zip
 
 originals = [const.Constant('h_fake', 'Not Planck',
                             0.0, 'J s', 0.0, 'fakeref',

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -10,8 +10,9 @@ import numpy as np
 from .core import Kernel, Kernel1D, Kernel2D, MAX_NORMALIZATION
 from ..utils.exceptions import AstropyUserWarning
 from ..utils.console import human_file_size
+from .. import units as u
 
-from astropy import units as u
+from ..extern.six.moves import range, zip
 
 
 # Disabling all doctests in this module until a better way of handling warnings

--- a/astropy/convolution/tests/test_convolve_speeds.py
+++ b/astropy/convolution/tests/test_convolve_speeds.py
@@ -6,6 +6,8 @@ import timeit
 
 import numpy as np  # pylint: disable=W0611
 
+from ...extern.six.moves import range, zip
+
 # largest image size to use for "linear" and fft convolutions
 max_exponents_linear = {1: 15, 2: 7, 3: 5}
 max_exponents_fft = {1: 15, 2: 10, 3: 7}

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from ..modeling.core import FittableModel, custom_model
+from ..extern.six.moves import range
 
 __all__ = ['discretize_model']
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -19,6 +19,7 @@ import numpy as np
 # Project
 from ..utils.compat.misc import override__dir__
 from ..extern import six
+from ..extern.six.moves import zip
 from .. import units as u
 from ..utils import OrderedDescriptor, OrderedDescriptorContainer
 from .transformations import TransformGraph

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -15,6 +15,8 @@ from .. import earth_orientation as earth
 
 from .utils import EQUINOX_B1950
 
+from ...extern.six.moves import range
+
 
 class FK4(BaseCoordinateFrame):
     """

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -17,6 +17,8 @@ from ...time import Time
 from ...utils import iers
 from ...utils.exceptions import AstropyWarning
 
+from ...extern.six.moves import range
+
 # The UTC time scale is not properly defined prior to 1960, so Time('B1950',
 # scale='utc') will emit a warning. Instead, we use Time('B1950', scale='tai')
 # which is equivalent, but does not emit a warning.

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -10,6 +10,7 @@ from ..utils.compat.numpy import matmul
 
 from .. import units as u
 from .angles import Angle
+from ..extern.six.moves import range
 
 
 def matrix_product(*matrices):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ..utils.compat.misc import override__dir__
 from ..extern import six
-from ..extern.six.moves import zip
+from ..extern.six.moves import zip, range
 from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord

--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -10,7 +10,8 @@ import os
 
 import numpy as np
 
-from astropy.table import Table, Column
+from ....table import Table, Column
+from ....extern.six.moves import range
 
 
 def ref_fk4_no_e_fk4(fnout='fk4_no_e_fk4.csv'):

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -11,6 +11,7 @@ from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
 from ....utils.data import get_pkg_data_contents
+from ....extern.six.moves import range
 
 #the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
@@ -11,6 +11,7 @@ from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
 from ....utils.data import get_pkg_data_contents
+from ....extern.six.moves import range
 
 #the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -11,6 +11,7 @@ from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
 from ....utils.data import get_pkg_data_contents
+from ....extern.six.moves import range
 
 #the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -11,6 +11,7 @@ from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
 from ....utils.data import get_pkg_data_contents
+from ....extern.six.moves import range
 
 #the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -11,6 +11,7 @@ Tests for the projected separation stuff
 import numpy as np
 
 from ...tests.helper import pytest, assert_quantity_allclose as assert_allclose
+from ...extern.six.moves import zip
 from ... import units as u
 from ..builtin_frames import ICRS, FK5, Galactic
 from .. import Angle, Distance

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -16,6 +16,8 @@ from ...tests.helper import (pytest, quantity_allclose as allclose,
 from .. import EarthLocation, CartesianRepresentation
 from ...time import Time
 
+from ...extern.six.moves import range
+
 # used below in the next parametrized test
 m31_sys = [ICRS, FK5, FK4, Galactic]
 m31_coo = [(10.6847929, 41.2690650), (10.6847929, 41.2690650), (10.0004738, 40.9952444), (121.1744050, -21.5729360)]

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -14,6 +14,7 @@ import numpy as np
 from ..earth import EarthLocation, ELLIPSOIDS
 from ..angles import Longitude, Latitude
 from ...tests.helper import pytest, quantity_allclose, remote_data
+from ...extern.six.moves import zip
 from ... import units as u
 from ..name_resolve import NameResolveError
 

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy import testing as npt
 from ...tests.helper import pytest, assert_quantity_allclose as assert_allclose
+from ...extern.six.moves import zip
 
 from ... import units as u
 from ...utils import minversion

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -1,4 +1,4 @@
-from ...extern.six.moves import cPickle as pickle
+from ...extern.six.moves import zip, cPickle as pickle
 from ...coordinates import Longitude
 from ... import coordinates as coord
 from ...tests.helper import pytest, pickle_protocol, check_pickling_recovery

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -18,6 +18,7 @@ from ... import units as u
 from ...tests.helper import (pytest, remote_data, catch_warnings,
                              quantity_allclose,
                              assert_quantity_allclose as assert_allclose)
+from ...extern.six.moves import zip
 from ..representation import REPRESENTATION_CLASSES
 from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             SphericalRepresentation, CartesianRepresentation,

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -14,6 +14,8 @@ from ...time import Time
 from ...tests.helper import (pytest, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 
+from ...extern.six.moves import range
+
 
 @pytest.mark.parametrize("inradec,expectedlatlon, tolsep", [
     ((45, 45)*u.deg, (0, 0)*u.deg, .001*u.arcsec),

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -29,6 +29,7 @@ import numpy as np
 from ..utils.compat import suppress
 from ..utils.compat.funcsigs import signature
 from ..extern import six
+from ..extern.six.moves import range
 
 
 __all__ = ['TransformGraph', 'CoordinateTransform', 'FunctionTransform',

--- a/astropy/cosmology/tests/test_pickle.py
+++ b/astropy/cosmology/tests/test_pickle.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 from ...tests.helper import pytest, pickle_protocol, check_pickling_recovery
+from ...extern.six.moves import zip
 from ... import cosmology as cosm
 
 originals = [cosm.FLRW]

--- a/astropy/extern/configobj/configobj.py
+++ b/astropy/extern/configobj/configobj.py
@@ -21,6 +21,7 @@ import collections
 from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF16_BE, BOM_UTF16_LE
 
 from ...extern import six
+from ...extern.six.moves import range, zip, map
 # from __future__ import __version__
 
 # imported lazily to avoid startup performance hit if it isn't used
@@ -140,28 +141,28 @@ class UnknownType(Exception):
 
 
 class Builder(object):
-    
+
     def build(self, o):
         if m is None:
             raise UnknownType(o.__class__.__name__)
         return m(o)
-    
+
     def build_List(self, o):
         return list(map(self.build, o.getChildren()))
-    
+
     def build_Const(self, o):
         return o.value
-    
+
     def build_Dict(self, o):
         d = {}
         i = iter(map(self.build, o.getChildren()))
         for el in i:
             d[el] = next(i)
         return d
-    
+
     def build_Tuple(self, o):
         return tuple(self.build_List(o))
-    
+
     def build_Name(self, o):
         if o.name == 'None':
             return None
@@ -169,10 +170,10 @@ class Builder(object):
             return True
         if o.name == 'False':
             return False
-        
+
         # An undefined Name
         raise UnknownType('Undefined Name')
-    
+
     def build_Add(self, o):
         real, imag = list(map(self.build_Const, o.getChildren()))
         try:
@@ -182,14 +183,14 @@ class Builder(object):
         if not isinstance(imag, complex) or imag.real != 0.0:
             raise UnknownType('Add')
         return real+imag
-    
+
     def build_Getattr(self, o):
         parent = self.build(o.expr)
         return getattr(parent, o.attrname)
-    
+
     def build_UnarySub(self, o):
         return -self.build_Const(o.getChildren()[0])
-    
+
     def build_UnaryAdd(self, o):
         return self.build_Const(o.getChildren()[0])
 
@@ -200,7 +201,7 @@ _builder = Builder()
 def unrepr(s):
     if not s:
         return s
-    
+
     # this is supposed to be safe
     import ast
     return ast.literal_eval(s)
@@ -305,7 +306,7 @@ class InterpolationEngine(object):
         # short-cut
         if not self._cookie in value:
             return value
-        
+
         def recursive_interpolate(key, value, section, backtrail):
             """The function that does the actual work.
 
@@ -405,7 +406,7 @@ class InterpolationEngine(object):
         (e.g., if we interpolated "$$" and returned "$").
         """
         raise NotImplementedError()
-    
+
 
 
 class ConfigParserInterpolation(InterpolationEngine):
@@ -454,27 +455,27 @@ interpolation_engines = {
 
 def __newobj__(cls, *args):
     # Hack for pickle
-    return cls.__new__(cls, *args) 
+    return cls.__new__(cls, *args)
 
 class Section(dict):
     """
     A dictionary-like object that represents a section in a config file.
-    
+
     It does string interpolation if the 'interpolation' attribute
     of the 'main' object is set to True.
-    
+
     Interpolation is tried first from this object, then from the 'DEFAULT'
     section of this object, next from the parent and its 'DEFAULT' section,
     and so on until the main object is reached.
-    
+
     A Section will behave like an ordered dictionary - following the
     order of the ``scalars`` and ``sections`` attributes.
     You can use this to change the order of members.
-    
+
     Iteration follows the order: scalars, then sections.
     """
 
-    
+
     def __setstate__(self, state):
         dict.update(self, state[0])
         self.__dict__.update(state[1])
@@ -482,8 +483,8 @@ class Section(dict):
     def __reduce__(self):
         state = (dict(self), self.__dict__)
         return (__newobj__, (self.__class__,), state)
-    
-    
+
+
     def __init__(self, parent, depth, main, indict=None, name=None):
         """
         * parent is the section above
@@ -508,8 +509,8 @@ class Section(dict):
         # (rather than just passing to ``dict.__init__``)
         for entry, value in indict.items():
             self[entry] = value
-            
-            
+
+
     def _initialise(self):
         # the sequence of scalar values in this Section
         self.scalars = []
@@ -553,7 +554,7 @@ class Section(dict):
     def __getitem__(self, key):
         """Fetch the item and do string interpolation."""
         val = dict.__getitem__(self, key)
-        if self.main.interpolation: 
+        if self.main.interpolation:
             if isinstance(val, six.string_types):
                 return self._interpolate(key, val)
             if isinstance(val, list):
@@ -570,20 +571,20 @@ class Section(dict):
     def __setitem__(self, key, value, unrepr=False):
         """
         Correctly set a value.
-        
+
         Making dictionary values Section instances.
         (We have to special case 'Section' instances - which are also dicts)
-        
+
         Keys must be strings.
         Values need only be strings (or lists of strings) if
         ``main.stringify`` is set.
-        
+
         ``unrepr`` must be set when setting a value to a dictionary, without
         creating a new sub-section.
         """
         if not isinstance(key, six.string_types):
             raise ValueError('The key "%s" is not a string.' % key)
-        
+
         # add the comment
         if key not in self.comments:
             self.comments[key] = []
@@ -684,7 +685,7 @@ class Section(dict):
         """
         A version of clear that also affects scalars/sections
         Also clears comments and configspec.
-        
+
         Leaves other attributes alone :
             depth/main/parent are not affected
         """
@@ -758,10 +759,10 @@ class Section(dict):
     def dict(self):
         """
         Return a deepcopy of self as a dictionary.
-        
+
         All members that are ``Section`` instances are recursively turned to
         ordinary dictionaries - by calling their ``dict`` method.
-        
+
         >>> n = a.dict()
         >>> n == a
         1
@@ -786,7 +787,7 @@ class Section(dict):
     def merge(self, indict):
         """
         A recursive update - useful for merging config files.
-        
+
         >>> a = '''[section1]
         ...     option1 = True
         ...     [[subsection]]
@@ -806,17 +807,17 @@ class Section(dict):
             if (key in self and isinstance(self[key], collections.Mapping) and
                                 isinstance(val, collections.Mapping)):
                 self[key].merge(val)
-            else:   
+            else:
                 self[key] = val
 
 
     def rename(self, oldkey, newkey):
         """
         Change a keyname to another, without changing position in sequence.
-        
+
         Implemented so that transformations can be made on keys,
         as well as on values. (used by encode and decode)
-        
+
         Also renames comments.
         """
         if oldkey in self.scalars:
@@ -844,30 +845,30 @@ class Section(dict):
             call_on_sections=False, **keywargs):
         """
         Walk every member and call a function on the keyword and value.
-        
+
         Return a dictionary of the return values
-        
+
         If the function raises an exception, raise the errror
         unless ``raise_errors=False``, in which case set the return value to
         ``False``.
-        
+
         Any unrecognised keyword arguments you pass to walk, will be pased on
         to the function you pass in.
-        
+
         Note: if ``call_on_sections`` is ``True`` then - on encountering a
         subsection, *first* the function is called for the *whole* subsection,
         and then recurses into it's members. This means your function must be
         able to handle strings, dictionaries and lists. This allows you
         to change the key of subsections as well as for ordinary members. The
         return value when called on the whole subsection has to be discarded.
-        
+
         See  the encode and decode methods for examples, including functions.
-        
+
         .. admonition:: caution
-        
+
             You can use ``walk`` to transform the names of members of a section
             but you mustn't add or delete members.
-        
+
         >>> config = '''[XXXXsection]
         ... XXXXkey = XXXXvalue'''.splitlines()
         >>> cfg = ConfigObj(config)
@@ -930,17 +931,17 @@ class Section(dict):
         Accepts a key as input. The corresponding value must be a string or
         the objects (``True`` or 1) or (``False`` or 0). We allow 0 and 1 to
         retain compatibility with Python 2.2.
-        
-        If the string is one of  ``True``, ``On``, ``Yes``, or ``1`` it returns 
+
+        If the string is one of  ``True``, ``On``, ``Yes``, or ``1`` it returns
         ``True``.
-        
-        If the string is one of  ``False``, ``Off``, ``No``, or ``0`` it returns 
+
+        If the string is one of  ``False``, ``Off``, ``No``, or ``0`` it returns
         ``False``.
-        
+
         ``as_bool`` is not case sensitive.
-        
+
         Any other input will raise a ``ValueError``.
-        
+
         >>> a = ConfigObj()
         >>> a['a'] = 'fish'
         >>> a.as_bool('a')
@@ -972,10 +973,10 @@ class Section(dict):
     def as_int(self, key):
         """
         A convenience method which coerces the specified value to an integer.
-        
+
         If the value is an invalid literal for ``int``, a ``ValueError`` will
         be raised.
-        
+
         >>> a = ConfigObj()
         >>> a['a'] = 'fish'
         >>> a.as_int('a')
@@ -995,10 +996,10 @@ class Section(dict):
     def as_float(self, key):
         """
         A convenience method which coerces the specified value to a float.
-        
+
         If the value is an invalid literal for ``float``, a ``ValueError`` will
         be raised.
-        
+
         >>> a = ConfigObj()
         >>> a['a'] = 'fish'
         >>> a.as_float('a')  #doctest: +IGNORE_EXCEPTION_DETAIL
@@ -1012,13 +1013,13 @@ class Section(dict):
         3.2...
         """
         return float(self[key])
-    
-    
+
+
     def as_list(self, key):
         """
         A convenience method which fetches the specified value, guaranteeing
         that it is a list.
-        
+
         >>> a = ConfigObj()
         >>> a['a'] = 1
         >>> a.as_list('a')
@@ -1034,15 +1035,15 @@ class Section(dict):
         if isinstance(result, (tuple, list)):
             return list(result)
         return [result]
-        
+
 
     def restore_default(self, key):
         """
         Restore (and return) default value for the specified key.
-        
+
         This method will only work for a ConfigObj that was created
         with a configspec and has been validated.
-        
+
         If there is no default value for this key, ``KeyError`` is raised.
         """
         default = self.default_values[key]
@@ -1051,20 +1052,20 @@ class Section(dict):
             self.defaults.append(key)
         return default
 
-    
+
     def restore_defaults(self):
         """
         Recursively restore default values to all members
         that have them.
-        
+
         This method will only work for a ConfigObj that was created
         with a configspec and has been validated.
-        
+
         It doesn't delete or modify entries without default values.
         """
         for key in self.default_values:
             self.restore_default(key)
-            
+
         for section in self.sections:
             self[section].restore_defaults()
 
@@ -1179,7 +1180,7 @@ class ConfigObj(Section):
                  write_empty_values=False, _inspec=False):
         """
         Parse a config file or create a config file object.
-        
+
         ``ConfigObj(infile=None, configspec=None, encoding=None,
                     interpolation=True, raise_errors=False, list_values=True,
                     create_empty=False, file_error=False, stringify=True,
@@ -1189,9 +1190,9 @@ class ConfigObj(Section):
         self._inspec = _inspec
         # init the superclass
         Section.__init__(self, self, 0, self)
-        
+
         infile = infile or []
-        
+
         _options = {'configspec': configspec,
                     'encoding': encoding, 'interpolation': interpolation,
                     'raise_errors': raise_errors, 'list_values': list_values,
@@ -1207,7 +1208,7 @@ class ConfigObj(Section):
             warnings.warn('Passing in an options dictionary to ConfigObj() is '
                           'deprecated. Use **options instead.',
                           DeprecationWarning)
-            
+
             # TODO: check the values too.
             for entry in options:
                 if entry not in OPTION_DEFAULTS:
@@ -1218,18 +1219,18 @@ class ConfigObj(Section):
                 keyword_value = _options[entry]
                 if value != keyword_value:
                     options[entry] = keyword_value
-        
+
         # XXXX this ignores an explicit list_values = True in combination
         # with _inspec. The user should *never* do that anyway, but still...
         if _inspec:
             options['list_values'] = False
-        
+
         self._initialise(options)
         configspec = options['configspec']
         self._original_configspec = configspec
         self._load(infile, configspec)
-        
-        
+
+
     def _load(self, infile, configspec):
         if isinstance(infile, six.string_types):
             self.filename = infile
@@ -1247,10 +1248,10 @@ class ConfigObj(Section):
                     with open(infile, 'w') as h:
                         h.write('')
                 content = []
-                
+
         elif isinstance(infile, (list, tuple)):
             content = list(infile)
-            
+
         elif isinstance(infile, dict):
             # initialise self
             # the Section class handles creating subsections
@@ -1263,18 +1264,18 @@ class ConfigObj(Section):
                         this_section[section] = {}
                         set_section(in_section[section], this_section[section])
                 set_section(infile, self)
-                
+
             else:
                 for entry in infile:
                     self[entry] = infile[entry]
             del self._errors
-            
+
             if configspec is not None:
                 self._handle_configspec(configspec)
             else:
                 self.configspec = None
             return
-        
+
         elif getattr(infile, 'read', MISSING) is not MISSING:
             # This supports file like objects
             content = infile.read() or []
@@ -1301,7 +1302,7 @@ class ConfigObj(Section):
 
         assert all(isinstance(line, six.string_types) for line in content), repr(content)
         content = [line.rstrip('\r\n') for line in content]
-            
+
         self._parse(content)
         # if we had any errors, now is the time to raise them
         if self._errors:
@@ -1319,17 +1320,17 @@ class ConfigObj(Section):
             raise error
         # delete private attributes
         del self._errors
-        
+
         if configspec is None:
             self.configspec = None
         else:
             self._handle_configspec(configspec)
-    
-    
+
+
     def _initialise(self, options=None):
         if options is None:
             options = OPTION_DEFAULTS
-            
+
         # initialise a few variables
         self.filename = None
         self._errors = []
@@ -1346,18 +1347,18 @@ class ConfigObj(Section):
         self.newlines = None
         self.write_empty_values = options['write_empty_values']
         self.unrepr = options['unrepr']
-        
+
         self.initial_comment = []
         self.final_comment = []
         self.configspec = None
-        
+
         if self._inspec:
             self.list_values = False
-        
+
         # Clear section attributes as well
         Section._initialise(self)
-        
-        
+
+
     def __repr__(self):
         def _getval(key):
             try:
@@ -1365,29 +1366,29 @@ class ConfigObj(Section):
             except MissingInterpolationOption:
                 return dict.__getitem__(self, key)
         return ('%s({%s})' % (self.__class__.__name__,
-                ', '.join([('%s: %s' % (repr(key), repr(_getval(key)))) 
+                ', '.join([('%s: %s' % (repr(key), repr(_getval(key))))
                 for key in (self.scalars + self.sections)])))
-    
-    
+
+
     def _handle_bom(self, infile):
         """
         Handle any BOM, and decode if necessary.
-        
+
         If an encoding is specified, that *must* be used - but the BOM should
         still be removed (and the BOM attribute set).
-        
+
         (If the encoding is wrongly specified, then a BOM for an alternative
         encoding won't be discovered or removed.)
-        
+
         If an encoding is not specified, UTF8 or UTF16 BOM will be detected and
         removed. The BOM attribute will be set. UTF16 will be decoded to
         unicode.
-        
+
         NOTE: This method must not be called with an empty ``infile``.
-        
+
         Specifying the *wrong* encoding is likely to cause a
         ``UnicodeDecodeError``.
-        
+
         ``infile`` must always be returned as a list of lines, but may be
         passed in as a single string.
         """
@@ -1398,7 +1399,7 @@ class ConfigObj(Section):
             # the encoding specified doesn't have one
             # just decode
             return self._decode(infile, self.encoding)
-        
+
         if isinstance(infile, (list, tuple)):
             line = infile[0]
         else:
@@ -1427,18 +1428,18 @@ class ConfigObj(Section):
                         ##self.BOM = True
                         # Don't need to remove BOM
                         return self._decode(infile, encoding)
-                    
+
                 # If we get this far, will *probably* raise a DecodeError
                 # As it doesn't appear to start with a BOM
                 return self._decode(infile, self.encoding)
-            
+
             # Must be UTF8
             BOM = BOM_SET[enc]
             if not line.startswith(BOM):
                 return self._decode(infile, self.encoding)
-            
+
             newline = line[len(BOM):]
-            
+
             # BOM removed
             if isinstance(infile, (list, tuple)):
                 infile[0] = newline
@@ -1446,7 +1447,7 @@ class ConfigObj(Section):
                 infile = newline
             self.BOM = True
             return self._decode(infile, self.encoding)
-        
+
         # No encoding specified - so we need to check for UTF8/UTF16
         for BOM, (encoding, final_encoding) in list(BOMS.items()):
             if not isinstance(line, six.binary_type) or not line.startswith(BOM):
@@ -1473,7 +1474,7 @@ class ConfigObj(Section):
                         return self._decode(infile, 'utf-8')
                 # UTF16 - have to decode
                 return self._decode(infile, encoding)
-            
+
 
         if six.PY2 and isinstance(line, str):
             # don't actually do any decoding, since we're on python 2 and
@@ -1497,7 +1498,7 @@ class ConfigObj(Section):
     def _decode(self, infile, encoding):
         """
         Decode infile to unicode. Using the specified encoding.
-        
+
         if is a string, it also needs converting to a list.
         """
         if isinstance(infile, six.string_types):
@@ -1546,14 +1547,14 @@ class ConfigObj(Section):
         temp_list_values = self.list_values
         if self.unrepr:
             self.list_values = False
-            
+
         comment_list = []
         done_start = False
         this_section = self
         maxline = len(infile) - 1
         cur_index = -1
         reset_comment = False
-        
+
         while cur_index < maxline:
             if reset_comment:
                 comment_list = []
@@ -1565,13 +1566,13 @@ class ConfigObj(Section):
                 reset_comment = False
                 comment_list.append(line)
                 continue
-            
+
             if not done_start:
                 # preserve initial comment
                 self.initial_comment = comment_list
                 comment_list = []
                 done_start = True
-                
+
             reset_comment = True
             # first we check if it's a section marker
             mat = self._sectionmarker.match(line)
@@ -1585,7 +1586,7 @@ class ConfigObj(Section):
                     self._handle_error("Cannot compute the section depth",
                                        NestingError, infile, cur_index)
                     continue
-                
+
                 if cur_depth < this_section.depth:
                     # the new section is dropping back to a previous level
                     try:
@@ -1605,13 +1606,13 @@ class ConfigObj(Section):
                     self._handle_error("Section too nested",
                                        NestingError, infile, cur_index)
                     continue
-                    
+
                 sect_name = self._unquote(sect_name)
                 if sect_name in parent:
                     self._handle_error('Duplicate section name',
                                        DuplicateError, infile, cur_index)
                     continue
-                
+
                 # create the new section
                 this_section = Section(
                     parent,
@@ -1712,7 +1713,7 @@ class ConfigObj(Section):
         """
         Given a section and a depth level, walk back through the sections
         parents to see if the depth level matches a previous section.
-        
+
         Return a reference to the right section,
         or raise a SyntaxError.
         """
@@ -1730,7 +1731,7 @@ class ConfigObj(Section):
     def _handle_error(self, text, ErrorClass, infile, cur_index):
         """
         Handle an error according to the error settings.
-        
+
         Either raise the error or store it.
         The error will have occured at ``cur_index``
         """
@@ -1759,19 +1760,19 @@ class ConfigObj(Section):
     def _quote(self, value, multiline=True):
         """
         Return a safely quoted version of a value.
-        
+
         Raise a ConfigObjError if the value cannot be safely quoted.
         If multiline is ``True`` (default) then use triple quotes
         if necessary.
-        
+
         * Don't quote values that don't need it.
         * Recursively quote members of a list and return a comma joined list.
         * Multiline is ``False`` for lists.
         * Obey list syntax for empty and single member lists.
-        
+
         If ``list_values=False`` then the value is only quoted if it contains
         a ``\\n`` (is multiline) or '#'.
-        
+
         If ``write_empty_values`` is set, and the value is an empty string, it
         won't be quoted.
         """
@@ -1779,7 +1780,7 @@ class ConfigObj(Section):
             # Only if multiline is set, so that it is used for values not
             # keys, and not values that are part of a list
             return ''
-        
+
         if multiline and isinstance(value, (list, tuple)):
             if not value:
                 return ','
@@ -1797,12 +1798,12 @@ class ConfigObj(Section):
 
         if not value:
             return '""'
-        
+
         no_lists_no_quotes = not self.list_values and '\n' not in value and '#' not in value
         need_triple = multiline and ((("'" in value) and ('"' in value)) or ('\n' in value ))
         hash_triple_quote = multiline and not need_triple and ("'" in value) and ('"' in value) and ('#' in value)
         check_for_single = (no_lists_no_quotes or not need_triple) and not hash_triple_quote
-        
+
         if check_for_single:
             if not self.list_values:
                 # we don't quote if ``list_values=False``
@@ -1820,13 +1821,13 @@ class ConfigObj(Section):
         else:
             # if value has '\n' or "'" *and* '"', it will need triple quotes
             quot = self._get_triple_quote(value)
-        
+
         if quot == noquot and '#' in value and self.list_values:
             quot = self._get_single_quote(value)
-                
+
         return quot % value
-    
-    
+
+
     def _get_single_quote(self, value):
         if ("'" in value) and ('"' in value):
             raise ConfigObjError('Value "%s" cannot be safely quoted.' % value)
@@ -1835,15 +1836,15 @@ class ConfigObj(Section):
         else:
             quot = dquot
         return quot
-    
-    
+
+
     def _get_triple_quote(self, value):
         if (value.find('"""') != -1) and (value.find("'''") != -1):
             raise ConfigObjError('Value "%s" cannot be safely quoted.' % value)
         if value.find('"""') == -1:
             quot = tdquot
         else:
-            quot = tsquot 
+            quot = tsquot
         return quot
 
 
@@ -1933,7 +1934,7 @@ class ConfigObj(Section):
 
     def _handle_configspec(self, configspec):
         """Parse the configspec."""
-        # FIXME: Should we check that the configspec was created with the 
+        # FIXME: Should we check that the configspec was created with the
         #        correct settings ? (i.e. ``list_values=False``)
         if not isinstance(configspec, ConfigObj):
             try:
@@ -1947,11 +1948,11 @@ class ConfigObj(Section):
                 raise ConfigspecError('Parsing configspec failed: %s' % e)
             except IOError as e:
                 raise IOError('Reading configspec failed: %s' % e)
-        
-        self.configspec = configspec
-            
 
-        
+        self.configspec = configspec
+
+
+
     def _set_configspec(self, section, copy):
         """
         Called by validate. Handles setting the configspec on subsections
@@ -1963,7 +1964,7 @@ class ConfigObj(Section):
             for entry in section.sections:
                 if entry not in configspec:
                     section[entry].configspec = many
-                    
+
         for entry in configspec.sections:
             if entry == '__many__':
                 continue
@@ -1974,11 +1975,11 @@ class ConfigObj(Section):
                     # copy comments
                     section.comments[entry] = configspec.comments.get(entry, [])
                     section.inline_comments[entry] = configspec.inline_comments.get(entry, '')
-                
+
             # Could be a scalar when we expect a section
             if isinstance(section[entry], Section):
                 section[entry].configspec = configspec[entry]
-                        
+
 
     def _write_line(self, indent_string, entry, this_entry, comment):
         """Write an individual line, for the write method"""
@@ -2018,9 +2019,9 @@ class ConfigObj(Section):
     def write(self, outfile=None, section=None):
         """
         Write the current ConfigObj as a file
-        
+
         tekNico: FIXME: use StringIO instead of real files
-        
+
         >>> filename = a.filename
         >>> a.filename = 'test.ini'
         >>> a.write()
@@ -2033,7 +2034,7 @@ class ConfigObj(Section):
         if self.indent_type is None:
             # this can be true if initialised from a dictionary
             self.indent_type = DEFAULT_INDENT_TYPE
-            
+
         out = []
         cs = self._a_to_u('#')
         csp = self._a_to_u('# ')
@@ -2047,7 +2048,7 @@ class ConfigObj(Section):
                 if stripped_line and not stripped_line.startswith(cs):
                     line = csp + line
                 out.append(line)
-                
+
         indent_string = self.indent_type * section.depth
         for entry in (section.scalars + section.sections):
             if entry in section.defaults:
@@ -2060,7 +2061,7 @@ class ConfigObj(Section):
                 out.append(indent_string + comment_line)
             this_entry = section[entry]
             comment = self._handle_comment(section.inline_comments[entry])
-            
+
             if isinstance(this_entry, Section):
                 # a section
                 out.append(self._write_marker(
@@ -2075,7 +2076,7 @@ class ConfigObj(Section):
                     entry,
                     this_entry,
                     comment))
-                
+
         if section is self:
             for line in self.final_comment:
                 line = self._decode_element(line)
@@ -2084,10 +2085,10 @@ class ConfigObj(Section):
                     line = csp + line
                 out.append(line)
             self.interpolation = int_val
-            
+
         if section is not self:
             return out
-        
+
         if (self.filename is None) and (outfile is None):
             # output a list of lines
             # might need to encode
@@ -2101,7 +2102,7 @@ class ConfigObj(Section):
                     out.append('')
                 out[0] = BOM_UTF8 + out[0]
             return out
-        
+
         # Turn the list to a string, joined with correct newlines
         newline = self.newlines or os.linesep
         if (getattr(outfile, 'mode', None) is not None and outfile.mode == 'w'
@@ -2133,34 +2134,34 @@ class ConfigObj(Section):
                  section=None):
         """
         Test the ConfigObj against a configspec.
-        
+
         It uses the ``validator`` object from *validate.py*.
-        
+
         To run ``validate`` on the current ConfigObj, call: ::
-        
+
             test = config.validate(validator)
-        
+
         (Normally having previously passed in the configspec when the ConfigObj
         was created - you can dynamically assign a dictionary of checks to the
         ``configspec`` attribute of a section though).
-        
+
         It returns ``True`` if everything passes, or a dictionary of
         pass/fails (True/False). If every member of a subsection passes, it
         will just have the value ``True``. (It also returns ``False`` if all
         members fail).
-        
+
         In addition, it converts the values from strings to their native
         types if their checks pass (and ``stringify`` is set).
-        
+
         If ``preserve_errors`` is ``True`` (``False`` is default) then instead
         of a marking a fail with a ``False``, it will preserve the actual
         exception object. This can contain info about the reason for failure.
         For example the ``VdtValueTooSmallError`` indicates that the value
         supplied was too small. If a value (or section) is missing it will
         still be marked as ``False``.
-        
+
         You must have the validate module to use ``preserve_errors=True``.
-        
+
         You can then use the ``flatten_errors`` function to turn your nested
         results dictionary into a flattened list of failures - useful for
         displaying meaningful error messages.
@@ -2173,7 +2174,7 @@ class ConfigObj(Section):
                 # Which makes importing configobj faster
                 from validate import VdtMissingValue
                 self._vdtMissingValue = VdtMissingValue
-                
+
             section = self
 
             if copy:
@@ -2183,23 +2184,23 @@ class ConfigObj(Section):
                 section.BOM = section.configspec.BOM
                 section.newlines = section.configspec.newlines
                 section.indent_type = section.configspec.indent_type
-            
+
         #
         # section.default_values.clear() #??
         configspec = section.configspec
         self._set_configspec(section, copy)
 
-        
+
         def validate_entry(entry, spec, val, missing, ret_true, ret_false):
             section.default_values.pop(entry, None)
-                
+
             try:
                 section.default_values[entry] = validator.get_default_value(configspec[entry])
             except (KeyError, AttributeError, validator.baseErrorClass):
                 # No default, bad default or validator has no 'get_default_value'
                 # (e.g. SimpleVal)
                 pass
-            
+
             try:
                 check = validator.check(spec,
                                         val,
@@ -2233,16 +2234,16 @@ class ConfigObj(Section):
                 if not copy and missing and entry not in section.defaults:
                     section.defaults.append(entry)
             return ret_true, ret_false
-        
+
         #
         out = {}
         ret_true = True
         ret_false = True
-        
+
         unvalidated = [k for k in section.scalars if k not in configspec]
-        incorrect_sections = [k for k in configspec.sections if k in section.scalars]        
+        incorrect_sections = [k for k in configspec.sections if k in section.scalars]
         incorrect_scalars = [k for k in configspec.scalars if k in section.sections]
-        
+
         for entry in configspec.scalars:
             if entry in ('__many__', '___many___'):
                 # reserved names
@@ -2262,16 +2263,16 @@ class ConfigObj(Section):
             else:
                 missing = False
                 val = section[entry]
-            
-            ret_true, ret_false = validate_entry(entry, configspec[entry], val, 
+
+            ret_true, ret_false = validate_entry(entry, configspec[entry], val,
                                                  missing, ret_true, ret_false)
-        
+
         many = None
         if '__many__' in configspec.scalars:
             many = configspec['__many__']
         elif '___many___' in configspec.scalars:
             many = configspec['___many___']
-        
+
         if many is not None:
             for entry in unvalidated:
                 val = section[entry]
@@ -2295,7 +2296,7 @@ class ConfigObj(Section):
                 ret_false = False
                 msg = 'Section %r was provided as a single value' % entry
                 out[entry] = validator.baseErrorClass(msg)
-                
+
         # Missing sections will have been created as empty ones when the
         # configspec was read.
         for entry in section.sections:
@@ -2316,7 +2317,7 @@ class ConfigObj(Section):
                 ret_false = False
             else:
                 ret_true = False
-        
+
         section.extra_values = unvalidated
         if preserve_errors and not section._created:
             # If the section wasn't created (i.e. it wasn't missing)
@@ -2345,12 +2346,12 @@ class ConfigObj(Section):
         self.configspec = None
         # Just to be sure ;-)
         self._original_configspec = None
-        
-        
+
+
     def reload(self):
         """
         Reload a ConfigObj from file.
-        
+
         This method raises a ``ReloadError`` if the ConfigObj doesn't have
         a filename attribute pointing to a file.
         """
@@ -2363,31 +2364,31 @@ class ConfigObj(Section):
             if entry == 'configspec':
                 continue
             current_options[entry] = getattr(self, entry)
-            
+
         configspec = self._original_configspec
         current_options['configspec'] = configspec
-            
+
         self.clear()
         self._initialise(current_options)
         self._load(filename, configspec)
-        
+
 
 
 class SimpleVal(object):
     """
     A simple validator.
     Can be used to check that all members expected are present.
-    
+
     To use it, provide a configspec with all your members in (the value given
     will be ignored). Pass an instance of ``SimpleVal`` to the ``validate``
     method of your ``ConfigObj``. ``validate`` will return ``True`` if all
     members are present, or a dictionary with True/False meaning
     present/missing. (Whole missing sections will be replaced with ``False``)
     """
-    
+
     def __init__(self):
         self.baseErrorClass = ConfigObjError
-    
+
     def check(self, check, member, missing=False):
         """A dummy check method, always returns the value unchanged."""
         if missing:
@@ -2399,32 +2400,32 @@ def flatten_errors(cfg, res, levels=None, results=None):
     """
     An example function that will turn a nested dictionary of results
     (as returned by ``ConfigObj.validate``) into a flat list.
-    
+
     ``cfg`` is the ConfigObj instance being checked, ``res`` is the results
     dictionary returned by ``validate``.
-    
+
     (This is a recursive function, so you shouldn't use the ``levels`` or
     ``results`` arguments - they are used by the function.)
-    
+
     Returns a list of keys that failed. Each member of the list is a tuple::
-    
+
         ([list of sections...], key, result)
-    
+
     If ``validate`` was called with ``preserve_errors=False`` (the default)
     then ``result`` will always be ``False``.
 
     *list of sections* is a flattened list of sections that the key was found
     in.
-    
+
     If the section was missing (or a section was expected and a scalar provided
     - or vice-versa) then key will be ``None``.
-    
+
     If the value (or section) was missing then ``result`` will be ``False``.
-    
+
     If ``validate`` was called with ``preserve_errors=True`` and a value
     was present, but failed the check, then ``result`` will be the exception
     object returned. You can use this as a string that describes the failure.
-    
+
     For example *The value "3" is of the wrong type*.
     """
     if levels is None:
@@ -2459,21 +2460,21 @@ def get_extra_values(conf, _prepend=()):
     """
     Find all the values and sections not in the configspec from a validated
     ConfigObj.
-    
+
     ``get_extra_values`` returns a list of tuples where each tuple represents
     either an extra section, or an extra value.
-    
-    The tuples contain two values, a tuple representing the section the value 
+
+    The tuples contain two values, a tuple representing the section the value
     is in and the name of the extra values. For extra values in the top level
     section the first member will be an empty tuple. For values in the 'foo'
     section the first member will be ``('foo',)``. For members in the 'bar'
     subsection of the 'foo' section the first member will be ``('foo', 'bar')``.
-    
+
     NOTE: If you call ``get_extra_values`` on a ConfigObj instance that hasn't
     been validated it will return an empty list.
     """
     out = []
-    
+
     out.extend([(_prepend, name) for name in conf.extra_values])
     for name in conf.sections:
         if name not in conf.extra_values:

--- a/astropy/extern/ply/cpp.py
+++ b/astropy/extern/ply/cpp.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2007
 # All rights reserved
 #
-# This module implements an ANSI-C style lexical preprocessor for PLY. 
+# This module implements an ANSI-C style lexical preprocessor for PLY.
 # -----------------------------------------------------------------------------
 from __future__ import generators
 
@@ -68,7 +68,7 @@ def t_CPP_COMMENT2(t):
     r'(//.*?(\n|$))'
     # replace with '/n'
     t.type = 'CPP_WS'; t.value = '\n'
-    
+
 def t_error(t):
     t.type = t.value[0]
     t.value = t.value[0]
@@ -80,10 +80,12 @@ import copy
 import time
 import os.path
 
+from ...extern.six.moves import range
+
 # -----------------------------------------------------------------------------
 # trigraph()
-# 
-# Given an input string, this function replaces all trigraph sequences. 
+#
+# Given an input string, this function replaces all trigraph sequences.
 # The following mapping is used:
 #
 #     ??=    #
@@ -253,7 +255,7 @@ class Preprocessor(object):
     # ----------------------------------------------------------------------
     # add_path()
     #
-    # Adds a search path to the preprocessor.  
+    # Adds a search path to the preprocessor.
     # ----------------------------------------------------------------------
 
     def add_path(self,path):
@@ -271,7 +273,7 @@ class Preprocessor(object):
     def group_lines(self,input):
         lex = self.lexer.clone()
         lines = [x.rstrip() for x in input.splitlines()]
-        for i in xrange(len(lines)):
+        for i in range(len(lines)):
             j = i+1
             while lines[i].endswith('\\') and (j < len(lines)):
                 lines[i] = lines[i][:-1]+lines[j]
@@ -297,7 +299,7 @@ class Preprocessor(object):
 
     # ----------------------------------------------------------------------
     # tokenstrip()
-    # 
+    #
     # Remove leading/trailing whitespace tokens from a token list
     # ----------------------------------------------------------------------
 
@@ -323,7 +325,7 @@ class Preprocessor(object):
     # argument.  Each argument is represented by a list of tokens.
     #
     # When collecting arguments, leading and trailing whitespace is removed
-    # from each argument.  
+    # from each argument.
     #
     # This function properly handles nested parenthesis and commas---these do not
     # define new arguments.
@@ -335,7 +337,7 @@ class Preprocessor(object):
         current_arg = []
         nesting = 1
         tokenlen = len(tokenlist)
-    
+
         # Search for the opening '('.
         i = 0
         while (i < tokenlen) and (tokenlist[i].type in self.t_WS):
@@ -369,7 +371,7 @@ class Preprocessor(object):
             else:
                 current_arg.append(t)
             i += 1
-    
+
         # Missing end argument
         self.error(self.source,tokenlist[-1].lineno,"Missing ')' in macro arguments")
         return 0, [],[]
@@ -381,9 +383,9 @@ class Preprocessor(object):
     # This is used to speed up macro expansion later on---we'll know
     # right away where to apply patches to the value to form the expansion
     # ----------------------------------------------------------------------
-    
+
     def macro_prescan(self,macro):
-        macro.patch     = []             # Standard macro arguments 
+        macro.patch     = []             # Standard macro arguments
         macro.str_patch = []             # String conversion expansion
         macro.var_comma_patch = []       # Variadic macro comma patch
         i = 0
@@ -430,7 +432,7 @@ class Preprocessor(object):
         rep = [copy.copy(_x) for _x in macro.value]
 
         # Make string expansion patches.  These do not alter the length of the replacement sequence
-        
+
         str_expansion = {}
         for argnum, i in macro.str_patch:
             if argnum not in str_expansion:
@@ -448,7 +450,7 @@ class Preprocessor(object):
         # Make all other patches.   The order of these matters.  It is assumed that the patch list
         # has been sorted in reverse order of patch location since replacements will cause the
         # size of the replacement sequence to expand from the patch point.
-        
+
         expanded = { }
         for ptype, argnum, i in macro.patch:
             # Concatenation.   Argument is left unexpanded
@@ -485,7 +487,7 @@ class Preprocessor(object):
                 if t.value in self.macros and t.value not in expanded:
                     # Yes, we found a macro match
                     expanded[t.value] = True
-                    
+
                     m = self.macros[t.value]
                     if not m.arglist:
                         # A simple macro
@@ -517,7 +519,7 @@ class Preprocessor(object):
                                     else:
                                         args[len(m.arglist)-1] = tokens[j+positions[len(m.arglist)-1]:j+tokcount-1]
                                         del args[len(m.arglist):]
-                                        
+
                                 # Get macro replacement text
                                 rep = self.macro_expand_args(m,args)
                                 rep = self.expand_macros(rep,expanded)
@@ -530,13 +532,13 @@ class Preprocessor(object):
                 elif t.value == '__LINE__':
                     t.type = self.t_INTEGER
                     t.value = self.t_INTEGER_TYPE(t.lineno)
-                
+
             i += 1
         return tokens
 
-    # ----------------------------------------------------------------------    
+    # ----------------------------------------------------------------------
     # evalexpr()
-    # 
+    #
     # Evaluate an expression token sequence for the purposes of evaluating
     # integral expressions.
     # ----------------------------------------------------------------------
@@ -583,7 +585,7 @@ class Preprocessor(object):
                 tokens[i].value = str(tokens[i].value)
                 while tokens[i].value[-1] not in "0123456789abcdefABCDEF":
                     tokens[i].value = tokens[i].value[:-1]
-        
+
         expr = "".join([str(x.value) for x in tokens])
         expr = expr.replace("&&"," and ")
         expr = expr.replace("||"," or ")
@@ -608,7 +610,7 @@ class Preprocessor(object):
 
         if not source:
             source = ""
-            
+
         self.define("__FILE__ \"%s\"" % source)
 
         self.source = source
@@ -627,7 +629,7 @@ class Preprocessor(object):
                 for tok in x:
                     if tok.type in self.t_WS and '\n' in tok.value:
                         chunk.append(tok)
-                
+
                 dirtokens = self.tokenstrip(x[i+1:])
                 if dirtokens:
                     name = dirtokens[0].value
@@ -635,7 +637,7 @@ class Preprocessor(object):
                 else:
                     name = ""
                     args = []
-                
+
                 if name == 'define':
                     if enable:
                         for tok in self.expand_macros(chunk):
@@ -695,7 +697,7 @@ class Preprocessor(object):
                                     iftrigger = True
                     else:
                         self.error(self.source,dirtokens[0].lineno,"Misplaced #elif")
-                        
+
                 elif name == 'else':
                     if ifstack:
                         if ifstack[-1][0]:
@@ -865,7 +867,7 @@ class Preprocessor(object):
     def parse(self,input,source=None,ignore={}):
         self.ignore = ignore
         self.parser = self.parsegen(input,source)
-        
+
     # ----------------------------------------------------------------------
     # token()
     #
@@ -899,7 +901,7 @@ if __name__ == '__main__':
 
 
 
-    
+
 
 
 

--- a/astropy/extern/ply/lex.py
+++ b/astropy/extern/ply/lex.py
@@ -41,6 +41,8 @@ import copy
 import os
 import inspect
 
+from ...extern.six.moves import zip
+
 # This tuple contains known string types
 try:
     # Python 2.6
@@ -181,7 +183,7 @@ class Lexer:
             tf.write('_lexliterals  = %s\n' % repr(self.lexliterals))
             tf.write('_lexstateinfo = %s\n' % repr(self.lexstateinfo))
 
-            # Rewrite the lexstatere table, replacing function objects with function names 
+            # Rewrite the lexstatere table, replacing function objects with function names
             tabre = {}
             for statename, lre in self.lexstatere.items():
                 titem = []
@@ -533,7 +535,7 @@ def _statetoken(s, names):
     for i, part in enumerate(parts[1:], 1):
         if part not in names and part != 'ANY':
             break
-    
+
     if i > 1:
         states = tuple(parts[1:i])
     else:

--- a/astropy/extern/ply/yacc.py
+++ b/astropy/extern/ply/yacc.py
@@ -67,6 +67,8 @@ import inspect
 import base64
 import warnings
 
+from ...extern.six.moves import zip
+
 __version__    = '3.6'
 __tabversion__ = '3.5'
 

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from . import core
+from ...extern.six.moves import zip
 
 class BasicHeader(core.BaseHeader):
     """

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -19,6 +19,7 @@ from . import core
 from . import fixedwidth
 
 from ...utils.compat import suppress
+from ...extern.six.moves import range
 
 
 __doctest_skip__ = ['*']

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 import numpy
 
 from ...extern import six
-from ...extern.six.moves import zip
+from ...extern.six.moves import zip, range
 from ...extern.six.moves import cStringIO as StringIO
 from ...utils.exceptions import AstropyWarning
 

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -17,7 +17,7 @@ from collections import defaultdict, OrderedDict
 
 from . import core
 from . import fixedwidth
-from ...extern.six.moves import zip, map
+from ...extern.six.moves import zip, map, range
 from .misc import first_true_index, first_false_index, groupmore
 
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -7,7 +7,7 @@ from . import core
 from ...extern import six
 from ...table import Table
 from . import cparser
-from ...extern.six.moves import zip as izip
+from ...extern.six.moves import zip
 from ...utils import set_locale
 
 @six.add_metaclass(core.MetaBaseReader)
@@ -317,7 +317,7 @@ class FastRdb(FastBasic):
         try_float = {}
         try_string = {}
 
-        for name, col_type in izip(self.engine.get_names(), types):
+        for name, col_type in zip(self.engine.get_names(), types):
             if col_type[-1].lower() == 's':
                 try_int[name] = 0
                 try_float[name] = 0

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -10,7 +10,7 @@ fixedwidth.py:
 
 from __future__ import absolute_import, division, print_function
 
-from ...extern.six.moves import zip
+from ...extern.six.moves import zip, range
 
 from . import core
 from .core import InconsistentTableError, DefaultSplitter

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function
 import warnings
 
 from ...extern import six
-from ...extern.six.moves import zip as izip
+from ...extern.six.moves import zip, range
 
 from . import core
 from ...table import Column
@@ -157,7 +157,7 @@ class HTMLOutputter(core.TableOutputter):
                 # Join elements of spanned columns together into list of tuples
                 span_cols = cols[col_num:col_num + col.colspan]
                 new_col = core.Column(col.name)
-                new_col.str_vals = list(izip(*[x.str_vals for x in span_cols]))
+                new_col.str_vals = list(zip(*[x.str_vals for x in span_cols]))
                 new_cols.append(new_col)
                 col_num += col.colspan
             else:
@@ -397,7 +397,7 @@ class HTML(core.BaseReader):
                                 w.end(indent=False)
                         col_str_iters = []
                         new_cols_escaped = []
-                        for col, col_escaped in izip(cols, cols_escaped):
+                        for col, col_escaped in zip(cols, cols_escaped):
                             if len(col.shape) > 1 and self.html['multicol']:
                                 span = col.shape[1]
                                 for i in range(span):
@@ -409,9 +409,9 @@ class HTML(core.BaseReader):
                                 col_str_iters.append(col.info.iter_str_vals())
                                 new_cols_escaped.append(col_escaped)
 
-                    for row in izip(*col_str_iters):
+                    for row in zip(*col_str_iters):
                         with w.tag('tr'):
-                            for el, col_escaped in izip(row, new_cols_escaped):
+                            for el, col_escaped in zip(row, new_cols_escaped):
                                 # Potentially disable HTML escaping for column
                                 method = ('escape_xml' if col_escaped else 'bleach_clean')
                                 with w.xml_cleaning_method(method, **raw_html_clean_kwargs):

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from ...extern import six
+from ...extern.six.moves import zip
 from . import core
 
 latexdicts = {'AA':  {'tabletype': 'table',

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from . import core
+from ...extern.six.moves import range
 
 
 class SExtractorHeader(core.BaseHeader):

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -5,6 +5,7 @@ try:
 except ImportError: # cStringIO doesn't exist in Python 3
     from io import BytesIO
     StringIO = lambda x: BytesIO(x.encode('ascii'))
+
 import os
 import functools
 
@@ -22,6 +23,7 @@ from ..fastbasic import FastBasic, FastCsv, FastTab, FastCommentedHeader, \
 from .common import assert_equal, assert_almost_equal, assert_true
 from ....tests.helper import pytest
 from ....extern import six
+from ....extern.six.moves import range
 
 TRAVIS = os.environ.get('TRAVIS', False)
 

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -2,11 +2,7 @@
 
 # TEST_UNICODE_LITERALS
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-
+from ....extern.six.moves import cStringIO as StringIO
 from ... import ascii
 from ..core import InconsistentTableError
 from .common import (assert_equal, assert_almost_equal,

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from .common import setup_function, teardown_function
 from ....tests.helper import pytest
-from ....extern.six.moves import cStringIO
+from ....extern.six.moves import range, cStringIO as StringIO
 from ....utils.xml.writer import HAS_BLEACH
 
 # Check to see if the BeautifulSoup dependency is present.
@@ -546,7 +546,7 @@ def test_raw_html_write():
     t = Table([['<em>x</em>'], ['<em>y</em>']], names=['a', 'b'])
 
     # One column contains raw HTML (string input)
-    out = cStringIO()
+    out = StringIO()
     t.write(out, format='ascii.html', htmldict={'raw_html_cols': 'a'})
     expected = """\
    <tr>
@@ -556,12 +556,12 @@ def test_raw_html_write():
     assert expected in out.getvalue()
 
     # One column contains raw HTML (list input)
-    out = cStringIO()
+    out = StringIO()
     t.write(out, format='ascii.html', htmldict={'raw_html_cols': ['a']})
     assert expected in out.getvalue()
 
     # Two columns contains raw HTML (list input)
-    out = cStringIO()
+    out = StringIO()
     t.write(out, format='ascii.html', htmldict={'raw_html_cols': ['a', 'b']})
     expected = """\
    <tr>
@@ -581,7 +581,7 @@ def test_raw_html_write_clean():
     t = Table([['<script>x</script>'], ['<p>y</p>'], ['<em>y</em>']], names=['a', 'b', 'c'])
 
     # Confirm that <script> and <p> get escaped but not <em>
-    out = cStringIO()
+    out = StringIO()
     t.write(out, format='ascii.html', htmldict={'raw_html_cols': t.colnames})
     expected = """\
    <tr>
@@ -592,7 +592,7 @@ def test_raw_html_write_clean():
     assert expected in out.getvalue()
 
     # Confirm that we can whitelist <p>
-    out = cStringIO()
+    out = StringIO()
     t.write(out, format='ascii.html',
             htmldict={'raw_html_cols': t.colnames,
                       'raw_html_clean_kwargs': {'tags': bleach.ALLOWED_TAGS + ['p']}})

--- a/astropy/io/ascii/tests/test_ipac_definitions.py
+++ b/astropy/io/ascii/tests/test_ipac_definitions.py
@@ -9,11 +9,7 @@ from ... import ascii
 from ....table import Table
 from ..core import masked
 
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from ....extern.six.moves import cStringIO as StringIO
 
 
 DATA = '''

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -10,7 +10,7 @@ import locale
 import numpy as np
 import platform
 
-from ....extern.six.moves import cStringIO as StringIO
+from ....extern.six.moves import zip, cStringIO as StringIO
 from ....tests.helper import pytest
 from ... import ascii
 from ....table import Table

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -1,9 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from ....extern.six.moves import cStringIO as StringIO
 
 from ... import ascii
 from .common import (assert_equal, assert_almost_equal,

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -2,14 +2,12 @@
 
 # TEST_UNICODE_LITERALS
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from ....extern.six.moves import cStringIO as StringIO
 
 import numpy as np
 
 from ... import ascii
+from ....extern.six.moves import zip
 
 from .common import assert_equal, setup_function, teardown_function
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -11,6 +11,7 @@ from .verify import _Verify, _ErrList, VerifyError, VerifyWarning
 
 from . import conf
 from ...extern.six import string_types, integer_types, text_type, binary_type
+from ...extern.six.moves import range
 from ...utils import deprecated
 from ...utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -20,6 +20,7 @@ from .util import (pairwise, _is_int, _convert_array, encode_ascii, cmp,
 from .verify import VerifyError, VerifyWarning
 
 from ...extern.six import string_types, iteritems, PY2
+from ...extern.six.moves import range, zip
 from ...utils import lazyproperty, isiterable, indent
 from ...utils.compat import suppress
 from ...utils.exceptions import AstropyDeprecationWarning

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -17,6 +17,7 @@ import os.path
 import textwrap
 
 from collections import defaultdict
+from functools import reduce
 from itertools import islice
 
 import numpy as np
@@ -24,7 +25,8 @@ import numpy as np
 from ... import __version__
 from ...extern import six
 from ...extern.six import u, string_types
-from ...extern.six.moves import zip, xrange, reduce, map
+from ...extern.six.moves import zip, range, map
+
 from ...utils import indent
 from ...utils.compat.funcsigs import signature
 from .card import Card, BLANK_CARD
@@ -1111,7 +1113,7 @@ class TableDataDiff(_BaseDiff):
                 diffs = where_not_allclose(arra, arrb, atol=0.0,
                                            rtol=self.tolerance)
             elif 'P' in col.format:
-                diffs = ([idx for idx in xrange(len(arra))
+                diffs = ([idx for idx in range(len(arra))
                           if not np.allclose(arra[idx], arrb[idx], atol=0.0,
                                              rtol=self.tolerance)],)
             else:

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -16,7 +16,7 @@ from .column import (ASCIITNULL, FITS2NUMPY, ASCII2NUMPY, ASCII2STR, ColDefs,
                      _wrapx, _unwrapx, _makep, Delayed)
 from .util import decode_ascii, encode_ascii
 from ...extern.six import string_types
-from ...extern.six.moves import xrange
+from ...extern.six.moves import range, zip
 from ...utils import lazyproperty
 from ...utils.compat import suppress
 from ...utils.exceptions import AstropyDeprecationWarning
@@ -97,7 +97,7 @@ class FITS_record(object):
             if indx < self.start or indx > self.end - 1:
                 raise KeyError("Key '%s' does not exist." % key)
         elif isinstance(key, slice):
-            for indx in xrange(slice.start, slice.stop, slice.step):
+            for indx in range(slice.start, slice.stop, slice.step):
                 indx = self._get_indx(indx)
                 self.array.field(indx)[self.row] = value
         else:
@@ -111,7 +111,7 @@ class FITS_record(object):
         return self[slice(start, end)]
 
     def __len__(self):
-        return len(xrange(self.start, self.end, self.step))
+        return len(range(self.start, self.end, self.step))
 
     def __repr__(self):
         """
@@ -119,7 +119,7 @@ class FITS_record(object):
         """
 
         outlist = []
-        for idx in xrange(len(self)):
+        for idx in range(len(self)):
             outlist.append(repr(self[idx]))
         return '(%s)' % ', '.join(outlist)
 
@@ -546,7 +546,7 @@ class FITS_rec(np.recarray):
             start = max(0, key.start or 0)
             end = min(end, start + len(value))
 
-            for idx in xrange(start, end):
+            for idx in range(start, end):
                 self.__setitem__(idx, value[idx - start])
             return
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -18,6 +18,7 @@ from ..util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
 from ..verify import _Verify, _ErrList
 
 from ....extern.six import string_types, add_metaclass
+from ....extern.six.moves import range
 from ....utils import lazyproperty, deprecated
 from ....utils.compat import suppress
 from ....utils.compat.funcsigs import signature, Parameter

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -21,6 +21,7 @@ from ..util import (_is_pseudo_unsigned, _unsigned_zero, _is_int,
                     _get_array_mmap)
 
 from ....extern.six import string_types, iteritems
+from ....extern.six.moves import range
 from ....utils import lazyproperty, deprecated
 from ....utils.compat import suppress
 from ....utils.exceptions import (AstropyPendingDeprecationWarning,

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -11,6 +11,7 @@ from ..fitsrec import FITS_rec, FITS_record
 from ..util import _is_int, _is_pseudo_unsigned, _unsigned_zero
 
 from ....utils import lazyproperty
+from ....extern.six.moves import range, zip
 
 
 class Group(FITS_record):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -20,6 +20,7 @@ from ..verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from ....extern.six import string_types
 from ....utils import indent
 from ....utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from ....extern.six.moves import range
 
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -11,6 +11,7 @@ from ..util import _is_pseudo_unsigned, _unsigned_zero, _is_int
 from ..verify import VerifyWarning
 
 from ....extern.six import string_types
+from ....extern.six.moves import range, zip
 from ....utils import isiterable, lazyproperty, classproperty, deprecated
 
 

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -3,12 +3,15 @@
 import gzip
 import os
 
-from ..file import _File
-from ..header import _pad_length
 from .base import _BaseHDU, BITPIX2DTYPE
 from .hdulist import HDUList
 from .image import PrimaryHDU
+
+from ..file import _File
+from ..header import _pad_length
 from ..util import fileobj_name
+
+from ....extern.six.moves import range
 
 
 class StreamingHDU(object):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -30,7 +30,7 @@ from ..util import _is_int, _str_to_num
 
 from ....extern import six
 from ....extern.six import string_types
-from ....extern.six.moves import xrange as range
+from ....extern.six.moves import range, zip
 from ....utils import deprecated, lazyproperty
 from ....utils.compat import suppress
 from ....utils.exceptions import AstropyUserWarning

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -8,6 +8,7 @@ import textwrap
 
 from ... import fits
 from ..util import fill
+from ....extern.six.moves import zip
 
 
 log = logging.getLogger('fitsdiff')

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -48,8 +48,10 @@ from __future__ import (absolute_import, division, print_function,
 import sys
 
 from ... import fits
+
 from .... import table
 from .... import log
+from ....extern.six.moves import range
 
 
 class ExtensionNotFoundException(Exception):

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -9,6 +9,7 @@ from .test_table import comparerecords
 from ..hdu.base import _ValidHDU
 from ....io import fits
 from ....tests.helper import pytest
+from ....extern.six.moves import zip
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -4,12 +4,15 @@ import warnings
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ... import fits
 from .. import HDUList, PrimaryHDU, BinTableHDU
-from ....table import Table
+
+from ... import fits
+
 from .... import units as u
+from ....extern.six.moves import range, zip
+from ....table import Table
 from ....tests.helper import pytest, catch_warnings
-from astropy.units.format.fits import UnitScaleError
+from ....units.format.fits import UnitScaleError
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -17,14 +17,17 @@ try:
 except ImportError:
     HAVE_STRINGIO = False
 
+from . import FitsTestCase
+
+from ..convenience import _getext
+from ..diff import FITSDiff
+from ..file import _File, GZIP_MAGIC
+
+from ....extern.six.moves import range, zip
 from ....io import fits
 from ....tests.helper import pytest, raises, catch_warnings, ignore_warnings
 from ....utils.exceptions import AstropyDeprecationWarning
 from ....utils.data import get_pkg_data_filename
-from . import FitsTestCase
-from ..convenience import _getext
-from ..diff import FITSDiff
-from ..file import _File, GZIP_MAGIC
 
 try:
     import pathlib

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -12,6 +12,7 @@ from ..hdu import HDUList, PrimaryHDU, ImageHDU
 from ..hdu.table import BinTableHDU
 from ..header import Header
 
+from ....extern.six.moves import range
 from ....io import fits
 
 from . import FitsTestCase

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -8,6 +8,7 @@ import sys
 import numpy as np
 
 from ..verify import VerifyError
+from ....extern.six.moves import range
 from ....io import fits
 from ....tests.helper import pytest, raises, catch_warnings, ignore_warnings
 from ....utils.exceptions import AstropyUserWarning

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from ....extern import six
 from ....extern.six import u, iterkeys, itervalues, iteritems
-from ....extern.six.moves import zip
+from ....extern.six.moves import zip, range
 from ....io import fits
 from ....io.fits.verify import VerifyWarning
 from ....tests.helper import pytest, catch_warnings, ignore_warnings
@@ -34,7 +34,7 @@ def test_init_with_dict():
 
 def test_init_with_ordereddict():
     # Create a list of tuples. Each tuple consisting of a letter and the number
-    list1 = [(i, j) for i, j in zip('abcdefghijklmnopqrstuvwxyz', range(26))]
+    list1 = [(i, j) for j, i in enumerate('abcdefghijklmnopqrstuvwxyz')]
     # Create an ordered dictionary and a header from this dictionary
     dict1 = collections.OrderedDict(list1)
     h1 = fits.Header(dict1)

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -10,6 +10,7 @@ import warnings
 
 import numpy as np
 
+from ....extern.six.moves import range
 from ....io import fits
 from ....utils.exceptions import (AstropyDeprecationWarning,
                                   AstropyPendingDeprecationWarning)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -15,7 +15,7 @@ except ImportError:
     HAVE_OBJGRAPH = False
 
 from ....extern import six
-from ....extern.six.moves import range
+from ....extern.six.moves import range, zip
 from ....extern.six.moves import cPickle as pickle
 from ....io import fits
 from ....tests.helper import pytest, catch_warnings, ignore_warnings

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -33,7 +33,7 @@ except ImportError:
 from ...extern import six
 from ...extern.six import (string_types, integer_types, text_type,
                            binary_type, next)
-from ...extern.six.moves import zip
+from ...extern.six.moves import zip, range
 from ...utils import wraps
 from ...utils.compat import suppress
 from ...utils.exceptions import AstropyUserWarning

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ...extern import six
+from ...extern.six.moves import range
 
 
 __all__ = ['fnpickle', 'fnunpickle']

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .. import fnpickle, fnunpickle
+from ....extern.six.moves import range
 
 def test_fnpickling_simple(tmpdir):
     """

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -14,7 +14,7 @@ from ...tests.helper import pytest
 from ..registry import _readers, _writers, _identifiers
 from .. import registry as io_registry
 from ...table import Table
-from ...extern.six.moves import zip
+from ...extern.six.moves import zip, range
 from ...extern.six import StringIO
 
 _READERS_ORIGINAL = copy(_readers)

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -6,7 +6,7 @@ to/from TABLEDATA_ and BINARY_ formats.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ...extern import six
-from ...extern.six.moves import xrange
+from ...extern.six.moves import range, zip
 
 # STDLIB
 import re
@@ -491,7 +491,7 @@ class VarArray(Array):
         result = []
         result_mask = []
         binparse = self._base.binparse
-        for i in xrange(length):
+        for i in range(length):
             val, mask = binparse(read)
             result.append(val)
             result_mask.append(mask)
@@ -526,7 +526,7 @@ class ArrayVarArray(VarArray):
             vo_raise(E02, (items, len(parts)), config, pos)
         result = []
         result_mask = []
-        for i in xrange(0, len(parts), items):
+        for i in range(0, len(parts), items):
             value, mask = parse_parts(parts[i:i+items], config, pos)
             result.append(value)
             result_mask.append(mask)
@@ -908,7 +908,7 @@ class ComplexArrayVarArray(VarArray):
             vo_raise(E02, (items, len(parts)), config, pos)
         result = []
         result_mask = []
-        for i in xrange(0, len(parts), items):
+        for i in range(0, len(parts), items):
             value, mask = parse_parts(parts[i:i + items], config, pos)
             result.append(value)
             result_mask.append(mask)
@@ -928,7 +928,7 @@ class ComplexVarArray(VarArray):
         parse_parts = self._base.parse_parts
         result = []
         result_mask = []
-        for i in xrange(0, len(parts), 2):
+        for i in range(0, len(parts), 2):
             value = [float(x) for x in parts[i:i + 2]]
             value, mask = parse_parts(value, config, pos)
             result.append(value)
@@ -960,7 +960,7 @@ class ComplexArray(NumericArray):
         base_parse = self._base.parse_parts
         result = []
         result_mask = []
-        for i in xrange(0, self._items, 2):
+        for i in range(0, self._items, 2):
             value = [float(x) for x in parts[i:i + 2]]
             value, mask = base_parse(value, config, pos)
             result.append(value)

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -16,6 +16,7 @@ from .. import exceptions
 from .. import tree
 
 from ..table import parse_single_table
+from ....extern.six.moves import range
 from ....tests.helper import raises, catch_warnings
 from ....utils.data import get_pkg_data_filename
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -14,6 +14,7 @@ from ....utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from ..table import parse, writeto
 from .. import tree
 from ....tests.helper import pytest
+from ....extern.six.moves import zip
 
 try:
     import pathlib

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -9,7 +9,7 @@ This is a set of regression tests for vo.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ....extern import six
-from ....extern.six.moves import xrange
+from ....extern.six.moves import range, zip
 
 # STDLIB
 import difflib
@@ -975,7 +975,7 @@ def test_resource_structure():
 
     assert len(vtf2.resources) == 3
 
-    for r in xrange(len(vtf2.resources)):
+    for r in range(len(vtf2.resources)):
         res = vtf2.resources[r]
         assert len(res.tables) == 2
         assert len(res.resources) == 0

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ...extern import six
-from ...extern.six.moves import xrange, urllib
+from ...extern.six.moves import range, urllib, zip
 
 # STDLIB
 import base64
@@ -2781,7 +2781,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                 fields = [(i, field.converter.output,
                            field.converter.supports_empty_values(kwargs))
                           for i, field in enumerate(fields)]
-                for row in xrange(len(array)):
+                for row in range(len(array)):
                     write(tr_start)
                     array_row = array.data[row]
                     mask_row = array.mask[row]
@@ -2817,7 +2817,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                                 for (i, field) in enumerate(fields)]
 
                 data = io.BytesIO()
-                for row in xrange(len(array)):
+                for row in range(len(array)):
                     array_row = array.data[row]
                     array_mask = array.mask[row]
 

--- a/astropy/io/votable/validator/html.py
+++ b/astropy/io/votable/validator/html.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ....extern import six
-from ....extern.six.moves import xrange
+from ....extern.six.moves import range
 
 # STDLIB
 import contextlib
@@ -234,7 +234,7 @@ def write_table(basename, name, results, root="results", chunk_size=500):
         with w.tag('center'):
             if j > 0:
                 w.element('a', '<< ', href='%s_%02d.html' % (basename, j-1))
-            for i in xrange(npages):
+            for i in range(npages):
                 if i == j:
                     w.data(six.text_type(i+1))
                 else:
@@ -247,7 +247,7 @@ def write_table(basename, name, results, root="results", chunk_size=500):
 
     npages = int(ceil(float(len(results)) / chunk_size))
 
-    for i, j in enumerate(xrange(0, max(len(results), 1), chunk_size)):
+    for i, j in enumerate(range(0, max(len(results), 1), chunk_size)):
         subresults = results[j:j+chunk_size]
         path = os.path.join(root, '%s_%02d.html' % (basename, i))
         with io.open(path, 'w', encoding='utf-8') as fd:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from ..utils import indent, isinstancemethod, metadata
 from ..extern import six
-from ..extern.six.moves import copyreg
+from ..extern.six.moves import copyreg, zip
 from ..table import Table
 from ..utils import (sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer)

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -36,6 +36,7 @@ import numpy as np
 from .utils import poly_map_domain
 from ..utils.exceptions import AstropyUserWarning
 from ..extern import six
+from ..extern.six.moves import range
 from .optimizers import (SLSQP, Simplex)
 from .statistic import (leastsquare)
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -12,6 +12,7 @@ from .parameters import Parameter, InputParameterError
 from .utils import ellipse_extent
 from ..utils import deprecated
 from ..extern import six
+from ..extern.six.moves import map
 from .utils import get_inputs_and_params
 from ..utils.exceptions import AstropyDeprecationWarning
 
@@ -253,7 +254,7 @@ class GaussianAbsorption1D(Fittable1DModel):
         GaussianAbsorption1D model function derivatives.
         """
         import operator
-        return list(six.moves.map(
+        return list(map(
             operator.neg, Gaussian1D.fit_deriv(x, amplitude, mean, stddev)))
 
 

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -4,6 +4,7 @@ which outputs from a source model are mapped to which inputs of a target model.
 """
 
 from .core import Model
+from ..extern.six.moves import range
 
 
 __all__ = ['Mapping', 'Identity']

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from ..utils import isiterable, OrderedDescriptor
 from ..extern import six
+from ..extern.six.moves import zip
 
 from .utils import get_inputs_and_params
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -14,6 +14,7 @@ from .functional_models import Shift
 from .parameters import Parameter
 from .utils import poly_map_domain, comb, check_broadcast
 from ..utils import indent
+from ..extern.six.moves import range
 
 
 __all__ = [

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from .core import Model
 from .parameters import Parameter
+from ..extern.six.moves import zip
 
 
 __all__ = ['RotateCelestial2Native', 'RotateNative2Celestial', 'Rotation2D',

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -22,6 +22,7 @@ import abc
 import numpy as np
 from .core import Model
 from ..utils import minversion
+from ..extern.six.moves import range
 
 try:
     import scipy

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ...logger import log
+from ...extern.six.moves import range
 import numpy as np
 
 

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -15,6 +15,7 @@ from .. import fitting
 from ..core import Model, FittableModel, Fittable1DModel
 from ..parameters import Parameter
 from ...tests.helper import pytest
+from ...extern.six.moves import range
 
 try:
     from scipy import optimize  # pylint: disable=W0611

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -24,6 +24,7 @@ from ..core import FittableModel
 from ..polynomial import PolynomialBase
 from ...tests.helper import pytest
 from ...utils import minversion
+from ...extern.six.moves import zip
 
 try:
     import scipy

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -14,6 +14,7 @@ from ...io import fits
 from ... import wcs
 from ...utils.data import get_pkg_data_filename
 from ...tests.helper import pytest
+from ...extern.six.moves import range, zip
 
 
 def test_Projection_properties():

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -12,7 +12,7 @@ from collections import deque, MutableMapping
 import numpy as np
 
 from ..extern import six
-from ..extern.six.moves import xrange, zip_longest
+from ..extern.six.moves import range, zip_longest, zip
 
 from ..utils import isiterable
 from ..utils.compat.funcsigs import signature
@@ -537,7 +537,7 @@ def comb(N, k):
     if (k > N) or (N < 0) or (k < 0):
         return 0
     val = 1
-    for j in xrange(min(k, N - k)):
+    for j in range(min(k, N - k)):
         val = (val * (N - j)) / (j + 1)
     return val
 

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -8,6 +8,7 @@ import warnings
 from ..utils import wraps
 from ..utils.exceptions import AstropyUserWarning
 from ..utils.compat.funcsigs import signature
+from ..extern.six.moves import zip
 
 from .nddata import NDData
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -11,6 +11,7 @@ from ..utils import (extract_array, add_array, subpixel_indices,
 from ...wcs import WCS
 from ...coordinates import SkyCoord
 from ... import units as u
+from ...extern.six.moves import zip
 
 try:
     import skimage  # pylint: disable=W0611

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -4,13 +4,16 @@ This module includes helper functions for array operations.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
+
 from .decorators import support_nddata
-from astropy.utils import lazyproperty
-from astropy.coordinates import SkyCoord
-from astropy.wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
-from astropy import units as u
+from .. import units as u
+from ..coordinates import SkyCoord
+from ..extern.six.moves import range, zip
+from ..utils import lazyproperty
+from ..wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
 
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -46,6 +46,7 @@ import numpy as np
 
 from ..utils.compat.funcsigs import signature
 from ..utils.exceptions import AstropyUserWarning
+from ..extern.six.moves import range
 
 # TODO: implement other fitness functions from appendix B of Scargle 2012
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -13,7 +13,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from ..extern.six.moves import xrange
+from ..extern.six.moves import range
 
 
 __all__ = ['binom_conf_interval', 'binned_binom_proportion',
@@ -1164,7 +1164,7 @@ def bootstrap(data, bootnum=100, samples=None, bootfunc=None):
     # create empty boot array
     boot = np.empty(resultdims)
 
-    for i in xrange(bootnum):
+    for i in range(bootnum):
         bootarr = np.random.randint(low=0, high=data.shape[0], size=samples)
         if bootfunc is None:
             boot[i] = data[bootarr]

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from ..extern.six.moves import range
 
 
 __all__ = ['jackknife_resampling', 'jackknife_stats']

--- a/astropy/stats/lombscargle/core.py
+++ b/astropy/stats/lombscargle/core.py
@@ -7,6 +7,7 @@ from .implementations import lombscargle, available_methods
 from .implementations.mle import periodic_fit
 from ... import units
 from ...utils.compat.numpy import broadcast_arrays
+from ...extern.six.moves import map
 
 
 def has_units(obj):

--- a/astropy/stats/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/stats/lombscargle/implementations/fastchi2_impl.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 import numpy as np
 
 from .utils import trig_sum
+from ....extern.six.moves import range, zip
 
 
 def lombscargle_fastchi2(t, y, dy, f0, df, Nf, normalization='standard',

--- a/astropy/stats/lombscargle/implementations/mle.py
+++ b/astropy/stats/lombscargle/implementations/mle.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 import numpy as np
+from ....extern.six.moves import range, map
 
 
 def design_matrix(t, frequency, dy=None, bias=True, nterms=1):

--- a/astropy/stats/lombscargle/implementations/slow_impl.py
+++ b/astropy/stats/lombscargle/implementations/slow_impl.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 import numpy as np
+from ....extern.six.moves import map
 
 
 def lombscargle_slow(t, y, dy, frequency, normalization='standard',

--- a/astropy/stats/lombscargle/implementations/tests/test_mle.py
+++ b/astropy/stats/lombscargle/implementations/tests/test_mle.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from .....tests.helper import pytest
+from .....extern.six.moves import range
 from ..mle import design_matrix, periodic_fit
 
 

--- a/astropy/stats/lombscargle/implementations/utils.py
+++ b/astropy/stats/lombscargle/implementations/utils.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 import warnings
 from math import factorial
 import numpy as np
+from ....extern.six.moves import range, map
 
 
 def add_at(arr, ind, vals):

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 import warnings
 from ..utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from ..extern.six.moves import range
 
 
 __all__ = ['sigma_clip', 'sigma_clipped_stats']

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -24,6 +24,7 @@ else:
     HAS_MPMATH = True
 
 from ...tests.helper import pytest
+from ...extern.six.moves import range
 
 from .. import funcs
 

--- a/astropy/table/bst.py
+++ b/astropy/table/bst.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import operator
 import numpy as np
-from ..extern.six.moves import zip
+from ..extern.six.moves import zip, range
 
 
 class MaxValue(object):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -15,6 +15,7 @@ from ..utils.compat import NUMPY_LT_1_8
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, dtype_info_name
+from ..extern.six.moves import range
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
-from ..extern.six.moves import zip as izip
+from ..extern.six.moves import zip
 
 import platform
 import warnings
@@ -86,7 +86,7 @@ def _table_group_by(table, keys):
     # If the sort is not stable (preserves original table order) then sort idx_sort in
     # place within each group.
     if not stable_sort:
-        for i0, i1 in izip(indices[:-1], indices[1:]):
+        for i0, i1 in zip(indices[:-1], indices[1:]):
             idx_sort[i0:i1].sort()
 
     # Make a new table and set the _groups to the appropriate TableGroups object.
@@ -195,7 +195,7 @@ class BaseGroups(object):
                                 'numpy mask or int array')
             mask = np.zeros(len(parent), dtype=np.bool)
             # Is there a way to vectorize this in numpy?
-            for i0, i1 in izip(i0s, i1s):
+            for i0, i1 in zip(i0s, i1s):
                 mask[i0:i1] = True
             out = parent[mask]
             out.groups._keys = parent.groups.keys[item]
@@ -254,7 +254,7 @@ class ColumnGroups(BaseGroups):
                         func = np.add
                     vals = func.reduceat(par_col, i0s)
             else:
-                vals = np.array([func(par_col[i0: i1]) for i0, i1 in izip(i0s, i1s)])
+                vals = np.array([func(par_col[i0: i1]) for i0, i1 in zip(i0s, i1s)])
         except Exception:
             raise TypeError("Cannot aggregate column '{0}' with type '{1}'"
                             .format(par_col.info.name,

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -36,6 +36,7 @@ from copy import deepcopy
 import numpy as np
 
 from ..extern import six
+from ..extern.six.moves import range
 from .bst import MinValue, MaxValue
 from .sorted_array import SortedArray
 from ..time import Time

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -11,7 +11,7 @@ Redistribution license restrictions apply.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
-from ..extern.six.moves import zip as izip
+from ..extern.six.moves import zip, range
 from ..utils.decorators import deprecated
 
 from itertools import chain
@@ -102,7 +102,7 @@ def get_descrs(arrays, col_name_map):
 
     for out_name, in_names in six.iteritems(col_name_map):
         # List of input arrays that contribute to this output column
-        in_cols = [arr[name] for arr, name in izip(arrays, in_names) if name is not None]
+        in_cols = [arr[name] for arr, name in zip(arrays, in_names) if name is not None]
 
         # List of names of the columns that contribute to this output column.
         names = [name for name in in_names if name is not None]
@@ -395,7 +395,7 @@ def vstack(arrays, join_type='inner', col_name_map=None):
 
     for out_name, in_names in six.iteritems(col_name_map):
         idx0 = 0
-        for name, array in izip(in_names, arrays):
+        for name, array in zip(in_names, arrays):
             idx1 = idx0 + len(array)
             if name in array.dtype.names:
                 out[out_name][idx0:idx1] = array[name]
@@ -501,7 +501,7 @@ def hstack(arrays, join_type='exact', uniq_col_name='{col_name}_{table_name}',
         out = np.empty(n_rows, dtype=out_descrs)
 
     for out_name, in_names in six.iteritems(col_name_map):
-        for name, array, arr_len in izip(in_names, arrays, arr_lens):
+        for name, array, arr_len in zip(in_names, arrays, arr_lens):
             if name is not None:
                 out[out_name][:arr_len] = array[name]
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -9,7 +9,7 @@ High-level table operations:
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
-from ..extern.six.moves import zip
+from ..extern.six.moves import zip, range
 
 from copy import deepcopy
 import warnings

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -3,8 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
 from ..extern.six import text_type
-from ..extern.six.moves import zip as izip
-from ..extern.six.moves import xrange
+from ..extern.six.moves import zip, range
 
 import os
 import sys
@@ -472,7 +471,7 @@ class TableFormatter(object):
             raise TypeError('align keyword must be str or list or tuple (got {0})'
                             .format(type(align)))
 
-        for align_, col in izip(align, table.columns.values()):
+        for align_, col in zip(align, table.columns.values()):
             lines, outs = self._pformat_col(col, max_lines, show_name=show_name,
                                             show_unit=show_unit, show_dtype=show_dtype,
                                             align=align_)
@@ -601,8 +600,8 @@ class TableFormatter(object):
                     pass  # No worries if clear screen call fails
                 lines = tabcol[i0:i1].pformat(**kwargs)
                 colors = ('red' if i < n_header else 'default'
-                          for i in xrange(len(lines)))
-                for color, line in izip(colors, lines):
+                          for i in range(len(lines)))
+                for color, line in zip(colors, lines):
                     color_print(line, color)
             showlines = True
             print()

--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from ..extern.six.moves import range, zip
 
 def _searchsorted(array, val, side='left'):
     '''

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2,8 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
-from ..extern.six.moves import zip as izip
-from ..extern.six.moves import range as xrange
+from ..extern.six.moves import zip, range
 from .index import TableIndices, TableLoc, TableILoc
 
 import re
@@ -124,7 +123,7 @@ class TableColumns(OrderedDict):
         new_names = [mapper.get(name, name) for name in self]
         cols = list(six.itervalues(self))
         self.clear()
-        self.update(list(izip(new_names, cols)))
+        self.update(list(zip(new_names, cols)))
 
     # Define keys and values for Python 2 and 3 source compatibility
     def keys(self):
@@ -1243,7 +1242,7 @@ class Table(object):
                     raise ValueError('Right side value needs {0} elements (one for each column)'
                                      .format(n_cols))
 
-                for col, val in izip(self.columns.values(), value):
+                for col, val in zip(self.columns.values(), value):
                     col[item] = val
 
             elif (isinstance(item, slice) or
@@ -1268,7 +1267,7 @@ class Table(object):
                                          .format(n_cols))
                     vals = value
 
-                for col, val in izip(self.columns.values(), vals):
+                for col, val in zip(self.columns.values(), vals):
                     col[item] = val
 
             else:
@@ -2132,7 +2131,7 @@ class Table(object):
         columns = self.TableColumns()
         try:
             # Insert val at index for each column
-            for name, col, val, mask_ in izip(colnames, self.columns.values(), vals, mask):
+            for name, col, val, mask_ in zip(colnames, self.columns.values(), vals, mask):
                 # If the new row caused a change in self.ColumnClass then
                 # Column-based classes need to be converted first.  This is
                 # typical for adding a row with mask values to an unmasked table.

--- a/astropy/table/tests/test_array.py
+++ b/astropy/table/tests/test_array.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from ..sorted_array import SortedArray
 from ..table import Table
+from ...extern.six.moves import range
 import pytest
 import numpy as np
 

--- a/astropy/table/tests/test_bst.py
+++ b/astropy/table/tests/test_bst.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from ..bst import BST
+from ...extern.six.moves import range
 import pytest
 
 def get_tree(TreeType):

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -8,6 +8,7 @@ from ..table import QTable, Row
 from ... import units as u
 from ...time import Time
 from ..column import BaseColumn
+from ...extern.six.moves import range
 
 @pytest.fixture(params=[BST, FastRBT, SortedArray])
 def engine(request):

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 import numpy as np
 
 from ...extern import six
+from ...extern.six.moves import cStringIO as StringIO
 from ... import units as u
 from ... import time
 from ... import coordinates
@@ -55,7 +56,7 @@ def test_table_info_attributes(table_types):
     assert np.all(tinfo['class'] == [cls, cls, cls, cls, 'Time', 'SkyCoord'])
 
     # Test that repr(t.info) is same as t.info()
-    out = six.moves.cStringIO()
+    out = StringIO()
     t.info(out=out)
     assert repr(t.info) == out.getvalue()
 
@@ -71,7 +72,7 @@ def test_table_info_stats(table_types):
 
     # option = 'stats'
     masked = 'masked=True ' if t.masked else ''
-    out = six.moves.cStringIO()
+    out = StringIO()
     t.info('stats', out=out)
     table_header_line = '<{0} {1}length=4>'.format(t.__class__.__name__, masked)
     exp = [table_header_line,
@@ -92,7 +93,7 @@ def test_table_info_stats(table_types):
     assert np.all(tinfo['min'] == ['1', '1.0', '--', '1.0'])
     assert np.all(tinfo['max'] == ['2', '2.0', '--', '2.0'])
 
-    out = six.moves.cStringIO()
+    out = StringIO()
     t.info('stats', out=out)
     exp = [table_header_line,
            'name mean std min max',
@@ -106,7 +107,7 @@ def test_table_info_stats(table_types):
     # option = ['attributes', custom]
     custom = data_info_factory(names=['sum', 'first'],
                                funcs=[np.sum, lambda col: col[0]])
-    out = six.moves.cStringIO()
+    out = StringIO()
     tinfo = t.info(['attributes', custom], out=None)
     assert tinfo.colnames == ['name', 'dtype', 'shape', 'unit', 'format', 'description',
                               'class', 'sum', 'first', 'n_bad', 'length']
@@ -138,7 +139,7 @@ def test_data_info():
                                      ('length', 3)])
 
         # Test the console (string) version which omits trivial values
-        out = six.moves.cStringIO()
+        out = StringIO()
         c.info(out=out)
         exp = ['name = name',
                'dtype = float64',
@@ -194,7 +195,7 @@ def test_scalar_info():
 
 def test_empty_table():
     t = table.Table()
-    out = six.moves.cStringIO()
+    out = StringIO()
     t.info(out=out)
     exp = ['<Table length=0>', '<No columns>']
     assert out.getvalue().splitlines() == exp
@@ -222,7 +223,7 @@ def test_class_attribute():
     for table_cls, exp in ((table.Table, texp),
                            (table.QTable, qexp)):
         t = table_cls(vals)
-        out = six.moves.cStringIO()
+        out = StringIO()
         t.info(out=out)
         assert out.getvalue().splitlines() == exp
 

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -4,6 +4,7 @@ import textwrap
 from ..table import Table
 from ... import extern
 from ...tests.helper import pytest
+from ...extern.six.moves import zip
 
 try:
     import IPython  # pylint: disable=W0611

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -2,11 +2,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-
-try:
     import h5py  # pylint: disable=W0611
 except ImportError:
     HAS_H5PY = False
@@ -23,7 +18,7 @@ import numpy as np
 import copy
 
 from ...extern import six
-from ...extern.six.moves import cPickle as pickle
+from ...extern.six.moves import cPickle as pickle, cStringIO as StringIO
 from ...tests.helper import pytest
 from ...table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
 from ... import time

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -11,6 +11,7 @@ from ... import table
 from ...table import Row
 from ...utils.compat import NUMPY_LT_1_8
 from ...utils.exceptions import AstropyDeprecationWarning
+from ...extern.six.moves import zip
 from .conftest import MaskedTable
 
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -20,7 +20,7 @@ from ... import table
 from ... import units as u
 from .conftest import MaskedTable
 
-from ...extern.six.moves import zip as izip, cStringIO as StringIO
+from ...extern.six.moves import zip, range, cStringIO as StringIO
 
 try:
     with ignore_warnings(DeprecationWarning):
@@ -339,7 +339,7 @@ class TestColumnAccess():
     def test_itercols(self, table_types):
         names = ['a', 'b', 'c']
         t = table_types.Table([[1], [2], [3]], names=names)
-        for name, col in izip(names, t.itercols()):
+        for name, col in zip(names, t.itercols()):
             assert name == col.name
             assert isinstance(col, table_types.Column)
 

--- a/astropy/tests/output_checker.py
+++ b/astropy/tests/output_checker.py
@@ -13,6 +13,7 @@ import re
 import numpy as np
 
 from ..extern import six
+from ..extern.six.moves import zip
 
 # Much of this code, particularly the parts of floating point handling, is
 # borrowed from the SymPy project with permission.  See licenses/SYMPY.rst

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 import __future__
 
 from ..extern import six
-from ..extern.six.moves import filter
+from ..extern.six.moves import filter, range
 
 import ast
 import doctest

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -25,6 +25,7 @@ from ..utils.compat.misc import override__dir__
 from ..utils.data_info import MixinInfo, data_info_factory
 from ..utils.compat.numpy import broadcast_to
 from ..extern import six
+from ..extern.six.moves import zip
 from .utils import day_frac
 from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
                       TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
@@ -409,7 +410,7 @@ class Time(ShapedLikeNDArray):
 
         # Transform the jd1,2 pairs through the chain of scale xforms.
         jd1, jd2 = self._time.jd1, self._time.jd2
-        for sys1, sys2 in six.moves.zip(xforms[:-1], xforms[1:]):
+        for sys1, sys2 in zip(xforms[:-1], xforms[1:]):
             # Some xforms require an additional delta_ argument that is
             # provided through Time methods.  These values may be supplied by
             # the user or computed based on available approximations.  The

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -14,6 +14,7 @@ import numpy as np
 from .. import units as u
 from .. import _erfa as erfa
 from ..extern import six
+from ..extern.six.moves import zip
 from .utils import day_frac, two_sum
 
 
@@ -709,7 +710,7 @@ class TimeString(TimeUnique):
                     continue
                 tm = tm.groupdict()
                 vals = [int(tm.get(component, default)) for component, default
-                        in six.moves.zip(components, defaults)]
+                        in zip(components, defaults)]
 
             # Add fractional seconds
             vals[-1] = vals[-1] + fracsec

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -13,6 +13,7 @@ import numpy as np
 from ...tests.helper import pytest, catch_warnings
 from ...tests.disable_internet import INTERNET_OFF
 from ...extern import six
+from ...extern.six.moves import zip
 from ...utils import isiterable
 from .. import Time, ScaleValueError, TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation

--- a/astropy/time/tests/test_pickle.py
+++ b/astropy/time/tests/test_pickle.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from .. import Time
-from ...extern.six.moves import cPickle as pickle
+from ...extern.six.moves import range, cPickle as pickle
 
 
 class TestPickle():

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -11,6 +11,7 @@ import warnings
 from fractions import Fraction
 
 from ...extern import six
+from ...extern.six.moves import zip
 from ...utils.misc import did_you_mean
 
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -18,6 +18,7 @@ import numpy as np
 
 # AstroPy
 from ..extern import six
+from ..extern.six.moves import zip
 from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
                    UnitBase, UnitsError, UnitConversionError, UnitTypeError)
 from .format.latex import Latex

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 from ...extern import six
+from ...extern.six.moves import zip
 
 import itertools
 import numpy as np

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -20,7 +20,7 @@ from ...tests.helper import raises, pytest
 from ...utils import isiterable, minversion
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
-from ...extern.six.moves import xrange
+from ...extern.six.moves import range
 from ...extern.six.moves import cPickle as pickle
 from ...extern import six
 
@@ -848,7 +848,7 @@ def test_arrays():
     assert qkpc1x == qkpcx1
 
     # can also create from lists, will auto-convert to arrays
-    qsec = u.Quantity(list(xrange(10)), u.second)
+    qsec = u.Quantity(list(range(10)), u.second)
     assert isinstance(qsec.value, np.ndarray)
 
     # quantity math should work with arrays

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -8,6 +8,7 @@ from numpy.testing.utils import assert_allclose
 
 from ... import units as u
 from ...tests.helper import pytest, raises
+from ...extern.six.moves import zip
 
 
 class TestUfuncCoverage(object):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.testing.utils import assert_allclose
 
 from ...extern import six
-from ...extern.six.moves import cPickle as pickle
+from ...extern.six.moves import range, cPickle as pickle
 from ...tests.helper import pytest, raises, catch_warnings
 
 from ... import units as u

--- a/astropy/utils/compat/futures/_base.py
+++ b/astropy/utils/compat/futures/_base.py
@@ -7,6 +7,8 @@ import time
 
 from collections import namedtuple
 
+from ....extern.six.moves import zip
+
 
 __author__ = 'Brian Quinlan (brian@sweetapp.com)'
 

--- a/astropy/utils/compat/futures/process.py
+++ b/astropy/utils/compat/futures/process.py
@@ -54,6 +54,7 @@ import weakref
 import sys
 
 from . import _base
+from ....extern.six.moves import range
 
 try:
     import queue

--- a/astropy/utils/compat/numpy/lib/stride_tricks.py
+++ b/astropy/utils/compat/numpy/lib/stride_tricks.py
@@ -15,6 +15,7 @@ if one sets ``subok=True``; see https://github.com/numpy/numpy/pull/4622
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
+from .....extern.six.moves import range
 
 __all__ = ['broadcast_arrays', 'broadcast_to', 'GE1P10']
 __doctest_skip__ = ['*']

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..extern import six
-from ..extern.six.moves import urllib
+from ..extern.six.moves import urllib, range
 
 import atexit
 import contextlib

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -28,6 +28,7 @@ from collections import OrderedDict
 
 from ..extern import six
 from ..utils.compat import NUMPY_LT_1_8
+from ..extern.six.moves import zip, cStringIO as StringIO
 
 # Tuple of filterwarnings kwargs to ignore when calling info
 IGNORE_WARNINGS = (dict(category=RuntimeWarning,
@@ -367,7 +368,7 @@ class DataInfo(object):
         if self._parent is None:
             return super(DataInfo, self).__repr__()
 
-        out = six.moves.cStringIO()
+        out = StringIO()
         self.__call__(out=out)
         return out.getvalue()
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -15,6 +15,7 @@ from .codegen import make_function_with_signature
 from .exceptions import (AstropyDeprecationWarning,
                          AstropyPendingDeprecationWarning)
 from ..extern import six
+from ..extern.six.moves import zip
 
 
 __all__ = ['deprecated', 'deprecated_attribute', 'classproperty',

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -11,6 +11,7 @@ import inspect
 import types
 
 from ..extern import six
+from ..extern.six.moves import range, zip
 
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
 
 from ..extern import six
-from ..extern.six.moves import urllib
+from ..extern.six.moves import urllib, range
 
 
 __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from ...extern import six  # pylint: disable=W0611
 from ...extern.six import next
-from ...extern.six.moves import xrange
+from ...extern.six.moves import range
 
 import io
 import locale
@@ -164,7 +164,7 @@ def test_progress_bar():
 
 
 def test_progress_bar2():
-    for x in console.ProgressBar(xrange(50)):
+    for x in console.ProgressBar(range(50)):
         pass
 
 
@@ -172,7 +172,7 @@ def test_progress_bar3():
     def do_nothing(*args, **kwargs):
         pass
 
-    console.ProgressBar.map(do_nothing, xrange(50))
+    console.ProgressBar.map(do_nothing, range(50))
 
 
 def test_zero_progress_bar():
@@ -182,7 +182,7 @@ def test_zero_progress_bar():
 
 def test_progress_bar_as_generator():
     sum = 0
-    for x in console.ProgressBar(xrange(50)):
+    for x in console.ProgressBar(range(50)):
         sum += x
     assert sum == 1225
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -6,19 +6,18 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ...extern import six
-
-from ...tests.helper import remote_data, raises, pytest, catch_warnings
-
 import hashlib
 import io
 import os
 import sys
 import tempfile
-from ...extern.six.moves.urllib.request import pathname2url
 
 from ..data import (_get_download_cache_locs, CacheMissingWarning,
                     get_pkg_data_filename, get_readable_fileobj)
+
+from ...extern import six
+from ...extern.six.moves import urllib
+from ...tests.helper import remote_data, raises, pytest, catch_warnings
 
 TESTURL = 'http://www.astropy.org'
 
@@ -130,7 +129,7 @@ def test_find_by_hash():
     from ..data import get_pkg_data_filename
 
     #this is of course not a real data file and not on any remote server, but it should *try* to go to the remote server
-    with pytest.raises(six.moves.urllib.error.URLError):
+    with pytest.raises(urllib.error.URLError):
         get_pkg_data_filename('kjfrhgjklahgiulrhgiuraehgiurhgiuhreglhurieghruelighiuerahiulruli')
 
 
@@ -376,10 +375,9 @@ def test_invalid_location_download():
     checks that download_file gives a URLError and not an AttributeError,
     as its code pathway involves some fiddling with the exception.
     """
-    from ...extern.six.moves.urllib_error import URLError
     from ..data import download_file
 
-    with pytest.raises(URLError):
+    with pytest.raises(urllib.error.URLError):
         download_file('http://astropy.org/nonexistentfile')
 
 
@@ -407,7 +405,7 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
     """checks that get_readable_fileobj leaves no temporary files behind"""
     # Create a 'file://' URL pointing to a path on the local filesystem
     local_filename = get_pkg_data_filename(os.path.join('data', 'local.dat'))
-    url = 'file://' + pathname2url(local_filename)
+    url = 'file://' + urllib.request.pathname2url(local_filename)
 
     # Save temporary files to a known location
     monkeypatch.setattr(tempfile, 'tempdir', str(tmpdir))

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..extern import six
+from ..extern.six.moves import range
 
 # STDLIB
 import time

--- a/astropy/utils/xml/check.py
+++ b/astropy/utils/xml/check.py
@@ -6,7 +6,7 @@ standards compliance.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ...extern.six.moves import xrange, urllib
+from ...extern.six.moves import range, urllib
 
 import re
 
@@ -54,7 +54,7 @@ def check_mime_content_type(content_type):
     Returns `True` if *content_type* is a valid MIME content type
     (syntactically at least), as defined by RFC 2045.
     """
-    ctrls = ''.join(chr(x) for x in xrange(0, 0x20))
+    ctrls = ''.join(chr(x) for x in range(0, 0x20))
     token_regex = '[^()<>@,;:\\\"/[\]?= %s\x7f]+' % ctrls
     return re.match(
         r'(?P<type>%s)/(?P<subtype>%s)$' % (token_regex, token_regex),

--- a/astropy/visualization/zscale.py
+++ b/astropy/visualization/zscale.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import, division
 
 import numpy as np
 
+from ..extern.six.moves import range
+
 __all__ = ['zscale']
 
 

--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -12,7 +12,7 @@ import time
 import uuid
 import warnings
 
-from ...extern.six.moves import queue
+from ...extern.six.moves import queue, range
 from ...extern.six.moves import xmlrpc_client as xmlrpc
 from ...extern.six.moves.urllib.parse import urlunparse
 from ... import log

--- a/astropy/vo/samp/utils.py
+++ b/astropy/vo/samp/utils.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 import inspect
 import traceback
 
-from ...extern.six.moves import queue
+from ...extern.six.moves import queue, range
 from ...extern.six.moves.urllib.request import urlopen
 from ...extern.six.moves import xmlrpc_client as xmlrpc
 from ...extern.six import StringIO

--- a/astropy/vo/validator/tests/test_inpect.py
+++ b/astropy/vo/validator/tests/test_inpect.py
@@ -11,6 +11,7 @@ import tempfile
 from .. import inspect
 from ....vo import conf
 from ....utils.data import _find_pkg_data_path, get_pkg_data_filename
+from ....extern.six.moves import zip
 
 
 __doctest_skip__ = ['*']

--- a/astropy/vo/validator/validate.py
+++ b/astropy/vo/validator/validate.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ...extern import six
+from ...extern.six.moves import map
 
 # STDLIB
 import multiprocessing
@@ -130,7 +131,7 @@ def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
     # Validate only a subset of the services.
     if url_list is not None:
         # Make sure URL is unique and fixed.
-        url_list = set(six.moves.map(unescape_all,
+        url_list = set(map(unescape_all,
             [cur_url.encode('utf-8') if isinstance(cur_url, str) else cur_url
              for cur_url in url_list]))
         uniq_rows = len(url_list)

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -6,6 +6,7 @@ from ...wcs import WCS
 from .. import utils
 from ..utils import proj_plane_pixel_scales, is_proj_plane_distorted, non_celestial_pixel_scales
 from ...tests.helper import pytest
+from ...extern.six.moves import range
 from ... import units as u
 
 import numpy as np

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -23,6 +23,7 @@ from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext
 from ...io import fits
+from ...extern.six.moves import range
 
 
 # test_maps() is a generator

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from .. import units as u
+from ..extern.six.moves import range
 
 __doctest_skip__ = ['wcs_to_celestial_frame']
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -45,6 +45,7 @@ import numpy as np
 # LOCAL
 from .. import log
 from ..extern import six
+from ..extern.six.moves import range, zip, map
 from ..io import fits
 from . import _docutil as __
 try:


### PR DESCRIPTION
This PR adds from `extern.six.moves` at all places where `map`, `zip` or `range` are used. 

Originally I only wanted to replace them where python2 names or the `try ... except ...` was still used, i.e. `from six.moves import xrange` or `izip`. But then I thought it probably wouldn't hurt to use the generator versions.

This PR also removes some trailing whitespaces or rows containing only whitespaces. (that was accidental because my editor is setup to remove them "on saving", but that doesn't hurt either, right?)