### PR TITLE
Ensure column is converted correctly if unit is set to logarithmic unit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,10 @@ Bug Fixes
 
 - ``astropy.table``
 
+  - Assigning a logarithmic unit to a ``QTable`` column that did not have a
+    unit yet now correctly turns it into the appropriate function quantity
+    subclass (such as ``Magnitude`` or ``Dex``). [#5345]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,6 +304,8 @@ Bug Fixes
   - Conversion from quantities to logarithmic units now correctly causes a
     logarithmic quantity such as ``Magnitude`` to be returned. [#5183]
 
+  - Ensure ``!=`` also works for function units such as ``MagUnit`` [#5345]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2602,11 +2602,10 @@ class QTable(Table):
 
     def _convert_col_for_table(self, col):
         if (isinstance(col, Column) and getattr(col, 'unit', None) is not None):
-            # We need to turn the column into a quantity. We just take a view
-            # and go through _new_view rather than the initializer (with
-            # copy=False) so that for function units (such as u.mag()), we
-            # returns the appropriate quantity subclass.
-            qcol = Quantity._new_view(col, unit=col.unit)
+            # We need to turn the column into a quantity, or a subclass
+            # identified in the unit (such as u.mag()).
+            q_cls = getattr(col.unit, '_quantity_class', Quantity)
+            qcol = q_cls(col.data, col.unit, copy=False)
             qcol.info = col.info
             col = qcol
         else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2602,7 +2602,11 @@ class QTable(Table):
 
     def _convert_col_for_table(self, col):
         if (isinstance(col, Column) and getattr(col, 'unit', None) is not None):
-            qcol = Quantity(col, unit=col.unit, copy=False)
+            # We need to turn the column into a quantity. We just take a view
+            # and go through _new_view rather than the initializer (with
+            # copy=False) so that for function units (such as u.mag()), we
+            # returns the appropriate quantity subclass.
+            qcol = Quantity._new_view(col, unit=col.unit)
             qcol.info = col.info
             col = qcol
         else:

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -542,3 +542,8 @@ def test_qtable_column_conversion():
     assert isinstance(qtab[0]['i'], u.Quantity)
     assert not isinstance(qtab['f'][0], u.Quantity)
     assert not isinstance(qtab[0]['f'], u.Quantity)
+
+    # Regression test for #5342: if a function unit is assigned, the column
+    # should become the appropriate FunctionQuantity subclass.
+    qtab['f'].unit = u.dex(u.cm/u.s**2)
+    assert isinstance(qtab['f'], u.Dex)

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -286,9 +286,7 @@ class FunctionUnitBase(object):
                 self.function_unit == getattr(other, 'function_unit', other))
 
     def __ne__(self, other):
-        return (self.physical_unit != getattr(other, 'physical_unit',
-                                              dimensionless_unscaled) or
-                self.funtional_unit != getattr(other, 'function_unit', other))
+        return not self.__eq__(other)
 
     def __mul__(self, other):
         if isinstance(other, (six.string_types, UnitBase, FunctionUnitBase)):

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -98,6 +98,17 @@ def test_predefined_string_roundtrip():
         assert u.Unit(u.m_bol.to_string()) == u.m_bol
 
 
+def test_inequality():
+    """Check __ne__ works (regresssion for #5342)."""
+    lu1 = u.mag(u.Jy)
+    lu2 = u.dex(u.Jy)
+    lu3 = u.mag(u.Jy**2)
+    lu4 = lu3 - lu1
+    assert lu1 != lu2
+    assert lu1 != lu3
+    assert lu1 == lu4
+
+
 class TestLogUnitStrings(object):
 
     def test_str(self):


### PR DESCRIPTION
Fixes #5342.

The main fix is to adapt `QTable._convert_col_for_table`. But it also turned out `!=` never worked for function units, so that is fixed as well.

Assigned to @taldcrof as the main change is in `table`.