### PR TITLE
Fix typo in input validation of get_transform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Fixed a bug where ``get_transform`` could sometimes produce confusing errors
+    because of a typo in the input validation. [#5645]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -310,7 +310,7 @@ class TransformGraph(object):
         """
         if not inspect.isclass(fromsys):
             raise TypeError('fromsys is not a class')
-        if not inspect.isclass(fromsys):
+        if not inspect.isclass(tosys):
             raise TypeError('tosys is not a class')
 
         path, distance = self.find_shortest_path(fromsys, tosys)


### PR DESCRIPTION
This fixes a small copy-paste bug in the `frame_transform_graph.get_transform()` method input validation.