### PR TITLE
Fix documentation Sersic1D and Sersic2D

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -583,7 +583,7 @@ class Sersic1D(Fittable1DModel):
 
     .. math::
 
-        I(r)=I_e exp\left[-b_n\left(\frac{r}{r_{e}}\right)^{(1/n)}-1\right]
+        I(r)=I_e\exp\left\{-b_n\left[\left(\frac{r}{r_{e}}\right)^{(1/n)}-1\right]\right\}
 
     The constant :math:`b_n` is defined such that :math:`r_e` contains half the total
     luminosity, and can be solved for numerically.
@@ -1997,7 +1997,7 @@ class Sersic2D(Fittable2DModel):
 
     .. math::
 
-        I(x,y) = I(r) = I_e\exp\left[-b_n\left(\frac{r}{r_{e}}\right)^{(1/n)}-1\right]
+        I(x,y) = I(r) = I_e\exp\left\{-b_n\left[\left(\frac{r}{r_{e}}\right)^{(1/n)}-1\right]\right\}
 
     The constant :math:`b_n` is defined such that :math:`r_e` contains half the total
     luminosity, and can be solved for numerically.


### PR DESCRIPTION
The documentation for both the Sersic1D and Sersic2D gives the wrong model formula (missing a set of brackets).  As can be seen in the reference and the code, the factor `-b_n` should be multiplied with the whole `(r/r_e)^(1/n) -1` term and not just `(r/r_e)^(1/n)`.  I have fixed this by changing the square brackets to curly brackets and putting the `(r/r_e)^(1/n) -1` term in square brackets as it is done in the reference.

EDIT: Formatted for readability.