### PR TITLE
Expand --remote-data to allow different modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,15 +59,21 @@ matrix:
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
-        # optional dependencies below, we can focus on older builds here.
+        # optional dependencies below, we can focus on older builds here. While
+        # we're at it we also use these builds to check that things work if
+        # setting --remote-data=none (since the default is --remote-data=astropy)
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test --open-files'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+               SETUP_CMD='test --open-files --remote-data=none'
         - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8 SETUP_CMD='test --open-files'
+          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
+               SETUP_CMD='test --open-files --remote-data=none'
         - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9 SETUP_CMD='test --open-files'
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+               SETUP_CMD='test --open-files --remote-data=none'
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10 SETUP_CMD='test --open-files'
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+               SETUP_CMD='test --open-files --remote-data=none'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
         # (with latest numpy).
@@ -93,7 +99,7 @@ matrix:
           env: MAIN_CMD='pycodestyle astropy --count' SETUP_CMD=''
 
         # Try developer version of Numpy with optional dependencies and also
-        # run remote tests. Since both cases will be potentially unstable, we
+        # run all remote tests. Since both cases will be potentially unstable, we
         # combine them into a single unstable build that we can mark as an
         # allowed failure below.
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
 
         # Try MacOS X
         - os: osx
-          env: SETUP_CMD='test'
+          env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem'
 
@@ -59,32 +59,30 @@ matrix:
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
-        # optional dependencies below, we can focus on older builds here. While
-        # we're at it we also use these builds to check that things work if
-        # setting --remote-data=none (since the default is --remote-data=astropy)
+        # optional dependencies below, we can focus on older builds here.
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
-               SETUP_CMD='test --open-files --remote-data=none'
+               SETUP_CMD='test --open-files'
         - os: linux
           env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
-               SETUP_CMD='test --open-files --remote-data=none'
+               SETUP_CMD='test --open-files'
         - os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               SETUP_CMD='test --open-files --remote-data=none'
+               SETUP_CMD='test --open-files'
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-               SETUP_CMD='test --open-files --remote-data=none'
+               SETUP_CMD='test --open-files'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
         # (with latest numpy).
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem mock'
                LC_CTYPE=C.ascii LC_ALL=C
 
         - os: linux
-          env: SETUP_CMD='test --coverage'
+          env: SETUP_CMD='test --coverage --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem'
                LC_CTYPE=C.ascii LC_ALL=C

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -334,6 +334,13 @@ Other Changes and Additions
 - To build the documentation, the ``build_sphinx`` command has been deprecated
   in favor of ``build_docs``. [#5179]
 
+- The ``--remote-data`` option to ``python setup.py test`` can now take
+  different arguments: ``--remote-data=none`` is the same as not specifying
+  ``--remote-data`` (skip all tests that require the internet),
+  ``--remote-data=astropy`` skips all tests that need remote data except those
+  that require only data from data.astropy.org, and ``--remote-data=any`` is
+  the same as ``--remote-data`` (run all tests that use remote data). [#5506]
+
 1.2.2 (unreleased)
 ------------------
 

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -25,7 +25,7 @@ def test_builtin_sites():
         reg['nonexistent site']
     assert exc.value.args[0] == "Site 'nonexistent site' not in database. Use the 'names' attribute to see available sites."
 
-@remote_data
+@remote_data(source='astropy')
 def test_online_stes():
     reg = get_downloaded_sites()
 
@@ -50,7 +50,7 @@ def test_online_stes():
     assert exc.value.args[0] == "Site 'kec' not in database. Use the 'names' attribute to see available sites. Did you mean one of: 'keck'?'"
 
 
-@remote_data
+@remote_data(source='astropy')
 # this will *try* the online so we have to make it remote_data, even though it
 # could fall back on the non-remote version
 def test_EarthLocation_basic():
@@ -82,7 +82,7 @@ def test_EarthLocation_state_offline():
     assert oldreg is not newreg
 
 
-@remote_data
+@remote_data(source='astropy')
 def test_EarthLocation_state_online():
     EarthLocation._site_registry = None
     EarthLocation._get_site_registry(force_download=True)

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -38,9 +38,12 @@ class FixRemoteDataOption(type):
     before distutils/setuptools try to parse the command-line options.
     """
     def __init__(cls, name, bases, dct):
-        for i in range(len(sys.argv)):
-            if sys.argv[i] == '--remote-data':
-                sys.argv[i] = '--remote-data=any'
+        try:
+            idx = sys.argv.index('--remote-data')
+        except ValueError:
+            pass
+        else:
+            sys.argv[idx] = '--remote-data=any'
         return super(FixRemoteDataOption, cls).__init__(name, bases, dct)
 
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -67,7 +67,7 @@ class AstropyTest(Command, object):
         ('args=', 'a',
          'Additional arguments to be passed to pytest.'),
         ('remote-data=', 'R', 'Run tests that download remote data. Should be '
-         'one of none/astropy/any.'),
+         'one of none/astropy/any (defaults to none).'),
         ('pep8', '8',
          'Enable PEP8 checking and disable regular tests. '
          'Requires the pytest-pep8 plugin.'),
@@ -107,7 +107,7 @@ class AstropyTest(Command, object):
         self.plugins = None
         self.pastebin = None
         self.args = None
-        self.remote_data = 'astropy'
+        self.remote_data = 'none'
         self.pep8 = False
         self.pdb = False
         self.coverage = False

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -107,7 +107,7 @@ class AstropyTest(Command, object):
         self.plugins = None
         self.pastebin = None
         self.args = None
-        self.remote_data = None
+        self.remote_data = 'astropy'
         self.pep8 = False
         self.pdb = False
         self.coverage = False

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -55,7 +55,8 @@ def check_internet_off(original_function, allow_astropy_data=False):
             valid_hosts = ('localhost', '127.0.0.1')
 
         if allow_astropy_data:
-            valid_hosts += ('data.astropy.org',)
+            data_astropy_org_ip = socket.gethostbyname('data.astropy.org')
+            valid_hosts += ('data.astropy.org', data_astropy_org_ip)
 
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -55,8 +55,9 @@ def check_internet_off(original_function, allow_astropy_data=False):
             valid_hosts = ('localhost', '127.0.0.1')
 
         if allow_astropy_data:
-            data_astropy_org_ip = socket.gethostbyname('data.astropy.org')
-            valid_hosts += ('data.astropy.org', 'astropy.stsci.edu', data_astropy_org_ip)
+            for valid_host in ('data.astropy.org', 'astropy.stsci.edu'):
+                valid_host_ip = socket.gethostbyname(valid_host)
+                valid_hosts += (valid_host, valid_host_ip)
 
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -26,7 +26,7 @@ _orig_opener = None
 # ::1 is apparently another valid name for localhost?
 # it is returned by getaddrinfo when that function is given localhost
 
-def check_internet_off(original_function):
+def check_internet_off(original_function, allow_astropy_data=False):
     """
     Wraps ``original_function``, which in most cases is assumed
     to be a `socket.socket` method, to raise an `IOError` for any operations
@@ -54,6 +54,9 @@ def check_internet_off(original_function):
             addr_arg = 0
             valid_hosts = ('localhost', '127.0.0.1')
 
+        if allow_astropy_data:
+            valid_hosts += ('data.astropy.org')
+
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()
 
@@ -70,7 +73,7 @@ def check_internet_off(original_function):
     return new_function
 
 
-def turn_off_internet(verbose=False):
+def turn_off_internet(verbose=False, allow_astropy_data=False):
     """
     Disable internet access via python by preventing connections from being
     created using the socket module.  Presumably this could be worked around by
@@ -98,9 +101,9 @@ def turn_off_internet(verbose=False):
     opener = urllib.request.build_opener(no_proxy_handler)
     urllib.request.install_opener(opener)
 
-    socket.create_connection = check_internet_off(socket_create_connection)
-    socket.socket.bind = check_internet_off(socket_bind)
-    socket.socket.connect = check_internet_off(socket_connect)
+    socket.create_connection = check_internet_off(socket_create_connection, allow_astropy_data=allow_astropy_data)
+    socket.socket.bind = check_internet_off(socket_bind, allow_astropy_data=allow_astropy_data)
+    socket.socket.connect = check_internet_off(socket_connect, allow_astropy_data=allow_astropy_data)
 
     return socket
 

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -56,7 +56,7 @@ def check_internet_off(original_function, allow_astropy_data=False):
 
         if allow_astropy_data:
             data_astropy_org_ip = socket.gethostbyname('data.astropy.org')
-            valid_hosts += ('data.astropy.org', data_astropy_org_ip)
+            valid_hosts += ('data.astropy.org', 'astropy.stsci.edu', data_astropy_org_ip)
 
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -55,7 +55,7 @@ def check_internet_off(original_function, allow_astropy_data=False):
             valid_hosts = ('localhost', '127.0.0.1')
 
         if allow_astropy_data:
-            valid_hosts += ('data.astropy.org')
+            valid_hosts += ('data.astropy.org',)
 
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()
@@ -69,7 +69,8 @@ def check_internet_off(original_function, allow_astropy_data=False):
             return original_function(*args, **kwargs)
         else:
             raise IOError("An attempt was made to connect to the internet "
-                          "by a test that was not marked `remote_data`.")
+                          "by a test that was not marked `remote_data`. The "
+                          "requested host was: {0}".format(host))
     return new_function
 
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):
     # The following means that if --remote-data is not specified, the default
     # is 'none', but if it is specified without arguments (--remote-data), it
     # defaults to '--remote-data=any'.
-    parser.addoption("--remote-data", nargs="?", const='any', default='astropy',
+    parser.addoption("--remote-data", nargs="?", const='any', default='none',
                      help="run tests with online data")
 
     parser.addoption("--open-files", action="store_true",

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 import types
+import argparse
 from collections import OrderedDict
 
 from ..config.paths import set_temp_config, set_temp_cache
@@ -42,9 +43,30 @@ except ImportError:  # Python 2.7
 # specific command line options.
 
 
+class remote_data_action(argparse.Action):
+    """
+    For backward-compatibility with old versions of astropy-helpers, we need to
+    pre-process the options for --remote-data and transform them into the new
+    options. This can be removed once astropy core and all affiliated packages
+    use a version of astropy-helpers that recognizes the none/astropy/any
+    options.
+    """
+    def __call__(self, parser, namespace, value, option_string=None):
+        if value == 'False':
+            value = 'none'
+        if value == '1':
+            value = 'any'
+        setattr(namespace, self.dest, value)
+
+
 def pytest_addoption(parser):
-    parser.addoption("--remote-data", action="store_true",
-                     help="run tests with online data")
+
+    # The following means that if --remote-data is not specified, the default
+    # is 'astropy', but if it is specified without arguments, it defaults to
+    # 'all'.
+    parser.addoption("--remote-data", nargs="?", const='any', default='astropy',
+                     help="run tests with online data", action=remote_data_action)
+
     parser.addoption("--open-files", action="store_true",
                      help="fail if any test leaves files open")
 
@@ -134,8 +156,10 @@ def pytest_configure(config):
 
     # Monkeypatch to deny access to remote resources unless explicitly told
     # otherwise
-    if not config.getoption('remote_data'):
-        turn_off_internet(verbose=config.option.verbose)
+
+    if config.getoption('remote_data') != 'any':
+        turn_off_internet(verbose=config.option.verbose,
+                          allow_astropy_data=config.getoption('remote_data') == 'astropy')
 
     doctest_plugin = config.pluginmanager.getplugin('doctest')
     if (doctest_plugin is None or config.option.doctestmodules or not
@@ -175,7 +199,7 @@ def pytest_configure(config):
             runner = doctest.DebugRunner(verbose=False, optionflags=opts)
             for test in finder.find(module):
                 if test.examples:  # skip empty doctests
-                    if not config.getvalue("remote_data"):
+                    if config.getvalue("remote_data") != 'any':
                         for example in test.examples:
                             if example.options.get(REMOTE_DATA):
                                 example.options[doctest.SKIP] = True
@@ -267,7 +291,7 @@ def pytest_configure(config):
                         not DocTestFinderPlus.check_required_modules(required)):
                         entry.options[doctest.SKIP] = True
 
-                    if (not config.getvalue('remote_data') and
+                    if (config.getvalue('remote_data') != 'any' and
                         entry.options.get(REMOTE_DATA)):
                         entry.options[doctest.SKIP] = True
 
@@ -479,10 +503,23 @@ def pytest_runtest_setup(item):
     if item.config.getvalue('open_files'):
         item.open_files = _get_open_file_list()
 
-    if ('remote_data' in item.keywords and
-            not item.config.getvalue("remote_data")):
-        pytest.skip("need --remote-data option to run")
+    remote_data = item.keywords.get('remote_data')
 
+    remote_data_config = item.config.getvalue("remote_data")
+
+    if remote_data is not None:
+
+        source = remote_data.kwargs.get('source', 'any')
+
+        if source not in ('astropy', 'any'):
+            raise ValueError("source should be 'astropy' or 'any'")
+
+        if remote_data_config == 'none':
+            if source in ('astropy', 'any'):
+                pytest.skip("need --remote-data option to run")
+        elif remote_data_config == 'astropy':
+            if source == 'any':
+                pytest.skip("need --remote-data option to run")
 
 def pytest_runtest_teardown(item, nextitem):
     if hasattr(item, 'set_temp_cache'):

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -47,7 +47,7 @@ def pytest_addoption(parser):
 
     # The following means that if --remote-data is not specified, the default
     # is 'astropy', but if it is specified without arguments, it defaults to
-    # 'all'.
+    # 'any'.
     parser.addoption("--remote-data", nargs="?", const='any', default='astropy',
                      help="run tests with online data")
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -43,29 +43,13 @@ except ImportError:  # Python 2.7
 # specific command line options.
 
 
-class remote_data_action(argparse.Action):
-    """
-    For backward-compatibility with old versions of astropy-helpers, we need to
-    pre-process the options for --remote-data and transform them into the new
-    options. This can be removed once astropy core and all affiliated packages
-    use a version of astropy-helpers that recognizes the none/astropy/any
-    options.
-    """
-    def __call__(self, parser, namespace, value, option_string=None):
-        if value == 'False':
-            value = 'none'
-        if value == '1':
-            value = 'any'
-        setattr(namespace, self.dest, value)
-
-
 def pytest_addoption(parser):
 
     # The following means that if --remote-data is not specified, the default
     # is 'astropy', but if it is specified without arguments, it defaults to
     # 'all'.
     parser.addoption("--remote-data", nargs="?", const='any', default='astropy',
-                     help="run tests with online data", action=remote_data_action)
+                     help="run tests with online data")
 
     parser.addoption("--open-files", action="store_true",
                      help="fail if any test leaves files open")

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -46,8 +46,8 @@ except ImportError:  # Python 2.7
 def pytest_addoption(parser):
 
     # The following means that if --remote-data is not specified, the default
-    # is 'astropy', but if it is specified without arguments, it defaults to
-    # 'any'.
+    # is 'none', but if it is specified without arguments (--remote-data), it
+    # defaults to '--remote-data=any'.
     parser.addoption("--remote-data", nargs="?", const='any', default='astropy',
                      help="run tests with online data")
 
@@ -499,8 +499,7 @@ def pytest_runtest_setup(item):
             raise ValueError("source should be 'astropy' or 'any'")
 
         if remote_data_config == 'none':
-            if source in ('astropy', 'any'):
-                pytest.skip("need --remote-data option to run")
+            pytest.skip("need --remote-data option to run")
         elif remote_data_config == 'astropy':
             if source == 'any':
                 pytest.skip("need --remote-data option to run")

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -58,7 +58,7 @@ class TestRunner(object):
 
         remote_data : {'none', 'astropy', 'any'}, optional
             Controls whether to run tests marked with @remote_data. This can be
-            set to run no tests with remote data (``no``), only ones that use
+            set to run no tests with remote data (``none``), only ones that use
             data from http://data.astropy.org (``astropy``), or all tests that
             use remote data (``any``). The default is ``none``.
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -21,9 +21,9 @@ class TestRunner(object):
         self.base_path = os.path.abspath(base_path)
 
     def run_tests(self, package=None, test_path=None, args=None, plugins=None,
-                  verbose=False, pastebin=None, remote_data=False, pep8=False,
-                  pdb=False, coverage=False, open_files=False, parallel=0,
-                  docs_path=None, skip_docs=False, repeat=None):
+                  verbose=False, pastebin=None, remote_data='astropy',
+                  pep8=False, pdb=False, coverage=False, open_files=False,
+                  parallel=0, docs_path=None, skip_docs=False, repeat=None):
         """
         Run Astropy tests using py.test. A proper set of arguments is
         constructed and passed to `pytest.main`.
@@ -56,10 +56,11 @@ class TestRunner(object):
             'failed' to upload info for failed tests, or 'all' to upload info
             for all tests.
 
-        remote_data : bool, optional
-            Controls whether to run tests marked with @remote_data. These
-            tests use online data and are not run by default. Set to True to
-            run these tests.
+        remote_data : {'none', 'astropy', 'any'}, optional
+            Controls whether to run tests marked with @remote_data. This can be
+            set to run no tests with remote data (``no``), only ones that use
+            data from http://data.astropy.org (``astropy``), or all tests that
+            use remote data (``any``). The default is ``astropy``.
 
         pep8 : bool, optional
             Turn on PEP8 checking via the pytest-pep8 plugin and disable normal
@@ -177,8 +178,7 @@ class TestRunner(object):
                 raise ValueError("pastebin should be 'failed' or 'all'")
 
         # run @remote_data tests
-        if remote_data:
-            all_args.append('--remote-data')
+        all_args.append('--remote-data={0}'.format(remote_data))
 
         if pep8:
             try:

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -21,7 +21,7 @@ class TestRunner(object):
         self.base_path = os.path.abspath(base_path)
 
     def run_tests(self, package=None, test_path=None, args=None, plugins=None,
-                  verbose=False, pastebin=None, remote_data='astropy',
+                  verbose=False, pastebin=None, remote_data='none',
                   pep8=False, pdb=False, coverage=False, open_files=False,
                   parallel=0, docs_path=None, skip_docs=False, repeat=None):
         """
@@ -60,7 +60,7 @@ class TestRunner(object):
             Controls whether to run tests marked with @remote_data. This can be
             set to run no tests with remote data (``no``), only ones that use
             data from http://data.astropy.org (``astropy``), or all tests that
-            use remote data (``any``). The default is ``astropy``.
+            use remote data (``any``). The default is ``none``.
 
         pep8 : bool, optional
             Turn on PEP8 checking via the pytest-pep8 plugin and disable normal

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -13,7 +13,7 @@ import warnings
 from ..config.paths import set_temp_config, set_temp_cache
 from ..extern import six
 from ..utils import wraps, find_current_module
-from ..utils.exceptions import AstropyWarning
+from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 
 class TestRunner(object):
@@ -183,6 +183,13 @@ class TestRunner(object):
             remote_data = 'any'
         elif remote_data is False:
             remote_data = 'none'
+        elif remote_data not in ('none', 'astropy', 'any'):
+            warnings.warn("The remote_data option should be one of "
+                          "none/astropy/any. For backward-compatibility, "
+                          "assuming 'any', but you should change the option to be "
+                          "one of the supported ones to avoid issues in future.",
+                          AstropyDeprecationWarning)
+            remote_data = 'any'
 
         all_args.append('--remote-data={0}'.format(remote_data))
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -178,6 +178,12 @@ class TestRunner(object):
                 raise ValueError("pastebin should be 'failed' or 'all'")
 
         # run @remote_data tests
+
+        if remote_data is True:
+            remote_data = 'any'
+        elif remote_data is False:
+            remote_data = 'none'
+
         all_args.append('--remote-data={0}'.format(remote_data))
 
         if pep8:

--- a/astropy/tests/tests/test_skip_remote_data.py
+++ b/astropy/tests/tests/test_skip_remote_data.py
@@ -35,8 +35,6 @@ def test_skip_remote_data_astropy(pytestconfig):
 
     if pytestconfig.getoption('remote_data') == 'none':
         pytest.fail('@remote_data was not skipped with remote_data=none')
-    else:
-        get_pkg_data_filename('galactic_center/gc_2mass_k.fits')
 
     # Test Astropy URL
     get_pkg_data_filename('galactic_center/gc_2mass_k.fits')

--- a/astropy/tests/tests/test_skip_remote_data.py
+++ b/astropy/tests/tests/test_skip_remote_data.py
@@ -10,16 +10,25 @@ from ..helper import pytest
 
 @remote_data
 def test_skip_remote_data(pytestconfig):
-    # this test was called from the command line and it should behave as if
-    # astropy.test() has remote_data=True
-    if not hasattr(pytestconfig.option, 'remotedata'):
-        assert True
 
-    # astropy.test() has remote_data=False but we still got here somehow,
+    # astropy.test() has remote_data=none or remote_data=astropy but we still
+    # got here somehow, so fail with a helpful message
+
+    if pytestconfig.getoption('remote_data') == 'none':
+        pytest.fail('@remote_data was not skipped with remote_data=none')
+    elif pytestconfig.getoption('remote_data') == 'astropy':
+        pytest.fail('@remote_data was not skipped with remote_data=astropy')
+    else:
+        pass
+
+
+@remote_data(source='astropy')
+def test_skip_remote_data_astropy(pytestconfig):
+
+    # astropy.test() has remote_data=none but we still got here somehow,
     # so fail with a helpful message
-    elif not getattr(pytestconfig.option, 'remotedata'):
-        pytest.fail('@remote_data was not skipped with remote_data=False')
 
-    # astropy.test() has remote_data=True, so pass
-    elif getattr(pytestconfig.option, 'remotedata'):
-        assert True
+    if pytestconfig.getoption('remote_data') == 'none':
+        pytest.fail('@remote_data was not skipped with remote_data=none')
+    else:
+        pass

--- a/astropy/tests/tests/test_skip_remote_data.py
+++ b/astropy/tests/tests/test_skip_remote_data.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from ..helper import remote_data
 from ..helper import pytest
+from ...utils.data import get_pkg_data_filename, download_file
 
 
 @remote_data
@@ -18,8 +19,12 @@ def test_skip_remote_data(pytestconfig):
         pytest.fail('@remote_data was not skipped with remote_data=none')
     elif pytestconfig.getoption('remote_data') == 'astropy':
         pytest.fail('@remote_data was not skipped with remote_data=astropy')
-    else:
-        pass
+
+    # Test Astropy URL
+    get_pkg_data_filename('galactic_center/gc_2mass_k.fits')
+
+    # Test non-Astropy URL
+    download_file('http://www.google.com')
 
 
 @remote_data(source='astropy')
@@ -31,4 +36,15 @@ def test_skip_remote_data_astropy(pytestconfig):
     if pytestconfig.getoption('remote_data') == 'none':
         pytest.fail('@remote_data was not skipped with remote_data=none')
     else:
-        pass
+        get_pkg_data_filename('galactic_center/gc_2mass_k.fits')
+
+    # Test Astropy URL
+    get_pkg_data_filename('galactic_center/gc_2mass_k.fits')
+
+    # Test non-Astropy URL
+    if pytestconfig.getoption('remote_data') == 'astropy':
+        with pytest.raises(Exception) as exc:
+            download_file('http://www.google.com')
+        assert "An attempt was made to connect to the internet" in str(exc.value)
+    else:
+        download_file('http://www.google.com')

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -340,10 +340,14 @@ local copy of the file.
 Tests that may retrieve remote data should be marked with the
 ``@remote_data`` decorator, or, if a doctest, flagged with the
 ``REMOTE_DATA`` flag.  Tests marked in this way will be skipped by default
-by ``astropy.test()`` to prevent test runs from taking too long. These
-tests can be run by ``astropy.test()`` by adding the
-``remote_data=True`` flag.  Turn on the remote data tests at the
-command line with ``pytest --remote-data``.
+by ``astropy.test()`` to prevent test runs from taking too long. These tests can be run by
+``astropy.test()`` by adding the ``remote_data='any'`` flag.  Turn on the remote
+data tests at the command line with ``python setup.py test --remote-data=any``.
+
+It is possible to mark tests using ``@remote_data(source='astropy')``, which can
+be used to indicate that the only required data is from the
+http://data.astropy.org server. These tests are run by default. To disable these
+tests, you can run the tests with ``python setup.py test --remote-data=none``.
 
 Examples
 ^^^^^^^^

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -346,8 +346,8 @@ data tests at the command line with ``python setup.py test --remote-data=any``.
 
 It is possible to mark tests using ``@remote_data(source='astropy')``, which can
 be used to indicate that the only required data is from the
-http://data.astropy.org server. These tests are run by default. To disable these
-tests, you can run the tests with ``python setup.py test --remote-data=none``.
+http://data.astropy.org server. To enable just these tests, you can run the
+tests with ``python setup.py test --remote-data=astropy``.
 
 Examples
 ^^^^^^^^


### PR DESCRIPTION
(This came out of a discussion in https://github.com/astropy/astropy/pull/5496)

This was a bit of work to get right, but with this pull request, it is now possible to **optionally** decorate remote tests using:

```python
@remote_data(source='astropy')
```

Such tests are run by default but will fail if the test tries to access non-astropy data (i.e. data not on data.astropy.org). The ``--remote-data`` option can now take three values:

```
python setup.py test --remote-data=none
python setup.py test --remote-data=astropy
python setup.py test --remote-data=any
```

The first skips all tests with ``@remote_data``, the second (which is the default) skips remote tests that don't specify ``source='astropy'`` (or specify ``source='any'`` explicitly), and the third runs all remote tests.

Note that this also preserves backward-compatibility with the plain option:

```
python setup.py test --remote-data
```

which is translated to ``--remote-data=any``.

So **this is backward-compatible** and now allows tests such as those for WCSAxes to run on Travis without enabling ALL the remote tests. Since the data.astropy.org server is pretty stable (unlike e.g. VO services), I don't think this should cause any issues.

Note that this can be expanded in future to allow more modes now that it is a string option!

cc @mhvk @eteq @bsipocz @pllim @MSeifert04 @keflavich @Cadair 

