### PR TITLE
Allow array with any dimension equal to 3 to initialize CartesianRepresentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,9 +38,9 @@ New Features
 
   - ``CartesianRepresentation`` can be initialized with plain arrays by passing
     in a ``unit``. Furthermore, for input with a vector array, the coordinates
-    no longer have to be in the first dimension, but can be at any ``axis``.
-    To complement the latter, a new ``get_xyz(axis)`` method allows one to get
-    a vector array out along a given axis. [#5439]
+    no longer have to be in the first dimension, but can be at any ``xyz_axis``.
+    To complement the latter, a new ``get_xyz(xyz_axis)`` method allows one to
+    get a vector array out along a given axis. [#5439]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,12 @@ New Features
     In all operations, the representations are treated as vectors. They are
     temporarily converted to ``CartesianRepresentation`` if necessary.  [#5301]
 
+  - ``CartesianRepresentation`` can be initialized with plain arrays by passing
+    in a ``unit``. Furthermore, for input with a vector array, the coordinates
+    no longer have to be in the first dimension, but can be at any ``axis``.
+    To complement the latter, a new ``get_xyz(axis)`` method allows one to get
+    a vector array out along a given axis. [#5439]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -47,8 +47,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # astrometric coordinate direction and *then* run the ERFA transform for
         # no parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
-        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
-                                            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
+                                            xyz_axis=-1, copy=False)
         newcart = icrs_coo.cartesian - astrom_eb
 
         srepr = newcart.represent_as(SphericalRepresentation)
@@ -94,8 +94,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
                                               distance=cirs_coo.distance,
                                               copy=False)
 
-        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
-                                            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
+                                            xyz_axis=-1, copy=False)
         newrep = intermedrep + astrom_eb
 
     return icrs_frame.realize_frame(newrep)
@@ -124,8 +124,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # have xyz in last dimension, and pos/vel in one-but-last.
     # (Note could use np.stack once our minimum numpy version is >=1.10.)
     pv = np.concatenate(
-        (gcrs_frame.obsgeoloc.get_xyz(axis=-1).value[..., np.newaxis, :],
-         gcrs_frame.obsgeovel.get_xyz(axis=-1).value[..., np.newaxis, :]),
+        (gcrs_frame.obsgeoloc.get_xyz(xyz_axis=-1).value[..., np.newaxis, :],
+         gcrs_frame.obsgeovel.get_xyz(xyz_axis=-1).value[..., np.newaxis, :]),
         axis=-2)
 
     # find the position and velocity of earth
@@ -150,8 +150,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # BCRS coordinate direction and *then* run the ERFA transform for no
         # parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
-        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
-                                            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
+                                            xyz_axis=-1, copy=False)
         newcart = icrs_coo.cartesian - astrom_eb
 
         srepr = newcart.represent_as(SphericalRepresentation)
@@ -175,8 +175,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
     pv = np.concatenate(
-        (gcrs_coo.obsgeoloc.get_xyz(axis=-1).value[..., np.newaxis, :],
-         gcrs_coo.obsgeovel.get_xyz(axis=-1).value[..., np.newaxis, :]),
+        (gcrs_coo.obsgeoloc.get_xyz(xyz_axis=-1).value[..., np.newaxis, :],
+         gcrs_coo.obsgeovel.get_xyz(xyz_axis=-1).value[..., np.newaxis, :]),
         axis=-2)
 
     jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
@@ -203,8 +203,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
                                               distance=gcrs_coo.distance,
                                               copy=False)
 
-        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
-                                            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
+                                            xyz_axis=-1, copy=False)
         newrep = intermedrep + astrom_eb
 
     return icrs_frame.realize_frame(newrep)
@@ -237,8 +237,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
     pv = np.concatenate(
-        (gcrs_coo.obsgeoloc.get_xyz(axis=-1).value[..., np.newaxis, :],
-         gcrs_coo.obsgeovel.get_xyz(axis=-1).value[..., np.newaxis, :]),
+        (gcrs_coo.obsgeoloc.get_xyz(xyz_axis=-1).value[..., np.newaxis, :],
+         gcrs_coo.obsgeovel.get_xyz(xyz_axis=-1).value[..., np.newaxis, :]),
         axis=-2)
 
     jd1, jd2 = get_jd12(hcrs_frame.obstime, 'tdb')
@@ -271,7 +271,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # against the shape of the pv array.
         # broadcast em to eh and scale eh
         eh = astrom['eh'] * astrom['em'][..., np.newaxis]
-        eh = CartesianRepresentation(eh, unit=u.au, axis=-1, copy=False)
+        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=False)
 
         newrep = intermedrep.to_cartesian() + eh
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -47,9 +47,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # astrometric coordinate direction and *then* run the ERFA transform for
         # no parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
-        astrom_eb = CartesianRepresentation(
-            u.Quantity(np.rollaxis(astrom['eb'], -1, 0), u.au, copy=False),
-            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
+                                            copy=False)
         newcart = icrs_coo.cartesian - astrom_eb
 
         srepr = newcart.represent_as(SphericalRepresentation)
@@ -95,9 +94,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
                                               distance=cirs_coo.distance,
                                               copy=False)
 
-        astrom_eb = CartesianRepresentation(
-            u.Quantity(np.rollaxis(astrom['eb'], -1, 0), u.au, copy=False),
-            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
+                                            copy=False)
         newrep = intermedrep + astrom_eb
 
     return icrs_frame.realize_frame(newrep)
@@ -122,12 +120,13 @@ def cirs_to_cirs(from_coo, to_frame):
 @frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # first set up the astrometry context for ICRS<->GCRS. There are a few steps...
-    # get the position and velocity arrays for the observatory
-    pv = np.array([gcrs_frame.obsgeoloc.xyz.value,
-                   gcrs_frame.obsgeovel.xyz.value])
-    # roll axes 0 and 1 to end
-    if pv.ndim > 2:
-        pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
+    # get the position and velocity arrays for the observatory.  Need to
+    # have xyz in last dimension, and pos/vel in one-but-last.
+    # (Note could use np.stack once our minimum numpy version is >=1.10.)
+    pv = np.concatenate(
+        (gcrs_frame.obsgeoloc.get_xyz(axis=-1).value[..., np.newaxis, :],
+         gcrs_frame.obsgeovel.get_xyz(axis=-1).value[..., np.newaxis, :]),
+        axis=-2)
 
     # find the position and velocity of earth
     jd1, jd2 = get_jd12(gcrs_frame.obstime, 'tdb')
@@ -151,9 +150,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # BCRS coordinate direction and *then* run the ERFA transform for no
         # parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
-        astrom_eb = CartesianRepresentation(
-            u.Quantity(np.rollaxis(astrom['eb'], -1, 0), u.au, copy=False),
-            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
+                                            copy=False)
         newcart = icrs_coo.cartesian - astrom_eb
 
         srepr = newcart.represent_as(SphericalRepresentation)
@@ -176,11 +174,10 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
-    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
-                   gcrs_coo.obsgeovel.xyz.value])
-    # roll axes 0 and 1 to end
-    if pv.ndim > 2:
-        pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
+    pv = np.concatenate(
+        (gcrs_coo.obsgeoloc.get_xyz(axis=-1).value[..., np.newaxis, :],
+         gcrs_coo.obsgeovel.get_xyz(axis=-1).value[..., np.newaxis, :]),
+        axis=-2)
 
     jd1, jd2 = get_jd12(gcrs_coo.obstime, 'tdb')
 
@@ -206,9 +203,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
                                               distance=gcrs_coo.distance,
                                               copy=False)
 
-        astrom_eb = CartesianRepresentation(
-            u.Quantity(np.rollaxis(astrom['eb'], -1, 0), u.au, copy=False),
-            copy=False)
+        astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au, axis=-1,
+                                            copy=False)
         newrep = intermedrep + astrom_eb
 
     return icrs_frame.realize_frame(newrep)
@@ -240,11 +236,10 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
-    pv = np.array([gcrs_coo.obsgeoloc.xyz.value,
-                   gcrs_coo.obsgeovel.xyz.value])
-    # roll axes 0 and 1 to end
-    if pv.ndim > 2:
-        pv = np.rollaxis(np.rollaxis(pv, 0, pv.ndim), 0, pv.ndim)
+    pv = np.concatenate(
+        (gcrs_coo.obsgeoloc.get_xyz(axis=-1).value[..., np.newaxis, :],
+         gcrs_coo.obsgeovel.get_xyz(axis=-1).value[..., np.newaxis, :]),
+        axis=-2)
 
     jd1, jd2 = get_jd12(hcrs_frame.obstime, 'tdb')
     earth_pv, earth_heliocentric = prepare_earth_position_vel(gcrs_coo.obstime)
@@ -276,9 +271,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # against the shape of the pv array.
         # broadcast em to eh and scale eh
         eh = astrom['eh'] * astrom['em'][..., np.newaxis]
-        eh = CartesianRepresentation(
-            u.Quantity(np.rollaxis(eh, -1, 0), u.au, copy=False),
-            copy=False)
+        eh = CartesianRepresentation(eh, unit=u.au, axis=-1, copy=False)
 
         newrep = intermedrep.to_cartesian() + eh
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -280,12 +280,13 @@ def prepare_earth_position_vel(time):
     # get barycentric position and velocity of earth
     earth_pv = get_body_barycentric_posvel('earth', time)
 
-    # get heliocentric position of earth
+    # get heliocentric position of earth, preparing it for passing to erfa.
     sun = get_body_barycentric('sun', time)
-    earth_heliocentric = (earth_pv[0].xyz - sun.xyz).to(u.au)
+    earth_heliocentric = (earth_pv[0] - sun).get_xyz(axis=-1).to(u.au).value
 
-    # prepare to pass to erfa
-    earth_pv = np.array([earth_pv[0].xyz.to(u.au), earth_pv[1].xyz.to(u.au/u.d)])
-    earth_pv = np.rollaxis(np.rollaxis(earth_pv, 0, earth_pv.ndim), 0, earth_pv.ndim)
-    earth_heliocentric = np.rollaxis(earth_heliocentric.value, 0, earth_heliocentric.ndim)
+    # also prepare earth_pv for passing to erfa.
+    earth_pv = np.concatenate(
+        (earth_pv[0].get_xyz(axis=-1).to(u.au)[..., np.newaxis, :],
+         earth_pv[1].get_xyz(axis=-1).to(u.au/u.d)[..., np.newaxis, :]),
+        axis=-2)
     return earth_pv, earth_heliocentric

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -282,11 +282,12 @@ def prepare_earth_position_vel(time):
 
     # get heliocentric position of earth, preparing it for passing to erfa.
     sun = get_body_barycentric('sun', time)
-    earth_heliocentric = (earth_pv[0] - sun).get_xyz(axis=-1).to(u.au).value
+    earth_heliocentric = (earth_pv[0] -
+                          sun).get_xyz(xyz_axis=-1).to(u.au).value
 
     # also prepare earth_pv for passing to erfa.
     earth_pv = np.concatenate(
-        (earth_pv[0].get_xyz(axis=-1).to(u.au)[..., np.newaxis, :],
-         earth_pv[1].get_xyz(axis=-1).to(u.au/u.d)[..., np.newaxis, :]),
+        (earth_pv[0].get_xyz(xyz_axis=-1).to(u.au)[..., np.newaxis, :],
+         earth_pv[1].get_xyz(xyz_axis=-1).to(u.au/u.d)[..., np.newaxis, :]),
         axis=-2)
     return earth_pv, earth_heliocentric

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -285,9 +285,11 @@ def prepare_earth_position_vel(time):
     earth_heliocentric = (earth_pv[0] -
                           sun).get_xyz(xyz_axis=-1).to(u.au).value
 
-    # also prepare earth_pv for passing to erfa.
-    earth_pv = np.concatenate(
-        (earth_pv[0].get_xyz(xyz_axis=-1).to(u.au)[..., np.newaxis, :],
-         earth_pv[1].get_xyz(xyz_axis=-1).to(u.au/u.d)[..., np.newaxis, :]),
-        axis=-2)
+    # Also prepare earth_pv for passing to erfa, which wants xyz in last
+    # dimension, and pos/vel in one-but-last.
+    # (Note could use np.stack once our minimum numpy version is >=1.10.)
+    earth_pv = np.concatenate((earth_pv[0].get_xyz(xyz_axis=-1).to(u.au)
+                               [..., np.newaxis, :].value,
+                               earth_pv[1].get_xyz(xyz_axis=-1).to(u.au/u.d)
+                               [..., np.newaxis, :].value), axis=-2)
     return earth_pv, earth_heliocentric

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -201,12 +201,12 @@ class BaseRepresentation(ShapedLikeNDArray):
 
         The record array fields will have the component names.
         """
-        allcomp = np.array([getattr(self, component).value
-                            for component in self.components])
+        sh = self.shape + (1,)
+        allcomp = np.concatenate([getattr(self, component).reshape(sh).value
+                                  for component in self.components], axis=-1)
         dtype = np.dtype([(str(component), getattr(self, component).dtype)
                           for component in self.components])
-        return (np.rollaxis(allcomp, 0, len(allcomp.shape))
-                .copy().view(dtype).squeeze())
+        return allcomp.view(dtype).squeeze()
 
     @property
     def _units(self):
@@ -421,39 +421,56 @@ class CartesianRepresentation(BaseRepresentation):
 
     Parameters
     ----------
-    x, y, z : `~astropy.units.Quantity`
-        The x, y, and z coordinates of the point(s). If ``x``, ``y``, and
-        ``z`` have different shapes, they should be broadcastable.
-
+    x, y, z : `~astropy.units.Quantity` or array
+        The x, y, and z coordinates of the point(s). If ``x``, ``y``, and ``z``
+        have different shapes, they should be broadcastable. If not quantity,
+        ``unit`` should be set.  If only ``x`` is given, it is assumed that it
+        contains an array with the 3 coordinates are stored along ``axis``.
+    unit : `~astropy.unit.Unit` or str
+        If given, the coordinates will be converted to this unit (or taken to
+        be in this unit if not given.
+    axis : int, optional
+        The axis along which the coordinates are stored for the case an array
+        of vectors is passed in (default: 0).
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If True (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('x', u.Quantity),
                                 ('y', u.Quantity),
                                 ('z', u.Quantity)])
 
-    def __init__(self, x, y=None, z=None, copy=True):
+    def __init__(self, x, y=None, z=None, unit=None, axis=0, copy=True):
+
+        if unit is None and not hasattr(x, 'unit'):
+            raise TypeError('x should have a unit unless an explicit unit '
+                            'is passed in.')
 
         if y is None and z is None:
+            if axis != 0:
+                x = np.rollaxis(x, axis, 0)
             x, y, z = x
         elif (y is None and z is not None) or (y is not None and z is None):
-            raise ValueError("x, y, and z are required to instantiate CartesianRepresentation")
+            raise ValueError("x, y, and z are required to instantiate {0}"
+                             .format(self.__class__.__name__))
 
-        if not isinstance(x, self.attr_classes['x']):
-            raise TypeError('x should be a {0}'.format(self.attr_classes['x'].__name__))
+        try:
+            x = self.attr_classes['x'](x, unit=unit, copy=copy)
+            y = self.attr_classes['y'](y, unit=unit, copy=copy)
+            z = self.attr_classes['z'](z, unit=unit, copy=copy)
+        except u.UnitsError:
+            raise u.UnitsError('x, y, and z should have a unit consistent with '
+                               '{0}'.format(unit))
+        except:
+            raise TypeError('x, y, and z should be able to initialize ' +
+                            ('a {0}'.format(self.attr_classes['x'].__name__))
+                             if len(set(self.attr_classes.values)) == 1 else
+                            ('{0}, {1}, and {2}, resp.'.format(
+                                cls.__name__ for cls in
+                                self.attr_classes.values())))
 
-        if not isinstance(y, self.attr_classes['x']):
-            raise TypeError('y should be a {0}'.format(self.attr_classes['y'].__name__))
-
-        if not isinstance(z, self.attr_classes['x']):
-            raise TypeError('z should be a {0}'.format(self.attr_classes['z'].__name__))
-
-        x = self.attr_classes['x'](x, copy=copy)
-        y = self.attr_classes['y'](y, copy=copy)
-        z = self.attr_classes['z'](z, copy=copy)
-
-        if not (x.unit.physical_type == y.unit.physical_type == z.unit.physical_type):
+        if not (x.unit.physical_type ==
+                y.unit.physical_type == z.unit.physical_type):
             raise u.UnitsError("x, y, and z should have matching physical types")
 
         try:
@@ -486,9 +503,41 @@ class CartesianRepresentation(BaseRepresentation):
         """
         return self._z
 
-    @property
-    def xyz(self):
-        return u.Quantity((self._x, self._y, self._z))
+    def get_xyz(self, axis=0):
+        """Return a vector array of the x, y, and z coordinates.
+
+        Parameters
+        ----------
+        axis : int, optional
+            The axis in the final array along which the x, y, z components
+            should be stored (default: 0).
+
+        Returns
+        -------
+        xyz : `~astropy.units.Quantity`
+            With dimension 3 along ``axis``.
+        """
+        # Add new axis in x, y, z so one can concatenate them around it.
+        # NOTE: just use np.stack once our minimum numpy version is 1.10.
+        result_ndim = self.ndim + 1
+        if not -result_ndim <= axis < result_ndim:
+            raise IndexError('axis {0} out of bounds [-{1}, {1})'
+                             .format(axis, result_ndim))
+        if axis < 0:
+            axis += result_ndim
+
+        sh = self.shape
+        sh = sh[:axis] + (1,) + sh[axis:]
+        # Get x, y, z to the same units (this is very fast for identical units)
+        # since np.concatenate cannot deal with quantity.
+        cls = self._x.__class__
+        x = self._x.reshape(sh)
+        y = cls(self._y, x.unit, copy=False).reshape(sh)
+        z = cls(self._z, x.unit, copy=False).reshape(sh)
+        return cls(np.concatenate((x.value, y.value, z.value), axis=axis),
+                   unit=x.unit, copy=False)
+
+    xyz = property(get_xyz)
 
     @classmethod
     def from_cartesian(cls, other):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -524,7 +524,7 @@ class CartesianRepresentation(BaseRepresentation):
         Returns
         -------
         xyz : `~astropy.units.Quantity`
-            With dimension 3 along ``axis``.
+            With dimension 3 along ``xyz_axis``.
         """
         # Add new axis in x, y, z so one can concatenate them around it.
         # NOTE: just use np.stack once our minimum numpy version is 1.10.

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -242,13 +242,12 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None,
                 body_pv_helio = erfa.plan94(jd1, jd2, body_index)
                 body_pv_bary = body_pv_helio + sun_pv_bary
 
-        # Move coordinate components to front, as needed for
-        # CartesianRepresentation.
-        body_pv_bary = np.rollaxis(body_pv_bary, -1, 0)
-        body_pos_bary = u.Quantity(body_pv_bary[..., 0], u.au, copy=False)
+        body_pos_bary = CartesianRepresentation(body_pv_bary[..., 0, :],
+                                                unit=u.au, axis=-1, copy=False)
         if get_velocity:
-            body_vel_bary = u.Quantity(body_pv_bary[..., 1], u.au/u.day,
-                                       copy=False)
+            body_vel_bary = CartesianRepresentation(body_pv_bary[..., 1, :],
+                                                    unit=u.au/u.day, axis=-1,
+                                                    copy=False)
 
     else:
         if isinstance(body, six.string_types):
@@ -290,17 +289,14 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None,
                     body_p_or_v += p_or_v
 
         body_posvel_bary.shape = body_posvel_bary.shape[:2] + jd1_shape
-        body_pos_bary = u.Quantity(body_posvel_bary[0], u.km, copy=False)
+        body_pos_bary = CartesianRepresentation(body_posvel_bary[0],
+                                                unit=u.km, copy=False)
         if get_velocity:
-            body_vel_bary = u.Quantity(body_posvel_bary[1], u.km/u.day,
-                                       copy=False)
+            body_vel_bary = CartesianRepresentation(body_posvel_bary[1],
+                                                    unit=u.km/u.day, copy=False)
 
-    body_pos_bary = CartesianRepresentation(body_pos_bary, copy=False)
-    if get_velocity:
-        body_vel_bary = CartesianRepresentation(body_vel_bary, copy=False)
-        return body_pos_bary, body_vel_bary
-    else:
-        return body_pos_bary
+    return (body_pos_bary, body_vel_bary) if get_velocity else body_pos_bary
+
 
 def get_body_barycentric_posvel(body, time, ephemeris=None):
     """Calculate the barycentric position and velocity of a solar system body.

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -242,12 +242,12 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None,
                 body_pv_helio = erfa.plan94(jd1, jd2, body_index)
                 body_pv_bary = body_pv_helio + sun_pv_bary
 
-        body_pos_bary = CartesianRepresentation(body_pv_bary[..., 0, :],
-                                                unit=u.au, axis=-1, copy=False)
+        body_pos_bary = CartesianRepresentation(
+            body_pv_bary[..., 0, :], unit=u.au, xyz_axis=-1, copy=False)
         if get_velocity:
-            body_vel_bary = CartesianRepresentation(body_pv_bary[..., 1, :],
-                                                    unit=u.au/u.day, axis=-1,
-                                                    copy=False)
+            body_vel_bary = CartesianRepresentation(
+                body_pv_bary[..., 1, :], unit=u.au/u.day, xyz_axis=-1,
+                copy=False)
 
     else:
         if isinstance(body, six.string_types):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -516,6 +516,30 @@ class TestCartesianRepresentation(object):
         assert_allclose(s1.y.value, 2)
         assert_allclose(s1.z.value, 3)
 
+        r = np.arange(27.).reshape(3, 3, 3) * u.kpc
+        s2 = CartesianRepresentation(r, xyz_axis=0)
+        assert s2.shape == (3, 3)
+        assert s2.x.unit == u.kpc
+        assert np.all(s2.x == r[0])
+        assert np.all(s2.xyz == r)
+        assert np.all(s2.get_xyz(xyz_axis=0) == r)
+        s3 = CartesianRepresentation(r, xyz_axis=1)
+        assert s3.shape == (3, 3)
+        assert np.all(s3.x == r[:, 0])
+        assert np.all(s3.y == r[:, 1])
+        assert np.all(s3.z == r[:, 2])
+        assert np.all(s3.get_xyz(xyz_axis=1) == r)
+        s4 = CartesianRepresentation(r, xyz_axis=2)
+        assert s4.shape == (3, 3)
+        assert np.all(s4.x == r[:, :, 0])
+        assert np.all(s4.get_xyz(xyz_axis=2) == r)
+        s5 = CartesianRepresentation(r, unit=u.pc)
+        assert s5.x.unit == u.pc
+        assert np.all(s5.xyz == r)
+        s6 = CartesianRepresentation(r.value, unit=u.pc, xyz_axis=2)
+        assert s6.x.unit == u.pc
+        assert np.all(s6.get_xyz(xyz_axis=2).value == r.value)
+
     def test_init_one_array_size_fail(self):
         with pytest.raises(ValueError) as exc:
             CartesianRepresentation(x=[1, 2, 3, 4] * u.pc)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -518,12 +518,18 @@ class TestCartesianRepresentation(object):
 
     def test_init_one_array_size_fail(self):
         with pytest.raises(ValueError) as exc:
-            s1 = CartesianRepresentation(x=[1, 2, 3, 4] * u.pc)
+            CartesianRepresentation(x=[1, 2, 3, 4] * u.pc)
         assert exc.value.args[0].startswith("too many values to unpack")
+
+    def test_init_xyz_but_more_than_one_array_fail(self):
+        with pytest.raises(ValueError) as exc:
+            CartesianRepresentation(x=[1, 2, 3] * u.pc, y=[2, 3, 4] * u.pc,
+                                    z=[3, 4, 5] * u.pc, xyz_axis=0)
+        assert 'xyz_axis should only be set' in str(exc)
 
     def test_init_one_array_yz_fail(self):
         with pytest.raises(ValueError) as exc:
-            s1 = CartesianRepresentation(x=[1, 2, 3, 4] * u.pc, y=[1, 2] * u.pc)
+            CartesianRepresentation(x=[1, 2, 3, 4] * u.pc, y=[1, 2] * u.pc)
         assert exc.value.args[0] == ("x, y, and z are required to instantiate "
                                      "CartesianRepresentation")
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -581,7 +581,7 @@ class TestCartesianRepresentation(object):
             s1 = CartesianRepresentation(x=[1 * u.kpc, 2 * u.Mpc],
                                          y=[3 * u.kpc, 4 * u.pc],
                                          z=[5. * u.cm, 6 * u.m])
-        assert exc.value.args[0] == "x should be a Quantity"
+        assert exc.value.args[0].startswith("x should")
 
     def test_readonly(self):
 

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -330,14 +330,13 @@ def test_earth_barycentric_velocity_multi_d():
     ep, ev = get_body_barycentric_posvel('earth', t)
     # note: assert_quantity_allclose doesn't like the shape mismatch.
     # this is a problem with np.testing.assert_allclose.
-    assert quantity_allclose(np.rollaxis(ep.xyz, 0, ep.xyz.ndim),
+    assert quantity_allclose(ep.get_xyz(axis=-1),
                              [[-1., 0., 0.], [+1., 0., 0.]]*u.AU,
                              atol=0.06*u.AU)
     expected = u.Quantity([0.*u.one,
                            np.cos(23.5*u.deg),
                            np.sin(23.5*u.deg)]) * ([[-30.], [30.]] * u.km / u.s)
-    assert quantity_allclose(np.rollaxis(ev.xyz, 0, ev.xyz.ndim),
-                             expected, atol=2.*u.km/u.s)
+    assert quantity_allclose(ev.get_xyz(axis=-1), expected, atol=2.*u.km/u.s)
 
 
 @remote_data

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -330,13 +330,14 @@ def test_earth_barycentric_velocity_multi_d():
     ep, ev = get_body_barycentric_posvel('earth', t)
     # note: assert_quantity_allclose doesn't like the shape mismatch.
     # this is a problem with np.testing.assert_allclose.
-    assert quantity_allclose(ep.get_xyz(axis=-1),
+    assert quantity_allclose(ep.get_xyz(xyz_axis=-1),
                              [[-1., 0., 0.], [+1., 0., 0.]]*u.AU,
                              atol=0.06*u.AU)
     expected = u.Quantity([0.*u.one,
                            np.cos(23.5*u.deg),
                            np.sin(23.5*u.deg)]) * ([[-30.], [30.]] * u.km / u.s)
-    assert quantity_allclose(ev.get_xyz(axis=-1), expected, atol=2.*u.km/u.s)
+    assert quantity_allclose(ev.get_xyz(xyz_axis=-1), expected,
+                             atol=2.*u.km/u.s)
 
 
 @remote_data


### PR DESCRIPTION
EDIT: this is now a PR!

For arrays holding `xyz` values, the dimension that holds `xyz` is in numpy often the last, but in `CartesianRepresentation` we only easily handle the case where it is the first. In https://github.com/astropy/astropy/pull/5434#discussion_r85426979, it was suggested to consider having a way to handle both cases, perhaps by having `axis` (and `unit`?) arguments (this would be for `Cartesian` only). 
