### PR TITLE
Let Gaussian2D be initialized to defaults with no arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,9 @@ New Features
 
   - Added ``Planar2D`` functional model. [#5456]
 
+  - Updated ``Gaussian2D`` to accept no arguments (will use default x/y_stddev
+    and theta). [#5537]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``
@@ -203,6 +206,9 @@ API Changes
 - ``astropy.io.votable``
 
 - ``astropy.modeling``
+
+  - ``Gaussian2D`` now raises an error if ``theta`` is set at the same time as
+    ``cov_matrix`` (previously ``theta`` was silently ignored). [#5537]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
-from .. import models
+from .. import models, InputParameterError
 from ...coordinates import Angle
 from .. import fitting
 from ...tests.helper import pytest
@@ -88,6 +88,28 @@ def test_Gaussian2DRotation():
     value1 = g1(*point1)
     value2 = g2(*point2)
     assert_allclose(value1, value2)
+
+
+def test_Gaussian2D_invalid_inputs():
+    x_stddev = 5.1
+    y_stddev = 3.3
+    theta = 10
+    cov_matrix = [[49., -16.], [-16., 9.]]
+
+    # first make sure the valid ones are OK
+    models.Gaussian2D()
+    models.Gaussian2D(x_stddev=x_stddev, y_stddev=y_stddev, theta=theta)
+    models.Gaussian2D(x_stddev=None, y_stddev=y_stddev, theta=theta)
+    models.Gaussian2D(x_stddev=x_stddev, y_stddev=None, theta=theta)
+    models.Gaussian2D(x_stddev=x_stddev, y_stddev=y_stddev, theta=None)
+    models.Gaussian2D(cov_matrix=cov_matrix)
+
+    with pytest.raises(InputParameterError):
+        models.Gaussian2D(x_stddev=0, cov_matrix=cov_matrix)
+    with pytest.raises(InputParameterError):
+        models.Gaussian2D(y_stddev=0, cov_matrix=cov_matrix)
+    with pytest.raises(InputParameterError):
+        models.Gaussian2D(theta=0, cov_matrix=cov_matrix)
 
 
 def test_RedshiftScaleFactor():


### PR DESCRIPTION
Up until this PR, doing ``Gaussian2D()`` would raise an error, complaining that either ``x/y_stddev`` had to be set or ``cov_matrix``.  This PR changes that, allowing ``Gaussian2D()`` to initialize a Gaussian2D with just stddev=1.  This seems more consistent with most of the other 2D models, and ``Gaussian1D``.  

At the same time, I realized in the current situation, setting ``cov_matrix`` will raise an error if ``x/y_stddev`` are set, but it will *not* if ``theta`` is set - ``theta`` is just silently ignored.  So this also now raises an error if ``theta`` and ``cov_matrix`` are set.  Nominally this is an API change, although I'm pretty sure it was just an oversight originally that this was allowed.

It also adds a test to make sure all this behavior is actually correct.