### PR TITLE
test_sidereal failure

### DIFF
--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -30,8 +30,8 @@ class TestERFATestCases():
     # reproduce this exactly. Now it does not really matter,
     # but may as well fake this (and avoid IERS table lookup here)
     time_ut1.delta_ut1_utc = 0.
-    time_ut1.delta_ut1_utc = 24*3600*(time_ut1.tt.jd2-time_tt.jd2)
-    assert np.allclose(time_ut1.tt.jd2 - time_tt.jd2, 0., atol=1.e-14)
+    time_ut1.delta_ut1_utc = 24*3600*(time_ut1.tt - time_tt).jd
+    assert np.allclose((time_ut1.tt - time_tt).jd, 0., atol=1.e-14)
 
     @pytest.mark.parametrize('erfa_test_input',
                              ((1.754174972210740592, 1e-12, "eraGmst00"),


### PR DESCRIPTION
Got the following during Fedora build of astropy:

```
_____________ ERROR collecting astropy/time/tests/test_sidereal.py _____________
astropy/time/tests/test_sidereal.py:24: in <module>
    class TestERFATestCases():
astropy/time/tests/test_sidereal.py:34: in TestERFATestCases
    assert np.allclose(time_ut1.tt.jd2 - time_tt.jd2, 0., atol=1.e-14)
E   assert False
E    +  where False = <function allclose at 0xf4fce80c>((-0.4999999999999999 - 0.5), 0.0, atol=1e-14)
E    +    where <function allclose at 0xf4fce80c> = np.allclose
E    +    and   -0.4999999999999999 = <Time object: scale='tt' format='jd' value=2453735.5>.jd2
E    +      where <Time object: scale='tt' format='jd' value=2453735.5> = <Time object: scale='ut1' format='jd' value=2453736.5>.tt
E    +    and   0.5 = <Time object: scale='tt' format='jd' value=2453736.5>.jd2
```