### PR TITLE
Fixes to sgr coordinates example

### DIFF
--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -134,18 +134,18 @@ def galactic_to_sgr(gal_coord, sgr_frame):
     l = np.atleast_1d(gal_coord.l.radian)
     b = np.atleast_1d(gal_coord.b.radian)
 
-    X = np.cos(b)*np.cos(l)
-    Y = np.cos(b)*np.sin(l)
-    Z = np.sin(b)
+    x = np.cos(b)*np.cos(l)
+    y = np.cos(b)*np.sin(l)
+    z = np.sin(b)
 
-    # Calculate X,Y,Z,distance in the Sgr system
-    Xs, Ys, Zs = SGR_MATRIX.dot(np.array([X, Y, Z]))
-    Zs = -Zs
+    # Calculate x,y,z,distance in the Sgr system
+    xs, ys, zs = SGR_MATRIX.dot(np.array([x, y, z]))
+    zs = -zs
 
     # Calculate the angular coordinates lambda,beta
-    Lambda = np.arctan2(Ys,Xs)*u.radian
+    Lambda = np.arctan2(ys,xs)*u.radian
     Lambda[Lambda < 0] = Lambda[Lambda < 0] + 2.*np.pi*u.radian
-    Beta = np.arcsin(Zs/np.sqrt(Xs*Xs+Ys*Ys+Zs*Zs))*u.radian
+    Beta = np.arcsin(zs/np.sqrt(xs*xs+ys*ys+zs*zs))*u.radian
 
     return Sagittarius(Lambda=Lambda, Beta=Beta,
                        distance=gal_coord.distance)
@@ -170,15 +170,15 @@ def sgr_to_galactic(sgr_coord, gal_frame):
     L = np.atleast_1d(sgr_coord.Lambda.radian)
     B = np.atleast_1d(sgr_coord.Beta.radian)
 
-    Xs = np.cos(B)*np.cos(L)
-    Ys = np.cos(B)*np.sin(L)
-    Zs = np.sin(B)
-    Zs = -Zs
+    xs = np.cos(B)*np.cos(L)
+    ys = np.cos(B)*np.sin(L)
+    zs = np.sin(B)
+    zs = -zs
 
-    X, Y, Z = SGR_MATRIX.T.dot(np.array([Xs, Ys, Zs]))
+    x, y, z = SGR_MATRIX.T.dot(np.array([xs, ys, zs]))
 
-    l = np.arctan2(Y,X)*u.radian
-    b = np.arcsin(Z/np.sqrt(X*X+Y*Y+Z*Z))*u.radian
+    l = np.arctan2(y, x)*u.radian
+    b = np.arcsin(z/np.sqrt(x*x + y*y + z*z))*u.radian
 
     l[l<=0] += 2*np.pi*u.radian
 

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -205,13 +205,15 @@ icrs = sgr.transform_to(coord.ICRS)
 ##############################################################################
 # Plot the points in both coordinate systems:
 
-fig,axes = plt.subplots(2, 1, figsize=(6,12),
-                        subplot_kw={'projection': 'aitoff'})
+fig, axes = plt.subplots(2, 1, figsize=(8, 10),
+                         subplot_kw={'projection': 'aitoff'})
 
 axes[0].set_title("Sagittarius")
-axes[0].scatter(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian)
+axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian,
+             linestyle='none', marker='.')
 
 axes[1].set_title("ICRS")
-axes[1].scatter(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian)
+axes[1].plot(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian,
+             linestyle='none', marker='.')
 
 plt.show()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -109,7 +109,7 @@ class Sagittarius(coord.BaseCoordinateFrame):
 # defining a function that accepts a coordinate and returns a new coordinate in
 # the new system. We'll start by constructing the transformation matrix using
 # pre-deteremined Euler angles and the ``rotation_matrix`` helper function
-# since both systems are Heliocentric::
+# since both systems are Heliocentric:
 
 SGR_PHI = np.radians(180+3.75) # Euler angles (from Law & Majewski 2010)
 SGR_THETA = np.radians(90-13.46)

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -162,14 +162,16 @@ sgr = icrs.transform_to(Sagittarius)
 print(sgr)
 
 ##############################################################################
-# Or, to transform from the ``Sagittarius`` frame to ICRS coordinates:
+# Or, to transform from the ``Sagittarius`` frame to ICRS coordinates (in this
+# case, a line along the ``Sagittarius`` x-y plane):
 
-sgr = Sagittarius(Lambda=np.linspace(0,2*np.pi,128)*u.radian,
+sgr = Sagittarius(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
                   Beta=np.zeros(128)*u.radian)
 icrs = sgr.transform_to(coord.ICRS)
+print(icrs)
 
 ##############################################################################
-# Plot the points in both coordinate systems:
+# And then to plot the points in both coordinate systems:
 
 fig, axes = plt.subplots(2, 1, figsize=(8, 10),
                          subplot_kw={'projection': 'aitoff'})

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -209,9 +209,9 @@ fig,axes = plt.subplots(2, 1, figsize=(6,12),
                         subplot_kw={'projection': 'aitoff'})
 
 axes[0].set_title("Sagittarius")
-axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian, linestyle='none')
+axes[0].scatter(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian)
 
 axes[1].set_title("ICRS")
-axes[1].plot(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian, linestyle='none')
+axes[1].scatter(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian)
 
 plt.show()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -55,7 +55,7 @@ plt.style.use(astropy_mpl_style)
 # Import the packages necessary for coordinates
 
 from astropy.coordinates import frame_transform_graph
-from astropy.coordinates.matrix_utilities import rotation_matrix
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 import astropy.coordinates as coord
 import astropy.units as u
 
@@ -118,7 +118,7 @@ SGR_PSI = np.radians(180+14.111534)
 D = rotation_matrix(SGR_PHI, "z", unit=u.radian)
 C = rotation_matrix(SGR_THETA, "x", unit=u.radian)
 B = rotation_matrix(SGR_PSI, "z", unit=u.radian)
-SGR_MATRIX = np.array(B.dot(C).dot(D))
+SGR_MATRIX = matrix_product(B, C, D)
 
 ##############################################################################
 # This is done at the module level, since it will be used by both the

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -139,7 +139,7 @@ def galactic_to_sgr(gal_coord, sgr_frame):
     z = np.sin(b)
 
     # Calculate x,y,z,distance in the Sgr system
-    xs, ys, zs = SGR_MATRIX.dot(np.array([x, y, z]))
+    xs, ys, zs = matrix_product(SGR_MATRIX, np.array([x, y, z]))
     zs = -zs
 
     # Calculate the angular coordinates lambda,beta
@@ -175,7 +175,7 @@ def sgr_to_galactic(sgr_coord, gal_frame):
     zs = np.sin(B)
     zs = -zs
 
-    x, y, z = SGR_MATRIX.T.dot(np.array([xs, ys, zs]))
+    x, y, z = matrix_product(SGR_MATRIX.T, np.array([xs, ys, zs]))
 
     l = np.arctan2(y, x)*u.radian
     b = np.arcsin(z/np.sqrt(x*x + y*y + z*z))*u.radian

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -107,8 +107,9 @@ class Sagittarius(coord.BaseCoordinateFrame):
 # other built-in coordinate system; we will use Galactic coordinates. We can do
 # this by defining functions that return transformation matrices, or by simply
 # defining a function that accepts a coordinate and returns a new coordinate in
-# the new system. We'll start by constructing the rotation matrix, using the
-# ``rotation_matrix`` helper function:
+# the new system. We'll start by constructing the transformation matrix using
+# pre-deteremined Euler angles and the ``rotation_matrix`` helper function
+# since both systems are Heliocentric::
 
 SGR_PHI = np.radians(180+3.75) # Euler angles (from Law & Majewski 2010)
 SGR_THETA = np.radians(90-13.46)
@@ -122,9 +123,9 @@ A = np.diag([1.,1.,-1.])
 SGR_MATRIX = matrix_product(A, B, C, D)
 
 ##############################################################################
-# This rotation matrix is defines at the module level, since it will be used
-# by both the transformation from Sgr to Galactic as well as the inverse from
-# Galactic to Sgr. Now we can define our first transformation function:
+# Since we already constructed the transformation (rotation) matrix above, and
+# the inverse of a rotation matrix is just its transpose, the required
+# transformation functions are very simple:
 
 @frame_transform_graph.transform(coord.StaticMatrixTransform, coord.Galactic, Sagittarius)
 def galactic_to_sgr():
@@ -137,8 +138,7 @@ def galactic_to_sgr():
 # The decorator ``@frame_transform_graph.transform(coord.StaticMatrixTransform,
 # coord.Galactic, Sagittarius)``  registers this function on the
 # ``frame_transform_graph`` as a coordinate transformation. Inside the function,
-# we simply construct a rotation matrix using the Euler angles (and the
-# z-axis flip matrix) since both systems are heliocentric.
+# we simply return the previously defined rotation matrix.
 #
 # We then register the inverse transformation by using the transpose of the
 # rotation matrix (which is faster to compute than the inverse):


### PR DESCRIPTION
This is a replacement for #5210 that changes the transformation to the Sagittarius plane coordinate from a function transform to a matrix transform. This simplifies the transform code and makes it more consistent with the other implemented transformations.

cc @eteq @mhvk 