### PR TITLE
Add classes to build RGB images based on Lupton et al. (2004)

### DIFF
--- a/astropy/visualization/__init__.py
+++ b/astropy/visualization/__init__.py
@@ -8,3 +8,4 @@ from .stretch import *
 from .transform import *
 from .ui import *
 from .units import *
+from .lupton_rgb import *

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -7,10 +7,10 @@ For details, see : http://adsabs.harvard.edu/abs/2004PASP..116..133L
 The three images must be aligned and have the same pixel scale and size.
 
 Example usage:
-    imageR = np.random.random((100,100))
-    imageG = np.random.random((100,100))
-    imageB = np.random.random((100,100))
-    image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
+    image_r = np.random.random((100,100))
+    image_g = np.random.random((100,100))
+    image_b = np.random.random((100,100))
+    image = lupton_rgb.make_rgb(image_r, image_g, image_b, filename='randoms.png')
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -18,7 +18,7 @@ import numpy as np
 from . import ZScaleInterval
 
 
-__all__ = ['makeRGB', 'Mapping', 'LinearMapping', 'AsinhMapping',
+__all__ = ['make_rgb', 'Mapping', 'LinearMapping', 'AsinhMapping',
            'AsinhZScaleMapping']
 
 
@@ -34,24 +34,24 @@ except (ImportError, AttributeError):
 # from lsst.afw.display.displayLib import replaceSaturatedPixels, getZScale
 
 
-def compute_intensity(imageR, imageG=None, imageB=None):
+def compute_intensity(image_r, image_g=None, image_b=None):
     """
     Return a naive total intensity from the red, blue, and green intensities.
 
     Parameters
     ----------
-    imageR : `~numpy.ndarray`
-        Intensity of image to be mapped to red; or total intensity if ``imageG``
-        and ``imageB`` are None.
-    imageG : `~numpy.ndarray`, optional
+    image_r : `~numpy.ndarray`
+        Intensity of image to be mapped to red; or total intensity if ``image_g``
+        and ``image_b`` are None.
+    image_g : `~numpy.ndarray`, optional
         Intensity of image to be mapped to green.
-    imageB : `~numpy.ndarray`, optional
+    image_b : `~numpy.ndarray`, optional
         Intensity of image to be mapped to blue.
 
     Returns
     -------
     intensity : `~numpy.ndarray`
-        Total intensity from the red, blue and green intensities, or ``imageR``
+        Total intensity from the red, blue and green intensities, or ``image_r``
         if green and blue images are not provided.
 
     Notes
@@ -59,16 +59,16 @@ def compute_intensity(imageR, imageG=None, imageB=None):
     Inputs may be MaskedImages, Images, or numpy arrays and the return is
     of the same type.
     """
-    if imageG is None or imageB is None:
-        if not (imageG is None and imageB is None):
+    if image_g is None or image_b is None:
+        if not (image_g is None and image_b is None):
             raise ValueError("please specify either a single image "
                              "or red, green, and blue images.")
-        return imageR
+        return image_r
 
-    intensity = (imageR + imageG + imageB)/3.0
+    intensity = (image_r + image_g + image_b)/3.0
 
     # Repack into whatever type was passed to us
-    return np.array(intensity, dtype=imageR.dtype)
+    return np.array(intensity, dtype=image_r.dtype)
 
 
 class Mapping(object):
@@ -84,7 +84,7 @@ class Mapping(object):
             Intensity that should be mapped to black (a scalar or array for R, G, B).
         image : `~numpy.ndarray`, optional
             The image to be used to calculate the mapping.
-            If provided, it is also used as the default for makeRgbImage().
+            If provided, it is also used as the default for make_rgb_image().
         """
         self._uint8Max = float(np.iinfo(np.uint8).max)
 
@@ -98,65 +98,65 @@ class Mapping(object):
         self.minimum = minimum
         self._image = np.asarray(image)
 
-    def makeRgbImage(self, imageR=None, imageG=None, imageB=None,
-                     xSize=None, ySize=None, rescaleFactor=None):
+    def make_rgb_image(self, image_r=None, image_g=None, image_b=None,
+                       x_size=None, y_size=None, rescale=None):
         """
-        Convert 3 arrays, imageR, imageG, and imageB into a numpy RGB image.
+        Convert 3 arrays, image_r, image_g, and image_b into a numpy RGB image.
 
         Parameters
         ----------
-        imageR : `~numpy.ndarray`, optional
+        image_r : `~numpy.ndarray`, optional
             Image to map to red (if None, use the image passed to the
             constructor).
-        imageG : `~numpy.ndarray`, optional
-            Image to map to green (if None, use imageR).
-        imageB : `~numpy.ndarray`, optional
-            Image to map to blue (if None, use imageR).
-        xSize : int, optional
-            Desired width of RGB image (or None).  If ySize is None, preserve
+        image_g : `~numpy.ndarray`, optional
+            Image to map to green (if None, use image_r).
+        image_b : `~numpy.ndarray`, optional
+            Image to map to blue (if None, use image_r).
+        x_size : int, optional
+            Desired width of RGB image (or None).  If y_size is None, preserve
             aspect ratio.
-        ySize : int, optional
+        y_size : int, optional
             Desired height of RGB image (or None).
-        rescaleFactor : float, optional
-            Make size of output image rescaleFactor*size of the input image.
-            Cannot be specified if xSize or ySize are given.
+        rescale : float, optional
+            Make size of output image rescale*size of the input image.
+            Cannot be specified if x_size or y_size are given.
 
         Returns
         -------
         RGBimage : `~numpy.ndarray`
             An image formed by stacking the input images.
         """
-        if imageR is None:
+        if image_r is None:
             if self._image is None:
                 raise RuntimeError("you must provide an image or pass one "
                                    "to the constructor.")
-            imageR = self._image
+            image_r = self._image
         else:
-            imageR = np.asarray(imageR)
+            image_r = np.asarray(image_r)
 
-        if imageG is None:
-            imageG = imageR
+        if image_g is None:
+            image_g = image_r
         else:
-            imageG = np.asarray(imageG)
+            image_g = np.asarray(image_g)
 
-        if imageB is None:
-            imageB = imageR
+        if image_b is None:
+            image_b = image_r
         else:
-            imageB = np.asarray(imageB)
+            image_b = np.asarray(image_b)
 
-        if xSize is not None or ySize is not None:
-            if rescaleFactor is not None:
-                raise ValueError("you may not specify a size and rescaleFactor.")
-            h, w = imageR.shape
-            if ySize is None:
-                ySize = int(xSize*h/float(w) + 0.5)
-            elif xSize is None:
-                xSize = int(ySize*w/float(h) + 0.5)
+        if x_size is not None or y_size is not None:
+            if rescale is not None:
+                raise ValueError("you may not specify a size and rescale.")
+            h, w = image_r.shape
+            if y_size is None:
+                y_size = int(x_size*h/float(w) + 0.5)
+            elif x_size is None:
+                x_size = int(y_size*w/float(h) + 0.5)
 
             # need to cast to int when passing tuple to imresize.
-            size = (int(ySize), int(xSize))  # n.b. y, x order for scipy
-        elif rescaleFactor is not None:
-            size = float(rescaleFactor)  # a float is intepreted as a percentage
+            size = (int(y_size), int(x_size))  # n.b. y, x order for scipy
+        elif rescale is not None:
+            size = float(rescale)  # a float is intepreted as a percentage
         else:
             size = None
 
@@ -165,39 +165,39 @@ class Mapping(object):
                 raise RuntimeError("unable to rescale as scipy.misc.imresize "
                                    "is unavailable.")
 
-            imageR = scipy.misc.imresize(imageR, size, interp='bilinear',
-                                         mode='F')
-            imageG = scipy.misc.imresize(imageG, size, interp='bilinear',
-                                         mode='F')
-            imageB = scipy.misc.imresize(imageB, size, interp='bilinear',
-                                         mode='F')
+            image_r = scipy.misc.imresize(image_r, size, interp='bilinear',
+                                          mode='F')
+            image_g = scipy.misc.imresize(image_g, size, interp='bilinear',
+                                          mode='F')
+            image_b = scipy.misc.imresize(image_b, size, interp='bilinear',
+                                          mode='F')
 
-        return np.dstack(self._convertImagesToUint8(imageR, imageG, imageB)).astype(np.uint8)
+        return np.dstack(self._convert_images_to_uint8(image_r, image_g, image_b)).astype(np.uint8)
 
-    def intensity(self, imageR, imageG, imageB):
+    def intensity(self, image_r, image_g, image_b):
         """
         Return the total intensity from the red, blue, and green intensities.
         This is a naive computation, and may be overridden by subclasses.
 
         Parameters
         ----------
-        imageR : `~numpy.ndarray`
+        image_r : `~numpy.ndarray`
             Intensity of image to be mapped to red; or total intensity if
-            ``imageG`` and ``imageB`` are None.
-        imageG : `~numpy.ndarray`, optional
+            ``image_g`` and ``image_b`` are None.
+        image_g : `~numpy.ndarray`, optional
             Intensity of image to be mapped to green.
-        imageB : `~numpy.ndarray`, optional
+        image_b : `~numpy.ndarray`, optional
             Intensity of image to be mapped to blue.
 
         Returns
         -------
         intensity : `~numpy.ndarray`
             Total intensity from the red, blue and green intensities, or
-            ``imageR`` if green and blue images are not provided.
+            ``image_r`` if green and blue images are not provided.
         """
-        return compute_intensity(imageR, imageG, imageB)
+        return compute_intensity(image_r, image_g, image_b)
 
-    def mapIntensityToUint8(self, I):
+    def map_intensity_to_uint8(self, I):
         """
         Return an array which, when multiplied by an image, returns that image
         mapped to the range of a uint8, [0, 255] (but not converted to uint8).
@@ -218,24 +218,24 @@ class Mapping(object):
         with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
             return np.where(I <= 0, 0, np.where(I < self._uint8Max, I, self._uint8Max))
 
-    def _convertImagesToUint8(self, imageR, imageG, imageB):
-        """Use the mapping to convert images imageR, imageG, and imageB to a triplet of uint8 images"""
-        imageR = imageR - self.minimum[0]  # n.b. makes copy
-        imageG = imageG - self.minimum[1]
-        imageB = imageB - self.minimum[2]
+    def _convert_images_to_uint8(self, image_r, image_g, image_b):
+        """Use the mapping to convert images image_r, image_g, and image_b to a triplet of uint8 images"""
+        image_r = image_r - self.minimum[0]  # n.b. makes copy
+        image_g = image_g - self.minimum[1]
+        image_b = image_b - self.minimum[2]
 
-        fac = self.mapIntensityToUint8(self.intensity(imageR, imageG, imageB))
+        fac = self.map_intensity_to_uint8(self.intensity(image_r, image_g, image_b))
 
-        imageRGB = [imageR, imageG, imageB]
-        for c in imageRGB:
+        image_rgb = [image_r, image_g, image_b]
+        for c in image_rgb:
             c *= fac
             c[c < 0] = 0                # individual bands can still be < 0, even if fac isn't
 
         pixmax = self._uint8Max
-        r0, g0, b0 = imageRGB           # copies -- could work row by row to minimise memory usage
+        r0, g0, b0 = image_rgb           # copies -- could work row by row to minimise memory usage
 
         with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
-            for i, c in enumerate(imageRGB):
+            for i, c in enumerate(image_rgb):
                 c = np.where(r0 > g0,
                              np.where(r0 > b0,
                                       np.where(r0 >= pixmax, c*pixmax/r0, c),
@@ -245,9 +245,9 @@ class Mapping(object):
                                       np.where(b0 >= pixmax, c*pixmax/b0, c))).astype(np.uint8)
                 c[c > pixmax] = pixmax
 
-                imageRGB[i] = c
+                image_rgb[i] = c
 
-        return imageRGB
+        return image_rgb
 
 
 class LinearMapping(Mapping):
@@ -285,7 +285,7 @@ class LinearMapping(Mapping):
                 raise ValueError("minimum and maximum values must not be equal")
             self._range = float(maximum - minimum)
 
-    def mapIntensityToUint8(self, I):
+    def map_intensity_to_uint8(self, I):
         with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
             return np.where(I <= 0, 0,
                             np.where(I >= self._range, self._uint8Max/I, self._uint8Max/self._range))
@@ -302,18 +302,18 @@ class AsinhMapping(Mapping):
     See http://adsabs.harvard.edu/abs/2004PASP..116..133L
     """
 
-    def __init__(self, minimum, dataRange, Q=8):
+    def __init__(self, minimum, data_range, Q=8):
         """
-        asinh stretch from minimum to minimum + dataRange, scaled by Q, via:
-            x = asinh(Q (I - minimum)/dataRange)/Q
+        asinh stretch from minimum to minimum + data_range, scaled by Q, via:
+            x = asinh(Q (I - minimum)/data_range)/Q
 
         Parameters
         ----------
 
         minimum : float
             Intensity that should be mapped to black (a scalar or array for R, G, B).
-        dataRange : float
-            minimum+dataRange defines the white level of the image.
+        data_range : float
+            minimum+data_range defines the white level of the image.
         Q : float
             The asinh softening parameter.
         """
@@ -330,9 +330,9 @@ class AsinhMapping(Mapping):
         frac = 0.1                  # gradient estimated using frac*range is _slope
         self._slope = frac*self._uint8Max/np.arcsinh(frac*Q)
 
-        self._soften = Q/float(dataRange)
+        self._soften = Q/float(data_range)
 
-    def mapIntensityToUint8(self, I):
+    def map_intensity_to_uint8(self, I):
         with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
             return np.where(I <= 0, 0, np.arcsinh(I*self._soften)*self._slope/I)
 
@@ -401,76 +401,78 @@ class AsinhZScaleMapping(AsinhMapping):
 
         zscale_limits = ZScaleInterval().get_limits(image)
         zscale = LinearMapping(*zscale_limits, image=image)
-        dataRange = zscale.maximum - zscale.minimum[0]  # zscale.minimum is always a triple
+        data_range = zscale.maximum - zscale.minimum[0]  # zscale.minimum is always a triple
         minimum = zscale.minimum
 
         for i, level in enumerate(pedestal):
             minimum[i] += level
 
-        AsinhMapping.__init__(self, minimum, dataRange, Q)
+        AsinhMapping.__init__(self, minimum, data_range, Q)
         self._image = image
 
 
-def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
-            saturatedBorderWidth=0, saturatedPixelValue=None,
-            xSize=None, ySize=None, rescaleFactor=None,
-            fileName=None):
+def make_rgb(image_r, image_g=None, image_b=None, minimum=0, data_range=5, Q=8,
+             saturated_border_width=0, saturated_pixel_value=None,
+             x_size=None, y_size=None, rescale=None,
+             filename=None):
     """
     Make an RGB color image from 3 images using an asinh stretch.
 
     Parameters
     ----------
 
-    imageR : `~numpy.ndarray`
+    image_r : `~numpy.ndarray`
         Image to map to red (if None, use the image passed to the constructor).
-    imageG : `~numpy.ndarray`
-        Image to map to green (if None, use imageR).
-    imageB : `~numpy.ndarray`
-        Image to map to blue (if None, use imageR).
+    image_g : `~numpy.ndarray`
+        Image to map to green (if None, use image_r).
+    image_b : `~numpy.ndarray`
+        Image to map to blue (if None, use image_r).
     minimum : float
         Intensity that should be mapped to black (a scalar or array for R, G, B).
-    dataRange : float
-        minimum+dataRange defines the white level of the image.
+    data_range : float
+        minimum+data_range defines the white level of the image.
     Q : float
         The asinh softening parameter.
-    saturatedBorderWidth : int
-        If saturatedBorderWidth is non-zero, replace saturated pixels with saturatedPixelValue.
+    saturated_border_width : int
+        If saturated_border_width is non-zero, replace saturated pixels with saturated_pixel_value.
         Note that replacing saturated pixels requires that the input images be MaskedImages.
-    saturatedPixelValue : float
+    saturated_pixel_value : float
         Value to replace saturated pixels with.
-    xSize : int
-        Desired width of RGB image (or None).  If ySize is None, preserve aspect ratio.
-    ySize : int
+    x_size : int
+        Desired width of RGB image (or None).  If y_size is None, preserve aspect ratio.
+    y_size : int
         Desired height of RGB image (or None).
-    rescaleFactor : float
-        Make size of output image rescaleFactor*size of the input image.
-        Cannot be specified if xSize or ySize are given.
+    rescale : float
+        Make size of output image rescale*size of the input image.
+        Cannot be specified if x_size or y_size are given.
+    filename: str
+        Write the resulting RGB image to a file (file type determined frome extension).
 
     Returns
     -------
     rgb : `~numpy.ndarray`
         RGB color image.
     """
-    imageR = np.asarray(imageR)
-    if imageG is None:
-        imageG = np.asarray(imageR)
-    if imageB is None:
-        imageB = imageR
+    image_r = np.asarray(image_r)
+    if image_g is None:
+        image_g = np.asarray(image_r)
+    if image_b is None:
+        image_b = image_r
 
-    if saturatedBorderWidth:
-        if saturatedPixelValue is None:
-            raise ValueError("saturatedPixelValue must be set if "
-                             "saturatedBorderWidth is set.")
+    if saturated_border_width:
+        if saturated_pixel_value is None:
+            raise ValueError("saturated_pixel_value must be set if "
+                             "saturated_border_width is set.")
         msg = "Cannot do this until we extract replaceSaturatedPixels out of afw/display/saturated.cc"
         raise NotImplementedError(msg)
-        # replaceSaturatedPixels(imageR, imageG, imageB, saturatedBorderWidth, saturatedPixelValue)
+        # replaceSaturatedPixels(image_r, image_g, image_b, saturated_border_width, saturated_pixel_value)
 
-    asinhMap = AsinhMapping(minimum, dataRange, Q)
-    rgb = asinhMap.makeRgbImage(imageR, imageG, imageB,
-                                xSize=xSize, ySize=ySize, rescaleFactor=rescaleFactor)
+    asinhMap = AsinhMapping(minimum, data_range, Q)
+    rgb = asinhMap.make_rgb_image(image_r, image_g, image_b,
+                                  x_size=x_size, y_size=y_size, rescale=rescale)
 
-    if fileName:
+    if filename:
         import matplotlib.image
-        matplotlib.image.imsave(fileName, rgb)
+        matplotlib.image.imsave(filename, rgb)
 
     return rgb

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -327,11 +327,8 @@ class AsinhMapping(Mapping):
             if Q > Qmax:
                 Q = Qmax
 
-        if False:
-            self._slope = self._uint8Max/Q  # gradient at origin is self._slope
-        else:
-            frac = 0.1                  # gradient estimated using frac*range is _slope
-            self._slope = frac*self._uint8Max/np.arcsinh(frac*Q)
+        frac = 0.1                  # gradient estimated using frac*range is _slope
+        self._slope = frac*self._uint8Max/np.arcsinh(frac*Q)
 
         self._soften = Q/float(dataRange)
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -395,7 +395,7 @@ class AsinhZScaleMapping(AsinhMapping):
         self._image = image
 
 
-def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q=8,
+def make_lupton_rgb(image_r, image_g, image_b, minimum=0, stretch=5, Q=8,
                     x_size=None, y_size=None, rescale=None,
                     filename=None):
     """
@@ -411,9 +411,9 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q
     image_r : `~numpy.ndarray`
         Image to map to red.
     image_g : `~numpy.ndarray`
-        Image to map to green (if None, use image_r).
+        Image to map to green.
     image_b : `~numpy.ndarray`
-        Image to map to blue (if None, use image_r).
+        Image to map to blue.
     minimum : float
         Intensity that should be mapped to black (a scalar or array for R, G, B).
     stretch : float
@@ -435,12 +435,6 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q
     rgb : `~numpy.ndarray`
         RGB (integer, 8-bits per channel) color image as an NxNx3 numpy array.
     """
-    image_r = image_r
-    if image_g is None:
-        image_g = image_r
-    if image_b is None:
-        image_b = image_r
-
     asinhMap = AsinhMapping(minimum, stretch, Q)
     rgb = asinhMap.make_rgb_image(image_r, image_g, image_b,
                                   x_size=x_size, y_size=y_size, rescale=rescale)

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -96,7 +96,7 @@ class Mapping(object):
             raise ValueError("please provide 1 or 3 values for minimum.")
 
         self.minimum = minimum
-        self._image = image
+        self._image = np.asarray(image)
 
     def makeRgbImage(self, imageR=None, imageG=None, imageB=None,
                      xSize=None, ySize=None, rescaleFactor=None):
@@ -131,11 +131,18 @@ class Mapping(object):
                 raise RuntimeError("you must provide an image or pass one "
                                    "to the constructor.")
             imageR = self._image
+        else:
+            imageR = np.asarray(imageR)
 
         if imageG is None:
             imageG = imageR
+        else:
+            imageG = np.asarray(imageG)
+
         if imageB is None:
             imageB = imageR
+        else:
+            imageB = np.asarray(imageB)
 
         if xSize is not None or ySize is not None:
             if rescaleFactor is not None:
@@ -386,7 +393,6 @@ class AsinhZScaleMapping(AsinhMapping):
             if len(pedestal) != 3:
                 raise ValueError("please provide 1 or 3 pedestals.")
 
-
             image = list(image)        # needs to be mutable
             for i, im in enumerate(image):
                 if pedestal[i] != 0.0:
@@ -448,8 +454,9 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
     rgb : `~numpy.ndarray`
         RGB color image.
     """
+    imageR = np.asarray(imageR)
     if imageG is None:
-        imageG = imageR
+        imageG = np.asarray(imageR)
     if imageB is None:
         imageB = imageR
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -12,7 +12,7 @@ Example usage:
     imageB = np.random.random((100,100))
     image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
 """
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from . import ZScaleInterval

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -56,7 +56,7 @@ def compute_intensity(image_r, image_g=None, image_b=None):
     intensity = (image_r + image_g + image_b)/3.0
 
     # Repack into whatever type was passed to us
-    return np.array(intensity, dtype=image_r.dtype)
+    return np.asarray(intensity, dtype=image_r.dtype)
 
 
 class Mapping(object):
@@ -203,8 +203,8 @@ class Mapping(object):
         mapped_I : `~numpy.ndarray`
             ``I`` mapped to uint8
         """
-        with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
-            return np.where(I <= 0, 0, np.where(I < self._uint8Max, I, self._uint8Max))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            return np.clip(I, 0, self._uint8Max)
 
     def _convert_images_to_uint8(self, image_r, image_g, image_b):
         """Use the mapping to convert images image_r, image_g, and image_b to a triplet of uint8 images"""
@@ -414,7 +414,7 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q
     ----------
 
     image_r : `~numpy.ndarray`
-        Image to map to red (if None, use the image passed to the constructor).
+        Image to map to red.
     image_g : `~numpy.ndarray`
         Image to map to green (if None, use image_r).
     image_b : `~numpy.ndarray`

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -11,7 +11,6 @@ Example usage:
     imageG = np.random.random((100,100))
     imageB = np.random.random((100,100))
     image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
-    lupton_rgb.displayRGB(image)
 """
 
 import numpy as np
@@ -24,6 +23,7 @@ __all__ = ['makeRGB', 'Mapping', 'LinearMapping', 'AsinhMapping',
 
 try:
     import scipy.misc
+    scipy.misc.imresize  # checking if it exists
     HAVE_SCIPY_MISC = True
 except ImportError:
     HAVE_SCIPY_MISC = False
@@ -138,7 +138,7 @@ class Mapping(object):
 
         if size is not None:
             if not HAVE_SCIPY_MISC:
-                raise RuntimeError("Unable to rescale as scipy.misc is unavailable.")
+                raise RuntimeError("Unable to rescale as scipy.misc.imresize is unavailable.")
 
             imageR = scipy.misc.imresize(imageR, size, interp='bilinear', mode='F')
             imageG = scipy.misc.imresize(imageG, size, interp='bilinear', mode='F')

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -16,9 +16,9 @@ Example usage:
 
 import numpy as np
 
-__all__ = ['displayRGB', 'makeRGB', 'writeRGB', 'zscale',
-           'Mapping', 'LinearMapping', 'ZScaleMapping', 'AsinhMapping',
-           'AsinhZScaleMapping']
+
+__all__ = ['makeRGB', 'writeRGB', 'Mapping', 'LinearMapping',
+           'AsinhMapping', 'AsinhZScaleMapping']
 
 try:
     import scipy.misc
@@ -463,28 +463,6 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
         writeRGB(fileName, rgb)
 
     return rgb
-
-
-def displayRGB(rgb, show=True, title=None):
-    """
-    Display an rgb image using matplotlib.
-
-    Parameters
-    ----------
-    rgb : `~numpy.ndarray`
-        The RGB image to display
-    show : bool
-        If true, call `~matplotlib.pyplot.show()`
-    title : str
-        Title to use for the displayed image.
-    """
-    import matplotlib.pyplot as plt
-    plt.imshow(rgb, interpolation='nearest', origin="lower")
-    if title:
-        plt.title(title)
-    if show:
-        plt.show()
-    return plt
 
 
 def writeRGB(fileName, rgbImage):

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -1,0 +1,383 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Map 3 images produce a properly-scaled RGB image following Lupton et al. (2004).
+
+For details, see : http://adsabs.harvard.edu/abs/2004PASP..116..133L
+"""
+
+import numpy as np
+
+try:
+    import scipy.misc
+    HAVE_SCIPY_MISC = True
+except ImportError:
+    HAVE_SCIPY_MISC = False
+
+# from lsst.afw.display.displayLib import replaceSaturatedPixels, getZScale
+
+
+def compute_intensity(imageR, imageG=None, imageB=None):
+    """!Return a naive total intensity from the red, blue, and green intensities
+    \param imageR intensity of image that'll be mapped to red; or intensity if imageG and imageB are None
+    \param imageG intensity of image that'll be mapped to green; or None
+    \param imageB intensity of image that'll be mapped to blue; or None
+
+    Inputs may be MaskedImages, Images, or numpy arrays and the return is of the same type
+    """
+    if imageG is None or imageB is None:
+        assert imageG is None and imageB is None, \
+            "Please specify either a single image or red, green, and blue images"
+        return imageR
+
+    intensity = (imageR + imageG + imageB)/3.0
+
+    # Repack into whatever type was passed to us
+    return np.array(intensity, dtype=imageR.dtype)
+
+
+def zscale(image, nSamples=1000, contrast=0.25):
+    """
+    This emulates ds9's zscale feature. Returns the suggested minimum and
+    maximum values to display.
+
+    Parameters
+    ----------
+    image : `~numpy.ndarray`
+        The image to compute the scaling on.
+    nSamples :  int
+        How many samples to take when building the histogram.
+    contrast : float
+        ???
+    """
+
+    stride = image.size/nSamples
+    samples = image.flatten()[::stride]
+    samples.sort()
+    chop_size = int(0.10*len(samples))
+    subset = samples[chop_size:-chop_size]
+
+    i_midpoint = int(len(subset)/2)
+    I_mid = subset[i_midpoint]
+
+    fit = np.polyfit(np.arange(len(subset)) - i_midpoint, subset, 1)
+    # fit = [ slope, intercept]
+
+    z1 = I_mid + fit[0]/contrast * (1-i_midpoint)/1.0
+    z2 = I_mid + fit[0]/contrast * (len(subset)-i_midpoint)/1.0
+    return z1, z2
+
+
+class Mapping(object):
+    """!Baseclass to map red, blue, green intensities into uint8 values"""
+
+    def __init__(self, minimum=None, image=None):
+        """!Create a mapping
+        \param minimum  Intensity that should be mapped to black (a scalar or array for R, G, B)
+        \param image The image to be used to calculate the mapping.
+
+        If provided, also the default for makeRgbImage()
+        """
+        self._uint8Max = float(np.iinfo(np.uint8).max)
+
+        try:
+            len(minimum)
+        except:
+            minimum = 3*[minimum]
+        assert len(minimum) == 3, "Please provide 1 or 3 values for minimum"
+
+        self.minimum = minimum
+        self._image = image
+
+    def makeRgbImage(self, imageR=None, imageG=None, imageB=None,
+                     xSize=None, ySize=None, rescaleFactor=None):
+        """!Convert 3 arrays, imageR, imageG, and imageB into a numpy RGB image
+        \param imageR Image to map to red (if None, use the image passed to the constructor)
+        \param imageG Image to map to green (if None, use imageR)
+        \param imageB Image to map to blue (if None, use imageR)
+        \param xSize  Desired width of RGB image (or None).  If ySize is None, preserve aspect ratio.
+        \param ySize  Desired height of RGB image (or None)
+        \param rescaleFactor Make size of output image rescaleFactor*size of the input image (or None)
+        """
+        if imageR is None:
+            if self._image is None:
+                raise RuntimeError("You must provide an image (or pass one to the constructor)")
+            imageR = self._image
+
+        if imageG is None:
+            imageG = imageR
+        if imageB is None:
+            imageB = imageR
+
+        imageRGB = [imageR, imageG, imageB]
+
+        if xSize is not None or ySize is not None:
+            assert rescaleFactor is None, "You may not specify a size and rescaleFactor"
+            h, w = imageRGB[0].shape
+            if ySize is None:
+                ySize = int(xSize*h/float(w) + 0.5)
+            elif xSize is None:
+                xSize = int(ySize*w/float(h) + 0.5)
+
+            # need to cast to int when passing tuple to imresize.
+            size = (int(ySize), int(xSize))  # n.b. y, x order for scipy
+        elif rescaleFactor is not None:
+            size = float(rescaleFactor)  # a float is intepreted as a percentage
+        else:
+            size = None
+
+        if size is not None:
+            if not HAVE_SCIPY_MISC:
+                raise RuntimeError("Unable to rescale as scipy.misc is unavailable.")
+
+            for i, im in enumerate(imageRGB):
+                imageRGB[i] = scipy.misc.imresize(im, size, interp='bilinear', mode='F')
+
+        return np.dstack(self._convertImagesToUint8(*imageRGB)).astype(np.uint8)
+
+    def intensity(self, imageR, imageG, imageB):
+        """!Return the total intensity from the red, blue, and green intensities
+
+        This is a naive computation, and may be overridden by subclasses
+        """
+        return compute_intensity(imageR, imageG, imageB)
+
+    def mapIntensityToUint8(self, I):
+        """Map an intensity into the range of a uint8, [0, 255] (but not converted to uint8)"""
+        with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
+            return np.where(I <= 0, 0, np.where(I < self._uint8Max, I, self._uint8Max))
+
+    def _convertImagesToUint8(self, imageR, imageG, imageB):
+        """Use the mapping to convert images imageR, imageG, and imageB to a triplet of uint8 images"""
+        imageR = imageR - self.minimum[0]  # n.b. makes copy
+        imageG = imageG - self.minimum[1]
+        imageB = imageB - self.minimum[2]
+
+        fac = self.mapIntensityToUint8(self.intensity(imageR, imageG, imageB))
+
+        imageRGB = [imageR, imageG, imageB]
+        for c in imageRGB:
+            c *= fac
+            c[c < 0] = 0                # individual bands can still be < 0, even if fac isn't
+
+        pixmax = self._uint8Max
+        r0, g0, b0 = imageRGB           # copies -- could work row by row to minimise memory usage
+
+        with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
+            for i, c in enumerate(imageRGB):
+                c = np.where(r0 > g0,
+                             np.where(r0 > b0,
+                                      np.where(r0 >= pixmax, c*pixmax/r0, c),
+                                      np.where(b0 >= pixmax, c*pixmax/b0, c)),
+                             np.where(g0 > b0,
+                                      np.where(g0 >= pixmax, c*pixmax/g0, c),
+                                      np.where(b0 >= pixmax, c*pixmax/b0, c))).astype(np.uint8)
+                c[c > pixmax] = pixmax
+
+                imageRGB[i] = c
+
+        return imageRGB
+
+
+class LinearMapping(Mapping):
+    """!A linear map map of red, blue, green intensities into uint8 values"""
+
+    def __init__(self, minimum=None, maximum=None, image=None):
+        """!A linear stretch from [minimum, maximum]; if one or both are omitted use image minimum/maximum to set them
+
+        \param minimum  Intensity that should be mapped to black (a scalar or array for R, G, B)
+        \param maximum  Intensity that should be mapped to white (a scalar)
+        """
+
+        if minimum is None or maximum is None:
+            assert image is not None, "You must provide an image if you don't set both minimum and maximum"
+
+            if minimum is None:
+                minimum = image.min()
+            if maximum is None:
+                maximum = image.max()
+
+        Mapping.__init__(self, minimum, image)
+        self.maximum = maximum
+
+        if maximum is None:
+            self._range = None
+        else:
+            assert maximum - minimum != 0, "minimum and maximum values must not be equal"
+            self._range = float(maximum - minimum)
+
+    def mapIntensityToUint8(self, I):
+        """Return an array which, when multiplied by an image, returns that image mapped to the range of a
+        uint8, [0, 255] (but not converted to uint8)
+
+        The intensity is assumed to have had minimum subtracted (as that can be done per-band)
+        """
+        with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
+            return np.where(I <= 0, 0,
+                            np.where(I >= self._range, self._uint8Max/I, self._uint8Max/self._range))
+
+
+class ZScaleMapping(LinearMapping):
+    """!A mapping for a linear stretch chosen by the zscale algorithm
+    (preserving colours independent of brightness)
+
+    x = (I - minimum)/range
+    """
+
+    def __init__(self, image, nSamples=1000, contrast=0.25):
+        """!A linear stretch from [z1, z2] chosen by the zscale algorithm
+        \param nSamples The number of samples to use to estimate the zscale parameters
+        \param contrast The number of samples to use to estimate the zscale parameters
+        """
+
+        z1, z2 = zscale(image, nSamples, contrast)
+        LinearMapping.__init__(self, z1, z2, image)
+
+
+class AsinhMapping(Mapping):
+    """!A mapping for an asinh stretch (preserving colours independent of brightness)
+
+    x = asinh(Q (I - minimum)/range)/Q
+
+    This reduces to a linear stretch if Q == 0
+
+    See http://adsabs.harvard.edu/abs/2004PASP..116..133L
+    """
+
+    def __init__(self, minimum, dataRange, Q=8):
+        Mapping.__init__(self, minimum)
+
+        epsilon = 1.0/2**23            # 32bit floating point machine epsilon; sys.float_info.epsilon is 64bit
+        if abs(Q) < epsilon:
+            Q = 0.1
+        else:
+            Qmax = 1e10
+            if Q > Qmax:
+                Q = Qmax
+
+        if False:
+            self._slope = self._uint8Max/Q  # gradient at origin is self._slope
+        else:
+            frac = 0.1                  # gradient estimated using frac*range is _slope
+            self._slope = frac*self._uint8Max/np.arcsinh(frac*Q)
+
+        self._soften = Q/float(dataRange)
+
+    def mapIntensityToUint8(self, I):
+        """Return an array which, when multiplied by an image, returns that image mapped to the range of a
+        uint8, [0, 255] (but not converted to uint8)
+
+        The intensity is assumed to have had minimum subtracted (as that can be done per-band)
+        """
+        with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
+            return np.where(I <= 0, 0, np.arcsinh(I*self._soften)*self._slope/I)
+
+
+class AsinhZScaleMapping(AsinhMapping):
+    """!A mapping for an asinh stretch, estimating the linear stretch by zscale
+
+    x = asinh(Q (I - z1)/(z2 - z1))/Q
+
+    See AsinhMapping
+    """
+
+    def __init__(self, image1, image2=None, image3=None, Q=8, pedestal=None):
+        """!
+        Create an asinh mapping from an image, setting the linear part of the stretch using zscale.
+
+        \param image1 The image to analyse,
+         # or a list of 3 images to be converted to an intensity image
+        \param image2 the second image to analyse (must be specified with image3)
+        \param image3 the third image to analyse (must be specified with image2)
+        \param Q The asinh softening parameter
+        \param pedestal The value, or array of 3 values, to subtract from the images; or None
+
+        N.b. pedestal, if not None, is removed from the images when calculating the zscale
+        stretch, and added back into Mapping.minimum[]
+        """
+
+        if image2 is None or image3 is None:
+            assert image2 is None and image3 is None, "Please specify either a single image or three images"
+            image = [image1]
+        else:
+            image = [image1, image2, image3]
+
+        if pedestal is not None:
+            try:
+                assert len(pedestal) in (1, 3,), "Please provide 1 or 3 pedestals"
+            except TypeError:
+                pedestal = 3*[pedestal]
+
+            image = list(image)        # needs to be mutable
+            for i, im in enumerate(image):
+                if pedestal[i] != 0.0:
+                    image[i] = im - pedestal[i]  # n.b. a copy
+        else:
+            pedestal = len(image)*[0.0]
+
+        image = compute_intensity(*image)
+
+        zscale = ZScaleMapping(image)
+        dataRange = zscale.maximum - zscale.minimum[0]  # zscale.minimum is always a triple
+        minimum = zscale.minimum
+
+        for i, level in enumerate(pedestal):
+            minimum[i] += level
+
+        AsinhMapping.__init__(self, minimum, dataRange, Q)
+        self._image = image             # support self.makeRgbImage()
+
+
+def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8, fileName=None,
+            saturatedBorderWidth=0, saturatedPixelValue=None,
+            xSize=None, ySize=None, rescaleFactor=None):
+    """Make a set of three images into an RGB image using an asinh stretch and optionally write it to disk
+
+    If saturatedBorderWidth is non-zero, replace saturated pixels with saturatedPixelValue.  Note
+    that replacing saturated pixels requires that the input images be MaskedImages.
+    """
+    if imageG is None:
+        imageG = imageR
+    if imageB is None:
+        imageB = imageR
+
+    if saturatedBorderWidth:
+        if saturatedPixelValue is None:
+            raise ValueError("saturatedPixelValue must be set if saturatedBorderWidth is set")
+        msg = "Cannot do this until we extract replaceSaturatedPixels out of afw/display/saturated.cc"
+        raise NotImplementedError(msg)
+        # replaceSaturatedPixels(imageR, imageG, imageB, saturatedBorderWidth, saturatedPixelValue)
+
+    asinhMap = AsinhMapping(minimum, dataRange, Q)
+    rgb = asinhMap.makeRgbImage(imageR, imageG, imageB,
+                                xSize=xSize, ySize=ySize, rescaleFactor=rescaleFactor)
+
+    if fileName:
+        writeRGB(fileName, rgb)
+
+    return rgb
+
+
+def displayRGB(rgb, show=True):
+    """!Display an rgb image using matplotlib
+    \param rgb  The RGB image in question
+    \param show If true, call plt.show()
+    """
+    import matplotlib.pyplot as plt
+    plt.imshow(rgb, interpolation='nearest', origin="lower")
+    if show:
+        plt.show()
+    return plt
+
+
+def writeRGB(fileName, rgbImage):
+    """!Write an RGB image to disk
+    \param fileName The output file.  The suffix defines the format, and must be supported by matplotlib
+    \param rgbImage The image, as made by e.g. makeRGB
+
+    Most versions of matplotlib support png and pdf (although the eps/pdf/svg writers may be buggy,
+    possibly due an interaction with useTeX=True in the matplotlib settings).
+
+    If your matplotlib bundles pil/pillow you should also be able to write jpeg and tiff files.
+    """
+    import matplotlib.image
+    matplotlib.image.imsave(fileName, rgbImage)

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -10,7 +10,7 @@ Example usage:
     image_r = np.random.random((100,100))
     image_g = np.random.random((100,100))
     image_b = np.random.random((100,100))
-    image = lupton_rgb.make_rgb(image_r, image_g, image_b, filename='randoms.png')
+    image = lupton_rgb.make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -18,7 +18,7 @@ import numpy as np
 from . import ZScaleInterval
 
 
-__all__ = ['make_rgb', 'Mapping', 'LinearMapping', 'AsinhMapping',
+__all__ = ['make_lupton_rgb', 'Mapping', 'LinearMapping', 'AsinhMapping',
            'AsinhZScaleMapping']
 
 
@@ -411,10 +411,10 @@ class AsinhZScaleMapping(AsinhMapping):
         self._image = image
 
 
-def make_rgb(image_r, image_g=None, image_b=None, minimum=0, data_range=5, Q=8,
-             saturated_border_width=0, saturated_pixel_value=None,
-             x_size=None, y_size=None, rescale=None,
-             filename=None):
+def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, data_range=5, Q=8,
+                    saturated_border_width=0, saturated_pixel_value=None,
+                    x_size=None, y_size=None, rescale=None,
+                    filename=None):
     """
     Make an RGB color image from 3 images using an asinh stretch.
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -86,7 +86,7 @@ def zscale(image, nSamples=1000, contrast=0.25):
 
 
 class Mapping(object):
-    """!Baseclass to map red, blue, green intensities into uint8 values"""
+    """Baseclass to map red, blue, green intensities into uint8 values"""
 
     def __init__(self, minimum=None, image=None):
         """
@@ -344,7 +344,7 @@ class AsinhZScaleMapping(AsinhMapping):
     """
 
     def __init__(self, image1, image2=None, image3=None, Q=8, pedestal=None):
-        """!
+        """
         Create an asinh mapping from an image, setting the linear part of the
         stretch using zscale.
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -18,8 +18,7 @@ import numpy as np
 from . import ZScaleInterval
 
 
-__all__ = ['make_lupton_rgb', 'Mapping', 'LinearMapping', 'AsinhMapping',
-           'AsinhZScaleMapping']
+__all__ = ['make_lupton_rgb']
 
 
 try:

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -16,6 +16,10 @@ Example usage:
 
 import numpy as np
 
+__all__ = ['displayRGB', 'makeRGB', 'writeRGB', 'zscale',
+           'Mapping', 'LinearMapping', 'ZScaleMapping', 'AsinhMapping',
+           'AsinhZScaleMapping']
+
 try:
     import scipy.misc
     HAVE_SCIPY_MISC = True
@@ -341,6 +345,7 @@ class AsinhZScaleMapping(AsinhMapping):
     x = asinh(Q (I - z1)/(z2 - z1))/Q
 
     See AsinhMapping
+
     """
 
     def __init__(self, image1, image2=None, image3=None, Q=8, pedestal=None):

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -17,8 +17,9 @@ Example usage:
 import numpy as np
 
 
-__all__ = ['makeRGB', 'writeRGB', 'Mapping', 'LinearMapping',
-           'AsinhMapping', 'AsinhZScaleMapping']
+__all__ = ['makeRGB', 'Mapping', 'LinearMapping', 'AsinhMapping',
+           'AsinhZScaleMapping']
+
 
 try:
     import scipy.misc
@@ -460,31 +461,7 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
                                 xSize=xSize, ySize=ySize, rescaleFactor=rescaleFactor)
 
     if fileName:
-        writeRGB(fileName, rgb)
+        import matplotlib.image
+        matplotlib.image.imsave(fileName, rgb)
 
     return rgb
-
-
-def writeRGB(fileName, rgbImage):
-    """
-    Write an RGB image to disk.
-
-    Parameters
-    ----------
-    fileName : str
-        The output file.  The extension defines the format, and must be
-        supported by `~matplotlib.imsave()`.
-    rgbImage : `~numpy.ndarray`
-        The RGB image to save.
-
-    Notes
-    -----
-    Most versions of matplotlib support png and pdf (although the
-    eps/pdf/svg writers may be buggy, possibly due an interaction with
-    useTeX=True in the matplotlib settings).
-
-    If your matplotlib bundles pil/pillow you should also be able to write
-    jpeg and tiff files.
-    """
-    import matplotlib.image
-    matplotlib.image.imsave(fileName, rgbImage)

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -2,15 +2,9 @@
 """
 Combine 3 images to produce a properly-scaled RGB image following Lupton et al. (2004).
 
-For details, see : http://adsabs.harvard.edu/abs/2004PASP..116..133L
-
 The three images must be aligned and have the same pixel scale and size.
 
-Example usage:
-    image_r = np.random.random((100,100))
-    image_g = np.random.random((100,100))
-    image_b = np.random.random((100,100))
-    image = lupton_rgb.make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
+For details, see : http://adsabs.harvard.edu/abs/2004PASP..116..133L
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -52,11 +46,6 @@ def compute_intensity(image_r, image_g=None, image_b=None):
     intensity : `~numpy.ndarray`
         Total intensity from the red, blue and green intensities, or ``image_r``
         if green and blue images are not provided.
-
-    Notes
-    -----
-    Inputs may be MaskedImages, Images, or numpy arrays and the return is
-    of the same type.
     """
     if image_g is None or image_b is None:
         if not (image_g is None and image_b is None):
@@ -100,7 +89,7 @@ class Mapping(object):
     def make_rgb_image(self, image_r=None, image_g=None, image_b=None,
                        x_size=None, y_size=None, rescale=None):
         """
-        Convert 3 arrays, image_r, image_g, and image_b into a numpy RGB image.
+        Convert 3 arrays, image_r, image_g, and image_b into an 8-bit RGB image.
 
         Parameters
         ----------
@@ -123,7 +112,7 @@ class Mapping(object):
         Returns
         -------
         RGBimage : `~numpy.ndarray`
-            An image formed by stacking the input images.
+            RGB (integer, 8-bits per channel) color image as an NxNx3 numpy array.
         """
         if image_r is None:
             if self._image is None:
@@ -415,7 +404,11 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, data_range=5
                     x_size=None, y_size=None, rescale=None,
                     filename=None):
     """
-    Make an RGB color image from 3 images using an asinh stretch.
+    Return a Red/Green/Blue color image from up to 3 images using an asinh stretch.
+    The input images can be int or float, and in any range or bit-depth.
+
+    For a more detailed look at the use of this method, see the document
+    :ref:`astropy-visualization-rgb`.
 
     Parameters
     ----------
@@ -434,7 +427,6 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, data_range=5
         The asinh softening parameter.
     saturated_border_width : int
         If saturated_border_width is non-zero, replace saturated pixels with saturated_pixel_value.
-        Note that replacing saturated pixels requires that the input images be MaskedImages.
     saturated_pixel_value : float
         Value to replace saturated pixels with.
     x_size : int
@@ -450,11 +442,11 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, data_range=5
     Returns
     -------
     rgb : `~numpy.ndarray`
-        RGB color image.
+        RGB (integer, 8-bits per channel) color image as an NxNx3 numpy array.
     """
-    image_r = np.asarray(image_r)
+    image_r = image_r
     if image_g is None:
-        image_g = np.asarray(image_r)
+        image_g = image_r
     if image_b is None:
         image_b = image_r
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -31,14 +31,17 @@ def compute_intensity(imageR, imageG=None, imageB=None):
 
     Parameters
     ----------
-
     imageR : `~numpy.ndarray`
         Intensity of image to be mapped to red; or total intensity if imageG and
         imageB are None.
-    imageG : `~numpy.ndarray`
-        Intensity of image to be mapped to green; or None.
-    imageB : `~numpy.ndarray`
-        Intensity of image to be mapped to blue; or None.
+    imageG : `~numpy.ndarray`, optional
+        Intensity of image to be mapped to green.
+    imageB : `~numpy.ndarray`, optional
+        Intensity of image to be mapped to blue.
+
+    Notes
+    -----
+    Inputs may be MaskedImages, Images, or numpy arrays and the return is of the same type.
     """
     if imageG is None or imageB is None:
         assert imageG is None and imageB is None, \
@@ -62,9 +65,9 @@ def zscale(image, nSamples=1000, contrast=0.25):
     ----------
     image : `~numpy.ndarray`
         The image to compute the scaling on.
-    nSamples :  int
-        How many samples to take when building the histogram.
-    contrast : float
+    nSamples :  int, optional
+        How many samples to take when building the histogram. Default is 1000.
+    contrast : float, optional
         ???
     """
 
@@ -86,18 +89,17 @@ def zscale(image, nSamples=1000, contrast=0.25):
 
 
 class Mapping(object):
-    """Baseclass to map red, blue, green intensities into uint8 values"""
+    """Baseclass to map red, blue, green intensities into uint8 values."""
 
     def __init__(self, minimum=None, image=None):
         """
-        Create a mapping
+        Create a mapping.
 
         Parameters
         ----------
-
         minimum : float or sequence(3)
             Intensity that should be mapped to black (a scalar or array for R, G, B).
-        image : `~numpy.ndarray`
+        image : `~numpy.ndarray`, optional
             The image to be used to calculate the mapping.
             If provided, it is also used as the default for makeRgbImage().
         """
@@ -105,7 +107,7 @@ class Mapping(object):
 
         try:
             len(minimum)
-        except:
+        except TypeError:
             minimum = 3*[minimum]
         assert len(minimum) == 3, "Please provide 1 or 3 values for minimum"
 
@@ -119,19 +121,19 @@ class Mapping(object):
 
         Parameters
         ----------
-
-        imageR : `~numpy.ndarray`
-            Image to map to red (if None, use the image passed to the constructor).
-        imageG : `~numpy.ndarray`
+        imageR : `~numpy.ndarray`, optional
+            Image to map to red (if None, use the image passed to the
+            constructor).
+        imageG : `~numpy.ndarray`, optional
             Image to map to green (if None, use imageR).
-        imageB : `~numpy.ndarray`
+        imageB : `~numpy.ndarray`, optional
             Image to map to blue (if None, use imageR).
-        xSize : int
+        xSize : int, optional
             Desired width of RGB image (or None).  If ySize is None, preserve
             aspect ratio.
-        ySize : int
+        ySize : int, optional
             Desired height of RGB image (or None).
-        rescaleFactor : float
+        rescaleFactor : float, optional
             Make size of output image rescaleFactor*size of the input image.
             Cannot be specified if xSize or ySize are given.
         """
@@ -230,7 +232,6 @@ class LinearMapping(Mapping):
 
         Parameters
         ----------
-
         minimum : float
             Intensity that should be mapped to black (a scalar or array for R, G, B).
         maximum : float
@@ -274,7 +275,6 @@ class ZScaleMapping(LinearMapping):
 
         Parameters
         ----------
-
         nSamples : int
             The number of samples to use to estimate the zscale parameters.
         contrast : float
@@ -350,20 +350,23 @@ class AsinhZScaleMapping(AsinhMapping):
 
         Parameters
         ----------
-
-        image1 : `~numpy.ndarray`
-            The image to analyse,
-         # or a list of 3 images to be converted to an intensity image.
-        image2 : `~numpy.ndarray`
+        image1 : `~numpy.ndarray` or a list of arrays
+            The image to analyse, or a list of 3 images to be converted to
+            an intensity image.
+        image2 : `~numpy.ndarray`, optional
             the second image to analyse (must be specified with image3).
-        image3 : `~numpy.ndarray`
+        image3 : `~numpy.ndarray`, optional
             the third image to analyse (must be specified with image2).
-        Q : float
-            The asinh softening parameter.
-        pedestal : float or sequence(3)
+        Q : float, optional
+            The asinh softening parameter. Default is 8.
+        pedestal : float or sequence(3), optional
             The value, or array of 3 values, to subtract from the images; or None.
-            pedestal, if not None, is removed from the images when calculating
-            the zscale stretch, and added back into Mapping.minimum.
+
+        Notes
+        -----
+        N.b. pedestal, if not None, is removed from the images when
+        calculating the zscale stretch, and added back into
+        Mapping.minimum[]
         """
 
         if image2 is None or image3 is None:
@@ -461,11 +464,10 @@ def displayRGB(rgb, show=True, title=None):
 
     Parameters
     ----------
-
     rgb : `~numpy.ndarray`
         The RGB image to display
     show : bool
-        If true, call plt.show()
+        If true, call `~matplotlib.pyplot.show()`
     title : str
         Title to use for the displayed image.
     """
@@ -482,21 +484,22 @@ def writeRGB(fileName, rgbImage):
     """
     Write an RGB image to disk.
 
-    Most versions of matplotlib support png and pdf (although the eps/pdf/svg
-    writers may be buggy, possibly due an interaction with useTeX=True in the
-    matplotlib settings).
-
-    If your matplotlib bundles pil/pillow you should also be able to write jpeg
-    and tiff files.
-
     Parameters
     ----------
-
     fileName : str
         The output file.  The extension defines the format, and must be
-        supported by matplotlib.imsave().
+        supported by `~matplotlib.imsave()`.
     rgbImage : `~numpy.ndarray`
         The RGB image to save.
+
+    Notes
+    -----
+    Most versions of matplotlib support png and pdf (although the
+    eps/pdf/svg writers may be buggy, possibly due an interaction with
+    useTeX=True in the matplotlib settings).
+
+    If your matplotlib bundles pil/pillow you should also be able to write
+    jpeg and tiff files.
     """
     import matplotlib.image
     matplotlib.image.imsave(fileName, rgbImage)

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -59,8 +59,7 @@ class Mapping(object):
         minimum : float or sequence(3)
             Intensity that should be mapped to black (a scalar or array for R, G, B).
         image : `~numpy.ndarray`, optional
-            The image to be used to calculate the mapping.
-            If provided, it is also used as the default for make_rgb_image().
+            An image used to calculate some parameters of sopme mappings.
         """
         self._uint8Max = float(np.iinfo(np.uint8).max)
 
@@ -74,41 +73,27 @@ class Mapping(object):
         self.minimum = minimum
         self._image = np.asarray(image)
 
-    def make_rgb_image(self, image_r=None, image_g=None, image_b=None):
+    def make_rgb_image(self, image_r, image_g, image_b):
         """
         Convert 3 arrays, image_r, image_g, and image_b into an 8-bit RGB image.
 
         Parameters
         ----------
-        image_r : `~numpy.ndarray`, optional
-            Image to map to red (if None, use the image passed to the
-            constructor).
-        image_g : `~numpy.ndarray`, optional
-            Image to map to green (if None, use image_r).
-        image_b : `~numpy.ndarray`, optional
-            Image to map to blue (if None, use image_r).
+        image_r : `~numpy.ndarray`
+            Image to map to red.
+        image_g : `~numpy.ndarray`
+            Image to map to green.
+        image_b : `~numpy.ndarray`
+            Image to map to blue.
 
         Returns
         -------
         RGBimage : `~numpy.ndarray`
             RGB (integer, 8-bits per channel) color image as an NxNx3 numpy array.
         """
-        if image_r is None:
-            if self._image is None:
-                raise ValueError("you must provide an image or pass one to the constructor.")
-            image_r = self._image
-        else:
-            image_r = np.asarray(image_r)
-
-        if image_g is None:
-            image_g = image_r
-        else:
-            image_g = np.asarray(image_g)
-
-        if image_b is None:
-            image_b = image_r
-        else:
-            image_b = np.asarray(image_b)
+        image_r = np.asarray(image_r)
+        image_g = np.asarray(image_g)
+        image_b = np.asarray(image_b)
 
         if (image_r.shape != image_g.shape) or (image_g.shape != image_b.shape):
             msg = "The image shapes must match. r: {}, g: {} b: {}"

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -41,16 +41,23 @@ def compute_intensity(imageR, imageG=None, imageB=None):
     Parameters
     ----------
     imageR : `~numpy.ndarray`
-        Intensity of image to be mapped to red; or total intensity if imageG and
-        imageB are None.
+        Intensity of image to be mapped to red; or total intensity if ``imageG``
+        and ``imageB`` are None.
     imageG : `~numpy.ndarray`, optional
         Intensity of image to be mapped to green.
     imageB : `~numpy.ndarray`, optional
         Intensity of image to be mapped to blue.
 
+    Returns
+    -------
+    intensity : `~numpy.ndarray`
+        Total intensity from the red, blue and green intensities, or ``imageR``
+        if green and blue images are not provided.
+
     Notes
     -----
-    Inputs may be MaskedImages, Images, or numpy arrays and the return is of the same type.
+    Inputs may be MaskedImages, Images, or numpy arrays and the return is
+    of the same type.
     """
     if imageG is None or imageB is None:
         if not (imageG is None and imageB is None):
@@ -113,6 +120,11 @@ class Mapping(object):
         rescaleFactor : float, optional
             Make size of output image rescaleFactor*size of the input image.
             Cannot be specified if xSize or ySize are given.
+
+        Returns
+        -------
+        RGBimage : `~numpy.ndarray`
+            An image formed by stacking the input images.
         """
         if imageR is None:
             if self._image is None:
@@ -159,6 +171,22 @@ class Mapping(object):
         """
         Return the total intensity from the red, blue, and green intensities.
         This is a naive computation, and may be overridden by subclasses.
+
+        Parameters
+        ----------
+        imageR : `~numpy.ndarray`
+            Intensity of image to be mapped to red; or total intensity if
+            ``imageG`` and ``imageB`` are None.
+        imageG : `~numpy.ndarray`, optional
+            Intensity of image to be mapped to green.
+        imageB : `~numpy.ndarray`, optional
+            Intensity of image to be mapped to blue.
+
+        Returns
+        -------
+        intensity : `~numpy.ndarray`
+            Total intensity from the red, blue and green intensities, or
+            ``imageR`` if green and blue images are not provided.
         """
         return compute_intensity(imageR, imageG, imageB)
 
@@ -169,6 +197,16 @@ class Mapping(object):
 
         The intensity is assumed to have had minimum subtracted (as that can be
         done per-band).
+
+        Parameters
+        ----------
+        I : `~numpy.ndarray`
+            Intensity to be mapped.
+
+        Returns
+        -------
+        mapped_I : `~numpy.ndarray`
+            ``I`` mapped to uint8
         """
         with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
             return np.where(I <= 0, 0, np.where(I < self._uint8Max, I, self._uint8Max))
@@ -404,6 +442,11 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
     rescaleFactor : float
         Make size of output image rescaleFactor*size of the input image.
         Cannot be specified if xSize or ySize are given.
+
+    Returns
+    -------
+    rgb : `~numpy.ndarray`
+        RGB color image.
     """
     if imageG is None:
         imageG = imageR

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -22,10 +22,6 @@ try:
 except (ImportError, AttributeError):
     HAVE_SCIPY_MISC = False
 
-# NOTE: these methods would have come from LSST C++ code. They won't be available
-# in astropy until they are converted somehow.
-# from lsst.afw.display.displayLib import replaceSaturatedPixels, getZScale
-
 
 def compute_intensity(image_r, image_g=None, image_b=None):
     """
@@ -400,7 +396,6 @@ class AsinhZScaleMapping(AsinhMapping):
 
 
 def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q=8,
-                    saturated_border_width=0, saturated_pixel_value=None,
                     x_size=None, y_size=None, rescale=None,
                     filename=None):
     """
@@ -425,10 +420,6 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q
         The linear stretch of the image.
     Q : float
         The asinh softening parameter.
-    saturated_border_width : int
-        If saturated_border_width is non-zero, replace saturated pixels with saturated_pixel_value.
-    saturated_pixel_value : float
-        Value to replace saturated pixels with.
     x_size : int
         Desired width of RGB image (or None).  If y_size is None, preserve aspect ratio.
     y_size : int
@@ -449,14 +440,6 @@ def make_lupton_rgb(image_r, image_g=None, image_b=None, minimum=0, stretch=5, Q
         image_g = image_r
     if image_b is None:
         image_b = image_r
-
-    if saturated_border_width:
-        if saturated_pixel_value is None:
-            raise ValueError("saturated_pixel_value must be set if "
-                             "saturated_border_width is set.")
-        msg = "Cannot do this until we extract replaceSaturatedPixels out of afw/display/saturated.cc"
-        raise NotImplementedError(msg)
-        # replaceSaturatedPixels(image_r, image_g, image_b, saturated_border_width, saturated_pixel_value)
 
     asinhMap = AsinhMapping(minimum, stretch, Q)
     rgb = asinhMap.make_rgb_image(image_r, image_g, image_b,

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     HAVE_SCIPY_MISC = False
 
+# NOTE: these methods would have come from LSST C++ code. They won't be available
+# in astropy until they are converted somehow.
 # from lsst.afw.display.displayLib import replaceSaturatedPixels, getZScale
 
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -26,7 +26,7 @@ try:
     import scipy.misc
     scipy.misc.imresize  # checking if it exists
     HAVE_SCIPY_MISC = True
-except ImportError:
+except (ImportError, AttributeError):
     HAVE_SCIPY_MISC = False
 
 # NOTE: these methods would have come from LSST C++ code. They won't be available

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -48,19 +48,18 @@ def compute_intensity(image_r, image_g=None, image_b=None):
 
 
 class Mapping(object):
-    """Baseclass to map red, blue, green intensities into uint8 values."""
+    """
+    Baseclass to map red, blue, green intensities into uint8 values.
+
+    Parameters
+    ----------
+    minimum : float or sequence(3)
+        Intensity that should be mapped to black (a scalar or array for R, G, B).
+    image : `~numpy.ndarray`, optional
+        An image used to calculate some parameters of sopme mappings.
+    """
 
     def __init__(self, minimum=None, image=None):
-        """
-        Create a mapping.
-
-        Parameters
-        ----------
-        minimum : float or sequence(3)
-            Intensity that should be mapped to black (a scalar or array for R, G, B).
-        image : `~numpy.ndarray`, optional
-            An image used to calculate some parameters of sopme mappings.
-        """
         self._uint8Max = float(np.iinfo(np.uint8).max)
 
         try:
@@ -178,21 +177,21 @@ class Mapping(object):
 
 
 class LinearMapping(Mapping):
-    """A linear map map of red, blue, green intensities into uint8 values"""
+    """
+    A linear map map of red, blue, green intensities into uint8 values.
+
+    A linear stretch from [minimum, maximum].
+    If one or both are omitted use image min and/or max to set them.
+
+    Parameters
+    ----------
+    minimum : float
+        Intensity that should be mapped to black (a scalar or array for R, G, B).
+    maximum : float
+        Intensity that should be mapped to white (a scalar).
+    """
 
     def __init__(self, minimum=None, maximum=None, image=None):
-        """
-        A linear stretch from [minimum, maximum].
-        If one or both are omitted use image min and/or max to set them.
-
-        Parameters
-        ----------
-        minimum : float
-            Intensity that should be mapped to black (a scalar or array for R, G, B).
-        maximum : float
-            Intensity that should be mapped to white (a scalar).
-        """
-
         if minimum is None or maximum is None:
             if image is None:
                 raise ValueError("you must provide an image if you don't "
@@ -222,28 +221,24 @@ class AsinhMapping(Mapping):
     """
     A mapping for an asinh stretch (preserving colours independent of brightness)
 
-    x = asinh(Q (I - minimum)/range)/Q
+    x = asinh(Q (I - minimum)/stretch)/Q
 
     This reduces to a linear stretch if Q == 0
 
     See http://adsabs.harvard.edu/abs/2004PASP..116..133L
+
+    Parameters
+    ----------
+
+    minimum : float
+        Intensity that should be mapped to black (a scalar or array for R, G, B).
+    stretch : float
+        The linear stretch of the image.
+    Q : float
+        The asinh softening parameter.
     """
 
     def __init__(self, minimum, stretch, Q=8):
-        """
-        asinh stretch from minimum to minimum + stretch, scaled by Q, via:
-            x = asinh(Q (I - minimum)/stretch)/Q
-
-        Parameters
-        ----------
-
-        minimum : float
-            Intensity that should be mapped to black (a scalar or array for R, G, B).
-        stretch : float
-            The linear stretch of the image.
-        Q : float
-            The asinh softening parameter.
-        """
         Mapping.__init__(self, minimum)
 
         epsilon = 1.0/2**23            # 32bit floating point machine epsilon; sys.float_info.epsilon is 64bit
@@ -270,34 +265,28 @@ class AsinhZScaleMapping(AsinhMapping):
 
     x = asinh(Q (I - z1)/(z2 - z1))/Q
 
-    See AsinhMapping
+    Parameters
+    ----------
+    image1 : `~numpy.ndarray` or a list of arrays
+        The image to analyse, or a list of 3 images to be converted to
+        an intensity image.
+    image2 : `~numpy.ndarray`, optional
+        the second image to analyse (must be specified with image3).
+    image3 : `~numpy.ndarray`, optional
+        the third image to analyse (must be specified with image2).
+    Q : float, optional
+        The asinh softening parameter. Default is 8.
+    pedestal : float or sequence(3), optional
+        The value, or array of 3 values, to subtract from the images; or None.
 
+    Notes
+    -----
+    pedestal, if not None, is removed from the images when calculating the
+    zscale stretch, and added back into Mapping.minimum[]
     """
 
     def __init__(self, image1, image2=None, image3=None, Q=8, pedestal=None):
         """
-        Create an asinh mapping from an image, setting the linear part of the
-        stretch using zscale.
-
-        Parameters
-        ----------
-        image1 : `~numpy.ndarray` or a list of arrays
-            The image to analyse, or a list of 3 images to be converted to
-            an intensity image.
-        image2 : `~numpy.ndarray`, optional
-            the second image to analyse (must be specified with image3).
-        image3 : `~numpy.ndarray`, optional
-            the third image to analyse (must be specified with image2).
-        Q : float, optional
-            The asinh softening parameter. Default is 8.
-        pedestal : float or sequence(3), optional
-            The value, or array of 3 values, to subtract from the images; or None.
-
-        Notes
-        -----
-        N.b. pedestal, if not None, is removed from the images when
-        calculating the zscale stretch, and added back into
-        Mapping.minimum[]
         """
 
         if image2 is None or image3 is None:

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -49,7 +49,7 @@ def saturate(image, satValue):
     """
     Return image with all points above satValue set to NaN.
 
-    Simulates saturation on an image, so we can test 'replaceSaturatedPixels'
+    Simulates saturation on an image, so we can test 'replace_saturated_pixels'
     """
     result = image.copy()
     saturated = image > satValue
@@ -62,35 +62,35 @@ def random_array(dtype, N=100):
 
 
 def test_compute_intensity_1_float():
-    imageR = random_array(np.float64)
-    intensity = lupton_rgb.compute_intensity(imageR)
-    assert imageR.dtype == intensity.dtype
-    assert_equal(imageR, intensity)
+    image_r = random_array(np.float64)
+    intensity = lupton_rgb.compute_intensity(image_r)
+    assert image_r.dtype == intensity.dtype
+    assert_equal(image_r, intensity)
 
 
 def test_compute_intensity_1_uint():
-    imageR = random_array(np.uint8)
-    intensity = lupton_rgb.compute_intensity(imageR)
-    assert imageR.dtype == intensity.dtype
-    assert_equal(imageR, intensity)
+    image_r = random_array(np.uint8)
+    intensity = lupton_rgb.compute_intensity(image_r)
+    assert image_r.dtype == intensity.dtype
+    assert_equal(image_r, intensity)
 
 
 def test_compute_intensity_3_float():
-    imageR = random_array(np.float64)
-    imageG = random_array(np.float64)
-    imageB = random_array(np.float64)
-    intensity = lupton_rgb.compute_intensity(imageR, imageG, imageB)
-    assert imageR.dtype == intensity.dtype
-    assert_equal(intensity, (imageR+imageG+imageB)/3.0)
+    image_r = random_array(np.float64)
+    image_g = random_array(np.float64)
+    image_b = random_array(np.float64)
+    intensity = lupton_rgb.compute_intensity(image_r, image_g, image_b)
+    assert image_r.dtype == intensity.dtype
+    assert_equal(intensity, (image_r+image_g+image_b)/3.0)
 
 
 def test_compute_intensity_3_uint():
-    imageR = random_array(np.uint8)
-    imageG = random_array(np.uint8)
-    imageB = random_array(np.uint8)
-    intensity = lupton_rgb.compute_intensity(imageR, imageG, imageB)
-    assert imageR.dtype == intensity.dtype
-    assert_equal(intensity, (imageR+imageG+imageB)//3)
+    image_r = random_array(np.uint8)
+    image_g = random_array(np.uint8)
+    image_b = random_array(np.uint8)
+    intensity = lupton_rgb.compute_intensity(image_r, image_g, image_b)
+    assert image_r.dtype == intensity.dtype
+    assert_equal(intensity, (image_r+image_g+image_b)//3)
 
 
 class TestLuptonRgb(object):
@@ -104,9 +104,9 @@ class TestLuptonRgb(object):
     images = []
 
     shape = (width, height)
-    imageR = np.zeros(shape)
-    imageG = np.zeros(shape)
-    imageB = np.zeros(shape)
+    image_r = np.zeros(shape)
+    image_g = np.zeros(shape)
+    image_b = np.zeros(shape)
 
     # pixel locations, values and colors
     points = [[15, 15], [50, 45], [30, 30], [45, 15]]
@@ -116,9 +116,9 @@ class TestLuptonRgb(object):
 
     # Put pixels in the images.
     for p, v, gr, ri in zip(points, values, g_r, r_i):
-        imageR[p[0], p[1]] = v*pow(10, 0.4*ri)
-        imageG[p[0], p[1]] = v*pow(10, 0.4*gr)
-        imageB[p[0], p[1]] = v
+        image_r[p[0], p[1]] = v*pow(10, 0.4*ri)
+        image_g[p[0], p[1]] = v*pow(10, 0.4*gr)
+        image_b[p[0], p[1]] = v
 
     # convolve the image with a reasonable PSF, and add Gaussian background noise
     def convolve_with_noise(image, psf):
@@ -127,9 +127,9 @@ class TestLuptonRgb(object):
         return randomImage + convolvedImage
 
     psf = Gaussian2DKernel(2.5)
-    imageR = convolve_with_noise(imageR, psf)
-    imageG = convolve_with_noise(imageG, psf)
-    imageB = convolve_with_noise(imageB, psf)
+    image_r = convolve_with_noise(image_r, psf)
+    image_g = convolve_with_noise(image_g, psf)
+    image_b = convolve_with_noise(image_b, psf)
 
     def tearDown(self):
         for im in self.images:
@@ -139,23 +139,23 @@ class TestLuptonRgb(object):
     def test_Asinh(self):
         """Test creating an RGB image using an asinh stretch"""
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
-        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        rgbImage = asinhMap.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def test_AsinhZscale(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale"""
 
-        map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
-        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        map = lupton_rgb.AsinhZScaleMapping(self.image_r, self.image_g, self.image_b)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def test_AsinhZscaleIntensity(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
 
-        map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
-        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        map = lupton_rgb.AsinhZScaleMapping(self.image_r, self.image_g, self.image_b)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
@@ -164,12 +164,12 @@ class TestLuptonRgb(object):
         where the images each have a pedestal added"""
 
         pedestal = [100, 400, -400]
-        self.imageR += pedestal[0]
-        self.imageG += pedestal[1]
-        self.imageB += pedestal[2]
+        self.image_r += pedestal[0]
+        self.image_g += pedestal[1]
+        self.image_b += pedestal[2]
 
-        map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB, pedestal=pedestal)
-        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        map = lupton_rgb.AsinhZScaleMapping(self.image_r, self.image_g, self.image_b, pedestal=pedestal)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
@@ -177,45 +177,45 @@ class TestLuptonRgb(object):
         """Test creating a black-and-white image using an asinh stretch estimated
         using zscale on the intensity"""
 
-        rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
+        rgbImage = lupton_rgb.AsinhZScaleMapping(self.image_r).make_rgb_image()
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
-    def test_MakeRGB(self):
+    def test_make_rgb(self):
         """Test the function that does it all"""
         satValue = 1000.0
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            red = saturate(self.imageR, satValue)
-            green = saturate(self.imageG, satValue)
-            blue = saturate(self.imageB, satValue)
-            lupton_rgb.makeRGB(red, green, blue, self.min_, self.range_, self.Q, fileName=temp)
+            red = saturate(self.image_r, satValue)
+            green = saturate(self.image_g, satValue)
+            blue = saturate(self.image_b, satValue)
+            lupton_rgb.make_rgb(red, green, blue, self.min_, self.range_, self.Q, filename=temp)
             assert os.path.exists(temp.name)
 
-    def test_makeRGB_saturated_fix(self):
+    def test_make_rgb_saturated_fix(self):
         satValue = 1000.0
         # TODO: Cannot test with these options yet, as that part of the code is not implemented.
         with pytest.raises(NotImplementedError):
-            red = saturate(self.imageR, satValue)
-            green = saturate(self.imageG, satValue)
-            blue = saturate(self.imageB, satValue)
-            lupton_rgb.makeRGB(red, green, blue, self.min_, self.range_, self.Q,
-                               saturatedBorderWidth=1, saturatedPixelValue=2000)
+            red = saturate(self.image_r, satValue)
+            green = saturate(self.image_g, satValue)
+            blue = saturate(self.image_b, satValue)
+            lupton_rgb.make_rgb(red, green, blue, self.min_, self.range_, self.Q,
+                                saturated_border_width=1, saturated_pixel_value=2000)
 
     def test_linear(self):
         """Test using a specified linear stretch"""
 
-        rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
+        rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).make_rgb_image(self.image_r)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def test_linear_min_max(self):
         """Test using a min/max linear stretch
 
-        N.b. also checks that an image passed to the ctor is used as the default in makeRgbImage()
+        N.b. also checks that an image passed to the ctor is used as the default in make_rgb_image()
         """
 
-        rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
+        rgbImage = lupton_rgb.LinearMapping(image=self.image_r).make_rgb_image()
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
@@ -224,15 +224,15 @@ class TestLuptonRgb(object):
         pytest.skip('replaceSaturatedPixels is not implemented in astropy yet')
 
         satValue = 1000.0
-        self.imageR = saturate(self.imageR, satValue)
-        self.imageG = saturate(self.imageG, satValue)
-        self.imageB = saturate(self.imageB, satValue)
+        self.image_r = saturate(self.image_r, satValue)
+        self.image_g = saturate(self.image_g, satValue)
+        self.image_b = saturate(self.image_b, satValue)
 
-        lupton_rgb.replaceSaturatedPixels(self.imageR, self.imageG, self.imageB, 1, 2000)
+        lupton_rgb.replaceSaturatedPixels(self.image_r, self.image_g, self.image_b, 1, 2000)
         # Check that we replaced those NaNs with some reasonable value
-        assert np.isfinite(self.imageR.getImage().getArray()).all()
-        assert np.isfinite(self.imageG.getImage().getArray()).all()
-        assert np.isfinite(self.imageB.getImage().getArray()).all()
+        assert np.isfinite(self.image_r.getImage().getArray()).all()
+        assert np.isfinite(self.image_g.getImage().getArray()).all()
+        assert np.isfinite(self.image_b.getImage().getArray()).all()
 
         # Prepare for generating an output file
         # TBD: FROMAFW
@@ -241,7 +241,7 @@ class TestLuptonRgb(object):
         self.imagesR = self.imagesB.getImage()
 
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
-        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        rgbImage = asinhMap.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
@@ -249,49 +249,49 @@ class TestLuptonRgb(object):
     def test_resize_to_uint(self):
         """Test creating an RGB image of a specified size"""
 
-        xSize = self.imageR.shape[0]/2
-        ySize = self.imageR.shape[1]/2
-        imageR = np.array(self.imageR, dtype=np.uint16)
-        imageG = np.array(self.imageG, dtype=np.uint16)
-        imageB = np.array(self.imageB, dtype=np.uint16)
-        asinhZ = lupton_rgb.AsinhZScaleMapping(imageR)
-        rgbImage = asinhZ.makeRgbImage(imageR, imageG, imageB, xSize=xSize, ySize=ySize)
+        x_size = self.image_r.shape[0]/2
+        y_size = self.image_r.shape[1]/2
+        image_r = np.array(self.image_r, dtype=np.uint16)
+        image_g = np.array(self.image_g, dtype=np.uint16)
+        image_b = np.array(self.image_b, dtype=np.uint16)
+        asinhZ = lupton_rgb.AsinhZScaleMapping(image_r)
+        rgbImage = asinhZ.make_rgb_image(image_r, image_g, image_b, x_size=x_size, y_size=y_size)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def _test_resize(self, xSize=None, ySize=None, frac=None):
+    def _test_resize(self, x_size=None, y_size=None, frac=None):
         """Test creating an RGB image changing the output """
 
-        map = lupton_rgb.AsinhZScaleMapping(self.imageR)
-        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB,
-                                    xSize=xSize, ySize=ySize, rescaleFactor=frac)
+        map = lupton_rgb.AsinhZScaleMapping(self.image_r)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_g, self.image_b,
+                                      x_size=x_size, y_size=y_size, rescale=frac)
 
         # TODO: I'm not positive that I got the width/height values correct:
         # afw and numpy have different conventions!
         h, w, _ = rgbImage.shape
-        if xSize is not None:
-            assert int(xSize) == w
-        if ySize is not None:
-            assert int(ySize) == h
+        if x_size is not None:
+            assert int(x_size) == w
+        if y_size is not None:
+            assert int(y_size) == h
         if frac is not None:
-            assert int(frac*self.imageR.shape[1]) == w
-            assert int(frac*self.imageR.shape[0]) == h
+            assert int(frac*self.image_r.shape[1]) == w
+            assert int(frac*self.image_r.shape[0]) == h
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def test_resize_xSize_ySize(self):
-        self._test_resize(xSize=self.imageR.shape[0]/2, ySize=self.imageR.shape[1]/2)
+    def test_resize_x_size_y_size(self):
+        self._test_resize(x_size=self.image_r.shape[0]/2, y_size=self.image_r.shape[1]/2)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def test_resize_twice_xSize(self):
-        self._test_resize(xSize=2*self.imageR.shape[0])
+    def test_resize_twice_x_size(self):
+        self._test_resize(x_size=2*self.image_r.shape[0])
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def test_resize_half_xSize(self):
-        self._test_resize(xSize=self.imageR.shape[0]/2)
+    def test_resize_half_x_size(self):
+        self._test_resize(x_size=self.image_r.shape[0]/2)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def test_resize_half_ySize(self):
-        self._test_resize(ySize=self.imageR.shape[0]/2)
+    def test_resize_half_y_size(self):
+        self._test_resize(y_size=self.image_r.shape[0]/2)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def test_resize_frac_half(self):
@@ -303,10 +303,10 @@ class TestLuptonRgb(object):
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testMakeRGBResize(self):
+    def test_make_rgb_resize(self):
         """Test the function that does it all, including rescaling"""
-        lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, xSize=40, ySize=60)
+        lupton_rgb.make_rgb(self.image_r, self.image_g, self.image_b, x_size=40, y_size=60)
 
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, fileName=temp, rescaleFactor=0.5)
+            lupton_rgb.make_rgb(self.image_r, self.image_g, self.image_b, filename=temp, rescale=0.5)
             assert os.path.exists(temp.name)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -136,14 +136,14 @@ class TestLuptonRgb(object):
             del im
         del self.images
 
-    def testStarsAsinh(self):
+    def test_Asinh(self):
         """Test creating an RGB image using an asinh stretch"""
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def testStarsAsinhZscale(self):
+    def test_AsinhZscale(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
@@ -151,7 +151,7 @@ class TestLuptonRgb(object):
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def testStarsAsinhZscaleIntensity(self):
+    def test_AsinhZscaleIntensity(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
@@ -159,7 +159,7 @@ class TestLuptonRgb(object):
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def testStarsAsinhZscaleIntensityPedestal(self):
+    def test_AsinhZscaleIntensityPedestal(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity
         where the images each have a pedestal added"""
 
@@ -173,7 +173,7 @@ class TestLuptonRgb(object):
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def testStarsAsinhZscaleIntensityBW(self):
+    def test_AsinhZscaleIntensityBW(self):
         """Test creating a black-and-white image using an asinh stretch estimated
         using zscale on the intensity"""
 
@@ -182,7 +182,7 @@ class TestLuptonRgb(object):
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
-    def testMakeRGB(self):
+    def test_MakeRGB(self):
         """Test the function that does it all"""
         satValue = 1000.0
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
@@ -192,7 +192,7 @@ class TestLuptonRgb(object):
             lupton_rgb.makeRGB(red, green, blue, self.min_, self.range_, self.Q, fileName=temp)
             assert os.path.exists(temp.name)
 
-    def testMakeRGB_saturated_fix(self):
+    def test_makeRGB_saturated_fix(self):
         satValue = 1000.0
         # TODO: Cannot test with these options yet, as that part of the code is not implemented.
         with pytest.raises(NotImplementedError):
@@ -202,14 +202,14 @@ class TestLuptonRgb(object):
             lupton_rgb.makeRGB(red, green, blue, self.min_, self.range_, self.Q,
                                saturatedBorderWidth=1, saturatedPixelValue=2000)
 
-    def testLinear(self):
+    def test_linear(self):
         """Test using a specified linear stretch"""
 
         rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def testLinearMinMax(self):
+    def test_linear_min_max(self):
         """Test using a min/max linear stretch
 
         N.b. also checks that an image passed to the ctor is used as the default in makeRgbImage()
@@ -219,7 +219,7 @@ class TestLuptonRgb(object):
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def testSaturated(self):
+    def test_saturated(self):
         """Test interpolating saturated pixels"""
         pytest.skip('replaceSaturatedPixels is not implemented in astropy yet')
 
@@ -246,18 +246,7 @@ class TestLuptonRgb(object):
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeToSize(self):
-        """Test creating an RGB image of a specified size"""
-
-        xSize = self.imageR.shape[0]/2
-        ySize = self.imageR.shape[1]/2
-        asinhZ = lupton_rgb.AsinhZScaleMapping(self.imageR)
-        rgbImage = asinhZ.makeRgbImage(self.imageR, self.imageG, self.imageB, xSize=xSize, ySize=ySize)
-        if display:
-            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
-
-    @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeToSize_uint(self):
+    def test_resize_to_uint(self):
         """Test creating an RGB image of a specified size"""
 
         xSize = self.imageR.shape[0]/2
@@ -270,7 +259,7 @@ class TestLuptonRgb(object):
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
-    def _testStarsResizeSpecifications(self, xSize=None, ySize=None, frac=None):
+    def _test_resize(self, xSize=None, ySize=None, frac=None):
         """Test creating an RGB image changing the output """
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR)
@@ -289,28 +278,28 @@ class TestLuptonRgb(object):
             assert int(frac*self.imageR.shape[0]) == h
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeSpecificaions_xSize_ySize(self):
-        self._testStarsResizeSpecifications(xSize=self.imageR.shape[0]/2, ySize=self.imageR.shape[1]/2)
+    def test_resize_xSize_ySize(self):
+        self._test_resize(xSize=self.imageR.shape[0]/2, ySize=self.imageR.shape[1]/2)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeSpecifications_twice_xSize(self):
-        self._testStarsResizeSpecifications(xSize=2*self.imageR.shape[0])
+    def test_resize_twice_xSize(self):
+        self._test_resize(xSize=2*self.imageR.shape[0])
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeSpecifications_half_xSize(self):
-        self._testStarsResizeSpecifications(xSize=self.imageR.shape[0]/2)
+    def test_resize_half_xSize(self):
+        self._test_resize(xSize=self.imageR.shape[0]/2)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeSpecifications_half_ySize(self):
-        self._testStarsResizeSpecifications(ySize=self.imageR.shape[0]/2)
+    def test_resize_half_ySize(self):
+        self._test_resize(ySize=self.imageR.shape[0]/2)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeSpecifications_frac_half(self):
-        self._testStarsResizeSpecifications(frac=0.5)
+    def test_resize_frac_half(self):
+        self._test_resize(frac=0.5)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
-    def testStarsResizeSpecifications_frac_twice(self):
-        self._testStarsResizeSpecifications(frac=2)
+    def test_resize_frac_twice(self):
+        self._test_resize(frac=2)
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -167,7 +167,8 @@ class TestLuptonRgb(object):
         """Test creating a black-and-white image using an asinh stretch estimated
         using zscale on the intensity"""
 
-        rgbImage = lupton_rgb.AsinhZScaleMapping(self.image_r).make_rgb_image()
+        map = lupton_rgb.AsinhZScaleMapping(self.image_r)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_r, self.image_r)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
@@ -197,18 +198,16 @@ class TestLuptonRgb(object):
     def test_linear(self):
         """Test using a specified linear stretch"""
 
-        rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).make_rgb_image(self.image_r)
+        map = lupton_rgb.LinearMapping(-8.45, 13.44)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def test_linear_min_max(self):
-        """Test using a min/max linear stretch
+        """Test using a min/max linear stretch determined from one image"""
 
-        Also checks that an image passed to the constructor is used as the
-        default in make_rgb_image().
-        """
-
-        rgbImage = lupton_rgb.LinearMapping(image=self.image_r).make_rgb_image()
+        map = lupton_rgb.LinearMapping(image=self.image_b)
+        rgbImage = map.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -27,9 +27,6 @@ try:
 except (ImportError, AttributeError):
     HAVE_SCIPY_MISC = False
 
-# set to True to have the finished RGBs displayed on your screen.
-display = False
-
 
 def my_name():
     """Return the name of the current method."""
@@ -172,26 +169,17 @@ class TestLuptonRgb(object):
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testStarsAsinhZscale(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testStarsAsinhZscaleIntensity(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testStarsAsinhZscaleIntensityPedestal(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity
@@ -205,17 +193,11 @@ class TestLuptonRgb(object):
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB, pedestal=pedestal)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testStarsAsinhZscaleIntensityBW(self):
         """Test creating a black-and-white image using an asinh stretch estimated
         using zscale on the intensity"""
 
         rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testMakeRGB(self):
         """Test the function that does it all"""
@@ -242,9 +224,6 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testLinearMinMax(self):
         """Test using a min/max linear stretch
 
@@ -253,16 +232,10 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testZScale(self):
         """Test using a zscale stretch"""
 
         rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testWriteStars(self):
         """Test writing RGB files to disk"""
@@ -296,9 +269,6 @@ class TestLuptonRgb(object):
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeToSize(self):
         """Test creating an RGB image of a specified size"""
@@ -307,9 +277,6 @@ class TestLuptonRgb(object):
         ySize = self.imageR.shape[1]/2
         asinhZ = lupton_rgb.AsinhZScaleMapping(self.imageR)
         rgbImage = asinhZ.makeRgbImage(self.imageR, self.imageG, self.imageB, xSize=xSize, ySize=ySize)
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeToSize_uint(self):
@@ -322,9 +289,6 @@ class TestLuptonRgb(object):
         imageB = np.array(self.imageB, dtype=np.uint16)
         asinhZ = lupton_rgb.AsinhZScaleMapping(imageR)
         rgbImage = asinhZ.makeRgbImage(imageR, imageG, imageB, xSize=xSize, ySize=ySize)
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def _testStarsResizeSpecifications(self, xSize=None, ySize=None, frac=None):
         """Test creating an RGB image changing the output """
@@ -343,9 +307,6 @@ class TestLuptonRgb(object):
         if frac is not None:
             assert int(frac*self.imageR.shape[1]) == w
             assert int(frac*self.imageR.shape[0]) == h
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeSpecificaions_xSize_ySize(self):

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -96,45 +96,40 @@ def test_compute_intensity_3_uint():
 class TestLuptonRgb(object):
     """A test case for Rgb"""
 
-    np.random.seed(1000)  # so we always get the same images.
+    def setup_method(self, method):
+        np.random.seed(1000)  # so we always get the same images.
 
-    min_, stretch_, Q = 0, 5, 20  # asinh
+        self.min_, self.stretch_, self.Q = 0, 5, 20  # asinh
 
-    width, height = 85, 75
-    images = []
+        width, height = 85, 75
 
-    shape = (width, height)
-    image_r = np.zeros(shape)
-    image_g = np.zeros(shape)
-    image_b = np.zeros(shape)
+        shape = (width, height)
+        image_r = np.zeros(shape)
+        image_g = np.zeros(shape)
+        image_b = np.zeros(shape)
 
-    # pixel locations, values and colors
-    points = [[15, 15], [50, 45], [30, 30], [45, 15]]
-    values = [1000, 5500, 600, 20000]
-    g_r = [1.0, -1.0, 1.0, 1.0]
-    r_i = [2.0, -0.5, 2.5, 1.0]
+        # pixel locations, values and colors
+        points = [[15, 15], [50, 45], [30, 30], [45, 15]]
+        values = [1000, 5500, 600, 20000]
+        g_r = [1.0, -1.0, 1.0, 1.0]
+        r_i = [2.0, -0.5, 2.5, 1.0]
 
-    # Put pixels in the images.
-    for p, v, gr, ri in zip(points, values, g_r, r_i):
-        image_r[p[0], p[1]] = v*pow(10, 0.4*ri)
-        image_g[p[0], p[1]] = v*pow(10, 0.4*gr)
-        image_b[p[0], p[1]] = v
+        # Put pixels in the images.
+        for p, v, gr, ri in zip(points, values, g_r, r_i):
+            image_r[p[0], p[1]] = v*pow(10, 0.4*ri)
+            image_g[p[0], p[1]] = v*pow(10, 0.4*gr)
+            image_b[p[0], p[1]] = v
 
-    # convolve the image with a reasonable PSF, and add Gaussian background noise
-    def convolve_with_noise(image, psf):
-        convolvedImage = convolve(image, psf, boundary='extend', normalize_kernel=True)
-        randomImage = np.random.normal(0, 2, image.shape)
-        return randomImage + convolvedImage
+        # convolve the image with a reasonable PSF, and add Gaussian background noise
+        def convolve_with_noise(image, psf):
+            convolvedImage = convolve(image, psf, boundary='extend', normalize_kernel=True)
+            randomImage = np.random.normal(0, 2, image.shape)
+            return randomImage + convolvedImage
 
-    psf = Gaussian2DKernel(2.5)
-    image_r = convolve_with_noise(image_r, psf)
-    image_g = convolve_with_noise(image_g, psf)
-    image_b = convolve_with_noise(image_b, psf)
-
-    def tearDown(self):
-        for im in self.images:
-            del im
-        del self.images
+        psf = Gaussian2DKernel(2.5)
+        self.image_r = convolve_with_noise(image_r, psf)
+        self.image_g = convolve_with_noise(image_g, psf)
+        self.image_b = convolve_with_noise(image_b, psf)
 
     def test_Asinh(self):
         """Test creating an RGB image using an asinh stretch"""
@@ -214,7 +209,8 @@ class TestLuptonRgb(object):
     def test_linear_min_max(self):
         """Test using a min/max linear stretch
 
-        N.b. also checks that an image passed to the ctor is used as the default in make_rgb_image()
+        Also checks that an image passed to the constructor is used as the
+        default in make_rgb_image().
         """
 
         rgbImage = lupton_rgb.LinearMapping(image=self.image_r).make_rgb_image()

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -31,10 +31,18 @@ try:
 except (ImportError, AttributeError):
     HAVE_SCIPY_MISC = False
 
+# Set display=True to get matplotlib imshow windows to help with debugging.
+display = False
 
-def my_name():
-    """Return the name of the current method."""
-    return sys._getframe().f_code.co_name
+
+def display_rgb(rgb, title=None):
+    """Display an rgb image using matplotlib (useful for debugging)"""
+    import matplotlib.pyplot as plt
+    plt.imshow(rgb, interpolation='nearest', origin='lower')
+    if title:
+        plt.title(title)
+    plt.show()
+    return plt
 
 
 def saturate(image, satValue):
@@ -94,40 +102,6 @@ def test_compute_intensity_3_uint():
 class TestLuptonRgb(object):
     """A test case for Rgb"""
 
-        # TBD: Old version. converted to the above.
-        # TBD: remove when it's clear the above is what was meant/works.
-
-        # self.images.append(afwImage.ImageF(afwGeom.ExtentI(width, height)))
-        # self.images.append(afwImage.ImageF(afwGeom.ExtentI(width, height)))
-        # self.images.append(afwImage.ImageF(afwGeom.ExtentI(width, height)))
-
-        # for (x, y, A, g_r, r_i) in [(15, 15, 1000,  1.0,  2.0),
-        #                             (50, 45, 5500, -1.0, -0.5),
-        #                             (30, 30,  600,  1.0,  2.5),
-        #                             (45, 15, 20000,  1.0,  1.0),
-        #                             ]:
-        #     for i in range(len(self.images)):
-        #         if i == B:
-        #             amp = A
-        #         elif i == G:
-        #             amp = A*math.pow(10, 0.4*g_r)
-        #         elif i == R:
-        #             amp = A*math.pow(10, 0.4*r_i)
-
-        #         self.images[i].set(x, y, amp)
-
-        # psf = afwMath.AnalyticKernel(15, 15, afwMath.GaussianFunction2D(2.5, 1.5, 0.5))
-        # convolvedImage = type(self.images[0])(self.images[0].getDimensions())
-        # randomImage = type(self.images[0])(self.images[0].getDimensions())
-        # rand = afwMath.Random("MT19937", 666)
-        # for i in range(len(self.images)):
-        #     afwMath.convolve(convolvedImage, self.images[i], psf, True, True)
-        #     afwMath.randomGaussianImage(randomImage, rand)
-        #     randomImage *= 2
-        #     convolvedImage += randomImage
-        #     self.images[i][:] = convolvedImage
-        # del convolvedImage
-        # del randomImage
     np.random.seed(1000)  # so we always get the same images.
 
     min_, range_, Q = 0, 5, 20  # asinh
@@ -172,18 +146,24 @@ class TestLuptonRgb(object):
         """Test creating an RGB image using an asinh stretch"""
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def testStarsAsinhZscale(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def testStarsAsinhZscaleIntensity(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def testStarsAsinhZscaleIntensityPedestal(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity
@@ -196,12 +176,16 @@ class TestLuptonRgb(object):
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB, pedestal=pedestal)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def testStarsAsinhZscaleIntensityBW(self):
         """Test creating a black-and-white image using an asinh stretch estimated
         using zscale on the intensity"""
 
         rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testMakeRGB(self):
@@ -228,6 +212,8 @@ class TestLuptonRgb(object):
         """Test using a specified linear stretch"""
 
         rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def testLinearMinMax(self):
         """Test using a min/max linear stretch
@@ -236,6 +222,8 @@ class TestLuptonRgb(object):
         """
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def testSaturated(self):
         """Test interpolating saturated pixels"""
@@ -260,6 +248,8 @@ class TestLuptonRgb(object):
 
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeToSize(self):
@@ -269,6 +259,8 @@ class TestLuptonRgb(object):
         ySize = self.imageR.shape[1]/2
         asinhZ = lupton_rgb.AsinhZScaleMapping(self.imageR)
         rgbImage = asinhZ.makeRgbImage(self.imageR, self.imageG, self.imageB, xSize=xSize, ySize=ySize)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeToSize_uint(self):
@@ -281,6 +273,8 @@ class TestLuptonRgb(object):
         imageB = np.array(self.imageB, dtype=np.uint16)
         asinhZ = lupton_rgb.AsinhZScaleMapping(imageR)
         rgbImage = asinhZ.makeRgbImage(imageR, imageG, imageB, xSize=xSize, ySize=ySize)
+        if display:
+            display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
 
     def _testStarsResizeSpecifications(self, xSize=None, ySize=None, frac=None):
         """Test creating an RGB image changing the output """

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -98,7 +98,7 @@ class TestLuptonRgb(object):
 
     np.random.seed(1000)  # so we always get the same images.
 
-    min_, range_, Q = 0, 5, 20  # asinh
+    min_, stretch_, Q = 0, 5, 20  # asinh
 
     width, height = 85, 75
     images = []
@@ -138,7 +138,7 @@ class TestLuptonRgb(object):
 
     def test_Asinh(self):
         """Test creating an RGB image using an asinh stretch"""
-        asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
+        asinhMap = lupton_rgb.AsinhMapping(self.min_, self.stretch_, self.Q)
         rgbImage = asinhMap.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)
@@ -189,7 +189,7 @@ class TestLuptonRgb(object):
             red = saturate(self.image_r, satValue)
             green = saturate(self.image_g, satValue)
             blue = saturate(self.image_b, satValue)
-            lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.range_, self.Q, filename=temp)
+            lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.stretch_, self.Q, filename=temp)
             assert os.path.exists(temp.name)
 
     def test_make_rgb_saturated_fix(self):
@@ -199,7 +199,7 @@ class TestLuptonRgb(object):
             red = saturate(self.image_r, satValue)
             green = saturate(self.image_g, satValue)
             blue = saturate(self.image_b, satValue)
-            lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.range_, self.Q,
+            lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.stretch_, self.Q,
                                        saturated_border_width=1, saturated_pixel_value=2000)
 
     def test_linear(self):
@@ -240,7 +240,7 @@ class TestLuptonRgb(object):
         self.imagesR = self.imagesG.getImage()
         self.imagesR = self.imagesB.getImage()
 
-        asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
+        asinhMap = lupton_rgb.AsinhMapping(self.min_, self.stretch_, self.Q)
         rgbImage = asinhMap.make_rgb_image(self.image_r, self.image_g, self.image_b)
         if display:
             display_rgb(rgbImage, title=sys._getframe().f_code.co_name)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -228,12 +228,12 @@ class TestLuptonRgb(unittest.TestCase):
             green = saturate(self.imageG, satValue)
             blue = saturate(self.imageB, satValue)
             lupton_rgb.makeRGB(red, green, blue, self.min, self.range, self.Q, fileName=temp)
-            self.assertTrue(os.path.exists(temp.name))
+            assert os.path.exists(temp.name)
 
     def testMakeRGB_saturated_fix(self):
         satValue = 1000.0
         # TODO: Cannot test with these options yet, as that part of the code is not implemented.
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             red = saturate(self.imageR, satValue)
             green = saturate(self.imageG, satValue)
             blue = saturate(self.imageB, satValue)
@@ -273,7 +273,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
             lupton_rgb.writeRGB(temp, rgbImage)
-            self.assertTrue(os.path.exists(temp.name))
+            assert os.path.exists(temp.name)
 
     def testSaturated(self):
         """Test interpolating saturated pixels"""
@@ -286,9 +286,9 @@ class TestLuptonRgb(unittest.TestCase):
 
         lupton_rgb.replaceSaturatedPixels(self.imageR, self.imageG, self.imageB, 1, 2000)
         # Check that we replaced those NaNs with some reasonable value
-        self.assertTrue(np.isfinite(self.imageR.getImage().getArray()).all())
-        self.assertTrue(np.isfinite(self.imageG.getImage().getArray()).all())
-        self.assertTrue(np.isfinite(self.imageB.getImage().getArray()).all())
+        assert np.isfinite(self.imageR.getImage().getArray()).all()
+        assert np.isfinite(self.imageG.getImage().getArray()).all()
+        assert np.isfinite(self.imageB.getImage().getArray()).all()
 
         # Prepare for generating an output file
         # TBD: FROMAFW
@@ -340,12 +340,12 @@ class TestLuptonRgb(unittest.TestCase):
         # afw and numpy have different conventions!
         h, w, _ = rgbImage.shape
         if xSize is not None:
-            self.assertEqual(int(xSize), w)
+            assert int(xSize) == w
         if ySize is not None:
-            self.assertEqual(int(ySize), h)
+            assert int(ySize) == h
         if frac is not None:
-            self.assertEqual(int(frac*self.imageR.shape[1]), w)
-            self.assertEqual(int(frac*self.imageR.shape[0]), h)
+            assert int(frac*self.imageR.shape[1]) == w
+            assert int(frac*self.imageR.shape[0]) == h
 
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
@@ -381,4 +381,4 @@ class TestLuptonRgb(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
             lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, fileName=temp, rescaleFactor=0.5)
-            self.assertTrue(os.path.exists(temp.name))
+            assert os.path.exists(temp.name)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -1,0 +1,357 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Tests for RGB Images
+"""
+
+from __future__ import division, print_function
+
+import os
+import unittest
+import tempfile
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from ...convolution import convolve, Gaussian2DKernel
+from .. import lupton_rgb
+
+ver1, ver2, ver3 = 1, 3, 1
+NO_MATPLOTLIB_STRING = "Requires matplotlib >= %d.%d.%d" % (ver1, ver2, ver3)
+try:
+    import matplotlib
+    versionInfo = tuple(int(s.strip("rc")) for s in matplotlib.__version__.split("."))
+    HAVE_MATPLOTLIB = versionInfo >= (ver1, ver2, ver3)
+except ImportError:
+    HAVE_MATPLOTLIB = False
+
+try:
+    import scipy.misc
+    scipy.misc.imresize
+    HAVE_SCIPY_MISC = True
+except (ImportError, AttributeError):
+    HAVE_SCIPY_MISC = False
+
+try:
+    type(display)
+except NameError:
+    display = False
+
+
+def saturate(image, satValue):
+    """
+    Return image with all points above satValue set to NaN.
+
+    Simulates saturation on an image, so we can test 'replaceSaturatedPixels'
+    """
+    # TBD: FROMAFW
+    # image = afwImage.makeMaskedImage(image)
+    # afwDetect.FootprintSet(image, afwDetect.Threshold(satValue), "SAT")
+    # arr = image.getImage().getArray()
+    # arr[np.where(arr >= satValue)] = np.nan
+
+    result = image.copy()
+    saturated = image > satValue
+    result[saturated] = np.nan
+    return result
+
+
+def random_array(dtype, N=100):
+    return np.array(np.random.random(10)*100, dtype=dtype)
+
+
+def test_compute_intensity_1_float():
+    imageR = random_array(np.float64)
+    intensity = lupton_rgb.compute_intensity(imageR)
+    assert imageR.dtype == intensity.dtype
+    assert_equal(imageR, intensity)
+
+
+def test_compute_intensity_1_uint():
+    imageR = random_array(np.uint8)
+    intensity = lupton_rgb.compute_intensity(imageR)
+    assert imageR.dtype == intensity.dtype
+    assert_equal(imageR, intensity)
+
+
+def test_compute_intensity_3_float():
+    imageR = random_array(np.float64)
+    imageG = random_array(np.float64)
+    imageB = random_array(np.float64)
+    intensity = lupton_rgb.compute_intensity(imageR, imageG, imageB)
+    assert imageR.dtype == intensity.dtype
+    assert_equal(intensity, (imageR+imageG+imageB)/3.0)
+
+
+def test_compute_intensity_3_uint():
+    imageR = random_array(np.uint8)
+    imageG = random_array(np.uint8)
+    imageB = random_array(np.uint8)
+    intensity = lupton_rgb.compute_intensity(imageR, imageG, imageB)
+    assert imageR.dtype == intensity.dtype
+    assert_equal(intensity, (imageR+imageG+imageB)//3)
+
+
+class TestLuptonRgb(unittest.TestCase):
+    """A test case for Rgb"""
+    def setUp(self):
+        self.min, self.range, self.Q = 0, 5, 20  # asinh
+
+        width, height = 85, 75
+        self.images = []
+
+        shape = (width, height)
+        self.imageR = np.zeros(shape)
+        self.imageG = np.zeros(shape)
+        self.imageB = np.zeros(shape)
+
+        # pixel locations, values and colors
+        points = [[15, 15], [50, 45], [30, 30], [45, 15]]
+        values = [1000, 5500, 600, 20000]
+        g_r = [1.0, -1.0, 1.0, 1.0]
+        r_i = [2.0, -0.5, 2.5, 1.0]
+
+        # Put pixels in the images.
+        for p, v, gr, ri in zip(points, values, g_r, r_i):
+            self.imageR[p[0], p[1]] = v*pow(10, 0.4*ri)
+            self.imageG[p[0], p[1]] = v*pow(10, 0.4*gr)
+            self.imageB[p[0], p[1]] = v
+
+        # convolve the image with a reasonable PSF, and add Gaussian background noise
+        def convolve_with_noise(image, psf):
+            convolvedImage = convolve(image, psf, boundary='extend', normalize_kernel=True)
+            randomImage = np.random.normal(0, 2, image.shape)
+            return randomImage + convolvedImage
+
+        psf = Gaussian2DKernel(2.5)
+        self.imageR = convolve_with_noise(self.imageR, psf)
+        self.imageG = convolve_with_noise(self.imageG, psf)
+        self.imageB = convolve_with_noise(self.imageB, psf)
+
+        # TBD: Old version. converted to the above.
+        # TBD: remove when it's clear the above is what was meant/works.
+
+        # self.images.append(afwImage.ImageF(afwGeom.ExtentI(width, height)))
+        # self.images.append(afwImage.ImageF(afwGeom.ExtentI(width, height)))
+        # self.images.append(afwImage.ImageF(afwGeom.ExtentI(width, height)))
+
+        # for (x, y, A, g_r, r_i) in [(15, 15, 1000,  1.0,  2.0),
+        #                             (50, 45, 5500, -1.0, -0.5),
+        #                             (30, 30,  600,  1.0,  2.5),
+        #                             (45, 15, 20000,  1.0,  1.0),
+        #                             ]:
+        #     for i in range(len(self.images)):
+        #         if i == B:
+        #             amp = A
+        #         elif i == G:
+        #             amp = A*math.pow(10, 0.4*g_r)
+        #         elif i == R:
+        #             amp = A*math.pow(10, 0.4*r_i)
+
+        #         self.images[i].set(x, y, amp)
+
+        # psf = afwMath.AnalyticKernel(15, 15, afwMath.GaussianFunction2D(2.5, 1.5, 0.5))
+        # convolvedImage = type(self.images[0])(self.images[0].getDimensions())
+        # randomImage = type(self.images[0])(self.images[0].getDimensions())
+        # rand = afwMath.Random("MT19937", 666)
+        # for i in range(len(self.images)):
+        #     afwMath.convolve(convolvedImage, self.images[i], psf, True, True)
+        #     afwMath.randomGaussianImage(randomImage, rand)
+        #     randomImage *= 2
+        #     convolvedImage += randomImage
+        #     self.images[i][:] = convolvedImage
+        # del convolvedImage
+        # del randomImage
+
+    def tearDown(self):
+        for im in self.images:
+            del im
+        del self.images
+
+    def testStarsAsinh(self):
+        """Test creating an RGB image using an asinh stretch"""
+        asinhMap = lupton_rgb.AsinhMapping(self.min, self.range, self.Q)
+        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    def testStarsAsinhZscale(self):
+        """Test creating an RGB image using an asinh stretch estimated using zscale"""
+
+        map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
+        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    def testStarsAsinhZscaleIntensity(self):
+        """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
+
+        map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
+        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    def testStarsAsinhZscaleIntensityPedestal(self):
+        """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity
+        where the images each have a pedestal added"""
+
+        pedestal = [100, 400, -400]
+        self.imageR += pedestal[0]
+        self.imageG += pedestal[1]
+        self.imageB += pedestal[2]
+
+        map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB, pedestal=pedestal)
+        rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    def testStarsAsinhZscaleIntensityBW(self):
+        """Test creating a black-and-white image using an asinh stretch estimated
+        using zscale on the intensity"""
+
+        rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    @unittest.skipUnless(HAVE_MATPLOTLIB, NO_MATPLOTLIB_STRING)
+    def testMakeRGB(self):
+        """Test the function that does it all"""
+        satValue = 1000.0
+        with tempfile.NamedTemporaryFile(suffix=".png") as temp:
+            red = saturate(self.imageR, satValue)
+            green = saturate(self.imageG, satValue)
+            blue = saturate(self.imageB, satValue)
+            lupton_rgb.makeRGB(red, green, blue, self.min, self.range, self.Q, fileName=temp,
+                               saturatedBorderWidth=1, saturatedPixelValue=2000)
+            self.assertTrue(os.path.exists(temp.name))
+
+    def testLinear(self):
+        """Test using a specified linear stretch"""
+
+        rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    def testLinearMinMax(self):
+        """Test using a min/max linear stretch
+
+        N.b. also checks that an image passed to the ctor is used as the default in makeRgbImage()
+        """
+
+        rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    def testZScale(self):
+        """Test using a zscale stretch"""
+
+        rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
+
+        if display:
+            plt = lupton_rgb.displayRGB(rgbImage, False)
+            plt.title("zscale")
+            plt.show()
+
+    @unittest.skipUnless(HAVE_MATPLOTLIB, NO_MATPLOTLIB_STRING)
+    def testWriteStars(self):
+        """Test writing RGB files to disk"""
+        asinhMap = lupton_rgb.AsinhMapping(self.min, self.range, self.Q)
+        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+        with tempfile.NamedTemporaryFile(suffix=".png") as temp:
+            lupton_rgb.writeRGB(temp, rgbImage)
+            self.assertTrue(os.path.exists(temp.name))
+
+    def testSaturated(self):
+        """Test interpolating saturated pixels"""
+
+        satValue = 1000.0
+        self.imageR = saturate(self.imageR, satValue)
+        self.imageG = saturate(self.imageG, satValue)
+        self.imageB = saturate(self.imageB, satValue)
+
+        lupton_rgb.replaceSaturatedPixels(self.imageR, self.imageG, self.imageB, 1, 2000)
+        # Check that we replaced those NaNs with some reasonable value
+        self.assertTrue(np.isfinite(self.imageR.getImage().getArray()).all())
+        self.assertTrue(np.isfinite(self.imageG.getImage().getArray()).all())
+        self.assertTrue(np.isfinite(self.imageB.getImage().getArray()).all())
+
+        # Prepare for generating an output file
+        # TBD: FROMAFW
+        self.imagesR = self.imagesR.getImage()
+        self.imagesR = self.imagesG.getImage()
+        self.imagesR = self.imagesB.getImage()
+
+        asinhMap = lupton_rgb.AsinhMapping(self.min, self.range, self.Q)
+        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    def testStarsResizeToSize(self):
+        """Test creating an RGB image of a specified size"""
+
+        xSize = self.imageR.shape[0]/2
+        ySize = self.imageR.shape[1]/2
+        asinhZ = lupton_rgb.AsinhZScaleMapping(self.imageR)
+        rgbImage = asinhZ.makeRgbImage(self.imageR, self.imageG, self.imageB, xSize=xSize, ySize=ySize)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    def testStarsResizeToSize_uint(self):
+        """Test creating an RGB image of a specified size"""
+
+        xSize = self.imageR.shape[0]/2
+        ySize = self.imageR.shape[1]/2
+        imageR = np.array(self.imageR, dtype=np.uint16)
+        imageG = np.array(self.imageG, dtype=np.uint16)
+        imageB = np.array(self.imageB, dtype=np.uint16)
+        asinhZ = lupton_rgb.AsinhZScaleMapping(imageR)
+        rgbImage = asinhZ.makeRgbImage(imageR, imageG, imageB, xSize=xSize, ySize=ySize)
+
+        if display:
+            lupton_rgb.displayRGB(rgbImage)
+
+    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    def testStarsResizeSpecifications(self):
+        """Test creating an RGB image changing the output """
+
+        map = lupton_rgb.AsinhZScaleMapping(self.imageR)
+
+        for xSize, ySize, frac in [(self.imageR.shape[0]/2, self.imageR.shape[1]/2, None),
+                                   (2*self.imageR.shape[0], None,                         None),
+                                   (self.imageR.shape[0]/2, None,                         None),
+                                   (None,                        self.imageR.shape[1]/2, None),
+                                   (None,                        None,                         0.5),
+                                   (None,                        None,                         2),
+                                   ]:
+            rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB,
+                                        xSize=xSize, ySize=ySize, rescaleFactor=frac)
+
+            h, w = rgbImage.shape[0:2]
+            self.assertTrue(xSize is None or xSize == w)
+            self.assertTrue(ySize is None or ySize == h)
+            self.assertTrue(frac is None or w == int(frac*self.imageR.shape[0]),
+                            "%g == %g" % (w, int((frac if frac else 1)*self.imageR.shape[0])))
+
+            if display:
+                lupton_rgb.displayRGB(rgbImage)
+
+    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @unittest.skipUnless(HAVE_MATPLOTLIB, NO_MATPLOTLIB_STRING)
+    def testMakeRGBResize(self):
+        """Test the function that does it all, including rescaling"""
+        lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, xSize=40, ySize=60)
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as temp:
+            lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, fileName=temp, rescaleFactor=0.5)
+            self.assertTrue(os.path.exists(temp.name))

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -189,7 +189,7 @@ class TestLuptonRgb(object):
             red = saturate(self.image_r, satValue)
             green = saturate(self.image_g, satValue)
             blue = saturate(self.image_b, satValue)
-            lupton_rgb.make_rgb(red, green, blue, self.min_, self.range_, self.Q, filename=temp)
+            lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.range_, self.Q, filename=temp)
             assert os.path.exists(temp.name)
 
     def test_make_rgb_saturated_fix(self):
@@ -199,8 +199,8 @@ class TestLuptonRgb(object):
             red = saturate(self.image_r, satValue)
             green = saturate(self.image_g, satValue)
             blue = saturate(self.image_b, satValue)
-            lupton_rgb.make_rgb(red, green, blue, self.min_, self.range_, self.Q,
-                                saturated_border_width=1, saturated_pixel_value=2000)
+            lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.range_, self.Q,
+                                       saturated_border_width=1, saturated_pixel_value=2000)
 
     def test_linear(self):
         """Test using a specified linear stretch"""
@@ -305,8 +305,8 @@ class TestLuptonRgb(object):
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def test_make_rgb_resize(self):
         """Test the function that does it all, including rescaling"""
-        lupton_rgb.make_rgb(self.image_r, self.image_g, self.image_b, x_size=40, y_size=60)
+        lupton_rgb.make_lupton_rgb(self.image_r, self.image_g, self.image_b, x_size=40, y_size=60)
 
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            lupton_rgb.make_rgb(self.image_r, self.image_g, self.image_b, filename=temp, rescale=0.5)
+            lupton_rgb.make_lupton_rgb(self.image_r, self.image_g, self.image_b, filename=temp, rescale=0.5)
             assert os.path.exists(temp.name)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -51,12 +51,6 @@ def saturate(image, satValue):
 
     Simulates saturation on an image, so we can test 'replaceSaturatedPixels'
     """
-    # TBD: FROMAFW
-    # image = afwImage.makeMaskedImage(image)
-    # afwDetect.FootprintSet(image, afwDetect.Threshold(satValue), "SAT")
-    # arr = image.getImage().getArray()
-    # arr[np.where(arr >= satValue)] = np.nan
-
     result = image.copy()
     saturated = image > satValue
     result[saturated] = np.nan

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -6,6 +6,7 @@ Tests for RGB Images
 
 from __future__ import division, print_function
 
+import sys
 import os
 import unittest
 import tempfile
@@ -16,26 +17,23 @@ from numpy.testing import assert_equal
 from ...convolution import convolve, Gaussian2DKernel
 from .. import lupton_rgb
 
-ver1, ver2, ver3 = 1, 3, 1
-NO_MATPLOTLIB_STRING = "Requires matplotlib >= %d.%d.%d" % (ver1, ver2, ver3)
-try:
-    import matplotlib
-    versionInfo = tuple(int(s.strip("rc")) for s in matplotlib.__version__.split("."))
-    HAVE_MATPLOTLIB = versionInfo >= (ver1, ver2, ver3)
-except ImportError:
-    HAVE_MATPLOTLIB = False
+import matplotlib
+matplotlib.use('TkAgg')
 
 try:
     import scipy.misc
-    scipy.misc.imresize
+    scipy.misc.imresize  # just checking if it exists.
     HAVE_SCIPY_MISC = True
 except (ImportError, AttributeError):
     HAVE_SCIPY_MISC = False
 
-try:
-    type(display)
-except NameError:
-    display = False
+# set to True to have the finished RGBs displayed on your screen.
+display = False
+
+
+def my_name():
+    """Return the name of the current method."""
+    return sys._getframe().f_code.co_name
 
 
 def saturate(image, satValue):
@@ -95,6 +93,8 @@ def test_compute_intensity_3_uint():
 class TestLuptonRgb(unittest.TestCase):
     """A test case for Rgb"""
     def setUp(self):
+        np.random.seed(1000)  # so we always get the same images.
+
         self.min, self.range, self.Q = 0, 5, 20  # asinh
 
         width, height = 85, 75
@@ -174,7 +174,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testStarsAsinhZscale(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale"""
@@ -183,7 +183,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testStarsAsinhZscaleIntensity(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
@@ -192,7 +192,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testStarsAsinhZscaleIntensityPedestal(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity
@@ -207,7 +207,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testStarsAsinhZscaleIntensityBW(self):
         """Test creating a black-and-white image using an asinh stretch estimated
@@ -216,9 +216,8 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_MATPLOTLIB, NO_MATPLOTLIB_STRING)
     def testMakeRGB(self):
         """Test the function that does it all"""
         satValue = 1000.0
@@ -236,7 +235,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testLinearMinMax(self):
         """Test using a min/max linear stretch
@@ -247,7 +246,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testZScale(self):
         """Test using a zscale stretch"""
@@ -255,11 +254,8 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
 
         if display:
-            plt = lupton_rgb.displayRGB(rgbImage, False)
-            plt.title("zscale")
-            plt.show()
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_MATPLOTLIB, NO_MATPLOTLIB_STRING)
     def testWriteStars(self):
         """Test writing RGB files to disk"""
         asinhMap = lupton_rgb.AsinhMapping(self.min, self.range, self.Q)
@@ -292,7 +288,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
     def testStarsResizeToSize(self):
@@ -304,7 +300,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = asinhZ.makeRgbImage(self.imageR, self.imageG, self.imageB, xSize=xSize, ySize=ySize)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
     def testStarsResizeToSize_uint(self):
@@ -319,7 +315,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = asinhZ.makeRgbImage(imageR, imageG, imageB, xSize=xSize, ySize=ySize)
 
         if display:
-            lupton_rgb.displayRGB(rgbImage)
+            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications(self):
@@ -337,17 +333,18 @@ class TestLuptonRgb(unittest.TestCase):
             rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB,
                                         xSize=xSize, ySize=ySize, rescaleFactor=frac)
 
-            h, w = rgbImage.shape[0:2]
-            self.assertTrue(xSize is None or xSize == w)
-            self.assertTrue(ySize is None or ySize == h)
+            h, w, _ = rgbImage.shape
+            # NOTE: This fails because h,w are somehow reversed.
+            # Did I screw something up in the conversion from AFW to numpy?
+            self.assertTrue(xSize is None or int(xSize) == w)
+            self.assertTrue(ySize is None or int(ySize) == h)
             self.assertTrue(frac is None or w == int(frac*self.imageR.shape[0]),
                             "%g == %g" % (w, int((frac if frac else 1)*self.imageR.shape[0])))
 
             if display:
-                lupton_rgb.displayRGB(rgbImage)
+                lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
-    @unittest.skipUnless(HAVE_MATPLOTLIB, NO_MATPLOTLIB_STRING)
     def testMakeRGBResize(self):
         """Test the function that does it all, including rescaling"""
         lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, xSize=40, ySize=60)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -17,8 +17,12 @@ from ...convolution import convolve, Gaussian2DKernel
 from ...tests.helper import pytest
 from .. import lupton_rgb
 
-import matplotlib
-matplotlib.use('TkAgg')
+try:
+    import matplotlib
+    matplotlib.use('TkAgg')
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 try:
     import scipy.misc
@@ -199,6 +203,7 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testMakeRGB(self):
         """Test the function that does it all"""
         satValue = 1000.0
@@ -332,6 +337,7 @@ class TestLuptonRgb(object):
     def testStarsResizeSpecifications_frac_twice(self):
         self._testStarsResizeSpecifications(frac=2)
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testMakeRGBResize(self):
         """Test the function that does it all, including rescaling"""

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -193,14 +193,16 @@ class TestLuptonRgb(object):
             assert os.path.exists(temp.name)
 
     def test_make_rgb_saturated_fix(self):
+        pytest.skip('saturation correction is not implemented')
         satValue = 1000.0
         # TODO: Cannot test with these options yet, as that part of the code is not implemented.
-        with pytest.raises(NotImplementedError):
+        with tempfile.NamedTemporaryFile(suffix=".png") as temp:
             red = saturate(self.image_r, satValue)
             green = saturate(self.image_g, satValue)
             blue = saturate(self.image_b, satValue)
             lupton_rgb.make_lupton_rgb(red, green, blue, self.min_, self.stretch_, self.Q,
-                                       saturated_border_width=1, saturated_pixel_value=2000)
+                                       saturated_border_width=1, saturated_pixel_value=2000,
+                                       filename=temp)
 
     def test_linear(self):
         """Test using a specified linear stretch"""

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -15,6 +15,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from ...convolution import convolve, Gaussian2DKernel
+from ...tests.helper import pytest
 from .. import lupton_rgb
 
 import matplotlib
@@ -274,9 +275,9 @@ class TestLuptonRgb(unittest.TestCase):
             lupton_rgb.writeRGB(temp, rgbImage)
             self.assertTrue(os.path.exists(temp.name))
 
-    @unittest.skip('replaceSaturatedPixels is not implemented in astropy yet')
     def testSaturated(self):
         """Test interpolating saturated pixels"""
+        pytest.skip('replaceSaturatedPixels is not implemented in astropy yet')
 
         satValue = 1000.0
         self.imageR = saturate(self.imageR, satValue)
@@ -301,7 +302,7 @@ class TestLuptonRgb(unittest.TestCase):
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeToSize(self):
         """Test creating an RGB image of a specified size"""
 
@@ -313,7 +314,7 @@ class TestLuptonRgb(unittest.TestCase):
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeToSize_uint(self):
         """Test creating an RGB image of a specified size"""
 
@@ -349,31 +350,31 @@ class TestLuptonRgb(unittest.TestCase):
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecificaions_xSize_ySize(self):
         self._testStarsResizeSpecifications(xSize=self.imageR.shape[0]/2, ySize=self.imageR.shape[1]/2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_twice_xSize(self):
         self._testStarsResizeSpecifications(xSize=2*self.imageR.shape[0])
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_half_xSize(self):
         self._testStarsResizeSpecifications(xSize=self.imageR.shape[0]/2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_half_ySize(self):
         self._testStarsResizeSpecifications(ySize=self.imageR.shape[0]/2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_frac_half(self):
         self._testStarsResizeSpecifications(frac=0.5)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_frac_twice(self):
         self._testStarsResizeSpecifications(frac=2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testMakeRGBResize(self):
         """Test the function that does it all, including rescaling"""
         lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, xSize=40, ySize=60)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -237,10 +237,6 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
-    def testZScale(self):
-        """Test using a zscale stretch"""
-
-        rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testWriteStars(self):

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -242,12 +242,13 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testWriteStars(self):
         """Test writing RGB files to disk"""
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
-        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            lupton_rgb.writeRGB(temp, rgbImage)
+            rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG,
+                                             self.imageB, fileName=temp)
             assert os.path.exists(temp.name)
 
     def testSaturated(self):

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -237,16 +237,6 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
-
-    @pytest.mark.skipif('not HAS_MATPLOTLIB')
-    def testWriteStars(self):
-        """Test writing RGB files to disk"""
-        asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
-        with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG,
-                                             self.imageB, fileName=temp)
-            assert os.path.exists(temp.name)
-
     def testSaturated(self):
         """Test interpolating saturated pixels"""
         pytest.skip('replaceSaturatedPixels is not implemented in astropy yet')

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -4,7 +4,7 @@
 Tests for RGB Images
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -4,7 +4,7 @@
 Tests for RGB Images
 """
 
-from __future__ import division, print_function
+from __future__ import absolute_import, division
 
 import sys
 import os

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -19,7 +19,6 @@ from .. import lupton_rgb
 
 try:
     import matplotlib
-    matplotlib.use('TkAgg')
     HAS_MATPLOTLIB = True
 except ImportError:
     HAS_MATPLOTLIB = False

--- a/docs/visualization/index.rst
+++ b/docs/visualization/index.rst
@@ -11,9 +11,11 @@ Introduction
 visualizing data. This includes a framework for plotting Astronomical images
 with coordinates with Matplotlib (previously the standalone **wcsaxes**
 package), functionality related to image normaliation (including both scaling
-and stretching), smart histogram plotting, and custom plotting styles for
-Matplotlib.
+and stretching), smart histogram plotting, RGB color image creation from between
+one and three separate images, and custom plotting styles for Matplotlib.
 
+Using `astropy.visualization`
+=============================
 .. toctree::
    :maxdepth: 2
 

--- a/docs/visualization/index.rst
+++ b/docs/visualization/index.rst
@@ -11,8 +11,8 @@ Introduction
 visualizing data. This includes a framework for plotting Astronomical images
 with coordinates with Matplotlib (previously the standalone **wcsaxes**
 package), functionality related to image normaliation (including both scaling
-and stretching), smart histogram plotting, RGB color image creation from between
-one and three separate images, and custom plotting styles for Matplotlib.
+and stretching), smart histogram plotting, RGB color image creation from
+separate images, and custom plotting styles for Matplotlib.
 
 Using `astropy.visualization`
 =============================

--- a/docs/visualization/index.rst
+++ b/docs/visualization/index.rst
@@ -20,6 +20,7 @@ Matplotlib.
    wcsaxes/index.rst
    normalization.rst
    histogram.rst
+   lupton_rgb.rst
 
 
 .. _fits2bitmap:

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -15,7 +15,7 @@ color PNG file with the default (arcsinh) scaling:
 >>> imageR = np.random.random((100,100))
 >>> imageG = np.random.random((100,100))
 >>> imageB = np.random.random((100,100))
->>> image = lupton_rgb.make_rgb(image_r, image_g, image_b, filename='randoms.png')
+>>> image = lupton_rgb.make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
 
 This method requires that the three images be aligned and have the same pixel
 scale and size.

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -15,13 +15,13 @@ color PNG file with the default (arcsinh) scaling:
 >>> imageR = np.random.random((100,100))
 >>> imageG = np.random.random((100,100))
 >>> imageB = np.random.random((100,100))
->>> image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
+>>> image = lupton_rgb.make_rgb(image_r, image_g, image_b, filename='randoms.png')
 
 This method requires that the three images be aligned and have the same pixel
 scale and size.
 
-Changing ``minimum`` and ``dataRange`` will change the black (``minimum``) and white
-(``minimum+dataRange``) levels of the resulting image, while changing ``Q`` will
+Changing ``minimum`` and ``data_range`` will change the black (``minimum``) and white
+(``minimum+data_range``) levels of the resulting image, while changing ``Q`` will
 change how the values between black and white are scaled.
 
 The SDSS SkyServer color images were made with this technique.

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -13,14 +13,17 @@ To generate a color PNG file with the default (arcsinh) scaling:
 
 .. _Lupton et al. (2004): http://adsabs.harvard.edu/abs/2004PASP..116..133L
 
-.. doctest-skip::
+.. plot::
+    :include-source:
 
     import numpy as np
+    import matplotlib.pyplot as plt
     from astropy.visualization import make_lupton_rgb
-    imageR = np.random.random((100,100))
-    imageG = np.random.random((100,100))
-    imageB = np.random.random((100,100))
-    image = make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
+    image_r = np.random.random((100,100))
+    image_g = np.random.random((100,100))
+    image_b = np.random.random((100,100))
+    image = make_lupton_rgb(image_r, image_g, image_b, stretch=0.5)
+    plt.imshow(image)
 
 This method requires that the three images be aligned and have the same pixel
 scale and size. Changing ``minimum`` will change the black level, while
@@ -67,4 +70,19 @@ Lupton et al. (2004):
    # this scaling is very similar to the one used in Lupton et al. (2004)
    rgb = make_lupton_rgb(i_new, r_new, g.data, Q=10, stretch=0.5, filename="ngc6976.jpeg")
 
-TODO: show example files in this document right here? How?
+This will produce the following two images.
+
+.. figure:: https://astropy.stsci.edu/data/visualization/ngc6976-default.jpeg
+    :scale: 30 %
+    :alt: default rgb image
+
+    Image generated with the default parameters.
+
+.. figure:: https://astropy.stsci.edu/data/visualization/ngc6976.jpeg
+    :scale: 30 %
+    :alt: wider stretch image
+
+    Image generated with Q=10, stretch=0.5, showing faint features of the galaxies.
+    Comapre with Fig. 1 of `Lupton et al. (2004)`_ or the `SDSS Skyserver image`_.
+
+.. _SDSS Skyserver image: http://skyserver.sdss.org/dr13/en/tools/chart/navi.aspx?ra=179.68929&dec=-0.45438&opt=

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -6,8 +6,12 @@ Creating color RGB images
 
 `Lupton et al. (2004)`_ describe an "optimal" algorithm for producing red-green-
 blue composite images from three separate high-dynamic range arrays. This method
-is implemented in `~astropy.visualization.make_lupton_rgb` as a convenience wraper function and an associated set of classes to provide alternate scalings. To
-generate a color PNG file with the default (arcsinh) scaling:
+is implemented in `~astropy.visualization.make_lupton_rgb` as a convenience
+wraper function and an associated set of classes to provide alternate scalings.
+The SDSS SkyServer color images were made using a variation on this technique.
+To generate a color PNG file with the default (arcsinh) scaling:
+
+.. _Lupton et al. (2004): http://adsabs.harvard.edu/abs/2004PASP..116..133L
 
 .. doctest-skip::
 
@@ -16,15 +20,51 @@ generate a color PNG file with the default (arcsinh) scaling:
 >>> imageR = np.random.random((100,100))
 >>> imageG = np.random.random((100,100))
 >>> imageB = np.random.random((100,100))
->>> image = lupton_rgb.make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
+>>> image = make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
 
 This method requires that the three images be aligned and have the same pixel
-scale and size.
+scale and size. Changing ``minimum`` will change the black level, while
+``stretch`` and ``Q`` will change how the values between black and white are
+scaled.
 
-Changing ``minimum`` and ``data_range`` will change the black (``minimum``) and white
-(``minimum+data_range``) levels of the resulting image, while changing ``Q`` will
-change how the values between black and white are scaled.
+For a more in-depth example, download the `g`_, `r`_, `i`_ SDSS frames of the
+area around the Hickson 88 group and try the example below (requires the
+`reproject package`_, installable via pip), and compare it with Figure 1 of
+Lupton et al. (2004):
 
-The SDSS SkyServer color images were made with this technique.
+.. _reproject package: https://reproject.readthedocs.io/
 
-.. _Lupton et al. (2004): http://adsabs.harvard.edu/abs/2004PASP..116..133L
+.. _g: http://dr13.sdss.org/sas/dr13/eboss/photoObj/frames/301/1737/5/frame-g-001737-5-0039.fits.bz2
+.. _r: http://dr13.sdss.org/sas/dr13/eboss/photoObj/frames/301/1737/5/frame-r-001737-5-0039.fits.bz2
+.. _i: http://dr13.sdss.org/sas/dr13/eboss/photoObj/frames/301/1737/5/frame-i-001737-5-0039.fits.bz2
+
+.. doctest-skip::
+
+   import numpy as np
+   from astropy.visualization import make_lupton_rgb
+   from astropy.io import fits
+   from reproject import reproject_interp
+
+   # Read in the three images downloaded from here:
+   # g: http://dr13.sdss.org/sas/dr13/eboss/photoObj/frames/301/1737/5/frame-g-001737-5-0039.fits.bz2
+   # r: http://dr13.sdss.org/sas/dr13/eboss/photoObj/frames/301/1737/5/frame-r-001737-5-0039.fits.bz2
+   # i: http://dr13.sdss.org/sas/dr13/eboss/photoObj/frames/301/1737/5/frame-i-001737-5-0039.fits.bz2
+   g = fits.open('frame-g-001737-5-0039.fits.bz2')[0]
+   r = fits.open('frame-r-001737-5-0039.fits.bz2')[0]
+   i = fits.open('frame-i-001737-5-0039.fits.bz2')[0]
+
+   # remap r and i onto g
+   r_new, r_mask = reproject_interp(r, g.header)
+   i_new, i_mask = reproject_interp(i, g.header)
+
+   # zero out the unmapped values
+   i_new[np.logical_not(i_mask)] = 0
+   r_new[np.logical_not(r_mask)] = 0
+
+   # red=i, green=r, blue=g
+   # make a file with the default scaling
+   rgb_default = make_lupton_rgb(i_new, r_new, g.data, filename="ngc6976-default.jpeg")
+   # this scaling is very similar to the one used in Lupton et al. (2004)
+   rgb = make_lupton_rgb(i_new, r_new, g.data, Q=10, stretch=0.5, filename="ngc6976.jpeg")
+
+TODO: show example files in this document right here? How?

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -1,17 +1,18 @@
-**********************************
+.. _astropy-visualization-rgb:
+
+*************************
 Creating color RGB images
-**********************************
+*************************
 
 `Lupton et al. (2004)`_ describe an "optimal" algorithm for producing red-green-
 blue composite images from three separate high-dynamic range arrays. This method
-is implemented in `~astropy.visualization.lupton_rgb` as a set of classes
-providing different scalings and a convenience wraper function. To generate a
-color PNG file with the default (arcsinh) scaling:
+is implemented in `~astropy.visualization.make_lupton_rgb` as a convenience wraper function and an associated set of classes to provide alternate scalings. To
+generate a color PNG file with the default (arcsinh) scaling:
 
 .. doctest-skip::
 
 >>> import numpy as np
->>> from astropy.visualization import lupton_rgb
+>>> from astropy.visualization import make_lupton_rgb
 >>> imageR = np.random.random((100,100))
 >>> imageG = np.random.random((100,100))
 >>> imageB = np.random.random((100,100))

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -1,11 +1,12 @@
 **********************************
-Color RGB image creation
+Creating color RGB images
 **********************************
 
 `Lupton et al. (2004)`_ describe an "optimal" algorithm for producing red-green-
-blue composite images from three separate high-dynamic range images. This method
-is implemented in `astropy.visualization.lupton_rgb`. To generate a color PNG
-file  with the default (arcsinh) scaling:
+blue composite images from three separate high-dynamic range arrays. This method
+is implemented in `astropy.visualization.lupton_rgb` as a set of classes
+providing different scalings and a convenience wraper function. To generate a
+color PNG file with the default (arcsinh) scaling:
 
 >>> from astropy.visualization import lupton_rgb
 >>> imageR = np.random.random((100,100))
@@ -13,7 +14,13 @@ file  with the default (arcsinh) scaling:
 >>> imageB = np.random.random((100,100))
 >>> image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
 
-.. _Lupton et al. (2004): http://adsabs.harvard.edu/abs/2004PASP..116..133L
-
 This method requires that the three images be aligned and have the same pixel
 scale and size.
+
+Changing `minimum` and `dataRange` will change the black (`minimum`) and white
+(`minimum+dataRange`) levels of the resulting image, while changing `Q` will
+change how the values between black and white are scaled.
+
+The SDSS SkyServer color images were made with this technique.
+
+.. _Lupton et al. (2004): http://adsabs.harvard.edu/abs/2004PASP..116..133L

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -1,0 +1,19 @@
+**********************************
+Color RGB image creation
+**********************************
+
+`Lupton et al. (2004)`_ describe an "optimal" algorithm for producing red-green-
+blue composite images from three separate high-dynamic range images. This method
+is implemented in `astropy.visualization.lupton_rgb`. To generate a color PNG
+file  with the default (arcsinh) scaling:
+
+>>> from astropy.visualization import lupton_rgb
+>>> imageR = np.random.random((100,100))
+>>> imageG = np.random.random((100,100))
+>>> imageB = np.random.random((100,100))
+>>> image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
+
+.. _Lupton et al. (2004): http://adsabs.harvard.edu/abs/2004PASP..116..133L
+
+This method requires that the three images be aligned and have the same pixel
+scale and size.

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -8,6 +8,9 @@ is implemented in `astropy.visualization.lupton_rgb` as a set of classes
 providing different scalings and a convenience wraper function. To generate a
 color PNG file with the default (arcsinh) scaling:
 
+.. plot::
+    :include-source:
+
 >>> import numpy as np
 >>> from astropy.visualization import lupton_rgb
 >>> imageR = np.random.random((100,100))

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -4,12 +4,11 @@ Creating color RGB images
 
 `Lupton et al. (2004)`_ describe an "optimal" algorithm for producing red-green-
 blue composite images from three separate high-dynamic range arrays. This method
-is implemented in `astropy.visualization.lupton_rgb` as a set of classes
+is implemented in `~astropy.visualization.lupton_rgb` as a set of classes
 providing different scalings and a convenience wraper function. To generate a
 color PNG file with the default (arcsinh) scaling:
 
-.. plot::
-    :include-source:
+.. doctest-skip::
 
 >>> import numpy as np
 >>> from astropy.visualization import lupton_rgb
@@ -21,8 +20,8 @@ color PNG file with the default (arcsinh) scaling:
 This method requires that the three images be aligned and have the same pixel
 scale and size.
 
-Changing `minimum` and `dataRange` will change the black (`minimum`) and white
-(`minimum+dataRange`) levels of the resulting image, while changing `Q` will
+Changing ``minimum`` and ``dataRange`` will change the black (``minimum``) and white
+(``minimum+dataRange``) levels of the resulting image, while changing ``Q`` will
 change how the values between black and white are scaled.
 
 The SDSS SkyServer color images were made with this technique.

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -8,6 +8,7 @@ is implemented in `astropy.visualization.lupton_rgb` as a set of classes
 providing different scalings and a convenience wraper function. To generate a
 color PNG file with the default (arcsinh) scaling:
 
+>>> import numpy as np
 >>> from astropy.visualization import lupton_rgb
 >>> imageR = np.random.random((100,100))
 >>> imageG = np.random.random((100,100))

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -15,12 +15,12 @@ To generate a color PNG file with the default (arcsinh) scaling:
 
 .. doctest-skip::
 
->>> import numpy as np
->>> from astropy.visualization import make_lupton_rgb
->>> imageR = np.random.random((100,100))
->>> imageG = np.random.random((100,100))
->>> imageB = np.random.random((100,100))
->>> image = make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
+    import numpy as np
+    from astropy.visualization import make_lupton_rgb
+    imageR = np.random.random((100,100))
+    imageG = np.random.random((100,100))
+    imageB = np.random.random((100,100))
+    image = make_lupton_rgb(image_r, image_g, image_b, filename='randoms.png')
 
 This method requires that the three images be aligned and have the same pixel
 scale and size. Changing ``minimum`` will change the black level, while

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -72,13 +72,13 @@ Lupton et al. (2004):
 
 This will produce the following two images.
 
-.. figure:: https://astropy.stsci.edu/data/visualization/ngc6976-default.jpeg
+.. figure:: https://data.astropy.org/visualization/ngc6976-default.jpeg
     :scale: 30 %
     :alt: default rgb image
 
     Image generated with the default parameters.
 
-.. figure:: https://astropy.stsci.edu/data/visualization/ngc6976.jpeg
+.. figure:: https://data.astropy.org/visualization/ngc6976.jpeg
     :scale: 30 %
     :alt: wider stretch image
 

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -70,19 +70,19 @@ and compare it with Figure 1 of Lupton et al. (2004):
    # this scaling is very similar to the one used in Lupton et al. (2004)
    rgb = make_lupton_rgb(i_new, r_new, g.data, Q=10, stretch=0.5, filename="ngc6976.jpeg")
 
-This will produce the following two images.
+This will produce the following two images. The first is the image generated
+with the default parameters.
 
-.. figure:: http://data.astropy.org/visualization/ngc6976-default.jpeg
-    :scale: 30 %
-    :alt: default rgb image
+.. raw:: html
 
-    Image generated with the default parameters.
+    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976-default.jpeg"><img alt="default rgb image" src="http://data.astropy.org/visualization/ngc6976-default.jpeg" /></a>
 
-.. figure:: http://data.astropy.org/visualization/ngc6976.jpeg
-    :scale: 30 %
-    :alt: wider stretch image
+The second is the image generated with Q=10, stretch=0.5, showing faint features
+of the galaxies. Compare with Fig. 1 of `Lupton et al. (2004)`_ or the
+`SDSS Skyserver image`_.
 
-    Image generated with Q=10, stretch=0.5, showing faint features of the galaxies.
-    Comapre with Fig. 1 of `Lupton et al. (2004)`_ or the `SDSS Skyserver image`_.
+.. raw:: html
+
+    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976.jpeg"><img alt="wider stretch image" src="http://data.astropy.org/visualization/ngc6976.jpeg" /></a>
 
 .. _SDSS Skyserver image: http://skyserver.sdss.org/dr13/en/tools/chart/navi.aspx?ra=179.68929&dec=-0.45438&opt=

--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -32,8 +32,8 @@ scaled.
 
 For a more in-depth example, download the `g`_, `r`_, `i`_ SDSS frames of the
 area around the Hickson 88 group and try the example below (requires the
-`reproject package`_, installable via pip), and compare it with Figure 1 of
-Lupton et al. (2004):
+`reproject package`_, installable via the astropy conda channel, or via pip),
+and compare it with Figure 1 of Lupton et al. (2004):
 
 .. _reproject package: https://reproject.readthedocs.io/
 
@@ -72,13 +72,13 @@ Lupton et al. (2004):
 
 This will produce the following two images.
 
-.. figure:: https://data.astropy.org/visualization/ngc6976-default.jpeg
+.. figure:: http://data.astropy.org/visualization/ngc6976-default.jpeg
     :scale: 30 %
     :alt: default rgb image
 
     Image generated with the default parameters.
 
-.. figure:: https://data.astropy.org/visualization/ngc6976.jpeg
+.. figure:: http://data.astropy.org/visualization/ngc6976.jpeg
     :scale: 30 %
     :alt: wider stretch image
 


### PR DESCRIPTION
This code implements the [Lupton et al. (2004) algorithm](http://adsabs.harvard.edu/abs/2004PASP..116..133L) for RGB image stacks, to make optimally colored images from 3 separate bands. Not all functionality is implemented (some LSST C++ code for better interpolation over saturated pixels will need to be ported eventually), but the code has been used by a few different people to make color JPEGs and PNGs from 1-3 FITS images.

Yet to do:
 * I still need to convert the code to use astropy's new `interval.ZScaleInterval` in place of `ZScaleMapping`.
 * Many of the tests just run the code and check that a file was generated, they don't actually check the contents of the generated image. We could do so, but there's not an independent set of images to check against, so the best I can think is to generate some images and save those as a baseline to test against. Whether that's necessary for incorporation into astropy, I don't know.
 * Convert `replaceSaturatedPixels` from `lsst::afw::display`. This should probably be a future feature: it's going to be a bit of work to convert that C++ into relatively fast python.

This code was pulled from lsst.afw.display.