### PR TITLE
Numpy dev array printing - update all tests to new numpy style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1732,6 +1732,9 @@ Other Changes and Additions
 - The bundled ERFA was updated to version 1.3.0.  This includes the
   leap second planned for 2016 Dec 13. [#5418]
 
+- Coordinates and their representations are printed with a slightly different
+  format, following how numpy >= 1.12 prints structured arrays. [#5423]
+
 1.0.10 (2016-06-09)
 -------------------
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -891,12 +891,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         >>> coord = SkyCoord(0*u.deg, 0*u.deg)
         >>> coord.represent_as(CartesianRepresentation)
         <CartesianRepresentation (x, y, z) [dimensionless]
-                (1.0, 0.0, 0.0)>
+                ( 1.,  0.,  0.)>
 
         >>> coord.representation = CartesianRepresentation
         >>> coord
         <SkyCoord (ICRS): (x, y, z) [dimensionless]
-            (1.0, 0.0, 0.0)>
+            ( 1.,  0.,  0.)>
         """
         new_representation = _get_repr_cls(new_representation)
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -93,16 +93,16 @@ class Galactocentric(BaseCoordinateFrame):
         ...                distance=[11.5, 24.12] * u.kpc)
         >>> c.transform_to(coord.Galactocentric) # doctest: +FLOAT_CMP
         <Galactocentric Coordinate (galcen_distance=8.3 kpc, galcen_ra=266d24m18.36s, galcen_dec=-28d56m10.23s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
-            [(-9.6083818980977, -9.400621883358546, 6.520560663896347),
-             (-21.283023068029138, 18.763340128812384, 7.846938548636718)]>
+            [( -9.6083819 , -9.40062188,  6.52056066),
+             (-21.28302307, 18.76334013,  7.84693855)]>
 
     To specify a custom set of parameters, you have to include extra keyword
     arguments when initializing the Galactocentric frame object::
 
         >>> c.transform_to(coord.Galactocentric(galcen_distance=8.1*u.kpc)) # doctest: +FLOAT_CMP
         <Galactocentric Coordinate (galcen_distance=8.1 kpc, galcen_ra=266d24m18.36s, galcen_dec=-28d56m10.23s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
-            [(-9.407859235565343, -9.400621883358546, 6.520665737962164),
-             (-21.08239383088295, 18.763340128812384, 7.84798134569032)]>
+            [( -9.40785924,  -9.40062188,  6.52066574),
+             (-21.08239383,  18.76334013,  7.84798135)]>
 
     Similarly, transforming from the Galactocentric frame to another coordinate frame::
 
@@ -111,8 +111,8 @@ class Galactocentric(BaseCoordinateFrame):
         ...                          z=[0.027, 24.12] * u.kpc)
         >>> c.transform_to(coord.ICRS) # doctest: +FLOAT_CMP
         <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
-            [(86.22349058727241, 28.8389413808627, 4.391577882957292e-05),
-             (289.6680265194508, 49.88763881149547, 85.96407345372828)]>
+            [(  86.22349059, 28.83894138,  4.39157788e-05),
+             ( 289.66802652, 49.88763881,  8.59640735e+01)]>
 
     Or, with custom specification of the Galactic center::
 
@@ -122,8 +122,8 @@ class Galactocentric(BaseCoordinateFrame):
         ...                          z_sun=21 * u.pc, galcen_distance=8. * u.kpc)
         >>> c.transform_to(coord.ICRS) # doctest: +FLOAT_CMP
         <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
-            [(86.25852490164378, 28.85773187391088, 2.7562547481200286e-05),
-             (289.77285254989323, 50.062904565432014, 85.92160096237191)]>
+            [(  86.2585249 ,  28.85773187,  2.75625475e-05),
+             ( 289.77285255,  50.06290457,  8.59216010e+01)]>
 
     """
     default_representation = CartesianRepresentation

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -183,18 +183,18 @@ def test_frame_repr():
     i3 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.kpc)
 
     assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
-                        '    (1.0, 2.0)>')
+                        '    ( 1.,  2.)>')
     assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
-                        '    (1.0, 2.0, 3.0)>')
+                        '    ( 1.,  2.,  3.)>')
 
     # try with arrays
     i2 = ICRS(ra=[1.1,2.1]*u.deg, dec=[2.1,3.1]*u.deg)
     i3 = ICRS(ra=[1.1,2.1]*u.deg, dec=[-15.6,17.1]*u.deg, distance=[11.,21.]*u.kpc)
 
     assert repr(i2) == ('<ICRS Coordinate: (ra, dec) in deg\n'
-                        '    [(1.1, 2.1), (2.1, 3.1)]>')
+                        '    [( 1.1,  2.1), ( 2.1,  3.1)]>')
     assert repr(i3) == ('<ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)\n'
-                        '    [(1.1, -15.6, 11.0), (2.1, 17.1, 21.0)]>')
+                        '    [( 1.1, -15.6,  11.), ( 2.1,  17.1,  21.)]>')
 
 
 def test_converting_units():
@@ -664,7 +664,7 @@ def test_representation_subclass():
     # A similar issue then happened in __repr__ with subclasses of
     # SphericalRepresentation.
     assert repr(frame) == ("<FK5 Coordinate (equinox=J2000.000): (lon, lat) in deg\n"
-                           "    (32.0, 20.0)>")
+                           "    ( 32.,  20.)>")
 
     # A more subtle issue is when specifying a custom
     # UnitSphericalRepresentation subclass for the data and

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -931,26 +931,26 @@ def test_no_unnecessary_copies():
 def test_representation_repr():
     r1 = SphericalRepresentation(lon=1 * u.deg, lat=2.5 * u.deg, distance=1 * u.kpc)
     assert repr(r1) == ('<SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)\n'
-                        '    (1.0, 2.5, 1.0)>')
+                        '    ( 1.,  2.5,  1.)>')
 
     r2 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
     assert repr(r2) == ('<CartesianRepresentation (x, y, z) in kpc\n'
-                        '    (1.0, 2.0, 3.0)>')
+                        '    ( 1.,  2.,  3.)>')
 
     r3 = CartesianRepresentation(x=[1, 2, 3] * u.kpc, y=4 * u.kpc, z=[9, 10, 11] * u.kpc)
     assert repr(r3) == ('<CartesianRepresentation (x, y, z) in kpc\n'
-                        '    [(1.0, 4.0, 9.0), (2.0, 4.0, 10.0), (3.0, 4.0, 11.0)]>')
+                        '    [( 1.,  4.,   9.), ( 2.,  4.,  10.), ( 3.,  4.,  11.)]>')
 
 
 def test_representation_str():
     r1 = SphericalRepresentation(lon=1 * u.deg, lat=2.5 * u.deg, distance=1 * u.kpc)
-    assert str(r1) == '(1.0, 2.5, 1.0) (deg, deg, kpc)'
+    assert str(r1) == '( 1.,  2.5,  1.) (deg, deg, kpc)'
 
     r2 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
-    assert str(r2) == '(1.0, 2.0, 3.0) kpc'
+    assert str(r2) == '( 1.,  2.,  3.) kpc'
 
     r3 = CartesianRepresentation(x=[1, 2, 3] * u.kpc, y=4 * u.kpc, z=[9, 10, 11] * u.kpc)
-    assert str(r3) == '[(1.0, 4.0, 9.0) (2.0, 4.0, 10.0) (3.0, 4.0, 11.0)] kpc'
+    assert str(r3) == '[( 1.,  4.,   9.), ( 2.,  4.,  10.), ( 3.,  4.,  11.)] kpc'
 
 
 def test_subclass_representation():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -488,17 +488,16 @@ def test_repr():
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)
 
     assert repr(sc1) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
-                         '    (0.0, 1.0)>')
+                         '    ( 0.,  1.)>')
     assert repr(sc2) == ('<SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)\n'
-                         '    (1.0, 1.0, 1.0)>')
+                         '    ( 1.,  1.,  1.)>')
 
     sc3 = SkyCoord(0.25 * u.deg, [1, 2.5] * u.deg, frame='icrs')
-    assert repr(sc3) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
-                         '    [(0.25, 1.0), (0.25, 2.5)]>')
+    assert repr(sc3).startswith('<SkyCoord (ICRS): (ra, dec) in deg\n')
 
     sc_default = SkyCoord(0 * u.deg, 1 * u.deg)
     assert repr(sc_default) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
-                                '    (0.0, 1.0)>')
+                                '    ( 0.,  1.)>')
 
 def test_repr_altaz():
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs', distance=1 * u.kpc)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -4,6 +4,7 @@ from __future__ import division, with_statement, print_function
 import contextlib
 import copy
 import gc
+import re
 
 import numpy as np
 from numpy import char as chararray
@@ -825,9 +826,11 @@ class TestTableFunctions(FitsTestCase):
 
         hdul = fits.open(self.temp('newtable.fits'))
 
-        assert str(hdu.data) == "[('NGC1002', 12.3) ('NGC1003', 15.2)]"
-
-        assert str(hdul[1].data) == "[('NGC1002', 12.3) ('NGC1003', 15.2)]"
+        # numpy >= 1.12 changes how structured arrays are printed, so we
+        # match to a regex rather than a specific string.
+        expect = r"\[\('NGC1002',\s+12.3[0-9]*\) \(\'NGC1003\',\s+15.[0-9]+\)\]"
+        assert re.match(expect, str(hdu.data))
+        assert re.match(expect, str(hdul[1].data))
 
         t.close()
         hdul.close()

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,7 @@ from ...utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_8', 'NUMPY_LT_1_9', 'NUMPY_LT_1_9_1', 'NUMPY_LT_1_10',
-           'NUMPY_LT_1_10_4', 'NUMPY_LT_1_11']
+           'NUMPY_LT_1_10_4', 'NUMPY_LT_1_11', 'NUMPY_LT_1_12']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -21,6 +21,7 @@ NUMPY_LT_1_9_1 = not minversion('numpy', '1.9.1')
 NUMPY_LT_1_10 = not minversion('numpy', '1.10.0')
 NUMPY_LT_1_10_4 = not minversion('numpy', '1.10.4')
 NUMPY_LT_1_11 = not minversion('numpy', '1.11.0')
+NUMPY_LT_1_12 = not minversion('numpy', '1.12dev')
 
 
 def _monkeypatch_unicode_mask_fill_values():

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -108,9 +108,9 @@ Angles will also behave correctly for appropriate arithmetic operations::
 |Angle| objects can also be used for creating coordinate objects::
 
     >>> from astropy.coordinates import ICRS
-    >>> ICRS(Angle(1, u.radian), Angle(0.5, u.radian))  # doctest: +FLOAT_CMP
+    >>> ICRS(Angle(1, u.deg), Angle(0.5, u.deg))  # doctest: +FLOAT_CMP
     <ICRS Coordinate: (ra, dec) in deg
-        (57.2957795131, 28.6478897565)>
+        ( 1.,  0.5)>
 
 
 Wrapping and bounds

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -71,10 +71,10 @@ equatorial systems)::
     >>> from astropy import units as u
     >>> ICRS(ra=1.1*u.deg, dec=2.2*u.deg)
     <ICRS Coordinate: (ra, dec) in deg
-        (1.1, 2.2)>
+        ( 1.1,  2.2)>
     >>> FK5(ra=1.1*u.deg, dec=2.2*u.deg, equinox='J1975')
     <FK5 Coordinate (equinox=J1975.000): (ra, dec) in deg
-        (1.1, 2.2)>
+        ( 1.1,  2.2)>
 
 These same attributes can be used to access the data in the frames, as
 |Angle| objects (or |Angle| subclasses)::
@@ -106,7 +106,7 @@ One can get the data in a different representation if needed::
 
     >>> icrs.represent_as('cartesian')  # doctest: +FLOAT_CMP
     <CartesianRepresentation (x, y, z) [dimensionless]
-         (0.99923861, 0.01744177, 0.0348995)>
+         ( 0.99923861,  0.01744177,  0.0348995)>
 
 The representation of the coordinate object can also be changed directly, as
 shown below.  This actually does *nothing* to the object internal data which
@@ -122,7 +122,7 @@ space.::
     >>> icrs.representation = CartesianRepresentation
     >>> icrs  # doctest: +FLOAT_CMP
     <ICRS Coordinate: (x, y, z) [dimensionless]
-        (0.999238614955, 0.0174417749028, 0.0348994967025)>
+        ( 0.99923861, 0.01744177, 0.0348995)>
     >>> icrs.x  # doctest: +FLOAT_CMP
     <Quantity 0.9992386149554826>
 
@@ -132,7 +132,7 @@ example to create a coordinate with cartesian data do::
 
     >>> ICRS(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc, representation=CartesianRepresentation)
     <ICRS Coordinate: (x, y, z) in kpc
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
 
 For more information about the use of representations in coordinates see the
 :ref:`astropy-skycoord-representations` section, and for details about the
@@ -146,7 +146,7 @@ any  frame attributes required::
     >>> rep = SphericalRepresentation(lon=1.1*u.deg, lat=2.2*u.deg, distance=3.3*u.kpc)
     >>> FK5(rep, equinox='J1975')
     <FK5 Coordinate (equinox=J1975.000): (ra, dec, distance) in (deg, deg, kpc)
-        (1.1, 2.2, 3.3)>
+        ( 1.1,  2.2,  3.3)>
 
 A final way is to create a frame object from an already existing frame
 (either one with or without data), using the ``realize_frame`` method. This
@@ -158,7 +158,7 @@ will yield a frame with the same attributes, but new data::
     >>> rep = SphericalRepresentation(lon=1.1*u.deg, lat=2.2*u.deg, distance=3.3*u.kpc)
     >>> f1.realize_frame(rep)
     <FK5 Coordinate (equinox=J1975.000): (ra, dec, distance) in (deg, deg, kpc)
-        (1.1, 2.2, 3.3)>
+        ( 1.1,  2.2,  3.3)>
 
 You can check if a frame object has data using the ``has_data`` attribute, and
 if it is preset, it can be accessed from the ``data`` attribute::
@@ -170,7 +170,7 @@ if it is preset, it can be accessed from the ``data`` attribute::
     True
     >>> cooi.data
     <UnitSphericalRepresentation (lon, lat) in deg
-        (1.1, 2.2)>
+        ( 1.1,  2.2)>
 
 All of the above methods can also accept array data (in the form of
 class:`~astropy.units.Quantity`, or other Python sequences) to create arrays of
@@ -178,14 +178,14 @@ coordinates::
 
     >>> ICRS(ra=[1.5, 2.5]*u.deg, dec=[3.5, 4.5]*u.deg)
     <ICRS Coordinate: (ra, dec) in deg
-        [(1.5, 3.5), (2.5, 4.5)]>
+        [( 1.5,  3.5), ( 2.5,  4.5)]>
 
 If you pass in mixed arrays and scalars, the arrays will be broadcast
 over the scalars appropriately::
 
     >>> ICRS(ra=[1.5, 2.5]*u.deg, dec=[3.5, 4.5]*u.deg, distance=5*u.kpc)
     <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
-        [(1.5, 3.5, 5.0), (2.5, 4.5, 5.0)]>
+        [( 1.5,  3.5,  5.), ( 2.5,  4.5,  5.)]>
 
 Similar broadcasting happens if you transform to another frame.  E.g.::
 
@@ -196,7 +196,7 @@ Similar broadcasting happens if you transform to another frame.  E.g.::
     ...            obstime=['2012-03-21T00:00:00', '2012-06-21T00:00:00'])
     >>> coo.transform_to(lf)  # doctest: +FLOAT_CMP
     <AltAz Coordinate (obstime=['2012-03-21T00:00:00.000' '2012-06-21T00:00:00.000'], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
-        [(94.71264994, 89.2142425), (307.69488826, 37.98077772)]>
+        [(  94.71264994,  89.2142425 ), ( 307.69488826,  37.98077772)]>
 
 Above, the shapes -- ``()`` for ``coo`` and ``(2,)`` for ``lf`` -- were
 broadcast against each other.  If you wished to determine the positions for a
@@ -219,10 +219,10 @@ set of coordinates, you'd need to make sure that the shapes allowed this::
       '2012-03-21T00:00:00.000']
      ['2012-06-21T00:00:00.000' '2012-06-21T00:00:00.000'
       '2012-06-21T00:00:00.000']], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
-        [[(93.09845202, 89.21613119), (126.85789652, 25.46600543),
-          (51.37993229, 37.18532521)],
-         [(307.71713699, 37.99437658), (231.37407871, 26.36768329),
-          (85.42187335, 89.69297997)]]>
+        [[(  93.09845202,  89.21613119), ( 126.85789652,  25.46600543),
+          (  51.37993229,  37.18532521)],
+         [( 307.71713699,  37.99437658), ( 231.37407871,  26.36768329),
+          (  85.42187335,  89.69297997)]]>
 
 .. Note::
    One sees that frames without data have a ``shape`` that is determined by
@@ -242,10 +242,10 @@ data)::
     >>> cooi = ICRS(1.5*u.deg, 2.5*u.deg)
     >>> cooi.transform_to(FK5)  # doctest: +FLOAT_CMP
     <FK5 Coordinate (equinox=J2000.000): (ra, dec) in deg
-        (1.50000660527, 2.50000238221)>
+        ( 1.50000661,  2.50000238)>
     >>> cooi.transform_to(FK5(equinox='J1975'))  # doctest: +FLOAT_CMP
     <FK5 Coordinate (equinox=J1975.000): (ra, dec) in deg
-        (1.17960348105, 2.36085320826)>
+        ( 1.17960348,  2.36085321)>
 
 The :ref:`astropy-coordinates-api` includes a list of all of the frames built
 into `astropy.coordinates`, as well as the defined transformations between
@@ -297,7 +297,7 @@ the way you want.  As an example::
   >>> c = MyFrame(R=10*u.deg, D=20*u.deg)
   >>> c  # doctest: +FLOAT_CMP
   <MyFrame Coordinate (location=None, equinox=B1950.000, obstime=B1950.000): (R, D) in rad
-      (0.174532925199, 0.349065850399)>
+      ( 0.17453293,  0.34906585)>
   >>> c.equinox
   <Time object: scale='utc' format='byear_str' value=B1950.000>
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -194,7 +194,8 @@ Similar broadcasting happens if you transform to another frame.  E.g.::
     >>> coo = ICRS(ra=180.*u.deg, dec=51.477811*u.deg)
     >>> lf = AltAz(location=EarthLocation.of_site('greenwich'),
     ...            obstime=['2012-03-21T00:00:00', '2012-06-21T00:00:00'])
-    >>> coo.transform_to(lf)  # doctest: +FLOAT_CMP
+    >>> lcoo = coo.transform_to(lf)  # this can load finals2000A.all # doctest: +IGNORE_OUTPUT
+    >>> lcoo  # doctest: +FLOAT_CMP
     <AltAz Coordinate (obstime=['2012-03-21T00:00:00.000' '2012-06-21T00:00:00.000'], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
         [(  94.71264994,  89.2142425 ), ( 307.69488826,  37.98077772)]>
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -33,7 +33,7 @@ equivalent::
     >>> c = SkyCoord('00:42.5 +41:12', unit=(u.hourangle, u.deg))
     >>> c
     <SkyCoord (ICRS): (ra, dec) in deg
-        (10.625, 41.2)>
+        ( 10.625,  41.2)>
 
 The examples above illustrate a few simple rules to follow when creating a coordinate
 object:
@@ -56,15 +56,14 @@ holding the data, |skycoord| objects can be sliced, reshaped, etc.::
     >>> c = SkyCoord(ra=[10, 11, 12, 13]*u.degree, dec=[41, -5, 42, 0]*u.degree)
     >>> c
     <SkyCoord (ICRS): (ra, dec) in deg
-        [(10.0, 41.0), (11.0, -5.0), (12.0, 42.0), (13.0, 0.0)]>
+        [( 10.,  41.), ( 11.,  -5.), ( 12.,  42.), ( 13.,   0.)]>
     >>> c[1]
     <SkyCoord (ICRS): (ra, dec) in deg
-        (11.0, -5.0)>
+        ( 11.,  -5.)>
     >>> c.reshape(2, 2)
     <SkyCoord (ICRS): (ra, dec) in deg
-        [[(10.0, 41.0), (11.0, -5.0)],
-         [(12.0, 42.0), (13.0, 0.0)]]>
-
+        [[( 10., 41.), ( 11., -5.)],
+         [( 12., 42.), ( 13.,  0.)]]>
 
 Coordinate access
 -----------------
@@ -112,7 +111,7 @@ the Galactic frame use::
     >>> c_icrs = SkyCoord(ra=10.68458*u.degree, dec=41.26917*u.degree, frame='icrs')
     >>> c_icrs.galactic  # doctest: +FLOAT_CMP
     <SkyCoord (Galactic): (l, b) in deg
-        (121.174241811, -21.5728855724)>
+        ( 121.17424181, -21.57288557)>
 
 For more control, you can use the `~astropy.coordinates.SkyCoord.transform_to`
 method, which accepts a frame name, frame class, or frame instance::
@@ -120,12 +119,12 @@ method, which accepts a frame name, frame class, or frame instance::
     >>> c_fk5 = c_icrs.transform_to('fk5')  # c_icrs.fk5 does the same thing
     >>> c_fk5  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
-        (10.6845915393, 41.2691714591)>
+        ( 10.68459154,  41.26917146)>
 
     >>> from astropy.coordinates import FK5
     >>> c_fk5.transform_to(FK5(equinox='J1975'))  # precess to a different equinox  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J1975.000): (ra, dec) in deg
-        (10.3420913461, 41.1323211229)>
+        ( 10.34209135,  41.13232112)>
 
 This form of `~astropy.coordinates.SkyCoord.transform_to` also makes it
 straightforward to convert from celestial coordinates to
@@ -152,14 +151,14 @@ coordinate objects::
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
     >>> c
     <SkyCoord (ICRS): (x, y, z) in kpc
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
     >>> c.x, c.y, c.z
     (<Quantity 1.0 kpc>, <Quantity 2.0 kpc>, <Quantity 3.0 kpc>)
 
     >>> c.representation = 'cylindrical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (kpc, deg, kpc)
-        (2.2360679775, 63.4349488229, 3.0)>
+        ( 2.23606798,  63.43494882,  3.)>
 
 For all the details see :ref:`astropy-skycoord-representations`.
 
@@ -208,7 +207,7 @@ for a particular named object::
 
     >>> SkyCoord.from_name("M42")  # doctest: +REMOTE_DATA +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        (83.82208, -5.39111)>
+        ( 83.82208, -5.39111)>
 
 For sites (primarily observatories) on the Earth, `astropy.coordinates` provides
 a quick way to get an `~astropy.coordinates.EarthLocation`::

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -94,8 +94,8 @@ positional offsets (e.g., for astrometry)::
     >>> target = ICRS(11*u.deg, 46*u.deg)
     >>> target.transform_to(SkyOffsetFrame(origin=center))  # doctest: +FLOAT_CMP
     <SkyOffsetICRS Coordinate (rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>): (lon, lat) in deg
-        (0.69474685, 1.00428706)>
+        ( 10.,  45.)>): (lon, lat) in deg
+        ( 0.69474685,  1.00428706)>
 
 
 Alternatively, the convenience method
@@ -106,12 +106,12 @@ frame from an already-existing |SkyCoord|::
     >>> aframe = center.skyoffset_frame()
     >>> target.transform_to(aframe)  # doctest: +FLOAT_CMP
     <SkyOffsetICRS Coordinate (rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>): (lon, lat) in deg
-        (0.69474685, 1.00428706)>
+        ( 10.,  45.)>): (lon, lat) in deg
+        ( 0.69474685,  1.00428706)>
     >>> other = SkyCoord(9*u.deg, 44*u.deg, frame='fk5')
     >>> other.transform_to(aframe)  # doctest: +FLOAT_CMP
     <SkyCoord (SkyOffsetICRS: rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
-        (10.0, 45.0)>): (lon, lat) in deg
+        ( 10.,  45.)>): (lon, lat) in deg
         (-0.71943945, -0.99556216)>
 
 .. note ::

--- a/docs/coordinates/remote_methods.rst
+++ b/docs/coordinates/remote_methods.rst
@@ -14,7 +14,7 @@ for a particular named object::
     >>> from astropy.coordinates import SkyCoord
     >>> SkyCoord.from_name("M42")  # doctest: +REMOTE_DATA +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        (83.82208, -5.39111)>
+        ( 83.82208, -5.39111)>
 
 The second is the :class:`~astropy.coordinates.EarthLocation` :meth:`~astropy.coordinates.EarthLocation.of_site` method, which
 provides a similar quick way to get an

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -46,7 +46,7 @@ objects::
     >>> car = CartesianRepresentation(3 * u.kpc, 5 * u.kpc, 4 * u.kpc)
     >>> car
     <CartesianRepresentation (x, y, z) in kpc
-        (3.0, 5.0, 4.0)>
+        ( 3.,  5.,  4.)>
 
 Representations can be converted to other representations using the
 ``represent_as`` method::
@@ -55,11 +55,11 @@ Representations can be converted to other representations using the
     >>> sph = car.represent_as(SphericalRepresentation)
     >>> sph  # doctest: +FLOAT_CMP
     <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
-        (1.03037682652, 0.601264216679, 7.07106781187)>
+        ( 1.03037683,  0.60126422,  7.07106781)>
     >>> cyl = car.represent_as(CylindricalRepresentation)
     >>> cyl  # doctest: +FLOAT_CMP
     <CylindricalRepresentation (rho, phi, z) in (kpc, rad, kpc)
-        (5.83095189485, 1.03037682652, 4.0)>
+        ( 5.83095189,  1.03037684, 4.)>
 
 All representations can be converted to each other without loss of
 information, with the exception of
@@ -72,7 +72,7 @@ dimensionless sphere::
     >>> sph_unit = car.represent_as(UnitSphericalRepresentation)
     >>> sph_unit  # doctest: +FLOAT_CMP
     <UnitSphericalRepresentation (lon, lat) in rad
-        (1.03037682652, 0.601264216679)>
+        ( 1.03037683,  0.60126422)>
 
 Converting back to cartesian, the absolute scaling information has been
 removed, and the points are still located on a unit sphere:
@@ -80,7 +80,7 @@ removed, and the points are still located on a unit sphere:
     >>> sph_unit = car.represent_as(UnitSphericalRepresentation)
     >>> sph_unit.represent_as(CartesianRepresentation) # doctest: +FLOAT_CMP
     <CartesianRepresentation (x, y, z) [dimensionless]
-        (0.424264068712, 0.707106781187, 0.565685424949)>
+        ( 0.42426407,  0.70710678,  0.56568542)>
 
 
 Array values and numpy array method analogs
@@ -97,16 +97,16 @@ methods as are available to `~numpy.ndarray`::
   >>> car_array = CartesianRepresentation(x * u.m, y * u.m, z * u.m)
   >>> car_array
   <CartesianRepresentation (x, y, z) in m
-      [(0.0, 10.0, 20.0), (1.0, 11.0, 21.0), (2.0, 12.0, 22.0),
-       (3.0, 13.0, 23.0), (4.0, 14.0, 24.0), (5.0, 15.0, 25.0)]>
+      [( 0.,  10.,  20.), ( 1.,  11.,  21.), ( 2.,  12.,  22.),
+       ( 3.,  13.,  23.), ( 4.,  14.,  24.), ( 5.,  15.,  25.)]>
   >>> car_array[2]
   <CartesianRepresentation (x, y, z) in m
-      (2.0, 12.0, 22.0)>
+      ( 2.,  12.,  22.)>
   >>> car_array.reshape(3, 2)
   <CartesianRepresentation (x, y, z) in m
-      [[(0.0, 10.0, 20.0), (1.0, 11.0, 21.0)],
-       [(2.0, 12.0, 22.0), (3.0, 13.0, 23.0)],
-       [(4.0, 14.0, 24.0), (5.0, 15.0, 25.0)]]>
+      [[( 0.,  10.,  20.), ( 1.,  11.,  21.)],
+       [( 2.,  12.,  22.), ( 3.,  13.,  23.)],
+       [( 4.,  14.,  24.), ( 5.,  15.,  25.)]]>
 
 .. _astropy-coordinates-create-repr:
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -72,11 +72,11 @@ RA and Dec::
 
   >>> SkyCoord(10, 20, unit='deg')  # Defaults to ICRS
   <SkyCoord (ICRS): (ra, dec) in deg
-      (10.0, 20.0)>
+      ( 10.,  20.)>
 
   >>> SkyCoord([1, 2, 3], [-30, 45, 8], frame='icrs', unit='deg')
   <SkyCoord (ICRS): (ra, dec) in deg
-      [(1.0, -30.0), (2.0, 45.0), (3.0, 8.0)]>
+      [( 1., -30.), ( 2., 45.), ( 3.,   8.)]>
 
 Notice that the first example above does not explicitly give a frame.  In
 this case, the default is taken to be the ICRS system (approximately
@@ -292,14 +292,14 @@ dicing, and selection, using the same methods and attributes that one uses for
   500
   >>> sc[2:4]  # doctest: +FLOAT_CMP
   <SkyCoord (ICRS): (ra, dec) in deg
-      [(72.0, -89.64), (108.0, -89.46)]>
+      [(  72., -89.64), ( 108., -89.46)]>
   >>> sc[500]  # doctest: +FLOAT_CMP
   <SkyCoord (ICRS): (ra, dec) in deg
-      (0.0, 0.0)>
+      ( 0.,  0.)>
   >>> sc[0:-1:100].reshape(2, 5)  # doctest: +FLOAT_CMP
   <SkyCoord (ICRS): (ra, dec) in deg
-      [[(0.0, -90.0), (0.0, -72.0), (0.0, -54.0), (0.0, -36.0), (0.0, -18.0)],
-       [(0.0, 0.0), (0.0, 18.0), (0.0, 36.0), (0.0, 54.0), (0.0, 72.0)]]>
+      [[( 0., -90.), ( 0., -72.), ( 0., -54.), ( 0., -36.), ( 0., -18.)],
+       [( 0.,   0.), ( 0.,  18.), ( 0.,  36.), ( 0.,  54.), ( 0.,  72.)]]>
 
 Note that similarly to the `~numpy.ndarray` methods, all but ``flatten`` try to
 use new views of the data, with the data copied only if that it is impossible
@@ -382,7 +382,7 @@ new |SkyCoord| object in the requested frame::
   >>> sc_gal = sc.galactic
   >>> sc_gal  # doctest: +FLOAT_CMP
   <SkyCoord (Galactic): (l, b) in deg
-      (99.6378552814, -58.7096929334)>
+      ( 99.63785528, -58.70969293)>
 
 Other attributes you should recognize are ``distance``, ``equinox``,
 ``obstime``, ``shape``.
@@ -432,7 +432,7 @@ and :ref:`astropy-coordinates-definitions`)::
 
   >>> sc.frame
   <ICRS Coordinate: (ra, dec) in deg
-      (1.0, 2.0)>
+      ( 1.,  2.)>
 
   >>> sc.has_data is sc.frame.has_data
   True
@@ -472,7 +472,7 @@ The lowest layer in the stack is the abstract
 
   >>> sc_gal.frame.data  # doctest: +FLOAT_CMP
   <UnitSphericalRepresentation (lon, lat) in rad
-      (1.73900863, -1.02467744)>
+      ( 1.73900863, -1.02467744)>
 
 Transformations
 ^^^^^^^^^^^^^^^^^
@@ -492,15 +492,15 @@ name, frame class, frame instance, or |SkyCoord|::
   >>> sc = SkyCoord(1, 2, frame='icrs', unit='deg')
   >>> sc.galactic  # doctest: +FLOAT_CMP
   <SkyCoord (Galactic): (l, b) in deg
-      (99.6378552814, -58.7096929334)>
+      ( 99.63785528, -58.70969293)>
 
   >>> sc.transform_to('fk5')  # Same as sc.fk5 and sc.transform_to(FK5)  # doctest: +FLOAT_CMP
   <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
-          (1.00000655566, 2.00000243092)>
+          ( 1.00000656,  2.00000243)>
 
   >>> sc.transform_to(FK5(equinox='J1975'))  # Transform to FK5 with a different equinox  # doctest: +FLOAT_CMP
   <SkyCoord (FK5: equinox=J1975.000): (ra, dec) in deg
-          (0.679672818323, 1.86083014099)>
+          ( 0.67967282,  1.86083014)>
 
 Transforming to a |SkyCoord| instance is an easy way of ensuring that two
 coordinates are in the exact same reference frame::
@@ -508,7 +508,7 @@ coordinates are in the exact same reference frame::
   >>> sc2 = SkyCoord(3, 4, frame='fk4', unit='deg', obstime='J1978.123', equinox='B1960.0')
   >>> sc.transform_to(sc2)  # doctest: +FLOAT_CMP
   <SkyCoord (FK4: equinox=B1960.000, obstime=J1978.123): (ra, dec) in deg
-      (0.48726331438, 1.77731617297)>
+      ( 0.48726331,  1.77731617)>
 
 .. _astropy-skycoord-representations:
 
@@ -534,7 +534,7 @@ supplying the corresponding components for that representation::
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
     >>> c
     <SkyCoord (ICRS): (x, y, z) in kpc
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
     >>> c.x, c.y, c.z
     (<Quantity 1.0 kpc>, <Quantity 2.0 kpc>, <Quantity 3.0 kpc>)
 
@@ -542,19 +542,19 @@ Other variations include::
 
     >>> SkyCoord(1, 2*u.deg, 3, representation='cylindrical')
     <SkyCoord (ICRS): (rho, phi, z) in (, deg, )
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
 
     >>> SkyCoord(rho=1*u.km, phi=2*u.deg, z=3*u.m, representation='cylindrical')
     <SkyCoord (ICRS): (rho, phi, z) in (km, deg, m)
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
 
     >>> SkyCoord(rho=1, phi=2, z=3, unit=(u.km, u.deg, u.m), representation='cylindrical')
     <SkyCoord (ICRS): (rho, phi, z) in (km, deg, m)
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
 
     >>> SkyCoord(1, 2, 3, unit=(None, u.deg, None), representation='cylindrical')
     <SkyCoord (ICRS): (rho, phi, z) in (, deg, )
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
 
 In general terms, the allowed syntax is as follows::
 
@@ -699,12 +699,12 @@ in 3d space.
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
     >>> c
     <SkyCoord (ICRS): (x, y, z) in kpc
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
 
     >>> c.representation = 'cylindrical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (kpc, deg, kpc)
-        (2.2360679775, 63.4349488229, 3.0)>
+        ( 2.23606798,  63.43494882,  3.)>
     >>> c.phi.to(u.deg)  # doctest: +FLOAT_CMP
     <Angle 63.43494882292201 deg>
     >>> c.x  # doctest: +SKIP
@@ -714,12 +714,12 @@ in 3d space.
     >>> c.representation = 'spherical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
-        (63.4349488229, 53.3007747995, 3.74165738677)>
+        ( 63.43494882,  53.3007748,  3.74165739)>
 
     >>> c.representation = 'unitspherical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        (63.4349488229, 53.3007747995)>
+        ( 63.43494882,  53.3007748)>
 
 You can also use any representation class to set the representation::
 
@@ -734,7 +734,7 @@ state of the |SkyCoord| object, you should instead use the
     >>> cart = c.represent_as(CartesianRepresentation)
     >>> cart
     <CartesianRepresentation (x, y, z) in kpc
-        (1.0, 2.0, 3.0)>
+        ( 1.,  2.,  3.)>
     >>> c.representation
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
 

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -38,8 +38,8 @@ without the need to download a large ephemerides file::
   >>> with solar_system_ephemeris.set('builtin'):
   ...     jup = get_body('jupiter', t, loc) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
   >>> jup  # doctest: +FLOAT_CMP +REMOTE_DATA
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.689878457, -550931.9118835592, 4961151.737334465) m, obsgeovel=(40.174593298404744, 288.00078051005755, -0.0) m / s): (ra, dec, distance) in (deg, deg, AU)
-    (136.91116201, 17.02935408, 5.94386022)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=( 3949481.689878457, -550931.9118838,  4961151.73733447) m, obsgeovel=( 40.1745933,  288.00078051,  0.) m / s): (ra, dec, distance) in (deg, deg, AU)
+    ( 136.91116201,  17.02935408,  5.94386022)>
 
 Above, we used ``solar_system_ephemeris`` as a context, which sets the default
 ephemeris while in the ``with`` clause, and resets it at the end.

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -54,14 +54,14 @@ downloaded and cached when the ephemeris is set):
   >>> solar_system_ephemeris.set('de432s') # doctest: +REMOTE_DATA, +IGNORE_OUTPUT
   <ScienceState solar_system_ephemeris: 'de432s'>
   >>> get_body('jupiter', t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.689878457, -550931.9118835592, 4961151.737334465) m, obsgeovel=(40.174593298404744, 288.00078051005755, -0.0) m / s): (ra, dec, distance) in (deg, deg, km)
-    (136.90234781, 17.03160686, 889196019.15383542)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=( 3949481.68990897, -550931.9118838,  4961151.73733447) m, obsgeovel=( 40.1745933,  288.00078051,  0.) m / s): (ra, dec, distance) in (deg, deg, km)
+      ( 136.90234781,  17.03160686,   8.89196019e+08)>
   >>> get_moon(t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.689878457, -550931.9118835592, 4961151.737334465) m, obsgeovel=(40.174593298404744, 288.00078051005755, -0.0) m / s): (ra, dec, distance) in (deg, deg, km)
-    (165.51840735, 2.32900633, 407226.68749643)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=( 3949481.68990897, -550931.9118838,  4961151.73733447) m, obsgeovel=( 40.1745933,  288.00078051,  0.) m / s): (ra, dec, distance) in (deg, deg, km)
+      ( 165.51840735,  2.32900633,  407226.68749646)>
   >>> get_body_barycentric('moon', t) # doctest: +REMOTE_DATA, +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
-      (150107535.1073409, -866789.11996916, -418963.55218495)>
+      (  1.50107535e+08, -866789.11996916, -418963.55218495)>
 
 For one-off calculations with a given ephemeris, one can also pass it directly
 to the various functions:
@@ -71,11 +71,11 @@ to the various functions:
   >>> get_body_barycentric('moon', t, ephemeris='de432s')
   ... # doctest: +REMOTE_DATA, +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
-      (150107535.1073409, -866789.11996916, -418963.55218495)>
+      (  1.50107535e+08, -866789.11996916, -418963.55218495)>
   >>> get_body_barycentric('moon', t, ephemeris='builtin')
   ... # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
-      (150107516.42468676, -866828.92708201, -418980.15909655)>
+      (  1.50107516e+08, -866828.92708201, -418980.15909655)>
 
 For a list of the bodies for which positions can be calculated, do:
 

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -24,7 +24,7 @@ The simplest method of transformation is shown below::
     >>> gc = SkyCoord(l=0*u.degree, b=45*u.degree, frame='galactic')
     >>> gc.fk5  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
-        (229.272514629, -1.12844288043)>
+        ( 229.27251463, -1.12844288)>
 
 While this appears to be simple attribute-style access, it is actually
 syntactic sugar for the more general
@@ -34,13 +34,13 @@ accept either a frame name, class or instance::
     >>> from astropy.coordinates import FK5
     >>> gc.transform_to('fk5')  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
-        (229.272514629, -1.12844288043)>
+        ( 229.27251463, -1.12844288)>
     >>> gc.transform_to(FK5)  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
-        (229.272514629, -1.12844288043)>
+        ( 229.27251463, -1.12844288)>
     >>> gc.transform_to(FK5(equinox='J1980.0'))  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J1980.000): (ra, dec) in deg
-        (229.014693505, -1.05560349378)>
+        ( 229.0146935, -1.05560349)>
 
 As a convenience it is also possible to use a |SkyCoord| object as the frame in
 :meth:`~astropy.coordinates.SkyCoord.transform_to`.  This allows easily putting one
@@ -49,7 +49,7 @@ coordinate object into the frame of another::
     >>> sc = SkyCoord(ra=1.0, dec=2.0, unit='deg', frame=FK5, equinox='J1980.0')
     >>> gc.transform_to(sc)  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J1980.000): (ra, dec) in deg
-        (229.014693505, -1.05560349378)>
+        ( 229.0146935, -1.05560349)>
 
 Additionally, some coordinate frames (including `~astropy.coordinates.FK5`,
 `~astropy.coordinates.FK4`, and `~astropy.coordinates.FK4NoETerms`) support
@@ -64,11 +64,11 @@ frames use a default equinox if you don't specify one::
     <Time object: scale='utc' format='jyear_str' value=J2000.000>
     >>> fk5c  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
-        (37.9545416667, 89.2641111111)>
+        ( 37.95454167,  89.26411111)>
     >>> fk5_2005 = FK5(equinox='J2005')  # String initializes an astropy.time.Time object
     >>> fk5c.transform_to(fk5_2005)  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2005.000): (ra, dec) in deg
-        (39.3931763878, 89.2858442155)>
+        ( 39.39317639,  89.28584422)>
 
 You can also specify the equinox when you create a coordinate using an
 `~astropy.time.Time` object::
@@ -79,7 +79,7 @@ You can also specify the equinox when you create a coordinate using an
     >>> fk5_2000 = FK5(equinox=Time(2000, format='jyear', scale='utc'))
     >>> fk5c.transform_to(fk5_2000)  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=2000.0): (ra, dec) in deg
-        (48.0231710002, 89.386724854)>
+        ( 48.023171,  89.38672485)>
 
 The same lower-level frame classes also have a
 :meth:`~astropy.coordinates.BaseCoordinateFrame.transform_to` method

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,9 +29,9 @@ specific sub-packages, for example::
 
     >>> from astropy import units as u
     >>> from astropy import coordinates as coord
-    >>> coord.SkyCoord(ra=10.68458*u.deg, dec=41.26917*u.deg, frame='icrs')
+    >>> coord.SkyCoord(ra=10.68458*u.deg, dec=41.26917*u.deg, frame='icrs')  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        (10.68458, 41.26917)>
+        ( 10.68458,  41.26917)>
 
 Finally, in some cases, most of the required functionality is contained in a
 single class (or a few classes). In those cases, the class can be directly

--- a/docs/nddata/utils.rst
+++ b/docs/nddata/utils.rst
@@ -287,7 +287,7 @@ positions::
     >>> x_cutout, y_cutout = (5, 10)
     >>> pixel_to_skycoord(x_cutout, y_cutout, cutout.wcs)    # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        (197.8747893, -1.32207626)>
+        ( 197.8747893, -1.32207626)>
 
 We now find the corresponding pixel in the original ``data`` array and
 its sky coordinates::
@@ -295,7 +295,7 @@ its sky coordinates::
     >>> x_data, y_data = cutout.to_original_position((x_cutout, y_cutout))
     >>> pixel_to_skycoord(x_data, y_data, wcs)    # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        (197.8747893, -1.32207626)>
+        ( 197.8747893, -1.32207626)>
 
 As expected, the sky coordinates in the original ``data`` and the
 cutout array agree.


### PR DESCRIPTION
This PR changes how representations are represented on the screen, by backporting the new `array2string` style for structured arrays.  This should solve the remaining bugs with numpy-dev reported in #5419. The first commit changes all tests that failed with the new numpy 1.12 development candidate to match the new style, and the second contains the backport.

Obviously, there is a bit of a question what to do anytime a code change leads to a different "visual appearance". Ideally, we wouldn't test for it at all: the only thing that matters should be whether numbers are correct. But there were so many doctests that failed that I felt it was better to bite the bullet...