### PR TITLE
Outlier removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,7 +245,7 @@ Bug Fixes
 
   - Fixed a problem with passing kwargs to fitters, specifically ``verblevel``. [#5815]
 
-  - Changed FittingWithOutlierRemoval to reject on the residual to the fit
+  - Changed FittingWithOutlierRemoval to reject on the residual to the fit [#5831]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,6 +245,8 @@ Bug Fixes
 
   - Fixed a problem with passing kwargs to fitters, specifically ``verblevel``. [#5815]
 
+  - Changed FittingWithOutlierRemoval to reject on the residual to the fit
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -415,19 +415,23 @@ class FittingWithOutlierRemoval(object):
 
         fitted_model = self.fitter(model, x, y, z, weights, **kwargs)
         if z is None:
+            fitted_model = self.fitter(fitted_model, x, y, **kwargs)
             filtered_data = y
             for n in range(self.niter):
-                filtered_data = self.outlier_func(filtered_data,
+                filtered_data = self.outlier_func(filtered_data - fitted_model(x),
                                                   **self.outlier_kwargs)
+                filtered_data += fitted_model(x)
                 fitted_model = self.fitter(fitted_model,
                                x[~filtered_data.mask],
                                filtered_data.data[~filtered_data.mask],
                                **kwargs)
         else:
+            fitted_model = self.fitter(fitted_model, x, y, z, **kwargs)
             filtered_data = z
             for n in range(self.niter):
-                filtered_data = self.outlier_func(filtered_data,
+                filtered_data = self.outlier_func(filtered_data - fitted_model(x, y),
                                                   **self.outlier_kwargs)
+                filtered_data += fitted_model(x, y)
                 fitted_model = self.fitter(fitted_model,
                                x[~filtered_data.mask],
                                y[~filtered_data.mask],

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -415,7 +415,6 @@ class FittingWithOutlierRemoval(object):
 
         fitted_model = self.fitter(model, x, y, z, weights, **kwargs)
         if z is None:
-            fitted_model = self.fitter(fitted_model, x, y, **kwargs)
             filtered_data = y
             for n in range(self.niter):
                 filtered_data = self.outlier_func(filtered_data - fitted_model(x),
@@ -426,7 +425,6 @@ class FittingWithOutlierRemoval(object):
                                filtered_data.data[~filtered_data.mask],
                                **kwargs)
         else:
-            fitted_model = self.fitter(fitted_model, x, y, z, **kwargs)
             filtered_data = z
             for n in range(self.niter):
                 filtered_data = self.outlier_func(filtered_data - fitted_model(x, y),

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -601,19 +601,19 @@ class Test2DFittingWithOutlierRemoval(object):
 
         # test with Levenberg-Marquardt Least Squares fitter
         fit = FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
-                                        niter=3, sigma=4.)
+                                        niter=3, sigma=3.)
         _, fitted_model = fit(g2_init, self.x, self.y, self.z)
         assert_allclose(fitted_model.parameters[0:5], self.model_params,
                         atol=1e-1)
         # test with Sequential Least Squares Programming fitter
         fit = FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip, niter=3,
-                                        sigma=4.)
+                                        sigma=3.)
         _, fitted_model = fit(g2_init, self.x, self.y, self.z)
         assert_allclose(fitted_model.parameters[0:5], self.model_params,
                         atol=1e-1)
         # test with Simplex LSQ fitter
         fit = FittingWithOutlierRemoval(SimplexLSQFitter(), sigma_clip,
-                                        niter=3, sigma=4.)
+                                        niter=3, sigma=3.)
         _, fitted_model = fit(g2_init, self.x, self.y, self.z)
         assert_allclose(fitted_model.parameters[0:5], self.model_params,
                         atol=1e-1)


### PR DESCRIPTION
On using `model.fitting.FittingWithOutlierRemoval`, I noticed that it rejects on the model instead of the residual of the model.  This PR updates the class to reject on the residual of the model.   