### PR TITLE
Add Planar2d model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ New Features
 
   - Added bounding box to ``Lorentz1D`` and ``MexicanHat1D`` models. [#5393]
 
+  - Added ``Planar2D`` functional model. [#5456]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -760,6 +760,53 @@ class Linear1D(Fittable1DModel):
         return self.__class__(slope=new_slope, intercept=new_intercept)
 
 
+class Planar2D(Fittable2DModel):
+    """
+    Two dimensional Plane model.
+
+    Parameters
+    ----------
+    slope_x : float
+        Slope of the straight line in X
+
+    slope_y: float
+        Slope of the straight line in Y
+
+    intercept : float
+        Z-intercept of the straight line
+
+    See Also
+    --------
+    Linear1D, Polynomial2D
+
+    Notes
+    -----
+    Model formula:
+
+        .. math:: f(x, y) = a x + b y + c
+    """
+
+    slope_x = Parameter(default=1)
+    slope_y = Parameter(default=1)
+    intercept = Parameter(default=0)
+    linear = True
+
+    @staticmethod
+    def evaluate(x, y, slope_x, slope_y, intercept):
+        """Two dimensional Plane model function"""
+
+        return slope_x * x + slope_y * y + intercept
+
+    @staticmethod
+    def fit_deriv(x, y, slope_x, slope_y, intercept):
+        """Two dimensional Plane model derivative with respect to parameters"""
+
+        d_slope_x = x
+        d_slope_y = y
+        d_intercept = np.ones_like(x)
+        return [d_slope_x, d_slope_y, d_intercept]
+
+
 class Lorentz1D(Fittable1DModel):
     """
     One dimensional Lorentzian model.

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -57,7 +57,7 @@ from ..functional_models import (
     MexicanHat1D, Trapezoid1D, Const1D, Moffat1D,
     Gaussian2D, Const2D, Box2D, MexicanHat2D,
     TrapezoidDisk2D, AiryDisk2D, Moffat2D, Disk2D,
-    Ring2D, Sersic1D, Sersic2D, Voigt1D)
+    Ring2D, Sersic1D, Sersic2D, Voigt1D, Planar2D)
 from ..polynomial import Polynomial1D, Polynomial2D
 from ..powerlaws import (
     PowerLaw1D, BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
@@ -316,5 +316,15 @@ models_2D = {
         'requires_scipy': True,
         'x_lim': [1, 1e10],
         'y_lim': [1, 1e10]
+    },
+
+    Planar2D: {
+        'parameters': [1, 1, 0],
+        'x_values': [0, np.pi, 42, -1],
+        'y_values': [np.pi, 0, -1, 42],
+        'z_values': [np.pi, np.pi, 41, 41],
+        'x_lim': [-10, 10],
+        'y_lim': [-10, 10],
+        'integral': 0
     }
 }


### PR DESCRIPTION
While one can use a 1st-degree Polynomial2D to represent a plane, there should be a Planar2D functional model to parallel the Linear1D functional model.