### PR TITLE
replace textnormal with text latex command and fix box1d and box2d model formulas

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -7,13 +7,10 @@ from __future__ import (absolute_import, unicode_literals, division,
 import warnings
 import numpy as np
 from .core import (Fittable1DModel, Fittable2DModel, Model,
-                   ModelDefinitionError, custom_model)
+                   ModelDefinitionError)
 from .parameters import Parameter, InputParameterError
 from .utils import ellipse_extent
-from ..utils import deprecated
-from ..extern import six
 from ..extern.six.moves import map
-from .utils import get_inputs_and_params
 from ..utils.exceptions import AstropyDeprecationWarning
 
 
@@ -1252,7 +1249,7 @@ class Ring2D(Fittable2DModel):
             f(r) = \\left \\{
                      \\begin{array}{ll}
                        A & : r_{in} \\leq r \\leq r_{out} \\\\
-                       0 & : \\textnormal{else}
+                       0 & : \\text{else}
                      \\end{array}
                    \\right.
 
@@ -1341,8 +1338,8 @@ class Box1D(Fittable1DModel):
 
             f(x) = \\left \\{
                      \\begin{array}{ll}
-                       A & : x_0 - w/2 \\geq x \\geq x_0 + w/2 \\\\
-                       0 & : \\textnormal{else}
+                       A & : x_0 - w/2 \\leq x \\leq x_0 + w/2 \\\\
+                       0 & : \\text{else}
                      \\end{array}
                    \\right.
 
@@ -1432,9 +1429,9 @@ class Box2D(Fittable2DModel):
 
             f(x, y) = \\left \\{
                      \\begin{array}{ll}
-                       A & : x_0 - w_x/2 \\geq x \\geq x_0 + w_x/2 \\\\
-                       A & : y_0 - w_y/2 \\geq y \\geq y_0 + w_y/2 \\\\
-                       0 & : \\textnormal{else}
+            A : & x_0 - w_x/2 \\leq x \\leq x_0 + w_x/2 \\text{ and} \\\\
+                & y_0 - w_y/2 \\leq y \\leq y_0 + w_y/2 \\\\
+            0 : & \\text{else}
                      \\end{array}
                    \\right.
 

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -126,7 +126,7 @@ class RunTimePredictor(object):
     pow(10, 810)
     10000000000...
 
-    Fit a straight line assuming :math:`\\textnormal{arg}^{1}` relationship
+    Fit a straight line assuming :math:`\\text{arg}^{1}` relationship
     (coefficients are returned):
 
     >>> p.do_fit()  # doctest: +SKIP
@@ -225,7 +225,7 @@ class RunTimePredictor(object):
         ----------
         model : `astropy.modeling.Model`
             Model for the expected trend of run time (Y-axis)
-            w.r.t. :math:`\\textnormal{arg}^{\\textnormal{power}}` (X-axis).
+            w.r.t. :math:`\\text{arg}^{\\text{power}}` (X-axis).
             If `None`, will use `~astropy.modeling.polynomial.Polynomial1D`
             with ``degree=1``.
 


### PR DESCRIPTION
This fixes #5293 and #5292 

The `textnormal` macro (or command) is not supported by MathJax. This PR replaces it with `text`. One alternative could be using `textrm`.

This also replaces the wrong greater equal signs in `Box1D` and `Box2D` with less equal signs.

![unbenannt](https://cloud.githubusercontent.com/assets/14200878/18175245/ea5c3074-7070-11e6-96a1-45fa0c36982c.jpg)

![unbenannt](https://cloud.githubusercontent.com/assets/14200878/18178925/8869650c-7080-11e6-96d0-7d503aade1b6.jpg)

