### PR TITLE
Allow use of JPL ephemerides in coordinate transforms and light travel time corrections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,7 +314,7 @@ Bug Fixes
 
 - ``astropy.time``
 
- - `light_travel_time` can now use more accurate JPL ephemerides.
+ - ``light_travel_time`` can now use more accurate JPL ephemerides.
 
 - ``astropy.units``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,8 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Transformations between coordinate systems can use the more accurate JPL ephemerides.
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -311,6 +313,8 @@ Bug Fixes
     subclass (such as ``Magnitude`` or ``Dex``). [#5345]
 
 - ``astropy.time``
+
+ - `light_travel_time` can now use more accurate JPL ephemerides.
 
 - ``astropy.units``
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -71,9 +71,8 @@ def icrs_to_helioecliptic(from_coo, to_frame):
 
     # get barycentric sun coordinate
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric, solar_system_ephemeris
-    ephemeris = solar_system_ephemeris.get()
-    bary_sun_pos = get_body_barycentric('sun', to_frame.equinox, ephemeris=ephemeris)
+    from ..solar_system import get_body_barycentric
+    bary_sun_pos = get_body_barycentric('sun', to_frame.equinox)
 
     # offset to heliocentric
     heliocart = CartesianRepresentation(from_coo.cartesian.x + bary_sun_pos.x, from_coo.cartesian.y + bary_sun_pos.y,
@@ -98,11 +97,10 @@ def helioecliptic_to_icrs(from_coo, to_frame):
     # now offset back to barycentric, which is the correct center for ICRS
 
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric, solar_system_ephemeris
+    from ..solar_system import get_body_barycentric
 
     # get barycentric sun coordinate
-    ephemeris = solar_system_ephemeris.get()
-    bary_sun_pos = get_body_barycentric('sun', from_coo.equinox, ephemeris=ephemeris)
+    bary_sun_pos = get_body_barycentric('sun', from_coo.equinox)
 
     newrepr = CartesianRepresentation(intermed_repr.x - bary_sun_pos.x, intermed_repr.y - bary_sun_pos.y,
                                       intermed_repr.z - bary_sun_pos.z)

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -75,9 +75,10 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     bary_sun_pos = get_body_barycentric('sun', to_frame.equinox)
 
     # offset to heliocentric
-    heliocart = CartesianRepresentation(from_coo.cartesian.x + bary_sun_pos.x,
-                                        from_coo.cartesian.y + bary_sun_pos.y,
-                                        from_coo.cartesian.z + bary_sun_pos.z)
+    from_coo_cartesian = from_coo.cartesian
+    heliocart = CartesianRepresentation(from_coo_cartesian.x + bary_sun_pos.x,
+                                        from_coo_cartesian.y + bary_sun_pos.y,
+                                        from_coo_cartesian.z + bary_sun_pos.z)
 
     # now compute the matrix to precess to the right orientation
     rmat = _ecliptic_rotation_matrix(to_frame.equinox)

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -75,7 +75,8 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     bary_sun_pos = get_body_barycentric('sun', to_frame.equinox)
 
     # offset to heliocentric
-    heliocart = CartesianRepresentation(from_coo.cartesian.x + bary_sun_pos.x, from_coo.cartesian.y + bary_sun_pos.y,
+    heliocart = CartesianRepresentation(from_coo.cartesian.x + bary_sun_pos.x,
+                                        from_coo.cartesian.y + bary_sun_pos.y,
                                         from_coo.cartesian.z + bary_sun_pos.z)
 
     # now compute the matrix to precess to the right orientation
@@ -102,6 +103,7 @@ def helioecliptic_to_icrs(from_coo, to_frame):
     # get barycentric sun coordinate
     bary_sun_pos = get_body_barycentric('sun', from_coo.equinox)
 
-    newrepr = CartesianRepresentation(intermed_repr.x - bary_sun_pos.x, intermed_repr.y - bary_sun_pos.y,
+    newrepr = CartesianRepresentation(intermed_repr.x - bary_sun_pos.x,
+                                      intermed_repr.y - bary_sun_pos.y,
                                       intermed_repr.z - bary_sun_pos.z)
     return to_frame.realize_frame(newrepr)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -41,14 +41,12 @@ def prepare_earth_position_vel(time):
         Heliocentric position of Earth in au
     """
     # this goes here to avoid circular import errors
-    from ..solar_system import (get_body_barycentric, get_body_barycentric_posvel,
-                                solar_system_ephemeris)
+    from ..solar_system import (get_body_barycentric, get_body_barycentric_posvel)
     # get barycentric position and velocity of earth
-    ephemeris = solar_system_ephemeris.get()
-    earth_pv = get_body_barycentric_posvel('earth', time, ephemeris=ephemeris)
+    earth_pv = get_body_barycentric_posvel('earth', time)
 
     # get heliocentric position of earth
-    sun = get_body_barycentric('sun', time, ephemeris=ephemeris)
+    sun = get_body_barycentric('sun', time)
     earth_heliocentric = (earth_pv[0].xyz - sun.xyz).to(u.au)
 
     # prepare to pass to erfa

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -20,7 +20,42 @@ from .icrs import ICRS
 from .gcrs import GCRS
 from .cirs import CIRS
 from .hcrs import HCRS
-from .utils import get_jd12, aticq, atciqz, get_cip, prepare_earth_position_vel
+from .utils import get_jd12, aticq, atciqz, get_cip
+
+
+# utility function for transforms
+def prepare_earth_position_vel(time):
+    """
+    Get barycentric position and velocity, and heliocentric position of Earth
+
+    Parameters
+    -----------
+    time : `~astropy.time.Time`
+        time at which to calculate position and velocity of Earth
+
+    Returns
+    --------
+    earth_pv : `np.ndarray`
+        Barycentric position and velocity of Earth, in au and au/day
+    earth_helio : `np.ndarray`
+        Heliocentric position of Earth in au
+    """
+    # this goes here to avoid circular import errors
+    from ..solar_system import (get_body_barycentric, get_body_barycentric_posvel,
+                                solar_system_ephemeris)
+    # get barycentric position and velocity of earth
+    ephemeris = solar_system_ephemeris.get()
+    earth_pv = get_body_barycentric_posvel('earth', time, ephemeris=ephemeris)
+
+    # get heliocentric position of earth
+    sun = get_body_barycentric('sun', time, ephemeris=ephemeris)
+    earth_heliocentric = (earth_pv[0].xyz - sun.xyz).to(u.au)
+
+    # prepare to pass to erfa
+    earth_pv = np.array([earth_pv[0].xyz.to(u.au), earth_pv[1].xyz.to(u.au/u.d)])
+    earth_pv = np.rollaxis(np.rollaxis(earth_pv, 0, earth_pv.ndim), 0, earth_pv.ndim)
+    earth_heliocentric = np.rollaxis(earth_heliocentric, 0, earth_heliocentric.ndim)
+    return earth_pv, earth_heliocentric
 
 
 # First the ICRS/CIRS related transforms

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -305,9 +305,9 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
 
     ephemeris = solar_system_ephemeris.get()
     bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime, ephemeris=ephemeris)
-    sun_vector = bary_sun_pos.xyz
-    new_vector = np.rollaxis(hcrs_coo.cartesian.xyz, -1, 0) + np.rollaxis(sun_vector, -1, 0)
-    newrep = CartesianRepresentation(np.rollaxis(new_vector, 0, new_vector.ndim))
+    hcrs_cart = hcrs_coo.cartesian
+    newrep = CartesianRepresentation(hcrs_cart.x + bary_sun_pos.x, hcrs_cart.y + bary_sun_pos.y,
+                                     hcrs_cart.z + bary_sun_pos.z)
     return icrs_frame.realize_frame(newrep)
 
 
@@ -322,9 +322,9 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
 
     ephemeris = solar_system_ephemeris.get()
     bary_sun_pos = get_body_barycentric('sun', hcrs_frame.obstime, ephemeris=ephemeris)
-    sun_vector = bary_sun_pos.xyz
-    new_vector = np.rollaxis(icrs_coo.cartesian.xyz, -1, 0) - np.rollaxis(sun_vector, -1, 0)
-    newrep = CartesianRepresentation(np.rollaxis(new_vector, 0, new_vector.ndim))
+    icrs_cart = icrs_coo.cartesian
+    newrep = CartesianRepresentation(icrs_cart.x - bary_sun_pos.x, icrs_cart.y - bary_sun_pos.y,
+                                     icrs_cart.z - bary_sun_pos.z)
     return hcrs_frame.realize_frame(newrep)
 
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -58,6 +58,25 @@ def prepare_earth_position_vel(time):
 
 
 def get_cip(jd1, jd2):
+    """
+    Find the X, Y coordinates of the CIP and the CIO locator, s.
+
+    Parameters
+    ----------
+    jd1 : float or `np.ndarray`
+        First part of two part Julian date (TDB)
+    jd2 : float or `np.ndarray`
+        Second part of two part Julian date (TDB)
+
+    Returns
+    --------
+    x : float or `np.ndarray`
+        x coordinate of the CIP
+    y : float or `np.ndarray`
+        y coordinate of the CIP
+    s : float or `np.ndarray`
+        CIO locator, s
+    """
     # classical NPB matrix, IAU 2006/2000A
     rpnb = erfa.pnm06a(jd1, jd2)
     # CIP X, Y coordinates from array

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -301,10 +301,8 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(hcrs_coo.__class__.__name__))
 
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric, solar_system_ephemeris
-
-    ephemeris = solar_system_ephemeris.get()
-    bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime, ephemeris=ephemeris)
+    from ..solar_system import get_body_barycentric
+    bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime)
     hcrs_cart = hcrs_coo.cartesian
     newrep = CartesianRepresentation(hcrs_cart.x + bary_sun_pos.x, hcrs_cart.y + bary_sun_pos.y,
                                      hcrs_cart.z + bary_sun_pos.z)
@@ -318,10 +316,8 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(icrs_coo.__class__.__name__))
 
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric, solar_system_ephemeris
-
-    ephemeris = solar_system_ephemeris.get()
-    bary_sun_pos = get_body_barycentric('sun', hcrs_frame.obstime, ephemeris=ephemeris)
+    from ..solar_system import get_body_barycentric
+    bary_sun_pos = get_body_barycentric('sun', hcrs_frame.obstime)
     icrs_cart = icrs_coo.cartesian
     newrep = CartesianRepresentation(icrs_cart.x - bary_sun_pos.x, icrs_cart.y - bary_sun_pos.y,
                                      icrs_cart.z - bary_sun_pos.z)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -304,7 +304,8 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
     from ..solar_system import get_body_barycentric
     bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime)
     hcrs_cart = hcrs_coo.cartesian
-    newrep = CartesianRepresentation(hcrs_cart.x + bary_sun_pos.x, hcrs_cart.y + bary_sun_pos.y,
+    newrep = CartesianRepresentation(hcrs_cart.x + bary_sun_pos.x,
+                                     hcrs_cart.y + bary_sun_pos.y,
                                      hcrs_cart.z + bary_sun_pos.z)
     return icrs_frame.realize_frame(newrep)
 
@@ -319,7 +320,8 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
     from ..solar_system import get_body_barycentric
     bary_sun_pos = get_body_barycentric('sun', hcrs_frame.obstime)
     icrs_cart = icrs_coo.cartesian
-    newrep = CartesianRepresentation(icrs_cart.x - bary_sun_pos.x, icrs_cart.y - bary_sun_pos.y,
+    newrep = CartesianRepresentation(icrs_cart.x - bary_sun_pos.x,
+                                     icrs_cart.y - bary_sun_pos.y,
                                      icrs_cart.z - bary_sun_pos.z)
     return hcrs_frame.realize_frame(newrep)
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -20,70 +20,7 @@ from .icrs import ICRS
 from .gcrs import GCRS
 from .cirs import CIRS
 from .hcrs import HCRS
-from .utils import get_jd12, aticq, atciqz
-
-
-def prepare_earth_position_vel(time):
-    """
-    Get barycentric position and velocity, and heliocentric position of Earth
-
-    Parameters
-    -----------
-    time : `~astropy.time.Time`
-        time at which to calculate position and velocity of Earth
-
-    Returns
-    --------
-    earth_pv : `np.ndarray`
-        Barycentric position and velocity of Earth, in au and au/day
-    earth_helio : `np.ndarray`
-        Heliocentric position of Earth in au
-    """
-    # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric, solar_system_ephemeris
-    # get barycentric position and velocity of earth
-    ephemeris = solar_system_ephemeris.get()
-    earth_pv = get_body_barycentric('earth', time,
-                                    ephemeris=ephemeris, get_velocity=True)
-
-    # get heliocentric position of earth
-    sun = get_body_barycentric('sun', time, ephemeris=ephemeris)
-    earth_heliocentric = (earth_pv[0].xyz - sun.xyz).to(u.au)
-
-    # prepare to pass to erfa
-    earth_pv = np.array([earth_pv[0].xyz.to(u.au), earth_pv[1].xyz.to(u.au/u.d)])
-    earth_pv = np.rollaxis(np.rollaxis(earth_pv, 0, earth_pv.ndim), 0, earth_pv.ndim)
-    earth_heliocentric = np.rollaxis(earth_heliocentric, 0, earth_heliocentric.ndim)
-    return earth_pv, earth_heliocentric
-
-
-def get_cip(jd1, jd2):
-    """
-    Find the X, Y coordinates of the CIP and the CIO locator, s.
-
-    Parameters
-    ----------
-    jd1 : float or `np.ndarray`
-        First part of two part Julian date (TDB)
-    jd2 : float or `np.ndarray`
-        Second part of two part Julian date (TDB)
-
-    Returns
-    --------
-    x : float or `np.ndarray`
-        x coordinate of the CIP
-    y : float or `np.ndarray`
-        y coordinate of the CIP
-    s : float or `np.ndarray`
-        CIO locator, s
-    """
-    # classical NPB matrix, IAU 2006/2000A
-    rpnb = erfa.pnm06a(jd1, jd2)
-    # CIP X, Y coordinates from array
-    x, y = erfa.bpn2xy(rpnb)
-    # CIO locator, s
-    s = erfa.s06(jd1, jd2, x, y)
-    return x, y, s
+from .utils import get_jd12, aticq, atciqz, get_cip, prepare_earth_position_vel
 
 
 # First the ICRS/CIRS related transforms
@@ -337,10 +274,10 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
                                               copy=False)
 
         newxyz = intermedrep.to_cartesian().xyz
-        # roll astrom['eh'] to the last axis and scale
-        eh = np.rollaxis(astrom['eh'], 0, astrom['eh'].ndim) * astrom['em'] * u.au
-        # roll astrom['eh'] back to the first axis
-        eh = np.rollaxis(eh, -1, 0)
+        # roll astrom['eh'] to the first axis and scale
+        eh = np.rollaxis(astrom['eh'], -1, 0) * astrom['em'] * u.au
+        # roll astrom['eh'] back to the last axis
+        eh = np.rollaxis(eh, 0, eh.ndim)
 
         # roll xyz to last axis and add the heliocentre position
         newxyz = np.rollaxis(newxyz, 0, newxyz.ndim) + eh

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -159,7 +159,6 @@ def cirs_to_cirs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
-
     # first set up the astrometry context for ICRS<->GCRS
     pv = np.array([gcrs_frame.obsgeoloc.xyz.value,
                    gcrs_frame.obsgeovel.xyz.value])
@@ -309,9 +308,14 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
                                               copy=False)
 
         newxyz = intermedrep.to_cartesian().xyz
-        # roll astrom['eh'] to the first axis and scale
+
+        # astrom['eh'] and astrom['em'] contain Sun to observer unit vector,
+        # and distance, respectively. Shapes are (X) and (X,3), where (X) is the
+        # shape resulting from broadcasting the shape of the times object
+        # against the shape of the pv array.
+        # roll 3-vector of astrom['eh'] to the first axis and scale
         eh = np.rollaxis(astrom['eh'], -1, 0) * astrom['em'] * u.au
-        # roll astrom['eh'] back to the last axis
+        # roll 3-vector of astrom['eh'] back to the last axis
         eh = np.rollaxis(eh, 0, eh.ndim)
 
         # roll xyz to last axis and add the heliocentre position

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -52,7 +52,7 @@ def prepare_earth_position_vel(time):
     # prepare to pass to erfa
     earth_pv = np.array([earth_pv[0].xyz.to(u.au), earth_pv[1].xyz.to(u.au/u.d)])
     earth_pv = np.rollaxis(np.rollaxis(earth_pv, 0, earth_pv.ndim), 0, earth_pv.ndim)
-    earth_heliocentric = np.rollaxis(earth_heliocentric, 0, earth_heliocentric.ndim)
+    earth_heliocentric = np.rollaxis(earth_heliocentric.value, 0, earth_heliocentric.ndim)
     return earth_pv, earth_heliocentric
 
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -157,17 +157,19 @@ def cirs_to_cirs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
-    # first set up the astrometry context for ICRS<->GCRS
+    # first set up the astrometry context for ICRS<->GCRS. There are a few steps...
+    # get the position and velocity arrays for the observatory
     pv = np.array([gcrs_frame.obsgeoloc.xyz.value,
                    gcrs_frame.obsgeovel.xyz.value])
     # roll axes 0 and 1 to end
     if pv.ndim > 2:
         pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
 
+    # find the position and velocity of earth
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
     earth_pv, earth_heliocentric = prepare_earth_position_vel(gcrs_frame.obstime)
 
-    # get astrometry context
+    # get astrometry context object, astrom.
     astrom = erfa.apcs(jd1, jd2, pv, earth_pv, earth_heliocentric)
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -311,10 +311,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # and distance, respectively. Shapes are (X) and (X,3), where (X) is the
         # shape resulting from broadcasting the shape of the times object
         # against the shape of the pv array.
-        # roll 3-vector of astrom['eh'] to the first axis and scale
-        eh = np.rollaxis(astrom['eh'], -1, 0) * astrom['em'] * u.au
-        # roll 3-vector of astrom['eh'] back to the last axis
-        eh = np.rollaxis(eh, 0, eh.ndim)
+        # broadcast em to eh and scale eh
+        eh = astrom['eh'] * astrom['em'][..., np.newaxis] * u.au
 
         # roll xyz to last axis and add the heliocentre position
         newxyz = np.rollaxis(newxyz, 0, newxyz.ndim) + eh

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -125,40 +125,6 @@ def norm(p):
     return p/np.sqrt(np.einsum('...i,...i', p, p))[..., np.newaxis]
 
 
-def prepare_earth_position_vel(time):
-    """
-    Get barycentric position and velocity, and heliocentric position of Earth
-
-    Parameters
-    -----------
-    time : `~astropy.time.Time`
-        time at which to calculate position and velocity of Earth
-
-    Returns
-    --------
-    earth_pv : `np.ndarray`
-        Barycentric position and velocity of Earth, in au and au/day
-    earth_helio : `np.ndarray`
-        Heliocentric position of Earth in au
-    """
-    # this goes here to avoid circular import errors
-    from ..solar_system import (get_body_barycentric, get_body_barycentric_posvel,
-                                solar_system_ephemeris)
-    # get barycentric position and velocity of earth
-    ephemeris = solar_system_ephemeris.get()
-    earth_pv = get_body_barycentric_posvel('earth', time, ephemeris=ephemeris)
-
-    # get heliocentric position of earth
-    sun = get_body_barycentric('sun', time, ephemeris=ephemeris)
-    earth_heliocentric = (earth_pv[0].xyz - sun.xyz).to(u.au)
-
-    # prepare to pass to erfa
-    earth_pv = np.array([earth_pv[0].xyz.to(u.au), earth_pv[1].xyz.to(u.au/u.d)])
-    earth_pv = np.rollaxis(np.rollaxis(earth_pv, 0, earth_pv.ndim), 0, earth_pv.ndim)
-    earth_heliocentric = np.rollaxis(earth_heliocentric, 0, earth_heliocentric.ndim)
-    return earth_pv, earth_heliocentric
-
-
 def get_cip(jd1, jd2):
     """
     Find the X, Y coordinates of the CIP and the CIO locator, s.

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -142,11 +142,11 @@ def prepare_earth_position_vel(time):
         Heliocentric position of Earth in au
     """
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric, solar_system_ephemeris
+    from ..solar_system import (get_body_barycentric, get_body_barycentric_posvel,
+                                solar_system_ephemeris)
     # get barycentric position and velocity of earth
     ephemeris = solar_system_ephemeris.get()
-    earth_pv = get_body_barycentric('earth', time,
-                                    ephemeris=ephemeris, get_velocity=True)
+    earth_pv = get_body_barycentric_posvel('earth', time, ephemeris=ephemeris)
 
     # get heliocentric position of earth
     sun = get_body_barycentric('sun', time, ephemeris=ephemeris)

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -109,6 +109,9 @@ class solar_system_ephemeris(ScienceState):
 
     @classmethod
     def validate(cls, value):
+        # make no changes if value is None
+        if value is None:
+            return cls._value
         # Set up Kernel; if the file is not in cache, this will download it.
         cls.get_kernel(value)
         return value

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -23,7 +23,6 @@ from .representation import CartesianRepresentation
 from .orbital_elements import calc_moon
 from .builtin_frames import GCRS, ICRS
 from .builtin_frames.utils import get_jd12
-from .. import _erfa
 from ..extern import six
 
 __all__ = ["get_body", "get_moon", "get_body_barycentric",
@@ -507,6 +506,6 @@ def _apparent_position_in_true_coordinates(skycoord):
     are defined w.r.t to the true equinox and poles of the Earth
     """
     jd1, jd2 = get_jd12(skycoord.obstime, 'tt')
-    _, _, _, _, _, _, _, rbpn = _erfa.pn00a(jd1, jd2)
+    _, _, _, _, _, _, _, rbpn = erfa.pn00a(jd1, jd2)
     return SkyCoord(skycoord.frame.realize_frame(
         skycoord.cartesian.transform(rbpn)))

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -574,8 +574,9 @@ class Time(ShapedLikeNDArray):
             If no location is given, the ``location`` attribute of the Time
             object is used
         ephemeris : str, optional
-            Solar system ephemeris to use. By default, use the one set with
-            ``astropy.coordinates.solar_system_ephemeris.set``
+            Solar system ephemeris to use (e.g., 'builtin', 'jpl'). By default,
+            use the one set with ``astropy.coordinates.solar_system_ephemeris.set``.
+            For more information, see `~astropy.coordinates.solar_system_ephemeris`.
 
         Returns
         -------

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -552,7 +552,7 @@ class Time(ShapedLikeNDArray):
         # the ``value`` attribute is cached.
         return getattr(self, self.format)
 
-    def light_travel_time(self, skycoord, kind='barycentric', location=None):
+    def light_travel_time(self, skycoord, kind='barycentric', location=None, ephemeris=None):
         """Light travel time correction to the barycentre or heliocentre.
 
         The frame transformations used to calculate the location of the solar
@@ -573,6 +573,9 @@ class Time(ShapedLikeNDArray):
             The location of the observatory to calculate the correction for.
             If no location is given, the ``location`` attribute of the Time
             object is used
+        ephemeris : str, optional
+            Solar system ephemeris to use. By default, use the one set with
+            ``astropy.coordinates.solar_system_ephemeris.set``
 
         Returns
         -------
@@ -594,7 +597,11 @@ class Time(ShapedLikeNDArray):
             location = self.location
 
         from ..coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
-                                   HCRS, ICRS, GCRS, EarthLocation, SkyCoord)
+                                   HCRS, ICRS, GCRS, solar_system_ephemeris)
+
+        # get the ephemeris for later (we don't want to set it to None)
+        if ephemeris is None:
+            ephemeris = solar_system_ephemeris.get()
 
         # ensure sky location is ICRS compatible
         if not skycoord.is_transformable_to(ICRS()):
@@ -606,15 +613,16 @@ class Time(ShapedLikeNDArray):
         except Exception:
             raise ValueError("Supplied location does not have a valid `get_itrs` method")
 
-        if kind.lower() == 'heliocentric':
-            # convert to heliocentric coordinates, aligned with ICRS
-            cpos = itrs.transform_to(HCRS(obstime=self)).cartesian.xyz
-        else:
-            # first we need to convert to GCRS coordinates with the correct
-            # obstime, since ICRS coordinates have no frame time
-            gcrs_coo = itrs.transform_to(GCRS(obstime=self))
-            # convert to barycentric (BCRS) coordinates, aligned with ICRS
-            cpos = gcrs_coo.transform_to(ICRS()).cartesian.xyz
+        with solar_system_ephemeris.set(ephemeris):
+            if kind.lower() == 'heliocentric':
+                # convert to heliocentric coordinates, aligned with ICRS
+                cpos = itrs.transform_to(HCRS(obstime=self)).cartesian.xyz
+            else:
+                # first we need to convert to GCRS coordinates with the correct
+                # obstime, since ICRS coordinates have no frame time
+                gcrs_coo = itrs.transform_to(GCRS(obstime=self))
+                # convert to barycentric (BCRS) coordinates, aligned with ICRS
+                cpos = gcrs_coo.transform_to(ICRS()).cartesian.xyz
 
         # get unit ICRS vector to star
         spos = (skycoord.icrs.represent_as(UnitSphericalRepresentation).

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -599,10 +599,6 @@ class Time(ShapedLikeNDArray):
         from ..coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
                                    HCRS, ICRS, GCRS, solar_system_ephemeris)
 
-        # get the ephemeris for later (we don't want to set it to None)
-        if ephemeris is None:
-            ephemeris = solar_system_ephemeris.get()
-
         # ensure sky location is ICRS compatible
         if not skycoord.is_transformable_to(ICRS()):
             raise ValueError("Given skycoord is not transformable to the ICRS")

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -114,10 +114,5 @@ manager, as shown below:
 For locations at large distances from the Solar system, using the JPL ephemerides will make a
 negligible difference, on the order of micro-arcseconds. For nearby objects, such as the Moon,
 the difference can be of the order of milli-arcseconds. For more details about what ephemerides
-are available, see :ref:`astropy-coordinates-solarsystem`.
+are available, including the requirements for using JPL ephemerides, see :ref:`astropy-coordinates-solarsystem`.
 
-.. note::
-   Using JPL ephemerides requires that the `jplephem
-   <https://pypi.python.org/pypi/jplephem>`_ package be installed. This is
-   most easily achieved via ``pip install jplephem``, although whatever
-   package management system you use might have it as well.

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -90,3 +90,32 @@ objects use any frame attributes they have for all transformation
 steps.  So |skycoord| can always transform from one frame to another and
 back again without change, while low-level classes may lose information
 and hence often do not round-trip.
+
+Transformations and Solar-system ephemerides
+--------------------------------------------
+
+Some transformations (e.g. the transformation between `~astropy.coordinates.ICRS` and
+`~astropy.coordinates.GCRS`) require the use of a Solar-system ephemeris to calculate
+the position and velocity of the Earth and Sun. By default, transformations are
+calculated using built-in `ERFA <https://github.com/liberfa/erfa>`_ routines,
+but they can also use more precise ones using the JPL ephemerides (which are derived from
+dynamical models).
+
+To use the JPL ephemerides, use the `~astropy.coordinates.solar_system_ephemeris` context
+manager, as shown below:
+
+    >>> from astropy.coordinates import solar_system_ephemeris
+    >>> from astropy.coordinates import GCRS
+    >>> with solar_system_ephemeris.set('jpl'):
+    >>>     fk5c.transform_to(GCRS(obstime=Time("J2000")))
+
+For locations at large distances from the Solar system, using the JPL ephemerides will make a
+negligible difference, on the order of micro-arcseconds. For nearby objects, such as the Moon,
+the difference can be of the order of milli-arcseconds. For more details about what ephemerides
+are available, see :ref:`astropy-coordinates-solarsystem`.
+
+.. note::
+   Using JPL ephemerides requires that the `jplephem
+   <https://pypi.python.org/pypi/jplephem>`_ package be installed. This is
+   most easily achieved via ``pip install jplephem``, although whatever
+   package management system you use might have it as well.

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -104,10 +104,12 @@ dynamical models).
 To use the JPL ephemerides, use the `~astropy.coordinates.solar_system_ephemeris` context
 manager, as shown below:
 
+.. doctest-requires:: jplephem
+
     >>> from astropy.coordinates import solar_system_ephemeris
     >>> from astropy.coordinates import GCRS
-    >>> with solar_system_ephemeris.set('jpl'):
-    >>>     fk5c.transform_to(GCRS(obstime=Time("J2000")))
+    >>> with solar_system_ephemeris.set('jpl'): # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    ...     fk5c.transform_to(GCRS(obstime=Time("J2000"))) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
 
 For locations at large distances from the Solar system, using the JPL ephemerides will make a
 negligible difference, on the order of micro-arcseconds. For nearby objects, such as the Moon,

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -940,13 +940,7 @@ dynamical models). An example using the JPL ephemerides is:
 The difference between the builtin ephemerides and the JPL ephemerides is normally
 of the order of 1/100th of a millisecond, so the builtin ephemerides should be suitable
 for most purposes. For more details about what ephemerides are available,
-see :ref:`astropy-coordinates-solarsystem`.
-
-.. note::
-   Using JPL ephemerides requires that the `jplephem
-   <https://pypi.python.org/pypi/jplephem>`_ package be installed. This is
-   most easily achieved via ``pip install jplephem``, although whatever
-   package management system you use might have it as well.
+including the requirements for using JPL ephemerides, see :ref:`astropy-coordinates-solarsystem`.
 
 Interaction with Time-like Quantities
 -------------------------------------

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -901,13 +901,13 @@ calculate light travel times to the barycentre as follows::
     >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
     ...                   scale='utc', location=greenwich)
     >>> ltt_bary = times.light_travel_time(ip_peg)
-    >>> ltt_bary
+    >>> ltt_bary # doctest: +FLOAT_CMP
     <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]>
 
 If you desire the light travel time to the heliocentre instead then use::
 
     >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric')
-    >>> ltt_helio
+    >>> ltt_helio # doctest: +FLOAT_CMP
     <TimeDelta object: scale='tdb' format='jd' value=[-0.00376576 -0.00376712]>
 
 The method returns an |TimeDelta| object, which can be added to
@@ -940,10 +940,10 @@ dynamical models). An example using the JPL ephemerides is:
 .. doctest-requires:: jplephem
 
     >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl') # doctest: +REMOTE_DATA +IGNORE_OUTPUT
-    >>> ltt_bary_jpl # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    >>> ltt_bary_jpl # doctest: +REMOTE_DATA +FLOAT_CMP
     <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]> # doctest: +REMOTE_DATA +IGNORE_OUTPUT
-    >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
-    <Quantity [-0.00132325,-0.00132861] ms> # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +FLOAT_CMP
+    <Quantity [-0.00132325,-0.00132861] ms> # doctest: +REMOTE_DATA +FLOAT_CMP
 
 The difference between the builtin ephemerides and the JPL ephemerides is normally
 of the order of 1/100th of a millisecond, so the builtin ephemerides should be suitable

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -941,7 +941,7 @@ dynamical models). An example using the JPL ephemerides is:
 
     >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl') # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     >>> ltt_bary_jpl # doctest: +REMOTE_DATA +FLOAT_CMP
-    <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]> # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]> # doctest: +REMOTE_DATA +FLOAT_CMP
     >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +FLOAT_CMP
     <Quantity [-0.00132325,-0.00132861] ms> # doctest: +REMOTE_DATA +FLOAT_CMP
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -933,7 +933,9 @@ of Earth and the Sun from built-in `ERFA <https://github.com/liberfa/erfa>`_ rou
 but one can also use more precise calculations using the JPL ephemerides (which are derived from
 dynamical models). An example using the JPL ephemerides is:
 
-    >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl')
+.. doctest-requires:: jplephem
+
+    >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl') # doctest: +REMOTE_DATA +IGNORE_OUTPUT
 
 The difference between the builtin ephemerides and the JPL ephemerides is normally
 of the order of 1/100th of a millisecond, so the builtin ephemerides should be suitable

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -901,10 +901,14 @@ calculate light travel times to the barycentre as follows::
     >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
     ...                   scale='utc', location=greenwich)
     >>> ltt_bary = times.light_travel_time(ip_peg)
+    >>> ltt_bary
+    <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]>
 
 If you desire the light travel time to the heliocentre instead then use::
 
     >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric')
+    >>> ltt_helio
+    <TimeDelta object: scale='tdb' format='jd' value=[-0.00376576 -0.00376712]>
 
 The method returns an |TimeDelta| object, which can be added to
 your times to give the arrival time of the photons at the barycentre or
@@ -936,6 +940,10 @@ dynamical models). An example using the JPL ephemerides is:
 .. doctest-requires:: jplephem
 
     >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl') # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    >>> ltt_bary_jpl # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]> # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    <Quantity [-0.00132325,-0.00132861] ms> # doctest: +REMOTE_DATA +IGNORE_OUTPUT
 
 The difference between the builtin ephemerides and the JPL ephemerides is normally
 of the order of 1/100th of a millisecond, so the builtin ephemerides should be suitable

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -928,6 +928,24 @@ the TDB timescale::
 
     >>> time_barycentre = times.tdb + ltt_bary
 
+By default, the light travel time is calculated using the position and velocity
+of Earth and the Sun from built-in `ERFA <https://github.com/liberfa/erfa>`_ routines,
+but one can also use more precise calculations using the JPL ephemerides (which are derived from
+dynamical models). An example using the JPL ephemerides is:
+
+    >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl')
+
+The difference between the builtin ephemerides and the JPL ephemerides is normally
+of the order of 1/100th of a millisecond, so the builtin ephemerides should be suitable
+for most purposes. For more details about what ephemerides are available,
+see :ref:`astropy-coordinates-solarsystem`.
+
+.. note::
+   Using JPL ephemerides requires that the `jplephem
+   <https://pypi.python.org/pypi/jplephem>`_ package be installed. This is
+   most easily achieved via ``pip install jplephem``, although whatever
+   package management system you use might have it as well.
+
 Interaction with Time-like Quantities
 -------------------------------------
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -941,9 +941,9 @@ dynamical models). An example using the JPL ephemerides is:
 
     >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl') # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     >>> ltt_bary_jpl # doctest: +REMOTE_DATA +FLOAT_CMP
-    <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]> # doctest: +REMOTE_DATA +FLOAT_CMP
+    <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]>
     >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +FLOAT_CMP
-    <Quantity [-0.00132325,-0.00132861] ms> # doctest: +REMOTE_DATA +FLOAT_CMP
+    <Quantity [-0.00132325,-0.00132861] ms>
 
 The difference between the builtin ephemerides and the JPL ephemerides is normally
 of the order of 1/100th of a millisecond, so the builtin ephemerides should be suitable


### PR DESCRIPTION
This PR is based upon the changes in #5231, and perhaps should include changes in #5253 and #5254 as well; I will rebase once #5231 is merged and also if #5253 and #5254 are merged before this.

This PR fixes #4942 by allowing the coordinate transformations, and the light travel time corrections which use them to respect the state of the ```solar_system_ephemeris``` context manager. ```light_travel_time``` takes an explicit ephemeris argument whilst the co-ordinate transformations don't. To set the ephemeris for coordinate transformations, one uses ```solar_system_ephemeris.set()```. The reason for this decision was that adding an ephemeris argument to the co-ordinate transforms meant adding a ```kwargs``` argument to all frame transforms when this was not really needed for most of them.

With this PR, one can use:

```python
from astropy.time import Time
from astropy.coordinates import GCRS, solar_system_ephemeris, SkyCoord, EarthLocation

ippeg = SkyCoord.from_name('IP Peg')
now = Time.now()
greenwich = EarthLocation.of_site('greenwich')
now.location = greenwich
gcrs_frame = GCRS(obstime=now)

dt = now.light_travel_time(ippeg)  # use builtin ephemeris
dt = now.light_travel_time(ippeg, ephemeris='jpl') # use jpl ephemeris
new_coo = ippeg.transform_to(gcrs_frame) # use builtin

solar_system_ephemeris.set('jpl')
dt = now.light_travel_time(ippeg)  # use jpl ephemeris
new_coo = ippeg.transform_to(gcrs_frame) # use jpl ephemeris
```