### PR TITLE
Remove some remaining numpy <1.7 compatibility checks.

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -24,8 +24,6 @@ __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
            "PhysicsSphericalRepresentation", "CylindricalRepresentation"]
 
-NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
-
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
 # get registered automatically.
@@ -244,14 +242,8 @@ class BaseRepresentation(ShapedLikeNDArray):
                 ', '.join(format_val(x[name]) for name in names))
         }
 
-        if NUMPY_LT_1P7:
-            arrstr = np.array2string(v, separator=', ',
-                                     prefix=prefixstr)
-
-        else:
-            arrstr = np.array2string(v, formatter=formatter,
-                                     separator=', ',
-                                     prefix=prefixstr)
+        arrstr = np.array2string(v, formatter=formatter,
+                                 separator=', ', prefix=prefixstr)
 
         if self._values.shape == ():
             arrstr = arrstr[1:-1]

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -15,8 +15,6 @@ from ...utils import OrderedDescriptorContainer
 from .. import representation
 from ..representation import REPRESENTATION_CLASSES
 
-NUMPY_LT_1P7 = [int(x) for x in np.__version__.split('.')[:2]] < [1, 7]
-
 
 def setup_function(func):
     func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
@@ -171,29 +169,19 @@ def test_frame_repr():
     i2 = ICRS(ra=1*u.deg, dec=2*u.deg)
     i3 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.kpc)
 
-    if NUMPY_LT_1P7:
-        assert repr(i2).startswith("<ICRS Coordinate: (ra, dec) in deg")
-        assert repr(i3).startswith("<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)")
-
-    else:
-        assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
-                            '    (1.0, 2.0)>')
-        assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
-                            '    (1.0, 2.0, 3.0)>')
+    assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
+                        '    (1.0, 2.0)>')
+    assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
+                        '    (1.0, 2.0, 3.0)>')
 
     # try with arrays
     i2 = ICRS(ra=[1.1,2.1]*u.deg, dec=[2.1,3.1]*u.deg)
     i3 = ICRS(ra=[1.1,2.1]*u.deg, dec=[-15.6,17.1]*u.deg, distance=[11.,21.]*u.kpc)
 
-    if NUMPY_LT_1P7:
-        assert repr(i2).startswith("<ICRS Coordinate: (ra, dec) in deg")
-        assert repr(i3).startswith("<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)")
-
-    else:
-        assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
-                            '    [(1.1, 2.1), (2.1, 3.1)]>')
-        assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
-                            '    [(1.1, -15.6, 11.0), (2.1, 17.1, 21.0)]>')
+    assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
+                        '    [(1.1, 2.1), (2.1, 3.1)]>')
+    assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
+                        '    [(1.1, -15.6, 11.0), (2.1, 17.1, 21.0)]>')
 
 
 def test_converting_units():
@@ -217,15 +205,13 @@ def test_converting_units():
 
     ri2 = ''.join(rexrepr.split(repr(i2)))
     ri4 = ''.join(rexrepr.split(repr(i4)))
-    if not NUMPY_LT_1P7:
-        assert ri2 == ri4
+    assert ri2 == ri4
     assert i2.data.lon.unit != i4.data.lon.unit  # Internal repr changed
 
     ri2_many = ''.join(rexrepr.split(repr(i2_many)))
     ri4_many = ''.join(rexrepr.split(repr(i4_many)))
 
-    if not NUMPY_LT_1P7:
-        assert ri2_many == ri4_many
+    assert ri2_many == ri4_many
     assert i2_many.data.lon.unit != i4_many.data.lon.unit  # Internal repr changed
 
     #but that *shouldn't* hold if we turn off units for the representation


### PR DESCRIPTION
In #4784, we dropped support for numpy < 1.7, but a few checks were not removed. This remedies that. I list the milestone to 1.2.2, since numpy < 1.7 support was dropped in 1.2.0, but if it is trouble to backport, it is obviously fine to just do it in current master.