### PR TITLE
copy cards when creating a new Header from another Header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -202,6 +202,10 @@ API Changes
     ``_BaseHDU.overwrite``, ``BinTableHDU.dump`` and
     ``HDUList.writeto``. [#5171]
 
+  - Added an optional ``copy`` parameter to ``fits.Header`` which controls if
+    a copy is made when creating an ``Header`` from another ``Header``.
+    [#5005, #5326]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
@@ -282,9 +286,6 @@ Bug Fixes
   - Copying a ``fits.Header`` using ``copy`` or ``deepcopy`` from the ``copy``
     module will use ``Header.copy`` to ensure that modifying the copy will
     not alter the other original Header and vice-versa. [#4990, #5323]
-
-  - Creating a ``fits.Header`` from another Header makes a deep copy instead
-    of a shallow copy. [#5005, #5326]
 
   - ``HDUList.info()`` no longer raises ``AttributeError`` in presence of
     ``BZERO``. [#5508]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,8 +282,9 @@ Bug Fixes
   - Copying a ``fits.Header`` using ``copy`` or ``deepcopy`` from the ``copy``
     module will use ``Header.copy`` to ensure that modifying the copy will
     not alter the other original Header and vice-versa. [#4990, #5323]
+
   - Creating a ``fits.Header`` from another Header makes a deep copy instead
-    of a shallow copy. [#5005]
+    of a shallow copy. [#5005, #5326]
 
   - ``HDUList.info()`` no longer raises ``AttributeError`` in presence of
     ``BZERO``. [#5508]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,8 @@ Bug Fixes
   - Copying a ``fits.Header`` using ``copy`` or ``deepcopy`` from the ``copy``
     module will use ``Header.copy`` to ensure that modifying the copy will
     not alter the other original Header and vice-versa. [#4990, #5323]
+  - Creating a ``fits.Header`` from another Header makes a deep copy instead
+    of a shallow copy. [#5005]
 
   - ``HDUList.info()`` no longer raises ``AttributeError`` in presence of
     ``BZERO``. [#5508]

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -77,7 +77,7 @@ class Header(object):
     See the Astropy documentation for more details on working with headers.
     """
 
-    def __init__(self, cards=[]):
+    def __init__(self, cards=[], copy=False):
         """
         Construct a `Header` from an iterable and/or text file.
 
@@ -90,14 +90,20 @@ class Header(object):
             .. versionchanged:: 1.2
                 Allowed ``cards`` to be a `dict`-like object.
 
-            .. versionchanged:: 1.3
-                If ``cards`` is a Header the new Header is a deepcopy instead
-                of a shallow copy.
+        copy : bool, optional
+
+            If ``True`` copies the ``cards`` if they were another `Header`
+            instance.
+            Default is ``False``.
+
+            .. versionadded:: 1.3
         """
         self.clear()
 
         if isinstance(cards, Header):
-            cards = (copy.copy(card) for card in cards._cards)
+            if copy:
+                cards = cards.copy()
+            cards = cards.cards
         elif isinstance(cards, dict):
             cards = six.iteritems(cards)
 
@@ -767,7 +773,7 @@ class Header(object):
             A new :class:`Header` instance.
         """
 
-        tmp = Header(self)
+        tmp = Header((copy.copy(card) for card in self._cards))
         if strip:
             tmp._strip()
         return tmp

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -87,11 +87,17 @@ class Header(object):
             The cards to initialize the header with. Also allowed are other
             `Header` (or `dict`-like) objects.
 
+            .. versionchanged:: 1.2
+                Allowed ``cards`` to be a `dict`-like object.
+
+            .. versionchanged:: 1.3
+                If ``cards`` is a Header the new Header is a deepcopy instead
+                of a shallow copy.
         """
         self.clear()
 
         if isinstance(cards, Header):
-            cards = cards.cards
+            cards = (copy.copy(card) for card in cards._cards)
         elif isinstance(cards, dict):
             cards = six.iteritems(cards)
 
@@ -761,7 +767,7 @@ class Header(object):
             A new :class:`Header` instance.
         """
 
-        tmp = Header([copy.copy(card) for card in self._cards])
+        tmp = Header(self)
         if strip:
             tmp._strip()
         return tmp

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -41,10 +41,11 @@ def test_shallow_copy():
 
 
 def test_init_with_header():
-    """Make sure that creating a Header from another Header makes a copy."""
+    """Make sure that creating a Header from another Header makes a copy if
+    copy is True."""
 
     original_header = fits.Header([('a', 10)])
-    new_header = fits.Header(original_header)
+    new_header = fits.Header(original_header, copy=True)
     original_header['a'] = 20
     assert new_header['a'] == 10
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -40,6 +40,18 @@ def test_shallow_copy():
     assert original_header['a'] == 1
 
 
+def test_init_with_header():
+    """Make sure that creating a Header from another Header makes a copy."""
+
+    original_header = fits.Header([('a', 10)])
+    new_header = fits.Header(original_header)
+    original_header['a'] = 20
+    assert new_header['a'] == 10
+
+    new_header['a'] = 0
+    assert original_header['a'] == 20
+
+
 def test_init_with_dict():
     dict1 = {'a': 11, 'b': 12, 'c': 13, 'd': 14, 'e': 15}
     h1 = fits.Header(dict1)


### PR DESCRIPTION
Closes #5005 

This change is not backwards compatible.

`Header.__init__(Header)` now copies the input-Header. This change makes the Header more like `dict` or `list` (which it resembles). This didn't break any existing tests but may break some code out in the wild.

Another change here is that `Header.copy` now just calls `Header.__init__` and the intermediate object is a generator instead of a `list`.

I also included a `versionchanged` directive which I have forgotten to add in #4663. I thought about making a seperate PR but that would inevitably lead to a merge conflict.
