### PR TITLE
Skycoord attributes slicing, dicing, propagation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,10 @@ Bug Fixes
   - Ensured that ``position_angle`` and ``separation`` give correct answers for
     frames with different equinox (see #5722). [#5762]
 
+  - Ensure that frame attributes set on ``SkyCoord`` are properly validated,
+    and that any ndarray-like operation (like slicing) will also be done on
+    those. [#5751]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -320,6 +324,9 @@ Other Changes and Additions
 
 - Updated bundled astropy-helpers to v1.3.1. [#5880]
 
+- In the process of fixing frame attributes on ``SkyCoord``, caching of the
+  all possible frame attributes was implemented (following #5703). This greatly
+  speeds up many ``SkyCoord`` operations. [#5751]
 
 1.3 (2016-12-22)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,13 @@ New Features
 
 - ``astropy.coordinates``
 
+  - Frame attributes set on ``SkyCoord`` are now always validated, and any
+    ndarray-like operation (like slicing) will also be done on those. [#575
+
+  - Caching of  all possible frame attributes was implemented. This greatly
+    speeds up many ``SkyCoord`` operations. [#5703, #5751]
+
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
@@ -215,10 +222,6 @@ Bug Fixes
 
   - Ensured that ``position_angle`` and ``separation`` give correct answers for
     frames with different equinox (see #5722). [#5762]
-
-  - Ensure that frame attributes set on ``SkyCoord`` are properly validated,
-    and that any ndarray-like operation (like slicing) will also be done on
-    those. [#5751]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -206,9 +206,8 @@ class SkyCoord(ShapedLikeNDArray):
                                   frame_transform_graph.frame_attributes and
                                   attr not in frame.get_frame_attr_names()]
         for attr in self._extra_attr_names:
-            setattr(self, '_' + attr, kwargs[attr])
-            # Validate it
-            frame_transform_graph.frame_attributes[attr].__get__(self)
+            # Setting it will also validate it.
+            setattr(self, attr, kwargs[attr])
 
         coord_kwargs = {}
         if 'representation' in kwargs:
@@ -515,10 +514,13 @@ class SkyCoord(ShapedLikeNDArray):
         if attr in attr in frame_transform_graph.frame_attributes:
             # All possible frame attributes can be set, but only via a private
             # variable.  See __getattr__ above.
-            attr = '_' + attr
+            super(SkyCoord, self).__setattr__('_' + attr, val)
+            # Validate it
+            frame_transform_graph.frame_attributes[attr].__get__(self)
 
-        # Otherwise, do the standard Python attribute setting
-        super(SkyCoord, self).__setattr__(attr, val)
+        else:
+            # Otherwise, do the standard Python attribute setting
+            super(SkyCoord, self).__setattr__(attr, val)
 
     @override__dir__
     def __dir__(self):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -71,7 +71,7 @@ class SkyCoordInfo(MixinInfo):
     def _represent_as_dict(self):
         obj = self._parent
         attrs = list(obj.representation_component_names)
-        attrs += list(frame_transform_graph.frame_attrnames_set)
+        attrs += list(frame_transform_graph.frame_attributes.keys())
         out = _get_obj_attrs_map(obj, attrs)
 
         # Don't output distance if it is all unitless 1.0
@@ -200,7 +200,7 @@ class SkyCoord(ShapedLikeNDArray):
         kwargs = self._parse_inputs(args, kwargs)
 
         # Set internal versions of object state attributes
-        for attr in frame_transform_graph.frame_attrnames_set:
+        for attr in frame_transform_graph.frame_attributes:
             setattr(self, '_' + attr, kwargs[attr])
 
         frame = kwargs['frame']
@@ -294,7 +294,7 @@ class SkyCoord(ShapedLikeNDArray):
         if 'representation' in kwargs:
             valid_kwargs['representation'] = _get_repr_cls(kwargs.pop('representation'))
 
-        for attr in frame_transform_graph.frame_attrnames_set:
+        for attr in frame_transform_graph.frame_attributes:
             valid_kwargs[attr] = kwargs.pop(attr, None)
 
         # Get units
@@ -406,7 +406,7 @@ class SkyCoord(ShapedLikeNDArray):
             new_frame_cls = frame.__class__
             # Get frame attributes, allowing defaults to be overridden by
             # explicitly set attributes of the source if ``merge_attributes``.
-            for attr in frame_transform_graph.frame_attrnames_set:
+            for attr in frame_transform_graph.frame_attributes:
                 self_val = getattr(self, attr, None)
                 frame_val = getattr(frame, attr, None)
                 if (frame_val is not None and not
@@ -453,7 +453,7 @@ class SkyCoord(ShapedLikeNDArray):
             # Anything in the set of all possible frame_attr_names is handled
             # here. If the attr is relevant for the current frame then delegate
             # to self.frame otherwise get it from self._<attr>.
-            if attr in frame_transform_graph.frame_attrnames_set:
+            if attr in frame_transform_graph.frame_attributes:
                 if attr in self.frame.get_frame_attr_names():
                     return getattr(self.frame, attr)
                 else:
@@ -497,7 +497,7 @@ class SkyCoord(ShapedLikeNDArray):
             if frame_cls is not None and self.frame.is_transformable_to(frame_cls):
                 raise AttributeError("'{0}' is immutable".format(attr))
 
-        if attr in attr in frame_transform_graph.frame_attrnames_set:
+        if attr in attr in frame_transform_graph.frame_attributes:
             # All possible frame attributes can be set, but only via a private
             # variable.  See __getattr__ above.
             attr = '_' + attr
@@ -524,7 +524,7 @@ class SkyCoord(ShapedLikeNDArray):
         dir_values.update(set(attr for attr in dir(self.frame) if not attr.startswith('_')))
 
         # Add all possible frame attributes
-        dir_values.update(frame_transform_graph.frame_attrnames_set)
+        dir_values.update(frame_transform_graph.frame_attributes.keys())
 
         return dir_values
 
@@ -637,7 +637,7 @@ class SkyCoord(ShapedLikeNDArray):
             if other.frame.name != self.frame.name:
                 return False
 
-            for fattrnm in frame_transform_graph.frame_attrnames_set:
+            for fattrnm in frame_transform_graph.frame_attributes:
                 if getattr(self, fattrnm) != getattr(other, fattrnm):
                     return False
             return True
@@ -1481,7 +1481,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # Get the value from `data` in the eventual representation
             values.append(getattr(data, repr_attr_name))
 
-        for attr in frame_transform_graph.frame_attrnames_set:
+        for attr in frame_transform_graph.frame_attributes:
             value = getattr(coords, attr, None)
             use_value = (isinstance(coords, SkyCoord)
                          or attr not in coords._attr_names_with_defaults)
@@ -1521,7 +1521,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # get the frame attributes from the first one, because from above we
             # know it matches all the others
-            for fattrnm in frame_transform_graph.frame_attrnames_set:
+            for fattrnm in frame_transform_graph.frame_attributes:
                 valid_kwargs[fattrnm] = getattr(scs[0], fattrnm)
 
             # Now combine the values, to be used below

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -32,18 +32,6 @@ J_PREFIXED_RA_DEC_RE = re.compile(
     ([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$  # Dec as DDMMSS.ss, optional decimal digits
     """, re.VERBOSE)
 
-
-# Define a convenience mapping.  This is used like a module constants
-# but is actually dynamically evaluated.
-def FRAME_ATTR_NAMES_SET():
-    """Set of all possible frame-specific attributes"""
-    out = set()
-    for frame_cls in frame_transform_graph.frame_set:
-        for attr in frame_cls.get_frame_attr_names().keys():
-            out.add(attr)
-    return out
-
-
 class SkyCoordInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is
@@ -83,7 +71,7 @@ class SkyCoordInfo(MixinInfo):
     def _represent_as_dict(self):
         obj = self._parent
         attrs = list(obj.representation_component_names)
-        attrs += list(FRAME_ATTR_NAMES_SET())
+        attrs += list(frame_transform_graph.frame_attrnames_set)
         out = _get_obj_attrs_map(obj, attrs)
 
         # Don't output distance if it is all unitless 1.0
@@ -212,7 +200,7 @@ class SkyCoord(ShapedLikeNDArray):
         kwargs = self._parse_inputs(args, kwargs)
 
         # Set internal versions of object state attributes
-        for attr in FRAME_ATTR_NAMES_SET():
+        for attr in frame_transform_graph.frame_attrnames_set:
             setattr(self, '_' + attr, kwargs[attr])
 
         frame = kwargs['frame']
@@ -306,7 +294,7 @@ class SkyCoord(ShapedLikeNDArray):
         if 'representation' in kwargs:
             valid_kwargs['representation'] = _get_repr_cls(kwargs.pop('representation'))
 
-        for attr in FRAME_ATTR_NAMES_SET():
+        for attr in frame_transform_graph.frame_attrnames_set:
             valid_kwargs[attr] = kwargs.pop(attr, None)
 
         # Get units
@@ -418,7 +406,7 @@ class SkyCoord(ShapedLikeNDArray):
             new_frame_cls = frame.__class__
             # Get frame attributes, allowing defaults to be overridden by
             # explicitly set attributes of the source if ``merge_attributes``.
-            for attr in FRAME_ATTR_NAMES_SET():
+            for attr in frame_transform_graph.frame_attrnames_set:
                 self_val = getattr(self, attr, None)
                 frame_val = getattr(frame, attr, None)
                 if (frame_val is not None and not
@@ -465,14 +453,14 @@ class SkyCoord(ShapedLikeNDArray):
             # Anything in the set of all possible frame_attr_names is handled
             # here. If the attr is relevant for the current frame then delegate
             # to self.frame otherwise get it from self._<attr>.
-            if attr in FRAME_ATTR_NAMES_SET():
+            if attr in frame_transform_graph.frame_attrnames_set:
                 if attr in self.frame.get_frame_attr_names():
                     return getattr(self.frame, attr)
                 else:
                     try:
                         return getattr(self, '_' + attr)
                     except AttributeError:
-                        # this can happen because FRAME_ATTR_NAMES_SET is
+                        # this can happen because frame_attrnames_set is
                         # dynamic.  So if a frame is added to the transform
                         # graph after this SkyCoord was created, the "real"
                         # underlying attribute - e.g. `_equinox` does not exist
@@ -509,7 +497,7 @@ class SkyCoord(ShapedLikeNDArray):
             if frame_cls is not None and self.frame.is_transformable_to(frame_cls):
                 raise AttributeError("'{0}' is immutable".format(attr))
 
-        if attr in FRAME_ATTR_NAMES_SET():
+        if attr in attr in frame_transform_graph.frame_attrnames_set:
             # All possible frame attributes can be set, but only via a private
             # variable.  See __getattr__ above.
             attr = '_' + attr
@@ -536,7 +524,7 @@ class SkyCoord(ShapedLikeNDArray):
         dir_values.update(set(attr for attr in dir(self.frame) if not attr.startswith('_')))
 
         # Add all possible frame attributes
-        dir_values.update(FRAME_ATTR_NAMES_SET())
+        dir_values.update(frame_transform_graph.frame_attrnames_set)
 
         return dir_values
 
@@ -649,7 +637,7 @@ class SkyCoord(ShapedLikeNDArray):
             if other.frame.name != self.frame.name:
                 return False
 
-            for fattrnm in FRAME_ATTR_NAMES_SET():
+            for fattrnm in frame_transform_graph.frame_attrnames_set:
                 if getattr(self, fattrnm) != getattr(other, fattrnm):
                     return False
             return True
@@ -1493,7 +1481,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # Get the value from `data` in the eventual representation
             values.append(getattr(data, repr_attr_name))
 
-        for attr in FRAME_ATTR_NAMES_SET():
+        for attr in frame_transform_graph.frame_attrnames_set:
             value = getattr(coords, attr, None)
             use_value = (isinstance(coords, SkyCoord)
                          or attr not in coords._attr_names_with_defaults)
@@ -1533,7 +1521,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
             # get the frame attributes from the first one, because from above we
             # know it matches all the others
-            for fattrnm in FRAME_ATTR_NAMES_SET():
+            for fattrnm in frame_transform_graph.frame_attrnames_set:
                 valid_kwargs[fattrnm] = getattr(scs[0], fattrnm)
 
             # Now combine the values, to be used below

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -200,8 +200,10 @@ class SkyCoord(ShapedLikeNDArray):
         kwargs = self._parse_inputs(args, kwargs)
 
         # Set internal versions of object state attributes
-        for attr in frame_transform_graph.frame_attributes:
-            setattr(self, '_' + attr, kwargs[attr])
+        for name, attribute in frame_transform_graph.frame_attributes.items():
+            setattr(self, '_' + name, kwargs[name])
+            # Validate it
+            attribute.__get__(self)
 
         frame = kwargs['frame']
         coord_kwargs = {}

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -652,7 +652,7 @@ class SkyCoord(ShapedLikeNDArray):
                 return False
 
             for fattrnm in frame_transform_graph.frame_attributes:
-                if getattr(self, fattrnm) != getattr(other, fattrnm):
+                if np.any(getattr(self, fattrnm) != getattr(other, fattrnm)):
                     return False
             return True
         else:

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -348,3 +348,9 @@ def test_regression_simple_5133():
     # az is more-or-less undefined for straight up or down
     assert_quantity_allclose(aa.alt, [90, -90]*u.deg, rtol=1e-5)
     assert_quantity_allclose(aa.distance, [90, 10]*u.km)
+
+
+def test_regression_5743():
+    sc = SkyCoord([5, 10], [20, 30], unit=u.deg,
+                  obstime=['2017-01-01T00:00', '2017-01-01T00:10'])
+    assert sc[0].obstime.shape == tuple()

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1362,3 +1362,14 @@ def test_extra_attributes():
     assert sc.is_equivalent_frame(sc)
     sc_1 = sc[1]
     assert sc_1.obstime == obstime[1]
+    # Transforming to FK4 should use sc.obstime.
+    sc_fk4 = sc.transform_to('fk4')
+    assert np.all(sc_fk4.frame.obstime == obstime)
+    # And transforming back should not loose it.
+    sc2 = sc_fk4.transform_to('icrs')
+    assert not hasattr(sc2.frame, 'obstime')
+    assert np.all(sc2.obstime == obstime)
+    # Finally, ensure obstime get taken from the SkyCoord if passed in directly.
+    # (regression test for #5749).
+    sc3 = SkyCoord([0., 1.], [2., 3.], unit='deg', frame=sc)
+    assert np.all(sc3.obstime == obstime)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1369,7 +1369,10 @@ def test_extra_attributes():
     sc2 = sc_fk4.transform_to('icrs')
     assert not hasattr(sc2.frame, 'obstime')
     assert np.all(sc2.obstime == obstime)
-    # Finally, ensure obstime get taken from the SkyCoord if passed in directly.
+    # Ensure obstime get taken from the SkyCoord if passed in directly.
     # (regression test for #5749).
     sc3 = SkyCoord([0., 1.], [2., 3.], unit='deg', frame=sc)
     assert np.all(sc3.obstime == obstime)
+    # Finally, check that we can delete such attributes.
+    del sc3.obstime
+    assert sc3.obstime is None

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1355,7 +1355,10 @@ def test_extra_attributes():
     obstime = Time(obstime_string)
     sc = SkyCoord([5, 10], [20, 30], unit=u.deg, obstime=obstime_string)
     assert not hasattr(sc.frame, 'obstime')
+    assert type(sc.obstime) is Time
     assert sc.obstime.shape == (2,)
     assert np.all(sc.obstime == obstime)
+    # ensure equivalency still works for more than one obstime.
+    assert sc.is_equivalent_frame(sc)
     sc_1 = sc[1]
     assert sc_1.obstime == obstime[1]

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -121,9 +121,9 @@ def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
         assert allclose(sc.ra, sc_rt.ra)
         assert allclose(sc.dec, sc_rt.dec)
     if equinox0:
-        assert Time(sc.equinox) == Time(sc_rt.equinox)
+        assert type(sc.equinox) is Time and sc.equinox == sc_rt.equinox
     if obstime0:
-        assert Time(sc.obstime) == Time(sc_rt.obstime)
+        assert type(sc.obstime) is Time and sc.obstime == sc_rt.obstime
 
 
 def test_coord_init_string():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1344,3 +1344,18 @@ def test_set_attribute_exceptions():
     sc.relative_humidity = 0.5
     assert sc.relative_humidity == 0.5
     assert not hasattr(sc.frame, 'relative_humidity')
+
+
+def test_extra_attributes():
+    """Ensure any extra attributes are dealt with correctly.
+
+    Regression test against #5743.
+    """
+    obstime_string = ['2017-01-01T00:00','2017-01-01T00:10']
+    obstime = Time(obstime_string)
+    sc = SkyCoord([5, 10], [20, 30], unit=u.deg, obstime=obstime_string)
+    assert not hasattr(sc.frame, 'obstime')
+    assert sc.obstime.shape == (2,)
+    assert np.all(sc.obstime == obstime)
+    sc_1 = sc[1]
+    assert sc_1.obstime == obstime[1]

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -70,6 +70,20 @@ class TransformGraph(object):
 
         return self._cached_frame_set.copy()
 
+    @property
+    def frame_attrnames_set(self):
+        """
+        A `frozenset` of all the attribute names of all frame classes in this `TransformGraph`.
+        """
+        if self._cached_frame_attrnames_set is None:
+            result = set()
+            for frame_cls in self.frame_set:
+                for attr in frame_cls.get_frame_attr_names().keys():
+                    result.add(attr)
+            self._cached_frame_attrnames_set = frozenset(result)
+
+        return self._cached_frame_attrnames_set
+
     def invalidate_cache(self):
         """
         Invalidates the cache that stores optimizations for traversing the
@@ -79,6 +93,7 @@ class TransformGraph(object):
         """
         self._cached_names_dct = None
         self._cached_frame_set = None
+        self._cached_frame_attrnames_set = None
         self._shortestpaths = {}
         self._composite_cache = {}
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -71,18 +71,17 @@ class TransformGraph(object):
         return self._cached_frame_set.copy()
 
     @property
-    def frame_attrnames_set(self):
+    def frame_attributes(self):
         """
-        A `frozenset` of all the attribute names of all frame classes in this `TransformGraph`.
+        A `dict` of all the attributes of all frame classes in this `TransformGraph`.
         """
-        if self._cached_frame_attrnames_set is None:
-            result = set()
+        if self._cached_frame_attributes is None:
+            result = {}
             for frame_cls in self.frame_set:
-                for attr in frame_cls.get_frame_attr_names().keys():
-                    result.add(attr)
-            self._cached_frame_attrnames_set = frozenset(result)
+                result.update(frame_cls.frame_attributes)
+            self._cached_frame_attributes = result
 
-        return self._cached_frame_attrnames_set
+        return self._cached_frame_attributes
 
     def invalidate_cache(self):
         """
@@ -93,7 +92,7 @@ class TransformGraph(object):
         """
         self._cached_names_dct = None
         self._cached_frame_set = None
-        self._cached_frame_attrnames_set = None
+        self._cached_frame_attributes = None
         self._shortestpaths = {}
         self._composite_cache = {}
 


### PR DESCRIPTION
fixes #5743, related to #5749 (but isn't a fix).

This PR ensures that any extra attributes which are set on a `SkyCoord`, but are not needed for initializing a particular frame, are properly validated, and taking into account both when doing `ndarray` operations such as slicing and resizing, and also when transforming to another `SkyCoord`.

cc @taldcroft, @eteq 

This PR requires #5750 and builds on #5703, as I needed to make the full set of frame attributes a dictionary that also contains the appriate `FrameAttribute` class. So, one gets the speed advantage brought by that PR. Nevertheless, I see this mostly as a bug fix.