### PR TITLE
add some documentation to io.registry and minor modifications

### DIFF
--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -234,7 +234,7 @@ def register_reader(data_format, data_class, function, force=False):
         _readers[(data_format, data_class)] = function
     else:
         raise IORegistryError("Reader for format '{0}' and class '{1}' is "
-                              'already defined.'
+                              'already defined'
                               ''.format(data_format, data_class.__name__))
 
     if data_class not in _delayed_docs_classes:
@@ -263,7 +263,7 @@ def register_writer(data_format, data_class, function, force=False):
         _writers[(data_format, data_class)] = function
     else:
         raise IORegistryError("Writer for format '{0}' and class '{1}' is "
-                              'already defined.'
+                              'already defined'
                               ''.format(data_format, data_class.__name__))
 
     if data_class not in _delayed_docs_classes:
@@ -286,15 +286,15 @@ def register_identifier(data_format, data_class, identifier, force=False):
         determine whether the input can be interpreted as a table of type
         ``data_format``. This function should take the following arguments:
 
-           - ``origin``: A string `read` or `write` identifying whether
+           - ``origin``: A string ``"read"`` or ``"write"`` identifying whether
              the file is to be opened for reading or writing.
            - ``path``: The path to the file.
            - ``fileobj``: An open file object to read the file's contents, or
              `None` if the file could not be opened.
-           - ``*args``: A list of positional arguments to the `read` or
-             `write` function.
-           - ``**kwargs``: A list of keyword arguments to the `read` or
-             `write` function.
+           - ``*args``: Positional arguments for the `read` or `write`
+             function.
+           - ``**kwargs``: Keyword arguments for the `read` or `write`
+             function.
 
         One or both of ``path`` or ``fileobj`` may be `None`.  If they are
         both `None`, the identifier will need to work from ``args[0]``.
@@ -320,14 +320,32 @@ def register_identifier(data_format, data_class, identifier, force=False):
         _identifiers[(data_format, data_class)] = identifier
     else:
         raise IORegistryError("Identifier for format '{0}' and class '{1}' is "
-                              'already defined.'.format(data_format,
-                                                        data_class.__name__))
+                              'already defined'.format(data_format,
+                                                       data_class.__name__))
 
 
 def identify_format(origin, data_class_required, path, fileobj, args, kwargs):
     """Loop through identifiers to see which formats match.
 
-    For the parameter description see `register_identifier`.
+    Parameters
+    ----------
+    origin : str
+        A string ``"read`` or ``"write"`` identifying whether the file is to be
+        opened for reading or writing.
+    data_class_required : object
+        The specified class for the result of `read` or the class that is to be
+        written.
+    path : str, other path object or None
+        The path to the file or None.
+    fileobj : File object or None.
+        An open file object to read the file's contents, or ``None`` if the
+        file could not be opened.
+    args : sequence
+        Positional arguments for the `read` or `write` function. Note that
+        these must be provided as sequence.
+    kwargs : dict-like
+        Keyword arguments for the `read` or `write` function. Note that this
+        parameter must be `dict`-like.
 
     Returns
     -------
@@ -460,7 +478,7 @@ def read(cls, *args, **kwargs):
                     raise TypeError('could not convert reader output to {0} '
                                     'class.'.format(cls.__name__))
             else:
-                raise TypeError("reader should return a {0} instance."
+                raise TypeError("reader should return a {0} instance"
                                 "".format(cls.__name__))
     finally:
         if ctx is not None:
@@ -531,7 +549,7 @@ def _get_valid_format(mode, cls, path, fileobj, args, kwargs):
                               "{0}".format(format_table_str))
     elif len(valid_formats) > 1:
         raise IORegistryError(
-            "Format is ambiguous - options are: {0}.".format(
+            "Format is ambiguous - options are: {0}".format(
                 ', '.join(sorted(valid_formats, key=itemgetter(0)))))
 
     return valid_formats[0]

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -38,7 +38,7 @@ else:
 
 
 class IORegistryError(Exception):
-    """Custom error for registry clashes
+    """Custom error for registry clashes.
     """
     pass
 
@@ -91,10 +91,10 @@ def get_formats(data_class=None, readwrite=None):
 
     Parameters
     ----------
-    data_class : classobj
+    data_class : classobj, optional
         Filter readers/writer to match data class (default = all classes).
 
-    readwrite : str or None
+    readwrite : str or None, optional
         Search only for readers (``"Read"``) or writers (``"Write"``). If None
         search for both.  Default is None.
 
@@ -102,7 +102,7 @@ def get_formats(data_class=None, readwrite=None):
 
     Returns
     -------
-    format_table: Table
+    format_table : Table
         Table of available I/O formats.
     """
     from ..table import Table
@@ -219,21 +219,22 @@ def register_reader(data_format, data_class, function, force=False):
     Parameters
     ----------
     data_format : str
-        The data type identifier. This is the string that will be used to
+        The data format identifier. This is the string that will be used to
         specify the data type when reading.
     data_class : classobj
-        The class of the object that the reader produces
+        The class of the object that the reader produces.
     function : function
         The function to read in a data object.
-    force : bool
+    force : bool, optional
         Whether to override any existing function if already present.
+        Default is ``False``.
     """
 
     if not (data_format, data_class) in _readers or force:
         _readers[(data_format, data_class)] = function
     else:
         raise IORegistryError("Reader for format '{0}' and class '{1}' is "
-                              'already defined'
+                              'already defined.'
                               ''.format(data_format, data_class.__name__))
 
     if data_class not in _delayed_docs_classes:
@@ -247,21 +248,22 @@ def register_writer(data_format, data_class, function, force=False):
     Parameters
     ----------
     data_format : str
-        The data type identifier. This is the string that will be used to
+        The data format identifier. This is the string that will be used to
         specify the data type when writing.
     data_class : classobj
-        The class of the object that can be written
+        The class of the object that can be written.
     function : function
         The function to write out a data object.
-    force : bool
+    force : bool, optional
         Whether to override any existing function if already present.
+        Default is ``False``.
     """
 
     if not (data_format, data_class) in _writers or force:
         _writers[(data_format, data_class)] = function
     else:
         raise IORegistryError("Writer for format '{0}' and class '{1}' is "
-                              'already defined'
+                              'already defined.'
                               ''.format(data_format, data_class.__name__))
 
     if data_class not in _delayed_docs_classes:
@@ -275,10 +277,10 @@ def register_identifier(data_format, data_class, identifier, force=False):
     Parameters
     ----------
     data_format : str
-        The data type identifier. This is the string that is used to
+        The data format identifier. This is the string that is used to
         specify the data type when reading/writing.
     data_class : classobj
-        The class of the object that can be written
+        The class of the object that can be written.
     identifier : function
         A function that checks the argument specified to `read` or `write` to
         determine whether the input can be interpreted as a table of type
@@ -299,12 +301,12 @@ def register_identifier(data_format, data_class, identifier, force=False):
 
         The function should return True if the input can be identified
         as being of format ``data_format``, and False otherwise.
-    force : bool
+    force : bool, optional
         Whether to override any existing function if already present.
+        Default is ``False``.
 
     Examples
     --------
-
     To set the identifier based on extensions, for formats that take a
     filename as a first argument, you can do for example::
 
@@ -318,12 +320,20 @@ def register_identifier(data_format, data_class, identifier, force=False):
         _identifiers[(data_format, data_class)] = identifier
     else:
         raise IORegistryError("Identifier for format '{0}' and class '{1}' is "
-                              'already defined'.format(data_format,
-                                                       data_class.__name__))
+                              'already defined.'.format(data_format,
+                                                        data_class.__name__))
 
 
 def identify_format(origin, data_class_required, path, fileobj, args, kwargs):
-    # Loop through identifiers to see which formats match
+    """Loop through identifiers to see which formats match.
+
+    For the parameter description see `register_identifier`.
+
+    Returns
+    -------
+    valid_formats : list
+        List of matching formats.
+    """
     valid_formats = []
     for data_format, data_class in _identifiers:
         if _is_best_match(data_class_required, data_class, _identifiers):
@@ -342,7 +352,21 @@ def _get_format_table_str(data_class, readwrite):
 
 
 def get_reader(data_format, data_class):
-    # Get all the readers that work for `data_format`
+    """Get reader for ``data_format``.
+
+    Parameters
+    ----------
+    data_format : str
+        The data format identifier. This is the string that is used to
+        specify the data type when reading/writing.
+    data_class : classobj
+        The class of the object that can be written.
+
+    Returns
+    -------
+    reader : callable
+        The registered reader function for this format and class.
+    """
     readers = [(fmt, cls) for fmt, cls in _readers if fmt == data_format]
     for reader_format, reader_class in readers:
         if _is_best_match(data_class, reader_class, readers):
@@ -356,6 +380,21 @@ def get_reader(data_format, data_class):
 
 
 def get_writer(data_format, data_class):
+    """Get writer for ``data_format``.
+
+    Parameters
+    ----------
+    data_format : str
+        The data format identifier. This is the string that is used to
+        specify the data type when reading/writing.
+    data_class : classobj
+        The class of the object that can be written.
+
+    Returns
+    -------
+    writer : callable
+        The registered writer function for this format and class.
+    """
     writers = [(fmt, cls) for fmt, cls in _writers if fmt == data_format]
     for writer_format, writer_class in writers:
         if _is_best_match(data_class, writer_class, writers):
@@ -370,9 +409,9 @@ def get_writer(data_format, data_class):
 
 def read(cls, *args, **kwargs):
     """
-    Read in data
+    Read in data.
 
-    The arguments passed to this method depend on the format
+    The arguments passed to this method depend on the format.
     """
 
     format = kwargs.pop('format', None)
@@ -421,7 +460,7 @@ def read(cls, *args, **kwargs):
                     raise TypeError('could not convert reader output to {0} '
                                     'class.'.format(cls.__name__))
             else:
-                raise TypeError("reader should return a {0} instance"
+                raise TypeError("reader should return a {0} instance."
                                 "".format(cls.__name__))
     finally:
         if ctx is not None:
@@ -432,9 +471,9 @@ def read(cls, *args, **kwargs):
 
 def write(data, *args, **kwargs):
     """
-    Write out data
+    Write out data.
 
-    The arguments passed to this method depend on the format
+    The arguments passed to this method depend on the format.
     """
 
     format = kwargs.pop('format', None)
@@ -492,7 +531,7 @@ def _get_valid_format(mode, cls, path, fileobj, args, kwargs):
                               "{0}".format(format_table_str))
     elif len(valid_formats) > 1:
         raise IORegistryError(
-            "Format is ambiguous - options are: {0}".format(
+            "Format is ambiguous - options are: {0}.".format(
                 ', '.join(sorted(valid_formats, key=itemgetter(0)))))
 
     return valid_formats[0]

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -83,7 +83,7 @@ def test_register_reader_invalid():
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_reader('test', TestData, empty_reader)
     assert (str(exc.value) == "Reader for format 'test' and class 'TestData' "
-                              "is already defined.")
+                              "is already defined")
 
 
 def test_register_writer_invalid():
@@ -91,7 +91,7 @@ def test_register_writer_invalid():
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_writer('test', TestData, empty_writer)
     assert (str(exc.value) == "Writer for format 'test' and class 'TestData' "
-                              "is already defined.")
+                              "is already defined")
 
 
 def test_register_identifier_invalid():
@@ -99,7 +99,7 @@ def test_register_identifier_invalid():
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_identifier('test', TestData, empty_identifier)
     assert (str(exc.value) == "Identifier for format 'test' and class "
-                              "'TestData' is already defined.")
+                              "'TestData' is already defined")
 
 
 def test_register_reader_force():
@@ -172,7 +172,7 @@ def test_read_toomanyformats():
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: True)
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read()
-    assert str(exc.value) == "Format is ambiguous - options are: test1, test2."
+    assert str(exc.value) == "Format is ambiguous - options are: test1, test2"
 
 
 def test_write_toomanyformats():
@@ -180,7 +180,7 @@ def test_write_toomanyformats():
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: True)
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write()
-    assert str(exc.value) == "Format is ambiguous - options are: test1, test2."
+    assert str(exc.value) == "Format is ambiguous - options are: test1, test2"
 
 
 def test_read_format_noreader():
@@ -277,7 +277,7 @@ def test_read_invalid_return():
     io_registry.register_reader('test', TestData, lambda: 'spam')
     with pytest.raises(TypeError) as exc:
         TestData.read(format='test')
-    assert str(exc.value) == "reader should return a TestData instance."
+    assert str(exc.value) == "reader should return a TestData instance"
 
 
 def test_non_existing_unknown_ext():

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -48,14 +48,14 @@ def empty_identifier(*args, **kwargs):
 def test_get_reader_invalid():
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.get_reader('test', TestData)
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No reader defined for format 'test' and class 'TestData'")
 
 
 def test_get_writer_invalid():
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.get_writer('test', TestData)
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No writer defined for format 'test' and class 'TestData'")
 
 
@@ -82,21 +82,24 @@ def test_register_reader_invalid():
     io_registry.register_reader('test', TestData, empty_reader)
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_reader('test', TestData, empty_reader)
-    assert exc.value.args[0] == "Reader for format 'test' and class 'TestData' is already defined"
+    assert (str(exc.value) == "Reader for format 'test' and class 'TestData' "
+                              "is already defined.")
 
 
 def test_register_writer_invalid():
     io_registry.register_writer('test', TestData, empty_writer)
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_writer('test', TestData, empty_writer)
-    assert exc.value.args[0] == "Writer for format 'test' and class 'TestData' is already defined"
+    assert (str(exc.value) == "Writer for format 'test' and class 'TestData' "
+                              "is already defined.")
 
 
 def test_register_identifier_invalid():
     io_registry.register_identifier('test', TestData, empty_identifier)
     with pytest.raises(io_registry.IORegistryError) as exc:
         io_registry.register_identifier('test', TestData, empty_identifier)
-    assert exc.value.args[0] == "Identifier for format 'test' and class 'TestData' is already defined"
+    assert (str(exc.value) == "Identifier for format 'test' and class "
+                              "'TestData' is already defined.")
 
 
 def test_register_reader_force():
@@ -117,13 +120,13 @@ def test_register_identifier_force():
 def test_read_noformat():
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read()
-    assert exc.value.args[0].startswith("Format could not be identified.")
+    assert str(exc.value).startswith("Format could not be identified.")
 
 
 def test_write_noformat():
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write()
-    assert exc.value.args[0].startswith("Format could not be identified.")
+    assert str(exc.value).startswith("Format could not be identified.")
 
 
 def test_read_noformat_arbitrary():
@@ -131,7 +134,7 @@ def test_read_noformat_arbitrary():
     _identifiers.update(_IDENTIFIERS_ORIGINAL)
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(object())
-    assert exc.value.args[0].startswith("Format could not be identified.")
+    assert str(exc.value).startswith("Format could not be identified.")
 
 
 def test_read_noformat_arbitrary_file(tmpdir):
@@ -143,7 +146,7 @@ def test_read_noformat_arbitrary_file(tmpdir):
 
     with pytest.raises(io_registry.IORegistryError) as exc:
         Table.read(testfile)
-    assert exc.value.args[0].startswith("Format could not be identified.")
+    assert str(exc.value).startswith("Format could not be identified.")
 
 
 def test_write_noformat_arbitrary():
@@ -151,7 +154,7 @@ def test_write_noformat_arbitrary():
     _identifiers.update(_IDENTIFIERS_ORIGINAL)
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(object())
-    assert exc.value.args[0].startswith("Format could not be identified.")
+    assert str(exc.value).startswith("Format could not be identified.")
 
 
 def test_write_noformat_arbitrary_file(tmpdir):
@@ -161,7 +164,7 @@ def test_write_noformat_arbitrary_file(tmpdir):
 
     with pytest.raises(io_registry.IORegistryError) as exc:
         Table().write(testfile)
-    assert exc.value.args[0].startswith("Format could not be identified.")
+    assert str(exc.value).startswith("Format could not be identified.")
 
 
 def test_read_toomanyformats():
@@ -169,7 +172,7 @@ def test_read_toomanyformats():
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: True)
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read()
-    assert exc.value.args[0] == "Format is ambiguous - options are: test1, test2"
+    assert str(exc.value) == "Format is ambiguous - options are: test1, test2."
 
 
 def test_write_toomanyformats():
@@ -177,20 +180,20 @@ def test_write_toomanyformats():
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: True)
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write()
-    assert exc.value.args[0] == "Format is ambiguous - options are: test1, test2"
+    assert str(exc.value) == "Format is ambiguous - options are: test1, test2."
 
 
 def test_read_format_noreader():
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(format='test')
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No reader defined for format 'test' and class 'TestData'")
 
 
 def test_write_format_nowriter():
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(format='test')
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No writer defined for format 'test' and class 'TestData'")
 
 
@@ -204,21 +207,21 @@ def test_read_identifier(tmpdir):
         lambda o, path, fileobj, *x, **y: path.endswith('b'))
 
     # Now check that we got past the identifier and are trying to get
-    # the reader. The io_registry.get_reader will fail but the error message will
-    # tell us if the identifier worked.
+    # the reader. The io_registry.get_reader will fail but the error message
+    # will tell us if the identifier worked.
 
     filename = tmpdir.join("testfile.a").strpath
     open(filename, 'w').close()
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(filename)
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No reader defined for format 'test1' and class 'TestData'")
 
     filename = tmpdir.join("testfile.b").strpath
     open(filename, 'w').close()
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(filename)
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No reader defined for format 'test2' and class 'TestData'")
 
 
@@ -228,17 +231,17 @@ def test_write_identifier():
     io_registry.register_identifier('test2', TestData, lambda o, *x, **y: x[0].startswith('b'))
 
     # Now check that we got past the identifier and are trying to get
-    # the reader. The io_registry.get_writer will fail but the error message will
-    # tell us if the identifier worked.
+    # the reader. The io_registry.get_writer will fail but the error message
+    # will tell us if the identifier worked.
 
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write('abc')
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No writer defined for format 'test1' and class 'TestData'")
 
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write('bac')
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No writer defined for format 'test2' and class 'TestData'")
 
 
@@ -255,12 +258,12 @@ def test_identifier_origin():
 
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(format='test2')
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No reader defined for format 'test2' and class 'TestData'")
 
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(format='test1')
-    assert exc.value.args[0].startswith(
+    assert str(exc.value).startswith(
         "No writer defined for format 'test1' and class 'TestData'")
 
 
@@ -274,7 +277,7 @@ def test_read_invalid_return():
     io_registry.register_reader('test', TestData, lambda: 'spam')
     with pytest.raises(TypeError) as exc:
         TestData.read(format='test')
-    assert exc.value.args[0] == "reader should return a TestData instance"
+    assert str(exc.value) == "reader should return a TestData instance."
 
 
 def test_non_existing_unknown_ext():


### PR DESCRIPTION
Some of the documentation of `io.registry` was still lacking or incorrect.

I wasn't sure about the change from `exc.value.args[0]` to `str(exc.value)` in the tests.