### PR TITLE
Explicit note on row orders when doing left/right joins

### DIFF
--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -675,6 +675,8 @@ Finally, to make a table with the union of rows from both tables do an "outer" j
       M82 2012-10-29  16.2  15.2  45.0
   NGC3516 2011-11-11    --    --  42.1
 
+In all cases the output join table will be sorted by the key column(s) and in general
+will not preserve the row order of the input tables.
 
 Non-identical key column names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It is apparent if one compares the row orders in the example given, but I thought it'd be worth noting this explicitly. For your consideration.