### PR TITLE
Remove Angstrom, erg and others from the list of deprecated FITS units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,9 @@ API Changes
 
 - ``astropy.io.fits``
 
+  - Angstrom, erg, G, and barn are no more reported as deprecated FITS units.
+    [#5929]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -33,13 +33,21 @@ class Fits(generic.Generic):
         names = {}
         deprecated_names = set()
 
+        # Note about deprecated units: before v2.0, several units were treated
+        # as deprecated (G, barn, erg, Angstrom, angstrom). However, in the
+        # FITS 3.0 standard, these units are explicitly listed in the allowed
+        # units, but deprecated in the IAU Style Manual (McNally 1988). So
+        # after discussion (https://github.com/astropy/astropy/issues/2933),
+        # these units have been removed from the lists of deprecated units and
+        # bases.
+
         bases = [
             'm', 'g', 's', 'rad', 'sr', 'K', 'A', 'mol', 'cd',
             'Hz', 'J', 'W', 'V', 'N', 'Pa', 'C', 'Ohm', 'S',
             'F', 'Wb', 'T', 'H', 'lm', 'lx', 'a', 'yr', 'eV',
-            'pc', 'Jy', 'mag', 'R', 'bit', 'byte'
+            'pc', 'Jy', 'mag', 'R', 'bit', 'byte', 'G', 'barn'
         ]
-        deprecated_bases = ['G', 'barn']
+        deprecated_bases = []
         prefixes = [
             'y', 'z', 'a', 'f', 'p', 'n', 'u', 'm', 'c', 'd',
             '', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
@@ -63,9 +71,9 @@ class Fits(generic.Generic):
             'deg', 'arcmin', 'arcsec', 'mas', 'min', 'h', 'd', 'Ry',
             'solMass', 'u', 'solLum', 'solRad', 'AU', 'lyr', 'count',
             'ct', 'photon', 'ph', 'pixel', 'pix', 'D', 'Sun', 'chan',
-            'bin', 'voxel', 'adu', 'beam'
+            'bin', 'voxel', 'adu', 'beam', 'erg', 'Angstrom', 'angstrom'
         ]
-        deprecated_units = ['erg', 'Angstrom', 'angstrom']
+        deprecated_units = []
 
         for unit in simple_units + deprecated_units:
             names[unit] = getattr(u, unit)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -358,14 +358,7 @@ def test_deprecated_did_you_mean_units():
     try:
         u.Unit('ANGSTROM', format='fits')
     except ValueError as e:
-        assert 'angstrom (deprecated)' in six.text_type(e)
-        assert 'Angstrom (deprecated)' in six.text_type(e)
-        assert '10**-1 nm' in six.text_type(e)
-
-    with catch_warnings() as w:
-        u.Unit('Angstrom', format='fits')
-    assert len(w) == 1
-    assert '10**-1 nm' in six.text_type(w[0].message)
+        assert 'Did you mean Angstrom or angstrom?' in six.text_type(e)
 
     try:
         u.Unit('crab', format='ogip')

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -198,7 +198,7 @@ Normally, passing an unrecognized unit string raises an exception::
     ...
   ValueError: 'Angstroem' did not parse as fits unit: At col 0, Unit
   'Angstroem' not supported by the FITS standard. Did you mean
-  10**-1 nm, Angstrom (deprecated) or angstrom (deprecated)?
+  Angstrom or angstrom?
 
 However, the `~astropy.units.Unit` constructor has the keyword
 argument ``parse_strict`` that can take one of three values to control


### PR DESCRIPTION
Fixes #2933: as discussed there, several units are treated as
deprecated (G, barn, erg, Angstrom, angstrom). However, in the FITS 3.0
standard, these units are explicitly listed in the allowed units (but
deprecated in the IAU Style Manual (McNally 1988)). After discussion in #2933,
the consensus is that we can simply allow these units, which is done here.