### PR TITLE
Add is_equivalent() convenience method for Quantity and test

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -768,6 +768,23 @@ class Quantity(np.ndarray):
 
     info = QuantityInfo()
 
+    def is_equivalent(self, other, equivalencies=[]):
+        """
+        Returns `True` if this quantity's unit is equivalent to ``other``.
+
+        Convenience method for `quantity.unit.is_equivalent()`
+
+        Parameters
+        ----------
+        other : Quantity or Unit or string or tuple
+            The unit to convert to. If a tuple of units is specified, this
+            method returns true if the unit matches any of those in the tuple.
+        """
+        if isinstance(other, Quantity):
+            return self.unit.is_equivalent(other.unit)
+        else:
+            return self.unit.is_equivalent(other)
+
     @property
     def value(self):
         """ The numerical value of this quantity. """

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -768,7 +768,7 @@ class Quantity(np.ndarray):
 
     info = QuantityInfo()
 
-    def is_equivalent(self, other, equivalencies=[]):
+    def is_equivalent(self, other, equivalencies=None):
         """
         Returns `True` if this quantity's unit is equivalent to ``other``.
 
@@ -780,10 +780,10 @@ class Quantity(np.ndarray):
             The unit to convert to. If a tuple of units is specified, this
             method returns true if the unit matches any of those in the tuple.
         """
-        if isinstance(other, Quantity):
-            return self.unit.is_equivalent(other.unit)
+        if hasattr(other, 'unit'):
+            return self.unit.is_equivalent(other.unit, equivalencies=equivalencies)
         else:
-            return self.unit.is_equivalent(other)
+            return self.unit.is_equivalent(other, equivalencies=equivalencies)
 
     @property
     def value(self):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -667,6 +667,13 @@ class TestQuantityComparison(object):
 
         assert u.Quantity(1200, unit=u.meter) != u.Quantity(1, unit=u.kilometer)
 
+    def test_quantity_is_equivalent(self):
+        assert u.Quantity(10, unit='m').is_equivalent(u.Quantity(1, unit='cm'))
+        assert u.Quantity(10, unit='m').is_equivalent(u.pc)
+        assert u.Quantity(10, unit='kg').is_equivalent('g')
+        assert not u.Quantity(10, unit='m').is_equivalent(u.Quantity(1, unit='mag'))
+        assert not u.Quantity(10, unit='m').is_equivalent(u.arcsec)
+
 
 class TestQuantityDisplay(object):
     scalarintq = u.Quantity(1, unit='m', dtype=int)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -671,8 +671,11 @@ class TestQuantityComparison(object):
         assert u.Quantity(10, unit='m').is_equivalent(u.Quantity(1, unit='cm'))
         assert u.Quantity(10, unit='m').is_equivalent(u.pc)
         assert u.Quantity(10, unit='kg').is_equivalent('g')
+
         assert not u.Quantity(10, unit='m').is_equivalent(u.Quantity(1, unit='mag'))
         assert not u.Quantity(10, unit='m').is_equivalent(u.arcsec)
+
+        assert u.Quantity(10, unit='Hz').is_equivalent(u.m, equivalencies=(u.spectral()))
 
 
 class TestQuantityDisplay(object):


### PR DESCRIPTION
`astropy.unit` objects can test whether they are equivalent to each other. It's useful to be able to test whether two quantities are in equivalent units, or whether a quantity is equivalent to a unit (or unit representation). This PR adds such a method on Quantity, with a few tests. I didn't see find the tests for `unit.is_equivalent()`, but I'm leveraging the assumption that it behaves itself, and not writing a full set of tests for the Quantity version.

I wasn't sure how to document the new method so that it's not just duplicating the full docstring of `unit.is_equivalent()`: I'd rather just change the bits that are different (e.g. `other` can be a Quantity, in addition to all other types accepted by the `unit` method), and for everything else tell the user to refer to the `unit.is_equivalent()` method.