### PR TITLE
Add return annotation support to u.quantity_input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ New Features
 
 - ``astropy.units``
 
+  - The `~astropy.units.quantity_input` decorator will now convert the output to
+    the unit specified as a return annotation under Python 3. [#5606]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -61,7 +61,7 @@ class QuantityInput(object):
 
             import astropy.units as u
             @u.quantity_input
-            def myfunction(myangle: u.arcsec) -> u.deg:
+            def myfunction(myangle: u.arcsec) -> u.deg**2:
                 return myangle**2
 
         Using equivalencies::

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -53,6 +53,17 @@ class QuantityInput(object):
             def myfunction(myangle: u.arcsec):
                 return myangle**2
 
+        Also in Python 3 you can specify a return value annotation, which will
+        cause the function to always return a `~astropy.units.Quantity` in that
+        unit.
+
+        .. code-block:: python3
+
+            import astropy.units as u
+            @u.quantity_input
+            def myfunction(myangle: u.arcsec) -> u.deg:
+                return myangle**2
+
         Using equivalencies::
 
             import astropy.units as u
@@ -127,7 +138,11 @@ class QuantityInput(object):
 
             # Call the original function with any equivalencies in force.
             with add_enabled_equivalencies(self.equivalencies):
-                return wrapped_function(*func_args, **func_kwargs)
+                return_ = wrapped_function(*func_args, **func_kwargs)
+            if wrapped_signature.return_annotation is not funcsigs.Signature.empty:
+                return return_.to(wrapped_signature.return_annotation)
+            else:
+                return return_
 
         return wrapper
 

--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -227,3 +227,14 @@ def test_kwarg_default3():
 
     solarx, solary = myfunc_args(1*u.arcsec)
     """
+
+@py3only
+def test_return_annotation():
+    """
+    @u.quantity_input
+    def myfunc_args(solarx: u.arcsec) -> u.deg:
+        return solarx
+
+    solarx = myfunc_args(1*u.arcsec)
+    assert solarx.unit is u.deg
+    """

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -372,6 +372,19 @@ Under Python 3 you can use the annotations syntax to provide the units:
     >>> myfunction(100*u.arcsec)  # doctest: +SKIP
     Unit("arcsec")
 
+Also under Python 3 only you can define a return decoration, to which the return
+value will be converted, i.e.::
+
+    >>> @u.quantity_input  # doctest: +SKIP
+    ... def myfunction(myarg: u.arcsec) -> u.deg:
+    ...     return myarg*1000
+
+    >>> myfunction(100*u.arcsec)  # doctest: +SKIP
+    <Quantity 27.77777777777778 deg>
+
+This both checks that the return value of your function is consistent with what
+you expect and makes it much neater to display the results of the function.
+
 Representing vectors with units
 -------------------------------
 


### PR DESCRIPTION
This adds a lovely Python 3 only feature to `u.quantity_input` which enables the use of the return annotation to specify a unit to convert the output to. This makes it much easier to unit convert the return value of a function, rather than explicitly doing it in the return statement. I have found this especially useful for when a value is often printed to screen.

I have assumed here that the error handling in `Quantity.to` is sufficient for type checking on the return value itself, so this does not need to be done in the decorator.

Also, this could be hacked to be 2.7 compatible by a special keyword argument to `quantity_input` but frankly that's ugly and I can't be bothered...