### PR TITLE
Expand JsonCustomEncoder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,9 @@ astropy.utils
 - The ``astropy.utils.compat.futures`` module has now been deprecated. Use the
   Python 'concurrent.futures' module directly instead. [#6598]
 
+- ``JsonCustomEncoder`` is expanded to handle ``Quantity`` and ``UnitBase``.
+  [#5471]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -371,6 +371,8 @@ class JsonCustomEncoder(json.JSONEncoder):
         * Complex number
         * Set
         * Bytes (Python 3)
+        * astropy.UnitBase
+        * astropy.Quantity
 
     Examples
     --------
@@ -383,8 +385,11 @@ class JsonCustomEncoder(json.JSONEncoder):
     """
 
     def default(self, obj):
+        from .. import units as u
         import numpy as np
-        if isinstance(obj, (np.ndarray, np.number)):
+        if isinstance(obj, u.Quantity):
+            return dict(value=obj.value, unit=obj.unit.to_string())
+        if isinstance(obj, (np.number, np.ndarray)):
             return obj.tolist()
         elif isinstance(obj, (complex, np.complex)):
             return [obj.real, obj.imag]
@@ -392,6 +397,12 @@ class JsonCustomEncoder(json.JSONEncoder):
             return list(obj)
         elif isinstance(obj, bytes):  # pragma: py3
             return obj.decode()
+        elif isinstance(obj, (u.UnitBase, u.FunctionUnitBase)):
+            if obj == u.dimensionless_unscaled:
+                obj = 'dimensionless_unit'
+            else:
+                return obj.to_string()
+        #
         return json.JSONEncoder.default(self, obj)
 
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -402,7 +402,7 @@ class JsonCustomEncoder(json.JSONEncoder):
                 obj = 'dimensionless_unit'
             else:
                 return obj.to_string()
-        #
+
         return json.JSONEncoder.default(self, obj)
 
 

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -52,6 +52,7 @@ def test_skip_hidden():
 
 
 def test_JsonCustomEncoder():
+    from ... import units as u
     assert json.dumps(np.arange(3), cls=misc.JsonCustomEncoder) == '[0, 1, 2]'
     assert json.dumps(1+2j, cls=misc.JsonCustomEncoder) == '[1.0, 2.0]'
     assert json.dumps(set([1, 2, 1]), cls=misc.JsonCustomEncoder) == '[1, 2]'
@@ -59,6 +60,20 @@ def test_JsonCustomEncoder():
                       cls=misc.JsonCustomEncoder) == '"hello world \\u00c5"'
     assert json.dumps({1: 2},
                       cls=misc.JsonCustomEncoder) == '{"1": 2}'  # default
+    assert json.dumps({1: u.m}, cls=misc.JsonCustomEncoder) == '{"1": "m"}'
+    # Quantities
+    tmp = json.dumps({'a': 5*u.cm}, cls=misc.JsonCustomEncoder)
+    newd = json.loads(tmp)
+    tmpd = {"a": {"unit": "cm", "value": 5.0}}
+    assert newd == tmpd
+    tmp2 = json.dumps({'a': np.arange(2)*u.cm}, cls=misc.JsonCustomEncoder)
+    newd = json.loads(tmp2)
+    tmpd = {"a": {"unit": "cm", "value": [0., 1.]}}
+    assert newd == tmpd
+    tmp3 = json.dumps({'a': np.arange(2)*u.erg/u.s}, cls=misc.JsonCustomEncoder)
+    newd = json.loads(tmp3)
+    tmpd = {"a": {"unit": "erg / s", "value": [0., 1.]}}
+    assert newd == tmpd
 
 
 def test_inherit_docstrings():


### PR DESCRIPTION
Adds support for several astropy-specific objects including
units and Quantity.

Also includes a simple method to use in place of json.dumps
for those less accustomed to its syntax:  astropy.utils.misc.jsondumps

Includes new tests (passing tests on Travis)