### PR TITLE
Add a new encoding parameter to ascii.read 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ New Features
 - ``astropy.io.ascii``
 
   - Allow to specify encoding in ``ascii.read``, only for Python 3 and with the
-    slow readers. [#5448]
+    pure-Python readers. [#5448]
 
 - ``astropy.io.fits``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ New Features
 
 - ``astropy.io.ascii``
 
+  - Allow to specify encoding in ``ascii.read``. [#5448]
+
 - ``astropy.io.fits``
 
   - Checking available disk space before writing out file. [#5550, #4065]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,8 @@ New Features
 
 - ``astropy.io.ascii``
 
-  - Allow to specify encoding in ``ascii.read``. [#5448]
+  - Allow to specify encoding in ``ascii.read``, only for Python 3 and with the
+    slow readers. [#5448]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1419,8 +1419,12 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     if 'fill_exclude_names' in kwargs:
         reader.data.fill_exclude_names = kwargs['fill_exclude_names']
     if 'encoding' in kwargs:
-        reader.encoding = kwargs['encoding']
-        reader.inputter.encoding = kwargs['encoding']
+        if six.PY2:
+            raise ValueError("the encoding parameter is not supported on "
+                             "Python 2")
+        else:
+            reader.encoding = kwargs['encoding']
+            reader.inputter.encoding = kwargs['encoding']
 
     return reader
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -256,6 +256,10 @@ class BaseInputter(object):
     Get the lines from the table input and return a list of lines.
 
     """
+
+    encoding = None
+    """Encoding used to read the file"""
+
     def get_lines(self, table):
         """
         Get the lines from the ``table`` input. The input table can be one of:
@@ -280,8 +284,9 @@ class BaseInputter(object):
         try:
             if (hasattr(table, 'read') or
                     ('\n' not in table + '' and '\r' not in table + '')):
-                with get_readable_fileobj(table) as file_obj:
-                    table = file_obj.read()
+                with get_readable_fileobj(table,
+                                          encoding=self.encoding) as fileobj:
+                    table = fileobj.read()
             lines = table.splitlines()
         except TypeError:
             try:
@@ -1085,6 +1090,7 @@ class BaseReader(object):
     exclude_names = None
     strict_names = False
     guessing = False
+    encoding = None
 
     header_class = BaseHeader
     data_class = BaseData
@@ -1327,7 +1333,7 @@ class WhitespaceSplitter(DefaultSplitter):
 
 extra_reader_pars = ('Reader', 'Inputter', 'Outputter',
                      'delimiter', 'comment', 'quotechar', 'header_start',
-                     'data_start', 'data_end', 'converters',
+                     'data_start', 'data_end', 'converters', 'encoding',
                      'data_Splitter', 'header_Splitter',
                      'names', 'include_names', 'exclude_names', 'strict_names',
                      'fill_values', 'fill_include_names', 'fill_exclude_names')
@@ -1412,6 +1418,9 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
         reader.data.fill_include_names = kwargs['fill_include_names']
     if 'fill_exclude_names' in kwargs:
         reader.data.fill_exclude_names = kwargs['fill_exclude_names']
+    if 'encoding' in kwargs:
+        reader.encoding = kwargs['encoding']
+        reader.inputter.encoding = kwargs['encoding']
 
     return reader
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -215,7 +215,7 @@ cdef class CParser:
             raise core.ParameterError("fast_reader cannot be False for fast readers")
         expchar = fast_reader.pop('exponent_style', 'E').upper()
         # parallel and use_fast_reader are False by default, but only the latter
-        # supports Fortran double precision notation 
+        # supports Fortran double precision notation
         if expchar == 'E':
             use_fast_converter = fast_reader.pop('use_fast_converter', False)
         else:
@@ -239,7 +239,6 @@ cdef class CParser:
                                           strip_line_whitespace,
                                           strip_line_fields,
                                           use_fast_converter)
-
         self.source = None
         if source is not None:
             self.setup_tokenizer(source)

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -239,6 +239,7 @@ cdef class CParser:
                                           strip_line_whitespace,
                                           strip_line_fields,
                                           use_fast_converter)
+
         self.source = None
         if source is not None:
             self.setup_tokenizer(source)

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -80,6 +80,8 @@ class FastBasic(object):
         elif 'converters' in self.kwargs:
             raise core.ParameterError("The C reader does not support passing "
                                       "specialized converters")
+        elif 'encoding' in self.kwargs:
+            raise core.ParameterError("The C reader does not use the encoding parameter")
         elif 'Outputter' in self.kwargs:
             raise core.ParameterError("The C reader does not use the Outputter parameter")
         elif 'Inputter' in self.kwargs:

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -337,7 +337,7 @@ class HTML(core.BaseReader):
         """
 
         self.outputter = HTMLOutputter()
-        return core.BaseReader.read(self, table)
+        return super(HTML, self).read(table)
 
     def write(self, table):
         """

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1266,12 +1266,13 @@ def test_read_with_encoding(tmpdir, encoding):
                                    '--- --- -----',
                                    '  1   2 héllo']
 
-        table = ascii.read(testfile, format=fmt, fast_reader=False,
-                           encoding=encoding)
-        assert table['è'].dtype.kind == 'U'
-        assert table.pformat() == [' à   b    è  ',
-                                   '--- --- -----',
-                                   '  1   2 héllo']
+        for guess in (True, False):
+            table = ascii.read(testfile, format=fmt, fast_reader=False,
+                               encoding=encoding, guess=guess)
+            assert table['è'].dtype.kind == 'U'
+            assert table.pformat() == [' à   b    è  ',
+                                       '--- --- -----',
+                                       '  1   2 héllo']
 
 
 def test_unsupported_read_with_encoding(tmpdir):

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -246,6 +246,8 @@ def read(table, guess=None, **kwargs):
             all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED)
+    encoding: str
+        Allow to specify encoding to read the file (default= ``None``).
 
     Returns
     -------
@@ -293,8 +295,9 @@ def read(table, guess=None, **kwargs):
         # which case the original `table` as the data filename must be left
         # intact.
         if 'readme' not in new_kwargs:
+            encoding = kwargs.get('encoding')
             try:
-                with get_readable_fileobj(table) as fileobj:
+                with get_readable_fileobj(table, encoding=encoding) as fileobj:
                     table = fileobj.read()
             except ValueError:  # unreadable or invalid binary file
                 raise

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -100,7 +100,9 @@ disable the fast engine::
 
    Reading a table which contains non-ASCII (unicode) characters is only
    supported in Python 3 or greater.  If you have Python 2.x and need
-   this functionality, consider using a newer version of Python.
+   this functionality, consider using a newer version of Python. With Python
+   3 and the pure-Python readers, it is also possible to specify the encoding
+   of the file with the ``encoding`` parameter.
 
 Writing Tables
 --------------


### PR DESCRIPTION
Allow to specify encoding when using `ascii.read(...)`. See #3826 for the motivations.
I added test files only for the simple reader, not sure if I should do the same for other readers ?
cc @taldcroft @pllim 
