### PR TITLE
Print remote-data value in test header

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -23,7 +23,6 @@ import os
 import re
 import sys
 import types
-import argparse
 from collections import OrderedDict
 
 from ..config.paths import set_temp_config, set_temp_cache
@@ -643,10 +642,13 @@ def pytest_report_header(config):
     special_opts = ["remote_data", "pep8"]
     opts = []
     for op in special_opts:
-        if getattr(config.option, op, None):
+        op_value = getattr(config.option, op, None)
+        if op_value:
+            if isinstance(op_value, six.string_types):
+                op = ': '.join((op, op_value))
             opts.append(op)
     if opts:
-        s += "Using Astropy options: {0}.\n".format(" ".join(opts))
+        s += "Using Astropy options: {0}.\n".format(", ".join(opts))
 
     if six.PY2:
         s = s.encode(stdoutencoding, 'replace')


### PR DESCRIPTION
Since the ``remote-data`` key is always added to the config since #5506 , the real info is in its value. Print that into the test header to ease bug fixing.

cc @astrofrog