### PR TITLE
io.ascii fast C converter support for Fortran formats and extended precision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ New Features
 
 - ``astropy.io.ascii``
 
+  - Files with "Fortran-style" columns (i.e. double-precision scientific notation
+    with a character other than "e", like ``1.495978707D+13``) can now be parsed by
+    the fast reader natively. [#5552]
+
   - Allow round-tripping masked data tables in most formats by using an
     empty string ``''`` as the default representation of masked values
     when writing. [#5347]

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -60,6 +60,7 @@ typedef struct
     char delimiter;        // delimiter character
     char comment;          // comment character
     char quotechar;        // quote character
+    char expchar;          // exponential character in scientific notation
     char **output_cols;    // array of output strings for each column
     char **col_ptrs;       // array of pointers to current output position for each col
     int *output_len;       // length of each output column string
@@ -90,9 +91,9 @@ output_cols: ["A\x0010\x001", "B\x005.\x002", "C\x006\x003"]
 #define INITIAL_COL_SIZE 500
 #define INITIAL_COMMENT_LEN 50
 
-tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar, int fill_extra_cols,
-                              int strip_whitespace_lines, int strip_whitespace_fields,
-                              int use_fast_converter);
+tokenizer_t *create_tokenizer(char delimiter, char comment, char quotechar, char expchar,
+                              int fill_extra_cols, int strip_whitespace_lines,
+                              int strip_whitespace_fields, int use_fast_converter);
 void delete_tokenizer(tokenizer_t *tokenizer);
 void delete_data(tokenizer_t *tokenizer);
 void resize_col(tokenizer_t *self, int index);
@@ -102,7 +103,7 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols);
 long str_to_long(tokenizer_t *self, char *str);
 double str_to_double(tokenizer_t *self, char *str);
 double xstrtod(const char *str, char **endptr, char decimal,
-               char sci, char tsep, int skip_trailing);
+               char expchar, char tsep, int skip_trailing);
 void start_iteration(tokenizer_t *self, int col);
 char *next_field(tokenizer_t *self, int *size);
 long file_len(FILE *fhandle);

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -39,8 +39,8 @@ def assert_equal(a, b):
     assert a == b
 
 
-def assert_almost_equal(a, b):
-    assert np.allclose(a, b)
+def assert_almost_equal(a, b, **kwargs):
+    assert np.allclose(a, b, **kwargs)
 
 
 def assert_true(a):

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -36,11 +36,14 @@ else:
     HAS_PATHLIB = True
 
 
-@pytest.mark.parametrize('fast_reader', [True, False, 'force'])
+@pytest.mark.parametrize('fast_reader', [True, False, {'use_fast_converter': False},
+                                         {'use_fast_converter': True}, 'force'])
 def test_convert_overflow(fast_reader):
     """
     Test reading an extremely large integer, which falls through to
-    string due to an overflow error (#2234).
+    string due to an overflow error (#2234). The C parsers used to
+    return inf (kind 'f') for this.
+    Kind should be 'S' in Python2, 'U' in Python3.
     """
     expected_kind = ('S', 'U')
     dat = ascii.read(['a', '1' * 10000], format='basic',

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -232,9 +232,18 @@ def read(table, guess=None, **kwargs):
         List of names to include in fill_values (default= ``None`` selects all names)
     fill_exclude_names : list
         List of names to exclude from fill_values (applied after ``fill_include_names``)
-    fast_reader : bool
+    fast_reader : bool or dict
         Whether to use the C engine, can also be a dict with options which default to ``False``
-        (default= ``True``)
+        (default= ``True``); parameters for options dict:
+
+        use_fast_converter: bool
+            enable faster but slightly imprecise floating point conversion method
+        parallel: bool or int
+            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
+        exponent_style: str
+            One-character string defining the exponent or ``'Fortran'`` to auto-detect
+            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
+            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
     Reader : `~astropy.io.ascii.BaseReader`
         Reader class (DEPRECATED) (default= :class:`Basic`).
 
@@ -363,8 +372,18 @@ def _guess(table, read_kwargs, format, fast_reader):
     format : str
         Table format
     fast_reader : bool
+    fast_reader : bool or dict
         Whether to use the C engine, can also be a dict with options which
-        default to ``False`` (default= ``True``)
+        default to ``False`` (default= ``True``); parameters for options dict:
+
+        use_fast_converter: bool
+            enable faster but slightly imprecise floating point conversion method
+        parallel: bool or int
+            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
+        exponent_style: str
+            Character to use for exponent or ``'Fortran'`` to auto-detect any
+            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
+            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
 
     Returns
     -------

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -64,11 +64,13 @@ These parameters are:
  * ``data_Splitter``
  * ``header_Splitter``
 
+.. _fast_conversion_opts:
+
 Parallel and fast conversion options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In addition to ``True`` and ``False``, the parameter ``fast_reader`` can also
-be a dict specifying one or both of two additional parameters, ``parallel`` and
-``use_fast_converter``. For example::
+be a dict specifying any of three additional parameters, ``parallel``,
+``use_fast_converter`` and ``exponent_style``. For example::
 
    >>> ascii.read('data.txt', format='basic', fast_reader={'parallel': True, 'use_fast_converter': True}) # doctest: +SKIP
 
@@ -83,6 +85,12 @@ IPython Notebook and so enabling multiprocessing in this context is discouraged.
 
 Setting ``use_fast_converter`` to be ``True`` enables a faster but
 slightly imprecise conversion method for floating-point values, as described below.
+
+The ``exponent_style`` parameter allows to define a different character
+from the default ``'e'`` for exponential formats in the input file.
+The special setting ``'fortran'`` enables auto-detection of any valid
+exponent character under Fortran notation.
+For details see the section on :ref:`fortran_style_exponents`.
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -419,6 +419,29 @@ The default converters for each column can be overridden with the
   ...               'col2': [ascii.convert_numpy(np.float32)]}
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
+
+.. _fortran_style_exponents:
+
+Fortran-style exponents
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The :ref:`fast converter <fast_conversion_opts>` available with the C
+input parser provides an ``exponent_style`` option to define a custom
+character instead of the standard ``'e'`` for exponential formats in
+the input file, to read for example Fortran-style double precision
+numbers like ``'1.495978707D+13'``:
+
+  >>> ascii.read('double.dat', format='basic', guess=False, 
+  ...            fast_reader={'exponent_style': 'D'})  # doctest: +SKIP
+
+The special setting ``'fortran'`` is provided to allow for the
+auto-detection of any valid Fortran exponent character (``'E'``,
+``'D'``, ``'Q'``), as well as of triple-digit exponents prefixed with no
+character at all (e.g. ``'2.1127123261674622-107'``).
+All values and exponent characters in the input data are
+case-insensitive; any value other than the default ``'E'`` implies the
+automatic setting of ``'use_fast_converter': True``.
+
 Advanced customization
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is the _Fortran-exponents_ branch from #3655 merged into the current master, since that PR apparently could not make it through CI anymore. Updated the tests for more checks at the `float64` precision limits.