### PR TITLE
Fix reading of latex tables

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -159,7 +159,11 @@ class LatexData(core.BaseData):
         if self.data_start:
             return find_latex_line(lines, self.data_start)
         else:
-            return self.header.start_line(lines) + 1
+            res = self.header.start_line(lines)
+            if res is None:
+                return None
+            else:
+                return res + 1
 
     def end_line(self, lines):
         if self.data_end:


### PR DESCRIPTION
While trying to load a table I copied-and-paste from a paper on arXiv, I encountered a strange error.  This led me to try even just round-tripping a trivial `Latex` table, and even that failed with the same error: `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'` (at the line I've changed in this PR).

My working assumption is that the `+1` is only right when `start_line` does not return None.  So then this fix is right.  But I admit I really don't understand the big-picture of this code so I'm not 100% sure this is the right fix.  @taldcroft or maybe @hamogu, does this seem right to you?

If this is right I'll add a regression test and changelog entry, but wanted to make sure this is the right fix first.
