### PR TITLE
Change Table behavior when setting column: default to replace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -243,7 +243,8 @@ API Changes
 
   - Setting an existing table column (e.g. ``t['a'] = [1, 2, 3]``) now defaults
     to *replacing* the column with a column corresponding to the new value
-    (using ``t.replace_column()``) instead of doing an in-place update.  An
+    (using ``t.replace_column()``) instead of doing an in-place update.  Any
+    existing meta-data in the column (e.g. the unit) is discarded.  An
     in-place update is still done when the new value is not a valid column,
     e.g. ``t['a'] = 0``.  To force an in-place update use the pattern
     ``t['a'][:] = [1, 2, 3]``. [#5556]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -241,6 +241,13 @@ API Changes
 
 - ``astropy.table``
 
+  - Setting an existing table column (e.g. ``t['a'] = [1, 2, 3]``) now defaults
+    to *replacing* the column with a column corresponding to the new value
+    (using ``t.replace_column()``) instead of doing an in-place update.  An
+    in-place update is still done when the new value is not a valid column,
+    e.g. ``t['a'] = 0``.  To force an in-place update use the pattern
+    ``t['a'][:] = [1, 2, 3]``. [#5556]
+
   - Allow ``collections.Mapping``-like ``data`` attribute when initializing a
     ``Table`` object (``dict``-like was already possible). [#5213]
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1250,7 +1250,10 @@ class Table(object):
 
             if isinstance(item, six.string_types):
                 # Set an existing column
-                self.columns[item][:] = value
+                try:
+                    self.replace_column(item, value)
+                except Exception:
+                    self.columns[item][:] = value
 
             elif isinstance(item, (int, np.integer)):
                 # Set the corresponding row assuming value is an iterable.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1256,13 +1256,16 @@ class Table(object):
             n_cols = len(self.columns)
 
             if isinstance(item, six.string_types):
-                # Set an existing column
-                try:
-                    # See definition of mask property for discussion of next line.
-                    assert not getattr(self, '_setitem_inplace', False)
-                    self.replace_column(item, value)
-                except Exception:
-                    self.columns[item][:] = value
+                # Set an existing column by first trying to replace, and if
+                # this fails do an in-place update.  See definition of mask
+                # property for discussion of the _setitem_inplace attribute.
+                if not getattr(self, '_setitem_inplace', False):
+                    try:
+                        self.replace_column(item, value)
+                        return
+                    except Exception:
+                        pass
+                self.columns[item][:] = value
 
             elif isinstance(item, (int, np.integer)):
                 # Set the corresponding row assuming value is an iterable.

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -195,7 +195,7 @@ class TestTableInit(SetupData):
         assert np.all(t.mask['a'] == np.array([False, False, False]))
         assert np.all(t.mask['b'] == np.array([True, True, True]))
         # Check that setting mask from table mask has the desired effect on column
-        t.mask['b'] = np.array([False, True, False])
+        t.mask['b'][:] = np.array([False, True, False])
         assert np.all(t['b'].mask == np.array([False, True, False]))
         # Non-masked table returns None for mask attribute
         t2 = Table([self.ca], masked=False)

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -195,7 +195,7 @@ class TestTableInit(SetupData):
         assert np.all(t.mask['a'] == np.array([False, False, False]))
         assert np.all(t.mask['b'] == np.array([True, True, True]))
         # Check that setting mask from table mask has the desired effect on column
-        t.mask['b'][:] = np.array([False, True, False])
+        t.mask['b'] = np.array([False, True, False])
         assert np.all(t['b'].mask == np.array([False, True, False]))
         # Non-masked table returns None for mask attribute
         t2 = Table([self.ca], masked=False)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1712,6 +1712,29 @@ def test_replace_column_qtable():
     assert t['a'].info.meta is None
     assert t['a'].info.format is None
 
+def test_replace_update_column_via_setitem():
+    """
+    Test table update like ``t['a'] = value``.  This leverages off the
+    already well-tested ``replace_column`` and in-place update
+    ``t['a'][:] = value``, so this testing is fairly light.
+    """
+    a = [1, 2] * u.m
+    b = [3, 4]
+    t = table.QTable([a, b], names=['a', 'b'])
+    assert isinstance(t['a'], u.Quantity)
+
+    # Inplace update
+    ta = t['a']
+    t['a'] = 5 * u.m
+    assert np.all(t['a'] == [5, 5] * u.m)
+    assert t['a'] is ta
+
+    # Replace
+    t['a'] = [5, 6]
+    assert np.all(t['a'] == [5, 6])
+    assert isinstance(t['a'], table.Column)
+    assert t['a'] is not ta
+
 def test_primary_key_is_inherited():
     """Test whether a new Table inherits the primary_key attribute from
     its parent Table. Issue #4672"""

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -200,7 +200,7 @@ columns (using column names), where the subset is returned as a new table::
 
 Modifying table values in place is flexible and works as one would expect::
 
-  >>> t['a'] = [-1, -2, -3]       # Set all column values
+  >>> t['a'][:] = [-1, -2, -3]    # Set all column values in place
   >>> t['a'][2] = 30              # Set row 2 of column 'a'
   >>> t[1] = (8, 9.0, "W")        # Set all row values
   >>> t[1]['b'] = -9              # Set column 'b' of row 1
@@ -213,11 +213,12 @@ Modifying table values in place is flexible and works as one would expect::
     8 100.000   W
    30   8.200   z
 
-Add, remove, and rename columns with the following::
+Replace, add, remove, and rename columns with the following::
 
-  >>> t['d'] = [1, 2, 3]
-  >>> del t['c']
-  >>> t.rename_column('a', 'A')
+  >>> t['b'] = ['a', 'new', 'dtype']   # Replace column b (different from in place)
+  >>> t['d'] = [1, 2, 3]               # Add column d
+  >>> del t['c']                       # Delete column c
+  >>> t.rename_column('a', 'A')        # Rename column a to A
   >>> t.colnames
   ['A', 'b', 'd']
 

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -28,11 +28,11 @@ The code below shows the basics of modifying a table and its data.
 **Modify data values**
 ::
 
-  >>> t['a'] = [1, -2, 3, -4, 5]  # Set all column values
-  >>> t['a'][2] = 30              # Set row 2 of column 'a'
-  >>> t[1] = (8, 9, 10)           # Set all row values
-  >>> t[1]['b'] = -9              # Set column 'b' of row 1
-  >>> t[0:3]['c'] = 100           # Set column 'c' of rows 0, 1, 2
+  >>> t['a'][:] = [1, -2, 3, -4, 5]  # Set all column values
+  >>> t['a'][2] = 30                 # Set row 2 of column 'a'
+  >>> t[1] = (8, 9, 10)              # Set all row values
+  >>> t[1]['b'] = -9                 # Set column 'b' of row 1
+  >>> t[0:3]['c'] = 100              # Set column 'c' of rows 0, 1, 2
 
 Note that ``table[row][column]`` assignments will not work with
 `numpy` "fancy" ``row`` indexing (in that case ``table[row]`` would be
@@ -111,15 +111,24 @@ Finally, columns can also be added from
 
 **Replace a column**
 
-For a table with an existing column ``a``, an expression like ``t['a'] = [1, 2,
-3]`` or ``t['a'] = 1`` replaces the data *values* without changing the data
-type or anything else about the column.  In order to entirely replace the
-column with a new column (and potentially change the data type), use the
-:meth:`~astropy.table.Table.replace_column` method.  For instance, to change
-the data type of the ``a`` column from ``int`` to ``float``:
+One can entirely replace an existing column with a new column by setting the
+column to any object that could be used to initialize a table column (e.g.  a
+list or numpy array).  For example, one could change the data type of the ``a``
+column from ``int`` to ``float`` using::
 
-  >>> a_float = t['a'].astype(float)
-  >>> t.replace_column('a', a_float)
+  >>> t['a'] = t['a'].astype(float)
+
+If the right hand side value is not column-like, then an in-place update
+using broadcasting will be done, e.g.::
+
+  >>> t['a'] = 1  # Internally does t['a'][:] = 1
+
+.. Note ::
+
+   Prior to astropy version 1.3, assignment as shown above performed
+   an in-place update of the existing column values and it was not possible
+   to change the data type in this way.  Prior to 1.3 it was necessary
+   to use the :meth:`~astropy.table.Table.replace_column` method in this case.
 
 **Rename columns**
 ::


### PR DESCRIPTION
This PR has a very simple code change so that when setting an existing Table column the code first tries to call `replace_column`, and only if that fails it tries the old behavior of doing an inplace update.  So in the past it was always an inplace update:
```
t['a'] = val  # equivalent to t['a'][:] = val
```
With this PR:
```
t['a'] = val  # equivalent to t.replace_column('a', val)
```
It might happen that `replace_column` will fail (e.g. if `val = 1`) in which case the inplace update will happen.

On the whole I believe that this new behavior is generally more intuitive.  It matches how pandas behaves, and matches the new (post astropy 1.0) basic concept that a table is a collection of independent columns.  The inplace update was previously forced by using a numpy structured array underneath to hold the table data.

I have been increasingly bothered by the inplace update behavior and the problems it creates (e.g. #2630).  I previously have argued that changing this behavior would introduce unexpected behaviors (#3809).  In reviewing my arguments I think those problems are definitely corner cases and not likely to impact many people.  In short I have changed my mind!

One thing to be aware of is something like this:
```
>>> t = Table([[1, 2]], names=['a'])
>>> ta = t['a']
>>> t['a'] = [3, 4]
>>> t['a'] is ta  # Completely new column
False
```
I'm not sure how surprising or problematic this would be. One small variant of this PR is to require that the right-hand side be either a Column subclass or a mixin column.  That would eliminate the above, but at the cost of less consistent / simple behavior.  For instance if `t['a']` were a `Time` mixin and you did `t['a'] = [3, 4]` then it fails because you cannot to an inplace assignment to a `Time` object.

I've been thinking about this change for some time, but seeing #2630 and the complications that come up made me seriously consider this API change.

@cdeil @mhvk @astrofrog 