### PR TITLE
Replace bare except blocks to only catch Exception.

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -184,7 +184,7 @@ def _initialize_astropy():
 
             try:
                 _rebuild_extensions()
-            except:
+            except BaseException as exc:
                 _rollback_import(
                     'An error occurred while attempting to rebuild the '
                     'extension modules.  Please try manually running '
@@ -192,6 +192,12 @@ def _initialize_astropy():
                     '--inplace` to see what the issue was.  Extension '
                     'modules must be successfully compiled and importable '
                     'in order to import astropy.')
+                # Reraise the Exception only in case it wasn't an Exception,
+                # for example if a "SystemExit" or "KeyboardInterrupt" was
+                # invoked.
+                if not isinstance(exc, Exception):
+                    raise
+
         else:
             # Outright broken installation; don't be nice.
             raise

--- a/astropy/_erfa/setup_package.py
+++ b/astropy/_erfa/setup_package.py
@@ -63,7 +63,7 @@ def preprocess_source():
         # If jinja2 isn't present, then print a warning and use existing files
         try:
             import jinja2  # pylint: disable=W0611
-        except:
+        except ImportError:
             log.warn("WARNING: jinja2 could not be imported, so the existing "
                      "ERFA core.py and core.c files will be used")
             return

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -71,7 +71,7 @@ def _find_home():
                 homedir = wreg.QueryValueEx(key, 'Personal')[0]
                 homedir = decodepath(homedir)
                 key.Close()
-            except:
+            except Exception:
                 # As a final possible resort, see if HOME is present
                 if 'HOME' in os.environ:
                     homedir = decodepath(os.environ['HOME'])

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -242,7 +242,7 @@ def test_configitem_setters():
     try:
         with conf.set_temp('tstnm12', 47):
             raise Exception
-    except:
+    except Exception:
         pass
 
     assert conf.tstnm12 == 43

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -403,7 +403,7 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt='_kdtree', forceunit=None):
     from scipy import spatial
     try:
         KDTree = spatial.cKDTree
-    except:
+    except Exception:
         warn('C-based KD tree not found, falling back on (much slower) '
              'python implementation')
         KDTree = spatial.KDTree

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -360,7 +360,7 @@ class SkyCoord(object):
         # Frame name (string) or frame class?  Coerce into an instance.
         try:
             frame = _get_frame_class(frame)()
-        except:
+        except Exception:
             pass
 
         if isinstance(frame, SkyCoord):
@@ -1399,7 +1399,7 @@ def _get_units(args, kwargs):
             units.extend(None for x in range(3 - len(units)))
             if len(units) > 3:
                 raise ValueError()
-        except:
+        except Exception:
             raise ValueError('Unit keyword must have one to three unit values as '
                              'tuple or comma-separated string')
 
@@ -1529,7 +1529,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # lengths the same
             try:
                 n_coords = sorted(set(len(x) for x in vals))
-            except:
+            except Exception:
                 raise ValueError('One or more elements of input sequence does not have a length')
 
             if len(n_coords) > 1:

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -159,7 +159,7 @@ def _get_kernel(value):
     else:
         try:
             six.moves.urllib.parse.urlparse(value)
-        except:
+        except Exception:
             raise ValueError('{} was not one of the standard strings and '
                              'could not be parsed as a URL'.format(value))
 

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -8,7 +8,7 @@ import numpy as np
 try:
     import scipy  # pylint: disable=W0611
     HAS_SCIPY = True
-except:
+except ImportError:
     HAS_SCIPY = False
 
 def test_basic():

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -105,10 +105,10 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             val = val.strip()
             try:
                 val = int(val)
-            except:
+            except Exception:
                 try:
                     val = float(val)
-                except:
+                except Exception:
                     # Strip leading/trailing quote.  The spec says that a matched pair
                     # of quotes is required, but this code will allow a non-quoted value.
                     for quote in ('"', "'"):
@@ -279,7 +279,7 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             try:
                 format_func = _format_funcs.get(col_format, _auto_format_func)
                 nullist.append((format_func(col_format, null)).strip())
-            except:
+            except Exception:
                 # It is possible that null and the column values have different
                 # data types (e.g. number and null = 'null' (i.e. a string).
                 # This could cause all kinds of exceptions, so a catch all

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -101,8 +101,6 @@ def raises(*exceptions):
                 func(*arg, **kw)
             except exceptions:
                 pass
-            except:
-                raise
             else:
                 message = "%s() did not raise %s" % (name, valid)
                 raise AssertionError(message)

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -65,7 +65,7 @@ def _probably_html(table, maxchars=100000):
                 if size > maxchars:
                     break
             table = os.linesep.join(table[:i+1])
-        except:
+        except Exception:
             pass
 
     if isinstance(table, six.string_types):
@@ -289,7 +289,7 @@ def read(table, guess=None, **kwargs):
                     table = fileobj.read()
             except ValueError:  # unreadable or invalid binary file
                 raise
-            except:
+            except Exception:
                 pass
             else:
                 # Ensure that `table` has at least one \r or \n in it

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -573,7 +573,7 @@ class Column(NotifierMixin):
             try:  # try to convert to a ndarray first
                 if array is not None:
                     array = np.array(array)
-            except:
+            except Exception:
                 try:  # then try to convert it to a strings array
                     itemsize = int(recformat[1:])
                     array = chararray.array(array, itemsize=itemsize)
@@ -1288,7 +1288,7 @@ class ColDefs(NotifierMixin):
             key = TDEF_RE.match(keyword)
             try:
                 keyword = key.group('label')
-            except:
+            except Exception:
                 continue  # skip if there is no match
             if keyword in KEYWORD_NAMES:
                 col = int(key.group('num'))
@@ -1787,7 +1787,7 @@ class _VLF(np.ndarray):
                 # this handles ['abc'] and [['a','b','c']]
                 # equally, beautiful!
                 input = [chararray.array(x, itemsize=1) for x in input]
-            except:
+            except Exception:
                 raise ValueError(
                     'Inconsistent input data array: {0}'.format(input))
 
@@ -1993,7 +1993,7 @@ def _parse_tformat(tform):
 
     try:
         (repeat, format, option) = TFORMAT_RE.match(tform.strip()).groups()
-    except:
+    except Exception:
         # TODO: Maybe catch this error use a default type (bytes, maybe?) for
         # unrecognized column types.  As long as we can determine the correct
         # byte width somehow..

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -77,7 +77,7 @@ BZIP2_MAGIC = b('\x42\x5a')
 
 try:
     import pathlib
-except:
+except ImportError:
     HAS_PATHLIB = False
 else:
     HAS_PATHLIB = True

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1539,7 +1539,7 @@ class CompImageHDU(BinTableHDU):
         for keyword in list(image_header['NAXIS?*']):
             try:
                 n = int(keyword[5:])
-            except:
+            except Exception:
                 continue
 
             if n > naxis:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -262,7 +262,7 @@ class _ImageBaseHDU(_ValidHDU):
             # some level, for most objects
             try:
                 data = np.array(data)
-            except:
+            except Exception:
                 raise TypeError('data object %r could not be coerced into an '
                                 'ndarray' % data)
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -645,7 +645,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
             match = TDEF_RE.match(keyword)
             try:
                 base_keyword = match.group('label')
-            except:
+            except Exception:
                 continue                # skip if there is no match
 
             if base_keyword in KEYWORD_TO_ATTRIBUTE:

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -599,8 +599,6 @@ class TestFileFunctions(FitsTestCase):
             fits.open(self.temp('foobar.fits'))
         except IOError as e:
             assert 'No such file or directory' in str(e)
-        except:
-            raise
 
         # But opening in ostream or append mode should be okay, since they
         # allow writing new files

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -588,7 +588,7 @@ if sys.platform.startswith('win32'):
                 # cdll.msvcrt directly. Not sure if that may cause problems.
                 # https://bugs.python.org/issue26727
                 msvcrt = cdll.msvcrt
-            except:
+            except Exception:
                 # TODO: This except probably should need some Exceptions to
                 # catch ... but since we return a Warning the user is likely
                 # to know that there is something wrong altogether.
@@ -956,7 +956,7 @@ def _words_group(input, strlen):
             offset = blank_loc[loc - 1] + 1
             if loc == 0:
                 offset = -1
-        except:
+        except Exception:
             offset = len(input)
 
         # check for one word longer than strlen, break in the middle

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -30,7 +30,7 @@ _identifiers = OrderedDict()
 PATH_TYPES = six.string_types
 try:
     import pathlib
-except:
+except ImportError:
     HAS_PATHLIB = False
 else:
     HAS_PATHLIB = True
@@ -474,7 +474,7 @@ def read(cls, *args, **kwargs):
                 # to desired subclass.
                 try:
                     data = cls(data)
-                except:
+                except Exception:
                     raise TypeError('could not convert reader output to {0} '
                                     'class.'.format(cls.__name__))
             else:

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -861,7 +861,7 @@ class Values(Element, _IDProperty):
             try:
                 null_val = self._field.converter.parse_scalar(
                     null, self._config, self._pos)[0]
-            except:
+            except Exception:
                 warn_or_raise(W36, W36, null, self._config, self._pos)
                 null_val = self._field.converter.parse_scalar(
                     '0', self._config, self._pos)[0]

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -64,7 +64,7 @@ class Result(object):
             try:
                 with open(path, 'rb') as fd:
                     self._attributes = pickle.load(fd)
-            except:
+            except Exception:
                 shutil.rmtree(self.get_dirpath())
                 os.makedirs(self.get_dirpath())
                 self._attributes = {}

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -130,7 +130,7 @@ def _teardown_log():
                     del loggerDict[key]
         finally:
             logging._releaseLock()
-    except:
+    except Exception:
         pass
 
 
@@ -200,7 +200,7 @@ class AstropyLogger(Logger):
                     # Believe it or not this can fail in some cases:
                     # https://github.com/astropy/astropy/issues/2671
                     path = os.path.splitext(getattr(mod, '__file__', ''))[0]
-                except:
+                except Exception:
                     continue
                 if path == mod_path:
                     mod_name = mod.__name__
@@ -211,7 +211,7 @@ class AstropyLogger(Logger):
                     if getattr(mod, '__file__', '') == mod_path:
                         mod_name = mod.__name__
                         break
-                except:
+                except Exception:
                     continue
 
         if mod_name is not None:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -470,7 +470,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
                     parts.append('{0}: {1}'.format(keyword, value))
 
             return '\n'.join(parts)
-        except:
+        except Exception:
             # If any of the above formatting fails fall back on the basic repr
             # (this is particularly useful in debugging)
             return parts[0]

--- a/astropy/modeling/setup_package.py
+++ b/astropy/modeling/setup_package.py
@@ -103,7 +103,7 @@ def preprocess_source():
         # If jinja2 isn't present, then print a warning and use existing files
         try:
             import jinja2  # pylint: disable=W0611
-        except:
+        except ImportError:
             log.warn("WARNING: jinja2 could not be imported, so the existing "
                      "modeling _projections.c file will be used")
             return

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -117,7 +117,7 @@ class Record(object):
         xyz = [l[:3] for l in fieldline]
         try:
             farr = np.array(xyz)
-        except:
+        except Exception:
             log.debug("Could not read array field %s" % fieldlist[0].split()[0])
         return farr.astype(np.float64)
 
@@ -241,7 +241,7 @@ class IDB(object):
         rl = dtb.split('begin')
         try:
             rl0 = rl[0].split('\n')
-        except:
+        except Exception:
             return rl
         if len(rl0) == 2 and rl0[0].startswith('#') and not rl0[1].strip():
             return rl[1:]

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -190,7 +190,7 @@ class BaseGroups(object):
             indices0, indices1 = self.indices[:-1], self.indices[1:]
             try:
                 i0s, i1s = indices0[item], indices1[item]
-            except:
+            except Exception:
                 raise TypeError('Index item for groups attribute must be a slice, '
                                 'numpy mask or int array')
             mask = np.zeros(len(parent), dtype=np.bool)

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -83,7 +83,7 @@ def _auto_format_func(format_, val):
         # it directly.  Otherwise, wrap it in a function that traps them.
         try:
             format_func(format_, np.ma.masked)
-        except:
+        except Exception:
             format_func = _use_str_for_masked_values(format_func)
     else:
         # For a masked element, we cannot set string-based format functions yet,
@@ -98,7 +98,7 @@ def _auto_format_func(format_, val):
                 out = format_func(format_, val)
                 # Require that the format statement actually did something.
                 assert out != format_
-            except:
+            except Exception:
                 continue
             else:
                 break
@@ -596,7 +596,7 @@ class TableFormatter(object):
             if showlines:  # Don't always show the table (e.g. after help)
                 try:
                     os.system('cls' if os.name == 'nt' else 'clear')
-                except:
+                except Exception:
                     pass  # No worries if clear screen call fails
                 lines = tabcol[i0:i1].pformat(**kwargs)
                 colors = ('red' if i < n_header else 'default'
@@ -610,7 +610,7 @@ class TableFormatter(object):
             while True:
                 try:
                     key = inkey().lower()
-                except:
+                except Exception:
                     print("\n")
                     log.error('Console does not support getting a character'
                               ' as required by more().  Use pprint() instead.')

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -342,7 +342,7 @@ class Table(object):
                     dtype = np.dtype(dtype)
                     names = dtype.names
                     dtype = [dtype[name] for name in names]
-                except:
+                except Exception:
                     raise ValueError('dtype was specified but could not be '
                                      'parsed for column names')
             # names is guaranteed to be set at this point

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -520,7 +520,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
     rtol =  u.Quantity(rtol, subok=True, copy=False)
     try:
         rtol = rtol.to(u.dimensionless_unscaled)
-    except:
+    except Exception:
         raise u.UnitsError("`rtol` should be dimensionless")
 
     return actual.value, desired.value, rtol.value, atol.value

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -220,7 +220,7 @@ class Time(ShapedLikeNDArray):
                 # check the location can be broadcast to self's shape.
                 self.location = broadcast_to(self.location, self.shape,
                                              subok=True)
-            except:
+            except Exception:
                 raise ValueError('The location with shape {0} cannot be '
                                  'broadcast against time with shape {1}. '
                                  'Typically, either give a single location or '
@@ -603,7 +603,7 @@ class Time(ShapedLikeNDArray):
         # get location of observatory in ITRS coordinates at this Time
         try:
             itrs = location.get_itrs(obstime=self)
-        except:
+        except Exception:
             raise ValueError("Supplied location does not have a valid `get_itrs` method")
 
         if kind.lower() == 'heliocentric':
@@ -1101,7 +1101,7 @@ class Time(ShapedLikeNDArray):
             try:
                 # check the value can be broadcast to the shape of self.
                 val = broadcast_to(val, self.shape, subok=True)
-            except:
+            except Exception:
                 raise ValueError('Attribute shape must match or be '
                                  'broadcastable to that of Time object. '
                                  'Typically, give either a single value or '
@@ -1265,7 +1265,7 @@ class Time(ShapedLikeNDArray):
         if not isinstance(other, Time):
             try:
                 other = TimeDelta(other)
-            except:
+            except Exception:
                 raise OperandTypeError(self, other, '-')
 
         # Tdelta - something is dealt with in TimeDelta, so we have
@@ -1313,7 +1313,7 @@ class Time(ShapedLikeNDArray):
         if not isinstance(other, Time):
             try:
                 other = TimeDelta(other)
-            except:
+            except Exception:
                 raise OperandTypeError(self, other, '+')
 
         # Tdelta + something is dealt with in TimeDelta, so we have
@@ -1362,7 +1362,7 @@ class Time(ShapedLikeNDArray):
         if other.__class__ is not self.__class__:
             try:
                 other = self.__class__(other, scale=self.scale)
-            except:
+            except Exception:
                 raise OperandTypeError(self, other, op)
 
         if(self.scale is not None and self.scale not in other.SCALES or
@@ -1474,7 +1474,7 @@ class TimeDelta(Time):
                     val = val.to(u.day)
                     if val2 is not None:
                         val2 = val2.to(u.day)
-                except:
+                except Exception:
                     raise ValueError('Only Quantities with Time units can '
                                      'be used to initiate {0} instances .'
                                      .format(self.__class__.__name__))
@@ -1523,7 +1523,7 @@ class TimeDelta(Time):
         else:
             try:
                 other = TimeDelta(other)
-            except:
+            except Exception:
                 raise OperandTypeError(self, other, '+')
 
         # the scales should be compatible (e.g., cannot convert TDB to TAI)
@@ -1555,7 +1555,7 @@ class TimeDelta(Time):
         else:
             try:
                 other = TimeDelta(other)
-            except:
+            except Exception:
                 raise OperandTypeError(self, other, '-')
 
         # the scales should be compatible (e.g., cannot convert TDB to TAI)
@@ -1604,7 +1604,7 @@ class TimeDelta(Time):
 
         try:   # convert to straight float if dimensionless quantity
             other = other.to(1)
-        except:
+        except Exception:
             pass
 
         try:
@@ -1613,7 +1613,7 @@ class TimeDelta(Time):
         except Exception as err:  # try downgrading self to a quantity
             try:
                 return self.to(u.day) * other
-            except:
+            except Exception:
                 raise err
 
         if self.format != 'jd':
@@ -1637,7 +1637,7 @@ class TimeDelta(Time):
         # cannot do __mul__(1./other) as that looses precision
         try:
             other = other.to(1)
-        except:
+        except Exception:
             pass
 
         try:   # convert to straight float if dimensionless quantity
@@ -1646,7 +1646,7 @@ class TimeDelta(Time):
         except Exception as err:  # try downgrading self to a quantity
             try:
                 return self.to(u.day) / other
-            except:
+            except Exception:
                 raise err
 
         if self.format != 'jd':

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -688,7 +688,7 @@ class TimeString(TimeUnique):
         # floating fraction of a second.
         try:
             idot = timestr.rindex('.')
-        except:
+        except Exception:
             fracsec = 0.0
         else:
             timestr, fracsec = timestr[:idot], timestr[idot:]

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -822,7 +822,7 @@ class UnitBase(object):
                     try:
                         (other/unit).decompose([a])
                         return True
-                    except:
+                    except Exception:
                         pass
                 else:
                     if(a._is_equivalent(unit) and b._is_equivalent(other) or
@@ -905,7 +905,7 @@ class UnitBase(object):
                         try:
                             return lambda v: b(self._get_converter(
                                 tunit, equivalencies=equivalencies)(v))
-                        except:
+                        except Exception:
                             pass
 
             raise exc

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -505,7 +505,7 @@ class FunctionQuantity(Quantity):
             # if iterable, see if first item has a unit; mixed lists fail below
             try:
                 value_unit = getattr(value[0], 'unit')
-            except:
+            except Exception:
                 pass
 
         if isinstance(value_unit, FunctionUnitBase):
@@ -595,7 +595,7 @@ class FunctionQuantity(Quantity):
             try:
                 # "or 'nonsense'" ensures `None` breaks, just in case.
                 unit = self._unit_class(function_unit=unit or 'nonsense')
-            except:
+            except Exception:
                 raise UnitTypeError(
                     "{0} instances require {1} function units"
                     .format(type(self).__name__, self._unit_class.__name__) +
@@ -635,7 +635,7 @@ class FunctionQuantity(Quantity):
                 self._to_own_unit(other, check_precision=False))
         except UnitsError:
             raise
-        except:
+        except Exception:
             return NotImplemented
 
     def __eq__(self, other):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1040,7 +1040,7 @@ class Quantity(np.ndarray):
         try:
             assert self.unit.is_unity()
             return self.value.__index__()
-        except:
+        except Exception:
             raise TypeError('Only integer dimensionless scalar quantities '
                             'can be converted to a Python index')
 

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -177,7 +177,7 @@ def validate_power(p, support_tuples=False):
     else:
         try:
             p = float(p)
-        except:
+        except Exception:
             if not np.isscalar(p):
                 raise ValueError("Quantities and Units may only be raised "
                                  "to a scalar power")

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -167,7 +167,7 @@ def terminal_size(file=None):
         if lines <= 0 or width <= 0:
             raise Exception('unable to get terminal size')
         return (lines, width)
-    except:
+    except Exception:
         try:
             # see if POSIX standard variables will work
             return (int(os.environ.get('LINES')),

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1062,7 +1062,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                             bytes_read += len(block)
                             p.update(bytes_read)
                             block = remote.read(conf.download_block_size)
-                    except:
+                    except BaseException:
                         if os.path.exists(f.name):
                             os.remove(f.name)
                         raise

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -115,7 +115,7 @@ def data_info_factory(names, funcs):
                     out = getattr(dat, func)()
                 else:
                     out = func(dat)
-            except:
+            except Exception:
                 outs.append('--')
             else:
                 outs.append(str(out))
@@ -348,7 +348,7 @@ class DataInfo(object):
         else:
             try:
                 n_bad = np.count_nonzero(np.isinf(dat) | np.isnan(dat))
-            except:
+            except Exception:
                 n_bad = 0
         info['n_bad'] = n_bad
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -195,7 +195,7 @@ class IERS(QTable):
         """
         try:  # see if this is a Time object
             jd1, jd2 = jd1.utc.jd1, jd1.utc.jd2
-        except:
+        except Exception:
             pass
         mjd = np.floor(jd1 - MJD_ZERO + jd2)
         utc = jd1 - (MJD_ZERO+mjd) + jd2
@@ -353,7 +353,7 @@ class IERS(QTable):
         from astropy.time import Time
         try:
             return self._time_now
-        except:
+        except Exception:
             return Time.now()
 
 

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -200,7 +200,7 @@ def _both_isinstance(left, right, cls):
 def _not_equal(left, right):
     try:
         return bool(left != right)
-    except:
+    except Exception:
         return True
 
 

--- a/astropy/utils/tests/test_codegen.py
+++ b/astropy/utils/tests/test_codegen.py
@@ -29,7 +29,7 @@ def test_make_function_with_signature_lineno():
 
     try:
         wrapped(1, 2)
-    except:
+    except Exception:
         exc_cls, exc, tb = sys.exc_info()
         assert exc_cls is ZeroDivisionError
         # The *last* line in the traceback should be the 1 / 0 line in

--- a/astropy/utils/xml/check.py
+++ b/astropy/utils/xml/check.py
@@ -72,6 +72,6 @@ def check_anyuri(uri):
         return False
     try:
         urllib.parse.urlparse(uri)
-    except:
+    except Exception:
         return False
     return True

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -9,7 +9,7 @@ try:
     import matplotlib  # pylint: disable=W0611
     HAS_MATPLOTLIB = True
     from ..fits2bitmap import fits2bitmap, main
-except:
+except ImportError:
     HAS_MATPLOTLIB = False
 
 

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -11,7 +11,7 @@ from ..stretch import SqrtStretch
 try:
     import matplotlib    # pylint: disable=W0611
     HAS_MATPLOTLIB = True
-except:
+except ImportError:
     HAS_MATPLOTLIB = False
 
 

--- a/astropy/vo/samp/utils.py
+++ b/astropy/vo/samp/utils.py
@@ -27,7 +27,7 @@ def internet_on():
         try:
             urlopen('http://google.com', timeout=1.)
             return True
-        except:
+        except Exception:
             return False
 
 __all__ = ["SAMPMsgReplierWrapper"]
@@ -117,7 +117,7 @@ class SAMPMsgReplierWrapper(object):
                         self.cli.hub.reply(self.cli.get_private_key(), args[2],
                                            {"samp.status": SAMP_STATUS_ERROR,
                                             "samp.result": result})
-                except:
+                except Exception:
                     err = StringIO()
                     traceback.print_exc(file=err)
                     txt = err.getvalue()

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1244,7 +1244,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 xy, origin = args
                 xy = np.asarray(xy)
                 origin = int(origin)
-            except:
+            except Exception:
                 raise TypeError(
                     "When providing two arguments, they must be "
                     "(coords[N][{0}], origin)".format(self.naxis))
@@ -1258,7 +1258,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             try:
                 axes = [np.asarray(x) for x in axes]
                 origin = int(origin)
-            except:
+            except Exception:
                 raise TypeError(
                     "When providing more than two arguments, they must be " +
                     "a 1-D array for each axis, followed by an origin.")


### PR DESCRIPTION
In most cases one doesn't want to catch a `KeyboardInterrupt` or `SystemExit` (both are non `Exception` errors) but I've left two places with a `BaseException` because they perform some cleanup and then reraise it.

There are two other `BaseExceptions`: `GeneratorExit` and `StopIteration` (latter one is Python2 only). I guess it's unlikely that any of those two escapes at any of these places. But I am not sure if that's a problem.

I didn't have time to investigate which explicit Exceptions should be catched at those places (except the ImportErrors) so if anyone wants to dig through those I'll gladly close this PR. If this PR is not needed feel free to close it as well.

Related issue: #3682 (not sure if this PR closes the issue)