### PR TITLE
Fix disabling arguments in test runner subclasses.

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -109,6 +109,20 @@ class TestRunnerBase(object):
         cls.keywords = OrderedDict()
         doc_keywords = ""
         for name, func in sorted_keywords:
+            # Here we test if the function has been overloaded to return
+            # NotImplemented which is the way to disable arguments on
+            # subclasses. If it has been disabled we need to remove it from the
+            # default keywords dict. We do it in the try except block because
+            # we do not have access to an instance of the class, so this is
+            # going to error unless the method is just doing `return
+            # NotImplemented`.
+            try:
+                if func(None, None, None) is NotImplemented:
+                    continue
+            except:
+                pass
+
+            # Construct the default kwargs dict and docstring
             cls.keywords[name] = func._default_value
             if func.__doc__:
                 doc_keywords += ' '*8

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import inspect
 import os
+import copy
 import shlex
 import sys
 import tempfile
@@ -117,7 +118,9 @@ class TestRunnerBase(object):
             # going to error unless the method is just doing `return
             # NotImplemented`.
             try:
-                if func(None, None, None) is NotImplemented:
+                # Second argument is False, as it is normally a bool.
+                # The other two are placeholders for objects.
+                if func(None, False, None) is NotImplemented:
                     continue
             except:
                 pass
@@ -138,12 +141,14 @@ class TestRunnerBase(object):
 
     def _generate_args(self, **kwargs):
         # Update default values with passed kwargs
-        self.keywords.update(kwargs)
+        # but don't modify the defaults
+        keywords = copy.deepcopy(self.keywords)
+        keywords.update(kwargs)
         # Iterate through the keywords (in order of priority)
         args = []
-        for keyword in self.keywords.keys():
+        for keyword in keywords.keys():
             func = getattr(self, keyword)
-            result = func(self.keywords[keyword], self.keywords)
+            result = func(keywords[keyword], self.keywords)
 
             # Allow disabaling of options in a subclass
             if result is NotImplemented:

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -122,7 +122,7 @@ class TestRunnerBase(object):
                 # The other two are placeholders for objects.
                 if func(None, False, None) is NotImplemented:
                     continue
-            except:
+            except Exception:
                 pass
 
             # Construct the default kwargs dict and docstring


### PR DESCRIPTION
We need to remove the kwarg from the defaults otherwise it triggers an unexpected kwarg error when the test method is called.

This feels a little cludgy, if anyone has a better suggestion I am open to it.

@astrofrog 