### PR TITLE
Add methods to help with potential problems from #5556

### DIFF
--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -20,6 +20,21 @@ class Conf(_config.ConfigNamespace):
         'The table class to be used in Jupyter notebooks when displaying '
         'tables (and not overridden). See <http://getbootstrap.com/css/#tables '
         'for a list of useful bootstrap classes.')
+    replace_warnings = _config.ConfigItem(
+        ['slice'],
+        'List of conditions for issuing a warning when replacing a table '
+        "column using setitem, e.g. t['a'] = value.  Allowed options are "
+        "'always', 'slice', 'refcount', 'attributes'.",
+        'list',
+        )
+    replace_inplace = _config.ConfigItem(
+        False,
+        'Always use in-place update of a table column when using setitem, '
+        "e.g. t['a'] = value.  This overrides the default behavior of "
+        "replacing the column entirely with the new value when possible. "
+        "This configuration option will be deprecated and then removed in "
+        "subsequent major releases."
+        )
 
 
 conf = Conf()
@@ -27,7 +42,8 @@ conf = Conf()
 
 from .column import Column, MaskedColumn
 from .groups import TableGroups, ColumnGroups
-from .table import Table, QTable, TableColumns, Row, TableFormatter, NdarrayMixin
+from .table import (Table, QTable, TableColumns, Row, TableFormatter,
+                    NdarrayMixin, TableReplaceWarning)
 from .operations import join, hstack, vstack, unique, TableMergeError
 from .bst import BST, FastBST, FastRBT
 from .sorted_array import SortedArray

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1631,7 +1631,7 @@ class Table(object):
         self.replace_column(name, col)
 
         if 'always' in warns:
-            warnings.warn("replacing column '{}'".format(name),
+            warnings.warn("replaced column '{}'".format(name),
                           TableReplaceWarning, stacklevel=3)
 
         if 'slice' in warns:
@@ -1640,8 +1640,8 @@ class Table(object):
                 # has an ndarray for the base while sliced has the same class
                 # as parent.
                 if isinstance(old_col.base, old_col.__class__):
-                    msg = ("replacing column '{}' which looks like an array slice. "
-                           "The new column will no longer share memory with the "
+                    msg = ("replaced column '{}' which looks like an array slice. "
+                           "The new column no longer shares memory with the "
                            "original array.".format(name))
                     warnings.warn(msg, TableReplaceWarning, stacklevel=3)
             except AttributeError:
@@ -1651,7 +1651,7 @@ class Table(object):
             # Did reference count change?
             new_refcount = sys.getrefcount(self[name])
             if refcount != new_refcount:
-                msg = ("replaced column '{}' and the number of the references "
+                msg = ("replaced column '{}' and the number of references "
                        "to the column changed.".format(name))
                 warnings.warn(msg, TableReplaceWarning, stacklevel=3)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -8,7 +8,7 @@ from .index import TableIndices, TableLoc, TableILoc
 import re
 import sys
 from collections import OrderedDict, Mapping
-
+import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -20,7 +20,7 @@ from ..units import Quantity
 from ..utils import isiterable, deprecated
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
-from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo
+from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
@@ -38,7 +38,19 @@ __doctest_skip__ = ['Table.read', 'Table.write',
                     ]
 
 
+class TableReplaceWarning(UserWarning):
+    """
+    Warning class for cases when a table column is replaced via the
+    Table.__setitem__ syntax e.g. t['a'] = val.
+
+    This does not inherit from AstropyWarning because we want to use
+    stacklevel=3 to show the user where the issue occurred in their code.
+    """
+    pass
+
+
 def descr(col):
+
     """Array-interface compliant full description of a column.
 
     This returns a 3-tuple (name, type, shape) that can always be
@@ -1259,9 +1271,10 @@ class Table(object):
                 # Set an existing column by first trying to replace, and if
                 # this fails do an in-place update.  See definition of mask
                 # property for discussion of the _setitem_inplace attribute.
-                if not getattr(self, '_setitem_inplace', False):
+                if (not getattr(self, '_setitem_inplace', False)
+                        and not conf.replace_inplace):
                     try:
-                        self.replace_column(item, value)
+                        self._replace_column_warnings(item, value)
                         return
                     except Exception:
                         pass
@@ -1600,6 +1613,61 @@ class Table(object):
                 existing_names.add(new_name)
 
         self._init_from_cols(newcols)
+
+    def _replace_column_warnings(self, name, col):
+        """
+        Same as replace_column but issues warnings under various circumstances.
+        """
+        warns = conf.replace_warnings
+
+        if 'refcount' in warns and name in self.colnames:
+            refcount = sys.getrefcount(self[name])
+
+        if name in self.colnames:
+            old_col = self[name]
+
+        # This may raise an exception (e.g. t['a'] = 1) in which case none of
+        # the downstream code runs.
+        self.replace_column(name, col)
+
+        if 'always' in warns:
+            warnings.warn("replacing column '{}'".format(name),
+                          TableReplaceWarning, stacklevel=3)
+
+        if 'slice' in warns:
+            try:
+                # Check for ndarray-subclass slice.  An unsliced instance
+                # has an ndarray for the base while sliced has the same class
+                # as parent.
+                if isinstance(old_col.base, old_col.__class__):
+                    msg = ("replacing column '{}' which looks like an array slice. "
+                           "The new column will no longer share memory with the "
+                           "original array.".format(name))
+                    warnings.warn(msg, TableReplaceWarning, stacklevel=3)
+            except AttributeError:
+                pass
+
+        if 'refcount' in warns:
+            # Did reference count change?
+            new_refcount = sys.getrefcount(self[name])
+            if refcount != new_refcount:
+                msg = ("replaced column '{}' and the number of the references "
+                       "to the column changed.".format(name))
+                warnings.warn(msg, TableReplaceWarning, stacklevel=3)
+
+        if 'attributes' in warns:
+            # Any of the standard column attributes changed?
+            changed_attrs = []
+            new_col = self[name]
+            # Check base DataInfo attributes that any column will have
+            for attr in DataInfo.attr_names:
+                if getattr(old_col.info, attr) != getattr(new_col.info, attr):
+                    changed_attrs.append(attr)
+
+            if changed_attrs:
+                msg = ("replaced column '{}' and column attributes {} changed."
+                       .format(name, changed_attrs))
+                warnings.warn(msg, TableReplaceWarning, stacklevel=3)
 
     def replace_column(self, name, col):
         """

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_allclose
 from ...extern import six
 from ...io import fits
 from ...tests.helper import (pytest, assert_follows_unicode_guidelines,
-                             ignore_warnings)
+                             ignore_warnings, catch_warnings)
 from ...utils.data import get_pkg_data_filename
 from ... import table
 from ... import units as u
@@ -1734,6 +1734,122 @@ def test_replace_update_column_via_setitem():
     assert np.all(t['a'] == [5, 6])
     assert isinstance(t['a'], table.Column)
     assert t['a'] is not ta
+
+
+def test_replace_update_column_via_setitem_warnings_normal():
+    """
+    Test warnings related to table replace change in #5556:
+    Normal warning-free replace
+    """
+    t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
+    with catch_warnings() as w:
+        with table.conf.set_temp('replace_warnings',
+                                 ['refcount', 'attributes', 'slice']):
+            t['a'] = 0  # in-place update
+            assert len(w) == 0
+
+            t['a'] = [10, 20, 30]  # replace column
+            assert len(w) == 0
+
+
+def test_replace_update_column_via_setitem_warnings_slice():
+    """
+    Test warnings related to table replace change in #5556:
+    Replace a slice, one warning.
+    """
+    t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
+    with catch_warnings() as w:
+        with table.conf.set_temp('replace_warnings',
+                                 ['refcount', 'attributes', 'slice']):
+            t2 = t[:2]
+
+            t2['a'] = 0  # in-place slice update
+            assert np.all(t['a'] == [0, 0, 3])
+            assert len(w) == 0
+
+            t2['a'] = [10, 20]  # replace slice
+            assert len(w) == 1
+            assert "replaced column 'a' which looks like an array slice" in str(w[0].message)
+
+
+def test_replace_update_column_via_setitem_warnings_attributes():
+    """
+    Test warnings related to table replace change in #5556:
+    Lost attributes.
+    """
+    t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
+    t['a'].unit = 'm'
+
+    with catch_warnings() as w:
+        with table.conf.set_temp('replace_warnings',
+                                 ['refcount', 'attributes', 'slice']):
+            t['a'] = [10, 20, 30]
+        assert len(w) == 1
+        assert "replaced column 'a' and column attributes ['unit']" in str(w[0].message)
+
+
+def test_replace_update_column_via_setitem_warnings_refcount():
+    """
+    Test warnings related to table replace change in #5556:
+    Reference count changes.
+    """
+    t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
+    ta = t['a']  # Generate an extra reference to original column
+
+    with catch_warnings() as w:
+        with table.conf.set_temp('replace_warnings',
+                                 ['refcount', 'attributes', 'slice']):
+            t['a'] = [10, 20, 30]
+        assert len(w) == 1
+        assert "replaced column 'a' and the number of references" in str(w[0].message)
+
+
+def test_replace_update_column_via_setitem_warnings_always():
+    """
+    Test warnings related to table replace change in #5556:
+    Test 'always' setting that raises warning for any replace.
+    """
+    t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
+
+    with catch_warnings() as w:
+        with table.conf.set_temp('replace_warnings', ['always']):
+            t['a'] = 0  # in-place slice update
+            assert len(w) == 0
+
+            from inspect import currentframe, getframeinfo
+            frameinfo = getframeinfo(currentframe())
+            t['a'] = [10, 20, 30]  # replace column
+            assert len(w) == 1
+            assert "replaced column 'a'" == str(w[0].message)
+
+            # Make sure the warning points back to the user code line
+            assert w[0].lineno == frameinfo.lineno + 1
+            assert w[0].category is table.TableReplaceWarning
+            assert w[0].filename == 'astropy.table.tests.test_table'
+
+
+def test_replace_update_column_via_setitem_replace_inplace():
+    """
+    Test the replace_inplace config option related to #5556.  In this
+    case no replace is done.
+    """
+    t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
+    ta = t['a']
+    t['a'].unit = 'm'
+
+    with catch_warnings() as w:
+        with table.conf.set_temp('replace_inplace', True):
+            with table.conf.set_temp('replace_warnings',
+                                     ['always', 'refcount', 'attributes', 'slice']):
+                t['a'] = 0  # in-place update
+                assert len(w) == 0
+                assert ta is t['a']
+
+                t['a'] = [10, 20, 30]  # normally replaces column, but not now
+                assert len(w) == 0
+                assert ta is t['a']
+                assert np.all(t['a'] == [10, 20, 30])
+
 
 def test_primary_key_is_inherited():
     """Test whether a new Table inherits the primary_key attribute from

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1825,7 +1825,7 @@ def test_replace_update_column_via_setitem_warnings_always():
             # Make sure the warning points back to the user code line
             assert w[0].lineno == frameinfo.lineno + 1
             assert w[0].category is table.TableReplaceWarning
-            assert w[0].filename == 'astropy.table.tests.test_table'
+            assert 'test_table' in w[0].filename
 
 
 def test_replace_update_column_via_setitem_replace_inplace():

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -129,6 +129,7 @@ using broadcasting will be done, e.g.::
    an in-place update of the existing column values and it was not possible
    to change the data type in this way.  Prior to 1.3 it was necessary
    to use the :meth:`~astropy.table.Table.replace_column` method in this case.
+   See the section `API change in replacing columns`_ for additional information.
 
 **Rename columns**
 ::
@@ -181,17 +182,11 @@ as the item as shown below::
 Caveats
 ^^^^^^^
 
-Modifying the table data and properties is fairly straightforward.  There are
-only a few things to keep in mind:
-
-- The data type for a column cannot be changed in place.  In order to do this
-  you must make a copy of the table with the column type changed appropriately.
-- Adding or removing a column will generate a new copy
-  in memory of all the data.  If the table is very large this may be slow.
-- Adding a row *may* require a new copy in memory of the table data.  This
-  depends on the detailed layout of Python objects in memory and cannot be
-  reliably controlled.  In some cases it may be possible to build a table
-  row by row in less than O(N**2) time but you cannot count on it.
+Modifying the table data and properties is fairly straightforward.  One thing
+to keep in mind is that adding a row *may* require a new copy in memory of the
+table data.  This depends on the detailed layout of Python objects in memory
+and cannot be reliably controlled.  In some cases it may be possible to build a
+table row by row in less than O(N**2) time but you cannot count on it.
 
 Another subtlety to keep in mind are cases where the return value of an
 operation results in a new table in memory versus a view of the existing
@@ -213,3 +208,99 @@ row 1 of the copy.  The original ``t`` table was unaffected and the new
 temporary table disappeared once the statement was complete.  The takeaway
 is to pay attention to how certain operations are performed one step at
 a time.
+
+API change in replacing columns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Astropy version 1.3 introduces an API change in the way that the following
+behaves::
+
+  >>> t = Table([[1, 2, 3]], names=['a'])
+  >>> t['a'] = [10.5, 20.5, 30.5]
+
+Prior to 1.3 this always did an in-place replacement of the data values so that
+the ``t['a']`` column object reference was maintained.  However, since the
+original data type was integer in this case, the replaced values would silently
+be converted to integer by truncation.
+
+Starting with astropy 1.3 the operation shown above does a *complete
+replacement* of the column object.  In this case it makes a new column
+object with float values by internally calling
+``t.replace_column('a', [10.5, 20.5, 30.5])``.  In general this behavior
+is more consistent with Python and Pandas behavior, but there is potential
+for somewhat subtle bugs in code that was written that expects the pre-1.3
+in-place behavior.
+
+**Examples**
+::
+
+  >>> t = Table([[1, 2, 3]], names=['a'])
+  >>> t['a'].description = 'My data column'
+
+  # Sliced column gets replaced
+  >>> t2 = t[:2]  # Make a slice
+
+  # In astropy 1.3 the following emits a warning about replacing a slice.
+  >>> t2['a'] = [10, 20]  # doctest: +SKIP
+
+  >>> list(t['a'])  # Outputs [10, 20, 3] prior to astropy 1.3.
+  [1, 2, 3]
+
+  # Column reference count changes
+  >>> ta = t['a']  # Make a reference to the original column
+  >>> t['a'] = [10, 20, 30]
+  >>> t['a'] is ta  # Outputs True prior to astropy 1.3
+  False
+
+  # Column attributes change
+  >>> print(t['a'].description)  # Outputs 'My data column' prior to astropy 1.3
+  None
+
+**Replicating pre-1.3 behavior**
+
+If the pre-1.3 in-place behavior is required in code, it is straightforward
+to achieve this.  Simply replace::
+
+  t[colname] = value
+
+with::
+
+  t[colname][:] = value
+
+As a *temporary* measure, or if the problematic code is in a package
+that cannot be modified, one can modify the ``table.replace_inplace``
+configuration variable::
+
+  from astropy import table
+  table.conf.replace_inplace = True
+
+This will entirely revert to the pre-1.3 behavior.  This configuration option
+will be deprecated and then subsequently removed in future releases, so it is
+meant only as a stop-gap to provide time to appropriately update all code.
+
+**Finding the source of problems**
+
+In order to find potential problems related to the API change, the
+configuration option ``table.conf.replace_warnings`` controls a set of warnings
+that are emitted under certain circumstances when a table column is replaced.
+This option must be set to a list that includes zero or more of the
+following string values:
+
+``always`` :
+  Print a warning every time a column gets replaced via the
+  setitem syntax (i.e. ``t['a'] = new_col``).
+
+``slice`` :
+  Print a warning when a column that appears to be a slice of
+  a parent column is replaced.
+
+``refcount`` :
+  Print a warning when the Python reference count for the
+  column changes.  This indicates that a stale object exists that might
+  be used elsewhere in the code and give unexpected results.
+
+``attributes`` :
+  Print a warning if any of the standard column attributes changed.
+
+The default value for the ``table.conf.replace_warnings`` option is
+``['slice']``.


### PR DESCRIPTION
This adds two new table configuration variables which help users with potential issues related to changing the default table setitem behavior for replacement:
- `table.conf.replace_warnings`: help to identify possible problems by raising warnings in certain situations.
- `table.conf.replace_inplace`: if set to `True` then revert to the previous "always inplace" behavior for now, with deprecation and then removal of this option in subsequent releases.

Todo:
- [x] Tests
- [x] Docs

cc: @cdeil @mhvk @astrofrog @eteq 
