### PR TITLE
Provide appropriate units for the return values of search_around_*

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,6 +169,10 @@ API Changes
     Similarly, ``EarthLocation.get_gcrs_posvel`` now returns a tuple of
     ``CartesianRepresentation`` objects. [#5253]
 
+  - ``search_around_3d`` and ``search_around_sky`` now return units
+    for the distance matching their input argument when no match is
+    found, instead of ``dimensionless_unscaled``. [#5528]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -198,7 +198,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
         and ``idx2``.
     dist3d : `~astropy.units.Quantity`
         The 3D distance between the coordinates. Shape matches ``idx1`` and
-        ``idx2``.
+        ``idx2``. The unit is that of ``coords1``.
 
     Notes
     -----
@@ -230,7 +230,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
         # Empty array input: return empty match
         return (np.array([], dtype=np.int), np.array([], dtype=np.int),
                 u.Quantity([], u.deg),
-                u.Quantity([], u.dimensionless_unscaled))
+                u.Quantity([], coords1.distance.unit))
 
     kdt2 = _get_cartesian_kdtree(coords2, storekdtree)
     cunit = coords2.cartesian.x.unit
@@ -256,7 +256,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='_kdtree_3d'):
 
     if idxs1.size == 0:
         d2ds = u.Quantity([], u.deg)
-        d3ds = u.Quantity([], u.dimensionless_unscaled)
+        d3ds = u.Quantity([], coords1.distance.unit)
     else:
         d2ds = coords1[idxs1].separation(coords2[idxs2])
         d3ds = coords1[idxs1].separation_3d(coords2[idxs2])
@@ -300,10 +300,11 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
         The on-sky separation between the coordinates. Shape matches ``idx1``
         and ``idx2``.
     dist3d : `~astropy.units.Quantity`
-        The 3D distance between the coordinates. Shape matches ``idx1`` and
-        ``idx2``. If either ``coords1`` or ``coords2`` don't have a distance,
-        this is the 3D distance on the unit sphere, rather than a physical
-        distance.
+        The 3D distance between the coordinates. Shape matches ``idx1``
+        and ``idx2``; the unit is that of ``coords1``.
+        If either ``coords1`` or ``coords2`` don't have a distance,
+        this is the 3D distance on the unit sphere, rather than a
+        physical distance.
 
     Notes
     -----
@@ -331,7 +332,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
         # Empty array input: return empty match
         return (np.array([], dtype=np.int), np.array([], dtype=np.int),
                 u.Quantity([], u.deg),
-                u.Quantity([], u.dimensionless_unscaled))
+                u.Quantity([], coords1.distance.unit))
 
     # we convert coord1 to match coord2's frame.  We do it this way
     # so that if the conversion does happen, the KD tree of coord2 at least gets
@@ -371,7 +372,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
 
     if idxs1.size == 0:
         d2ds = u.Quantity([], u.deg)
-        d3ds = u.Quantity([], u.dimensionless_unscaled)
+        d3ds = u.Quantity([], coords1.distance.unit)
     else:
 
         d2ds = coords1[idxs1].separation(coords2[idxs2])

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -330,9 +330,13 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
 
     if len(coords1) == 0 or len(coords2) == 0:
         # Empty array input: return empty match
+        if coords2.distance.unit == u.dimensionless_unscaled:
+            distunit = u.dimensionless_unscaled
+        else:
+            distunit = coords1.distance.unit
         return (np.array([], dtype=np.int), np.array([], dtype=np.int),
                 u.Quantity([], u.deg),
-                u.Quantity([], coords1.distance.unit))
+                u.Quantity([], distunit))
 
     # we convert coord1 to match coord2's frame.  We do it this way
     # so that if the conversion does happen, the KD tree of coord2 at least gets
@@ -371,10 +375,13 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='_kdtree_sky'):
     idxs2 = np.array(idxs2, dtype=np.int)
 
     if idxs1.size == 0:
+        if coords2.distance.unit == u.dimensionless_unscaled:
+            distunit = u.dimensionless_unscaled
+        else:
+            distunit = coords1.distance.unit
         d2ds = u.Quantity([], u.deg)
-        d3ds = u.Quantity([], coords1.distance.unit)
+        d3ds = u.Quantity([], distunit)
     else:
-
         d2ds = coords1[idxs1].separation(coords2[idxs2])
         try:
             d3ds = coords1[idxs1].separation_3d(coords2[idxs2])

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -126,7 +126,7 @@ def test_matching_method():
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 @pytest.mark.skipif(str('OLDER_SCIPY'))
 def test_search_around():
-    from .. import ICRS
+    from .. import ICRS, SkyCoord
     from ..matching import search_around_sky, search_around_3d
 
     coo1 = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 5] * u.kpc)
@@ -153,31 +153,59 @@ def test_search_around():
     idx1, idx2, d2d, d3d = search_around_sky(coo1, coo2, 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(coo1, coo2, 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
 
     # Test when one or both of the coordinate arrays is empty, #4875
     empty = ICRS(ra=[] * u.degree, dec=[] * u.degree, distance=[] * u.kpc)
     idx1, idx2, d2d, d3d = search_around_sky(empty, coo2, 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_sky(coo1, empty, 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
     empty = ICRS(ra=[] * u.degree, dec=[] * u.degree, distance=[] * u.kpc)
     idx1, idx2, d2d, d3d = search_around_sky(empty, empty[:], 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(empty, coo2, 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(coo1, empty, 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(empty, empty[:], 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
     assert idx1.dtype == idx2.dtype == np.int
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.kpc
+
+    # Test that input without distance units results in a
+    # 'dimensionless_unscaled' unit
+    cempty = SkyCoord(ra=[], dec=[], unit=u.deg)
+    idx1, idx2, d2d, d3d = search_around_3d(cempty, cempty[:], 1*u.m)
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.dimensionless_unscaled
+    idx1, idx2, d2d, d3d = search_around_sky(cempty, cempty[:], 1*u.m)
+    assert d2d.unit == u.deg
+    assert d3d.unit == u.dimensionless_unscaled
+
+
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))


### PR DESCRIPTION
The ``search_around_3d`` and ``search_around_sky`` functions and
methods previously returned an empty distance list with a unit of
``dimensionless_unscaled`` when no match was found. This PR grabs
the distance unit from the first input argument and uses that instead.