### PR TITLE
Handle sorting NaNs and masked values in jsviewer [rebased]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -265,6 +265,8 @@ Bug Fixes
   - Fix problem where key for caching column format function was not
     sufficiently unique. [#5803]
 
+  - Handle sorting NaNs and masked values in jsviewer. [#4052, #5572]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -387,8 +387,9 @@ class HTML(core.BaseReader):
                             w.data('')  # need this instead of pass to get <script></script>
             with w.tag('body'):
                 if 'js' in self.html:
-                    with w.tag('script'):
-                        w.data(self.html['js'])
+                    with w.xml_cleaning_method('none'):
+                        with w.tag('script'):
+                            w.data(self.html['js'])
                 if isinstance(self.html['table_id'], six.string_types):
                     html_table_id = self.html['table_id']
                 else:

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -41,10 +41,10 @@ require.config({{paths: {{
 require(["datatables"], function(){{
     console.log("$('#{tid}').dataTable()");
     $('#{tid}').dataTable({{
-        "order": [],
-        "iDisplayLength": {display_length},
-        "aLengthMenu": {display_length_menu},
-        "pagingType": "full_numbers"
+        order: [],
+        pageLength: {display_length},
+        lengthMenu: {display_length_menu},
+        pagingType: "full_numbers"
     }});
 }});
 </script>
@@ -69,12 +69,11 @@ jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
 
 $(document).ready(function() {{
     $('#{tid}').dataTable({{
-     "iDisplayLength": {display_length},
-     "aLengthMenu": {display_length_menu},
-     "pagingType": "full_numbers",
-     "bJQueryUI": true,
-     "sPaginationType": "full_numbers",
-     "aoColumnDefs": [{{"sType": "optionalnum", "aTargets": {sort_columns}}}]
+        order: [],
+        pageLength: {display_length},
+        lengthMenu: {display_length_menu},
+        pagingType: "full_numbers",
+        columnDefs: [{{targets: {sort_columns}, type: "optionalnum"}}]
     }});
 }} );
 """

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -51,12 +51,20 @@ require(["datatables"], function(){{
 """
 
 HTML_JS_SCRIPT = """
+jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
+    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return ''; else return b;}},
+    "optionalnum-asc": function (a,b) {{ return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }},
+    "optionalnum-desc": function (a,b) {{ return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }}
+}});
+
 $(document).ready(function() {{
     $('#{tid}').dataTable({{
-        "order": [],
-        "iDisplayLength": {display_length},
-        "aLengthMenu": {display_length_menu},
-        "pagingType": "full_numbers"
+     "iDisplayLength": {display_length},
+     "aLengthMenu": {display_length_menu},
+     "pagingType": "full_numbers",
+     "bJQueryUI": true,
+     "sPaginationType": "full_numbers",
+     "aoColumnDefs": [{{"sType": "optionalnum", "aTargets": {sort_columns}}}]
     }});
 }} );
 """
@@ -137,11 +145,11 @@ class JSViewer(object):
             tid=table_id)
         return html
 
-    def html_js(self, table_id='table0'):
+    def html_js(self, table_id='table0', sort_columns='[]'):
         return HTML_JS_SCRIPT.format(
             display_length=self.display_length,
             display_length_menu=self.display_length_menu,
-            tid=table_id).strip()
+            tid=table_id, sort_columns=sort_columns).strip()
 
 
 def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
@@ -153,13 +161,15 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
     jskwargs = jskwargs or {}
     jsv = JSViewer(**jskwargs)
 
+    sortable_columns = list(i for i, col in enumerate(table.columns.values())
+                            if col.dtype.kind in 'iufc')
     htmldict = {
         'table_id': table_id,
         'table_class': table_class,
         'css': css,
         'cssfiles': jsv.css_urls,
         'jsfiles': jsv.jquery_urls,
-        'js':  jsv.html_js(table_id=table_id)
+        'js':  jsv.html_js(table_id=table_id, sort_columns=sortable_columns)
     }
 
     if max_lines < len(table):

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -52,7 +52,7 @@ require(["datatables"], function(){{
 
 HTML_JS_SCRIPT = """
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
-    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return ''; else return b;}},
+    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;}},
     "optionalnum-asc": function (a,b) {{ return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }},
     "optionalnum-desc": function (a,b) {{ return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }}
 }});

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -51,10 +51,20 @@ require(["datatables"], function(){{
 """
 
 HTML_JS_SCRIPT = """
+var astropy_sort_num = function(a, b) {{
+    var a_num = parseFloat(a);
+    var b_num = parseFloat(b);
+
+    if (isNaN(a_num) && isNaN(b_num))
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    else if (!isNaN(a_num) && !isNaN(b_num))
+        return ((a_num < b_num) ? -1 : ((a_num > b_num) ? 1 : 0));
+    else
+        return isNaN(a_num) ? -1 : 1;
+}}
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
-    "optionalnum-pre": function (a) {{ var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;}},
-    "optionalnum-asc": function (a,b) {{ return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }},
-    "optionalnum-desc": function (a,b) {{ return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }}
+    "optionalnum-asc": astropy_sort_num,
+    "optionalnum-desc": function (a,b) {{ return -astropy_sort_num(a, b); }}
 }});
 
 $(document).ready(function() {{

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -33,24 +33,7 @@ conf = Conf()
 EXTERN_JS_DIR = abspath(join(dirname(extern.__file__), 'js'))
 EXTERN_CSS_DIR = abspath(join(dirname(extern.__file__), 'css'))
 
-IPYNB_JS_SCRIPT = """
-<script>
-require.config({{paths: {{
-    datatables: '{datatables_url}'
-}}}});
-require(["datatables"], function(){{
-    console.log("$('#{tid}').dataTable()");
-    $('#{tid}').dataTable({{
-        order: [],
-        pageLength: {display_length},
-        lengthMenu: {display_length_menu},
-        pagingType: "full_numbers"
-    }});
-}});
-</script>
-"""
-
-HTML_JS_SCRIPT = """
+_SORTING_SCRIPT_PART_1 = """
 var astropy_sort_num = function(a, b) {{
     var a_num = parseFloat(a);
     var b_num = parseFloat(b);
@@ -62,11 +45,37 @@ var astropy_sort_num = function(a, b) {{
     else
         return isNaN(a_num) ? -1 : 1;
 }}
+"""
+
+_SORTING_SCRIPT_PART_2 = """
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {{
     "optionalnum-asc": astropy_sort_num,
     "optionalnum-desc": function (a,b) {{ return -astropy_sort_num(a, b); }}
 }});
+"""
 
+IPYNB_JS_SCRIPT = """
+<script>
+%(sorting_script1)s
+require.config({{paths: {{
+    datatables: '{datatables_url}'
+}}}});
+require(["datatables"], function(){{
+    console.log("$('#{tid}').dataTable()");
+    %(sorting_script2)s
+    $('#{tid}').dataTable({{
+        order: [],
+        pageLength: {display_length},
+        lengthMenu: {display_length_menu},
+        pagingType: "full_numbers",
+        columnDefs: [{{targets: {sort_columns}, type: "optionalnum"}}]
+    }});
+}});
+</script>
+""" % dict(sorting_script1=_SORTING_SCRIPT_PART_1,
+           sorting_script2=_SORTING_SCRIPT_PART_2)
+
+HTML_JS_SCRIPT = _SORTING_SCRIPT_PART_1 + _SORTING_SCRIPT_PART_2 + """
 $(document).ready(function() {{
     $('#{tid}').dataTable({{
         order: [],
@@ -144,14 +153,14 @@ class JSViewer(object):
         else:
             return conf.datatables_url[:-3]
 
-    def ipynb(self, table_id, css=None):
+    def ipynb(self, table_id, css=None, sort_columns='[]'):
         html = '<style>{0}</style>'.format(css if css is not None
                                            else DEFAULT_CSS_NB)
         html += IPYNB_JS_SCRIPT.format(
             display_length=self.display_length,
             display_length_menu=self.display_length_menu,
             datatables_url=self._jstable_file(),
-            tid=table_id)
+            tid=table_id, sort_columns=sort_columns)
         return html
 
     def html_js(self, table_id='table0', sort_columns='[]'):
@@ -170,8 +179,8 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
     jskwargs = jskwargs or {}
     jsv = JSViewer(**jskwargs)
 
-    sortable_columns = list(i for i, col in enumerate(table.columns.values())
-                            if col.dtype.kind in 'iufc')
+    sortable_columns = [i for i, col in enumerate(table.columns.values())
+                        if col.dtype.kind in 'iufc']
     htmldict = {
         'table_id': table_id,
         'table_class': table_class,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -987,7 +987,10 @@ class Table(object):
                                          max_lines=-1, show_dtype=False,
                                          tableclass=table_class)
 
-        html += jsv.ipynb(tableid, css=css)
+        columns = display_table.columns.values()
+        sortable_columns = [i for i, col in enumerate(columns)
+                            if col.dtype.kind in 'iufc']
+        html += jsv.ipynb(tableid, css=css, sort_columns=sortable_columns)
         return HTML(html)
 
     def show_in_browser(self, max_lines=5000, jsviewer=False,

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -34,7 +34,7 @@ table.dataTable {width: auto !important; margin: 0 !important;}
  <body>
   <script>
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
-    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return ''; else return b;},
+    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;},
     "optionalnum-asc": function (a,b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); },
     "optionalnum-desc": function (a,b) { return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }
 });

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -33,10 +33,20 @@ table.dataTable {width: auto !important; margin: 0 !important;}
  </head>
  <body>
   <script>
+var astropy_sort_num = function(a, b) {
+    var a_num = parseFloat(a);
+    var b_num = parseFloat(b);
+
+    if (isNaN(a_num) && isNaN(b_num))
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    else if (!isNaN(a_num) && !isNaN(b_num))
+        return ((a_num < b_num) ? -1 : ((a_num > b_num) ? 1 : 0));
+    else
+        return isNaN(a_num) ? -1 : 1;
+}
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
-    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return Number.NEGATIVE_INFINITY; else return b;},
-    "optionalnum-asc": function (a,b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); },
-    "optionalnum-desc": function (a,b) { return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }
+    "optionalnum-asc": astropy_sort_num,
+    "optionalnum-desc": function (a,b) { return -astropy_sort_num(a, b); }
 });
 
 $(document).ready(function() {

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -33,12 +33,20 @@ table.dataTable {width: auto !important; margin: 0 !important;}
  </head>
  <body>
   <script>
+jQuery.extend( jQuery.fn.dataTableExt.oSort, {
+    "optionalnum-pre": function (a) { var b=parseFloat(a); if (isNaN(b)) return ''; else return b;},
+    "optionalnum-asc": function (a,b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); },
+    "optionalnum-desc": function (a,b) { return ((a < b) ? 1 : ((a > b) ? -1 : 0)); }
+});
+
 $(document).ready(function() {
     $('#%(table_id)s').dataTable({
-        "order": [],
-        "iDisplayLength": %(length)s,
-        "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
-        "pagingType": "full_numbers"
+     "iDisplayLength": %(length)s,
+     "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
+     "pagingType": "full_numbers",
+     "bJQueryUI": true,
+     "sPaginationType": "full_numbers",
+     "aoColumnDefs": [{"sType": "optionalnum", "aTargets": [0]}]
     });
 } );  </script>
   <table class="%(table_class)s" id="%(table_id)s">

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -44,6 +44,7 @@ var astropy_sort_num = function(a, b) {
     else
         return isNaN(a_num) ? -1 : 1;
 }
+
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
     "optionalnum-asc": astropy_sort_num,
     "optionalnum-desc": function (a,b) { return -astropy_sort_num(a, b); }

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -51,12 +51,11 @@ jQuery.extend( jQuery.fn.dataTableExt.oSort, {
 
 $(document).ready(function() {
     $('#%(table_id)s').dataTable({
-     "iDisplayLength": %(length)s,
-     "aLengthMenu": [[%(display_length)s, -1], [%(display_length)s, 'All']],
-     "pagingType": "full_numbers",
-     "bJQueryUI": true,
-     "sPaginationType": "full_numbers",
-     "aoColumnDefs": [{"sType": "optionalnum", "aTargets": [0]}]
+        order: [],
+        pageLength: %(length)s,
+        lengthMenu: [[%(display_length)s, -1], [%(display_length)s, 'All']],
+        pagingType: "full_numbers",
+        columnDefs: [{targets: [0], type: "optionalnum"}]
     });
 } );  </script>
   <table class="%(table_class)s" id="%(table_id)s">

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -168,6 +168,9 @@ class XMLWriter:
         Any additional keyword arguments will be passed directly to the
         ``clean`` function.
 
+        Finally, use ``method='none'`` to disable any sanitization. This should
+        be used sparingly.
+
         Example::
 
           w = writer.XMLWriter(ListWriter(lines))
@@ -179,8 +182,8 @@ class XMLWriter:
         Parameters
         ----------
         method : str
-            Cleaning method.  Allowed values are "escape_xml" and
-            "bleach_clean".
+            Cleaning method.  Allowed values are "escape_xml",
+            "bleach_clean", and "none".
 
         **clean_kwargs : keyword args
             Additional keyword args that are passed to the
@@ -196,8 +199,10 @@ class XMLWriter:
             else:
                 raise ValueError('bleach package is required when HTML escaping is disabled.\n'
                                  'Use "pip install bleach".')
+        elif method == "none":
+            self.xml_escape_cdata = lambda x: x
         elif method != 'escape_xml':
-            raise ValueError('allowed values of method are "escape_xml" and "bleach_clean"')
+            raise ValueError('allowed values of method are "escape_xml", "bleach_clean", and "none"')
 
         yield
 


### PR DESCRIPTION
This is a rebased version of #4052, which a few enhancements:
- Use the new dataTable API and remove duplicate/useless options, as proposed in https://github.com/astropy/astropy/pull/4052#r60187025
- Handle sorting NaNs also in `show_in_notebook`
cc @astrofrog , and maybe @taldcroft @eteq ?

EDIT: Close #4052, fix #2966