### PR TITLE
[DON'T MERGE] Test astropy against Travis-built python 3.6 (minimal dependencies)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,130 +1,30 @@
-# We set the language to c because python isn't supported on the MacOS X nodes
-# on Travis. However, the language ends up being irrelevant anyway, since we
-# install Python ourselves using conda.
-language: c
+language: python
+
 
 os:
-    - linux
+  - linux
 
-# Setting sudo to false opts in to Travis-CI container-based builds.
-sudo: false
 
-# The apt packages below are needed for sphinx builds, which can no longer
-# be installed with sudo apt-get.
+python:
+  - "3.6-dev"
+  - "nightly"
+
+
 addons:
-    apt:
-        packages:
-            - graphviz
-            - texlive-latex-extra
-            - dvipng
-            - language-pack-de
-env:
-    global:
-        # Set defaults to avoid repeating in most cases
-        - PYTHON_VERSION=3.5
-        - NUMPY_VERSION=stable
-        - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
-        - PIP_DEPENDENCIES=''
-        - SETUP_XVFB=True
-        - SPHINX_VERSION='<1.5'
+  apt:
+    packages:
+      - graphviz
+      - texlive-latex-extra
+      - dvipng
+      - language-pack-de
 
-    matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
 
-matrix:
+before_install:
+  - pip install --upgrade pip
+  - pip install --only-binary=numpy numpy
+  - pip install cython
+  - pip install jinja2
 
-    # Don't wait for allowed failures
-    fast_finish: true
-
-    include:
-
-        # Try MacOS X
-        - os: osx
-          env: SETUP_CMD='test --remote-data=astropy'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem'
-
-        # Check for sphinx doc build warnings - we do this first because it
-        # runs for a long time. The sphinx build also has some additional
-        # dependencies.
-        - os: linux
-          env: SETUP_CMD='build_docs -w'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.3 pillow --no-deps jplephem'
-
-        # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different
-        # versions of Python, we can vary Python and Numpy versions at the same
-        # time. Since we test the latest Numpy as part of the builds with all
-        # optional dependencies below, we can focus on older builds here.
-        # For the image tests, we also include Matplotlib 1.4 in the Numpy 1.9
-        # build.
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-               SETUP_CMD='test --open-files'
-
-        # Now try with all optional dependencies the latest 3.x and on 2.7.
-        # (with latest numpy). We also test the two latest matplotlib versions
-        # for the image tests.
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem mock pytest-mpl'
-               LC_CTYPE=C.ascii LC_ALL=C
-               NUMPY_VERSION=1.10
-               MATPLOTLIB_VERSION=1.4
-
-        - os: linux
-          env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl'
-               LC_CTYPE=C.ascii LC_ALL=C
-               CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
-               MATPLOTLIB_VERSION=1.5
-
-        # Try pre-release version of Numpy without optional dependencies
-        - os: linux
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
-
-        # Do a PEP8 test with pycodestyle
-        - os: linux
-          env: MAIN_CMD='pycodestyle astropy --count' SETUP_CMD=''
-
-        # Try developer version of Numpy with optional dependencies and also
-        # run all remote tests. Since both cases will be potentially unstable, we
-        # combine them into a single unstable build that we can mark as an
-        # allowed failure below.
-        - os: linux
-          env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-
-    allow_failures:
-      - env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
-             CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-
-install:
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
 script:
-    - $MAIN_CMD $SETUP_CMD
-
-after_success:
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then
-        cpp-coveralls -E ".*convolution.*" -E ".*_erfa.*" -E ".*\.l" -E ".*\.y" -E ".*flexed.*" -E ".*cextern.*" -E ".*_np_utils.*" -E ".*cparser.*" -E ".*cython_impl.*" --dump c-coveralls.json;
-        coveralls --merge=c-coveralls.json --rcfile='astropy/tests/coveragerc';
-      fi
+  - python setup.py test


### PR DESCRIPTION
Just to make sure #5631 isn't present in the development version. [skip appveyor]