### PR TITLE
io.fits: Use more sensible fix values for invalid NAXISj header values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -309,6 +309,8 @@ Bug Fixes
     to ``COMMENT`` instead of ``COMMENTS`` header. Similarly, ``COMMENT``
     headers are read into ``comments`` meta [#6097]
 
+  - Use more sensible fix values for invalid NAXISj header values. [#5935]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -15,7 +15,7 @@ from ..file import _File
 from ..header import Header, _pad_length
 from ..util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
                     itersubclasses, decode_ascii, _get_array_mmap, first,
-                    _free_space_check)
+                    _free_space_check, _extract_number)
 from ..verify import _Verify, _ErrList
 
 from ....extern.six import string_types, add_metaclass
@@ -999,9 +999,11 @@ class _ValidHDU(_BaseHDU, _Verify):
         naxis = self._header.get('NAXIS', 0)
         if naxis < 1000:
             for ax in range(3, naxis + 3):
-                self.req_cards('NAXIS' + str(ax - 2), ax,
-                               lambda v: (_is_int(v) and v >= 0), 1, option,
-                               errs)
+                key = 'NAXIS' + str(ax - 2)
+                self.req_cards(key, ax,
+                               lambda v: (_is_int(v) and v >= 0),
+                               _extract_number(self._header[key], default=1),
+                               option, errs)
 
             # Remove NAXISj cards where j is not in range 1, naxis inclusive.
             for keyword in self._header:

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -436,6 +436,52 @@ class TestHDUListFunctions(FitsTestCase):
         assert 'EXTEND' in hdul[0].header
         assert hdul[0].header['EXTEND'] is True
 
+    def test_fix_malformed_naxisj(self):
+        """
+        Tests that malformed NAXISj values are fixed sensibly.
+        """
+
+        hdu = fits.open(self.data('arange.fits'))
+
+        # Malform NAXISj header data
+        hdu[0].header['NAXIS1'] = 11.0
+        hdu[0].header['NAXIS2'] = '10.0'
+        hdu[0].header['NAXIS3'] = '7'
+
+        # Axes cache needs to be malformed as well
+        hdu[0]._axes = [11.0, '10.0', '7']
+
+        # Perform verification including the fix
+        hdu.verify('silentfix')
+
+        # Check that malformed data was converted
+        assert hdu[0].header['NAXIS1'] == 11
+        assert hdu[0].header['NAXIS2'] == 10
+        assert hdu[0].header['NAXIS3'] == 7
+
+    def test_fix_wellformed_naxisj(self):
+        """
+        Tests that wellformed NAXISj values are not modified.
+        """
+
+        hdu = fits.open(self.data('arange.fits'))
+
+        # Fake new NAXISj header data
+        hdu[0].header['NAXIS1'] = 768
+        hdu[0].header['NAXIS2'] = 64
+        hdu[0].header['NAXIS3'] = 8
+
+        # Axes cache needs to be faked as well
+        hdu[0]._axes = [768, 64, 8]
+
+        # Perform verification including the fix
+        hdu.verify('silentfix')
+
+        # Check that malformed data was converted
+        assert hdu[0].header['NAXIS1'] == 768
+        assert hdu[0].header['NAXIS2'] == 64
+        assert hdu[0].header['NAXIS3'] == 8
+
     def test_new_hdulist_extend_keyword(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/114
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -882,3 +882,17 @@ def _free_space_check(hdulist, dirname=None):
             hdu._close()
 
         raise OSError(error_message + str(exc))
+
+
+def _extract_number(value, default):
+    """
+    Attempts to extract an integer number from the given value. If the
+    extraction fails, the value of the 'default' argument is returned.
+    """
+
+    try:
+        # The _str_to_num method converts the value to string/float
+        # so we need to perform one additional conversion to int on top
+        return int(_str_to_num(value))
+    except (TypeError, ValueError):
+        return default


### PR DESCRIPTION
When encountering an invalid NAXISj value (i.e. NAXIS1=91.0) the
_ValidHDU._verify method fixed the value with 1 invariantly, which
is not very useful, particularly for invalid values from which an
sensible intenger can be extracted.

Replace this hard-coded value with an integer extraction logic.

Fixes #5881.