### PR TITLE
Allow function units to override the quantity class if subok=True.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,10 @@ New Features
   - The `~astropy.units.quantity_input` decorator will now convert the output to
     the unit specified as a return annotation under Python 3. [#5606]
 
+  - Passing a logarithmic unit to the ``Quantity`` constructor now returns the
+    appropriate logarithmic quantity class if ``subok=True``. For instance,
+    ``Quantity(1, u.dex(u.m), subok=True)`` yields ``<Dex 1.0 dex(m)>``. [#5928]
+
 - ``astropy.utils``
 
 - ``astropy.visualization``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -195,7 +195,9 @@ class Quantity(np.ndarray):
 
     subok : bool, optional
         If `False` (default), the returned array will be forced to be a
-        `Quantity`.  Otherwise, `Quantity` subclasses will be passed through.
+        `Quantity`.  Otherwise, `Quantity` subclasses will be passed through,
+        or a subclass appropriate for the unit will be used (such as
+        `~astropy.units.Dex` for ``u.dex(u.AA)``).
 
     ndmin : int, optional
         Specifies the minimum number of dimensions that the resulting array
@@ -236,6 +238,11 @@ class Quantity(np.ndarray):
         if unit is not None:
             # convert unit first, to avoid multiple string->unit conversions
             unit = Unit(unit)
+            # if we allow subclasses, allow a class from the unit.
+            if subok:
+                qcls = getattr(unit, '_quantity_class', cls)
+                if issubclass(qcls, cls):
+                    cls = qcls
 
         # optimize speed for Quantity with no dtype given, copy=False
         if isinstance(value, Quantity):

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -481,6 +481,15 @@ class TestLogQuantityCreation(object):
         assert lq.unit.physical_unit == u.dimensionless_unscaled
         assert np.all(q == lq)
 
+    def test_using_quantity_class(self):
+        """Check that we can use Quantity if we have subok=True"""
+        # following issue #5851
+        lu = u.dex(u.AA)
+        with pytest.raises(u.UnitTypeError):
+            u.Quantity(1., lu)
+        q = u.Quantity(1., lu, subok=True)
+        assert type(q) is lu._quantity_class
+
 
 def test_conversion_to_and_from_physical_quantities():
     """Ensures we can convert from regular quantities."""

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1301,3 +1301,15 @@ class TestQuantityMatplotlib(object):
         x = u.Quantity([4, 5, 6], 'second')
         y = [1, 3, 4] * u.m
         plt.scatter(x, y)
+
+
+def test_unit_class_override():
+    class MyQuantity(u.Quantity):
+        pass
+
+    my_unit = u.Unit("my_deg", u.deg)
+    my_unit._quantity_class = MyQuantity
+    q1 = u.Quantity(1., my_unit)
+    assert type(q1) is u.Quantity
+    q2 = u.Quantity(1., my_unit, subok=True)
+    assert type(q2) is  MyQuantity


### PR DESCRIPTION
In #5851, @weaverba137 asked whether it would be possible to instantiate `Quantity` with function units such as `u.dex(u.AA)`. In general, this should not be possible, since one should get a `Quantity` object out. But if `subok=True`, this seems reasonable. So, with this PR:
```
In [3]: u.Quantity(1., u.dex(u.AA), subok=True)
Out[3]: <Dex 1.0 dex(Angstrom)>
```