### PR TITLE
Define __getslice__ and __setslice__ only on PY2 (if needed).

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -15,7 +15,7 @@ from .column import (ASCIITNULL, FITS2NUMPY, ASCII2NUMPY, ASCII2STR, ColDefs,
                      _AsciiColDefs, _FormatX, _FormatP, _VLF, _get_index,
                      _wrapx, _unwrapx, _makep, Delayed)
 from .util import decode_ascii, encode_ascii
-from ...extern.six import string_types
+from ...extern.six import string_types, PY2
 from ...extern.six.moves import range, zip
 from ...utils import lazyproperty
 from ...utils.compat import suppress
@@ -95,9 +95,6 @@ class FITS_record(object):
                 raise IndexError('Index out of bounds')
 
         self.array.field(indx)[self.row] = value
-
-    def __getslice__(self, start, end):
-        return self[slice(start, end)]
 
     def __len__(self):
         return len(range(self.start, self.end, self.step))
@@ -553,11 +550,13 @@ class FITS_rec(np.recarray):
             raise TypeError('Assignment requires a FITS_record, tuple, or '
                             'list as input.')
 
-    def __getslice__(self, start, end):
-        return self[slice(start, end)]
+    if PY2:
+        # avoid falling back through to ndarray.__getslice__
+        def __getslice__(self, start, end):
+            return self.__getitem__(slice(start, end))
 
-    def __setslice__(self, start, end, value):
-        self[slice(start, end)] = value
+        def __setslice__(self, start, end, value):
+            self.__setitem__(slice(start, end), value)
 
     def copy(self, order='C'):
         """

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -370,16 +370,6 @@ class HDUList(list, _Verify):
             self._truncate = False
             self._resize = True
 
-    def __getslice__(self, start, end):
-        return self[slice(start, end)]
-
-    def __delslice__(self, start, stop):
-        """
-        Delete a slice of HDUs from the `HDUList`, indexed by number only.
-        """
-
-        del self[slice(start, stop)]
-
     # Support the 'with' statement
     def __enter__(self):
         return self

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -21,7 +21,7 @@ from ..header import _pad_length
 from ..util import (_is_int, _tmp_name, fileobj_closed, ignore_sigint,
                     _get_array_mmap, _free_space_check)
 from ..verify import _Verify, _ErrList, VerifyError, VerifyWarning
-from ....extern.six import string_types
+from ....extern.six import string_types, PY2
 from ....utils import indent
 from ....utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 from ....utils.decorators import deprecated_renamed_argument
@@ -369,6 +369,16 @@ class HDUList(list, _Verify):
         else:
             self._truncate = False
             self._resize = True
+
+    if PY2:  # don't fall through to list.__getslice__, __delslice__
+        def __getslice__(self, start, end):
+            return self.__getitem__(slice(start, end))
+
+        def __delslice__(self, start, stop):
+            """
+            Delete a slice of HDUs from the `HDUList`, indexed by number only.
+            """
+            self.__delitem__(slice(start, stop))
 
     # Support the 'with' statement
     def __enter__(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1037,16 +1037,14 @@ class Quantity(np.ndarray):
         return out
 
     def __setitem__(self, i, value):
-        # update indices
-        if not self.isscalar:
+        # update indices if we're part of a table.
+        if not self.isscalar and 'info' in self.__dict__:
             self.info.adjust_indices(i, value, len(self))
         self.view(np.ndarray).__setitem__(i, self._to_own_unit(value))
 
-    def __setslice__(self, i, j, value):
-        # update indices
-        if not self.isscalar:
-            self.info.adjust_indices(slice(i, j), value, len(self))
-        self.view(np.ndarray).__setslice__(i, j, self._to_own_unit(value))
+    if six.PY2:  # don't fall through to ndarray.__setslice__
+        def __setslice__(self, i, j, value):
+            self.__setitem__(slice(i, j), value)
 
     # __contains__ is OK
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1037,7 +1037,9 @@ class Quantity(np.ndarray):
         return out
 
     def __setitem__(self, i, value):
-        # update indices if we're part of a table.
+        # update indices in info if the info property has been accessed
+        # (in which case 'info' in self.__dict__ is True; this is guaranteed
+        # to be the case if we're part of a table).
         if not self.isscalar and 'info' in self.__dict__:
             self.info.adjust_indices(i, value, len(self))
         self.view(np.ndarray).__setitem__(i, self._to_own_unit(value))


### PR DESCRIPTION
Inspired by the removal of `__getslice__` and `__setslice__` from numpy (https://github.com/numpy/numpy/pull/8592/files), I looked through our code. These methods have been deprecated since 2.5 and in pure python will not get called at all in 2.7. However, for C code they do get called in python 2.7 , so anything depending on `ndarray` has to intercept them still. But only in python2, so I at least marked them with `if six.PY2`, so they will get automatically removed in astropy 3.0.

In the process, I also ensured that quantity item setting does not get slowed down if a quantity is not part of a table.