### PR TITLE
Deprecate VO Simple Cone Search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,10 @@ API Changes
 
 - ``astropy.vo``
 
+  - Cone Search now issues deprecation warning because it is moved to
+    Astroquery 0.3.5 and will be removed from Astropy in a future version.
+    [#5558, #5904]
+
 - ``astropy.wcs``
 
 - ``astropy.extern``

--- a/astropy/vo/__init__.py
+++ b/astropy/vo/__init__.py
@@ -7,6 +7,9 @@ functionality.
 from .. import config as _config
 
 
+# NOTE: This is deprecated along with other Cone Search stuff, but it feels
+#       weird for config item to be issuing deprecation warnings.
+
 class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `astropy.vo`.

--- a/astropy/vo/client/async.py
+++ b/astropy/vo/client/async.py
@@ -4,11 +4,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 # LOCAL
 from ...utils.compat.futures import ThreadPoolExecutor
+from ...utils.decorators import deprecated
 
 
 __all__ = ['AsyncBase']
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.async.AsyncBase')
 class AsyncBase(object):
     """Base class for asynchronous VO service requests
     using :py:class:`concurrent.futures.ThreadPoolExecutor`.

--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -19,6 +19,7 @@ from ...coordinates import (ICRS, BaseCoordinateFrame, Longitude, Latitude,
 from ...units import Quantity
 from ...utils.timer import timefunc, RunTimePredictor
 from ...utils.exceptions import AstropyUserWarning
+from ...utils.decorators import deprecated
 from ...utils import data
 
 __all__ = ['AsyncConeSearch', 'conesearch', 'AsyncSearchAll', 'search_all',
@@ -30,6 +31,8 @@ __all__ = ['AsyncConeSearch', 'conesearch', 'AsyncSearchAll', 'search_all',
 __doctest_skip__ = ['AsyncConeSearch', 'AsyncSearchAll']
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.AsyncConeSearch')
 class AsyncConeSearch(AsyncBase):
     """Perform a Cone Search asynchronously and returns the result of the
     first successful query.
@@ -76,6 +79,8 @@ class AsyncConeSearch(AsyncBase):
         super(AsyncConeSearch, self).__init__(conesearch, *args, **kwargs)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.conesearch')
 def conesearch(center, radius, verb=1, **kwargs):
     """Perform Cone Search and returns the result of the
     first successful query.
@@ -188,6 +193,8 @@ def conesearch(center, radius, verb=1, **kwargs):
                                        kwargs=args, **kwargs)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.AsyncSearchAll')
 class AsyncSearchAll(AsyncBase):
     """Perform a Cone Search asynchronously, storing all results
     instead of just the result from first successful query.
@@ -233,6 +240,8 @@ class AsyncSearchAll(AsyncBase):
         AsyncBase.__init__(self, search_all, *args, **kwargs)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.search_all')
 def search_all(*args, **kwargs):
     """Perform Cone Search and returns the results of
     all successful queries.
@@ -285,6 +294,8 @@ def search_all(*args, **kwargs):
     return all_results
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.list_catalogs')
 def list_catalogs(**kwargs):
     """Return the available Cone Search catalogs as a list of strings.
     These can be used for the ``catalog_db`` argument to
@@ -321,6 +332,8 @@ def list_catalogs(**kwargs):
     return vos_catalog.list_catalogs(conf.conesearch_dbname, **kwargs)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.predict_search')
 def predict_search(url, *args, **kwargs):
     """Predict the run time needed and the number of objects
     for a Cone Search for the given access URL, position, and
@@ -454,6 +467,8 @@ def predict_search(url, *args, **kwargs):
     return t_est, n_est
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.conesearch.conesearch_timer')
 @timefunc(1)
 def conesearch_timer(*args, **kwargs):
     """Time a single Cone Search using `astropy.utils.timer.timefunc`

--- a/astropy/vo/client/exceptions.py
+++ b/astropy/vo/client/exceptions.py
@@ -7,6 +7,10 @@ __all__ = ['BaseVOError', 'VOSError', 'MissingCatalog', 'DuplicateCatalogName',
            'DuplicateCatalogURL', 'InvalidAccessURL', 'ConeSearchError']
 
 
+# NOTE: All the exceptions here are deprecated as well, along with all other
+#       Cone Search related stuff, but it seems weird for exception to issue
+#       deprecation warning.
+
 class BaseVOError(Exception):  # pragma: no cover
     """Base class for VO exceptions."""
     pass

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 # STDLIB
 import os
 import time
+import warnings
 
 # THIRD-PARTY
 import numpy as np
@@ -18,6 +19,7 @@ from .... import units as u
 from ....coordinates import ICRS, SkyCoord
 from ....tests.helper import pytest, remote_data
 from ....utils.data import get_pkg_data_filename
+from ....utils.exceptions import AstropyDeprecationWarning
 from ....utils import data
 
 
@@ -30,6 +32,15 @@ SCS_DEC = 0
 SCS_SR = 0.1
 SCS_CENTER = ICRS(SCS_RA * u.degree, SCS_DEC * u.degree)
 SCS_RADIUS = SCS_SR * u.degree
+
+
+def setup_module():
+    """Ignore all deprecation warnings here."""
+    warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
+
+def teardown_module():
+    warnings.resetwarnings()
 
 
 @remote_data

--- a/astropy/vo/client/tests/test_vos_catalog.py
+++ b/astropy/vo/client/tests/test_vos_catalog.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import shutil
 import tempfile
+import warnings
 
 # LOCAL
 from .. import vos_catalog
@@ -27,6 +28,15 @@ from ....utils.data import get_pkg_data_filename
 __doctest_skip__ = ['*']
 
 DB_FILE = get_pkg_data_filename(os.path.join('data', 'basic.json'))
+
+
+def setup_module():
+    """Ignore all deprecation warnings here."""
+    warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
+
+def teardown_module():
+    warnings.resetwarnings()
 
 
 class TestCatalog(object):

--- a/astropy/vo/client/vos_catalog.py
+++ b/astropy/vo/client/vos_catalog.py
@@ -29,7 +29,7 @@ from ...utils.data import conf as data_conf
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.misc import JsonCustomEncoder
 from ...utils.xml.unescaper import unescape_all
-from ...utils.decorators import deprecated_renamed_argument
+from ...utils.decorators import deprecated, deprecated_renamed_argument
 
 
 __all__ = ['VOSBase', 'VOSCatalog', 'VOSDatabase', 'get_remote_catalog_db',
@@ -38,6 +38,8 @@ __all__ = ['VOSBase', 'VOSCatalog', 'VOSDatabase', 'get_remote_catalog_db',
 __dbversion__ = 1
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.vos_catalog.VOSBase')
 class VOSBase(object):
     """Base class for `VOSCatalog` and `VOSDatabase`.
 
@@ -78,6 +80,8 @@ class VOSBase(object):
                           indent=4)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.vos_catalog.VOSCatalog')
 class VOSCatalog(VOSBase):
     """A class to represent VO Service Catalog.
 
@@ -161,6 +165,8 @@ class VOSCatalog(VOSBase):
         return cls(tree)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.vos_catalog.VOSDatabase')
 class VOSDatabase(VOSBase):
     """A class to represent a collection of `VOSCatalog`.
 
@@ -613,6 +619,9 @@ class VOSDatabase(VOSBase):
         return db
 
 
+@deprecated(
+    '2.0',
+    alternative='astroquery.vo_conesearch.vos_catalog.get_remote_catalog_db')
 def get_remote_catalog_db(dbname, cache=True, verbose=True):
     """Get a database of VO services (which is a JSON file) from a remote
     location.
@@ -709,6 +718,8 @@ def _vo_service_request(url, pedantic, kwargs, cache=True, verbose=False):
     return vo_tab_parse(tab, url, kwargs)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.vos_catalog.vo_tab_parse')
 def vo_tab_parse(tab, url, kwargs):
     """In case of errors from the server, a complete and correct
     'stub' VOTable file may still be returned.  This is to
@@ -780,6 +791,8 @@ def vo_tab_parse(tab, url, kwargs):
     return out_tab
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.vos_catalog.call_vo_service')
 def call_vo_service(service_type, catalog_db=None, pedantic=None,
                     verbose=True, cache=True, kwargs={}):
     """Makes a generic VO service call.
@@ -881,6 +894,8 @@ def call_vo_service(service_type, catalog_db=None, pedantic=None,
     raise VOSError(err_msg)
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.vos_catalog.list_catalogs')
 def list_catalogs(service_type, cache=True, verbose=True, **kwargs):
     """List the catalogs available for the given service type.
 

--- a/astropy/vo/validator/__init__.py
+++ b/astropy/vo/validator/__init__.py
@@ -6,6 +6,9 @@ from ... import config as _config
 from ...utils.data import get_pkg_data_contents
 
 
+# NOTE: This is deprecated along with other Cone Search stuff, but it feels
+#       weird for config item to be issuing deprecation warnings.
+
 class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `astropy.vo.validator`.

--- a/astropy/vo/validator/exceptions.py
+++ b/astropy/vo/validator/exceptions.py
@@ -6,6 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 __all__ = ['BaseVOValidationError', 'ValidationMultiprocessingError']
 
 
+# NOTE: All the exceptions here are deprecated as well, along with all other
+#       Cone Search related stuff, but it seems weird for exception to issue
+#       deprecation warning.
+
 class BaseVOValidationError(Exception):  # pragma: no cover
     """Base class for VO validation exceptions."""
     pass

--- a/astropy/vo/validator/inspect.py
+++ b/astropy/vo/validator/inspect.py
@@ -7,11 +7,14 @@ import sys
 
 # LOCAL
 from ..client.vos_catalog import get_remote_catalog_db
-
+from ...utils.decorators import deprecated
 
 __all__ = ['ConeSearchResults']
 
 
+@deprecated(
+    '2.0',
+    alternative='astroquery.vo_conesearch.validator.inspect.ConeSearchResults')
 class ConeSearchResults(object):
     """A class to store Cone Search validation results.
 

--- a/astropy/vo/validator/tests/test_inpect.py
+++ b/astropy/vo/validator/tests/test_inpect.py
@@ -6,15 +6,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import shutil
 import tempfile
+import warnings
 
 # LOCAL
 from .. import inspect
 from ....vo import conf
 from ....utils.data import _find_pkg_data_path, get_pkg_data_filename
+from ....utils.exceptions import AstropyDeprecationWarning
 from ....extern.six.moves import zip
 
 
 __doctest_skip__ = ['*']
+
+
+def setup_module():
+    """Ignore all deprecation warnings here."""
+    warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
+
+def teardown_module():
+    warnings.resetwarnings()
 
 
 class TestConeSearchResults(object):

--- a/astropy/vo/validator/tests/test_validate.py
+++ b/astropy/vo/validator/tests/test_validate.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import shutil
 import tempfile
+import warnings
 
 # LOCAL
 from .. import conf
@@ -21,10 +22,20 @@ from .. import validate
 from ...client.vos_catalog import VOSDatabase
 from ....tests.helper import pytest, remote_data
 from ....utils.data import get_pkg_data_filename
+from ....utils.exceptions import AstropyDeprecationWarning
 from ....utils import data
 
 
 __doctest_skip__ = ['*']
+
+
+def setup_module():
+    """Ignore all deprecation warnings here."""
+    warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
+
+def teardown_module():
+    warnings.resetwarnings()
 
 
 @remote_data

--- a/astropy/vo/validator/tstquery.py
+++ b/astropy/vo/validator/tstquery.py
@@ -21,9 +21,12 @@ from collections import OrderedDict
 
 # LOCAL
 from ...utils.data import get_readable_fileobj
+from ...utils.decorators import deprecated
 from ...utils.exceptions import AstropyUserWarning
 
 
+@deprecated(
+    '2.0', alternative='astroquery.vo_conesearch.validator.tstquery.parse_cs')
 def parse_cs(id):
     """Return ``<testQuery>`` pars as dict for given Resource ID."""
     if isinstance(id, bytes):  # pragma: py3

--- a/astropy/vo/validator/validate.py
+++ b/astropy/vo/validator/validate.py
@@ -21,6 +21,7 @@ from ...io.votable.exceptions import E19
 from ...io.votable.validator import html, result
 from ...logger import log
 from ...utils import data
+from ...utils.decorators import deprecated
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.timer import timefunc
 from ...utils.xml.unescaper import unescape_all
@@ -33,6 +34,8 @@ from .tstquery import parse_cs
 __all__ = ['check_conesearch_sites']
 
 
+@deprecated('2.0', alternative=('astroquery.vo_conesearch.validator.'
+                                'validate.check_conesearch_sites'))
 @timefunc(1)
 def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
                            url_list='default'):

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -29,6 +29,10 @@ The classification is as follows:
               color: #03a913;
               content: "⬤";
          }
+         .deprecated:before {
+              color: #ff0000;
+              content: "⬤";
+         }
     </style>
 
     <table align='center'>
@@ -47,6 +51,10 @@ The classification is as follows:
       <tr>
         <td align='center'><span class="mature"></span></td>
         <td>Mature.  Additions/improvements possible, but no major changes planned. </td>
+      </tr>
+      <tr>
+        <td align='center'><span class="deprecated"></span></td>
+        <td>Deprecated.  Might be removed in a future version.</td>
       </tr>
     </table>
 
@@ -271,13 +279,25 @@ The current planned and existing sub-packages are:
         </tr>
         <tr>
             <td>
-                astropy.vo
+                astropy.vo.samp
             </td>
             <td align='center'>
                 <span class="stable"></span>
             </td>
             <td>
-                Virtual Observatory service access and validation. Currently, only Simple Cone Search and SAMP are supported.
+                Virtual Observatory service access: SAMP.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                astropy.vo.client<br/>
+                astropy.vo.validator
+            </td>
+            <td align='center'>
+                <span class="deprecated"></span>
+            </td>
+            <td>
+                Virtual Observatory service access and validation: Simple Cone Search. This is deprecated in Astropy 2.0 and moved to Astroquery 0.3.5.
             </td>
         </tr>
         <tr>

--- a/docs/vo/conesearch/index.rst
+++ b/docs/vo/conesearch/index.rst
@@ -2,8 +2,16 @@
 
 .. _astropy_conesearch:
 
-VO Simple Cone Search
-=====================
+VO Simple Cone Search (deprecated)
+==================================
+
+.. warning::
+
+    Cone Search has been moved to Astroquery 0.3.5 and will be
+    removed from Astropy in a future version. The API here will
+    be preserved as "classic" API in Astroquery, however some
+    configuration behavior might change; See Astroquery documentation
+    for new usage details.
 
 Astropy offers Simple Cone Search Version 1.03 as defined in IVOA
 Recommendation (February 22, 2008). Cone Search queries an


### PR DESCRIPTION
**Astroquery 0.3.5 must be released before this is merged.**

Follow-up of astropy/astroquery#859, next step towards #5558. Local test results with remote data:
```
===== test session starts =====
platform linux -- Python 3.5.2, pytest-3.0.4, py-1.4.31, pluggy-0.4.0

Running tests with Astropy version 2.0.dev18040.
Running tests in lib.linux-x86_64-3.5/astropy/vo docs/vo.

Date: 2017-03-23T13:04:20

Platform: Linux-2.6.32-642.15.1.el6.x86_64-x86_64-with-redhat-6.8-Santiago

Executable: .../bin/python

Full Python Version: 
3.5.2 |Continuum Analytics, Inc.| (default, Jul  2 2016, 17:53:06) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.12.0
Scipy: 0.18.1
Matplotlib: 2.0.0
h5py: 2.6.0
Pandas: 0.19.2
Cython: 0.24
Using Astropy options: remote_data: any.

rootdir: /tmp/astropy-test-q5z_veyw, inifile: setup.cfg
collected 72 items 

astropy/vo/client/tests/test_conesearch.py ......x..........x.
astropy/vo/client/tests/test_vos_catalog.py ...............
astropy/vo/samp/tests/test_client.py ....
astropy/vo/samp/tests/test_errors.py ...
astropy/vo/samp/tests/test_hub.py ...
astropy/vo/samp/tests/test_hub_proxy.py .....
astropy/vo/samp/tests/test_hub_script.py .
astropy/vo/samp/tests/test_standard_profile.py ...
astropy/vo/samp/tests/test_web_profile.py ..
astropy/vo/validator/tests/test_inpect.py ....
astropy/vo/validator/tests/test_validate.py ....
../docs/vo/index.rst .
../docs/vo/conesearch/client.rst .
../docs/vo/conesearch/index.rst .
../docs/vo/conesearch/validator.rst .
../docs/vo/samp/advanced_embed_samp_hub.rst .
../docs/vo/samp/example_clients.rst .
../docs/vo/samp/example_hub.rst .
../docs/vo/samp/example_table_image.rst .
../docs/vo/samp/index.rst .

===== pytest-warning summary =====
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
===== 70 passed, 2 xfailed, 1 pytest-warnings in 59.22 seconds =====
```

With this change, most user-facing API in `astropy.vo.client` and `astropy.vo.validator` will emit `AstropyDeprecationWarning`, except for their related config and exceptions (IMHO that would be overkill). Example:
```python
>>> from astropy.coordinates import SkyCoord
>>> from astropy.vo.client import conesearch
>>> c = SkyCoord.from_name("M31")
>>> result = conesearch.conesearch(c, 0.1)
WARNING: AstropyDeprecationWarning: The conesearch function is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.conesearch.conesearch instead. [astropy.utils.decorators]
WARNING: AstropyDeprecationWarning: The call_vo_service function is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.call_vo_service instead. [astropy.vo.client.conesearch]
WARNING: AstropyDeprecationWarning: The get_remote_catalog_db function is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.get_remote_catalog_db instead. [astropy.vo.client.vos_catalog]
Downloading ...
WARNING: AstropyDeprecationWarning: The VOSDatabase class is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.VOSDatabase instead. [astropy.vo.client.vos_catalog]
WARNING: AstropyDeprecationWarning: The VOSBase class is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.VOSBase instead. [astropy.vo.client.vos_catalog]
WARNING: AstropyDeprecationWarning: The VOSCatalog class is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.VOSCatalog instead. [astropy.vo.client.vos_catalog]
WARNING: AstropyDeprecationWarning: The VOSBase class is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.VOSBase instead. [astropy.vo.client.vos_catalog]
Trying http://...
...
WARNING: AstropyDeprecationWarning: The vo_tab_parse function is deprecated and may be removed in a future version.
        Use astroquery.vo_conesearch.vos_catalog.vo_tab_parse instead. [astropy.vo.client.vos_catalog]
```