### PR TITLE
Full coverage for function units

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -27,7 +27,6 @@ from . import format as unit_format
 if six.PY2:
     import cmath
 
-# TODO: Support function units, e.g. log(x), ln(x)
 
 __all__ = [
     'UnitsError', 'UnitsWarning', 'UnitConversionError', 'UnitTypeError',

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -14,10 +14,10 @@ from .. import (Unit, UnitBase, UnitsError, UnitTypeError,
 
 __all__ = ['FunctionUnitBase', 'FunctionQuantity']
 
-SUPPORTED_UFUNCS = set([getattr(np.core.umath, ufunc) for ufunc in (
+SUPPORTED_UFUNCS = set(getattr(np.core.umath, ufunc) for ufunc in (
     'isfinite', 'isinf', 'isnan', 'sign', 'signbit',
     'rint', 'floor', 'ceil', 'trunc', 'power',
-    '_ones_like', 'ones_like') if hasattr(np.core.umath, ufunc)])
+    '_ones_like', 'ones_like') if hasattr(np.core.umath, ufunc))
 
 # TODO: the following could work if helper changed relative to Quantity:
 # - spacing should return dimensionless, not same unit

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -70,9 +70,9 @@ class LogUnit(FunctionUnitBase):
         # u.dex, and u.dB are OK, i.e., other does not have to be LogUnit
         # (this will indirectly test whether other is a unit at all).
         try:
-            self._function_unit._to(getattr(other, 'function_unit', other))
+            getattr(other, 'function_unit', other)._to(self._function_unit)
         except AttributeError:
-            # if other is not a unit (_to cannot decompose).
+            # if other is not a unit (i.e., does not have _to).
             return NotImplemented
         except UnitsError:
             raise UnitsError("Can only add/subtract logarithmic units of"

--- a/astropy/units/function/mixin.py
+++ b/astropy/units/function/mixin.py
@@ -1,27 +1,25 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .. import core
+from ..core import IrreducibleUnit, Unit
+
 
 class FunctionMixin(object):
     """Mixin class that makes UnitBase subclasses callable.
 
     Provides a __call__ method that passes on arguments to a FunctionUnit.
+    Instances of this class should define ``_function_unit_class`` pointing
+    to the relevant class.
 
     See units.py and logarithmic.py for usage.
     """
-    _function_unit_class = None
-
     def __call__(self, unit=None):
-        if self._function_unit_class is None:
-            raise TypeError("Cannot call unit since corresponding "
-                            "function unit class is not defined.")
         return self._function_unit_class(physical_unit=unit,
                                          function_unit=self)
 
 
-class IrreducibleFunctionUnit(FunctionMixin, core.IrreducibleUnit):
+class IrreducibleFunctionUnit(FunctionMixin, IrreducibleUnit):
     pass
 
 
-class RegularFunctionUnit(FunctionMixin, core.Unit):
+class RegularFunctionUnit(FunctionMixin, Unit):
     pass


### PR DESCRIPTION
In a spate of idealism, I ensured that the code for logarithmic units is fully covered by the tests. It turned out to be somewhat useful, as it uncovered a few bugs (which, however, would have been not easy to trigger in practice, e.g., a ufunc being allowed that really shouldn't be; so perhaps not quite worth backporting any more).