### PR TITLE
Fix #5629

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -177,8 +177,8 @@ def _sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
             if axis != 0:
                 min_value = np.expand_dims(min_value, axis=axis)
                 max_value = np.expand_dims(max_value, axis=axis)
-        _filtered_data.mask |= _filtered_data > max_value
-        _filtered_data.mask |= _filtered_data < min_value
+        _filtered_data.mask |= (_filtered_data > max_value).data
+        _filtered_data.mask |= (_filtered_data < min_value).data
 
     if sigma_lower is None:
         sigma_lower = sigma


### PR DESCRIPTION
Looks like numpy 1.2 doesn't allow the operation ``boolean array | maskedarray`` anymore.

I think that should probably be reported to numpy as well but it's definetly not wrong to use `boolean array | boolean array`.