### PR TITLE
Skip update of naxisj if the slice for dimension j contains non integers

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -93,6 +93,14 @@ def test_slice():
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2,0.2]))
     assert slice_wcs._naxis == [500, 250]
 
+    # Non-integral values do not alter the naxis attribute
+    slice_wcs = mywcs.slice([slice(50.), slice(20.)])
+    assert slice_wcs._naxis == [1000, 500]
+    slice_wcs = mywcs.slice([slice(50.), slice(20)])
+    assert slice_wcs._naxis == [20, 500]
+    slice_wcs = mywcs.slice([slice(50), slice(20.5)])
+    assert slice_wcs._naxis == [1000, 50]
+
 def test_slice_getitem():
     mywcs = WCS(naxis=2)
     mywcs.wcs.crval = [1,1]

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2959,8 +2959,18 @@ reduce these to 2 dimensions using the naxis kwarg.
                 else:
                     wcs_new.wcs.crpix[wcs_index] -= iview.start
 
-            nitems = len(builtins.range(self._naxis[wcs_index])[iview])
-            wcs_new._naxis[wcs_index] = nitems
+            try:
+                # range requires integers but the other attributes can also
+                # handle arbitary values, so this needs to be in a try/except.
+                nitems = len(builtins.range(self._naxis[wcs_index])[iview])
+            except TypeError as exc:
+                if 'indices must be integers' not in str(exc):
+                    raise
+                warnings.warn("NAXIS{0} could not be updated because one or "
+                              "multiple indices ('{1}') were not integral."
+                              "".format(wcs_index, iview), AstropyUserWarning)
+            else:
+                wcs_new._naxis[wcs_index] = nitems
 
         return wcs_new
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2966,8 +2966,8 @@ reduce these to 2 dimensions using the naxis kwarg.
             except TypeError as exc:
                 if 'indices must be integers' not in str(exc):
                     raise
-                warnings.warn("NAXIS{0} could not be updated because one or "
-                              "multiple indices ('{1}') were not integral."
+                warnings.warn("NAXIS{0} attribute is not updated because at "
+                              "least one indix ('{1}') is no integer."
                               "".format(wcs_index, iview), AstropyUserWarning)
             else:
                 wcs_new._naxis[wcs_index] = nitems


### PR DESCRIPTION
This fixes another problem originating from #5411 (see https://github.com/astropy/astroquery/pull/771 and https://github.com/astropy/astroquery/pull/782). The `range`-object cannot be sliced with non-integral values. This PR doesn't fix that but it throws a Warning instead of a `TypeError` and just doesn't slice that dimension.

I wasn't sure what would be best:

- implicitly convert start/stop/step values from floats to integers.
- raise a deprecation-warning that slicing requires integral start/stop/step in the future (the #5411 could be backported and we don't want API changes in bugfix releases) and remove the `except`-block for astropy 1.3, 2.0, 3.0 or later.
- raise a Warning that slicing the `naxis` with non-integral start/stop/step is not possible and just keep the original naxis value for this dimension.

I've implemented the last option because it doesn't restrict the current options but also provides an (annoying) Warning that something did not work instead of implicitly truncating/rounding the values.