### PR TITLE
Omit coverage tests for "_erfa" submodule files

### DIFF
--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -10,7 +10,7 @@ omit =
    astropy/utils/compat/*
    astropy/version*
    astropy/wcs/docstrings*
-   astropy/_erfa/erfa_generator.py
+   astropy/_erfa/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
As mentioned in https://github.com/astropy/astropy/pull/5418#issuecomment-254826746 I think we do not need to test `_erfa` coverage.