### PR TITLE
Update "naxisx" attributes when slicing the WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -353,8 +353,6 @@ Bug Fixes
 
   - Improved log messages in ``to_header``. [#5239]
 
-  - Update the ``_naxisx`` attributes when calling ``WCS.slice``. [#5411]
-
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1704,6 +1702,9 @@ Bug Fixes
 - ``astropy.vo``
 
 - ``astropy.wcs``
+
+  - Update the ``_naxis{x}`` attributes when calling ``WCS.slice``. [#5411]
+
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -353,6 +353,9 @@ Bug Fixes
 
   - Improved log messages in ``to_header``. [#5239]
 
+  - Update the ``_naxisx`` attributes when calling ``WCS.slice``. [#5411]
+
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -78,16 +78,20 @@ def test_slice():
     mywcs.wcs.crval = [1,1]
     mywcs.wcs.cdelt = [0.1,0.1]
     mywcs.wcs.crpix = [1,1]
+    mywcs._naxis = [1000, 500]
 
     slice_wcs = mywcs.slice([slice(1,None),slice(0,None)])
     assert np.all(slice_wcs.wcs.crpix == np.array([1,0]))
+    assert slice_wcs._naxis == [1000, 499]
 
     slice_wcs = mywcs.slice([slice(1,None,2),slice(0,None,4)])
     assert np.all(slice_wcs.wcs.crpix == np.array([0.625, 0.25]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.4,0.2]))
+    assert slice_wcs._naxis == [250, 250]
 
     slice_wcs = mywcs.slice([slice(None,None,2),slice(0,None,2)])
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2,0.2]))
+    assert slice_wcs._naxis == [500, 250]
 
 def test_slice_getitem():
     mywcs = WCS(naxis=2)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -33,6 +33,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # STDLIB
 import copy
 import io
+import itertools
+import math
 import os
 import re
 import textwrap
@@ -2654,13 +2656,28 @@ reduce these to 2 dimensions using the naxis kwarg.
         f.write(') # color={0}, width={1:d} \n'.format(color, width))
         f.close()
 
+    @property
+    def _naxis1(self):
+        return self._naxis[0]
+
+    @property
+    def _naxis2(self):
+        return self._naxis[1]
+
     def _get_naxis(self, header=None):
-        self._naxis1 = 0
-        self._naxis2 = 0
+        _naxis = []
         if (header is not None and
-            not isinstance(header, (six.text_type, six.binary_type))):
-            self._naxis1 = header.get('NAXIS1', 0)
-            self._naxis2 = header.get('NAXIS2', 0)
+                not isinstance(header, (six.text_type, six.binary_type))):
+            for naxis in itertools.count(1):
+                try:
+                    _naxis.append(header['NAXIS{}'.format(naxis)])
+                except KeyError:
+                    break
+        if len(_naxis) == 0:
+            _naxis = [0, 0]
+        elif len(_naxis) == 1:
+            _naxis.append(0)
+        self._naxis = _naxis
 
     @deprecated('1.3')
     def rotateCD(self, theta):
@@ -2903,7 +2920,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         elif not hasattr(view, '__len__'): # view MUST be an iterable
             view = [view]
 
-        if not all([isinstance(x, slice) for x in view]):
+        if not all(isinstance(x, slice) for x in view):
             raise ValueError("Cannot downsample a WCS with indexing.  Use "
                              "wcs.sub or wcs.dropaxis if you want to remove "
                              "axes.")
@@ -2913,6 +2930,12 @@ reduce these to 2 dimensions using the naxis kwarg.
             if iview.step is not None and iview.step < 0:
                 raise NotImplementedError("Reversing an axis is not "
                                           "implemented.")
+
+            if numpy_order:
+                wcs_index = self.wcs.naxis - 1 - i
+            else:
+                wcs_index = i
+
             if iview.step is not None and iview.start is None:
                 # Slice from "None" is equivalent to slice from 0 (but one
                 # might want to downsample, so allow slices with
@@ -2920,11 +2943,6 @@ reduce these to 2 dimensions using the naxis kwarg.
                 iview = slice(0, iview.stop, iview.step)
 
             if iview.start is not None:
-                if numpy_order:
-                    wcs_index = self.wcs.naxis - 1 - i
-                else:
-                    wcs_index = i
-
                 if iview.step not in (None, 1):
                     crpix = self.wcs.crpix[wcs_index]
                     cdelt = self.wcs.cdelt[wcs_index]

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -46,7 +46,7 @@ import numpy as np
 # LOCAL
 from .. import log
 from ..extern import six
-from ..extern.six.moves import range, zip, map
+from ..extern.six.moves import range, zip, map, builtins
 from ..io import fits
 from . import _docutil as __
 try:
@@ -2954,7 +2954,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 else:
                     wcs_new.wcs.crpix[wcs_index] -= iview.start
 
-            nitems = len(range(self._naxis[wcs_index])[iview])
+            nitems = len(builtins.range(self._naxis[wcs_index])[iview])
             wcs_new._naxis[wcs_index] = nitems
 
         return wcs_new

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -34,7 +34,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import io
 import itertools
-import math
 import os
 import re
 import textwrap
@@ -2722,8 +2721,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 s += sfmt
                 description.append(s.format(*self.wcs.cd[i]))
 
-        description.append('NAXIS    : {0!r} {1!r}'.format(self._naxis1,
-                           self._naxis2))
+        description.append('NAXIS : {}'.format('  '.join(map(str, self._naxis))))
         return '\n'.join(description)
 
     def get_axis_types(self):
@@ -2955,6 +2953,10 @@ reduce these to 2 dimensions using the naxis kwarg.
                     wcs_new.wcs.cdelt[wcs_index] = cdelt * iview.step
                 else:
                     wcs_new.wcs.crpix[wcs_index] -= iview.start
+
+            nitems = len(range(self._naxis[wcs_index])[iview])
+            wcs_new._naxis[wcs_index] = nitems
+
         return wcs_new
 
     def __getitem__(self, item):


### PR DESCRIPTION
Fixes https://github.com/astropy/ccdproc/issues/281 and Fixes #4498

This PR adds a `_naxis1` and `_naxis2` property (mostly for backwards-compatibility) but the `_naxis` is now saved internally as `list`. This allows to support more than 2 axis, especially if someone wants to expand the `calculate_footprint` method.

Of course it also updates the `_naxis` attribute when being sliced.
