### PR TITLE
Allow to choose median function for mad_std and median_absolute_deviation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -172,6 +172,10 @@ Bug Fixes
 
 - ``astropy.stats``
 
+  - Allow to choose which median function is used in ``mad_std`` and
+    ``median_absolute_deviation``. And allow to use these functions with
+    a multi-dimensional ``axis``. [#5835]
+
 - ``astropy.sphinx``
 
 - ``astropy.table``

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -728,7 +728,7 @@ def median_absolute_deviation(a, axis=None, func=None):
     ----------
     a : array-like
         Input array or object that can be converted to an array.
-    axis : int, optional
+    axis : {int, sequence of int, None}, optional
         Axis along which the MADs are computed.  The default (`None`) is
         to compute the MAD of the flattened array.
     func : callable, optional
@@ -775,11 +775,11 @@ def median_absolute_deviation(a, axis=None, func=None):
 
     # broadcast the median array before subtraction
     if axis is not None:
-        if isinstance(axis, (tuple, list)):
-            for ax in sorted(axis):
-                a_median = np.expand_dims(a_median, axis=ax)
-        else:
+        try:
             a_median = np.expand_dims(a_median, axis=axis)
+        except (ValueError, TypeError):
+            for ax in sorted(list(axis)):
+                a_median = np.expand_dims(a_median, axis=ax)
 
     return func(np.abs(a - a_median), axis=axis)
 
@@ -804,7 +804,7 @@ def mad_std(data, axis=None, func=None):
     ----------
     data : array-like
         Data array or object that can be converted to an array.
-    axis : int, optional
+    axis : {int, sequence of int, None}, optional
         Axis along which the robust standard deviations are computed.
         The default (`None`) is to compute the robust standard deviation
         of the flattened array.

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -718,7 +718,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
     return conf_interval
 
 
-def median_absolute_deviation(a, axis=None, func=np.median):
+def median_absolute_deviation(a, axis=None, func=None):
     """
     Calculate the median absolute deviation (MAD).
 
@@ -731,6 +731,9 @@ def median_absolute_deviation(a, axis=None, func=np.median):
     axis : int, optional
         Axis along which the MADs are computed.  The default (`None`) is
         to compute the MAD of the flattened array.
+    func : callable, optional
+        The function used to compute the median. Defaults to `numpy.ma.median`
+        for masked arrays, otherwise to `numpy.median`.
 
     Returns
     -------
@@ -757,12 +760,15 @@ def median_absolute_deviation(a, axis=None, func=np.median):
     mad_std
     """
 
-    # Check if the array has a mask and if so use np.ma.median
-    # See https://github.com/numpy/numpy/issues/7330 why using np.ma.median
-    # for normal arrays should not be done (summary: np.ma.median always
-    # returns an masked array even if the result should be scalar). (#4658)
-    if isinstance(a, np.ma.MaskedArray):
-        func = np.ma.median
+    if func is None:
+        # Check if the array has a mask and if so use np.ma.median
+        # See https://github.com/numpy/numpy/issues/7330 why using np.ma.median
+        # for normal arrays should not be done (summary: np.ma.median always
+        # returns an masked array even if the result should be scalar). (#4658)
+        if isinstance(a, np.ma.MaskedArray):
+            func = np.ma.median
+        else:
+            func = np.median
 
     a = np.asanyarray(a)
     a_median = func(a, axis=axis)
@@ -778,7 +784,7 @@ def median_absolute_deviation(a, axis=None, func=np.median):
     return func(np.abs(a - a_median), axis=axis)
 
 
-def mad_std(data, axis=None, func=np.median):
+def mad_std(data, axis=None, func=None):
     r"""
     Calculate a robust standard deviation using the `median absolute
     deviation (MAD)
@@ -802,6 +808,9 @@ def mad_std(data, axis=None, func=np.median):
         Axis along which the robust standard deviations are computed.
         The default (`None`) is to compute the robust standard deviation
         of the flattened array.
+    func : callable, optional
+        The function used to compute the median. Defaults to `numpy.ma.median`
+        for masked arrays, otherwise to `numpy.median`.
 
     Returns
     -------

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -15,6 +15,7 @@ import math
 
 import numpy as np
 
+from ..utils import isiterable
 from ..extern.six.moves import range
 
 
@@ -775,11 +776,11 @@ def median_absolute_deviation(a, axis=None, func=None):
 
     # broadcast the median array before subtraction
     if axis is not None:
-        try:
-            a_median = np.expand_dims(a_median, axis=axis)
-        except (ValueError, TypeError):
+        if isiterable(axis):
             for ax in sorted(list(axis)):
                 a_median = np.expand_dims(a_median, axis=ax)
+        else:
+            a_median = np.expand_dims(a_median, axis=axis)
 
     return func(np.abs(a - a_median), axis=axis)
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -718,7 +718,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
     return conf_interval
 
 
-def median_absolute_deviation(a, axis=None):
+def median_absolute_deviation(a, axis=None, func=np.median):
     """
     Calculate the median absolute deviation (MAD).
 
@@ -763,20 +763,22 @@ def median_absolute_deviation(a, axis=None):
     # returns an masked array even if the result should be scalar). (#4658)
     if isinstance(a, np.ma.MaskedArray):
         func = np.ma.median
-    else:
-        func = np.median
 
     a = np.asanyarray(a)
     a_median = func(a, axis=axis)
 
     # broadcast the median array before subtraction
     if axis is not None:
-        a_median = np.expand_dims(a_median, axis=axis)
+        if isinstance(axis, (tuple, list)):
+            for ax in sorted(axis):
+                a_median = np.expand_dims(a_median, axis=ax)
+        else:
+            a_median = np.expand_dims(a_median, axis=axis)
 
     return func(np.abs(a - a_median), axis=axis)
 
 
-def mad_std(data, axis=None):
+def mad_std(data, axis=None, func=np.median):
     r"""
     Calculate a robust standard deviation using the `median absolute
     deviation (MAD)
@@ -823,7 +825,7 @@ def mad_std(data, axis=None):
     """
 
     # NOTE: 1. / scipy.stats.norm.ppf(0.75) = 1.482602218505602
-    return median_absolute_deviation(data, axis=axis) * 1.482602218505602
+    return median_absolute_deviation(data, axis=axis, func=func) * 1.482602218505602
 
 
 def biweight_location(a, c=6.0, M=None, axis=None):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -32,6 +32,7 @@ from .. import funcs
 # of poisson_upper_limit
 # from ..funcs import scipy_poisson_upper_limit, mpmath_poisson_upper_limit
 
+from ...utils.compat import NUMPY_LT_1_10
 from ...utils.misc import NumpyRNGContext
 from ... import units as u
 
@@ -103,6 +104,18 @@ def test_median_absolute_deviation_masked():
         funcs.median_absolute_deviation(array, axis=0).data, [0, 1])
     np.testing.assert_array_equal(
         funcs.median_absolute_deviation(array, axis=1).data, [0, 0])
+
+
+@pytest.mark.skipif('NUMPY_LT_1_10')
+def test_median_absolute_deviation_nans():
+    array = np.array([[1, 4, 3, np.nan],
+                      [2, 5, np.nan, 4]])
+    assert_equal(funcs.median_absolute_deviation(array, func=np.nanmedian,
+                                                 axis=1),
+                 [1, 1])
+
+    array = np.ma.masked_invalid(array)
+    assert funcs.median_absolute_deviation(array) == 1
 
 
 def test_median_absolute_deviation_quantity():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -32,7 +32,7 @@ from .. import funcs
 # of poisson_upper_limit
 # from ..funcs import scipy_poisson_upper_limit, mpmath_poisson_upper_limit
 
-from ...utils.compat import NUMPY_LT_1_10
+from ...utils.compat import NUMPY_LT_1_10, NUMPY_LT_1_9  # pylint: disable=W0611
 from ...utils.misc import NumpyRNGContext
 from ... import units as u
 
@@ -118,6 +118,7 @@ def test_median_absolute_deviation_nans():
     assert funcs.median_absolute_deviation(array) == 1
 
 
+@pytest.mark.skipif('NUMPY_LT_1_9')
 def test_median_absolute_deviation_multidim_axis():
     array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]
     assert_equal(funcs.median_absolute_deviation(array, axis=(1, 2)),

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -118,6 +118,12 @@ def test_median_absolute_deviation_nans():
     assert funcs.median_absolute_deviation(array) == 1
 
 
+def test_median_absolute_deviation_multidim_axis():
+    array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]
+    assert_equal(funcs.median_absolute_deviation(array, axis=(1, 2)),
+                 np.zeros(5))
+
+
 def test_median_absolute_deviation_quantity():
     # Based on the changes introduces in #4658
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -123,6 +123,8 @@ def test_median_absolute_deviation_multidim_axis():
     array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]
     assert_equal(funcs.median_absolute_deviation(array, axis=(1, 2)),
                  np.zeros(5))
+    assert_equal(funcs.median_absolute_deviation(array, axis=np.array([1, 2])),
+                 np.zeros(5))
 
 
 def test_median_absolute_deviation_quantity():


### PR DESCRIPTION
The idea here is to allow the user to choose which function must be used for the median computation for `mad_std` and `median_absolute_deviation` (similarly to `sigma_clip`), which would be useful for arrays containing NaNs. Using `np.nanmedian` can be much faster than having to use masked arrays (see example below). 
Also, `np.nanmedian` allows to use a multi-dimensional `axis`, as well as `np.median`, but `np.ma.median` cannot do this (though it's possible to bypass this limitation with a reshape).

Example on a data cube:
```
In [3]: cube.shape
Out[3]: (3681, 337, 336) 
```
Masked array version: 
```
In [4]: %time std = mad_std(mcube.reshape(mcube.shape[0], -1), axis=1)
CPU times: user 1min 56s, sys: 22.4 s, total: 2min 19s
Wall time: 2min 19s   
```
With this PR, `np.nanmedian` and a multi-dimensional `axis`:
```
In [5]: %time std2 = mad_std(cube, axis=(1, 2), func=np.nanmedian)        
CPU times: user 14 s, sys: 2.41 s, total: 16.4 s                             
Wall time: 16.4 s
                                                                       
In [6]: np.allclose(std, std2)                                                              
Out[6]: True                 
```
With bottleneck (does not support multi-dimensional `axis`):
```
In [9]: %time std3 = mad_std(cube.reshape(mcube.shape[0], -1), axis=1, func=bn.nanmedian)
CPU times: user 12.2 s, sys: 1.82 s, total: 14.1 s
Wall time: 14.1 s
```

The PR is not polished yet, it needs tests, docstring, changelog etc., but first I wanted to open the discussion (@larrybradley , anyone else ?)