### PR TITLE
remove wcsaxes from pip-requirements-doc because its already included

### DIFF
--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -1,6 +1,5 @@
 -r pip-requirements
 matplotlib
-wcsaxes
 scipy
 pillow
 sphinx-gallery


### PR DESCRIPTION
Says just what it does... @astrofrog can you confirm that this is intended? (I.e., no need at all for the external package now or in the future for the doc build?)