### PR TITLE
Add note on pre-releasing in affiliated package release docs 

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -514,10 +514,10 @@ Releasing an affiliated package
 ===============================
 
 You can release an affiliated package using the steps given below. In these
-instructions, we assume that the release is made from a fresh clone of the 
-remote "main" repository and not from a forked copy. We also assume that 
-the changelog file is named ``CHANGES.rst``, like for the astropy core 
-package. If instead you use Markdown, then you should replace ``CHANGES.rst`` 
+instructions, we assume that the release is made from a fresh clone of the
+remote "main" repository and not from a forked copy. We also assume that
+the changelog file is named ``CHANGES.rst``, like for the astropy core
+package. If instead you use Markdown, then you should replace ``CHANGES.rst``
 by ``CHANGES.md`` in the instructions.
 
 #. Make sure that Travis and any other continuous integration is passing.
@@ -660,3 +660,21 @@ by ``CHANGES.md`` in the instructions.
       document.body.innerHTML = document.body.innerHTML.replace(/&lt;packagename&gt;/g, packagename);
     }
     </script>
+
+
+Modifications for a beta/release candidate release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+   For major releases we do beta and/or release candidates to have a chance to
+   catch significant bugs before the true release. If the release you are
+   performing is this kind of pre-release, some of the above steps need to be
+   modified.
+
+   The primary modifications to the release procedure are:
+
+   * When entering the new version number, instead of just removing the
+     ``.dev``, enter "1.2b1" or "1.2rc1".  It is critical that you follow this
+     numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
+     is ordered "before" the main release by various automated tools, and also
+     tells PyPI that this is a "pre-release".
+   * Do not do step #21 or later, as those are tasks for an actual release.

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -665,16 +665,15 @@ by ``CHANGES.md`` in the instructions.
 Modifications for a beta/release candidate release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   For major releases we do beta and/or release candidates to have a chance to
-   catch significant bugs before the true release. If the release you are
-   performing is this kind of pre-release, some of the above steps need to be
-   modified.
+   Before a new release of your package, you may wish do a "pre-release" of the
+   code, for example to allow collaborators to independently test the release.
+   If the release you are performing is this kind of pre-release,
+   some of the above steps need to be modified.
 
-   The primary modifications to the release procedure are:
+   The primary modifications to the release procedure is:
 
    * When entering the new version number, instead of just removing the
      ``.dev``, enter "1.2b1" or "1.2rc1".  It is critical that you follow this
      numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
      is ordered "before" the main release by various automated tools, and also
      tells PyPI that this is a "pre-release".
-   * Do not do step #21 or later, as those are tasks for an actual release.


### PR DESCRIPTION
As discussed with @bsipocz in [Halotools Issue 713](https://github.com/astropy/halotools/pull/713), the pre-release procedure is clearly covered in the [Release Procedures](http://docs.astropy.org/en/stable/development/releasing.html#modifications-for-a-beta-release-candidate-release) used by the astropy developers, but this information is hard to discover in the documentation on the [Affiliated Package Release procedures](http://docs.astropy.org/en/stable/development/affiliated-packages.html#releasing-an-affiliated-package). This PR simply copies and pastes this information from the [Release Procedures](http://docs.astropy.org/en/stable/development/releasing.html#modifications-for-a-beta-release-candidate-release) documentation page to the [Affiliated Package Release procedures](http://docs.astropy.org/en/stable/development/affiliated-packages.html#releasing-an-affiliated-package) documentation page.