### PR TITLE
Remove mention of astrpy 0.4 on top documentation page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,7 +159,7 @@ necessary.
 For astropy-helpers
 -------------------
 
-As of Astropy v0.4, Astropy and many affiliated packages use a package of
+Astropy and many affiliated packages use a package of
 utilities called astropy-helpers during building and installation.  If you have
 any build/installation issue--particularly if you're getting a traceback
 mentioning the ``astropy_helpers`` or ``ah_bootstrap`` modules--please send a


### PR DESCRIPTION
Astropy-helpers has been split out for a long time. We are working towards 2.0 now, so I don't think we need to explain to people how live was before 0.4.

[skip ci]