### PR TITLE
Moving coverage travis build from python2.7 to python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,15 +70,14 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10 SETUP_CMD='test --open-files'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
-        # (with latest numpy). We also note the code coverage on Python 2.7.
-        # NOTE: move coverage to 3.x once speed issues have been solved; #4826
+        # (with latest numpy).
         - os: linux
-          env: SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem'
                LC_CTYPE=C.ascii LC_ALL=C
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage'
+          env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem'
                LC_CTYPE=C.ascii LC_ALL=C


### PR DESCRIPTION
As it was discussed in #4826 the slowness of the python3 coverage run should be solved when using a newer version, so probably we can move to python3 with this PR.