### PR TITLE
Wcs data size

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -189,8 +189,8 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             else:
                 message = ('The {func} {obj_type} is deprecated and may '
                            'be removed in a future version.')
-            if alternative:
-                altmessage = '\n        Use {} instead.'.format(alternative)
+        if alternative:
+            altmessage = '\n        Use {} instead.'.format(alternative)
 
         message = ((message.format(**{
             'func': name,

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -78,20 +78,20 @@ def test_slice():
     mywcs.wcs.crval = [1,1]
     mywcs.wcs.cdelt = [0.1,0.1]
     mywcs.wcs.crpix = [1,1]
-    mywcs._naxis = [1000, 500]
+    mywcs._naxis_size = [1000, 500]
 
     slice_wcs = mywcs.slice([slice(1,None),slice(0,None)])
     assert np.all(slice_wcs.wcs.crpix == np.array([1,0]))
-    assert slice_wcs._naxis == [1000, 499]
+    assert slice_wcs._naxis_size == [1000, 499]
 
     slice_wcs = mywcs.slice([slice(1,None,2),slice(0,None,4)])
     assert np.all(slice_wcs.wcs.crpix == np.array([0.625, 0.25]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.4,0.2]))
-    assert slice_wcs._naxis == [250, 250]
+    assert slice_wcs._naxis_size == [250, 250]
 
     slice_wcs = mywcs.slice([slice(None,None,2),slice(0,None,2)])
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2,0.2]))
-    assert slice_wcs._naxis == [500, 250]
+    assert slice_wcs._naxis_size == [500, 250]
 
 def test_slice_getitem():
     mywcs = WCS(naxis=2)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1038,14 +1038,14 @@ def test_naxis():
     w.wcs.crval = [1, 1]
     w.wcs.cdelt = [0.1, 0.1]
     w.wcs.crpix = [1, 1]
-    w._naxis = [1000, 500]
+    w._naxis_size = [1000, 500]
 
-    assert w._naxis1 == 1000
-    assert w._naxis2 == 500
+    assert w.naxis1 == 1000
+    assert w.naxis2 == 500
 
-    w._naxis1 = 99
-    w._naxis2 = 59
-    assert w._naxis == [99, 59]
+    w.naxis1 = 99
+    w.naxis2 = 59
+    assert w._naxis_size == [99, 59]
 
 
 def test_sip_with_altkey():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -67,7 +67,7 @@ if _wcs is not None:
 
 from ..utils.compat import possible_filename
 from ..utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
-from ..utils.decorators import deprecated
+from ..utils.decorators import deprecated, deprecated_attribute
 
 if _wcs is not None:
     assert _wcs._sanity_check(), \
@@ -2706,6 +2706,26 @@ reduce these to 2 dimensions using the naxis kwarg.
             f.write('polygon(')
             self.calc_footprint().tofile(f, sep=',')
             f.write(') # color={0}, width={1:d} \n'.format(color, width))
+
+    @property
+    @deprecated("1.3", name="_naxis1", alternative="naxis1", obj_type="attribute")
+    def _naxis1(self):
+        return self._naxis_size[0]
+
+    @_naxis1.setter
+    @deprecated("1.3", name="_naxis1", alternative="naxis1", obj_type="attribute")
+    def _naxis1(self, value):
+        self._naxis_size[0] = value
+
+    @property
+    @deprecated("1.3", name="_naxis2", alternative="naxis2", obj_type="attribute")
+    def _naxis2(self):
+        return self._naxis_size[1]
+
+    @_naxis2.setter
+    @deprecated("1.3", name="_naxis2", alternative="naxis2", obj_type="attribute")
+    def _naxis2(self, value):
+        self._naxis_size[1] = value
 
     def _get_naxis(self, header=None):
         _naxis = []


### PR DESCRIPTION
This PR addresses #5461 and adds properties for all `NAXISj` keywords in a header. It's a bit of a kludge because it adds the properties in the `__init__`  method. If anyone knows of a better method that does not involve rewriting the entire `WCS` class and adding a metaclass, I'd like to know it.

I also renamed `_naxis` to `_naxis_size` and defined it in the `__init__`. The reason is there's an attribute `WCS.naxis` which stores the number of WCS axes and it's confusing to have a private variable with the same name but different meaning. Since `_naxis` was added only recently this is not an API change and hopefully will not cause much trouble.

This PR deprecates the properties for the private `_naxisj` attributes. Note that there are no private attributes now as the new properties work with the `_naxis_size` list. 
(Accessing the deprecated attributes prints [__main__], not sure why.)

@astrofrog @MSeifert04 @saimn 
