### PR TITLE
Fix int overflow in the c parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1702,6 +1702,8 @@ Bug Fixes
 
   - Fix a bug where the ``fill_values`` parameter was ignored when writing a
     table to HTML format. [#5379]
+  - Fix reading of big ASCII tables (more than 2Gb) with the fast reader.
+    [#5319]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -90,7 +90,7 @@ cdef extern from "src/tokenizer.h":
     double str_to_double(tokenizer_t *self, char *str)
     void start_iteration(tokenizer_t *self, int col)
     char *next_field(tokenizer_t *self, int *size)
-    char *get_line(char *ptr, int *len, int map_len)
+    char *get_line(char *ptr, size_t *len, size_t map_len)
     void reset_comments(tokenizer_t *self)
 
 cdef extern from "Python.h":
@@ -152,8 +152,8 @@ cdef class FileString:
         """
         cdef char *ptr = <char *>self.mmap_ptr
         cdef char *tmp
-        cdef int line_len
-        cdef int map_len = <int>len(self.mmap)
+        cdef size_t line_len
+        cdef size_t map_len = len(self.mmap)
 
         while ptr:
             tmp = get_line(ptr, &line_len, map_len)

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -408,7 +408,7 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                 {
                     // In this case we don't want to left-strip the field,
                     // so we backtrack
-                    long tmp = self->source_pos;
+                    off_t tmp = self->source_pos;
                     --self->source_pos;
 
                     while (self->source_pos >= 0 &&

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -924,9 +924,9 @@ char *next_field(tokenizer_t *self, int *size)
 }
 
 
-char *get_line(char *ptr, int *len, int map_len)
+char *get_line(char *ptr, size_t *len, size_t map_len)
 {
-    int pos = 0;
+    size_t pos = 0;
 
     while (pos < map_len)
     {

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -408,7 +408,7 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                 {
                     // In this case we don't want to left-strip the field,
                     // so we backtrack
-                    int tmp = self->source_pos;
+                    long tmp = self->source_pos;
                     --self->source_pos;
 
                     while (self->source_pos >= 0 &&

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -54,8 +54,8 @@ typedef enum
 typedef struct
 {
     char *source;          // single string containing all of the input
-    int source_len;        // length of the input
-    int source_pos;        // current index in source for tokenization
+    unsigned long source_len; // length of the input
+    unsigned long source_pos; // current index in source for tokenization
     char delimiter;        // delimiter character
     char comment;          // comment character
     char quotechar;        // quote character

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -55,7 +55,7 @@ typedef struct
 {
     char *source;          // single string containing all of the input
     unsigned long source_len; // length of the input
-    unsigned long source_pos; // current index in source for tokenization
+    long source_pos;       // current index in source for tokenization
     char delimiter;        // delimiter character
     char comment;          // comment character
     char quotechar;        // quote character

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -10,6 +10,7 @@
 #include <math.h>
 #include <float.h>
 #include <ctype.h>
+#include <sys/types.h>
 
 #ifdef _MSC_VER
     #define inline __inline
@@ -54,8 +55,8 @@ typedef enum
 typedef struct
 {
     char *source;          // single string containing all of the input
-    unsigned long source_len; // length of the input
-    long source_pos;       // current index in source for tokenization
+    off_t source_len;      // length of the input
+    off_t source_pos;      // current index in source for tokenization
     char delimiter;        // delimiter character
     char comment;          // comment character
     char quotechar;        // quote character

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -106,7 +106,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
 void start_iteration(tokenizer_t *self, int col);
 char *next_field(tokenizer_t *self, int *size);
 long file_len(FILE *fhandle);
-char *get_line(char *ptr, int *len, int map_len);
+char *get_line(char *ptr, size_t *len, size_t map_len);
 void reset_comments(tokenizer_t *self);
 
 #endif


### PR DESCRIPTION
Fixes #5302 : int overflow when the file size is too big.
Tested with @yannick1974, works on his example. 
I don't see a mean to add a regression test, obviously we can't generate a ~4Gb file on Travis ;-).
