### PR TITLE
Ensure that mixin columns can be set to scalars if broadcasting is supported

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -258,8 +258,9 @@ Bug Fixes
 
   - Handle sorting NaNs and masked values in jsviewer. [#4052, #5572]
 
-  - Ensure mixin columns can be set to scalars if the type supports
-    broadcasting (e.g., for a ``QTable``, ``t['q'] = 3*u.m``). [#5820]
+  - Ensure mixin columns can be added to a table using a scalar value for the
+    right-hand side if the type supports broadcasting. E.g., for an existing
+    ``QTable``, ``t['q'] = 3*u.m`` will now add a column as expected. [#5820]
 
 - ``astropy.time``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,6 +257,8 @@ Bug Fixes
     sufficiently unique. [#5803]
 
   - Handle sorting NaNs and masked values in jsviewer. [#4052, #5572]
+  - Ensure mixin columns can be set to scalars if the type supports
+    broadcasting (e.g., for a ``QTable``, ``t['q'] = 3*u.m``). [#5820]
 
 - ``astropy.time``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,6 +257,7 @@ Bug Fixes
     sufficiently unique. [#5803]
 
   - Handle sorting NaNs and masked values in jsviewer. [#4052, #5572]
+
   - Ensure mixin columns can be set to scalars if the type supports
     broadcasting (e.g., for a ``QTable``, ``t['q'] = 3*u.m``). [#5820]
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1247,7 +1247,7 @@ class Table(object):
             if isinstance(value, BaseColumn) or self._add_as_mixin_column(value):
                 # If we're setting a new column to a scalar, broadcast it.
                 # (things will fail in _init_from_cols if this doesn't work)
-                if (len(self) > 1 and (getattr(value, 'isscalar', False) or
+                if (len(self) > 0 and (getattr(value, 'isscalar', False) or
                                        getattr(value, 'shape', None) == () or
                                        len(value) == 1)):
                     new_shape = (len(self),) + getattr(value, 'shape', ())[1:]

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,8 @@ from numpy import ma
 from .. import log
 from ..io import registry as io_registry
 from ..units import Quantity
-from ..utils import isiterable
+from ..utils import isiterable, ShapedLikeNDArray
+from ..utils.compat.numpy import broadcast_to as np_broadcast_to
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
@@ -1244,17 +1245,29 @@ class Table(object):
             name = item
             # If this is a column-like object that could be added directly to table
             if isinstance(value, BaseColumn) or self._add_as_mixin_column(value):
+                # If we're setting a new column to a scalar, broadcast it.
+                # (things will fail in _init_from_cols if this doesn't work)
+                if (len(self) > 1 and (getattr(value, 'isscalar', False) or
+                                       getattr(value, 'shape', None) == () or
+                                       len(value) == 1)):
+                    new_shape = (len(self),) + getattr(value, 'shape', ())[1:]
+                    if isinstance(value, np.ndarray):
+                        value = np_broadcast_to(value, shape=new_shape,
+                                                subok=True)
+                    elif isinstance(value, ShapedLikeNDArray):
+                        value = value._apply(np_broadcast_to, shape=new_shape,
+                                             subok=True)
+
                 new_column = col_copy(value)
                 new_column.info.name = name
+
             elif len(self) == 0:
                 new_column = NewColumn(value, name=name)
             else:
                 new_column = NewColumn(name=name, length=len(self), dtype=value.dtype,
-                                       shape=value.shape[1:])
+                                       shape=value.shape[1:],
+                                       unit=getattr(value, 'unit', None))
                 new_column[:] = value
-
-                if isinstance(value, Quantity):
-                    new_column.unit = value.unit
 
             # Now add new column to the table
             self.add_columns([new_column], copy=False)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -277,17 +277,28 @@ def test_add_column(mixin_cols):
     m.info.meta = {'a': 1}
     t = QTable([m])
 
-    # Add columns m2 and m3 by two different methods and test expected equality
+    # Add columns m2, m3, m4 by two different methods and test expected equality
     t['m2'] = m
     m.info.name = 'm3'
     t.add_columns([m], copy=True)
     m.info.name = 'm4'
     t.add_columns([m], copy=False)
     for name in ('m2', 'm3', 'm4'):
-        assert_table_name_col_equal(t, 'm', t[name])
+        assert_table_name_col_equal(t, name, m)
         for attr in attrs:
             if attr != 'name':
                 assert getattr(t['m'].info, attr) == getattr(t[name].info, attr)
+    # Also check that one can set using a scalar.
+    s = m[0]
+    if type(s) is type(m):
+        # We're not going to worry about testing classes for which scalars
+        # are a different class than the real array (and thus loose info, etc.)
+        t['s'] = m[0]
+        assert_table_name_col_equal(t, 's', m[0])
+        for attr in attrs:
+            if attr != 'name':
+                assert getattr(t['m'].info, attr) == getattr(t['s'].info, attr)
+
 
 def test_vstack():
     """

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -299,6 +299,15 @@ def test_add_column(mixin_cols):
             if attr != 'name':
                 assert getattr(t['m'].info, attr) == getattr(t['s'].info, attr)
 
+    # While we're add it, also check a length-1 table.
+    t = QTable([m[1:2]], names=['m'])
+    if type(s) is type(m):
+        t['s'] = m[0]
+        assert_table_name_col_equal(t, 's', m[0])
+        for attr in attrs:
+            if attr != 'name':
+                assert getattr(t['m'].info, attr) == getattr(t['s'].info, attr)
+
 
 def test_vstack():
     """


### PR DESCRIPTION
While seeing whether `QTable` can pass all the `Table` tests, I found that currently, for a `QTable`, one cannot set a column to a scalar quantity (unlike for a `Table`):
```
qt = QTable([np.arange(3)*u.m], names=('a',))
qt['b'] = 1.*u.m
# TypeError: 'Quantity' object with a scalar value has no len()
```
This would seem a bug.

This PR solves this by checking whether input to `__setitem__` is scalar, and if so, trying to broadcast it. As a nice by-product, this ensures columns can also be set to scalar `Time` and `SkyCoord` instances (the values are copied after, so the column itself does not have zero strides).

Note, though, that with this `add_columns` and `_init_from_columns` cannot handle scalars; I think that's OK, but obviously one could put the broadcasting higher up if needed (though in that case one likely would get zero strides unless yet another copy is made).

@taldcroft - what do you think?