### PR TITLE
Speed up __getitem__ and other representation methods.

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -254,8 +254,11 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         else:
             apply_method = operator.methodcaller(method, *args, **kwargs)
 
-        return self.__class__(*[apply_method(getattr(self, component))
-                                for component in self.components], copy=False)
+        new = super().__new__(self.__class__)
+        for component in self.components:
+            setattr(new, '_' + component,
+                    apply_method(getattr(self, component)))
+        return new
 
     @property
     def shape(self):


### PR DESCRIPTION
Inspired by #3323, which notes that iterating over a `SkyCoord` is very slow, I looked at what happened for representations.  For those, getting an item or slice causes a new representation object to be created, which does a lot of tests on the inputs, which are not necessary, since the input data is known-to-be-good.  By skipping this, we can speed up accessing a single element by a factor of 3 to 4.

E.g.,:
```
import astropy.units as u, numpy as np
from astropy.coordinates import SphericalRepresentation
data = SphericalRepresentation(np.arange(180.)*u.deg, np.arange(-90, 90.)*u.deg, np.arange(180.)*u.kpc)
%timeit for d in data: pass
# 10 loops, best of 3: 70.7 ms per loop
```
With this PR:
```
10 loops, best of 3: 20.9 ms per loop
```

Note: I'm not quite sure this hack for getting a new class item is the right way to go; one might also add a flag to the initializer to skip the checks (or even allow a `copy='nocheck'` or so).

p.s. This will need some benchmarks...