### PR TITLE
Remove deprecated NumCode and ImgCode properties on FITS _ImageBaseHDU

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ New Features
 
   - New convenience function ``printdiff`` to print out diff reports. [#5759]
 
+  - Remove deprecated ``NumCode`` and ``ImgCode`` properties on FITS ``_ImageBaseHDU``.
+    Use module-level constants ``BITPIX2DTYPE`` and ``DTYPE2BITPIX`` instead. [#4993]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -12,7 +12,7 @@ from ..verify import VerifyWarning
 
 from ....extern.six import string_types
 from ....extern.six.moves import range, zip
-from ....utils import isiterable, lazyproperty, classproperty, deprecated
+from ....utils import isiterable, lazyproperty, classproperty
 
 
 class _ImageBaseHDU(_ValidHDU):
@@ -835,18 +835,6 @@ class _ImageBaseHDU(_ValidHDU):
             # all.  This can also be handled in a generic manner.
             return super(_ImageBaseHDU, self)._calculate_datasum(
                 blocking=blocking)
-
-    @classproperty
-    @deprecated('1.1.0', alternative='the module level constant BITPIX2DTYPE',
-                obj_type='class attribute')
-    def NumCode(cls):
-        return BITPIX2DTYPE
-
-    @classproperty
-    @deprecated('1.1.0', alternative='the module level constant DTYPE2BITPIX',
-                obj_type='class attribute')
-    def ImgCode(cls):
-        return DTYPE2BITPIX
 
 
 class Section(object):


### PR DESCRIPTION
With Python 3.5 from Macports and Sphinx 1.4.1 and current Astropy master (8c7db8a38b525456d19eb1498555e0c7fe3270a5) I'm getting a bunch or warnings.

Especially the `AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict` warnings I find annoying, I'm seeing those as well in the Sphinx logs of affiliated package, making it hard to see the real warnings that cause issues in Sphinx build logs.

Does someone else see those warnings as well? Are they known issues? Any idea how to fix them?

Full log:

```
$ python setup.py build_sphinx
Freezing version number to astropy/version.py
running build_sphinx
creating /Users/deil/code/astropy/docs/_build
creating /Users/deil/code/astropy/docs/_build/doctrees
creating /Users/deil/code/astropy/docs/_build/html
running build
running build_py
running pre_hook from astropy._erfa.setup_package for build_py command
running pre_hook from astropy.modeling.setup_package for build_py command
copying astropy/version.py -> build/lib.macosx-10.11-x86_64-3.5/astropy
copying astropy/coordinates/sky_coordinate.py -> build/lib.macosx-10.11-x86_64-3.5/astropy/coordinates
copying astropy/coordinates/builtin_frames/astrometric.py -> build/lib.macosx-10.11-x86_64-3.5/astropy/coordinates/builtin_frames
copying astropy/coordinates/tests/test_astrometric_transformations.py -> build/lib.macosx-10.11-x86_64-3.5/astropy/coordinates/tests
running build_ext
running pre_hook from astropy._erfa.setup_package for build_ext command
running pre_hook from astropy.modeling.setup_package for build_ext command
skipping 'astropy/table/_np_utils.c' Cython extension (up-to-date)
skipping 'astropy/table/_column_mixins.c' Cython extension (up-to-date)
skipping 'astropy/io/ascii/cparser.c' Cython extension (up-to-date)
skipping 'astropy/convolution/boundary_extend.c' Cython extension (up-to-date)
skipping 'astropy/convolution/boundary_fill.c' Cython extension (up-to-date)
skipping 'astropy/convolution/boundary_none.c' Cython extension (up-to-date)
skipping 'astropy/convolution/boundary_wrap.c' Cython extension (up-to-date)
skipping 'astropy/cosmology/scalar_inv_efuncs.c' Cython extension (up-to-date)
skipping 'astropy/stats/lombscargle/implementations/cython_impl.c' Cython extension (up-to-date)
Running Sphinx v1.4.1
WARNING: The sphinx_gallery extension is not installed, so the gallery will not be built.  You will probably see additional warnings about undefined references due to this.
loading pickled environment... not yet created
loading intersphinx inventory from http://docs.python.org/3/objects.inv...
loading intersphinx inventory from http://matplotlib.org/objects.inv...
loading intersphinx inventory from http://docs.scipy.org/doc/numpy/objects.inv...
loading intersphinx inventory from http://docs.h5py.org/en/latest/objects.inv...
loading intersphinx inventory from /Users/deil/code/astropy/astropy_helpers/astropy_helpers/sphinx/local/python3_local_links.inv...
loading intersphinx inventory from http://pytest.org/latest/objects.inv...
loading intersphinx inventory from http://ipython.readthedocs.io/en/stable/objects.inv...
loading intersphinx inventory from http://docs.scipy.org/doc/scipy/reference/objects.inv...
[automodsumm] table/index.rst: found 21 automodsumm entries to generate
[automodsumm] nddata/index.rst: found 33 automodsumm entries to generate
[automodsumm] stats/index.rst: found 34 automodsumm entries to generate
[automodsumm] cosmology/index.rst: found 11 automodsumm entries to generate
[automodsumm] time/index.rst: found 30 automodsumm entries to generate
[automodsumm] io/ascii/index.rst: found 55 automodsumm entries to generate
[automodsumm] coordinates/index.rst: found 67 automodsumm entries to generate
[automodsumm] convolution/index.rst: found 22 automodsumm entries to generate
[automodsumm] modeling/index.rst: found 184 automodsumm entries to generate
[automodsumm] utils/index.rst: found 87 automodsumm entries to generate
[automodsumm] analytic_functions/index.rst: found 2 automodsumm entries to generate
[automodsumm] visualization/index.rst: found 23 automodsumm entries to generate
[automodsumm] vo/samp/index.rst: found 11 automodsumm entries to generate
[automodsumm] config/index.rst: found 10 automodsumm entries to generate
[automodsumm] vo/conesearch/index.rst: found 27 automodsumm entries to generate
[automodsumm] io/registry.rst: found 10 automodsumm entries to generate
[automodsumm] io/misc.rst: found 4 automodsumm entries to generate
[automodsumm] units/index.rst: found 83 automodsumm entries to generate
[automodsumm] io/votable/index.rst: found 33 automodsumm entries to generate
[automodsumm] wcs/index.rst: found 29 automodsumm entries to generate
[automodsumm] testhelpers.rst: found 10 automodsumm entries to generate
[automodsumm] constants/index.rst: found 2 automodsumm entries to generate
[automodsumm] nddata/utils.rst: found 9 automodsumm entries to generate
[automodsumm] logging.rst: found 3 automodsumm entries to generate
[autosummary] generating autosummary for: analytic_functions/index.rst, changelog.rst, config/config_0_4_transition.rst, config/index.rst, constants/index.rst, convolution/index.rst, convolution/kernels.rst, convolution/using.rst, coordinates/angles.rst, coordinates/definitions.rst, ..., wcs/history.rst, wcs/index.rst, wcs/relax.rst, whatsnew/0.1.rst, whatsnew/0.2.rst, whatsnew/0.3.rst, whatsnew/0.4.rst, whatsnew/1.0.rst, whatsnew/1.1.rst, whatsnew/index.rst
building [mo]: all of 0 po files
building [html]: all source files
updating environment: 944 added, 0 changed, 0 removed
/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/matplotlib/__init__.py:872: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.
  warnings.warn(self.msg_depr % (key, alt_key))
/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/matplotlib/__init__.py:872: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.
  warnings.warn(self.msg_depr % (key, alt_key))
WARNING: AstropyDeprecationWarning: The ImgCode class attribute is deprecated and may be removed in a future version.
        Use the module level constant DTYPE2BITPIX instead. [astropy.utils.decorators]
WARNING: AstropyDeprecationWarning: The NumCode class attribute is deprecated and may be removed in a future version.
        Use the module level constant BITPIX2DTYPE instead. [astropy.utils.decorators]
/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/matplotlib/__init__.py:872: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.
  warnings.warn(self.msg_depr % (key, alt_key))
WARNING: p0 does not seem to accurately represent the false positive rate for event data. It is highly recommended that you run random trials on signal-free noise to calibrate ncp_prior to achieve a desired false positive rate. [astropy.stats.bayesian_blocks]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
WARNING: AstropyDeprecationWarning: astropy.utils.compat.odict.OrderedDict is now deprecated - import OrderedDict from the collections module instead [astropy.utils.compat.odict]
/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/matplotlib/__init__.py:872: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.
  warnings.warn(self.msg_depr % (key, alt_key))
WARNING: p0 does not seem to accurately represent the false positive rate for event data. It is highly recommended that you run random trials on signal-free noise to calibrate ncp_prior to achieve a desired false positive rate. [astropy.stats.bayesian_blocks]
reading sources... [100%] whatsnew/index                                       
/Users/deil/code/astropy/docs/index.rst:55: WARNING: toctree contains reference to nonexisting document 'generated/examples/index'
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
[changelog_links] Adding changelog links to "changelog"                        rorsingErrorning
[changelog_links] Adding changelog links to "whatsnew/0.1"                     
[changelog_links] Adding changelog links to "whatsnew/0.2"                     
[changelog_links] Adding changelog links to "whatsnew/0.3"                     
[changelog_links] Adding changelog links to "whatsnew/0.4"                     
[changelog_links] Adding changelog links to "whatsnew/1.0"                     
[changelog_links] Adding changelog links to "whatsnew/1.1"                     
[changelog_links] Adding changelog links to "whatsnew/index"                   

/Users/deil/code/astropy/docs/api/astropy.constants.EMConstant.rst:1: WARNING: py:obj reference target not found: exceptions.TypeError
/Users/deil/code/astropy/docs/api/astropy.constants.EMConstant.rst:9: WARNING: py:obj reference target not found: exceptions.TypeError
coordinates/references.txt:4: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/api/astropy.coordinates.Latitude.rst:9: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/api/astropy.io.misc.fnpickle.rst:17: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/api/astropy.io.misc.fnunpickle.rst:13: WARNING: py:obj reference target not found: file
io/votable/references.txt:4: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/api/astropy.time.Time.rst:15: WARNING: py:obj reference target not found: exceptions.IndexError
/Users/deil/code/astropy/docs/api/astropy.units.quantity_input.rst:14: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/api/astropy.utils.collections.HomogeneousList.rst:9: WARNING: py:obj reference target not found: exceptions.TypeError
/Users/deil/code/astropy/docs/api/astropy.utils.console.ProgressBar.rst:36: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/api/astropy.utils.console.ProgressBar.rst:37: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/api/astropy.utils.console.ProgressBarOrSpinner.rst:48: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/api/astropy.utils.console.Spinner.rst:32: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/api/astropy.utils.console.isatty.rst:9: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/api/astropy.utils.metadata.MetaData.rst:11: WARNING: py:obj reference target not found: collections.Mapping
/Users/deil/code/astropy/docs/api/astropy.wcs.WCS.rst:117: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/api/astropy.wcs.Wcsprm.rst:7: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/coordinates/angles.rst:166: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/coordinates/frames.rst:278: WARNING: undefined label: sphx_glr_generated_examples_coordinates_plot_sgr-coordinate-frame.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/coordinates/index.rst:125: WARNING: undefined label: sphx_glr_generated_examples_coordinates_plot_obs-planning.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/coordinates/index.rst:272: WARNING: undefined label: sphx_glr_generated_examples_coordinates_plot_obs-planning.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/development/codeguide.rst:772: WARNING: py:obj reference target not found: exceptions.TypeError
/Users/deil/code/astropy/docs/development/workflow/git_edit_workflow_examples.rst:417: WARNING: py:obj reference target not found: exceptions.TypeError
/Users/deil/code/astropy/docs/development/workflow/git_edit_workflow_examples.rst:430: WARNING: py:obj reference target not found: exceptions.TypeError
['StreamingHDU.write(data)', ':module: astropy.io.fits', '', 'Write the given data to the stream.', '', ':Parameters:', '', '    **data** : ndarray', '', '        Data to stream to the file.', '', ':Returns:', '', '    **writecomplete** : int', '', '        Flag that when `True` indicates that all of the required', '        data has been written to the stream.', '', '.. rubric:: Notes', '', 'Only the amount of data specified in the header provided to the class', 'constructor may be written to the stream.  If the provided data would', 'cause the stream to overflow, an `~.exceptions.IOError` exception is', 'raised and the data is not written. Once sufficient data has been', 'written to the stream to satisfy the amount specified in the header,', 'the stream is padded to fill a complete FITS block and no more data', 'will be accepted. An attempt to write more data after the stream has', 'been filled will raise an `~.exceptions.IOError` exception. If the', 'dtype of the input data does not match what is expected by the header,', 'a `.exceptions.TypeError` exception is raised.']:20: WARNING: py:obj reference target not found: exceptions.IOError
['StreamingHDU.write(data)', ':module: astropy.io.fits', '', 'Write the given data to the stream.', '', ':Parameters:', '', '    **data** : ndarray', '', '        Data to stream to the file.', '', ':Returns:', '', '    **writecomplete** : int', '', '        Flag that when `True` indicates that all of the required', '        data has been written to the stream.', '', '.. rubric:: Notes', '', 'Only the amount of data specified in the header provided to the class', 'constructor may be written to the stream.  If the provided data would', 'cause the stream to overflow, an `~.exceptions.IOError` exception is', 'raised and the data is not written. Once sufficient data has been', 'written to the stream to satisfy the amount specified in the header,', 'the stream is padded to fill a complete FITS block and no more data', 'will be accepted. An attempt to write more data after the stream has', 'been filled will raise an `~.exceptions.IOError` exception. If the', 'dtype of the input data does not match what is expected by the header,', 'a `.exceptions.TypeError` exception is raised.']:20: WARNING: py:obj reference target not found: exceptions.IOError
['StreamingHDU.write(data)', ':module: astropy.io.fits', '', 'Write the given data to the stream.', '', ':Parameters:', '', '    **data** : ndarray', '', '        Data to stream to the file.', '', ':Returns:', '', '    **writecomplete** : int', '', '        Flag that when `True` indicates that all of the required', '        data has been written to the stream.', '', '.. rubric:: Notes', '', 'Only the amount of data specified in the header provided to the class', 'constructor may be written to the stream.  If the provided data would', 'cause the stream to overflow, an `~.exceptions.IOError` exception is', 'raised and the data is not written. Once sufficient data has been', 'written to the stream to satisfy the amount specified in the header,', 'the stream is padded to fill a complete FITS block and no more data', 'will be accepted. An attempt to write more data after the stream has', 'been filled will raise an `~.exceptions.IOError` exception. If the', 'dtype of the input data does not match what is expected by the header,', 'a `.exceptions.TypeError` exception is raised.']:20: WARNING: py:obj reference target not found: exceptions.TypeError
["Header.fromfile(fileobj, sep='', endcard=True, padding=True)", ':module: astropy.io.fits', '', 'Similar to :meth:`Header.fromstring`, but reads the header string from', 'a given file-like object or filename.', '', ':Parameters:', '', '    **fileobj** : str, file-like', '', '        A filename or an open file-like object from which a FITS header is', '        to be read.  For open file handles the file pointer must be at the', '        beginning of the header.', '', '    **sep** : str, optional', '', '        The string separating cards from each other, such as a newline.  By', '        default there is no card separator (as is the case in a raw FITS', '        file).', '', '    **endcard** : bool, optional', '', '        If True (the default) the header must end with an END card in order', '        to be considered valid.  If an END card is not found an', '        `~.exceptions.IOError` is raised.', '', '    **padding** : bool, optional', '', '        If True (the default) the header will be required to be padded out', '        to a multiple of 2880, the FITS header block size.  Otherwise any', '        padding, or lack thereof, is ignored.', '', ':Returns:', '', '    header', '', '        A new `Header` instance.']:22: WARNING: py:obj reference target not found: exceptions.IOError
['Header.rename_keyword(oldkeyword, newkeyword, force=False)', ':module: astropy.io.fits', '', "Rename a card's keyword in the header.", '', ':Parameters:', '', '    **oldkeyword** : str or int', '', '        Old keyword or card index', '', '    **newkeyword** : str', '', '        New keyword', '', '    **force** : bool, optional', '', '        When `True`, if the new keyword already exists in the header, force', '        the creation of a duplicate keyword. Otherwise a', '        `~.exceptions.ValueError` is raised.']:17: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/io/fits/appendix/faq.rst:111: WARNING: py:obj reference target not found: exceptions.KeyError
/Users/deil/code/astropy/docs/io/fits/appendix/faq.rst:283: WARNING: undefined label: sphx_glr_generated_examples_io_skip_create-large-fits.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/io/fits/appendix/faq.rst:307: WARNING: undefined label: sphx_glr_generated_examples_io_create-mef.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/io/fits/appendix/header_transition.rst:201: WARNING: py:obj reference target not found: exceptions.KeyError
/Users/deil/code/astropy/docs/io/fits/appendix/header_transition.rst:258: WARNING: py:obj reference target not found: exceptions.KeyError
/Users/deil/code/astropy/docs/io/fits/index.rst:169: WARNING: py:obj reference target not found: exceptions.KeyError
/Users/deil/code/astropy/docs/io/fits/index.rst:273: WARNING: undefined label: sphx_glr_generated_examples_io_modify-fits-header.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/io/fits/index.rst:351: WARNING: undefined label: sphx_glr_generated_examples_io_plot_fits-image.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/io/fits/index.rst:466: WARNING: undefined label: sphx_glr_generated_examples_io_fits-tables.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/io/fits/index.rst:619: WARNING: undefined label: sphx_glr_generated_examples_io_create-mef.py (if the link has no caption the label must precede a section header)
/Users/deil/code/astropy/docs/io/votable/index.rst:1: WARNING: py:obj reference target not found: exceptions.ValueError
/Users/deil/code/astropy/docs/utils/index.rst:1: WARNING: py:obj reference target not found: file
/Users/deil/code/astropy/docs/whatsnew/1.0.rst:68: WARNING: undefined label: sphx_glr_generated_examples_coordinates_plot_obs-planning.py (if the link has no caption the label must precede a section header)
generating indices... genindex py-modindex
 (186 module code pages) _modules/index
writing additional pages... search
copying images... [100%] api/../_build/plot_directive/api/astropy-modeling-functional_models-Const1D-1.pngggngg1D-1.png
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 45 warnings.
```
