### PR TITLE
[EXP] Add deprecation warning for emu CGS unit

### DIFF
--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -7,10 +7,12 @@ top-level `astropy.units` namespace.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import warnings
 from fractions import Fraction
 
 from . import si
 from .core import UnitBase, def_unit
+from ..utils.exceptions import AstropyDeprecationWarning
 
 
 _ns = globals()
@@ -97,6 +99,9 @@ def_unit(['Fr', 'Franklin', 'statcoulomb', 'statC', 'esu'],
 def_unit(['statA', 'statampere'], Fr * s ** -1, namespace=_ns,
          doc='statampere: CGS (ESU) unit of current')
 
+# TODO: Remove emu in v3.1
+warnings.warn('emu is deprecated due to ambiguous definition and '
+              'will be removed in a future release', AstropyDeprecationWarning)
 def_unit(['Bi', 'Biot', 'abA', 'abampere', 'emu'],
          g ** Fraction(1, 2) * cm ** Fraction(1, 2) * s ** -1, namespace=_ns,
          doc='Biot: CGS (EMU) unit of current')


### PR DESCRIPTION
Here is an idea for deprecating `emu`, as discussed in #4918. With this change, the warning will be emitted on import:

```python
>>> import astropy  # no warning
>>> from astropy import units as u  # has warning
WARNING: AstropyDeprecationWarning: emu is deprecated...
```

This might not be a good idea, since we turn all deprecation warnings into exceptions in our tests. Hence, that is why I skipped CI in the commit, as I am pretty sure things will fail spectacularly.

I looked at `units/core.py` and could not find an easy way to only emit warning when `u.emu` is called. I tried adding a new keyword called `deprecated_aliases` in `def_unit()` but that turned complicated really fast, as I had to propagate that new keyword to `__init__` and `__call__` in several different places. Not sure if it is worth the while to add so many LOCs just to deprecate a unit.

Anyway, if nothing else, this PR serves as a reminder and a place for discussions until a better one supersedes it. c/c @mhvk , @bsipocz 

TODO (if we decide to proceed):
- [ ] Add change log.
- [ ] Add test.