### PR TITLE
Add setters for WCS._naxis1/_naxis2

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1016,3 +1016,18 @@ def test_bounds_check():
     ra, dec = w.wcs_pix2world(300,0,0)
     assert_allclose(ra, -180)
     assert_allclose(dec, -30)
+
+
+def test_naxis():
+    w = wcs.WCS(naxis=2)
+    w.wcs.crval = [1, 1]
+    w.wcs.cdelt = [0.1, 0.1]
+    w.wcs.crpix = [1, 1]
+    w._naxis = [1000, 500]
+
+    assert w._naxis1 == 1000
+    assert w._naxis2 == 500
+
+    w._naxis1 = 99
+    w._naxis2 = 59
+    assert w._naxis == [99, 59]

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2664,9 +2664,17 @@ reduce these to 2 dimensions using the naxis kwarg.
     def _naxis1(self):
         return self._naxis[0]
 
+    @_naxis1.setter
+    def _naxis1(self, value):
+        self._naxis[0] = value
+
     @property
     def _naxis2(self):
         return self._naxis[1]
+
+    @_naxis2.setter
+    def _naxis2(self, value):
+        self._naxis[1] = value
 
     def _get_naxis(self, header=None):
         _naxis = []


### PR DESCRIPTION
Following #5411 which replaced the _naxis1/_naxis2 attributes with properties but without adding setters. This break existing code that set these values (even if there are private, there is no other way to use the shape
information from a WCS object). See discussion in #5411