### PR TITLE
Added a mirror for the astropy data repository

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -585,6 +585,9 @@ New Features
     rename a function argument, while it still allows for the use of the older
     argument name. [#5214]
 
+  - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``
+    that is used to indicate a mirror for the astropy data server.
+
 - ``astropy.visualization``
 
   - Added a ``make_lupton_rgb`` function to generate color images from three

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ New Features
     arrays are fixed-width and silently drop characters which do not
     fit within the fixed width. [#5624, #5819]
 
-  - Added functionality to allow ``astropy.units.Quantity`` to be written 
+  - Added functionality to allow ``astropy.units.Quantity`` to be written
     as a normal column to FITS files. [#5910]
 
   - Add support for Quantity columns (within a ``QTable``) in table
@@ -85,6 +85,9 @@ New Features
     ``Quantity(1, u.dex(u.m), subok=True)`` yields ``<Dex 1.0 dex(m)>``. [#5928]
 
 - ``astropy.utils``
+
+  - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``
+    that is used to indicate a mirror for the astropy data server. [#5547]
 
 - ``astropy.visualization``
 
@@ -584,9 +587,6 @@ New Features
   - Added a new decorator: ``deprecated_renamed_argument``. This can be used to
     rename a function argument, while it still allows for the use of the older
     argument name. [#5214]
-
-  - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``
-    that is used to indicate a mirror for the astropy data server.
 
 - ``astropy.visualization``
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -52,7 +52,10 @@ class Conf(_config.ConfigNamespace):
 
     dataurl = _config.ConfigItem(
         'http://data.astropy.org/',
-        'URL for astropy remote data site.')
+        'Primary URL for astropy remote data site.')
+    dataurl_mirror = _config.ConfigItem(
+        'http://astropy.org/astropy-data/',
+        'Mirror URL for astropy remote data site.')
     remote_timeout = _config.ConfigItem(
         10.,
         'Time to wait for remote data queries (in seconds).',
@@ -484,8 +487,16 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
     elif os.path.isfile(datafn):  # local file
         return get_readable_fileobj(datafn, encoding=encoding)
     else:  # remote file
-        return get_readable_fileobj(conf.dataurl + datafn, encoding=encoding,
-                                    cache=cache)
+        all_urls = (conf.dataurl, conf.dataurl_mirror)
+        for url in all_urls:
+            try:
+                return get_readable_fileobj(url + datafn, encoding=encoding,
+                                            cache=cache)
+            except urllib.error.URLError as e:
+                pass
+        urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
+        raise urllib.error.URLError("Failed to download {0} from the following "
+                                    "repositories:\n\n{1}".format(datafn, urls))
 
 
 def get_pkg_data_filename(data_name, package=None, show_progress=True,
@@ -582,11 +593,20 @@ def get_pkg_data_filename(data_name, package=None, show_progress=True,
     if data_name.startswith('hash/'):
         # first try looking for a local version if a hash is specified
         hashfn = _find_hash_fn(data_name[5:])
+
         if hashfn is None:
-            return download_file(
-                conf.dataurl + data_name, cache=True,
-                show_progress=show_progress,
-                timeout=remote_timeout)
+            all_urls = (conf.dataurl, conf.dataurl_mirror)
+            for url in all_urls:
+                try:
+                    return download_file(url + data_name, cache=True,
+                                         show_progress=show_progress,
+                                         timeout=remote_timeout)
+                except urllib.error.URLError:
+                    pass
+            urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
+            raise urllib.error.URLError("Failed to download {0} from the following "
+                                        "repositories:\n\n{1}\n\n".format(data_name, urls))
+
         else:
             return hashfn
     else:
@@ -597,10 +617,17 @@ def get_pkg_data_filename(data_name, package=None, show_progress=True,
         elif os.path.isfile(datafn):  # local file
             return datafn
         else:  # remote file
-            return download_file(
-                conf.dataurl + data_name, cache=True,
-                show_progress=show_progress,
-                timeout=remote_timeout)
+            all_urls = (conf.dataurl, conf.dataurl_mirror)
+            for url in all_urls:
+                try:
+                    return download_file(url + data_name, cache=True,
+                                         show_progress=show_progress,
+                                         timeout=remote_timeout)
+                except urllib.error.URLError:
+                    pass
+            urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
+            raise urllib.error.URLError("Failed to download {0} from the following "
+                                        "repositories:\n\n{1}".format(data_name, urls))
 
 
 def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):


### PR DESCRIPTION
In view of the STScI server being down this weekend, this seems like a good time to add a config item for a mirror for data.astropy.org :) While doing this, I realized that in the remote-data plugin, I need to actually read the URLs from the astropy.utils.data config not hard-code URLs....
