### PR TITLE
Error trying to set astropy_mpl_style

### DIFF
--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-__doctest_requires__ = {'*': ['matplotlib']}
-
 """ This module contains dictionaries that can be used to set a
 matplotlib plotting style.
+
 It is mostly here to allow a consistent plotting style in tutorials,
 but can be used to prepare any matplotlib figure.
 
-Using a matplotlib version > 1.4 you can do::
+Using a matplotlib version >= 1.5 you can do::
 
     >>> import matplotlib.pyplot as plt
     >>> from astropy.visualization import astropy_mpl_style
@@ -30,8 +28,9 @@ example), you should reset the matplotlib settings to the library defaults
     >>> from astropy.visualization import astropy_mpl_style
     >>> mpl.rcdefaults()
     >>> mpl.rcParams.update(astropy_mpl_style)
-"""
+    """
 
+__doctest_requires__ = {'*': ['matplotlib']}
 
 astropy_mpl_style_1 = {
 


### PR DESCRIPTION
I tried to set the `astropy_mpl_style` as suggested here:
https://github.com/astropy/astropy/blob/59cbe17ee75a34143bca38d064f561a075ca2099/astropy/visualization/mpl_style.py#L10

``` python
import matplotlib.pyplot as plt
from astropy.visualization import astropy_mpl_style
plt.style.use(astropy_mpl_style)
```

With matplotlib 1.4.3 and astropy master I'm getting this error:

```
Python 3.4.3 (default, Aug 18 2015, 21:38:53) 
[GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib.pyplot as plt
>>> from astropy.visualization import astropy_mpl_style
>>> plt.style.use(astropy_mpl_style)
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/matplotlib/style/core.py", line 60, in use
    rc = rc_params_from_file(style, use_default_template=False)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/matplotlib/__init__.py", line 1069, in rc_params_from_file
    config_from_file = _rc_params_in_file(fname, fail_on_error)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/matplotlib/__init__.py", line 996, in _rc_params_in_file
    with _open_file_or_url(fname) as fd:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/contextlib.py", line 59, in __enter__
    return next(self.gen)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/matplotlib/__init__.py", line 981, in _open_file_or_url
    with open(fname) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'ytick.color'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/matplotlib/style/core.py", line 66, in use
    raise ValueError(msg % style)
ValueError: 'ytick.color' not found in the style library and input is not a valid URL or path. See `style.available` for list of available styles.
```

Is this a bug or an issue with my setup?
