### PR TITLE
Change [pep8] to [pycodestyle] in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ bitmap = static/wininst_background.bmp
 [ah_bootstrap]
 auto_use = True
 
-[pep8]
+[pycodestyle]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
 # W291 - trailing whitespace


### PR DESCRIPTION
Change `[pep8]` to `[pycodestyle]` in `setup.cfg` to remove the following deprecation warning in Travis CI:

```
/home/travis/miniconda/envs/test/lib/python3.5/site-packages/pycodestyle.py:2155:
  UserWarning: [pep8] section is deprecated. Use [pycodestyle].

  warnings.warn('[pep8] section is deprecated. Use [pycodestyle].')
```