### PR TITLE
Fix for compressed header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,9 @@ Bug Fixes
   - Recognize PrimaryHDU when non boolean values are present for the
     'GROUPS' header keyword. [#5808]
 
+  - Fix the insertion of new keywords in compressed image headers
+    (``CompImageHeader``). [#5866]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -197,9 +197,9 @@ class CompImageHeader(Header):
         card = Card(remapped_keyword, card.value, card.comment)
 
         # Here we disable the use of blank cards, because the call above to
-        # `Header.append` may have already deleted a blank card in the table
-        # header, thanks to inheritance: `Header.append` calls `del self[-1]`
-        # to delete a blank card, which calls `CompImageHeader.__deltitem__`,
+        # Header.append may have already deleted a blank card in the table
+        # header, thanks to inheritance: Header.append calls 'del self[-1]'
+        # to delete a blank card, which calls CompImageHeader.__deltitem__,
         # which deletes the blank card both in the image and the table headers!
         self._table_header.append(card=card, useblanks=False,
                                   bottom=bottom, end=end)
@@ -245,9 +245,9 @@ class CompImageHeader(Header):
         card = Card(remapped_keyword, card.value, card.comment)
 
         # Here we disable the use of blank cards, because the call above to
-        # `Header.insert` may have already deleted a blank card in the table
-        # header, thanks to inheritance: `Header.insert` calls `del self[-1]`
-        # to delete a blank card, which calls `CompImageHeader.__deltitem__`,
+        # Header.insert may have already deleted a blank card in the table
+        # header, thanks to inheritance: Header.insert calls 'del self[-1]'
+        # to delete a blank card, which calls CompImageHeader.__delitem__,
         # which deletes the blank card both in the image and the table headers!
         self._table_header.insert(remapped_index, card, useblanks=False,
                                   after=after)

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -195,7 +195,13 @@ class CompImageHeader(Header):
 
         remapped_keyword = self._remap_keyword(card.keyword)
         card = Card(remapped_keyword, card.value, card.comment)
-        self._table_header.append(card=card, useblanks=useblanks,
+
+        # Here we disable the use of blank cards, because the call above to
+        # `Header.append` may have already deleted a blank card in the table
+        # header, thanks to inheritance: `Header.append` calls `del self[-1]`
+        # to delete a blank card, which calls `CompImageHeader.__deltitem__`,
+        # which deletes the blank card both in the image and the table headers!
+        self._table_header.append(card=card, useblanks=False,
                                   bottom=bottom, end=end)
 
     def insert(self, key, card, useblanks=True, after=False):
@@ -238,7 +244,12 @@ class CompImageHeader(Header):
 
         card = Card(remapped_keyword, card.value, card.comment)
 
-        self._table_header.insert(remapped_index, card, useblanks=useblanks,
+        # Here we disable the use of blank cards, because the call above to
+        # `Header.insert` may have already deleted a blank card in the table
+        # header, thanks to inheritance: `Header.insert` calls `del self[-1]`
+        # to delete a blank card, which calls `CompImageHeader.__deltitem__`,
+        # which deletes the blank card both in the image and the table headers!
+        self._table_header.insert(remapped_index, card, useblanks=False,
                                   after=after)
 
     def _update(self, card):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1694,7 +1694,7 @@ class Header(object):
         """
 
         if idx < 0:
-            idx += len(self._cards) - 1
+            idx += len(self._cards)
 
         keyword = self._cards[idx].keyword
         keyword = Card.normalize_keyword(keyword)

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1476,6 +1476,20 @@ class TestCompressedImage(FitsTestCase):
             assert 'ZHECKSUM' in tblhdr
             assert tblhdr['ZHECKSUM'] == 'abcd1234'
 
+    def test_compression_header_append2(self):
+        """
+        Regresion test for issue https://github.com/astropy/astropy/issues/5827
+        """
+        with fits.open(self.data('comp.fits')) as hdul:
+            header = hdul[1].header
+            while (len(header) < 1000):
+                header.append()    # pad with grow room
+
+            # Append stats to header:
+            header.append(("Q1_OSAVG", 1, "[adu] quadrant 1 overscan mean"))
+            header.append(("Q1_OSSTD", 1, "[adu] quadrant 1 overscan stddev"))
+            header.append(("Q1_OSMED", 1, "[adu] quadrant 1 overscan median"))
+
     def test_compression_header_insert(self):
         with fits.open(self.data('comp.fits')) as hdul:
             imghdr = hdul[1].header


### PR DESCRIPTION
For #5827, alternative solution to #5852.
See discussion there and especially https://github.com/astropy/astropy/pull/5852#issuecomment-284857842 which explains the root of the issue. The fix in this PR preserves the number of blank cards.
 
Who wants to take a look ? (yes this `compressed` module is quite [fun](https://github.com/astropy/astropy/blob/master/astropy/io/fits/hdu/compressed.py#L90) ;-))