### PR TITLE
Let data_info RuntimeWarning filter on message rather than module.

### DIFF
--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -31,8 +31,8 @@ from ..utils.compat import NUMPY_LT_1_8
 from ..extern.six.moves import zip, cStringIO as StringIO
 
 # Tuple of filterwarnings kwargs to ignore when calling info
-IGNORE_WARNINGS = (dict(category=RuntimeWarning,
-                        module=r'numpy\.lib\.nanfunctions'),)
+IGNORE_WARNINGS = (dict(category=RuntimeWarning, message='All-NaN|'
+                        'Mean of empty slice|Degrees of freedom <= 0'),)
 
 STRING_TYPE_NAMES = {(False, 'S'): 'str',  # not PY3
                      (False, 'U'): 'unicode',


### PR DESCRIPTION
Currently, `data_info` filters out warning messages about all-NaN axes since presumably when one gathers statistics these are not useful. However, https://github.com/numpy/numpy/pull/7985/files made these message appear to originate from `data_info` itself rather than from `numpy.lib.nanfunctions`. To make this work independently of numpy version, filtering is now down by message content.

Setting milestone 1.2.2 since presumably we want that version to work well with the new numpy as well. It does not have to go back to 1.0, since `data_info` did not yet exist then.

@taldcroft: does this approach make sense to you?