### PR TITLE
Representations repr fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ API Changes
 
 - ``astropy.coordinates``
 
+  - Fix bug where ``repr`` and ``str`` would give ``TypeError`` for
+    representations that had multiple dimensions and non-C order. [#5896]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -216,17 +216,13 @@ class BaseRepresentation(ShapedLikeNDArray):
 
         The record array fields will have the component names.
         """
-        coordinates = [getattr(self, c) for c in self.components]
-        if NUMPY_LT_1_8:
-            # numpy 1.7 has problems concatenating broadcasted arrays.
-            coordinates = [(coo.copy() if 0 in coo.strides else coo)
-                           for coo in coordinates]
-
-        sh = self.shape + (1,)
-        dtype = np.dtype([(str(c), coo.dtype)
-                          for c, coo in zip(self.components, coordinates)])
-        return np.concatenate([coo.reshape(sh).value for coo in coordinates],
-                              axis=-1).view(dtype).squeeze()
+        # For PY2, convert possible unicode literal to string
+        coo_items = [(str(c) if six.PY2 else c, getattr(self, c))
+                     for c in self.components]
+        result = np.empty(self.shape, [(c, coo.dtype) for c, coo in coo_items])
+        for c, coo in coo_items:
+            result[c] = coo.value
+        return result
 
     @property
     def _units(self):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -976,6 +976,22 @@ def test_representation_repr():
                         '    [( 1.,  4.,   9.), ( 2.,  4.,  10.), ( 3.,  4.,  11.)]>')
 
 
+def test_representation_repr_multi_d():
+    """Regression test for #5889."""
+    cr = CartesianRepresentation(np.arange(27).reshape(3,3,3), unit='m')
+    assert repr(cr) == (
+        '<CartesianRepresentation (x, y, z) in m\n'
+        '    [[( 0.,   9.,  18.), ( 1.,  10.,  19.), ( 2.,  11.,  20.)],\n'
+        '     [( 3.,  12.,  21.), ( 4.,  13.,  22.), ( 5.,  14.,  23.)],\n'
+        '     [( 6.,  15.,  24.), ( 7.,  16.,  25.), ( 8.,  17.,  26.)]]>')
+    # This was broken before.
+    assert repr(cr.T) == (
+        '<CartesianRepresentation (x, y, z) in m\n'
+        '    [[( 0.,   9.,  18.), ( 3.,  12.,  21.), ( 6.,  15.,  24.)],\n'
+        '     [( 1.,  10.,  19.), ( 4.,  13.,  22.), ( 7.,  16.,  25.)],\n'
+        '     [( 2.,  11.,  20.), ( 5.,  14.,  23.), ( 8.,  17.,  26.)]]>')
+
+
 def test_representation_str():
     r1 = SphericalRepresentation(lon=1 * u.deg, lat=2.5 * u.deg, distance=1 * u.kpc)
     assert str(r1) == '( 1.,  2.5,  1.) (deg, deg, kpc)'
@@ -985,6 +1001,20 @@ def test_representation_str():
 
     r3 = CartesianRepresentation(x=[1, 2, 3] * u.kpc, y=4 * u.kpc, z=[9, 10, 11] * u.kpc)
     assert str(r3) == '[( 1.,  4.,   9.), ( 2.,  4.,  10.), ( 3.,  4.,  11.)] kpc'
+
+
+def test_representation_str_multi_d():
+    """Regression test for #5889."""
+    cr = CartesianRepresentation(np.arange(27).reshape(3,3,3), unit='m')
+    assert str(cr) == (
+        '[[( 0.,   9.,  18.), ( 1.,  10.,  19.), ( 2.,  11.,  20.)],\n'
+        ' [( 3.,  12.,  21.), ( 4.,  13.,  22.), ( 5.,  14.,  23.)],\n'
+        ' [( 6.,  15.,  24.), ( 7.,  16.,  25.), ( 8.,  17.,  26.)]] m')
+    # This was broken before.
+    assert str(cr.T) == (
+        '[[( 0.,   9.,  18.), ( 3.,  12.,  21.), ( 6.,  15.,  24.)],\n'
+        ' [( 1.,  10.,  19.), ( 4.,  13.,  22.), ( 7.,  16.,  25.)],\n'
+        ' [( 2.,  11.,  20.), ( 5.,  14.,  23.), ( 8.,  17.,  26.)]] m')
 
 
 def test_subclass_representation():


### PR DESCRIPTION
fixes #5889 

Now, instead of `TypeError`, this works:
```
CartesianRepresentation(np.arange(27).reshape(3,3,3), unit='m').T
# <CartesianRepresentation (x, y, z) in m
#     [[( 0.,   9.,  18.), ( 3.,  12.,  21.), ( 6.,  15.,  24.)],
#      [( 1.,  10.,  19.), ( 4.,  13.,  22.), ( 7.,  16.,  25.)],
#      [( 2.,  11.,  20.), ( 5.,  14.,  23.), ( 8.,  17.,  26.)]]>
```
