### PR TITLE
Remove py2.6 remnant mentions

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -15,9 +15,9 @@ both for the core package and for affiliated packages.
 Interface and Dependencies
 --------------------------
 
-* All code must be compatible with Python 2.6, 2.7, as well as 3.3 and
+* All code must be compatible with Python 2.7, as well as 3.3 and
   later.  The use of `six`_ for writing code that is portable between Python
-  2.x and 3.x is encouraged going forward.  However, much of our affiliate code
+  2.x and 3.x is encouraged going forward.  However, our affiliate code
   may still use `2to3`_ to process Python 2.x files to be compatible with
   Python 3.x.
 
@@ -46,16 +46,12 @@ Interface and Dependencies
   :ref:`dev-portable`.
 
 * The new Python 3 formatting style should be used (i.e.
-  ``"{0:s}".format("spam")`` instead of ``"%s" % "spam"``), although
-  when using positional arguments, the position should always be
-  specified (i.e.  ``"{:s}"`` is not compatible with Python
-  2.6).
+  ``"{0:s}".format("spam")`` instead of ``"%s" % "spam"``).
 
-* The core package and affiliated packages should be importable with
-  no dependencies other than components already in the Astropy core,
-  the `Python Standard Library
-  <http://docs.python.org/release/2.6/library/index.html>`_, and
-  NumPy_ |minimum_numpy_version| or later.
+* The core package and affiliated packages should be importable with no
+  dependencies other than components already in the Astropy core, the
+  `Python Standard Library <https://docs.python.org/library/index.html>`_,
+  and NumPy_ |minimum_numpy_version| or later.
 
 * The package should be importable from the source tree at build time. This
   means that, for example, if the package relies on C extensions that have
@@ -449,7 +445,7 @@ example::
    x = np.array([1.0, 2.0, 3.0], dtype=[(str('name'), '>f8')])
 
 The same is true of structure specifiers in the built-in `struct`
-module on Python 2.6.
+module on Python 2.7.
 
 ``pytest.mark.skipif`` also requires a "native" string, i.e.::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Astropy has the following strict requirements:
 
-- `Python <http://www.python.org/>`_ 2.7, 3.3, 3.4 or 3.5
+- `Python <http://www.python.org/>`_ 2.7, 3.3, 3.4, 3.5 or 3.6
 
   - Prior to Astropy v1.0, Python 3.1 and 3.2 were also supported
 
@@ -120,7 +120,7 @@ run::
 Binary installers
 -----------------
 
-Binary installers are available on Windows for Python 2.6, 2.7, and >= 3.3
+Binary installers are available on Windows for Python 2.7, and >= 3.3
 at `PyPI <https://pypi.python.org/pypi/astropy>`_.
 
 .. _testing_installed_astropy:

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -129,7 +129,6 @@ not limited to
 
 * OS X, Python 2.7.5 via homebrew
 * Linux, Python 2.7.6 via conda [#]_
-* Linux, Python 2.6.9 via conda
 
 are built without support for the ``bsddb`` module, resulting in an error
 such as::
@@ -169,18 +168,6 @@ certain circumstances output the following error::
 
 This can be resolved by upgrading to Python 2.7.4 or later (at the time of
 writing, the latest Python 2.7.x version is 2.7.9).
-
-
-Floating point precision issues on Python 2.6 on Microsoft Windows
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When converting floating point numbers to strings on Python 2.6 on a
-Microsoft Windows platform, some of the requested precision may be
-lost.
-
-The easiest workaround is to install Python 2.7.
-
-The Python issue: http://bugs.python.org/issue7117
 
 
 Color printing on Windows


### PR DESCRIPTION
Somehow cam across of the known issues page, and realized that there are still quite a lot of py2.6 mention there.

~~Also we can remove the ``funcsigs`` compatibility submodule as we don't support python versions any more where those are missing from the standard ``inspect`` module. Probably we don't even need the deprecation, but leaving it out for a release cycle won't hurt either.~~