### PR TITLE
ECSV column 'type' or 'datatype'?

### DIFF
--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -12,6 +12,8 @@ from ...extern import six
 from . import core, basic
 from ...table import meta
 
+__doctest_requires__ = {'Ecsv': ['yaml']}
+
 ECSV_VERSION = '0.9'
 DELIMITERS = (' ', ',')
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -166,16 +166,27 @@ class Ecsv(basic.Basic):
     and column meta-data, in particular the data type and unit.  For details
     see: https://github.com/astropy/astropy-APEs/blob/master/APE6.rst.
 
-    For example::
+    Examples
+    --------
 
-      # %ECSV 0.9
-      # ---
-      # datatype:
-      # - {name: a, unit: m / s, type: int64, format: '%03d'}
-      # - {name: b, unit: km, type: int64, description: This is column b}
-      a b
-      001 2
-      004 3
+    >>> from astropy.table import Table
+    >>> ecsv_content = '''# %ECSV 0.9
+    ... # ---
+    ... # datatype:
+    ... # - {name: a, unit: m / s, datatype: int64, format: '%03d'}
+    ... # - {name: b, unit: km, datatype: int64, description: This is column b}
+    ... a b
+    ... 001 2
+    ... 004 3
+    ... '''
+    >>> Table.read(ecsv_content, format='ascii.ecsv')
+    <Table length=2>
+      a     b
+    m / s   km
+    int64 int64
+    ----- -----
+      001     2
+      004     3
     """
     _format_name = 'ecsv'
     _description = 'Enhanced CSV'


### PR DESCRIPTION
@taldcroft - Is the basic ECSV example from the Astropy docs broken again?

http://docs.astropy.org/en/latest/api/astropy.io.ascii.Ecsv.html

I thought we fixed it and I checked that it worked in #5263, but now I get an error again:
```python
from astropy.table import Table
ecsv_content = """# %ECSV 0.9
# ---
# datatype:
# - {name: a, unit: m / s, type: int64, format: '%03d'}
# - {name: b, unit: km, datatype: int64, description: This is column b}
a b
001 2
004 3
"""
Table.read(ecsv_content, format='ascii.ecsv')
```
gives this error:
```
KeyError                                  Traceback (most recent call last)
<ipython-input-11-8cfe8b05e3da> in <module>()
      9 004 3
     10 """
---> 11 Table.read(ecsv_content, format='ascii.ecsv')

/Users/deil/Library/Python/3.5/lib/python/site-packages/astropy-1.3.dev16202-py3.5-macosx-10.12-x86_64.egg/astropy/table/table.py in read(cls, *args, **kwargs)
   2333         passed through to the underlying data reader (e.g. `~astropy.io.ascii.read`).
   2334         """
-> 2335         return io_registry.read(cls, *args, **kwargs)
   2336 
   2337     def write(self, *args, **kwargs):

/Users/deil/Library/Python/3.5/lib/python/site-packages/astropy-1.3.dev16202-py3.5-macosx-10.12-x86_64.egg/astropy/io/registry.py in read(cls, *args, **kwargs)
    466 
    467         reader = get_reader(format, cls)
--> 468         data = reader(*args, **kwargs)
    469 
    470         if not isinstance(data, cls):

/Users/deil/Library/Python/3.5/lib/python/site-packages/astropy-1.3.dev16202-py3.5-macosx-10.12-x86_64.egg/astropy/io/ascii/connect.py in io_read(format, filename, **kwargs)
     35     from .ui import read
     36     format = re.sub(r'^ascii\.', '', format)
---> 37     return read(filename, format=format, **kwargs)
     38 
     39 

/Users/deil/Library/Python/3.5/lib/python/site-packages/astropy-1.3.dev16202-py3.5-macosx-10.12-x86_64.egg/astropy/io/ascii/ui.py in read(table, guess, **kwargs)
    339                                              ' with fast (no guessing)'})
    340         else:
--> 341             dat = reader.read(table)
    342             _read_trace.append({'kwargs': new_kwargs,
    343                                 'status': 'Success with specified Reader class '

/Users/deil/Library/Python/3.5/lib/python/site-packages/astropy-1.3.dev16202-py3.5-macosx-10.12-x86_64.egg/astropy/io/ascii/core.py in read(self, table)
   1151 
   1152         # Get the table column definitions
-> 1153         self.header.get_cols(self.lines)
   1154 
   1155         # Make sure columns are valid

/Users/deil/Library/Python/3.5/lib/python/site-packages/astropy-1.3.dev16202-py3.5-macosx-10.12-x86_64.egg/astropy/io/ascii/ecsv.py in get_cols(self, lines)
    143                 if attr in header_cols[col.name]:
    144                     setattr(col, attr, header_cols[col.name][attr])
--> 145             col.dtype = header_cols[col.name]['datatype']
    146             # ECSV "string" means numpy dtype.kind == 'U' AKA str in Python 3
    147             if not six.PY2 and col.dtype == 'string':

KeyError: 'datatype'
```

I think the problem now is that the column info has the key `type` instead of `datatype`?
```
# - {name: a, unit: m / s, type: int64, format: '%03d'}
```
Was there a change in the ECSV reader or was this example always broken?

It looks like this issue is also present in the original APE, which I guess is still the reference to look at for ECSV
https://github.com/astropy/astropy-APEs/blame/master/APE6.rst#L319