### PR TITLE
Make footprint_to_file more useful

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -122,6 +122,10 @@ New Features
 
 - ``astropy.wcs``
 
+  - Improved ``footprint_to_file``: allow to specify the coordinate system, and
+    use by default the one from ``RADESYS``. Overwrite the file instead of
+    appending to it. [#5494]
+
 
 API Changes
 ^^^^^^^^^^^

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -604,8 +604,25 @@ def test_footprint_to_file(tmpdir):
                  'CTYPE2': 'DEC--ZPN', 'CRUNIT2': 'deg',
                  'CRPIX2': 3.0453999e+03, 'CRVAL2': 4.388538000000e+01,
                  'PV2_1': 1., 'PV2_3': 220.})
-    # Just check that this doesn't raise an exception:
-    w.footprint_to_file(str(tmpdir.join('test.txt')))
+
+    testfile = str(tmpdir.join('test.txt'))
+    w.footprint_to_file(testfile)
+
+    with open(testfile, 'r') as f:
+        lines = f.readlines()
+
+    assert len(lines) == 4
+    assert lines[2] == 'ICRS\n'
+    assert 'color=green' in lines[3]
+
+    w.footprint_to_file(testfile, coordsys='FK5', color='red')
+
+    with open(testfile, 'r') as f:
+        lines = f.readlines()
+
+    assert len(lines) == 4
+    assert lines[2] == 'ICRS\n'
+    assert 'color=red' in lines[3]
 
 
 def test_validate_faulty_wcs():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -621,8 +621,11 @@ def test_footprint_to_file(tmpdir):
         lines = f.readlines()
 
     assert len(lines) == 4
-    assert lines[2] == 'ICRS\n'
+    assert lines[2] == 'FK5\n'
     assert 'color=red' in lines[3]
+
+    with pytest.raises(ValueError):
+        w.footprint_to_file(testfile, coordsys='FOO')
 
 
 def test_validate_faulty_wcs():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2629,8 +2629,8 @@ reduce these to 2 dimensions using the naxis kwarg.
         """
         return str(self.to_header(relax))
 
-    def footprint_to_file(self, filename=None, color='green', width=2,
-                          coordsys=None):
+    def footprint_to_file(self, filename='footprint.reg', color='green',
+                          width=2, coordsys=None):
         """
         Writes out a `ds9`_ style regions file. It can be loaded
         directly by `ds9`_.
@@ -2652,16 +2652,23 @@ reduce these to 2 dimensions using the naxis kwarg.
             http://ds9.si.edu/doc/ref/region.html#RegionFileFormat
 
         """
-        if not filename:
-            filename = 'footprint.reg'
         comments = ('# Region file format: DS9 version 4.0 \n'
                     '# global color=green font="helvetica 12 bold '
                     'select=1 highlite=1 edit=1 move=1 delete=1 '
                     'include=1 fixed=0 source\n')
 
+        coordsys = coordsys or self.wcs.radesys
+
+        if coordsys not in ('PHYSICAL', 'IMAGE', 'FK4', 'B1950', 'FK5',
+                            'J2000', 'GALACTIC', 'ECLIPTIC', 'ICRS', 'LINEAR',
+                            'AMPLIFIER', 'DETECTOR'):
+            raise ValueError("Coordinate system '{}' is not supported. A valid"
+                             " one can be given with the 'coordsys' argument."
+                             .format(coordsys))
+
         with open(filename, mode='w') as f:
             f.write(comments)
-            f.write('{}\n'.format(self.wcs.radesys))
+            f.write('{}\n'.format(coordsys))
             f.write('polygon(')
             self.calc_footprint().tofile(f, sep=',')
             f.write(') # color={0}, width={1:d} \n'.format(color, width))

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2629,7 +2629,8 @@ reduce these to 2 dimensions using the naxis kwarg.
         """
         return str(self.to_header(relax))
 
-    def footprint_to_file(self, filename=None, color='green', width=2):
+    def footprint_to_file(self, filename=None, color='green', width=2,
+                          coordsys=None):
         """
         Writes out a `ds9`_ style regions file. It can be loaded
         directly by `ds9`_.
@@ -2644,21 +2645,26 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         width : int, optional
             Width of the region line.
+
+        coordsys : str, optional
+            Coordinate system. If not specified (default), the ``radesys``
+            value is used. For all possible values, see
+            http://ds9.si.edu/doc/ref/region.html#RegionFileFormat
+
         """
         if not filename:
             filename = 'footprint.reg'
-        comments = '# Region file format: DS9 version 4.0 \n'
-        comments += ('# global color=green font="helvetica 12 bold ' +
-                     'select=1 highlite=1 edit=1 move=1 delete=1 ' +
-                     'include=1 fixed=0 source\n')
+        comments = ('# Region file format: DS9 version 4.0 \n'
+                    '# global color=green font="helvetica 12 bold '
+                    'select=1 highlite=1 edit=1 move=1 delete=1 '
+                    'include=1 fixed=0 source\n')
 
-        f = open(filename, 'a')
-        f.write(comments)
-        f.write('linear\n')
-        f.write('polygon(')
-        self.calc_footprint().tofile(f, sep=',')
-        f.write(') # color={0}, width={1:d} \n'.format(color, width))
-        f.close()
+        with open(filename, mode='w') as f:
+            f.write(comments)
+            f.write('{}\n'.format(self.wcs.radesys))
+            f.write('polygon(')
+            self.calc_footprint().tofile(f, sep=',')
+            f.write(') # color={0}, width={1:d} \n'.format(color, width))
 
     @property
     def _naxis1(self):


### PR DESCRIPTION
I discovered `WCS.footprint_to_file` recently while looking for a similar method, but found a few issues that I attempt to fix here:

- The default coordinate system was 'linear', which was not working with aplpy/pyregion. Instead I changed to use by default the one from `wcs.radesys` (typically ICRS or FK5) and added a new parameter to allow to overwrite this coordinate system. See the [supported coordinate systems](http://ds9.si.edu/doc/ref/region.html#RegionFileFormat), is it useful to add a check that the value is correct ?

- When using the method multiple times, the new string were appended to the old ones,  with the global parameters written multiple times. So I changed to overwrite the file ('w' instead of 'a'). I thought about adding a parameter for this, but ideally in append mode this would need to detect if the global parameters are already there to not write them again.

cc @nden 