### PR TITLE
Change deprecated_renamed_argument to allow hiding the deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,6 +171,14 @@ Other Changes and Additions
 1.3.1 (unreleased)
 ------------------
 
+New Features
+^^^^^^^^^^^^
+
+- ``astropy.utils``
+
+  - The ``deprecated_renamed_argument`` decorator got a new ``pending``
+    parameter to suppress the deprecation warnings. [#5761]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -203,7 +211,7 @@ Bug Fixes
     ``PyMem_Realloc()`` [#5696, #4739, #2100]
 
 - ``astropy.modeling``
- 
+
   - Fixed a problem with setting ``bounding_box`` on 1D models. [#5718]
 
 - ``astropy.nddata``
@@ -244,6 +252,10 @@ Other Changes and Additions
 
 - Fixed a deprecation warning that occurred when running tests with
   astropy.test(). [#5689]
+
+- The deprecation of the ``clobber`` argument (originally deprecated in 1.3.0)
+  in the ``io.fits`` write functions was changed to a "pending" deprecation
+  (without displaying warnings) for now. [#5761]
 
 1.3 (2016-12-22)
 ----------------

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -394,7 +394,7 @@ def delval(filename, keyword, *args, **kwargs):
         hdulist._close(closed=closed)
 
 
-@deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+@deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
 def writeto(filename, data, header=None, output_verify='exception',
             overwrite=False, checksum=False):
     """
@@ -709,7 +709,7 @@ def info(filename, output=None, **kwargs):
     return ret
 
 
-@deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+@deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
 def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
               overwrite=False):
     """

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -135,7 +135,7 @@ class _BaseDiff(object):
         return not any(getattr(self, attr) for attr in self.__dict__
                        if attr.startswith('diff_'))
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def report(self, fileobj=None, indent=0, overwrite=False):
         """
         Generates a text report on the differences (if any) between two

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -79,7 +79,7 @@ class _File(object):
     Represents a FITS file on disk (or in some other file-like object).
     """
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def __init__(self, fileobj=None, mode=None, memmap=None, overwrite=False,
                  cache=True):
         self.strict_memmap = bool(memmap)

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -334,7 +334,7 @@ class _BaseHDU(object):
         fileobj.seek(hdu._data_offset + hdu._data_size, os.SEEK_SET)
         return hdu
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
         """
@@ -1580,7 +1580,7 @@ class ExtensionHDU(_ValidHDU):
 
         raise NotImplementedError
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
         """

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -816,7 +816,7 @@ class HDUList(list, _Verify):
                 n = hdr['NAXIS']
                 hdr.set('EXTEND', True, after='NAXIS' + str(n))
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def writeto(self, fileobj, output_verify='exception', overwrite=False,
                 checksum=False):
         """

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -968,7 +968,7 @@ class BinTableHDU(_TableBaseHDU):
           image.
       """)
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def dump(self, datafile=None, cdfile=None, hfile=None, overwrite=False):
         """
         Dump the table HDU to a file in ASCII format.  The table may be dumped

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -640,7 +640,7 @@ class Header(object):
             s += ' ' * _pad_length(len(s))
         return s
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def tofile(self, fileobj, sep='', endcard=True, padding=True,
                overwrite=False):
         r"""
@@ -722,7 +722,7 @@ class Header(object):
 
         return cls.fromfile(fileobj, sep='\n', endcard=endcard, padding=False)
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '1.3')
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
     def totextfile(self, fileobj, endcard=False, overwrite=False):
         """
         Write the header as text to a file or a file-like object.

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -728,7 +728,8 @@ class TestDiff(FitsTestCase):
         report_as_string = diffobj.report()
         with catch_warnings(AstropyDeprecationWarning) as warning_lines:
             diffobj.report(fileobj=outpath, clobber=True)
-            assert warning_lines[0].category == AstropyDeprecationWarning
-            assert (str(warning_lines[0].message) == '"clobber" was '
-                    'deprecated in version 1.3 and will be removed in a '
-                    'future version. Use argument "overwrite" instead.')
+            assert len(warning_lines) == 0
+            # assert warning_lines[0].category == AstropyDeprecationWarning
+            # assert (str(warning_lines[0].message) == '"clobber" was '
+            #         'deprecated in version 1.3 and will be removed in a '
+            #         'future version. Use argument "overwrite" instead.')

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -789,10 +789,11 @@ class TestHDUListFunctions(FitsTestCase):
         hdulist.writeto(self.temp('test_overwrite.fits'), overwrite=True)
         with catch_warnings(AstropyDeprecationWarning) as warning_lines:
             hdulist.writeto(self.temp('test_overwrite.fits'), clobber=True)
-            assert warning_lines[0].category == AstropyDeprecationWarning
-            assert (str(warning_lines[0].message) == '"clobber" was '
-                    'deprecated in version 1.3 and will be removed in a '
-                    'future version. Use argument "overwrite" instead.')
+            assert len(warning_lines) == 0
+            # assert warning_lines[0].category == AstropyDeprecationWarning
+            # assert (str(warning_lines[0].message) == '"clobber" was '
+            #         'deprecated in version 1.3 and will be removed in a '
+            #         'future version. Use argument "overwrite" instead.')
 
     def test_invalid_hdu_key_in_contains(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2491,10 +2491,11 @@ class TestTableFunctions(FitsTestCase):
             tbhdu.dump(datafile, cdfile, hfile, overwrite=True)
             with catch_warnings(AstropyDeprecationWarning) as warning_lines:
                 tbhdu.dump(datafile, cdfile, hfile, clobber=True)
-                assert warning_lines[0].category == AstropyDeprecationWarning
-                assert (str(warning_lines[0].message) == '"clobber" was '
-                        'deprecated in version 1.3 and will be removed in a '
-                        'future version. Use argument "overwrite" instead.')
+                assert len(warning_lines) == 0
+                # assert warning_lines[0].category == AstropyDeprecationWarning
+                # assert (str(warning_lines[0].message) == '"clobber" was '
+                #         'deprecated in version 1.3 and will be removed in a '
+                #         'future version. Use argument "overwrite" instead.')
 
 
 @contextlib.contextmanager

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -274,7 +274,8 @@ def deprecated_attribute(name, since, message=None, alternative=None,
 
 
 def deprecated_renamed_argument(old_name, new_name, since,
-                                arg_in_kwargs=False, relax=False):
+                                arg_in_kwargs=False, relax=False,
+                                pending=False):
     """Deprecate a _renamed_ function argument.
 
     The decorator assumes that the argument with the ``old_name`` was removed
@@ -306,6 +307,11 @@ def deprecated_renamed_argument(old_name, new_name, since,
         If ``False`` a ``TypeError`` is raised if both ``new_name`` and
         ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
         and a Warning is issued.
+        Default is ``False``.
+
+    pending : bool or list/tuple thereof, optional
+        If ``True`` this will hide the deprecation warning and ignore the
+        corresponding ``relax`` parameter value.
         Default is ``False``.
 
     Raises
@@ -402,6 +408,8 @@ def deprecated_renamed_argument(old_name, new_name, since,
             arg_in_kwargs = [arg_in_kwargs] * n
         if not isinstance(relax, cls_iter):
             relax = [relax] * n
+        if not isinstance(pending, cls_iter):
+            pending = [pending] * n
     else:
         # To allow a uniform approach later on, wrap all arguments in lists.
         n = 1
@@ -410,6 +418,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
         since = [since]
         arg_in_kwargs = [arg_in_kwargs]
         relax = [relax]
+        pending = [pending]
 
     def decorator(function):
         # Lazy import to avoid cyclic imports
@@ -462,12 +471,15 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 # parameter was renamed to newkeyword.
                 if old_name[i] in kwargs:
                     value = kwargs.pop(old_name[i])
-                    warnings.warn('"{0}" was deprecated in version {1} '
-                                  'and will be removed in a future version. '
-                                  'Use argument "{2}" instead.'
-                                  ''.format(old_name[i], since[i],
-                                            new_name[i]),
-                                  AstropyDeprecationWarning)
+                    # Display the deprecation warning only when it's only
+                    # pending.
+                    if not pending[i]:
+                        warnings.warn(
+                            '"{0}" was deprecated in version {1} '
+                            'and will be removed in a future version. '
+                            'Use argument "{2}" instead.'
+                            ''.format(old_name[i], since[i], new_name[i]),
+                            AstropyDeprecationWarning)
 
                     # Check if the newkeyword was given as well.
                     newarg_in_args = (position[i] is not None and
@@ -475,17 +487,19 @@ def deprecated_renamed_argument(old_name, new_name, since,
                     newarg_in_kwargs = new_name[i] in kwargs
 
                     if newarg_in_args or newarg_in_kwargs:
-                        # If both are given print a Warning if relax is True or
-                        # raise an Exception is relax is False.
-                        if relax[i]:
-                            warnings.warn('"{0}" and "{1}" keywords were set. '
-                                          'Using the value of "{1}".'
-                                          ''.format(old_name[i], new_name[i]),
-                                          AstropyUserWarning)
-                        else:
-                            raise TypeError('cannot specify both "{}" and "{}"'
-                                            '.'.format(old_name[i],
-                                                       new_name[i]))
+                        if not pending[i]:
+                            # If both are given print a Warning if relax is
+                            # True or raise an Exception is relax is False.
+                            if relax[i]:
+                                warnings.warn(
+                                    '"{0}" and "{1}" keywords were set. '
+                                    'Using the value of "{1}".'
+                                    ''.format(old_name[i], new_name[i]),
+                                    AstropyUserWarning)
+                            else:
+                                raise TypeError(
+                                    'cannot specify both "{}" and "{}"'
+                                    '.'.format(old_name[i], new_name[i]))
                     else:
                         # If the new argument isn't specified just pass the old
                         # one with the name of the new argument to the function

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -354,6 +354,35 @@ def test_deprecated_argument_relaxed():
         assert len(w) == 1
 
 
+def test_deprecated_argument_pending():
+    # Relax turns the TypeError if both old and new keyword are used into
+    # a warning.
+    @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
+    def test(overwrite):
+        return overwrite
+
+    # As positional argument only
+    assert test(1) == 1
+
+    # As new keyword argument
+    assert test(overwrite=1) == 1
+
+    # Using the deprecated name
+    with catch_warnings(AstropyUserWarning, AstropyDeprecationWarning) as w:
+        assert test(clobber=1) == 1
+        assert len(w) == 0
+
+    # Using both. Both keyword
+    with catch_warnings(AstropyUserWarning, AstropyDeprecationWarning) as w:
+        assert test(clobber=2, overwrite=1) == 1
+        assert len(w) == 0
+
+    # One positional, one keyword
+    with catch_warnings(AstropyUserWarning, AstropyDeprecationWarning) as w:
+        assert test(1, clobber=2) == 1
+        assert len(w) == 0
+
+
 def test_deprecated_argument_multi_deprecation():
     @deprecated_renamed_argument(['x', 'y', 'z'], ['a', 'b', 'c'],
                                  [1.3, 1.2, 1.3], relax=True)


### PR DESCRIPTION
This is to adress the issues mentioned in #5644.

- It is still possible with 1.3 to use `overwrite`.
- It doesn't emit a deprecation when `clobber` is used.

I'm not exactly pleased with this. But the only other way is to create an `astropy-compat` package (like `six` for python) that affiliated packages could use if they want to continue to use the old API.