### PR TITLE
Ensure ShapedLikeNDArray is not iterable for scalars.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,7 +137,8 @@ API Changes
   - ``SkyCoord``, ``ICRS``, and other coordinate objects, as well as the
     underlying representations such as ``SphericalRepresentation`` and
     ``CartesianRepresentation`` can now be reshaped using methods named like the
-    numpy ones for ``ndarray`` (``reshape``, ``swapaxes``, etc.) [#4123, #5254]
+    numpy ones for ``ndarray`` (``reshape``, ``swapaxes``, etc.)
+    [#4123, #5254, #5482]
 
   - The ``obsgeoloc`` and ``obsgeovel`` attributes of ``GCRS`` and
     ``PrecessedGeocentric`` frames are now stored and returned as

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -720,18 +720,20 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         """
         return self._data is not None
 
+    @property
+    def shape(self):
+        return self.data.shape if self.has_data else self._no_data_shape
+
+    # We have to override the ShapedLikeNDArray definitions, since our shape
+    # does not have to be that of the data.
     def __len__(self):
         return len(self.data)
 
     def __nonzero__(self):  # Py 2.x
-        return self.isscalar or len(self) != 0
+        return self.has_data and self.size > 0
 
     def __bool__(self):  # Py 3.x
-        return self.isscalar or len(self) != 0
-
-    @property
-    def shape(self):
-        return self.data.shape if self.has_data else self._no_data_shape
+        return self.has_data and self.size > 0
 
     @property
     def size(self):
@@ -739,7 +741,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
     @property
     def isscalar(self):
-        return self.data.isscalar
+        return self.has_data and self.data.isscalar
 
     @classmethod
     def get_frame_attr_names(cls):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -172,19 +172,6 @@ class BaseRepresentation(ShapedLikeNDArray):
         return self.__class__( *[apply_method(getattr(self, component))
                                  for component in self.components], copy=False)
 
-    def __len__(self):
-        if self.isscalar:
-            raise TypeError("'{cls}' object with scalar values have no "
-                            "len()".format(cls=self.__class__.__name__))
-        else:
-            return len(getattr(self, self.components[0]))
-
-    def __nonzero__(self):  # Py 2.x
-        return self.isscalar or len(self) != 0
-
-    def __bool__(self):  # Py 3.x
-        return self.isscalar or len(self) != 0
-
     @property
     def shape(self):
         """The shape of the instance and underlying arrays.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -227,15 +227,6 @@ class SkyCoord(ShapedLikeNDArray):
     def representation(self, value):
         self.frame.representation = value
 
-    def __len__(self):
-        return len(self.frame)
-
-    def __nonzero__(self):  # Py 2.x
-        return self.frame.__nonzero__()
-
-    def __bool__(self):  # Py 3.x
-        return self.frame.__bool__()
-
     @property
     def shape(self):
         return self.frame.shape

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_allclose
 from ... import units as u
 from ...tests.helper import (pytest, assert_quantity_allclose as
                              assert_allclose_quantity)
+from ...utils import isiterable
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
 from ..representation import (REPRESENTATION_CLASSES,
@@ -173,7 +174,7 @@ class TestSphericalRepresentation(object):
         with pytest.raises(AttributeError):
             s1.distance = 1. * u.kpc
 
-    def test_getitem(self):
+    def test_getitem_len_iterable(self):
 
         s = SphericalRepresentation(lon=np.arange(10) * u.deg,
                                     lat=-np.arange(10) * u.deg,
@@ -185,7 +186,10 @@ class TestSphericalRepresentation(object):
         assert_allclose_quantity(s_slc.lat, [-2, -4, -6] * u.deg)
         assert_allclose_quantity(s_slc.distance, [1, 1, 1] * u.kpc)
 
-    def test_getitem_scalar(self):
+        assert len(s) == 10
+        assert isiterable(s)
+
+    def test_getitem_len_iterable_scalar(self):
 
         s = SphericalRepresentation(lon=1 * u.deg,
                                     lat=-2 * u.deg,
@@ -193,6 +197,9 @@ class TestSphericalRepresentation(object):
 
         with pytest.raises(TypeError):
             s_slc = s[0]
+        with pytest.raises(TypeError):
+            len(s)
+        assert not isiterable(s)
 
 
 class TestUnitSphericalRepresentation(object):

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -534,8 +534,15 @@ def test_ops():
 
     assert sc_arr[0].isscalar
     assert len(sc_arr[:1]) == 1
+    # A scalar shouldn't be indexable
     with pytest.raises(TypeError):
-        sc[0:]  # scalar, so it shouldn't be indexable
+        sc[0:]
+    # but it should be possible to just get an item
+    sc_item = sc[()]
+    assert sc_item.shape == ()
+    # and to turn it into an array
+    sc_1d = sc[np.newaxis]
+    assert sc_1d.shape == (1,)
 
     with pytest.raises(TypeError):
         iter(sc)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -542,6 +542,11 @@ def test_ops():
     assert not isiterable(sc)
     assert isiterable(sc_arr)
     assert isiterable(sc_empty)
+    it = iter(sc_arr)
+    assert next(it).dec == sc_arr[0].dec
+    assert next(it).dec == sc_arr[1].dec
+    with pytest.raises(StopIteration):
+        next(it)
 
 
 def test_none_transform():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -27,8 +27,8 @@ from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             frame_transform_graph)
 from ...coordinates import Latitude, EarthLocation
 from ...time import Time
-from ...utils import minversion
-from ...utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from ...utils import minversion, isiterable
+from ...utils.exceptions import AstropyDeprecationWarning
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
@@ -535,7 +535,13 @@ def test_ops():
     assert sc_arr[0].isscalar
     assert len(sc_arr[:1]) == 1
     with pytest.raises(TypeError):
-        assert sc[0:]  # scalar, so it shouldn't be indexable
+        sc[0:]  # scalar, so it shouldn't be indexable
+
+    with pytest.raises(TypeError):
+        iter(sc)
+    assert not isiterable(sc)
+    assert isiterable(sc_arr)
+    assert isiterable(sc_empty)
 
 
 def test_none_transform():

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -10,7 +10,6 @@ astronomy.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import itertools
 import copy
 import operator
 from datetime import datetime
@@ -521,13 +520,6 @@ class Time(ShapedLikeNDArray):
                 else:
                     reshaped.append(val)
 
-    def __bool__(self):
-        """Any time should evaluate to True, except when it is empty."""
-        return self.size > 0
-
-    # In python2, __bool__ is not defined.
-    __nonzero__ = __bool__
-
     def _shaped_like_input(self, value):
         return value if self._time.jd1.shape else value.item()
 
@@ -882,21 +874,6 @@ class Time(ShapedLikeNDArray):
         copy of the JD arrays.
         """
         return self.copy()
-
-    def __iter__(self):
-        if self.isscalar:
-            raise TypeError('scalar {0!r} object is not iterable.'.format(
-                self.__class__.__name__))
-
-        def time_iter():
-            try:
-                for idx in itertools.count():
-                    yield self[idx]
-            except IndexError:
-                # Results in StopIteration
-                pass
-
-        return time_iter()
 
     def _advanced_index(self, indices, axis=None, keepdims=False):
         """Turn argmin, argmax output into an advanced index.
@@ -1274,12 +1251,6 @@ class Time(ShapedLikeNDArray):
     # called with the optional jd1 and jd2 args.
     delta_tdb_tt = property(_get_delta_tdb_tt, _set_delta_tdb_tt)
     """TDB - TT time scale offset"""
-
-    def __len__(self):
-        if self.isscalar:
-            raise TypeError("Scalar {0} object has no len()"
-                            .format(self.__class__.__name__))
-        return len(self.jd1)
 
     def __sub__(self, other):
         if not isinstance(other, Time):

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -938,14 +938,14 @@ class ShapedLikeNDArray(object):
 
     def __getitem__(self, item):
         if self.isscalar:
-            raise TypeError('scalar {0!r} object is not subscriptable.'.format(
-                self.__class__.__name__))
+            raise TypeError('scalar {0!r} object is not subscriptable.'
+                            .format(self.__class__.__name__))
         return self._apply('__getitem__', item)
 
     def __iter__(self):
         if self.isscalar:
-            raise TypeError('scalar {0!r} object is not iterable.'.format(
-                self.__class__.__name__))
+            raise TypeError('scalar {0!r} object is not iterable.'
+                            .format(self.__class__.__name__))
 
         # We cannot just write a generator here, since then the above error
         # would only be raised once we try to use the iterator, rather than

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -937,10 +937,14 @@ class ShapedLikeNDArray(object):
         return self.size > 0
 
     def __getitem__(self, item):
-        if self.isscalar:
-            raise TypeError('scalar {0!r} object is not subscriptable.'
-                            .format(self.__class__.__name__))
-        return self._apply('__getitem__', item)
+        try:
+            return self._apply('__getitem__', item)
+        except IndexError:
+            if self.isscalar:
+                raise TypeError('scalar {0!r} object is not subscriptable.'
+                                .format(self.__class__.__name__))
+            else:
+                raise
 
     def __iter__(self):
         if self.isscalar:

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -922,11 +922,39 @@ class ShapedLikeNDArray(object):
     def isscalar(self):
         return self.shape == ()
 
+    def __len__(self):
+        if self.isscalar:
+            raise TypeError("Scalar {0!r} object has no len()"
+                            .format(self.__class__.__name__))
+        return self.shape[0]
+
+    def __bool__(self):  # Python 3
+        """Any instance should evaluate to True, except when it is empty."""
+        return self.size > 0
+
+    def __nonzero__(self):  # Python 2
+        """Any instance should evaluate to True, except when it is empty."""
+        return self.size > 0
+
     def __getitem__(self, item):
-        if not self.shape:
+        if self.isscalar:
             raise TypeError('scalar {0!r} object is not subscriptable.'.format(
                 self.__class__.__name__))
         return self._apply('__getitem__', item)
+
+    def __iter__(self):
+        if self.isscalar:
+            raise TypeError('scalar {0!r} object is not iterable.'.format(
+                self.__class__.__name__))
+
+        # We cannot just write a generator here, since then the above error
+        # would only be raised once we try to use the iterator, rather than
+        # upon its definition using iter(self).
+        def self_iter():
+            for idx in range(len(self)):
+                yield self[idx]
+
+        return self_iter()
 
     def copy(self, *args, **kwargs):
         """Return an instance containing copies of the internal data.


### PR DESCRIPTION
Any of the classes using `ShapedLikeNDArray` will now raise an exception if one tries to construct an iterator of a scalar instance (as was already the case for `Time`). See #5481.

Note that since this uses `ShapedLikeNDArray`, it cannot easily be backported