### PR TITLE
WIP: Centralize the spherical <-> cartesian conversions to avoid code duplication

### DIFF
--- a/astropy/coordinates/geometry.py
+++ b/astropy/coordinates/geometry.py
@@ -1,0 +1,51 @@
+import numpy as np
+from .. import units as u
+
+
+# What follows is a set of functions to convert between spherical and
+# cartesian coordinate frames. The aim here is to be as performant as possible,
+# so this includes routines that assume angles are in radians and ones that
+# assume angles are in degrees, since using astropy.units can introduce
+# overheads. For even better performance, the *_radian functions could be
+# re-written in Cython, but it is important that all these functions work with
+# n-d arrays.
+
+
+def spherical_to_cartesian_radian(lon, lat, radius=1):
+    cos_lat = np.cos(lat)
+    x = radius * cos_lat * np.cos(lon)
+    y = radius * cos_lat * np.sin(lon)
+    z = radius * np.sin(lat)
+    return x, y, z
+
+
+def cartesian_to_spherical_radian(x, y, z):
+    s = np.hypot(x, y)
+    r = np.hypot(s, z)
+    lon = np.arctan2(y, x)
+    lat = np.arctan2(z, s)
+    return lon, lat, r
+
+
+def spherical_to_cartesian_degree(lon, lat, radius=1):
+    return spherical_to_cartesian_radian(np.radians(lon), np.radians(lat), radius=radius)
+
+
+def cartesian_to_spherical_degree(x, y, z):
+    lon, lat, r = cartesian_to_spherical_radian(x, y, z)
+    return np.degrees(lon), np.degrees(lat), r
+
+
+def spherical_to_cartesian(lon, lat, radius=1 * u.one):
+    lon = lon.to(u.rad).value
+    lat = lat.to(u.rad).value
+    x, y, z = spherical_to_cartesian_radian(lon, lat, radius.value)
+    return x * radius.unit, y * radius.unit, z * radius.unit
+
+
+def cartesian_to_spherical(x, y, z):
+    xv = x.value
+    yv = y.to(x.unit).value
+    zv = z.to(x.unit).value
+    lon, lat, r = cartesian_to_spherical_radian(xv, yv, zv)
+    return lon * u.radian, lat * u.radian, r * x.unit

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -17,6 +17,7 @@ import astropy.units as u
 
 from .angles import Angle, Longitude, Latitude
 from .distances import Distance
+from .geometry import spherical_to_cartesian, cartesian_to_spherical
 from ..extern import six
 from ..utils import ShapedLikeNDArray, classproperty
 from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
@@ -757,11 +758,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         Converts spherical polar coordinates to 3D rectangular cartesian
         coordinates.
         """
-
-        x = u.one * np.cos(self.lat) * np.cos(self.lon)
-        y = u.one * np.cos(self.lat) * np.sin(self.lon)
-        z = u.one * np.sin(self.lat)
-
+        x, y, z = spherical_to_cartesian(self.lon, self.lat)
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
     @classmethod
@@ -770,12 +767,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         Converts 3D rectangular cartesian coordinates to spherical polar
         coordinates.
         """
-
-        s = np.hypot(cart.x, cart.y)
-
-        lon = np.arctan2(cart.y, cart.x)
-        lat = np.arctan2(cart.z, s)
-
+        lon, lat = cartesian_to_spherical(cart.x, cart.y, cart.z)[:2]
         return cls(lon=lon, lat=lat, copy=False)
 
     def represent_as(self, other_class):
@@ -963,17 +955,12 @@ class SphericalRepresentation(BaseRepresentation):
         Converts spherical polar coordinates to 3D rectangular cartesian
         coordinates.
         """
-
         # We need to convert Distance to Quantity to allow negative values.
         if isinstance(self.distance, Distance):
             d = self.distance.view(u.Quantity)
         else:
             d = self.distance
-
-        x = d * np.cos(self.lat) * np.cos(self.lon)
-        y = d * np.cos(self.lat) * np.sin(self.lon)
-        z = d * np.sin(self.lat)
-
+        x, y, z = spherical_to_cartesian(self.lon, self.lat, d)
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
     @classmethod
@@ -982,13 +969,7 @@ class SphericalRepresentation(BaseRepresentation):
         Converts 3D rectangular cartesian coordinates to spherical polar
         coordinates.
         """
-
-        s = np.hypot(cart.x, cart.y)
-        r = np.hypot(s, cart.z)
-
-        lon = np.arctan2(cart.y, cart.x)
-        lat = np.arctan2(cart.z, s)
-
+        lon, lat, r = cartesian_to_spherical(cart.x, cart.y, cart.z)
         return cls(lon=lon, lat=lat, distance=r, copy=False)
 
     def norm(self):
@@ -1106,17 +1087,12 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         Converts spherical polar coordinates to 3D rectangular cartesian
         coordinates.
         """
-
         # We need to convert Distance to Quantity to allow negative values.
         if isinstance(self.r, Distance):
             d = self.r.view(u.Quantity)
         else:
             d = self.r
-
-        x = d * np.sin(self.theta) * np.cos(self.phi)
-        y = d * np.sin(self.theta) * np.sin(self.phi)
-        z = d * np.cos(self.theta)
-
+        x, y, z = spherical_to_cartesian(self.phi, self.theta, d)
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
     @classmethod
@@ -1125,13 +1101,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         Converts 3D rectangular cartesian coordinates to spherical polar
         coordinates.
         """
-
-        s = np.hypot(cart.x, cart.y)
-        r = np.hypot(s, cart.z)
-
-        phi = np.arctan2(cart.y, cart.x)
-        theta = np.arctan2(s, cart.z)
-
+        phi, theta, r = cartesian_to_spherical(cart.x, cart.y, cart.z)
         return cls(phi=phi, theta=theta, r=r, copy=False)
 
     def norm(self):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -26,6 +26,8 @@ import math
 
 import numpy as np
 
+from ..coordinates.geometry import (spherical_to_cartesian_degree,
+                                    cartesian_to_spherical_degree)
 from .core import Model
 from .parameters import Parameter
 from ..extern.six.moves import zip
@@ -66,22 +68,6 @@ class _EulerRotation(object):
         return np.dot(matrices[2], np.dot(matrices[1], matrices[0]))
 
     @staticmethod
-    def spherical2cartesian(alpha, delta):
-        alpha = np.deg2rad(alpha)
-        delta = np.deg2rad(delta)
-        x = np.cos(alpha) * np.cos(delta)
-        y = np.cos(delta) * np.sin(alpha)
-        z = np.sin(delta)
-        return np.array([x, y, z])
-
-    @staticmethod
-    def cartesian2spherical(x, y, z):
-        h = np.hypot(x, y)
-        alpha  = np.rad2deg(np.arctan2(y, x))
-        delta = np.rad2deg(np.arctan2(z, h))
-        return alpha, delta
-
-    @staticmethod
     def rotation_matrix_from_angle(angle):
         """
         Clockwise rotation matrix.
@@ -100,10 +86,10 @@ class _EulerRotation(object):
             alpha = alpha.flatten()
             delta = delta.flatten()
             shape = alpha.shape
-        inp = self.spherical2cartesian(alpha, delta)
+        inp = spherical_to_cartesian_degree(alpha, delta)
         matrix = self._create_matrix(phi, theta, psi, axes_order)
         result = np.dot(matrix, inp)
-        a, b = self.cartesian2spherical(*result)
+        a, b, _ = cartesian_to_spherical_degree(*result)
         if shape is not None:
             a.shape = shape
             b.shape = shape
@@ -159,10 +145,10 @@ class EulerAngleRotation(_EulerRotation, Model):
             alpha = alpha.flatten()
             delta = delta.flatten()
             shape = alpha.shape
-        inp = self.spherical2cartesian(alpha, delta)
+        inp = spherical_to_cartesian_degree(alpha, delta)
         matrix = self._create_matrix(phi, theta, psi, self.axes_order)
         result = np.dot(matrix, inp)
-        a, b = self.cartesian2spherical(*result)
+        a, b, _ = cartesian_to_spherical_degree(*result)
         if shape is not None:
             a.shape = shape
             b.shape = shape


### PR DESCRIPTION
This is a possible first pass at https://github.com/astropy/astropy/issues/5734. The idea is that e.g. in modeling, using representation classes would be overkill and introduce performance overheads, and there are some cases where one just wants a fast spherical <-> cartesian conversion. In addition, we want to avoid code duplication.

There is still scope for optimizing ``spherical_to_cartesian_radian`` and ``cartesian_to_spherical_radian``, and in particular it would be worth investigating a Cython implementation (to avoid allocation/deallocation of multiple arrays) that would operate on 1D arrays, and ravel/unravel arrays on the fly. I don't have time to investigate this right now, but at least this lays the foundation for doing something like this.

If we agree on this kind of approach (namely having astropy.coordinates.geometry), then we can also add e.g. cylindrical <-> cartesian conversion since that is also used in representations.

Here's a comparison of the _radian functions with the ERFA routines:

![conversions](https://cloud.githubusercontent.com/assets/314716/22256168/dc9e3b0a-e251-11e6-997d-e1e56e30d113.png)

So the ones here are much better for <1000 elements and equivalent above
