### PR TITLE
Fixed Bug when calling signal_number_to_name with Python3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1712,6 +1712,9 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - Fixed AttributeError when calling ``utils.misc.signal_number_to_name`` with
+    Python3 [#5430].
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -288,8 +288,8 @@ def signal_number_to_name(signum):
     # Since these numbers and names are platform specific, we use the
     # builtin signal module and build a reverse mapping.
 
-    signal_to_name_map = dict(
-        (k, v) for v, k in signal.__dict__.iteritems() if v.startswith('SIG'))
+    signal_to_name_map = dict((k, v) for v, k in six.iteritems(signal.__dict__)
+                              if v.startswith('SIG'))
 
     return signal_to_name_map.get(signum, 'UNKNOWN')
 

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -24,9 +24,8 @@ def test_isiterable():
 
 
 def test_signal_number_to_name_no_failure():
-    # Regression test that the signal_number_to_name throws no
-    # AttributeError (it tried accessing ".iteritems()" which was removed in
-    # Python3).
+    # Regression test for #5340: ensure signal_number_to_name throws no
+    # AttributeError (it used ".iteritems()" which was removed in Python3).
     misc.signal_number_to_name(0)
 
 

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -23,6 +23,13 @@ def test_isiterable():
     assert misc.isiterable(np.array([1, 2, 3])) is True
 
 
+def test_signal_number_to_name_no_failure():
+    # Regression test that the signal_number_to_name throws no
+    # AttributeError (it tried accessing ".iteritems()" which was removed in
+    # Python3).
+    misc.signal_number_to_name(0)
+
+
 @remote_data
 def test_api_lookup():
     strurl = misc.find_api_page('astropy.utils.misc', 'dev', False, timeout=3)


### PR DESCRIPTION
This is a Bugfix for a place where `dict.iteritems()` was accessed (This method was removed in Python3!) in `astropy/utils/misc.py`:

```
>>> from astropy.utils.misc import signal_number_to_name
>>> signal_number_to_name(100)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-69f9f3740eb0> in <module>()
----> 1 signal_number_to_name(100)

c:\...\git\astropy\astropy\utils\misc.py in signal_number_to_name(signum)
    290 
    291     signal_to_name_map = dict(
--> 292         (k, v) for v, k in signal.__dict__.iteritems() if v.startswith('SIG'))
    293 
    294     return signal_to_name_map.get(signum, 'UNKNOWN')

AttributeError: 'dict' object has no attribute 'iteritems'
```

Is 1.0.11 is the correct version for this fix?