### PR TITLE
Fix handling of blank values in ASCII FITS numerical columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,6 +302,9 @@ Bug Fixes
     instead of ``self.verify('fix')`` so headers with invalid keywords will
     not raise a ``VerifyError`` on printing. [#887,#5054]
 
+  - ``FITS_Record._convert_ascii`` now converts blank fields to 0 when a
+    non-blank null column value is set. [#5134, #5394]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -851,13 +851,13 @@ class FITS_rec(np.recarray):
         # But if the nullval itself is a blank string and it's an int column,
         # it must be converted to a 0 before being loaded into the numpy array.
         # The nullval for an empty string is the string 'None'.
-        if nullval == 'None' and format.startswith('I'):
+        if nullval == b'None' and format.startswith('I'):
             int_null_fill = encode_ascii(str(0).rjust(format.width))
-            dummy = np.where(np.char.strip(dummy) == '', int_null_fill, dummy)
+            dummy = np.where(np.char.strip(dummy) == b'', int_null_fill, dummy)
 
         # Replace blank values in float columns with nullval.
         if format.startswith('F'):
-            dummy = np.where(np.char.strip(dummy) == '', nullval, dummy)
+            dummy = np.where(np.char.strip(dummy) == b'', nullval, dummy)
 
         try:
             dummy = np.array(dummy, dtype=recformat)

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -848,6 +848,16 @@ class FITS_rec(np.recarray):
         null_fill = encode_ascii(str(ASCIITNULL).rjust(format.width))
         dummy = np.where(np.char.strip(dummy) == nullval, null_fill, dummy)
 
+        # If there's a blank string in a float column, fill in the nullval.
+        #dummy = np.where(np.char.strip(dummy) == '', nullval, dummy)
+
+        # But if the nullval itself is a blank string and it's an int column,
+        # it must be converted to a 0 before being loaded into the numpy array.
+        # The nullval for an empty string is the string 'None'.
+        if nullval == 'None' and format.startswith('I'):
+            int_null_fill = encode_ascii(str(0).rjust(format.width))
+            dummy = np.where(np.char.strip(dummy) == '', int_null_fill, dummy)
+
         try:
             dummy = np.array(dummy, dtype=recformat)
         except ValueError as exc:

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -855,8 +855,9 @@ class FITS_rec(np.recarray):
             int_null_fill = encode_ascii(str(0).rjust(format.width))
             dummy = np.where(np.char.strip(dummy) == '', int_null_fill, dummy)
 
-        # If there's a blank string in a float column, fill in the nullval.
-        dummy = np.where(np.char.strip(dummy) == '', nullval, dummy)
+        # Replace blank values in float columns with nullval.
+        if format.startswith('F'):
+            dummy = np.where(np.char.strip(dummy) == '', nullval, dummy)
 
         try:
             dummy = np.array(dummy, dtype=recformat)

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -848,15 +848,15 @@ class FITS_rec(np.recarray):
         null_fill = encode_ascii(str(ASCIITNULL).rjust(format.width))
         dummy = np.where(np.char.strip(dummy) == nullval, null_fill, dummy)
 
-        # If there's a blank string in a float column, fill in the nullval.
-        #dummy = np.where(np.char.strip(dummy) == '', nullval, dummy)
-
         # But if the nullval itself is a blank string and it's an int column,
         # it must be converted to a 0 before being loaded into the numpy array.
         # The nullval for an empty string is the string 'None'.
         if nullval == 'None' and format.startswith('I'):
             int_null_fill = encode_ascii(str(0).rjust(format.width))
             dummy = np.where(np.char.strip(dummy) == '', int_null_fill, dummy)
+
+        # If there's a blank string in a float column, fill in the nullval.
+        dummy = np.where(np.char.strip(dummy) == '', nullval, dummy)
 
         try:
             dummy = np.array(dummy, dtype=recformat)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2179,7 +2179,9 @@ class TestTableFunctions(FitsTestCase):
             h.write(nulled)
 
         with fits.open(self.temp('ascii_null2.fits'), memmap=True) as f:
-            assert f[1].data[2][0] == 0.0
+            # (Currently it should evaluate to 0.0, but if a TODO in fitsrec is
+            # completed, then it should evaluate to NaN.)
+            assert f[1].data[2][0] == 0.0 or np.isnan(f[1].data[2][0])
 
     def test_column_array_type_mismatch(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/218"""

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2139,24 +2139,20 @@ class TestTableFunctions(FitsTestCase):
     def test_ascii_column_null(self):
         """Regression test for https://github.com/astropy/astropy/issues/5134
 
-        Blank values in numerical columns of ASCII tables should be replaced 
+        Blank values in numerical columns of ASCII tables should be replaced
         before being placed in numpy arrays.
-
-        (fitsverify reports that this is valid)
 
         Null strings in integer columns with blank-string TNULL* values 
         should be replaced with 0.
         Null strings in float columns should be properly replaced with the
-        TNULL* value. 
-
-        TODO: What to do about blank-string TNULL* values for float cols?"""
+        TNULL* value."""
 
         # Test an integer column with blank string as null
-        nullval1 = ' '
-        
+        nullval1 = u' '
+
         c1 = fits.Column('F1', format='I8', null=nullval1,
-                        array=np.array([0, 1, 2, 3, 4]),
-                        ascii=True)
+                         array=np.array([0, 1, 2, 3, 4]),
+                         ascii=True)
         table = fits.TableHDU.from_columns([c1])
         table.writeto(self.temp('ascii_null.fits'))
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2136,16 +2136,15 @@ class TestTableFunctions(FitsTestCase):
                          "the header may be missing the necessary TNULL1 "
                          "keyword or the table contains invalid data")
 
-    def test_ascii_column_null(self):
+    def test_blank_field_zero(self):
         """Regression test for https://github.com/astropy/astropy/issues/5134
 
         Blank values in numerical columns of ASCII tables should be replaced
-        before being placed in numpy arrays.
+        with zeros, so they can be loaded into numpy arrays.
 
-        Null strings in integer columns with blank-string TNULL* values
-        should be replaced with 0.
-        Null strings in float columns should be properly replaced with the
-        TNULL* value."""
+        When a TNULL value is set and there are blank fields not equal to that
+        value, they should be replaced with zeros.
+        """
 
         # Test an integer column with blank string as null
         nullval1 = u' '
@@ -2165,7 +2164,7 @@ class TestTableFunctions(FitsTestCase):
         with fits.open(self.temp('ascii_null.fits'), memmap=True) as f:
             assert f[1].data[2][0] == 0
 
-        # Test a float column with NaN as null.
+        # Test a float column with a null value set and blank fields.
         nullval2 = 'NaN'
         c2 = fits.Column('F1', format='F12.8', null=nullval2,
                          array=np.array([1.0, 2.0, 3.0, 4.0]),
@@ -2180,7 +2179,7 @@ class TestTableFunctions(FitsTestCase):
             h.write(nulled)
 
         with fits.open(self.temp('ascii_null2.fits'), memmap=True) as f:
-            assert np.isnan(f[1].data[2][0])
+            assert f[1].data[2][0] == 0.0
 
     def test_column_array_type_mismatch(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/218"""

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2136,6 +2136,34 @@ class TestTableFunctions(FitsTestCase):
                          "the header may be missing the necessary TNULL1 "
                          "keyword or the table contains invalid data")
 
+    def test_ascii_number_null_value(self):
+        """Regression test for https://github.com/astropy/astropy/issues/5134"""
+
+        # Test an integer column with blank string as null
+        nullval = ' '
+        c1 = fits.Column('F1', format='I8', null=nullval,
+                        array=np.array([0, 1, 2, 3, 4]),
+                        ascii=True)
+        table = fits.TableHDU.from_columns([c1])
+        table.writeto(self.temp('ascii_null.fits'), clobber=True)
+
+        # Replace the 3rd row with a null field
+        with open(self.temp('ascii_null.fits'), mode='r+') as h:
+            nulled = h.read().replace('2       ', '        ')
+            h.seek(0)
+            h.write(nulled)
+
+        # Now try to open it
+        with fits.open(self.temp('ascii_null.fits'), memmap=True) as f:
+            assert f[1].data[2][0] == 0
+
+        ## Test a float column
+        #c2 = fits.Column('F1', format='F12.8', null='NaN',
+        #                 array=np.array([1.0, 2.0, '', 3.0]),
+        #                 ascii=True)
+        #table = fits.TableHDU.from_columns([c2])
+
+
     def test_column_array_type_mismatch(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/218"""
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2142,7 +2142,7 @@ class TestTableFunctions(FitsTestCase):
         Blank values in numerical columns of ASCII tables should be replaced 
         before being placed in numpy arrays.
 
-        (fitsverify reports that this is valid FITS.)
+        (fitsverify reports that this is valid)
 
         Null strings in integer columns with blank-string TNULL* values 
         should be replaced with 0.
@@ -2162,7 +2162,7 @@ class TestTableFunctions(FitsTestCase):
 
         # Replace the 1st col, 3rd row, with a null field.
         with open(self.temp('ascii_null.fits'), mode='r+') as h:
-            nulled = h.read().replace('2       ', '        ')
+            nulled = h.read().replace(u'2       ', u'        ')
             h.seek(0)
             h.write(nulled)
 
@@ -2179,7 +2179,7 @@ class TestTableFunctions(FitsTestCase):
 
         # Replace the 1st col, 3rd row, with a null field.
         with open(self.temp('ascii_null2.fits'), mode='r+') as h:
-            nulled = h.read().replace('3.00000000', '          ')
+            nulled = h.read().replace(u'3.00000000', u'          ')
             h.seek(0)
             h.write(nulled)
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2142,7 +2142,7 @@ class TestTableFunctions(FitsTestCase):
         Blank values in numerical columns of ASCII tables should be replaced
         before being placed in numpy arrays.
 
-        Null strings in integer columns with blank-string TNULL* values 
+        Null strings in integer columns with blank-string TNULL* values
         should be replaced with 0.
         Null strings in float columns should be properly replaced with the
         TNULL* value."""


### PR DESCRIPTION
Fixes #5134 in which astropy.io.fits didn't properly convert blank values in integer columns to 0, which meant the FITS file got loaded properly but threw an error whenever you tried to access that value.

I was having a similar issue, but with a float column - it had null-string values that would fail to be converted to the TNULL\* value in the header, so it would throw a similar error on accessing that value.

I added checks for these two situations, and wrote tests.

This is all apparently valid FITS, according to [FITS Verify](http://fits.gsfc.nasa.gov/fits_verify.html). Both my issue and the previous person's issue come from using FITS files from Vizier, which are probably auto-generated with these quirks, but they are definitely valid.

One thing I'm curious about - how should a float column with a null-string TNULL\* value be handled, considering that's valid FITS? Should it just default to NaN?
