### PR TITLE
MAINT: make LombScargle.autopower() keywords explicit

### DIFF
--- a/astropy/stats/lombscargle/core.py
+++ b/astropy/stats/lombscargle/core.py
@@ -214,7 +214,9 @@ class LombScargle(object):
         return f0 + df * np.arange(Nf)
 
     def autopower(self, method='auto', method_kwds=None,
-                  normalization='standard', **kwargs):
+                  normalization='standard', samples_per_peak=5,
+                  nyquist_factor=5, minimum_frequency=None,
+                  maximum_frequency=None):
         """Compute Lomb-Scargle power at automatically-determined frequencies
 
         Parameters
@@ -242,15 +244,27 @@ class LombScargle(object):
         normalization : string (optional, default='standard')
             Normalization to use for the periodogram.
             Options are 'standard', 'model', or 'psd'.
-        **kwargs :
-            additional keyword arguments will be passed to autofrequency()
+        samples_per_peak : float (optional, default=5)
+            The approximate number of desired samples across the typical peak
+        nyquist_factor : float (optional, default=5)
+            The multiple of the average nyquist frequency used to choose the
+            maximum frequency if maximum_frequency is not provided.
+        minimum_frequency : float (optional)
+            If specified, then use this minimum frequency rather than one
+            chosen based on the size of the baseline.
+        maximum_frequency : float (optional)
+            If specified, then use this maximum frequency rather than one
+            chosen based on the average nyquist frequency.
 
         Returns
         -------
         frequency, power : ndarrays
             The frequency and Lomb-Scargle power
         """
-        frequency = self.autofrequency(**kwargs)
+        frequency = self.autofrequency(samples_per_peak=samples_per_peak,
+                                       nyquist_factor=nyquist_factor,
+                                       minimum_frequency=minimum_frequency,
+                                       maximum_frequency=maximum_frequency)
         power = self.power(frequency,
                            normalization=normalization,
                            method=method, method_kwds=method_kwds,

--- a/astropy/stats/lombscargle/tests/test_lombscargle.py
+++ b/astropy/stats/lombscargle/tests/test_lombscargle.py
@@ -312,3 +312,16 @@ def test_model_units_mismatch(data):
     with pytest.raises(ValueError) as err:
         LombScargle(t, y, dy).model(t_fit, frequency)
     assert str(err.value).startswith('Units of dy not equivalent')
+
+
+def test_autopower(data):
+    t, y, dy = data
+    ls = LombScargle(t, y, dy)
+    kwargs = dict(samples_per_peak=6, nyquist_factor=2,
+                  minimum_frequency=2, maximum_frequency=None)
+    freq1 = ls.autofrequency(**kwargs)
+    power1 = ls.power(freq1)
+    freq2, power2 = ls.autopower(**kwargs)
+
+    assert_allclose(freq1, freq2)
+    assert_allclose(power1, power2)


### PR DESCRIPTION
... to aid in IPython tab-completion of arguments to the method.

Also added a quick test to make sure these arguments are correctly forwarded to ``autofrequency()``.