### PR TITLE
delegate copy and deepcopy (copy module) on fits.Header to Header.copy method.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,10 @@ Bug Fixes
   - Made TFORMx keyword check more flexible in test of compressed images to
     enable compatibility of the test with cfitsio 3.380. [#4646]
 
+  - Copying a ``fits.Header`` using ``copy`` or ``deepcopy`` from the ``copy``
+    module will use ``Header.copy`` to ensure that modifying the copy will
+    not alter the other original Header and vice-versa. [#4990, #5323]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -719,6 +719,10 @@ class Header(object):
         """
         Make a copy of the :class:`Header`.
 
+        .. versionchanged:: 1.3
+            `copy.copy` and `copy.deepcopy` on a `Header` will call this
+            method.
+
         Parameters
         ----------
         strip : bool, optional
@@ -736,6 +740,12 @@ class Header(object):
         if strip:
             tmp._strip()
         return tmp
+
+    def __copy__(self):
+        return self.copy()
+
+    def __deepcopy__(self, *args, **kwargs):
+        return self.copy()
 
     @classmethod
     def fromkeys(cls, iterable, value=None):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -4,6 +4,7 @@
 
 from __future__ import division, with_statement
 
+import copy
 import warnings
 import collections
 
@@ -22,6 +23,21 @@ from . import FitsTestCase
 from ..card import _pad
 from ..header import _pad_length
 from ..util import encode_ascii
+
+
+def test_shallow_copy():
+    """Make sure that operations on a shallow copy do not alter the original.
+    #4990."""
+    original_header = fits.Header([('a', 1), ('b', 1)])
+    copied_header = copy.copy(original_header)
+
+    # Modifying the original dict should not alter the copy
+    original_header['c'] = 100
+    assert 'c' not in copied_header
+
+    # and changing the copy should not change the original.
+    copied_header['a'] = 0
+    assert original_header['a'] == 1
 
 
 def test_init_with_dict():


### PR DESCRIPTION
Closes #4990 

Note: This fix is not backwards-compatible.

I've added a `__copy__` and `__deepcopy__` method to `fits.Header` so `copy.copy(Header)` really copies the cards and changes on either of them will not modify the other one.
