### PR TITLE
Enable Easy TestRunner Subclassing

### DIFF
--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -4,7 +4,7 @@ omit =
    astropy/__init__*
    astropy/conftest.py
    astropy/*setup*
-   astropy/*tests/*
+   astropy/*/tests/*
    astropy/extern/*
    astropy/sphinx/*
    astropy/utils/compat/*

--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -5,6 +5,7 @@ omit =
    astropy/conftest.py
    astropy/*setup*
    astropy/*/tests/*
+   astropy/tests/test_*
    astropy/extern/*
    astropy/sphinx/*
    astropy/utils/compat/*

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -1,5 +1,4 @@
 """Implements the Astropy TestRunner which is a thin wrapper around py.test."""
-
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
@@ -53,7 +52,11 @@ class TestRunner(object):
         signature.
         """
         # Get all 'function' members as the wrapped methods are functions
-        functions = inspect.getmembers(cls, predicate=inspect.isfunction)
+        if six.PY2:
+            functions = inspect.getmembers(cls, predicate=inspect.ismethod)
+        else:
+            functions = inspect.getmembers(cls, predicate=inspect.isfunction)
+
         # Filter out anything that's not got the name 'keyword'
         keywords = filter(lambda func: func[1].__name__ == 'keyword', functions)
         # Sort all keywords based on the priority flag.
@@ -65,8 +68,10 @@ class TestRunner(object):
             cls.keywords[name] = func._default_value
             if func.__doc__:
                 doc_keywords += func.__doc__
-
-        cls.run_tests.__doc__ = cls.run_tests.__doc__.format(keywords=doc_keywords)
+        if six.PY2:
+            cls.run_tests.__func__.__doc__ = cls.run_tests.__doc__.format(keywords=doc_keywords)
+        else:
+            cls.run_tests.__doc__ = cls.run_tests.__doc__.format(keywords=doc_keywords)
 
         return super(TestRunner, cls).__new__(cls)
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -18,9 +18,8 @@ from ..utils import wraps, find_current_module
 from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 class keyword(object):
-    def __init__(self, default_value, include_doc_string=True, priority=0):
+    def __init__(self, default_value, priority=0):
         self.default_value = default_value
-        self.include_doc_string = include_doc_string
         self.priority = priority
 
     def __call__(self, f):
@@ -28,8 +27,7 @@ class keyword(object):
             return f(*args, **kwargs)
         keyword._default_value = self.default_value
         keyword._priority = self.priority
-        if self.include_doc_string:
-            keyword.__doc__ = f.__doc__
+        keyword.__doc__ = f.__doc__
         return keyword
 
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -16,17 +16,35 @@ from ..extern import six
 from ..utils import wraps, find_current_module
 from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
+
 class keyword(object):
-    def __init__(self, default_value, priority=0):
+    """
+    A decorator to mark a method as keyword argument for the ``TestRunner``.
+
+    Parameters
+    ----------
+    default_value : `object`
+        The default value for the keyword argument. (Default: `None`)
+
+    priority : `int`
+        keyword argument methods are executed in order of descending priority.
+
+    """
+
+    def __init__(self, default_value=None, priority=0):
         self.default_value = default_value
         self.priority = priority
 
     def __call__(self, f):
         def keyword(*args, **kwargs):
             return f(*args, **kwargs)
+
         keyword._default_value = self.default_value
         keyword._priority = self.priority
+        # Set __doc__ explicitly here rather than using wraps because we want
+        # to keep the function name as keyword so we can inspect it later.
         keyword.__doc__ = f.__doc__
+
         return keyword
 
 
@@ -75,7 +93,8 @@ class TestRunner(object):
 
         return super(TestRunner, cls).__new__(cls)
 
-    @keyword(None, priority=100)
+    # Increase priority so this warning is displayed first.
+    @keyword(priority=1000)
     def coverage(self, coverage, kwargs):
         if coverage:
             warnings.warn(
@@ -86,7 +105,9 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None, priority=1)
+    # test_path depends on self.package_path so make sure this runs before
+    # test_path.
+    @keyword(priority=1)
     def package(self, package, kwargs):
         """
         package : str, optional
@@ -108,7 +129,7 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None)
+    @keyword
     def test_path(self, test_path, kwargs):
         """
         test_path : str, optional
@@ -152,8 +173,7 @@ class TestRunner(object):
 
         return []
 
-
-    @keyword(None)
+    @keyword
     def args(self, args, kwargs):
         """
         args : str, optional
@@ -162,12 +182,11 @@ class TestRunner(object):
 
         """
         if args:
-            return shlex.split(args,
-                               posix=not sys.platform.startswith('win'))
+            return shlex.split(args, posix=not sys.platform.startswith('win'))
 
         return []
 
-    @keyword(None)
+    @keyword
     def plugins(self, plugins, kwargs):
         """
         plugins : list, optional
@@ -177,7 +196,7 @@ class TestRunner(object):
         """
         return []
 
-    @keyword(None)
+    @keyword
     def verbose(self, verbose, kwargs):
         """
         verbose : bool, optional
@@ -190,7 +209,7 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None)
+    @keyword
     def pastebin(self, pastebin, kwargs):
         """
         pastebin : {{'failed', 'all', None}}, optional
@@ -207,7 +226,7 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None)
+    @keyword
     def remote_data(self, remote_data, kwargs):
         """
         remote_data : {'none', 'astropy', 'any'}, optional
@@ -232,7 +251,7 @@ class TestRunner(object):
 
         return '--remote-data={0}'.format(remote_data)
 
-    @keyword(None)
+    @keyword
     def pep8(self, pep8, kwargs):
         """
         pep8 : bool, optional
@@ -251,7 +270,7 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None)
+    @keyword
     def pdb(self, pdb, kwargs):
         """
         pdb : bool, optional
@@ -263,7 +282,7 @@ class TestRunner(object):
             return ['--pdb']
         return []
 
-    @keyword(None)
+    @keyword
     def open_files(self, open_files, kwargs):
         """
         open_files : bool, optional
@@ -305,7 +324,7 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None)
+    @keyword
     def docs_path(self, docs_path, kwargs):
         """
         docs_path : str, optional
@@ -326,7 +345,7 @@ class TestRunner(object):
 
         return []
 
-    @keyword(None)
+    @keyword
     def skip_docs(self, skip_docs, kwargs):
         """
         skip_docs : bool, optional
@@ -336,7 +355,7 @@ class TestRunner(object):
         # Skip docs is a bool used by docs_path only.
         return []
 
-    @keyword(None)
+    @keyword
     def repeat(self, repeat, kwargs):
         """
         repeat : int, optional
@@ -348,7 +367,6 @@ class TestRunner(object):
             return ['--repeat={0}'.format(repeat)]
 
         return []
-
 
     def run_tests(self, **kwargs):
         """

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -12,8 +12,6 @@ import tempfile
 import warnings
 from collections import OrderedDict
 
-import pytest
-
 from ..config.paths import set_temp_config, set_temp_cache
 from ..extern import six
 from ..utils import wraps, find_current_module
@@ -361,6 +359,10 @@ class TestRunner(object):
         pytest.main : py.test function wrapped by `run_tests`.
 
         """
+
+        # Don't import pytest until it's actually needed to run the tests
+        from .helper import pytest
+
         # Raise error for undefined kwargs
         allowed_kwargs = set(self.keywords.keys())
         passed_kwargs = set(kwargs.keys())

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -345,7 +345,7 @@ class TestRunner(TestRunnerBase):
                           AstropyDeprecationWarning)
             remote_data = 'any'
 
-        return '--remote-data={0}'.format(remote_data)
+        return ['--remote-data={0}'.format(remote_data)]
 
     @keyword()
     def pep8(self, pep8, kwargs):

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -308,7 +308,7 @@ class TestRunner(TestRunnerBase):
     def args(self, args, kwargs):
         """
         args : str, optional
-            Additional arguments to be passed to `pytest.main` in the `args`
+            Additional arguments to be passed to ``pytest.main`` in the ``args``
             keyword argument.
         """
         if args:
@@ -320,7 +320,7 @@ class TestRunner(TestRunnerBase):
     def plugins(self, plugins, kwargs):
         """
         plugins : list, optional
-            Plugins to be passed to `pytest.main` in the `plugins` keyword
+            Plugins to be passed to ``pytest.main`` in the ``plugins`` keyword
             argument.
         """
         return []
@@ -330,7 +330,7 @@ class TestRunner(TestRunnerBase):
         """
         verbose : bool, optional
             Convenience option to turn on verbose output from py.test. Passing
-            True is the same as specifying `-v` in `args`.
+            True is the same as specifying ``-v`` in ``args``.
         """
         if verbose:
             return ['-v']
@@ -382,7 +382,7 @@ class TestRunner(TestRunnerBase):
         """
         pep8 : bool, optional
             Turn on PEP8 checking via the pytest-pep8 plugin and disable normal
-            tests. Same as specifying `--pep8 -k pep8` in `args`.
+            tests. Same as specifying ``--pep8 -k pep8`` in ``args``.
         """
         if pep8:
             try:
@@ -400,7 +400,7 @@ class TestRunner(TestRunnerBase):
         """
         pdb : bool, optional
             Turn on PDB post-mortem analysis for failing tests. Same as
-            specifying `--pdb` in `args`.
+            specifying ``--pdb`` in ``args``.
         """
         if pdb:
             return ['--pdb']
@@ -439,7 +439,7 @@ class TestRunner(TestRunnerBase):
         parallel : int, optional
             When provided, run the tests in parallel on the specified
             number of CPUs.  If parallel is negative, it will use the all
-            the cores on the machine.  Requires the `pytest-xdist` plugin.
+            the cores on the machine.  Requires the ``pytest-xdist`` plugin.
         """
         if parallel != 0:
             return ['-n', six.text_type(parallel)]
@@ -469,7 +469,7 @@ class TestRunner(TestRunnerBase):
     @keyword()
     def skip_docs(self, skip_docs, kwargs):
         """
-        skip_docs : bool, optional
+        skip_docs : `bool`, optional
             When `True`, skips running the doctests in the .rst files.
         """
         # Skip docs is a bool used by docs_path only.
@@ -478,7 +478,7 @@ class TestRunner(TestRunnerBase):
     @keyword()
     def repeat(self, repeat, kwargs):
         """
-        repeat : int, optional
+        repeat : `int`, optional
             If set, specifies how many times each test should be run. This is
             useful for diagnosing sporadic failures.
         """

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -124,7 +124,7 @@ class TestRunner(object):
                         "Can not test .rst files without a docs_path "
                         "specified.")
 
-                abs_docs_path = os.path.abspath(docs_path)
+                abs_docs_path = os.path.abspath(kwargs['docs_path'])
                 abs_test_path = os.path.abspath(
                     os.path.join(abs_docs_path, os.pardir, test_path))
 
@@ -268,7 +268,7 @@ class TestRunner(object):
 
         """
         if open_files:
-            if parallel != 0:
+            if kwargs['parallel'] != 0:
                 raise SystemError(
                     "open file detection may not be used in conjunction with "
                     "parallel testing.")

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -22,7 +22,7 @@ from ..helper import pytest
 # run_tests should raise ValueError when asked to run on a module it can't find
 def test_module_not_found():
     with helper.pytest.raises(ValueError):
-        run_tests('fake.module')
+        run_tests(package='fake.module')
 
 
 # run_tests should raise ValueError when passed an invalid pastebin= option

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,18 +1,31 @@
 from astropy.tests.runner import TestRunner, TestRunnerBase, keyword
 from astropy.tests.helper import pytest
 
-@pytest.fixture
-def runner():
-    return TestRunner('.')
-
 
 def test_disable_kwarg():
     class no_remote_data(TestRunner):
-        @keyword
+        @keyword()
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
 
     r = no_remote_data('.')
+    with pytest.raises(TypeError):
+        r.run_tests(remote_data='bob')
+
+
+def test_wrong_kwarg():
+    r = TestRunner('.')
+    with pytest.raises(TypeError):
+        r.run_tests(spam='eggs')
+
+
+def test_invalid_kwarg():
+    class bad_return(TestRunnerBase):
+        @keyword()
+        def remote_data(self, remote_data, kwargs):
+            return 'bob'
+
+    r = bad_return('.')
     with pytest.raises(TypeError):
         r.run_tests(remote_data='bob')
 
@@ -46,6 +59,7 @@ def test_priority():
 
     assert ['eggs', 'spam'] == args
 
+
 def test_docs():
     class Spam(TestRunnerBase):
         @keyword()
@@ -63,6 +77,5 @@ def test_docs():
             return [eggs]
 
     r = Spam('.')
-    help(r.run_tests)
     assert "eggs" in r.run_tests.__doc__
     assert "Spam Spam Spam" in r.run_tests.__doc__

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,0 +1,68 @@
+from astropy.tests.runner import TestRunner, TestRunnerBase, keyword
+from astropy.tests.helper import pytest
+
+@pytest.fixture
+def runner():
+    return TestRunner('.')
+
+
+def test_disable_kwarg():
+    class no_remote_data(TestRunner):
+        @keyword
+        def remote_data(self, remote_data, kwargs):
+            return NotImplemented
+
+    r = no_remote_data('.')
+    with pytest.raises(TypeError):
+        r.run_tests(remote_data='bob')
+
+
+def test_new_kwarg():
+    class Spam(TestRunnerBase):
+        @keyword()
+        def spam(self, spam, kwargs):
+            return [spam]
+
+    r = Spam('.')
+
+    args = r._generate_args(spam='spam')
+
+    assert ['spam'] == args
+
+
+def test_priority():
+    class Spam(TestRunnerBase):
+        @keyword()
+        def spam(self, spam, kwargs):
+            return [spam]
+
+        @keyword(priority=1)
+        def eggs(self, eggs, kwargs):
+            return [eggs]
+
+    r = Spam('.')
+
+    args = r._generate_args(spam='spam', eggs='eggs')
+
+    assert ['eggs', 'spam'] == args
+
+def test_docs():
+    class Spam(TestRunnerBase):
+        @keyword()
+        def spam(self, spam, kwargs):
+            """
+            Spam Spam Spam
+            """
+            return [spam]
+
+        @keyword()
+        def eggs(self, eggs, kwargs):
+            """
+            eggs asldjasljd
+            """
+            return [eggs]
+
+    r = Spam('.')
+    help(r.run_tests)
+    assert "eggs" in r.run_tests.__doc__
+    assert "Spam Spam Spam" in r.run_tests.__doc__

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -122,6 +122,11 @@ Enable PEP8 compliance testing with ``pep8=True`` in the call to
     variable (see :doc:`/config/index`) or the `pytest`_ method described
     above.
 
+Astropy Test Function
+#####################
+
+.. autofunction:: astropy.test
+
 Tox
 ---
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -123,7 +123,7 @@ Enable PEP8 compliance testing with ``pep8=True`` in the call to
     above.
 
 Astropy Test Function
-#####################
+^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: astropy.test
 

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -5,7 +5,7 @@ Astropy Testing Tools
 *********************
 
 This section is primarily a reference for developers that want to understand or
-add to the Astropy testing machinery. See :doc:/development/testguide for an
+add to the Astropy testing machinery. See :doc:`/development/testguide` for an
 overview of running or writing the tests.
 
 

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -1,9 +1,11 @@
 .. _testhelpers:
 
-************************************************
-Astropy Testing helpers (`astropy.tests.helper`)
-************************************************
+***************
+Astropy Testing
+***************
 
+`astropy.tests.helper` Module
+=============================
 To ease development of tests that work with Astropy, the
 `astropy.tests.helper` module provides some utility functions to make
 tests that use Astropy conventions or classes easier to work with. e.g.,
@@ -33,10 +35,25 @@ This test will now only run if the test suite is invoked as
 
 
 Reference/API
-=============
+-------------
 
 .. module:: astropy.tests.helper
 
 .. automodapi:: astropy.tests.helper
     :no-main-docstr:
     :no-inheritance-diagram:
+
+
+Astropy Test Runner
+===================
+
+When executing tests with either `astropy.test` or ``python setup.py test`` the call to pytest is controlled by the `astropy.tests.runner.TestRunner` class.
+
+
+Reference/API
+-------------
+
+.. module:: astropy.tests.runner
+
+.. automodapi:: astropy.tests.runner
+    :no-main-docstr:

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -1,8 +1,13 @@
 .. _testhelpers:
 
-***************
-Astropy Testing
-***************
+*********************
+Astropy Testing Tools
+*********************
+
+This section is primarily a reference for developers that want to understand or
+add to the Astropy testing machinery. See :doc:/development/testguide for an
+overview of running or writing the tests.
+
 
 `astropy.tests.helper` Module
 =============================
@@ -47,8 +52,20 @@ Reference/API
 Astropy Test Runner
 ===================
 
-When executing tests with either `astropy.test` or ``python setup.py test`` the call to pytest is controlled by the `astropy.tests.runner.TestRunner` class.
+When executing tests with either `astropy.test` or ``python setup.py test`` the
+call to pytest is controlled by the `astropy.tests.runner.TestRunner` class.
 
+The `~astropy.tests.runner.TestRunner` class is used to generate the
+`astropy.test` function, the test function generates a set of command line
+arguments to pytest. The arguments to pytest are defined in the
+`~astropy.tests.runner.TestRunner.run_tests` method, the arguments to
+``run_tests`` and their respective logic are defined in methods of
+`~astropy.tests.runner.TestRunner` decorated with the
+`~astropy.tests.runner.keyword` decorator. For an example of this see
+`~astropy.tests.runner.TestRunnerBase`. This design makes it easy for affiliated
+packages to add or remove keyword arguments to their test runners, or define a
+whole new set of arguments by subclassing from
+`~astropy.tests.runner.TestRunnerBase`.
 
 Reference/API
 -------------


### PR DESCRIPTION
This PR is designed to make it simple for affiliated packages to add or remove arguments from the astropy test runner based on custom needs not shared by astropy core.

The way this works is by separating each kwarg out into a separate method which can be overloaded by a subclass or new methods added. The `__new__` constructor then looks for all the methods defined on the class which have been decorated with the `keyword` decorator and adds them to a dictionary which forms the allowed keyword arguments and their default values for the `run_tests` method. Documentation is also delegated to the keyword methods.

Removal of keyword arguments is supported by overloading the method and returning `NotImplemented`.

One (unintended) side effect of this is that the `run_tests` method is now keyword argument only.

Finally, I would be interested in extending this to automatically generate the setup.py command, that requires that command importing the TestRunner class, I don't know if that is going to break the setup.py machinery in any way?

ping @wkerzendorf @astrofrog 