### PR TITLE
Support generalized value formatting for mixin cols

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ New Features
 
 - ``astropy.table``
 
+  - Support generalized value formatting for mixin columns in tables. [#5274]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -913,7 +913,7 @@ cdef class FastWriter:
                     self.format_funcs.append(None)
                 else:
                     self.format_funcs.append(pprint._format_funcs.get(
-                        col.format, pprint._auto_format_func))
+                        (col.format, col.name), pprint.get_auto_format_func(col.name)))
                 # col is a numpy.ndarray, so we convert it to
                 # an ordinary list because csv.writer will call
                 # np.array_str() on each numpy value, which is

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -22,7 +22,7 @@ from . import core
 from . import fixedwidth
 from . import basic
 from ...utils.exceptions import AstropyUserWarning
-from ...table.pprint import _format_funcs, _auto_format_func
+from ...table.pprint import _format_funcs, get_auto_format_func
 
 
 class IpacFormatErrorDBMS(Exception):
@@ -277,7 +277,9 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             # This may be incompatible with mixin columns
             null = col.fill_values[core.masked]
             try:
-                format_func = _format_funcs.get(col_format, _auto_format_func)
+                format_key = (col_format, col.info.name)
+                auto_format_func = get_auto_format_func(col.info.name)
+                format_func = _format_funcs.get(format_key, auto_format_func)
                 nullist.append((format_func(col_format, null)).strip())
             except Exception:
                 # It is possible that null and the column values have different

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -512,3 +512,33 @@ def test_ndarray_mixin():
                            "(2, 'b') (20, 'bb') (200, 'rbb') 2 .. 3",
                            "(3, 'c') (30, 'cc') (300, 'rcc') 4 .. 5",
                            "(4, 'd') (40, 'dd') (400, 'rdd') 6 .. 7"]
+
+
+def test_possible_string_format_functions():
+    """
+    The QuantityInfo info class for Quantity implements a
+    possible_string_format_functions() method that overrides the
+    standard pprint._possible_string_format_functions() function.
+    Test this.
+    """
+    t = QTable([[1, 2] * u.m])
+    t['col0'].info.format = '%.3f'
+    assert t.pformat() == [' col0',
+                           '  m  ',
+                           '-----',
+                           '1.000',
+                           '2.000']
+
+    t['col0'].info.format = 'hi {:.3f}'
+    assert t.pformat() == ['  col0  ',
+                           '   m    ',
+                           '--------',
+                           'hi 1.000',
+                           'hi 2.000']
+
+    t['col0'].info.format = '.4f'
+    assert t.pformat() == [' col0 ',
+                           '  m   ',
+                           '------',
+                           '1.0000',
+                           '2.0000']

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -140,6 +140,9 @@ class QuantityInfo(ParentDtypeInfo):
 
         A string can either be a format specifier for the format built-in,
         a new-style format string, or an old-style format string.
+
+        This method is overridden in order to suppress printing the unit
+        in each row since it is already at the top in the column header.
         """
         yield lambda format_, val: format(val.value, format_)
         yield lambda format_, val: format_.format(val.value)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -134,6 +134,17 @@ class QuantityInfo(ParentDtypeInfo):
     def default_format(val):
         return '{0.value:}'.format(val)
 
+    @staticmethod
+    def possible_string_format_functions(format_):
+        """Iterate through possible string-derived format functions.
+
+        A string can either be a format specifier for the format built-in,
+        a new-style format string, or an old-style format string.
+        """
+        yield lambda format_, val: format(val.value, format_)
+        yield lambda format_, val: format_.format(val.value)
+        yield lambda format_, val: format_ % val.value
+
 
 @six.add_metaclass(InheritDocstrings)
 class Quantity(np.ndarray):


### PR DESCRIPTION
This is a solution for #5265.  The key idea is to allow the mixin Info class override the `possible_string_format_functions` function by wrapping the original `_auto_format_func`.

@mhvk 