### PR TITLE
Add pep8 error check for bare excepts

### DIFF
--- a/astropy/coordinates/calculation.py
+++ b/astropy/coordinates/calculation.py
@@ -107,7 +107,7 @@ def horoscope(birthday, corrected=True):
         doc = parse(f)
         item = doc.getElementsByTagName('item')[0]
         desc = item.getElementsByTagName('description')[0].childNodes[0].nodeValue
-    except:
+    except Exception:
         raise CelestialError("Invalid response from celestial gods (failed to load horoscope).")
     finally:
         f.close()

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -451,7 +451,7 @@ class CartesianRepresentation(BaseRepresentation):
         except u.UnitsError:
             raise u.UnitsError('x, y, and z should have a unit consistent with '
                                '{0}'.format(unit))
-        except:
+        except Exception:
             raise TypeError('x, y, and z should be able to initialize ' +
                             ('a {0}'.format(self.attr_classes['x'].__name__))
                              if len(set(self.attr_classes.values)) == 1 else

--- a/astropy/visualization/wcsaxes/tests/datasets.py
+++ b/astropy/visualization/wcsaxes/tests/datasets.py
@@ -25,7 +25,7 @@ def fetch_hdu(filename, cache=True):
     for retry in range(MAX_RETRIES):
         try:
             path = download_file(URL + filename, cache=cache, timeout=30)
-        except:
+        except URLError:
             if retry == MAX_RETRIES - 1:
                 raise
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,17 +39,18 @@ auto_use = True
 # E111 - 4 spaces per indentation level
 # E112 - 4 spaces per indentation level
 # E113 - 4 spaces per indentation level
+# E722 - do not use bare except
 # E901 - SyntaxError or IndentationError
 # E902 - IOError
 
 # If you want to exclude a line from checking, simply add '  # noqa' at the end of the line
 
 [pycodestyle]
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E722,E901,E902
 exclude = extern,sphinx,*parsetab.py
 
 [flake8]
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E722,E901,E902
 exclude = extern,sphinx,*parsetab.py
 
 [zest.releaser]


### PR DESCRIPTION
Bare excepts recently [got their error code](https://github.com/PyCQA/pycodestyle/issues/579), and based on our [previous discussion](https://github.com/astropy/astropy/pull/5335#issuecomment-247760968), we should use it.

