### PR TITLE
Specifying data types for columns when using fast ASCII readers, using the converter paramater

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ New Features
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
+  - Added `converters` parameter to `FastBasic.read()`, to optimize memory usage. [#5845].
 
 - ``astropy.io.fits``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``
-  - Added `converters` parameter to `FastBasic.read()`, to optimize memory usage. [#5845].
+  - Added ``converters`` parameter to ``FastBasic.read()``, to optimize memory usage. [#5885].
 
 - ``astropy.io.fits``
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -869,7 +869,7 @@ def convert_numpy(numpy_type):
     else:
         converter_type = AllType
 
-    def bool_converter(vals, fast):
+    def bool_converter(vals):
         """
         Convert values "False" and "True" to bools.  Raise an exception
         for any other string values.

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -950,7 +950,7 @@ class BaseOutputter(object):
                     converter_func, converter_type = col.converters[0]
                     if not issubclass(converter_type, col.type):
                         raise TypeError('converter type does not match column type')
-                    col.data = converter_func(col.str_vals, False)
+                    col.data = converter_func(col.str_vals)
                     col.type = converter_type
                 except (TypeError, ValueError) as err:
                     col.converters.pop(0)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -891,7 +891,7 @@ def convert_numpy(numpy_type):
 
     def generic_converter(vals, fast):
     	if fast:
-    		return vals.astype(numpy_type, copy = False)
+    		return vals.astype(numpy_type, copy=False)
     	else:
         	return numpy.array(vals, numpy_type)
 
@@ -924,6 +924,7 @@ class BaseOutputter(object):
         except (ValueError, TypeError):
             raise ValueError('Error: invalid format for converters, see '
                              'documentation\n{}'.format(converters))
+
         return converters_out
 
     def _convert_vals(self, cols):

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -869,7 +869,7 @@ def convert_numpy(numpy_type):
     else:
         converter_type = AllType
 
-    def bool_converter(vals):
+    def bool_converter(vals, fast):
         """
         Convert values "False" and "True" to bools.  Raise an exception
         for any other string values.
@@ -889,8 +889,11 @@ def convert_numpy(numpy_type):
             raise ValueError('bool input strings must be only False or True')
         return trues
 
-    def generic_converter(vals):
-        return numpy.array(vals, numpy_type)
+    def generic_converter(vals, fast):
+    	if fast:
+    		return vals.astype(numpy_type, copy = False)
+    	else:
+        	return numpy.array(vals, numpy_type)
 
     converter = bool_converter if converter_type is BoolType else generic_converter
 
@@ -929,7 +932,6 @@ class BaseOutputter(object):
             # to set the defaults, otherwise use the generic defaults.
             default_converters = ([convert_numpy(col.dtype)] if col.dtype
                                   else self.default_converters)
-
             # If the user supplied a specific convert then that takes precedence over defaults
             converters = self.converters.get(col.name, default_converters)
 
@@ -946,7 +948,7 @@ class BaseOutputter(object):
                     converter_func, converter_type = col.converters[0]
                     if not issubclass(converter_type, col.type):
                         raise TypeError('converter type does not match column type')
-                    col.data = converter_func(col.str_vals)
+                    col.data = converter_func(col.str_vals, False)
                     col.type = converter_type
                 except (TypeError, ValueError) as err:
                     col.converters.pop(0)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -889,8 +889,8 @@ def convert_numpy(numpy_type):
             raise ValueError('bool input strings must be only False or True')
         return trues
 
-    def generic_converter(vals, default_kwargs={}):
-        fast = default_kwargs.get('fast', 0)
+    def generic_converter(vals, **kwargs):
+        fast = kwargs.get('fast', False)
     	if fast:
     		return vals.astype(numpy_type, copy=False)
     	else:

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -891,10 +891,10 @@ def convert_numpy(numpy_type):
 
     def generic_converter(vals, **kwargs):
         fast = kwargs.get('fast', False)
-    	if fast:
-    		return vals.astype(numpy_type, copy=False)
-    	else:
-        	return numpy.array(vals, numpy_type)
+        if fast:
+            return vals.astype(numpy_type, copy=False)
+        else:
+            return numpy.array(vals, numpy_type)
 
     converter = bool_converter if converter_type is BoolType else generic_converter
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -889,7 +889,8 @@ def convert_numpy(numpy_type):
             raise ValueError('bool input strings must be only False or True')
         return trues
 
-    def generic_converter(vals, fast):
+    def generic_converter(vals, default_kwargs={}):
+        fast = default_kwargs.get('fast', 0)
     	if fast:
     		return vals.astype(numpy_type, copy=False)
     	else:

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -93,12 +93,12 @@ class FastBasic(object):
                             if converter_first is None:
                                 converter_first = (converter_func , converter_type)
                             if issubclass(converter_type, col_type):
-                                data[col_name] = converter_func(data[col_name], True)
+                                data[col_name] = converter_func(data[col_name], fast = True)
                                 modified_col = True
                                 break
                             
                         except (ValueError, TypeError):
-                            raise ValueError('Error: invalid format for converters, see documentation\n {}'.format(converters))
+                            raise ValueError('Error: invalid format for converters, see documentation\n{}'.format(converters))
                              
                     if modified_col != True:
                         converter_func , converter_type = converter_first

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -96,18 +96,17 @@ class FastBasic(object):
                                 converter_first = (converter_func , converter_type)
                             if issubclass(converter_type, col_type):
                                 data[col_name] = converter_func(data[col_name], fast=True)
-                                print data[col_name]
                                 modified_col = True
                                 break
                             
                     except (ValueError, TypeError):
                         raise ValueError('Error: invalid format for converters, see documentation\n{}'.format(converters))
                              
-                    if modified_col is not None:
+                    if modified_col is None:
                         converter_func , converter_type = converter_first
                         data[col_name] = converter_func(data[col_name], fast=True)
-                        modified_col = None
-                        
+                    
+                    modified_col = None    
                     converter_first = None
                     
         return data
@@ -166,8 +165,7 @@ class FastBasic(object):
         if comments:
             meta['comments'] = comments
         
-        data = self._convert_vals(data)     
-        print data
+        data = self._convert_vals(data)
         
         return Table(data, names=list(self.engine.get_names()), meta=meta)
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -98,8 +98,7 @@ class FastBasic(object):
                                 break
                             
                         except (ValueError, TypeError):
-                            raise ValueError('Error: invalid format for converters, see documentation\n%s' %
-                             converters)
+                            raise ValueError('Error: invalid format for converters, see documentation\n {}'.format(converters))
                              
                     if modified_col != True:
                         converter_func , converter_type = converter_first

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -17,7 +17,7 @@ class FastBasic(object):
     ordinary :class:`Basic` writer, but it acts as a wrapper for underlying C
     code and is therefore much faster. Unlike the other ASCII readers and
     writers, this class is not very extensible and is restricted
-    by optimization requirements. 
+    by optimization requirements.
     """
     _format_name = 'fast_basic'
     _description = 'Basic table with custom delimiter using the fast C engine'
@@ -73,20 +73,20 @@ class FastBasic(object):
         else:
             col_type = core.AllType
         return col_type
-        
+
     def _convert_vals(self, data):
         converter_first = None
         modified_col = None
-        
+
         if self.converters is not None:
             for col_name in data:
-                converters = self.converters.get(col_name, None) 
+                converters = self.converters.get(col_name, None)
                 if converters is not None:
                     if len(converters) == 0:
                         raise ValueError('Column {} failed to convert: no converters defined'.format(col_name))
                     col_dtype = data[col_name].dtype
                     col_type = self._get_col_type(col_dtype)
-                    
+
                     try:
                         for converter in converters:
                             converter_func , converter_type = converter
@@ -98,19 +98,19 @@ class FastBasic(object):
                                 data[col_name] = converter_func(data[col_name], fast=True)
                                 modified_col = True
                                 break
-                            
+
                     except (ValueError, TypeError):
                         raise ValueError('Error: invalid format for converters, see documentation\n{}'.format(converters))
-                             
+
                     if modified_col is None:
                         converter_func , converter_type = converter_first
                         data[col_name] = converter_func(data[col_name], fast=True)
-                    
-                    modified_col = None    
+
+                    modified_col = None
                     converter_first = None
-                    
+
         return data
-        
+
     def read(self, table):
         """
         Read input data (file-like object, filename, list of strings, or
@@ -136,9 +136,9 @@ class FastBasic(object):
             raise core.ParameterError("The C reader does not use the Inputter parameter")
         elif 'data_Splitter' in self.kwargs or 'header_Splitter' in self.kwargs:
             raise core.ParameterError("The C reader does not use a Splitter class")
-        
+
         self.converters = self.kwargs.pop('converters', None)
-            
+
         self.strict_names = self.kwargs.pop('strict_names', False)
 
         self.engine = cparser.CParser(table, self.strip_whitespace_lines,
@@ -161,12 +161,12 @@ class FastBasic(object):
 
         with set_locale('C'):
             data, comments = self.engine.read(try_int, try_float, try_string)
-        meta = OrderedDict()    
+        meta = OrderedDict()
         if comments:
             meta['comments'] = comments
-        
+
         data = self._convert_vals(data)
-        
+
         return Table(data, names=list(self.engine.get_names()), meta=meta)
 
     def check_header(self):

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -341,7 +341,6 @@ def test_invalid_parameters():
                       'quotechar': '##', # multi-char quote signifier
                       'data_start': -1, # negative data_start
                       'header_start': -1, # negative header_start
-                      'converters': converters, # passing converters
                       'Inputter': ascii.ContinuationLinesInputter, # passing Inputter
                       'header_Splitter': ascii.DefaultSplitter, # passing Splitter
                       'data_Splitter': ascii.DefaultSplitter

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -344,13 +344,13 @@ def test_start_end():
     assert_equal(data.field('statname')[0], 'chi2xspecvar')
     assert_equal(data.field('statname')[-1], 'chi2gehrels')
 
-
-def test_set_converters():
+@pytest.mark.parametrize('fast_reader', [True, False, 'force'])
+def test_set_converters(fast_reader):
     converters = {'zabs1.nh': [ascii.convert_numpy('int32'),
                                ascii.convert_numpy('float32')],
                   'p1.gamma': [ascii.convert_numpy('str')]
                   }
-    data = ascii.read('t/test4.dat', converters=converters)
+    data = ascii.read('t/test4.dat', fast_reader=fast_reader, converters=converters)
     assert_equal(str(data['zabs1.nh'].dtype), 'float32')
     assert_equal(data['p1.gamma'][0], '1.26764544642')
 

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -58,7 +58,6 @@ These parameters are:
  * ``comment`` string not of length 1
  * ``delimiter`` string not of length 1
  * ``quotechar`` string not of length 1
- * ``converters``
  * ``Outputter``
  * ``Inputter``
  * ``data_Splitter``
@@ -91,6 +90,13 @@ from the default ``'e'`` for exponential formats in the input file.
 The special setting ``'fortran'`` enables auto-detection of any valid
 exponent character under Fortran notation.
 For details see the section on :ref:`fortran_style_exponents`.
+
+In order to optimize memory usage, specify the dtype of columns when reading in data using the fast readers.
+This can be done using the converters paramater which is consistent with the converters paramater used in basic read.
+   >>> import numpy as np
+   >>> converters = {'col1': [ascii.convert_numpy(np.uint)],
+   ...               'col2': [ascii.convert_numpy(np.float32)]}
+   >>> ascii.read('file.dat', format = 'fast_basic', converters=converters)
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -95,9 +95,13 @@ In order to optimize memory usage, specify the dtype of columns when reading in 
 This can be done using the converters paramater which is consistent with the converters paramater used in basic read.
    >>> import numpy as np
    >>> from astropy.io import ascii
-   >>> converters = {'col1': [ascii.convert_numpy(np.uint)],
-   ...               'col2': [ascii.convert_numpy(np.float32)]}
-   >>> ascii.read('file.dat', format = 'fast_basic', converters=converters)
+   >>> table = ['Mag   Mag_err',
+   ...          '14.0      0.3',
+   ...          '10.3    0.234',
+   ...          ' 7.0      0.1']
+   >>> converters = {'Mag': [ascii.convert_numpy(np.uint)],
+   ...               'Mag_err': [ascii.convert_numpy(np.float32)]}
+   >>> ascii.read(table, format = 'fast_basic', converters=converters)  # doctest: +SKIP
 
 Writing
 ^^^^^^^

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -94,7 +94,7 @@ For details see the section on :ref:`fortran_style_exponents`.
 In order to optimize memory usage, specify the dtype of columns when reading in data using the fast readers.
 This can be done using the converters paramater which is consistent with the converters paramater used in basic read.
    >>> import numpy as np
-   >>> from astropy.io import ascii 
+   >>> from astropy.io import ascii
    >>> converters = {'col1': [ascii.convert_numpy(np.uint)],
    ...               'col2': [ascii.convert_numpy(np.float32)]}
    >>> ascii.read('file.dat', format = 'fast_basic', converters=converters)

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -94,6 +94,7 @@ For details see the section on :ref:`fortran_style_exponents`.
 In order to optimize memory usage, specify the dtype of columns when reading in data using the fast readers.
 This can be done using the converters paramater which is consistent with the converters paramater used in basic read.
    >>> import numpy as np
+   >>> from astropy.io import ascii 
    >>> converters = {'col1': [ascii.convert_numpy(np.uint)],
    ...               'col2': [ascii.convert_numpy(np.float32)]}
    >>> ascii.read('file.dat', format = 'fast_basic', converters=converters)


### PR DESCRIPTION
This allows specifying data types when using fast ASCII readers through 'converters' parameter.
This is in order to optimise memory usage.

This handles the case when multiple converters are specified for a column by finding the best suited data type of all specified. If this fails, the first one takes precedence. 

EDIT: Fix #5845 