### PR TITLE
Adding workaround to the sphinx builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
         - PIP_DEPENDENCIES=''
         - SETUP_XVFB=True
+        - SPHINX_VERSION='<1.5'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'


### PR DESCRIPTION
until the new astropy-helpers is out with the fix for https://github.com/astropy/astropy-helpers/issues/274. 
Version 1.4.9 works locally, but 1.5 gives the deprecation warnings.

cc @eteq @astrofrog