### PR TITLE
Move astropy's LICENSE.rst file to the root of the repository

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2016, Astropy Developers
+Copyright (c) 2011-2017, Astropy Developers
 
 All rights reserved.
 

--- a/README.rst
+++ b/README.rst
@@ -44,4 +44,4 @@ with the Astropy Project, see http://dashboard.astropy.org.
 License
 -------
 Astropy is licensed under a 3-clause BSD style license - see the
-``licenses/LICENSE.rst`` file.
+``LICENSE.rst`` file.

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -7,7 +7,7 @@ Astropy License
 
 Astropy is licensed under a 3-clause BSD style license:
 
-.. include:: ../licenses/LICENSE.rst
+.. include:: ../LICENSE.rst
 
 Other Licenses
 ==============

--- a/licenses/README.rst
+++ b/licenses/README.rst
@@ -1,5 +1,6 @@
 Licenses
 ========
 
-This directory holds license and credit information for astropy, works astropy is derived from, and/or datasets.
+This directory holds license and credit information for works astropy is derived from or distributes, and/or datasets.
 
+The license file for the astropy package is placed in the root directory of this repository.

--- a/licenses/README.rst
+++ b/licenses/README.rst
@@ -3,4 +3,4 @@ Licenses
 
 This directory holds license and credit information for works astropy is derived from or distributes, and/or datasets.
 
-The license file for the astropy package is placed in the root directory of this repository.
+The license file for the astropy package itself is placed in the root directory of this repository.


### PR DESCRIPTION
This implements the suggestions in #5914 , in particular:

* Moves the `LICENSE.rst` file to the root
* Updates the copyright year
* Adds a note to the `licenses/README.rst` about the location of the main license file

The new location is well recognized by Github, as can be seen on my fork: https://github.com/tbabej/astropy

EDIT: Fix #5914