### PR TITLE
Update matchsep.rst

### DIFF
--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -148,7 +148,7 @@ Matching Catalogs
 `~astropy.coordinates` supports leverages the coordinate framework to make it
 straightforward to find the closest coordinates in a catalog to a desired set
 of other coordinates. For example, assuming ``ra1``/``dec1`` and
-``ra2``/``dec2`` are numpy arrays loaded from some file::
+``ra2``/``dec2`` are numpy arrays loaded from some file using match_to_catalog_sky::
 
     >>> from astropy.coordinates import SkyCoord
     >>> from astropy import units as u


### PR DESCRIPTION
adding some more links an explanation to catalog matching section

This is work in progress and my first attempt at the sort of thing.

My goal is add inline links to the docs that describe match_coordinates_sky and match_to_catalog_sky

http://docs.astropy.org/en/stable/api/astropy.coordinates.match_coordinates_sky.html#astropy.coordinates.match_coordinates_sky

http://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html#astropy.coordinates.SkyCoord.match_to_catalog_sky
