### PR TITLE
Avoid importing matplotlib.pyplot when importing astropy.visualization.wcsaxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -194,6 +194,9 @@ Bug Fixes
 
 - ``astropy.visualization``
 
+  - Avoid importing matplotlib.pyplot when importing
+    astropy.visualization.wcsaxes. [#5680]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -3,7 +3,7 @@
 # The following few lines skip this module when running tests if matplotlib is
 # not available (and will have no impact otherwise)
 from ...tests.helper import pytest
-pytest.importorskip("matplotlib.pyplot")
+pytest.importorskip("matplotlib")
 del pytest
 
 from .core import *


### PR DESCRIPTION
Closes #5680 