### PR TITLE
FutureWarning: elementwise comparison failed in table.info()

### DIFF
--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -89,10 +89,6 @@ def table_info(tbl, option='attributes', out=''):
 
     # Since info is going to a filehandle for viewing then remove uninteresting
     # columns.
-    for name in info.colnames:
-        if np.all(info[name] == ''):
-            del info[name]
-
     if 'class' in info.colnames:
         # Remove 'class' info column if all table columns are the same class
         # and they are the default column class for that table.
@@ -106,6 +102,10 @@ def table_info(tbl, option='attributes', out=''):
     # Standard attributes has 'length' but this is typically redundant
     if 'length' in info.colnames and np.all(info['length'] == len(tbl)):
         del info['length']
+
+    for name in info.colnames:
+        if info[name].dtype.kind in 'SU' and np.all(info[name] == ''):
+            del info[name]
 
     if tbl.colnames:
         outlines.extend(info.pformat(max_width=-1, max_lines=-1, show_unit=False))

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -16,6 +16,8 @@ from ... import coordinates
 from ... import table
 from ...utils.data_info import data_info_factory, dtype_info_name
 from ...utils.compat import NUMPY_LT_1_8
+from ..table_helpers import simple_table
+
 
 def test_table_info_attributes(table_types):
     """
@@ -232,4 +234,13 @@ def test_ignore_warnings():
     t = table.Table([[np.nan, np.nan]])
     with warnings.catch_warnings(record=True) as warns:
         t.info('stats', out=None)
+        assert len(warns) == 0
+
+
+def test_no_deprecation_warning():
+    # regression test for #5459, where numpy deprecation warnings were
+    # emitted unnecessarily.
+    t = simple_table()
+    with warnings.catch_warnings(record=True) as warns:
+        t.info()
         assert len(warns) == 0


### PR DESCRIPTION
Have not had a chance to track down where this is happening, but it will be a bug at some point.

```
In [2]: t = simple_table()

In [3]: t.info
astropy/table/column.py:264: FutureWarning: elementwise comparison failed; returning scalar instead, but in the fu
  return self.data.__eq__(other)
Out[3]: 
<Table length=3>
name  dtype 
---- -------
   a   int64
   b float64
   c    str1
```
