### PR TITLE
Emit string truncation warnings for MaskedColumn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ New Features
   - Issue a warning when assigning a string value to a column and
     the string gets truncated.  This can occur because numpy string
     arrays are fixed-width and silently drop characters which do not
-    fit within the fixed width. [#5624]
+    fit within the fixed width. [#5624, #5819]
 
 - ``astropy.time``
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1124,12 +1124,12 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         return out
 
     def __setitem__(self, index, value):
-        # Account for a bug in np.ma.MaskedArray setitem.
-        # https://github.com/numpy/numpy/issues/8624
-        value = np.ma.asanyarray(value, dtype=self.dtype.type)
-
         # Issue warning for string assignment that truncates ``value``
         if issubclass(self.dtype.type, np.character):
+            # Account for a bug in np.ma.MaskedArray setitem.
+            # https://github.com/numpy/numpy/issues/8624
+            value = np.ma.asanyarray(value, dtype=self.dtype.type)
+
             # Turn value into a flat masked array with at least 1d
             vals = np.ma.atleast_1d(value).flatten()
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -585,6 +585,16 @@ def test_string_truncation_warning(masked):
         assert ('truncated right side string(s) longer than 2 character(s)'
                 in str(w[0].message))
 
+    with catch_warnings() as w:
+        # Test the obscure case of assigning from an array that was originally
+        # wider than any of the current elements (i.e. dtype is U4 but actual
+        # elements are U1 at the time of assignment).
+        val = np.array(['ffff', 'gggg'])
+        val[:] = ['f', 'g']
+        t['a'][:] = val
+        assert np.all(t['a'] == ['f', 'g'])
+        assert len(w) == 0
+
 
 def test_string_truncation_warning_masked():
     """

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -592,16 +592,23 @@ def test_string_truncation_warning_masked():
     to a masked column, specifically where the right hand side
     contains np.ma.masked.
     """
-    mc = table.MaskedColumn(['aa', 'bb'])
 
-    with catch_warnings() as w:
-        mc[1] = np.ma.masked
-        assert len(w) == 0
-        assert np.all(mc.mask == [False, True])
+    # Test for strings, but also cover assignment of np.ma.masked to
+    # int and float masked column setting.  This was previously only
+    # covered in an unrelated io.ascii test (test_line_endings) which
+    # showed an unexpected difference between handling of str and numeric
+    # masked arrays.
+    for values in (['a', 'b'], [1, 2], [1.0, 2.0]):
+        mc = table.MaskedColumn(values)
 
-        mc[:] = np.ma.masked
-        assert len(w) == 0
-        assert np.all(mc.mask == [True, True])
+        with catch_warnings() as w:
+            mc[1] = np.ma.masked
+            assert len(w) == 0
+            assert np.all(mc.mask == [False, True])
+
+            mc[:] = np.ma.masked
+            assert len(w) == 0
+            assert np.all(mc.mask == [True, True])
 
     mc = table.MaskedColumn(['aa', 'bb'])
 


### PR DESCRIPTION
Closes #5817.

This also implements a workaround for https://github.com/numpy/numpy/issues/8624.  If we think this is important enough to backport then this bit would need to go in a separate PR.