### PR TITLE
Add BaseCoordinateFrame.cache and doc inplace modification.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -392,7 +392,8 @@ Other Changes and Additions
 
   - A new ``BaseCoordinateFrame.cache`` dictionary has been created to expose
     the internal cache. This is useful when modifying representation data
-    inplace without using ``realize_frame`` [#5575]
+    inplace without using ``realize_frame``. Additionally, documentation for
+    inplace operations on coordinates were added. [#5575]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -392,8 +392,8 @@ Other Changes and Additions
 
   - A new ``BaseCoordinateFrame.cache`` dictionary has been created to expose
     the internal cache. This is useful when modifying representation data
-    inplace without using ``realize_frame``. Additionally, documentation for
-    inplace operations on coordinates were added. [#5575]
+    in-place without using ``realize_frame``. Additionally, documentation for
+    in-place operations on coordinates were added. [#5575]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -390,6 +390,10 @@ Other Changes and Additions
     ``angles.angle_axis`` are also deprecated, in favour of the new routines
     with the same name in ``coordinates.matrix_utilities``. [#5104]
 
+  - A new ``BaseCoordinateFrame.cache`` dictionary has been created to expose
+    the internal cache. This is useful when modifying representation data
+    inplace without using ``realize_frame`` [#5575]
+
 - ``astropy.cosmology``
 
   - The default cosmological model has been changed to Planck 2015,

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -703,14 +703,22 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @lazyproperty
     def cache(self):
         """
-        Cache for this frame.
+        Cache for this frame, a dict.  It stores anything that should be
+        computed from the coordinate data (*not* from the frame attributes).
+        This can be used in functions to store anything that might be
+        expensive to compute but might be re-used by some other function.
+        E.g.::
 
-        If modifications are made to the frame not through public methods the
-        appropriate cache should be cleared by deleting elements from this
-        cache. i.e. if you update the values in the representation the cache of
-        representations should be cleared with::
+            if 'user_data' in myframe.cache:
+                data = myframe.cache['user_data']
+            else:
+                myframe.cache['user_data'] = data = expensive_func(myframe.lat)
 
-            del myframe.cache['representation]
+        If in-place modifications are made to the frame data, the cache should
+        be cleared::
+
+            myframe.cache.clear()
+
         """
         return defaultdict(dict)
 

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -444,14 +444,14 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt='kdtree', forceunit=None):
     if isinstance(attrname_or_kdt, six.string_types):
         kdt = coord.cache.get(attrname_or_kdt, None)
         if kdt is not None and not isinstance(kdt, KDTree):
-            raise ValueError('The `attrname_or_kdt` "{0}" is not a scipy KD tree!'.format(attrname_or_kdt))
+            raise TypeError('The `attrname_or_kdt` "{0}" is not a scipy KD tree!'.format(attrname_or_kdt))
     elif isinstance(attrname_or_kdt, KDTree):
         kdt = attrname_or_kdt
         attrname_or_kdt = None
     elif not attrname_or_kdt:
         kdt = None
     else:
-        raise ValueError('Invalid `attrname_or_kdt` argument for KD-Tree:' +
+        raise TypeError('Invalid `attrname_or_kdt` argument for KD-Tree:' +
                          str(attrname_or_kdt))
 
     if kdt is None:

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -163,6 +163,9 @@ def match_coordinates_sky(matchcoord, catalogcoord, nthneighbor=1, storekdtree='
     # update the kdtree on the actual passed-in coordinate
     if isinstance(storekdtree, six.string_types):
         catalogcoord.cache[storekdtree] = newcat_u.cache[storekdtree]
+    elif storekdtree is True:
+        # the old backwards-compatible name
+        catalogcoord.cache['kdtree'] = newcat_u.cache['kdtree']
 
     return idx, sep2d, sep3d
 
@@ -366,7 +369,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='kdtree_sky'):
         kdt2 = _get_cartesian_kdtree(ucoords2, storekdtree)
         if storekdtree:
             # save the KD-Tree in coords2, *not* ucoords2
-            coords2.cache[storekdtree] = kdt2
+            coords2.cache['kdtree' if storekdtree is True else storekdtree] = kdt2
 
     # this is the *cartesian* 3D distance that corresponds to the given angle
     r = (2 * np.sin(Angle(seplimit) / 2.0)).value

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -770,18 +770,3 @@ def test_inplace_change():
     # This will use a second (potentially cached rep)
     assert i.ra == 10 * u.deg
     assert i.dec == 2 * u.deg
-
-
-def test_cache_clear_sc():
-    from .. import SkyCoord
-
-    i = SkyCoord(1*u.deg, 2*u.deg)
-
-    # Add an in frame units version of the rep to the cache.
-    repr(i)
-
-    assert len(i.cache['representation']) == 2
-
-    i.cache.clear()
-
-    assert len(i.cache['representation']) == 0

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -723,9 +723,31 @@ def test_cache_clear():
 
     assert len(i.cache['representation']) == 2
 
-    del i.cache['representation']
+    i.cache.clear()
 
     assert len(i.cache['representation']) == 0
+
+
+def test_inplace_array():
+    from ..builtin_frames import ICRS
+
+    i = ICRS([[1, 2], [3, 4]]*u.deg, [[10, 20], [30, 40]]*u.deg)
+
+    # Add an in frame units version of the rep to the cache.
+    repr(i)
+
+    # Check that repr() has added a rep to the cache
+    assert len(i.cache['representation']) == 2
+
+    # Modify the data
+    i.data.lon[:, 0] = [100, 200]*u.deg
+
+    # Clear the cache
+    i.cache.clear()
+
+    # This will use a second (potentially cached rep)
+    assert_allclose(i.ra, [[100, 2], [200, 4]]*u.deg)
+    assert_allclose(i.dec, [[10, 20], [30, 40]]*u.deg)
 
 
 def test_inplace_change():
@@ -734,7 +756,7 @@ def test_inplace_change():
     i = ICRS(1*u.deg, 2*u.deg)
 
     # Add an in frame units version of the rep to the cache.
-    a = repr(i)
+    repr(i)
 
     # Check that repr() has added a rep to the cache
     assert len(i.cache['representation']) == 2
@@ -743,8 +765,23 @@ def test_inplace_change():
     i.data.lon[()] = 10*u.deg
 
     # Clear the cache
-    del i.cache['representation']
+    i.cache.clear()
 
     # This will use a second (potentially cached rep)
     assert i.ra == 10 * u.deg
     assert i.dec == 2 * u.deg
+
+
+def test_cache_clear_sc():
+    from .. import SkyCoord
+
+    i = SkyCoord(1*u.deg, 2*u.deg)
+
+    # Add an in frame units version of the rep to the cache.
+    repr(i)
+
+    assert len(i.cache['representation']) == 2
+
+    i.cache.clear()
+
+    assert len(i.cache['representation']) == 0

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -745,5 +745,6 @@ def test_inplace_change():
     # Clear the cache
     del i.cache['representation']
 
-    # Old repr and new repr should be different (this checks for removal of the cache)
-    assert a != repr(i)
+    # This will use a second (potentially cached rep)
+    assert i.ra == 10 * u.deg
+    assert i.dec == 2 * u.deg

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -711,3 +711,39 @@ def test_component_error_useful():
         i.lon  # lon is *not* the component name despite being the underlying representation's name
     assert "object has no attribute 'foobar'" in str(excinfo1.value)
     assert "object has no attribute 'lon'" in str(excinfo2.value)
+
+
+def test_cache_clear():
+    from ..builtin_frames import ICRS
+
+    i = ICRS(1*u.deg, 2*u.deg)
+
+    # Add an in frame units version of the rep to the cache.
+    repr(i)
+
+    assert len(i.cache['representation']) == 2
+
+    del i.cache['representation']
+
+    assert len(i.cache['representation']) == 0
+
+
+def test_inplace_change():
+    from ..builtin_frames import ICRS
+
+    i = ICRS(1*u.deg, 2*u.deg)
+
+    # Add an in frame units version of the rep to the cache.
+    a = repr(i)
+
+    # Check that repr() has added a rep to the cache
+    assert len(i.cache['representation']) == 2
+
+    # Modify the data
+    i.data.lon[()] = 10*u.deg
+
+    # Clear the cache
+    del i.cache['representation']
+
+    # Old repr and new repr should be different (this checks for removal of the cache)
+    assert a != repr(i)

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -82,15 +82,15 @@ def test_kdtree_storage():
     ccatalog = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree)
 
     idx, d2d, d3d = match_coordinates_3d(cmatch, ccatalog, storekdtree=False)
-    assert not hasattr(ccatalog, '_kdtree')
+    assert 'kdtree' not in ccatalog.cache
 
     idx, d2d, d3d = match_coordinates_3d(cmatch, ccatalog, storekdtree=True)
-    assert hasattr(ccatalog, '_kdtree')
+    assert 'kdtree' in ccatalog.cache
 
-    assert not hasattr(ccatalog, 'tislit_cheese')
+    assert 'tislit_cheese' not in ccatalog.cache
     idx, d2d, d3d = match_coordinates_3d(cmatch, ccatalog, storekdtree='tislit_cheese')
-    assert hasattr(ccatalog, 'tislit_cheese')
-    assert not hasattr(cmatch, 'tislit_cheese')
+    assert 'tislit_cheese' in ccatalog.cache
+    assert 'tislit_cheese' not in cmatch.cache
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -117,6 +117,13 @@ def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
     else:
         assert 'tislit_cheese' not in cmatch.cache
 
+    # now a bit of a hacky trick to make sure it at least tries to *use* it
+    ccatalog.cache['tislit_cheese'] = 1
+    cmatch.cache['tislit_cheese'] = 1
+    with pytest.raises(TypeError) as e:
+        functocheck(cmatch, ccatalog, *args, storekdtree='tislit_cheese')
+    assert 'KD' in e.value.args[0]
+
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching_method():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1278,3 +1278,18 @@ def test_frame_attr_changes():
     assert 'fakeattr' not in dir(sc_before)
     assert 'fakeattr' not in dir(sc_after1)
     assert 'fakeattr' not in dir(sc_after2)
+
+
+def test_cache_clear_sc():
+    from .. import SkyCoord
+
+    i = SkyCoord(1*u.deg, 2*u.deg)
+
+    # Add an in frame units version of the rep to the cache.
+    repr(i)
+
+    assert len(i.cache['representation']) == 2
+
+    i.cache.clear()
+
+    assert len(i.cache['representation']) == 0

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -313,6 +313,7 @@ listed below.
    galactocentric
    remote_methods
    definitions
+   inplace
 
 
 In addition, another resource for the capabilities of this package is the

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -1,0 +1,35 @@
+In Place Modification of Coordinates
+====================================
+
+Coordinates are generally considered to be immutable. If you want to create
+another coordinate frame with different data you should use
+`~astropy.coordinates.BaseCoordinateFrame.realize_frame`, this is the safest way
+to change the data in a frame as it creates a new frame with that data.
+
+Due to the fact that this creates a new frame it is quite slow, and in some
+situations it is required that the data is replaced inside a frame with minimal
+changes to the frame for maximum speed. This modification can be done by
+modifiying the values of the representation data as follows::
+
+    c = SkyCoord([1,2],[3,4], unit='deg')
+    c.data.lon[:] = [10, 20] * u.deg
+
+This changes the longitude values for the frame, however
+`~astropy.coordinates.SkyCoord` and `~astropy.coordinates.BaseCoordinateFrame`
+cache representations of the data held within the frame as they are calculated
+to speed up future operations of different representations of the same data. If
+you modify the data in the representation the frame contains it is important to
+clear this cache so future calculations of new representations are recomputed
+using the new data. This can be achieved by doing::
+
+      del c.frame.cache['representation']
+
+
+It should be noted that the only way to modify the data in a frame is by using
+the ``.data`` attribute directly and not the aliases for components on the frame
+i.e.::
+
+    c.ra[:] = 20 * u.deg
+
+will not work as a different representation object is used when acessing the
+aliased component names.

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -5,10 +5,9 @@ Coordinates are generally considered to be immutable. If you want to create
 another coordinate frame with different data you should use
 `~astropy.coordinates.BaseCoordinateFrame.realize_frame`, this is the safest way
 to change the data in a frame as it creates a new frame with that data.
-
-Due to the fact that this creates a new frame it is relatively slow, and in some
-situations it is required that the data is replaced inside a frame with minimal
-changes to the frame for maximum speed. This modification can be done by
+Creating a new frame can be relatively slow, however, particularly for scalar
+coordinates. Hence some situations may require that data by changed in-place in
+an already existing frame object. This modification can be done by
 modifiying the values of the representation data as follows::
 
     >>> import astropy.units as u
@@ -19,23 +18,21 @@ modifiying the values of the representation data as follows::
     <SkyCoord (ICRS): (ra, dec) in deg
         [( 10.,  3.), ( 20.,  4.)]>
 
-This changes the longitude values for the frame, however
-`~astropy.coordinates.SkyCoord` and `~astropy.coordinates.BaseCoordinateFrame`
-cache representations of the data held within the frame as they are calculated
-to speed up future operations of different representations of the same data. If
-you modify the data in the representation the frame contains it is important to
-clear this cache so future calculations of new representations are recomputed
-using the new data. This can be achieved by doing::
 
-    >>> del c.cache['representation']
+This changes the longitude values of the frame. Unfortunately, doing just this
+introduces problems: `~astropy.coordinates.SkyCoord` and
+`~astropy.coordinates.BaseCoordinateFrame` cache various kinds of information to
+speed up some repeated operations. So we need to tell the cache that it should
+be cleared so that it can be re-calculated from the new data. This can be
+achieved by doing::
+
+    >>> c.cache.clear()
 
 or::
 
     >>> del c.frame.cache
 
-which removes the whole cache, but can only be done on frame instances and not
-`~astropy.coordinates.SkyCoord` instances.
-
+which removes the whole cache.
 
 It should be noted that the only way to modify the data in a frame is by using
 the ``.data`` attribute directly and not the aliases for components on the frame

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -32,16 +32,15 @@ using the new data. This can be achieved by doing::
 
 It should be noted that the only way to modify the data in a frame is by using
 the ``.data`` attribute directly and not the aliases for components on the frame
-i.e.::
+*i.e.* the following will not work:::
 
     >>> c.ra[()] = 20 * u.deg
 
-will not work as a different representation object is used when acessing the
+This is because a different representation object is used when acessing the
 aliased component names. If you wish to inspect the mapping between frame
 attributes i.e. ``.ra`` and representation attributes i.e. ``.lon`` you can look
-at the::
+at the following dictionary.::
 
     >>> c.representation_component_names
     OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
 
-dictionary.

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -29,6 +29,13 @@ using the new data. This can be achieved by doing::
 
     >>> del c.cache['representation']
 
+or::
+
+    >>> del c.frame.cache
+
+which removes the whole cache, but can only be done on frame instances and not
+`~astropy.coordinates.SkyCoord` instances.
+
 
 It should be noted that the only way to modify the data in a frame is by using
 the ``.data`` attribute directly and not the aliases for components on the frame

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -6,13 +6,18 @@ another coordinate frame with different data you should use
 `~astropy.coordinates.BaseCoordinateFrame.realize_frame`, this is the safest way
 to change the data in a frame as it creates a new frame with that data.
 
-Due to the fact that this creates a new frame it is quite slow, and in some
+Due to the fact that this creates a new frame it is relatively slow, and in some
 situations it is required that the data is replaced inside a frame with minimal
 changes to the frame for maximum speed. This modification can be done by
 modifiying the values of the representation data as follows::
 
-    c = SkyCoord([1,2],[3,4], unit='deg')
-    c.data.lon[:] = [10, 20] * u.deg
+    >>> import astropy.units as u
+    >>> from astropy.coordinates import SkyCoord
+    >>> c = SkyCoord([1,2],[3,4], unit='deg')
+    >>> c.data.lon[()] = [10, 20] * u.deg
+    >>> c
+    <SkyCoord (ICRS): (ra, dec) in deg
+        [( 10.,  3.), ( 20.,  4.)]>
 
 This changes the longitude values for the frame, however
 `~astropy.coordinates.SkyCoord` and `~astropy.coordinates.BaseCoordinateFrame`
@@ -22,14 +27,21 @@ you modify the data in the representation the frame contains it is important to
 clear this cache so future calculations of new representations are recomputed
 using the new data. This can be achieved by doing::
 
-      del c.frame.cache['representation']
+    >>> del c.cache['representation']
 
 
 It should be noted that the only way to modify the data in a frame is by using
 the ``.data`` attribute directly and not the aliases for components on the frame
 i.e.::
 
-    c.ra[:] = 20 * u.deg
+    >>> c.ra[()] = 20 * u.deg
 
 will not work as a different representation object is used when acessing the
-aliased component names.
+aliased component names. If you wish to inspect the mapping between frame
+attributes i.e. ``.ra`` and representation attributes i.e. ``.lon`` you can look
+at the::
+
+    >>> c.representation_component_names
+    OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
+
+dictionary.

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -28,12 +28,6 @@ achieved by doing::
 
     >>> c.cache.clear()
 
-or::
-
-    >>> del c.frame.cache
-
-which removes the whole cache.
-
 It should be noted that the only way to modify the data in a frame is by using
 the ``.data`` attribute directly and not the aliases for components on the frame
 *i.e.* the following will not work:::


### PR DESCRIPTION
This is the result of the discussion in #3797 It adds a section to the documentation about inplace modification of data and the requirements to clear the new cache when doing this.

This also refactors the cache to be a lazyproperty `cache` of `BaseCoordinateFrame` which is a `defaultdict(dict)` and the `_rep_cache` is replaced by `cache['representation']`