### PR TITLE
Revert premature pytest 3.x feature

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[tool:pytest]
+[pytest]
 minversion = 2.3.3
 norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled


### PR DESCRIPTION
Revert a change introduced in #5678. That change should be re-introduced in #5688 instead. Fix #5695.

NOTE: Do not merge until it is sure that doctest reappears in Travis CI.