### PR TITLE
Ensure that __str__ works for all cds units, including non-pure-ascii ones.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1652,6 +1652,10 @@ Bug Fixes
 
   - Fixed bug in Ci definition. [#5106]
 
+  - Non-ascii cds unit strings are now correctly represented using ``str`` also
+    on python2. This solves bugs in parsing coordinates involving strings too.
+    [#5355]
+
 - ``astropy.utils``
 
 - ``astropy.vo``

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -521,7 +521,7 @@ class UnitBase(object):
 
     def __bytes__(self):
         """Return string representation for unit"""
-        return unit_format.Generic.to_string(self).encode('ascii')
+        return unit_format.Generic.to_string(self).encode('unicode_escape')
     if six.PY2:
         __str__ = __bytes__
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -276,6 +276,14 @@ def test_cds_units_available():
     u_format.CDS._units
 
 
+def test_cds_non_ascii_unit():
+    """Regression test for #5350.  This failed with a decoding error as
+    μas could not be represented in ascii."""
+    from .. import cds
+    with cds.enable():
+        u.radian.find_equivalent_units(include_prefix_units=True)
+
+
 def test_latex():
     fluxunit = u.erg / (u.cm ** 2 * u.s)
     assert fluxunit.to_string('latex') == r'$\mathrm{\frac{erg}{s\,cm^{2}}}$'


### PR DESCRIPTION
*Partially* fixes #5350.

With this PR, `__str__` encodes unit strings the same way as `__repr__`, so that non-ascii unit strings, which happen in CDS, can be safely presented.