### PR TITLE
Fix undefined variables based on static code analysis

### DIFF
--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -525,10 +525,10 @@ class _File(object):
             os.fsync(tmpfd)
             try:
                 mm = mmap.mmap(tmpfd, 1, access=mmap.ACCESS_WRITE)
-            except mmap.error as e:
+            except mmap.error as exc:
                 warnings.warn('Failed to create mmap: {}; mmap use will be '
-                              'disabled'.format(str(e)), AstropyUserWarning)
-                del e
+                              'disabled'.format(str(exc)), AstropyUserWarning)
+                del exc
                 return False
             try:
                 mm.flush()

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import bz2
 import gzip
 import os
 import shutil

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -616,7 +616,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
             else:
                 for after_keyword in KEYWORD_NAMES[keyword_idx + 1:]:
                     after_keyword += str(col_idx + 1)
-                    if after_keyword in header:
+                    if after_keyword in self._header:
                         self._header.insert(after_keyword,
                                             (keyword, new_value))
                         break

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -229,7 +229,7 @@ class TestCore(FitsTestCase):
             del hdu.header['NAXIS']
             try:
                 hdu.verify('ignore')
-            except Exception as e:
+            except Exception as exc:
                 self.fail('An exception occurred when the verification error '
                           'should have been ignored: {}'.format(e))
         # Make sure the error wasn't fixed either, silently or otherwise

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -231,7 +231,7 @@ class TestCore(FitsTestCase):
                 hdu.verify('ignore')
             except Exception as exc:
                 self.fail('An exception occurred when the verification error '
-                          'should have been ignored: {}'.format(e))
+                          'should have been ignored: {}'.format(exc))
         # Make sure the error wasn't fixed either, silently or otherwise
         assert 'NAXIS' not in hdu.header
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2893,3 +2893,14 @@ class TestColumnFunctions(FitsTestCase):
         assert c4.format == c3.format
         assert np.all(c4.array[0] == c3.array[0])
         assert np.all(c4.array[1] == c3.array[1])
+
+
+def test_regression_5383():
+
+    # Regression test for an undefined variable
+
+    x = np.array([1, 2, 3])
+    col = fits.Column(name='a', array=x, format='E')
+    hdu = fits.BinTableHDU.from_columns([col])
+    del hdu._header['TTYPE1']
+    hdu.columns[0].name = 'b'

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -19,6 +19,7 @@ from ...extern import six
 import keyword
 import math
 import os
+import copy
 import warnings
 from fractions import Fraction
 

--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -1333,7 +1333,7 @@ class SAMPHubServer(object):
                 return
 
         # If we are here, then the above attempts failed
-        error_message = method_name + " failed after " + tries + " attempts"
+        error_message = samp_method_name + " failed after " + conf.n_retries + " attempts"
         raise SAMPHubError(error_message)
 
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -18,7 +18,6 @@ from numpy.testing import (
 
 from ...tests.helper import raises, catch_warnings, pytest
 from ... import wcs
-from .. import _wcs  # pylint: disable=W0611
 from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext
@@ -384,15 +383,6 @@ def test_to_fits():
     assert isinstance(wfits, fits.HDUList)
     assert isinstance(wfits[0], fits.PrimaryHDU)
     assert header_string == wfits[0].header[-8:]
-
-
-def test_to_fits_1():
-    fits_name = get_pkg_data_filename('data/dist.fits')
-    w = wcs.WCS(fits_name)
-    wfits = w.to_fits()
-    assert isinstance(wfits, fits.HDUList)
-    assert isinstance(wfits[0], fits.PrimaryHDU)
-    assert isinstance(wfits[1], fits.ImageHDU)
 
 
 def test_to_header_warning():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -18,6 +18,7 @@ from numpy.testing import (
 
 from ...tests.helper import raises, catch_warnings, pytest
 from ... import wcs
+from .. import _wcs
 from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -18,7 +18,7 @@ from numpy.testing import (
 
 from ...tests.helper import raises, catch_warnings, pytest
 from ... import wcs
-from .. import _wcs  # pylint: disable=W0611
+from .. import _wcs
 from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext
@@ -983,7 +983,7 @@ def test_passing_ImageHDU():
     assert wcs_hdu.wcs.compare(wcs_header.wcs)
 
 
-def inconsistent_sip():
+def test_inconsistent_sip():
     """
     Test for #4814
     """
@@ -991,39 +991,40 @@ def inconsistent_sip():
     w = wcs.WCS(hdr)
     newhdr = w.to_header(relax=None)
     # CTYPE should not include "-SIP" if relax is None
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
     newhdr = w.to_header(relax=False)
     assert('A_0_2' not in newhdr)
     # CTYPE should not include "-SIP" if relax is False
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
     newhdr = w.to_header(key="C")
     assert('A_0_2' not in newhdr)
     # Test writing header with a different key
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
     newhdr = w.to_header(key=" ")
     # Test writing a primary WCS to header
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
     # Test that "-SIP" is kept into CTYPE if relax=True and
     # "-SIP" was in the original header
     newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in w.wcs.ctype]))
     assert('A_0_2' in newhdr)
     # Test that SIP coefficients are also written out.
-    wtest = WCS(newhdr)
+    wtest = wcs.WCS(newhdr)
     assert wtest.sip is not None
     ########## broken header ###########
     # Test that "-SIP" is added to CTYPE if relax=True and
     # "-SIP" was not in the original header
-    w = WCS(hdr)
+    w = wcs.WCS(hdr)
     w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
     newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in w.wcs.ctype]))
     del hdr['CTYPE2']
     newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in w.wcs.ctype]))
     w = wcs.WCS()
     newhdr = w.to_header()
     assert('CTYPE1' not in newhdr)
+
 
 def test_bounds_check():
     """Test for #4957"""

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -18,7 +18,7 @@ from numpy.testing import (
 
 from ...tests.helper import raises, catch_warnings, pytest
 from ... import wcs
-from .. import _wcs
+from .. import _wcs  # pylint: disable=W0611
 from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext
@@ -991,39 +991,39 @@ def test_inconsistent_sip():
     w = wcs.WCS(hdr)
     newhdr = w.to_header(relax=None)
     # CTYPE should not include "-SIP" if relax is None
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
+    wnew = wcs.WCS(newhdr)
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
     newhdr = w.to_header(relax=False)
     assert('A_0_2' not in newhdr)
     # CTYPE should not include "-SIP" if relax is False
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
+    wnew = wcs.WCS(newhdr)
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
     newhdr = w.to_header(key="C")
     assert('A_0_2' not in newhdr)
     # Test writing header with a different key
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
+    wnew = wcs.WCS(newhdr, key='C')
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
     newhdr = w.to_header(key=" ")
     # Test writing a primary WCS to header
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
+    wnew = wcs.WCS(newhdr)
+    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
     # Test that "-SIP" is kept into CTYPE if relax=True and
     # "-SIP" was in the original header
     newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in w.wcs.ctype]))
+    wnew = wcs.WCS(newhdr)
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in wnew.wcs.ctype]))
     assert('A_0_2' in newhdr)
     # Test that SIP coefficients are also written out.
-    wtest = wcs.WCS(newhdr)
-    assert wtest.sip is not None
+    assert wnew.sip is not None
     ########## broken header ###########
     # Test that "-SIP" is added to CTYPE if relax=True and
-    # "-SIP" was not in the original header
+    # "-SIP" was not in the original header but SIP coefficients
+    # are present.
     w = wcs.WCS(hdr)
     w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
     newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in w.wcs.ctype]))
-    del hdr['CTYPE2']
-    newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in w.wcs.ctype]))
-    w = wcs.WCS()
-    newhdr = w.to_header()
-    assert('CTYPE1' not in newhdr)
+    wnew = wcs.WCS(newhdr)
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in wnew.wcs.ctype]))
 
 
 def test_bounds_check():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -983,26 +983,26 @@ def test_inconsistent_sip():
     newhdr = w.to_header(relax=None)
     # CTYPE should not include "-SIP" if relax is None
     wnew = wcs.WCS(newhdr)
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
+    assert all(not ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
     newhdr = w.to_header(relax=False)
     assert('A_0_2' not in newhdr)
     # CTYPE should not include "-SIP" if relax is False
     wnew = wcs.WCS(newhdr)
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
+    assert all(not ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
     newhdr = w.to_header(key="C")
     assert('A_0_2' not in newhdr)
     # Test writing header with a different key
     wnew = wcs.WCS(newhdr, key='C')
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
+    assert all(not ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
     newhdr = w.to_header(key=" ")
     # Test writing a primary WCS to header
     wnew = wcs.WCS(newhdr)
-    assert(all([ctyp[-4 :] != '-SIP' for ctyp in wnew.wcs.ctype]))
+    assert all(not ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
     # Test that "-SIP" is kept into CTYPE if relax=True and
     # "-SIP" was in the original header
     newhdr = w.to_header(relax=True)
     wnew = wcs.WCS(newhdr)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in wnew.wcs.ctype]))
+    assert all(ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
     assert('A_0_2' in newhdr)
     # Test that SIP coefficients are also written out.
     assert wnew.sip is not None
@@ -1014,7 +1014,7 @@ def test_inconsistent_sip():
     w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
     newhdr = w.to_header(relax=True)
     wnew = wcs.WCS(newhdr)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in wnew.wcs.ctype]))
+    assert all(ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
 
 
 def test_bounds_check():


### PR DESCRIPTION
@nden - it turns out one of the WCS tests related to SIP was not being run because it didn't have a name that started with `test` - I think it must have been moved out of a class in the past. That test is failing now:

``` python
    def test_inconsistent_sip():
        """
        Test for #4814
        """
        hdr = get_pkg_data_contents("data/sip-broken.hdr")
        w = wcs.WCS(hdr)
        newhdr = w.to_header(relax=None)
        # CTYPE should not include "-SIP" if relax is None
>       assert(all([ctyp[-4 :] != '-SIP' for ctyp in w.wcs.ctype]))
E       assert all([False, False])
```

Could you let me know if I've fixed the test incorrectly, or if this is a real issue? Feel free to open a PR to my branch if you like.

