### PR TITLE
In examples, query objects with well-known positions.

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -205,9 +205,9 @@ connection. The `~astropy.coordinates.SkyCoord.from_name` method of |skycoord|
 uses `Sesame <http://cds.u-strasbg.fr/cgi-bin/Sesame>`_ to retrieve coordinates
 for a particular named object::
 
-    >>> SkyCoord.from_name("M42")  # doctest: +REMOTE_DATA +FLOAT_CMP
+    >>> SkyCoord.from_name("PSR J1012+5307")  # doctest: +REMOTE_DATA +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        ( 83.82208, -5.39111)>
+        ( 153.1393271,  53.117343)>
 
 For sites (primarily observatories) on the Earth, `astropy.coordinates` provides
 a quick way to get an `~astropy.coordinates.EarthLocation`::

--- a/docs/coordinates/remote_methods.rst
+++ b/docs/coordinates/remote_methods.rst
@@ -12,9 +12,9 @@ The first is the :class:`~astropy.coordinates.SkyCoord` :meth:`~astropy.coordina
 for a particular named object::
 
     >>> from astropy.coordinates import SkyCoord
-    >>> SkyCoord.from_name("M42")  # doctest: +REMOTE_DATA +FLOAT_CMP
+    >>> SkyCoord.from_name("PSR J1012+5307")  # doctest: +REMOTE_DATA +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        ( 83.82208, -5.39111)>
+        ( 153.1393271,  53.117343)>
 
 The second is the :class:`~astropy.coordinates.EarthLocation` :meth:`~astropy.coordinates.EarthLocation.of_site` method, which
 provides a similar quick way to get an


### PR DESCRIPTION
This so that the coordinates will not change over time, making the tests fail (as it was, the tests used 'M42', for which apparently the best known position changed, as the `remote-data` tests started failing; e.g., https://travis-ci.org/astropy/astropy/jobs/197533290).

(not completely sure 1.3.1 is appropriate, but ended up feeling that if people run tests, they should pass)