### PR TITLE
Documentation guidelines still have v0.4 notes

### DIFF
--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -59,9 +59,8 @@ The details of the docstring format are described on a separate page:
 Sphinx Documentation Themes
 ---------------------------
 
-A custom Sphinx HTML theme is included in the `astropy-helpers`_ package (it is
-also included in Astropy's source package, but this will be removed after v0.4
-and subsequently only be available through astropy-helpers). This allows the
+A custom Sphinx HTML theme is included in the `astropy-helpers`_ package. 
+This allows the
 theme to be used by both Astropy and affiliated packages. This is done by
 setting the theme in the global Astropy sphinx configuration, which is imported
 in the sphinx configuration of both Astropy and affiliated packages.
@@ -98,14 +97,6 @@ Sphinx extensions
 Astropy-helpers includes a number of sphinx extensions that are used in Astropy
 and its affiliated packages to facilitate easily documenting code in a
 homogeneous and readable way.
-
-.. note::
-
-  These extensions are also included with Astropy itself in v0.4 and
-  below, to facilitate backwards-compatibility for existing affiliated
-  packages.  The versions actually in astropy will not receive further
-  updates, however, and will likely be removed in a future version. So
-  we strongly recommend using the astropy-helper versions instead.
 
 
 automodapi Extension


### PR DESCRIPTION
Even worse, they say "will be removed in version 0.4" indicating that version 0.4 is a thing of the future not the past.
I looked for the extensions in astropy itself and could not find them; thus I'm fairly certain that there where actually removed. In principle, I could obviously go through old PRs and reference them here but it's soooo long ago that I don't really feel the need to find the number of the PR that removed that stuff.