### PR TITLE
Revert "Ensure we set equal_nan=True if needed in comparisons."

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -9,10 +9,6 @@ from numpy.testing.utils import assert_allclose
 from ... import units as u
 from ...tests.helper import pytest, raises
 from ...extern.six.moves import zip
-from ...utils.compat import NUMPY_LT_1_10
-
-
-EQUAL_NAN = {} if NUMPY_LT_1_10 else {'equal_nan': True}
 
 
 class TestUfuncCoverage(object):
@@ -508,8 +504,7 @@ class TestInvariantUfuncs(object):
         q_o = ufunc(q_i1, arbitrary_unit_value)
         assert isinstance(q_o, u.Quantity)
         assert q_o.unit == q_i1.unit
-        assert_allclose(q_o.value, ufunc(q_i1.value, arbitrary_unit_value),
-                        **EQUAL_NAN)
+        assert_allclose(q_o.value, ufunc(q_i1.value, arbitrary_unit_value))
 
     @pytest.mark.parametrize(('ufunc'), [np.add, np.subtract, np.hypot,
                                          np.maximum, np.minimum, np.nextafter,

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -7,7 +7,6 @@ from ...tests.helper import pytest
 from ..mpl_normalize import ImageNormalize, simple_norm
 from ..interval import ManualInterval
 from ..stretch import SqrtStretch
-from ...utils.compat import NUMPY_LT_1_10
 
 try:
     import matplotlib    # pylint: disable=W0611
@@ -15,8 +14,6 @@ try:
 except ImportError:
     HAS_MATPLOTLIB = False
 
-
-EQUAL_NAN = {} if NUMPY_LT_1_10 else {'equal_nan': True}
 
 DATA = np.linspace(0., 15., 6)
 DATA2 = np.arange(3)
@@ -61,10 +58,10 @@ class TestNormalize(object):
         output = norm(DATA)
         expected = [np.nan, 0.35355339, 0.70710678, 0.93541435, 1.11803399,
                     1.27475488]
-        assert_allclose(output, expected, **EQUAL_NAN)
+        assert_allclose(output, expected)
         assert_allclose(output.mask, [0, 0, 0, 0, 0, 0])
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
-        assert_allclose(output, norm2(DATA), **EQUAL_NAN)
+        assert_allclose(output, norm2(DATA))
 
     def test_implicit_autoscale(self):
         norm = ImageNormalize(vmin=None, vmax=10., stretch=SqrtStretch(),
@@ -83,7 +80,7 @@ class TestNormalize(object):
         output = norm(DATA)
         assert norm.vmin == 2.
         assert norm.vmax == np.max(DATA)
-        assert_allclose(output, norm2(DATA), **EQUAL_NAN)
+        assert_allclose(output, norm2(DATA))
 
     def test_masked_clip(self):
         mdata = ma.array(DATA, mask=[0, 0, 1, 0, 0, 0])
@@ -106,11 +103,11 @@ class TestNormalize(object):
         output = norm(mdata)
         expected = [np.nan, 0.35355339, -10, 0.93541435, 1.11803399,
                     1.27475488]
-        assert_allclose(output.filled(-10), expected, **EQUAL_NAN)
+        assert_allclose(output.filled(-10), expected)
         assert_allclose(output.mask, [0, 0, 1, 0, 0, 0])
 
         assert_allclose(norm.inverse(norm(DATA))[1:], DATA[1:])
-        assert_allclose(output, norm2(mdata), **EQUAL_NAN)
+        assert_allclose(output, norm2(mdata))
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -6,10 +6,7 @@ from ..stretch import (LinearStretch, SqrtStretch, PowerStretch,
                        PowerDistStretch, SquaredStretch, LogStretch,
                        AsinhStretch, SinhStretch, HistEqStretch,
                        ContrastBiasStretch)
-from ...utils.compat import NUMPY_LT_1_10
 
-
-EQUAL_NAN = {} if NUMPY_LT_1_10 else {'equal_nan': True}
 
 DATA = np.array([0.00, 0.25, 0.50, 0.75, 1.00])
 
@@ -104,5 +101,4 @@ def test_clip_invalid():
     np.testing.assert_allclose(values, [0., 0., 0.70710678, 1., 1.])
 
     values = stretch([-1., 0., 0.5, 1., 1.5], clip=False)
-    np.testing.assert_allclose(values, [np.nan, 0., 0.70710678, 1., 1.2247448],
-                               **EQUAL_NAN)
+    np.testing.assert_allclose(values, [np.nan, 0., 0.70710678, 1., 1.2247448])


### PR DESCRIPTION
Reverts astropy/astropy#5420

It turns out the default for `equal_nan` was changed in https://github.com/numpy/numpy/pull/8184, which means #5420 is not necessary any more. For code cleanliness, I think it is best just to revert...

I'll merge this if the tests are OK.
