### PR TITLE
Fix ImportError on Python 3.x with NumPy < 1.7 in numpycompat utils module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
-        - NUMPY_VERSION=stable
+        - NUMPY_VERSION=1.11
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautiful-soup'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - Fixed ImportError with NumPy < 1.7 and Python 3.x in
+    ``_register_patched_dtype_reduce``. [#5848]
+
 - ``astropy.visualization``
 
 - ``astropy.vo``

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -59,7 +59,6 @@ def _register_patched_dtype_reduce():
 
     if NUMPY_LT_1_7:
         import numpy as np
-        import copy_reg
 
         # Originally this created an alternate constructor that fixed this
         # issue, and returned that constructor from the new reduce_dtype;
@@ -74,7 +73,7 @@ def _register_patched_dtype_reduce():
                 info = (info[0], args) + info[2:]
             return info
 
-        copy_reg.pickle(np.dtype, reduce_dtype)
+        six.moves.copyreg.pickle(np.dtype, reduce_dtype)
 
 
 if not _ASTROPY_SETUP_:


### PR DESCRIPTION
Supersedes #4510.