### PR TITLE
Fix memoryleak in io.fits.compressionmodule.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -345,6 +345,8 @@ Bug Fixes
     float32 instead of float64 (with the E and F formats). These values are now
     always read as float64. [#5362]
 
+  - Fixed memoryleak when using the compression module. [#5399, #5464]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -963,6 +963,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
     tmp = (PyArrayObject*) PyArray_SimpleNewFromData(1, &znaxis, NPY_UBYTE,
                                                      outbuf);
 
+    PyArray_ENABLEFLAGS(tmp, NPY_ARRAY_OWNDATA);
 
     // Leaves refcount of tmp untouched, so its refcount should remain as 1
     retval = Py_BuildValue("KN", heapsize, tmp);


### PR DESCRIPTION
Fixes: #5399 

Related: 
- https://github.com/spacetelescope/PyFITS/issues/110

References: 
- https://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html#c.PyArray_SimpleNewFromData
- http://stackoverflow.com/questions/27912483/memory-leak-in-python-extension-when-array-is-created-with-pyarray-simplenewfrom

Note:
- The change cannot be backported to LTS because it requires numpy >= 1.7 and LTS still supports 1.6.

I checked the references and it seems the suggested fix (https://github.com/spacetelescope/PyFITS/issues/110#issuecomment-251710362) really does fix the issue, so I went ahead and implemented it.

Does anyone has any idea how to test for a non-python-object memoryleak in the tests?