### PR TITLE
Update development workflow doc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -571,6 +571,12 @@ API Changes
   - Allow ``collections.Mapping``-like ``data`` attribute when initializing a
     ``Table`` object (``dict``-like was already possible). [#5213]
 
+- ``astropy.tests``
+
+  - The inputs to the ``TestRunner.run_tests()`` method now must be
+    keyword arguments (no positional arguments).  This applies to the
+    ``astropy.test()`` function as well. [#5505]
+
 - ``astropy.utils``
 
   - Renamed ``ignored`` context manager in ``compat.misc`` to ``suppress``

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -92,7 +92,7 @@ This will run all the default tests for AstroPy.
 Tests for a specific package can be run by specifying the package in the call
 to the ``test()`` function::
 
-    astropy.test('io.fits')
+    astropy.test(package='io.fits')
 
 This method works only with package names that can be mapped to Astropy
 directories. As an alternative you can test a specific directory or file
@@ -106,7 +106,7 @@ or absolutely.
 By default `astropy.test()`_ will skip tests which retrieve data from the
 internet. To turn these tests on use the ``remote_data`` flag::
 
-    astropy.test('io.fits', remote_data=True)
+    astropy.test(package='io.fits', remote_data=True)
 
 In addition, the ``test`` function supports any of the options that can be
 passed to `pytest.main() <http://pytest.org/latest/builtin.html#pytest.main>`_,

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -302,7 +302,7 @@ In more detail
    run just those tests::
 
      import astropy
-     astropy.test('time')
+     astropy.test(package='time')
 
 #. Make sure your code includes appropriate docstrings, described at
    :ref:`doc-rules`. If appropriate, as when you are adding a new feature,

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -304,6 +304,17 @@ In more detail
      import astropy
      astropy.test(package='time')
 
+   Tests can also be run from the command line while in the package
+   root directory, e.g.::
+
+     python setup.py test
+
+   To run the tests in only a single package, e.g. Time, you can do::
+
+     python setup.py test -P time
+
+   For more details on running tests, please see :ref:`testing-guidelines`.
+
 #. Make sure your code includes appropriate docstrings, described at
    :ref:`doc-rules`. If appropriate, as when you are adding a new feature,
    you should update the appropriate documentation in the ``docs`` directory;


### PR DESCRIPTION
The test runner now requires keyword arguments.