### PR TITLE
Guard against memory unmapping errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -204,6 +204,9 @@ Bug Fixes
 
   - Fix out-of-order TUNITn cards when writing tables to FITS. [#5720]
 
+  - Guard against extremely unlikely problems in compressed images, which
+    could lead to memory unmapping errors. 
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,7 +205,7 @@ Bug Fixes
   - Fix out-of-order TUNITn cards when writing tables to FITS. [#5720]
 
   - Guard against extremely unlikely problems in compressed images, which
-    could lead to memory unmapping errors. 
+    could lead to memory unmapping errors. [#5775]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -769,10 +769,10 @@ void init_output_buffer(PyObject* hdu, void** buf, size_t* bufsize) {
 
     *buf = calloc(*bufsize, sizeof(char));
     if (*buf == NULL) {
-      // Checking if calloc failed.
-      PyErr_SetString(PyExc_TypeError,
+        // Checking if calloc failed.
+        PyErr_SetString(PyExc_MemoryError,
                         "Failed to allocate memory for output data buffer.");
-      goto fail;
+        goto fail;
     }
 
 fail:

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -724,6 +724,12 @@ void init_output_buffer(PyObject* hdu, void** buf, size_t* bufsize) {
         goto fail;
     }
 
+    if(strstr(header,"ZNAXIS") != NULL) {
+      PyErr_SetString(PyExc_TypeError,
+                        "ZNAXIS keyword not present in header.");
+      goto fail;
+    }
+
     if (0 != get_header_int(header, "ZNAXIS", &znaxis, 0)) {
         goto fail;
     }
@@ -764,6 +770,13 @@ void init_output_buffer(PyObject* hdu, void** buf, size_t* bufsize) {
     }
 
     *buf = calloc(*bufsize, sizeof(char));
+    if (*buf == NULL) {
+      // Checking if calloc failed.
+      PyErr_SetString(PyExc_TypeError,
+                        "Failed to allocate memory for output data buffer.");
+      goto fail;
+    }
+
 fail:
     Py_XDECREF(header);
     return;

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -724,13 +724,9 @@ void init_output_buffer(PyObject* hdu, void** buf, size_t* bufsize) {
         goto fail;
     }
 
-    if(strstr(header,"ZNAXIS") != NULL) {
-      PyErr_SetString(PyExc_TypeError,
-                        "ZNAXIS keyword not present in header.");
-      goto fail;
-    }
-
     if (0 != get_header_int(header, "ZNAXIS", &znaxis, 0)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "ZNAXIS keyword not present in header.");
         goto fail;
     }
 
@@ -751,6 +747,8 @@ void init_output_buffer(PyObject* hdu, void** buf, size_t* bufsize) {
 
     // Get the ZBITPIX header value; if this is missing we're in trouble
     if (0 != get_header_int(header, "ZBITPIX", &zbitpix, 0)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "ZBITPIX keyword not present in header.");
         goto fail;
     }
 
@@ -901,7 +899,7 @@ PyObject* compression_compress_hdu(PyObject* self, PyObject* args)
     PyObject* retval = NULL;
     tcolumn* columns = NULL;
 
-    void* outbuf;
+    void* outbuf = NULL;
     size_t outbufsize;
 
     PyArrayObject* indata = NULL;

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1634,6 +1634,10 @@ class TestCompressedImage(FitsTestCase):
         comp_hdu._header.pop('ZNAXIS')
         with pytest.raises(TypeError):
             comp_hdu.compressed_data
+        comp_hdu = fits.CompImageHDU(a)
+        comp_hdu._header.pop('ZBITPIX')
+        with pytest.raises(TypeError):
+            comp_hdu.compressed_data
 
 
 def test_comphdu_bscale(tmpdir):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1628,6 +1628,13 @@ class TestCompressedImage(FitsTestCase):
             hdul[1].data[:] = 0
             assert np.allclose(hdul[1].data, 0)
 
+    def test_compressed_header_missing_znaxis(self):
+        a = np.arange(100, 200, dtype=np.uint16)
+        comp_hdu = fits.CompImageHDU(a)
+        comp_hdu._header.pop('ZNAXIS')
+        with pytest.raises(TypeError):
+            comp_hdu.compressed_data
+
 
 def test_comphdu_bscale(tmpdir):
     """


### PR DESCRIPTION
This is an update of #4585, which ensures we don't get stack traces from badly corrupted compressed data hdus. It makes an additional change so that the code actually works as advertised (initializing `*buf=NULL`), simplifies it a bit, adds an extra error message, and adds tests.

fixes #3118

