### PR TITLE
Automatically import the mpl_normalize module in the visualization subpackage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -212,6 +212,10 @@ API Changes
 
   - Deprecated the ``scale_image`` function. [#5206]
 
+  - The ``mpl_normalize`` module (containing the ``ImageNormalize``
+    class) is now automatically imported with the ``visualization``
+    subpackage. [#5491]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/__init__.py
+++ b/astropy/visualization/__init__.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .stretch import *
+from .hist import *
 from .interval import *
+from .mpl_normalize import *
+from .mpl_style import *
+from .stretch import *
 from .transform import *
 from .ui import *
-from .mpl_style import *
-from .hist import *
 from .units import *

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -30,6 +30,8 @@ except ImportError:
 
 __all__ = ['ImageNormalize', 'simple_norm']
 
+__doctest_requires__ = {'*': ['matplotlib']}
+
 
 class ImageNormalize(Normalize):
     """

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -152,8 +152,8 @@ the data and the interval and stretch objects:
     import numpy as np
     import matplotlib.pyplot as plt
 
-    from astropy.visualization import MinMaxInterval, SqrtStretch
-    from astropy.visualization.mpl_normalize import ImageNormalize
+    from astropy.visualization import (MinMaxInterval, SqrtStretch,
+                                       ImageNormalize)
 
     # Generate a test image
     image = np.arange(65536).reshape((256, 256))
@@ -191,8 +191,8 @@ also be the vmin and vmax limits, which you can determine from the
     import numpy as np
     import matplotlib.pyplot as plt
 
-    from astropy.visualization import MinMaxInterval, SqrtStretch
-    from astropy.visualization.mpl_normalize import ImageNormalize
+    from astropy.visualization import (MinMaxInterval, SqrtStretch,
+                                       ImageNormalize)
 
     # Generate a test image
     image = np.arange(65536).reshape((256, 256))
@@ -223,7 +223,7 @@ to be used in scripted programs; it's better to use
 
     import numpy as np
     import matplotlib.pyplot as plt
-    from astropy.visualization.mpl_normalize import simple_norm
+    from astropy.visualization import simple_norm
 
     # Generate a test image
     image = np.arange(65536).reshape((256, 256))


### PR DESCRIPTION
With this change one no longer needs to explicitly import `ImageNormalize` and `simple_norm` from `astropy.visualization.mpl_normalize`.  They are now available directly in the `astropy.visualization` namespace.
