### PR TITLE
Removing obsolete badge from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,11 +5,8 @@ Astropy
 .. image:: https://img.shields.io/pypi/v/astropy.svg
     :target: https://pypi.python.org/pypi/astropy
 
-.. image:: https://img.shields.io/pypi/dm/astropy.svg
-    :target: https://pypi.python.org/pypi/astropy
-
 .. image:: https://badges.gitter.im/Join%20Chat.svg
-    :target: https://gitter.im/astropy/astropy 
+    :target: https://gitter.im/astropy/astropy
 
 Astropy (http://astropy.org/) is a package intended to contain much of
 the core functionality and some common tools needed for performing
@@ -41,7 +38,7 @@ Project Status
 .. image:: https://ci.appveyor.com/api/projects/status/ym7lxajcs5qwm31e/branch/master?svg=true
     :target: https://ci.appveyor.com/project/Astropy/astropy/branch/master
 
-For an overview of the testing and build status of all packages associated 
+For an overview of the testing and build status of all packages associated
 with the Astropy Project, see http://dashboard.astropy.org.
 
 License


### PR DESCRIPTION
The pypi download stat badge seems to be broken (0/months clearly isn't real), and nevetheless the main way of installing astropy is via conda these days.