### PR TITLE
Fix problem reading AASTex table without trailing backslashes at end

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1737,6 +1737,9 @@ Bug Fixes
 
   - Fix problem reading a zero-length ECSV table with a bool type column. [#5010]
 
+  - Fix problem reading an AASTex format table that does not have ``\\``
+    at the end of the last table row. [#5427]
+
 - ``astropy.io.fits``
 
   - Fix convenience functions (``getdata``, ``getheader``, ``append``,

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1206,3 +1206,38 @@ a b c
 # Data starts after the header column definition, blank lines ignored
 -- 2 3
 4 5 6 """)['a'][0] is np.ma.masked
+
+
+def test_latex_no_trailing_backslash():
+    """
+    Test that latex/aastex file with no trailing backslash can be read.
+    """
+    lines = r"""
+\begin{table}
+\begin{tabular}{ccc}
+a & b & c \\
+1 & 1.0 & c \\ % comment
+3\% & 3.0 & e  % comment
+\end{tabular}
+\end{table}
+"""
+    dat = ascii.read(lines, format='latex')
+    assert dat.colnames == ['a', 'b', 'c']
+    assert np.all(dat['a'] == ['1', r'3\%'])
+    assert np.all(dat['c'] == ['c', 'e'])
+
+def text_aastex_no_trailing_backslash():
+    lines = r"""
+\begin{deluxetable}{ccc}
+\tablehead{\colhead{a} & \colhead{b} & \colhead{c}}
+\startdata
+1 & 1.0 & c \\
+2 & 2.0 & d \\ % comment
+3\% & 3.0 & e  % comment
+\enddata
+\end{deluxetable}
+"""
+    dat = ascii.read(lines, format='aastex')
+    assert dat.colnames == ['a', 'b', 'c']
+    assert np.all(dat['a'] == ['1', r'3\%'])
+    assert np.all(dat['c'] == ['c', 'e'])


### PR DESCRIPTION
Closes #5236.  (By superceding).
