### PR TITLE
Moving backported changelog entries to section v1.0.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,13 +203,7 @@ Bug Fixes
 
 - ``astropy.convolution``
 
-  - Fixed bug in ``discretize_integrate_2D`` in which x and y coordinates
-    where swapped. [#5634]
-
 - ``astropy.coordinates``
-
-  - Fixed a bug where ``get_transform`` could sometimes produce confusing errors
-    because of a typo in the input validation. [#5645]
 
   - Changed ``SkyCoord`` so that frame attributes which are not valid for the
     current ``frame`` (but are valid for other frames) are stored on the
@@ -224,9 +218,6 @@ Bug Fixes
 
   - Fix out-of-order TUNITn cards when writing tables to FITS. [#5720]
 
-  - Guard against extremely unlikely problems in compressed images, which
-    could lead to memory unmapping errors. [#5775]
-
   - Recognize PrimaryHDU when non boolean values are present for the
     'GROUPS' header keyword. [#5808]
 
@@ -235,9 +226,6 @@ Bug Fixes
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``
-
-  - Fixed a bug where stdlib ``realloc()`` was used instead of
-    ``PyMem_Realloc()`` [#5696, #4739, #2100]
 
 - ``astropy.modeling``
 
@@ -2093,7 +2081,13 @@ Bug Fixes
 
 - ``astropy.convolution``
 
+  - Fixed bug in ``discretize_integrate_2D`` in which x and y coordinates
+    where swapped. [#5634]
+
 - ``astropy.coordinates``
+
+  - Fixed a bug where ``get_transform`` could sometimes produce confusing errors
+    because of a typo in the input validation. [#5645]
 
 - ``astropy.cosmology``
 
@@ -2101,11 +2095,17 @@ Bug Fixes
 
 - ``astropy.io.fits``
 
+  - Guard against extremely unlikely problems in compressed images, which
+    could lead to memory unmapping errors. [#5775]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``
+
+  - Fixed a bug where stdlib ``realloc()`` was used instead of
+    ``PyMem_Realloc()`` [#5696, #4739, #2100]
 
 - ``astropy.modeling``
 


### PR DESCRIPTION
Some bugfix got backported to LTS, this PR moves their changelog entries, too.