### PR TITLE
Fix WCSAxes output with Matplotlib 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
                PIP_DEPENDENCIES='jplephem mock pytest-mpl'
                LC_CTYPE=C.ascii LC_ALL=C
                NUMPY_VERSION=1.10
-               MATPLOTLIB_VERSION=1.4
+               MATPLOTLIB_VERSION=1.5
                ASTROPY_USE_SYSTEM_PYTEST=1
                EVENT_TYPE='push pull_request cron'
 
@@ -97,7 +97,7 @@ matrix:
                PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl'
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
-               MATPLOTLIB_VERSION=1.5
+               MATPLOTLIB_VERSION=2.0
                ASTROPY_USE_SYSTEM_PYTEST=1
                EVENT_TYPE='push pull_request cron'
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,7 +245,7 @@ Bug Fixes
   - Avoid importing matplotlib.pyplot when importing
     astropy.visualization.wcsaxes. [#5680, #5684]
 
-  - Fix compatibility issues between WCSAxes and Matplotlib 2.x.
+  - Fix compatibility issues between WCSAxes and Matplotlib 2.x. [#5786]
 
 - ``astropy.vo``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,6 +245,8 @@ Bug Fixes
   - Avoid importing matplotlib.pyplot when importing
     astropy.visualization.wcsaxes. [#5680, #5684]
 
+  - Fix compatibility issues between WCSAxes and Matplotlib 2.x.
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -100,7 +100,7 @@ class BaseFrame(OrderedDict):
 
         self.parent_axes = parent_axes
         self._transform = transform
-        self._linewidth = None
+        self._linewidth = 1
         self._color = 'black'
         self._path = path
 

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -155,7 +155,7 @@ class TestAngleFormatterLocator(object):
         fl = AngleFormatterLocator(number=5, format="dd:mm:ss")
         assert fl.formatter([15.392231] * u.degree, None)[0] == six.u('15\xb023\'32"')
         with rc_context(rc={'text.usetex': True}):
-            assert fl.formatter([15.392231] * u.degree, None)[0] == "15$^\circ$23'32\""
+            assert fl.formatter([15.392231] * u.degree, None)[0] == "15$^\\circ$23'32\""
 
     @pytest.mark.parametrize(('format'), ['x.xxx', 'dd.ss', 'dd:ss', 'mdd:mm:ss'])
     def test_invalid_formats(self, format):

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -58,7 +58,6 @@ class TestBasic(BaseImageTests):
         return fig
 
     @remote_data(source='astropy')
-    @remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='contour_overlay.png',
                                    tolerance=1.5)

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -26,17 +26,17 @@ class Ticks(Line2D):
     we read defaults from `xtick.*`. The following settings affect the
     default appearance of ticks:
 
+    * `xtick.direction`
     * `xtick.major.size`
     * `xtick.major.width`
     * `xtick.color`
     """
 
-    def __init__(self, ticksize=None, tick_out=False, **kwargs):
+    def __init__(self, ticksize=None, tick_out=None, **kwargs):
         if ticksize is None:
             ticksize = rcParams['xtick.major.size']
         self.set_ticksize(ticksize)
-        self.set_tick_out(tick_out)
-        # FIXME: tick_out is incompatible with Matplotlib tickdir option
+        self.set_tick_out(rcParams.get('xtick.direction', 'in') == 'out')
         self.clear()
         line2d_kwargs = {'color': rcParams['xtick.color'],
                          # For the linewidth we need to set a default since old versions of


### PR DESCRIPTION
**Before:**

![test_mpl2](https://cloud.githubusercontent.com/assets/314716/22804510/4cfae5ee-ef11-11e6-94eb-d72c596ee1cf.png)

**After:**

![test_mpl2](https://cloud.githubusercontent.com/assets/314716/22804500/423ee04c-ef11-11e6-8fe3-21dafb689a2a.png)

I think this should be treated as a bug fix and included in 1.3.1