### PR TITLE
Adding YES and NO in Boolean converter + test

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -1177,6 +1177,8 @@ class Boolean(Converter):
             return False, True
         mapping = {'TRUE'  : (True, False),
                    'FALSE' : (False, False),
+                   'YES'   : (True, False),
+                   'NO'    : (False, False),
                    '1'     : (True, False),
                    '0'     : (False, False),
                    'T'     : (True, False),

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -182,7 +182,7 @@ def test_boolean():
         None, name='c', datatype='boolean',
         config=config)
     c = converters.get_converter(field, config=config)
-    c.parse('YES')
+    c.parse('XXX')
 
 
 def test_boolean_array():


### PR DESCRIPTION
Parsing the Exoplanet catalogue of exoplanet.eu, I stumbled upon "Yes" data cells of Bool datatype. And I am wondering why these were not included in the Boolean converter of astropy (a matter of discussion, I totally agree). So here they are. But if there was a reason for not included `Yes` and `No`, I'm happy to hear why.