### PR TITLE
Check for scipy geq than 0.14.0 in _scipy_kraft_burrows_nousek

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1197,16 +1197,22 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
 
     Notes
     -----
-    Requires `scipy`. This implementation will cause Overflow Errors for
-    about N > 100 (the exact limit depends on details of how scipy was
-    compiled).  See `~astropy.stats.mpmath_poisson_upper_limit` for an
-    implementation that is slower, but can deal with arbitrarily high
+    Requires `scipy` greater or equal than 0.14.0. This implementation will
+    cause Overflow Errors for about N > 100 (the exact limit depends on
+    details of how scipy was compiled).  See `~astropy.stats.mpmath_poisson_upper_limit`
+    for an implementation that is slower, but can deal with arbitrarily high
     numbers since it is based on the `mpmath <http://mpmath.org/>`_
     library.
     '''
+
     from scipy.optimize import brentq
     from scipy.integrate import quad
-    from scipy.special import factorial
+
+    try:
+        from scipy.special import factorial
+    except ImportError:
+        raise ImportError("scipy's version greater or equal than 0.14.0 is "
+                          "required.")
 
     def eqn8(N, B):
         n = np.arange(N + 1)

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -9,12 +9,16 @@ from numpy.random import randn, normal
 from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
+from astropy.utils import minversion
+
 try:
     import scipy  # pylint: disable=W0611
 except ImportError:
     HAS_SCIPY = False
+    SCIPY_LT_0_14 = True
 else:
     HAS_SCIPY = True
+    SCIPY_LT_0_14 = not minversion(scipy, '0.14.0')
 
 try:
     import mpmath  # pylint: disable=W0611
@@ -611,7 +615,7 @@ def test_poisson_conf_gehrels86(n):
         rtol=0.02)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif('SCIPY_LT_0_14')
 def test_scipy_poisson_limit():
     '''Test that the lower-level routine gives the snae number.
 
@@ -656,7 +660,7 @@ def test_poisson_conf_value_errors():
     assert 'Invalid method' in str(e.value)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif('SCIPY_LT_0_14')
 def test_poisson_conf_kbn_value_errors():
     with pytest.raises(ValueError) as e:
         funcs.poisson_conf_interval(5., 'kraft-burrows-nousek',


### PR DESCRIPTION
This addresses issue #5064.

Basically, the code checks whether one's scipy version is greater or equal than ``0.14.0`` (in which ``scipy.special.factorial`` was included). 

The other scipy functionalities needed for ``_scipy_kraft_burrows_nousek``, namely ``optimize.brentq`` and ``integrate.quad``, are present since ``scipy 0.11``.

cc @embray @hamogu 