### PR TITLE
Removed some unnecessary list creations (Part 2)

### DIFF
--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -2,6 +2,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import math
+
 import numpy as np
 
 from .core import Kernel1D, Kernel2D, Kernel
@@ -18,7 +20,7 @@ __all__ = ['Gaussian1DKernel', 'Gaussian2DKernel', 'CustomKernel',
 
 
 def _round_up_to_odd_integer(value):
-    i = int(np.ceil(value))
+    i = int(math.ceil(value))  # TODO: int() call is only needed for six.PY2
     if i % 2 == 0:
         return i + 1
     else:
@@ -1004,7 +1006,7 @@ class CustomKernel(Kernel):
             raise TypeError("Must be list or array.")
 
         # Check if array is odd in all axes
-        odd = np.all([axes_size % 2 != 0 for axes_size in self.shape])
+        odd = all(axes_size % 2 != 0 for axes_size in self.shape)
         if not odd:
             raise KernelSizeError("Kernel size must be odd in all axes.")
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1039,7 +1039,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             del header[str('A_ORDER')]
             del header[str('B_ORDER')]
             ctype=[header['CTYPE{0}'.format(nax)] for nax in range(1, self.naxis + 1)]
-            if any([ctyp[-4 :] != '-SIP' for ctyp in ctype]):
+            if any(not ctyp.endswith('-SIP') for ctyp in ctype):
                 message = """
                 Inconsistent SIP distortion information is present in the FITS header and the WCS object:
                 SIP coefficients were detected, but CTYPE is missing a "-SIP" suffix.
@@ -2537,7 +2537,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             header = fits.Header()
 
         if do_sip and self.sip is not None:
-            if self.wcs is not None and any([ctyp[-4 :] != '-SIP' for ctyp in self.wcs.ctype]):
+            if self.wcs is not None and any(not ctyp.endswith('-SIP') for ctyp in self.wcs.ctype):
                 self._fix_ctype(header, add_sip=True)
 
             for kw, val in self._write_sip_kw().items():


### PR DESCRIPTION
This is almost like #5429 but this time I found some list creations in `all()` and `any()` and removed those (not sure why I haven't found them in the last PR).

I also changed two other things I've noticed:

- replaced ``ctype[-4:] != '-SIP'`` with `not ctyp.endswith` (wcs)
- replaced call to `np.ceil` with `math.ceil` in a utility function because the subsequent `if` already prevents `np.array`s and `math` is a lot faster for scalars. (convolution kernels)