### PR TITLE
Remove one unnecessary lambda wrapper in equivalencies

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -37,7 +37,7 @@ def logarithmic():
     """Allow logarithmic units to be converted to dimensionless fractions"""
     return [
         (dimensionless_unscaled, function_units.dex,
-         lambda x: np.log10(x), lambda x: 10.**x)
+         np.log10, lambda x: 10.**x)
     ]
 
 


### PR DESCRIPTION
In one case it is not necessary to create a `lambda` because it just forwards the argument to another function.