### PR TITLE
Update docs to use smaller images

### DIFF
--- a/docs/visualization/lupton_rgb.rst
+++ b/docs/visualization/lupton_rgb.rst
@@ -75,7 +75,7 @@ with the default parameters.
 
 .. raw:: html
 
-    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976-default.jpeg"><img alt="default rgb image" src="http://data.astropy.org/visualization/ngc6976-default.jpeg" /></a>
+    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976-default.jpeg"><img alt="default rgb image" src="http://data.astropy.org/visualization/ngc6976-default-small.jpeg" /></a>
 
 The second is the image generated with Q=10, stretch=0.5, showing faint features
 of the galaxies. Compare with Fig. 1 of `Lupton et al. (2004)`_ or the
@@ -83,6 +83,6 @@ of the galaxies. Compare with Fig. 1 of `Lupton et al. (2004)`_ or the
 
 .. raw:: html
 
-    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976.jpeg"><img alt="wider stretch image" src="http://data.astropy.org/visualization/ngc6976.jpeg" /></a>
+    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976.jpeg"><img alt="wider stretch image" src="http://data.astropy.org/visualization/ngc6976-small.jpeg" /></a>
 
 .. _SDSS Skyserver image: http://skyserver.sdss.org/dr13/en/tools/chart/navi.aspx?ra=179.68929&dec=-0.45438&opt=

--- a/docs/whatsnew/1.3.rst
+++ b/docs/whatsnew/1.3.rst
@@ -40,7 +40,7 @@ images.  The technique is detailed in `Lupton et al. (2004)`_ and implemented in
 .. We use raw here because image directives pointing to external locations fail for some sphinx versions
 .. raw:: html
 
-    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976.jpeg"><img alt="lupton RGB image" src="http://data.astropy.org/visualization/ngc6976.jpeg" /></a>
+    <a class="reference internal image-reference" href="http://data.astropy.org/visualization/ngc6976.jpeg"><img alt="lupton RGB image" src="http://data.astropy.org/visualization/ngc6976-small.jpeg" /></a>
 
 
 


### PR DESCRIPTION
I've made the images on the what's new page and the lupton_rgb docs a 30%-resized version that links to the full size. Don't want to eat people's bandwidth unnecessarily!