### PR TITLE
Allow renaming mixin columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ New Features
 
 - ``astropy.table``
 
+  - Allow renaming mixin columns. [#5469]
+
   - Support generalized value formatting for mixin columns in tables. [#5274]
 
 - ``astropy.time``

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -116,6 +116,9 @@ class TableColumns(OrderedDict):
         return "<{1} names=({0})>".format(",".join(names), self.__class__.__name__)
 
     def _rename_column(self, name, new_name):
+        if name == new_name:
+            return
+
         if new_name in self:
             raise KeyError("Column {0} already exists".format(new_name))
 
@@ -1975,9 +1978,6 @@ class Table(object):
 
         if name not in self.keys():
             raise KeyError("Column {0} does not exist".format(name))
-
-        if not isinstance(self.columns[name], BaseColumn):
-            raise NotImplementedError('cannot rename a mixin column')
 
         self.columns[name].info.name = new_name
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -542,3 +542,20 @@ def test_possible_string_format_functions():
                            '------',
                            '1.0000',
                            '2.0000']
+
+
+def test_rename_mixin_columns(mixin_cols):
+    """
+    Rename a mixin column.
+    """
+    t = QTable(mixin_cols)
+    tc = t.copy()
+    t.rename_column('m', 'mm')
+    assert t.colnames == ['i', 'a', 'b', 'mm']
+    if isinstance(t['mm'], table_helpers.ArrayWrapper):
+        assert np.all(t['mm'].data == tc['m'].data)
+    elif isinstance(t['mm'], coordinates.SkyCoord):
+        assert np.all(t['mm'].ra == tc['m'].ra)
+        assert np.all(t['mm'].dec == tc['m'].dec)
+    else:
+        assert np.all(t['mm'] == tc['m'])

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -483,7 +483,18 @@ class BaseColumnInfo(DataInfo):
 
 
 class MixinInfo(BaseColumnInfo):
-    pass
+
+    def __setattr__(self, attr, value):
+        # For mixin columns that live within a table, rename the column in the
+        # table when setting the name attribute.  This mirrors the same
+        # functionality in the BaseColumn class.
+        if attr == 'name' and self.parent_table is not None:
+            from ..table.np_utils import fix_column_name
+            new_name = fix_column_name(value)  # Ensure col name is numpy compatible
+            self.parent_table.columns._rename_column(self.name, new_name)
+
+        super(MixinInfo, self).__setattr__(attr, value)
+
 
 class ParentDtypeInfo(MixinInfo):
     """Mixin that gets info.dtype from parent"""


### PR DESCRIPTION
This was a leftover to-be-done from the original mixin implementation.