### PR TITLE
Running cron jobs only for the latest and dev numpy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
         - PIP_DEPENDENCIES=''
         - SETUP_XVFB=True
         - SPHINX_VERSION='<1.5'
+        - EVENT_TYPE='push pull_request'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
@@ -88,6 +89,7 @@ matrix:
                NUMPY_VERSION=1.10
                MATPLOTLIB_VERSION=1.4
                ASTROPY_USE_SYSTEM_PYTEST=1
+               EVENT_TYPE='push pull_request cron'
 
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
@@ -97,10 +99,12 @@ matrix:
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=1.5
                ASTROPY_USE_SYSTEM_PYTEST=1
+               EVENT_TYPE='push pull_request cron'
 
         # Try pre-release version of Numpy without optional dependencies
         - os: linux
           env: NUMPY_VERSION=prerelease SETUP_CMD='test'
+               EVENT_TYPE='push pull_request cron'
 
         # Do a PEP8 test with pycodestyle
         - os: linux
@@ -113,10 +117,12 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               EVENT_TYPE='push pull_request cron'
 
     allow_failures:
       - env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
              CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+             EVENT_TYPE='push pull_request cron'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
as there is no need to burn CI time on already passed builds that are already passed on old versions. Maybe even running it on the latest numpy is an overkill as it isn't expected to change.

cc @astrofrog 