### PR TITLE
fix KeyError mentioned in #5350

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -47,8 +47,8 @@ class _AngleParser(object):
     def _get_simple_unit_names(cls):
         simple_units = set(
             u.radian.find_equivalent_units(include_prefix_units=True))
-        simple_units.remove(u.deg)
-        simple_units.remove(u.hourangle)
+        simple_units.discard(u.deg)
+        simple_units.discard(u.hourangle)
         simple_unit_names = set()
         for unit in simple_units:
             simple_unit_names.update(unit.names)

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -14,8 +14,15 @@ from numpy.testing.utils import assert_allclose, assert_array_equal
 from ..angles import Longitude, Latitude, Angle, rotation_matrix, angle_axis
 from ...tests.helper import pytest, catch_warnings
 from ... import units as u
+from ...units import cds
 from ..errors import IllegalSecondError, IllegalMinuteError, IllegalHourError
 from ...utils.exceptions import AstropyDeprecationWarning
+
+
+def test_angle_cds():
+    # Regression test for KeyError in #5350.
+    with u.cds.enable():
+        Angle('10d')
 
 
 def test_create_angles():


### PR DESCRIPTION
This is one possibility to not let the `units.cds.enable()` break the `_AngleParser`. 

However this does not adress the underlying issue that the "equivalent units" are cached - and that this may produce other errors in the future when using additional equivalencies and units.