### PR TITLE
Looping on a list rather than iterator to avoid RuntimeError

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -211,7 +211,7 @@ def treat_deprecations_as_exceptions():
     warning state.
     """
     # First, totally reset the warning state
-    for module in six.itervalues(sys.modules):
+    for module in list(six.itervalues(sys.modules)):
         # We don't want to deal with six.MovedModules, only "real"
         # modules.
         if (isinstance(module, types.ModuleType) and

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -210,7 +210,9 @@ def treat_deprecations_as_exceptions():
     This completely resets the warning filters and any "already seen"
     warning state.
     """
-    # First, totally reset the warning state
+    # First, totally reset the warning state. The modules may change during
+    # this iteration thus we copy the original state to a list to iterate
+    # on. See https://github.com/astropy/astropy/pull/5513.
     for module in list(six.itervalues(sys.modules)):
         # We don't want to deal with six.MovedModules, only "real"
         # modules.


### PR DESCRIPTION
This was recently changed in #5429, but using the iterator instead of a static list raises a RuntimeError e.g. here: https://travis-ci.org/astropy/saba/jobs/179464471

```
copying saba/tests/coveragerc -> build/lib.macosx-10.10-x86_64-3.4/saba/tests
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/var/folders/dc/hsm7tqpx2d57n7vb3k1l81xw0000gq/T/saba-test-921eh7vo/lib.macosx-10.10-x86_64-3.4/saba/__init__.py", line 15, in <module>
    from .main import SherpaFitter, SherpaMCMC, Stat, OptMethod, EstMethod, Dataset, ConvertedModel
  File "/private/var/folders/dc/hsm7tqpx2d57n7vb3k1l81xw0000gq/T/saba-test-921eh7vo/lib.macosx-10.10-x86_64-3.4/saba/main.py", line 21, in <module>
    with catch_warnings(AstropyUserWarning) as warns:
  File "/Users/bsipocz/munka/devel/astropy/astropy/tests/helper.py", line 309, in __enter__
    treat_deprecations_as_exceptions()
  File "/Users/bsipocz/munka/devel/astropy/astropy/tests/helper.py", line 214, in treat_deprecations_as_exceptions
    for module in six.itervalues(sys.modules):
RuntimeError: dictionary changed size during iteration
```


