### PR TITLE
Table unicode sandwich - make 'S' type useful in Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,7 @@ New Features
 
   - Add support for Quantity columns (within a ``QTable``) in table
     ``join()``, ``hstack()`` and ``vstack()`` operations. [#5841]
+
   - Allow unicode strings to be stored in a Table bytestring column in
     Python 3 using UTF-8 encoding.  Allow comparison and assignment of
     Python 3 ``str`` object in a bytestring column (numpy ``'S'`` dtype).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,10 @@ New Features
 
   - Add support for Quantity columns (within a ``QTable``) in table
     ``join()``, ``hstack()`` and ``vstack()`` operations. [#5841]
+  - Allow unicode strings to be stored in a Table bytestring column in
+    Python 3 using UTF-8 encoding.  Allow comparison and assignment of
+    Python 3 ``str`` object in a bytestring column (numpy ``'S'`` dtype).
+    [#5700]
 
 - ``astropy.time``
 
@@ -161,6 +165,11 @@ API Changes
 - ``astropy.sphinx``
 
 - ``astropy.table``
+
+  - In Python 3, when getting an item from a bytestring Column it is now
+    converted to ``str``.  This means comparing a single item to a ``bytes``
+    object will always fail, and instead one must compare with a ``str``
+    object. [#5700]
 
   - Removed the deprecated ``data`` property of Row. [#5729]
 

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -289,7 +289,7 @@ def test_non_existing_unknown_ext():
 
 def test_read_basic_table():
     data = np.array(list(zip([1, 2, 3], ['a', 'b', 'c'])),
-                    dtype=[(str('A'), int), (str('B'), '|S1')])
+                    dtype=[(str('A'), int), (str('B'), '|U1')])
     io_registry.register_reader('test', Table, lambda x: Table(x))
     t = Table.read(data, format='test')
     assert t.keys() == ['A', 'B']

--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -57,11 +57,11 @@ cdef inline object base_getitem(object self, object item, item_getter getitem):
 
     value = getitem(self, item)
 
-    # In Py3+ return a scalar bytes value as latin1-encoded str
+    # In Py3+ return a scalar bytes value as utf-8-encoded str
     if PYV != 2:
         try:
             if value.dtype.char == 'S' and not value.shape:
-                value = value.decode('latin1')
+                value = value.decode('utf-8')
         except AttributeError:
             pass
 

--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -25,11 +25,8 @@ Column is itself an array.
 import sys
 import numpy as np
 
-
-if sys.version_info[0] == 3:
-    INTEGER_TYPES = (int, np.integer)
-else:
-    INTEGER_TYPES = (int, long, np.integer)
+cdef int PYV = sys.version_info[0]
+cdef tuple INTEGER_TYPES = (int, long, np.integer) if PYV == 2 else (int, np.integer)
 
 
 # Annoying boilerplate that we shouldn't have to write; Cython should
@@ -58,7 +55,17 @@ cdef inline object base_getitem(object self, object item, item_getter getitem):
     if (<ndarray>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
         return self.data[item]
 
-    return getitem(self, item)
+    value = getitem(self, item)
+
+    # In Py3+ return a scalar bytes value as latin1-encoded str
+    if PYV != 2:
+        try:
+            if value.dtype.char == 'S' and not value.shape:
+                value = value.decode('latin1')
+        except AttributeError:
+            pass
+
+    return value
 
 
 cdef inline object column_getitem(object self, object item):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -138,7 +138,7 @@ def _encode_str_utf8(value):
     """
     if isinstance(value, str):
         value = value.encode('utf-8')
-    elif isinstance(value, bytes):
+    elif isinstance(value, bytes) or value is np.ma.masked:
         pass
     else:
         value = np.asarray(value)
@@ -1213,6 +1213,9 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
 
     def __setitem__(self, index, value):
         # Issue warning for string assignment that truncates ``value``
+        if not six.PY2 and self.dtype.char == 'S':
+            value = _encode_str_utf8(value)
+
         if issubclass(self.dtype.type, np.character):
             # Account for a bug in np.ma.MaskedArray setitem.
             # https://github.com/numpy/numpy/issues/8624

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -131,19 +131,19 @@ class FalseArray(np.ndarray):
             self.__setitem__(slice(start, stop), val)
 
 
-def _encode_str_latin1(value):
+def _encode_str_utf8(value):
     """
-    Encode anything that is unicode-ish as latin1.  This method is used
+    Encode anything that is unicode-ish as utf-8.  This method is used
     in Column and is only called for Py3+.
     """
     if isinstance(value, str):
-        value = value.encode('latin1')
+        value = value.encode('utf-8')
     elif isinstance(value, bytes):
         pass
     else:
         value = np.asarray(value)
         if value.dtype.char == 'U':
-            value = np.char.encode(value, encoding='latin1')
+            value = np.char.encode(value, encoding='utf-8')
 
     return value
 
@@ -882,7 +882,7 @@ class Column(BaseColumn):
 
     def __setitem__(self, index, value):
         if not six.PY2 and self.dtype.char == 'S':
-            value = _encode_str_latin1(value)
+            value = _encode_str_utf8(value)
 
         # Issue warning for string assignment that truncates ``value``
         if issubclass(self.dtype.type, np.character):
@@ -903,12 +903,12 @@ class Column(BaseColumn):
 
     def _make_compare(oper):
         """
-        Make comparison methods which encode the ``other`` object to latin1
+        Make comparison methods which encode the ``other`` object to utf-8
         in the case of a bytestring dtype for Py3+.
         """
         def _compare(self, other):
             if not six.PY2 and self.dtype.char == 'S':
-                other = _encode_str_latin1(other)
+                other = _encode_str_utf8(other)
             return getattr(self.data, oper)(other)
         return _compare
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -230,6 +230,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
                 meta = deepcopy(data.info.meta)
 
         else:
+            if not six.PY2 and np.dtype(dtype).char == 'S':
+                data = _encode_str_utf8(data)
             self_data = np.array(data, dtype=dtype, copy=copy)
 
         self = self_data.view(cls)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -884,7 +884,7 @@ class Column(BaseColumn):
 
     def __setitem__(self, index, value):
         if not six.PY2 and self.dtype.char == 'S':
-            value = self.__class__._encode_str(value)
+            value = self._encode_str(value)
 
         # Issue warning for string assignment that truncates ``value``
         if issubclass(self.dtype.type, np.character):
@@ -910,7 +910,7 @@ class Column(BaseColumn):
         """
         def _compare(self, other):
             if not six.PY2 and self.dtype.char == 'S':
-                other = self.__class__._encode_str(other)
+                other = self._encode_str(other)
             return getattr(self.data, oper)(other)
         return _compare
 
@@ -1216,7 +1216,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     def __setitem__(self, index, value):
         # Issue warning for string assignment that truncates ``value``
         if not six.PY2 and self.dtype.char == 'S':
-            value = self.__class__._encode_str(value)
+            value = self._encode_str(value)
 
         if issubclass(self.dtype.type, np.character):
             # Account for a bug in np.ma.MaskedArray setitem.

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -131,7 +131,7 @@ class FalseArray(np.ndarray):
             self.__setitem__(slice(start, stop), val)
 
 
-def _encode_str_utf8(value):
+def _encode_str(value):
     """
     Encode anything that is unicode-ish as utf-8.  This method is used
     in Column and is only called for Py3+.
@@ -231,7 +231,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         else:
             if not six.PY2 and np.dtype(dtype).char == 'S':
-                data = _encode_str_utf8(data)
+                data = _encode_str(data)
             self_data = np.array(data, dtype=dtype, copy=copy)
 
         self = self_data.view(cls)
@@ -884,7 +884,7 @@ class Column(BaseColumn):
 
     def __setitem__(self, index, value):
         if not six.PY2 and self.dtype.char == 'S':
-            value = _encode_str_utf8(value)
+            value = _encode_str(value)
 
         # Issue warning for string assignment that truncates ``value``
         if issubclass(self.dtype.type, np.character):
@@ -910,7 +910,7 @@ class Column(BaseColumn):
         """
         def _compare(self, other):
             if not six.PY2 and self.dtype.char == 'S':
-                other = _encode_str_utf8(other)
+                other = _encode_str(other)
             return getattr(self.data, oper)(other)
         return _compare
 
@@ -1216,7 +1216,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     def __setitem__(self, index, value):
         # Issue warning for string assignment that truncates ``value``
         if not six.PY2 and self.dtype.char == 'S':
-            value = _encode_str_utf8(value)
+            value = _encode_str(value)
 
         if issubclass(self.dtype.type, np.character):
             # Account for a bug in np.ma.MaskedArray setitem.

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -630,10 +630,27 @@ def test_string_truncation_warning_masked():
                 in str(w[0].message))
 
 
+@pytest.mark.skipif('six.PY2')
+@pytest.mark.parametrize('Column', (table.Column, table.MaskedColumn))
+def test_col_unicode_sandwich_create_from_str(Column):
+    """
+    Create a bytestring Column from strings (including unicode) in Py3.
+    """
+    # a-umlaut is a 2-byte character in utf-8, test fails with ascii encoding.
+    # Stress the system by injecting non-ASCII characters.
+    uba = u'bä'
+    c = Column([uba, 'def'], dtype='S')
+    assert c.dtype.char == 'S'
+    assert c[0] == uba
+    assert isinstance(c[0], str)
+    assert isinstance(c[:0], table.Column)
+    assert np.all(c[:2] == np.array([uba, 'def']))
+
+
 @pytest.mark.parametrize('Column', (table.Column, table.MaskedColumn))
 def test_col_unicode_sandwich_bytes(Column):
     """
-    Create a bytestring Column and ensure that it works in Python 3 in
+    Create a bytestring Column from bytes and ensure that it works in Python 3 in
     a convenient way like in Python 2.
     """
     # a-umlaut is a 2-byte character in utf-8, test fails with ascii encoding.

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -692,6 +692,7 @@ def test_col_unicode_sandwich_unicode():
     """
     Sanity check that Unicode Column behaves normally.
     """
+    # On Py2 the unicode must be ASCII-compatible, else the final test fails.
     uba = 'ba' if six.PY2 else u'bä'
     uba8 = uba.encode('utf-8')
 
@@ -735,9 +736,9 @@ def test_masked_col_unicode_sandwich():
     ok = c == ['abc', 'def']
     assert ok[0] == True
     assert ok[1] is np.ma.masked
-    #assert c == [b'abc', b'def']
-    #assert c == np.array([u'abc', u'def'])
-    #assert c == np.array([b'abc', b'def'])
+    assert np.all(c == [b'abc', b'def'])
+    assert np.all(c == np.array([u'abc', u'def']))
+    assert np.all(c == np.array([b'abc', b'def']))
 
     for cmp in (u'abc', b'abc'):
         ok = c == cmp
@@ -767,3 +768,7 @@ def test_unicode_sandwich_set(Column):
 
     c[:] = uba
     assert np.all(c == [uba, uba])
+
+    c[:] = ''
+    c[:] = [uba, b'def']
+    assert np.all(c == [uba, b'def'])

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # TEST_UNICODE_LITERALS
@@ -668,9 +669,11 @@ def test_col_unicode_sandwich_unicode():
     assert c[:].dtype.char == 'U'
 
     assert np.all(c == ['abc', 'def'])
-    assert np.all(c != [b'abc', b'def'])
+    if not six.PY2:
+        assert np.all(c != [b'abc', b'def'])
     assert np.all(c == np.array([u'abc', u'def']))
-    assert np.all(c != np.array([b'abc', b'def']))
+    if not six.PY2:
+        assert np.all(c != np.array([b'abc', b'def']))
 
 
 def test_masked_col_unicode_sandwich():
@@ -681,11 +684,10 @@ def test_masked_col_unicode_sandwich():
     c = table.MaskedColumn([b'abc', b'def'])
     c[1] = np.ma.masked
     assert isinstance(c[:0], table.MaskedColumn)
-    assert isinstance(c[0], six.text_type)
+    assert isinstance(c[0], str)
 
     assert c[0] == 'abc'
     assert c[1] is np.ma.masked
-    assert isinstance(c[0], str)
 
     assert isinstance(c[:], table.MaskedColumn)
     assert c[:].dtype.char == 'S'
@@ -718,9 +720,3 @@ def test_unicode_sandwich_set(Column):
     assert np.all(c == ['cc', 'cc'])
     c[:] = u'dd'
     assert np.all(c == ['dd', 'dd'])
-
-
-def test_unicode_sandwich_non_ascii():
-    c = table.Column([b'abc', bytes(bytearray([40, 200, 230]))])
-    assert c.dtype.char == 'S'
-    assert c[1] == u'(Èæ'

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -115,7 +115,7 @@ def test_table_info_stats(table_types):
     assert np.all(tinfo['name'] == ['a', 'b', 'c', 'd'])
     assert np.all(tinfo['dtype'] == ['int32', 'float32', dtype_info_name('S1'), 'object'])
     assert np.all(tinfo['sum'] == ['6', '6.0', '--', '--'])
-    assert np.all(tinfo['first'] == ['1', '1.0', 'a' if six.PY2 else "b'a'", '1.0'])
+    assert np.all(tinfo['first'] == ['1', '1.0', 'a', '1.0'])
 
 def test_data_info():
     """

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -535,10 +535,10 @@ def test_pprint_py3_bytes():
     Also make sure special characters are printed in Python 2.
     """
     val = str('val') if PY2 else bytes('val', encoding='utf-8')
-    blah = u'bläh'.encode('latin1')
+    blah = u'bläh'.encode('utf-8')
     dat = np.array([val, blah], dtype=[(str('col'), 'S10')])
     t = table.Table(dat)
-    assert t['col'].pformat() == ['col ', '----', ' val', u'bl\xe4h']
+    assert t['col'].pformat() == ['col ', '----', ' val', u'bläh']
 
 
 def test_pprint_nameless_col():

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -535,7 +535,7 @@ def test_pprint_py3_bytes():
     Also make sure special characters are printed in Python 2.
     """
     val = str('val') if PY2 else bytes('val', encoding='utf-8')
-    blah = u'bläh'.encode('utf-8') if PY2 else bytes('bläh', encoding='utf-8')
+    blah = u'bläh'.encode('latin1')
     dat = np.array([val, blah], dtype=[(str('col'), 'S10')])
     t = table.Table(dat)
     assert t['col'].pformat() == ['col ', '----', ' val', u'bl\xe4h']

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -622,11 +622,11 @@ class TestAddRow(SetupData):
         t = table_types.Table(names=('a', 'b', 'c'), dtype=('(2,)i', 'S4', 'O'))
         t.add_row()
         assert np.all(t['a'][0] == [0, 0])
-        assert t['b'][0] == b''
+        assert t['b'][0] == ''
         assert t['c'][0] == 0
         t.add_row()
         assert np.all(t['a'][1] == [0, 0])
-        assert t['b'][1] == b''
+        assert t['b'][1] == ''
         assert t['c'][1] == 0
 
     def test_add_stuff_to_empty_table(self, table_types):
@@ -634,13 +634,13 @@ class TestAddRow(SetupData):
         t = table_types.Table(names=('a', 'b', 'obj'), dtype=('(2,)i', 'S8', 'O'))
         t.add_row([[1, 2], 'hello', 'world'])
         assert np.all(t['a'][0] == [1, 2])
-        assert t['b'][0] == b'hello'
+        assert t['b'][0] == 'hello'
         assert t['obj'][0] == 'world'
         # Make sure it is not repeating last row but instead
         # adding zeros (as documented)
         t.add_row()
         assert np.all(t['a'][1] == [0, 0])
-        assert t['b'][1] == b''
+        assert t['b'][1] == ''
         assert t['obj'][1] == 0
 
     def test_add_table_row(self, table_types):
@@ -1465,8 +1465,8 @@ def test_unicode_bytestring_conversion(table_types):
     assert t1['col0'].dtype.kind == 'S'
     assert t1['col1'].dtype.kind == 'S'
     assert t1['col2'].dtype.kind == 'i'
-    assert t1['col0'][0] == 'abc'.encode('ascii')
-    assert t1['col1'][0] == 'def'.encode('ascii')
+    assert t1['col0'][0] == 'abc'
+    assert t1['col1'][0] == 'def'
     assert t1['col2'][0] == 1
 
     t1 = t.copy()
@@ -1541,7 +1541,7 @@ class TestPandas(object):
                     t[endian + kind + byte] = x
 
         t['u'] = ['a','b','c']
-        t['s'] = [b'a', b'b', b'c']
+        t['s'] = ['a', 'b', 'c']
 
         d = t.to_pandas()
 
@@ -1550,7 +1550,7 @@ class TestPandas(object):
                 assert np.all(t['u'] == np.array(['a','b','c']))
                 assert d[column].dtype == np.dtype("O")  # upstream feature of pandas
             elif column == 's':
-                assert np.all(t['s'] == np.array([b'a',b'b',b'c']))
+                assert np.all(t['s'] == np.array(['a','b','c']))
                 assert d[column].dtype == np.dtype("O")  # upstream feature of pandas
             else:
                 # We should be able to compare exact values here
@@ -1614,7 +1614,7 @@ class TestPandas(object):
         t['u'] = ['a','b','c']
         t['u'].mask = [False, True, False]
 
-        t['s'] = [b'a', b'b', b'c']
+        t['s'] = ['a', 'b', 'c']
         t['s'].mask = [False, True, False]
 
         d = t.to_pandas()

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -692,19 +692,19 @@ single element of a bytestring column.  Previously one was required to compare
 with a ``bytes`` object while now one must compare with a ``str`` object.  When
 comparing with the entire column one can use either a ``bytes`` or ``str``.
 
-**Before astropy 2.0**
+.. doctest-skip-all
 
-.. doctest-skip::
+**Before astropy 2.0**
 
     >>> from astropy.table import Table
     >>> t = Table([['abc', 'def']], names=['a'], dtype=['S'])
-    >>>
+
     >>> t['a'] == 'abc'  # WRONG answer!
     False
-    >>>
+
     >>> t['a'] == b'abc'  # Must explicitly compare to bytestring
     array([ True, False], dtype=bool)
-    >>>
+
     >>> t = Table([['bä', 'def']], dtype=['S'])
     Traceback (most recent call last):
       ...
@@ -713,22 +713,20 @@ comparing with the entire column one can use either a ``bytes`` or ``str``.
 
 **Astropy 2.0 or later**:
 
-.. doctest-skip::
-
     >>> t = Table([['abc', 'def']], names=['a'], dtype=['S'])
-    
+
     >>> t['a'] == 'abc'  # Gives expected answer
     array([ True, False], dtype=bool)
-    
+
     >>> t['a'] == b'abc'  # Still gives expected answer
     array([ True, False], dtype=bool)
-    
+
     >>> t['a'][0] == 'abc'  # Expected answer
     True
-    
+
     >>> t['a'][0] == b'abc'  # API change, this NO LONGER WORKS
     False
-    
+
     >>> t['a'][0] = 'bä'
     >>> t
     <Table length=2>
@@ -737,10 +735,10 @@ comparing with the entire column one can use either a ``bytes`` or ``str``.
     ------
         bä
        def
-    
+
     >>> t['a'] == 'bä'
     array([ True, False], dtype=bool)
-    
+
     >>> # Round trip unicode strings through HDF5
     >>> t = Table([['bä', 'def']], dtype=['S'])
     >>> t.write('test.hdf5', format='hdf5', path='data', overwrite=True)

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -698,56 +698,56 @@ comparing with the entire column one can use either a ``bytes`` or ``str``.
 
     >>> from astropy.table import Table
     >>> t = Table([['abc', 'def']], names=['a'], dtype=['S'])
-
+    >>>
     >>> t['a'] == 'abc'  # WRONG answer!
     False
-
+    >>>
     >>> t['a'] == b'abc'  # Must explicitly compare to bytestring
     array([ True, False], dtype=bool)
-
+    >>>
     >>> t = Table([['bä', 'def']], dtype=['S'])
     Traceback (most recent call last):
       ...
-    UnicodeEncodeError: 'ascii' codec can't encode character '\xe4' in position 1: 
+    UnicodeEncodeError: 'ascii' codec can't encode character '\xe4' in position 1:
                         ordinal not in range(128)
 
-**Astropy 2.0 or later**
+**Astropy 2.0 or later**:
 
 .. doctest-skip::
 
     >>> t = Table([['abc', 'def']], names=['a'], dtype=['S'])
-
+    
     >>> t['a'] == 'abc'  # Gives expected answer
     array([ True, False], dtype=bool)
-
+    
     >>> t['a'] == b'abc'  # Still gives expected answer
     array([ True, False], dtype=bool)
-
+    
     >>> t['a'][0] == 'abc'  # Expected answer
     True
-
+    
     >>> t['a'][0] == b'abc'  # API change, this NO LONGER WORKS
     False
-
+    
     >>> t['a'][0] = 'bä'
     >>> t
     <Table length=2>
-      a   
+      a
     bytes3
     ------
         bä
        def
-
+    
     >>> t['a'] == 'bä'
     array([ True, False], dtype=bool)
-
-    # Round trip unicode strings through HDF5
+    
+    >>> # Round trip unicode strings through HDF5
     >>> t = Table([['bä', 'def']], dtype=['S'])
     >>> t.write('test.hdf5', format='hdf5', path='data', overwrite=True)
     >>> t2 = Table.read('test.hdf5', format='hdf5', path='data')
     >>> t2
     <Table length=2>
-     col0 
+     col0
     bytes3
     ------
         bä

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -32,6 +32,10 @@ Currently `astropy.table` is used when reading an ASCII table using
 `astropy.io.ascii`.  Future releases of Astropy are expected to use
 the |Table| class for other subpackages such as `astropy.io.votable` and `astropy.io.fits` .
 
+.. Warning:: Astropy 2.0 introduces an API change that affects comparison of
+   bytestring column elements in Python 3.  See
+   :ref:`bytestring-columns-python-3` for details.
+
 Getting Started
 ===============
 

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -14,6 +14,7 @@ the 1.3.x series of releases.
 
 In particular, this release includes:
 
+* `Easier use of efficient bytestring Table columns in Python 3`_
 *
 
 In addition to these major changes, Astropy 2.0 includes a large number of
@@ -24,6 +25,23 @@ smaller improvements and bug fixes, which are described in the
 * xxx pull requests have been merged since v1.3
 * xxx distinct people have contributed code
 
+Easier use of efficient bytestring Table columns in Python 3
+============================================================
+
+Working with bytestring Table columns (numpy ``'S'`` dtype) in Python
+3 has been made more convenient because it is now possible to compare
+and set array elements with the natural Python string (``str``) type.
+Previously one had to use the Python ``bytes`` type and bytestring literals
+like ``b'hello'``.  This change allows working with ASCII data columns
+in Python 3 using only 1-byte per character instead of the default
+4-bytes per character for the numpy ``'U'`` unicode dtype.  For large
+datasets this improves memory performance.
+
+Please see :ref:`bytestring-columns-python-3` for details.  Note that no
+change has been made to behavior for Python 2.
+
+.. Note:: This introduces an API change that affects comparison of
+     bytestring column elements in Python 3.
 
 Other significant changes
 =========================


### PR DESCRIPTION
Currently the numpy bytestring (`S` ) dtype is difficult to use in Python 3 because one cannot assign or compare to the natural `str` type.  When dealing with most FITS or HDF5 or other binary type tabular data formats, text data will be read into a table that has `S` type columns.

This led to one workaround #1974 around 3 years ago to make it easy to convert `S` columns in a table to unicode.  So you can write natural code that works, but you still pay a big price because memory use inflates by a factor of 4 by going to the numpy `U` type.

Now taking inspiration from the work that @embray did at https://github.com/embray/PyFITS/blob/stringy/lib/pyfits/fitsrec.py#L999, this PR implements the idea of the unicode sandwich for bytestring Table columns (see http://nedbatchelder.com/text/unipain.html for discussion of the sandwich concept).  

In Python 3 the values are always *decoded* as UTF-8 when being accessed, and always *encoded* as UTF-8 when being set.  The upshot is that bytestring columns have the same behavior in Python 2 and 3 with respect to natural usage with the default `str` type.

One important feature is that this PR takes pains to not do anything differently for Python 2.  Basically all the code only applies to Python 3.

To be clear, this will be a significant API change because if people have been using bytestring literals in their Python 3 code, then that will break.  But that is definitely the wrong way to do it.  Astropy 2.0 seems like a nice opportunity for this API change.