### PR TITLE
Fix io.fits boolean index test fails with numpy-dev

### DIFF
--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -332,9 +332,10 @@ class TestImageFunctions(FitsTestCase):
         assert np.array_equal(fs[0].section[:, ::2], dat[:, ::2])
         assert np.array_equal(fs[0].section[:, [1, 2, 4], 3],
                               dat[:, [1, 2, 4], 3])
-        assert np.array_equal(
-            fs[0].section[:, np.array([True, False, True]), :],
-            dat[:, np.array([True, False, True]), :])
+        bool_index = np.array([True, False, True, True, False,
+                               False, True, True, False, True])
+        assert np.array_equal(fs[0].section[:, bool_index, :],
+                              dat[:, bool_index, :])
 
         assert np.array_equal(
             fs[0].section[3:6, 3, :, ...], dat[3:6, 3, :, ...])


### PR DESCRIPTION
Current master is failing with numpy-dev, since an already deprecated behaviour, where an array was indexed with a bool array that was short, now raises an exception. This causes one test in `io.fits` to fail, which is fixed here.  If we get this in 1.3.0, it means it can work with the next numpy as well...