### PR TITLE
[pytest] section in setup.cfg files is deprecated, using [tool:pytest] instead.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.8
 norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 2.8
+minversion = 3.0
 norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
 doctest_norecursedirs = "astropy[\/]sphinx"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ entry_points['console_scripts'] = [
 ]
 
 setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
-install_requires = ['pytest>=2.8', 'numpy>=' + astropy.__minimum_numpy_version__]
+install_requires = ['pytest>=3.0', 'numpy>=' + astropy.__minimum_numpy_version__]
 # Avoid installing setup_requires dependencies if the user just
 # queries for information
 if is_distutils_display_option():


### PR DESCRIPTION
Bug fixed in version 3.0.0 of Pytest
### Reference: pytest-dev/pytest#567

*Maintainer edit:*
- [ ] Need to add change log when v3.0 section is available.