### PR TITLE
Ensure we set equal_nan=True if needed in comparisons.

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -504,7 +504,8 @@ class TestInvariantUfuncs(object):
         q_o = ufunc(q_i1, arbitrary_unit_value)
         assert isinstance(q_o, u.Quantity)
         assert q_o.unit == q_i1.unit
-        assert_allclose(q_o.value, ufunc(q_i1.value, arbitrary_unit_value))
+        assert_allclose(q_o.value, ufunc(q_i1.value, arbitrary_unit_value),
+                        equal_nan=True)
 
     @pytest.mark.parametrize(('ufunc'), [np.add, np.subtract, np.hypot,
                                          np.maximum, np.minimum, np.nextafter,

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -9,6 +9,10 @@ from numpy.testing.utils import assert_allclose
 from ... import units as u
 from ...tests.helper import pytest, raises
 from ...extern.six.moves import zip
+from ...utils.compat import NUMPY_LT_1_10
+
+
+EQUAL_NAN = {} if NUMPY_LT_1_10 else {'equal_nan': True}
 
 
 class TestUfuncCoverage(object):
@@ -505,7 +509,7 @@ class TestInvariantUfuncs(object):
         assert isinstance(q_o, u.Quantity)
         assert q_o.unit == q_i1.unit
         assert_allclose(q_o.value, ufunc(q_i1.value, arbitrary_unit_value),
-                        equal_nan=True)
+                        **EQUAL_NAN)
 
     @pytest.mark.parametrize(('ufunc'), [np.add, np.subtract, np.hypot,
                                          np.maximum, np.minimum, np.nextafter,

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -7,6 +7,7 @@ from ...tests.helper import pytest
 from ..mpl_normalize import ImageNormalize, simple_norm
 from ..interval import ManualInterval
 from ..stretch import SqrtStretch
+from ...utils.compat import NUMPY_LT_1_10
 
 try:
     import matplotlib    # pylint: disable=W0611
@@ -14,6 +15,8 @@ try:
 except ImportError:
     HAS_MATPLOTLIB = False
 
+
+EQUAL_NAN = {} if NUMPY_LT_1_10 else {'equal_nan': True}
 
 DATA = np.linspace(0., 15., 6)
 DATA2 = np.arange(3)
@@ -58,10 +61,10 @@ class TestNormalize(object):
         output = norm(DATA)
         expected = [np.nan, 0.35355339, 0.70710678, 0.93541435, 1.11803399,
                     1.27475488]
-        assert_allclose(output, expected, equal_nan=True)
+        assert_allclose(output, expected, **EQUAL_NAN)
         assert_allclose(output.mask, [0, 0, 0, 0, 0, 0])
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
-        assert_allclose(output, norm2(DATA), equal_nan=True)
+        assert_allclose(output, norm2(DATA), **EQUAL_NAN)
 
     def test_implicit_autoscale(self):
         norm = ImageNormalize(vmin=None, vmax=10., stretch=SqrtStretch(),
@@ -80,7 +83,7 @@ class TestNormalize(object):
         output = norm(DATA)
         assert norm.vmin == 2.
         assert norm.vmax == np.max(DATA)
-        assert_allclose(output, norm2(DATA), equal_nan=True)
+        assert_allclose(output, norm2(DATA), **EQUAL_NAN)
 
     def test_masked_clip(self):
         mdata = ma.array(DATA, mask=[0, 0, 1, 0, 0, 0])
@@ -103,11 +106,11 @@ class TestNormalize(object):
         output = norm(mdata)
         expected = [np.nan, 0.35355339, -10, 0.93541435, 1.11803399,
                     1.27475488]
-        assert_allclose(output.filled(-10), expected, equal_nan=True)
+        assert_allclose(output.filled(-10), expected, **EQUAL_NAN)
         assert_allclose(output.mask, [0, 0, 1, 0, 0, 0])
 
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
-        assert_allclose(output, norm2(mdata), equal_nan=True)
+        assert_allclose(output, norm2(mdata), **EQUAL_NAN)
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -58,10 +58,10 @@ class TestNormalize(object):
         output = norm(DATA)
         expected = [np.nan, 0.35355339, 0.70710678, 0.93541435, 1.11803399,
                     1.27475488]
-        assert_allclose(output, expected)
+        assert_allclose(output, expected, equal_nan=True)
         assert_allclose(output.mask, [0, 0, 0, 0, 0, 0])
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
-        assert_allclose(output, norm2(DATA))
+        assert_allclose(output, norm2(DATA), equal_nan=True)
 
     def test_implicit_autoscale(self):
         norm = ImageNormalize(vmin=None, vmax=10., stretch=SqrtStretch(),
@@ -80,7 +80,7 @@ class TestNormalize(object):
         output = norm(DATA)
         assert norm.vmin == 2.
         assert norm.vmax == np.max(DATA)
-        assert_allclose(output, norm2(DATA))
+        assert_allclose(output, norm2(DATA), equal_nan=True)
 
     def test_masked_clip(self):
         mdata = ma.array(DATA, mask=[0, 0, 1, 0, 0, 0])
@@ -103,11 +103,11 @@ class TestNormalize(object):
         output = norm(mdata)
         expected = [np.nan, 0.35355339, -10, 0.93541435, 1.11803399,
                     1.27475488]
-        assert_allclose(output.filled(-10), expected)
+        assert_allclose(output.filled(-10), expected, equal_nan=True)
         assert_allclose(output.mask, [0, 0, 1, 0, 0, 0])
 
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
-        assert_allclose(output, norm2(mdata))
+        assert_allclose(output, norm2(mdata), equal_nan=True)
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -6,7 +6,10 @@ from ..stretch import (LinearStretch, SqrtStretch, PowerStretch,
                        PowerDistStretch, SquaredStretch, LogStretch,
                        AsinhStretch, SinhStretch, HistEqStretch,
                        ContrastBiasStretch)
+from ...utils.compat import NUMPY_LT_1_10
 
+
+EQUAL_NAN = {} if NUMPY_LT_1_10 else {'equal_nan': True}
 
 DATA = np.array([0.00, 0.25, 0.50, 0.75, 1.00])
 
@@ -102,4 +105,4 @@ def test_clip_invalid():
 
     values = stretch([-1., 0., 0.5, 1., 1.5], clip=False)
     np.testing.assert_allclose(values, [np.nan, 0., 0.70710678, 1., 1.2247448],
-                               equal_nan=True)
+                               **EQUAL_NAN)

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -101,4 +101,5 @@ def test_clip_invalid():
     np.testing.assert_allclose(values, [0., 0., 0.70710678, 1., 1.])
 
     values = stretch([-1., 0., 0.5, 1., 1.5], clip=False)
-    np.testing.assert_allclose(values, [np.nan, 0., 0.70710678, 1., 1.2247448])
+    np.testing.assert_allclose(values, [np.nan, 0., 0.70710678, 1., 1.2247448],
+                               equal_nan=True)


### PR DESCRIPTION
With recent numpy, `assert_allclose` started to follow its docstring correctly, raising an error if `NaN` were compared. This can be avoided by setting `equal_nan=True`, which this PR does.