### PR TITLE
Install a recent version of Sphinx for ReadTheDocs

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - python>=3
   - numpy
   - cython
+  - sphinx
   - matplotlib
   - scipy
   - pillow


### PR DESCRIPTION
Currently the Astropy docs are built with Sphinx 1.3.5 (released 2016-01-24) on ReadTheDocs.

This can be seen in build logs (latest: https://readthedocs.org/projects/astropy/builds/4872087/) and also in the footer of the docs pages in "Created using Sphinx 1.3.5."

The current Sphinx version is 1.5.1 (released 2016-12-13).

This PR adds Sphinx to `.rtd-environment.yml`, i.e. the packages installed by conda on ReadTheDocs.

Locally for me Sphinx 1.5.1 works fine, but I didn't test this on ReadTheDocs, i.e. we'll only find out if this works when this is merged to master. Should there be a problem we can always roll the change back with an extra commit.

@bsipocz @astrofrog - Thoughts?