### PR TITLE
Ignore generated NGC6976 images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ _build
 _generated
 docs/api
 docs/generated
+docs/visualization/ngc6976.jpeg
+docs/visualization/ngc6976-default.jpeg
 
 # Packages/installer info
 *.egg


### PR DESCRIPTION
These two files are generated when I build doc locally and then `git` complains about them:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	docs/visualization/ngc6976-default.jpeg
	docs/visualization/ngc6976.jpeg
```