### PR TITLE
Table column assignment doesn't update column description

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1249,8 +1249,17 @@ class Table(object):
             n_cols = len(self.columns)
 
             if isinstance(item, six.string_types):
-                # Set an existing column
-                self.columns[item][:] = value
+                # Set *in-place* an existing column
+                col = self.columns[item]
+                col[:] = value
+
+                # Transfer attributes when setting to a Column instance.
+                # TODO later: generalize to mixin columns on the right side (value)
+                if isinstance(value, Column):
+                    for attr in ('description', 'unit', 'format', 'meta'):
+                        setattr(col.info, attr, getattr(value, attr))
+                        # Note that setattr(col.info, ...) is used instead of setattr(col, ..)
+                        # because this generalizes to mixins (on the left side).
 
             elif isinstance(item, (int, np.integer)):
                 # Set the corresponding row assuming value is an iterable.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1747,3 +1747,18 @@ def test_qtable_read_for_ipac_table_with_char_columns():
     t1.write(out, format="ascii.ipac")
     t2 = table.QTable.read(out.getvalue(), format="ascii.ipac", guess=False)
     assert t2["B"].unit is None
+
+
+def test_table_setitem_column():
+    """
+    Test that setitem with a `Column` works properly.
+
+    Regression test for https://github.com/astropy/astropy/issues/2630
+    """
+    t = table.Table()
+    t['a'] = table.Column([1, 2, 3], unit='m', description='old')
+    t['a'] = table.Column([4, 5, 6], unit='s', description='new')
+
+    assert_allclose(t['a'].data, [4, 5, 6])
+    assert t['a'].unit == u.Unit('s')
+    assert t['a'].description == 'new'


### PR DESCRIPTION
I would have expected the column `description='updated'` to be stored in the `table['a']` column in this example:

``` python
>>> from astropy.table import Table, Column
>>> table = Table()
>>> table['a'] = Column([1, 2, 3], description='original')
>>> table['a']
<Column name='a' unit=None format=None description='original'>
array([1, 2, 3])
>>> table['a'] = Column([4, 5, 6], description='updated')
>>> table['a']
<Column name='a' unit=None format=None description='original'>
array([4, 5, 6])
```

@taldcroft Is this a bug?
