### PR TITLE
Fix for #5472

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,6 +138,9 @@ API Changes
 
 - ``astropy.convolution``
 
+  - ``discretize_model`` now raises an exception if non-integer ranges are used.
+    Previously it had incorrect behavior but did not raise an exception. [#5538]
+
 - ``astropy.coordinates``
 
   - ``SkyCoord``, ``ICRS``, and other coordinate objects, as well as the

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -151,3 +151,19 @@ def test_dim_exception_2d():
     with pytest.raises(ValueError) as exc:
         discretize_model(f, (-10, 11))
     assert exc.value.args[0] == "y range not specified, but model is 2-d"
+
+def test_float_x_range_exception():
+    def f(x, y):
+        return x ** 2 + y ** 2
+    with pytest.raises(ValueError) as exc:
+        discretize_model(f, (-10.002, 11.23))
+    assert exc.value.args[0] == ("The difference between the upper an lower"
+                                 " limit of 'x_range' must be a whole number.")
+
+def test_float_y_range_exception():
+    def f(x, y):
+        return x ** 2 + y ** 2
+    with pytest.raises(ValueError) as exc:
+        discretize_model(f, (-10, 11), (-10.002, 11.23))
+    assert exc.value.args[0] == ("The difference between the upper an lower"
+                                 " limit of 'y_range' must be a whole number.")

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -85,10 +85,13 @@ def discretize_model(model, x_range, y_range=None, mode='center', factor=10):
         instances of `~astropy.modeling.FittableModel` are passed to
         `~astropy.modeling.custom_model` and then evaluated.
     x_range : tuple
-        x range in which the model is evaluated.
+        x range in which the model is evaluated. The difference between the
+        upper an lower limit must be a whole number, so that the output array
+        size is well defined.
     y_range : tuple, optional
-        y range in which the model is evaluated.
-        Necessary only for 2D models.
+        y range in which the model is evaluated. The difference between the
+        upper an lower limit must be a whole number, so that the output array
+        size is well defined. Necessary only for 2D models.
     mode : str, optional
         One of the following modes:
             * ``'center'`` (default)
@@ -146,6 +149,15 @@ def discretize_model(model, x_range, y_range=None, mode='center', factor=10):
     ndim = model.n_inputs
     if ndim > 2:
         raise ValueError('discretize_model only supports 1-d and 2-d models.')
+
+    if not float(np.diff(x_range)).is_integer():
+        raise ValueError("The difference between the upper an lower limit of"
+                         " 'x_range' must be a whole number.")
+
+    if y_range:
+        if not float(np.diff(y_range)).is_integer():
+            raise ValueError("The difference between the upper an lower limit of"
+                             " 'y_range' must be a whole number.")
 
     if ndim == 2 and y_range is None:
         raise ValueError("y range not specified, but model is 2-d")


### PR DESCRIPTION
This PR includes a fix for #5472. I decided to just disallow non-integer `x_range` and `y_range` limits in `discretize_model` (corresponding to solution 1. proposed by @astrofrog in the linked issue).