### PR TITLE
Add dX_2000A/dY_2000A access to the IERS_A table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,10 @@ astropy.utils
 
 - ``JsonCustomEncoder`` is expanded to handle ``Quantity`` and ``UnitBase``.
   [#5471]
+- ``astropy.utils``
+  - Added ``dcip_xy`` method to IERS
+	The data for the CIP offsets is now available for use
+	in coordinate frame conversion
 
 - The functions ``matmul``, ``broadcast_arrays``, ``broadcast_to`` of the
   ``astropy.utils.compat.numpy`` module have been deprecated. Use the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,6 +152,7 @@ astropy.utils
 - ``JsonCustomEncoder`` is expanded to handle ``Quantity`` and ``UnitBase``.
   [#5471]
 - ``astropy.utils``
+
   - Added ``dcip_xy`` method to IERS
 	The data for the CIP offsets is now available for use
 	in coordinate frame conversion

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,11 +151,10 @@ astropy.utils
 
 - ``JsonCustomEncoder`` is expanded to handle ``Quantity`` and ``UnitBase``.
   [#5471]
-- ``astropy.utils``
 
-  - Added ``dcip_xy`` method to IERS
-	The data for the CIP offsets is now available for use
-	in coordinate frame conversion
+- Added a ``dcip_xy`` method to IERS that interpolates along the dX_2000A and 
+  dY_2000A columns of the IERS table.  Hence, the data for the CIP offsets is 
+  now available for use in coordinate frame conversion. [#5837]
 
 - The functions ``matmul``, ``broadcast_arrays``, ``broadcast_to`` of the
   ``astropy.utils.compat.numpy`` module have been deprecated. Use the

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -255,7 +255,7 @@ class IERS(QTable):
             ``iers.TIME_BEYOND_IERS_RANGE``
         """
         return self._interpolate(jd1, jd2, ['dX_2000A', 'dY_2000A'],
-                                 self.ut1_utc_source if return_status else None)
+                                 self.dcip_source if return_status else None)
 
     def pm_xy(self, jd1, jd2=0., return_status=False):
         """Interpolate polar motions from IERS Table for given dates.

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -114,7 +114,7 @@ class IERS(QTable):
     """Generic IERS table class, defining interpolation functions.
 
     Sub-classed from `astropy.table.QTable`.  The table should hold columns
-    'MJD', 'UT1_UTC', and 'PM_x'/'PM_y'.
+    'MJD', 'UT1_UTC', 'dX_2000A'/'dY_2000A', and 'PM_x'/'PM_y'.
     """
 
     iers_table = None
@@ -224,6 +224,37 @@ class IERS(QTable):
             ``iers.TIME_BEYOND_IERS_RANGE``
         """
         return self._interpolate(jd1, jd2, ['UT1_UTC'],
+                                 self.ut1_utc_source if return_status else None)
+
+    def dcip_xy(self, jd1, jd2=0., return_status=False):
+        """Interpolate CIP corrections in IERS Table for given dates.
+
+        Parameters
+        ----------
+        jd1 : float, float array, or Time object
+            first part of two-part JD, or Time object
+        jd2 : float or float array, optional
+            second part of two-part JD (default 0., ignored if jd1 is Time)
+        return_status : bool
+            Whether to return status values.  If False (default),
+            raise ``IERSRangeError`` if any time is out of the range covered
+            by the IERS table.
+
+        Returns
+        -------
+		D_x : Quantity with angle units
+			x component of CIP correction for the requested times
+		D_y : Quantity with angle units
+			y component of CIP correction for the requested times
+        status : int or int array
+            Status values (if ``return_status``=``True``)::
+            ``iers.FROM_IERS_B``
+            ``iers.FROM_IERS_A``
+            ``iers.FROM_IERS_A_PREDICTION``
+            ``iers.TIME_BEFORE_IERS_RANGE``
+            ``iers.TIME_BEYOND_IERS_RANGE``
+        """
+        return self._interpolate(jd1, jd2, ['dX_2000A', 'dY_2000A'],
                                  self.ut1_utc_source if return_status else None)
 
     def pm_xy(self, jd1, jd2=0., return_status=False):
@@ -337,6 +368,10 @@ class IERS(QTable):
         """Source for UT1-UTC.  To be overridden by subclass."""
         return np.zeros_like(i)
 
+	def dcip_source(self, i):
+		"""Source for CIP correction.  To be overridden by subclass."""
+		return np.zeros_like(i)
+
     def pm_source(self, i):
         """Source for polar motion.  To be overridden by subclass."""
         return np.zeros_like(i)
@@ -407,6 +442,20 @@ class IERS_A(IERS):
                                       table['PolPMFlag_A'].data,
                                       'B')
 
+        table['dX_2000A'] = np.where(table['dX_2000A_B'].mask,
+									 table['dX_2000A_A'].data,
+									 table['dX_2000A_B'].data)
+        table['dX_2000A'].unit = table['dX_2000A_A'].unit
+
+        table['dY_2000A'] = np.where(table['dY_2000A_B'].mask,
+                                     table['dY_2000A_A'].data,
+                                     table['dY_2000A_B'].data)
+        table['dY_2000A'].unit = table['dY_2000A_A'].unit
+
+        table['NutFlag'] = np.where(table['dX_2000A_B'].mask,
+                                    table['NutFlag_A'].data,
+                                    'B')
+
         # Get the table index for the first row that has predictive values
         # PolPMFlag_A  IERS (I) or Prediction (P) flag for
         #              Bull. A polar motion values
@@ -465,6 +514,14 @@ class IERS_A(IERS):
         source[ut1flag == 'P'] = FROM_IERS_A_PREDICTION
         return source
 
+	def dcip_source(self, i):
+		"""Set CIP correction source flag for entries in IERS table"""
+		nutflag = self['NutFlag'][i]
+		source = np.ones_like(i) * FROM_IERS_B
+		source[nutflag == 'I'] = FROM_IERS_A
+		source[nutflag == 'P'] = FROM_IERS_A_PREDICTION
+		return source
+
     def pm_source(self, i):
         """Set polar motion source flag for entries in IERS table"""
         pmflag = self['PolPMFlag'][i]
@@ -520,6 +577,10 @@ class IERS_B(IERS):
     def ut1_utc_source(self, i):
         """Set UT1-UTC source flag for entries in IERS table"""
         return np.ones_like(i) * FROM_IERS_B
+
+	def dcip_source(self, i):
+		"""Set CIP correction source flag for entries in IERS table"""
+		return np.ones_like(i) * FROM_IERS_B
 
     def pm_source(self, i):
         """Set PM source flag for entries in IERS table"""

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -242,10 +242,10 @@ class IERS(QTable):
 
         Returns
         -------
-		D_x : Quantity with angle units
-			x component of CIP correction for the requested times
-		D_y : Quantity with angle units
-			y component of CIP correction for the requested times
+        D_x : Quantity with angle units
+            x component of CIP correction for the requested times
+        D_y : Quantity with angle units
+            y component of CIP correction for the requested times
         status : int or int array
             Status values (if ``return_status``=``True``)::
             ``iers.FROM_IERS_B``
@@ -368,9 +368,9 @@ class IERS(QTable):
         """Source for UT1-UTC.  To be overridden by subclass."""
         return np.zeros_like(i)
 
-	def dcip_source(self, i):
-		"""Source for CIP correction.  To be overridden by subclass."""
-		return np.zeros_like(i)
+    def dcip_source(self, i):
+        """Source for CIP correction.  To be overridden by subclass."""
+        return np.zeros_like(i)
 
     def pm_source(self, i):
         """Source for polar motion.  To be overridden by subclass."""
@@ -443,8 +443,8 @@ class IERS_A(IERS):
                                       'B')
 
         table['dX_2000A'] = np.where(table['dX_2000A_B'].mask,
-									 table['dX_2000A_A'].data,
-									 table['dX_2000A_B'].data)
+                                     table['dX_2000A_A'].data,
+                                     table['dX_2000A_B'].data)
         table['dX_2000A'].unit = table['dX_2000A_A'].unit
 
         table['dY_2000A'] = np.where(table['dY_2000A_B'].mask,
@@ -514,13 +514,13 @@ class IERS_A(IERS):
         source[ut1flag == 'P'] = FROM_IERS_A_PREDICTION
         return source
 
-	def dcip_source(self, i):
-		"""Set CIP correction source flag for entries in IERS table"""
-		nutflag = self['NutFlag'][i]
-		source = np.ones_like(i) * FROM_IERS_B
-		source[nutflag == 'I'] = FROM_IERS_A
-		source[nutflag == 'P'] = FROM_IERS_A_PREDICTION
-		return source
+    def dcip_source(self, i):
+        """Set CIP correction source flag for entries in IERS table"""
+        nutflag = self['NutFlag'][i]
+        source = np.ones_like(i) * FROM_IERS_B
+        source[nutflag == 'I'] = FROM_IERS_A
+        source[nutflag == 'P'] = FROM_IERS_A_PREDICTION
+        return source
 
     def pm_source(self, i):
         """Set polar motion source flag for entries in IERS table"""
@@ -578,9 +578,9 @@ class IERS_B(IERS):
         """Set UT1-UTC source flag for entries in IERS table"""
         return np.ones_like(i) * FROM_IERS_B
 
-	def dcip_source(self, i):
-		"""Set CIP correction source flag for entries in IERS table"""
-		return np.ones_like(i) * FROM_IERS_B
+    def dcip_source(self, i):
+        """Set CIP correction source flag for entries in IERS table"""
+        return np.ones_like(i) * FROM_IERS_B
 
     def pm_source(self, i):
         """Set PM source flag for entries in IERS table"""

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -95,6 +95,15 @@ class TestIERS_AExcerpt():
                       (iers_tab['UT1Flag'] == 'P') |
                       (iers_tab['UT1Flag'] == 'B'))
 
+        assert iers_tab['dX_2000A'].unit is u.marcsec
+        assert iers_tab['dY_2000A'].unit is u.marcsec
+        assert 'P' in iers_tab['NutFlag']
+        assert 'I' in iers_tab['NutFlag']
+        assert 'B' in iers_tab['NutFlag']
+        assert np.all((iers_tab['NutFlag'] == 'P') |
+                      (iers_tab['NutFlag'] == 'I') |
+                      (iers_tab['NutFlag'] == 'B'))
+
         assert iers_tab['PM_x'].unit is u.arcsecond
         assert iers_tab['PM_y'].unit is u.arcsecond
         assert 'P' in iers_tab['PolPMFlag']
@@ -113,6 +122,21 @@ class TestIERS_AExcerpt():
         assert_quantity_allclose(ut1_utc,
                                  [-0.4916557, -0.4925323, -0.4934373] * u.s,
                                  atol=1.*u.ns)
+
+
+        dcip_x,dcip_y, status = iers_tab.dcip_xy(t, return_status=True)
+        assert status[0] == iers.FROM_IERS_B
+        assert np.all(status[1:] == iers.FROM_IERS_A)
+        # These values are *exactly* as given in the table, so they should
+        # match to double precision accuracy.
+        print(dcip_x)
+        print(dcip_y)
+        assert_quantity_allclose(dcip_x,
+                                 [-0.086, -0.093, -0.087] * u.marcsec,
+                                 atol=1.*u.narcsec)
+        assert_quantity_allclose(dcip_y,
+                                 [0.094, 0.081, 0.072] * u.marcsec,
+                                 atol=1*u.narcsec)
 
         pm_x, pm_y, status = iers_tab.pm_xy(t, return_status=True)
         assert status[0] == iers.FROM_IERS_B


### PR DESCRIPTION
As stated above, it adds interpolation of the dX_2000A and dY_2000A columns to the IERS table.  This allows for more accurate conversion between the coordinate frames that use the Celestial Intermediate Pole.  The use of these new columns are not currently wired into any of the rest of the coordinate transform code.