### PR TITLE
Fix segfault with FastCsv and row with too many columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1741,8 +1741,11 @@ Bug Fixes
 
   - Fix a bug where the ``fill_values`` parameter was ignored when writing a
     table to HTML format. [#5379]
+
   - Fix reading of big ASCII tables (more than 2Gb) with the fast reader.
     [#5319]
+
+  - Fix segfault with FastCsv and row with too many columns. [#5534]
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -384,6 +384,8 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
             }
             else if (c == self->delimiter) // field ends before it begins
             {
+                if (col >= self->num_cols)
+                    RETURN(TOO_MANY_COLS);
                 END_FIELD();
                 BEGIN_FIELD();
                 break;

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -400,6 +400,8 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                     // e.g. '1,2, '->['1','2','']
                     else
                     {
+                        if (col >= self->num_cols)
+                            RETURN(TOO_MANY_COLS);
                         END_FIELD();
                     }
                 }

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -363,7 +363,7 @@ def test_invalid_parameters():
         table = FastBasic(Outputter=ascii.TableOutputter).read('1 2 3\n4 5 6')
 
 
-def test_too_many_cols():
+def test_too_many_cols1():
     """
     If a row contains too many columns, the C reader should raise an error.
     """
@@ -379,9 +379,23 @@ A B C
     assert 'CParserError: an error occurred while parsing table data: too many ' \
         'columns found in line 3 of data' in str(e)
 
+
+def test_too_many_cols2():
     text = """\
 aaa,bbb
 1,2,
+3,4,
+"""
+    with pytest.raises(CParserError) as e:
+        table = FastCsv().read(text)
+    assert 'CParserError: an error occurred while parsing table data: too many ' \
+        'columns found in line 1 of data' in str(e)
+
+
+def test_too_many_cols3():
+    text = """\
+aaa,bbb
+1,2,,
 3,4,
 """
     with pytest.raises(CParserError) as e:

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -379,6 +379,16 @@ A B C
     assert 'CParserError: an error occurred while parsing table data: too many ' \
         'columns found in line 3 of data' in str(e)
 
+    text = """\
+aaa,bbb
+1,2,
+3,4,
+"""
+    with pytest.raises(CParserError) as e:
+        table = FastCsv().read(text)
+    assert 'CParserError: an error occurred while parsing table data: too many ' \
+        'columns found in line 1 of data' in str(e)
+
 
 @pytest.mark.parametrize("parallel", [True, False])
 def test_not_enough_cols(parallel, read_csv):


### PR DESCRIPTION
Adding a check that the currently parsed column number is not greater than the number of columns defined in the header.  (This is already checked in several other places).

Fix #5276. cc @taldcroft @cdeil 