### PR TITLE
Remove warning in Kernel.normalize

### DIFF
--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -112,12 +112,6 @@ class Kernel(object):
         else:
             np.divide(self._array, normalization, self._array)
 
-            if np.abs(1.0 / normalization) > MAX_NORMALIZATION:
-                warnings.warn('The kernel normalization factor is '
-                              'exceptionally large,'
-                              ' > {0}.'.format(MAX_NORMALIZATION),
-                              AstropyUserWarning)
-
         self._kernel_sum = self._array.sum()
 
     @property

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -473,16 +473,6 @@ class TestKernels(object):
             kernel = CustomKernel(np.ones(3))
             kernel.normalize(mode='invalid')
 
-    def test_kernel_normalization_large(self, recwarn):
-        """
-        Test that a warning is issued when the inverse normalization factor
-        is large.
-        """
-        kernel = CustomKernel(np.ones(3) * 1.e-3)
-        kernel.normalize()
-        w = recwarn.pop(AstropyUserWarning)
-        assert issubclass(w.category, AstropyWarning)
-
     def test_kernel1d_int_size(self):
         """
         Test that an error is raised if ``Kernel1D`` ``x_size`` is not


### PR DESCRIPTION
Currently `Kernel.normalize` emits a warning
```python
>>> from astropy.convolution import Tophat2DKernel
>>> Tophat2DKernel(radius=10).normalize('peak')
WARNING: The kernel normalization factor is exceptionally large, > 100. [astropy.convolution.core]
```
when
```
if np.abs(1.0 / normalization) > MAX_NORMALIZATION:
```
where `MAX_NORMALIZATION = 100`, i.e. if
```
normalization > 0.01
```

A tophat kernel with 10 pix radius, normalised to peak value 1 is perfectly OK usage.
There should be no warning.
This pull request removes the check and warning.

---

FYI: In the past months we've been getting this warning from several places in Gammapy, and I'd prefer to just remove it here instead of having to catch it everywhere.

It looks like this warning was added in #3747 by @larrybradley, a PR that was reviewed by @adonath . As far as I can see, the motivation for #3747 was a different bug and different checks were added for that, and this check wasn't motivated / discussed.

I did discuss this in person with @adonath today and he agrees the warning should go.

@larrybradley - Can you please review this?
If possible I'd like to get this in for the 1.3 release.
Does this need a changelog entry? (I don't think so, but I can add if others think yes)
