### PR TITLE
add step of milestones to release instructions

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -215,7 +215,9 @@ packages that use the full bugfix/maintenance branch approach.)
    branch's ``CHANGES.rst`` into master.
 
 #. Create a github milestone for the next bugfix version, move any remaining
-   issues from the version you just released, and close the milestone.
+   issues from the version you just released, and close the milestone. When
+   releasing a major release, close the last milestone on the previous
+   maintanance branch, too.
 
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -214,6 +214,9 @@ packages that use the full bugfix/maintenance branch approach.)
    be better off just copying-and-pasting the relevant parts of the maintenance
    branch's ``CHANGES.rst`` into master.
 
+#. Create a github milestone for the next bugfix version, move any remaining
+   issues from the version you just released, and close the milestone.
+
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -302,8 +305,7 @@ The procedure for this is straightforward:
 
 #. On the github issue tracker, add a new milestone for the next major version.
 
-
-#. Repeat tbe above steps for the astropy-helpers, using the same version series.
+#. Repeat the above steps for the astropy-helpers, using the same version series.
 
 Maintaining Bug Fix Releases
 ----------------------------


### PR DESCRIPTION
This adds a step to the release instructions to update the milestones.  Prompted by #5663, where @pllim helpfully pointed out that I had forgotten this during the 1.3/1.2.2/1.0.11 release.

cc @astrofrog @bsipocz 