### PR TITLE
WCSAxes bug: frame visual properties lost after resetting WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -252,6 +252,9 @@ Bug Fixes
 
   - Fix compatibility issues between WCSAxes and Matplotlib 2.x. [#5786]
 
+  - Fix a bug that caused WCSAxes frame visual properties to not be copied
+    over when resetting the WCS. [#5791]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -254,14 +254,20 @@ class WCSAxes(Axes):
         # to continue updating it. CoordinatesMap will create a new frame
         # instance, but we can tell that instance to keep using the old path.
         if hasattr(self, 'coords'):
-            previous_frame_path = self.coords.frame._path
+            previous_frame = {'path': self.coords.frame._path,
+                              'color': self.coords.frame.get_color(),
+                              'linewidth': self.coords.frame.get_linewidth()}
         else:
-            previous_frame_path = None
+            previous_frame = {'path': None}
 
         self.coords = CoordinatesMap(self, wcs=self.wcs, slice=slices,
                                      transform=transform, coord_meta=coord_meta,
                                      frame_class=self.frame_class,
-                                     previous_frame_path=previous_frame_path)
+                                     previous_frame_path=previous_frame['path'])
+
+        if previous_frame['path'] is not None:
+            self.coords.frame.set_color(previous_frame['color'])
+            self.coords.frame.set_linewidth(previous_frame['linewidth'])
 
         self._all_coords = [self.coords]
 

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -155,3 +155,17 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(-0.5, 11.5)
 
         return fig
+
+    def test_copy_frame_properties_change_wcs(self):
+
+        # When WCS is changed, a new frame is created, so we need to make sure
+        # that the color and linewidth are transferred over
+
+        fig = plt.figure()
+        ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
+        fig.add_axes(ax)
+        ax.coords.frame.set_linewidth(5)
+        ax.coords.frame.set_color('purple')
+        ax.reset_wcs()
+        assert ax.coords.frame.get_linewidth() == 5
+        assert ax.coords.frame.get_color() == 'purple'


### PR DESCRIPTION
This fixes a bug that caused WCSAxes frame visual properties to not be copied over when resetting the WCS.