### PR TITLE
`SkyCoord.directional_offset_by()` and `.directional_offset_to()` functions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ astropy.coordinates
   speedups (up to 50% in some cases) when creating new scalar frame or
   ``SkyCoord`` objects. [#7949]
 
+- Added a ``directional_offset_by`` method to ``SkyCoord` that computes a new
+  coordinate given a coordinate, position angle, and angular separation [#5727]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,7 @@ astropy.coordinates
   speedups (up to 50% in some cases) when creating new scalar frame or
   ``SkyCoord`` objects. [#7949]
 
-- Added a ``directional_offset_by`` method to ``SkyCoord` that computes a new
+- Added a ``directional_offset_by`` method to ``SkyCoord`` that computes a new
   coordinate given a coordinate, position angle, and angular separation [#5727]
 
 astropy.cosmology

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -746,14 +746,14 @@ def offset_by(lon, lat, posang, distance):
         Longitude and latitude of the starting point,
         position angle and distance to the final point.
         Quantities should be in angular units; floats in radians.
-        Polar points at lat= +/-90 are treated as +/-(90-epsilon) and same lon
+        Polar points at lat= +/-90 are treated as limit of +/-(90-epsilon) and same lon.
 
     Returns
     -------
     lon, lat : `~astropy.coordinates.Angle`
         The position of the final point.  If any of the angles are arrays,
         these will contain arrays following the appropriate `numpy` broadcasting rules.
-        0 <= lon < 2pi
+        0 <= lon < 2pi.
 
     Notes
     -----

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -735,3 +735,69 @@ def position_angle(lon1, lat1, lon2, lat2):
     y = np.sin(deltalon) * colat
 
     return Angle(np.arctan2(y, x), u.radian).wrap_at(360*u.deg)
+
+def offset_by(lon, lat, posang, distance):
+    """
+    Point with the given offset from the given point.
+
+    Parameters
+    ----------
+    lon, lat, posang, distance : `Angle`, `~astropy.units.Quantity` or float
+        Longitude and latitude of the starting point,
+        position angle and distance to the final point.
+        Quantities should be in angular units; floats in radians.
+        Polar points at lat= +/-90 are treated as +/-(90-epsilon) and same lon
+
+    Returns
+    -------
+    lon, lat : `~astropy.coordinates.Angle`
+        The position of the final point.  If any of the angles are arrays,
+        these will contain arrays following the appropriate `numpy` broadcasting rules.
+        0 <= lon < 2pi
+
+    Notes
+    -----
+    """
+    from .angles import Angle
+
+    # Calculations are done using the spherical trigonometry sine and cosine rules
+    # of the triangle A at North Pole,   B at starting point,   C at final point
+    # with angles     A (change in lon), B (posang),            C (not used, but negative reciprocal posang)
+    # with sides      a (distance),      b (final co-latitude), c (starting colatitude)
+    # B, a, c are knowns; A and b are unknowns
+    # https://en.wikipedia.org/wiki/Spherical_trigonometry
+
+    cos_a = np.cos(distance)
+    sin_a = np.sin(distance)
+    cos_c = np.sin(lat)
+    sin_c = np.cos(lat)
+    cos_B = np.cos(posang)
+    sin_B = np.sin(posang)
+
+    # cosine rule: Know two sides: a,c and included angle: B; get unknown side b
+    cos_b = cos_c * cos_a + sin_c * sin_a * cos_B
+    # sin_b = np.sqrt(1 - cos_b**2)
+    # sine rule and cosine rule for A (using both lets arctan2 pick quadrant).
+    # multiplying both sin_A and cos_A by x=sin_b * sin_c prevents /0 errors
+    # at poles.  Correct for the x=0 multiplication a few lines down.
+    # sin_A/sin_a == sin_B/sin_b    # Sine rule
+    xsin_A = sin_a * sin_B * sin_c
+    # cos_a == cos_b * cos_c + sin_b * sin_c * cos_A  # cosine rule
+    xcos_A = cos_a - cos_b * cos_c
+
+    A = Angle(np.arctan2(xsin_A, xcos_A), u.radian)
+    # Treat the poles as if they are infinitesimally far from pole but at given lon
+    # The +0*xsin_A is to broadcast a scalar to vector as necessary
+    w_pole = np.argwhere((sin_c + 0*xsin_A) < 1e-12)
+    if len(w_pole) > 0:
+        # For south pole (cos_c = -1), A = posang; for North pole, A=180 deg - posang
+        A_pole = (90*u.deg + cos_c*(90*u.deg-Angle(posang, u.radian))).to(u.rad)
+        try:
+            A[w_pole] = A_pole[w_pole]
+        except TypeError as e: # scalar
+            A = A_pole
+
+    outlon = (Angle(lon, u.radian) + A).wrap_at(360.0*u.deg).to(u.deg)
+    outlat = Angle(np.arcsin(cos_b), u.radian).to(u.deg)
+
+    return outlon, outlat

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -949,7 +949,7 @@ class SkyCoord(ShapedLikeNDArray):
             The (positive) position angle of the vector pointing from ``self``
             to ``tocoord``.
         separation : `~astropy.coordinates.Angle`
-            The distance between ``self`` and ``tocoord``.
+            The angular separation between ``self`` and ``tocoord``.
 
         If either ``self`` or ``tocoord`` contain arrays, these will be a
         arrays following the appropriate `numpy` broadcasting rules.
@@ -961,6 +961,7 @@ class SkyCoord(ShapedLikeNDArray):
         directional_offset_by : use offset to go from a coordinate to a new coordinate.
 
         """
+        from . import angle_utilities
 
         if self.is_equivalent_frame(tocoord):
             other_in_self_frame = tocoord
@@ -1005,6 +1006,8 @@ class SkyCoord(ShapedLikeNDArray):
         system for small offsets.
 
         """
+        from . import angle_utilities
+
         slat = self.represent_as(UnitSphericalRepresentation).lat
         slon = self.represent_as(UnitSphericalRepresentation).lon
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -996,11 +996,11 @@ class SkyCoord(ShapedLikeNDArray):
         Notes
         -----
         Returned SkyCoord frame retains only those parameters specific
-        to the frame type.  (e.g. if the input frame is `ICRS`, an `equinox`
-        value will be retained, but an `obstime` will not.)
+        to the frame type.  (e.g. if the input frame is `~astropy.coordinates.ICRS`, an ``equinox``
+        value will be retained, but an ``obstime`` will not.)
 
-        For a more complete set of transform offsets, use the `WCS` framework.
-        `SkyOffsetFrame` can also be used to create a spherical frame with
+        For a more complete set of transform offsets, use the `~astropy.wcs.WCS` framework.
+        `~astropy.coordinates.SkyCoord` can also be used to create a spherical frame with
         (lat=0,lon=0) at a reference point, approximating an xy cartesian
         system for small offsets.
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1000,8 +1000,8 @@ class SkyCoord(ShapedLikeNDArray):
         value will be retained, but an ``obstime`` will not.)
 
         For a more complete set of transform offsets, use the `~astropy.wcs.WCS` framework.
-        `~astropy.coordinates.SkyCoord` can also be used to create a spherical frame with
-        (lat=0,lon=0) at a reference point, approximating an xy cartesian
+        `~astropy.coordinates.SkyCoord.skyoffset_frame()` can also be used to create a spherical
+        frame with (lat=0, lon=0) at a reference point, approximating an xy cartesian
         system for small offsets.
 
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -921,7 +921,6 @@ class SkyCoord(ShapedLikeNDArray):
         --------
         separation : for the *total* angular offset (not broken out into components).
         position_angle : for the direction of the offset.
-        directional_offsets_to : for both position_angle and separation.
 
         """
         if not self.is_equivalent_frame(tocoord):
@@ -934,76 +933,40 @@ class SkyCoord(ShapedLikeNDArray):
         dlat = acoord.spherical.lat.view(Angle)
         return dlon, dlat
 
-    def directional_offsets_to(self, tocoord):
-        r"""
-        Computes direction and distance to go *from* this coordinate *to* another.
-
-        Parameters
-        ----------
-        tocoord : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
-            The coordinate to find the offset to.
-
-        Returns
-        -------
-        position_angle : `~astropy.coordinates.Angle`
-            The (positive) position angle of the vector pointing from ``self``
-            to ``tocoord``.
-        separation : `~astropy.coordinates.Angle`
-            The angular separation between ``self`` and ``tocoord``.
-
-        If either ``self`` or ``tocoord`` contain arrays, these will be a
-        arrays following the appropriate `numpy` broadcasting rules.
-
-        See Also
-        --------
-        position_angle : for the postion_angle component.
-        separation : for the angular offset component.
-        directional_offset_by : use offset to go from a coordinate to a new coordinate.
-
-        """
-        from . import angle_utilities
-
-        if self.is_equivalent_frame(tocoord):
-            other_in_self_frame = tocoord
-        else:
-            other_in_self_frame = tocoord.frame.transform_to(self.frame)
-
-        slat = self.represent_as(UnitSphericalRepresentation).lat
-        slon = self.represent_as(UnitSphericalRepresentation).lon
-        olat = other_in_self_frame.represent_as(UnitSphericalRepresentation).lat
-        olon = other_in_self_frame.represent_as(UnitSphericalRepresentation).lon
-
-        posang = angle_utilities.position_angle(slon, slat, olon, olat)
-        separation = angle_utilities.angular_separation(slon, slat, olon, olat)
-        return Angle(posang), Angle(separation)
-
     def directional_offset_by(self, position_angle, separation):
-        r"""
+        """
         Computes coordinates at the given offset from this coordinate.
 
         Parameters
         ----------
-        All parameters are `~astropy.coordinates.Angle` or float,
-        where float values are radians.
-
-        position_angle : position_angle of offset.
-        separation : offset distance.
+        position_angle : `~astropy.coordinates.Angle`
+            position_angle of offset
+        separation : `~astropy.coordinates.Angle`
+            offset angular separation
 
         Returns
         -------
-        newpoints : SkyCoord offset by the given values.
-            `numpy` broadcasting rules apply if self or any arguments are arrays.
+        newpoints : `~astropy.coordinates.SkyCoord`
+            The coordinates for the location that corresponds to offsetting by
+            the given `position_angle` and `separation`.
 
         Notes
         -----
-        Returned SkyCoord frame retains only those parameters specific
-        to the frame type.  (e.g. if the input frame is `~astropy.coordinates.ICRS`, an ``equinox``
-        value will be retained, but an ``obstime`` will not.)
+        Returned SkyCoord frame retains only the frame attributes that are for
+        the resulting frame type.  (e.g. if the input frame is
+        `~astropy.coordinates.ICRS`, an ``equinox`` value will be retained, but
+        an ``obstime`` will not.)
 
-        For a more complete set of transform offsets, use the `~astropy.wcs.WCS` framework.
-        `~astropy.coordinates.SkyCoord.skyoffset_frame()` can also be used to create a spherical
-        frame with (lat=0, lon=0) at a reference point, approximating an xy cartesian
-        system for small offsets.
+        For a more complete set of transform offsets, use `~astropy.wcs.WCS`.
+        `~astropy.coordinates.SkyCoord.skyoffset_frame()` can also be used to
+        create a spherical frame with (lat=0, lon=0) at a reference point,
+        approximating an xy cartesian system for small offsets. This method
+        is distinct in that it is accurate on the sphere.
+
+        See Also
+        --------
+        position_angle : inverse operation for the ``position_angle`` component
+        separation : inverse operation for the ``separation`` component
 
         """
         from . import angle_utilities
@@ -1011,12 +974,11 @@ class SkyCoord(ShapedLikeNDArray):
         slat = self.represent_as(UnitSphericalRepresentation).lat
         slon = self.represent_as(UnitSphericalRepresentation).lon
 
-        newlon,newlat = angle_utilities.offset_by(
+        newlon, newlat = angle_utilities.offset_by(
             lon=slon, lat=slat,
             posang=position_angle, distance=separation)
 
-        result = SkyCoord(newlon, newlat, frame=self.frame)
-        return result
+        return SkyCoord(newlon, newlat, frame=self.frame)
 
     def match_to_catalog_sky(self, catalogcoord, nthneighbor=1):
         """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -632,10 +632,13 @@ def test_directional_offset_by():
                     SkyCoord(np.linspace(0, 359, npoints), np.linspace(-90, 90, npoints),
                              unit=u.deg, frame='galactic')]:
             # Find the displacement from sc1 to sc2,
-            posang,sep = sc1.directional_offsets_to(sc2)
+            posang = sc1.position_angle(sc2)
+            sep = sc1.separation(sc2)
+
             # then do the offset from sc1 and verify that you are at sc2
             sc2a = sc1.directional_offset_by(position_angle=posang, separation=sep)
             assert np.max(np.abs(sc2.separation(sc2a).arcsec)) < 1e-3
+
     # Specific test cases
     # Go over the North pole a little way, and
     # over the South pole a long way, to get to same spot
@@ -647,6 +650,7 @@ def test_directional_offset_by():
         # and that >360deg is supported
         sc2 = sc1.directional_offset_by(posang, 2*sep)
         assert allclose([sc2.ra.degree, sc2.dec.degree], [180, 87])
+
     # Verify that a separation of 180 deg in any direction gets to the antipode
     # and 360 deg returns to start
     sc1 = SkyCoord(10*u.deg, 47*u.deg)
@@ -655,6 +659,7 @@ def test_directional_offset_by():
         assert allclose([sc2.ra.degree, sc2.dec.degree], [190, -47])
         sc2 = sc1.directional_offset_by(posang, 360*u.deg)
         assert allclose([sc2.ra.degree, sc2.dec.degree], [10, 47])
+
     # Verify that a 90 degree posang, which means East
     # corresponds to an increase in RA, by ~separation/cos(dec) and
     # a slight convergence to equator
@@ -662,6 +667,7 @@ def test_directional_offset_by():
     sc2 = sc1.directional_offset_by(90*u.deg, 1.0*u.deg)
     assert 11.9 < sc2.ra.degree < 12.0
     assert 59.9 < sc2.dec.degree < 60.0
+
 
 def test_table_to_coord():
     """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -615,6 +615,22 @@ def test_sep_pa_equivalence():
     assert_allclose(sep3d_forward, sep3d_backward)
 
 
+def test_directional_offset_by():
+    npoints = 7 # How many points when doing vectors of SkyCoords
+    for sc1 in [SkyCoord(0*u.deg,-90*u.deg),    # South pole
+                SkyCoord(0 * u.deg, 90 * u.deg), # North pole
+                SkyCoord(1*u.deg,2*u.deg),
+                SkyCoord(np.linspace(0,359,npoints),np.linspace(-90, 90,npoints), unit=u.deg, frame='fk4'),
+                SkyCoord(np.linspace(359,0,npoints),np.linspace(-90, 90,npoints), unit=u.deg, frame='icrs'),
+                SkyCoord(np.linspace(-3,3,npoints),np.linspace(-90, 90,npoints), unit=(u.rad, u.deg), frame='barycentrictrueecliptic')]:
+        for sc2 in [SkyCoord(5*u.deg,10*u.deg),
+                    SkyCoord(np.linspace(0, 359, npoints), np.linspace(-90, 90, npoints), unit=u.deg, frame='galactic')]:
+            # Find the displacement from sc1 to sc2, then do the offset from sc1 and verify that you are at sc2
+            posang,sep = sc1.directional_offsets_to(sc2)
+            sc2a = sc1.directional_offset_by(position_angle=posang, separation=sep)
+            assert np.max(np.abs(sc2.separation(sc2a).arcsec)) < 1e-3
+
+
 def test_table_to_coord():
     """
     Checks "end-to-end" use of `Table` with `SkyCoord` - the `Quantity`

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -616,20 +616,52 @@ def test_sep_pa_equivalence():
 
 
 def test_directional_offset_by():
+    # Round-trip tests: where is sc2 from sc1?
+    # Use those offsets from sc1 and verify you get to sc2.
     npoints = 7 # How many points when doing vectors of SkyCoords
     for sc1 in [SkyCoord(0*u.deg,-90*u.deg),    # South pole
                 SkyCoord(0 * u.deg, 90 * u.deg), # North pole
                 SkyCoord(1*u.deg,2*u.deg),
-                SkyCoord(np.linspace(0,359,npoints),np.linspace(-90, 90,npoints), unit=u.deg, frame='fk4'),
-                SkyCoord(np.linspace(359,0,npoints),np.linspace(-90, 90,npoints), unit=u.deg, frame='icrs'),
-                SkyCoord(np.linspace(-3,3,npoints),np.linspace(-90, 90,npoints), unit=(u.rad, u.deg), frame='barycentrictrueecliptic')]:
+                SkyCoord(np.linspace(0,359,npoints),np.linspace(-90, 90,npoints),
+                         unit=u.deg, frame='fk4'),
+                SkyCoord(np.linspace(359,0,npoints),np.linspace(-90, 90,npoints),
+                         unit=u.deg, frame='icrs'),
+                SkyCoord(np.linspace(-3,3,npoints),np.linspace(-90, 90,npoints),
+                         unit=(u.rad, u.deg), frame='barycentrictrueecliptic')]:
         for sc2 in [SkyCoord(5*u.deg,10*u.deg),
-                    SkyCoord(np.linspace(0, 359, npoints), np.linspace(-90, 90, npoints), unit=u.deg, frame='galactic')]:
-            # Find the displacement from sc1 to sc2, then do the offset from sc1 and verify that you are at sc2
+                    SkyCoord(np.linspace(0, 359, npoints), np.linspace(-90, 90, npoints),
+                             unit=u.deg, frame='galactic')]:
+            # Find the displacement from sc1 to sc2,
             posang,sep = sc1.directional_offsets_to(sc2)
+            # then do the offset from sc1 and verify that you are at sc2
             sc2a = sc1.directional_offset_by(position_angle=posang, separation=sep)
             assert np.max(np.abs(sc2.separation(sc2a).arcsec)) < 1e-3
-
+    # Specific test cases
+    # Go over the North pole a little way, and
+    # over the South pole a long way, to get to same spot
+    sc1 = SkyCoord(0*u.deg, 89*u.deg)
+    for posang,sep in [(0*u.deg, 2*u.deg), (180*u.deg, 358*u.deg)]:
+        sc2 = sc1.directional_offset_by(posang, sep)
+        assert allclose([sc2.ra.degree, sc2.dec.degree], [180, 89])
+        # Go twice as far to ensure that dec is actually changing
+        # and that >360deg is supported
+        sc2 = sc1.directional_offset_by(posang, 2*sep)
+        assert allclose([sc2.ra.degree, sc2.dec.degree], [180, 87])
+    # Verify that a separation of 180 deg in any direction gets to the antipode
+    # and 360 deg returns to start
+    sc1 = SkyCoord(10*u.deg, 47*u.deg)
+    for posang in np.linspace(0, 377, npoints):
+        sc2 = sc1.directional_offset_by(posang, 180*u.deg)
+        assert allclose([sc2.ra.degree, sc2.dec.degree], [190, -47])
+        sc2 = sc1.directional_offset_by(posang, 360*u.deg)
+        assert allclose([sc2.ra.degree, sc2.dec.degree], [10, 47])
+    # Verify that a 90 degree posang, which means East
+    # corresponds to an increase in RA, by ~separation/cos(dec) and
+    # a slight convergence to equator
+    sc1 = SkyCoord(10*u.deg, 60*u.deg)
+    sc2 = sc1.directional_offset_by(90*u.deg, 1.0*u.deg)
+    assert 11.9 < sc2.ra.degree < 12.0
+    assert 59.9 < sc2.dec.degree < 60.0
 
 def test_table_to_coord():
     """

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -2,8 +2,8 @@
 
 .. _astropy-coordinates-separations-matching:
 
-Separations, Catalog Matching, and Related Functionality
-********************************************************
+Separations, Offsets, Catalog Matching, and Related Functionality
+*****************************************************************
 
 `astropy.coordinates` contains commonly-used tools for comparing or
 matching coordinate objects.  Of particular importance are those for
@@ -60,6 +60,41 @@ defined::
     >>> sep  # doctest: +FLOAT_CMP
     <Distance 28.743988157814094 kpc>
 
+
+Offsets
+=======
+
+Closely related to angular separations are offsets between coordinates. The key
+distinction for offsets is generally the concept of a "from" and "to" coordinate
+rather than the single scalar angular offset of a separation.
+`~astropy.coordinates` contains conveniences to compute some of the common
+offsets encountered in astronomy.
+
+The first piece of such functionality is the
+:meth:`~astropy.coordinates.SkyCoord.position_angle` method, which gives the
+conventional astronomy position angle (positive angles East of North) from one
+the |skycoord| it is called on to another given as the argument::
+
+    >>> from astropy.coordinates import SkyCoord
+    >>> c1 = SkyCoord(1*u.deg, 1*u.deg, frame='icrs')
+    >>> c2 = SkyCoord(2*u.deg, 2*u.deg, frame='icrs')
+    >>> c1.position_angle(c2).to(u.deg)  # doctest: +FLOAT_CMP
+    <Angle 44.97818294 deg>
+
+The combination of :meth:`~astropy.coordinates.SkyCoord.separation` and
+:meth:`~astropy.coordinates.SkyCoord.position_angle` thus give a set of
+directional offsets. To do the inverse operation - determining the new
+"destination" coordinate given a separation and position angle - the
+:meth:`~astropy.coordinates.SkyCoord.directional_offset_by` method is provided::
+
+    >>> from astropy.coordinates import SkyCoord
+    >>> c1 = SkyCoord(1*u.deg, 1*u.deg, frame='icrs')
+    >>> position_angle = 45 * u.deg
+    >>> separation = 1.414 * u.deg
+    >>> c1.directional_offset_by(position_angle, separation)  # doctest: +FLOAT_CMP
+    <SkyCoord (ICRS): (ra, dec) in deg
+    (2.0004075, 1.99964588)>
+
 There is also a :meth:`~astropy.coordinates.SkyCoord.spherical_offsets_to` method
 for computing angular offsets (e.g., small shifts like you might give a
 telescope operator to move from a bright star to a fainter target.)::
@@ -73,10 +108,11 @@ telescope operator to move from a bright star to a fainter target.)::
     >>> ddec.to(u.arcsec)  # doctest: +FLOAT_CMP
     <Angle 10.605103417374696 arcsec>
 
+
 .. _astropy-skyoffset-frames:
 
 "Sky Offset" Frames
-===================
+-------------------
 
 To extend the concept of spherical offsets, `~astropy.coordinates` has
 a frame class :class:`~astropy.coordinates.builtin_frames.skyoffset.SkyOffsetFrame`


### PR DESCRIPTION
This pull request is not ready to be accepted.  It is placed here as a strawman for discussion.

This is an enhancement discussed in #5702.  It depends on and incorporates PR #5723 (which is not yet accepted, but which has code that is used here.)

Some decisions need to be made.   In particular for
```
     def offset_by(self, position_angle=None, separation=None,
                  dra=None, dra_distance=None, ddec=None,
                  dlon=None, dlon_distance=None, dlat=None):
```
we may want to remove the dra/ddec/dlon/dlat functionality or replace it with the something more aware of spherical coordinates.

Also, the function doesn't preserve obstime, pressure, etc.  This functionality needs to be added, and this is best done in combination with PR #5703 (also not yet accepted).


Also, crawfordsm #5715 (sigma clipping) got tangled into my work, and due to the github standard of  squashing and discarding all the version control information, I will have to separate it out manually.
I will do this when I update or replace this pull request.
