### PR TITLE
Adding back value checking for header['GROUPS'] 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,9 @@ Bug Fixes
   - Guard against extremely unlikely problems in compressed images, which
     could lead to memory unmapping errors. [#5775]
 
+  - Recognize PrimaryHDU when non boolean values are present for the
+    'GROUPS' header keyword. [#5808]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1008,7 +1008,7 @@ class PrimaryHDU(_ImageBaseHDU):
     def match_header(cls, header):
         card = header.cards[0]
         return (card.keyword == 'SIMPLE' and
-                ('GROUPS' not in header or not header['GROUPS']) and
+                ('GROUPS' not in header or header['GROUPS'] is not True) and
                 card.value)
 
     def update_header(self):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1007,8 +1007,10 @@ class PrimaryHDU(_ImageBaseHDU):
     @classmethod
     def match_header(cls, header):
         card = header.cards[0]
+        # Due to problems discussed in #5808, we cannot assume the 'GROUPS'
+        # keyword to be True/False, have to check the value
         return (card.keyword == 'SIMPLE' and
-                ('GROUPS' not in header or header['GROUPS'] is not True) and
+                ('GROUPS' not in header or header['GROUPS'] != True) and  # noqa
                 card.value)
 
     def update_header(self):


### PR DESCRIPTION
The value of this keyword is not a boolean in the bug report, which I think is a diversion from the standard (see below).  Anyway this fix should do the trick.

The standard (from here: http://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html) says this:

```
KEYWORD:   GROUPS
REFERENCE: FITS Standard 
STATUS:    mandatory
HDU:       groups
VALUE:     logical
COMMENT:   indicates random groups structure
DEFINITION: The value field shall contain the logical constant T.  The
value T associated with this keyword implies that random groups records
are present.
```

Close #5807