### PR TITLE
Fix up lazy loading issues

### DIFF
--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -276,7 +276,24 @@ class HDUList(list, _Verify):
         Get an HDU from the `HDUList`, indexed by number or name.
         """
 
+        # If the key is a slice we need to make sure the necessary HDUs
+        # have been loaded before passing the slice on to super.
         if isinstance(key, slice):
+            max_idx = self._positive_index_of(key.stop)
+            if max_idx == sys.maxsize:
+                # We need all of the HDUs, so load them
+                # and reset the maximum to the actual length.
+                max_idx = len(self)
+
+            number_loaded = super(HDUList, self).__len__()
+            if max_idx >= number_loaded:
+                # We need more than we have, try loading up to and including
+                # max_idx. Note we do not try to be clever about skipping HDUs
+                # even though key.step might conceivably allow it.
+                for i in range(number_loaded, max_idx):
+                    print(i)
+                    self._read_next_hdu()
+
             hdus = super(HDUList, self).__getitem__(key)
             return HDUList(hdus)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -320,7 +320,7 @@ class HDUList(list, _Verify):
 
         try:
             self._try_while_unread_hdus(self.index_of, item)
-        except (KeyError, TypeError):
+        except KeyError:
             return False
 
         return True
@@ -661,7 +661,7 @@ class HDUList(list, _Verify):
             _ver = None
 
         if not isinstance(_key, string_types):
-            raise TypeError(
+            raise KeyError(
                 '%s indices must be integers, extension names as strings, '
                 'or (extname, version) tuples; got %r' %
                 (self.__class__.__name__, _key))

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -293,7 +293,7 @@ class HDUList(list, _Verify):
 
         try:
             self._try_while_unread_hdus(self.index_of, item)
-        except KeyError:
+        except (KeyError, TypeError):
             return False
 
         return True

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -438,13 +438,13 @@ class HDUList(list, _Verify):
             np.ndarray((), dtype='ubyte', buffer=data)
         except TypeError:
             raise TypeError(
-                'The provided object %r does not contain an underlying '
+                'The provided object {} does not contain an underlying '
                 'memory buffer.  fromstring() requires an object that '
                 'supports the buffer interface such as bytes, str '
                 '(in Python 2.x but not in 3.x), buffer, memoryview, '
                 'ndarray, etc.  This restriction is to ensure that '
                 'efficient access to the array/table data is possible.'
-                % data)
+                ''.format(data))
 
         return cls._readfrom(data=data, **kwargs)
 
@@ -662,9 +662,9 @@ class HDUList(list, _Verify):
 
         if not isinstance(_key, string_types):
             raise KeyError(
-                '%s indices must be integers, extension names as strings, '
-                'or (extname, version) tuples; got %r' %
-                (self.__class__.__name__, _key))
+                '{} indices must be integers, extension names as strings, '
+                'or (extname, version) tuples; got {}'
+                ''.format(self.__class__.__name__, _key))
 
         _key = (_key.strip()).upper()
 
@@ -706,7 +706,7 @@ class HDUList(list, _Verify):
 
         if abs(index) > len(self):
             raise IndexError(
-                'Extension %s is out of bound or not found.' % index)
+                'Extension {} is out of bound or not found.'.format(index))
 
         return len(self) + index
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -279,20 +279,30 @@ class HDUList(list, _Verify):
         # If the key is a slice we need to make sure the necessary HDUs
         # have been loaded before passing the slice on to super.
         if isinstance(key, slice):
-            max_idx = self._positive_index_of(key.stop)
-            if max_idx == sys.maxsize:
+            max_idx = key.stop
+            # Check for and handle the case when no maximum was
+            # specified (e.g. [1:]).
+            # The first part of the or below is for python 2.7, the second
+            # part for python 3.
+            if max_idx == sys.maxsize or max_idx is None:
                 # We need all of the HDUs, so load them
                 # and reset the maximum to the actual length.
                 max_idx = len(self)
 
+            # Just in case the max_idx is negative...
+            max_idx = self._positive_index_of(max_idx)
+
             number_loaded = super(HDUList, self).__len__()
+
             if max_idx >= number_loaded:
                 # We need more than we have, try loading up to and including
                 # max_idx. Note we do not try to be clever about skipping HDUs
                 # even though key.step might conceivably allow it.
                 for i in range(number_loaded, max_idx):
-                    print(i)
-                    self._read_next_hdu()
+                    # Read until max_idx or to the end of the file, whichever
+                    # comes first.
+                    if not self._read_next_hdu():
+                        break
 
             hdus = super(HDUList, self).__getitem__(key)
             return HDUList(hdus)

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1174,7 +1174,7 @@ class HDUList(list, _Verify):
                     'uses zero-based indexing).\n{}\n'
                     'There may be extra bytes after the last HDU or the '
                     'file is corrupted.'.format(
-                        len(hdulist), indent(str(exc))), VerifyWarning)
+                        len(self), indent(str(exc))), VerifyWarning)
                 del exc
                 self._read_all = True
                 return False

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -844,3 +844,20 @@ class TestHDUListFunctions(FitsTestCase):
         # omitted.
         read_exts = [ext for ext in f[1:4] if ext.header['EXTNAME'] == 'SCI']
         assert len(read_exts) == 2
+
+    def test_proper_error_raised_on_non_fits_file_with_unicode(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/5594
+
+        The failure shows up when (in python 3+) you try to open a file
+        with unicode content that is not actually a FITS file. See:
+        https://github.com/astropy/astropy/issues/5594#issuecomment-266583218
+        """
+        import codecs
+        filename = self.temp('not-fits-with-unicode.fits')
+        with codecs.open(filename, mode='w', encoding='utf=8') as f:
+            f.write(u'Ce\xe7i ne marche pas')
+
+        # This should raise an IOError because there is no end card.
+        with pytest.raises(IOError):
+            fits.open(filename)

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -793,3 +793,18 @@ class TestHDUListFunctions(FitsTestCase):
             assert (str(warning_lines[0].message) == '"clobber" was '
                     'deprecated in version 1.3 and will be removed in a '
                     'future version. Use argument "overwrite" instead.')
+
+    def test_invalid_hdu_key_in_contains(self):
+        """
+        Make sure invalid keys in the 'in' operator return False.
+        Regression test for https://github.com/astropy/astropy/issues/5583
+        """
+        hdulist = fits.HDUList(fits.PrimaryHDU())
+        hdulist.append(fits.ImageHDU())
+        hdulist.append(fits.ImageHDU())
+
+        # A more or less random assortment of things which are not valid keys.
+        bad_keys = [None, 3.5, {}]
+
+        for key in bad_keys:
+            assert not (key in hdulist)


### PR DESCRIPTION
Fix or address these issues which resulted from lazy loading. In each case the goal is to maintain the current (1.x) behavior of io.fits.

- [x] Handling of invalid key in the `in` operator (closes #5583)
- [x] Slices not working (closes #5585)
- [x] Variable name incorrect (closes #5594)
- ~~[ ] Address behavior of `close` #5582~~ Won't change unless someone requests it.

@eteq -- I believe I've milestoned this correctly, but please modify if not.

edit: changed text of second todo.