### PR TITLE
Use representation arithmetic

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1294,12 +1294,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 
-        dx = self.cartesian.x - other_in_self_system.cartesian.x
-        dy = self.cartesian.y - other_in_self_system.cartesian.y
-        dz = self.cartesian.z - other_in_self_system.cartesian.z
-
-        distval = (dx.value ** 2 + dy.value ** 2 + dz.value ** 2) ** 0.5
-        return Distance(distval, dx.unit)
+        return Distance((self.cartesian -
+                         other_in_self_system.cartesian).norm())
 
     @property
     def cartesian(self):

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -75,10 +75,7 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     bary_sun_pos = get_body_barycentric('sun', to_frame.equinox)
 
     # offset to heliocentric
-    from_coo_cartesian = from_coo.cartesian
-    heliocart = CartesianRepresentation(from_coo_cartesian.x + bary_sun_pos.x,
-                                        from_coo_cartesian.y + bary_sun_pos.y,
-                                        from_coo_cartesian.z + bary_sun_pos.z)
+    heliocart = from_coo.cartesian + bary_sun_pos
 
     # now compute the matrix to precess to the right orientation
     rmat = _ecliptic_rotation_matrix(to_frame.equinox)
@@ -104,7 +101,5 @@ def helioecliptic_to_icrs(from_coo, to_frame):
     # get barycentric sun coordinate
     bary_sun_pos = get_body_barycentric('sun', from_coo.equinox)
 
-    newrepr = CartesianRepresentation(intermed_repr.x - bary_sun_pos.x,
-                                      intermed_repr.y - bary_sun_pos.y,
-                                      intermed_repr.z - bary_sun_pos.z)
+    newrepr = intermed_repr - bary_sun_pos
     return to_frame.realize_frame(newrepr)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -726,12 +726,8 @@ class SkyCoord(ShapedLikeNDArray):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 
-        dx = self_in_other_system.cartesian.x - other.cartesian.x
-        dy = self_in_other_system.cartesian.y - other.cartesian.y
-        dz = self_in_other_system.cartesian.z - other.cartesian.z
-
-        distval = (dx.value ** 2 + dy.value ** 2 + dz.value ** 2) ** 0.5
-        return Distance(distval, dx.unit)
+        return Distance((self_in_other_system.cartesian -
+                         other.cartesian).norm())
 
     def spherical_offsets_to(self, tocoord):
         r"""

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -411,8 +411,7 @@ def _get_apparent_body_position(body, time, ephemeris):
     earth_loc = get_body_barycentric('earth', time, ephemeris)
     while np.any(np.fabs(delta_light_travel_time) > 1.0e-8*u.s):
         body_loc = get_body_barycentric(body, emitted_time, ephemeris)
-        earth_body_vector = body_loc.xyz - earth_loc.xyz
-        earth_distance = np.sqrt(np.sum(earth_body_vector**2, axis=0))
+        earth_distance = (body_loc - earth_loc).norm()
         delta_light_travel_time = (light_travel_time -
                                    earth_distance/speed_of_light)
         light_travel_time = earth_distance/speed_of_light

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -755,18 +755,9 @@ class StaticMatrixTransform(CoordinateTransform):
             priority=priority, register_graph=register_graph)
 
     def __call__(self, fromcoord, toframe):
-        from .representation import CartesianRepresentation, \
-                                    UnitSphericalRepresentation
+        from .representation import UnitSphericalRepresentation
 
-        xyz = fromcoord.represent_as(CartesianRepresentation).xyz
-        v = xyz.reshape((3, xyz.size // 3))
-        v2 = np.dot(np.asarray(self.matrix), v)
-        subshape = xyz.shape[1:]
-        x = v2[0].reshape(subshape)
-        y = v2[1].reshape(subshape)
-        z = v2[2].reshape(subshape)
-
-        newrep = CartesianRepresentation(x, y, z)
+        newrep = fromcoord.cartesian.transform(self.matrix)
         if issubclass(fromcoord.data.__class__, UnitSphericalRepresentation):
             #need to special-case this because otherwise the new class will
             #think it has a valid distance


### PR DESCRIPTION
As it seems the representation arithmetic is nearing merging, I thought it would be useful to see how much simpler the coordinate transformation code becomes if one uses it.  I'm quite pleased: now almost all fiddling with dimensions is to get stuff to and from `erfa`.

Note: for now built on top of #5301; just look at the last commit only to see the effect on the transformations.

p.s. The only part I did not touch is `matching.py`.