### PR TITLE
Ensure it is possible to initialize Angle with cds units enabled.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1709,6 +1709,9 @@ Bug Fixes
     without e-terms, which will have affected coordinates not on the unit
     sphere (i.e., with distances). [#4293]
 
+  - Fix bug where with cds units enabled it was no longer possible to initialize
+    an ``Angle``. [#5483]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -40,6 +40,9 @@ class _AngleParser(object):
     instead.
     """
     def __init__(self):
+        # TODO: in principle, the parser should be invalidated if we change unit
+        # system (from CDS to FITS, say).  Might want to keep a link to the
+        # unit_registry used, and regenerate the parser/lexer if it changes.
         if '_parser' not in _AngleParser.__dict__:
             _AngleParser._parser, _AngleParser._lexer = self._make_parser()
 
@@ -47,11 +50,12 @@ class _AngleParser(object):
     def _get_simple_unit_names(cls):
         simple_units = set(
             u.radian.find_equivalent_units(include_prefix_units=True))
-        simple_units.remove(u.deg)
-        simple_units.remove(u.hourangle)
         simple_unit_names = set()
+        # We filter out degree and hourangle, since those are treated
+        # separately.
         for unit in simple_units:
-            simple_unit_names.update(unit.names)
+            if unit != u.deg and unit != u.hourangle:
+                simple_unit_names.update(unit.names)
         return list(simple_unit_names)
 
     @classmethod

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -43,6 +43,10 @@ class _AngleParser(object):
         # TODO: in principle, the parser should be invalidated if we change unit
         # system (from CDS to FITS, say).  Might want to keep a link to the
         # unit_registry used, and regenerate the parser/lexer if it changes.
+        # Alternatively, perhaps one should not worry at all and just pre-
+        # generate the parser for each release (as done for unit formats).
+        # For some discussion of this problem, see
+        # https://github.com/astropy/astropy/issues/5350#issuecomment-248770151
         if '_parser' not in _AngleParser.__dict__:
             _AngleParser._parser, _AngleParser._lexer = self._make_parser()
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -879,3 +879,19 @@ def test_angle_axis_deprecation():
         an1, ax1 = angle_axis(m)
     assert_allclose(an1.to(u.deg).value, 90.)
     assert_allclose(ax1, [0., 0., 1.])
+
+
+def test_angle_with_cds_units_enabled():
+    """Regression test for #5350
+
+    Especially the example in
+    https://github.com/astropy/astropy/issues/5350#issuecomment-248770151
+    """
+    from ...units import cds
+    # the problem is with the parser, so remove it temporarily
+    from ..angle_utilities import _AngleParser
+    del _AngleParser._parser
+    with cds.enable():
+        Angle('5d')
+    del _AngleParser._parser
+    Angle('5d')


### PR DESCRIPTION
In https://github.com/astropy/astropy/issues/5350#issuecomment-248770151, @timj noted that the following gave an error:
```
from astropy.units import cds
from astropy.coordinates import Angle
cds.enable()
Angle('5d')
```
This was due to the angle parser in `astropy.coordinates.angle_utilities` setting up its parser using `cds` units, but trying to remove some regular ones.

This PR solves it by filtering using unit comparison rather than testing for specific instances. 

In principle, one could try to be neater, and regenerate the angle parser if the unit system changes. But this seems a bit of overkill. One could also argue the reverse: that the lexer and parser should just be generated once and that astropy should ship with that.