### PR TITLE
Representation differentials -- building blocks for proper motion and radial velocity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New Features
   - Caching of  all possible frame attributes was implemented. This greatly
     speeds up many ``SkyCoord`` operations. [#5703, #5751]
 
+  - A class hierarchy was added to allow the representation layer to store
+    differentials (i.e., finite derivatives) of coordinates.  This is intended
+    to enable support for velocities in coordinate frames down the road. [#5871]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1791,11 +1791,13 @@ class CartesianDifferential(BaseDifferential):
 
     def get_d_xyz(self, xyz_axis=0):
         """Return a vector array of the x, y, and z coordinates.
+
         Parameters
         ----------
         xyz_axis : int, optional
             The axis in the final array along which the x, y, z components
             should be stored (default: 0).
+
         Returns
         -------
         xyz : `~astropy.units.Quantity`

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -94,8 +94,12 @@ class RepresentationBase(ShapedLikeNDArray):
         try:
             attrs = broadcast_arrays(*attrs, subok=True)
         except ValueError:
-            raise ValueError("Input parameters cannot be broadcast")
-
+            if len(components) <= 2:
+                c_str = ' and '.join(components)
+            else:
+                c_str = ', '.join(components[:2]) + ', and ' + components[2]
+            raise ValueError("Input parameters {0} cannot be broadcast"
+                             .format(c_str))
         for component, attr in zip(components, attrs):
             setattr(self, '_' + component, attr)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -22,13 +22,14 @@ from ..utils import ShapedLikeNDArray, classproperty
 from ..utils.compat import NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
-__all__ = ["BaseRepresentation", "CartesianRepresentation",
-           "SphericalRepresentation", "UnitSphericalRepresentation",
-           "RadialRepresentation",
+__all__ = ["RepresentationBase", "BaseRepresentation",
+           "CartesianRepresentation", "SphericalRepresentation",
+           "UnitSphericalRepresentation", "RadialRepresentation",
            "PhysicsSphericalRepresentation", "CylindricalRepresentation",
-           "BaseDifferential", "CartesianDifferential", "SphericalDifferential",
-           "UnitSphericalDifferential", "PhysicsSphericalDifferential",
-           "CylindricalDifferential", "RadialDifferential"]
+           "BaseDifferential", "BaseSphericalDifferential",
+           "CartesianDifferential", "SphericalDifferential",
+           "UnitSphericalDifferential", "RadialDifferential",
+           "PhysicsSphericalDifferential", "CylindricalDifferential"]
 
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
@@ -65,13 +66,23 @@ def _array2string(values, prefix=''):
 
 
 class RepresentationBase(ShapedLikeNDArray):
-    """Base for 3D coordinate representations and their differentials."""
+    """3D coordinate representations and differentials.
+
+    Parameters
+    ----------
+    comp1, comp2, comp3 : `~astropy.units.Quantity` or subclass
+        The components of the 3D point or differential.  The names are the
+        keys and the subclasses the values of the ``attr_classes`` attribute.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
 
     # Ensure multiplication/division with ndarray or Quantity doesn't lead to
     # object arrays.
     __array_priority__ = 50000
 
     def __init__(self, *args, **kwargs):
+        # make argument a list, so we can pop them off.
         args = list(args)
         components = self.components
         attrs = [args.pop(0) if args else kwargs.pop(component)
@@ -89,6 +100,7 @@ class RepresentationBase(ShapedLikeNDArray):
 
             raise TypeError('unexpected keyword arguments: {0}'.format(kwargs))
 
+        # Pass attributes through the required initializing classes.
         attrs = [self.attr_classes[component](attr, copy=copy)
                  for component, attr in zip(components, attrs)]
         try:
@@ -100,10 +112,13 @@ class RepresentationBase(ShapedLikeNDArray):
                 c_str = ', '.join(components[:2]) + ', and ' + components[2]
             raise ValueError("Input parameters {0} cannot be broadcast"
                              .format(c_str))
+        # Set private attributes for the attributes. (If not defined explicitly
+        # on the class, the metaclass will define properties to access these.)
         for component, attr in zip(components, attrs):
             setattr(self, '_' + component, attr)
 
-    # Should be replaced by abstractclassmethod once we support only Python 3
+    # The two methods that any subclass has to define.
+    # Should be replaced by abstractclassmethod once we support only PY3
     @abc.abstractmethod
     def from_cartesian(self):
         raise NotImplementedError()
@@ -114,7 +129,7 @@ class RepresentationBase(ShapedLikeNDArray):
 
     @property
     def components(self):
-        """A tuple with the in-order names of the coordinate components"""
+        """A tuple with the in-order names of the coordinate components."""
         return tuple(self.attr_classes)
 
     def _apply(self, method, *args, **kwargs):
@@ -186,6 +201,8 @@ class RepresentationBase(ShapedLikeNDArray):
                 else:
                     reshaped.append(val)
 
+    # Required to support multiplication and division, and defined by the base
+    # representation and differential classes.
     @abc.abstractmethod
     def _scale_operation(self, op, *args):
         raise NotImplementedError()
@@ -209,6 +226,8 @@ class RepresentationBase(ShapedLikeNDArray):
     def __pos__(self):
         return self.copy()
 
+    # Required to support addition and subtraction, and defined by the base
+    # representation and differential classes.
     @abc.abstractmethod
     def _combine_operation(self, op, other, reverse=False):
         raise NotImplementedError()
@@ -225,6 +244,7 @@ class RepresentationBase(ShapedLikeNDArray):
     def __rsub__(self, other):
         return self._combine_operation(operator.sub, other, reverse=True)
 
+    # The following are used for repr and str
     @property
     def _values(self):
         """Turn the coordinates into a record array with the coordinate values.
@@ -270,6 +290,16 @@ class RepresentationBase(ShapedLikeNDArray):
 
 
 def _make_getter(component):
+    """Make an attribute getter for use in a property.
+
+    Parameters
+    ----------
+    component : str
+        The name of the component that should be accessed.  This assumes the
+        actual value is stored in an attribute of that name prefixed by '_'.
+    """
+    # This has to be done in a function to ensure the reference to component
+    # is not lost/redirected.
     component = '_' + component
     def get_component(self):
         return getattr(self, component)
@@ -295,7 +325,8 @@ class MetaBaseRepresentation(abc.ABCMeta):
         repr_name = cls.get_name()
 
         if repr_name in REPRESENTATION_CLASSES:
-            raise ValueError("Representation class {0} already defined".format(repr_name))
+            raise ValueError("Representation class {0} already defined"
+                             .format(repr_name))
 
         REPRESENTATION_CLASSES[repr_name] = cls
 
@@ -312,23 +343,41 @@ class MetaBaseRepresentation(abc.ABCMeta):
 class BaseRepresentation(RepresentationBase):
     """Base for representing a point in a 3D coordinate system.
 
+    Parameters
+    ----------
+    comp1, comp2, comp3 : `~astropy.units.Quantity` or subclass
+        The components of the 3D points.  The names are the keys and the
+        subclasses the values of the ``attr_classes`` attribute.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+
     Notes
     -----
-    All representation classes should subclass this base representation
-    class. All subclasses should then define a ``to_cartesian`` method and a
-    ``from_cartesian`` class method. By default, transformations are done via
-    the cartesian system, but classes that want to define a smarter
-    transformation path can overload the ``represent_as`` method.
-    Furthermore, all classes must define an ``attr_classes`` attribute, an
-    `~collections.OrderedDict` which maps component names to the class that
-    creates them.  They can also define a `recommended_units` dictionary, which
-    maps component names to the units they are best presented to users in.  Note
-    that frame classes may override this with their own preferred units.
+    All representation classes should subclass this base representation class,
+    and define an ``attr_classes`` attribute, an `~collections.OrderedDict`
+    which maps component names to the class that creates them. They must also
+    define a ``to_cartesian`` method and a ``from_cartesian`` class method. By
+    default, transformations are done via the cartesian system, but classes
+    that want to define a smarter transformation path can overload the
+    ``represent_as`` method. Finally, classes can also define a
+    ``recommended_units`` dictionary, which maps component names to the units
+    they are best presented to users in (this is used only in representations
+    of coordinates, and may be overridden by frame classes).
     """
 
     recommended_units = {}  # subclasses can override
 
     def represent_as(self, other_class):
+        """Convert coordinates to another representation.
+
+        If the instance is of the requested class, it is returned unmodified.
+        By default, conversion is done via cartesian coordinates.
+
+        Parameters
+        ----------
+        other_class : `~astropy.coordinates.BaseRepresentation` subclass
+            The type of representation to turn the coordinates into.
+        """
         if other_class is self.__class__:
             return self
         else:
@@ -337,16 +386,38 @@ class BaseRepresentation(RepresentationBase):
 
     @classmethod
     def from_representation(cls, representation):
+        """Create a new instance of this representation from another one.
+
+        Parameters
+        ----------
+        representation : `~astropy.coordinates.BaseRepresentation` instance
+            The presentation that should be converted to this class.
+        """
         return representation.represent_as(cls)
 
     @classmethod
     def get_name(cls):
+        """Name of the representation.
+
+        In lower case, with any trailing 'representation' removed.
+        (E.g., 'spherical' for `~astropy.coordinates.SphericalRepresentation`.)
+        """
         name = cls.__name__.lower()
         if name.endswith('representation'):
             name = name[:-14]
         return name
 
     def _scale_operation(self, op, *args):
+        """Scale all non-angular components, leaving angular ones unchanged.
+
+        Parameters
+        ----------
+        op : `~operator` callable
+            Operator to apply (e.g., `~operator.mul`, `~operator.neg`, etc.
+        *args
+            Any arguments required for the operator (typically, what is to
+            be multiplied with, divided by).
+        """
         results = []
         for component, cls in self.attr_classes.items():
             value = getattr(self, component)
@@ -364,6 +435,20 @@ class BaseRepresentation(RepresentationBase):
             return NotImplemented
 
     def _combine_operation(self, op, other, reverse=False):
+        """Combine two representation.
+
+        By default, operate on the cartesian representations of both.
+
+        Parameters
+        ----------
+        op : `~operator` callable
+            Operator to apply (e.g., `~operator.add`, `~operator.sub`, etc.
+        other : `~astropy.coordinates.BaseRepresentation` instance
+            The other representation.
+        reverse : bool
+            Whether the operands should be reversed (e.g., as we got here via
+            ``self.__rsub__`` because ``self`` is a subclass of ``other``).
+        """
         result = self.to_cartesian()._combine_operation(op, other, reverse)
         if result is NotImplemented:
             return NotImplemented
@@ -472,7 +557,7 @@ class CartesianRepresentation(BaseRepresentation):
         The x, y, and z coordinates of the point(s). If ``x``, ``y``, and ``z``
         have different shapes, they should be broadcastable. If not quantity,
         ``unit`` should be set.  If only ``x`` is given, it is assumed that it
-        contains an array with the 3 coordinates are stored along ``xyz_axis``.
+        contains an array with the 3 coordinates stored along ``xyz_axis``.
     unit : `~astropy.units.Unit` or str
         If given, the coordinates will be converted to this unit (or taken to
         be in this unit if not given.
@@ -480,7 +565,7 @@ class CartesianRepresentation(BaseRepresentation):
         The axis along which the coordinates are stored when a single array is
         provided rather than distinct ``x``, ``y``, and ``z`` (default: 0).
     copy : bool, optional
-        If True (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('x', u.Quantity),
@@ -745,7 +830,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         `~astropy.coordinates.Longitude`, or `~astropy.coordinates.Latitude`.
 
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('lon', Longitude),
@@ -849,7 +934,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
                                                 distance=1. / other)
 
     def __neg__(self):
-        return self.__class__(self.lon + 180. * u.deg, -self.lat)
+        return self.__class__(self.lon + 180. * u.deg, -self.lat, copy=False)
 
     def norm(self):
         """Vector norm.
@@ -935,7 +1020,7 @@ class RadialRepresentation(BaseRepresentation):
         The distance of the point(s) from the origin.
 
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('distance', u.Quantity)])
@@ -1016,7 +1101,7 @@ class SphericalRepresentation(BaseRepresentation):
         it is passed to the :class:`~astropy.units.Quantity` class.
 
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('lon', Longitude),
@@ -1164,7 +1249,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         it is passed to the :class:`~astropy.units.Quantity` class.
 
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('phi', Angle),
@@ -1312,7 +1397,7 @@ class CylindricalRepresentation(BaseRepresentation):
     rho : `~astropy.units.Quantity`
         The distance from the z axis to the point(s).
 
-    phi : `~astropy.units.Quantity`
+    phi : `~astropy.units.Quantity` or str
         The azimuth of the point(s), in angular units, which will be wrapped
         to an angle between 0 and 360 degrees. This can also be instances of
         `~astropy.coordinates.Angle`,
@@ -1321,7 +1406,7 @@ class CylindricalRepresentation(BaseRepresentation):
         The z coordinate(s) of the point(s)
 
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
     """
 
     attr_classes = OrderedDict([('rho', u.Quantity),
@@ -1420,6 +1505,7 @@ class MetaBaseDifferential(abc.ABCMeta):
     def __init__(cls, name, bases, dct):
         super(MetaBaseDifferential, cls).__init__(name, bases, dct)
 
+        # Don't do anything for base helper classes.
         if cls.__name__ in ('BaseDifferential', 'BaseSphericalDifferential'):
             return
 
@@ -1427,11 +1513,13 @@ class MetaBaseDifferential(abc.ABCMeta):
             raise NotImplementedError('Differential representations must have a'
                                       '"base_representation" class attribute.')
 
+        # If not defined explicitly, create attr_classes.
         if not hasattr(cls, 'attr_classes'):
             base_attr_classes = cls.base_representation.attr_classes
             cls.attr_classes = OrderedDict([('d_' + c, u.Quantity)
                                             for c in base_attr_classes])
 
+        # If not defined explicitly, create properties for the components.
         for component in cls.attr_classes:
             if not hasattr(cls, component):
                 setattr(cls, component,
@@ -1446,14 +1534,21 @@ class BaseDifferential(RepresentationBase):
 
     Parameters
     ----------
-    d_* : `~astropy.units.Quantity`
-        The differentials in terms of the components of the base representation.
-        They can either be given in order in ``args`` or by name in ``kwargs``,
-        where the names are the base representation names prefixed by 'd_'.
-        The units should be equivalent between different angular and different
-        physical components (e.g., between ``d_lon`` and ``d_theta``).
+    d_comp1, d_comp2, d_comp3 : `~astropy.units.Quantity` or subclass
+        The components of the 3D differentials.  The names are the keys and the
+        subclasses the values of the ``attr_classes`` attribute.
     copy : bool, optional
-        If True arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied rather than referenced.
+
+    Notes
+    -----
+    All differential representation classes should subclass this base class,
+    and define an ``base_representation`` attribute with the class of the
+    regular `~astropy.coordinates.BaseRepresentation` for which differential
+    coordinates are provided. This will set up a default ``attr_classes``
+    instance with names equal to the base component names prefixed by ``d_``,
+    and all classes set to `~astropy.units.Quantity`, plus properties to access
+    those, and a default ``__init__`` for initialization.
     """
 
     @classmethod
@@ -1469,7 +1564,7 @@ class BaseDifferential(RepresentationBase):
         Parameters
         ----------
         base : instance of ``self.base_representation``
-             The points for which the differentials are to converted: each of
+             The points for which the differentials are to be converted: each of
              the components is multiplied by its unit vectors and scale factors.
         """
         self._check_base(base)
@@ -1495,6 +1590,20 @@ class BaseDifferential(RepresentationBase):
                      for component, e in six.iteritems(base_e)), copy=False)
 
     def represent_as(self, other_class, base):
+        """Convert coordinates to another representation.
+
+        If the instance is of the requested class, it is returned unmodified.
+        By default, conversion is done via cartesian coordinates.
+
+        Parameters
+        ----------
+        other_class : `~astropy.coordinates.BaseRepresentation` subclass
+            The type of representation to turn the coordinates into.
+        base : instance of ``self.base_representation``, optional
+            Base relative to which the differentials are defined.  If the other
+            class is a differential representation, the base will be converted
+            to its ``base_representation``.
+        """
         if other_class is self.__class__:
             return self
 
@@ -1508,6 +1617,17 @@ class BaseDifferential(RepresentationBase):
 
     @classmethod
     def from_representation(cls, representation, base):
+        """Create a new instance of this representation from another one.
+
+        Parameters
+        ----------
+        representation : `~astropy.coordinates.BaseRepresentation` instance
+            The presentation that should be converted to this class.
+        base : instance of ``cls.base_representation``
+            The base relative to which the differentials will be defined. If
+            the representation is a differential itself, the base will be
+            converted to its ``base_representation`` to help convert it.
+        """
         cls._check_base(base)
         if isinstance(representation, BaseDifferential):
             cartesian = representation.to_cartesian(
@@ -1518,10 +1638,37 @@ class BaseDifferential(RepresentationBase):
         return cls.from_cartesian(cartesian, base)
 
     def _scale_operation(self, op, *args):
+        """Scale all components.
+
+        Parameters
+        ----------
+        op : `~operator` callable
+            Operator to apply (e.g., `~operator.mul`, `~operator.neg`, etc.
+        *args
+            Any arguments required for the operator (typically, what is to
+            be multiplied with, divided by).
+        """
         scaled_attrs = [op(getattr(self, c), *args) for c in self.components]
         return self.__class__(*scaled_attrs, copy=False)
 
     def _combine_operation(self, op, other, reverse=False):
+        """Combine two differentials, or a differential with a representation.
+
+        If ``other`` is of the same differential type as ``self``, the
+        components will simply be combined.  If ``other`` is a representation,
+        it will be used as a base for which to evaluate the differential,
+        and the result is a new representation.
+
+        Parameters
+        ----------
+        op : `~operator` callable
+            Operator to apply (e.g., `~operator.add`, `~operator.sub`, etc.
+        other : `~astropy.coordinates.BaseRepresentation` instance
+            The other differential or representation.
+        reverse : bool
+            Whether the operands should be reversed (e.g., as we got here via
+            ``self.__rsub__`` because ``self`` is a subclass of ``other``).
+        """
         if isinstance(self, type(other)):
             first, second = (self, other) if not reverse else (other, self)
             return self.__class__(*[op(getattr(first, c), getattr(second, c))
@@ -1535,6 +1682,7 @@ class BaseDifferential(RepresentationBase):
             return other._combine_operation(op, self_cartesian, not reverse)
 
     def __sub__(self, other):
+        # avoid "differential - representation".
         if isinstance(other, BaseRepresentation):
             return NotImplemented
         return super(BaseDifferential, self).__sub__(other)
@@ -1561,6 +1709,25 @@ class BaseDifferential(RepresentationBase):
 
 
 class CartesianDifferential(BaseDifferential):
+    """Differentials in of points in 3D cartesian coordinates.
+
+    Parameters
+    ----------
+    d_x, d_y, d_z : `~astropy.units.Quantity` or array
+        The x, y, and z coordinates of the differentials. If ``d_x``, ``d_y``,
+        and ``d_z`` have different shapes, they should be broadcastable. If not
+        quantities, ``unit`` should be set.  If only ``d_x`` is given, it is
+        assumed that it contains an array with the 3 coordinates stored along
+        ``xyz_axis``.
+    unit : `~astropy.units.Unit` or str
+        If given, the differentials will be converted to this unit (or taken to
+        be in this unit if not given.
+    xyz_axis : int, optional
+        The axis along which the coordinates are stored when a single array is
+        provided instead of distinct ``d_x``, ``d_y``, and ``d_z`` (default: 0).
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
     base_representation = CartesianRepresentation
     def __init__(self, d_x, d_y=None, d_z=None, unit=None, xyz_axis=None,
                  copy=True):
@@ -1600,9 +1767,28 @@ class CartesianDifferential(BaseDifferential):
 
 class BaseSphericalDifferential(BaseDifferential):
     def _combine_operation(self, op, other, reverse=False):
-        # We allow combining, e.g., Spherical, UnitSpherical and Radial.
-        # Any combination of those yields Spherical; addings things to
-        # other differentials of the same class is left to the superclass.
+        """Combine two differentials, or a differential with a representation.
+
+        If ``other`` is of the same differential type as ``self``, the
+        components will simply be combined.  If both are different parts of
+        a `~astropy.coordinates.SphericalDifferential` (e.g., a
+        `~astropy.coordinates.UnitSphericalDifferential` and a
+        `~astropy.coordinates.RadialDifferential`), they will combined
+        appropriately.
+
+        If ``other`` is a representation, it will be used as a base for which
+        to evaluate the differential, and the result is a new representation.
+
+        Parameters
+        ----------
+        op : `~operator` callable
+            Operator to apply (e.g., `~operator.add`, `~operator.sub`, etc.
+        other : `~astropy.coordinates.BaseRepresentation` instance
+            The other differential or representation.
+        reverse : bool
+            Whether the operands should be reversed (e.g., as we got here via
+            ``self.__rsub__`` because ``self`` is a subclass of ``other``).
+        """
         if (isinstance(other, BaseSphericalDifferential) and
                 not isinstance(self, type(other))):
             all_components = set(self.components) | set(other.components)
@@ -1616,6 +1802,17 @@ class BaseSphericalDifferential(BaseDifferential):
 
 
 class SphericalDifferential(BaseSphericalDifferential):
+    """Differential(s) of points in 3D spherical coordinates.
+
+    Parameters
+    ----------
+    d_lon, d_lat : `~astropy.units.Quantity`
+        The differential longitude and latitude.
+    d_distance : `~astropy.units.Quantity`
+        The differential distance.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
     base_representation = SphericalRepresentation
 
     def __init__(self, d_lon, d_lat, d_distance, copy=True):
@@ -1646,6 +1843,15 @@ class SphericalDifferential(BaseSphericalDifferential):
 
 
 class UnitSphericalDifferential(BaseSphericalDifferential):
+    """Differential(s) of points on a unit sphere.
+
+    Parameters
+    ----------
+    d_lon, d_lat : `~astropy.units.Quantity`
+        The longitude and latitude of the differentials.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
     base_representation = UnitSphericalRepresentation
 
     def __init__(self, d_lon, d_lat, copy=True):
@@ -1677,6 +1883,15 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
 
 
 class RadialDifferential(BaseSphericalDifferential):
+    """Differential(s) of radial distances.
+
+    Parameters
+    ----------
+    d_distance : `~astropy.units.Quantity`
+        The differential distance.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
     base_representation = RadialRepresentation
 
     def to_cartesian(self, base):
@@ -1711,6 +1926,17 @@ class RadialDifferential(BaseSphericalDifferential):
 
 
 class PhysicsSphericalDifferential(BaseDifferential):
+    """Differential(s) of 3D spherical coordinates using physics convention.
+
+    Parameters
+    ----------
+    d_phi, d_theta : `~astropy.units.Quantity`
+        The differential azimuth and inclination.
+    d_r : `~astropy.units.Quantity`
+        The differential radial distance.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
     base_representation = PhysicsSphericalRepresentation
 
     def __init__(self, d_phi, d_theta, d_r, copy=True):
@@ -1742,6 +1968,19 @@ class PhysicsSphericalDifferential(BaseDifferential):
 
 
 class CylindricalDifferential(BaseDifferential):
+    """Differential(s) of points in cylindrical coordinates.
+
+    Parameters
+    ----------
+    d_rho : `~astropy.units.Quantity`
+        The differential cylindrical radius.
+    d_phi : `~astropy.units.Quantity`
+        The differential azimuth.
+    d_z : `~astropy.units.Quantity`
+        The differential height.
+    copy : bool, optional
+        If `True` (default), arrays will be copied rather than referenced.
+    """
     base_representation = CylindricalRepresentation
 
     def __init__(self, d_rho, d_phi, d_z, copy=False):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -31,10 +31,11 @@ __all__ = ["RepresentationBase", "BaseRepresentation",
            "UnitSphericalDifferential", "RadialDifferential",
            "PhysicsSphericalDifferential", "CylindricalDifferential"]
 
-# Module-level dict mapping representation string alias names to class.
-# This is populated by the metaclass init so all representation classes
-# get registered automatically.
+# Module-level dict mapping representation string alias names to classes.
+# This is populated by the metaclass init so all representation and differential
+# classes get registered automatically.
 REPRESENTATION_CLASSES = {}
+DIFFERENTIAL_CLASSES = {}
 
 def _array2string(values, prefix=''):
     # Mimic numpy >=1.12 array2string, in which structured arrays are
@@ -1535,6 +1536,13 @@ class MetaBaseDifferential(abc.ABCMeta):
             base_attr_classes = cls.base_representation.attr_classes
             cls.attr_classes = OrderedDict([('d_' + c, u.Quantity)
                                             for c in base_attr_classes])
+
+        repr_name = cls.get_name()
+        if repr_name in DIFFERENTIAL_CLASSES:
+            raise ValueError("Differential class {0} already defined"
+                             .format(repr_name))
+
+        DIFFERENTIAL_CLASSES[repr_name] = cls
 
         # If not defined explicitly, create properties for the components.
         for component in cls.attr_classes:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -68,9 +68,22 @@ def _array2string(values, prefix=''):
 
 def _combine_xyz(x, y, z, xyz_axis=0):
     """
-    Combine the 3 input arrays, ``x``, ``y``, ``z``.
-    """
+    Combine components ``x``, ``y``, ``z`` into a single Quantity array.
 
+    Parameters
+    ----------
+    x, y, z : `~astropy.units.Quantity`
+        The individual x, y, and z components.
+    xyz_axis : int, optional
+        The axis in the final array along which the x, y, z components
+        should be stored (default: 0).
+
+    Returns
+    -------
+    xyz : `~astropy.units.Quantity`
+        With dimension 3 along ``xyz_axis``, i.e., using the default of ``0``,
+        the shape will be ``(3,) + x.shape``.
+    """
     # Add new axis in x, y, z so one can concatenate them around it.
     # NOTE: just use np.stack once our minimum numpy version is 1.10.
     result_ndim = x.ndim + 1
@@ -1519,9 +1532,11 @@ class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
 
 @six.add_metaclass(MetaBaseDifferential)
 class BaseDifferential(BaseRepresentationOrDifferential):
-    """A base class representing differentials of representations.  I.e.,
-    differences of points in a particular representation (numerical realizations
-    of derivatives).
+    r"""A base class representing differentials of representations.
+
+    These represent differences or derivatives along each component.
+    E.g., for physics spherical coordinates, these would be
+    :math:`\delta r, \delta \theta, \delta \phi`.
 
     Parameters
     ----------

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -139,26 +139,6 @@ class TestSphericalRepresentation(object):
                                          distance=[1, 2] * u.kpc)
         assert exc.value.args[0] == "Input parameters lon, lat, and distance cannot be broadcast"
 
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_init_str(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = SphericalRepresentation(lon='2h6m3.3s',
-                                         lat='0.1rad',
-                                         distance=1 * u.kpc)
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = SphericalRepresentation(lon=[8 * u.hourangle, 135 * u.deg],
-                                         lat=[5 * u.deg, (6 * np.pi / 180) * u.rad],
-                                         distance=1 * u.kpc)
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
-
     def test_readonly(self):
 
         s1 = SphericalRepresentation(lon=8 * u.hourangle,
@@ -275,23 +255,6 @@ class TestUnitSphericalRepresentation(object):
             s1 = UnitSphericalRepresentation(lon=[8, 9, 10] * u.hourangle,
                                              lat=[5, 6] * u.deg)
         assert exc.value.args[0] == "Input parameters lon and lat cannot be broadcast"
-
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_init_str(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = UnitSphericalRepresentation(lon='2h6m3.3s', lat='0.1rad')
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = UnitSphericalRepresentation(lon=[8 * u.hourangle, 135 * u.deg],
-                                             lat=[5 * u.deg, (6 * np.pi / 180) * u.rad])
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
 
     def test_readonly(self):
 
@@ -411,24 +374,6 @@ class TestPhysicsSphericalRepresentation(object):
                                                 theta=[5, 6] * u.deg,
                                                 r=[1, 2] * u.kpc)
         assert exc.value.args[0] == "Input parameters phi, theta, and r cannot be broadcast"
-
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_init_str(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = PhysicsSphericalRepresentation(phi='2h6m3.3s', theta='0.1rad', r=1 * u.kpc)
-        assert exc.value.args[0] == "phi should be a Quantity or Angle"
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = PhysicsSphericalRepresentation(phi=[8 * u.hourangle, 135 * u.deg],
-                                                theta=[5 * u.deg, (6 * np.pi / 180) * u.rad],
-                                                r=[1. * u.kpc, 500 * u.pc])
-        assert exc.value.args[0] == "phi should be a Quantity or Angle"
 
     def test_readonly(self):
 
@@ -608,18 +553,6 @@ class TestCartesianRepresentation(object):
             s1 = CartesianRepresentation(x=[1, 2] * u.kpc, y=[3, 4] * u.kpc, z=[5, 6, 7] * u.kpc)
         assert exc.value.args[0] == "Input parameters x, y, and z cannot be broadcast"
 
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = CartesianRepresentation(x=[1 * u.kpc, 2 * u.Mpc],
-                                         y=[3 * u.kpc, 4 * u.pc],
-                                         z=[5. * u.cm, 6 * u.m])
-        assert exc.value.args[0].startswith("x should")
-
     def test_readonly(self):
 
         s1 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
@@ -782,18 +715,6 @@ class TestCylindricalRepresentation(object):
         with pytest.raises(ValueError) as exc:
             s1 = CylindricalRepresentation(rho=[1, 2] * u.kpc, phi=[3, 4] * u.deg, z=[5, 6, 7] * u.kpc)
         assert exc.value.args[0] == "Input parameters rho, phi, and z cannot be broadcast"
-
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = CylindricalRepresentation(rho=[1 * u.kpc, 2 * u.Mpc],
-                                           phi=[3 * u.deg, 4 * u.arcmin],
-                                           z=[5. * u.cm, 6 * u.m])
-        assert exc.value.args[0] == "phi should be a Quantity or Angle"
 
     def test_readonly(self):
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -37,6 +37,9 @@ def teardown_function(func):
 
 class TestSphericalRepresentation(object):
 
+    def test_name(self):
+        assert SphericalRepresentation.get_name() == 'spherical'
+
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
             s = SphericalRepresentation()
@@ -187,6 +190,9 @@ class TestSphericalRepresentation(object):
 
 class TestUnitSphericalRepresentation(object):
 
+    def test_name(self):
+        assert UnitSphericalRepresentation.get_name() == 'unitspherical'
+
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
             s = UnitSphericalRepresentation()
@@ -290,6 +296,9 @@ class TestUnitSphericalRepresentation(object):
 
 
 class TestPhysicsSphericalRepresentation(object):
+
+    def test_name(self):
+        assert PhysicsSphericalRepresentation.get_name() == 'physicsspherical'
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -416,6 +425,9 @@ class TestPhysicsSphericalRepresentation(object):
 
 
 class TestCartesianRepresentation(object):
+
+    def test_name(self):
+        assert CartesianRepresentation.get_name() == 'cartesian'
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -644,6 +656,9 @@ class TestCartesianRepresentation(object):
 
 
 class TestCylindricalRepresentation(object):
+
+    def test_name(self):
+        assert CylindricalRepresentation.get_name() == 'cylindrical'
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -453,7 +453,7 @@ class TestCartesianRepresentation(object):
 
     def test_init_singleunit(self):
 
-        s1 = CartesianRepresentation(x=1 * u.kpc, y=2* u.kpc, z=3* u.kpc)
+        s1 = CartesianRepresentation(x=1, y=2, z=3, unit=u.kpc)
 
         assert s1.x.unit is u.kpc
         assert s1.y.unit is u.kpc

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -26,6 +26,8 @@ from ..representation import (REPRESENTATION_CLASSES,
                               _combine_xyz)
 
 
+# Preserve the original REPRESENTATION_CLASSES dict so that importing
+#   the test file doesn't add a persistent test subclass (LogDRepresentation)
 def setup_function(func):
     func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
 
@@ -39,6 +41,7 @@ class TestSphericalRepresentation(object):
 
     def test_name(self):
         assert SphericalRepresentation.get_name() == 'spherical'
+        assert SphericalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -192,6 +195,7 @@ class TestUnitSphericalRepresentation(object):
 
     def test_name(self):
         assert UnitSphericalRepresentation.get_name() == 'unitspherical'
+        assert UnitSphericalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -299,6 +303,7 @@ class TestPhysicsSphericalRepresentation(object):
 
     def test_name(self):
         assert PhysicsSphericalRepresentation.get_name() == 'physicsspherical'
+        assert PhysicsSphericalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -428,6 +433,7 @@ class TestCartesianRepresentation(object):
 
     def test_name(self):
         assert CartesianRepresentation.get_name() == 'cartesian'
+        assert CartesianRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -659,6 +665,7 @@ class TestCylindricalRepresentation(object):
 
     def test_name(self):
         assert CylindricalRepresentation.get_name() == 'cylindrical'
+        assert CylindricalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -22,7 +22,8 @@ from ..representation import (REPRESENTATION_CLASSES,
                               UnitSphericalRepresentation,
                               CartesianRepresentation,
                               CylindricalRepresentation,
-                              PhysicsSphericalRepresentation)
+                              PhysicsSphericalRepresentation,
+                              _combine_xyz)
 
 
 def setup_function(func):
@@ -1022,3 +1023,31 @@ def test_minimal_subclass():
             attr_classes = OrderedDict([('lon', Longitude),
                                         ('lat', Latitude),
                                         ('logr', u.Dex)])
+
+def test_combine_xyz():
+
+    x,y,z = np.arange(27).reshape(3, 9) * u.kpc
+    xyz = _combine_xyz(x, y, z, xyz_axis=0)
+    assert xyz.shape == (3, 9)
+    assert np.all(xyz[0] == x)
+    assert np.all(xyz[1] == y)
+    assert np.all(xyz[2] == z)
+
+    x,y,z = np.arange(27).reshape(3, 3, 3) * u.kpc
+    xyz = _combine_xyz(x, y, z, xyz_axis=0)
+    assert xyz.ndim == 3
+    assert np.all(xyz[0] == x)
+    assert np.all(xyz[1] == y)
+    assert np.all(xyz[2] == z)
+
+    xyz = _combine_xyz(x, y, z, xyz_axis=1)
+    assert xyz.ndim == 3
+    assert np.all(xyz[:,0] == x)
+    assert np.all(xyz[:,1] == y)
+    assert np.all(xyz[:,2] == z)
+
+    xyz = _combine_xyz(x, y, z, xyz_axis=-1)
+    assert xyz.ndim == 3
+    assert np.all(xyz[...,0] == x)
+    assert np.all(xyz[...,1] == y)
+    assert np.all(xyz[...,2] == z)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -619,7 +619,7 @@ class TestSphericalDifferential():
 
     def test_differential_init_errors(self):
         s = self.s
-        with pytest.raises(TypeError):
+        with pytest.raises(u.UnitsError):
             SphericalDifferential(1.*u.arcsec, 0., 0.)
         with pytest.raises(TypeError):
             SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -835,6 +835,33 @@ class TestCylindricalOffset():
         assert_representation_allclose(s_z2, s_z)
 
 
+class TestCartesianOffset():
+    """Test copied from SphericalOffset, so less extensive."""
+    def setup(self):
+        s = CartesianRepresentation(x=[1, 2, 3] * u.kpc,
+                                    y=[2, 3, 1] * u.kpc,
+                                    z=[3, 1, 2] * u.kpc)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_offsets(self):
+        s, e, sf = self.s, self.e, self.sf
+
+        for d, offset in (('x', CartesianOffset(1.*u.pc, 0.*u.pc, 0.*u.pc)),
+                          ('y', CartesianOffset(0.*u.pc, 1.*u.pc, 0.*u.pc)),
+                          ('z', CartesianOffset(0.*u.pc, 0.*u.pc, 1.*u.pc))):
+            o_c = offset.tocartesian(base=s)
+            o_c2 = offset.to_cartesian()
+            assert np.all(representation_equal(o_c, o_c2))
+            assert all(np.all(getattr(offset, 'd_'+c) == getattr(o_c, c))
+                       for c in ('x', 'y', 'z'))
+            s_off = s + 1.*u.pc * sf[d] * e[d]
+            assert_representation_allclose(o_c, s_off - s, atol=1e-10*u.kpc)
+            s_off2 = s + offset
+            assert_representation_allclose(s_off2, s_off)
+
+
 class TestOffsetConversion():
     def setup(self):
         s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -13,6 +13,7 @@ from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 CartesianDifferential, UnitSphericalDifferential,
                 PhysicsSphericalDifferential, CylindricalDifferential,
                 RadialRepresentation, RadialDifferential, Longitude, Latitude)
+from ..representation import DIFFERENTIAL_CLASSES
 from ..angle_utilities import angular_separation
 from ...utils.compat.numpy import broadcast_arrays
 from ...tests.helper import assert_quantity_allclose
@@ -547,6 +548,7 @@ class TestSphericalDifferential():
 
     def test_name(self):
         assert SphericalDifferential.get_name() == 'spherical'
+        assert SphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -684,6 +686,7 @@ class TestUnitSphericalDifferential():
 
     def test_name(self):
         assert UnitSphericalDifferential.get_name() == 'unitspherical'
+        assert UnitSphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -783,6 +786,7 @@ class TestRadialDifferential():
 
     def test_name(self):
         assert RadialDifferential.get_name() == 'radial'
+        assert RadialDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         r, s, e, sf = self.r, self.s, self.e, self.sf
@@ -821,6 +825,7 @@ class TestPhysicsSphericalDifferential():
 
     def test_name(self):
         assert PhysicsSphericalDifferential.get_name() == 'physicsspherical'
+        assert PhysicsSphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -876,6 +881,7 @@ class TestCylindricalDifferential():
 
     def test_name(self):
         assert CylindricalDifferential.get_name() == 'cylindrical'
+        assert CylindricalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -926,6 +932,7 @@ class TestCartesianDifferential():
 
     def test_name(self):
         assert CartesianDifferential.get_name() == 'cartesian'
+        assert CartesianDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -545,6 +545,9 @@ class TestSphericalDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert SphericalDifferential.get_name() == 'spherical'
+
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
@@ -679,6 +682,9 @@ class TestUnitSphericalDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert UnitSphericalDifferential.get_name() == 'unitspherical'
+
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
@@ -775,6 +781,9 @@ class TestRadialDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert RadialDifferential.get_name() == 'radial'
+
     def test_simple_differentials(self):
         r, s, e, sf = self.r, self.s, self.e, self.sf
 
@@ -809,6 +818,9 @@ class TestPhysicsSphericalDifferential():
         self.s = s
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
+
+    def test_name(self):
+        assert PhysicsSphericalDifferential.get_name() == 'physicsspherical'
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -862,6 +874,9 @@ class TestCylindricalDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert CylindricalDifferential.get_name() == 'cylindrical'
+
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
@@ -908,6 +923,9 @@ class TestCartesianDifferential():
         self.s = s
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
+
+    def test_name(self):
+        assert CartesianDifferential.get_name() == 'cartesian'
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf

--- a/docs/coordinates/definitions.rst
+++ b/docs/coordinates/definitions.rst
@@ -24,7 +24,9 @@ the IAU2000 resolutions on celestial coordinate systems):
   point in a vector space. (Here, this means three-dimensional space, but future
   extensions might have different dimensionality, particularly if relativistic
   effects are desired.)  Examples include Cartesian coordinates, cylindrical
-  polar, or latitude/longitude spherical polar coordinates.
+  polar, or latitude/longitude spherical polar coordinates.  Note that this term
+  applies to the positions, *not* their velocities or other derivatives (which
+  are represented as "differential" classes).
 
 * A "Reference System" is a scheme for orienting points in a space and
   describing how they transforms to other systems.Examples include the ICRS,

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -274,8 +274,41 @@ Often, one has just a proper motion or a radial velocity, but not both::
       ( 0.00239684,  0.,  2.02271798)>
 
 Note in the above that the proper motion is defined strictly as a change in
-longitude, i.e., it does not include a ``cos(latitude)`` term.
+longitude, i.e., it does not include a ``cos(latitude)`` term. There are
+special classes where that terms is included::
 
+  >>> from astropy.coordinates import UnitSphericalCosLatDifferential
+  >>> sph_lat60 = SphericalRepresentation(lon=0.*u.deg, lat=60.*u.deg,
+  ...                                     distance=1.*u.kpc)
+  >>> pm = UnitSphericalDifferential(1.*u.mas/u.yr, 0.*u.mas/u.yr)
+  >>> pm
+  <UnitSphericalDifferential (d_lon, d_lat) in mas / yr
+      ( 1.,  0.)>
+  >>> pm_coslat = UnitSphericalCosLatDifferential(1.*u.mas/u.yr, 0.*u.mas/u.yr)
+  >>> pm_coslat
+  <UnitSphericalCosLatDifferential (d_lon_coslat, d_lat) in mas / yr
+      ( 1.,  0.)>
+  >>> sph_lat60 + pm * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.0048481,  1.04719246,  1.00000294)>
+  >>> sph_lat60 + pm_coslat * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.00969597,  1.0471772,  1.00001175)>
+
+Close inspections shows that indeed the changes are as expected.  The systems
+with and without ``cos(latitute)`` can be converted to each other, provided one
+provides the ``base``::
+
+  >>> usph_lat60 = sph_lat60.represent_as(UnitSphericalRepresentation)
+  >>> pm_coslat2 = pm.represent_as(UnitSphericalCosLatDifferential,
+  ...                              base=usph_lat60)
+  >>> pm_coslat2  # doctest: +FLOAT_CMP
+  <UnitSphericalCosLatDifferential (d_lon_coslat, d_lat) in mas / yr
+      ( 0.5,  0.)>
+  >>> sph_lat60 + pm_coslat2 * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.0048481,  1.04719246,  1.00000294)>
+  
 .. _astropy-coordinates-create-repr:
 
 Creating your own representations

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -212,18 +212,90 @@ To see how the operations work, consider the following examples::
         (  3.06161700e-16,  -5.00000000e+00,  12.),
         ( -4.00000000e+00,  -3.00000000e+00, -12.)]]>
 
+For coordinates, one also has to deal with proper motions, which describe
+velocities in spherical coordinates.  To support this, the representations
+all have corresponding ``Differential`` classes, which can holds offsets or
+derivatives in terms of the components of the representation class. Adding such
+an offset to a representation means the offset is taken in the direction of
+the corresponding coordinate.
+
+To see how this works, consider the following::
+
+  >>> from astropy.coordinates import SphericalRepresentation, SphericalDifferential
+  >>> sph_coo = SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
+                                        distance=1.*u.kpc)
+  >>> sph_derivative = SphericalDifferential(d_lon=1.*u.arcsec/u.yr,
+                                             d_lat=0.*u.arcsec/u.yr,
+					     d_distance=0.*u.km/u.s)
+  >>> sph_derivative.to_cartesian(base=sph_coo)
+  <CartesianRepresentation (x, y, z) in arcsec kpc / (rad yr)
+      ( 0.,  1.,  0.)>
+
+Note how the conversion to cartesian can only done using a ``base``, since
+otherwise the code cannot know what direction an increase in longitude
+corresponds to.  For ``lon=0``, this is in the ``y`` direction.  Now, to get
+the coordinates at two laters times::
+  
+  >>> sph_coo + sph_derivative * [1., 3600*180/np.pi] * u.yr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      [(  4.84813681e-06,  0.,  1.        ),
+       (  7.85398163e-01,  0.,  1.41421356)]>
+
+The above shows how addition is not to longitude itself, but in the direction
+of increasing longitude: for the large shift, by the equivalent of one radian,
+the distance has increased as well (after all, a source will likely not move
+along a curve on the sky!).  This also means that the order of operations is
+important::
+
+  >>> big_offset = SphericalDifferential(1.*u.radian, 0.*u.radian, 0.*u.kpc)
+  >>> sph_coo + big_offset + big_offset  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 1.57079633,  0.,  2.)>
+  >>> sph_coo + (big_offset + big_offset)  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 1.10714872,  0.,  2.23606798)>
+
+Often, one has just a proper motion or a radial velocity, but not both::
+
+  >>> from astropy.coordinates import UnitSphericalDifferential, RadialDifferential
+  >>> radvel = RadialDifferential(1000*u.km/u.s)
+  >>> sph_coo + radvel * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.,  0.,  2.02271217)>
+  >>> pm = UnitSphericalDifferential(1.*u.mas/u.yr, 0.*u.mas/u.yr)
+  >>> sph_coo + pm * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.0048481,  0.,  1.00001175)>
+  >>> pm + radvel
+  <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
+      ( 1.,  0.,  1000.)>
+  >>> sph_coo + (pm + radvel) * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.00239684,  0.,  2.02271798)>
+
+Note in the above that the proper motion is defined strictly as a change in
+longitude, i.e., it does not include a ``cos(latitude)`` term.
+
 .. _astropy-coordinates-create-repr:
 
 Creating your own representations
 =================================
 
 To create your own representation class, your class must inherit from the
-``BaseRepresentation`` class.  In addition the following must be defined:
+`~astropy.coordinates.BaseRepresentation` class.  This base has an ``__init__``
+method that will put all arguments components through their initializers,
+verify they can be broadcast against each other, and store the components on
+``self`` as the name prefixed with '_'.  Furthermore, through its metaclass it
+provides default properties for the components so that they can be accessed
+using ``<instance>.<component>``).  For the machinery to work, the following
+must be defined:
 
-* ``__init__`` method:
+* ``attr_classes`` class attribute (``OrderedDict``):
 
-  Has a signature like ``__init__(self, comp1, comp2, comp3, copy=True)``
-  for inputting the representation component values.
+  Defines through its keys the names of the components (as well as the default
+  order), and through its values the class they should be instances of (which
+  should be `~astropy.units.Quantity` or a subclass, or anything that can
+  initialize it).
 
 * ``from_cartesian`` class method:
 
@@ -234,25 +306,60 @@ To create your own representation class, your class must inherit from the
 
   Returns a `~astropy.coordinates.CartesianRepresentation` object.
 
-* ``attr_classes`` class attribute (``OrderedDict``):
+* ``__init__`` method (optional):
 
-  Defines the initializer class for each component.In most cases this
-  class should be derived from `~astropy.units.Quantity`. In particular
-  these class initializers must take the value as the first argument and
-  accept a ``unit`` keyword which takes a `~astropy.units.Unit`
-  initializer or ``None`` to indicate no unit. Also not that the keys of
-  this dictionary are treated as the names of the components for this
-  representation, with the default ordered given in the order they
-  appear as keys.
+  If you want more than the basic initialization and checks provided by the
+  base representation class, or just an explicit signature, you can define your
+  own ``__init__``. In general, it is recommended to stay close to the
+  signature assumed by the base representation, ``__init__(self, comp1, comp2,
+  comp3, copy=True)``, and use ``super`` to call the base representation
+  initializer.
 
 * ``recommended_units`` dictionary (optional):
 
-  Maps component names to the recommended unit to convert the values of
-  that component to.  Can be ``None`` (or missing) to indicate there is
-  no preferred unit.  If this dictionary is not defined, no conversion
-  of components to particular units will occur.
+  Maps component names to the recommended unit to convert the values of that
+  component to if the representation is part of a coordinate frame.  Can be
+  ``None`` (or missing) to indicate there is no preferred unit.  If this
+  dictionary is not defined, no conversion of components to particular units
+  will occur.
 
-In pseudo-code, this means that your class will look like::
+Once you do this, you will then automatically be able to call ``represent_as``
+to convert other representations to/from your representation class.  Your
+representation will also be available for use in |skycoord| and all frame
+classes.
+
+A representation class may also have a ``_unit_representation`` attribute
+(although it is not required). This attribute points to the appropriate
+"unit" representation (i.e., a representation that is dimensionless). This is
+probably only meaningful for subclasses of
+`~astropy.coordinates.SphericalRepresentation`, where it is assumed that it
+will be a subclass of `~astropy.coordinates.UnitSphericalRepresentation`.
+
+Finally, if you wish to use also offsets in your coordinate system, two further
+methods should be defined (please see, e.g.,
+`~astropy.coordinates.SphericalRepresentation` for an example):
+
+* ``unit_vectors`` method:
+
+  Returns a ``dict`` with for each component a
+  `~astropy.coordinates.CartesianRepresentation` of unit vectors in the
+  direction of each component.
+
+* ``scale_factors`` method:
+
+  Returns a ``dict`` with for each component a `~astropy.units.Quantity` with
+  the appropriate physical scale factor for a unit change in that direction.
+
+And furthermore you should define a ``Differential`` class based on
+`~astropy.coordinates.BaseDifferential`. This class can be extremly simple,
+and only needs to define:
+
+* ``base_representation`` attribute:
+
+  A link back to the representation for which this differential holds.
+
+
+In pseudo-code, this means that a class will look like::
 
     class MyRepresentation(BaseRepresentation):
 
@@ -263,7 +370,9 @@ In pseudo-code, this means that your class will look like::
         # recommended_units is optional
         recommended_units = {'comp1': u.unit1, 'comp2': u.unit2, 'comp3': u.unit3}
 
-        def __init__(self, ...):
+	# __init__ is optional
+        def __init__(self, comp1, comp2, comp3, copy=True):
+            super(MyRepresentation, self).__init__(comp1, comp2, comp3, copy=copy)
             ...
 
         @classmethod
@@ -275,14 +384,18 @@ In pseudo-code, this means that your class will look like::
             ...
             return CartesianRepresentation(...)
 
-Once you do this, you will then automatically be able to call
-``represent_as`` to convert other representations to/from your representation
-class.  Your representation will also be available for use in |skycoord|
-and all frame classes.
+	# if differential motion is needed
+	def unit_vectors(self):
+	    ...
+	    return {'comp1': CartesianRepresentation(...),
+	            'comp2': CartesianRepresentation(...),
+		    'comp3': CartesianRepresentation(...)}
 
-A representation class may also have a ``_unit_representation`` attribute
-(although it is not required). This attribute points to the appropriate
-"unit" representation (i.e., a representation that is dimensionless). This is
-probably only meaningful for subclasses of
-`~astropy.coordinates.SphericalRepresentation`, where it is assumed that it
-will be a subclass of `~astropy.coordinates.UnitSphericalRepresentation`.
+        def scale_factors(self):
+	    ...
+	    return {'comp1': ...,
+	            'comp2': ...,
+		    'comp3': ...}
+
+    class MyDifferential(BaseDifferential):
+        base_representation = MyRepresentation

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -223,10 +223,10 @@ To see how this works, consider the following::
 
   >>> from astropy.coordinates import SphericalRepresentation, SphericalDifferential
   >>> sph_coo = SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
-                                        distance=1.*u.kpc)
+  ...                                   distance=1.*u.kpc)
   >>> sph_derivative = SphericalDifferential(d_lon=1.*u.arcsec/u.yr,
-                                             d_lat=0.*u.arcsec/u.yr,
-					     d_distance=0.*u.km/u.s)
+  ...                                        d_lat=0.*u.arcsec/u.yr,
+  ...                                        d_distance=0.*u.km/u.s)
   >>> sph_derivative.to_cartesian(base=sph_coo)
   <CartesianRepresentation (x, y, z) in arcsec kpc / (rad yr)
       ( 0.,  1.,  0.)>

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -212,12 +212,17 @@ To see how the operations work, consider the following examples::
         (  3.06161700e-16,  -5.00000000e+00,  12.),
         ( -4.00000000e+00,  -3.00000000e+00, -12.)]]>
 
-For coordinates, one also has to deal with proper motions, which describe
-velocities in spherical coordinates.  To support this, the representations
-all have corresponding ``Differential`` classes, which can holds offsets or
-derivatives in terms of the components of the representation class. Adding such
-an offset to a representation means the offset is taken in the direction of
-the corresponding coordinate.
+Differentials and derivatives of Representations
+================================================
+In addition to positions in 3D space, coordinates also deal with proper motions
+and radial velocities, which require a way to represent differentials of
+coordinates (i.e., finite realizations) of derivatives.  To support this, the
+representations all have corresponding ``Differential`` classes, which can hold
+offsets or derivatives in terms of the components of the representation class.
+Adding such an offset to a representation means the offset is taken in the
+direction of the corresponding coordinate. (Although for any representation
+other than Cartesian, this is only defined relative to a specific location, as
+the unit vectors are not invariant.)
 
 To see how this works, consider the following::
 
@@ -235,7 +240,7 @@ Note how the conversion to cartesian can only done using a ``base``, since
 otherwise the code cannot know what direction an increase in longitude
 corresponds to.  For ``lon=0``, this is in the ``y`` direction.  Now, to get
 the coordinates at two laters times::
-  
+
   >>> sph_coo + sph_derivative * [1., 3600*180/np.pi] * u.yr  # doctest: +FLOAT_CMP
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
       [(  4.84813681e-06,  0.,  1.        ),
@@ -308,7 +313,7 @@ provides the ``base``::
   >>> sph_lat60 + pm_coslat2 * 1. * u.Myr  # doctest: +FLOAT_CMP
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
       ( 0.0048481,  1.04719246,  1.00000294)>
-  
+
 .. _astropy-coordinates-create-repr:
 
 Creating your own representations


### PR DESCRIPTION
@eteq, @adrn, @astrofrog -- following our discussion about proper motions and radial velocities, I went ahead an implemented the low-level building blocks: the ability to deal with offsets and derivatives in different representations. It definitely required a lot of mind-warping, but I'm fairly sure what I have here is roughly what we need. To get a sense of how it works, maybe start with just looking at the short addition to the documentation (and I'd recommend to look at the test cases before turning to the code).

For the code itself, I ended up doing quite a refactor, so the changes may be larger than you'd really want; it may help to go in order of the commits...