### PR TITLE
Allow round-tripping ASCII masked tables for most formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ New Features
 
 - ``astropy.io.ascii``
 
+  - Allow round-tripping masked data tables in most formats by using an
+    empty string ``''`` as the default representation of masked values
+    when writing. [#5347]
+
   - Allow reading HTML tables with unicode column values in Python 2.7. [#5410]
 
   - Check for self-consistency of ECSV header column names. [#5463]
@@ -161,6 +165,9 @@ API Changes
     issued when overwriting an existing file unless ``overwrite=True``.
     In a future version this will be changed from a warning to an
     exception to prevent accidentally overwriting a file. [#5007]
+
+  - The default representation of masked values when writing tables was
+    changed from ``'--'`` to the empty string ``''``. [#5347]
 
 - ``astropy.io.fits``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -167,7 +167,9 @@ API Changes
     exception to prevent accidentally overwriting a file. [#5007]
 
   - The default representation of masked values when writing tables was
-    changed from ``'--'`` to the empty string ``''``. [#5347]
+    changed from ``'--'`` to the empty string ``''``.  Previously any
+    user-supplied ``fill_values`` parameter would overwrite the class
+    default, but now the values are prepended to the class default. [#5347]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -671,7 +671,6 @@ class BaseData(object):
     write_spacer_lines = ['ASCII_TABLE_WRITE_SPACER_LINE']
     fill_include_names = None
     fill_exclude_names = None
-    # Currently, the default matches the numpy default for masked values.
     fill_values = [(masked, '')]
     formats = {}
 
@@ -1430,7 +1429,7 @@ def _get_writer(Writer, fast_writer, **kwargs):
 
     from .fastbasic import FastBasic
 
-    # A values of None for fill_values imply getting the default string
+    # A value of None for fill_values imply getting the default string
     # representation of masked values (depending on the writer class), but the
     # machinery expects a list.  The easiest here is to just pop the value off,
     # i.e. fill_values=None is the same as not providing it at all.

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -672,7 +672,7 @@ class BaseData(object):
     fill_include_names = None
     fill_exclude_names = None
     # Currently, the default matches the numpy default for masked values.
-    fill_values = [(masked, '--')]
+    fill_values = [(masked, '')]
     formats = {}
 
     def __init__(self):
@@ -1430,6 +1430,13 @@ def _get_writer(Writer, fast_writer, **kwargs):
 
     from .fastbasic import FastBasic
 
+    # A values of None for fill_values imply getting the default string
+    # representation of masked values (depending on the writer class), but the
+    # machinery expects a list.  The easiest here is to just pop the value off,
+    # i.e. fill_values=None is the same as not providing it at all.
+    if 'fill_values' in kwargs and kwargs['fill_values'] is None:
+        kwargs.pop('fill_values')
+
     if issubclass(Writer, FastBasic): # Fast writers handle args separately
         return Writer(**kwargs)
     elif fast_writer and 'fast_{0}'.format(Writer._format_name) in FAST_CLASSES:
@@ -1466,7 +1473,8 @@ def _get_writer(Writer, fast_writer, **kwargs):
     if 'exclude_names' in kwargs:
         writer.exclude_names = kwargs['exclude_names']
     if 'fill_values' in kwargs:
-        writer.data.fill_values = kwargs['fill_values']
+        # Prepend user-specified values to the class default.  Both are lists.
+        writer.data.fill_values = kwargs['fill_values'] + writer.data.fill_values
     if 'fill_include_names' in kwargs:
         writer.data.fill_include_names = kwargs['fill_include_names']
     if 'fill_exclude_names' in kwargs:

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1435,7 +1435,7 @@ def _get_writer(Writer, fast_writer, **kwargs):
     # machinery expects a list.  The easiest here is to just pop the value off,
     # i.e. fill_values=None is the same as not providing it at all.
     if 'fill_values' in kwargs and kwargs['fill_values'] is None:
-        kwargs.pop('fill_values')
+        del kwargs['fill_values']
 
     if issubclass(Writer, FastBasic): # Fast writers handle args separately
         return Writer(**kwargs)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1473,7 +1473,12 @@ def _get_writer(Writer, fast_writer, **kwargs):
     if 'exclude_names' in kwargs:
         writer.exclude_names = kwargs['exclude_names']
     if 'fill_values' in kwargs:
-        # Prepend user-specified values to the class default.  Both are lists.
+        # Prepend user-specified values to the class default.
+        with suppress(TypeError, IndexError):
+            # Test if it looks like (match, replace_string, optional_colname),
+            # in which case make it a list
+            kwargs['fill_values'][1] + ''
+            kwargs['fill_values'] = [kwargs['fill_values']]
         writer.data.fill_values = kwargs['fill_values'] + writer.data.fill_values
     if 'fill_include_names' in kwargs:
         writer.data.fill_include_names = kwargs['fill_include_names']

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -985,7 +985,7 @@ cdef class FastWriter:
 
                 if orig_field is None: # tolist() converts ma.masked to None
                     field = core.masked
-                    rows[i % N][j] = '--'
+                    rows[i % N][j] = ''
 
                 elif self.format_funcs[j] is not None:
                     field = self.format_funcs[j](self.formats[j], orig_field)

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -12,7 +12,9 @@ from __future__ import absolute_import, division, print_function
 
 import warnings
 import numpy
+from contextlib import contextmanager
 
+import numpy as np
 from ...extern import six
 from ...extern.six.moves import zip, range
 
@@ -21,6 +23,19 @@ from ...table import Column
 from ...utils.xml import writer
 
 from copy import deepcopy
+
+@contextmanager
+def _set_numpy_masked_string(value):
+    """
+    Internal context manager to temporarily set the numpy masked
+    value output to ``value``.  This is used so masked values in
+    HTML writer output are the empty string "".
+    """
+    current = np.ma.masked_print_option.display()
+    np.ma.masked_print_option.set_display(value)
+    yield
+    np.ma.masked_print_option.set_display(current)
+
 
 class SoupString(str):
     """
@@ -427,15 +442,20 @@ class HTML(core.BaseReader):
 
                                 new_cols_escaped.append(col_escaped)
 
-                    for row in zip(*col_str_iters):
-                        with w.tag('tr'):
-                            for el, col_escaped in zip(row, new_cols_escaped):
-                                # Potentially disable HTML escaping for column
-                                method = ('escape_xml' if col_escaped else 'bleach_clean')
-                                with w.xml_cleaning_method(method, **raw_html_clean_kwargs):
-                                    w.start('td')
-                                    w.data(el.strip())
-                                    w.end(indent=False)
+                    with _set_numpy_masked_string(''):
+                        # Do all the output formatting within the context manager so
+                        # that masked values are replaced by an empty string instead of
+                        # the numpy default '--'.  This is a bit of a hack because the
+                        # io.ascii fill_values machinery is entirely ignored.  See #5354.
+                        for row in zip(*col_str_iters):
+                            with w.tag('tr'):
+                                for el, col_escaped in zip(row, new_cols_escaped):
+                                    # Potentially disable HTML escaping for column
+                                    method = ('escape_xml' if col_escaped else 'bleach_clean')
+                                    with w.xml_cleaning_method(method, **raw_html_clean_kwargs):
+                                        w.start('td')
+                                        w.data(el.strip())
+                                        w.end(indent=False)
 
         # Fixes XMLWriter's insertion of unwanted line breaks
         return [''.join(lines)]

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -652,6 +652,7 @@ def test_roundtrip_masked(fmt_name_class):
         return
 
     t = simple_table(masked=True)
+    t['a'][1] = 2 ** 40  # Force a big value so fast reader on Windows returns int64
 
     out = StringIO()
     fast = fmt_name in ascii.core.FAST_CLASSES

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -655,7 +655,10 @@ def test_roundtrip_masked(fmt_name_class):
 
     out = StringIO()
     fast = fmt_name in ascii.core.FAST_CLASSES
-    ascii.write(t, out, format=fmt_name, fast_writer=fast)
+    try:
+        ascii.write(t, out, format=fmt_name, fast_writer=fast)
+    except ImportError:  # Some failed dependency, e.g. PyYAML, skip test
+        return
 
     # No-header formats need to be told the column names
     kwargs = {'names': t.colnames} if 'no_header' in fmt_name else {}

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -17,6 +17,13 @@ from .... import units
 
 from .common import setup_function, teardown_function
 
+# Check to see if the BeautifulSoup dependency is present.
+try:
+    from bs4 import BeautifulSoup, FeatureNotFound
+    HAS_BEAUTIFUL_SOUP = True
+except ImportError:
+    HAS_BEAUTIFUL_SOUP = False
+
 test_defs = [
     dict(kwargs=dict(),
          out="""\
@@ -649,6 +656,9 @@ def test_roundtrip_masked(fmt_name_class):
 
     # Skip certain readers.  Aastex should be OK after #????
     if fmt_name in ['fixed_width', 'aastex', 'latex']:
+        return
+
+    if fmt_name == 'html' and not HAS_BEAUTIFUL_SOUP:
         return
 
     t = simple_table(masked=True)

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -654,11 +654,9 @@ def test_roundtrip_masked(fmt_name_class):
     if not getattr(fmt_cls, '_io_registry_can_write', True):
         return
 
-    # Skip certain readers.  Aastex should be OK after #????
-    if fmt_name in ['fixed_width', 'aastex', 'latex']:
-        return
-
-    if fmt_name == 'html' and not HAS_BEAUTIFUL_SOUP:
+    # Skip tests for fixed_width or HTML without bs4
+    if ((fmt_name == 'html' and not HAS_BEAUTIFUL_SOUP)
+            or fmt_name == 'fixed_width'):
         return
 
     t = simple_table(masked=True)

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -648,7 +648,7 @@ def test_roundtrip_masked(fmt_name_class):
         return
 
     # Skip certain readers.  Aastex should be OK after #????
-    if fmt_name in ['html', 'fixed_width', 'aastex', 'latex']:
+    if fmt_name in ['fixed_width', 'aastex', 'latex']:
         return
 
     t = simple_table(masked=True)

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -652,7 +652,6 @@ def test_roundtrip_masked(fmt_name_class):
         return
 
     t = simple_table(masked=True)
-    t['a'][1] = 2 ** 40  # Force a big value so fast reader on Windows returns int64
 
     out = StringIO()
     fast = fmt_name in ascii.core.FAST_CLASSES
@@ -665,4 +664,8 @@ def test_roundtrip_masked(fmt_name_class):
     kwargs = {'names': t.colnames} if 'no_header' in fmt_name else {}
 
     t2 = ascii.read(out.getvalue(), format=fmt_name, fast_reader=fast, guess=False, **kwargs)
-    assert np.all(t2 == t)
+
+    assert t.colnames == t2.colnames
+    for col, col2 in zip(t.itercols(), t2.itercols()):
+        assert col.dtype.kind == col2.dtype.kind
+        assert np.all(col == col2)

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -110,7 +110,7 @@ table.  For example the following writes a table as a simple space-delimited
 file::
 
   >>> import numpy as np
-  >>> from astropy.table import Table, Column
+  >>> from astropy.table import Table, Column, MaskedColumn
   >>> x = np.array([1, 2, 3])
   >>> y = x ** 2
   >>> data = Table([x, y], names=['x', 'y'])

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -148,11 +148,13 @@ To disable this engine, use the parameter ``fast_writer``::
 Finally, one can write data in the `ECSV table format
 <https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ which allows
 preserving table meta-data such as column data types and units.  In this way a
-data table can be stored and read back as ASCII with no loss of information.
+data table (including one with masked entries) can be stored and read back as
+ASCII with no loss of information.
 
-  >>> t = Table()
-  >>> t['x'] = Column([1.0, 2.0], unit='m', dtype='float32')
-  >>> t['y'] = Column([False, True], dtype='bool')
+  >>> t = Table(masked=True)
+  >>> t['x'] = MaskedColumn([1.0, 2.0], unit='m', dtype='float32')
+  >>> t['x'][1] = np.ma.masked
+  >>> t['y'] = MaskedColumn([False, True], dtype='bool')
 
   >>> from astropy.extern.six.moves import StringIO
   >>> fh = StringIO()
@@ -161,21 +163,29 @@ data table can be stored and read back as ASCII with no loss of information.
   >>> print(table_string)               # doctest: +SKIP
   # %ECSV 0.9
   # ---
-  # columns:
-  # - {name: x, unit: m, type: float32}
-  # - {name: y, type: bool}
+  # datatype:
+  # - {name: x, unit: m, datatype: float32}
+  # - {name: y, datatype: bool}
   x y
   1.0 False
-  2.0 True
+  "" True
 
   >>> Table.read(table_string, format='ascii')  # doctest: +SKIP
-  <Table length=2>
+  <Table masked=True length=2>
      x      y
      m
   float32  bool
   ------- -----
       1.0 False
-      2.0  True
+       --  True
+
+.. Note::
+
+   For most supported formats one can write a masked table and then
+   read it back without losing information about the masked table
+   entries.  This is accomplished by using a blank string entry to
+   indicate a masked (missing) value.  See the :ref:`replace_bad_or_missing_values`
+   section for more information.
 
 .. _supported_formats:
 

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -209,13 +209,13 @@ details.
   Exclude these names from the list of output columns.  This is applied *after*
   the ``include_names`` filtering.  If not specified then no columns are excluded.
 
-**fill_values**: fill value specifier of lists
+**fill_values**: list of fill value specifiers
   This can be used to fill missing values in the table or replace values with special meaning.
 
   See the :ref:`replace_bad_or_missing_values` section for more information on the syntax.
   The syntax is almost the same as when reading a table.
   There is a special value ``astropy.io.ascii.masked`` that is used a say "output this string
-  for all masked values in a masked table (the default is to use a ``'--'``)::
+  for all masked values in a masked table (the default is to use an empty string ``""``)::
 
       >>> import sys
       >>> from astropy.table import Table, Column, MaskedColumn
@@ -224,7 +224,7 @@ details.
       >>> t['a'].mask = [True, False]
       >>> ascii.write(t, sys.stdout)
       a b
-      -- 3
+      "" 3
       2 4
       >>> ascii.write(t, sys.stdout, fill_values=[(ascii.masked, 'N/A')])
       a b
@@ -236,7 +236,7 @@ details.
 
       >>> ascii.write(t, sys.stdout, fill_values=[])
       a b
-      -- 3
+      "" 3
       2 4
 
   Note that when writing a table all values are converted to strings, before

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -231,14 +231,6 @@ details.
       N/A 3
       2 4
 
-  If no ``fill_values`` is applied for masked values in ``astropy.io.ascii``, the default set
-  with ``numpy.ma.masked_print_option.set_display`` applies (usually that is also ``'--'``)::
-
-      >>> ascii.write(t, sys.stdout, fill_values=[])
-      a b
-      "" 3
-      2 4
-
   Note that when writing a table all values are converted to strings, before
   any value is replaced. Because ``fill_values`` only replaces cells that
   are an exact match to the specification, you need to provide the string


### PR DESCRIPTION
This PR allows round-tripping ASCII masked tables for most formats by changing the default `io.ascii` masked value output from `--` to an empty string.

This is a relatively significant API change, but backward compatible output is possible by adding `fill_values=[(ascii.masked, '--')]` to any existing `write` statements that require the old convention.

Overall I think the API break is worth it given the substantial benefit.  It turns out that certain things in the existing output `fill_values` machinery were not working or inconsistent anyway.  For instance the slow writers use the numpy default string for a masked value (`np.ma.masked_print_option`) while the fast writers always use `--`.

As for the actual table value representing "missing data", the precedent of an empty string from CSV seems compelling and all formats support this already.  Otherwise one needs to make up some arbitrary sentinel value since `--` is not unique enough.  The fact that the readers _already_ interpret an empty value as missing in every format is good and means there is no API change from that perspective.

Closes #5337.

The current version does not pass tests for  ['fixed_width', 'aastex', 'latex'].   `fixed_width` needs some special handling in the test.  The `tex` formats should work pending the tex lastline fix (e.g. #5236).

Closes #5235.
This PR includes complete round-tripping tests.

cc: @hamogu @astrofrog 
