### PR TITLE
Representation arithmetic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,12 +22,19 @@ New Features
 
   - Transformations between coordinate systems can use the more accurate JPL
     ephemerides. [#5273, #5436]
+
   - Arithmetic on representations, such as addition of two representations,
     multiplication with a ``Quantity``, or calculating the norm via ``abs``,
     has now become possible. Furthermore, there are new methods ``mean``,
     ``sum``, ``dot``, and ``cross``. For all these, the representations are
     treated as vectors in cartesian space (temporarily converting to
     ``CartesianRepresentation`` if necessary).  [#5301]
+    has now become possible. Furthermore, there are news methods ``mean``,
+    ``sum``, ``dot``, and ``cross`` with obvious meaning. [#5301]
+    multiplication with a ``Quantity`` has now become possible. Furthermore,
+    there are new methods ``norm``, ``mean``, ``sum``, ``dot``, and ``cross``.
+    In all operations, the representations are treated as vectors. They are
+    temporarily converted to ``CartesianRepresentation`` if necessary.  [#5301]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ New Features
 
   - Transformations between coordinate systems can use the more accurate JPL
     ephemerides. [#5273, #5436]
+  - Arithmetic on representations, such as addition of two representations,
+    multiplication with a ``Quantity``, or calculating the norm via ``abs``,
+    has now become possible. Furthermore, there are new methods ``mean``,
+    ``sum``, ``dot``, and ``cross``. For all these, the representations are
+    treated as vectors in cartesian space (temporarily converting to
+    ``CartesianRepresentation`` if necessary).  [#5301]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -909,7 +909,7 @@ class SphericalRepresentation(BaseRepresentation):
         return cls(lon=lon, lat=lat, distance=r, copy=False)
 
     def __abs__(self):
-        return self.distance
+        return np.abs(self.distance)
 
 
 class PhysicsSphericalRepresentation(BaseRepresentation):
@@ -1041,7 +1041,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         return cls(phi=phi, theta=theta, r=r, copy=False)
 
     def __abs__(self):
-        return self.r
+        return np.abs(self.r)
 
 
 class CylindricalRepresentation(BaseRepresentation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -255,29 +255,6 @@ class BaseRepresentation(ShapedLikeNDArray):
         return np.array2string(values, formatter=formatter, style=fmt,
                                separator=', ', prefix=prefix)
 
-    def __eq__(self, other):
-        """Check for equality with another representation.
-
-        If either ``self`` or ``other`` are not scalar, this returns a boolean
-        array, just like is the case for ``ndarray``.  Elements are `True` only
-        if all components of that element are exactly equal.
-        """
-        try:
-            # this ensures that other can be compared sensibly to self.
-            # note that it immediately returns if the classes are the same.
-            other = other.represent_as(self.__class__)
-        except Exception:
-            return False
-
-        # Ensure we return a bool or array of bool as appropriate.
-        return functools.reduce(np.logical_and,
-                                (getattr(self, component) ==
-                                 getattr(other, component)
-                                 for component in self.components))
-
-    def __ne__(self, other):
-        return np.logical_not(self.__eq__(other))
-
     def _scale_operation(self, op, *args):
         results = []
         for component, cls in self.attr_classes.items():

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -260,13 +260,15 @@ class BaseRepresentation(ShapedLikeNDArray):
             if issubclass(cls, Angle):
                 results.append(value)
             else:
-                result = op(value, *args)
-                if result is NotImplemented:
-                    return NotImplemented
-                else:
-                    results.append(result)
+                results.append(op(value, *args))
 
-        return self.__class__(*results)
+        # try/except catches anything that cannot initialize the class, such
+        # as operations that returned NotImplemented or a representation
+        # instead of a quantity (as would happen for, e.g., rep * rep).
+        try:
+            return self.__class__(*results)
+        except Exception:
+            return NotImplemented
 
     def __mul__(self, other):
         return self._scale_operation(operator.mul, other)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import abc
+import functools
 import operator
 from collections import OrderedDict
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -10,7 +10,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from ... import units as u
-from ...tests.helper import pytest
+from ...tests.helper import (pytest, assert_quantity_allclose as
+                             assert_allclose_quantity)
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
 from ..representation import (REPRESENTATION_CLASSES,
@@ -28,10 +29,6 @@ def setup_function(func):
 def teardown_function(func):
     REPRESENTATION_CLASSES.clear()
     REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
-
-
-def assert_allclose_quantity(q1, q2):
-    assert_allclose(q1.value, q2.to(q1.unit).value)
 
 
 class TestSphericalRepresentation(object):

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -1,0 +1,300 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# TEST_UNICODE_LITERALS
+import numpy as np
+
+from ... import units as u
+from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
+                CylindricalRepresentation, SphericalRepresentation,
+                UnitSphericalRepresentation, Longitude, Latitude)
+from ..angle_utilities import angular_separation
+from ...tests.helper import pytest, assert_quantity_allclose
+
+
+class TestArithmetic():
+    """Test absolute value, multiplication, and division."""
+
+    def setup(self):
+        self.lon = Longitude(np.arange(0, 12.1, 2), u.hourangle)
+        self.lat = Latitude(np.arange(-90, 91, 30), u.deg)
+        self.distance = [5., 12., 4., 2., 4., 12., 5.] * u.kpc
+        self.spherical = SphericalRepresentation(self.lon, self.lat,
+                                                 self.distance)
+        self.unit_spherical = self.spherical.represent_as(
+            UnitSphericalRepresentation)
+        self.cartesian = self.spherical.to_cartesian()
+
+    def test_equality(self):
+        assert np.all(self.spherical == self.spherical)
+        s1 = SphericalRepresentation(self.lon, self.lat, self.distance)
+        assert np.all(s1 == self.spherical)
+        assert not np.any(s1 != self.spherical)
+        s2 = SphericalRepresentation(self.lon, self.lat,
+                                     self.distance * np.arange(len(s1)))
+        assert np.all((s2 == self.spherical) == (np.arange(len(s1)) == 1))
+        assert np.all((s2 != self.spherical) == (np.arange(len(s1)) != 1))
+
+    def test_abs_spherical(self):
+        abs_s = abs(self.spherical)
+        assert isinstance(abs_s, u.Quantity)
+        assert np.all(abs_s == self.distance)
+
+    @pytest.mark.parametrize('representation',
+                             (PhysicsSphericalRepresentation,
+                              CartesianRepresentation,
+                              CylindricalRepresentation))
+    def test_abs(self, representation):
+        in_rep = self.spherical.represent_as(representation)
+        abs_rep = abs(in_rep)
+        assert isinstance(abs_rep, u.Quantity)
+        assert_quantity_allclose(abs_rep, self.distance)
+
+    def test_abs_unitspherical(self):
+        abs_rep = abs(self.unit_spherical)
+        assert abs_rep.unit == u.dimensionless_unscaled
+        assert np.all(abs_rep == 1. * u.dimensionless_unscaled)
+
+    def test_mul_div_spherical(self):
+        s0 = self.spherical / (1. * u.Myr)
+        assert isinstance(s0, SphericalRepresentation)
+        assert np.all(s0.lon == self.spherical.lon)
+        assert np.all(s0.lat == self.spherical.lat)
+        assert np.all(s0.distance == self.distance / (1. * u.Myr))
+        s1 = (1./u.Myr) * self.spherical
+        assert isinstance(s1, SphericalRepresentation)
+        assert np.all(s1 == s0)
+        s2 = self.spherical * np.array([[1.], [2.]])
+        assert isinstance(s2, SphericalRepresentation)
+        assert s2.shape == (2, self.spherical.shape[0])
+        assert np.all(s2.lon == self.spherical.lon)
+        assert np.all(s2.lat == self.spherical.lat)
+        assert np.all(s2.distance ==
+                      self.spherical.distance * np.array([[1.], [2.]]))
+        s3 = np.array([[1.], [2.]]) * self.spherical
+        assert isinstance(s3, SphericalRepresentation)
+        assert np.all(s3 == s2)
+
+    @pytest.mark.parametrize('representation',
+                             (PhysicsSphericalRepresentation,
+                              CartesianRepresentation,
+                              CylindricalRepresentation))
+    def test_mul_div(self, representation):
+        in_rep = self.spherical.represent_as(representation)
+        r1 = in_rep / (1. * u.Myr)
+        assert isinstance(r1, representation)
+        for component in in_rep.components:
+            in_rep_comp = getattr(in_rep, component)
+            r1_comp = getattr(r1, component)
+            if in_rep_comp.unit == self.distance.unit:
+                assert np.all(r1_comp == in_rep_comp / (1.*u.Myr))
+            else:
+                assert np.all(r1_comp == in_rep_comp)
+
+        r2 = np.array([[1.], [2.]]) * in_rep
+        assert isinstance(r2, representation)
+        assert r2.shape == (2, in_rep.shape[0])
+        assert_quantity_allclose(abs(r2),
+                                 self.distance * np.array([[1.], [2.]]))
+
+    def test_mul_div_unit_spherical(self):
+        s1 = self.unit_spherical * self.distance
+        assert isinstance(s1, SphericalRepresentation)
+        assert np.all(s1.lon == self.unit_spherical.lon)
+        assert np.all(s1.lat == self.unit_spherical.lat)
+        assert np.all(s1.distance == self.spherical.distance)
+        s2 = self.unit_spherical / u.s
+        assert isinstance(s2, SphericalRepresentation)
+        assert np.all(s2.lon == self.unit_spherical.lon)
+        assert np.all(s2.lat == self.unit_spherical.lat)
+        assert np.all(s2.distance == 1./u.s)
+
+    def test_add_sub_cartesian(self):
+        c1 = self.cartesian + self.cartesian
+        assert isinstance(c1, CartesianRepresentation)
+        assert np.all(c1 == 2. * self.cartesian)
+        with pytest.raises(TypeError):
+            self.cartesian + 10.*u.m
+        with pytest.raises(u.UnitsError):
+            self.cartesian + (self.cartesian / u.s)
+        c2 = self.cartesian - self.cartesian
+        assert isinstance(c2, CartesianRepresentation)
+        assert np.all(c2 == CartesianRepresentation(0.*u.m, 0.*u.m, 0.*u.m))
+        c3 = self.cartesian - self.cartesian / 2.
+        assert isinstance(c3, CartesianRepresentation)
+        assert np.all(c3 == self.cartesian / 2.)
+
+    @pytest.mark.parametrize('representation',
+                             (PhysicsSphericalRepresentation,
+                              SphericalRepresentation,
+                              CylindricalRepresentation))
+    def test_add_sub(self, representation):
+        in_rep = self.cartesian.represent_as(representation)
+        r1 = in_rep + in_rep
+        assert isinstance(r1, representation)
+        expected = 2. * in_rep
+        for component in in_rep.components:
+            assert_quantity_allclose(getattr(r1, component),
+                                     getattr(expected, component))
+        with pytest.raises(TypeError):
+            in_rep + 10.*u.m
+        with pytest.raises(u.UnitsError):
+            in_rep + (in_rep / u.s)
+        r2 = in_rep - in_rep
+        assert isinstance(r2, representation)
+        assert np.all(r2.to_cartesian() ==
+                      CartesianRepresentation(0.*u.m, 0.*u.m, 0.*u.m))
+        r3 = in_rep - in_rep / 2.
+        assert isinstance(r3, representation)
+        expected = in_rep / 2.
+        for component in in_rep.components:
+            assert_quantity_allclose(getattr(r3, component),
+                                     getattr(expected, component))
+
+    def test_add_sub_unit_spherical(self):
+        s1 = self.unit_spherical + self.unit_spherical
+        assert isinstance(s1, SphericalRepresentation)
+        expected = 2. * self.unit_spherical
+        for component in s1.components:
+            assert_quantity_allclose(getattr(s1, component),
+                                     getattr(expected, component))
+        with pytest.raises(TypeError):
+            self.unit_spherical + 10.*u.m
+        with pytest.raises(u.UnitsError):
+            self.unit_spherical + (self.unit_spherical / u.s)
+        s2 = self.unit_spherical - self.unit_spherical / 2.
+        assert isinstance(s2, SphericalRepresentation)
+        expected = self.unit_spherical / 2.
+        for component in s2.components:
+            assert_quantity_allclose(getattr(s2, component),
+                                     getattr(expected, component))
+
+    @pytest.mark.parametrize('representation',
+                             (CartesianRepresentation,
+                              PhysicsSphericalRepresentation,
+                              SphericalRepresentation,
+                              CylindricalRepresentation))
+    def test_sum_mean(self, representation):
+        in_rep = self.spherical.represent_as(representation)
+        r_sum = in_rep.sum()
+        assert isinstance(r_sum, representation)
+        expected = SphericalRepresentation(
+            90. * u.deg, 0. * u.deg, 14. * u.kpc).represent_as(representation)
+        for component in expected.components:
+            exp_component = getattr(expected, component)
+            assert_quantity_allclose(getattr(r_sum, component),
+                                     exp_component,
+                                     atol=1e-10*exp_component.unit)
+
+        r_mean = in_rep.mean()
+        assert isinstance(r_mean, representation)
+        expected = expected / len(in_rep)
+        for component in expected.components:
+            exp_component = getattr(expected, component)
+            assert_quantity_allclose(getattr(r_mean, component),
+                                     exp_component,
+                                     atol=1e-10*exp_component.unit)
+
+    def test_sum_mean_unit_spherical(self):
+        s_sum = self.unit_spherical.sum()
+        assert isinstance(s_sum, SphericalRepresentation)
+        expected = SphericalRepresentation(
+            90. * u.deg, 0. * u.deg, 3. * u.dimensionless_unscaled)
+        for component in expected.components:
+            exp_component = getattr(expected, component)
+            assert_quantity_allclose(getattr(s_sum, component),
+                                     exp_component,
+                                     atol=1e-10*exp_component.unit)
+
+        s_mean = self.unit_spherical.mean()
+        assert isinstance(s_mean, SphericalRepresentation)
+        expected = expected / len(self.unit_spherical)
+        for component in expected.components:
+            exp_component = getattr(expected, component)
+            assert_quantity_allclose(getattr(s_mean, component),
+                                     exp_component,
+                                     atol=1e-10*exp_component.unit)
+
+    @pytest.mark.parametrize('representation',
+                             (CartesianRepresentation,
+                              PhysicsSphericalRepresentation,
+                              SphericalRepresentation,
+                              CylindricalRepresentation))
+    def test_dot(self, representation):
+        in_rep = self.cartesian.represent_as(representation)
+        r_dot_r = in_rep.dot(in_rep)
+        assert isinstance(r_dot_r, u.Quantity)
+        assert r_dot_r.shape == in_rep.shape
+        assert_quantity_allclose(np.sqrt(r_dot_r), self.distance)
+        r_dot_r_rev = in_rep.dot(in_rep[::-1])
+        assert isinstance(r_dot_r_rev, u.Quantity)
+        assert r_dot_r_rev.shape == in_rep.shape
+        expected = [-25., -126., 2., 4., 2., -126., -25.] * u.kpc**2
+        assert_quantity_allclose(r_dot_r_rev, expected)
+        for axis in 'xyz':
+            project = CartesianRepresentation(*(
+                (1. if axis == _axis else 0.) * u.dimensionless_unscaled
+                for _axis in 'xyz'))
+            assert_quantity_allclose(in_rep.dot(project),
+                                     getattr(self.cartesian, axis),
+                                     atol=1.*u.upc)
+
+    def test_dot_unit_spherical(self):
+        u_dot_u = self.unit_spherical.dot(self.unit_spherical)
+        assert isinstance(u_dot_u, u.Quantity)
+        assert u_dot_u.shape == self.unit_spherical.shape
+        assert_quantity_allclose(u_dot_u, 1.*u.dimensionless_unscaled)
+        cartesian = self.unit_spherical.to_cartesian()
+        for axis in 'xyz':
+            project = CartesianRepresentation(*(
+                (1. if axis == _axis else 0.) * u.dimensionless_unscaled
+                for _axis in 'xyz'))
+            assert_quantity_allclose(self.unit_spherical.dot(project),
+                                     getattr(cartesian, axis), atol=1.e-10)
+
+    @pytest.mark.parametrize('representation',
+                             (CartesianRepresentation,
+                              PhysicsSphericalRepresentation,
+                              SphericalRepresentation,
+                              CylindricalRepresentation))
+    def test_cross(self, representation):
+        in_rep = self.cartesian.represent_as(representation)
+        r_cross_r = in_rep.cross(in_rep)
+        assert isinstance(r_cross_r, representation)
+        assert_quantity_allclose(abs(r_cross_r), 0.*u.kpc**2, atol=1.*u.mpc**2)
+        r_cross_r_rev = in_rep.cross(in_rep[::-1])
+        sep = angular_separation(self.lon, self.lat,
+                                 self.lon[::-1], self.lat[::-1])
+        expected = self.distance * self.distance[::-1] * np.sin(sep)
+        assert_quantity_allclose(abs(r_cross_r_rev), expected,
+                                 atol=1.*u.mpc**2)
+        unit_vectors = CartesianRepresentation(
+            [1., 0., 0.]*u.one,
+            [0., 1., 0.]*u.one,
+            [0., 0., 1.]*u.one)[:, np.newaxis]
+        r_cross_uv = in_rep.cross(unit_vectors)
+        zeros = np.zeros(len(in_rep)) * u.kpc
+        expected = CartesianRepresentation(
+            u.Quantity((zeros, -self.cartesian.z, self.cartesian.y)),
+            u.Quantity((self.cartesian.z, zeros, -self.cartesian.x)),
+            u.Quantity((-self.cartesian.y, self.cartesian.x, zeros)))
+        assert_quantity_allclose(abs(r_cross_uv), abs(expected),
+                                 atol=1.*u.upc)
+        # Comparison with spherical is hard since some distances are zero,
+        # implying the angles are undefined.
+        r_cross_uv_cartesian = r_cross_uv.to_cartesian()
+        for component in expected.components:
+            assert_quantity_allclose(getattr(r_cross_uv_cartesian, component),
+                                     getattr(expected, component),
+                                     atol=1.*u.upc)
+
+    def test_cross_unit_spherical(self):
+        u_cross_u = self.unit_spherical.cross(self.unit_spherical)
+        assert isinstance(u_cross_u, SphericalRepresentation)
+        assert_quantity_allclose(abs(u_cross_u), 0.*u.one, atol=1.e-10*u.one)
+        u_cross_u_rev = self.unit_spherical.cross(self.unit_spherical[::-1])
+        assert isinstance(u_cross_u_rev, SphericalRepresentation)
+        sep = angular_separation(self.lon, self.lat,
+                                 self.lon[::-1], self.lat[::-1])
+        expected = np.sin(sep)
+        assert_quantity_allclose(abs(u_cross_u_rev), expected,
+                                 atol=1.e-10*u.one)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -60,6 +60,25 @@ class TestArithmetic():
         assert abs_rep.unit == u.dimensionless_unscaled
         assert np.all(abs_rep == 1. * u.dimensionless_unscaled)
 
+    @pytest.mark.parametrize('representation',
+                             (SphericalRepresentation,
+                              PhysicsSphericalRepresentation,
+                              CartesianRepresentation,
+                              CylindricalRepresentation,
+                              UnitSphericalRepresentation))
+    def test_neg_pos(self, representation):
+        in_rep = self.cartesian.represent_as(representation)
+        pos_rep = +in_rep
+        assert type(pos_rep) is type(in_rep)
+        assert pos_rep is not in_rep
+        assert np.all(representation_equal(pos_rep, in_rep))
+        neg_rep = -in_rep
+        assert type(neg_rep) is type(in_rep)
+        assert np.all(abs(neg_rep) == abs(in_rep))
+        in_rep_xyz = in_rep.to_cartesian().xyz
+        assert_quantity_allclose(neg_rep.to_cartesian().xyz,
+                                 -in_rep_xyz, atol=1.e-10*in_rep_xyz.unit)
+
     def test_mul_div_spherical(self):
         s0 = self.spherical / (1. * u.Myr)
         assert isinstance(s0, SphericalRepresentation)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -130,6 +130,10 @@ class TestArithmetic():
                                  self.distance * np.array([[1.], [2.]]))
         r3 = -in_rep
         assert np.all(representation_equal(r3, in_rep * -1.))
+        with pytest.raises(TypeError):
+            in_rep * in_rep
+        with pytest.raises(TypeError):
+            dict() * in_rep
 
     def test_mul_div_unit_spherical(self):
         s1 = self.unit_spherical * self.distance
@@ -183,7 +187,7 @@ class TestArithmetic():
             assert_quantity_allclose(getattr(r1, component),
                                      getattr(expected, component))
         with pytest.raises(TypeError):
-            in_rep + 10.*u.m
+            10.*u.m + in_rep
         with pytest.raises(u.UnitsError):
             in_rep + (in_rep / u.s)
         r2 = in_rep - in_rep
@@ -203,7 +207,7 @@ class TestArithmetic():
             assert_quantity_allclose(getattr(s1, component),
                                      getattr(expected, component))
         with pytest.raises(TypeError):
-            self.unit_spherical + 10.*u.m
+            10.*u.m - self.unit_spherical
         with pytest.raises(u.UnitsError):
             self.unit_spherical + (self.unit_spherical / u.s)
         s2 = self.unit_spherical - self.unit_spherical / 2.
@@ -282,6 +286,8 @@ class TestArithmetic():
             assert_quantity_allclose(in_rep.dot(project),
                                      getattr(self.cartesian, axis),
                                      atol=1.*u.upc)
+        with pytest.raises(TypeError):
+            in_rep.dot(self.cartesian.xyz)
 
     def test_dot_unit_spherical(self):
         u_dot_u = self.unit_spherical.dot(self.unit_spherical)
@@ -329,6 +335,8 @@ class TestArithmetic():
         r_cross_uv_cartesian = r_cross_uv.to_cartesian()
         assert_representation_allclose(r_cross_uv_cartesian,
                                        expected, atol=1.*u.upc)
+        with pytest.raises(TypeError):
+            in_rep.cross(self.cartesian.xyz)
 
     def test_cross_unit_spherical(self):
         u_cross_u = self.unit_spherical.cross(self.unit_spherical)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -29,6 +29,8 @@ class TestArithmetic():
     """Test absolute value, multiplication, and division."""
 
     def setup(self):
+        # Choose some specific coordinates, for which ``sum`` and ``dot``
+        # works out nicely.
         self.lon = Longitude(np.arange(0, 12.1, 2), u.hourangle)
         self.lat = Latitude(np.arange(-90, 91, 30), u.deg)
         self.distance = [5., 12., 4., 2., 4., 12., 5.] * u.kpc

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -73,6 +73,14 @@ class TestArithmetic():
         s3 = np.array([[1.], [2.]]) * self.spherical
         assert isinstance(s3, SphericalRepresentation)
         assert np.all(s3 == s2)
+        s4 = -self.spherical
+        assert isinstance(s4, SphericalRepresentation)
+        assert np.all(s4.lon == self.spherical.lon)
+        assert np.all(s4.lat == self.spherical.lat)
+        assert np.all(s4.distance == -self.spherical.distance)
+        s5 = +self.spherical
+        assert s5 is not self.spherical
+        assert np.all(s5 == self.spherical)
 
     @pytest.mark.parametrize('representation',
                              (PhysicsSphericalRepresentation,
@@ -95,6 +103,8 @@ class TestArithmetic():
         assert r2.shape == (2, in_rep.shape[0])
         assert_quantity_allclose(abs(r2),
                                  self.distance * np.array([[1.], [2.]]))
+        r3 = -in_rep
+        assert np.all(r3 == in_rep * -1.)
 
     def test_mul_div_unit_spherical(self):
         s1 = self.unit_spherical * self.distance
@@ -107,6 +117,17 @@ class TestArithmetic():
         assert np.all(s2.lon == self.unit_spherical.lon)
         assert np.all(s2.lat == self.unit_spherical.lat)
         assert np.all(s2.distance == 1./u.s)
+        u3 = -self.unit_spherical
+        assert isinstance(u3, UnitSphericalRepresentation)
+        assert_quantity_allclose(u3.lon, self.unit_spherical.lon + 180.*u.deg)
+        assert np.all(u3.lat == -self.unit_spherical.lat)
+        assert_quantity_allclose(u3.to_cartesian().xyz,
+                                 -self.unit_spherical.to_cartesian().xyz,
+                                 atol=1.e-10*u.dimensionless_unscaled)
+        u4 = +self.unit_spherical
+        assert isinstance(u4, UnitSphericalRepresentation)
+        assert u4 is not self.unit_spherical
+        assert np.all(u4 == self.unit_spherical)
 
     def test_add_sub_cartesian(self):
         c1 = self.cartesian + self.cartesian

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -5,11 +5,14 @@
 Using and Designing Coordinate Representations
 ----------------------------------------------
 
-As described in the :ref:`astropy-coordinates-overview`, the actual coordinate
-data in `astropy.coordinates` frames is represented via
-"Representation classes". These can be used to store 3-d coordinates in
-various representations, such as cartesian, spherical polar, cylindrical, and
-so on. The built-in representation classes are:
+Points in a 3-d vector space can be represented in different ways, such as
+cartesian, spherical polar, cylindrical, and so on. These underlie the way
+coordinate data in `astropy.coordinates` is represented, as described in the
+:ref:`astropy-coordinates-overview`. Below, we describe how one can use them on
+their own, as a way to convert between different representations, including
+ones not built-in, and to do simple vector arithmetic.
+
+The built-in representation classes are:
 
 * `~astropy.coordinates.CartesianRepresentation`: cartesian
   coordinates ``x``, ``y``, and ``z``
@@ -38,7 +41,7 @@ so on. The built-in representation classes are:
 Instantiating and converting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Representation classes should be instantiated with `~astropy.units.Quantity`
+Representation classes are instantiated with `~astropy.units.Quantity`
 objects::
 
     >>> from astropy import units as u
@@ -47,6 +50,26 @@ objects::
     >>> car
     <CartesianRepresentation (x, y, z) in kpc
         ( 3.,  5.,  4.)>
+
+Array `~astropy.units.Quantity` objects can also be passed to
+representations. They will have the expected shape, which can be changed using
+methods with the same names as those for `~numpy.ndarray`, such as ``reshape``,
+``ravel``, etc.::
+
+  >>> x = u.Quantity([[1., 0., 0.], [3., 5., 3.]], u.m)
+  >>> y = u.Quantity([[0., 2., 0.], [4., 0., -4.]], u.m)
+  >>> z = u.Quantity([[0., 0., 3.], [0., 12., -12.]], u.m)
+  >>> car_array = CartesianRepresentation(x, y, z)
+  >>> car_array
+  <CartesianRepresentation (x, y, z) in m
+      [[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
+       [(3.0, 4.0, 0.0), (5.0, 0.0, 12.0), (3.0, -4.0, -12.0)]]>
+  >>> car_array.shape
+  (2, 3)
+  >>> car_array.ravel()
+  <CartesianRepresentation (x, y, z) in m
+      [(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0), (3.0, 4.0, 0.0),
+       (5.0, 0.0, 12.0), (3.0, -4.0, -12.0)]>
 
 Representations can be converted to other representations using the
 ``represent_as`` method::
@@ -108,6 +131,78 @@ methods as are available to `~numpy.ndarray`::
        [( 2.,  12.,  22.), ( 3.,  13.,  23.)],
        [( 4.,  14.,  24.), ( 5.,  15.,  25.)]]>
 
+
+Vector arithmetic
+^^^^^^^^^^^^^^^^^
+
+Representations support basic vector arithmetic, in particular taking the norm,
+multiplying with and dividing by quantities, taking dot and cross products, as
+well as adding, subtracting, summing and taking averages of representations,
+and multiplying with matrices.
+
+.. Note:: All arithmetic except the matrix multiplication works with
+   non-cartesian representations as well.  For taking the norm, multiplication,
+   and division this uses just the non-angular components, while for the other
+   operations the representation is converted to cartesian internally before
+   the operation is done, and the result is converted back to the original
+   representation.  Hence, for optimal speed it may be best to work using
+   cartesian representations.
+
+To see how the operations work, consider the following examples::
+
+  >>> car_array = CartesianRepresentation([[1., 0., 0.], [3., 5.,  3.]] * u.m,
+  ...                                     [[0., 2., 0.], [4., 0., -4.]] * u.m,
+  ...                                     [[0., 0., 3.], [0.,12.,-12.]] * u.m)
+  >>> car_array
+  <CartesianRepresentation (x, y, z) in m
+      [[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
+       [(3.0, 4.0, 0.0), (5.0, 0.0, 12.0), (3.0, -4.0, -12.0)]]>
+  >>> car_array.norm()  # doctest: +FLOAT_CMP
+  <Quantity [[  1.,  2.,  3.],
+             [  5., 13., 13.]] m>
+  >>> car_array / car_array.norm()  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) [dimensionless]
+      [[(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)],
+       [(0.6, 0.8, 0.0), (0.38461538, 0.0, 0.92307692),
+        (0.23076923, -0.30769231, -0.92307692)]]>
+  >>> (car_array[1] - car_array[0]) / (10. * u.s)  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m / s
+      [(0.2, 0.4, 0.0), (0.5, -0.2, 1.2), (0.3, -0.4, -1.5)]>
+  >>> car_array.sum()  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      (12.0, 2.0, 3.0)>
+  >>> car_array.mean(axis=0)  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      [(2.0, 2.0, 0.0), (2.5, 1.0, 6.0), (1.5, -2.0, -4.5)]>
+
+  >>> unit_x = UnitSphericalRepresentation(0.*u.deg, 0.*u.deg)
+  >>> unit_y = UnitSphericalRepresentation(90.*u.deg, 0.*u.deg)
+  >>> unit_z = UnitSphericalRepresentation(0.*u.deg, 90.*u.deg)
+  >>> car_array.dot(unit_x)  # doctest: +FLOAT_CMP
+  <Quantity [[ 1., 0., 0.],
+             [ 3., 5., 3.]] m>
+  >>> car_array.dot(unit_y)  # doctest: +FLOAT_CMP
+  <Quantity [[  6.12323400e-17,  2.00000000e+00,  0.00000000e+00],
+             [  4.00000000e+00,  3.06161700e-16, -4.00000000e+00]] m>
+  >>> car_array.dot(unit_z)  # doctest: +FLOAT_CMP
+  <Quantity [[  6.12323400e-17,  0.00000000e+00,  3.00000000e+00],
+             [  1.83697020e-16,  1.20000000e+01, -1.20000000e+01]] m>
+  >>> car_array.cross(unit_x)  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      [[(0.0, 0.0, 0.0), (0.0, 0.0, -2.0), (0.0, 3.0, 0.0)],
+       [(0.0, 0.0, -4.0), (0.0, 12.0, 0.0), (0.0, -12.0, 4.0)]]>
+
+  >>> from astropy.coordinates.matrix_utilities import rotation_matrix
+  >>> rotation = rotation_matrix(90 * u.deg, axis='z')
+  >>> rotation  # doctest: +FLOAT_CMP
+  array([[  6.12323400e-17,   1.00000000e+00,   0.00000000e+00],
+         [ -1.00000000e+00,   6.12323400e-17,   0.00000000e+00],
+         [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00]])
+  >>> car_array.transform(rotation)  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      [[(0.0, -1.0, 0.0), (2.0, 0.0, 0.0), (0.0, 0.0, 3.0)],
+       [(4.0, -3.0, 0.0), (0.0, -5.0, 12.0), (-4.0, -3.0, -12.0)]]>
+
 .. _astropy-coordinates-create-repr:
 
 Creating your own representations
@@ -129,11 +224,6 @@ To create your own representation class, your class must inherit from the
 * ``to_cartesian`` method:
 
   Returns a `~astropy.coordinates.CartesianRepresentation` object.
-
-* ``components`` property:
-
-  Returns a tuple of the names of the coordinate components (such as ``x``,
-  ``lon``, and so on).
 
 * ``attr_classes`` class attribute (``OrderedDict``):
 
@@ -175,10 +265,6 @@ In pseudo-code, this means that your class will look like::
         def to_cartesian(self):
             ...
             return CartesianRepresentation(...)
-
-        @property
-        def components(self):
-            return 'comp1', 'comp2', 'comp3'
 
 Once you do this, you will then automatically be able to call
 ``represent_as`` to convert other representations to/from your representation

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -62,14 +62,14 @@ methods with the same names as those for `~numpy.ndarray`, such as ``reshape``,
   >>> car_array = CartesianRepresentation(x, y, z)
   >>> car_array
   <CartesianRepresentation (x, y, z) in m
-      [[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
-       [(3.0, 4.0, 0.0), (5.0, 0.0, 12.0), (3.0, -4.0, -12.0)]]>
+      [[( 1.,  0.,   0.), ( 0.,  2.,   0.), ( 0.,  0.,   3.)],
+       [( 3.,  4.,   0.), ( 5.,  0.,  12.), ( 3., -4., -12.)]]>
   >>> car_array.shape
   (2, 3)
   >>> car_array.ravel()
   <CartesianRepresentation (x, y, z) in m
-      [(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0), (3.0, 4.0, 0.0),
-       (5.0, 0.0, 12.0), (3.0, -4.0, -12.0)]>
+      [( 1.,  0.,   0.), ( 0.,  2.,   0.), ( 0.,  0.,   3.), ( 3.,  4.,   0.),
+       ( 5.,  0.,  12.), ( 3., -4., -12.)]>
 
 Representations can be converted to other representations using the
 ``represent_as`` method::
@@ -155,25 +155,28 @@ To see how the operations work, consider the following examples::
   ...                                     [[0., 0., 3.], [0.,12.,-12.]] * u.m)
   >>> car_array
   <CartesianRepresentation (x, y, z) in m
-      [[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
-       [(3.0, 4.0, 0.0), (5.0, 0.0, 12.0), (3.0, -4.0, -12.0)]]>
+      [[( 1.,  0.,   0.), ( 0.,  2.,   0.), ( 0.,  0.,   3.)],
+       [( 3.,  4.,   0.), ( 5.,  0.,  12.), ( 3., -4., -12.)]]>
   >>> car_array.norm()  # doctest: +FLOAT_CMP
   <Quantity [[  1.,  2.,  3.],
              [  5., 13., 13.]] m>
   >>> car_array / car_array.norm()  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) [dimensionless]
-      [[(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)],
-       [(0.6, 0.8, 0.0), (0.38461538, 0.0, 0.92307692),
-        (0.23076923, -0.30769231, -0.92307692)]]>
+      [[( 1.        ,  0.        ,  0.        ),
+        ( 0.        ,  1.        ,  0.        ),
+        ( 0.        ,  0.        ,  1.        )],
+       [( 0.6       ,  0.8       ,  0.        ),
+        ( 0.38461538,  0.        ,  0.92307692),
+        ( 0.23076923, -0.30769231, -0.92307692)]]>
   >>> (car_array[1] - car_array[0]) / (10. * u.s)  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m / s
-      [(0.2, 0.4, 0.0), (0.5, -0.2, 1.2), (0.3, -0.4, -1.5)]>
+      [( 0.2,  0.4,  0. ), ( 0.5, -0.2,  1.2), ( 0.3, -0.4, -1.5)]>
   >>> car_array.sum()  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m
-      (12.0, 2.0, 3.0)>
+      ( 12.,  2.,  3.)>
   >>> car_array.mean(axis=0)  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m
-      [(2.0, 2.0, 0.0), (2.5, 1.0, 6.0), (1.5, -2.0, -4.5)]>
+      [( 2. ,  2.,  0. ), ( 2.5,  1.,  6. ), ( 1.5, -2., -4.5)]>
 
   >>> unit_x = UnitSphericalRepresentation(0.*u.deg, 0.*u.deg)
   >>> unit_y = UnitSphericalRepresentation(90.*u.deg, 0.*u.deg)
@@ -189,8 +192,8 @@ To see how the operations work, consider the following examples::
              [  1.83697020e-16,  1.20000000e+01, -1.20000000e+01]] m>
   >>> car_array.cross(unit_x)  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m
-      [[(0.0, 0.0, 0.0), (0.0, 0.0, -2.0), (0.0, 3.0, 0.0)],
-       [(0.0, 0.0, -4.0), (0.0, 12.0, 0.0), (0.0, -12.0, 4.0)]]>
+      [[( 0.,  0.,  0.), ( 0.,   0., -2.), ( 0.,   3.,  0.)],
+       [( 0.,  0., -4.), ( 0.,  12.,  0.), ( 0., -12.,  4.)]]>
 
   >>> from astropy.coordinates.matrix_utilities import rotation_matrix
   >>> rotation = rotation_matrix(90 * u.deg, axis='z')
@@ -200,8 +203,12 @@ To see how the operations work, consider the following examples::
          [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00]])
   >>> car_array.transform(rotation)  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m
-      [[(0.0, -1.0, 0.0), (2.0, 0.0, 0.0), (0.0, 0.0, 3.0)],
-       [(4.0, -3.0, 0.0), (0.0, -5.0, 12.0), (-4.0, -3.0, -12.0)]]>
+      [[(  6.12323400e-17,  -1.00000000e+00,   0.),
+        (  2.00000000e+00,   1.22464680e-16,   0.),
+        (  0.00000000e+00,   0.00000000e+00,   3.)],
+       [(  4.00000000e+00,  -3.00000000e+00,   0.),
+        (  3.06161700e-16,  -5.00000000e+00,  12.),
+        ( -4.00000000e+00,  -3.00000000e+00, -12.)]]>
 
 .. _astropy-coordinates-create-repr:
 

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -372,6 +372,17 @@ Under Python 3 you can use the annotations syntax to provide the units:
     >>> myfunction(100*u.arcsec)  # doctest: +SKIP
     Unit("arcsec")
 
+Representing vectors with units
+-------------------------------
+
+|quantity| objects can, like numpy arrays, be used to represent vectors or
+matrices by assigning specific dimensions to represent the coordinates or
+matrix elements, but that implies tracking those dimensions carefully. For
+vectors, one can use instead the representations underlying coordinates, which
+allow one to use representations other than cartesian (such as spherical or
+cylindrical), as well as simple vector arithmetic.  For details, see
+:ref:`astropy-coordinates-representations`.
+
 Known issues with conversion to numpy arrays
 --------------------------------------------
 


### PR DESCRIPTION
This aims to address #5255, by making it possible to do arithmetic on representations, such as addition of two representations, multiplication with a ``Quantity``, or calculating the norm via ``abs``. It also introduces news methods ``mean``, ``sum``, ``dot``, and ``cross`` with obvious meaning.

cc @StuartLittlefair, @eteq, @adrn, @astrofrog