### PR TITLE
Add docs for stats module-level constants

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -33,14 +33,14 @@ __doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))
 """
-Factor with which to multiply Gaussian 1-sigma standard deviation(s) to
-convert them to full width at half maximum(s).
+Factor with which to multiply Gaussian 1-sigma standard deviation to
+convert it to full width at half maximum (FWHM).
 """
 
 gaussian_fwhm_to_sigma = 1. / gaussian_sigma_to_fwhm
 """
-Factor with which to multiply Gaussian full width at half maximum(s) to
-convert them to 1-sigma standard deviation(s).
+Factor with which to multiply Gaussian full width at half maximum (FWHM)
+to convert it to 1-sigma standard deviation.
 """
 
 

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -27,6 +27,30 @@ listed below.
 
    lombscargle.rst
 
+Constants
+=========
+
+The `astropy.stats` package defines two constants useful for
+converting between Gaussian sigma and full width at half maximum
+(FWHM):
+
+.. data:: gaussian_sigma_to_fwhm
+
+    Factor with which to multiply Gaussian 1-sigma standard deviation
+    to convert it to full width at half maximum (FWHM).
+
+    >>> from astropy.stats import gaussian_sigma_to_fwhm
+    >>> gaussian_sigma_to_fwhm
+    2.3548200450309493
+
+.. data:: gaussian_fwhm_to_sigma
+
+    Factor with which to multiply Gaussian full width at half maximum
+    (FWHM) to convert it to 1-sigma standard deviation.
+
+    >>> from astropy.stats import gaussian_fwhm_to_sigma
+    >>> gaussian_fwhm_to_sigma
+    0.42466090014400953
 
 See Also
 ========


### PR DESCRIPTION
This PR adds docs (and includes them in the Sphinx index) for the `stats` module-level constants `gaussian_sigma_to_fwhm` and `gaussian_fwhm_to_sigma`.  These constants are currently not found in the docs.