### PR TITLE
Change FITS unit warnings to warn only on write, not read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ New Features
   - Checking available disk space before writing out file. [#5550, #4065]
 
   - Change behavior to warn about units that are not FITS-compliant when
-    writing a FITS file but not when reading. [#5674]
+    writing a FITS file but not when reading. [#5675]
 
 - ``astropy.io.misc``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ New Features
 
   - Checking available disk space before writing out file. [#5550, #4065]
 
+  - Change behavior to warn about units that are not FITS-compliant when
+    writing a FITS file but not when reading. [#5674]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -158,7 +158,7 @@ def read_table_fits(input, hdu=None):
     for col in table.columns:
         if col.unit is not None:
             t[col.name].unit = u.Unit(
-                col.unit, format='fits', parse_strict='warn')
+                col.unit, format='fits', parse_strict='silent')
 
     # TODO: deal properly with unsigned integers
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -69,6 +69,7 @@ from .hdu.table import BinTableHDU
 from .header import Header
 from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
 from .fitsrec import FITS_rec
+from ...units import Unit
 from ...units.format.fits import UnitScaleError
 from ...extern import six
 from ...extern.six import string_types
@@ -510,6 +511,9 @@ def table_to_hdu(table):
                 warnings.warn(
                     "The unit '{0}' could not be saved to FITS format".format(
                         unit.to_string()), AstropyUserWarning)
+
+            # Try creating a Unit to issue a warning if the unit is not FITS compliant
+            Unit(col.unit, format='fits', parse_strict='warn')
 
     for key, value in table.meta.items():
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -311,3 +311,19 @@ def test_unicode_column(tmpdir):
 
     with pytest.raises(UnicodeEncodeError):
         t2.write(str(tmpdir.join('test.fits')), overwrite=True)
+
+
+def test_unit_warnings_read_write(tmpdir):
+    filename = str(tmpdir.join('test_unit.fits'))
+    t1 = Table([[1, 2], [3, 4]], names=['a', 'b'])
+    t1['a'].unit = 'm/s'
+    t1['b'].unit = 'not-a-unit'
+
+    with catch_warnings() as l:
+        t1.write(filename, overwrite=True)
+        assert len(l) == 1
+        assert str(l[0].message).startswith("'not-a-unit' did not parse as fits unit")
+
+    with catch_warnings() as l:
+        Table.read(filename, hdu=1)
+    assert len(l) == 0

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -46,7 +46,14 @@ class TestConvenience(FitsTestCase):
     def test_table_to_hdu(self, tmpdir):
         table = Table([[1, 2, 3], ['a', 'b', 'c'], [2.3, 4.5, 6.7]],
                       names=['a', 'b', 'c'], dtype=['i', 'U1', 'f'])
-        hdu = fits.table_to_hdu(table)
+        table['a'].unit = 'm/s'
+        table['b'].unit = 'not-a-unit'
+
+        with catch_warnings() as w:
+            hdu = fits.table_to_hdu(table)
+            assert len(w) == 1
+            assert str(w[0].message).startswith("'not-a-unit' did not parse as fits unit")
+
         assert isinstance(hdu, fits.BinTableHDU)
         filename = str(tmpdir.join('test_table_to_hdu.fits'))
         hdu.writeto(filename, overwrite=True)


### PR DESCRIPTION
This reverses the warning behavior of `io.fits` to be liberal on input (read), conservative on output (write).  So with this PR:
```
>>> t1 = Table([[1, 2], [3, 4]], names=['a', 'b'])
>>> t1['a'].unit = 'm/s'
>>> t1['b'].unit = 'not-a-unit'

>>> t1.write('junk.fits', overwrite=True)
WARNING: UnitsWarning: 'not-a-unit' did not parse as fits unit: At col 0, Unit 'not' not supported by the FITS standard. Did you mean nT? [astropy.units.core]

>>> Table.read('junk.fits', hdu=1)
<Table length=2>
  a       b     
m / s not-a-unit
int64   int64   
----- ----------
    1          3
    2          4
```

The driver here is that I work with FITS files all the time which have non-compliant units, namely Chandra data products.  I can't control the definition of those files and there is 0% chance that the upstream creator will change it.  This is probably not uncommon, and so most of the time there is really nothing the consumer of a FITS file can do about bad units except write tedious code to suppress the warning.

However, we *should* be warning when writing out a file with bad units.