### PR TITLE
Set _n_models in CompoundModel instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,6 +274,8 @@ Bug Fixes
 
 - ``astropy.modeling``
 
+  - CompoundModel now correctly inherits _n_models, allowing the use of model sets [#5358]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,8 +274,6 @@ Bug Fixes
 
 - ``astropy.modeling``
 
-  - CompoundModel now correctly inherits _n_models, allowing the use of model sets [#5358]
-
 - ``astropy.nddata``
 
 - ``astropy.stats``
@@ -1634,6 +1632,8 @@ Bug Fixes
 - ``astropy.io.votable``
 
 - ``astropy.modeling``
+
+  - CompoundModel now correctly inherits _n_models, allowing the use of model sets [#5358]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2015,6 +2015,12 @@ class _CompoundModelMeta(_ModelMeta):
             instance._user_inverse = mcls._make_user_inverse(
                     operator, left, right)
 
+            if left._n_models == right._n_models:
+                instance._n_models = left._n_models
+            else:
+                raise ValueError('Model sets must have the same number of '
+                                 'components.')
+
             return instance
 
         # Otherwise return the new uninstantiated class itself

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -51,6 +51,34 @@ def test_two_model_class_arithmetic_1d(expr, result):
 
 
 @pytest.mark.parametrize(('expr', 'result'),
+                         [(lambda x, y: x + y, [5.0, 5.0]),
+                          (lambda x, y: x - y, [-1.0, -1.0]),
+                          (lambda x, y: x * y, [6.0, 6.0]),
+                          (lambda x, y: x / y, [2.0 / 3.0, 2.0 / 3.0]),
+                          (lambda x, y: x ** y, [8.0, 8.0])])
+def test_model_set(expr, result):
+    s = expr(Const1D((2, 2), n_models=2), Const1D((3, 3), n_models=2))
+    out = s(0, model_set_axis=False)
+
+    assert_array_equal(out, result)
+
+
+@pytest.mark.parametrize(('expr', 'result'),
+                         [(lambda x, y: x + y, [5.0, 5.0]),
+                          (lambda x, y: x - y, [-1.0, -1.0]),
+                          (lambda x, y: x * y, [6.0, 6.0]),
+                          (lambda x, y: x / y, [2.0 / 3.0, 2.0 / 3.0]),
+                          (lambda x, y: x ** y, [8.0, 8.0])])
+def test_model_set_raises_value_error(expr, result):
+    """Check that creating model sets with components whose _n_models are
+       different raise a value error
+    """
+
+    with pytest.raises(ValueError):
+        s = expr(Const1D((2, 2), n_models=2), Const1D(3, n_models=1))
+
+
+@pytest.mark.parametrize(('expr', 'result'),
                          [(lambda x, y: x + y, 5.0),
                           (lambda x, y: x - y, -1.0),
                           (lambda x, y: x * y, 6.0),


### PR DESCRIPTION
This is an attempt to fix #4892.

From what I've investigated, there was not a way that a CompositeModel would "inherit" the class variable `_n_models` from model sets that constitute a CompositeModel.

Hence, I'm just assign `_n_models` from one of the model sets to the CompositeModel, providing that the model sets have the same `_n_models`.

@pllim @nden Do you see any drawback in doing this? If that sounds OK, I can go ahead and create an example in the docs page.
