### PR TITLE
Add ref tags to standard units page

### DIFF
--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -1,3 +1,5 @@
+.. _doc_standard_units:
+
 Standard units
 ==============
 
@@ -45,6 +47,8 @@ all the existing predefined units of a given type::
     t            | 1000 kg         | tonne                            ,
     u            | 1.66054e-27 kg  | Da, Dalton                       ,
   ]
+
+.. _doc_dimensionless_unit:
 
 The dimensionless unit
 ----------------------


### PR DESCRIPTION
Add `ref` tags to standard units page, so every section there can be referred to via `intersphinx` tagging. I need this for some cross-reference in another package.

Should be uncontroversial enough but I'll leave this open for a few days for comments anyway. I'll let Travis CI run to make sure the new tags didn't break doc build. Should not change the rendered doc in any way.