### PR TITLE
Always import pytest from astropy.tests.helper

### DIFF
--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import io
-import pytest
+from ....tests.helper import pytest
 
 import numpy as np
 

--- a/astropy/table/tests/test_array.py
+++ b/astropy/table/tests/test_array.py
@@ -2,7 +2,7 @@
 from ..sorted_array import SortedArray
 from ..table import Table
 from ...extern.six.moves import range
-import pytest
+from ...tests.helper import pytest
 import numpy as np
 
 @pytest.fixture

--- a/astropy/table/tests/test_bst.py
+++ b/astropy/table/tests/test_bst.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from ..bst import BST
 from ...extern.six.moves import range
-import pytest
+from ...tests.helper import pytest
 
 def get_tree(TreeType):
     b = TreeType([], [])

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
+from ...tests.helper import pytest
 import numpy as np
 from .test_table import SetupData
 from ..bst import BST, FastRBT

--- a/astropy/vo/samp/tests/test_client.py
+++ b/astropy/vo/samp/tests/test_client.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
-
+from ....tests.helper import pytest
 from ..hub_proxy import SAMPHubProxy
 from ..client import SAMPClient
 from ..integrated_client import SAMPIntegratedClient


### PR DESCRIPTION
There were some occurences where `pytest` is imported instead of `astropy.tests.helper.pytest`.