### PR TITLE
Add more useful exceptions for empty catalogs

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -62,6 +62,10 @@ def match_coordinates_3d(matchcoord, catalogcoord, nthneighbor=1, storekdtree='_
     This function requires `SciPy <http://www.scipy.org>`_ to be installed
     or it will fail.
     """
+    if catalogcoord.isscalar or len(catalogcoord) < 1:
+        raise ValueError('The catalog for coordinate matching cannot be a '
+                         'scalar or length-0.')
+
     kdt = _get_cartesian_kdtree(catalogcoord, storekdtree)
 
     #make sure coordinate systems match
@@ -130,6 +134,9 @@ def match_coordinates_sky(matchcoord, catalogcoord, nthneighbor=1, storekdtree='
     This function requires `SciPy <http://www.scipy.org>`_ to be installed
     or it will fail.
     """
+    if catalogcoord.isscalar or len(catalogcoord) < 1:
+        raise ValueError('The catalog for coordinate matching cannot be a '
+                         'scalar or length-0.')
 
     # send to catalog frame
     newmatch = matchcoord.transform_to(catalogcoord)

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -227,6 +227,8 @@ def test_search_around_scalar():
         cat.search_around_3d(target, Angle('2d'))
     assert 'search_around_3d' in str(excinfo.value)
 
+@pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
 def test_match_catalog_empty():
     from astropy.coordinates import SkyCoord
 

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -226,3 +226,31 @@ def test_search_around_scalar():
     with pytest.raises(ValueError) as excinfo:
         cat.search_around_3d(target, Angle('2d'))
     assert 'search_around_3d' in str(excinfo.value)
+
+def test_match_catalog_empty():
+    from astropy.coordinates import SkyCoord
+
+    sc1 = SkyCoord(1, 2, unit="deg")
+    cat0  = SkyCoord([], [], unit="deg")
+    cat1  = SkyCoord([1.1], [2.1], unit="deg")
+    cat2  = SkyCoord([1.1, 3], [2.1, 5], unit="deg")
+
+    sc1.match_to_catalog_sky(cat2)
+    sc1.match_to_catalog_3d(cat2)
+
+    sc1.match_to_catalog_sky(cat1)
+    sc1.match_to_catalog_3d(cat1)
+
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_sky(cat1[0])
+    assert 'catalog' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_3d(cat1[0])
+    assert 'catalog' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_sky(cat0)
+    assert 'catalog' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_3d(cat0)
+    assert 'catalog' in str(excinfo.value)


### PR DESCRIPTION
This closes #5518 by implementing the second suggestion in https://github.com/astropy/astropy/issues/5518#issuecomment-264066325 :  it adds a more useful error message when an attempt is made to match to an empty (or scalar catalog).

I judge no changelog being necessary because it's not really an API change, just a clarification of the message.

cc @evertrol 