### PR TITLE
Update local ERFA to include 2016-Dec-31 leap second

### DIFF
--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -422,8 +422,7 @@ class TestBasic():
             Time('2000-01-02T03:04:05(UT(NIST)')
 
     def test_utc_leap_sec(self):
-        """Time behaves properly near or in UTC leap second.  This
-        uses the 2012-06-30 leap second for testing."""
+        """Time behaves properly near or in UTC leap second."""
         for year in ('2012', '2015'):
             # Start with a day without a leap second and note rollover
             t1 = Time(year + '-06-01 23:59:60.0', scale='utc')
@@ -446,6 +445,23 @@ class TestBasic():
             t0 = Time(year + '-06-30 23:59:59', scale='utc')
             t1 = Time(year + '-07-01 00:00:00', scale='utc')
             assert allclose_sec((t1 - t0).sec, 2.0)
+
+        t1 = Time('2016-12-31 23:59:59.900', scale='utc')
+        assert t1.iso == '2016-12-31 23:59:59.900'
+
+        t1 = Time('2016-12-31 23:59:60.000', scale='utc')
+        assert t1.iso == '2016-12-31 23:59:60.000'
+
+        t1 = Time('2016-12-31 23:59:60.999', scale='utc')
+        assert t1.iso == '2016-12-31 23:59:60.999'
+
+        t1 = Time('2016-12-31 23:59:61.0', scale='utc')
+        assert t1.iso == '2017-01-01 00:00:00.000'
+
+        # Delta time gives 2 seconds here as expected
+        t0 = Time('2016-12-31 23:59:59', scale='utc')
+        t1 = Time('2016-01-01 00:00:00', scale='utc')
+        assert allclose_sec((t1 - t0).sec, 2.0)
 
     def test_init_from_time_objects(self):
         """Initialize from one or more Time objects"""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -460,7 +460,7 @@ class TestBasic():
 
         # Delta time gives 2 seconds here as expected
         t0 = Time('2016-12-31 23:59:59', scale='utc')
-        t1 = Time('2016-01-01 00:00:00', scale='utc')
+        t1 = Time('2017-01-01 00:00:00', scale='utc')
         assert allclose_sec((t1 - t0).sec, 2.0)
 
     def test_init_from_time_objects(self):

--- a/cextern/erfa/dat.c
+++ b/cextern/erfa/dat.c
@@ -36,7 +36,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **     :  even if no leap seconds have been       :
 **     :  added.                                  :
 **     :                                          :
-**     :  Latest leap second:  2015 June 30       :
+**     :  Latest leap second:  2016 December 31   :
 **     :                                          :
 **     :__________________________________________:
 **
@@ -115,12 +115,12 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **  Called:
 **     eraCal2jd    Gregorian calendar to JD
 **
-**  Copyright (C) 2013-2015, NumFOCUS Foundation.
+**  Copyright (C) 2013-2016, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Release year for this version of eraDat */
-   enum { IYV = 2015};
+   enum { IYV = 2016};
 
 /* Reference dates (MJD) and drift rates (s/day), pre leap seconds */
    static const double drift[][2] = {
@@ -188,7 +188,8 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
       { 2006,  1, 33.0       },
       { 2009,  1, 34.0       },
       { 2012,  7, 35.0       },
-      { 2015,  7, 36.0       }
+      { 2015,  7, 36.0       },
+      { 2017,  1, 37.0       }
    };
 
 /* Number of Delta(AT) changes */
@@ -244,7 +245,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2015, NumFOCUS Foundation.
+**  Copyright (C) 2013-2016, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International


### PR DESCRIPTION
Following the pattern of https://github.com/astropy/astropy/pull/3794. Test written but not actually tested.