### PR TITLE
fix bounding_box setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,7 +197,7 @@ Bug Fixes
 
 - ``astropy.modeling``
  
-  - Fixed a problem with setting ``bounding_box`` on 1D models. [5718]
+  - Fixed a problem with setting ``bounding_box`` on 1D models. [#5718]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -196,6 +196,8 @@ Bug Fixes
     ``PyMem_Realloc()`` [#5696, #4739, #2100]
 
 - ``astropy.modeling``
+ 
+  - Fixed a problem with setting ``bounding_box`` on 1D models. [5718]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -342,3 +342,26 @@ def test_render_model_3d():
                 if (z0, y0, x0) == (8, 10, 13):
                     boxed = model.render()
                     assert (np.sum(expected) - np.sum(boxed)) == 0
+
+
+def test_custom_bounding_box_1d():
+    """
+    Tests that the bounding_box setter works.
+    """
+    # 1D models
+    g1 = models.Gaussian1D()
+    bb = g1.bounding_box
+    expected = g1.render()
+
+    # assign the same bounding_box, now through the bounding_box setter
+    g1.bounding_box = bb
+    assert_allclose(g1.render(), expected)
+
+    # 2D models
+    g2 = models.Gaussian2D()
+    bb = g2.bounding_box
+    expected = g2.render()
+
+    # assign the same bounding_box, now through the bounding_box setter
+    g2.bounding_box = bb
+    assert_allclose(g2.render(), expected)

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -408,7 +408,7 @@ class _BoundingBox(tuple):
             if len(bounding_box) == 1:
                 return cls((tuple(bounding_box[0]),))
             else:
-                return cls((tuple(bounding_box),))
+                return cls(tuple(bounding_box))
         else:
             msg = ("Bounding box for {0} model must be a sequence of length "
                    "{1} (the number of model inputs) consisting of pairs of "


### PR DESCRIPTION
Fixes a bug in the `bounding_box` setter for 1D models. A failing example is:

```
p = Polynomial1D(1, c0=10, c1=1)
p.bounding_box=(-1., 3.)
p.render()
/user/dencheva/conda-dev/envs/jwstdev/lib/python3.5/site-packages/astropy/modeling/core.py in <listcomp>(.0)
   1124             pd = np.array([(np.mean(bb), np.ceil((bb[1] - bb[0]) / 2))
-> 1125                            for bb in bbox]).astype(int).T
   
IndexError: tuple index out of range

```