### PR TITLE
change plot_formats in conf.py to list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ from astropy import visualization
 plot_rcparams = visualization.astropy_mpl_docs_style
 plot_apply_rcparams = True
 plot_html_show_source_link = False
-plot_formats = ('png', 'svg', 'pdf')
+plot_formats = ['png', 'svg', 'pdf']
 
 # -- General configuration ----------------------------------------------------
 


### PR DESCRIPTION
This is an *extremely* simple change, necessary because sphinx 1.4.x raises a warning if this configuration item is a tuple instead of being a list (1.3.x didn't produce this warning, otherwise we'd have noticed it already in Travis)

In a related item: @bsipocz, do you think it's safe to try switching travis' sphinx to 1.4.x ?  I've been running 1.4.8 locally and it now is working fine.  Maybe sphinx fixed whatever the previous problem was?