### PR TITLE
Raise exception when fast_reader called with incompatible formats, guess all available fast formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,11 +36,13 @@ astropy.io.ascii
 - Latex reader now ignores ``\toprule``, ``\midrule``, and ``\bottomrule``
   commands [#7349]
 
-- Added the RST (Restructured-text) table format to the set of formats that are
-  guessed by default. [#5578]
+- Added the RST (Restructured-text) table format and the fast version of the
+  RDB reader to the set of formats that are guessed by default. [#5578]
 
 - The read trace (used primarily for debugging) now includes guess argument
-  sets that were skipped entirely for some reason. [#5578]
+  sets that were skipped entirely e.g. for not supporting user-supplied kwargs.
+  All guesses thus removed from ``filtered_guess_kwargs`` are now listed as
+  "Disabled" at the beginning of the trace. [#5578]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -309,6 +309,11 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+  - Options not available with the fast reader raise a ``ParameterError``
+    if the latter was explicitly requested; ``guess=True`` will try
+    all formats with a fast reader instead of falling back to the slow
+    reader after the first one (``FastBasic``). [#5578]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,12 @@ astropy.io.ascii
 - Latex reader now ignores ``\toprule``, ``\midrule``, and ``\bottomrule``
   commands [#7349]
 
+- Added the RST (Restructured-text) table format to the set of formats that are
+  guessed by default. [#5578]
+
+- The read trace (used primarily for debugging) now includes guess argument
+  sets that were skipped entirely for some reason. [#5578]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -137,6 +143,15 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- If a fast reader is explicitly selected (e.g. ``fast_reader='force') and
+  options which are incompatible with the fast reader are provided
+  (e.g. ``quotechar='##') then now a ``ParameterError`` exception will be
+  raised. [#5578]
+
+- The fast readers will now raise ``InconsistentTableError`` instead of
+  ``CParserError`` if the number of data and header columns do not match.
+  [#5578]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -218,6 +233,9 @@ astropy.extern
 
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
+
+- Fixed a problem when ``guess=True`` that ``fast_reader`` options
+  could be dropped after the first fast reader class was tried. [#5578]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
@@ -308,11 +326,6 @@ astropy.extern
 
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
-
-  - Options not available with the fast reader raise a ``ParameterError``
-    if the latter was explicitly requested; ``guess=True`` will try
-    all formats with a fast reader instead of falling back to the slow
-    reader after the first one (``FastBasic``). [#5578]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -141,12 +141,22 @@ class MaskedConstant(numpy.ma.core.MaskedConstant):
     The constant ``numpy.ma.masked`` is not hashable (see
     https://github.com/numpy/numpy/issues/4660), so we need to extend it
     here with a hash value.
+
+    See https://github.com/numpy/numpy/issues/11021 for rationale for
+    __copy__ and __deepcopy__ methods.
     """
 
     def __hash__(self):
         '''All instances of this class shall have the same hash.'''
         # Any large number will do.
         return 1234567890
+
+    def __copy__(self):
+        """This is a singleton so just return self."""
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
 
 
 masked = MaskedConstant()

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1379,10 +1379,10 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     # If user explicitly passed a fast reader with 'force' or with non-default
     # options for the fast reader, raise an error for slow readers
     if 'fast_reader' in kwargs:
-        if kwargs['fast_reader'] == 'force' or \
-           isinstance(kwargs['fast_reader'] , dict):
+        if (kwargs['fast_reader'] == 'force' or
+            isinstance(kwargs['fast_reader'] , dict)):
             raise ParameterError('fast_reader required with ' +
-                                 '{0}, but this is a slow reader: {1}'
+                                 '{0}, but this is not a fast C reader: {1}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
             del kwargs['fast_reader'] # otherwise ignore fast_reader parameter

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1376,8 +1376,17 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
             kwargs['Inputter'] = Inputter
         return Reader(**kwargs)
 
+    # If user explicitly passed a fast reader with 'force' or with non-default
+    # options for the fast reader, raise an error for slow readers
     if 'fast_reader' in kwargs:
-        del kwargs['fast_reader']  # ignore fast_reader parameter for slow readers
+        if kwargs['fast_reader'] == 'force' or \
+           isinstance(kwargs['fast_reader'] , dict):
+            raise ParameterError('fast_reader required with ' +
+                                 '{0}, but this is a slow reader: {1}'
+                                 .format(kwargs['fast_reader'], Reader))
+        else:
+            del kwargs['fast_reader'] # otherwise ignore fast_reader parameter 
+
     reader_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_reader_pars)
     reader = Reader(**reader_kwargs)
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -643,7 +643,7 @@ class BaseHeader:
                     len(name) == 0 or
                     name[0] in bads or
                     name[-1] in bads):
-                    raise ValueError('Column name {0!r} does not meet strict name requirements'
+                        raise ValueError('Column name {0!r} does not meet strict name requirements'
                                      .format(name))
         # When guessing require at least two columns
         if guessing and len(self.colnames) <= 1:
@@ -1175,8 +1175,8 @@ class BaseReader(metaclass=MetaBaseReader):
                               ' data columns ({}) at data line {}\n'
                               'Header values: {}\n'
                               'Data values: {}'.format(
-                            n_cols, len(str_vals), i,
-                            [x.name for x in cols], str_vals))
+                                  n_cols, len(str_vals), i,
+                                  [x.name for x in cols], str_vals))
 
                     raise InconsistentTableError(errmsg)
 
@@ -1384,7 +1384,7 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
                                  '{0}, but this is not a fast C reader: {1}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
-            del kwargs['fast_reader'] # Otherwise ignore fast_reader parameter
+            del kwargs['fast_reader']  # Otherwise ignore fast_reader parameter
 
     reader_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_reader_pars)
     reader = Reader(**reader_kwargs)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1385,7 +1385,7 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
                                  '{0}, but this is a slow reader: {1}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
-            del kwargs['fast_reader'] # otherwise ignore fast_reader parameter 
+            del kwargs['fast_reader'] # otherwise ignore fast_reader parameter
 
     reader_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_reader_pars)
     reader = Reader(**reader_kwargs)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1376,16 +1376,15 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
             kwargs['Inputter'] = Inputter
         return Reader(**kwargs)
 
-    # If user explicitly passed a fast reader with 'force' or with non-default
-    # options for the fast reader, raise an error for slow readers
+    # If user explicitly passed a fast reader with enable='force'
+    # (e.g. by passing non-default options), raise an error for slow readers
     if 'fast_reader' in kwargs:
-        if (kwargs['fast_reader'] == 'force' or
-            isinstance(kwargs['fast_reader'] , dict)):
+        if kwargs['fast_reader']['enable'] == 'force':
             raise ParameterError('fast_reader required with ' +
                                  '{0}, but this is not a fast C reader: {1}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
-            del kwargs['fast_reader'] # otherwise ignore fast_reader parameter
+            del kwargs['fast_reader'] # Otherwise ignore fast_reader parameter
 
     reader_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_reader_pars)
     reader = Reader(**reader_kwargs)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -649,11 +649,9 @@ class BaseHeader:
             # Impose strict requirements on column names (normally used in guessing)
             bads = [" ", ",", "|", "\t", "'", '"']
             for name in self.colnames:
-                if (_is_number(name) or
-                    len(name) == 0 or
-                    name[0] in bads or
-                    name[-1] in bads):
-                        raise ValueError('Column name {0!r} does not meet strict name requirements'
+                if (_is_number(name) or len(name) == 0
+                        or name[0] in bads or name[-1] in bads):
+                    raise ValueError('Column name {0!r} does not meet strict name requirements'
                                      .format(name))
         # When guessing require at least two columns
         if guessing and len(self.colnames) <= 1:
@@ -661,7 +659,7 @@ class BaseHeader:
                              .format(list(self.colnames)))
 
         if names is not None and len(names) != len(self.colnames):
-            raise ValueError('Length of names argument ({0}) does not match number'
+            raise InconsistentTableError('Length of names argument ({0}) does not match number'
                              ' of table columns ({1})'.format(len(names), len(self.colnames)))
 
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -380,7 +380,12 @@ cdef class CParser:
             data_end = max(self.data_end - self.data_start, 0) # read nothing if data_end < 0
 
         if tokenize(self.tokenizer, data_end, 0, <int>len(self.names)) != 0:
-            self.raise_error("an error occurred while parsing table data")
+            if self.tokenizer.code in (NOT_ENOUGH_COLS, TOO_MANY_COLS):
+                raise core.InconsistentTableError("Number of header columns " +
+                      "({0}) inconsistent with data columns in data line {1}"
+                      .format(self.tokenizer.num_cols, self.tokenizer.num_rows))
+            else:
+                self.raise_error("an error occurred while parsing table data")
         elif self.tokenizer.num_rows == 0: # no data
             return ([np.array([], dtype=np.int_)] * self.width, [])
         self._set_fill_values()

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -37,7 +37,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
         # since they may contain a dict item which would end up as a ref to the
         # original and get munged later (e.g. in cparser.pyx validation of
         # fast_reader dict).
-        kwargs = default_kwargs.copy()
+        kwargs = copy.deepcopy(default_kwargs)
         kwargs.update(copy.deepcopy(user_kwargs))
 
         delimiter = kwargs.pop('delimiter', ' ')

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -982,6 +982,9 @@ def test_data_out_of_range(parallel, fast_reader, guess):
         fast_reader['parallel'] = parallel
         if fast_reader.get('use_fast_converter'):
             rtol = 1.e-15
+        elif np.iinfo(np.int).dtype == np.dtype(np.int32):
+            # On 32bit the standard C parser (strtod) returns strings for these
+            pytest.xfail("C parser cannot handle float64 on 32bit systems")
 
     if parallel:
         if not fast_reader:

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1225,24 +1225,28 @@ def test_fortran_reader_notbasic():
 
     assert t3['b'].dtype.kind == 'f'
 
-    # In the special case of fast_converter=True (the default),
-    # incompatibility is ignored
-    t4 = ascii.read(tabrst.split('\n'), format='rst', fast_reader=True)
+    t4 = ascii.read(tabrst.split('\n'), guess=True)
 
     assert t4['b'].dtype.kind == 'f'
 
-    with pytest.raises(ParameterError):
-        t5 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
-                        fast_reader='force')
+    # In the special case of fast_converter=True (the default),
+    # incompatibility is ignored
+    t5 = ascii.read(tabrst.split('\n'), format='rst', fast_reader=True)
+
+    assert t5['b'].dtype.kind == 'f'
 
     with pytest.raises(ParameterError):
         t6 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                        fast_reader='force')
+
+    with pytest.raises(ParameterError):
+        t7 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
                         fast_reader=dict(use_fast_converter=False))
 
     tabrst = tabrst.replace('E', 'D')
 
     with pytest.raises(ParameterError):
-        t7 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
+        t8 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
                         fast_reader=dict(exponent_style='D'))
 
 @pytest.mark.parametrize("guess", [True, False])

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1002,7 +1002,7 @@ def test_data_out_of_range(parallel, fast_reader, guess):
     # Test some additional corner cases
     fields = ['.0101E202', '0.000000314E+314', '1777E+305', '-1799E+305',
               '0.2e-323', '5200e-327', ' 0.0000000000000000000001024E+330']
-    values = np.array([ 1.01e200, 3.14e307, 1.777e308, -np.inf, 0.0, 4.94e-324, 1.024e308 ])
+    values = np.array([1.01e200, 3.14e307, 1.777e308, -np.inf, 0.0, 4.94e-324, 1.024e308])
     t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    guess=guess, fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
@@ -1253,8 +1253,8 @@ def test_fortran_reader_notbasic():
 
 
 @pytest.mark.parametrize("guess", [True, False])
-@pytest.mark.parametrize('fast_reader', [ dict(exponent_style='D'),
-                                          dict(exponent_style='A') ])
+@pytest.mark.parametrize('fast_reader', [dict(exponent_style='D'),
+                                         dict(exponent_style='A')])
 
 def test_dict_kwarg_integrity(fast_reader, guess):
     """
@@ -1262,7 +1262,7 @@ def test_dict_kwarg_integrity(fast_reader, guess):
     left intact by ascii.read()
     """
     expstyle = fast_reader.get('exponent_style', 'E')
-    fields = [ '10.1D+199', '3.14d+313', '2048d+306', '0.6D-325', '-2.d345' ]
+    fields = ['10.1D+199', '3.14d+313', '2048d+306', '0.6D-325', '-2.d345']
 
     t = ascii.read(StringIO(' '.join(fields)), guess=guess,
                    fast_reader=fast_reader)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -996,7 +996,7 @@ def test_data_out_of_range(parallel, reader):
 
     # test some additional corner cases
     fields = [ '.0101E202', '0.000000314E+314', '1777E+305', '-1799E+305', '0.2e-323',
-               '2500e-327', ' 0.0000000000000000000001024E+330' ]
+               '5200e-327', ' 0.0000000000000000000001024E+330' ]
     values = np.array([ 1.01e200, 3.14e307, 1.777e308, -np.inf, 0.0, 4.94e-324, 1.024e308 ])
     t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    fast_reader=fast_reader)
@@ -1148,23 +1148,24 @@ def test_fortran_invalid_exp(parallel):
     # iterate for (default) expchar 'E'
     for s in formats.values():
         t3 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
-                fast_reader={'parallel': parallel, 'use_fast_converter': False})
-
-        assert_table_equal(t3, Table([[col] for col in vals_e], names=header),
-                                     rtol=1.0e-30, atol=0.0)
-
-    for s in formats.values():
-        t4 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
                 fast_reader={'parallel': parallel, 'use_fast_converter': True})
 
-        assert_table_equal(t4, Table([[col] for col in vals_e], names=header))
+        assert_table_equal(t3, Table([[col] for col in vals_e], names=header))
 
-    # iterate for expchar 'D'
+    # iterate for regular converter (strtod)
     for s in formats.values():
-        t5 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+        t4 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
                 fast_reader={'parallel': parallel, 'exponent_style': 'D'})
 
-        assert_table_equal(t5, Table([[col] for col in vals_d], names=header))
+        assert_table_equal(t4, Table([[col] for col in vals_d], names=header))
+
+    # iterate for regular converter (strtod)
+    for s in formats.values():
+        t5 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+                fast_reader={'parallel': parallel, 'use_fast_converter': False})
+
+        read_values = [col[0] for col in t5.itercols()]
+        assert read_values == vals_e
 
 
 def test_fortran_reader_notbasic():

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -2,6 +2,7 @@
 
 import os
 import functools
+import copy
 
 from io import BytesIO
 from textwrap import dedent
@@ -12,7 +13,7 @@ from numpy import ma
 
 from ....table import Table, MaskedColumn
 from ... import ascii
-from ...ascii.core import ParameterError, FastOptionsError
+from ...ascii.core import ParameterError, FastOptionsError, InconsistentTableError
 from ...ascii.cparser import CParserError
 from ..fastbasic import (
     FastBasic, FastCsv, FastTab, FastCommentedHeader, FastRdb, FastNoHeader)
@@ -22,8 +23,11 @@ from .common import assert_equal, assert_almost_equal, assert_true
 StringIO = lambda x: BytesIO(x.encode('ascii'))
 TRAVIS = os.environ.get('TRAVIS', False)
 
-
-def assert_table_equal(t1, t2, check_meta=False):
+def assert_table_equal(t1, t2, check_meta=False, rtol=1.e-15, atol=1.e-300):
+    """
+    Test equality of all columns in a table, with stricter tolerances for
+    float columns than the np.allclose default.
+    """
     assert_equal(len(t1), len(t2))
     assert_equal(t1.colnames, t2.colnames)
     if check_meta:
@@ -39,7 +43,7 @@ def assert_table_equal(t1, t2, check_meta=False):
                     elif isinstance(el, str):
                         assert_equal(el, t2[name][i])
                     else:
-                        assert_almost_equal(el, t2[name][i])
+                        assert_almost_equal(el, t2[name][i], rtol=rtol, atol=atol)
                 except (TypeError, NotImplementedError):
                     pass  # ignore for now
 
@@ -370,10 +374,10 @@ A B C
 7 8 9 10
 11 12 13
 """
-    with pytest.raises(CParserError) as e:
+    with pytest.raises(InconsistentTableError) as e:
         table = FastBasic().read(text)
-    assert 'CParserError: an error occurred while parsing table data: too many ' \
-        'columns found in line 3 of data' in str(e)
+    assert 'InconsistentTableError: Number of header columns (3) ' \
+           'inconsistent with data columns in data line 2' in str(e)
 
 
 def test_too_many_cols2():
@@ -382,10 +386,10 @@ aaa,bbb
 1,2,
 3,4,
 """
-    with pytest.raises(CParserError) as e:
+    with pytest.raises(InconsistentTableError) as e:
         table = FastCsv().read(text)
-    assert 'CParserError: an error occurred while parsing table data: too many ' \
-        'columns found in line 1 of data' in str(e)
+    assert 'InconsistentTableError: Number of header columns (2) ' \
+           'inconsistent with data columns in data line 0' in str(e)
 
 
 def test_too_many_cols3():
@@ -394,10 +398,10 @@ aaa,bbb
 1,2,,
 3,4,
 """
-    with pytest.raises(CParserError) as e:
+    with pytest.raises(InconsistentTableError) as e:
         table = FastCsv().read(text)
-    assert 'CParserError: an error occurred while parsing table data: too many ' \
-        'columns found in line 1 of data' in str(e)
+    assert 'InconsistentTableError: Number of header columns (2) ' \
+           'inconsistent with data columns in data line 0' in str(e)
 
 
 @pytest.mark.parametrize("parallel", [True, False])
@@ -416,7 +420,7 @@ A,B,C
     assert table['B'][1] is not ma.masked
     assert table['C'][1] is ma.masked
 
-    with pytest.raises(CParserError) as e:
+    with pytest.raises(InconsistentTableError) as e:
         table = FastBasic(delimiter=',').read(text)
 
 
@@ -751,10 +755,11 @@ A B C
     expected = Table([[7, 10], [8, 11], [91, 12]], names=('A', 'B', 'C'))
     assert_table_equal(table, expected)
 
-    with pytest.raises(CParserError) as e:
+    with pytest.raises(InconsistentTableError) as e:
         # tries to begin in the middle of quoted field
         read_basic(text, data_start=4, parallel=parallel)
-    assert 'not enough columns found in line 1 of data' in str(e)
+    assert 'header columns (3) inconsistent with data columns in data line 0' \
+        in str(e)
 
     table = read_basic(text, data_start=5, parallel=parallel)
     # ignore commented line
@@ -821,9 +826,10 @@ def test_strip_line_trailing_whitespace(parallel, read_basic):
     row.
     """
     text = 'a b c\n1 2 \n3 4 5'
-    with pytest.raises(CParserError) as e:
+    with pytest.raises(InconsistentTableError) as e:
         ascii.read(StringIO(text), format='fast_basic', guess=False)
-    assert 'not enough columns found in line 1' in str(e)
+    assert 'header columns (3) inconsistent with data columns in data line 0' \
+        in str(e)
 
     text = 'a b c\n 1 2 3   \t \n 4 5 6 '
     table = read_basic(text, parallel=parallel)
@@ -954,7 +960,8 @@ def test_read_big_table(tmpdir):
 
 
 # fast_reader configurations: False| 'use_fast_converter'=False|True
-@pytest.mark.parametrize('reader', [0, 1, 2])
+@pytest.mark.parametrize('reader', [ False, dict(use_fast_converter=False),
+                                     dict(use_fast_converter=True) ])
 # catch Windows environment since we cannot use _read() with custom fast_reader
 @pytest.mark.parametrize("parallel", [False,
     pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows"))])
@@ -967,42 +974,44 @@ def test_data_out_of_range(parallel, reader):
     """
     # Python reader and strtod() are expected to return precise results
     rtol = 1.e-30
-    if reader > 1:
-        rtol = 1.e-15
-    # passing fast_reader dict with parametrize does not work!
-    if reader > 0:
-        fast_reader = {'parallel': parallel, 'use_fast_converter': reader > 1}
-    else:
-        fast_reader = False
+
+    # update fast_reader dict; pass only copies to avoid changing during read()!
+    if reader:
+        reader['parallel'] = parallel
+        if reader.get('use_fast_converter'):
+            rtol = 1.e-15
+
     if parallel:
-        if reader < 1:
+        if not reader:
             pytest.skip("Multiprocessing only available in fast reader")
         elif TRAVIS:
             pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
 
-    fields = ['10.1E+199', '3.14e+313', '2048e+306', '0.6E-325', '-2.e345']
-    values = np.array([1.01e200, np.inf, np.inf, 0.0, -np.inf])
-    t = ascii.read(StringIO(' '.join(fields)), format='no_header', guess=False,
+    fields = [ '10.1E+199', '3.14e+313', '2048e+306', '0.6E-325', '-2.e345' ]
+    values = np.array([ 1.01e200, np.inf, np.inf, 0.0, -np.inf ])
+    t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
     assert_almost_equal(read_values, values, rtol=rtol, atol=1.e-324)
 
     # test some additional corner cases
-    fields = ['.0101E202', '0.000000314E+314', '1777E+305', '-1799E+305', '0.4e-324',
-               '2500e-327', ' 0.0000000000000000000001024E+330']
-    values = np.array([1.01e200, 3.14e307, 1.777e308, -np.inf, 0.0, 4.94e-324, 1.024e308])
-    t = ascii.read(StringIO(' '.join(fields)), format='no_header', guess=False,
+    fields = [ '.0101E202', '0.000000314E+314', '1777E+305', '-1799E+305', '0.2e-323',
+               '2500e-327', ' 0.0000000000000000000001024E+330' ]
+    values = np.array([ 1.01e200, 3.14e307, 1.777e308, -np.inf, 0.0, 4.94e-324, 1.024e308 ])
+    t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
     assert_almost_equal(read_values, values, rtol=rtol, atol=1.e-324)
 
     # test corner cases again with non-standard exponent_style (auto-detection)
-    if reader < 2:
+    if reader and reader.get('use_fast_converter'):
+        reader.update({'exponent_style': 'A'})
+    else:
         pytest.skip("Fortran exponent style only available in fast converter")
-    fast_reader.update({'exponent_style': 'A'})
-    fields = ['.0101D202', '0.000000314d+314', '1777+305', '-1799E+305', '0.2e-323',
-               '2500-327', ' 0.0000000000000000000001024Q+330']
-    t = ascii.read(StringIO(' '.join(fields)), format='no_header', guess=False,
+
+    fields = [ '.0101D202', '0.000000314d+314', '1777+305', '-1799E+305', '0.2e-323',
+               '2500-327', ' 0.0000000000000000000001024Q+330' ]
+    t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
     assert_almost_equal(read_values, values, rtol=rtol, atol=1.e-324)
@@ -1023,14 +1032,14 @@ def test_int_out_of_range(parallel):
 
     text = 'P M S\n {:d} {:d} {:s}'.format(imax, imin, huge)
     expected = Table([[imax], [imin], [huge]], names=('P', 'M', 'S'))
-    table = ascii.read(text, format='basic', guess=False,
+    table = ascii.read(text, format='basic',
                        fast_reader={'parallel': parallel})
     assert_table_equal(table, expected)
 
     # check with leading zeroes to make sure strtol does not read them as octal
     text = 'P M S\n000{:d} -0{:d} 00{:s}'.format(imax, -imin, huge)
     expected = Table([[imax], [imin], ['00'+huge]], names=('P', 'M', 'S'))
-    table = ascii.read(text, format='basic', guess=False,
+    table = ascii.read(text, format='basic',
                        fast_reader={'parallel': parallel})
     assert_table_equal(table, expected)
 
@@ -1041,10 +1050,10 @@ def test_int_out_of_range(parallel):
     expected = Table([[12.3, 10.*imax], [10.*imax, 4.56e8]],
                      names=('A', 'B'))
 
-    table = ascii.read(text, format='basic', guess=False,
+    table = ascii.read(text, format='basic',
                        fast_reader={'parallel': parallel})
     assert_table_equal(table, expected)
-    table = ascii.read(text, format='basic', guess=False, fast_reader=False)
+    table = ascii.read(text, format='basic', fast_reader=False)
     assert_table_equal(table, expected)
 
 
@@ -1056,39 +1065,40 @@ def test_fortran_reader(parallel):
     Make sure that ascii.read() can read Fortran-style exponential notation
     using the fast_reader.
     """
-    text = 'A B C\n100.01{:s}+99 2.0 3\n 4.2{:s}-1 5.0{:s}-1 0.6{:s}4'
-    expected = Table([[1.0001e101, 0.42], [2, 0.5], [3.0, 6000]],
-                     names=('A', 'B', 'C'))
+    # check
+    rtol = 1.e-15
+    atol = 1.e-308
+    text = 'A B C D\n100.01{:s}99       2.0  2.0{:s}-103 3\n' + \
+           ' 4.2{:s}-1 5.0{:s}-1     0.6{:s}4 .017{:s}+309'
+    expc = Table([[1.0001e101, 0.42], [2, 0.5], [2.e-103, 6.e3], [3, 1.7e307]],
+                 names=('A', 'B', 'C', 'D'))
 
-    expstyles = {'e': 4*('E'), 'D': ('D', 'd', 'd', 'D'), 'Q': 2*('q', 'Q'),
-                  'fortran': ('D', 'E', 'Q', 'd')}
+    expstyles = { 'e': 6*('E'),
+                  'D': ('D', 'd', 'd', 'D', 'd', 'D'),
+                  'Q': 3*('q', 'Q'),
+                  'Fortran': ('E', '0', 'D', 'Q', 'd', '0') }
 
     # C strtod (not-fast converter) can't handle Fortran exp
     with pytest.raises(FastOptionsError) as e:
-        ascii.read(text.format(*(4*('D'))), format='basic', guess=False,
+        ascii.read(text.format(*(6*('D'))), format='basic',
                    fast_reader={'use_fast_converter': False,
                                 'parallel': parallel, 'exponent_style': 'D'})
     assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
 
-    # enable multiprocessing and the fast converter
-    # iterate over all style-exponent combinations
+    # enable multiprocessing and the fast converter iterate over
+    # all style-exponent combinations, with auto-detection
     for s, c in expstyles.items():
-        table = ascii.read(text.format(*c), format='basic', guess=False,
-                           fast_reader={'parallel': parallel,
-                                        'exponent_style': s})
-        assert_table_equal(table, expected)
+        table = ascii.read(text.format(*c), fast_reader={'parallel': parallel,
+                                                         'exponent_style': s})
+        assert_table_equal(table, expc, rtol=rtol, atol=atol)
 
-    # mixes and triple-exponents without any character using autodetect option
-    text = 'A B C\n1.0001+101 2.0E0 3\n.42d0 0.5 6.+003'
-    table = ascii.read(text, format='basic', guess=False,
-                       fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
-    assert_table_equal(table, expected)
-
-    # additional corner-case checks
-    text = 'A B C\n1.0001+101 2.0+000 3\n0.42+000 0.5 6000.-000'
-    table = ascii.read(text, format='basic', guess=False,
-                       fast_reader={'parallel': parallel, 'exponent_style': 'fortran'})
-    assert_table_equal(table, expected)
+    # additional corner-case checks including triple-exponents without
+    # any character and mixed whitespace separators
+    text = 'A B\t\t C D\n1.0001+101 2.0+000\t 0.0002-099 3\n ' + \
+           '0.42-000 \t 0.5 6.+003   0.000000000000000000000017+330'
+    table = ascii.read(text, fast_reader={'parallel': parallel,
+                                          'exponent_style': 'A'})
+    assert_table_equal(table, expc, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("parallel", [
@@ -1103,12 +1113,120 @@ def test_fortran_invalid_exp(parallel):
     if parallel and TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
 
-    fields = ['1.0001+1', '.42d1', '2.3+10', '0.5', '3+1001', '3000.',
-               '2', '4.56e-2.3', '8000', '4.2-122']
-    values = ['1.0001+1', 4.2, '2.3+10', 0.5, '3+1001', 3.e3,
-               2, '4.56e-2.3', 8000, 4.2e-122]
+    rtol = 1.e-15
+    atol = 1.e-308
 
-    t = ascii.read(StringIO(' '.join(fields)), format='no_header', guess=False,
-                   fast_reader={'parallel': parallel, 'exponent_style': 'A'})
-    read_values = [col[0] for col in t.itercols()]
-    assert read_values == values
+    formats = { 'basic': ' ', 'tab': '\t', 'csv': ',' }
+    header = ['S1', 'F2', 'S2', 'F3', 'S3', 'F4', 'F5', 'S4', 'I1', 'F6', 'F7']
+    # tested entries and expected returns, first for auto-detect,
+    # then for different specified exponents
+    fields = [ '1.0001+1', '.42d1', '2.3+10', '0.5', '3+1001', '3000.',
+               '2', '4.56e-2.3', '8000', '4.2-022', '.00000145e314' ]
+    vals_e = [ '1.0001+1', '.42d1', '2.3+10',   0.5, '3+1001',  3.e3,
+               2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308 ]
+    vals_d = [ '1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
+               2, '4.56e-2.3',    8000,  '4.2-022', '.00000145e314' ]
+    vals_a = [ '1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
+               2, '4.56e-2.3',    8000,   4.2e-22,  1.45e308 ]
+
+    # iterate over supported format types and separators
+    for f, s in formats.items():
+        t1 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), format=f,
+                fast_reader={'parallel': parallel, 'exponent_style': 'A'})
+        # assert t1['I1'].dtype.kind == 'i'
+        assert_table_equal(t1, Table([[col] for col in vals_a], names=header))
+
+    # try another separator as well with auto-detection
+    #formats['bar'] = '|'
+
+    for s in formats.values():
+        t2 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+                fast_reader={'parallel': parallel, 'exponent_style': 'a'})
+
+        assert_table_equal(t2, Table([[col] for col in vals_a], names=header))
+
+    # iterate for (default) expchar 'E'
+    for s in formats.values():
+        t3 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+                fast_reader={'parallel': parallel, 'use_fast_converter': False})
+
+        assert_table_equal(t3, Table([[col] for col in vals_e], names=header),
+                                     rtol=1.0e-30, atol=0.0)
+
+    for s in formats.values():
+        t4 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+                fast_reader={'parallel': parallel, 'use_fast_converter': True})
+
+        assert_table_equal(t4, Table([[col] for col in vals_e], names=header))
+
+    # iterate for expchar 'D'
+    for s in formats.values():
+        t5 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+                fast_reader={'parallel': parallel, 'exponent_style': 'D'})
+
+        assert_table_equal(t5, Table([[col] for col in vals_d], names=header))
+
+
+def test_fortran_reader_notbasic():
+    """
+    Check if readers without a fast option raise a value error when a
+    fast_reader is asked for.
+    """
+
+    tabstr = dedent("""
+    a b
+    1 1.23D4
+    2 5.67D-8
+    """)[1:-1]
+
+    t1 = ascii.read(tabstr.split('\n'), fast_reader=dict(exponent_style='D'))
+
+    assert t1['b'].dtype.kind == 'f'
+
+    tabrdb = dedent("""
+    a\tb
+    # A simple RDB table
+    N\tN
+    1\t 1.23D4
+    2\t 5.67-008
+    """)[1:-1]
+
+    t2 = ascii.read(tabrdb.split('\n'), format='rdb',
+                    fast_reader=dict(exponent_style='fortran'))
+
+    assert t2['b'].dtype.kind == 'f'
+
+    tabrst = dedent("""
+    = =======
+    a b
+    = =======
+    1 1.23E4
+    2 5.67E-8
+    = =======
+    """)[1:-1]
+
+    t3 = ascii.read(tabrst.split('\n'), format='rst')
+
+    assert t3['b'].dtype.kind == 'f'
+
+    # in the special case of fast_converter=True (the default),
+    # incompatibility is ignored
+    t4 = ascii.read(tabrst.split('\n'), format='rst', fast_reader=True)
+
+    assert t4['b'].dtype.kind == 'f'
+
+    # pytest.xfail("Readers do not correctly check for incompatible options")
+    with pytest.raises(ParameterError):
+        t5 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                        fast_reader='force')
+
+    with pytest.raises(ParameterError):
+        t6 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                        fast_reader=dict(use_fast_converter=False))
+
+    tabrst = tabrst.replace('E', 'D')
+
+    with pytest.raises(ParameterError):
+        t7 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                        fast_reader=dict(exponent_style='D'))
+

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1128,6 +1128,12 @@ def test_fortran_invalid_exp(parallel):
                2, '4.56e-2.3',    8000,  '4.2-022', '.00000145e314' ]
     vals_a = [ '1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
                2, '4.56e-2.3',    8000,   4.2e-22,  1.45e308 ]
+    if os.name == 'nt':
+        # apparently C strtod() on Windows recognises 'd' exponents!
+        vals_c = [ '1.0001+1', 4.2, '2.3+10',   0.5, '3+1001',  3.e3,
+                   2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308 ]
+    else:
+        vals_c = vals_e
 
     # iterate over supported format types and separators
     for f, s in formats.items():
@@ -1165,7 +1171,7 @@ def test_fortran_invalid_exp(parallel):
                 fast_reader={'parallel': parallel, 'use_fast_converter': False})
 
         read_values = [col[0] for col in t5.itercols()]
-        assert read_values == vals_e
+        assert read_values == vals_c
 
 
 def test_fortran_reader_notbasic():

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -957,12 +957,12 @@ def test_read_big_table(tmpdir):
     t = Table.read(filename, format='ascii.csv', fast_reader=True)
     assert len(t) == NB_ROWS
 
-# test these both with guessing turned on and off
+# Test these both with guessing turned on and off
 @pytest.mark.parametrize("guess", [True, False])
 # fast_reader configurations: False| 'use_fast_converter'=False|True
-@pytest.mark.parametrize('fast_reader', [ False, dict(use_fast_converter=False),
-                                     dict(use_fast_converter=True) ])
-# catch Windows environment since we cannot use _read() with custom fast_reader
+@pytest.mark.parametrize('fast_reader', [False, dict(use_fast_converter=False),
+                                         dict(use_fast_converter=True)])
+# Catch Windows environment since we cannot use _read() with custom fast_reader
 @pytest.mark.parametrize("parallel", [False,
     pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows"))])
 def test_data_out_of_range(parallel, fast_reader, guess):
@@ -975,7 +975,7 @@ def test_data_out_of_range(parallel, fast_reader, guess):
     # Python reader and strtod() are expected to return precise results
     rtol = 1.e-30
 
-    # update fast_reader dict
+    # Update fast_reader dict
     if fast_reader:
         fast_reader['parallel'] = parallel
         if fast_reader.get('use_fast_converter'):
@@ -987,30 +987,30 @@ def test_data_out_of_range(parallel, fast_reader, guess):
         elif TRAVIS:
             pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
 
-    fields = [ '10.1E+199', '3.14e+313', '2048e+306', '0.6E-325', '-2.e345' ]
+    fields = ['10.1E+199', '3.14e+313', '2048e+306', '0.6E-325', '-2.e345']
     values = np.array([ 1.01e200, np.inf, np.inf, 0.0, -np.inf ])
     t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    guess=guess, fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
     assert_almost_equal(read_values, values, rtol=rtol, atol=1.e-324)
 
-    # test some additional corner cases
-    fields = [ '.0101E202', '0.000000314E+314', '1777E+305', '-1799E+305', '0.2e-323',
-               '5200e-327', ' 0.0000000000000000000001024E+330' ]
+    # Test some additional corner cases
+    fields = ['.0101E202', '0.000000314E+314', '1777E+305', '-1799E+305',
+              '0.2e-323', '5200e-327', ' 0.0000000000000000000001024E+330']
     values = np.array([ 1.01e200, 3.14e307, 1.777e308, -np.inf, 0.0, 4.94e-324, 1.024e308 ])
     t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    guess=guess, fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
     assert_almost_equal(read_values, values, rtol=rtol, atol=1.e-324)
 
-    # test corner cases again with non-standard exponent_style (auto-detection)
+    # Test corner cases again with non-standard exponent_style (auto-detection)
     if fast_reader and fast_reader.get('use_fast_converter'):
         fast_reader.update({'exponent_style': 'A'})
     else:
         pytest.skip("Fortran exponent style only available in fast converter")
 
-    fields = [ '.0101D202', '0.000000314d+314', '1777+305', '-1799E+305', '0.2e-323',
-               '2500-327', ' 0.0000000000000000000001024Q+330' ]
+    fields = ['.0101D202', '0.000000314d+314', '1777+305', '-1799E+305',
+              '0.2e-323', '2500-327', ' 0.0000000000000000000001024Q+330']
     t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    guess=guess, fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
@@ -1045,7 +1045,7 @@ def test_int_out_of_range(parallel, guess):
                        fast_reader={'parallel': parallel})
     assert_table_equal(table, expected)
 
-    # mixed columns should be returned as float, but if the out-of-range integer
+    # Mixed columns should be returned as float, but if the out-of-range integer
     # shows up first, it will produce a string column - with both readers
     pytest.xfail("Integer fallback depends on order of rows")
     text = 'A B\n 12.3 {0:d}9\n {0:d}9 45.6e7'.format(imax)
@@ -1090,14 +1090,14 @@ def test_fortran_reader(parallel, guess):
                                 'parallel': parallel, 'exponent_style': 'D'})
     assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
 
-    # enable multiprocessing and the fast converter iterate over
+    # Enable multiprocessing and the fast converter iterate over
     # all style-exponent combinations, with auto-detection
     for s, c in expstyles.items():
         table = ascii.read(text.format(*c), guess=guess,
                            fast_reader={'parallel': parallel, 'exponent_style': s})
         assert_table_equal(table, expc, rtol=rtol, atol=atol)
 
-    # additional corner-case checks including triple-exponents without
+    # Additional corner-case checks including triple-exponents without
     # any character and mixed whitespace separators
     text = 'A B\t\t C D\n1.0001+101 2.0+000\t 0.0002-099 3\n ' + \
            '0.42-000 \t 0.5 6.+003   0.000000000000000000000017+330'
@@ -1122,35 +1122,33 @@ def test_fortran_invalid_exp(parallel, guess):
     rtol = 1.e-15
     atol = 0.0
 
-    formats = { 'basic': ' ', 'tab': '\t', 'csv': ',' }
+    formats = {'basic': ' ', 'tab': '\t', 'csv': ','}
     header = ['S1', 'F2', 'S2', 'F3', 'S3', 'F4', 'F5', 'S4', 'I1', 'F6', 'F7']
-    # tested entries and expected returns, first for auto-detect,
+    # Tested entries and expected returns, first for auto-detect,
     # then for different specified exponents
-    fields = [ '1.0001+1', '.42d1', '2.3+10', '0.5', '3+1001', '3000.',
-               '2', '4.56e-2.3', '8000', '4.2-022', '.00000145e314' ]
-    vals_e = [ '1.0001+1', '.42d1', '2.3+10',   0.5, '3+1001',  3.e3,
-               2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308 ]
-    vals_d = [ '1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
-               2, '4.56e-2.3',    8000,  '4.2-022', '.00000145e314' ]
-    vals_a = [ '1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
-               2, '4.56e-2.3',    8000,   4.2e-22,  1.45e308 ]
-    vals_v = [ '1.0001+1', 4.2, '2.3+10',   0.5, '3+1001',  3.e3,
-               2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308 ]
+    fields = ['1.0001+1', '.42d1', '2.3+10', '0.5', '3+1001', '3000.',
+              '2', '4.56e-2.3', '8000', '4.2-022', '.00000145e314']
+    vals_e = ['1.0001+1', '.42d1', '2.3+10',   0.5, '3+1001',  3.e3,
+              2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308]
+    vals_d = ['1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
+              2, '4.56e-2.3',    8000,  '4.2-022', '.00000145e314']
+    vals_a = ['1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
+              2, '4.56e-2.3',    8000,   4.2e-22,  1.45e308]
+    vals_v = ['1.0001+1', 4.2, '2.3+10',   0.5, '3+1001',  3.e3,
+               2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308]
 
-    # iterate over supported format types and separators
+    # Iterate over supported format types and separators
     for f, s in formats.items():
         t1 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
                         format=f, guess=guess,
                         fast_reader={'parallel': parallel, 'exponent_style': 'A'})
-        # assert t1['I1'].dtype.kind == 'i'
         assert_table_equal(t1, Table([[col] for col in vals_a], names=header))
 
-    # try another separator as well with auto-detection
-    #formats['bar'] = '|'
-
-    # non-basic separators require guessing enabled to be detected
-    if not guess:
-        formats = { 'basic': ' ' }
+    # Non-basic separators require guessing enabled to be detected
+    if guess:
+        formats['bar'] = '|'
+    else:
+        formats = {'basic': ' '}
 
     for s in formats.values():
         t2 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
@@ -1158,28 +1156,28 @@ def test_fortran_invalid_exp(parallel, guess):
 
         assert_table_equal(t2, Table([[col] for col in vals_a], names=header))
 
-    # iterate for (default) expchar 'E'
+    # Iterate for (default) expchar 'E'
     for s in formats.values():
         t3 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
                 fast_reader={'parallel': parallel, 'use_fast_converter': True})
 
         assert_table_equal(t3, Table([[col] for col in vals_e], names=header))
 
-    # iterate for regular converter (strtod)
+    # Iterate for expchar 'D'
     for s in formats.values():
         t4 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
                 fast_reader={'parallel': parallel, 'exponent_style': 'D'})
 
         assert_table_equal(t4, Table([[col] for col in vals_d], names=header))
 
-    # iterate for regular converter (strtod)
+    # Iterate for regular converter (strtod)
     for s in formats.values():
         t5 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
                 fast_reader={'parallel': parallel, 'use_fast_converter': False})
 
         read_values = [col[0] for col in t5.itercols()]
         if os.name == 'nt':
-            # apparently C strtod() on (some?) MSVC recognises 'd' exponents!
+            # Apparently C strtod() on (some?) MSVC recognises 'd' exponents!
             assert read_values == vals_v or read_values == vals_e
         else:
             assert read_values == vals_e
@@ -1188,7 +1186,7 @@ def test_fortran_invalid_exp(parallel, guess):
 def test_fortran_reader_notbasic():
     """
     Check if readers without a fast option raise a value error when a
-    fast_reader is asked for.
+    fast_reader is asked for (implies the default 'guess=True').
     """
 
     tabstr = dedent("""
@@ -1227,7 +1225,7 @@ def test_fortran_reader_notbasic():
 
     assert t3['b'].dtype.kind == 'f'
 
-    # in the special case of fast_converter=True (the default),
+    # In the special case of fast_converter=True (the default),
     # incompatibility is ignored
     t4 = ascii.read(tabrst.split('\n'), format='rst', fast_reader=True)
 
@@ -1258,7 +1256,7 @@ def test_dict_kwarg_integrity(fast_reader, guess):
     """
     expstyle = fast_reader.get('exponent_style', 'E')
     fields = [ '10.1D+199', '3.14d+313', '2048d+306', '0.6D-325', '-2.d345' ]
-    # values = np.array([ 1.01e200, np.inf, np.inf, 0.0, -np.inf ])
+
     t = ascii.read(StringIO(' '.join(fields)), guess=guess,
                    fast_reader=fast_reader)
     assert fast_reader.get('exponent_style', None) == expstyle

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -2,7 +2,6 @@
 
 import os
 import functools
-import copy
 
 from io import BytesIO
 from textwrap import dedent

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -22,6 +22,7 @@ from .common import assert_equal, assert_almost_equal, assert_true
 StringIO = lambda x: BytesIO(x.encode('ascii'))
 TRAVIS = os.environ.get('TRAVIS', False)
 
+
 def assert_table_equal(t1, t2, check_meta=False, rtol=1.e-15, atol=1.e-300):
     """
     Test equality of all columns in a table, with stricter tolerances for
@@ -957,6 +958,7 @@ def test_read_big_table(tmpdir):
     t = Table.read(filename, format='ascii.csv', fast_reader=True)
     assert len(t) == NB_ROWS
 
+
 # Test these both with guessing turned on and off
 @pytest.mark.parametrize("guess", [True, False])
 # fast_reader configurations: False| 'use_fast_converter'=False|True
@@ -988,7 +990,7 @@ def test_data_out_of_range(parallel, fast_reader, guess):
             pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
 
     fields = ['10.1E+199', '3.14e+313', '2048e+306', '0.6E-325', '-2.e345']
-    values = np.array([ 1.01e200, np.inf, np.inf, 0.0, -np.inf ])
+    values = np.array([1.01e200, np.inf, np.inf, 0.0, -np.inf])
     t = ascii.read(StringIO(' '.join(fields)), format='no_header',
                    guess=guess, fast_reader=fast_reader)
     read_values = np.array([col[0] for col in t.itercols()])
@@ -1078,10 +1080,10 @@ def test_fortran_reader(parallel, guess):
     expc = Table([[1.0001e101, 0.42], [2, 0.5], [2.e-103, 6.e3], [3, 1.7e307]],
                  names=('A', 'B', 'C', 'D'))
 
-    expstyles = { 'e': 6*('E'),
-                  'D': ('D', 'd', 'd', 'D', 'd', 'D'),
-                  'Q': 3*('q', 'Q'),
-                  'Fortran': ('E', '0', 'D', 'Q', 'd', '0') }
+    expstyles = {'e': 6*('E'),
+                 'D': ('D', 'd', 'd', 'D', 'd', 'D'),
+                 'Q': 3*('q', 'Q'),
+                  'Fortran': ('E', '0', 'D', 'Q', 'd', '0')}
 
     # C strtod (not-fast converter) can't handle Fortran exp
     with pytest.raises(FastOptionsError) as e:
@@ -1118,9 +1120,6 @@ def test_fortran_invalid_exp(parallel, guess):
     """
     if parallel and TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
-
-    rtol = 1.e-15
-    atol = 0.0
 
     formats = {'basic': ' ', 'tab': '\t', 'csv': ','}
     header = ['S1', 'F2', 'S2', 'F3', 'S3', 'F4', 'F5', 'S4', 'I1', 'F6', 'F7']
@@ -1248,6 +1247,7 @@ def test_fortran_reader_notbasic():
     with pytest.raises(ParameterError):
         t8 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
                         fast_reader=dict(exponent_style='D'))
+
 
 @pytest.mark.parametrize("guess", [True, False])
 @pytest.mark.parametrize('fast_reader', [ dict(exponent_style='D'),

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -120,8 +120,13 @@ def test_read_with_names_arg(fast_reader):
     """
     Test that a bad value of `names` raises an exception.
     """
-    with pytest.raises(ValueError):
-        ascii.read(['c d', 'e f'], names=('a', ), guess=False, fast_reader=fast_reader)
+    # CParser only uses columns in `names` and thus reports mismach in num_col
+    if fast_reader:
+        e = ascii.InconsistentTableError
+    else:
+        e = ValueError
+    with pytest.raises(e):
+        dat = ascii.read(['c d', 'e f'], names=('a', ), guess=False, fast_reader=fast_reader)
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -105,6 +105,24 @@ def test_guess_with_format_arg():
     assert dat.colnames == ['a', 'b']
 
 
+def test_guess_with_delimiter_arg():
+    """
+    When the delimiter is explicitly given then do not try others in guessing.
+    """
+    fields = ['10.1E+19', '3.14', '2048', '-23']
+    values = [1.01e20, 3.14, 2048, -23]
+
+    # Default guess should recognise CSV with optional spaces
+    t0 = ascii.read(StringIO(', '.join(fields)), guess=True)
+    for n, v in zip(t0.colnames, values):
+        assert t0[n][0] == v
+
+    # Forcing space as delimiter produces type str columns ('10.1E+19,')
+    t1 = ascii.read(StringIO(', '.join(fields)), guess=True, delimiter=' ')
+    for n, v in zip(t1.colnames[:-1], fields[:-1]):
+        assert t1[n][0] == v+','
+
+
 def test_reading_mixed_delimiter_tabs_spaces():
     # Regression test for https://github.com/astropy/astropy/issues/6770
     dat = ascii.read('1 2\t3\n1 2\t3', format='no_header', names=list('abc'))

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -157,9 +157,9 @@ def test_read_all_files(fast_reader):
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
             if ('Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name)
-                in core.FAST_CLASSES):  # has fast version
-                    if 'Inputter' not in test_opts:  # fast reader doesn't allow this
-                        test_opts['fast_reader'] = fast_reader
+                    in core.FAST_CLASSES):  # has fast version
+                if 'Inputter' not in test_opts:  # fast reader doesn't allow this
+                    test_opts['fast_reader'] = fast_reader
             table = ascii.read(testfile['name'], **test_opts)
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -34,6 +34,8 @@ except ImportError:
 else:
     HAS_BZ2 = True
 
+asciiIO = lambda x: BytesIO(x.encode('ascii'))
+
 
 @pytest.mark.parametrize('fast_reader', [True, False, {'use_fast_converter': False},
                                          {'use_fast_converter': True}, 'force'])
@@ -113,12 +115,12 @@ def test_guess_with_delimiter_arg():
     values = [1.01e20, 3.14, 2048, -23]
 
     # Default guess should recognise CSV with optional spaces
-    t0 = ascii.read(StringIO(', '.join(fields)), guess=True)
+    t0 = ascii.read(asciiIO(', '.join(fields)), guess=True)
     for n, v in zip(t0.colnames, values):
         assert t0[n][0] == v
 
     # Forcing space as delimiter produces type str columns ('10.1E+19,')
-    t1 = ascii.read(StringIO(', '.join(fields)), guess=True, delimiter=' ')
+    t1 = ascii.read(asciiIO(', '.join(fields)), guess=True, delimiter=' ')
     for n, v in zip(t1.colnames[:-1], fields[:-1]):
         assert t1[n][0] == v+','
 
@@ -158,8 +160,8 @@ def test_read_all_files(fast_reader):
             test_opts = testfile['opts'].copy()
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
-            if 'Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name) \
-                in core.FAST_CLASSES:  # has fast version
+            if ('Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name) 
+                in core.FAST_CLASSES):  # has fast version
                 if 'Inputter' not in test_opts:  # fast reader doesn't allow this
                     test_opts['fast_reader'] = fast_reader
             table = ascii.read(testfile['name'], **test_opts)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -141,12 +141,8 @@ def test_read_with_names_arg(fast_reader):
     Test that a bad value of `names` raises an exception.
     """
     # CParser only uses columns in `names` and thus reports mismach in num_col
-    if fast_reader:
-        e = ascii.InconsistentTableError
-    else:
-        e = ValueError
-    with pytest.raises(e):
-        dat = ascii.read(['c d', 'e f'], names=('a', ), guess=False, fast_reader=fast_reader)
+    with pytest.raises(ascii.InconsistentTableError):
+        ascii.read(['c d', 'e f'], names=('a', ), guess=False, fast_reader=fast_reader)
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1409,3 +1409,16 @@ def test_read_non_ascii():
     table = Table.read(['col1, col2', '\u2119, \u01b4', '1, 2'], format='csv')
     assert np.all(table['col1'] == ['\u2119', '1'])
     assert np.all(table['col2'] == ['\u01b4', '2'])
+
+
+@pytest.mark.parametrize('enable', [True, False, 'force'])
+def test_kwargs_dict_guess(enable):
+    """Test that fast_reader dictionary is preserved through guessing sequence.
+    """
+    # Fails for enable=(True, 'force') - #5578
+    ascii.read('a\tb\n 1\t2\n3\t 4.0', fast_reader=dict(enable=enable))
+    assert get_read_trace()[-1]['kwargs']['Reader'] is (
+        ascii.Tab if (enable is False) else ascii.FastTab)
+    for k in get_read_trace():
+        if not k.get('status', 'Disabled').startswith('Disabled'):
+            assert k.get('kwargs').get('fast_reader').get('enable') is enable

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -163,7 +163,7 @@ def test_read_all_files(fast_reader):
             if ('Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name)
                 in core.FAST_CLASSES):  # has fast version
                     if 'Inputter' not in test_opts:  # fast reader doesn't allow this
-                    test_opts['fast_reader'] = fast_reader
+                        test_opts['fast_reader'] = fast_reader
             table = ascii.read(testfile['name'], **test_opts)
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -160,9 +160,9 @@ def test_read_all_files(fast_reader):
             test_opts = testfile['opts'].copy()
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
-            if ('Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name) 
+            if ('Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name)
                 in core.FAST_CLASSES):  # has fast version
-                if 'Inputter' not in test_opts:  # fast reader doesn't allow this
+                    if 'Inputter' not in test_opts:  # fast reader doesn't allow this
                     test_opts['fast_reader'] = fast_reader
             table = ascii.read(testfile['name'], **test_opts)
             assert_equal(table.dtype.names, testfile['cols'])
@@ -307,7 +307,7 @@ def test_set_include_names(fast_reader):
     names = ('c1', 'c2', 'c3', 'c4', 'c5', 'c6')
     include_names = ('c1', 'c3')
     data = ascii.read('t/simple3.txt', names=names, include_names=include_names,
-                           delimiter='|', fast_reader=fast_reader)
+                      delimiter='|', fast_reader=fast_reader)
     assert_equal(data.dtype.names, include_names)
 
 
@@ -453,7 +453,7 @@ def test_fill_values_include_names(fast_reader):
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
     data = ascii.read(f, fill_values=('a', '1'), fast_reader=fast_reader,
-                           fill_include_names=['b'], **testfile['opts'])
+                      fill_include_names=['b'], **testfile['opts'])
     check_fill_values(data)
 
 
@@ -462,7 +462,7 @@ def test_fill_values_exclude_names(fast_reader):
     f = 't/fill_values.txt'
     testfile = get_testfiles(f)
     data = ascii.read(f, fill_values=('a', '1'), fast_reader=fast_reader,
-                           fill_exclude_names=['a'], **testfile['opts'])
+                      fill_exclude_names=['a'], **testfile['opts'])
     check_fill_values(data)
 
 
@@ -528,7 +528,7 @@ def test_Ipac_meta():
 def test_set_guess_kwarg():
     """Read a file using guess with one of the typical guess_kwargs explicitly set."""
     data = ascii.read('t/space_delim_no_header.dat',
-                           delimiter=',', guess=True)
+                      delimiter=',', guess=True)
     assert(data.dtype.names == ('1 3.4 hello',))
     assert(len(data) == 1)
 
@@ -857,7 +857,8 @@ def test_header_start_exception():
     This was implemented in response to issue #885.
     '''
     for readerclass in [ascii.NoHeader, ascii.SExtractor, ascii.Ipac,
-                   ascii.BaseReader, ascii.FixedWidthNoHeader, ascii.Cds, ascii.Daophot]:
+                        ascii.BaseReader, ascii.FixedWidthNoHeader,
+                        ascii.Cds, ascii.Daophot]:
         with pytest.raises(ValueError):
             reader = ascii.core._get_reader(readerclass, header_start=5)
 
@@ -890,8 +891,8 @@ def test_sextractor_units():
     """
     table = ascii.read('t/sextractor2.dat', Reader=ascii.SExtractor, guess=False)
     expected_units = [None, Unit('pix'), Unit('pix'), Unit('mag'),
-                Unit('mag'), None, Unit('pix**2'), Unit('m**(-6)'),
-                Unit('mag * arcsec**(-2)')]
+                      Unit('mag'), None, Unit('pix**2'), Unit('m**(-6)'),
+                      Unit('mag * arcsec**(-2)')]
     expected_descrs = ['Running object number',
                        'Windowed position estimate along x',
                        'Windowed position estimate along y',
@@ -1076,7 +1077,7 @@ def test_probably_html():
                   'junk < table baz> <tr foo > <td bar> </td> </tr> </table> junk',
                   ['junk < table baz>', ' <tr foo >', ' <td bar> ', '</td> </tr>', '</table> junk'],
                   (' <! doctype html > ', ' hello world'),
-    ):
+                   ):
         assert _probably_html(table) is True
 
     for table in ('t/html.htms',
@@ -1088,7 +1089,7 @@ def test_probably_html():
                   ['junk < table baz>', ' <t foo >', ' <td bar> ', '</td> </tr>', '</table> junk'],
                   (' <! doctype htm > ', ' hello world'),
                   [[1, 2, 3]],
-    ):
+                   ):
         assert _probably_html(table) is False
 
 
@@ -1102,8 +1103,8 @@ def test_data_header_start(fast_reader):
                '1 2'],  # line 2
               [{'header_start': 1},
                {'header_start': 1, 'data_start': 2}
-           ]
-           ),
+               ]
+               ),
 
              (['# comment',
                '',

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -164,7 +164,10 @@ def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
     # This function is a light wrapper around core._get_reader to provide a public interface
     # with a default Reader.
     if Reader is None:
-        Reader = basic.Basic
+        if kwargs.get('fast_reader', False):
+            Reader = fastbasic.FastBasic
+        else:
+            Reader = basic.Basic
     reader = core._get_reader(Reader, Inputter=Inputter, Outputter=Outputter, **kwargs)
     return reader
 
@@ -353,8 +356,8 @@ def read(table, guess=None, **kwargs):
             guess = False
 
     if not guess:
-        reader = get_reader(**new_kwargs)
         if format is None:
+            reader = get_reader(**new_kwargs)
             format = reader._format_name
 
         # Try the fast reader version of `format` first if applicable.  Note that
@@ -376,12 +379,14 @@ def read(table, guess=None, **kwargs):
                         'fast reader {} exception: {}'
                         .format(fast_reader_rdr.__class__, err))
                 # If the fast reader doesn't work, try the slow version
+                reader = get_reader(**new_kwargs)
                 dat = reader.read(table)
                 _read_trace.append({'kwargs': new_kwargs,
                                     'Reader': reader.__class__,
                                     'status': 'Success with slow reader after failing'
                                              ' with fast (no guessing)'})
         else:
+            reader = get_reader(**new_kwargs)
             dat = reader.read(table)
             _read_trace.append({'kwargs': new_kwargs,
                                 'Reader': reader.__class__,
@@ -431,6 +436,11 @@ def _guess(table, read_kwargs, format, fast_reader):
         full_list_guess = [fast_kwargs] + full_list_guess
     else:
         fast_kwargs = None
+
+    # dictionary arguments are passed by reference per default and might
+    # (usually will!) be altered by `read()` - especially `cparser` - calls,
+    # backup them here
+    user_kwargs = copy.deepcopy(read_kwargs)
 
     # Filter the full guess list so that each entry is consistent with user kwarg inputs.
     # This also removes any duplicates from the list.
@@ -487,12 +497,19 @@ def _guess(table, read_kwargs, format, fast_reader):
     # keep track of the failed guess and move on.
     for guess_kwargs in filtered_guess_kwargs:
         t0 = time.time()
+        for key, val in user_kwargs.items():
+            # update guess_kwargs again; need a deep copy to preserve dicts
+            if key not in guess_kwargs:
+                guess_kwargs[key] = val.copy()
+            elif val != guess_kwargs[key] and guess_kwargs != fast_kwargs:
+                guess_kwargs[key] = val.copy()
         try:
             # If guessing will try all Readers then use strict req'ts on column names
             if 'Reader' not in read_kwargs:
                 guess_kwargs['strict_names'] = True
 
             reader = get_reader(**guess_kwargs)
+
             reader.guessing = True
             dat = reader.read(table)
             _read_trace.append({'kwargs': guess_kwargs,

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -463,7 +463,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                 guess_kwargs['Reader'] in core.FAST_CLASSES.values()):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': guess_kwargs['Reader'].__class__,
-                                'status': 'Reader only available in fast version',
+                                'status': 'Disabled: reader only available in fast version',
                                 'dt': '{0:.3f} ms'.format(0.0)})
             continue
 
@@ -473,7 +473,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                 guess_kwargs['Reader'] not in core.FAST_CLASSES.values()):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': guess_kwargs['Reader'].__class__,
-                                'status': 'No fast version of reader available',
+                                'status': 'Disabled: no fast version of reader available',
                                 'dt': '{0:.3f} ms'.format(0.0)})
             continue
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -29,6 +29,7 @@ from . import sextractor
 from . import ipac
 from . import latex
 from . import html
+from . import rst
 from . import fastbasic
 from . import cparser
 from . import fixedwidth
@@ -161,10 +162,10 @@ def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
     reader : `~astropy.io.ascii.BaseReader` subclass
         ASCII format reader instance
     """
-    # This function is a light wrapper around core._get_reader to provide a public interface
-    # with a default Reader.
+    # This function is a light wrapper around core._get_reader to provide a
+    # public interface with a default Reader.
     if Reader is None:
-        if kwargs.get('fast_reader', False):
+        if kwargs.get('fast_reader', False) and len(kwargs.get('delimiter', ' ')) < 2:
             Reader = fastbasic.FastBasic
         else:
             Reader = basic.Basic
@@ -300,6 +301,7 @@ def read(table, guess=None, **kwargs):
     # Dictionary arguments are passed by reference per default and thus need
     # special protection:
     new_kwargs = copy.deepcopy(kwargs)
+    kwargs['fast_reader'] = copy.deepcopy(fast_reader)
 
     # Get the Reader class based on possible format and Reader kwarg inputs.
     Reader = _get_format_class(format, kwargs.get('Reader'), 'Reader')
@@ -444,7 +446,7 @@ def _guess(table, read_kwargs, format, fast_reader, fulltrace=False):
     # If a fast version of the reader is available, try that before the slow version
     if (fast_reader['enable'] and format is not None and 'fast_{0}'.format(format) in
         core.FAST_CLASSES):
-        fast_kwargs = read_kwargs.copy()
+        fast_kwargs = copy.deepcopy(read_kwargs)
         fast_kwargs['Reader'] = core.FAST_CLASSES['fast_{0}'.format(format)]
         full_list_guess = [fast_kwargs] + full_list_guess
     else:
@@ -613,8 +615,9 @@ def _get_guess_kwargs_list(read_kwargs):
 
     # Now try readers that accept the user-supplied keyword arguments
     # (actually include all here - check for compatibility of arguments later).
-    # FixedWidthTwoLine would also be read by Basic, so it needs to come first.
-    for reader in [fixedwidth.FixedWidthTwoLine,
+    # FixedWidthTwoLine would also be read by Basic, so it needs to come first;
+    # same for RST.
+    for reader in [fixedwidth.FixedWidthTwoLine, rst.RST,
                    fastbasic.FastBasic, basic.Basic,
                    fastbasic.FastRdb, basic.Rdb,
                    fastbasic.FastTab, basic.Tab,

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -295,6 +295,11 @@ def read(table, guess=None, **kwargs):
 
     format = kwargs.get('format')
     new_kwargs.update(kwargs)
+    # dictionary arguments are passed by reference per default and thus need
+    # special protection:
+    for k in kwargs:
+        if isinstance(kwargs[k], dict):
+            new_kwargs[k] = copy.deepcopy(kwargs[k])
 
     # Get the Reader class based on possible format and Reader kwarg inputs.
     Reader = _get_format_class(format, kwargs.get('Reader'), 'Reader')

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -439,7 +439,7 @@ def _guess(table, read_kwargs, format, fast_reader):
 
     # dictionary arguments are passed by reference per default and might
     # (usually will!) be altered by `read()` - especially `cparser` - calls,
-    # backup them here
+    # back them up here
     user_kwargs = copy.deepcopy(read_kwargs)
 
     # Filter the full guess list so that each entry is consistent with user kwarg inputs.
@@ -497,12 +497,12 @@ def _guess(table, read_kwargs, format, fast_reader):
     # keep track of the failed guess and move on.
     for guess_kwargs in filtered_guess_kwargs:
         t0 = time.time()
+        # update guess_kwargs again; need a deep copy to preserve dicts
         for key, val in user_kwargs.items():
-            # update guess_kwargs again; need a deep copy to preserve dicts
             if key not in guess_kwargs:
-                guess_kwargs[key] = val.copy()
+                guess_kwargs[key] = copy.deepcopy(val)
             elif val != guess_kwargs[key] and guess_kwargs != fast_kwargs:
-                guess_kwargs[key] = val.copy()
+                guess_kwargs[key] = copy.deepcopy(val)
         try:
             # If guessing will try all Readers then use strict req'ts on column names
             if 'Reader' not in read_kwargs:

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -301,7 +301,6 @@ def read(table, guess=None, **kwargs):
         kwargs['fill_values'] = [('', '0')]
 
     # If an Outputter is supplied in kwargs that will take precedence.
-    fast_reader_param = kwargs.get('fast_reader', True)
     if 'Outputter' in kwargs:  # user specified Outputter, not supported for fast reading
         fast_reader['enable'] = False
 
@@ -467,8 +466,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                                 'dt': '{0:.3f} ms'.format(0.0)})
             continue
 
-        # If user explicitly required a fast reader with 'force' or as dict of
-        # options then skip all non-fast readers
+        # If user required a fast reader then skip all non-fast readers
         if (fast_reader['enable'] == 'force' and
                 guess_kwargs['Reader'] not in core.FAST_CLASSES.values()):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -262,9 +262,6 @@ def read(table, guess=None, **kwargs):
         Reader class (DEPRECATED)
     encoding: str
         Allow to specify encoding to read the file (default= ``None``).
-    fulltrace: bool
-        Keep a full trace of guessed readers in ascii.get_read_trace(),
-        including those skipped due to inconsistent options
 
     Returns
     -------
@@ -312,11 +309,6 @@ def read(table, guess=None, **kwargs):
     # Remove format keyword if there, this is only allowed in read() not get_reader()
     if 'format' in new_kwargs:
         del new_kwargs['format']
-    if 'fulltrace' in new_kwargs:
-        fulltrace = new_kwargs['fulltrace']
-        del new_kwargs['fulltrace']
-    else:
-        fulltrace = False
 
     if guess is None:
         guess = _GUESS
@@ -408,7 +400,7 @@ def read(table, guess=None, **kwargs):
     return dat
 
 
-def _guess(table, read_kwargs, format, fast_reader, fulltrace=False):
+def _guess(table, read_kwargs, format, fast_reader):
     """
     Try to read the table using various sets of keyword args.  Start with the
     standard guess list and filter to make it unique and consistent with
@@ -426,9 +418,6 @@ def _guess(table, read_kwargs, format, fast_reader, fulltrace=False):
         Table format
     fast_reader : dict
         Options for the C engine fast reader.  See read() function for details.
-    fulltrace : bool
-        Keep a full trace of guessed readers in ascii.get_read_trace(),
-        including those skipped due to inconsistent options
 
     Returns
     -------
@@ -461,20 +450,20 @@ def _guess(table, read_kwargs, format, fast_reader, fulltrace=False):
         # If user specified slow reader then skip all fast readers
         if (fast_reader['enable'] is False and
                 guess_kwargs['Reader'] in core.FAST_CLASSES.values()):
-            if fulltrace:
-                _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
-                                    'status': 'Reader only available in fast version',
-                                    'dt': '{0:.3f} ms'.format(0.0)})
+            _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
+                                'Reader': guess_kwargs['Reader'].__class__,
+                                'status': 'Reader only available in fast version',
+                                'dt': '{0:.3f} ms'.format(0.0)})
             continue
 
         # If user explicitly required a fast reader with 'force' or as dict of
         # options then skip all non-fast readers
         if (fast_reader['enable'] == 'force' and
                 guess_kwargs['Reader'] not in core.FAST_CLASSES.values()):
-            if fulltrace:
-                _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
-                                    'status': 'No fast version of reader available',
-                                    'dt': '{0:.3f} ms'.format(0.0)})
+            _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
+                                'Reader': guess_kwargs['Reader'].__class__,
+                                'status': 'No fast version of reader available',
+                                'dt': '{0:.3f} ms'.format(0.0)})
             continue
 
         guess_kwargs_ok = True  # guess_kwargs are consistent with user_kwargs?

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -37,11 +37,15 @@ To disable the fast engine, specify ``fast_reader=False`` or
 
 .. Note:: Guessing and Fast reading
 
-   By default |read| will try to guess the format of in the input data by
+   By default |read| will try to guess the format of the input data by
    successively trying different formats until one succeeds
-   (see the section on :ref:`guess_formats`).
-   For the default ``'ascii'`` format it will try all fast reader formats
-   before testing any pure Python readers with no fast implementation.
+   (see the section on :ref:`guess_formats`). For each supported
+   format it will first try the fast, then the slow version of that
+   reader. Without any additional options this means that both some pure
+   Python readers with no fast implementation and the Python versions
+   of some readers will be tried before getting to some of the fast
+   readers. To bypass them entirely a fast reader should be explicitly
+   requested as above.
 
    **For optimum performance** however, it is recommended to turn off
    guessing entirely (``guess=False``) or narrow down the format options

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -39,7 +39,7 @@ To disable the fast engine, specify ``fast_reader=False`` or
 
    By default |read| will try to guess the format of in the input data by
    successively trying different formats until one succeeds
-   (see the section on :ref:`guess_formats`). 
+   (see the section on :ref:`guess_formats`).
    For the default ``'ascii'`` format it will try all fast reader formats
    before testing any pure Python readers with no fast implementation.
 

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -19,7 +19,9 @@ are currently compatible with the fast engine:
  * ``tab``
 
 The fast engine can also be enabled through the format parameter by prefixing
-a compatible format with "fast" and then an underscore. In this case, |read|
+a compatible format with "fast" and then an underscore. In this case, or
+when enforcing the fast engine by either setting ``fast_reader='force'``
+or explicitly setting any of the :ref:`fast_conversion_opts`, |read|
 will not fall back on an ordinary reader if fast reading fails.
 For example::
 
@@ -35,21 +37,24 @@ To disable the fast engine, specify ``fast_reader=False`` or
 
 .. Note:: Guessing and Fast reading
 
-   By default |read| will try to guess the format of in the input data by successively
-   trying different formats until one succeeds ([reference the guessing section]).
-   For the default ``'ascii'`` format this means that a number of pure Python readers
-   with no fast implementation will be tried before getting to the fast readers.
+   By default |read| will try to guess the format of in the input data by
+   successively trying different formats until one succeeds
+   (see the section on :ref:`guess_formats`). 
+   For the default ``'ascii'`` format it will try all fast reader formats
+   before testing any pure Python readers with no fast implementation.
 
-   **For optimum performance**, turn off guessing entirely (``guess=False``) or
-   narrow down the format options as much as possible by specifying the format
-   (e.g. ``format='csv'``) and/or other options such as the delimiter.
+   **For optimum performance** however, it is recommended to turn off
+   guessing entirely (``guess=False``) or narrow down the format options
+   as much as possible by specifying the format (e.g. ``format='csv'``)
+   and/or other options such as the delimiter.
 
 Reading
 =======
 Since the fast engine is not part of the ordinary :mod:`astropy.io.ascii`
 infrastructure, fast readers raise an error when passed certain
-parameters which are not implemented in the fast reader
-infrastructure. In this case |read| will fall back on the ordinary reader.
+parameters which are not implemented in the fast reader infrastructure.
+In this case |read| will fall back on the ordinary reader, unless the
+fast reader has been explicitly requested (see above).
 These parameters are:
 
  * Negative ``header_start`` (except for commented-header format)

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -318,8 +318,8 @@ Guess order
 The order of guessing is shown by this Python code, where ``Reader`` is the
 class which actually implements reading the different file formats::
 
-  for Reader in (Ecsv, FixedWidthTwoLine, FastBasic, Basic,
-                 Rdb, FastTab, Tab, Cds, Daophot, SExtractor,
+  for Reader in (Ecsv, FixedWidthTwoLine, Rst, FastBasic, Basic,
+                 FastRdb, Rdb, FastTab, Tab, Cds, Daophot, SExtractor,
                  Ipac, Latex, AASTex):
       read(Reader=Reader)
 
@@ -340,13 +340,16 @@ without checking the column requirements.  In this way a table with only one
 column or column names that look like a number can still be successfully read.
 
 The guessing process respects any values of the Reader, delimiter, and
-quotechar parameters that were supplied to the read() function.  Any guesses
-that would conflict are skipped.  For example the call::
+quotechar parameters as well as options for the fast reader that were
+supplied to the read() function.  Any guesses that would conflict are
+skipped.  For example the call::
 
  >>> data = ascii.read(table, Reader=ascii.NoHeader, quotechar="'")
 
 would only try the four delimiter possibilities, skipping all the conflicting
-Reader and quotechar combinations.
+Reader and quotechar combinations.  Similarly with any setting of
+``fast_reader`` that requires use of the fast engine, only the fast
+variants in the Reader list above will be tried.
 
 Disabling
 ---------

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -290,6 +290,8 @@ values in with typical placeholders::
          used ``'nan'`` for the ``<match_string>`` value then integer columns
          would wind up as float.
 
+.. _guess_formats:
+
 Guess table format
 ==================
 


### PR DESCRIPTION
Test the updated exception handling in incompatible reader/fast_reader settings (see #5574) to check if they pass CI, and improve `guess` strategy to work with all supported formats of the fast reader.

- with `fast_reader` explicitly requested, options and formats not supported by same now raise a `ParameterError` rather than silently falling back to a slow reader.

- for tables with a mismatches in the number of data columns the fast reader now raises an `InconsistentTableError` just like its Python counterpart, instead of a `CParserError`. A different return remains in case of fewer columns specified in the header, where the Python parser raises a `ValueError`.

- where `fast_reader` is enabled, `guess=True` should now try all formats available in fast versions instead of only the first one (`FastBasic`) before falling back on the slow readers (if `fast_reader` has been flagged as optional, i.e. `fast_reader=True`, but not `'force'` or a specific fast_reader `dict`).