### PR TITLE
Fix FITS ASCII to float conversion for columns with E/F types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -268,6 +268,10 @@ Bug Fixes
 
   - Handle unicode FITS BinTable column names on Python 2 [#5204, #4805]
 
+  - Fix reading of float values from ASCII tables, that could be read as
+    float32 instead of float64 (with the E and F formats). These values are now
+    always read as float64. [#5362]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -69,7 +69,7 @@ FITSUPCONVERTERS = {'E': 'D', 'C': 'M'}
 # F: Float (32-bit; fixed decimal notation)
 # E: Float (32-bit; exponential notation)
 # D: Float (64-bit; exponential notation, always 64-bit by convention)
-ASCII2NUMPY = {'A': 'a', 'I': 'i4', 'J': 'i8', 'F': 'f4', 'E': 'f4',
+ASCII2NUMPY = {'A': 'a', 'I': 'i4', 'J': 'i8', 'F': 'f8', 'E': 'f8',
                'D': 'f8'}
 
 # Maps FITS ASCII column format codes to the appropriate Python string
@@ -2287,14 +2287,6 @@ def _convert_ascii_format(format, reverse=False):
         # values [for the non-standard J format code just always force 64-bit]
         if format == 'I' and width <= 4:
             recformat = 'i2'
-        elif format == 'F' and width > 7:
-            # 32-bit floats (the default) may not be accurate enough to support
-            # all values that can fit in this field, so upgrade to 64-bit
-            recformat = 'f8'
-        elif format == 'E' and precision > 6:
-            # Again upgrade to a 64-bit int if we require greater decimal
-            # precision
-            recformat = 'f8'
         elif format == 'A':
             recformat += str(width)
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -66,11 +66,10 @@ FITSUPCONVERTERS = {'E': 'D', 'C': 'M'}
 # A: Character
 # I: Integer (32-bit)
 # J: Integer (64-bit; non-standard)
-# F: Float (32-bit; fixed decimal notation)
-# E: Float (32-bit; exponential notation)
+# F: Float (64-bit; fixed decimal notation)
+# E: Float (64-bit; exponential notation)
 # D: Float (64-bit; exponential notation, always 64-bit by convention)
-ASCII2NUMPY = {'A': 'a', 'I': 'i4', 'J': 'i8', 'F': 'f8', 'E': 'f8',
-               'D': 'f8'}
+ASCII2NUMPY = {'A': 'a', 'I': 'i4', 'J': 'i8', 'F': 'f8', 'E': 'f8', 'D': 'f8'}
 
 # Maps FITS ASCII column format codes to the appropriate Python string
 # formatting codes for that type.

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -844,7 +844,7 @@ class FITS_rec(np.recarray):
         """
 
         format = column.format
-        recformat = ASCII2NUMPY[format[0]]
+        recformat = format.recformat
         # if the string = TNULL, return ASCIITNULL
         nullval = str(column.null).strip().encode('ascii')
         if len(nullval) > format.width:

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -844,7 +844,7 @@ class FITS_rec(np.recarray):
         """
 
         format = column.format
-        recformat = format.recformat
+        recformat = ASCII2NUMPY[format[0]]
         # if the string = TNULL, return ASCIITNULL
         nullval = str(column.null).strip().encode('ascii')
         if len(nullval) > format.width:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2739,7 +2739,7 @@ class TestColumnFunctions(FitsTestCase):
 
         with fits.open(self.temp('test.fits')) as hdul:
             assert hdul[1].header['TFORM1'] == 'F5.0'
-            assert hdul[1].data['TEST'].dtype == np.dtype('float32')
+            assert hdul[1].data['TEST'].dtype == np.dtype('float64')
             assert np.all(hdul[1].data['TEST'] == [1.0, 2.0, 3.0])
 
             # Check how the raw data looks

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -367,7 +367,7 @@ class TestTableFunctions(FitsTestCase):
         bright = np.rec.array([(1, 'Serius', -1.45, 'A1V'),
                                (2, 'Canopys', -0.73, 'F0Ib'),
                                (3, 'Rigil Kent', -0.1, 'G2V')],
-                              formats='int16,a20,float32,a10',
+                              formats='int16,a20,float64,a10',
                               names='order,name,mag,Sp')
         hdu = fits.TableHDU.from_columns(bright, nrows=2)
 
@@ -424,7 +424,7 @@ class TestTableFunctions(FitsTestCase):
         assert hdu.data[0][1] == 'Serius'
         assert hdu.data[1][1] == 'Canopys'
         assert (hdu.data.field(2) ==
-                np.array([-1.45, -0.73], dtype=np.float32)).all()
+                np.array([-1.45, -0.73], dtype=np.float64)).all()
         assert hdu.data[0][3] == 'A1V'
         assert hdu.data[1][3] == 'F0Ib'
 
@@ -437,7 +437,7 @@ class TestTableFunctions(FitsTestCase):
             assert hdul[1].data[0][1] == 'Serius'
             assert hdul[1].data[1][1] == 'Canopys'
             assert (hdul[1].data.field(2) ==
-                    np.array([-1.45, -0.73], dtype=np.float32)).all()
+                    np.array([-1.45, -0.73], dtype=np.float64)).all()
             assert hdul[1].data[0][3] == 'A1V'
             assert hdul[1].data[1][3] == 'F0Ib'
         del hdul
@@ -445,7 +445,7 @@ class TestTableFunctions(FitsTestCase):
         hdu = fits.BinTableHDU.from_columns(bright, nrows=2)
         tmp = np.rec.array([(1, 'Serius', -1.45, 'A1V'),
                             (2, 'Canopys', -0.73, 'F0Ib')],
-                           formats='int16,a20,float32,a10',
+                           formats='int16,a20,float64,a10',
                            names='order,name,mag,Sp')
         assert comparerecords(hdu.data, tmp)
         with ignore_warnings():
@@ -2218,7 +2218,11 @@ class TestTableFunctions(FitsTestCase):
                 tbdata2 = hdul2[1].data
                 assert np.all(tbdata['c1'] == tbdata2['c1'])
                 assert np.all(tbdata['c2'] == tbdata2['c2'])
-                assert np.all(tbdata['c3'] == tbdata2['c3'])
+                # c3 gets converted from float32 to float64 when writing
+                # test.fits, so cast to float32 before testing that the correct
+                # value is retrieved
+                assert np.all(tbdata['c3'].astype(np.float32) ==
+                              tbdata2['c3'].astype(np.float32))
                 # c4 is a boolean column in the original table; we want ASCII
                 # columns to convert these to columns of 'T'/'F' strings
                 assert np.all(np.where(tbdata['c4'], 'T', 'F') ==

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -60,8 +60,8 @@ binary table, they are:
 
     Aw         Character string
     Iw         (Decimal) Integer
-    Fw.d       Single precision real
-    Ew.d       Single precision real, in exponential notation
+    Fw.d       Double precision real
+    Ew.d       Double precision real, in exponential notation
     Dw.d       Double precision real, in exponential notation
 
 where, w is the width, and d the number of digits after the decimal point. The
@@ -109,7 +109,7 @@ technically require a character width for each column, such as ``'I10'`` to
 create a column that can hold integers up to 10 characters wide.
 
 However, PyFITS allows the width specification to be omitted in some cases.
-When it is ommitted from ``'I'`` format columns the minimum width needed to
+When it is omitted from ``'I'`` format columns the minimum width needed to
 accurately represent all integers in the column is used.  The only problem with
 using this shortcut is its ambiguity with the binary table ``'I'`` format, so
 specifying ``ascii=True`` is a good practice (though PyFITS will still figure


### PR DESCRIPTION
A possible solution to fix #5353 : use the `.recformat` attribute computed by `_convert_ascii_format`.

Two tests were failing because of this change, and because by default float values are written with the `E15.7` format which is now read correctly as `float64`.