### PR TITLE
Fix itemsize logic in realign_dtype helper

### DIFF
--- a/astropy/io/fits/_numpy_hacks.py
+++ b/astropy/io/fits/_numpy_hacks.py
@@ -43,8 +43,8 @@ def realign_dtype(dtype, offsets):
     names, fields = state[3:5]
     fields = fields.copy()
 
-    max_offset = 0
-    itemsize = state[5]  # Default to the original itemsize
+    itemsize = 0  # We will re-determine the itemsize based on the type
+                  # of the field with the largest (offset + itemsize)
 
     if fields is None or len(offsets) != len(names):
         raise ValueError(
@@ -53,14 +53,10 @@ def realign_dtype(dtype, offsets):
 
     for name, offset in zip(names, offsets):
         field = fields[name]
-        if offset == field[1]:
-            continue
+        itemsize = max(itemsize, offset + field[0].itemsize)
 
-        fields[name] = (field[0], offset)
-
-        if offset > max_offset:
-            itemsize = offset + field[0].itemsize
-            max_offset = offset
+        if offset != field[1]:
+            fields[name] = (field[0], offset)
 
     new_typespec = '|V{0}'.format(itemsize)
 

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -5,8 +5,11 @@ from __future__ import with_statement
 import os
 import signal
 
+import numpy as np
+
 from ....tests.helper import pytest, catch_warnings
 from ..util import ignore_sigint
+from .._numpy_hacks import realign_dtype
 
 from . import FitsTestCase
 
@@ -26,3 +29,32 @@ class TestUtils(FitsTestCase):
                     'KeyboardInterrupt ignored until test is complete!')
 
         pytest.raises(KeyboardInterrupt, test)
+
+    def test_realign_dtype(self):
+        """
+        Tests a few corner-cases for the realign_dtype hack.
+
+        These are unlikely to come in practice given how this is currently
+        used in astropy.io.fits, but nonetheless tests for bugs that were
+        present in earlier versions of the function.
+        """
+
+        dt = np.dtype([('a', np.int32), ('b', np.int16)])
+        dt2 = realign_dtype(dt, [0, 0])
+        assert dt2.itemsize == 4
+
+        dt2 = realign_dtype(dt, [0, 1])
+        assert dt2.itemsize == 4
+
+        dt2 = realign_dtype(dt, [1, 0])
+        assert dt2.itemsize == 5
+
+        dt = np.dtype([('a', np.float64), ('b', np.int8), ('c', np.int8)])
+        dt2 = realign_dtype(dt, [0, 0, 0])
+        assert dt2.itemsize == 8
+
+        dt2 = realign_dtype(dt, [0, 0, 1])
+        assert dt2.itemsize == 8
+
+        dt2 = realign_dtype(dt, [0, 0, 27])
+        assert dt2.itemsize == 28


### PR DESCRIPTION
I don't think this caused any known problems, nor was it likely to given how the `realign_dtype` hack is used in practice.  But I was looking at it the other day for some reason and noticed that the logic for determining the new dtype's itemsize was totally wrong.  Added some tests that demonstrate examples where it was wrong.
