### PR TITLE
Pinning python version to 3.5 for RTD

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,7 +7,7 @@
 name: astropy
 
 dependencies:
-  - python>=3
+  - python=3.5*
   - numpy
   - cython
   - matplotlib


### PR DESCRIPTION
The RTD builds are failing for a while since their python3 default changed to 3.6. However many of the dependencies are not yet available, thus the builds are failing. The PR ping the python version, so the builds should be able to run.