### PR TITLE
Fix for pickling unregistered units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,6 +274,8 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Fixed problem where IrreducibleUnits could fail to unpickle. [#5868]
+
 - ``astropy.utils``
 
   - Avoid importing ``ipython`` in ``utils.console`` until it is necessary, to

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1638,11 +1638,17 @@ def _recreate_irreducible_unit(cls, names, registered):
     """
     registry = get_current_unit_registry().registry
     if names[0] in registry:
+        # If in local registry return that object.
         return registry[names[0]]
     else:
         unit = cls(names)
         if registered:
+            # If not in local registry but registered in origin registry,
+            # enable unit in local registry.
             get_current_unit_registry().add_enabled_units([unit])
+        else:
+            # If not registered at all, just return the unit.
+            return unit
 
 
 class IrreducibleUnit(NamedUnit):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1641,14 +1641,14 @@ def _recreate_irreducible_unit(cls, names, registered):
         # If in local registry return that object.
         return registry[names[0]]
     else:
+        # otherwise, recreate the unit.
         unit = cls(names)
         if registered:
             # If not in local registry but registered in origin registry,
             # enable unit in local registry.
             get_current_unit_registry().add_enabled_units([unit])
-        else:
-            # If not registered at all, just return the unit.
-            return unit
+
+        return unit
 
 
 class IrreducibleUnit(NamedUnit):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -503,6 +503,13 @@ def test_pickling():
     assert other is u.m
 
     new_unit = u.IrreducibleUnit(['foo'], format={'baz': 'bar'})
+    # Test pickling unregistered unit
+    p = pickle.dumps(new_unit)
+    new_unit_copy = pickle.loads(p)
+    assert new_unit_copy.names == ['foo']
+    assert new_unit_copy.get_format_name('baz') == 'bar'
+
+    # Test pickling registered unit
     with u.add_enabled_units([new_unit]):
         p = pickle.dumps(new_unit)
         new_unit_copy = pickle.loads(p)

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -503,19 +503,32 @@ def test_pickling():
     assert other is u.m
 
     new_unit = u.IrreducibleUnit(['foo'], format={'baz': 'bar'})
-    # Test pickling unregistered unit
+    # This is local, so the unit should not be registered.
+    assert 'foo' not in u.get_current_unit_registry().registry
+
+    # Test pickling of this unregistered unit.
     p = pickle.dumps(new_unit)
     new_unit_copy = pickle.loads(p)
     assert new_unit_copy.names == ['foo']
     assert new_unit_copy.get_format_name('baz') == 'bar'
+    # It should still not be registered.
+    assert 'foo' not in u.get_current_unit_registry().registry
 
-    # Test pickling registered unit
+    # Now try the same with a registered unit.
     with u.add_enabled_units([new_unit]):
         p = pickle.dumps(new_unit)
+        assert 'foo' in u.get_current_unit_registry().registry
+
+    # Check that a registered unit can be loaded and that it gets re-enabled.
+    with u.add_enabled_units([]):
+        assert 'foo' not in u.get_current_unit_registry().registry
         new_unit_copy = pickle.loads(p)
         assert new_unit_copy.names == ['foo']
         assert new_unit_copy.get_format_name('baz') == 'bar'
+        assert 'foo' in u.get_current_unit_registry().registry
 
+    # And just to be sure, that it gets removed outside of the context.
+    assert 'foo' not in u.get_current_unit_registry().registry
 
 def test_pickle_unrecognized_unit():
     """


### PR DESCRIPTION
My attempt at a fix that allows for pickling unregistered irreducible units. I have added comments for my (possibly flawed) understanding of the various stages of _recreate_irreducible_unit.

I also included a test case to check pickling works for unregistered units.

Reference:
#5867 