### PR TITLE
[EXP] changed yield to parameterize

### DIFF
--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -65,5 +65,3 @@ def test_spectrum(filename):
         x = np.random.rand(2 ** 16, wcsobj.wcs.naxis)
         world = wcsobj.wcs_pix2world(x, 1)
         pix = wcsobj.wcs_world2pix(x, 1)
-
-

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -31,8 +31,7 @@ def test_read_map_files():
     # how many map files we expect to see
     n_map_files = 28
 
-    if len(hdr_map_file_list) != n_map_files:
-       assert False, (
+    assert len(hdr_map_file_list) == n_map_files, (
            "test_read_map_files has wrong number data files: found {}, expected "
            " {}".format(len(hdr_map_file_list), n_map_files))
 
@@ -52,10 +51,9 @@ def test_read_spec_files():
     # how many spec files expected
     n_spec_files = 6
 
-    if len(hdr_spec_file_list) != n_spec_files:
-        assert False, (
+    assert len(hdr_spec_file_list) == n_spec_files, (
             "test_spectra has wrong number data files: found {}, expected "
-            " {}".format(len(hdr_file_list), n_data_files))
+            " {}".format(len(hdr_spec_file_list), n_spec_files))
         # b.t.w.  If this assert happens, py.test reports one more test
         # than it would have otherwise.
 

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -7,14 +7,37 @@ import os
 
 import numpy as np
 
+from ...tests.helper import pytest
 from ...utils.data import get_pkg_data_filenames, get_pkg_data_contents
 from ...utils.misc import NumpyRNGContext
 
 from ... import wcs
 
+#hdr_map_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
 
-def test_maps():
-    def test_map(filename):
+# use the base name of the file, because everything we yield
+# will show up in the test name in the pandokia report
+hdr_map_file_list = [os.path.basename(fname) for fname in get_pkg_data_filenames("maps", pattern="*.hdr")]
+
+# Checking the number of files before reading them in.
+# OLD COMMENTS:
+# AFTER we tested with every file that we found, check to see that we
+# actually have the list we expect.  If N=0, we will not have performed
+# any tests at all.  If N < n_data_files, we are missing some files,
+# so we will have skipped some tests.  Without this check, both cases
+# happen silently!
+
+def test_read_map_files():
+    # how many map files we expect to see
+    n_map_files = 28
+
+    if len(hdr_map_file_list) != n_map_files:
+       assert False, (
+           "test_read_map_files has wrong number data files: found {}, expected "
+           " {}".format(len(hdr_map_file_list), n_map_files))
+
+@pytest.mark.parametrize("filename", hdr_map_file_list)
+def test_map(filename):
         header = get_pkg_data_contents(os.path.join("maps", filename))
         wcsobj = wcs.WCS(header)
 
@@ -23,68 +46,26 @@ def test_maps():
             world = wcsobj.wcs_pix2world(x, 1)
             pix = wcsobj.wcs_world2pix(x, 1)
 
-    hdr_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
+hdr_spec_file_list = [os.path.basename(fname) for fname in get_pkg_data_filenames("spectra", pattern="*.hdr")]
 
-    # actually perform a test for each one
-    for filename in hdr_file_list:
+def test_read_spec_files():
+    # how many spec files expected
+    n_spec_files = 6
 
-        # use the base name of the file, because everything we yield
-        # will show up in the test name in the pandokia report
-        filename = os.path.basename(filename)
-
-        # yield a function name and parameters to make a generated test
-        yield test_map, filename
-
-    # AFTER we tested with every file that we found, check to see that we
-    # actually have the list we expect.  If N=0, we will not have performed
-    # any tests at all.  If N < n_data_files, we are missing some files,
-    # so we will have skipped some tests.  Without this check, both cases
-    # happen silently!
-
-    # how many do we expect to see?
-    n_data_files = 28
-
-    if len(hdr_file_list) != n_data_files:
-        assert False, (
-            "test_maps has wrong number data files: found {}, expected "
-            " {}".format(len(hdr_file_list), n_data_files))
-        # b.t.w.  If this assert happens, py.test reports one more test
-        # than it would have otherwise.
-
-
-def test_spectra():
-    def test_spectrum(filename):
-        header = get_pkg_data_contents(os.path.join("spectra", filename))
-        wcsobj = wcs.WCS(header)
-        with NumpyRNGContext(123456789):
-            x = np.random.rand(2 ** 16, wcsobj.wcs.naxis)
-            world = wcsobj.wcs_pix2world(x, 1)
-            pix = wcsobj.wcs_world2pix(x, 1)
-
-    hdr_file_list = list(get_pkg_data_filenames("spectra", pattern="*.hdr"))
-
-    # actually perform a test for each one
-    for filename in hdr_file_list:
-
-        # use the base name of the file, because everything we yield
-        # will show up in the test name in the pandokia report
-        filename = os.path.basename(filename)
-
-        # yield a function name and parameters to make a generated test
-        yield test_spectrum, filename
-
-    # AFTER we tested with every file that we found, check to see that we
-    # actually have the list we expect.  If N=0, we will not have performed
-    # any tests at all.  If N < n_data_files, we are missing some files,
-    # so we will have skipped some tests.  Without this check, both cases
-    # happen silently!
-
-    # how many do we expect to see?
-    n_data_files = 6
-
-    if len(hdr_file_list) != n_data_files:
+    if len(hdr_spec_file_list) != n_spec_files:
         assert False, (
             "test_spectra has wrong number data files: found {}, expected "
             " {}".format(len(hdr_file_list), n_data_files))
         # b.t.w.  If this assert happens, py.test reports one more test
         # than it would have otherwise.
+
+@pytest.mark.parametrize("filename", hdr_spec_file_list)
+def test_spectrum(filename):
+    header = get_pkg_data_contents(os.path.join("spectra", filename))
+    wcsobj = wcs.WCS(header)
+    with NumpyRNGContext(123456789):
+        x = np.random.rand(2 ** 16, wcsobj.wcs.naxis)
+        world = wcsobj.wcs_pix2world(x, 1)
+        pix = wcsobj.wcs_world2pix(x, 1)
+
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.3.3
 norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled


### PR DESCRIPTION
fixes a deprecated warning with pytest3. implemented fix in test_profiling.py but same fix didnt work in test_wcs.py. #hackaas cc @nden @pllim 