### PR TITLE
Add instructions for making small tweaks to documentation style

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -242,16 +242,17 @@ configuration file. You can also tweak aspects of the documentation theme by
 creating a custom CSS file in your package documentation.
 
 To do this, create a new CSS file in ``<packagename>/_static/`` -- let's call it
-``custom.css``::
+``<packagename>.css``::
 
     cd <packagename>/_static/
-    touch custom.css
+    touch <packagename>.css
 
-We're going to set the HTML style to this new ``custom.css`` stylesheet, so we
-need to import the original ``bootstrap-astropy`` style before we start
-modifying entries. To the first line of your ``custom.css`` file, import the
-default style. We can add any custom CSS below the import. For example, to hide
-the Astropy logo and Astropy link from your project's documentation menu bar:
+We're going to set the HTML style to this new ``<packagename>.css`` stylesheet,
+so we need to import the original ``bootstrap-astropy`` style before we start
+modifying entries. To the first line of your ``<packagename>.css`` file, import
+the default style. We can add any custom CSS below the import. For example, to
+hide the Astropy logo and Astropy link from your project's documentation menu
+bar:
 
 .. code-block:: css
 
@@ -267,13 +268,13 @@ the Astropy logo and Astropy link from your project's documentation menu bar:
         background-image: none;
     }
 
-We now have to include the ``custom.css`` in the documentation, and tell Sphinx
-to use the new style. To do this, edit your ``<packagename>/docs/conf.py`` file
-and add the lines::
+We now have to include the ``<packagename>.css`` in the documentation, and tell
+Sphinx to use the new style. To do this, edit your
+``<packagename>/docs/conf.py`` file and add the lines::
 
     # Static files to copy after template files
     html_static_path = ['_static']
-    html_style = 'custom.css'
+    html_style = '<packagename>.css'
 
 Managing the template files via git
 ===================================

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -231,6 +231,49 @@ You can find out what the latest version of astropy-helpers is by checking the
 `astropy-helpers <https://pypi.python.org/pypi/astropy-helpers/>`__ entry on
 PyPI.
 
+Customizing the documentation CSS
+---------------------------------
+
+As described in the documentation configuration file (`teplate/docs/conf.py
+<>`_), the documentation uses a custom theme based on `bootstrap <>`_. You can
+swap out this theme by editing the configuration file. You can also tweak
+aspects of the documentation theme by creating a custom CSS file in your package
+documentation.
+
+To do this, create a new CSS file in ``<packagename>/_static/`` -- let's call it
+``custom.css``::
+
+    cd <packagename>/_static/
+    touch custom.css
+
+We're going to set the HTML style to this new ``custom.css`` stylesheet, so we
+need to import the original ``bootstrap-astropy`` style before we start
+modifying entries. To the first line of your ``custom.css`` file, import the
+default style. We can add any custom CSS below the import. For example, to hide
+the Astropy logo and Astropy link from your project's documentation menu bar:
+
+.. code-block:: css
+
+    @import url("bootstrap-astropy.css");
+
+    div.topbar a.brand {
+        background: none;
+        background-image: none;
+    }
+
+    div.topbar ul li a.homelink {
+        background: none;
+        background-image: none;
+    }
+
+We now have to include the ``custom.css`` in the documentation, and tell Sphinx
+to use the new style. To do this, edit your ``<packagename>/docs/conf.py`` file
+and add the lines::
+
+    # Static files to copy after template files
+    html_static_path = ['_static']
+    html_style = 'gala.css'
+
 Managing the template files via git
 ===================================
 
@@ -274,7 +317,7 @@ files manually`_ section since this explains what many of the files do.
    directly, to make the move.  For example, with git::
 
     git mv packagename <packagename>
-      
+
 #. Update the main package docstring in ``<packagename>/__init__.py``.
 
 #. Decide what license you want to use to release your source code. If

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -235,10 +235,11 @@ Customizing the documentation CSS
 ---------------------------------
 
 As described in the documentation configuration file (`teplate/docs/conf.py
-<>`_), the documentation uses a custom theme based on `bootstrap <>`_. You can
-swap out this theme by editing the configuration file. You can also tweak
-aspects of the documentation theme by creating a custom CSS file in your package
-documentation.
+<https://github.com/astropy/package-template/blob/master/docs/conf.py#L95>`_),
+the documentation uses a custom theme based on `bootstrap
+<http://getbootstrap.com/css/>`_. You can swap out this theme by editing the
+configuration file. You can also tweak aspects of the documentation theme by
+creating a custom CSS file in your package documentation.
 
 To do this, create a new CSS file in ``<packagename>/_static/`` -- let's call it
 ``custom.css``::

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -272,7 +272,7 @@ and add the lines::
 
     # Static files to copy after template files
     html_static_path = ['_static']
-    html_style = 'gala.css'
+    html_style = 'custom.css'
 
 Managing the template files via git
 ===================================


### PR DESCRIPTION
I added some notes to the package template doc page about how to add a custom CSS stylesheet to override some CSS directives from the default `bootstrap-astropy` style.