### PR TITLE
Add n_submodels shared method to compound models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,11 @@ New Features
 - ``astropy.io.votable``
 
 - ``astropy.modeling``
+
   - Added ``SmoothlyBrokenPowerLaw1D`` model. [#5656]
+
+  - Add ``n_submodels`` property to compound models, which allows users to get
+    the number of components of a given compound model. [#5747]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,8 +33,9 @@ New Features
 
   - Added ``SmoothlyBrokenPowerLaw1D`` model. [#5656]
 
-  - Add ``n_submodels`` property to compound models, which allows users to get
-    the number of components of a given compound model. [#5747]
+  - Add ``n_submodels`` shared method to single and compound models, which
+    allows users to get the number of components of a given single (compound)
+    model. [#5747]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2421,6 +2421,10 @@ class _CompoundModel(Model):
         return self.__class__.submodel_names
 
     @property
+    def n_submodels(self):
+        return len(self.submodel_names)
+
+    @property
     def param_names(self):
         return self.__class__.param_names
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1215,6 +1215,15 @@ class Model(object):
         new_model._name = name
         return new_model
 
+    @sharedmethod
+    def n_submodels(self):
+        """
+        Return the number of components in a single model, which is
+        obviously 1.
+        """
+
+        return 1
+
     # *** Internal methods ***
     @sharedmethod
     def _from_existing(self, existing, param_names):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1221,7 +1221,6 @@ class Model(object):
         Return the number of components in a single model, which is
         obviously 1.
         """
-
         return 1
 
     # *** Internal methods ***

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2420,7 +2420,7 @@ class _CompoundModel(Model):
     def submodel_names(self):
         return self.__class__.submodel_names
 
-    @property
+    @sharedmethod
     def n_submodels(self):
         return len(self.submodel_names)
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -181,6 +181,22 @@ def test_simple_two_model_class_compose_2d():
     r3 = R2(45, 45, 45, 45)
     assert_allclose(r3(0, 1), (0, -1), atol=1e-10)
 
+def test_n_submodels():
+    """
+    Test that CompoundModel.n_submodels properly returns the number
+    of components.
+    """
+    g2 = Gaussian1D() + Gaussian1D()
+    assert g2.n_submodels == 2
+
+    g3 = g2 + Gaussian1D()
+    assert g3.n_submodels == 3
+
+    g5 = g3 | g2
+    assert g5.n_submodels == 5
+
+    g7 = g5 / g2
+    assert g7.n_submodels == 7
 
 def test_expression_formatting():
     """

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -187,16 +187,21 @@ def test_n_submodels():
     of components.
     """
     g2 = Gaussian1D() + Gaussian1D()
-    assert g2.n_submodels == 2
+    assert g2.n_submodels() == 2
 
     g3 = g2 + Gaussian1D()
-    assert g3.n_submodels == 3
+    assert g3.n_submodels() == 3
 
     g5 = g3 | g2
-    assert g5.n_submodels == 5
+    assert g5.n_submodels() == 5
 
     g7 = g5 / g2
-    assert g7.n_submodels == 7
+    assert g7.n_submodels() == 7
+
+    # make sure it works as class method
+    p = Polynomial1D + Polynomial1D
+
+    assert p.n_submodels() == 2
 
 def test_expression_formatting():
     """

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -365,3 +365,7 @@ def test_custom_bounding_box_1d():
     # assign the same bounding_box, now through the bounding_box setter
     g2.bounding_box = bb
     assert_allclose(g2.render(), expected)
+
+def test_n_submodels_in_single_models():
+    assert models.Gaussian1D.n_submodels() == 1
+    assert models.Gaussian2D.n_submodels() == 1

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -177,9 +177,9 @@ from the user's perspective it is treated as a single model.  However, as this
 is the default behavior it is good to be aware of.
 
 One is also able to get the number of components (also known as submodels) in
-a compound model by accessing the property ``n_submodels``::
+a compound model by accessing the method ``n_submodels``::
 
-    >>> FourGaussians.n_submodels
+    >>> FourGaussians.n_submodels()
     4
 
 

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -176,6 +176,12 @@ In a future version it may be possible to "freeze" a compound model, so that
 from the user's perspective it is treated as a single model.  However, as this
 is the default behavior it is good to be aware of.
 
+One is also able to get the number of components (also known as submodels) in
+a compound model by accessing the property ``n_submodels``::
+
+    >>> FourGaussians.n_submodels
+    4
+
 
 Model names
 ^^^^^^^^^^^


### PR DESCRIPTION
This PR adds a ~~property~~ shared method called ``n_submodels`` to ``_CompoundModel`` which provides a clearer way to get the number of components in a compound model.

Fix #4093 

cc @pllim @nden 