### PR TITLE
replaced ~hasattr with not hasattr

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -745,7 +745,7 @@ class BaseData(object):
             # when we write tables the columns may be astropy.table.Columns
             # which don't carry a fill_values by default
             for col in cols:
-                if ~hasattr(col, 'fill_values'):
+                if not hasattr(col, 'fill_values'):
                     col.fill_values = {}
 
             # if input is only one <fill_spec>, then make it a list


### PR DESCRIPTION
Closes #5336 

This replaces the `~hasattr` with `not hasattr`.

I tried to find an example where this would actually matter (existing but not-empty `col.fill_values`) but couldn't find any. Except for `ipac` and `daophot`, but they just enter this function twice and they hit that branch on the second round.