### PR TITLE
Adding new_table to the list of removed functions 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -442,7 +442,8 @@ API Changes
       ``create_card``, ``create_card_from_string``, ``upper_key``,
       ``Header.ascard``, ``Header.rename_key``, ``Header.get_history``,
       ``Header.get_comment``, ``Header.toTxtFile``, ``Header.fromTxtFile``,
-      ``tdump``, ``tcreate``, ``BinTableHDU.tdump``, ``BinTableHDU.tcreate``.
+      ``new_table``, ``tdump``, ``tcreate``, ``BinTableHDU.tdump``,
+      ``BinTableHDU.tcreate``.
 
     - Removed ``txtfile`` argument to the ``Header`` constructor.
 


### PR DESCRIPTION
This should close #5704, and need to be backported into 1.3.1 