### PR TITLE
Added support for checking optional keyword arguments in quantity_input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,14 @@ New Features
     physical type. For example, ``@u.quantity_input(x='angle')`` is now
     functionally the same as ``@u.quantity_input(x=u.degree)``. [#3847]
 
+  - The ``quantity_input`` decorator now also supports unit checking for
+    optional keyword arguments and accepts iterables of units or physical types
+    for specifying multiple valid equivalent inputs. For example,
+    ``@u.quantity_input(x=['angle', 'angular speed'])`` or
+    ``@u.quantity_input(x=[u.radian, u.radian/u.yr])`` would both allow either
+    a ``Quantity`` angle or angular speed passed in to the argument ``x``.
+    [#5653]
+
 - ``astropy.utils``
 
   - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -202,7 +202,7 @@ class QuantityInput(object):
                 # Check for None in the supplied list of allowed units and, if
                 #   present and the passed value is also None, ignore.
                 elif None in targets:
-                    valid_targets = targets.copy()
+                    valid_targets = [t for t in targets] # make a shallow copy
 
                     if arg is None:
                         continue

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -171,6 +171,7 @@ class QuantityInput(object):
                 if param.kind in (funcsigs.Parameter.VAR_KEYWORD,
                                   funcsigs.Parameter.VAR_POSITIONAL):
                     continue
+
                 # Catch the (never triggered) case where bind relied on a default value.
                 if param.name not in bound_args.arguments and param.default is not param.empty:
                     bound_args.arguments[param.name] = param.default
@@ -188,6 +189,11 @@ class QuantityInput(object):
                 # If the targets is empty, then no target units or physical
                 #   types were specified so we can continue to the next arg
                 if targets is funcsigs.Parameter.empty:
+                    continue
+
+                # If the argument value is None, and the default value is None,
+                #   pass through the None even if there is a target unit
+                if arg is None and param.default is None:
                     continue
 
                 # Here, we check whether multiple target unit/physical type's

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -16,7 +16,7 @@ def _get_allowed_units(targets):
     types, return a list of Unit objects.
     """
 
-    allows_units = []
+    allowed_units = []
     for target in targets:
         if isinstance(target, str): # Could be a string unit or physical type
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -12,8 +12,8 @@ from .physical import _unit_physical_mapping
 
 def _get_allowed_units(targets):
     """
-    Given a list of possible Unit objects, string units, and string physical
-    types, return a list of allowed Unit objects.
+    From a list of target units (either as strings or unit objects) and physical
+    types, return a list of Unit objects.
     """
 
     allows_units = []

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -42,7 +42,7 @@ def _get_allowed_units(targets):
 
     return allowed_units
 
-def _validate_arg_value(arg, targets, equivalencies):
+def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
     """
     Validates the object passed in to the wrapped function, ``arg``, with target
     unit or physical type, ``target``.
@@ -66,18 +66,18 @@ def _validate_arg_value(arg, targets, equivalencies):
 
             raise TypeError("Argument '{0}' to function '{1}' has {2}. "
                   "You may want to pass in an astropy Quantity instead."
-                     .format(param.name, wrapped_function.__name__, error_msg))
+                     .format(param_name, func_name, error_msg))
 
     else:
         if len(targets) > 1:
             raise UnitsError("Argument '{0}' to function '{1}' must be in units"
-                             " convertible to one of: {2}"
-                             .format(param.name, wrapped_function.__name__,
+                             " convertible to one of: {2}."
+                             .format(param_name, func_name,
                                      [str(targ) for targ in targets]))
         else:
             raise UnitsError("Argument '{0}' to function '{1}' must be in units"
-                             " convertible to '{2}'"
-                             .format(param.name, wrapped_function.__name__,
+                             " convertible to '{2}'."
+                             .format(param_name, func_name,
                                      str(targets[0])))
 
 class QuantityInput(object):
@@ -199,7 +199,8 @@ class QuantityInput(object):
 
                 # Now we loop over the allowed units/physical types and validate
                 #   the value of the argument:
-                _validate_arg_value(arg, targets, self.equivalencies)
+                _validate_arg_value(param.name, wrapped_function.__name__,
+                                    arg, targets, self.equivalencies)
 
             # Call the original function with any equivalencies in force.
             with add_enabled_equivalencies(self.equivalencies):

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -202,12 +202,10 @@ class QuantityInput(object):
                 # Check for None in the supplied list of allowed units and, if
                 #   present and the passed value is also None, ignore.
                 elif None in targets:
-                    valid_targets = [t for t in targets] # make a shallow copy
-
                     if arg is None:
                         continue
                     else:
-                        valid_targets.remove(None)
+                        valid_targets = [t for t in targets if t is not None]
 
                 else:
                     valid_targets = targets

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -50,6 +50,10 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
 
     allowed_units = _get_allowed_units(targets)
 
+    # short-circuit if None is passed, and None is allowed
+    if arg is None and None in targets:
+        return
+
     for allowed_unit in allowed_units:
         try:
             is_equivalent = arg.unit.is_equivalent(allowed_unit,

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -254,6 +254,26 @@ def test_args_None():
     x_target = u.deg
     x_unit = u.arcsec
     y_target = u.km
+    y_unit = u.kpc
+
+    @u.quantity_input(x=[x_target, None], y=[y_target, None])
+    def myfunc_args(x, y):
+        return x, y
+
+    x, y = myfunc_args(1*x_unit, None)
+    assert isinstance(x, u.Quantity)
+    assert x.unit == x_unit
+    assert y is None
+
+    x, y = myfunc_args(None, 1*y_unit)
+    assert isinstance(y, u.Quantity)
+    assert y.unit == y_unit
+    assert x is None
+
+def test_args_None_kwarg():
+    x_target = u.deg
+    x_unit = u.arcsec
+    y_target = u.km
 
     @u.quantity_input(x=x_target, y=y_target)
     def myfunc_args(x, y=None):

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -9,7 +9,10 @@ from .py3_test_quantity_annotations import *
 
 # list of pairs (target unit/physical type, input unit)
 x_inputs = [(u.arcsec, u.deg), ('angle', u.deg),
-            (u.kpc/u.Myr, u.km/u.s), ('speed', u.km/u.s)]
+            (u.kpc/u.Myr, u.km/u.s), ('speed', u.km/u.s),
+            ([u.arcsec, u.km], u.deg), ([u.arcsec, u.km], u.km), # multiple allowed
+            (['angle', 'length'], u.deg), (['angle', 'length'], u.km)]
+
 y_inputs = [(u.arcsec, u.deg), ('angle', u.deg),
             (u.kpc/u.Myr, u.km/u.s), ('speed', u.km/u.s)]
 
@@ -22,7 +25,6 @@ def x_input(request):
                 params=list(range(len(y_inputs))))
 def y_input(request):
     return y_inputs[request.param]
-
 
 # ---- Tests that use the fixtures defined above ----
 
@@ -247,3 +249,25 @@ def test_kwarg_invalid_physical_type():
     with pytest.raises(ValueError) as e:
         x, y = myfunc_args(1*u.arcsec, y=100*u.deg)
     assert str(e.value) == "Invalid unit or physical type 'africanswallow'."
+
+def test_args_None():
+    x_target = u.deg
+    x_unit = u.arcsec
+    y_target = u.km
+
+    @u.quantity_input(x=x_target, y=y_target)
+    def myfunc_args(x, y=None):
+        return x, y
+
+    x, y = myfunc_args(1*x_unit)
+    assert isinstance(x, u.Quantity)
+    assert x.unit == x_unit
+    assert y is None
+
+    x, y = myfunc_args(1*x_unit, None)
+    assert isinstance(x, u.Quantity)
+    assert x.unit == x_unit
+    assert y is None
+
+    with pytest.raises(TypeError):
+        x, y = myfunc_args(None, None)

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -246,4 +246,4 @@ def test_kwarg_invalid_physical_type():
 
     with pytest.raises(ValueError) as e:
         x, y = myfunc_args(1*u.arcsec, y=100*u.deg)
-    assert str(e.value) == "Invalid unit of physical type 'africanswallow'."
+    assert str(e.value) == "Invalid unit or physical type 'africanswallow'."

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -250,13 +250,28 @@ def test_kwarg_invalid_physical_type():
         x, y = myfunc_args(1*u.arcsec, y=100*u.deg)
     assert str(e.value) == "Invalid unit or physical type 'africanswallow'."
 
+def test_default_value_check():
+    x_target = u.deg
+    x_unit = u.arcsec
+
+    with pytest.raises(TypeError):
+        @u.quantity_input(x=x_target)
+        def myfunc_args(x=1.):
+            return x
+
+        x = myfunc_args()
+
+    x = myfunc_args(1*x_unit)
+    assert isinstance(x, u.Quantity)
+    assert x.unit == x_unit
+
 def test_args_None():
     x_target = u.deg
     x_unit = u.arcsec
     y_target = u.km
     y_unit = u.kpc
 
-    @u.quantity_input(x=[x_target, None], y=[y_target, None])
+    @u.quantity_input(x=[x_target, None], y=[None, y_target])
     def myfunc_args(x, y):
         return x, y
 

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -340,8 +340,8 @@ Instead, only dimensionless values can be converted to plain Python scalars:
     >>> int(6. * u.km / (2. * u.m))
     3000
 
-Functions Accepting Quantities
-==============================
+Functions that accept Quantities
+================================
 
 Validation of quantity arguments to functions can lead to many repetitions
 of the same checking code. A decorator is provided which verifies that certain
@@ -373,6 +373,18 @@ It is also possible to instead specify the physical type of the desired unit:
     >>> myfunction(100*u.arcsec)
     Unit("arcsec")
 
+Optionally ``None`` keyword arguments are also supported; for such cases, the
+input is only checked when a value other than ``None`` is passed:
+
+    >>> @u.quantity_input(a='length', b='angle')
+    ... def myfunction(a, b=None):
+    ...     return a, b
+
+    >>> myfunction(1.*u.km)
+    (<Quantity 1.0 km>, None)
+    >>> myfunction(1.*u.km, 1*u.deg)
+    (<Quantity 1.0 km>, <Quantity 1.0 deg>)
+
 Under Python 3 you can use the annotations syntax to provide the units:
 
     >>> @u.quantity_input  # doctest: +SKIP
@@ -394,6 +406,19 @@ value will be converted, i.e.::
 
 This both checks that the return value of your function is consistent with what
 you expect and makes it much neater to display the results of the function.
+
+The decorator also supports specifying a list of valid equivalent units or
+physical types for functions that should accept inputs with multiple valid
+units:
+
+    >>> @u.quantity_input(a=['length', 'speed'])
+    ... def myfunction(a):
+    ...     return a.unit
+
+    >>> myfunction(1.*u.km)
+    Unit("km")
+    >>> myfunction(1.*u.km/u.s)
+    Unit("km / s")
 
 Representing vectors with units
 ===============================


### PR DESCRIPTION
I have a function with complex behavior for default input, but the non-default values should always have a certain unit. For (a contrived) example:

```python
@u.quantity_input(t=u.day)
def shift_time(t, offset=None):
    if offset is None:    
        offset = np.median(t)
    else:
        # I would need to explicitly check for units of offset!
    return t - offset
```

On `master`, I have to check the units of the non-default `offset`. This PR adds support for validating the units of optional kwargs:

```python
@u.quantity_input(t=u.day, offset=(u.day,None))
def shift_time(t, offset=None):
    if offset is None:    
        offset = np.median(t)
    return t - offset
```

The way this is implemented in this PR, the arguments to `quantity_input` can now be iterable so that you have to explicitly say that you want to interpret `None` as the default value. Meaning, this doesn't work:

```python
@u.quantity_input(t=u.day, offset=u.day)
def shift_time(t, offset=None):
    # ...
```

If we want to support the above instead, I'm happy to implement that. 

A side effect of the way I implemented this is that now you can pass in multiple units to be validated against. In my own code, I sometimes have cases where I want a function to accept a length-like, velocity-like, or dimensionless Quantity. This would also enable that, e.g.:

```python
@u.quantity_input(xv=(u.pc, u.pc/u.Myr, u.dimensionless_unscaled))
def do_the_dynamics(xv):
    # ...
```

cc @mhvk 