### PR TITLE
added section to release instructions to remind us to add "what's new"

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -280,8 +280,8 @@ The procedure for this is straightforward:
 
    You'll then need to edit ``docs/whatsnew/<next_version>.rst``, removing all
    the content but leaving the basic structure.  You'll also want to be sure to
-   rplace the "by the numbers" numbers with "xxx" as a reminder to update them
-   before the next release. The add the new version to the top of
+   replace the "by the numbers" numbers with "xxx" as a reminder to update them
+   before the next release. Then add the new version to the top of
    ``docs/whatsnew/index.rst``, and commit these changes ::
 
       $ git add docs/whatsnew/<next_version>.rst

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -273,6 +273,21 @@ The procedure for this is straightforward:
       $ git add CHANGES.rst
       $ git commit -m "Add <next_version> to changelog"
 
+#. Also update the "what's new" section of the docs to include a section for the
+   next major version.  E.g.::
+
+      $ cp docs/whatsnew/<current_version>.rst docs/whatsnew/<next_version>.rst
+
+   You'll then need to edit ``docs/whatsnew/<next_version>.rst``, removing all
+   the content but leaving the basic structure.  You'll also want to be sure to
+   rplace the "by the numbers" numbers with "xxx" as a reminder to update them
+   before the next release. The add the new version to the top of
+   ``docs/whatsnew/index.rst``, and commit these changes ::
+
+      $ git add docs/whatsnew/<next_version>.rst
+      $ git add docs/whatsnew/index.rst
+      $ git commit -m "Added <next_version> whats new section"
+
 #. Push all of these changes up to github::
 
       $ git push upstream v<version>.x:v<version>.x


### PR DESCRIPTION
I noticed we forgot to add a "what's new" section for 1.3.  This adds a bullet to the release instructions to remind us to do that. 

I thought about adding the what's new in 1.3 here too, but I already did that in mhvk/astropy#18 (which might get merged in #5253), so lets hold off on that until either #5253 goes through or not.

cc @astrofrog