### PR TITLE
Speedup in submodel_names

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -32,18 +32,17 @@ import numpy as np
 
 from ..utils import indent, isinstancemethod, metadata
 from ..extern import six
-from ..extern.six.moves import copyreg, zip
+from ..extern.six.moves import copyreg
 from ..table import Table
 from ..utils import (sharedmethod, find_current_module,
-                     check_broadcast, IncompatibleShapeError,
                      InheritDocstrings, OrderedDescriptorContainer)
 from ..utils.codegen import make_function_with_signature
-from ..utils.compat import suppress
+from ..utils.compat import ignored
 from ..utils.compat.funcsigs import signature
 from ..utils.exceptions import AstropyDeprecationWarning
-from .utils import (array_repr_oneline, combine_labels,
+from .utils import (array_repr_oneline, check_broadcast, combine_labels,
                     make_binary_operator_eval, ExpressionTree,
-                    AliasDict, get_inputs_and_params,
+                    IncompatibleShapeError, AliasDict, get_inputs_and_params,
                     _BoundingBox)
 from ..nddata.utils import add_array, extract_array
 
@@ -418,7 +417,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
     __or__ =      _model_oper('|')
     __and__ =     _model_oper('&')
 
-    if six.PY2:
+    if not six.PY3:
         # The classic __div__ operator need only be implemented for Python 2
         # without from __future__ import division
         __div__ = _model_oper('/')
@@ -471,7 +470,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
                     parts.append('{0}: {1}'.format(keyword, value))
 
             return '\n'.join(parts)
-        except Exception:
+        except:
             # If any of the above formatting fails fall back on the basic repr
             # (this is particularly useful in debugging)
             return parts[0]
@@ -700,7 +699,7 @@ class Model(object):
     __or__ =      _model_oper('|')
     __and__ =     _model_oper('&')
 
-    if six.PY2:
+    if not six.PY3:
         __div__ = _model_oper('/')
 
     # *** Properties ***
@@ -1311,7 +1310,7 @@ class Model(object):
         n_models = kwargs.pop('n_models', None)
 
         if not (n_models is None or
-                    (isinstance(n_models, (int, np.integer)) and n_models >=1)):
+                    (isinstance(n_models, int) and n_models >=1)):
             raise ValueError(
                 "n_models must be either None (in which case it is "
                 "determined from the model_set_axis of the parameter initial "
@@ -1433,9 +1432,9 @@ class Model(object):
                 default = getattr(self, name).default
 
                 if default is None:
-                    # No value was supplied for the parameter and the
-                    # parameter does not have a default, therefore the model
-                    # is underspecified
+                    # No value was supplied for the parameter, and the
+                    # parameter does not have a default--therefor the model is
+                    # underspecified
                     raise TypeError(
                         "{0}.__init__() requires a value for parameter "
                         "{1!r}".format(self.__class__.__name__, name))
@@ -1796,7 +1795,7 @@ class _CompoundModelMeta(_ModelMeta):
     def __getitem__(cls, index):
         index = cls._normalize_index(index)
 
-        if isinstance(index, (int, np.integer)):
+        if isinstance(index, int):
             return cls._get_submodels()[index]
         else:
             return cls._get_slice(index.start, index.stop)
@@ -1806,7 +1805,6 @@ class _CompoundModelMeta(_ModelMeta):
         # an attribute on a concrete compound model class and should just raise
         # the AttributeError
         if cls._tree is not None and attr in cls.param_names:
-            cls._init_param_descriptors()
             return getattr(cls, attr)
 
         raise AttributeError(attr)
@@ -1850,7 +1848,7 @@ class _CompoundModelMeta(_ModelMeta):
 
         if isinstance(rv, tuple):
             # Delete _evaluate from the members dict
-            with suppress(KeyError):
+            with ignored(KeyError):
                 del rv[1][2]['_evaluate']
 
         return rv
@@ -1858,37 +1856,32 @@ class _CompoundModelMeta(_ModelMeta):
 
     @property
     def submodel_names(cls):
-        if cls._submodel_names is not None:
-            return cls._submodel_names
+        if cls._submodel_names is None:
+            seen = {}
+            names = []
+            for idx, submodel in enumerate(cls._get_submodels()):
+                name = submodel.name
+                if name is None:
+                    names.append(name)
+                elif name in seen:
+                    names.append('{0}_{1}'.format(name, idx))
+                    if seen[name] >= 0:
+                        jdx = seen[name]
+                        names[jdx] = '{0}_{1}'.format(names[jdx], jdx)
+                        seen[name] = -1
+                else:
+                    names.append(name)
+                    seen[name] = idx
+            cls._submodel_names = tuple(names)
 
-        by_name = defaultdict(list)
-
-        for idx, submodel in enumerate(cls._get_submodels()):
-            # Keep track of the original sort order of the submodels
-            by_name[submodel.name].append(idx)
-
-        names = []
-        for basename, indices in six.iteritems(by_name):
-            if len(indices) == 1:
-                # There is only one model with this name, so it doesn't need an
-                # index appended to its name
-                names.append((basename, indices[0]))
-            else:
-                for idx in indices:
-                    names.append(('{0}_{1}'.format(basename, idx), idx))
-
-        # Sort according to the models' original sort orders
-        names.sort(key=lambda k: k[1])
-
-        names = tuple(k[0] for k in names)
-
-        cls._submodels_names = names
-        return names
+        return cls._submodel_names
 
     @property
     def param_names(cls):
         if cls._param_names is None:
             cls._init_param_names()
+            if isinstance(cls, (_CompoundModelMeta, _CompoundModel)):
+                cls._init_param_descriptors()
 
         return cls._param_names
 
@@ -2266,9 +2259,9 @@ class _CompoundModelMeta(_ModelMeta):
             start = index.start if index.start is not None else 0
             stop = (index.stop
                     if index.stop is not None else len(cls.submodel_names))
-            if isinstance(start, (int, np.integer)):
+            if isinstance(start, int):
                 start = check_for_negative_index(start)
-            if isinstance(stop, (int, np.integer)):
+            if isinstance(stop, int):
                 stop = check_for_negative_index(stop)
             if isinstance(start, six.string_types):
                 start = get_index_from_name(start)
@@ -2282,7 +2275,7 @@ class _CompoundModelMeta(_ModelMeta):
                 raise ValueError("Empty slice of a compound model.")
 
             return slice(start, stop)
-        elif isinstance(index, (int, np.integer)):
+        elif isinstance(index, int):
             if index >= len(cls.submodel_names):
                 raise IndexError(
                         "Model index {0} out of range.".format(index))

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1858,22 +1858,43 @@ class _CompoundModelMeta(_ModelMeta):
 
     @property
     def submodel_names(cls):
+        # If results are not cached, then set the cache
         if cls._submodel_names is None:
+            
+            # Duplicate names must be disambiguated.
             seen = {}
             names = []
             for idx, submodel in enumerate(cls._get_submodels()):
                 name = submodel.name
                 if name is None:
+                    # No need to disambiguate None
                     names.append(name)
+    
                 elif name in seen:
+                    # Disambiguate names seen before by
+                    # adding a traailing number. 
                     names.append('{0}_{1}'.format(name, idx))
+                    
                     if seen[name] >= 0:
+                        # We don't know a name is ambiguous until we've seen the
+                        # second one and we only make one pass over the data. So
+                        # we track the first occurence of each name with
+                        # an index to it in the seen dictionary and set it after
+                        # setting the second occurence.
                         jdx = seen[name]
                         names[jdx] = '{0}_{1}'.format(names[jdx], jdx)
+                        
+                        # Reset the  index to a negative number to keep from
+                        # setting the first occurence more than once.
                         seen[name] = -1
+                        
                 else:
+                    # No ambiguity in name (yet), add it to the seen dictionary
+                    # so we can find ambiguities later.
                     names.append(name)
                     seen[name] = idx
+
+            # Save all this work in the cache
             cls._submodel_names = tuple(names)
 
         return cls._submodel_names

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -908,7 +908,7 @@ class Model(object):
 
     @property
     def bounding_box(self):
-        r"""
+        """
         A `tuple` of length `n_inputs` defining the bounding box limits, or
         `None` for no bounding box.
 
@@ -2008,12 +2008,6 @@ class _CompoundModelMeta(_ModelMeta):
             # computing the inverse
             instance._user_inverse = mcls._make_user_inverse(
                     operator, left, right)
-
-            if left._n_models == right._n_models:
-                instance._n_models = left._n_models
-            else:
-                raise ValueError('Model sets must have the same number of '
-                                 'components.')
 
             return instance
 


### PR DESCRIPTION
Since submodel_names was a hotspot in the code, it seemed worth the time to optimize it. The original code updated the names in random (hash) order and then sorted. The new code updates them in their original order, doing away for the need for a sort. Also, cases where the name is None are handled as a specially. There is no value to building names like None_1, None_2, and so on. After rewriting I noticed the caching of the submodel names was incorrect, so I also changed that.