### PR TITLE
speedup for import astropy: "io.registry.get_formats"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -184,6 +184,11 @@ Other Changes and Additions
     ``angles.angle_axis`` are also deprecated, in favour of the new routines
     with the same name in ``coordinates.matrix_utilities``. [#5104]
 
+- ``astropy.io.registry``
+
+  - Reduced the time spent in the ``get_formats`` function. This also reduces
+    the time it takes to import astropy subpackages, i.e.
+    ``astropy.coordinates``. [#5262]
 
 - To build the documentation, the ``build_sphinx`` command has been deprecated
   in favor of ``build_docs``. [#5179]

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -77,9 +77,13 @@ def get_formats(data_class=None):
         rows.append((format_class[1].__name__, format_class[0], has_read,
                      has_write, has_identify, deprecated))
 
-    data = None
+    # Sorting the list of tuples is much faster than sorting it after the table
+    # is created. (#5262)
     if rows:
+        # Indices represent "Data Class", "Deprecated" and "Format".
         data = list(zip(*sorted(rows, key=itemgetter(0, 5, 1))))
+    else:
+        data = None
     format_table = Table(data, names=('Data class', 'Format', 'Read', 'Write',
                                       'Auto-identify', 'Deprecated'))
 

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -77,10 +77,11 @@ def get_formats(data_class=None):
         rows.append((format_class[1].__name__, format_class[0], has_read,
                      has_write, has_identify, deprecated))
 
-    data = list(zip(*rows)) if rows else None
+    data = None
+    if rows:
+        data = list(zip(*sorted(rows, key=itemgetter(0, 5, 1))))
     format_table = Table(data, names=('Data class', 'Format', 'Read', 'Write',
                                       'Auto-identify', 'Deprecated'))
-    format_table.sort(['Data class', 'Deprecated', 'Format'])
 
     if not np.any(format_table['Deprecated'] == 'Yes'):
         format_table.remove_column('Deprecated')


### PR DESCRIPTION
Upon reviewing #5222 and #4598 I noticed that `io.registry.get_formats` is in the top50 of the cumulative time consumers when importing `astropy`.

Some measurements:

```
%prun from astropy.coordinates import SkyCoord
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       68    0.021    0.000    1.213    0.018 registry.py:44(get_formats)

from astropy.io import registry
%load_ext line_profiler
%lprun -f registry.get_formats registry.get_formats()
Line #      Hits         Time  Per Hit   % Time  Line Contents
    83         1        47175  47175.0     74.0      format_table.sort(['Data class', 'Deprecated', 'Format'])

%timeit registry.get_formats()
100 loops, best of 3: 14.1 ms per loop
```
Compared with the same data with these changes
```
%prun from astropy.coordinates import SkyCoord
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       68    0.019    0.000    0.350    0.005 registry.py:44(get_formats)

from astropy.io import registry
%load_ext line_profiler
%lprun -f registry.get_formats registry.get_formats()
Line #      Hits         Time  Per Hit   % Time  Line Contents
    80         1            5      5.0      0.0      data = None
    81         1            4      4.0      0.0      if rows:
    82         1          141    141.0      1.0          data = list(zip(*sorted(rows, key=itemgetter(0, 5, 1))))

%timeit registry.get_formats()
100 loops, best of 3: 4.07 ms per loop
```

This improves the import time of astropy by more than 10% on my computer. 

There is still room for lots of improvement, for example reducing the number of calls to this function, caching the result or improving the table-creation-time (which now takes 80% of the functions execution time). But this way it's a lot faster on my computer without having to do any fancy stuff. 

And I'm not sure if this actually works for everyone. Before I do more work here it would be good to know if this actually improves the import time for other people as well.

Btw: What makes the `Table.sort` so inefficient?