### PR TITLE
Skip generating generic unit parsing tables

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -156,9 +156,14 @@ class Generic(Base):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
-        lexer = lex.lex(optimize=True, lextab='generic_lextab',
-                        outputdir=os.path.dirname(__file__),
-                        reflags=re.UNICODE)
+        try:
+            from . import generic_lextab
+            lexer = lex.lex(optimize=True, lextab=generic_lextab,
+                            reflags=re.UNICODE)
+        except ImportError:
+            lexer = lex.lex(optimize=True, lextab='generic_lextab',
+                            outputdir=os.path.dirname(__file__),
+                            reflags=re.UNICODE)
 
         return lexer
 
@@ -176,7 +181,6 @@ class Generic(Base):
         formats, the only difference being the set of available unit
         strings.
         """
-
         from ...extern.ply import yacc
 
         tokens = cls._tokens
@@ -419,9 +423,14 @@ class Generic(Base):
         def p_error(p):
             raise ValueError()
 
-        parser = yacc.yacc(debug=False, tabmodule='generic_parsetab',
-                           outputdir=os.path.dirname(__file__),
-                           write_tables=True)
+        try:
+            from . import generic_parsetab
+            parser = yacc.yacc(debug=False, tabmodule=generic_parsetab,
+                               write_tables=False)
+        except ImportError:
+            parser = yacc.yacc(debug=False, tabmodule='generic_parsetab',
+                               outputdir=os.path.dirname(__file__))
+
         return parser
 
     @classmethod


### PR DESCRIPTION
Upgrading the external PLY package to version 3.9 somehow broke the parsing table parsing. Running the tests with python2 now always overwrites the existing tables (as pointed out here https://github.com/astropy/astropy/pull/5526#issuecomment-265038856). The tables in master were generated and then treated by clean_parse_tables.py at the time of the PLY upgrade.

There are 4 sets of these parsing tables, but it only effects ``units.format.generic``, as it's somehow accessed early during the setup process (?). I couldn't pin point the exact location, but braking the ``_parse()`` classmethod gives the following traceback below.

 Anyhow, since none of the code in this traceback found to be changed recently, my workaround to fix this asap would be to revert the removal of the try/except from 9ee8d3c53a19af735ea44afcc7ea8cd4e59b102c only for this file only (as the 3 others are still working as expected).

cc @taldcroft and @mhvk 

```
Traceback (most recent call last):
  File "setup.py", line 48, in <module>
    package_info = get_package_info()
  File "/Users/bsipocz/munka/devel/astropy/astropy_helpers/astropy_helpers/setup_helpers.py", line 396, in get_package_info
    ext_modules.extend(setuppkg.get_extensions())
  File "astropy/wcs/setup_package.py", line 252, in get_extensions
    generate_c_docstrings()
  File "astropy/wcs/setup_package.py", line 126, in generate_c_docstrings
    from astropy.wcs import docstrings
  File "/Users/bsipocz/munka/devel/astropy/astropy/wcs/__init__.py", line 30, in <module>
    from .wcs import *
  File "/Users/bsipocz/munka/devel/astropy/astropy/wcs/wcs.py", line 50, in <module>
    from ..io import fits
  File "/Users/bsipocz/munka/devel/astropy/astropy/io/fits/__init__.py", line 64, in <module>
    from . import convenience
  File "/Users/bsipocz/munka/devel/astropy/astropy/io/fits/convenience.py", line 72, in <module>
    from ...units.format.fits import UnitScaleError
  File "/Users/bsipocz/munka/devel/astropy/astropy/units/__init__.py", line 20, in <module>
    from . import astrophys
  File "/Users/bsipocz/munka/devel/astropy/astropy/units/astrophys.py", line 46, in <module>
    def_unit(['lyr', 'lightyear'], (_si.c * si.yr).to(si.m),
  File "/Users/bsipocz/munka/devel/astropy/astropy/constants/constant.py", line 45, in wrapper
    self.unit.to(inst.unit)
  File "/Users/bsipocz/munka/devel/astropy/astropy/units/quantity.py", line 757, in unit
    return self._unit
  File "/Users/bsipocz/munka/devel/astropy/astropy/utils/decorators.py", line 722, in __get__
    val = self.fget(obj)
  File "/Users/bsipocz/munka/devel/astropy/astropy/constants/constant.py", line 165, in _unit
    return Unit(self._unit_string)
  File "/Users/bsipocz/munka/devel/astropy/astropy/units/core.py", line 1836, in __call__
    raise ValueError(msg)
ValueError: 'm / (s)' did not parse as unit: type object 'Generic' has no attribute '_parser'
```

