### PR TITLE
io.votables tablewriter: Change realloc() to PyMem_Realloc()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,6 +178,8 @@ Bug Fixes
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``
+  - Fixed a bug where stdlib ``realloc()`` was used instead of
+   ``PyMem_Realloc()`` [#4739, #2100]
 
 - ``astropy.modeling``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,8 +178,9 @@ Bug Fixes
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``
+
   - Fixed a bug where stdlib ``realloc()`` was used instead of
-   ``PyMem_Realloc()`` [#4739, #2100]
+    ``PyMem_Realloc()`` [#4739, #2100]
 
 - ``astropy.modeling``
 

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -71,7 +71,7 @@ _buffer_realloc(
         return -1;
     }
 
-    new_mem = realloc((void *)*buffer, n * sizeof(CHAR));
+    new_mem = PyMem_Realloc((void *)*buffer, n * sizeof(CHAR));
     if (new_mem == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Out of memory for XML text.");
         return -1;


### PR DESCRIPTION
This fixes a reproducible segfault in `io.votable` tests on python 3.6 (anaconda built CPython) #4739.

stdlib `realloc()` should not be used on a `Py_Object`.

pinging @mdboom for review.