### PR TITLE
Fix remaining casting issue when scaling compressed fits files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -264,6 +264,9 @@ Bug Fixes
   - ``HDUList.info()`` no longer raises ``AttributeError`` in presence of
     ``BZERO``. [#5508]
 
+  - Avoid exceptions with numpy 1.10 and up when using scaled integer data
+    where ``BZERO`` has float type but integer value. [#4639]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1743,7 +1743,11 @@ class CompImageHDU(BinTableHDU):
 
         # Do the scaling
         if _zero != 0:
-            self.data += -_zero
+            # We have to explicitly cast self._bzero to prevent numpy from
+            # raising an error when doing self.data -= _zero, and we
+            # do this instead of self.data = self.data - _zero to
+            # avoid doubling memory usage.
+            np.subtract(self.data, _zero, out=self.data, casting='unsafe')
             self.header['BZERO'] = _zero
         else:
             # Delete from both headers

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -13,6 +13,7 @@ import numpy as np
 from ....extern.six.moves import range
 from ....io import fits
 from ....utils.exceptions import AstropyPendingDeprecationWarning
+from ....utils.compat import NUMPY_LT_1_10
 from ....tests.helper import pytest, raises, catch_warnings, ignore_warnings
 from ..hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
 from .test_table import comparerecords
@@ -988,6 +989,45 @@ class TestImageFunctions(FitsTestCase):
         hdul = fits.HDUList.fromstring(file_data)
         assert np.allclose(hdul[0].data, a)
 
+    def test_set_data(self):
+        """
+        Test data assignment - issue #5087
+        """
+
+        im = fits.ImageHDU()
+        ar = np.arange(12)
+        im.data = ar
+
+    def test_scale_bzero_with_int_data(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4600
+        """
+
+        a = np.arange(100, 200, dtype=np.int16)
+
+        hdu1 = fits.PrimaryHDU(data=a.copy())
+        hdu2 = fits.PrimaryHDU(data=a.copy())
+        # Previously the following line would throw a TypeError,
+        # now it should be identical to the integer bzero case
+        hdu1.scale('int16', bzero=99.0)
+        hdu2.scale('int16', bzero=99)
+        assert np.allclose(hdu1.data, hdu2.data)
+
+    def test_scale_back_uint_assignment(self):
+        """
+        Extend fix for #4600 to assignment to data
+
+        Suggested by:
+        https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+        """
+
+        a = np.arange(100, 200, dtype=np.uint16)
+        fits.PrimaryHDU(a).writeto(self.temp('test.fits'))
+        with fits.open(self.temp('test.fits'), mode="update",
+                       scale_back=True) as (hdu,):
+            hdu.data[:] = 0
+            assert np.allclose(hdu.data, 0)
+
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):
@@ -1550,14 +1590,42 @@ class TestCompressedImage(FitsTestCase):
             # technically it isn't invalid either :/
             assert hdul[1]._header.count('ZTENSION') == 2
 
+    def test_scale_bzero_with_compressed_int_data(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4600
+        and https://github.com/astropy/astropy/issues/4588
 
-def test_set_data():
-    """
-    Test data assignment - issue #5087
-    """
-    im = fits.ImageHDU()
-    ar = np.arange(12)
-    im.data = ar
+        Identical to test_scale_bzero_with_int_data() but uses a compressed
+        image.
+        """
+
+        a = np.arange(100, 200, dtype=np.int16)
+
+        hdu1 = fits.CompImageHDU(data=a.copy())
+        hdu2 = fits.CompImageHDU(data=a.copy())
+        # Previously the following line would throw a TypeError,
+        # now it should be identical to the integer bzero case
+        hdu1.scale('int16', bzero=99.0)
+        hdu2.scale('int16', bzero=99)
+        assert np.allclose(hdu1.data, hdu2.data)
+
+        def test_scale_back_compressed_uint_assignment(self):
+            """
+            Extend fix for #4600 to assignment to data
+
+            Identical to test_scale_back_uint_assignment() but uses a compressed
+            image.
+
+            Suggested by:
+            https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+            """
+
+            a = np.arange(100, 200, dtype=np.uint16)
+            fits.CompImageHDU(a).writeto(self.temp('test.fits'))
+            with fits.open(self.temp('test.fits'), mode="update",
+                           scale_back=True) as hdul:
+                hdul[1].data[:] = 0
+                assert np.allclose(hdul[1].data, 0)
 
 
 def test_comphdu_bscale(tmpdir):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1609,23 +1609,23 @@ class TestCompressedImage(FitsTestCase):
         hdu2.scale('int16', bzero=99)
         assert np.allclose(hdu1.data, hdu2.data)
 
-        def test_scale_back_compressed_uint_assignment(self):
-            """
-            Extend fix for #4600 to assignment to data
+    def test_scale_back_compressed_uint_assignment(self):
+        """
+        Extend fix for #4600 to assignment to data
 
-            Identical to test_scale_back_uint_assignment() but uses a compressed
-            image.
+        Identical to test_scale_back_uint_assignment() but uses a compressed
+        image.
 
-            Suggested by:
-            https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
-            """
+        Suggested by:
+        https://github.com/astropy/astropy/pull/4602#issuecomment-208713748
+        """
 
-            a = np.arange(100, 200, dtype=np.uint16)
-            fits.CompImageHDU(a).writeto(self.temp('test.fits'))
-            with fits.open(self.temp('test.fits'), mode="update",
-                           scale_back=True) as hdul:
-                hdul[1].data[:] = 0
-                assert np.allclose(hdul[1].data, 0)
+        a = np.arange(100, 200, dtype=np.uint16)
+        fits.CompImageHDU(a).writeto(self.temp('test.fits'))
+        with fits.open(self.temp('test.fits'), mode="update",
+                       scale_back=True) as hdul:
+            hdul[1].data[:] = 0
+            assert np.allclose(hdul[1].data, 0)
 
 
 def test_comphdu_bscale(tmpdir):


### PR DESCRIPTION
This fixes the issue addressed in #4639 that were not fixed in #5250. Essentially a squash with edits as needed to resolve conflicts with #5250 and remove the parts of #4639 that had been fixed by #5250. 

Closing #4639 and #4602 (an alternative to #4639).

Fixes #4600.