### PR TITLE
Ensure QTable is tested everywhere non-masked Table is

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,10 @@ New Features
     arrays are fixed-width and silently drop characters which do not
     fit within the fixed width. [#5624]
 
+  - ``vstack``, ``hstack``, and ``join`` now also work with ``QTable``
+    instances that hold ``Quantity`` columns, as long as the output
+    does not require any masking. [#5811]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -253,6 +253,9 @@ Bug Fixes
   - Fix problem where key for caching column format function was not
     sufficiently unique. [#5803]
 
+  - Ensure mixin columns can be set to scalars if the type supports
+    broadcasting (e.g., for a ``QTable``, ``t['q'] = 3*u.m``). [#5820]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -427,11 +427,11 @@ def hstack(tables, join_type='outer',
     if len(tables) == 1:
         return tables[0]  # no point in stacking a single table
     col_name_map = OrderedDict()
-
+    # since every column originates from a single other one,
+    # column meta data is automatically correct.
     out = _hstack(tables, join_type, uniq_col_name, table_names,
                   col_name_map)
 
-    _merge_col_meta(out, tables, col_name_map, metadata_conflicts=metadata_conflicts)
     _merge_table_meta(out, tables, metadata_conflicts=metadata_conflicts)
 
     return out

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,8 @@ from numpy import ma
 from .. import log
 from ..io import registry as io_registry
 from ..units import Quantity
-from ..utils import isiterable
+from ..utils import isiterable, ShapedLikeNDArray
+from ..utils.compat.numpy import broadcast_to as np_broadcast_to
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
@@ -1237,17 +1238,29 @@ class Table(object):
             name = item
             # If this is a column-like object that could be added directly to table
             if isinstance(value, BaseColumn) or self._add_as_mixin_column(value):
+                # If we're setting a new column to a scalar, broadcast it.
+                # (things will fail in _init_from_cols if this doesn't work)
+                if (len(self) > 1 and (getattr(value, 'isscalar', False) or
+                                       getattr(value, 'shape', None) == () or
+                                       len(value) == 1)):
+                    new_shape = (len(self),) + getattr(value, 'shape', ())[1:]
+                    if isinstance(value, np.ndarray):
+                        value = np_broadcast_to(value, shape=new_shape,
+                                                subok=True)
+                    elif isinstance(value, ShapedLikeNDArray):
+                        value = value._apply(np_broadcast_to, shape=new_shape,
+                                             subok=True)
+
                 new_column = col_copy(value)
                 new_column.info.name = name
+
             elif len(self) == 0:
                 new_column = NewColumn(value, name=name)
             else:
                 new_column = NewColumn(name=name, length=len(self), dtype=value.dtype,
-                                       shape=value.shape[1:])
+                                       shape=value.shape[1:],
+                                       unit=getattr(value, 'unit', None))
                 new_column[:] = value
-
-                if isinstance(value, Quantity):
-                    new_column.unit = value.unit
 
             # Now add new column to the table
             self.add_columns([new_column], copy=False)

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from ...tests.helper import pytest
 from ... import table
-from ...table import table_helpers, Table
+from ...table import table_helpers, Table, QTable
 from ... import time
 from ... import units as u
 from ... import coordinates
@@ -181,3 +181,8 @@ def T1(request):
     if request.param:
         T.add_index('a')
     return T
+
+
+@pytest.fixture(params=[Table, QTable])
+def operation_table_type(request):
+    return request.param

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -38,6 +38,7 @@ def Column(request):
 
 
 class MaskedTable(table.Table):
+    Column = table.MaskedColumn
     def __init__(self, *args, **kwargs):
         kwargs['masked'] = True
         table.Table.__init__(self, *args, **kwargs)
@@ -72,19 +73,19 @@ class MyTable(table.Table):
 
 # Fixture to run all the Column tests for both an unmasked (ndarray)
 # and masked (MaskedArray) column.
-@pytest.fixture(params=['unmasked', 'masked', 'subclass'])
+@pytest.fixture(params=['unmasked', 'masked', 'subclass', 'qtable'])
 def table_types(request):
     class TableTypes:
         def __init__(self, request):
             if request.param == 'unmasked':
                 self.Table = table.Table
-                self.Column = table.Column
             elif request.param == 'masked':
                 self.Table = MaskedTable
-                self.Column = table.MaskedColumn
             elif request.param == 'subclass':
                 self.Table = MyTable
-                self.Column = MyColumn
+            elif request.param == 'qtable':
+                self.Table = QTable
+            self.Column = self.Table.Column
     return TableTypes(request)
 
 

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -89,25 +89,6 @@ def table_types(request):
     return TableTypes(request)
 
 
-# Fixture to run all the Column tests for both an unmasked (ndarray)
-# and masked (MaskedArray) column.
-@pytest.fixture(params=[False, True])
-def table_data(request):
-    class TableData:
-        def __init__(self, request):
-            self.Table = MaskedTable if request.param else table.Table
-            self.Column = table.MaskedColumn if request.param else table.Column
-            self.COLS = [
-                self.Column(name='a', data=[1, 2, 3], description='da',
-                            format='fa', meta={'ma': 1}, unit='ua'),
-                self.Column(name='b', data=[4, 5, 6], description='db',
-                            format='fb', meta={'mb': 1}, unit='ub'),
-                self.Column(name='c', data=[7, 8, 9], description='dc',
-                            format='fc', meta={'mc': 1}, unit='ub')]
-            self.DATA = self.Table(self.COLS)
-    return TableData(request)
-
-
 class SubclassTable(table.Table):
     pass
 
@@ -123,18 +104,6 @@ def protocol(request):
     Fixture to run all the tests for all available pickle protocols.
     """
     return request.param
-
-
-# Fixture to run all tests for both an unmasked (ndarray) and masked
-# (MaskedArray) column.
-@pytest.fixture(params=[False, True])
-def table_type(request):
-    # return MaskedTable if request.param else table.Table
-    try:
-        request.param
-        return MaskedTable
-    except AttributeError:
-        return table.Table
 
 
 # Stuff for testing mixin columns

--- a/astropy/table/tests/test_array.py
+++ b/astropy/table/tests/test_array.py
@@ -6,18 +6,18 @@ from ...tests.helper import pytest
 import numpy as np
 
 @pytest.fixture
-def array():
+def array(table_types):
     # composite index
     col0 = np.array([x % 2 for x in range(1, 11)])
     col1 = np.array([x for x in range(1, 11)])
-    t = Table([col0, col1])
+    t = table_types.Table([col0, col1])
     t = t[t.argsort()]
     return SortedArray(t, t['col1'].copy())
 
 @pytest.fixture
-def wide_array():
+def wide_array(table_types):
     # array with 100 columns
-    t = Table([[x] * 10 for x in np.arange(100)])
+    t = table_types.Table([[x] * 10 for x in np.arange(100)])
     return SortedArray(t, t['col0'].copy())
 
 def test_array_find(array):

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -18,7 +18,6 @@ _col = [1, 2, 3, 4, 5]
 
 @pytest.fixture(params=[
     _col,
-    u.Quantity(_col),
     Time(_col, format='jyear'),
 ])
 def main_col(request):
@@ -34,10 +33,13 @@ def assert_col_equal(col, array):
 class TestIndex(SetupData):
     def _setup(self, main_col, table_types):
         super(TestIndex, self)._setup(table_types)
-        self.main_col = main_col
-        if isinstance(main_col, u.Quantity):
-            self._table_type = QTable
-        if not isinstance(main_col, list):
+        if (isinstance(main_col, list) and
+            table_types.Table is QTable):
+            self.main_col = u.Quantity(_col)
+        else:
+            self.main_col = _col
+
+        if not isinstance(self.main_col, list):
             self._column_type = lambda x: x # don't change mixin type
         self.mutable = isinstance(main_col, (list, u.Quantity))
 

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -40,7 +40,8 @@ def test_table_info_attributes(table_types):
 
     # All output fields including a mixin column
     t['d'] = [1, 2, 3] * u.m
-    t['d'].description = 'quantity'
+    # need to set the description via `info`, since in QTable 'd' is a Quantity
+    t['d'].info.description = 'quantity'
     t['a'].format = '%02d'
     t['e'] = time.Time([1,2,3], format='mjd')
     t['e'].info.description = 'time'
@@ -55,7 +56,8 @@ def test_table_info_attributes(table_types):
     assert np.all(tinfo['format'] == ['%02d', '', '', '', '', ''])
     assert np.all(tinfo['description'] == ['', '', '', 'quantity', 'time', 'skycoord'])
     cls = t.ColumnClass.__name__
-    assert np.all(tinfo['class'] == [cls, cls, cls, cls, 'Time', 'SkyCoord'])
+    cls_d = 'Quantity' if type(t) is table.QTable else cls
+    assert np.all(tinfo['class'] == [cls, cls, cls, cls_d, 'Time', 'SkyCoord'])
 
     # Test that repr(t.info) is same as t.info()
     out = StringIO()

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -7,255 +7,279 @@ https://github.com/astropy/astropy/wiki/Table-item-access-definition
 """
 import numpy as np
 
+from ...units import Quantity
 from ...tests.helper import pytest
+from ..table import QTable
 
 
-@pytest.mark.usefixtures('table_data')
+def attrs_equal(col1, col2):
+    try:
+        return col1.attrs_equal(col2)
+    except AttributeError:
+        pass
+
+    # copied from Column,attrs_equal
+    attrs = ('name', 'unit', 'dtype', 'format', 'description', 'meta')
+    return all(getattr(col1.info, x) == getattr(col2.info, x) for x in attrs)
+
+
 class BaseTestItems():
-    pass
+    def _setup(self, table_types):
+        # use reals to ensure no dtype conversion is done with Quantity.
+        self.cols = [
+            table_types.Column(name='a', data=[1., 2., 3.], description='da',
+                               format='d', meta={'ma': 1}, unit='ua'),
+            table_types.Column(name='b', data=[4., 5., 6.], description='db',
+                               format='f', meta={'mb': 1}, unit='ub'),
+            table_types.Column(name='c', data=[7., 8., 9.], description='dc',
+                               format='g', meta={'mc': 1}, unit='ub')]
+        self.table = table_types.Table(self.cols)
+        if table_types.Table is not QTable:
+            self.expected_column_cls = table_types.Column
+        else:
+            self.expected_column_cls = Quantity
+
+    def q_if_needed(self, item, name='a'):
+        """Make an item into a quantity if we're comparing to a quantity."""
+        col = self.table[name]
+        return item * col.unit if isinstance(col, Quantity) else item
 
 
-@pytest.mark.usefixtures('table_data')
+@pytest.mark.usefixtures('table_types')
 class TestTableColumnsItems(BaseTestItems):
 
-    def test_by_name(self, table_data):
+    def test_by_name(self, table_types):
         """Access TableColumns by name and show that item access returns
         a Column that refers to underlying table data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
+        tc = self.table.columns
 
-        assert self.tc['a'].name == 'a'
-        assert self.tc['a'][1] == 2
-        assert self.tc['a'].description == 'da'
-        assert self.tc['a'].format == 'fa'
-        assert self.tc['a'].meta == {'ma': 1}
-        assert self.tc['a'].unit == 'ua'
-        assert self.tc['a'].attrs_equal(table_data.COLS[0])
-        assert isinstance(self.tc['a'], table_data.Column)
+        assert tc['a'].info.name == 'a'
+        assert tc['a'][1] == self.q_if_needed(2)
+        assert tc['a'].info.description == 'da'
+        assert tc['a'].info.format == 'd'
+        assert tc['a'].info.meta == {'ma': 1}
+        assert tc['a'].info.unit == 'ua'
+        assert attrs_equal(tc['a'], self.cols[0])
+        assert isinstance(tc['a'], self.expected_column_cls)
 
-        self.tc['b'][1] = 0
-        assert self.t['b'][1] == 0
+        tc['b'][1] = 0
+        assert self.table['b'][1] == 0
 
-    def test_by_position(self, table_data):
+    def test_by_position(self, table_types):
         """Access TableColumns by position and show that item access returns
         a Column that refers to underlying table data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
+        tc = self.table.columns
 
-        assert self.tc[1].name == 'b'
-        assert np.all(self.tc[1].data == table_data.COLS[1].data)
-        assert self.tc[1].description == 'db'
-        assert self.tc[1].format == 'fb'
-        assert self.tc[1].meta == {'mb': 1}
-        assert self.tc[1].unit == 'ub'
-        assert self.tc[1].attrs_equal(table_data.COLS[1])
-        assert isinstance(self.tc[1], table_data.Column)
+        assert tc[1].info.name == 'b'
+        assert np.all(tc[1].data == self.cols[1].data)
+        assert tc[1].info.description == 'db'
+        assert tc[1].info.format == 'f'
+        assert tc[1].info.meta == {'mb': 1}
+        assert tc[1].info.unit == 'ub'
+        assert attrs_equal(tc[1], self.cols[1])
+        assert isinstance(tc[1], self.expected_column_cls)
 
-        assert self.tc[2].unit == 'ub'
+        assert tc[2].unit == 'ub'
 
-        self.tc[1][1] = 0
-        assert self.t['b'][1] == 0
+        tc[1][1] = 0
+        assert self.table['b'][1] == 0
 
-    def test_mult_columns(self, table_data):
+    def test_mult_columns(self, table_types):
         """Access TableColumns with "fancy indexing" and showed that returned
         TableColumns object still references original data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
+        tc = self.table.columns
 
-        tc2 = self.tc['b', 'c']
-        assert tc2[1].name == 'c'
-        assert tc2[1][1] == 8
-        assert tc2[0].name == 'b'
-        assert tc2[0][1] == 5
+        tc2 = tc['b', 'c']
+        assert tc2[1].info.name == 'c'
+        assert tc2[1][1] == self.q_if_needed(8, 'c')
+        assert tc2[0].info.name == 'b'
+        assert tc2[0][1] == self.q_if_needed(5, 'b')
 
         tc2['c'][1] = 0
-        assert self.tc['c'][1] == 0
-        assert self.t['c'][1] == 0
+        assert tc['c'][1] == 0
+        assert self.table['c'][1] == 0
 
-    def test_column_slice(self, table_data):
+    def test_column_slice(self, table_types):
         """Access TableColumns with slice and showed that returned
         TableColumns object still references original data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
+        tc = self.table.columns
 
-        tc2 = self.tc[1:3]
-        assert tc2[1].name == 'c'
-        assert tc2[1][1] == 8
-        assert tc2[0].name == 'b'
-        assert tc2[0][1] == 5
+        tc2 = tc[1:3]
+        assert tc2[1].info.name == 'c'
+        assert tc2[1][1] == self.q_if_needed(8, 'c')
+        assert tc2[0].info.name == 'b'
+        assert tc2[0][1] == self.q_if_needed(5, 'b')
 
         tc2['c'][1] = 0
-        assert self.tc['c'][1] == 0
-        assert self.t['c'][1] == 0
+        assert tc['c'][1] == 0
+        assert self.table['c'][1] == 0
 
 
-@pytest.mark.usefixtures('table_data')
+@pytest.mark.usefixtures('table_types')
 class TestTableItems(BaseTestItems):
 
-    def test_column(self, table_data):
+    def test_column(self, table_types):
         """Column access returns REFERENCE to data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
-        a = self.t['a']
-        assert a[1] == 2
+        a = self.table['a']
+        assert a[1] == self.q_if_needed(2)
         a[1] = 0
-        assert self.t['a'][1] == 0
+        assert self.table['a'][1] == 0
 
-    def test_row(self, table_data):
+    def test_row(self, table_types):
         """Row  access returns REFERENCE to data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
-        row = self.t[1]
-        assert row['a'] == 2
-        assert row[1] == 5
-        assert row.columns['a'].attrs_equal(table_data.COLS[0])
-        assert row.columns['b'].attrs_equal(table_data.COLS[1])
-        assert row.columns['c'].attrs_equal(table_data.COLS[2])
+        row = self.table[1]
+        assert row['a'] == self.q_if_needed(2)
+        assert row[1] == self.q_if_needed(5, 'b')
+        assert attrs_equal(row.columns['a'], self.cols[0])
+        assert attrs_equal(row.columns['b'], self.cols[1])
+        assert attrs_equal(row.columns['c'], self.cols[2])
 
         # Check that setting by col index sets the table and row value
         row[1] = 0
         assert row[1] == 0
         assert row['b'] == 0
-        assert self.t['b'][1] == 0
-        assert self.t[1]['b'] == 0
+        assert self.table['b'][1] == 0
+        assert self.table[1]['b'] == 0
 
         # Check that setting by col name sets the table and row value
         row['a'] = 0
         assert row[0] == 0
         assert row['a'] == 0
-        assert self.t['a'][1] == 0
-        assert self.t[1]['a'] == 0
+        assert self.table['a'][1] == 0
+        assert self.table[1]['a'] == 0
 
-    def test_empty_iterable_item(self, table_data):
+    def test_empty_iterable_item(self, table_types):
         """
         Table item access with [], (), or np.array([]) returns the same table
         with no rows.
         """
-        self.t = table_data.Table(table_data.COLS)
+        self._setup(table_types)
         for item in [], (), np.array([]):
-            t2 = self.t[item]
+            t2 = self.table[item]
             assert not t2
             assert len(t2) == 0
-            assert t2['a'].attrs_equal(table_data.COLS[0])
-            assert t2['b'].attrs_equal(table_data.COLS[1])
-            assert t2['c'].attrs_equal(table_data.COLS[2])
+            assert attrs_equal(t2['a'], self.cols[0])
+            assert attrs_equal(t2['b'], self.cols[1])
+            assert attrs_equal(t2['c'], self.cols[2])
 
-    def test_table_slice(self, table_data):
+    def test_table_slice(self, table_types):
         """Table slice returns REFERENCE to data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
-        t2 = self.t[1:3]
-        assert np.all(t2['a'] == table_data.DATA['a'][1:3])
-        assert t2['a'].attrs_equal(table_data.COLS[0])
-        assert t2['b'].attrs_equal(table_data.COLS[1])
-        assert t2['c'].attrs_equal(table_data.COLS[2])
+        t2 = self.table[1:3]
+        assert np.all(t2['a'] == self.table['a'][1:3])
+        assert attrs_equal(t2['a'], self.cols[0])
+        assert attrs_equal(t2['b'], self.cols[1])
+        assert attrs_equal(t2['c'], self.cols[2])
         t2['a'][0] = 0
-        assert np.all(self.t['a'] == np.array([1, 0, 3]))
-        assert t2.masked == self.t.masked
-        assert t2._column_class == self.t._column_class
-        assert isinstance(t2, table_data.Table)
+        assert np.all(self.table['a'] == self.q_if_needed(np.array([1, 0, 3])))
+        assert t2.masked == self.table.masked
+        assert t2._column_class == self.table._column_class
+        assert isinstance(t2, table_types.Table)
 
-    def test_fancy_index_slice(self, table_data):
+    def test_fancy_index_slice(self, table_types):
         """Table fancy slice returns COPY of data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
-        slice = np.array([0, 2])
-        t2 = self.t[slice]
-        assert np.all(t2['a'] == table_data.DATA['a'][slice])
-        assert t2['a'].attrs_equal(table_data.COLS[0])
-        assert t2['b'].attrs_equal(table_data.COLS[1])
-        assert t2['c'].attrs_equal(table_data.COLS[2])
+        slc = np.array([0, 2])
+        t2 = self.table[slc]
+        assert np.all(t2['a'] == self.table['a'][slc])
+        assert attrs_equal(t2['a'], self.cols[0])
+        assert attrs_equal(t2['b'], self.cols[1])
+        assert attrs_equal(t2['c'], self.cols[2])
         t2['a'][0] = 0
 
-        assert np.all(self.t.as_array() == table_data.DATA)
-        assert np.any(t2['a'] != table_data.DATA['a'][slice])
-        assert t2.masked == self.t.masked
-        assert t2._column_class == self.t._column_class
-        assert isinstance(t2, table_data.Table)
+        assert np.all(self.table.as_array() == self.table)
+        assert np.any(t2['a'] != self.table['a'][slc])
+        assert t2.masked == self.table.masked
+        assert t2._column_class == self.table._column_class
+        assert isinstance(t2, table_types.Table)
 
-    def test_list_index_slice(self, table_data):
+    def test_list_index_slice(self, table_types):
         """Table list index slice returns COPY of data"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
-        slice = [0, 2]
-        t2 = self.t[slice]
-        assert np.all(t2['a'] == table_data.DATA['a'][slice])
-        assert t2['a'].attrs_equal(table_data.COLS[0])
-        assert t2['b'].attrs_equal(table_data.COLS[1])
-        assert t2['c'].attrs_equal(table_data.COLS[2])
+        slc = [0, 2]
+        t2 = self.table[slc]
+        assert np.all(t2['a'] == self.table['a'][slc])
+        assert attrs_equal(t2['a'], self.cols[0])
+        assert attrs_equal(t2['b'], self.cols[1])
+        assert attrs_equal(t2['c'], self.cols[2])
         t2['a'][0] = 0
 
-        assert np.all(self.t.as_array() == table_data.DATA)
-        assert np.any(t2['a'] != table_data.DATA['a'][slice])
-        assert t2.masked == self.t.masked
-        assert t2._column_class == self.t._column_class
-        assert isinstance(t2, table_data.Table)
+        assert np.all(self.table.as_array() == self.table)
+        assert np.any(t2['a'] != self.table['a'][slc])
+        assert t2.masked == self.table.masked
+        assert t2._column_class == self.table._column_class
+        assert isinstance(t2, table_types.Table)
 
-    def test_select_columns(self, table_data):
+    def test_select_columns(self, table_types):
         """Select columns returns COPY of data and all column
         attributes"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
         # try both lists and tuples
         for columns in (('a', 'c'), ['a', 'c']):
-            t2 = self.t[columns]
-            assert np.all(t2['a'] == table_data.DATA['a'])
-            assert np.all(t2['c'] == table_data.DATA['c'])
-            assert t2['a'].attrs_equal(table_data.COLS[0])
-            assert t2['c'].attrs_equal(table_data.COLS[2])
+            t2 = self.table[columns]
+            assert np.all(t2['a'] == self.table['a'])
+            assert np.all(t2['c'] == self.table['c'])
+            assert attrs_equal(t2['a'], self.cols[0])
+            assert attrs_equal(t2['c'], self.cols[2])
             t2['a'][0] = 0
-            assert np.all(self.t.as_array() == table_data.DATA)
-            assert np.any(t2['a'] != table_data.DATA['a'])
-            assert t2.masked == self.t.masked
-            assert t2._column_class == self.t._column_class
+            assert np.all(self.table.as_array() == self.table)
+            assert np.any(t2['a'] != self.table['a'])
+            assert t2.masked == self.table.masked
+            assert t2._column_class == self.table._column_class
 
-    def test_select_columns_fail(self, table_data):
+    def test_select_columns_fail(self, table_types):
         """Selecting a column that doesn't exist fails"""
-        self.t = table_data.Table(table_data.COLS)
+        self._setup(table_types)
 
         with pytest.raises(ValueError) as err:
-            self.t[['xxxx']]
+            self.table[['xxxx']]
         assert 'Slice name(s) xxxx not valid column name(s)' in str(err)
 
         with pytest.raises(ValueError) as err:
-            self.t[['xxxx', 'yyyy']]
+            self.table[['xxxx', 'yyyy']]
         assert 'Slice name(s) xxxx, yyyy not valid column name(s)' in str(err)
 
-    def test_np_where(self, table_data):
+    def test_np_where(self, table_types):
         """Select rows using output of np.where"""
-        t = table_data.Table(table_data.COLS)
+        self._setup(table_types)
+
         # Select last two rows
-        rows = np.where(t['a'] > 1.5)
-        t2 = t[rows]
-        assert np.all(t2['a'] == [2, 3])
-        assert np.all(t2['b'] == [5, 6])
-        assert isinstance(t2, table_data.Table)
+        rows = np.where(self.table['a'] > self.q_if_needed(1.5))
+        t2 = self.table[rows]
+        assert np.all(t2['a'] == self.q_if_needed([2, 3]))
+        assert np.all(t2['b'] == self.q_if_needed([5, 6], 'b'))
+        assert isinstance(t2, table_types.Table)
 
         # Select no rows
-        rows = np.where(t['a'] > 100)
-        t2 = t[rows]
+        rows = np.where(self.table['a'] > self.q_if_needed(100))
+        t2 = self.table[rows]
         assert len(t2) == 0
-        assert isinstance(t2, table_data.Table)
+        assert isinstance(t2, table_types.Table)
 
-    def test_np_integers(self, table_data):
+    def test_np_integers(self, table_types):
         """
         Select rows using numpy integers.  This is a regression test for a
         py 3.3 failure mode
         """
-        t = table_data.Table(table_data.COLS)
-        idxs = np.random.randint(len(t), size=2)
-        item = t[idxs[1]]
+        self._setup(table_types)
+        idxs = np.random.randint(len(self.table), size=2)
+        self.table[idxs[1]]
 
-    def test_select_bad_column(self, table_data):
+    def test_select_bad_column(self, table_types):
         """Select column name that does not exist"""
-        self.t = table_data.Table(table_data.COLS)
-        self.tc = self.t.columns
+        self._setup(table_types)
 
         with pytest.raises(ValueError):
-            self.t['a', 1]
+            self.table['a', 1]

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -277,17 +277,28 @@ def test_add_column(mixin_cols):
     m.info.meta = {'a': 1}
     t = QTable([m])
 
-    # Add columns m2 and m3 by two different methods and test expected equality
+    # Add columns m2, m3, m4 by two different methods and test expected equality
     t['m2'] = m
     m.info.name = 'm3'
     t.add_columns([m], copy=True)
     m.info.name = 'm4'
     t.add_columns([m], copy=False)
     for name in ('m2', 'm3', 'm4'):
-        assert_table_name_col_equal(t, 'm', t[name])
+        assert_table_name_col_equal(t, name, m)
         for attr in attrs:
             if attr != 'name':
                 assert getattr(t['m'].info, attr) == getattr(t[name].info, attr)
+    # Also check that one can set using a scalar.
+    s = m[0]
+    if type(s) is type(m):
+        # We're not going to worry about testing classes for which scalars
+        # are a different class than the real array (and thus loose info, etc.)
+        t['s'] = m[0]
+        assert_table_name_col_equal(t, 's', m[0])
+        for attr in attrs:
+            if attr != 'name':
+                assert getattr(t['m'].info, attr) == getattr(t['s'].info, attr)
+
 
 def test_vstack():
     """

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -212,7 +212,7 @@ class TestJoin():
             pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
-        t1m = Table(self.t1, masked=True)
+        t1m = operation_table_type(self.t1, masked=True)
         t2 = self.t2
 
         # Result should be masked even though not req'd by inner join
@@ -250,9 +250,9 @@ class TestJoin():
         if operation_table_type is QTable:
             pytest.xfail('Quantity columns do not support masking.')
         t1 = self.t1
-        t1m = Table(self.t1, masked=True)
+        t1m = operation_table_type(self.t1, masked=True)
         t2 = self.t2
-        t2m = Table(self.t2, masked=True)
+        t2m = operation_table_type(self.t2, masked=True)
 
         # Result should be masked even though not req'd by inner join
         t1m2m = table.join(t1m, t2m, join_type='inner')
@@ -333,7 +333,7 @@ class TestJoin():
         if operation_table_type is QTable:
             pytest.xfail('Quantity columns do not support masking.')
         t1 = self.t1
-        t2 = Table(self.t2, masked=True)
+        t2 = operation_table_type(self.t2, masked=True)
         table.join(t1, t2)  # OK
         t2['a'].mask[0] = True
         with pytest.raises(TableMergeError):
@@ -394,11 +394,11 @@ class TestJoin():
         # Regression test for #2984, which was an issue where join did not work
         # on multi-dimensional columns.
 
-        t1 = Table()
+        t1 = operation_table_type()
         t1['a'] = [1,2,3]
         t1['b'] = np.ones((3,4))
 
-        t2 = Table()
+        t2 = operation_table_type()
         t2['a'] = [1,2,3]
         t2['c'] = [4,5,6]
 
@@ -431,8 +431,8 @@ class TestJoin():
                           [2, 2],
                           [3, 3]],
                          name='c')
-        t1 = Table([a, b])
-        t2 = Table([a2, c])
+        t1 = operation_table_type([a, b])
+        t2 = operation_table_type([a2, c])
         t12 = table.join(t1, t2, join_type='inner')
 
         assert np.all(t12['b'].mask == [[ True, False],
@@ -937,20 +937,21 @@ class TestHStack():
         assert (self.t1 == table.hstack([self.t1])).all()
 
 
-def test_unique():
-    t = table.Table.read([' a b  c  d',
-                          ' 2 b 7.0 0',
-                          ' 1 c 3.0 5',
-                          ' 2 b 6.0 2',
-                          ' 2 a 4.0 3',
-                          ' 1 a 1.0 7',
-                          ' 2 b 5.0 1',
-                          ' 0 a 0.0 4',
-                          ' 1 a 2.0 6',
-                          ' 1 c 3.0 5',
-                          ], format='ascii')
+def test_unique(operation_table_type):
+    t = operation_table_type.read(
+        [' a b  c  d',
+         ' 2 b 7.0 0',
+         ' 1 c 3.0 5',
+         ' 2 b 6.0 2',
+         ' 2 a 4.0 3',
+         ' 1 a 1.0 7',
+         ' 2 b 5.0 1',
+         ' 0 a 0.0 4',
+         ' 1 a 2.0 6',
+         ' 1 c 3.0 5',
+        ], format='ascii')
 
-    tu = table.Table(np.sort(t[:-1]))
+    tu = operation_table_type(np.sort(t[:-1]))
 
     t_all = table.unique(t)
     assert sort_eq(t_all.pformat(), tu.pformat())
@@ -1015,7 +1016,7 @@ def test_unique():
     assert exc.value.args[0] == (
         "'keep' should be one of 'first', 'last', 'none'")
 
-    t1_m = table.Table(t1a, masked=True)
+    t1_m = operation_table_type(t1a, masked=True)
     t1_m['a'].mask[1] = True
 
     with pytest.raises(ValueError) as exc:
@@ -1034,7 +1035,7 @@ def test_unique():
     with pytest.raises(ValueError) as e:
         t1_mu = table.unique(t1_m, silent=True, keys='a')
 
-    t1_m = table.Table(t, masked=True)
+    t1_m = operation_table_type(t, masked=True)
     t1_m['a'].mask[1] = True
     t1_m['d'].mask[3] = True
 
@@ -1048,12 +1049,12 @@ def test_unique():
                                ' --   c 3.0   5']
 
 
-def test_vstack_bytes():
+def test_vstack_bytes(operation_table_type):
     """
     Test for issue #5617 when vstack'ing bytes columns in Py3.
     This is really an upsteam numpy issue numpy/numpy/#8403.
     """
-    t = table.Table([[b'a']], names=['a'])
+    t = operation_table_type([[b'a']], names=['a'])
     assert t['a'].itemsize == 1
 
     t2 = table.vstack([t, t])

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -6,11 +6,10 @@ import sys
 
 import numpy as np
 
-from ...tests.helper import pytest, catch_warnings
+from ...tests.helper import pytest
 from ... import table
 from ...table import Row
 from ...utils.compat import NUMPY_LT_1_8
-from ...utils.exceptions import AstropyDeprecationWarning
 from ...extern.six.moves import zip
 from .conftest import MaskedTable
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -136,14 +136,15 @@ class TestSetTableColumn(SetupData):
         """Create a new column (from a quantity) in empty table using the item access syntax"""
         self._setup(table_types)
         t = table_types.Table()
-
-        t['aa'] = np.array([1,2,3]) * u.m
-        assert np.all(t['aa'] == np.array([1,2,3]))
-        assert t['aa'].unit == u.m
-
-        t['bb'] = 3 * u.m
-        assert np.all(t['bb'] == 3)
-        assert t['bb'].unit == u.m
+        for name, value in (('aa', np.array([1,2,3]) * u.m), ('bb', 3 * u.m)):
+            t[name] = value
+            assert t[name].unit == u.m
+            if type(t) is table.QTable:
+                assert isinstance(t[name], u.Quantity)
+                assert np.all(t[name] == value)
+            else:
+                assert isinstance(t[name], table.column.BaseColumn)
+                assert np.all(t[name] == value.value)
 
     def test_set_new_col_existing_table(self, table_types):
         """Create a new column in an existing table using the item access syntax"""
@@ -181,15 +182,16 @@ class TestSetTableColumn(SetupData):
         t['f'] = 10
         assert np.all(t['f'] == 10)
 
-        # Add a column from a Quantity
-        t['g'] = np.array([1,2,3]) * u.m
-        assert np.all(t['g'].data == np.array([1,2,3]))
-        assert t['g'].unit == u.m
-
-        # Add a column from a (scalar) Quantity
-        t['g'] = 3 * u.m
-        assert np.all(t['g'].data == 3)
-        assert t['g'].unit == u.m
+        # Add a column from array and scalar Quantity
+        for name, value in (('g', np.array([1,2,3]) * u.m), ('h', 3 * u.m)):
+            t[name] = value
+            assert t[name].unit == u.m
+            if type(t) is table.QTable:
+                assert isinstance(t[name], u.Quantity)
+                assert np.all(t[name] == value)
+            else:
+                assert isinstance(t[name], table.column.BaseColumn)
+                assert np.all(t[name] == value.value)
 
     def test_set_new_unmasked_col_existing_table(self, table_types):
         """Create a new column in an existing table using the item access syntax"""


### PR DESCRIPTION
Still work in progress, but building on #5811 and and #5820, I can now get `QTable` to pass nearly all tests done on `Table` (skipping `test_masked` and `test_jsviewer` -- the latter puts units on every row, which is probably better dealt with as a separate bug).

Note that this involved quite a bit of refactoring of the tests: almost all now use the `table_types` fixtures (the `table_data` and `table_type` ones have been removed).

fixes #5785