### PR TITLE
Raise error in ImageNormalize inputs are not class instances

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -9,9 +9,9 @@ import numpy as np
 from numpy import ma
 
 from .interval import (PercentileInterval, AsymmetricPercentileInterval,
-                       ManualInterval, MinMaxInterval)
+                       ManualInterval, MinMaxInterval, BaseInterval)
 from .stretch import (LinearStretch, SqrtStretch, PowerStretch, LogStretch,
-                      AsinhStretch)
+                      AsinhStretch, BaseStretch)
 
 try:
     import matplotlib  # pylint: disable=W0611
@@ -76,8 +76,16 @@ class ImageNormalize(Normalize):
             if self.vmax is None:
                 self.vmax = _vmax
 
+        if stretch is not None and not isinstance(stretch, BaseStretch):
+            raise TypeError('stretch must be an instance of a BaseStretch '
+                            'subclass')
         self.stretch = stretch
+
+        if interval is not None and not isinstance(interval, BaseInterval):
+            raise TypeError('interval must be an instance of a BaseInterval '
+                            'subclass')
         self.interval = interval
+
         self.inverse_stretch = stretch.inverse
         self.clip = clip
 

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -30,6 +30,15 @@ def test_normalize_error_message():
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 class TestNormalize(object):
+    def test_invalid_interval(self):
+        with pytest.raises(TypeError):
+            ImageNormalize(vmin=2., vmax=10., interval=ManualInterval,
+                           clip=True)
+
+    def test_invalid_stretch(self):
+        with pytest.raises(TypeError):
+            ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch,
+                           clip=True)
 
     def test_scalar(self):
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),


### PR DESCRIPTION
With this PR an error will be raised if the `stretch` or `interval` inputs to `ImageNormalize` are not class instances.  Addresses #3569.