### PR TITLE
Replace scipy.special.factorial with math.factorial and np.cumprod in _scipy_kraft_burrows_nousek

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,6 +279,13 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``astropy.stats``
+
+  - ``poisson_conf_interval`` with ``'kraft-burrows-nousek'`` interval is now
+    faster and useable with SciPy versions < 0.14. [#5064, #5290]
+
+
+
 1.2.1 (2016-06-22)
 ------------------
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1209,6 +1209,8 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
     from scipy.optimize import brentq
     from scipy.integrate import quad
 
+    from math import exp
+
     def eqn8(N, B):
         n = np.arange(N + 1, dtype=np.float64)
         # Create an array containing the factorials. scipy.special.factorial
@@ -1218,18 +1220,18 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
         # might also be a bit faster.
         factorial_n = np.ones(n.shape, dtype=np.float64)
         np.cumprod(n[1:], out=factorial_n[1:])
-        return 1. / (math.exp(-B) * np.sum(np.power(B, n) / factorial_n))
+        return 1. / (exp(-B) * np.sum(np.power(B, n) / factorial_n))
 
     # The parameters of eqn8 do not vary between calls so we can calculate the
     # result once and reuse it. The same is True for the factorial of N.
-    # eqn7 is called 200-1000 times so "caching" these values yields a lot of
-    # speedup (factor 10).
+    # eqn7 is called hundred times so "caching" these values yields a
+    # significant speedup (factor 10).
     eqn8_res = eqn8(N, B)
     factorial_N = float(math.factorial(N))
 
     def eqn7(S, N, B):
         SpB = S + B
-        return eqn8_res * (math.exp(-SpB) * SpB**N / factorial_N)
+        return eqn8_res * (exp(-SpB) * SpB**N / factorial_N)
 
     def eqn9_left(S_min, S_max, N, B):
         return quad(eqn7, S_min, S_max, args=(N, B), limit=500)
@@ -1302,7 +1304,7 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
 
     def eqn7(S, N, B):
         SpB = S + B
-        return eqn8_res * (exp(-SpB) * (SpB)**N / factorial_N)
+        return eqn8_res * (exp(-SpB) * SpB**N / factorial_N)
 
     def eqn9_left(S_min, S_max, N, B):
         def eqn7NB(S):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -11,6 +11,8 @@ access.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import math
+
 import numpy as np
 
 from ..extern.six.moves import range
@@ -1197,29 +1199,37 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
 
     Notes
     -----
-    Requires `scipy` greater or equal than 0.14.0. This implementation will
-    cause Overflow Errors for about N > 100 (the exact limit depends on
-    details of how scipy was compiled).  See `~astropy.stats.mpmath_poisson_upper_limit`
-    for an implementation that is slower, but can deal with arbitrarily high
-    numbers since it is based on the `mpmath <http://mpmath.org/>`_
-    library.
+    Requires `scipy`. This implementation will cause Overflow Errors for about
+    N > 100 (the exact limit depends on details of how scipy was compiled).
+    See `~astropy.stats.mpmath_poisson_upper_limit` for an implementation that
+    is slower, but can deal with arbitrarily high numbers since it is based on
+    the `mpmath <http://mpmath.org/>`_ library.
     '''
 
     from scipy.optimize import brentq
     from scipy.integrate import quad
 
-    try:
-        from scipy.special import factorial
-    except ImportError:
-        raise ImportError("scipy's version greater or equal than 0.14.0 is "
-                          "required.")
-
     def eqn8(N, B):
-        n = np.arange(N + 1)
-        return 1. / (np.exp(-B) * np.sum(np.power(B, n) / factorial(n)))
+        n = np.arange(N + 1, dtype=np.float64)
+        # Create an array containing the factorials. scipy.special.factorial
+        # requires SciPy 0.14 (#5064) therefore this is calculated by using
+        # numpy.cumprod. This could be replaced by factorial again as soon as
+        # older SciPy are not supported anymore but the cumprod alternative
+        # might also be a bit faster.
+        factorial_n = np.ones(n.shape, dtype=np.float64)
+        np.cumprod(n[1:], out=factorial_n[1:])
+        return 1. / (math.exp(-B) * np.sum(np.power(B, n) / factorial_n))
+
+    # The parameters of eqn8 do not vary between calls so we can calculate the
+    # result once and reuse it. The same is True for the factorial of N.
+    # eqn7 is called 200-1000 times so "caching" these values yields a lot of
+    # speedup (factor 10).
+    eqn8_res = eqn8(N, B)
+    factorial_N = float(math.factorial(N))
 
     def eqn7(S, N, B):
-        return eqn8(N, B) * (np.exp(-S - B) * (S + B)**N / factorial(N))
+        SpB = S + B
+        return eqn8_res * (math.exp(-SpB) * SpB**N / factorial_N)
 
     def eqn9_left(S_min, S_max, N, B):
         return quad(eqn7, S_min, S_max, args=(N, B), limit=500)
@@ -1287,8 +1297,12 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
         sumterms = [power(B, n) / factorial(n) for n in range(int(N) + 1)]
         return 1. / (exp(-B) * fsum(sumterms))
 
+    eqn8_res = eqn8(N, B)
+    factorial_N = factorial(N)
+
     def eqn7(S, N, B):
-        return eqn8(N, B) * (exp(-S-B) * (S + B)**N / factorial(N))
+        SpB = S + B
+        return eqn8_res * (exp(-SpB) * (SpB)**N / factorial_N)
 
     def eqn9_left(S_min, S_max, N, B):
         def eqn7NB(S):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -9,16 +9,12 @@ from numpy.random import randn, normal
 from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
-from astropy.utils import minversion
-
 try:
     import scipy  # pylint: disable=W0611
 except ImportError:
     HAS_SCIPY = False
-    SCIPY_LT_0_14 = True
 else:
     HAS_SCIPY = True
-    SCIPY_LT_0_14 = not minversion(scipy, '0.14.0')
 
 try:
     import mpmath  # pylint: disable=W0611
@@ -616,7 +612,7 @@ def test_poisson_conf_gehrels86(n):
         rtol=0.02)
 
 
-@pytest.mark.skipif('SCIPY_LT_0_14')
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_scipy_poisson_limit():
     '''Test that the lower-level routine gives the snae number.
 
@@ -661,7 +657,7 @@ def test_poisson_conf_value_errors():
     assert 'Invalid method' in str(e.value)
 
 
-@pytest.mark.skipif('SCIPY_LT_0_14')
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_poisson_conf_kbn_value_errors():
     with pytest.raises(ValueError) as e:
         funcs.poisson_conf_interval(5., 'kraft-burrows-nousek',


### PR DESCRIPTION
This closes #5064 and supersedes #5271

I wasn't sure if I should've commented on #5271 instead of creating a seperate PR. But the approach in this PR is radically different.

As noted in the comments of the original issue the `factorials` are evaluated on an array, which makes it impossible to replace it with `math.factorial` (at least in `eqn8`) but fortunatly it's evaluated on an `np.arange`. So the factorials can be calculated by using `np.cumprod` (except for the first element). 

The second time factorial is used the value is a scalar so it's possible to replace it with `math.factorial`.

This PR also includes some performance optimizations (nothing fancy though):
- The result of eqn8 and factorial(N) are calculated once and then just reused (on my computer this yields a speedup of a factor 10).
- The second change is that `math.exp` is used (`math` is already imported because of `factorial`) instead of `np.exp`.

Since `exp7` is called hundreds of times the time difference is enormous:

The runtime for the command (taken from the tests) `%timeit funcs._scipy_kraft_burrows_nousek(5., 2.5, .99)`:
Before: `10 loops, best of 3: 124 ms per loop`
With this PR: `100 loops, best of 3: 4.69 ms per loop`

If it was wrong to open another PR for the issue please close this again.