### PR TITLE
Added note in Table.copy() and constructor that meta is always deepcopied.

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -167,6 +167,10 @@ class Table(object):
         Copy any indices in the input data (default=True)
     **kwargs : dict, optional
         Additional keyword args when converting table-like object
+
+    .. note::
+        If the input is a Table the ``meta`` is always copied regardless of the
+        ``copy`` parameter.
     """
 
     meta = MetaData()
@@ -2351,12 +2355,15 @@ class Table(object):
         '''
         Return a copy of the table.
 
-
         Parameters
         ----------
         copy_data : bool
             If `True` (the default), copy the underlying data array.
             Otherwise, use the same data array
+
+        .. note::
+            The ``meta`` is always deepcopied regardless of the value for
+            ``copy_data``.
         '''
         out = self.__class__(self, copy=copy_data)
 


### PR DESCRIPTION
This was discussed in #4989 (or #4990).

Not sure if this note is justified in both places. But it would be consistent.