### PR TITLE
Change representation arithmetic tests to be n-d

### DIFF
--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -25,14 +25,15 @@ def representation_equal(first, second):
                              getattr(second, component)
                              for component in first.components))
 
-class TestArithmetic():
 
+class TestArithmetic():
     def setup(self):
         # Choose some specific coordinates, for which ``sum`` and ``dot``
         # works out nicely.
-        self.lon = Longitude(np.arange(0, 12.1, 2), u.hourangle)
-        self.lat = Latitude(np.arange(-90, 91, 30), u.deg)
-        self.distance = [5., 12., 4., 2., 4., 12., 5.] * u.kpc
+        # these are 2-d arrays to make sure all the arithmetic works in >1 dim
+        self.lon = Longitude([np.arange(0, 12.1, 2)]*4, u.hourangle)
+        self.lat = Latitude([np.arange(-90, 91, 30)]*4, u.deg)
+        self.distance = u.Quantity([[5., 12., 4., 2., 4., 12., 5.] * u.kpc]*4)
         self.spherical = SphericalRepresentation(self.lon, self.lat,
                                                  self.distance)
         self.unit_spherical = self.spherical.represent_as(


### PR DESCRIPTION
This changes the tests for the arithmetic added in #5301 to be 2D for _everything_.  This is currently erroring on my local machine, so initially this PR is just a test to see if that holds up for travis (as @mhvk reported _not_ seeing these errors).  

If travis passes this can probably be closed, although I might end up editing it into a more thorough regression test. On the other hand, if travis _fails_ like I see locally, this is a bug report :wink:.
