### PR TITLE
Use ctype for an alternate WCS when reading in SIP coefficients

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -449,6 +449,9 @@ Bug Fixes
 
   - Improved log messages in ``to_header``. [#5239]
 
+  - SIP distortion for an alternate WCS is correctly initialized now by
+    looking at the "CTYPE" values matching the alternate WCS. [#5443]
+
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,6 +304,9 @@ Bug Fixes
 
 - ``astropy.wcs``
 
+  - SIP distortion for an alternate WCS is correctly initialized now by
+    looking at the "CTYPE" values matching the alternate WCS. [#5443]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -448,10 +451,6 @@ Bug Fixes
     distortion is present in the WCS object. [#5239]
 
   - Improved log messages in ``to_header``. [#5239]
-
-  - SIP distortion for an alternate WCS is correctly initialized now by
-    looking at the "CTYPE" values matching the alternate WCS. [#5443]
-
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -859,6 +859,7 @@ def test_hst_wcs():
     assert w.sip.bp_order == 0
     assert_array_equal(w.sip.crpix, [2048., 1024.])
     wcs.WCS(hdulist[1].header, hdulist)
+    hdulist.close()
 
 
 def test_list_naxis():
@@ -881,6 +882,7 @@ def test_list_naxis():
     w = wcs.WCS(content, naxis=['spectral'])
     assert w.naxis == 0
     assert w.wcs.naxis == 0
+    hdulist.close()
 
 
 def test_sip_broken():
@@ -972,6 +974,7 @@ def test_passing_ImageHDU():
     wcs_hdu = wcs.WCS(hdulist[1])
     wcs_header = wcs.WCS(hdulist[1].header)
     assert wcs_hdu.wcs.compare(wcs_header.wcs)
+    hdulist.close()
 
 
 def test_inconsistent_sip():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1016,26 +1016,8 @@ def test_inconsistent_sip():
     w = wcs.WCS(hdr)
     w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
     newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
-    del hdr['CTYPE2']
-    newhdr = w.to_header(relax=True)
-    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
-    w = wcs.WCS()
-    newhdr = w.to_header()
-    assert('CTYPE1' not in newhdr)
-    # Test that when creating a WCS object using a key, CTYPE with
-    # that key is looked at and not the primary CTYPE.
-    # fix for #5443.
-    with fits.open(get_pkg_data_filename('data/sip.fits')) as f:
-        w = wcs.WCS(f[0].header)
-    # create a header with two WCSs.
-    h1 = w.to_header(relax=True, key='A')
-    h2 = w.to_header(relax=False)
-    h1['CTYPE1A'] = "RA---SIN-SIP"
-    h1['CTYPE2A'] = "DEC--SIN-SIP"
-    h1.update(h2)
-    w = wcs.WCS(h1, key='A')
-    assert w.wcs.ctype == ['RA---SIN-SIP', 'DEC--SIN-SIP']
+    wnew = wcs.WCS(newhdr)
+    assert all(ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
 
 
 def test_bounds_check():
@@ -1064,3 +1046,21 @@ def test_naxis():
     w._naxis1 = 99
     w._naxis2 = 59
     assert w._naxis == [99, 59]
+
+
+def test_sip_with_altkey():
+    """
+    Test that when creating a WCS object using a key, CTYPE with
+    that key is looked at and not the primary CTYPE.
+    fix for #5443.
+    """
+    with fits.open(get_pkg_data_filename('data/sip.fits')) as f:
+        w = wcs.WCS(f[0].header)
+    # create a header with two WCSs.
+    h1 = w.to_header(relax=True, key='A')
+    h2 = w.to_header(relax=False)
+    h1['CTYPE1A'] = "RA---SIN-SIP"
+    h1['CTYPE2A'] = "DEC--SIN-SIP"
+    h1.update(h2)
+    w = wcs.WCS(h1, key='A')
+    assert w.wcs.ctype == ['RA---SIN-SIP', 'DEC--SIN-SIP']

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1013,8 +1013,26 @@ def test_inconsistent_sip():
     w = wcs.WCS(hdr)
     w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
     newhdr = w.to_header(relax=True)
-    wnew = wcs.WCS(newhdr)
-    assert all(ctyp.endswith('-SIP') for ctyp in wnew.wcs.ctype)
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    del hdr['CTYPE2']
+    newhdr = w.to_header(relax=True)
+    assert(all([ctyp[-4 :] == '-SIP' for ctyp in self.wcs.ctype]))
+    w = wcs.WCS()
+    newhdr = w.to_header()
+    assert('CTYPE1' not in newhdr)
+    # Test that when creating a WCS object using a key, CTYPE with
+    # that key is looked at and not the primary CTYPE.
+    # fix for #5443.
+    with fits.open(get_pkg_data_filename('data/sip.fits')) as f:
+        w = wcs.WCS(f[0].header)
+    # create a header with two WCSs.
+    h1 = w.to_header(relax=True, key='A')
+    h2 = w.to_header(relax=False)
+    h1['CTYPE1A'] = "RA---SIN-SIP"
+    h1['CTYPE2A'] = "DEC--SIN-SIP"
+    h1.update(h2)
+    w = wcs.WCS(h1, key='A')
+    assert w.wcs.ctype == ['RA---SIN-SIP', 'DEC--SIN-SIP']
 
 
 def test_bounds_check():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1063,4 +1063,16 @@ def test_sip_with_altkey():
     h1['CTYPE2A'] = "DEC--SIN-SIP"
     h1.update(h2)
     w = wcs.WCS(h1, key='A')
-    assert w.wcs.ctype == ['RA---SIN-SIP', 'DEC--SIN-SIP']
+    assert (w.wcs.ctype == np.array(['RA---SIN-SIP', 'DEC--SIN-SIP'])).all()
+
+
+def test_to_fits_1():
+    """
+    Test to_fits() with LookupTable distortion.
+    """
+    fits_name = get_pkg_data_filename('data/dist.fits')
+    w = wcs.WCS(fits_name)
+    wfits = w.to_fits()
+    assert isinstance(wfits, fits.HDUList)
+    assert isinstance(wfits[0], fits.PrimaryHDU)
+    assert isinstance(wfits[1], fits.ImageHDU)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -444,7 +444,7 @@ class WCS(WCSBase):
             det2im = self._read_det2im_kw(header, fobj, err=minerr)
             cpdis = self._read_distortion_kw(
                 header, fobj, dist='CPDIS', err=minerr)
-            sip = self._read_sip_kw(header)
+            sip = self._read_sip_kw(header, wcskey=key)
             self._remove_sip_kw(header)
 
             header_string = header.tostring()
@@ -997,7 +997,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                     if m is not None):
             del header[key]
 
-    def _read_sip_kw(self, header):
+    def _read_sip_kw(self, header, wcskey=""):
         """
         Reads `SIP`_ header keywords and returns a `~astropy.wcs.Sip`
         object.
@@ -1038,7 +1038,8 @@ reduce these to 2 dimensions using the naxis kwarg.
 
             del header[str('A_ORDER')]
             del header[str('B_ORDER')]
-            ctype=[header['CTYPE{0}'.format(nax)] for nax in range(1, self.naxis + 1)]
+
+            ctype = [header['CTYPE{0}{1}'.format(nax, wcskey)] for nax in range(1, self.naxis + 1)]
             if any(not ctyp.endswith('-SIP') for ctyp in ctype):
                 message = """
                 Inconsistent SIP distortion information is present in the FITS header and the WCS object:
@@ -1110,8 +1111,8 @@ reduce these to 2 dimensions using the naxis kwarg.
             raise ValueError(
                 "Header has SIP keywords without CRPIX keywords")
 
-        crpix1 = header.get("CRPIX1")
-        crpix2 = header.get("CRPIX2")
+        crpix1 = header.get("CRPIX1{0}".format(wcskey))
+        crpix2 = header.get("CRPIX2{0}".format(wcskey))
 
         return Sip(a, b, ap, bp, (crpix1, crpix2))
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1111,8 +1111,8 @@ reduce these to 2 dimensions using the naxis kwarg.
             raise ValueError(
                 "Header has SIP keywords without CRPIX keywords")
 
-        crpix1 = header.get("CRPIX1{0}".format(wcskey))
-        crpix2 = header.get("CRPIX2{0}".format(wcskey))
+        crpix1 = header.get("CRPIX1")
+        crpix2 = header.get("CRPIX2")
 
         return Sip(a, b, ap, bp, (crpix1, crpix2))
 


### PR DESCRIPTION
`WCS._read_sip_kw`  checks for consistent SIP representation in the header. However it checks  `CTYPE` keywords of the primary WCS even if a `key` argument is passed to use an alternate WCS. 
This PR passes the `key` argument to `_read_sip_kw` and checks that `CTYPE`.
