### PR TITLE
Correctly account for height in transformations between intermediate and AltAz frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -465,6 +465,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Transformations between CIRS and AltAz now correctly account for the
+    location of the observer. [#xxxx]
+
   - GCRS frames representing a location on Earth with multiple obstimes are now
     allowed. This means that the solar system routines ``get_body``,
     ``get_moon`` and ``get_sun`` now work with non-scalar times and a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -466,7 +466,7 @@ Bug Fixes
 - ``astropy.coordinates``
 
   - Transformations between CIRS and AltAz now correctly account for the
-    location of the observer. [#xxxx]
+    location of the observer. [#5591]
 
   - GCRS frames representing a location on Earth with multiple obstimes are now
     allowed. This means that the solar system routines ``get_body``,

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -12,7 +12,7 @@ import numpy as np
 from ... import units as u
 from ..baseframe import frame_transform_graph
 from ..transformations import FunctionTransform
-from ..representation import (SphericalRepresentation, CartesianRepresentation,
+from ..representation import (SphericalRepresentation,
                               UnitSphericalRepresentation)
 from ... import _erfa as erfa
 
@@ -40,7 +40,7 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
         # compute an "astrometric" ra/dec -i.e., the direction of the
         # displacement vector from the observer to the target in CIRS
         loccirs = altaz_frame.location.get_itrs(cirs_coo.obstime).transform_to(cirs_coo)
-        diffrepr = (cirs_coo.cartesian-loccirs.cartesian).represent_as(SphericalRepresentation)
+        diffrepr = (cirs_coo.cartesian - loccirs.cartesian).represent_as(UnitSphericalRepresentation)
 
         cirs_ra = diffrepr.lon.to(u.radian).value
         cirs_dec = diffrepr.lat.to(u.radian).value

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -14,7 +14,8 @@ from ...tests.helper import (pytest, remote_data,
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
                 PrecessedGeocentric, CartesianRepresentation, SkyCoord,
-                SphericalRepresentation, HCRS, HeliocentricTrueEcliptic)
+                SphericalRepresentation, UnitSphericalRepresentation,
+                HCRS, HeliocentricTrueEcliptic)
 
 
 from ..._erfa import epv00
@@ -356,7 +357,7 @@ def test_gcrs_altaz_bothroutes(testframe):
 def test_cirs_altaz_moonish(testframe):
     """
     Sanity-check that an object resembling the moon goes to the right place with
-    a CIRS->AltAz transformation
+    a CIRS<->AltAz transformation
     """
     moon = CIRS(MOONDIST_CART, obstime=testframe.obstime)
 
@@ -366,6 +367,19 @@ def test_cirs_altaz_moonish(testframe):
     # now check that it round-trips
     moon2 = moonaa.transform_to(moon)
     assert_allclose(moon.cartesian.xyz, moon2.cartesian.xyz)
+
+
+@pytest.mark.parametrize('testframe', totest_frames)
+def test_cirs_altaz_nodist(testframe):
+    """
+    Sanity-check that an object resembling the moon goes to the right place with
+    a CIRS<->AltAz transformation
+    """
+    coo0 = CIRS(UnitSphericalRepresentation(10*u.deg, 20*u.deg), obstime=testframe.obstime)
+
+    # check that it round-trips
+    coo1 = coo0.transform_to(testframe).transform_to(coo0)
+    assert_allclose(coo0.cartesian.xyz, coo1.cartesian.xyz)
 
 
 @pytest.mark.parametrize('testframe', totest_frames)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -376,8 +376,8 @@ def test_cirs_altaz_moonish(testframe):
 @pytest.mark.parametrize('testframe', totest_frames)
 def test_cirs_altaz_nodist(testframe):
     """
-    Sanity-check that an object resembling the moon goes to the right place with
-    a CIRS<->AltAz transformation
+    Check that a UnitSphericalRepresentation coordinate round-trips for the
+    CIRS<->AltAz transformation.
     """
     coo0 = CIRS(UnitSphericalRepresentation(10*u.deg, 20*u.deg), obstime=testframe.obstime)
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -332,6 +332,10 @@ def test_gcrs_altaz_moonish(testframe):
     # now check that the distance change is similar to earth radius
     assert 1000*u.km < np.abs(moonaa.distance - moon.distance).to(u.au) < 7000*u.km
 
+    # now check that it round-trips
+    moon2 = moonaa.transform_to(moon)
+    assert_allclose(moon.cartesian.xyz, moon2.cartesian.xyz)
+
     # also should add checks that the alt/az are different for different earth locations
 
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -337,3 +337,14 @@ def test_itrs_vals_5133():
 
     assert_quantity_allclose(aacs[2].alt, 90*u.deg, atol=1*u.arcsec)
     assert_quantity_allclose(aacs[2].distance, 10*u.km)
+
+
+def test_regression_simple_5133():
+    t = Time('J2010')
+    obj = EarthLocation(-1*u.deg, 52*u.deg, height=[100., 0.]*u.km)
+    home = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    aa = obj.get_itrs(t).transform_to(AltAz(obstime=t, location=home))
+
+    # az is more-or-less undefined for straight up or down
+    assert_quantity_allclose(aa.alt, [90, -90]*u.deg, rtol=1e-5)
+    assert_quantity_allclose(aa.distance, [90, 10]*u.km)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -322,13 +322,18 @@ def test_itrs_vals_5133():
     aaf = AltAz(obstime=time, location=el)
     aacs = [coo.transform_to(aaf) for coo in coos]
 
-    assert_quantity_allclose(aacs[0].az, 180*u.deg)
+    assert all([coo.isscalar for coo in aacs])
+
+    # the ~1 arcsec tolerance is b/c aberration makes it not exact
+    assert_quantity_allclose(aacs[0].az, 180*u.deg, atol=1*u.arcsec)
     assert aacs[0].alt < 0*u.deg
     assert aacs[0].distance > 50*u.km
 
-    assert_quantity_allclose(aacs[1].az, 90*u.deg)
+    # it should *not* actually be 90 degrees, b/c constant latitude is not
+    # straight east anywhere except the equator... but should be close-ish
+    assert_quantity_allclose(aacs[1].az, 90*u.deg, atol=5*u.deg)
     assert aacs[1].alt < 0*u.deg
     assert aacs[1].distance > 50*u.km
 
-    assert_quantity_allclose(aacs[2].alt, 90*u.deg)
+    assert_quantity_allclose(aacs[2].alt, 90*u.deg, atol=1*u.arcsec)
     assert_quantity_allclose(aacs[2].distance, 10*u.km)


### PR DESCRIPTION
This addresses the problem pointed out in #5133, where the exact observer location (particularly the height above the other's surface) seemed to be getting ignored when converting to `AltAz`.

The root of the problem is that the ERFA transformations from CIRS to AltAz behave somewhat unexpectedly and do not properly account for these distance effects (in essence they assume the target is at infinite distance).  Because  everything goes through CIRS to get to AltAz, this showed up even in #5133 (where the starting point is ITRS).  This PR fixes that by computing the "astrometric" ra/dec - i.e., the ra/dec of the angle from the observer to the target - and passes *that* into the ERFA transformations.  (Then it reverses the transformation on the way back out into CIRS when going the other way.)

This PR also adds a set of regression tests to ensure this doesn't happen, inspired by #5133  (including @mhvk's https://github.com/astropy/astropy/issues/5133#issuecomment-264314721).

This closes #5133.  Tentatively milestoning it as 1.3.0, as it is a bugfix.