### PR TITLE
Update standard_units.rst

### DIFF
--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -146,6 +146,7 @@ enable additional units::
     >>> from astropy.units import imperial
     >>> with imperial.enable():
     ...     print(u.m.find_equivalent_units())
+          Primary name | Unit definition | Aliases
     ...
 
 To enable just specific units, use `~astropy.units.add_enabled_units`::
@@ -154,4 +155,5 @@ To enable just specific units, use `~astropy.units.add_enabled_units`::
     >>> from astropy.units import imperial
     >>> with u.add_enabled_units([imperial.knot]):
     ...     print(u.m.find_equivalent_units())
+          Primary name | Unit definition | Aliases
     ...

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -152,6 +152,6 @@ To enable just specific units, use `~astropy.units.add_enabled_units`::
 
     >>> from astropy import units as u
     >>> from astropy.units import imperial
-    >>> with u.add_enabled_units_context([imperial.knot]):
+    >>> with u.add_enabled_units([imperial.knot]):
     ...     u.m.find_equivalent_units()  # doctest: +SKIP
     ...

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -145,7 +145,7 @@ enable additional units::
     >>> from astropy import units as u
     >>> from astropy.units import imperial
     >>> with imperial.enable():
-    ...     u.m.find_equivalent_units()  # doctest: +SKIP
+    ...     print(u.m.find_equivalent_units())
     ...
 
 To enable just specific units, use `~astropy.units.add_enabled_units`::
@@ -153,5 +153,5 @@ To enable just specific units, use `~astropy.units.add_enabled_units`::
     >>> from astropy import units as u
     >>> from astropy.units import imperial
     >>> with u.add_enabled_units([imperial.knot]):
-    ...     u.m.find_equivalent_units()  # doctest: +SKIP
+    ...     print(u.m.find_equivalent_units())
     ...


### PR DESCRIPTION
Module 'units' object has no attribute 'add_enabled_units_context', hence the line
```
>>> with u.add_enabled_units_context([imperial.knot]):
```
should be changed to 
```
>>> with u.add_enabled_units([imperial.knot]):
```