### PR TITLE
Make convolution support NDData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New Features
 
 - ``astropy.convolution``
 
+  - The ``convolve`` and ``convolve_fft`` arguments now support a ``mask`` keyword,
+    which allows them to also support ``NDData`` objects as inputs. [#5554]
+
 - ``astropy.coordinates``
 
   - Added an ``of_address`` classmethod to ``EarthLocation`` to enable fast creation of
@@ -131,8 +134,8 @@ New Features
 
   - Added a default ``vmin/vmax`` for the ``ManualInterval`` class.
     [#5206].
-    
-  - The ``wcsaxes`` subpackage has now been integrated in astropy as 
+
+  - The ``wcsaxes`` subpackage has now been integrated in astropy as
     ``astropy.visualization.wcsaxes``.  This allows plotting of astronomical
     data/coordinate systems in Matplotlib. [#5496]
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -163,10 +163,8 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     # This requires copying the array_internal
     array_internal_copied = False
     if np.ma.is_masked(array):
-        if not array_internal_copied:
-            array_internal = array_internal.copy()
-            array_internal_copied = True
-        array_internal[array.mask] = np.nan
+        array_internal = array_internal.filled(np.nan)
+        array_internal_copied = True
     if mask is not None:
         if not array_internal_copied:
             array_internal = array_internal.copy()

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -60,7 +60,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         The value to use outside the array when using ``boundary='fill'``
     normalize_kernel : bool, optional
         Whether to normalize the kernel prior to convolving
-    mask : None or `numpy.ndarray`
+    mask : `None` or `numpy.ndarray`
         A "mask" array.  Shape must match ``array``, and anything that is masked
         (i.e., not 0/`False`) will be set to NaN for the convolution.  If
         `None`, no masking will be performed unless ``array`` is a masked array.

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -62,8 +62,10 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         Whether to normalize the kernel prior to convolving
     mask : None or `numpy.ndarray`
         A "mask" array.  Shape must match ``array``, and anything that is masked
-        (i.e., not 0/False) will be set to NaN for the convolution.  If None, no
-        masking will be performed unless ``array`` is a masked array.
+        (i.e., not 0/`False`) will be set to NaN for the convolution.  If
+        `None`, no masking will be performed unless ``array`` is a masked array.
+        If ``mask`` is not `None` *and* ``array`` is a masked array, a pixel is
+        masked of it is masked in either ``mask`` *or* ``array.mask``.
 
     Returns
     -------
@@ -311,10 +313,12 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0, crop=True,
         e.g., ``normalize_kernel=np.sum`` means that kernel will be modified to be:
         ``kernel = kernel / np.sum(kernel)``.  If True, defaults to
         ``normalize_kernel = np.sum``.
-    mask : None or `numpy.ndarray`
+    mask : `None` or `numpy.ndarray`
         A "mask" array.  Shape must match ``array``, and anything that is masked
-        (i.e., not 0/False) will be set to NaN for the convolution.  If None, no
-        masking will be performed unless ``array`` is a masked array.
+        (i.e., not 0/`False`) will be set to NaN for the convolution.  If
+        `None`, no masking will be performed unless ``array`` is a masked array.
+        If ``mask`` is not `None` *and* ``array`` is a masked array, a pixel is
+        masked of it is masked in either ``mask`` *or* ``array.mask``.
 
     Other Parameters
     ----------------

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -170,9 +170,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         # mask != 0 yields a bool mask for all ints/floats/bool
         array_internal[mask != 0] = np.nan
     if np.ma.is_masked(kernel):
-        if not array_internal_copied:
-            array_internal = array_internal.copy()
-            array_internal_copied = True
+        kernel_internal = kernel_internal.copy()
         kernel_internal[kernel.mask] = np.nan
 
     # Because the Cython routines have to normalize the kernel on the fly, we

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -36,10 +36,11 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
 
     Parameters
     ----------
-    array : `numpy.ndarray`
+    array : `numpy.ndarray` or `~astropy.nddata.NDData`
         The array to convolve. This should be a 1, 2, or 3-dimensional array
         or a list or a set of nested lists representing a 1, 2, or
-        3-dimensional array.
+        3-dimensional array.  If an `~astropy.nddata.NDData`, the ``mask`` of
+        the `~astropy.nddata.NDData` will be used as the ``mask`` argument.
     kernel : `numpy.ndarray` or `~astropy.convolution.Kernel`
         The convolution kernel. The number of dimensions should match those
         for the array, and the dimensions should be odd in all directions.
@@ -279,8 +280,10 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0, crop=True,
 
     Parameters
     ----------
-    array : `numpy.ndarray`
-          Array to be convolved with ``kernel``
+    array : `numpy.ndarray` or `~astropy.nddata.NDData`
+          Array to be convolved with ``kernel``. If `~astropy.nddata.NDData`,
+          the ``mask`` of the `~astropy.nddata.NDData` will be used as the
+          ``mask`` argument.
     kernel : `numpy.ndarray`
           Will be normalized if ``normalize_kernel`` is set.  Assumed to be
           centered (i.e., shifts may result if your kernel is asymmetric).

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -155,13 +155,24 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         raise Exception('array and kernel have differing number of '
                         'dimensions.')
 
-    # anything that's masked must be turned into NaNs for the interpolation
+    # anything that's masked must be turned into NaNs for the interpolation.
+    # This requires copying the array_internal
+    array_internal_copied = False
     if np.ma.is_masked(array):
+        if not array_internal_copied:
+            array_internal = array_internal.copy()
+            array_internal_copied = True
         array_internal[array.mask] = np.nan
     if mask is not None:
+        if not array_internal_copied:
+            array_internal = array_internal.copy()
+            array_internal_copied = True
         # mask != 0 yields a bool mask for all ints/floats/bool
         array_internal[mask != 0] = np.nan
     if np.ma.is_masked(kernel):
+        if not array_internal_copied:
+            array_internal = array_internal.copy()
+            array_internal_copied = True
         kernel_internal[kernel.mask] = np.nan
 
     # Because the Cython routines have to normalize the kernel on the fly, we

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -11,6 +11,7 @@ from .core import Kernel, Kernel1D, Kernel2D, MAX_NORMALIZATION
 from ..utils.exceptions import AstropyUserWarning
 from ..utils.console import human_file_size
 from .. import units as u
+from ..nddata import support_nddata
 
 from ..extern.six.moves import range, zip
 
@@ -20,6 +21,7 @@ from ..extern.six.moves import range, zip
 __doctest_skip__ = ['*']
 
 
+@support_nddata(data='array')
 def convolve(array, kernel, boundary='fill', fill_value=0.,
              normalize_kernel=False, mask=None):
     '''
@@ -237,6 +239,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         return result
 
 
+@support_nddata(data='array')
 def convolve_fft(array, kernel, boundary='fill', fill_value=0, crop=True,
                  return_fft=False, fft_pad=None, psf_pad=None,
                  interpolate_nan=False, quiet=False, ignore_edge_zeros=False,

--- a/astropy/convolution/tests/test_convolve_nddata.py
+++ b/astropy/convolution/tests/test_convolve_nddata.py
@@ -1,0 +1,56 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from ...tests.helper import pytest
+
+from ..convolve import convolve, convolve_fft
+from ..kernels import Gaussian2DKernel
+from ...nddata import NDData
+
+
+def test_basic_nddata():
+    arr = np.zeros((11, 11))
+    arr[5, 5] = 1
+    ndd = NDData(arr)
+    test_kernel = Gaussian2DKernel(1)
+
+    result = convolve(ndd, test_kernel)
+
+    x, y = np.mgrid[:11, :11]
+    expected = result[5, 5] * np.exp(-0.5 * ((x - 5)**2 + (y - 5)**2))
+
+    np.testing.assert_allclose(result, expected, atol=1e-6)
+
+    resultf = convolve_fft(ndd, test_kernel)
+    np.testing.assert_allclose(resultf, expected, atol=1e-6)
+
+@pytest.mark.parametrize('convfunc', [convolve,
+    lambda *args: convolve_fft(*args, interpolate_nan=True, normalize_kernel=True)])
+def test_masked_nddata(convfunc):
+    arr = np.zeros((11, 11))
+    arr[4, 5] = arr[6, 5] = arr[5, 4] = arr[5, 6] = 0.2
+    ndd_base = NDData(arr)
+
+    mask = arr < 0
+    mask[5, 5] = True
+    ndd_mask = NDData(arr, mask=mask)
+
+    arrnan = arr.copy()
+    arrnan[5, 5] = np.nan
+    ndd_nan = NDData(arrnan)
+
+    test_kernel = Gaussian2DKernel(1)
+
+    result_base = convfunc(ndd_base, test_kernel)
+    result_nan = convfunc(ndd_nan, test_kernel)
+    result_mask = convfunc(ndd_mask, test_kernel)
+
+    assert np.allclose(result_nan, result_mask)
+    assert not np.allclose(result_base, result_mask)
+    assert not np.allclose(result_base, result_nan)
+
+    # check to make sure the mask run doesn't talk back to the initial array
+    assert np.sum(np.isnan(ndd_base.data)) != np.sum(np.isnan(ndd_nan.data))


### PR DESCRIPTION
This adds support for allowing the `convolution` functions to accept nddata objects. 

The key change this requires (other than the @support_nddata decorator, of course), is adding a `mask` keyword to the convolve function.  Any masked values will be treated as NaN for the purposes of interpolation.

cc @astrofrog 