### PR TITLE
Prevent PLY to overwrite its generated files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -225,6 +225,8 @@ Bug Fixes
 
 - ``astropy.extern``
 
+  - Fixed a bug where PLY was overwriting its generated files. [#5728]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -126,6 +126,7 @@ class _AngleParser(object):
                 "Invalid character at col {0}".format(t.lexpos))
 
         # Build the lexer
+        # PY2: need str() to ensure we do not pass on a unicode object.
         lexer = lex.lex(optimize=True, lextab=str('angle_lextab'),
                         outputdir=os.path.dirname(__file__))
 
@@ -251,6 +252,7 @@ class _AngleParser(object):
         def p_error(p):
             raise ValueError
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         parser = yacc.yacc(debug=False, tabmodule=str('angle_parsetab'),
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -126,7 +126,7 @@ class _AngleParser(object):
                 "Invalid character at col {0}".format(t.lexpos))
 
         # Build the lexer
-        lexer = lex.lex(optimize=True, lextab='angle_lextab',
+        lexer = lex.lex(optimize=True, lextab=str('angle_lextab'),
                         outputdir=os.path.dirname(__file__))
 
         def p_angle(p):
@@ -251,7 +251,7 @@ class _AngleParser(object):
         def p_error(p):
             raise ValueError
 
-        parser = yacc.yacc(debug=False, tabmodule='angle_parsetab',
+        parser = yacc.yacc(debug=False, tabmodule=str('angle_parsetab'),
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)
 

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -124,7 +124,7 @@ class CDS(Base):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
-        lexer = lex.lex(optimize=True, lextab='cds_lextab',
+        lexer = lex.lex(optimize=True, lextab=str('cds_lextab'),
                         outputdir=os.path.dirname(__file__),
                         reflags=re.UNICODE)
 
@@ -257,7 +257,7 @@ class CDS(Base):
         def p_error(p):
             raise ValueError()
 
-        parser = yacc.yacc(debug=False, tabmodule='cds_parsetab',
+        parser = yacc.yacc(debug=False, tabmodule=str('cds_parsetab'),
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)
 

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -124,6 +124,7 @@ class CDS(Base):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         lexer = lex.lex(optimize=True, lextab=str('cds_lextab'),
                         outputdir=os.path.dirname(__file__),
                         reflags=re.UNICODE)
@@ -257,6 +258,7 @@ class CDS(Base):
         def p_error(p):
             raise ValueError()
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         parser = yacc.yacc(debug=False, tabmodule=str('cds_parsetab'),
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -156,6 +156,7 @@ class Generic(Base):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         lexer = lex.lex(optimize=True, lextab=str('generic_lextab'),
                         outputdir=os.path.dirname(__file__),
                         reflags=re.UNICODE)
@@ -418,6 +419,7 @@ class Generic(Base):
         def p_error(p):
             raise ValueError()
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         parser = yacc.yacc(debug=False, tabmodule=str('generic_parsetab'),
                            outputdir=os.path.dirname(__file__))
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -156,14 +156,9 @@ class Generic(Base):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
-        try:
-            from . import generic_lextab
-            lexer = lex.lex(optimize=True, lextab=generic_lextab,
-                            reflags=re.UNICODE)
-        except ImportError:
-            lexer = lex.lex(optimize=True, lextab='generic_lextab',
-                            outputdir=os.path.dirname(__file__),
-                            reflags=re.UNICODE)
+        lexer = lex.lex(optimize=True, lextab=str('generic_lextab'),
+                        outputdir=os.path.dirname(__file__),
+                        reflags=re.UNICODE)
 
         return lexer
 
@@ -423,13 +418,8 @@ class Generic(Base):
         def p_error(p):
             raise ValueError()
 
-        try:
-            from . import generic_parsetab
-            parser = yacc.yacc(debug=False, tabmodule=generic_parsetab,
-                               write_tables=False)
-        except ImportError:
-            parser = yacc.yacc(debug=False, tabmodule='generic_parsetab',
-                               outputdir=os.path.dirname(__file__))
+        parser = yacc.yacc(debug=False, tabmodule=str('generic_parsetab'),
+                           outputdir=os.path.dirname(__file__))
 
         return parser
 

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -163,6 +163,7 @@ class OGIP(generic.Generic):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         lexer = lex.lex(optimize=True, lextab=str('ogip_lextab'),
                         outputdir=os.path.dirname(__file__))
 
@@ -353,6 +354,7 @@ class OGIP(generic.Generic):
         def p_error(p):
             raise ValueError()
 
+        # PY2: need str() to ensure we do not pass on a unicode object.
         parser = yacc.yacc(debug=False, tabmodule=str('ogip_parsetab'),
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -163,7 +163,7 @@ class OGIP(generic.Generic):
             raise ValueError(
                 "Invalid character at col {0}".format(t.lexpos))
 
-        lexer = lex.lex(optimize=True, lextab='ogip_lextab',
+        lexer = lex.lex(optimize=True, lextab=str('ogip_lextab'),
                         outputdir=os.path.dirname(__file__))
 
         return lexer
@@ -353,7 +353,7 @@ class OGIP(generic.Generic):
         def p_error(p):
             raise ValueError()
 
-        parser = yacc.yacc(debug=False, tabmodule='ogip_parsetab',
+        parser = yacc.yacc(debug=False, tabmodule=str('ogip_parsetab'),
                            outputdir=os.path.dirname(__file__),
                            write_tables=True)
 


### PR DESCRIPTION
Ref #5581, fixes #5726.

After #5526 updated PLY to 3.9, some files were re-generated at runtime
(astropy/coordinates/{angle_lextab.py,angle_parsetab.py}). This is because of
this line https://github.com/dabeaz/ply/blob/master/ply/lex.py#L901 which
assumes that the lextab parameter in `lex.lex` is a str only, not unicode, which
leads to some surprise when unicode_literals is used on Python 2 ! Then the 
module is not imported, so it is regenerated.

So this commit just wraps the lextab value to make sure that a str is always
passed to `lex.lex`. And it also reverts #5563 as wrapping in a try/except is no 
more necessary.

cc @bsipocz @eteq @mhvk 