### PR TITLE
Fix undefined variables and attributes in  votable Resource repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1663,6 +1663,9 @@ Bug Fixes
 
 - ``astropy.io.votable``
 
+  - Fixed bug of ``Resource.__repr__()`` having undefined attributes and
+    variables. [#5382]
+
 - ``astropy.modeling``
 
 - ``astropy.nddata``

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -614,6 +614,9 @@ class TestParse:
         # Smoke test
         repr(list(self.votable.iter_groups()))
 
+        # Resource
+        assert repr(self.votable.resources) == '[</>]'
+
 
 class TestThroughTableData(TestParse):
     def setup_class(self):

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -418,6 +418,9 @@ class Element(object):
     A base class for all classes that represent XML elements in the
     VOTABLE file.
     """
+    _element_name = ''
+    _attr_list = []
+
     def _add_unknown_tag(self, iterator, tag, data, config, pos):
         warn_or_raise(W10, W10, tag, config, pos)
 
@@ -3010,7 +3013,8 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
 
     def __repr__(self):
         buff = io.StringIO()
-        XMLWriter(buff).element(
+        w = XMLWriter(buff)
+        w.element(
             self._element_name,
             attrib=w.object_attrs(self, self._attr_list))
         return buff.getvalue().strip()


### PR DESCRIPTION
Fix undefined variables and attributes in `io.votable.tree.Resource`'s `repr` method.

Fixes #5381 .

TODO:
- [x] Add test.
- [x] Add changelog.
- [x] Set milestone.