### PR TITLE
Fix ECSV table example in docstring

### DIFF
--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -170,7 +170,7 @@ class Ecsv(basic.Basic):
 
       # %ECSV 0.9
       # ---
-      # columns:
+      # datatype:
       # - {name: a, unit: m / s, type: int64, format: '%03d'}
       # - {name: b, unit: km, type: int64, description: This is column b}
       a b


### PR DESCRIPTION
@taldcroft - This PR fixes the ECSV file example in the docstring.

It currently fails like this:
```
In [24]: Table.read('example.ecsv', format='ascii.ecsv')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-24-1b015e2f57a2> in <module>()
----> 1 Table.read('example.ecsv', format='ascii.ecsv')

/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/table/table.py in read(cls, *args, **kwargs)
   2330         passed through to the underlying data reader (e.g. `~astropy.io.ascii.read`).
   2331         """
-> 2332         return io_registry.read(cls, *args, **kwargs)
   2333 
   2334     def write(self, *args, **kwargs):

/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/io/registry.py in read(cls, *args, **kwargs)
    349 
    350         reader = get_reader(format, cls)
--> 351         data = reader(*args, **kwargs)
    352 
    353         if not isinstance(data, cls):

/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/io/ascii/connect.py in io_read(format, filename, **kwargs)
     35     from .ui import read
     36     format = re.sub(r'^ascii\.', '', format)
---> 37     return read(filename, format=format, **kwargs)
     38 
     39 

/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/io/ascii/ui.py in read(table, guess, **kwargs)
    339                                              ' with fast (no guessing)'})
    340         else:
--> 341             dat = reader.read(table)
    342             _read_trace.append({'kwargs': new_kwargs,
    343                                 'status': 'Success with specified Reader class '

/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/io/ascii/core.py in read(self, table)
   1148 
   1149         # Get the table column definitions
-> 1150         self.header.get_cols(self.lines)
   1151 
   1152         # Make sure columns are valid

/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/astropy/io/ascii/ecsv.py in get_cols(self, lines)
    133 
    134         # Create the list of io.ascii column objects from `header`
--> 135         header_cols = OrderedDict((x['name'], x) for x in header['datatype'])
    136         self.names = [x['name'] for x in header['datatype']]
    137         self._set_cols_from_names()  # BaseHeader method to create self.cols

KeyError: 'datatype'
```
and after making this change `columns` -> `datatype` it works.