### PR TITLE
Emit warning when assigned string value is truncated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ New Features
 
 - ``astropy.table``
 
+  - Issue a warning when assigning a string value to a column and
+    the string gets truncated.  This can occur because numpy string
+    arrays are fixed-width and silently drop characters which do not
+    fit within the fixed width. [#5624]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -40,7 +40,7 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .column import Column, MaskedColumn
+from .column import Column, MaskedColumn, StringTruncateWarning
 from .groups import TableGroups, ColumnGroups
 from .table import (Table, QTable, TableColumns, Row, TableFormatter,
                     NdarrayMixin, TableReplaceWarning)


### PR DESCRIPTION
This is a partial fix for #5551 so that a warning is emitted if a string value gets truncated when assigning in-place to a string column item.

There will be a performance penalty, but I think it is not too bad given that setitem is already using pure-Python code.  Quick timeit testing showed that the difference is within the run-to-run uncertainty.