### PR TITLE
strip non-numeric/non-dot characters from version string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -256,6 +256,10 @@ Bug Fixes
 
 - ``astropy.utils``
 
+  - On systems that do not have ``pkg_resources`` non-numerical additions to
+    version numbers like ``dev`` or ``rc1`` are stripped in ``minversion`` to
+    avoid a ``TypeError`` in ``distutils.version.LooseVersion`` [#5944]
+
 - ``astropy.visualization``
 
 - ``astropy.vo``

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 
 
 import inspect
+import re
 import types
 
 from ..extern import six
@@ -154,6 +155,13 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
         from pkg_resources import parse_version
     except ImportError:
         from distutils.version import LooseVersion as parse_version
+        # LooseVersion raises a TypeError when strings like dev, rc1 are part
+        # of the version number. Match the dotted numbers only. Regex taken
+        # from PEP440, https://www.python.org/dev/peps/pep-0440/, Appendix B
+        expr = '^([1-9]\\d*!)?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))*'
+        m = re.match(expr, version)
+        if m:
+            version = m.group(0)
 
     if inclusive:
         return parse_version(have_version) >= parse_version(version)

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -9,7 +9,7 @@ from ...extern import six
 from ...tests.helper import pytest
 from .. import introspection
 from ..introspection import (find_current_module, find_mod_objs,
-                             isinstancemethod)
+                             isinstancemethod, minversion)
 
 
 def test_pkg_finder():
@@ -92,3 +92,26 @@ def test_isinstancemethod():
     assert not isinstancemethod(MyClass, MyClass.another_classmethod)
     assert not isinstancemethod(MyClass, MyClass.a_staticmethod)
     assert isinstancemethod(MyClass, MyClass.an_instancemethod)
+
+
+def _minversion_test():
+    from types import ModuleType
+    test_module = ModuleType(str("test_module"))
+    test_module.__version__ = '0.12.2'
+    good_versions = ['0.12', '0.12.1', '0.12.0.dev']
+    bad_versions = ['1', '1.2rc1']
+    for version in good_versions:
+        assert minversion(test_module, version)
+    for version in bad_versions:
+        assert not minversion(test_module, version)
+
+
+def test_minversion():
+    import sys
+    if 'pkg_resources' in sys.modules:
+        pkg_resources_saved = sys.modules['pkg_resources']
+        # Force ImportError for pkg_resources in minversion()
+        sys.modules['pkg_resource'] = None
+        _minversion_test()
+        sys.modules['pkg_resource'] = pkg_resources_saved
+    _minversion_test()


### PR DESCRIPTION
Strip non-numeric version name extensions like `'dev'` or `rc1` from version string if `LooseVersion()` is used for version comparison. This fixes #5814 and adds a first test suite for `minversion()`.