### PR TITLE
Add regression test for #5336

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1183,3 +1183,26 @@ def test_no_units_for_char_columns():
     ascii.write(t1, out, format="ipac")
     t2 = ascii.read(out.getvalue(), format="ipac", guess=False)
     assert t2["B"].unit is None
+
+
+def test_initial_column_fill_values():
+    """Regression test for #5336, #5338."""
+
+    class TestHeader(ascii.BasicHeader):
+        def _set_cols_from_names(self):
+            self.cols = [ascii.Column(name=x) for x in self.names]
+            # Set some initial fill values
+            for i in self.cols:
+                i.fill_values = {'--': 0}
+
+    class Tester(ascii.Basic):
+        header_class = TestHeader
+
+    reader = ascii.get_reader(Reader=Tester)
+
+    assert reader.read("""# Column definition is the first uncommented line
+# Default delimiter is the space character.
+apples oranges pears
+# Data starts after the header column definition, blank lines ignored
+-- 2 3
+4 5 6 """)['apples'][0] is np.ma.masked

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1192,8 +1192,8 @@ def test_initial_column_fill_values():
         def _set_cols_from_names(self):
             self.cols = [ascii.Column(name=x) for x in self.names]
             # Set some initial fill values
-            for i in self.cols:
-                i.fill_values = {'--': 0}
+            for col in self.cols:
+                col.fill_values = {'--': '0'}
 
     class Tester(ascii.Basic):
         header_class = TestHeader
@@ -1202,7 +1202,7 @@ def test_initial_column_fill_values():
 
     assert reader.read("""# Column definition is the first uncommented line
 # Default delimiter is the space character.
-apples oranges pears
+a b c
 # Data starts after the header column definition, blank lines ignored
 -- 2 3
-4 5 6 """)['apples'][0] is np.ma.masked
+4 5 6 """)['a'][0] is np.ma.masked


### PR DESCRIPTION
This adds a regression test for #5336.

There are certainly better/other ways to test this but it doesn't work with `~hasattr` and it works with `not hasattr`. Is there a way to demonstrate this?

Feedback would be very welcome! 

cc: @eteq @taldcroft 