### PR TITLE
Allow custom root directory for config/cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,11 @@ astropy.table
   
 - Improved exception handling and error messages when column ``format`` 
   attribute is incorrect for the column type. [#6385]
+  - The config and cache directories and the name of the config file are now
+    customizable. This allows affiliated packages to put their configuration
+    files in locations other than ``CONFIG_DIR/.astropy/``. [#5828]
+
+- ``astropy.constants``
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -850,6 +855,12 @@ astropy.wcs
 ^^^^^^^^^^^
 
 - Removed deprecated ``wcs.rotateCD``. [#6170]
+- The bundled version of pytest has now been removed, but the
+  astropy.tests.helper.pytest import will continue to work properly.
+  Affiliated packages should nevertheless transition to importing pytest
+  directly rather than from astropy.tests.helper. This also means that
+  pytest is now a formal requirement for testing for both Astropy and
+  for affiliated packages. [#5694]
 
 
 Bug Fixes

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -478,7 +478,7 @@ def get_config_filename(packageormod=None):
 _override_config_file = None
 
 
-def get_config(packageormod=None, reload=False):
+def get_config(packageormod=None, reload=False, rootname='astropy'):
     """ Gets the configuration object or section associated with a particular
     package or module.
 
@@ -515,10 +515,10 @@ def get_config(packageormod=None, reload=False):
             packageormod = packageormod.__name__
 
     packageormodspl = packageormod.split('.')
-    rootname = packageormodspl[0]
+    pkgname = packageormodspl[0]
     secname = '.'.join(packageormodspl[1:])
 
-    cobj = _cfgobjs.get(rootname, None)
+    cobj = _cfgobjs.get(pkgname, None)
 
     if cobj is None or reload:
         if _ASTROPY_SETUP_:
@@ -531,7 +531,7 @@ def get_config(packageormod=None, reload=False):
                 if _override_config_file is not None:
                     cfgfn = _override_config_file
                 else:
-                    cfgfn = path.join(get_config_dir(rootname), rootname + '.cfg')
+                    cfgfn = path.join(get_config_dir(rootname), pkgname + '.cfg')
                 cobj = configobj.ConfigObj(cfgfn, interpolation=False)
             except (IOError, OSError) as e:
                 msg = ('Configuration defaults will be used due to ')
@@ -544,7 +544,7 @@ def get_config(packageormod=None, reload=False):
                 # function won't see it unless the module is reloaded
                 cobj = configobj.ConfigObj(interpolation=False)
 
-        _cfgobjs[rootname] = cobj
+        _cfgobjs[pkgname] = cobj
 
     if secname:  # not the root package
         if secname not in cobj:

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -554,7 +554,7 @@ def get_config(packageormod=None, reload=False, rootname='astropy'):
         return cobj
 
 
-def reload_config(packageormod=None):
+def reload_config(packageormod=None, rootname='astropy'):
     """ Reloads configuration settings from a configuration file for the root
     package of the requested package/module.
 
@@ -569,7 +569,7 @@ def reload_config(packageormod=None):
     packageormod : str or None
         The package or module name - see `get_config` for details.
     """
-    sec = get_config(packageormod, True)
+    sec = get_config(packageormod, True, rootname=rootname)
     # look for the section that is its own parent - that's the base object
     while sec.parent is not sec:
         sec = sec.parent
@@ -668,7 +668,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
         # system, so just return.
         return False
 
-    cfgfn = get_config(pkg).filename
+    cfgfn = get_config(pkg, rootname='astropy').filename
 
     with io.open(default_cfgfn, 'rt', encoding='latin-1') as fr:
         template_content = fr.read()
@@ -695,7 +695,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     # spamming `~/.astropy/config`.
     if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir(pkg), '{0}.{1}.cfg'.format(pkg, version))
+            get_config_dir('astropy'), '{0}.{1}.cfg'.format(pkg, version))
         needs_template = not path.exists(template_path)
     else:
         needs_template = False

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -478,7 +478,7 @@ def get_config_filename(packageormod=None):
 _override_config_file = None
 
 
-def get_config(packageormod=None, reload=False, rootname='astropy'):
+def get_config(packageormod=None, reload=False, rootname=None):
     """ Gets the configuration object or section associated with a particular
     package or module.
 
@@ -486,11 +486,17 @@ def get_config(packageormod=None, reload=False, rootname='astropy'):
     -----------
     packageormod : str or None
         The package for which to retrieve the configuration object. If a
-        string, it must be a valid package name, or if `None`, the package from
+        string, it must be a valid package name, or if ``None``, the package from
         which this function is called will be used.
 
     reload : bool, optional
         Reload the file, even if we have it cached.
+
+    rootname : str or None
+        Name of the root configuration directory. If ``None`` and
+        ``packageormod`` is ``None``, this defaults to be the name of
+        the package from which this function is called. If ``None`` and
+        ``packageormod`` is not ``None``, this defaults to ``astropy``.
 
     Returns
     -------
@@ -514,9 +520,20 @@ def get_config(packageormod=None, reload=False, rootname='astropy'):
         else:
             packageormod = packageormod.__name__
 
+        _autopkg = True
+
+    else:
+        _autopkg = False
+
     packageormodspl = packageormod.split('.')
     pkgname = packageormodspl[0]
     secname = '.'.join(packageormodspl[1:])
+
+    if rootname is None:
+        if _autopkg:
+            rootname = pkgname
+        else:
+            rootname = 'astropy'
 
     cobj = _cfgobjs.get(pkgname, None)
 
@@ -554,7 +571,7 @@ def get_config(packageormod=None, reload=False, rootname='astropy'):
         return cobj
 
 
-def reload_config(packageormod=None, rootname='astropy'):
+def reload_config(packageormod=None, rootname=None):
     """ Reloads configuration settings from a configuration file for the root
     package of the requested package/module.
 
@@ -568,6 +585,9 @@ def reload_config(packageormod=None, rootname='astropy'):
     ----------
     packageormod : str or None
         The package or module name - see `get_config` for details.
+    rootname : str or None
+        Name of the root configuration directory - see `get_config`
+        for details.
     """
     sec = get_config(packageormod, True, rootname=rootname)
     # look for the section that is its own parent - that's the base object
@@ -668,7 +688,9 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
         # system, so just return.
         return False
 
-    cfgfn = get_config(pkg, rootname='astropy').filename
+    # rootname hard-coded because I think we only ever need to do this for affiliated pkgs?
+    rootname = 'astropy'
+    cfgfn = get_config(pkg, rootname=rootname).filename
 
     with io.open(default_cfgfn, 'rt', encoding='latin-1') as fr:
         template_content = fr.read()
@@ -695,7 +717,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     # spamming `~/.astropy/config`.
     if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir('astropy'), '{0}.{1}.cfg'.format(pkg, version))
+            get_config_dir(rootname), '{0}.{1}.cfg'.format(pkg, version))
         needs_template = not path.exists(template_path)
     else:
         needs_template = False

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -531,7 +531,7 @@ def get_config(packageormod=None, reload=False):
                 if _override_config_file is not None:
                     cfgfn = _override_config_file
                 else:
-                    cfgfn = path.join(get_config_dir(), rootname + '.cfg')
+                    cfgfn = path.join(get_config_dir(rootname), rootname + '.cfg')
                 cobj = configobj.ConfigObj(cfgfn, interpolation=False)
             except (IOError, OSError) as e:
                 msg = ('Configuration defaults will be used due to ')
@@ -695,7 +695,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     # spamming `~/.astropy/config`.
     if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir(), '{0}.{1}.cfg'.format(pkg, version))
+            get_config_dir(pkg), '{0}.{1}.cfg'.format(pkg, version))
         needs_template = not path.exists(template_path)
     else:
         needs_template = False

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -511,6 +511,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         If ``packageormod`` is `None`, but the package this item is created
         from cannot be determined.
     """
+
     if packageormod is None:
         packageormod = find_current_module(2)
         if packageormod is None:
@@ -533,7 +534,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         if _autopkg:
             rootname = pkgname
         else:
-            rootname = 'astropy'
+            rootname = 'astropy' # so we don't break affiliated packages
 
     cobj = _cfgobjs.get(pkgname, None)
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -198,7 +198,7 @@ class ConfigItem(object):
         element (e.g. 'astropy' if this is 'astropy.config.configuration')
         will be used to determine the name of the configuration file, while
         the remaining items determine the section. If None, the package will be
-        inferred from the package within whiich this object's initializer is
+        inferred from the package within which this object's initializer is
         called.
 
     aliases : str, or list of str, optional

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -83,7 +83,7 @@ def _find_home():
             homedir = decodepath(os.environ['HOME'])
         else:
             raise OSError('Could not find a home directory to search for '
-                          'astropy config dir - are you on an unspported '
+                          'astropy config dir - are you on an unsupported '
                           'platform?')
     return homedir
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -88,7 +88,7 @@ def _find_home():
     return homedir
 
 
-def get_config_dir(pkgname, create=True):
+def get_config_dir(rootname, create=True):
     """
     Determines the package configuration directory name and creates the
     directory if it doesn't exist.
@@ -98,9 +98,18 @@ def get_config_dir(pkgname, create=True):
     ``$XDG_CONFIG_HOME/astropy`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
+    Parameters
+    ----------
+    rootname : str
+        Name of the root configuration directory. For example, if
+        ``rootname = 'pkgname'``, the configuration directory will be
+        ``<home>/.pkgname/``.
+
+    create : bool, optional
+        Create the path if it doesn't exist.
+
     Returns
     -------
-    pkgname : TODO
     configdir : str
         The absolute path to the configuration directory.
 
@@ -112,7 +121,7 @@ def get_config_dir(pkgname, create=True):
     # If using set_temp_config, that overrides all
     if set_temp_config._temp_path is not None:
         xch = set_temp_config._temp_path
-        config_path = os.path.join(xch, pkgname)
+        config_path = os.path.join(xch, rootname)
         if not os.path.exists(config_path):
             os.mkdir(config_path)
         return os.path.abspath(config_path)
@@ -121,16 +130,16 @@ def get_config_dir(pkgname, create=True):
     xch = os.environ.get('XDG_CONFIG_HOME')
 
     if xch is not None and os.path.exists(xch):
-        xchpth = os.path.join(xch, pkgname)
+        xchpth = os.path.join(xch, rootname)
         if not os.path.islink(xchpth):
             if os.path.exists(xchpth):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
-    return os.path.abspath(_find_or_create_root_dir('config', linkto, pkgname))
+    return os.path.abspath(_find_or_create_root_dir('config', linkto, rootname))
 
 
-def get_cache_dir(pkgname):
+def get_cache_dir(rootname):
     """
     Determines the Astropy cache directory name and creates the directory if it
     doesn't exist.
@@ -140,9 +149,15 @@ def get_cache_dir(pkgname):
     ``$XDG_CACHE_HOME/astropy`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
+    Parameters
+    ----------
+    rootname : str
+        Name of the root cache directory. For example, if
+        ``rootname = 'pkgname'``, the cache directory will be
+        ``<cache>/.pkgname/``.
+
     Returns
     -------
-    pkgname : TODO
     cachedir : str
         The absolute path to the cache directory.
 
@@ -154,7 +169,7 @@ def get_cache_dir(pkgname):
     # If using set_temp_cache, that overrides all
     if set_temp_cache._temp_path is not None:
         xch = set_temp_cache._temp_path
-        cache_path = os.path.join(xch, pkgname)
+        cache_path = os.path.join(xch, rootname)
         if not os.path.exists(cache_path):
             os.mkdir(cache_path)
         return os.path.abspath(cache_path)
@@ -163,14 +178,14 @@ def get_cache_dir(pkgname):
     xch = os.environ.get('XDG_CACHE_HOME')
 
     if xch is not None and os.path.exists(xch):
-        xchpth = os.path.join(xch, pkgname)
+        xchpth = os.path.join(xch, rootname)
         if not os.path.islink(xchpth):
             if os.path.exists(xchpth):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
 
-    return os.path.abspath(_find_or_create_root_dir('cache', linkto, pkgname))
+    return os.path.abspath(_find_or_create_root_dir('cache', linkto, rootname))
 
 
 class _SetTempPath(object):

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -21,31 +21,31 @@ from ...utils.exceptions import AstropyDeprecationWarning
 
 
 def test_paths():
-    assert 'astropy' in paths.get_config_dir()
-    assert 'astropy' in paths.get_cache_dir()
+    assert 'astropy' in paths.get_config_dir('astropy')
+    assert 'astropy' in paths.get_cache_dir('astropy')
 
 
 def test_set_temp_config(tmpdir, monkeypatch):
     monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
 
-    orig_config_dir = paths.get_config_dir()
+    orig_config_dir = paths.get_config_dir('astropy')
     temp_config_dir = str(tmpdir.mkdir('config'))
     temp_astropy_config = os.path.join(temp_config_dir, 'astropy')
 
     # Test decorator mode
     @paths.set_temp_config(temp_config_dir)
     def test_func():
-        assert paths.get_config_dir() == temp_astropy_config
+        assert paths.get_config_dir('astropy') == temp_astropy_config
 
         # Test temporary restoration of original default
         with paths.set_temp_config() as d:
-            assert d == orig_config_dir == paths.get_config_dir()
+            assert d == orig_config_dir == paths.get_config_dir('astropy')
 
     test_func()
 
     # Test context manager mode (with cleanup)
     with paths.set_temp_config(temp_config_dir, delete=True):
-        assert paths.get_config_dir() == temp_astropy_config
+        assert paths.get_config_dir('astropy') == temp_astropy_config
 
     assert not os.path.exists(temp_config_dir)
 
@@ -53,24 +53,24 @@ def test_set_temp_config(tmpdir, monkeypatch):
 def test_set_temp_cache(tmpdir, monkeypatch):
     monkeypatch.setattr(paths.set_temp_cache, '_temp_path', None)
 
-    orig_cache_dir = paths.get_cache_dir()
+    orig_cache_dir = paths.get_cache_dir('astropy')
     temp_cache_dir = str(tmpdir.mkdir('cache'))
     temp_astropy_cache = os.path.join(temp_cache_dir, 'astropy')
 
     # Test decorator mode
     @paths.set_temp_cache(temp_cache_dir)
     def test_func():
-        assert paths.get_cache_dir() == temp_astropy_cache
+        assert paths.get_cache_dir('astropy') == temp_astropy_cache
 
         # Test temporary restoration of original default
         with paths.set_temp_cache() as d:
-            assert d == orig_cache_dir == paths.get_cache_dir()
+            assert d == orig_cache_dir == paths.get_cache_dir('astropy')
 
     test_func()
 
     # Test context manager mode (with cleanup)
     with paths.set_temp_cache(temp_cache_dir, delete=True):
-        assert paths.get_cache_dir() == temp_astropy_cache
+        assert paths.get_cache_dir('astropy') == temp_astropy_cache
 
     assert not os.path.exists(temp_cache_dir)
 
@@ -194,18 +194,18 @@ def test_config_noastropy_fallback(monkeypatch):
     monkeypatch.delenv(str('XDG_CONFIG_HOME'))
     monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
 
-    # make sure the _find_or_create_astropy_dir function fails as though the
+    # make sure the _find_or_create_root_dir function fails as though the
     # astropy dir could not be accessed
-    def osraiser(dirnm, linkto):
+    def osraiser(dirnm, linkto, pkgname=None):
         raise OSError
-    monkeypatch.setattr(paths, '_find_or_create_astropy_dir', osraiser)
+    monkeypatch.setattr(paths, '_find_or_create_root_dir', osraiser)
 
     # also have to make sure the stored configuration objects are cleared
     monkeypatch.setattr(configuration, '_cfgobjs', {})
 
     with pytest.raises(OSError):
         # make sure the config dir search fails
-        paths.get_config_dir()
+        paths.get_config_dir('astropy')
 
     # now run the basic tests, and make sure the warning about no astropy
     # is present

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -24,6 +24,9 @@ def test_paths():
     assert 'astropy' in paths.get_config_dir('astropy')
     assert 'astropy' in paths.get_cache_dir('astropy')
 
+    assert 'testpkg' in paths.get_config_dir('testpkg')
+    assert 'testpkg' in paths.get_cache_dir('testpkg')
+
 
 def test_set_temp_config(tmpdir, monkeypatch):
     monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
@@ -87,6 +90,10 @@ def test_config_file():
     assert cfgsec.parent.filename.endswith('astropy.cfg')
 
     reload_config('astropy')
+
+    # try with a different package name, still inside astropy config dir:
+    testcfg = get_config('testpkg', rootname='astropy')
+    assert testcfg.filename.endswith('testpkg.cfg')
 
 
 def test_configitem():

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -89,12 +89,36 @@ def test_config_file():
     assert cfgsec.name == 'config'
     assert cfgsec.parent.filename.endswith('astropy.cfg')
 
-    reload_config('astropy')
-
     # try with a different package name, still inside astropy config dir:
     testcfg = get_config('testpkg', rootname='astropy')
-    assert testcfg.filename.endswith('testpkg.cfg')
+    parts = os.path.normpath(testcfg.filename).split(os.sep)
+    assert 'astropy' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
 
+    # try with a different package name, no specified root name (should
+    #   default to astropy):
+    testcfg = get_config('testpkg')
+    parts = os.path.normpath(testcfg.filename).split(os.sep)
+    assert 'astropy' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
+
+    # try with a different package name, specified root name:
+    testcfg = get_config('testpkg', rootname='testpkg')
+    parts = os.path.normpath(testcfg.filename).split(os.sep)
+    assert 'testpkg' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
+
+    # try with a subpackage with specified root name:
+    testcfg_sec = get_config('testpkg.somemodule', rootname='testpkg')
+    parts = os.path.normpath(testcfg_sec.parent.filename).split(os.sep)
+    assert 'testpkg' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
+
+    reload_config('astropy')
 
 def test_configitem():
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -511,7 +511,7 @@ class AstropyLogger(Logger):
             try:
                 if log_file_path == '' or testing_mode:
                     log_file_path = os.path.join(
-                        _config.get_config_dir(), "astropy.log")
+                        _config.get_config_dir('astropy'), "astropy.log")
                 else:
                     log_file_path = os.path.expanduser(log_file_path)
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -250,7 +250,7 @@ def test_data_noastropy_fallback(monkeypatch):
     from ...config import paths
 
     # needed for testing the *real* lock at the end
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+    lockdir = os.path.join(_get_download_cache_locs('astropy')[0], 'lock')
 
     # better yet, set the configuration to make sure the temp files are deleted
     data.conf.delete_temporary_downloads_at_exit = True
@@ -266,13 +266,13 @@ def test_data_noastropy_fallback(monkeypatch):
 
     # make sure the _find_or_create_astropy_dir function fails as though the
     # astropy dir could not be accessed
-    def osraiser(dirnm, linkto):
+    def osraiser(dirnm, linkto, pkgname=None):
         raise OSError
-    monkeypatch.setattr(paths, '_find_or_create_astropy_dir', osraiser)
+    monkeypatch.setattr(paths, '_find_or_create_root_dir', osraiser)
 
     with pytest.raises(OSError):
         # make sure the config dir search fails
-        paths.get_cache_dir()
+        paths.get_cache_dir('astropy')
 
     # first try with cache
     with catch_warnings(CacheMissingWarning) as w:


### PR DESCRIPTION
The idea here is to provide the option to put / look for config and cache files in a customizable directory (i.e. not default to `~/.astropy/pkgname`). This would mainly be for packages that use Astropy but aren't planned to be affiliated packages. My own need for this is that I like the `ConfigObj` validation and the extra class-based `ConfigItem` functionality built on top, but I don't want my package to have config settings that live in `~/.astropy/XX.cfg`. In looking through the config code, however, I'm wondering why we don't try contributing it back to the Python 3 port of `ConfigObj` itself? Most of the code is very general and not astronomy-specific...

I think the changes made here won't affect affiliated packages because the root path will default to `.astropy`. 

This is probably still a work in progress because I think it still needs some more robust testing of the new functionality. But I need to figure out the best way to do that...

Fixes #5779.

cc @eteq 