### PR TITLE
Remove deprecated FITS code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,24 @@ API Changes
 
 - ``astropy.io.fits``
 
+  - The following previously deprecated functions, classes and methods have been
+    removed entirely: ``CardList``, ``Card.key``, ``Card.cardimage``,
+    ``Card.ascardimage``, ``create_card``, ``create_card_from_string``,
+    ``upper_key``, ``Header.ascard``, ``Header.rename_key``,
+    ``Header.get_history``, ``Header.get_comment``, ``Header.toTxtFile``,
+    ``Header.fromTxtFile``, ``tdump``, ``tcreate``, ``BinTableHDU.tdump``,
+    ``BinTableHDU.tcreate``. [#5310]
+
+  - A few other deprecated features were removed in [#5310]:
+
+    - The ``txtfile`` argument to the ``Header`` constructor.
+
+    - The usage of ``Header.update`` with ``Header.update(keyword, value,
+      comment)`` arguments.
+
+    - The ``startColumn`` and ``endColumn`` arguments to the ``FITS_record``
+      constructor.
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,22 +91,23 @@ API Changes
 
 - ``astropy.io.fits``
 
-  - The following previously deprecated functions, classes and methods have been
-    removed entirely: ``CardList``, ``Card.key``, ``Card.cardimage``,
-    ``Card.ascardimage``, ``create_card``, ``create_card_from_string``,
-    ``upper_key``, ``Header.ascard``, ``Header.rename_key``,
-    ``Header.get_history``, ``Header.get_comment``, ``Header.toTxtFile``,
-    ``Header.fromTxtFile``, ``tdump``, ``tcreate``, ``BinTableHDU.tdump``,
-    ``BinTableHDU.tcreate``. [#5310]
+  - The old ``Header`` interface, deprecated since Astropy 0.1 (PyFITS 3.1), has
+    been removed entirely. See :ref:`header-transition-guide` for explanations
+    on this change and help on the transition. [#5310]
 
-  - A few other deprecated features were removed in [#5310]:
+    - The following functions, classes and methods have been removed:
+      ``CardList``, ``Card.key``, ``Card.cardimage``, ``Card.ascardimage``,
+      ``create_card``, ``create_card_from_string``, ``upper_key``,
+      ``Header.ascard``, ``Header.rename_key``, ``Header.get_history``,
+      ``Header.get_comment``, ``Header.toTxtFile``, ``Header.fromTxtFile``,
+      ``tdump``, ``tcreate``, ``BinTableHDU.tdump``, ``BinTableHDU.tcreate``.
 
-    - The ``txtfile`` argument to the ``Header`` constructor.
+    - Removed ``txtfile`` argument to the ``Header`` constructor.
 
-    - The usage of ``Header.update`` with ``Header.update(keyword, value,
+    - Removed usage of ``Header.update`` with ``Header.update(keyword, value,
       comment)`` arguments.
 
-    - The ``startColumn`` and ``endColumn`` arguments to the ``FITS_record``
+    - Removed ``startColumn`` and ``endColumn`` arguments to the ``FITS_record``
       constructor.
 
 - ``astropy.io.misc``

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -73,7 +73,6 @@ from .hdu import *
 from .hdu.groups import GroupData
 from .hdu.hdulist import fitsopen as open
 from .hdu.image import Section
-from .hdu.table import new_table
 from .header import Header
 from .verify import VerifyError
 
@@ -81,4 +80,4 @@ from .verify import VerifyError
 __all__ = (['Conf', 'conf'] + card.__all__ + column.__all__ +
            convenience.__all__ + hdu.__all__ +
            ['FITS_record', 'FITS_rec', 'GroupData', 'open', 'Section',
-            'new_table', 'Header', 'VerifyError', 'conf'])
+            'Header', 'VerifyError', 'conf'])

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1149,25 +1149,8 @@ class ColDefs(NotifierMixin):
     _padding_byte = '\x00'
     _col_format_cls = _ColumnFormat
 
-    def __new__(cls, input, tbtype=None, ascii=False):
-        if tbtype is not None:
-            warnings.warn(
-                'The ``tbtype`` argument to `ColDefs` is deprecated as of '
-                'Astropy 0.4; instead the appropriate table type should be '
-                'inferred from the formats of the supplied columns.  Use the '
-                '``ascii=True`` argument to ensure that ASCII table columns '
-                'are used.', AstropyDeprecationWarning)
-        else:
-            tbtype = 'BinTableHDU'  # The old default
-
-        # Backwards-compat support
-        # TODO: Remove once the tbtype argument is removed entirely
-        if tbtype == 'BinTableHDU':
-            klass = cls
-        elif tbtype == 'TableHDU':
-            klass = _AsciiColDefs
-        else:
-            raise ValueError('Invalid table type: %s.' % tbtype)
+    def __new__(cls, input, ascii=False):
+        klass = cls
 
         if (hasattr(input, '_columns_type') and
                 issubclass(input._columns_type, ColDefs)):
@@ -1184,7 +1167,7 @@ class ColDefs(NotifierMixin):
     def __getnewargs__(self):
         return (self._arrays,)
 
-    def __init__(self, input, tbtype=None, ascii=False):
+    def __init__(self, input, ascii=False):
         """
         Parameters
         ----------
@@ -1193,16 +1176,10 @@ class ColDefs(NotifierMixin):
             An existing table HDU, an existing `ColDefs`, or any multi-field
             Numpy array or `numpy.recarray`.
 
-        **(Deprecated)** tbtype : str, optional
-            which table HDU, ``"BinTableHDU"`` (default) or
-            ``"TableHDU"`` (text table).
-            Now ColDefs for a normal (binary) table by default, but converted
-            automatically to ASCII table ColDefs in the appropriate contexts
-            (namely, when creating an ASCII table).
-
         ascii : bool
-        """
+            Use True to ensure that ASCII table columns are used.
 
+        """
         from .hdu.table import _TableBaseHDU
         from .fitsrec import FITS_rec
 
@@ -1684,7 +1661,7 @@ class _AsciiColDefs(ColDefs):
     _padding_byte = ' '
     _col_format_cls = _AsciiColumnFormat
 
-    def __init__(self, input, tbtype=None, ascii=True):
+    def __init__(self, input, ascii=True):
         super(_AsciiColDefs, self).__init__(input)
 
         # if the format of an ASCII column has no width, add one

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -72,13 +72,12 @@ from .fitsrec import FITS_rec
 from ...units.format.fits import UnitScaleError
 from ...extern import six
 from ...extern.six import string_types
-from ...utils import deprecated
 from ...utils.exceptions import AstropyUserWarning
 
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
-           'append', 'update', 'info', 'tdump', 'tcreate', 'tabledump',
-           'tableload', 'table_to_hdu']
+           'append', 'update', 'info', 'tabledump', 'tableload',
+           'table_to_hdu']
 
 
 def getheader(filename, *args, **kwargs):
@@ -725,7 +724,7 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
     -----
     The primary use for the `tabledump` function is to allow editing in a
     standard text editor of the table data and parameters.  The
-    ``tcreate`` function can be used to reassemble the table from the
+    ``tableload`` function can be used to reassemble the table from the
     three ASCII files.
     """
 
@@ -752,12 +751,6 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
 
 if isinstance(tabledump.__doc__, string_types):
     tabledump.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
-
-
-@deprecated('0.1', alternative=':func:`tabledump`')
-def tdump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
-          clobber=False):
-    tabledump(filename, datafile, cdfile, hfile, ext, clobber)
 
 
 def tableload(datafile, cdfile, hfile=None):
@@ -796,11 +789,6 @@ def tableload(datafile, cdfile, hfile=None):
 
 if isinstance(tableload.__doc__, string_types):
     tableload.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
-
-
-@deprecated('0.1', alternative=':func:`tableload`')
-def tcreate(datafile, cdfile, hfile=None):
-    return tableload(datafile, cdfile, hfile)
 
 
 def _getext(filename, mode, *args, **kwargs):

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -724,7 +724,7 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
     -----
     The primary use for the `tabledump` function is to allow editing in a
     standard text editor of the table data and parameters.  The
-    ``tableload`` function can be used to reassemble the table from the
+    `tableload` function can be used to reassemble the table from the
     three ASCII files.
     """
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -19,7 +19,6 @@ from ...extern.six import string_types
 from ...extern.six.moves import range, zip
 from ...utils import lazyproperty
 from ...utils.compat import suppress
-from ...utils.exceptions import AstropyDeprecationWarning
 
 
 class FITS_record(object):
@@ -51,16 +50,6 @@ class FITS_record(object):
            The ending column in the row associated with this object.
            Used for subsetting the columns of the `FITS_rec` object.
         """
-
-        # For backward compatibility...
-        for arg in [('startColumn', 'start'), ('endColumn', 'end')]:
-            if arg[0] in kwargs:
-                warnings.warn('The %s argument to FITS_record is deprecated; '
-                              'use %s instead' % arg, AstropyDeprecationWarning)
-                if arg[0] == 'startColumn':
-                    start = kwargs[arg[0]]
-                elif arg[0] == 'endColumn':
-                    end = kwargs[arg[0]]
 
         self.array = input
         self.row = row

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -276,7 +276,7 @@ class FITS_rec(np.recarray):
 
         .. note::
 
-            This was originally part of the `new_table` function in the table
+            This was originally part of the ``new_table`` function in the table
             module but was moved into a class method since most of its
             functionality always had more to do with initializing a `FITS_rec`
             object than anything else, and much of it also overlapped with

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -19,7 +19,7 @@ from ..verify import _Verify, _ErrList
 
 from ....extern.six import string_types, add_metaclass
 from ....extern.six.moves import range
-from ....utils import lazyproperty, deprecated
+from ....utils import lazyproperty
 from ....utils.compat import suppress
 from ....utils.compat.funcsigs import signature, Parameter
 from ....utils.exceptions import AstropyUserWarning
@@ -240,102 +240,6 @@ class _BaseHDU(object):
     @property
     def _has_data(self):
         return self._data_loaded and self.data is not None
-
-    @property
-    @deprecated('0.3', alternative='the `._header_offset` attribute',
-                pending=True)
-    def _hdrLoc(self):
-        """The byte offset of this HDU's header in the file it came from;
-        available for backwards compatibility--use ._header_offset instead.
-        """
-
-        return self._header_offset
-
-    @_hdrLoc.setter
-    @deprecated('0.3', alternative='the `._header_offset` attribute',
-                pending=True)
-    def _hdrLoc(self, value):
-        self._header_offset = value
-
-    @property
-    @deprecated('0.3', alternative='the `._data_offset` attribute',
-                pending=True)
-    def _datLoc(self):
-        """The byte offset of this HDU's data portion in the file it came from;
-        available for backwards compatibility--use ._data_offset instead.
-        """
-
-        return self._data_offset
-
-    @_datLoc.setter
-    @deprecated('0.3', alternative='the `._data_offset` attribute',
-                pending=True)
-    def _datLoc(self, value):
-        self._data_offset = value
-
-    @property
-    @deprecated('0.3', alternative='the `._data_size` attribute',
-                pending=True)
-    def _datSpan(self):
-        """The byte size of this HDU's data portion in the file it came from;
-        available for backwards compatibility--use ._data_size instead.
-        """
-
-        return self._data_size
-
-    @_datSpan.setter
-    @deprecated('0.3', alternative='the `._data_size` attribute',
-                pending=True)
-    def _datSpan(self, value):
-        self._data_size = value
-
-    @property
-    @deprecated('0.3', alternative='the `._header_offset` attribute',
-                pending=True)
-    def _hdrLoc(self):
-        """The byte offset of this HDU's header in the file it came from;
-        available for backwards compatibility--use ._header_offset instead.
-        """
-
-        return self._header_offset
-
-    @_hdrLoc.setter
-    @deprecated('0.3', alternative='the `._header_offset` attribute',
-                pending=True)
-    def _hdrLoc(self, value):
-        self._header_offset = value
-
-    @property
-    @deprecated('0.3', alternative='the `._data_offset` attribute',
-                pending=True)
-    def _datLoc(self):
-        """The byte offset of this HDU's data portion in the file it came from;
-        available for backwards compatibility--use ._data_offset instead.
-        """
-
-        return self._data_offset
-
-    @_datLoc.setter
-    @deprecated('0.3', alternative='the `._data_offset` attribute',
-                pending=True)
-    def _datLoc(self, value):
-        self._data_offset = value
-
-    @property
-    @deprecated('0.3', alternative='the `._data_size` attribute',
-                pending=True)
-    def _datSpan(self):
-        """The byte size of this HDU's data portion in the file it came from;
-        available for backwards compatibility--use ._data_size instead.
-        """
-
-        return self._data_size
-
-    @_datSpan.setter
-    @deprecated('0.3', alternative='the `._data_size` attribute',
-                pending=True)
-    def _datSpan(self, value):
-        self._data_size = value
 
     @classmethod
     def register_hdu(cls, hducls):
@@ -1056,98 +960,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         else:
             data = None
         return self.__class__(data=data, header=self._header.copy())
-
-    @deprecated('0.3', alternative='the ``.name`` attribute or `Header.set`',
-                pending=True)
-    def update_ext_name(self, value, comment=None, before=None,
-                        after=None, savecomment=False):
-        """
-        Update the extension name associated with the HDU.
-
-        If the keyword already exists in the Header, it's value and/or comment
-        will be updated.  If it does not exist, a new card will be created
-        and it will be placed before or after the specified location.
-        If no ``before`` or ``after`` is specified, it will be appended at
-        the end.
-
-        Parameters
-        ----------
-        value : str
-            Value to be used for the new extension name
-
-        comment : str, optional
-            To be used for updating, default=None.
-
-        before : str or int, optional
-            Name of the keyword, or index of the `Card` before which the new
-            card will be placed in the Header.  The argument ``before`` takes
-            precedence over ``after`` if both are specified.
-
-        after : str or int, optional
-            Name of the keyword, or index of the `Card` after which
-            the new card will be placed in the Header
-
-        savecomment : bool, optional
-            When `True`, preserve the current comment for an existing
-            keyword.  The argument ``savecomment`` takes precedence over
-            ``comment`` if both specified.  If ``comment`` is not
-            specified then the current comment will automatically be
-            preserved.
-        """
-
-        if 'EXTNAME' in self._header and savecomment:
-            comment = None
-
-        self._header.set('EXTNAME', value, comment, before, after)
-        # This may seem redundant, but the previous header.set call just
-        # handles anyone who might use the before/after keywords to set the
-        # position of the EXTNAME keyword.  Setting self.name = name does some
-        # additional processing on the value such as handling
-        # conf.extension_name_case_sensitive
-        self.name = value
-
-    @deprecated('0.3', alternative='the ``.ver`` attribute or `Header.set`',
-                pending=True)
-    def update_ext_version(self, value, comment=None, before=None,
-                           after=None, savecomment=False):
-        """
-        Update the extension version associated with the HDU.
-
-        If the keyword already exists in the Header, it's value and/or comment
-        will be updated.  If it does not exist, a new card will be created
-        and it will be placed before or after the specified location.
-        If no ``before`` or ``after`` is specified, it will be appended at
-        the end.
-
-        Parameters
-        ----------
-        value : str
-            Value to be used for the new extension version
-
-        comment : str, optional
-            To be used for updating; default=None.
-
-        before : str or int, optional
-            Name of the keyword, or index of the `Card` before which the new
-            card will be placed in the Header.  The argument ``before`` takes
-            precedence over ``after`` if both are specified.
-
-        after : str or int, optional
-            Name of the keyword, or index of the `Card` after which
-            the new card will be placed in the Header.
-
-        savecomment : bool, optional
-            When `True`, preserve the current comment for an existing
-            keyword.  The argument ``savecomment`` takes precedence over
-            ``comment`` if both specified.  If ``comment`` is not
-            specified then the current comment will automatically be
-            preserved.
-        """
-
-        if 'EXTVER' in self._header and savecomment:
-            comment = None
-
-        self._header.set('EXTVER', value, comment, before, after)
 
     def _verify(self, option='warn'):
         errs = _ErrList([], unit='Card')

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -22,7 +22,7 @@ from ..util import (_is_pseudo_unsigned, _unsigned_zero, _is_int,
 
 from ....extern.six import string_types, iteritems
 from ....extern.six.moves import range
-from ....utils import lazyproperty, deprecated
+from ....utils import lazyproperty
 from ....utils.compat import suppress
 from ....utils.exceptions import (AstropyPendingDeprecationWarning,
                                   AstropyUserWarning)
@@ -1362,21 +1362,6 @@ class CompImageHDU(BinTableHDU):
             for _ in range(required_blanks - table_blanks):
                 self._header.append()
 
-    @deprecated('0.3', alternative='(refactor your code)', pending=True)
-    def updateHeaderData(self, image_header,
-                         name=None,
-                         compressionType=None,
-                         tileSize=None,
-                         hcompScale=None,
-                         hcompSmooth=None,
-                         quantizeLevel=None):
-        self._update_header_data(image_header, name=name,
-                                 compression_type=compressionType,
-                                 tile_size=tileSize,
-                                 hcomp_scale=hcompScale,
-                                 hcomp_smooth=hcompSmooth,
-                                 quantize_level=quantizeLevel)
-
     @lazyproperty
     def data(self):
         # The data attribute is the image data (not the table data).
@@ -1466,12 +1451,6 @@ class CompImageHDU(BinTableHDU):
             # since this reference leak can sometimes hang around longer than
             # welcome go ahead and force a garbage collection
             gc.collect()
-
-    @lazyproperty
-    @deprecated('0.3', alternative='the ``compressed_data`` attribute',
-                pending=True)
-    def compData(self):
-        return self.compressed_data
 
     @property
     def shape(self):
@@ -1699,16 +1678,6 @@ class CompImageHDU(BinTableHDU):
         self.compressed_data._heapoffset = self._theap
         self.compressed_data._heapsize = heapsize
 
-    @deprecated('0.3', alternative='(refactor your code)')
-    def updateCompressedData(self):
-        self._update_compressed_data()
-
-    @deprecated('0.3',
-                alternative='(refactor your code; this function no '
-                            'longer does anything)')
-    def updateHeader(self):
-        pass
-
     def scale(self, type=None, option='old', bscale=1, bzero=0):
         """
         Scale image data by using ``BSCALE`` and ``BZERO``.
@@ -1881,9 +1850,6 @@ class CompImageHDU(BinTableHDU):
         if (closed and self._data_loaded and
                 _get_array_mmap(self.compressed_data) is not None):
             del self.compressed_data
-            # Close off the deprected compData attribute as well if it has been
-            # used
-            del self.compData
 
     # TODO: This was copied right out of _ImageBaseHDU; get rid of it once we
     # find a way to rewrite this class as either a subclass or wrapper for an

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -31,7 +31,7 @@ from ..util import _is_int, _str_to_num
 from ....extern import six
 from ....extern.six import string_types
 from ....extern.six.moves import range, zip
-from ....utils import deprecated, lazyproperty
+from ....utils import lazyproperty
 from ....utils.compat import suppress
 from ....utils.exceptions import AstropyUserWarning
 
@@ -82,9 +82,7 @@ class _TableLikeHDU(_ValidHDU):
         the class this method was called on using the column definition from
         the input.
 
-        This is an alternative to the now deprecated `new_table` function,
-        and otherwise accepts the same arguments.  See also
-        `FITS_rec.from_columns`.
+        See also `FITS_rec.from_columns`.
 
         Parameters
         ----------
@@ -1033,10 +1031,6 @@ class BinTableHDU(_TableBaseHDU):
     if isinstance(dump.__doc__, string_types):
         dump.__doc__ += _tdump_file_format.replace('\n', '\n        ')
 
-    @deprecated('0.1', alternative=':meth:`dump`')
-    def tdump(self, datafile=None, cdfile=None, hfile=None, clobber=False):
-        self.dump(datafile, cdfile, hfile, clobber)
-
     def load(cls, datafile, cdfile=None, hfile=None, replace=False,
              header=None):
         """
@@ -1121,12 +1115,6 @@ class BinTableHDU(_TableBaseHDU):
     load = classmethod(load)
     # Have to create a classmethod from this here instead of as a decorator;
     # otherwise we can't update __doc__
-
-    @deprecated('0.1', alternative=':meth:`load`')
-    @classmethod
-    def tcreate(cls, datafile, cdfile=None, hfile=None, replace=False,
-                header=None):
-        return cls.load(datafile, cdfile, hfile, replace, header)
 
     def _dump_data(self, fileobj):
         """
@@ -1299,8 +1287,7 @@ class BinTableHDU(_TableBaseHDU):
 
         # TODO: In the future maybe enable loading a bit at a time so that we
         # can convert from this format to an actual FITS file on disk without
-        # needing enough physical memory to hold the entire thing at once;
-        # new_table() could use a similar feature.
+        # needing enough physical memory to hold the entire thing at once
         hdu = BinTableHDU.from_columns(np.recarray(shape=1, dtype=dtype),
                                        nrows=nrows, fill=True)
 
@@ -1402,67 +1389,6 @@ class BinTableHDU(_TableBaseHDU):
             fileobj.close()
 
         return ColDefs(columns)
-
-
-@deprecated('0.4',
-            alternative=':meth:`BinTableHDU.from_columns` for new BINARY '
-                        'tables or :meth:`TableHDU.from_columns` for new '
-                        'ASCII tables')
-def new_table(input, header=None, nrows=0, fill=False, tbtype=BinTableHDU):
-    """
-    Create a new table from the input column definitions.
-
-    Warning: Creating a new table using this method creates an in-memory *copy*
-    of all the column arrays in the input.  This is because if they are
-    separate arrays they must be combined into a single contiguous array.
-
-    If the column data is already in a single contiguous array (such as an
-    existing record array) it may be better to create a `BinTableHDU` instance
-    directly.  See the Astropy documentation for more details.
-
-    Parameters
-    ----------
-    input : sequence of `Column` or a `ColDefs`
-        The data to create a table from
-
-    header : `Header` instance
-        Header to be used to populate the non-required keywords
-
-    nrows : int
-        Number of rows in the new table
-
-    fill : bool
-        If `True`, will fill all cells with zeros or blanks.  If
-        `False`, copy the data from input, undefined cells will still
-        be filled with zeros/blanks.
-
-    tbtype : str or type
-        Table type to be created (`BinTableHDU` or `TableHDU`) or the class
-        name as a string.  Currently only `BinTableHDU` and `TableHDU` (ASCII
-        tables) are supported.
-    """
-
-    # tbtype defaults to classes now, but in all prior version of PyFITS it was
-    # a string, so we still support that use case as well
-    if not isinstance(tbtype, string_types):
-        cls = tbtype
-        tbtype = cls.__name__
-    else:
-        # Right now the string input must be one of 'TableHDU' or 'BinTableHDU'
-        # and nothing else, though we will allow this to be case insensitive
-        # This could be done more generically through the HDU registry, but my
-        # hope is to deprecate this function anyways so there's not much point
-        # in trying to make it more "generic".
-        if tbtype.lower() == 'tablehdu':
-            cls = TableHDU
-        elif tbtype.lower() == 'bintablehdu':
-            cls = BinTableHDU
-        else:
-            raise ValueError("tbtype must be one of 'TableHDU' or "
-                             "'BinTableHDU'")
-
-    # construct a table HDU of the requested type
-    return cls.from_columns(input, header=header, nrows=nrows, fill=fill)
 
 
 @contextlib.contextmanager

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -802,7 +802,8 @@ class Header(object):
         created in the specified position, or appended to the end of the header
         if no position is specified.
 
-        This method is similar to :meth:`Header.update` prior to PyFITS 3.1.
+        This method is similar to :meth:`Header.update` prior to PyFITS 3.1
+        / Astropy v0.1.
 
         .. note::
             It should be noted that ``header.set(keyword, value)`` and
@@ -985,9 +986,9 @@ class Header(object):
         .. warning::
             As this method works similarly to `dict.update` it is very
             different from the ``Header.update()`` method in PyFITS versions
-            prior to 3.1.0. Use of the old API was **deprecated** for a long
-            time and is now removed. Most uses of the old API can be replaced
-            as follows:
+            prior to 3.1.0 (or Astropy v0.1). Use of the old API was
+            **deprecated** for a long time and is now removed. Most uses of the
+            old API can be replaced as follows:
 
             * Replace ::
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1202,7 +1202,7 @@ class Header(object):
             'SIMPLE' keyword.  This behavior is otherwise dumb as to whether or
             not the resulting header is a valid primary or extension header.
             This is mostly provided to support backwards compatibility with the
-            old :meth:`Header.fromTxtFile` method, and only applies if
+            old ``Header.fromTxtFile`` method, and only applies if
             ``update=True``.
 
         useblanks, bottom, end : bool, optional

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -26,7 +26,6 @@ from ..file import _File, GZIP_MAGIC
 from ....extern.six.moves import range, zip
 from ....io import fits
 from ....tests.helper import pytest, raises, catch_warnings, ignore_warnings
-from ....utils.exceptions import AstropyDeprecationWarning
 from ....utils.data import get_pkg_data_filename
 
 try:
@@ -128,7 +127,6 @@ class TestCore(FitsTestCase):
                 assert table.data.dtype.names == ('c2', 'c4', 'foo')
                 assert table.columns.names == ['c2', 'c4', 'foo']
 
-    @ignore_warnings(AstropyDeprecationWarning)
     def test_update_header_card(self):
         """A very basic test for the Header.update method--I'd like to add a
         few more cases to this at some point.
@@ -139,23 +137,12 @@ class TestCore(FitsTestCase):
         header['BITPIX'] = (16, comment)
         assert 'BITPIX' in header
         assert header['BITPIX'] == 16
-        assert header.ascard['BITPIX'].comment == comment
+        assert header.comments['BITPIX'] == comment
 
-        # The new API doesn't support savecomment so leave this line here; at
-        # any rate good to have testing of the new API mixed with the old API
-        header.update('BITPIX', 32, savecomment=True)
-        # Make sure the value has been updated, but the comment was preserved
+        header.update(BITPIX=32)
         assert header['BITPIX'] == 32
-        assert header.ascard['BITPIX'].comment == comment
+        assert header.comments['BITPIX'] == ''
 
-        # The comment should still be preserved--savecomment only takes effect
-        # if a new comment is also specified
-        header['BITPIX'] = 16
-        assert header.ascard['BITPIX'].comment == comment
-        header.update('BITPIX', 16, 'foobarbaz', savecomment=True)
-        assert header.ascard['BITPIX'].comment == comment
-
-    @ignore_warnings(AstropyDeprecationWarning)
     def test_set_card_value(self):
         """Similar to test_update_header_card(), but tests the the
         `header['FOO'] = 'bar'` method of updating card values.
@@ -164,15 +151,15 @@ class TestCore(FitsTestCase):
         header = fits.Header()
         comment = 'number of bits per data pixel'
         card = fits.Card.fromstring('BITPIX  = 32 / %s' % comment)
-        header.ascard.append(card)
+        header.append(card)
 
         header['BITPIX'] = 32
 
         assert 'BITPIX' in header
         assert header['BITPIX'] == 32
-        assert header.ascard['BITPIX'].key == 'BITPIX'
-        assert header.ascard['BITPIX'].value == 32
-        assert header.ascard['BITPIX'].comment == comment
+        assert header.cards[0].keyword == 'BITPIX'
+        assert header.cards[0].value == 32
+        assert header.cards[0].comment == comment
 
     def test_uint(self):
         hdulist_f = fits.open(self.data('o4sp040b0_raw.fits'), uint=False)
@@ -182,14 +169,13 @@ class TestCore(FitsTestCase):
         assert hdulist_i[1].data.dtype == np.uint16
         assert np.all(hdulist_f[1].data == hdulist_i[1].data)
 
-    @ignore_warnings(AstropyDeprecationWarning)
     def test_fix_missing_card_append(self):
         hdu = fits.ImageHDU()
         errs = hdu.req_cards('TESTKW', None, None, 'foo', 'silentfix', [])
         assert len(errs) == 1
         assert 'TESTKW' in hdu.header
         assert hdu.header['TESTKW'] == 'foo'
-        assert hdu.header.ascard[-1].key == 'TESTKW'
+        assert hdu.header.cards[-1].keyword == 'TESTKW'
 
     def test_fix_invalid_keyword_value(self):
         hdu = fits.ImageHDU()
@@ -564,7 +550,6 @@ class TestConvenienceFunctions(FitsTestCase):
         assert len(hdul) == 1
         assert (data == hdul[0].data).all()
 
-    @ignore_warnings(AstropyDeprecationWarning)
     def test_writeto_2(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/107
@@ -572,7 +557,7 @@ class TestConvenienceFunctions(FitsTestCase):
         Test of `writeto()` with a trivial header containing a single keyword.
         """
 
-        data = np.zeros((100,100))
+        data = np.zeros((100, 100))
         header = fits.Header()
         header.set('CRPIX1', 1.)
         fits.writeto(self.temp('array.fits'), data, header=header,

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -17,11 +17,10 @@ from . import FitsTestCase
 
 
 class TestHDUListFunctions(FitsTestCase):
-    @ignore_warnings()
     def test_update_name(self):
         hdul = fits.open(self.data('o4sp040b0_raw.fits'))
-        hdul[4].update_ext_name('Jim', "added by Jim")
-        hdul[4].update_ext_version(9, "added by Jim")
+        hdul[4].name = 'Jim'
+        hdul[4].ver = 9
         assert hdul[('JIM', 9)].header['extname'] == 'JIM'
 
     def test_hdu_file_bytes(self):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -17,7 +17,6 @@ from ....extern.six.moves import zip, range
 from ....io import fits
 from ....io.fits.verify import VerifyWarning
 from ....tests.helper import pytest, catch_warnings, ignore_warnings
-from ....utils.exceptions import AstropyDeprecationWarning
 
 from . import FitsTestCase
 from ..card import _pad
@@ -40,48 +39,6 @@ def test_init_with_ordereddict():
     h1 = fits.Header(dict1)
     # Check that the order is preserved of the initial list
     assert all(h1[val] == list1[i][1] for i, val in enumerate(h1))
-
-
-class TestOldApiHeaderFunctions(FitsTestCase):
-    """
-    Tests that specifically use attributes and methods from the old
-    Header/CardList API from PyFITS 3.0 and prior.
-
-    This tests backward compatibility support for those interfaces.
-    """
-
-    # FIXME: This one still works and does not trigger any warning
-    @ignore_warnings(AstropyDeprecationWarning)
-    def test_add_commentary(self):
-        header = fits.Header([('A', 'B', 'C'), ('HISTORY', 1),
-                              ('HISTORY', 2), ('HISTORY', 3), ('', '', ''),
-                              ('', '', '')])
-        header.add_history(4)
-        # One of the blanks should get used, so the length shouldn't change
-        assert len(header) == 6
-        assert header.cards[4].value == 4
-        assert header['HISTORY'] == [1, 2, 3, 4]
-
-        header.add_history(0, after='A')
-        assert len(header) == 6
-        assert header.cards[1].value == 0
-        assert header['HISTORY'] == [0, 1, 2, 3, 4]
-
-        header = fits.Header([('A', 'B', 'C'), ('', 1), ('', 2), ('', 3),
-                              ('', '', ''), ('', '', '')])
-        header.add_blank(4)
-        # This time a new blank should be added, and the existing blanks don't
-        # get used... (though this is really kinda sketchy--there's a
-        # distinction between truly blank cards, and cards with blank keywords
-        # that isn't currently made int he code)
-        assert len(header) == 7
-        assert header.cards[6].value == 4
-        assert header[''] == [1, 2, 3, '', '', 4]
-
-        header.add_blank(0, after='A')
-        assert len(header) == 8
-        assert header.cards[1].value == 0
-        assert header[''] == [0, 1, 2, 3, '', '', 4]
 
 
 class TestHeaderFunctions(FitsTestCase):
@@ -176,6 +133,37 @@ class TestHeaderFunctions(FitsTestCase):
             c = fits.Card('abc+', 9)
         assert len(w) == 1
         assert c.image == _pad('HIERARCH abc+ =                    9')
+
+    def test_add_commentary(self):
+        header = fits.Header([('A', 'B', 'C'), ('HISTORY', 1),
+                              ('HISTORY', 2), ('HISTORY', 3), ('', '', ''),
+                              ('', '', '')])
+        header.add_history(4)
+        # One of the blanks should get used, so the length shouldn't change
+        assert len(header) == 6
+        assert header.cards[4].value == 4
+        assert header['HISTORY'] == [1, 2, 3, 4]
+
+        header.add_history(0, after='A')
+        assert len(header) == 6
+        assert header.cards[1].value == 0
+        assert header['HISTORY'] == [0, 1, 2, 3, 4]
+
+        header = fits.Header([('A', 'B', 'C'), ('', 1), ('', 2), ('', 3),
+                              ('', '', ''), ('', '', '')])
+        header.add_blank(4)
+        # This time a new blank should be added, and the existing blanks don't
+        # get used... (though this is really kinda sketchy--there's a
+        # distinction between truly blank cards, and cards with blank keywords
+        # that isn't currently made int he code)
+        assert len(header) == 7
+        assert header.cards[6].value == 4
+        assert header[''] == [1, 2, 3, '', '', 4]
+
+        header.add_blank(0, after='A')
+        assert len(header) == 8
+        assert header.cards[1].value == 0
+        assert header[''] == [0, 1, 2, 3, '', '', 4]
 
     def test_commentary_cards(self):
         # commentary cards

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -553,54 +553,54 @@ class TestHeaderFunctions(FitsTestCase):
 
         header = fits.Header()
         with catch_warnings(VerifyWarning) as w:
-            header.update('HIERARCH BLAH BLAH', 'TESTA')
+            header.update({'HIERARCH BLAH BLAH': 'TESTA'})
             assert len(w) == 0
             assert 'BLAH BLAH' in header
             assert header['BLAH BLAH'] == 'TESTA'
 
-            header.update('HIERARCH BLAH BLAH', 'TESTB')
+            header.update({'HIERARCH BLAH BLAH': 'TESTB'})
             assert len(w) == 0
             assert header['BLAH BLAH'], 'TESTB'
 
             # Update without explicitly stating 'HIERARCH':
-            header.update('BLAH BLAH', 'TESTC')
-            assert len(w) == 0
+            header.update({'BLAH BLAH': 'TESTC'})
+            assert len(w) == 1
             assert len(header) == 1
             assert header['BLAH BLAH'], 'TESTC'
 
             # Test case-insensitivity
-            header.update('HIERARCH blah blah', 'TESTD')
-            assert len(w) == 0
+            header.update({'HIERARCH blah blah': 'TESTD'})
+            assert len(w) == 1
             assert len(header) == 1
             assert header['blah blah'], 'TESTD'
 
-            header.update('blah blah', 'TESTE')
-            assert len(w) == 0
+            header.update({'blah blah': 'TESTE'})
+            assert len(w) == 2
             assert len(header) == 1
             assert header['blah blah'], 'TESTE'
 
             # Create a HIERARCH card > 8 characters without explicitly stating
             # 'HIERARCH'
-            header.update('BLAH BLAH BLAH', 'TESTA')
-            assert len(w) == 1
+            header.update({'BLAH BLAH BLAH': 'TESTA'})
+            assert len(w) == 3
             assert msg in str(w[0].message)
 
-            header.update('HIERARCH BLAH BLAH BLAH', 'TESTB')
-            assert len(w) == 1
+            header.update({'HIERARCH BLAH BLAH BLAH': 'TESTB'})
+            assert len(w) == 3
             assert header['BLAH BLAH BLAH'], 'TESTB'
 
             # Update without explicitly stating 'HIERARCH':
-            header.update('BLAH BLAH BLAH', 'TESTC')
-            assert len(w) == 1
+            header.update({'BLAH BLAH BLAH': 'TESTC'})
+            assert len(w) == 4
             assert header['BLAH BLAH BLAH'], 'TESTC'
 
             # Test case-insensitivity
-            header.update('HIERARCH blah blah blah', 'TESTD')
-            assert len(w) == 1
+            header.update({'HIERARCH blah blah blah': 'TESTD'})
+            assert len(w) == 4
             assert header['blah blah blah'], 'TESTD'
 
-            header.update('blah blah blah', 'TESTE')
-            assert len(w) == 1
+            header.update({'blah blah blah': 'TESTE'})
+            assert len(w) == 5
             assert header['blah blah blah'], 'TESTE'
 
     def test_short_hierarch_create_and_update(self):
@@ -616,28 +616,28 @@ class TestHeaderFunctions(FitsTestCase):
 
         header = fits.Header()
         with catch_warnings(VerifyWarning) as w:
-            header.update('HIERARCH BLA BLA', 'TESTA')
+            header.update({'HIERARCH BLA BLA': 'TESTA'})
             assert len(w) == 0
             assert 'BLA BLA' in header
             assert header['BLA BLA'] == 'TESTA'
 
-            header.update('HIERARCH BLA BLA', 'TESTB')
+            header.update({'HIERARCH BLA BLA': 'TESTB'})
             assert len(w) == 0
             assert header['BLA BLA'], 'TESTB'
 
             # Update without explicitly stating 'HIERARCH':
-            header.update('BLA BLA', 'TESTC')
-            assert len(w) == 0
+            header.update({'BLA BLA': 'TESTC'})
+            assert len(w) == 1
             assert header['BLA BLA'], 'TESTC'
 
             # Test case-insensitivity
-            header.update('HIERARCH bla bla', 'TESTD')
-            assert len(w) == 0
+            header.update({'HIERARCH bla bla': 'TESTD'})
+            assert len(w) == 1
             assert len(header) == 1
             assert header['bla bla'], 'TESTD'
 
-            header.update('bla bla', 'TESTE')
-            assert len(w) == 0
+            header.update({'bla bla': 'TESTE'})
+            assert len(w) == 2
             assert len(header) == 1
             assert header['bla bla'], 'TESTE'
 
@@ -645,28 +645,28 @@ class TestHeaderFunctions(FitsTestCase):
         with catch_warnings(VerifyWarning) as w:
             # Create a HIERARCH card containing invalid characters without
             # explicitly stating 'HIERARCH'
-            header.update('BLA BLA', 'TESTA')
+            header.update({'BLA BLA': 'TESTA'})
             print([x.category for x in w])
             assert len(w) == 1
             assert msg in str(w[0].message)
 
-            header.update('HIERARCH BLA BLA', 'TESTB')
+            header.update({'HIERARCH BLA BLA': 'TESTB'})
             assert len(w) == 1
             assert header['BLA BLA'], 'TESTB'
 
             # Update without explicitly stating 'HIERARCH':
-            header.update('BLA BLA', 'TESTC')
-            assert len(w) == 1
+            header.update({'BLA BLA': 'TESTC'})
+            assert len(w) == 2
             assert header['BLA BLA'], 'TESTC'
 
             # Test case-insensitivity
-            header.update('HIERARCH bla bla', 'TESTD')
-            assert len(w) == 1
+            header.update({'HIERARCH bla bla': 'TESTD'})
+            assert len(w) == 2
             assert len(header) == 1
             assert header['bla bla'], 'TESTD'
 
-            header.update('bla bla', 'TESTE')
-            assert len(w) == 1
+            header.update({'bla bla': 'TESTE'})
+            assert len(w) == 3
             assert len(header) == 1
             assert header['bla bla'], 'TESTE'
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -12,8 +12,7 @@ import numpy as np
 
 from ....extern.six.moves import range
 from ....io import fits
-from ....utils.exceptions import (AstropyDeprecationWarning,
-                                  AstropyPendingDeprecationWarning)
+from ....utils.exceptions import AstropyPendingDeprecationWarning
 from ....tests.helper import pytest, raises, catch_warnings, ignore_warnings
 from ..hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
 from .test_table import comparerecords
@@ -118,11 +117,7 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp('test.fits')) as hdul:
             assert hdul[0].name == 'XPRIMARY2'
 
-    @ignore_warnings(AstropyDeprecationWarning)
     def test_io_manipulation(self):
-        # This legacy test also tests numerous deprecated interfaces for
-        # backwards compatibility
-
         # Get a keyword value.  An extension can be referred by name or by
         # number.  Both extension and keyword names are case insensitive.
         with fits.open(self.data('test0.fits')) as r:
@@ -137,19 +132,19 @@ class TestImageFunctions(FitsTestCase):
             # append (using "update()") a new card
             r[0].header['xxx'] = 1.234e56
 
-            assert (str(r[0].header.ascard[-3:]) ==
+            assert ('\n'.join(str(x) for x in r[0].header.cards[-3:]) ==
                     "EXPFLAG = 'NORMAL            ' / Exposure interruption indicator                \n"
                     "FILENAME= 'vtest3.fits'        / File name                                      \n"
                     "XXX     =            1.234E+56                                                  ")
 
             # rename a keyword
-            r[0].header.rename_key('filename', 'fname')
-            pytest.raises(ValueError, r[0].header.rename_key, 'fname',
+            r[0].header.rename_keyword('filename', 'fname')
+            pytest.raises(ValueError, r[0].header.rename_keyword, 'fname',
                           'history')
 
-            pytest.raises(ValueError, r[0].header.rename_key, 'fname',
+            pytest.raises(ValueError, r[0].header.rename_keyword, 'fname',
                           'simple')
-            r[0].header.rename_key('fname', 'filename')
+            r[0].header.rename_keyword('fname', 'filename')
 
             # get a subsection of data
             assert np.array_equal(r[2].data[:3, :3],
@@ -253,7 +248,7 @@ class TestImageFunctions(FitsTestCase):
         hdu2 = fits.ImageHDU(header=r[1].header, data=np.array([1, 2],
                              dtype='int32'))
 
-        assert (str(hdu2.header.ascard[1:5]) ==
+        assert ('\n'.join(str(x) for x in hdu2.header.cards[1:5]) ==
             "BITPIX  =                   32 / array data type                                \n"
             "NAXIS   =                    1 / number of array dimensions                     \n"
             "NAXIS1  =                    2                                                  \n"

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -858,8 +858,8 @@ reduce these to 2 dimensions using the naxis kwarg.
                                      'Coordinate increment along axis')
             header[str('CDELT2')] = (det2im.cdelt[1],
                                      'Coordinate increment along axis')
-            image.update_ext_version(
-                int(hdulist[0].header[str('{0}{1:d}.EXTVER').format(d_kw, num)]))
+            image.ver = int(hdulist[0].header[str('{0}{1:d}.EXTVER')
+                                              .format(d_kw, num)])
             hdulist.append(image)
         write_d2i(1, self.det2im1)
         write_d2i(2, self.det2im2)

--- a/docs/io/fits/api/cards.rst
+++ b/docs/io/fits/api/cards.rst
@@ -11,21 +11,3 @@ Cards
    :inherited-members:
    :undoc-members:
    :show-inheritance:
-
-Deprecated Interfaces
-^^^^^^^^^^^^^^^^^^^^^
-
-The following classes and functions are deprecated as of the PyFITS 3.1 header
-refactoring, though they are currently still available for backwards-compatibility.
-
-.. autoclass:: CardList
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. autofunction:: create_card
-
-.. autofunction:: create_card_from_string
-
-.. autofunction:: upper_key
-

--- a/docs/io/fits/api/tables.rst
+++ b/docs/io/fits/api/tables.rst
@@ -50,10 +50,6 @@ Tables
 Table Functions
 ^^^^^^^^^^^^^^^
 
-:func:`new_table`
-"""""""""""""""""
-.. autofunction:: new_table
-
 :func:`tabledump`
 """""""""""""""""
 .. autofunction:: tabledump

--- a/docs/io/fits/appendix/header_transition.rst
+++ b/docs/io/fits/appendix/header_transition.rst
@@ -87,12 +87,12 @@ This will output any deprecation warnings to the console.
 
 Two of the most common deprecation warnings related to Headers are for:
 
-- :meth:``Header.has_key``--this has actually been deprecated since PyFITS 3.0,
+- ``Header.has_key``--this has actually been deprecated since PyFITS 3.0,
   just as Python's `dict.has_key` is deprecated.  For checking a key's presence
   in a mapping object like `dict` or :class:`Header`, use the ``key in d``
   syntax.  This has long been the preference in Python.
 
-- :meth:``Header.ascardlist`` and ``Header.ascard``--these were used to
+- ``Header.ascardlist`` and ``Header.ascard``--these were used to
   access the ``CardList`` object underlying a header.  They should still
   work, and return a skeleton CardList implementation that should support most
   of the old CardList functionality.  But try removing as much of this as
@@ -337,7 +337,7 @@ much--the deprecated interfaces will not be removed for several more versions
 because of this.
 
 - The first change worth making, which is supported by any PyFITS version in
-  the last several years, is remove any use of :meth:``Header.has_key`` and
+  the last several years, is remove any use of ``Header.has_key`` and
   replace it with ``keyword in header`` syntax.  It's worth making this change
   for any dict as well, since `dict.has_key` is deprecated.  Running the
   following regular expression over your code may help with most (but not all)

--- a/docs/io/fits/appendix/header_transition.rst
+++ b/docs/io/fits/appendix/header_transition.rst
@@ -32,7 +32,7 @@ Background
 ==========
 
 Prior to 3.1, PyFITS users interacted with FITS headers by way of three
-different classes: :class:`Card`, :class:`CardList`, and :class:`Header`.
+different classes: :class:`Card`, ``CardList``, and :class:`Header`.
 
 The Card class represents a single header card with a keyword, value, and
 comment.  It also contains all the machinery for parsing FITS header cards,
@@ -67,7 +67,7 @@ Users familiar with the FITS format know what a header is, but it's not clear
 how a "card list" is distinct from that, or why operations go through the
 Header object, while some have to be performed through the CardList.
 
-So the primary goal of this redesign was eliminate the :class:`CardList` class
+So the primary goal of this redesign was eliminate the ``CardList`` class
 altogether, and make it possible for users to perform all header manipulations
 directly through :class:`Header` objects.  It also tries to present headers as
 similar as possible to more a more familiar data structure--an ordered mapping
@@ -92,8 +92,8 @@ Two of the most common deprecation warnings related to Headers are for:
   in a mapping object like `dict` or :class:`Header`, use the ``key in d``
   syntax.  This has long been the preference in Python.
 
-- :meth:``Header.ascardlist`` and :attr:`Header.ascard`--these were used to
-  access the :class:`CardList` object underlying a header.  They should still
+- :meth:``Header.ascardlist`` and ``Header.ascard``--these were used to
+  access the ``CardList`` object underlying a header.  They should still
   work, and return a skeleton CardList implementation that should support most
   of the old CardList functionality.  But try removing as much of this as
   possible.  If direct access to the :class:`Card` objects making up a header

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -307,12 +307,10 @@ or directly use the :meth:`BinTableHDU.from_columns` method::
 .. note::
 
     Users familiar with older versions of PyFITS or Astropy will wonder what
-    happened to :func:`~astropy.io.fits.new_table`.  It is still there, but is
-    deprecated.  :meth:`BinTableHDU.from_columns` and its companion for ASCII
-    tables :meth:`TableHDU.from_columns` are the same as
-    :func:`~astropy.io.fits.new_table` in the arguments they accept and their
-    behavior.  They just make it more explicit what type of table HDU they
-    create.
+    happened to ``astropy.io.fits.new_table``. :meth:`BinTableHDU.from_columns`
+    and its companion for ASCII tables :meth:`TableHDU.from_columns` are the
+    same in the arguments they accept and their behavior.  They just make it
+    more explicit what type of table HDU they create.
 
 A look of the newly created HDU's header will show that relevant keywords are
 properly populated::


### PR DESCRIPTION
Following comments in #5006, I started to remove deprecated code in `io.fits`. The removed code was deprecated in Astropy 0.3/0.4, see also the list in the [changelog](http://docs.astropy.org/en/latest/changelog.html#id85). 
I updated several tests that were testing the old API, to use the new one, as I wasn't sure if these tests have an equivalent for the new API. 
cc @embray 