### PR TITLE
Position-angle bug fix that does not introduce new method (based on #5723)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,8 @@ Bug Fixes
     current ``frame`` (but are valid for other frames) are stored on the
     ``SkyCoord`` instance instead of the underlying ``frame`` instance (e.g.,
     setting ``relative_humidity`` on an ICRS ``SkyCoord`` instance.) [#5750]
+  - Ensured that ``position_angle`` and ``separation`` give correct answers for
+    frames with different equinox (see #5722). [#5762]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,7 @@ Bug Fixes
     current ``frame`` (but are valid for other frames) are stored on the
     ``SkyCoord`` instance instead of the underlying ``frame`` instance (e.g.,
     setting ``relative_humidity`` on an ICRS ``SkyCoord`` instance.) [#5750]
+
   - Ensured that ``position_angle`` and ``separation`` give correct answers for
     frames with different equinox (see #5722). [#5762]
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -682,16 +682,17 @@ class SkyCoord(ShapedLikeNDArray):
         from . import Angle
         from .angle_utilities import angular_separation
 
-        try:
-            other_in_self_frame = other.transform_to(self, strict=True)
-        except TypeError:
-            raise TypeError('Can only get separation to another SkyCoord or a '
-                            'coordinate frame with data')
+        if not self.is_equivalent_frame(other):
+            try:
+                other = other.transform_to(self, strict=True)
+            except TypeError:
+                raise TypeError('Can only get separation to another SkyCoord '
+                                'or a coordinate frame with data')
 
         lon1 = self.spherical.lon
         lat1 = self.spherical.lat
-        lon2 = other_in_self_frame.spherical.lon
-        lat2 = other_in_self_frame.spherical.lat
+        lon2 = other.spherical.lon
+        lat2 = other.spherical.lat
 
         # Get the separation as a Quantity, convert to Angle in degrees
         sep = angular_separation(lon1, lat1, lon2, lat2)
@@ -720,7 +721,12 @@ class SkyCoord(ShapedLikeNDArray):
         ValueError
             If this or the other coordinate do not have distances.
         """
-
+        if not self.is_equivalent_frame(other):
+            try:
+                other = other.transform_to(self, strict=True)
+            except TypeError:
+                raise TypeError('Can only get separation to another SkyCoord '
+                                'or a coordinate frame with data')
 
         if issubclass(self.data.__class__, UnitSphericalRepresentation):
             raise ValueError('This object does not have a distance; cannot '
@@ -729,14 +735,7 @@ class SkyCoord(ShapedLikeNDArray):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 
-        try:
-            other_in_self_frame = other.transform_to(self, strict=True)
-        except TypeError:
-            raise TypeError('Can only get separation to another SkyCoord or a '
-                            'coordinate frame with data')
-
-        return Distance((self.cartesian -
-                         other_in_self_frame.cartesian).norm())
+        return Distance((self.cartesian - other.cartesian).norm())
 
     def spherical_offsets_to(self, tocoord):
         r"""
@@ -1064,16 +1063,17 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from . import angle_utilities
 
-        try:
-            other_in_self_frame = other.transform_to(self, strict=True)
-        except TypeError as e:
-            raise TypeError('Can only get position_angle to another SkyCoord or a '
-                            'coordinate frame with data')
+        if not self.is_equivalent_frame(other):
+            try:
+                other = other.transform_to(self, strict=True)
+            except TypeError:
+                raise TypeError('Can only get position_angle to another '
+                                'SkyCoord or a coordinate frame with data')
 
         slat = self.represent_as(UnitSphericalRepresentation).lat
         slon = self.represent_as(UnitSphericalRepresentation).lon
-        olat = other_in_self_frame.represent_as(UnitSphericalRepresentation).lat
-        olon = other_in_self_frame.represent_as(UnitSphericalRepresentation).lon
+        olat = other.represent_as(UnitSphericalRepresentation).lat
+        olon = other.represent_as(UnitSphericalRepresentation).lon
 
         return angle_utilities.position_angle(slon, slat, olon, olat)
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -903,13 +903,9 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from .matching import match_coordinates_3d
 
-
         if (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
                 and catalogcoord.has_data):
-            if self.is_equivalent_frame(catalogcoord):
-                self_in_catalog_frame = self
-            else:
-                self_in_catalog_frame = self.transform_to(catalogcoord)
+            self_in_catalog_frame = self.transform_to(catalogcoord)
         else:
             raise TypeError('Can only get separation to another SkyCoord or a '
                             'coordinate frame with data')

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -362,24 +362,32 @@ class SkyCoord(ShapedLikeNDArray):
 
         return valid_kwargs
 
-    def transform_to(self, frame, strict=False):
+    def transform_to(self, frame, override_defaults=True):
         """Transform this coordinate to a new frame.
 
-        The frame attributes (e.g. equinox or obstime) for the returned object
-        depend on the corresponding attributes of SkyCoord object and the
-        supplied ``frame``, with the following precedence:
+        The frame attributes (e.g., equinox or obstime) for the returned object
+        depend on the corresponding attributes of both the destination ``frame``
+        and the `SkyCoord` instance being transformed, with a precedence that
+        depends on whether ``override_defaults`` is set or not.
 
-        1. Non-default value in the supplied frame
-        2. Non-default value in the SkyCoord instance (if not ``strict``)
-        3. Default value in the supplied frame
+        If ``override_defaults`` is `True`:
+
+        1. Explicitly set (i.e., non-default) values in the destination frame;
+        2. Explicitly set values in the `SkyCoord` instance;
+        3. Default value in the destination frame.
+
+        If ``override_defaults`` is `False`:
+
+        1. Any attribute, explicitly set or default, in the destination frame;
+        2. Explicitly set attributes  in the `SkyCoord` instance.
 
         Parameters
         ----------
         frame : str or `BaseCoordinateFrame` class / instance or `SkyCoord` instance
             The frame to transform this coordinate into.
-        strict : bool, optional
-            Whether or not the destination frame's default parameters override
-            the original frame's explicit parameters (default: `False`).
+        override_defaults : bool, optional
+            Whether the source frame's explicit parameters should override the
+            destination frame's default parameters (default: `True`).
 
         Returns
         -------
@@ -416,8 +424,8 @@ class SkyCoord(ShapedLikeNDArray):
             for attr in FRAME_ATTR_NAMES_SET():
                 self_val = getattr(self, attr, None)
                 frame_val = getattr(frame, attr, None)
-                if (frame_val is not None and
-                        (strict or not frame.is_frame_attr_default(attr))):
+                if (frame_val is not None and not
+                    (override_defaults and frame.is_frame_attr_default(attr))):
                     frame_kwargs[attr] = frame_val
                 elif (self_val is not None and
                       not self.is_frame_attr_default(attr)):
@@ -684,7 +692,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         if not self.is_equivalent_frame(other):
             try:
-                other = other.transform_to(self, strict=True)
+                other = other.transform_to(self, override_defaults=False)
             except TypeError:
                 raise TypeError('Can only get separation to another SkyCoord '
                                 'or a coordinate frame with data')
@@ -723,7 +731,7 @@ class SkyCoord(ShapedLikeNDArray):
         """
         if not self.is_equivalent_frame(other):
             try:
-                other = other.transform_to(self, strict=True)
+                other = other.transform_to(self, override_defaults=False)
             except TypeError:
                 raise TypeError('Can only get separation to another SkyCoord '
                                 'or a coordinate frame with data')
@@ -1065,7 +1073,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         if not self.is_equivalent_frame(other):
             try:
-                other = other.transform_to(self, strict=True)
+                other = other.transform_to(self, override_defaults=False)
             except TypeError:
                 raise TypeError('Can only get position_angle to another '
                                 'SkyCoord or a coordinate frame with data')

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -918,7 +918,7 @@ def test_frame_attr_transform_inherit():
     c2 = c1.transform_to(c)
     assert not c2.is_equivalent_frame(c) # counterintuitive, but documented
     assert c2.equinox.value == 'B1950.000'
-    c3 = c1.transform_to(c, strict=True)
+    c3 = c1.transform_to(c, merge_attributes=False)
     assert c3.equinox.value == 'J2000.000'
     assert c3.is_equivalent_frame(c)
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -601,23 +601,38 @@ def test_position_angle():
     assert cicrs.position_angle(cfk5) > 90.0 * u.deg
     assert cicrs.position_angle(cfk5) < 91.0 * u.deg
 
-    # regression check for bug in #5702
-    cfk5B1950 = SkyCoord(1*u.deg, 0*u.deg, frame='fk5', equinox='B1950')
-    # test with both default and explicit equinox #5722 and #3106
-    for cfk5J2000 in (SkyCoord(1*u.deg, 0*u.deg, frame='fk5', equinox='J2000'),
-                      SkyCoord(1 * u.deg, 0 * u.deg, frame='fk5')):
-        posang_forward = cfk5.position_angle(cfk5B1950)
-        posang_backward = cfk5B1950.position_angle(cfk5)
-        assert posang_forward.degree != 0 and posang_backward.degree != 0
-        assert 179 < (posang_forward - posang_backward).wrap_at(360*u.deg).degree < 181
-
-
 def test_position_angle_directly():
     """Regression check for #3800: position_angle should accept floats."""
     from ..angle_utilities import position_angle
     result = position_angle(10., 20., 10., 20.)
     assert result.unit is u.radian
     assert result.value == 0.
+
+
+def test_sep_pa_equivalence():
+    """Regression check for bug in #5702.
+
+    PA and separation from object 1 to 2 should be consistent with those
+    from 2 to 1
+    """
+    cfk5 = SkyCoord(1*u.deg, 0*u.deg, frame='fk5')
+    cfk5B1950 = SkyCoord(1*u.deg, 0*u.deg, frame='fk5', equinox='B1950')
+    # test with both default and explicit equinox #5722 and #3106
+    sep_forward = cfk5.separation(cfk5B1950)
+    sep_backward = cfk5B1950.separation(cfk5)
+    assert sep_forward != 0 and sep_backward != 0
+    assert_allclose(sep_forward, sep_backward)
+    posang_forward = cfk5.position_angle(cfk5B1950)
+    posang_backward = cfk5B1950.position_angle(cfk5)
+    assert posang_forward != 0 and posang_backward != 0
+    assert 179 < (posang_forward - posang_backward).wrap_at(360*u.deg).degree < 181
+    dcfk5 = SkyCoord(1*u.deg, 0*u.deg, frame='fk5', distance=1*u.pc)
+    dcfk5B1950 = SkyCoord(1*u.deg, 0*u.deg, frame='fk5', equinox='B1950',
+                          distance=1.*u.pc)
+    sep3d_forward = dcfk5.separation_3d(dcfk5B1950)
+    sep3d_backward = dcfk5B1950.separation_3d(dcfk5)
+    assert sep3d_forward != 0 and sep3d_backward != 0
+    assert_allclose(sep3d_forward, sep3d_backward)
 
 
 def test_table_to_coord():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -918,7 +918,7 @@ def test_frame_attr_transform_inherit():
     c2 = c1.transform_to(c)
     assert not c2.is_equivalent_frame(c) # counterintuitive, but documented
     assert c2.equinox.value == 'B1950.000'
-    c3 = c1.transform_to(c, accepting_defaults=True)
+    c3 = c1.transform_to(c, strict=True)
     assert c3.equinox.value == 'J2000.000'
     assert c3.is_equivalent_frame(c)
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -918,7 +918,7 @@ def test_frame_attr_transform_inherit():
     c2 = c1.transform_to(c)
     assert not c2.is_equivalent_frame(c) # counterintuitive, but documented
     assert c2.equinox.value == 'B1950.000'
-    c3 = c1.transform_to(c, override_defaults=False)
+    c3 = c1.transform_to(c, strict=True)
     assert c3.equinox.value == 'J2000.000'
     assert c3.is_equivalent_frame(c)
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -601,6 +601,7 @@ def test_position_angle():
     assert cicrs.position_angle(cfk5) > 90.0 * u.deg
     assert cicrs.position_angle(cfk5) < 91.0 * u.deg
 
+
 def test_position_angle_directly():
     """Regression check for #3800: position_angle should accept floats."""
     from ..angle_utilities import position_angle

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -918,7 +918,7 @@ def test_frame_attr_transform_inherit():
     c2 = c1.transform_to(c)
     assert not c2.is_equivalent_frame(c) # counterintuitive, but documented
     assert c2.equinox.value == 'B1950.000'
-    c3 = c1.transform_to(c, strict=True)
+    c3 = c1.transform_to(c, override_defaults=False)
     assert c3.equinox.value == 'J2000.000'
     assert c3.is_equivalent_frame(c)
 


### PR DESCRIPTION
This is a suggested further fix to #5723 (which, annoyingly, I don't seem to be able to make a PR to @dmopalmer's branch for). It does two things:
1. Remove the new `transforms` method, since this is a bug fix and we should not introduce new features.
2. Rename the new `accepting_defaults` keyword argument to `transform_to` to `strict`, which at least to me is more intuitive (@taldcroft?)

This does leave a question of whether it is OK to introduce the new keyword argument. In principle, if anybody subclassed `SkyCoord` and wrote their own `transform_to`, they will now get errors that an extra keyword argument is passed in if they use `separation`.

But I fear this is hard to avoid: we could make a private method `_transform`, but then presumably, if `transform_to` was overridden, it was done so for a reason, so effectively circumventing this would be a bad idea. So, to me, the current approach seems best. @eteq?