### PR TITLE
Add a option to suppress config loading

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 
 astropy.config
 ^^^^^^^^^^^^^^
+  - The environment variable ``ASTROPY_SUPPRESS_CONFIG`` can now be used to
+    avoid loading of configuration files. [#5907]
 
 astropy.constants
 ^^^^^^^^^^^^^^^^^

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -12,7 +12,7 @@ configuration files for Astropy and affiliated packages.
 from contextlib import contextmanager
 import hashlib
 import io
-from os import path
+from os import path, environ
 import re
 from warnings import warn
 
@@ -516,7 +516,7 @@ def get_config(packageormod=None, reload=False):
     cobj = _cfgobjs.get(rootname, None)
 
     if cobj is None or reload:
-        if _ASTROPY_SETUP_:
+        if _ASTROPY_SETUP_ or "ASTROPY_SUPPRESS_CONFIG" in environ:
             # There's no reason to use anything but the default config
             cobj = configobj.ConfigObj(interpolation=False)
         else:

--- a/astropy/config/tests/data/suppress.cfg
+++ b/astropy/config/tests/data/suppress.cfg
@@ -1,0 +1,2 @@
+[utils.data]
+dataurl = http://example.org/astropy/suppress_config/

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -353,3 +353,35 @@ def test_unedited_template():
     config_dir = os.path.join(os.path.dirname(__file__), '..', '..')
     configuration.update_default_config('astropy', config_dir)
     assert configuration.update_default_config('astropy', config_dir) is False
+
+
+class TestSuppressConfig(object):
+
+    def setup_class(self):
+        configuration._override_config_file = get_pkg_data_filename(
+            'data/suppress.cfg')
+
+    def test_suppress_config(self):
+        from astropy.utils.data import conf
+        from os import environ
+
+        environ["ASTROPY_SUPPRESS_CONFIG"] = "True"
+
+        conf.reload()
+        # dataurl should be http://example.org/astropy/suppress_config/
+        # if config was loaded. test for default value
+        assert conf.dataurl == "http://data.astropy.org/"
+
+        # Test that it reads the overridden config after removing the env var
+        del environ["ASTROPY_SUPPRESS_CONFIG"]
+        conf.reload()
+        assert conf.dataurl == "http://example.org/astropy/suppress_config/"
+
+    def teardown_class(self):
+        from astropy.utils.data import conf
+        from os import environ
+
+        configuration._override_config_file = None
+        if "ASTROPY_SUPPRESS_CONFIG" in environ:
+            del environ["ASTROPY_SUPPRESS_CONFIG"]
+        conf.reload()

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -57,6 +57,18 @@ want to see your changes immediately in your current Astropy session, just do::
     data download systems will then use those directories and never try to
     access the ``$HOME/.astropy`` directory.
 
+If you need to bypass the configuration system, for example when you are using
+astropy in a daemon and don't want it to access any configuraton file (yet),
+set the environment variable ``ASTROPY_SUPPRESS_CONFIG``.  If it exists,
+astropy will not load any external configuration.
+
+.. note::
+    To re-activate loading of external configurations, just unset the
+    environment variable.
+
+    >>> import os
+    >>> del os.environ['ASTROPY_SUPPRESS_CONFIG']
+
 
 Using `astropy.config`
 ======================


### PR DESCRIPTION
PR for https://github.com/astropy/astropy/issues/5899

It adds the option to prevent (or delay) the loading of anything else than the default configuration, like it does while in setup mode.
This is done by adding a check for the environment variable "ASTROPY_SUPPRESS_CONFIG" next to the check for `_ASTROPY_SETUP_` in the `config` module.

The indented usecase is for server side applications which are likely to have their own configuration system.
(which might not have been the initial scope of astropy, as a scientific library. nevertheless it has features which are useful in such an environment as well)