### PR TITLE
Adding np1.11 to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
-        # For the image tests, we also include Matplotlib 1.4 in the Numpy 1.9
-        # build.
+        # Numpy 1.10 is tested below in the image tests.
+
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
                SETUP_CMD='test --open-files'
@@ -75,7 +75,7 @@ matrix:
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
                SETUP_CMD='test --open-files'
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.


### PR DESCRIPTION
As the current stable is 1.12.

Also I wonder when will we drop 1.7? As I remember we aim to support the current and previous 4 versions.