### PR TITLE
fix SkyCoord.__init__ edge case with list of one skycoord

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,9 @@ Bug Fixes
     ``get_moon`` and ``get_sun`` now work with non-scalar times and a
     non-geocentric observer. [#5253]
 
+  - Initialising a SkyCoord from a list containing a single SkyCoord no longer removes
+    the distance from the coordinate. [#5270]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1490,6 +1490,10 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                                      "frames: {0} != {1}".format(sc, scs[0]))
                 if allunitsphrepr and not isinstance(sc.data, UnitSphericalRepresentation):
                     allunitsphrepr = False
+            # special case of the above logic for edge case where we have a list of one
+            # SkyCoord
+            if len(scs) == 1:
+                allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
 
             # get the frame attributes from the first one, because from above we
             # know it matches all the others

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1481,15 +1481,14 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # SkyCoords from the list elements and then combine them.
             scs = [SkyCoord(coord, **init_kwargs) for coord in coords]
 
-            # now check that they're all self-consistent in their frames and
-            # check if they are all UnitSphericalRepresentation internally
-            allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
+            # Check that all frames are equivalent
             for sc in scs[1:]:
                 if not sc.is_equivalent_frame(scs[0]):
                     raise ValueError("List of inputs don't have equivalent "
                                      "frames: {0} != {1}".format(sc, scs[0]))
-                if allunitsphrepr and not isinstance(sc.data, UnitSphericalRepresentation):
-                    allunitsphrepr = False
+
+            # Now use the first to determine if they are all UnitSpherical
+            allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
 
             # get the frame attributes from the first one, because from above we
             # know it matches all the others

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1483,17 +1483,13 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # now check that they're all self-consistent in their frames and
             # check if they are all UnitSphericalRepresentation internally
-            allunitsphrepr = True
+            allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
             for sc in scs[1:]:
                 if not sc.is_equivalent_frame(scs[0]):
                     raise ValueError("List of inputs don't have equivalent "
                                      "frames: {0} != {1}".format(sc, scs[0]))
                 if allunitsphrepr and not isinstance(sc.data, UnitSphericalRepresentation):
                     allunitsphrepr = False
-            # special case of the above logic for edge case where we have a list of one
-            # SkyCoord
-            if len(scs) == 1:
-                allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
 
             # get the frame attributes from the first one, because from above we
             # know it matches all the others

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -13,9 +13,14 @@ import numpy as np
 
 from ... import units as u
 from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
+<<<<<<< fc47f12ab0e84e9ca11e31341db490795fe5152f
                 GeocentricTrueEcliptic, Longitude, Latitude, GCRS, HCRS,
                 get_moon, FK4, FK4NoETerms)
 from ..sites import get_builtin_sites
+=======
+                GeocentricTrueEcliptic, Longitude, Latitude, GCRS,
+                FK4, FK4NoETerms, get_moon)
+>>>>>>> added regresion test and changelog entry
 from ...time import Time
 from ...utils import iers
 
@@ -275,3 +280,11 @@ def test_regression_4926():
     # and some others to increase coverage of transforms
     moon.transform_to(HCRS(obstime="J2000"))
     moon.transform_to(HCRS(obstime=times))
+
+
+def test_regression_5209():
+    "check that distances are not lost on SkyCoord init"
+    time = Time('2015-01-01')
+    moon = get_moon(time)
+    new_coord = SkyCoord([moon])
+    assert_quantity_allclose(new_coord[0].distance, moon.distance)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -13,14 +13,9 @@ import numpy as np
 
 from ... import units as u
 from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
-<<<<<<< fc47f12ab0e84e9ca11e31341db490795fe5152f
                 GeocentricTrueEcliptic, Longitude, Latitude, GCRS, HCRS,
                 get_moon, FK4, FK4NoETerms)
 from ..sites import get_builtin_sites
-=======
-                GeocentricTrueEcliptic, Longitude, Latitude, GCRS,
-                FK4, FK4NoETerms, get_moon)
->>>>>>> added regresion test and changelog entry
 from ...time import Time
 from ...utils import iers
 


### PR DESCRIPTION
This PR fixes #5209.

There are two bugs in that PR. One is that initialising a SkyCoord from a list of SkyCoords that have distances will raise an exception. This is fixed in the current master. 

The second bug is an edge case where the distance goes missing when initialising a SkyCoord from a list which contains a single SkyCoord, as shown below. This PR fixes that edge case.

```python
In [1]: from astropy.coordinates import EarthLocation, SkyCoord, GCRS
In [2]: from astropy import units as u
In [3]: from astropy.time import Time
In [4]: time = Time("2014-01-20 22:00")
In [5]: location = EarthLocation.from_geodetic(-17.88*u.deg, -28.76*u.deg, 2327*u.m)
In [6]: gcrs_loc = u.Quantity([1712675, 5328049, -3053885], unit=u.m)
In [7]: gcrs_vel = u.Quantity([-388, 125, 0], unit=u.m/u.s)
In [8]: moon = SkyCoord(GCRS(172.4*u.deg, 0.51*u.deg, 0.002671*u.au,
                obstime=time, obsgeoloc=gcrs_loc, obsgeovel=gcrs_vel))

In [9]: SkyCoord([moon])  # ODD! Where has the distance gone?
Out[9]: 
<SkyCoord (ICRS): (ra, dec) in deg
    (172.4, 0.51)>
```