### PR TITLE
Fix out-of-order TUNITn cards when writing tables to FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -191,6 +191,8 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Fix out-of-order TUNITn cards when writing tables to FITS. [#5720]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -473,8 +473,7 @@ def table_to_hdu(table):
             if column.dtype.kind == 'f' and np.allclose(fill_value, 1e20):
                 column.set_fill_value(np.nan)
 
-        fits_rec = FITS_rec.from_columns(np.array(table.filled()))
-        table_hdu = BinTableHDU(fits_rec)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()))
         for col in table_hdu.columns:
             # Binary FITS tables support TNULL *only* for integer data columns
             # TODO: Determine a schema for handling non-integer masked columns
@@ -491,8 +490,7 @@ def table_to_hdu(table):
 
             col.null = fill_value.astype(table[col.name].dtype)
     else:
-        fits_rec = FITS_rec.from_columns(np.array(table.filled()))
-        table_hdu = BinTableHDU(fits_rec)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()))
 
     # Set units for output HDU
     for col in table_hdu.columns:

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -54,6 +54,10 @@ class TestConvenience(FitsTestCase):
             assert len(w) == 1
             assert str(w[0].message).startswith("'not-a-unit' did not parse as fits unit")
 
+        # Check that TUNITn cards appear in the correct order
+        # (https://github.com/astropy/astropy/pull/5720)
+        assert hdu.header.index('TUNIT1') < hdu.header.index('TTYPE2')
+
         assert isinstance(hdu, fits.BinTableHDU)
         filename = str(tmpdir.join('test_table_to_hdu.fits'))
         hdu.writeto(filename, overwrite=True)


### PR DESCRIPTION
When writing an `astropy.table.Table` instance to a FITS file, the metadata for each column should appear contiguously. There is a bug where the `TUNITn` cards show up all at the end of the header instead of immediately after the corresponding `TUNITn` and `TFORMn` cards. For example:

    >>> from astropy.io import fits
    >>> from astropy.table import Table
    >>> from astropy import units as u
    >>> table = Table(rows=[[1.0, 2.0, 3.0]], names='foo bar bat'.split())
    >>> table['foo'].unit = u.arcsec
    >>> table['bar'].unit = u.Mpc
    >>> table['bat'].unit = u.mag * u.arcsec**-2
    >>> table.write('test.fits')
    >>> fits.getheader('test.fits', 1)
    XTENSION= 'BINTABLE'           / binary table extension
    BITPIX  =                    8 / array data type
    NAXIS   =                    2 / number of array dimensions
    NAXIS1  =                   24 / length of dimension 1
    NAXIS2  =                    1 / length of dimension 2
    PCOUNT  =                    0 / number of group parameters
    GCOUNT  =                    1 / number of groups
    TFIELDS =                    3 / number of table fields
    TTYPE1  = 'foo     '
    TFORM1  = 'D       '
    TTYPE2  = 'bar     '
    TFORM2  = 'D       '
    TTYPE3  = 'bat     '
    TFORM3  = 'D       '
    TUNIT1  = 'arcsec  '
    TUNIT2  = 'Mpc     '
    TUNIT3  = 'arcsec-2 mag'

I studied how the column metadata are added and I determined that the root cause is that `astropy.io.fits.hdu.table._TableBaseHDU._update_column_attribute_changed` is not getting called. I added the following line to `astropy.io.fits.convenience.table_to_hdu`:

        table_hdu.columns._add_listener(table_hdu)

Although I doubt that is where this code should go, this patch does fix it so that the `TUNITn` fields appear in the correct order, like this:

    XTENSION= 'BINTABLE'           / binary table extension
    BITPIX  =                    8 / array data type
    NAXIS   =                    2 / number of array dimensions
    NAXIS1  =                   24 / length of dimension 1
    NAXIS2  =                    1 / length of dimension 2
    PCOUNT  =                    0 / number of group parameters
    GCOUNT  =                    1 / number of groups
    TFIELDS =                    3 / number of table fields
    TTYPE1  = 'foo     '
    TFORM1  = 'D       '
    TUNIT1  = 'arcsec  '
    TTYPE2  = 'bar     '
    TFORM2  = 'D       '
    TUNIT2  = 'Mpc     '
    TTYPE3  = 'bat     '
    TFORM3  = 'D       '
    TUNIT3  = 'arcsec-2 mag'