### PR TITLE
Allow pytest 3.x to use plugin for doctests in .rst files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
-        - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='pytest>=3'
         - SETUP_XVFB=True
         - SPHINX_VERSION='<1.5'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
+        - ASTROPY_USE_SYSTEM_PYTEST=1
         - PYTHON_VERSION=3.5
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,12 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
-        - ASTROPY_USE_SYSTEM_PYTEST=1
         - PYTHON_VERSION=3.5
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
-        - PIP_DEPENDENCIES='pytest>=3'
+        - PIP_DEPENDENCIES=''
         - SETUP_XVFB=True
         - SPHINX_VERSION='<1.5'
 
@@ -80,7 +79,7 @@ matrix:
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
         # (with latest numpy). We also test the two latest matplotlib versions
-        # for the image tests.
+        # for the image tests, and with the system rather than build-in pytest.
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
@@ -88,6 +87,7 @@ matrix:
                LC_CTYPE=C.ascii LC_ALL=C
                NUMPY_VERSION=1.10
                MATPLOTLIB_VERSION=1.4
+               ASTROPY_USE_SYSTEM_PYTEST=1
 
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
@@ -96,6 +96,7 @@ matrix:
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=1.5
+               ASTROPY_USE_SYSTEM_PYTEST=1
 
         # Try pre-release version of Numpy without optional dependencies
         - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@
 environment:
 
     global:
+        ASTROPY_USE_SYSTEM_PYTEST: 1
         PYTHON: "C:\\conda"
         MINICONDA_VERSION: "latest"
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@
 environment:
 
     global:
-        ASTROPY_USE_SYSTEM_PYTEST: 1
         PYTHON: "C:\\conda"
         MINICONDA_VERSION: "latest"
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
@@ -20,6 +19,7 @@ environment:
           NUMPY_VERSION: "stable"
         - PYTHON_VERSION: "3.5"
           NUMPY_VERSION: "stable"
+          ASTROPY_USE_SYSTEM_PYTEST: 1
 
 matrix:
     fast_finish: true

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -14,3 +14,6 @@ else:
 enable_deprecations_as_exceptions(include_astropy_deprecations=False)
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
+
+# To avoid warnings in pytest 3.x
+collect_ignore = ['astropy/tests/runner.py']

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -14,6 +14,3 @@ else:
 enable_deprecations_as_exceptions(include_astropy_deprecations=False)
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
-
-# To avoid warnings in pytest 3.x
-collect_ignore = ['astropy/tests/runner.py']

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -195,6 +195,21 @@ def pytest_configure(config):
             return
 
     class DocTestTextfilePlus(doctest_plugin.DoctestTextfile):
+        def collect(self):
+            # inspired by doctest.testfile; ideally we would use it directly,
+            # but it doesn't support passing a custom checker
+            text = self.fspath.read()
+            filename = str(self.fspath)
+            name = self.fspath.basename
+            globs = {'__name__': '__main__'}
+
+            runner = doctest.DebugRunner(verbose=0, optionflags=opts)
+
+            parser = DocTestParserPlus()
+            test = parser.get_doctest(text, globs, name, filename, 0)
+            if test.examples:
+                yield doctest_plugin.DoctestItem(test.name, self, runner, test)
+
         def runtest(self):
             # satisfy `FixtureRequest` constructor...
             self.funcargs = {}

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,9 +1,11 @@
-from astropy.tests.runner import TestRunner, TestRunnerBase, keyword
+from astropy.tests.runner import TestRunner as T_Runner
+from astropy.tests.runner import TestRunnerBase as T_RunnerBase
+from astropy.tests.runner import keyword
 from astropy.tests.helper import pytest
 
 
 def test_disable_kwarg():
-    class no_remote_data(TestRunner):
+    class no_remote_data(T_Runner):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
@@ -14,13 +16,13 @@ def test_disable_kwarg():
 
 
 def test_wrong_kwarg():
-    r = TestRunner('.')
+    r = T_Runner('.')
     with pytest.raises(TypeError):
         r.run_tests(spam='eggs')
 
 
 def test_invalid_kwarg():
-    class bad_return(TestRunnerBase):
+    class bad_return(T_RunnerBase):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return 'bob'
@@ -31,7 +33,7 @@ def test_invalid_kwarg():
 
 
 def test_new_kwarg():
-    class Spam(TestRunnerBase):
+    class Spam(T_RunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -44,7 +46,7 @@ def test_new_kwarg():
 
 
 def test_priority():
-    class Spam(TestRunnerBase):
+    class Spam(T_RunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -61,7 +63,7 @@ def test_priority():
 
 
 def test_docs():
-    class Spam(TestRunnerBase):
+    class Spam(T_RunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             """

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,11 +1,15 @@
-from astropy.tests.runner import TestRunner as T_Runner
-from astropy.tests.runner import TestRunnerBase as T_RunnerBase
+# Renamed these imports so that them being in the namespace will not
+# cause pytest 3 to discover them as tests and then complain that
+# they have __init__ defined.
+from astropy.tests.runner import TestRunner as _TestRunner
+from astropy.tests.runner import TestRunnerBase as _TestRunnerBase
+
 from astropy.tests.runner import keyword
 from astropy.tests.helper import pytest
 
 
 def test_disable_kwarg():
-    class no_remote_data(T_Runner):
+    class no_remote_data(_TestRunner):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
@@ -16,13 +20,13 @@ def test_disable_kwarg():
 
 
 def test_wrong_kwarg():
-    r = T_Runner('.')
+    r = _TestRunner('.')
     with pytest.raises(TypeError):
         r.run_tests(spam='eggs')
 
 
 def test_invalid_kwarg():
-    class bad_return(T_RunnerBase):
+    class bad_return(_TestRunnerBase):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return 'bob'
@@ -33,7 +37,7 @@ def test_invalid_kwarg():
 
 
 def test_new_kwarg():
-    class Spam(T_RunnerBase):
+    class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -46,7 +50,7 @@ def test_new_kwarg():
 
 
 def test_priority():
-    class Spam(T_RunnerBase):
+    class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -63,7 +67,7 @@ def test_priority():
 
 
 def test_docs():
-    class Spam(T_RunnerBase):
+    class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             """


### PR DESCRIPTION
With this fix, all tests, including doctests, pass even with pytest 3.x. As it is very much a copy & paste hack, please have a careful look. Also, while we're at it, should we remove the cruft for pytest <2.4? What is our minimum version? 