### PR TITLE
Allow proper copying and pickling of Table indices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,8 @@ New Features
 
   - Support generalized value formatting for mixin columns in tables. [#5274]
 
+  - Support persistence of table indices when pickling and copying table. [#5468]
+
 - ``astropy.time``
 
   - ``light_travel_time`` can now use more accurate JPL ephemerides. [#5273, #5436]

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..extern import six
+from ..extern.six.moves import zip
 
 import weakref
 
@@ -224,8 +225,10 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         purposes.  This requires that the last element of ``state`` is a
         5-tuple that has Column-specific state values.
         """
-        # Get the Column attributes and meta
-        name, unit, format, description, meta = state[-1]
+        # Get the Column attributes
+        names = ('_name', 'unit', 'format', 'description', 'meta', 'indices')
+        attrs = {name: val for name, val in zip(names, state[-1])}
+
         state = state[:-1]
 
         # Using super(type(self), self).__setstate__() gives an infinite
@@ -234,12 +237,9 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         super_class = ma.MaskedArray if isinstance(self, ma.MaskedArray) else np.ndarray
         super_class.__setstate__(self, state)
 
-        # Set the Column attributes and meta
-        self._name = name
-        self.unit = unit
-        self.format = format
-        self.description = description
-        self.meta = meta
+        # Set the Column attributes
+        for name, val in attrs.items():
+            setattr(self, name, val)
         self._parent_table = None
 
     def __reduce__(self):
@@ -253,7 +253,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         # Define Column-specific attrs and meta that gets added to state.
         column_state = (self.name, self.unit, self.format, self.description,
-                        self.meta)
+                        self.meta, self.indices)
         state = state + (column_state,)
 
         return reconstruct_func, reconstruct_func_args, state

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -70,6 +70,14 @@ class Index(object):
     '''
     def __new__(cls, *args, **kwargs):
         self = super(Index, cls).__new__(cls)
+
+        # If (and only if) unpickling for protocol >= 2, then args and kwargs
+        # are both empty.  The class __init__ requires at least the `columns`
+        # arg.  In this case return a bare `Index` object which is then morphed
+        # by the unpickling magic into the correct SlicedIndex object.
+        if not args and not kwargs:
+            return self
+
         self.__init__(*args, **kwargs)
         return SlicedIndex(self, slice(0, 0, None), original=True)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -711,6 +711,18 @@ class Table(object):
         newcols = [self._convert_col_for_table(col) for col in cols]
         self._make_table_from_cols(self, newcols)
 
+        # Deduplicate indices.  It may happen that after pickling or when
+        # initing from an existing table that column indices which had been
+        # references to a single index object got *copied* into an independent
+        # object.  This results in duplicates which will cause downstream problems.
+        index_dict = {}
+        for col in self.itercols():
+            for i, index in enumerate(col.info.indices or []):
+                names = tuple(ind_col.info.name for ind_col in index.columns)
+                if names in index_dict:
+                    col.info.indices[i] = index_dict[names]
+                else:
+                    index_dict[names] = index
 
     def _new_from_slice(self, slice_):
         """Create a new table as a referenced slice from self."""

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -17,6 +17,7 @@ between modules.
 
 from copy import deepcopy
 from collections import OrderedDict
+import pickle
 
 import numpy as np
 
@@ -115,10 +116,10 @@ def tableclass(request):
     return table.Table if request.param else SubclassTable
 
 
-@pytest.fixture(params=[0, 1, -1])
+@pytest.fixture(params=list(range(0, pickle.HIGHEST_PROTOCOL + 1)))
 def protocol(request):
     """
-    Fixture to run all the tests for protocols 0 and 1, and -1 (most advanced).
+    Fixture to run all the tests for all available pickle protocols.
     """
     return request.param
 

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -431,3 +431,14 @@ class TestIndex(SetupData):
         if self.mutable:
             with pytest.raises(ValueError):
                 t.add_row((5, 5.0, '9'))
+
+    def test_copy_indexed_table(self, table_types):
+        self._setup(_col, table_types)
+        t = self.t
+        t.add_index('a')
+        t.add_index(['a', 'b'])
+        for tp in (self._table_type(t), t.copy()):
+            assert len(t.indices) == len(tp.indices)
+            for index, indexp in zip(t.indices, tp.indices):
+                assert np.all(index.data.data == indexp.data.data)
+                assert index.data.data.colnames == indexp.data.data.colnames

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -110,7 +110,7 @@ def test_pickle_indexed_table(protocol):
     t.add_index(['a', 'b'])
     ts = pickle.dumps(t)
     tp = pickle.loads(ts)
-    
+
     assert len(t.indices) == len(tp.indices)
     for index, indexp in zip(t.indices, tp.indices):
         assert np.all(index.data.data == indexp.data.data)

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -3,6 +3,7 @@ from ...extern.six.moves import cPickle as pickle
 import numpy as np
 
 from ...table import Table, Column, MaskedColumn, QTable
+from ...table.table_helpers import simple_table
 from ...units import Quantity, deg
 from ...time import Time
 from ...coordinates import SkyCoord
@@ -98,3 +99,19 @@ def test_pickle_masked_table(protocol):
     assert tp['a'].attrs_equal(t['a'])
     assert tp['b'].attrs_equal(t['b'])
     assert tp.meta == t.meta
+
+
+def test_pickle_indexed_table(protocol):
+    """
+    Ensure that any indices that have been added will survive pickling.
+    """
+    t = simple_table()
+    t.add_index('a')
+    t.add_index(['a', 'b'])
+    ts = pickle.dumps(t)
+    tp = pickle.loads(ts)
+    
+    assert len(t.indices) == len(tp.indices)
+    for index, indexp in zip(t.indices, tp.indices):
+        assert np.all(index.data.data == indexp.data.data)
+        assert index.data.data.colnames == indexp.data.data.colnames


### PR DESCRIPTION
Fixes #4111.

Also fixes an related issue that copying a table results in a corrupted set of indices attributes.  In the case of multi-column indices one can get `indices` tables that should be references to a single object but are in fact copies of the object.

I've marked as both a Bug (table copying) and Enhancement (allowing pickling of indices).  Maybe the latter could be considered a bug also?

This changes the pickle format.  It should be back-compatible with pickle files from astropy < 1.3, but the reverse will not be true.  Astropy 1.2 will not read table pickle files from astropy 1.3, though in theory we could split out the change in the outputting (dump) from the change in the inputting (load) to fix that and thus allow backporting of most of this.