### PR TITLE
Ignore Numpy warnings that happen inside coordinate transformations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,6 +250,8 @@ Bug Fixes
   - Avoid importing matplotlib.pyplot when importing
     astropy.visualization.wcsaxes. [#5680, #5684]
 
+  - Ignore Numpy warnings that happen in coordinate transforms in WCSAxes.
+
   - Fix compatibility issues between WCSAxes and Matplotlib 2.x. [#5786]
 
 - ``astropy.vo``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -251,6 +251,7 @@ Bug Fixes
     astropy.visualization.wcsaxes. [#5680, #5684]
 
   - Ignore Numpy warnings that happen in coordinate transforms in WCSAxes.
+    [#5792]
 
   - Fix compatibility issues between WCSAxes and Matplotlib 2.x. [#5786]
 

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -244,7 +244,11 @@ class CoordinateTransform(CurvedTransform):
         c_in = SkyCoord(x_in, y_in, unit=(u.deg, u.deg),
                         frame=self.input_system)
 
-        c_out = c_in.transform_to(self.output_system)
+        # We often need to transform arrays that contain NaN values, and filtering
+        # out the NaN values would have a performance hit, so instead we just pass
+        # on all values and just ignore Numpy warnings
+        with np.errstate(all='ignore'):
+            c_out = c_in.transform_to(self.output_system)
 
         if issubclass(c_out.representation, (SphericalRepresentation, UnitSphericalRepresentation)):
             lon = c_out.data.lon.deg


### PR DESCRIPTION
... since we know that arrays can contain NaN values in WCSAxes, and filtering them out would be detrimental to performance.

I'm labelling this as a bug since before this a ridiculous number of warnings could be shown, which is bad.

@Cadair - can you review and confirm this solves your issues?