### PR TITLE
Update scipy.org links following the mailing-list migration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ rst_epilog += """
 
 .. Astropy
 .. _Astropy: http://astropy.org
-.. _`Astropy mailing list`: http://mail.scipy.org/mailman/listinfo/astropy
+.. _`Astropy mailing list`: http://mail.python.org/mailman/listinfo/astropy
 .. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev
 """.format(astropy)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ rst_epilog += """
 
 .. Astropy
 .. _Astropy: http://astropy.org
-.. _`Astropy mailing list`: http://mail.python.org/mailman/listinfo/astropy
+.. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy
 .. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev
 """.format(astropy)
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -226,8 +226,7 @@ Other Credits
 * Kyle Barbary for designing the Astropy logos and documentation themes.
 * Andrew Pontzen and the `pynbody <https://github.com/pynbody/pynbody>`_ team
   (For code that grew into :mod:`astropy.units`)
-* Everyone on `astropy-dev <http://groups.google.com/group/astropy-dev>`_
-  and the `astropy mailing list <https://mail.python.org/mailman/listinfo/astropy>`_
+* Everyone on the `astropy-dev mailing list`_ and the `Astropy mailing list`_
   for contributing to many discussions and decisions!
 
 (If you have contributed to the Astropy project and your name is missing,

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -227,7 +227,7 @@ Other Credits
 * Andrew Pontzen and the `pynbody <https://github.com/pynbody/pynbody>`_ team
   (For code that grew into :mod:`astropy.units`)
 * Everyone on `astropy-dev <http://groups.google.com/group/astropy-dev>`_
-  and the `astropy mailing list <http://mail.scipy.org/mailman/listinfo/astropy>`_
+  and the `astropy mailing list <https://mail.python.org/mailman/listinfo/astropy>`_
   for contributing to many discussions and decisions!
 
 (If you have contributed to the Astropy project and your name is missing,

--- a/docs/development/workflow/git_links.inc
+++ b/docs/development/workflow/git_links.inc
@@ -51,7 +51,7 @@
 .. _deleting master on github: http://matthew-brett.github.com/pydagogue/gh_delete_master.html
 .. _rebase without tears: http://matthew-brett.github.com/pydagogue/rebase_without_tears.html
 .. _resolving a merge: http://schacon.github.com/git/user-manual.html#resolving-a-merge
-.. _ipython git workflow: http://mail.scipy.org/pipermail/ipython-dev/2010-October/006746.html
+.. _ipython git workflow: https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html
 .. _ipython notebook on using git in science: http://nbviewer.ipython.org/github/fperez/reprosw/blob/master/Version%20Control.ipynb
 
 .. other stuff

--- a/docs/development/workflow/known_projects.inc
+++ b/docs/development/workflow/known_projects.inc
@@ -8,37 +8,17 @@
 .. numpy
 .. _numpy: http://numpy.scipy.org
 .. _`numpy github`: http://github.com/numpy/numpy
-.. _`numpy mailing list`: http://mail.scipy.org/mailman/listinfo/numpy-discussion
+.. _`numpy mailing list`: http://mail.python.org/mailman/listinfo/numpy-discussion
 
 .. scipy
 .. _scipy: http://www.scipy.org
 .. _`scipy github`: http://github.com/scipy/scipy
-.. _`scipy mailing list`: http://mail.scipy.org/mailman/listinfo/scipy-dev
-
-.. nipy
-.. _nipy: http://nipy.org/nipy
-.. _`nipy github`: http://github.com/nipy/nipy
-.. _`nipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
+.. _`scipy mailing list`: http://mail.python.org/mailman/listinfo/scipy-dev
 
 .. ipython
 .. _ipython: http://ipython.scipy.org
 .. _`ipython github`: http://github.com/ipython/ipython
-.. _`ipython mailing list`: http://mail.scipy.org/mailman/listinfo/IPython-dev
-
-.. dipy
-.. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
-.. _`dipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
-
-.. nibabel
-.. _nibabel: http://nipy.org/nibabel
-.. _`nibabel github`: http://github.com/nipy/nibabel
-.. _`nibabel mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
-
-.. marsbar
-.. _marsbar: http://marsbar.sourceforge.net
-.. _`marsbar github`: http://github.com/matthew-brett/marsbar
-.. _`MarsBaR mailing list`: https://lists.sourceforge.net/lists/listinfo/marsbar-users
+.. _`ipython mailing list`: http://mail.python.org/mailman/listinfo/IPython-dev
 
 .. pip
 .. _pip: http://www.pip-installer.org/en/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,5 +228,5 @@ Indices and Tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. _astropy mailing list: http://mail.scipy.org/mailman/listinfo/astropy
+.. _astropy mailing list: http://mail.python.org/mailman/listinfo/astropy
 .. _feedback@astropy.org: mailto:feedback@astropy.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,7 +127,7 @@ Getting help
 ************
 
 If you want to get help or discuss issues with other Astropy users, you can sign
-up for the `astropy mailing list`_. Alternatively, the `astropy-dev mailing
+up for the `Astropy mailing list`_. Alternatively, the `astropy-dev mailing
 list`_ is where you should go to discuss more technical aspects of Astropy with
 the developers. You can also email the astropy developers privately at
 `feedback@astropy.org`_...but remember that questions you ask
@@ -145,7 +145,7 @@ create a new issue on the Astropy `GitHub issue page
 account <https://github.com>`_ on GitHub if you do not have one.
 
 If you prefer not to create a GitHub account, please report the issue to either
-the `astropy mailing list`_, the `astropy-dev mailing list`_ or sending a
+the `Astropy mailing list`_, the `astropy-dev mailing list`_ or sending a
 private email to the astropy core developers at
 `feedback@astropy.org <mailto:feedback@astropy.org>`_.
 
@@ -228,5 +228,4 @@ Indices and Tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. _astropy mailing list: http://mail.python.org/mailman/listinfo/astropy
 .. _feedback@astropy.org: mailto:feedback@astropy.org

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -349,7 +349,7 @@ system package in an inconsistent state.
 
 As the best course of action at this point depends largely on the individual
 system and how it is configured, if you are not sure yourself what do please
-ask on the Astropy mailing list.
+ask on the `Astropy mailing list`_.
 
 
 The Windows installer can't find Python in the registry


### PR DESCRIPTION
Not sure if the mailing-list will stay on python.org, but it does not hurt to update these links.