### PR TITLE
Fix padding problem on FITS table columns converted from unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -222,6 +222,9 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fix problem with padding bytes written for BinTable columns converted
+    from unicode [#5280, #5287, #5288, #5296].
+
   - Fix out-of-order TUNITn cards when writing tables to FITS. [#5720]
 
   - Recognize PrimaryHDU when non boolean values are present for the

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -909,11 +909,21 @@ class BinTableHDU(_TableBaseHDU):
         for idx in range(len(self.data)):
             for field in fields:
                 item = field[idx]
+                field_width = None
 
                 if field.dtype.kind == 'U':
+                    # Read the field *width* by reading past the field kind.
+                    i = field.dtype.str.index(field.dtype.kind)
+                    field_width = int(field.dtype.str[i+1:])
                     item = np.char.encode(item, 'ascii')
 
                 fileobj.writearray(item)
+                if field_width is not None:
+                    j = item.dtype.str.index(item.dtype.kind)
+                    item_length = int(item.dtype.str[j+1:])
+                    # Fix padding problem (see #5296).
+                    padding = '\x00'*(field_width - item_length)
+                    fileobj.write(padding.encode('ascii'))
 
     _tdump_file_format = textwrap.dedent("""
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -365,6 +365,19 @@ class TestTableFunctions(FitsTestCase):
         assert comparerecords(hdu.data, hdul[1].data)
         hdul.close()
 
+    def test_numpy_ndarray_to_bintablehdu_with_unicode(self):
+        desc = np.dtype({'names': ['order', 'name', 'mag', 'Sp'],
+                         'formats': ['int', 'U20', 'float32', 'U10']})
+        a = np.array([(1, u'Serius', -1.45, u'A1V'),
+                      (2, u'Canopys', -0.73, u'F0Ib'),
+                      (3, u'Rigil Kent', -0.1, u'G2V')], dtype=desc)
+        hdu = fits.BinTableHDU(a)
+        assert comparerecords(hdu.data, a.view(fits.FITS_rec))
+        hdu.writeto(self.temp('toto.fits'), clobber=True)
+        hdul = fits.open(self.temp('toto.fits'))
+        assert comparerecords(hdu.data, hdul[1].data)
+        hdul.close()
+
     def test_new_table_from_recarray(self):
         bright = np.rec.array([(1, 'Serius', -1.45, 'A1V'),
                                (2, 'Canopys', -0.73, 'F0Ib'),


### PR DESCRIPTION
This PR is related to #5288, #5287, #5280, and possibly others.  In brief:
- When numpy arrays with unicode columns (_e.g._ `dtype('U5')`) are converted to `BinTableHDU` objects and written to a file, the encode step was not padding the resulting ASCII byte strings with null characters as needed to match the width of the column.
- This PR adds padding to the column, and adds a test run on a numpy array with unicode columns.
- This PR replaces #5291.
