### PR TITLE
Travis: use flake8 instead of pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,9 @@ matrix:
           env: NUMPY_VERSION=prerelease SETUP_CMD='test'
                EVENT_TYPE='push pull_request cron'
 
-        # Do a PEP8 test with pycodestyle
+        # Do a PEP8/pyflakes test with flake8
         - os: linux
-          env: MAIN_CMD='pycodestyle astropy --count' SETUP_CMD=''
+          env: MAIN_CMD='flake8 astropy --count' SETUP_CMD=''
 
         # Try developer version of Numpy with optional dependencies and also
         # run all remote tests. Since both cases will be potentially unstable, we

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -132,13 +132,13 @@ def test_trailing_spaces_in_row_definition():
     """ Trailing spaces in the row definition column shouldn't matter"""
     table = """
 # comment (with blank line above)
-   ==== ==== ====
+   ==== ==== ====    
    Col1 Col2 Col3
-   ==== ==== ====
+   ==== ==== ====  
     3    3.4  foo
     1    4.5  bar
-   ==== ==== ====
-"""  # nopep8
+   ==== ==== ====  
+"""  # noqa
     reader = ascii.get_reader(Reader=ascii.RST)
     dat = reader.read(table)
     assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -132,12 +132,12 @@ def test_trailing_spaces_in_row_definition():
     """ Trailing spaces in the row definition column shouldn't matter"""
     table = """
 # comment (with blank line above)
-   ==== ==== ====    
+   ==== ==== ====
    Col1 Col2 Col3
-   ==== ==== ====  
+   ==== ==== ====
     3    3.4  foo
     1    4.5  bar
-   ==== ==== ====  
+   ==== ==== ====
 """  # nopep8
     reader = ascii.get_reader(Reader=ascii.RST)
     dat = reader.read(table)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,11 @@ bitmap = static/wininst_background.bmp
 [ah_bootstrap]
 auto_use = True
 
-[pycodestyle]
+# We now have sections for the pep8 and flake8 commands. We need to repeat the
+# configuration once for each command. Rather than check all warnings, we only
+# select certain ones that really matter.
+
+# PEP8 errors/warnings:
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
 # W291 - trailing whitespace
@@ -37,6 +41,14 @@ auto_use = True
 # E113 - 4 spaces per indentation level
 # E901 - SyntaxError or IndentationError
 # E902 - IOError
+
+# If you want to exclude a line from checking, simply add '  # noqa' at the end of the line
+
+[pycodestyle]
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
+exclude = extern,sphinx,*parsetab.py
+
+[flake8]
 select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
 exclude = extern,sphinx,*parsetab.py
 


### PR DESCRIPTION
At the moment I haven't added any new warnings/errors to check for, but with this we can start checking for pyflakes errors by adding them to the list in the flake8 section of setup.cfg. Note that this requires astropy/ci-helpers#158 to be merged first.