### PR TITLE
Allow numpy-1.12's formatter for repr of scalar representations.

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -10,6 +10,7 @@ from .. import units as u
 from ..extern import six
 from ..extern.six.moves import urllib
 from ..utils.exceptions import AstropyUserWarning
+from ..utils.compat.numpycompat import NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_to
 from .angles import Longitude, Latitude
 from .builtin_frames import ITRS, GCRS
@@ -577,6 +578,14 @@ class EarthLocation(u.Quantity):
         return self._new_view(converted.view(self.dtype).reshape(self.shape),
                               unit)
     to.__doc__ = u.Quantity.to.__doc__
+
+    if NUMPY_LT_1_12:
+        def __repr__(self):
+            # Use the numpy >=1.12 way to format structured arrays.
+            from  .representation import _array2string
+            prefixstr = '<' + self.__class__.__name__ + ' '
+            arrstr = _array2string(self.view(np.ndarray), prefix=prefixstr)
+            return '{0}{1}{2:s}>'.format(prefixstr, arrstr, self._unitstr)
 
 
 # need to do this here at the bottom to avoid circular dependencies

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -236,7 +236,7 @@ class BaseRepresentation(ShapedLikeNDArray):
         # TODO: in final numpy 1.12, the scalar case should work as well;
         # see https://github.com/numpy/numpy/issues/8172
         values = self._values
-        if NUMPY_LT_1_12 or self.isscalar:
+        if NUMPY_LT_1_12:
             # Mimic StructureFormat from numpy >=1.12 assuming float-only data.
             from numpy.core.arrayprint import FloatFormat
             opts = np.get_printoptions()

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -31,6 +31,34 @@ __all__ = ["BaseRepresentation", "CartesianRepresentation",
 # get registered automatically.
 REPRESENTATION_CLASSES = {}
 
+def _array2string(values, prefix=''):
+    # Mimic numpy >=1.12 array2string, in which structured arrays are
+    # typeset taking into account all printoptions.
+    # TODO: in final numpy 1.12, the scalar case should work as well;
+    # see https://github.com/numpy/numpy/issues/8172
+    if NUMPY_LT_1_12:
+        # Mimic StructureFormat from numpy >=1.12 assuming float-only data.
+        from numpy.core.arrayprint import FloatFormat
+        opts = np.get_printoptions()
+        format_functions = [FloatFormat(np.atleast_1d(values[component]).ravel(),
+                                        precision=opts['precision'],
+                                        suppress_small=opts['suppress'])
+                            for component in values.dtype.names]
+
+        def fmt(x):
+            return '({})'.format(', '.join(format_function(field)
+                                           for field, format_function in
+                                           zip(x, format_functions)))
+        # Before 1.12, structures arrays were set as "numpystr",
+        # so that is the formmater we need to replace.
+        formatter = {'numpystr': fmt}
+    else:
+        fmt = repr
+        formatter = {}
+
+    return np.array2string(values, formatter=formatter, style=fmt,
+                           separator=', ', prefix=prefix)
+
 # Need to subclass ABCMeta rather than type, so that this meta class can be
 # combined with a ShapedLikeNDArray subclass (which is an ABC).  Without it:
 # "TypeError: metaclass conflict: the metaclass of a derived class must be a
@@ -230,35 +258,6 @@ class BaseRepresentation(ShapedLikeNDArray):
                            for component in self.components]))
         return unitstr
 
-    def _array2string(self, prefix=''):
-        # Mimic numpy >=1.12 array2string, in which structured arrays are
-        # typeset taking into account all printoptions.
-        # TODO: in final numpy 1.12, the scalar case should work as well;
-        # see https://github.com/numpy/numpy/issues/8172
-        values = self._values
-        if NUMPY_LT_1_12:
-            # Mimic StructureFormat from numpy >=1.12 assuming float-only data.
-            from numpy.core.arrayprint import FloatFormat
-            opts = np.get_printoptions()
-            format_functions = [FloatFormat(np.atleast_1d(values[component]).ravel(),
-                                            precision=opts['precision'],
-                                            suppress_small=opts['suppress'])
-                                for component in self.components]
-
-            def fmt(x):
-                return '({})'.format(', '.join(format_function(field)
-                                               for field, format_function in
-                                               zip(x, format_functions)))
-            # Before 1.12, structures arrays were set as "numpystr",
-            # so that is the formmater we need to replace.
-            formatter = {'numpystr': fmt}
-        else:
-            fmt = repr
-            formatter = {}
-
-        return np.array2string(values, formatter=formatter, style=fmt,
-                               separator=', ', prefix=prefix)
-
     def _scale_operation(self, op, *args):
         results = []
         for component, cls in self.attr_classes.items():
@@ -407,11 +406,11 @@ class BaseRepresentation(ShapedLikeNDArray):
         return self.from_cartesian(self.to_cartesian().cross(other))
 
     def __str__(self):
-        return '{0} {1:s}'.format(self._array2string(), self._unitstr)
+        return '{0} {1:s}'.format(_array2string(self._values), self._unitstr)
 
     def __repr__(self):
         prefixstr = '    '
-        arrstr = self._array2string(prefix=prefixstr)
+        arrstr = _array2string(self._values, prefix=prefixstr)
 
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -214,7 +214,7 @@ a quick way to get an `~astropy.coordinates.EarthLocation`::
 
     >>> from astropy.coordinates import EarthLocation
     >>> EarthLocation.of_site('Apache Point Observatory')  # doctest: +REMOTE_DATA +FLOAT_CMP
-    <EarthLocation (-1463969.3018517173, -5166673.342234327, 3434985.7120456537) m>
+    <EarthLocation (-1463969.30185172, -5166673.34223433,  3434985.71204565) m>
 
 To see the list of site names available, use
 :func:`astropy.coordinates.EarthLocation.get_site_names`.
@@ -227,12 +227,12 @@ Google maps, this works with fully specified addresses, location names, city
 names, and etc.::
 
     >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO')  # doctest: +REMOTE_DATA +FLOAT_CMP
-    <EarthLocation (-26727.247396719715, -4997012.160946069, 3950268.2727357596) m>
+    <EarthLocation (-26727.24739672, -4997012.16094607,  3950268.27273576) m>
     >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO',
     ...                          get_height=True)  # doctest: +REMOTE_DATA +FLOAT_CMP
-    <EarthLocation (-26727.890243898288, -4997132.349722762, 3950363.9254298285) m>
+    <EarthLocation (-26727.8902439, -4997132.34972276,  3950363.92542983) m>
     >>> EarthLocation.of_address('Danbury, CT')  # doctest: +REMOTE_DATA +FLOAT_CMP
-    <EarthLocation (1364606.6451165068, -4593292.942827304, 4195415.936951392) m>
+    <EarthLocation ( 1364606.64511651, -4593292.9428273,  4195415.93695139) m>
 
 .. note::
     `~astropy.coordinates.SkyCoord.from_name`,


### PR DESCRIPTION
Now that fix for those has been merged in https://github.com/numpy/numpy/pull/8200.

This follows up on #5423 removing a work-around for scalar representations.  If tests pass, I'll merge, as it is a trivial change.