### PR TITLE
Update sky_coordinate.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Ensure that checking equivalance of ``SkyCoord`` objects works with
+    non-scalar attributes [#5884]
+
 - ``astropy.cosmology``
 
 - ``astropy.extern``

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -650,7 +650,7 @@ class SkyCoord(ShapedLikeNDArray):
                 return False
 
             for fattrnm in FRAME_ATTR_NAMES_SET():
-                if getattr(self, fattrnm) != getattr(other, fattrnm):
+                if np.any(getattr(self, fattrnm) != getattr(other, fattrnm)):
                     return False
             return True
         else:

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -353,12 +353,12 @@ def test_regression_simple_5133():
 def test_regression_5884():
     # ensure comparison of frames with non-scalar attributes works
     times = Time(["2015-08-28 03:30", "2015-08-28 12:00", "2015-09-05 10:30", "2015-09-15 18:35"])
-    coo1 = coord.SkyCoord(40*u.deg, 50*u.deg, obstime=times)
-    coo2 = coord.SkyCoord(41*u.deg, 52*u.deg, obstime=times)
+    coo1 = SkyCoord(40*u.deg, 50*u.deg, obstime=times)
+    coo2 = SkyCoord(41*u.deg, 52*u.deg, obstime=times)
     # check this does not raise a ValueError
     coo1.is_equivalent_frame(coo2)
     # let's do N-D whilst we're at it
     times = times.reshape((2,2))
-    coo1 = coord.SkyCoord(40*u.deg, 50*u.deg, obstime=times)
-    coo2 = coord.SkyCoord(41*u.deg, 52*u.deg, obstime=times)
+    coo1 = SkyCoord(40*u.deg, 50*u.deg, obstime=times)
+    coo2 = SkyCoord(41*u.deg, 52*u.deg, obstime=times)
     coo1.is_equivalent_frame(coo2)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -348,3 +348,17 @@ def test_regression_simple_5133():
     # az is more-or-less undefined for straight up or down
     assert_quantity_allclose(aa.alt, [90, -90]*u.deg, rtol=1e-5)
     assert_quantity_allclose(aa.distance, [90, 10]*u.km)
+
+
+def test_regression_5884():
+    # ensure comparison of frames with non-scalar attributes works
+    times = Time(["2015-08-28 03:30", "2015-08-28 12:00", "2015-09-05 10:30", "2015-09-15 18:35"])
+    coo1 = coord.SkyCoord(40*u.deg, 50*u.deg, obstime=times)
+    coo2 = coord.SkyCoord(41*u.deg, 52*u.deg, obstime=times)
+    # check this does not raise a ValueError
+    coo1.is_equivalent_frame(coo2)
+    # let's do N-D whilst we're at it
+    times = times.reshape((2,2))
+    coo1 = coord.SkyCoord(40*u.deg, 50*u.deg, obstime=times)
+    coo2 = coord.SkyCoord(41*u.deg, 52*u.deg, obstime=times)
+    coo1.is_equivalent_frame(coo2)


### PR DESCRIPTION
Minor fix to deal with issues checking if ```SkyCoord```s with non-scalar attributes are equivalent.

This fixes #5884