### PR TITLE
Compound models - copy vs reference

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ New Features
   - Add ``n_submodels`` shared method to single and compound models, which
     allows users to get the number of components of a given single (compound)
     model. [#5747]
+  - Added a ``name`` setter for instances of ``_CompoundModel``. [#5741]
 
 - ``astropy.nddata``
 
@@ -145,6 +146,10 @@ Bug Fixes
 - ``astropy.io.votable``
 
 - ``astropy.modeling``
+
+  - Creating a compound model where one of the submodels is
+    a compound model whose parameters were changed now uses the
+    updated parameters and not the parameters of the original model. [#5741]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1919,7 +1919,6 @@ class _CompoundModelMeta(_ModelMeta):
             # but it is necessary on Python 2 since looking up cls._evaluate
             # will return an unbound method otherwise
             cls._evaluate = staticmethod(func)
-        print('args', args)
         inputs = args[:cls.n_inputs]
         params = iter(args[cls.n_inputs:])
         result = cls._evaluate(inputs, params)
@@ -1961,14 +1960,16 @@ class _CompoundModelMeta(_ModelMeta):
         ``standard_broadcasting``, and ``__module__`.  This is currently for
         internal use only.
         """
-
+        import copy
         # Note, currently this only supports binary operators, but could be
         # easily extended to support unary operators (namely '-') if/when
         # needed
         children = []
         for child in (left, right):
             if isinstance(child, (_CompoundModelMeta, _CompoundModel)):
-                children.append(child._tree)
+                children.append(copy.deepcopy(child._tree))
+            elif isinstance(child, Model):
+                children.append(ExpressionTree(child.copy()))
             else:
                 children.append(ExpressionTree(child))
 
@@ -2159,8 +2160,6 @@ class _CompoundModelMeta(_ModelMeta):
                 # Take the parameter's default from the model's value for that
                 # parameter
                 default = orig_param.value
-            #elif isinstance(submodel, _CompoundModel):
-                #default =
             else:
                 default = orig_param.default
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1890,7 +1890,7 @@ class _CompoundModelMeta(_ModelMeta):
 
         names = tuple(k[0] for k in names)
 
-        cls._submodels_names = names
+        cls._submodel_names = names
         return names
 
     @property
@@ -1919,7 +1919,7 @@ class _CompoundModelMeta(_ModelMeta):
             # but it is necessary on Python 2 since looking up cls._evaluate
             # will return an unbound method otherwise
             cls._evaluate = staticmethod(func)
-
+        print('args', args)
         inputs = args[:cls.n_inputs]
         params = iter(args[cls.n_inputs:])
         result = cls._evaluate(inputs, params)
@@ -2159,6 +2159,8 @@ class _CompoundModelMeta(_ModelMeta):
                 # Take the parameter's default from the model's value for that
                 # parameter
                 default = orig_param.value
+            #elif isinstance(submodel, _CompoundModel):
+                #default =
             else:
                 default = orig_param.default
 
@@ -2172,6 +2174,7 @@ class _CompoundModelMeta(_ModelMeta):
             new_param = orig_param.copy(name=param_name, default=default,
                                         **constraints)
 
+            #setattr(cls, param_name, orig_param)
             setattr(cls, param_name, new_param)
 
     def _init_param_names(cls):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1971,6 +1971,15 @@ class _CompoundModelMeta(_ModelMeta):
         children = []
         for child in (left, right):
             if isinstance(child, (_CompoundModelMeta, _CompoundModel)):
+                """
+                Although the original child models were copied we make another
+                copy here to ensure that changes in this child compound model
+                parameters will not propagate to the reuslt, that is
+                cm1 = Gaussian1D(1, 5, .1) + Gaussian1D()
+                cm2 = cm1 | Scale()
+                cm1.amplitude_0 = 100
+                assert(cm2.amplitude_0 == 1)
+                """
                 children.append(copy.deepcopy(child._tree))
             elif isinstance(child, Model):
                 children.append(ExpressionTree(child.copy()))

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -710,6 +710,12 @@ class Model(object):
 
         return self._name
 
+    @name.setter
+    def name(self, val):
+        """Assign a (new) name to this model."""
+
+        self._name = val
+
     @property
     def n_inputs(self):
         """
@@ -1210,7 +1216,6 @@ class Model(object):
         """
         Return a copy of this model with a new name.
         """
-
         new_model = self.copy()
         new_model._name = name
         return new_model
@@ -1960,7 +1965,6 @@ class _CompoundModelMeta(_ModelMeta):
         ``standard_broadcasting``, and ``__module__`.  This is currently for
         internal use only.
         """
-        import copy
         # Note, currently this only supports binary operators, but could be
         # easily extended to support unary operators (namely '-') if/when
         # needed
@@ -2173,7 +2177,6 @@ class _CompoundModelMeta(_ModelMeta):
             new_param = orig_param.copy(name=param_name, default=default,
                                         **constraints)
 
-            #setattr(cls, param_name, orig_param)
             setattr(cls, param_name, new_param)
 
     def _init_param_names(cls):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -309,7 +309,6 @@ class Parameter(OrderedDescriptor):
 
         return self._name
 
-
     @property
     def default(self):
         """Parameter default value"""

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -309,11 +309,6 @@ class Parameter(OrderedDescriptor):
 
         return self._name
 
-    @name.setter
-    def name(self, val):
-        """Parameter name"""
-
-        self._name = val
 
     @property
     def default(self):
@@ -697,7 +692,6 @@ class Parameter(OrderedDescriptor):
                     "as the current value does".format(self._name, param_size))
 
             model._parameters[param_slice] = np.array(value).ravel()
-        #print('model1', self._name, value, model)
         _update_parameter_value(model, self._name, value)
         if hasattr(model, "_param_map"):
             submodel_ind, param_name = model._param_map[self._name]

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -309,6 +309,12 @@ class Parameter(OrderedDescriptor):
 
         return self._name
 
+    @name.setter
+    def name(self, val):
+        """Parameter name"""
+
+        self._name = val
+
     @property
     def default(self):
         """Parameter default value"""
@@ -679,18 +685,24 @@ class Parameter(OrderedDescriptor):
         array) but other mechanisms may be desireable, in which case really the
         model class itself should dictate this and *not* `Parameter` itself.
         """
+        def _update_parameter_value(model, name, value):
+            # TODO: Maybe handle exception on invalid input shape
+            param_slice = model._param_metrics[name]['slice']
+            param_shape = model._param_metrics[name]['shape']
+            param_size = np.prod(param_shape)
 
-        # TODO: Maybe handle exception on invalid input shape
-        param_slice = model._param_metrics[self._name]['slice']
-        param_shape = model._param_metrics[self._name]['shape']
-        param_size = np.prod(param_shape)
+            if np.size(value) != param_size:
+                raise InputParameterError(
+                    "Input value for parameter {0!r} does not have {1} elements "
+                    "as the current value does".format(self._name, param_size))
 
-        if np.size(value) != param_size:
-            raise InputParameterError(
-                "Input value for parameter {0!r} does not have {1} elements "
-                "as the current value does".format(self._name, param_size))
-
-        model._parameters[param_slice] = np.array(value).ravel()
+            model._parameters[param_slice] = np.array(value).ravel()
+        #print('model1', self._name, value, model)
+        _update_parameter_value(model, self._name, value)
+        if hasattr(model, "_param_map"):
+            submodel_ind, param_name = model._param_map[self._name]
+            if hasattr(model._submodels[submodel_ind], "_param_metrics"):
+                _update_parameter_value(model._submodels[submodel_ind], param_name, value)
 
     @staticmethod
     def _create_value_wrapper(wrapper, model):

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -279,9 +279,6 @@ def test_indexing_on_class():
 
     M = Gaussian1D + p
     assert M[0] is Gaussian1D
-    #assert M[1] is p
-    #assert M['Gaussian1D'] is M[0]
-    #assert M['p'] is M[1]
     assert isinstance(M['p'], Polynomial1D)
 
     m = g + p
@@ -903,3 +900,17 @@ def test_update_parameters():
     assert(m(1) == 200)
     m2 = m | offx
     assert(m2(1) == 242)
+
+
+def test_name():
+    offx = Shift(1)
+    scl = Scale(2)
+    m = offx | scl
+    scl.name = "scale"
+    assert m._submodel_names == ('None_0', 'None_1')
+    assert m.name is None
+    m.name = "M"
+    assert m.name == "M"
+    m1 = m.rename("M1")
+    assert m.name == "M"
+    assert m1.name == "M1"

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -279,9 +279,10 @@ def test_indexing_on_class():
 
     M = Gaussian1D + p
     assert M[0] is Gaussian1D
-    assert M[1] is p
-    assert M['Gaussian1D'] is M[0]
-    assert M['p'] is M[1]
+    #assert M[1] is p
+    #assert M['Gaussian1D'] is M[0]
+    #assert M['p'] is M[1]
+    assert isinstance(M['p'], Polynomial1D)
 
     m = g + p
     assert isinstance(m[0], Gaussian1D)
@@ -890,10 +891,15 @@ def test_pickle_compound_fallback():
 
 
 def test_update_parameters():
-    g = Gaussian1D(10, 2, 1) | Const1D(4)
-    p = Polynomial1D(1) | Scale(1)
-    m = g | p
+    offx = Shift(1)
+    scl = Scale(2)
+    m = offx | scl
+    assert(m(1) == 4)
 
-    assert(m(1) == 0)
-    m[1].c1_0 = 100
-    assert(m(1) == 100)
+    offx.offset=42
+    assert(m(1) == 4)
+
+    m.factor_1 = 100
+    assert(m(1) == 200)
+    m2 = m | offx
+    assert(m2(1) == 242)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -887,3 +887,13 @@ def test_pickle_compound_fallback():
     gg = (Gaussian1D + Gaussian1D)()
     with pytest.raises(RuntimeError):
         pickle.dumps(gg)
+
+
+def test_update_parameters():
+    g = Gaussian1D(10, 2, 1) | Const1D(4)
+    p = Polynomial1D(1) | Scale(1)
+    m = g | p
+
+    assert(m(1) == 0)
+    m[1].c1_0 = 100
+    assert(m(1) == 100)

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -254,6 +254,25 @@ to be used for evaluation::
     >>> both_gaussians(0.2)  # doctest: +FLOAT_CMP
     0.6343031510582392
 
+In this case it is possible to directly assign a name to the compound model instance
+by using the `Model.name <astropy.modeling.Model.name>` attribute.
+
+    >>> both_gaussians.name = "BothGaussians" # doctest: +FLOAT_CMP
+    >>> print(both_gaussian)
+    Model: CompoundModel6
+    Name: BothGaussians
+    Inputs: ('x',)
+    Outputs: ('y',)
+    Model set size: 1
+    Expression: [0] + [1]
+    Components:
+        [0]: <Gaussian1D(amplitude=1.0, mean=0.0, stddev=0.2)>
+        [1]: <Gaussian1D(amplitude=2.5, mean=0.5, stddev=0.1)>
+    Parameters:
+        amplitude_0 mean_0 stddev_0 amplitude_1 mean_1 stddev_1
+        ----------- ------ -------- ----------- ------ --------
+        ...
+
 This was found to be much more convenient and natural, in this case, than
 returning a class.  It is worth understanding that the way this works under the
 hood is to create the compound class, and then immediately instantiate it with

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -257,8 +257,8 @@ to be used for evaluation::
 In this case it is possible to directly assign a name to the compound model instance
 by using the `Model.name <astropy.modeling.Model.name>` attribute.
 
-    >>> both_gaussians.name = "BothGaussians" # doctest: +FLOAT_CMP
-    >>> print(both_gaussian)
+    >>> both_gaussians.name = "BothGaussians"
+    >>> print(both_gaussians)  # doctest: +SKIP
     Model: CompoundModel6
     Name: BothGaussians
     Inputs: ('x',)
@@ -271,7 +271,7 @@ by using the `Model.name <astropy.modeling.Model.name>` attribute.
     Parameters:
         amplitude_0 mean_0 stddev_0 amplitude_1 mean_1 stddev_1
         ----------- ------ -------- ----------- ------ --------
-        ...
+                1.0    0.0      0.2         2.5    0.5      0.1
 
 This was found to be much more convenient and natural, in this case, than
 returning a class.  It is worth understanding that the way this works under the


### PR DESCRIPTION
This PR introduces changes in the design of compound models in modeling. 
A couple use cases which prompted this are below:

```
shift = Shift(1)
scale = Scale(2)

m1 = shift | scale
m1(1)
Out[15]: 4.0
# Update the scale
m1.factor_1 = 100
m1(1)
Out[]: 200.0  # as expected

# Chain another shift
m2 = m1 | shift
m2(1)
Out[]: 5.0 # I expected 201
```

```
shift = Shift(1)
scale = Scale(2)

m1 = shift | scale
m1(1)
Out[]: 4

shift.offset = 42
m2 = m1 | scale
m2(1)
Out[]: 172 # I expected 8
```
The reason for this behaviour is that CompoundModel holds references to the original models but makes a copy of their parameters. The copied parameters are not kept in sync with the underlying `CompoundModel._tree` models which in turn are used to create new compound models. To illustrate the problem using the first example:

```
m1 = shift | scale
m1._submodels
Out[]: [<Shift(offset=1.0)>, <Scale(factor=2.0)>]

m1.factor_1=100
m1._submodels
Out[]: [<Shift(offset=1.0)>, <Scale(factor=2.0)>]
```

This PR makes the following changes:

- When a compound model is created it makes copies of he original child models in its `._tree`.
- When a compound model parameter is updated the updated value propagates to the corresponding parameter in the original model in `._tree`.

This will increase memory usage in some cases. A memory profiler on a test case of a JWST WCS transform which holds 109 models shows that the memory usage increases by 12 MiB with this PR.

This also has the (nice) side effect that now it is possible to rename a model without returning a new copy. This PR adds a `@name.setter` in Model although the `rename` method is still available and returns a copy as previously ( I think this is still useful). However, being able to reset the name decreases memory in the common case when one wants to set a name of a compound model (currently this is only possible by using `rename`).

Please comment whether you agree the behaviour in the above use cases should be changed and also on the approach taken in this PR.

Some discussion on copies is in #3828.

Todo:
- [x] Need to update documentation
- [x] EDIT: Also need change log, see comment.

EDIT: Fix #3251, fix #4819 