### PR TITLE
Remove unnecessary headers and "warning" note in nddata decorator docs

### DIFF
--- a/docs/nddata/decorator.rst
+++ b/docs/nddata/decorator.rst
@@ -2,19 +2,10 @@
 Decorating functions to accept NDData objects
 *********************************************
 
-.. important:: The functionality described here is still experimental and will
-               likely evolve over time as more packages make use of it.
-
-Introduction
-============
-
 The `astropy.nddata` module includes a decorator
 :func:`~astropy.nddata.support_nddata` that makes it easy for developers and
 users to write functions that can accept either :class:`~astropy.nddata.NDData`
 objects and also separate arguments.
-
-Getting started
-===============
 
 Let's consider the following function::
 
@@ -67,4 +58,3 @@ sub-classes (and sub-classes of those) using the ``accepts`` option::
     @support_nddata(accepts=CCDImage)
     def test(data, wcs=None, unit=None, n_iterations=3):
         ...
-


### PR DESCRIPTION
This is a simple doc PR that occurred to me while reviewing #5477 - it just removes a note saying support nddata is "experimental" (I think that's not really true anymore), and got read of the section headings, as I thought they just distract from the flow.  (That is, a "getting started" without anything else isn't really necessary)

cc @MSeifert04 @mwcraig 