### PR TITLE
Change URL Protocol and String formating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ RELEASE = 'dev' not in VERSION
 if not RELEASE:
     VERSION += get_git_devstr(False)
 
-DOWNLOAD_BASE_URL = 'http://pypi.python.org/packages/source/a/astropy'
+DOWNLOAD_BASE_URL = 'https://pypi.python.org/packages/source/a/astropy'
 
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially
@@ -84,7 +84,7 @@ setup(name=NAME,
       license='BSD',
       url='http://astropy.org',
       long_description=astropy.__doc__,
-      download_url='%s/astropy-%s.tar.gz' % (DOWNLOAD_BASE_URL, VERSION),
+      download_url='{0}/astropy-{1}.tar.gz'.format(DOWNLOAD_BASE_URL, VERSION),
       keywords=['astronomy', 'astrophysics', 'cosmology', 'space', 'science',
                 'units', 'table', 'wcs', 'vo', 'samp', 'coordinate', 'fits',
                 'modeling', 'models', 'fitting', 'ascii'],


### PR DESCRIPTION
Changing Download_Base_URL protocol from 'http' to 'https' for more secure connection, only change the pypi.python.org cause the  astropy.org yet support secure connection. and base on PEP 310, the formatting operations use here [% substitutions] are obsolete and may go away in future versions of Python. so i do change it to new format [.format()]