### PR TITLE
Add examples dir to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ include astropy/table/tests/notebook_repr_html.ipynb
 include astropy/utils/misc/data/.hidden_file.txt
 
 recursive-include docs *
+recursive-include examples *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *


### PR DESCRIPTION
This adds the `examples` directory to the `MANIFEST.in`.

See discussion in #5019