### PR TITLE
Update Cython requirement

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -5,7 +5,7 @@ docker info
 cat << EOF | docker run -i \
                         -v ${PWD}:/astropy_src \
                         -a stdin -a stdout -a stderr \
-                        astropy/astropy-32bit-test-env:1.6 \
+                        astropy/astropy-32bit-test-env:1.7 \
                         bash || exit $?
 
 cd /astropy_src

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -12,3 +12,5 @@ else:
     matplotlib.use('Agg')
 
 enable_deprecations_as_exceptions(include_astropy_deprecations=False)
+
+PYTEST_HEADER_MODULES['Cython'] = 'cython'

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - docker pull astropy/astropy-32bit-test-env:1.6
+    - docker pull astropy/astropy-32bit-test-env:1.7
 
 test:
   override:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,7 +46,7 @@ Astropy also depends on other packages for optional features:
 
 - `setuptools <https://pythonhosted.org/setuptools/>`_: Used for discovery of entry points which are used to insert fitters into modeling.fitting
 
-- `mock <https://github.com/testing-cabal/mock>`_ (python <= 3.2) or `unittest.mock <https://docs.python.org/dev/library/unittest.mock.html>`_ (python > 3.3): 
+- `mock <https://github.com/testing-cabal/mock>`_ (python <= 3.2) or `unittest.mock <https://docs.python.org/dev/library/unittest.mock.html>`_ (python > 3.3):
   Used for testing the entry point discovery functionality in `astropy.modeling.fitting`
 
 However, note that these only need to be installed if those particular features
@@ -164,7 +164,7 @@ Prerequisites
 You will need a compiler suite and the development headers for Python and
 Numpy in order to build Astropy.
 
-You will also need `Cython <http://cython.org/>`_ (v0.19 or later) and
+You will also need `Cython <http://cython.org/>`_ (v0.22 or later) and
 `jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed
 to build from source, unless you are installing a numbered release. (The
 releases packages have the necessary C files packaged with them, and hence do
@@ -403,7 +403,7 @@ Any astropy affiliated package can be installed the same way (e.g. the
 `spectral-cube <http://spectral-cube.readthedocs.io/en/latest/>`_ or other
 packages that may be useful for radioastronomy).
 
-.. note:: The above instructions have been tested and are known to work on 
+.. note:: The above instructions have been tested and are known to work on
           MacOS X with CASA 4.3.1 and Linux with CASA 4.3.1, 4.4.0, 4.5.3, and
           pre-releases of CASA 4.7. However, due to missing header files in
           CASA, they are known to **not** work on Linux with CASA 4.2.1 and

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -164,7 +164,7 @@ Prerequisites
 You will need a compiler suite and the development headers for Python and
 Numpy in order to build Astropy.
 
-You will also need `Cython <http://cython.org/>`_ (v0.22 or later) and
+You will also need `Cython <http://cython.org/>`_ (v0.21 or later) and
 `jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed
 to build from source, unless you are installing a numbered release. (The
 releases packages have the necessary C files packaged with them, and hence do

--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -1,6 +1,6 @@
 -r pip-requirements
 -r pip-requirements-doc
-Cython>=0.22
+Cython>=0.21
 jinja2
 pyyaml
 scipy

--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -1,6 +1,6 @@
 -r pip-requirements
 -r pip-requirements-doc
-Cython
+Cython>=0.22
 jinja2
 pyyaml
 scipy


### PR DESCRIPTION
Because of https://github.com/astropy/astropy/pull/5319, we now require Cython 0.21 or later, so this PR updates the minimum required version and also fixes the CircleCI build.