### PR TITLE
Fix a bug with empty value at end of tab-delimited table on windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1644,6 +1644,8 @@ Bug Fixes
 
 - ``astropy.io.ascii``
 
+  - Fix a bug with empty value at end of tab-delimited table on Windows. [#5370]
+
 - ``astropy.io.fits``
 
   - Removed raising of AssertionError that could occur after closing or

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -351,6 +351,9 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
         else
             c = self->source[self->source_pos];
 
+        if (c == '\r')
+            c = '\n';
+
         parse_newline = 0;
 
         switch (self->state)

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -39,7 +39,6 @@ typedef enum
     QUOTED_FIELD,
     QUOTED_FIELD_NEWLINE,
     COMMENT,
-    CARRIAGE_RETURN
 } tokenizer_state;
 
 typedef enum

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -844,10 +844,15 @@ def test_line_endings(parallel, read_basic, read_commented_header, read_rdb):
     for newline in ('\r\n', '\r'):
         table = read_commented_header(text.replace('\n', newline), parallel=parallel)
         assert_table_equal(table, expected)
-    text = 'a\tb\tc\nN\tN\tN\n1\t2\t3\n4\t5\t6\n7\t8\t9\n'
+
+    expected = Table([[1, 4, 7], [2, 5, 8], [3, 6, 9]], names=('a', 'b', 'c'), masked=True)
+    expected['a'][0] = np.ma.masked
+    expected['c'][0] = np.ma.masked
+    text = 'a\tb\tc\nN\tN\tN\n\t2\t\n4\t5\t6\n7\t8\t9\n'
     for newline in ('\r\n', '\r'):
         table = read_rdb(text.replace('\n', newline), parallel=parallel)
         assert_table_equal(table, expected)
+        assert np.all(table == expected)
 
 
 @pytest.mark.parametrize("parallel", [True, False])


### PR DESCRIPTION
A table like below (spaces added for clarity) was failing in the fast tab reader on Windows.  This is related to the `\r\n` line endings:
```
a \t b
1 \t
2 \t 3
```
This PR changes the way the fast reader handles Windows CRLF line endings by effectively replacing the `\r` with `\n` on-the-fly in the tokenizer (but not in the code that does line counting).  This is safe because an empty line is just ignored.

This change had a beneficial side effect of simplifying code, reducing states etc.

@mdmueller ?