### PR TITLE
use mathring A instead for Angstrom in latex-math-mode

### DIFF
--- a/astropy/analytic_functions/blackbody.py
+++ b/astropy/analytic_functions/blackbody.py
@@ -120,7 +120,7 @@ def blackbody_lambda(in_x, temperature):
     -------
     flux : `~astropy.units.Quantity`
         Blackbody monochromatic flux in
-        :math:`erg \\; cm^{-2} s^{-1} \\AA^{-1} sr^{-1}`.
+        :math:`erg \\; cm^{-2} s^{-1} \\mathring{A}^{-1} sr^{-1}`.
 
     """
     if getattr(in_x, 'unit', None) is None:

--- a/docs/analytic_functions/index.rst
+++ b/docs/analytic_functions/index.rst
@@ -50,7 +50,7 @@ Blackbody flux is calculated with Planck law
     B_{\nu}(T) = \frac{2 h \nu^{3} / c^{2}}{exp(h \nu / k T) - 1}
 
 where the unit of :math:`B_{\lambda}(T)` is
-:math:`erg \; s^{-1} cm^{-2} \AA^{-1} sr^{-1}`, and :math:`B_{\nu}(T)` is
+:math:`erg \; s^{-1} cm^{-2} \mathring{A}^{-1} sr^{-1}`, and :math:`B_{\nu}(T)` is
 :math:`erg \; s^{-1} cm^{-2} Hz^{-1} sr^{-1}`.
 :func:`~astropy.analytic_functions.blackbody.blackbody_lambda` and
 :func:`~astropy.analytic_functions.blackbody.blackbody_nu` calculate the


### PR DESCRIPTION
Closes #5351 

The `\mathring{A}` variant is also used in several other places in astropy.