### PR TITLE
remote-data shortcut -R stopped working

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -38,12 +38,21 @@ class FixRemoteDataOption(type):
     before distutils/setuptools try to parse the command-line options.
     """
     def __init__(cls, name, bases, dct):
+
         try:
             idx = sys.argv.index('--remote-data')
         except ValueError:
             pass
         else:
             sys.argv[idx] = '--remote-data=any'
+
+        try:
+            idx = sys.argv.index('-R')
+        except ValueError:
+            pass
+        else:
+            sys.argv[idx] = '-R=any'
+
         return super(FixRemoteDataOption, cls).__init__(name, bases, dct)
 
 


### PR DESCRIPTION
#5506 extended the ``remote-data`` testing options, however it broke the previous short version ``-R``, and now it gives the following error:

```
error: option -R requires argument
```

I think this should be fixed before we release 1.3.

cc @eteq 