### PR TITLE
development_workflow: expand 'squash' and 'rebase' developer documentation

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -498,9 +498,6 @@ A squash may also be performed staying within the existing branch using::
   git fetch upstream
   git rebase -i upstream/master
 
-Where ``n`` is the number of commits to per squashed.  This method
-does not keep any textual record of the earlier commits/commit hashes.
-
 .. _howto_push_force:
 
 How to push

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -434,7 +434,7 @@ Rebase, but only if asked
 =========================
 
 Sometimes the maintainers of Astropy may ask a pull request to be *rebased*
-(`git rebase`) or *squashed*/*squished* (`git merge --squash`) before
+(``git rebase``) or *squashed*/*squished* (``git merge --squash``) before
 changes in a Pull Request are merged into the main Astropy
 *master* repository.
 
@@ -457,8 +457,9 @@ start make a branch to serve as a backup copy of your work::
 
     git branch tmp my-new-feature # make temporary branch--will be deleted later
 
-After altering the history with `git rebase` or `git merge --squash` a normal
-`git push` is prevented, and for both a `git push --force` will be required.
+After altering the history with ``git rebase`` or ``git merge --squash``
+a normal ``git push`` is prevented, and for both a ``git push
+--force`` will be required.
 
 ... _howto_rebase:
 
@@ -492,7 +493,7 @@ refining a final 10-line change).  Conceptually this is equivalent to
 exporting the final diff from a feature branch, then starting a new branch and
 applying only that patch:
 
-The actual squashing is done on a new branch, using `git merge --squash`::
+The actual squashing is done on a new branch, using ``git merge --squash``::
 
   git checkout master -b squashed-new-feature
   git merge --squash --no-commit my-new-feature
@@ -508,7 +509,7 @@ The new squashed branch can be checked and then renamed over the old one::
 How to push
 ===========
 
-After using `git rebase` or `git merge --squash` you will still need
+After using ``git rebase`` or ``git merge --squash`` you will still need
 to push your changes to GitHub so that they are visible to others and
 the Pull Request can be updated.  Use of a simple `git push` will be
 prevented because of the changed history, and will need to be manually

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -433,23 +433,41 @@ to GitHub. GitHub will automatically update your pull request.
 Rebase, but only if asked
 =========================
 
-Sometimes the maintainers of Astropy will ask you to *rebase* your changes
-before they are merged into the main Astropy repository.
+Sometimes the maintainers of Astropy may ask a pull request to be *rebased*
+(`git rebase`) or *squashed*/*squished* (`git merge --squash`) before
+changes in a Pull Request are merged into the main Astropy
+*master* repository.
+
+The decisions of when to request a *squash* or *rebase* are left to
+individual maintainers.  These may be requested done to reduce the number of
+visible commits saved in the repositary history, or becauses of code-changes
+in Astropy in the mean-time.  Both involve rewriting the Git history, meaning
+that commit IDs will change, which is why you should do it only if asked.
 
 Conceptually, rebasing means taking your changes and applying them to the latest
 version of the development branch of the official astropy as though that was the
-version you had originally branched from.
-
-Behind the scenes, `git`_ is deleting the changes and branch you made, making the
-changes others made to the development branch of Astropy, then re-making your
-branch from the development branch and applying your changes to your branch.
-This results in re-writing the history of commits, which is why you should do it
-only if asked.
+version you had originally branched from.  Each individual commit remains
+visible, but with new metadata/commit IDs.  A squashed merge changes the
+metadata/commit IDs, and also removes separate visibility of individual commits;
+a new commit and commit message will only contain a textual list of the earlier
+commits.
 
 It is easier to make mistakes rebasing than other areas of `git`_, so before you
 start make a branch to serve as a backup copy of your work::
 
     git branch tmp my-new-feature # make temporary branch--will be deleted later
+
+After altering the history with `git rebase` or `git merge --squash` a normal
+`git push` is prevented, and for both a `git push --force` will be required.
+
+... _howto_rebase:
+
+How to rebase
+=============
+
+Behind the scenes, `git`_ is deleting the changes and branch you made, making the
+changes others made to the development branch of Astropy, then re-making your
+branch from the development branch and applying your changes to your branch.
 
 The actual rebasing is usually easy::
 
@@ -460,17 +478,49 @@ You are more likely to run into *conflicts* here--places where the changes you
 made conflict with changes that someone else made--than anywhere else. Ask for
 help if you need it.
 
-After the rebase you need to push your changes to GitHub; you will need force
-the push because `git`_ objects to re-writing the history of the repository
-after you have pushed it somewhere::
+... _howto_squash:
 
-    git push -f
+How to squash
+=============
+
+Typically we ask to *squash*/*squish* when there was a fair amount of trial
+and error, but the final patch remains quite small, or when files were added
+and removed (especially binary files or files that should not remain in the
+repository) or if the number of commits in the history is disproportionate
+compared to the work being carried out (for example 30 commits gradually
+refining a final 10-line change).  Conceptually this is equivalent to
+exporting the final diff from a feature branch, then starting a new branch and
+only applying only that patch:
+
+The actual squashing is done on a new branch, using `git merge --squash`::
+
+  git checkout master -b squashed-new-feature
+  git merge --squash --no-commit my-new-feature
+  git commit -m "example of preferred squash message format"
+
+The new squashed branch can be checked and then renamed over the old one::
+
+  git branch -m my-new-feature tmp
+  git branch -m squashed-new-feature my-new-feature
+
+... _howto_push_force:
+
+How to push
+===========
+
+After using `git rebase` or `git merge --squash` you will still need
+to push your changes to GitHub so that they are visible to others and
+the Pull Request can be updated.  Use of a simple `git push` will be
+prevented because of the changed history, and will need to be manually
+overridden using::
+
+    git push --force
 
 If you run into any problems, do not hesitate to ask. A more detailed conceptual
 discussing of rebasing is at :ref:`rebase-on-trunk`.
 
-Once your rebase is successfully pushed to GitHub you can delete the backup
-branch you made::
+Once the modifications and new git history are successfully pushed to GitHub you
+can delete any backup branches that may have been created::
 
     git branch -D tmp
 

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -493,26 +493,10 @@ refining a final 10-line change).  Conceptually this is equivalent to
 exporting the final diff from a feature branch, then starting a new branch and
 applying only that patch.
 
-The actual squashing is done on a new branch, using ``git merge --squash``::
+A squash may also be performed staying within the existing branch using::
 
-  git checkout master -b squashed-new-feature
-  git merge --squash --no-commit my-new-feature
-  git commit -m "example of preferred squash message format"
-
-The new squashed branch can be checked and then renamed over the old one::
-
-  git branch -m my-new-feature tmp
-  git branch -m squashed-new-feature my-new-feature
-
-.. _howto_squash_rebase:
-
-How to squash using rebase
-==========================
-
-Instead ``git merge --squash`` as show in the example above,
-a squash may also be performed staying within the existing branch using::
-
-  git rebase -i HEAD~n
+  git fetch upstream
+  git rebase -i upstream/master
 
 Where ``n`` is the number of commits to per squashed.  This method
 does not keep any textual record of the earlier commits/commit hashes.

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -434,14 +434,14 @@ Rebase, but only if asked
 =========================
 
 Sometimes the maintainers of Astropy may ask a pull request to be *rebased*
-(``git rebase``) or *squashed*/*squished* (``git merge --squash``) before
-changes in a Pull Request are merged into the main Astropy
-*master* repository.
+(``git rebase``) or *squashed* (``git merge --squash``) in the process of
+reviewing a Pull Request for merging into the main Astropy *master* repository.
 
 The decisions of when to request a *squash* or *rebase* are left to
 individual maintainers.  These may be requested to reduce the number of
 visible commits saved in the repository history, or because of code-changes
-in Astropy in the mean-time.  Both involve rewriting the Git history, meaning
+in Astropy in the mean-time.  A rebase may be necessary to allow the Continious
+Integration tests to run.  Both involve rewriting the Git history, meaning
 that commit IDs will change, which is why you should do it only if asked.
 
 Conceptually, rebasing means taking your changes and applying them to the latest
@@ -461,7 +461,7 @@ After altering the history with ``git rebase`` or ``git merge --squash``
 a normal ``git push`` is prevented, and for both a ``git push
 --force`` will be required.
 
-... _howto_rebase:
+.. _howto_rebase:
 
 How to rebase
 =============
@@ -479,12 +479,12 @@ You are more likely to run into *conflicts* here--places where the changes you
 made conflict with changes that someone else made--than anywhere else. Ask for
 help if you need it.
 
-... _howto_squash:
+.. _howto_squash:
 
 How to squash
 =============
 
-Typically we ask to *squash*/*squish* when there was a fair amount of trial
+Typically we ask to *squash* when there was a fair amount of trial
 and error, but the final patch remains quite small, or when files were added
 and removed (especially binary files or files that should not remain in the
 repository) or if the number of commits in the history is disproportionate
@@ -504,7 +504,7 @@ The new squashed branch can be checked and then renamed over the old one::
   git branch -m my-new-feature tmp
   git branch -m squashed-new-feature my-new-feature
 
-... _howto_push_force:
+.. _howto_push_force:
 
 How to push
 ===========

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -499,7 +499,7 @@ you can rebase and squash within the existing branch using::
   git fetch upstream
   git rebase -i upstream/master
 
-The last command will open an editor with all your commits, allowing you to 
+The last command will open an editor with all your commits, allowing you to
 squash several commits together, rename them, etc. Helpfully, the file you are
 editing has the instructions on what to do.
 
@@ -510,7 +510,7 @@ How to push
 
 After using ``git rebase`` or ``git merge --squash`` you will still need
 to push your changes to GitHub so that they are visible to others and
-the pull request can be updated.  Use of a simple `git push` will be
+the pull request can be updated.  Use of a simple ``git push`` will be
 prevented because of the changed history, and will need to be manually
 overridden using::
 

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -434,8 +434,8 @@ Rebase, but only if asked
 =========================
 
 Sometimes the maintainers of Astropy may ask a pull request to be *rebased*
-(``git rebase``) or *squashed* (``git merge --squash``) in the process of
-reviewing a pull request for merging into the main Astropy *master* repository.
+or *squashed* in the process of reviewing a pull request for merging into
+the main Astropy *master* repository.
 
 The decisions of when to request a *squash* or *rebase* are left to
 individual maintainers.  These may be requested to reduce the number of
@@ -446,8 +446,8 @@ that commit hashes will change, which is why you should do it only if asked.
 
 Conceptually, rebasing means taking your changes and applying them to the latest
 version of the development branch of the official Astropy as though that was the
-version you had originally branched from.  Each individual commit remains
-visible, but with new metadata/commit hashes.  A squashed merge changes the
+version you had originally branched from. Each individual commit remains
+visible, but with new metadata/commit hashes. Squashing commits changes the
 metadata/commit hash, and also removes separate visibility of individual
 commits; a new commit and commit message will only contain a textual
 list of the earlier commits.
@@ -457,9 +457,8 @@ start make a branch to serve as a backup copy of your work::
 
     git branch tmp my-new-feature # make temporary branch--will be deleted later
 
-After altering the history with ``git rebase`` or ``git merge --squash``,
-a normal ``git push`` is prevented, and for both a ``git push
---force`` will be required.
+After altering the history, e.g. with ``git rebase``, a normal ``git push``
+is prevented, and a ``git push --force`` will be required.
 
 .. _howto_rebase:
 
@@ -508,11 +507,10 @@ editing has the instructions on what to do.
 How to push
 ===========
 
-After using ``git rebase`` or ``git merge --squash`` you will still need
-to push your changes to GitHub so that they are visible to others and
-the pull request can be updated.  Use of a simple ``git push`` will be
-prevented because of the changed history, and will need to be manually
-overridden using::
+After using ``git rebase`` you will still need to push your changes to
+GitHub so that they are visible to others and the pull request can be
+updated.  Use of a simple ``git push`` will be prevented because of the
+changed history, and will need to be manually overridden using::
 
     git push --force
 

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -504,6 +504,19 @@ The new squashed branch can be checked and then renamed over the old one::
   git branch -m my-new-feature tmp
   git branch -m squashed-new-feature my-new-feature
 
+.. _howto_squash_rebase:
+
+How to squash using rebase
+==========================
+
+Instead ``git merge --squash`` as show in the example above,
+a squash may also be performed staying within the existing branch using::
+
+  git rebase -i HEAD~n
+
+Where ``n`` is the number of commits to per squashed.  This method
+does not keep any textual record of the earlier commits/commit hashes.
+
 .. _howto_push_force:
 
 How to push

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -439,13 +439,13 @@ changes in a Pull Request are merged into the main Astropy
 *master* repository.
 
 The decisions of when to request a *squash* or *rebase* are left to
-individual maintainers.  These may be requested done to reduce the number of
-visible commits saved in the repositary history, or becauses of code-changes
+individual maintainers.  These may be requested to reduce the number of
+visible commits saved in the repository history, or because of code-changes
 in Astropy in the mean-time.  Both involve rewriting the Git history, meaning
 that commit IDs will change, which is why you should do it only if asked.
 
 Conceptually, rebasing means taking your changes and applying them to the latest
-version of the development branch of the official astropy as though that was the
+version of the development branch of the official Astropy as though that was the
 version you had originally branched from.  Each individual commit remains
 visible, but with new metadata/commit IDs.  A squashed merge changes the
 metadata/commit IDs, and also removes separate visibility of individual commits;
@@ -490,7 +490,7 @@ repository) or if the number of commits in the history is disproportionate
 compared to the work being carried out (for example 30 commits gradually
 refining a final 10-line change).  Conceptually this is equivalent to
 exporting the final diff from a feature branch, then starting a new branch and
-only applying only that patch:
+applying only that patch:
 
 The actual squashing is done on a new branch, using `git merge --squash`::
 

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -493,10 +493,15 @@ refining a final 10-line change).  Conceptually this is equivalent to
 exporting the final diff from a feature branch, then starting a new branch and
 applying only that patch.
 
-A squash may also be performed staying within the existing branch using::
+Many of us find that is it actually easiest to squash using rebase. In particular,
+you can rebase and squash within the existing branch using::
 
   git fetch upstream
   git rebase -i upstream/master
+
+The last command will open an editor with all your commits, allowing you to 
+squash several commits together, rename them, etc. Helpfully, the file you are
+editing has the instructions on what to do.
 
 .. _howto_push_force:
 

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -435,29 +435,29 @@ Rebase, but only if asked
 
 Sometimes the maintainers of Astropy may ask a pull request to be *rebased*
 (``git rebase``) or *squashed* (``git merge --squash``) in the process of
-reviewing a Pull Request for merging into the main Astropy *master* repository.
+reviewing a pull request for merging into the main Astropy *master* repository.
 
 The decisions of when to request a *squash* or *rebase* are left to
 individual maintainers.  These may be requested to reduce the number of
-visible commits saved in the repository history, or because of code-changes
-in Astropy in the mean-time.  A rebase may be necessary to allow the Continious
-Integration tests to run.  Both involve rewriting the Git history, meaning
-that commit IDs will change, which is why you should do it only if asked.
+visible commits saved in the repository history, or because of code changes
+in Astropy in the meantime.  A rebase may be necessary to allow the Continious
+Integration tests to run.  Both involve rewriting the `git`_ history, meaning
+that commit hashes will change, which is why you should do it only if asked.
 
 Conceptually, rebasing means taking your changes and applying them to the latest
 version of the development branch of the official Astropy as though that was the
 version you had originally branched from.  Each individual commit remains
-visible, but with new metadata/commit IDs.  A squashed merge changes the
-metadata/commit IDs, and also removes separate visibility of individual commits;
-a new commit and commit message will only contain a textual list of the earlier
-commits.
+visible, but with new metadata/commit hashes.  A squashed merge changes the
+metadata/commit hash, and also removes separate visibility of individual
+commits; a new commit and commit message will only contain a textual
+list of the earlier commits.
 
 It is easier to make mistakes rebasing than other areas of `git`_, so before you
 start make a branch to serve as a backup copy of your work::
 
     git branch tmp my-new-feature # make temporary branch--will be deleted later
 
-After altering the history with ``git rebase`` or ``git merge --squash``
+After altering the history with ``git rebase`` or ``git merge --squash``,
 a normal ``git push`` is prevented, and for both a ``git push
 --force`` will be required.
 
@@ -491,7 +491,7 @@ repository) or if the number of commits in the history is disproportionate
 compared to the work being carried out (for example 30 commits gradually
 refining a final 10-line change).  Conceptually this is equivalent to
 exporting the final diff from a feature branch, then starting a new branch and
-applying only that patch:
+applying only that patch.
 
 The actual squashing is done on a new branch, using ``git merge --squash``::
 
@@ -511,7 +511,7 @@ How to push
 
 After using ``git rebase`` or ``git merge --squash`` you will still need
 to push your changes to GitHub so that they are visible to others and
-the Pull Request can be updated.  Use of a simple `git push` will be
+the pull request can be updated.  Use of a simple `git push` will be
 prevented because of the changed history, and will need to be manually
 overridden using::
 


### PR DESCRIPTION
Expand *squash* and *rebase* developer documentation based on discussion from end of [bug #5869].

Kudos to @pllim, @bsipocz, @astrofrog, @MSeifert04 for contributing to the discussion.

_(Hopefully this accurately reflects the discussion, feedback and suggestions for further refinement welcomed)._
