### PR TITLE
Fixes for DeprecationWarning and pytest

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -243,6 +243,21 @@ def treat_deprecations_as_exceptions():
     except ImportError:
         pass
 
+    try:
+        import pygments  # pylint: disable=W0611
+    except ImportError:
+        pass
+
+    try:
+        import ipykernel  # pylint: disable=W0611
+    except ImportError:
+        pass
+
+    try:
+        import setuptools  # pylint: disable=W0611
+    except ImportError:
+        pass
+
     # Now, start over again with the warning filters
     warnings.resetwarnings()
     # Now, turn DeprecationWarnings into exceptions

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -12,7 +12,7 @@ class QuantityInput(object):
 
     @classmethod
     def as_decorator(cls, func=None, **kwargs):
-        """
+        r"""
         A decorator for validating the units of arguments to functions.
 
         Unit specifications can be provided as keyword arguments to the decorator,

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1162,7 +1162,7 @@ class Quantity(np.ndarray):
                       if self.unit is not None
                       else _UNIT_NOT_INITIALISED)
 
-        return '${0} \; {1}$'.format(latex_value, latex_unit)
+        return r'${0} \; {1}$'.format(latex_value, latex_unit)
 
     def __format__(self, format_spec):
         """

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -155,7 +155,7 @@ class TestAngleFormatterLocator(object):
         fl = AngleFormatterLocator(number=5, format="dd:mm:ss")
         assert fl.formatter([15.392231] * u.degree, None)[0] == six.u('15\xb023\'32"')
         with rc_context(rc={'text.usetex': True}):
-            assert fl.formatter([15.392231] * u.degree, None)[0] == "15$^\circ$23'32\""
+            assert fl.formatter([15.392231] * u.degree, None)[0] == "15$^\\circ$23'32\""
 
     @pytest.mark.parametrize(('format'), ['x.xxx', 'dd.ss', 'dd:ss', 'mdd:mm:ss'])
     def test_invalid_formats(self, format):


### PR DESCRIPTION
A few fixes to be able to run tests with `import astropy; astropy.test()` or directly with pytest, for Python 3.6 (related to the deprecated escape sequences). This also needs #5755 to work.

Astropy's test configuration turns all DeprecationWarning into exceptions, however some of these were not showing while running `python setup.py test`. But they can be seen while running directly `pytest` or with the `import astropy; astropy()` in a Python console. So, this PR fixes:

- A few uses of deprecated escape sequences.
- 2 warnings because of deprecated escape sequences in dependencies,  setuptools and pygments.

Astropy's `treat_deprecations_as_exceptions` function has already a list of modules to import so they don't trigger warnings later, so I added setuptools and pygments there. These warnings did not show up with `python setup.py test` because it obviously imports setuptools, and pygments is imported via docutils.