### PR TITLE
Support heaviside ufunc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,6 +250,8 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Add support for ``heaviside`` ufunc (new in numpy 1.13). [#5920]
+
 - ``astropy.utils``
 
   - Fix to allow the C-based _fast_iterparse() VOTable XML parser to

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -86,13 +86,8 @@ if isinstance(getattr(np, 'cbrt', None), np.ufunc):
     UFUNC_HELPERS[np.cbrt] = lambda f, unit: (
         [None], (unit ** Fraction(1, 3) if unit is not None
                  else dimensionless_unscaled))
-# ones_like was not private in numpy <= 1.6
-if isinstance(getattr(np.core.umath, 'ones_like', None), np.ufunc):
-    UFUNC_HELPERS[np.core.umath.ones_like] = (lambda f, unit:
-                                              ([None], dimensionless_unscaled))
-if isinstance(getattr(np.core.umath, '_ones_like', None), np.ufunc):
-    UFUNC_HELPERS[np.core.umath._ones_like] = (lambda f, unit:
-                                              ([None], dimensionless_unscaled))
+UFUNC_HELPERS[np.core.umath._ones_like] = (lambda f, unit:
+                                           ([None], dimensionless_unscaled))
 
 # ufuncs that require dimensionless input and and give dimensionless output
 def helper_dimensionless_to_dimensionless(f, unit):
@@ -240,6 +235,19 @@ def helper_copysign(f, unit1, unit2):
         return [None, None], unit1
 
 UFUNC_HELPERS[np.copysign] = helper_copysign
+
+# heaviside only was added in numpy 1.13
+if isinstance(getattr(np, 'heaviside', None), np.ufunc):
+    def helper_heaviside(f, unit1, unit2):
+        try:
+            converter2 = (get_converter(unit2, dimensionless_unscaled)
+                          if unit2 is not None else None)
+        except UnitsError:
+            raise TypeError("Can only apply 'heaviside' function with a "
+                            "dimensionless second argument.")
+        return ([None, converter2], dimensionless_unscaled)
+
+    UFUNC_HELPERS[np.heaviside] = helper_heaviside
 
 
 def helper_two_arg_dimensionless(f, unit1, unit2):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -273,6 +273,21 @@ class TestQuantityMathFuncs(object):
                       == np.array([1., 0.5, 0.25]) / u.m)
 
     # cbrt only introduced in numpy 1.10
+    # heaviside only introduced in numpy 1.13
+    @pytest.mark.skipif("not hasattr(np, 'heaviside')")
+    def test_heaviside_scalar(self):
+        assert np.heaviside(0. * u.m) == 0.5 * u.dimensionless_unscaled
+        assert np.heaviside(0. * u.s, 0.25) == 0.25 * u.dimensionless_unscaled
+        assert np.heaviside(2. * u.J, 0.25) == 1. * u.dimensionless_unscaled
+
+    @pytest.mark.skipif("not hasattr(np, 'heaviside')")
+    def test_heaviside_array(self):
+        values = np.array([-1., 0., 0., +1.])
+        halfway = np.array([0.5, 0.25, 0.75, 0.5]) * u.dimensionless_unscaled
+        assert np.all(np.heaviside(values * u.m,
+                                   halfway * u.dimensionless_unscaled) ==
+                      [-1., 0.25, 0.75, +1.] * u.dimensionless_unscaled)
+
     @pytest.mark.skipif("not hasattr(np, 'cbrt')")
     def test_cbrt_scalar(self):
         assert np.cbrt(8. * u.m**3) == 2. * u.m

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -276,17 +276,18 @@ class TestQuantityMathFuncs(object):
     # heaviside only introduced in numpy 1.13
     @pytest.mark.skipif("not hasattr(np, 'heaviside')")
     def test_heaviside_scalar(self):
-        assert np.heaviside(0. * u.m) == 0.5 * u.dimensionless_unscaled
-        assert np.heaviside(0. * u.s, 0.25) == 0.25 * u.dimensionless_unscaled
+        assert np.heaviside(0. * u.m, 0.5) == 0.5 * u.dimensionless_unscaled
+        assert np.heaviside(0. * u.s,
+                            25 * u.percent) == 0.25 * u.dimensionless_unscaled
         assert np.heaviside(2. * u.J, 0.25) == 1. * u.dimensionless_unscaled
 
     @pytest.mark.skipif("not hasattr(np, 'heaviside')")
     def test_heaviside_array(self):
         values = np.array([-1., 0., 0., +1.])
-        halfway = np.array([0.5, 0.25, 0.75, 0.5]) * u.dimensionless_unscaled
+        halfway = np.array([0.75, 0.25, 0.75, 0.25]) * u.dimensionless_unscaled
         assert np.all(np.heaviside(values * u.m,
                                    halfway * u.dimensionless_unscaled) ==
-                      [-1., 0.25, 0.75, +1.] * u.dimensionless_unscaled)
+                      [0, 0.25, 0.75, +1.] * u.dimensionless_unscaled)
 
     @pytest.mark.skipif("not hasattr(np, 'cbrt')")
     def test_cbrt_scalar(self):


### PR DESCRIPTION
As noted by @saimn in ~~https://github.com/astropy/astropy/issues/2933#issuecomment-290009552~~ https://github.com/astropy/astropy/pull/5835#issuecomment-290055672, numpy-dev now has a `heaviside` ufunc. This adds support. Set the milestone to 1.3.2, since ideally all tests pass also on numpy-dev with 1.3.