### PR TITLE
Fix conesearch remote test failure

### DIFF
--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Support VO Simple Cone Search capabilities."""
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 # STDLIB
 import warnings
@@ -13,7 +14,8 @@ from . import vos_catalog
 from .async import AsyncBase
 from .exceptions import ConeSearchError, VOSError
 from ... import units as u
-from ...coordinates import ICRS, BaseCoordinateFrame, Longitude, Latitude, SkyCoord
+from ...coordinates import (ICRS, BaseCoordinateFrame, Longitude, Latitude,
+                            SkyCoord)
 from ...units import Quantity
 from ...utils.timer import timefunc, RunTimePredictor
 from ...utils.exceptions import AstropyUserWarning
@@ -81,7 +83,7 @@ def conesearch(center, radius, verb=1, **kwargs):
     Parameters
     ----------
     center : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`, or sequence of length 2
-        Position of the center of the cone to search.  It may be specified as an
+        Position of the center of the cone to search. It may be specified as an
         object from the :ref:`astropy-coordinates` package, or as a length 2
         sequence.  If a sequence, it is assumed to be ``(RA, DEC)`` in the
         ICRS coordinate frame, given in decimal degrees.
@@ -203,7 +205,7 @@ class AsyncSearchAll(AsyncBase):
     >>> from astropy import coordinates as coord
     >>> from astropy import units as u
     >>> c = coord.ICRS(6.0223 * u.degree, -72.0814 * u.degree)
-    >>> async_searchall = conesearch.AsyncSearchAll(c, 0.5 * u.degree)
+    >>> async_search = conesearch.AsyncSearchAll(c, 0.5 * u.degree)
 
     Check search status:
 
@@ -412,11 +414,13 @@ def predict_search(url, *args, **kwargs):
     t_est = cs_pred.predict_time(sr)
 
     if t_est < 0 or t_coeffs[1] < 0:  # pragma: no cover
-        warnings.warn('Estimated runtime ({0} s) is non-physical with slope of '
-                      '{1}'.format(t_est, t_coeffs[1]), AstropyUserWarning)
+        warnings.warn(
+            'Estimated runtime ({0} s) is non-physical with slope of '
+            '{1}'.format(t_est, t_coeffs[1]), AstropyUserWarning)
     elif t_est > data.conf.remote_timeout:  # pragma: no cover
-        warnings.warn('Estimated runtime is longer than timeout of '
-                      '{0} s'.format(data.conf.remote_timeout), AstropyUserWarning)
+        warnings.warn(
+            'Estimated runtime is longer than timeout of '
+            '{0} s'.format(data.conf.remote_timeout), AstropyUserWarning)
 
     # Predict number of objects
     sr_arr = sorted(cs_pred.results)  # Orig with floating point error

--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -85,7 +85,7 @@ def conesearch(center, radius, verb=1, **kwargs):
     center : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`, or sequence of length 2
         Position of the center of the cone to search. It may be specified as an
         object from the :ref:`astropy-coordinates` package, or as a length 2
-        sequence.  If a sequence, it is assumed to be ``(RA, DEC)`` in the
+        sequence. If a sequence, it is assumed to be ``(RA, DEC)`` in the
         ICRS coordinate frame, given in decimal degrees.
 
     radius : float or `~astropy.units.quantity.Quantity`
@@ -142,8 +142,8 @@ def conesearch(center, radius, verb=1, **kwargs):
 
     pedantic : bool or `None`
         When `True`, raise an error when the file violates the spec,
-        otherwise issue a warning.  Warnings may be controlled using
-        :py:mod:`warnings` module.  When not provided, uses the
+        otherwise issue a warning. Warnings may be controlled using
+        :py:mod:`warnings` module. When not provided, uses the
         configuration setting `astropy.io.votable.Conf.pedantic`,
         which defaults to `False`.
 

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -149,6 +149,9 @@ class TestConeSearch(object):
         async_search = conesearch.AsyncConeSearch(
             SCS_CENTER, SCS_RADIUS, pedantic=self.pedantic)
 
+        # Wait a little for the instance to set up properly
+        time.sleep(3)
+
         tab = async_search.get(timeout=data.conf.remote_timeout)
 
         assert async_search.done()

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -150,7 +150,7 @@ class TestConeSearch(object):
             SCS_CENTER, SCS_RADIUS, pedantic=self.pedantic)
 
         # Wait a little for the instance to set up properly
-        time.sleep(3)
+        time.sleep(5)
 
         tab = async_search.get(timeout=data.conf.remote_timeout)
 


### PR DESCRIPTION
Fixed `conesearch` remote test failure. PEP8  clean-up on `conesearch` and tests.

I thought the failure was temporarily due to remote hosts but I keep seeing it, so turns out it needs a fix. The fix is just to wait a few seconds for the instance to properly set up before trying to get the data. The test passed locally, but we should wait for Travis report before merge (you need to look at the "allowed failure" test suite).

This is a follow-up of #5073

- [x] Make async tests pass.
- [x] Is the 8 sec addition to wait time for remote data test worth it? Or should we just mark these two `async` tests as `xfail`? Since this PR is approved, I guess this is not an issue.

c/c @astrofrog 