### PR TITLE
Ensure FrameAttribute not on present frame are set on SkyCoord, not on its frame

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,9 +201,11 @@ Bug Fixes
   - Fixed a bug where ``get_transform`` could sometimes produce confusing errors
     because of a typo in the input validation. [#5645]
 
-  - Ensured that frame attributes cannot be set on ``SkyCoord``, even if the
-    current frame does not have them (e.g., setting ``relative_humidity`` on an
-    ICRS ``SkyCoord`` is now properly captured). [#5750]
+  - Ensured that frame attributes cannot be set on ``SkyCoord`` if the current
+    frame has them, and that any that the frame does not have (but which are
+    valid for other frames), get set on the ``SkyCoord`` instance, not on its
+    underlying ``frame`` (e.g., setting ``relative_humidity`` on an ICRS
+    ``SkyCoord`` now stores this on the ``SkyCoord``). [#5750]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,10 @@ Bug Fixes
   - Fixed a bug where ``get_transform`` could sometimes produce confusing errors
     because of a typo in the input validation. [#5645]
 
+  - Ensured that frame attributes cannot be set on ``SkyCoord``, even if the
+    current frame does not have them (e.g., setting ``relative_humidity`` on an
+    ICRS ``SkyCoord`` is now properly captured). [#5750]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,11 +201,10 @@ Bug Fixes
   - Fixed a bug where ``get_transform`` could sometimes produce confusing errors
     because of a typo in the input validation. [#5645]
 
-  - Ensured that frame attributes cannot be set on ``SkyCoord`` if the current
-    frame has them, and that any that the frame does not have (but which are
-    valid for other frames), get set on the ``SkyCoord`` instance, not on its
-    underlying ``frame`` (e.g., setting ``relative_humidity`` on an ICRS
-    ``SkyCoord`` now stores this on the ``SkyCoord``). [#5750]
+  - Changed ``SkyCoord`` so that frame attributes which are not valid for the
+    current ``frame`` (but are valid for other frames) are stored on the
+    ``SkyCoord`` instance instead of the underlying ``frame`` instance (e.g.,
+    setting ``relative_humidity`` on an ICRS ``SkyCoord`` instance.) [#5750]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -492,8 +492,7 @@ class SkyCoord(ShapedLikeNDArray):
             if self.frame.name == attr:
                 raise AttributeError("'{0}' is immutable".format(attr))
 
-            if not attr.startswith('_') and hasattr(self._sky_coord_frame,
-                                                    attr):
+            if not attr.startswith('_') and hasattr(self._sky_coord_frame, attr):
                 setattr(self._sky_coord_frame, attr, val)
                 return
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -492,15 +492,19 @@ class SkyCoord(ShapedLikeNDArray):
             if self.frame.name == attr:
                 raise AttributeError("'{0}' is immutable".format(attr))
 
-            if hasattr(self._sky_coord_frame, attr):
+            if not attr.startswith('_') and hasattr(self._sky_coord_frame,
+                                                    attr):
                 setattr(self._sky_coord_frame, attr, val)
+                return
 
             frame_cls = frame_transform_graph.lookup_name(attr)
             if frame_cls is not None and self.frame.is_transformable_to(frame_cls):
                 raise AttributeError("'{0}' is immutable".format(attr))
 
         if attr in FRAME_ATTR_NAMES_SET():
-            raise AttributeError('cannot set possible frame attribute.')
+            # All possible frame attributes can be set, but only via a private
+            # variable.  See __getattr__ above.
+            attr = '_' + attr
 
         # Otherwise, do the standard Python attribute setting
         super(SkyCoord, self).__setattr__(attr, val)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -492,14 +492,15 @@ class SkyCoord(ShapedLikeNDArray):
             if self.frame.name == attr:
                 raise AttributeError("'{0}' is immutable".format(attr))
 
-            if (attr in FRAME_ATTR_NAMES_SET() or
-                (not attr.startswith('_') and
-                 hasattr(self._sky_coord_frame, attr))):
+            if hasattr(self._sky_coord_frame, attr):
                 setattr(self._sky_coord_frame, attr, val)
 
             frame_cls = frame_transform_graph.lookup_name(attr)
             if frame_cls is not None and self.frame.is_transformable_to(frame_cls):
                 raise AttributeError("'{0}' is immutable".format(attr))
+
+        if attr in FRAME_ATTR_NAMES_SET():
+            raise AttributeError('cannot set possible frame attribute.')
 
         # Otherwise, do the standard Python attribute setting
         super(SkyCoord, self).__setattr__(attr, val)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1293,3 +1293,14 @@ def test_cache_clear_sc():
     i.cache.clear()
 
     assert len(i.cache['representation']) == 0
+
+
+def test_set_attribute_exceptions():
+    """Ensure no attrbute for any frame can be set directly.
+
+    Even if the current frame does not have it."""
+    sc = SkyCoord(1.*u.deg, 2.*u.deg, frame='fk5')
+    with pytest.raises(AttributeError):
+        sc.equinox = 'B1950'
+    with pytest.raises(AttributeError):
+        sc.relative_humidity = 0.1

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1298,9 +1298,13 @@ def test_cache_clear_sc():
 def test_set_attribute_exceptions():
     """Ensure no attrbute for any frame can be set directly.
 
-    Even if the current frame does not have it."""
+    Though it is fine if the current frame does not have it."""
     sc = SkyCoord(1.*u.deg, 2.*u.deg, frame='fk5')
+    assert hasattr(sc.frame, 'equinox')
     with pytest.raises(AttributeError):
         sc.equinox = 'B1950'
-    with pytest.raises(AttributeError):
-        sc.relative_humidity = 0.1
+
+    assert sc.relative_humidity is None
+    sc.relative_humidity = 0.5
+    assert sc.relative_humidity == 0.5
+    assert not hasattr(sc.frame, 'relative_humidity')


### PR DESCRIPTION
Currently, if one defines, e.g., a SkyCoord with an ICRS frame, one can set any existing frame attribute that is not on that frame. Oddly, this gets set on the frame, without any validation:
```
sc = SkyCoord(ra=0., dec=0., unit='deg')
sc.relative_humidity = 'bla'
sc.frame.relative_humidity
# 'bla'
```
This commit ~~prevents one from setting any attribute that is a `FrameAttribute` of any frame~~ [EDIT] ensures that possible frame attributes that are not on the present frame are stored on the `SkyCoord` instance.

EDIT: now went with alternative given that the setting is used in the wild (for sensible purposes).

@taldcroft, @eteq - please check this is in fact desired behaviour; the alternative would be to set the attribute on the `SkyCoord` itself, but my sense was that this violated the immutability.