### PR TITLE
Added function biweight_midcovariance to stats module in funcs.py script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ New Features
 - ``astropy.nddata``
 
 - ``astropy.stats``
+  - Added ``biweight_midcovariance`` method. [#5777]
 
 - ``astropy.sphinx``
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1054,18 +1054,16 @@ def biweight_midcovariance(a, c=9.0, M=None):
     >>> from astropy.stats import biweight_midcovariance
     >>> rng = np.random.RandomState(1)
     >>> d = np.array([rng.normal(0,1,200), rng.normal(0,3,200)])
-    >>> d[0,0] = 30
+    >>> d[0,0] = 30.0
     >>> np_cov = np.cov(d)
     >>> bw_cov = biweight_midcovariance(d)
-    >>> print(np.around((np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal())),1))
-    [[ 2.4  3.1]
-     [ 1.   3.1]]
+    >>> print(np.around((np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal())), 1))
+    [[ 2.3, 3.1], [ 0.9, 3.1]]
 
     See Also
     --------
     biweight_midvariance, biweight_location
     """
-
     a = np.asanyarray(a)
 
     if M is None:

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -28,7 +28,8 @@ __doctest_skip__ = ['binned_binom_proportion']
 __doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
                         'poisson_conf_interval': ['scipy.special',
                                                   'scipy.optimize',
-                                                  'scipy.integrate']}
+                                                  'scipy.integrate',
+                                                  'scipy.stats']}
 
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1058,7 +1058,8 @@ def biweight_midcovariance(a, c=9.0, M=None):
     >>> np_cov = np.cov(d)
     >>> bw_cov = biweight_midcovariance(d)
     >>> print(np.around((np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal())), 1))
-    [[ 2.3, 3.1], [ 0.9, 3.1]]
+    [[ 2.3  3.1]
+     [ 0.9  3.1]]
 
     See Also
     --------

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1052,11 +1052,14 @@ def biweight_midcovariance(a, c=9.0, M=None):
 
     >>> import numpy as np
     >>> from astropy.stats import biweight_midcovariance
-    >>> d = np.array([np.random.normal(0,1,1000), np.random.normal(0,3,1000)])
+    >>> rng = np.random.RandomState(1)
+    >>> d = np.array([rng.normal(0,1,200), rng.normal(0,3,200)])
     >>> d[0,0] = 30
     >>> np_cov = np.cov(d)
     >>> bw_cov = biweight_midcovariance(d)
-    >>> print(np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal()))
+    >>> print(np.around((np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal())),1))
+    [[ 2.4  3.1]
+     [ 1.   3.1]]
 
     See Also
     --------

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1085,7 +1085,7 @@ def biweight_midcovariance(a, c=9.0, M=None):
 
     # now compute numerator and denominators
     numerator = d * usub1 ** 2
-    denominator = (usub1 * usub5).sum(axis=1)[:,np.newaxis]
+    denominator = (usub1 * usub5).sum(axis=1)[:, np.newaxis]
 
     return n * np.dot(numerator, numerator.T) / np.dot(denominator, denominator.T)
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1108,7 +1108,6 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     return n * (np.dot(numerator, numerator.T) /
                 np.dot(denominator, denominator.T))
 
-
 def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,
                             gain=1.0):
     """Computes the signal to noise ratio for source being observed in the

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -28,8 +28,7 @@ __doctest_skip__ = ['binned_binom_proportion']
 __doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
                         'poisson_conf_interval': ['scipy.special',
                                                   'scipy.optimize',
-                                                  'scipy.integrate'],
-                        'biweight_midcovariance':['scipy.stats']}
+                                                  'scipy.integrate']}
 
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1044,6 +1044,7 @@ def biweight_midcovariance(a, c=9.0, M=None):
     Returns
     -------
     biweight_covariance : `~numpy.ndarray`
+        Estimate of the covariance matrix of <a, a.T>
 
     Examples
     --------
@@ -1051,9 +1052,8 @@ def biweight_midcovariance(a, c=9.0, M=None):
     numpy covariance and the biweight_covariance
 
     >>> import numpy as np
-    >>> from scipy import stats
     >>> from astropy.stats import biweight_midcovariance
-    >>> d = np.array([stats.norm.rvs(0,1,1000), stats.norm.rvs(0,3,1000)])
+    >>> d = np.array([np.random.normal(0,1,1000), np.random.normal(0,3,1000)])
     >>> d[0,0] = 30
     >>> np_cov = np.cov(d)
     >>> bw_cov = biweight_midcovariance(d)
@@ -1085,11 +1085,10 @@ def biweight_midcovariance(a, c=9.0, M=None):
     usub1[~mask] = 0.0
 
     # now compute numerator and denominators
-    numerator = np.array(map(lambda x: d * usub1 ** 2 * x, d * usub1 ** 2)).sum(axis=2)
-    denominator = (usub1 * usub5).sum(axis=1)
-    denominator = np.array(map(lambda x: denominator * x, denominator))
+    numerator = d * usub1 ** 2
+    denominator = (usub1 * usub5).sum(axis=1)[:,np.newaxis]
 
-    return n * numerator / denominator
+    return n * np.dot(numerator, numerator.T) / np.dot(denominator, denominator.T)
 
 
 def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1051,7 +1051,7 @@ def biweight_midcovariance(a, c=9.0, M=None):
     numpy covariance and the biweight_covariance
 
     >>> import numpy as np
-    >>> import scipy.stats as stats
+    >>> from scipy import stats
     >>> from astropy.stats import biweight_midcovariance
     >>> d = np.array([stats.norm.rvs(0,1,1000),stats.norm.rvs(0,3,1000)])
     >>> d[0,0] = 30

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -21,8 +21,8 @@ from ..extern.six.moves import range
 __all__ = ['binom_conf_interval', 'binned_binom_proportion',
            'poisson_conf_interval', 'median_absolute_deviation',
            'mad_std', 'biweight_location', 'biweight_midvariance',
-           'signal_to_noise_oir_ccd', 'bootstrap', 'gaussian_fwhm_to_sigma',
-           'gaussian_sigma_to_fwhm']
+           'biweight_midcovariance', 'signal_to_noise_oir_ccd',
+           'bootstrap', 'gaussian_fwhm_to_sigma', 'gaussian_sigma_to_fwhm']
 
 __doctest_skip__ = ['binned_binom_proportion']
 __doctest_requires__ = {'binom_conf_interval': ['scipy.special'],

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1019,6 +1019,77 @@ def biweight_midvariance(a, c=9.0, M=None, axis=None):
 
     return (n ** 0.5) * f1 / f2
 
+def biweight_midcovariance(a, c=9.0, M=None):
+    r"""
+    Compute the biweight midcovariance.
+
+    This is a robust and resistant estimator of the covariance matrix.
+
+    For more details, see:
+    `<http://www.itl.nist.gov/div898/software/
+    dataplot/refman2/auxillar/biwmidc.htm>_.`
+
+    Parameters
+    ----------
+    a : array-like, shape=(N_dims, N_samples)
+    Input array
+
+    c : float, optional
+    Tuning constant. Default is 9.0
+
+    M : array-like, optional, shape=(N_dims,)
+    Initial guess for biweight location
+
+    Returns
+    -------
+    biweight_covariance : `~numpy.ndarray`
+
+    Examples
+    --------
+    Generate multivariate Gaussian with outliers and compute
+    numpy covariance and the biweight_covariance
+
+    >>> import numpy as np
+    >>> import scipy.stats as stats
+    >>> from astropy.stats import biweight_midcovariance
+    >>> d = np.array([stats.norm.rvs(0,1,1000),stats.norm.rvs(0,3,1000)])
+    >>> d[0,0] = 30
+    >>> np_cov = np.cov(d)
+    >>> bw_cov = biweight_midcovariance(d)
+    >>> print(np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal()))
+    (array([ 1.38868655,  2.97004256]), array([ 1.0232835 ,  3.02582728]))
+
+    See Also
+    --------
+    biweight_midvariance, biweight_location
+    """
+
+    a = np.asanyarray(a)
+
+    if M is None:
+        M = np.median(a, axis=1)
+
+    # set up the differences
+    d = (a.T - M).T
+
+    # set up the weighting
+    mad = median_absolute_deviation(a, axis=1)
+    u = (d.T / (c * mad)).T
+
+    # now remove the outlier points
+    mask = np.abs(u) < 1
+    n = mask.sum(axis=1)
+    usub1 = (1-u**2)
+    usub5 = (1-5*u**2)
+    usub1[~mask] = 0.0
+
+    # now compute nominator and denominators
+    numerator = np.array(map(lambda x: d*usub1**2*x, d*usub1**2)).sum(axis=2)
+    denominator = (usub1*usub5).sum(axis=1)
+    denominator = np.array(map(lambda x: denominator*x, denominator))
+
+    return n * numerator / denominator
+
 
 def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,
                             gain=1.0):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1027,12 +1027,12 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     Parameters
     ----------
     a : array-like
-        A 2D input array of shape (N_variables, N_observations)
+        A 2D numpy.ndarray of shape (N_variables, N_observations)
         Each row of a represents a variable, and each column
         a single observation of all variables (same as numpy.cov convention)
 
-    c : float, optional
-        Tuning constant. Default is 9.0
+    c : float, optional, default=9.0
+        Tuning constant.
 
     M : array-like, optional, shape=(N_dims,)
         Initial guess for biweight location
@@ -1057,12 +1057,9 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     >>> d = np.array([rng.normal(0, 1, 200), rng.normal(0, 3, 200)])
     >>> # Introduce an obvious outlier
     >>> d[0,0] = 30.0
-    >>> # Calculate numpy and biweight covariances
-    >>> np_cov = np.cov(d)
+    >>> # Calculate biweight covariances
     >>> bw_cov = biweight_midcovariance(d)
     >>> # Print out recovered standard deviations
-    >>> print(np.around(np.sqrt(np_cov.diagonal()), 1))
-    [ 2.3  3.1]
     >>> print(np.around(np.sqrt(bw_cov.diagonal()), 1))
     [ 0.9  3.1]
 
@@ -1078,8 +1075,15 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     # Ensure a is array-like
     a = np.asanyarray(a)
 
+    # Ensure a is 2D
+    if a.ndim != 2:
+        if a.ndim == 1:
+            a = a[np.newaxis,:]
+        else:
+            raise ValueError("a.ndim should equal 2")
+
     # Transpose
-    if transpose == True:
+    if transpose == True and a.ndim == 2:
         a = a.T
 
     # Estimate location if not given

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1057,7 +1057,6 @@ def biweight_midcovariance(a, c=9.0, M=None):
     >>> np_cov = np.cov(d)
     >>> bw_cov = biweight_midcovariance(d)
     >>> print(np.sqrt(np_cov.diagonal()), np.sqrt(bw_cov.diagonal()))
-    (array([ 1.38868655,  2.97004256]), array([ 1.0232835 ,  3.02582728]))
 
     See Also
     --------

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -28,8 +28,8 @@ __doctest_skip__ = ['binned_binom_proportion']
 __doctest_requires__ = {'binom_conf_interval': ['scipy.special'],
                         'poisson_conf_interval': ['scipy.special',
                                                   'scipy.optimize',
-                                                  'scipy.integrate',
-                                                  'scipy.stats']}
+                                                  'scipy.integrate'],
+                        'biweight_midcovariance':['scipy.stats']}
 
 
 gaussian_sigma_to_fwhm = 2.0 * np.sqrt(2.0 * np.log(2.0))
@@ -1033,13 +1033,13 @@ def biweight_midcovariance(a, c=9.0, M=None):
     Parameters
     ----------
     a : array-like, shape=(N_dims, N_samples)
-    Input array
+        Input array
 
     c : float, optional
-    Tuning constant. Default is 9.0
+        Tuning constant. Default is 9.0
 
     M : array-like, optional, shape=(N_dims,)
-    Initial guess for biweight location
+        Initial guess for biweight location
 
     Returns
     -------
@@ -1053,7 +1053,7 @@ def biweight_midcovariance(a, c=9.0, M=None):
     >>> import numpy as np
     >>> from scipy import stats
     >>> from astropy.stats import biweight_midcovariance
-    >>> d = np.array([stats.norm.rvs(0,1,1000),stats.norm.rvs(0,3,1000)])
+    >>> d = np.array([stats.norm.rvs(0,1,1000), stats.norm.rvs(0,3,1000)])
     >>> d[0,0] = 30
     >>> np_cov = np.cov(d)
     >>> bw_cov = biweight_midcovariance(d)
@@ -1080,14 +1080,14 @@ def biweight_midcovariance(a, c=9.0, M=None):
     # now remove the outlier points
     mask = np.abs(u) < 1
     n = mask.sum(axis=1)
-    usub1 = (1-u**2)
-    usub5 = (1-5*u**2)
+    usub1 = (1 - u ** 2)
+    usub5 = (1 - 5 * u ** 2)
     usub1[~mask] = 0.0
 
-    # now compute nominator and denominators
-    numerator = np.array(map(lambda x: d*usub1**2*x, d*usub1**2)).sum(axis=2)
-    denominator = (usub1*usub5).sum(axis=1)
-    denominator = np.array(map(lambda x: denominator*x, denominator))
+    # now compute numerator and denominators
+    numerator = np.array(map(lambda x: d * usub1 ** 2 * x, d * usub1 ** 2)).sum(axis=2)
+    denominator = (usub1 * usub5).sum(axis=1)
+    denominator = np.array(map(lambda x: denominator * x, denominator))
 
     return n * numerator / denominator
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from numpy.random import randn, normal
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_raises
 from numpy.testing.utils import assert_allclose
 
 try:
@@ -268,6 +268,13 @@ def test_midcov_midvar():
     cov_std = np.around(np.sqrt(cov.diagonal()), 1)
     std = np.around(list(map(funcs.biweight_midvariance, d)), 1)
     assert_allclose(cov_std, std)
+
+def test_midcovariance_shape():
+    """
+    test that midcovariance raises error when feed 3D array
+    """
+    d = np.arange(27).reshape(3,3,3)
+    assert_raises(ValueError, funcs.biweight_midcovariance, d)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_binom_conf_interval():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -244,14 +244,30 @@ def test_biweight_midvariance_axis_3d():
 
 def test_biweight_midcovariance():
     """test biweight_midcovariance method"""
-    d = np.array([np.random.normal(0,1,500), np.random.normal(0,5,500)])
+    # Test 1
+    rng = np.random.RandomState(1)
+    d = np.array([np.random.normal(0, 2, 100) for i in range(5)])
     cov = funcs.biweight_midcovariance(d)
-    std = np.sqrt(cov.diagonal())
-    # Check array shape is correct
-    assert_allclose(cov.shape[0], d.shape[0])
-    # Check result is **roughly** correct
-    assert_allclose(std[0],1,0.5)
-    assert_allclose(std[1],5,2.5)
+    std = np.around(np.sqrt(cov.diagonal()), 1)
+    assert_allclose(std, [ 2.2,  2. ,  2.3,  2.3,  1.8])
+    # Test 2
+    rng = np.random.RandomState(1)
+    d = np.array([np.random.normal(0, 2, 10) for i in range(5)])
+    cov = funcs.biweight_midcovariance(d)
+    std = np.around(np.sqrt(cov.diagonal()), 1)
+    assert_allclose(std, [ 1.2,  1.7,  1.9,  2. ,  1.6])
+
+def test_midcov_midvar():
+    """
+    test biweight_midcovariance and biweight_midvariance
+    are compatible
+    """
+    rng = np.random.RandomState(1)
+    d = np.array([np.random.normal(0, 2, 100) for i in range(3)])
+    cov = funcs.biweight_midcovariance(d)
+    cov_std = np.around(np.sqrt(cov.diagonal()), 1)
+    std = np.around(map(funcs.biweight_midvariance, d)), 1)
+    assert_allclose(cov_std, std)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_binom_conf_interval():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 from numpy.random import randn, normal
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal
 from numpy.testing.utils import assert_allclose
 
 try:
@@ -273,8 +273,11 @@ def test_midcovariance_shape():
     """
     test that midcovariance raises error when feed 3D array
     """
-    d = np.arange(27).reshape(3,3,3)
-    assert_raises(ValueError, funcs.biweight_midcovariance, d)
+    rng = np.random.RandomState(1)
+    d = rng.normal(0,1,27).reshape(3,3,3)
+    with pytest.raises(ValueError) as e:
+        funcs.biweight_midcovariance(d)
+    assert 'a.ndim should equal 2' in str(e.value)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_binom_conf_interval():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -266,7 +266,7 @@ def test_midcov_midvar():
     d = np.array([rng.normal(0, 2, 100) for i in range(3)])
     cov = funcs.biweight_midcovariance(d)
     cov_std = np.around(np.sqrt(cov.diagonal()), 1)
-    std = np.around(list(map(funcs.biweight_midvariance, d), 1))
+    std = np.around(list(map(funcs.biweight_midvariance, d)), 1)
     assert_allclose(cov_std, std)
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -266,7 +266,7 @@ def test_midcov_midvar():
     d = np.array([rng.normal(0, 2, 100) for i in range(3)])
     cov = funcs.biweight_midcovariance(d)
     cov_std = np.around(np.sqrt(cov.diagonal()), 1)
-    std = np.around(map(funcs.biweight_midvariance, d), 1)
+    std = np.around(list(map(funcs.biweight_midvariance, d), 1))
     assert_allclose(cov_std, std)
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -246,16 +246,16 @@ def test_biweight_midcovariance():
     """test biweight_midcovariance method"""
     # Test 1
     rng = np.random.RandomState(1)
-    d = np.array([np.random.normal(0, 2, 100) for i in range(5)])
+    d = np.array([rng.normal(0, 2, 100) for i in range(5)])
     cov = funcs.biweight_midcovariance(d)
     std = np.around(np.sqrt(cov.diagonal()), 1)
-    assert_allclose(std, [ 2.2,  2. ,  2.3,  2.3,  1.8])
+    assert_allclose(std, [ 1.8,  1.9,  2. ,  2.1,  2.1])
     # Test 2
     rng = np.random.RandomState(1)
-    d = np.array([np.random.normal(0, 2, 10) for i in range(5)])
+    d = np.array([rng.normal(0, 2, 10) for i in range(5)])
     cov = funcs.biweight_midcovariance(d)
     std = np.around(np.sqrt(cov.diagonal()), 1)
-    assert_allclose(std, [ 1.2,  1.7,  1.9,  2. ,  1.6])
+    assert_allclose(std, [ 2.6,  2.1,  1.6,  1.5,  1.9])
 
 def test_midcov_midvar():
     """
@@ -263,10 +263,10 @@ def test_midcov_midvar():
     are compatible
     """
     rng = np.random.RandomState(1)
-    d = np.array([np.random.normal(0, 2, 100) for i in range(3)])
+    d = np.array([rng.normal(0, 2, 100) for i in range(3)])
     cov = funcs.biweight_midcovariance(d)
     cov_std = np.around(np.sqrt(cov.diagonal()), 1)
-    std = np.around(map(funcs.biweight_midvariance, d)), 1)
+    std = np.around(map(funcs.biweight_midvariance, d), 1)
     assert_allclose(cov_std, std)
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -246,7 +246,12 @@ def test_biweight_midcovariance():
     """test biweight_midcovariance method"""
     d = np.array([np.random.normal(0,1,500), np.random.normal(0,5,500)])
     cov = funcs.biweight_midcovariance(d)
+    std = np.sqrt(cov.diagonal())
+    # Check array shape is correct
     assert_allclose(cov.shape[0], d.shape[0])
+    # Check result is **roughly** correct
+    assert_allclose(std[0],1,0.5)
+    assert_allclose(std[1],5,2.5)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_binom_conf_interval():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -242,6 +242,11 @@ def test_biweight_midvariance_axis_3d():
         bwi = np.array(bwi)
         assert_allclose(bw[y], bwi)
 
+def test_biweight_midcovariance():
+    """test biweight_midcovariance method"""
+    d = np.array([np.random.normal(0,1,500), np.random.normal(0,5,500)])
+    cov = funcs.biweight_midcovariance(d)
+    assert_allclose(cov.shape[0], d.shape[0])
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_binom_conf_interval():


### PR DESCRIPTION
I added a function in the stats module in the func.py script called biweight_midcovariance(), which is a robust and resistant estimator of the covariance matrix for a multidimensional sampling of points. It is documented according to the other biweight_***() functions and has an example included in the doc string.