### PR TITLE
Fits header normalize keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -370,6 +370,8 @@ Bug Fixes
     always read as float64. [#5362]
 
   - Fixed memoryleak when using the compression module. [#5399, #5464]
+  - Able to insert and remove lower case HIERARCH keywords in a consistent
+    manner [#5313, #5321]
 
 - ``astropy.io.misc``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -370,6 +370,7 @@ Bug Fixes
     always read as float64. [#5362]
 
   - Fixed memoryleak when using the compression module. [#5399, #5464]
+
   - Able to insert and remove lower case HIERARCH keywords in a consistent
     manner [#5313, #5321]
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -568,7 +568,7 @@ class Card(_Verify):
             # Remove 'HIERARCH' from HIERARCH keywords; this could lead to
             # ambiguity if there is actually a keyword card containing
             # "HIERARCH HIERARCH", but shame on you if you do that.
-            return keyword[9:].strip()
+            return keyword[9:].strip().upper()
         else:
             # A normal FITS keyword, but provided in non-standard case
             return keyword.strip().upper()

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -221,6 +221,7 @@ class Header(object):
         card = self._cards[idx]
         keyword = card.keyword
         del self._cards[idx]
+        keyword = Card.normalize_keyword(keyword)
         indices = self._keyword_indices[keyword]
         indices.remove(idx)
         if not indices:
@@ -1408,6 +1409,7 @@ class Header(object):
         # All the keyword indices above the insertion point must be updated
         self._updateindices(idx)
 
+        keyword = Card.normalize_keyword(keyword)
         self._keyword_indices[keyword].append(idx)
         count = len(self._keyword_indices[keyword])
         if count > 1:
@@ -1567,7 +1569,7 @@ class Header(object):
         keyword = keyword.upper()
         if keyword.startswith('HIERARCH '):
             keyword = keyword[9:]
-
+        
         if (keyword not in Card._commentary_keywords and
                 keyword in self._keyword_indices):
             # Easy; just update the value/comment
@@ -1660,6 +1662,7 @@ class Header(object):
             idx += len(self._cards) - 1
 
         keyword = self._cards[idx].keyword
+        keyword = Card.normalize_keyword(keyword)
         repeat = self._keyword_indices[keyword].index(idx)
         return keyword, repeat
 
@@ -1727,7 +1730,6 @@ class Header(object):
         For all cards with index above idx, increment or decrement its index
         value in the keyword_indices dict.
         """
-
         if idx > len(self._cards):
             # Save us some effort
             return

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1569,7 +1569,7 @@ class Header(object):
         keyword = keyword.upper()
         if keyword.startswith('HIERARCH '):
             keyword = keyword[9:]
-        
+
         if (keyword not in Card._commentary_keywords and
                 keyword in self._keyword_indices):
             # Easy; just update the value/comment

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -611,7 +611,7 @@ class TestHeaderFunctions(FitsTestCase):
         del header['abcdefghij']
         header.insert(2, ('abcdefghij', 10))
         del header[2]
-        assert header.keys()[2]=='abcdefg'.upper()
+        assert list(header.keys())[2]=='abcdefg'.upper()
 
     def test_hierarch_create_and_update(self):
         """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -597,6 +597,22 @@ class TestHeaderFunctions(FitsTestCase):
         # should be treated case-insensitively when performing lookups
         assert 'ABCDEFGHI' in header
 
+    def test_hierarch_card_delete(self):
+        header = fits.Header()
+        header['hierarch abcdefghi'] = 10
+        del header['hierarch abcdefghi']
+
+    def test_hierarch_card_insert_delete(self):
+        header = fits.Header()
+        header['abcdefghi'] = 10
+        header['abcdefgh'] = 10
+        header['abcdefg'] = 10
+        header.insert(2, ('abcdefghij', 10))
+        del header['abcdefghij']
+        header.insert(2, ('abcdefghij', 10))
+        del header[2]
+        assert header.keys()[2]=='abcdefg'.upper()
+
     def test_hierarch_create_and_update(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/158


### PR DESCRIPTION
Update how a number of tasks work in fits.io.hdu.header such that they are more  consistent in how it treats HIERARCH keywords including how they are inserted and removed.   For more details see #5313.

Closes #5313
