### PR TITLE
Ensure Quantity subclasses always propagate correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -332,9 +332,10 @@ Bug Fixes
     be taken from logarithmic quanties such as ``Magnitude`` if the physical
     unit is dimensionless. [#5070]
 
-  - Operations involving ``Angle`` or ``Distance`` now also keep the type if
-    the angle or distance was the second argument (and if the resulting unit
-    is consistent with an angle or distance). [#5327]
+  - Operations involving ``Angle`` or ``Distance``, or any other 
+    ``SpecificTypeQuantity`` instance, now also keep return an instance of the
+    same type if the instance was the second argument (if the resulting unit
+    is consistent with the specific type). [#5327]
 
   - For inverse trig functions that operate on quantities, catch any warnings
     that occur from evaluating the function on the unscaled quantity value

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -332,6 +332,10 @@ Bug Fixes
     be taken from logarithmic quanties such as ``Magnitude`` if the physical
     unit is dimensionless. [#5070]
 
+  - Operations involving ``Angle`` or ``Distance`` now also keep the type if
+    the angle or distance was the second argument (and if the resulting unit
+    is consistent with an angle or distance). [#5327]
+
   - For inverse trig functions that operate on quantities, catch any warnings
     that occur from evaluating the function on the unscaled quantity value
     between __array_prepare__ and __array_wrap__. [#5153]

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -169,9 +169,17 @@ def test_angle_ops():
     assert a1 < a5
     assert a1 <= a5
 
+    # check operations with non-angular result give Quantity.
     a6 = Angle(45., u.degree)
     a7 = a6 * a5
     assert type(a7) is u.Quantity
+
+    # but those with angular result yield Angle.
+    # (a9 is regression test for #5327)
+    a8 = a1 + 1.*u.deg
+    assert type(a8) is Angle
+    a9 = 1.*u.deg + a1
+    assert type(a9) is Angle
 
     with pytest.raises(TypeError):
         a6 *= a5

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1532,6 +1532,9 @@ class SpecificTypeQuantity(Quantity):
     # Default unit for initialization through the constructor.
     _default_unit = None
 
+    # ensure that we get precedence over our superclass.
+    __array_priority__ = Quantity.__array_priority__ + 10
+
     def __quantity_subclass__(self, unit):
         if unit.is_equivalent(self._equivalent_unit):
             return type(self), True


### PR DESCRIPTION
-- edit: now turned into a PR that fixes this --

Partially as a reminder to myself: `Quantity` subclasses should be preferred over `Quantity` itself when that makes sense, so I'd expect an `Angle` to remain an angle as long as the unit remains angular. However, currently, this only happens if the left-hand side of an operation is an `Angle`; if it is a `Quantity`, the result is too:
```
from astropy import units as u
from astropy.coordinates import Angle
Angle(1., 'deg') + 1.*u.deg
# <Angle 2.0 deg>
1.*u.deg + Angle(1., 'deg')
# <Quantity 2.0 deg>
```