### PR TITLE
match coordinates once with merge_attributes set to False, fixes #5857

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -12,6 +12,9 @@ from ..extern import six
 from .representation import UnitSphericalRepresentation
 from .. import units as u
 
+from .sky_coordinate import SkyCoord
+from .baseframe import BaseCoordinateFrame
+
 __all__ = ['match_coordinates_3d', 'match_coordinates_sky', 'search_around_3d',
            'search_around_sky']
 
@@ -69,7 +72,10 @@ def match_coordinates_3d(matchcoord, catalogcoord, nthneighbor=1, storekdtree='k
     kdt = _get_cartesian_kdtree(catalogcoord, storekdtree)
 
     # make sure coordinate systems match
-    matchcoord = matchcoord.transform_to(catalogcoord)
+    if (isinstance(matchcoord, (SkyCoord))):
+        newmatch = matchcoord.transform_to(catalogcoord, merge_attributes=False)
+    elif (isinstance(matchcoord, (BaseCoordinateFrame))):
+        newmatch = matchcoord.transform_to(catalogcoord)
 
     # make sure units match
     catunit = catalogcoord.cartesian.x.unit
@@ -139,7 +145,10 @@ def match_coordinates_sky(matchcoord, catalogcoord, nthneighbor=1, storekdtree='
                          'scalar or length-0.')
 
     # send to catalog frame
-    newmatch = matchcoord.transform_to(catalogcoord)
+    if (isinstance(matchcoord, (SkyCoord))):
+        newmatch = matchcoord.transform_to(catalogcoord, merge_attributes=False)
+    elif (isinstance(matchcoord, (BaseCoordinateFrame))):
+        newmatch = matchcoord.transform_to(catalogcoord)
 
     # strip out distance info
     match_urepr = newmatch.data.represent_as(UnitSphericalRepresentation)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -873,14 +873,12 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from .matching import match_coordinates_sky
 
-        if (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
+        if not (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
                 and catalogcoord.has_data):
-            self_in_catalog_frame = self.transform_to(catalogcoord)
-        else:
             raise TypeError('Can only get separation to another SkyCoord or a '
                             'coordinate frame with data')
 
-        res = match_coordinates_sky(self_in_catalog_frame, catalogcoord,
+        res = match_coordinates_sky(self, catalogcoord,
                                     nthneighbor=nthneighbor,
                                     storekdtree='_kdtree_sky')
         return res
@@ -938,14 +936,12 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from .matching import match_coordinates_3d
 
-        if (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
+        if not (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
                 and catalogcoord.has_data):
-            self_in_catalog_frame = self.transform_to(catalogcoord)
-        else:
             raise TypeError('Can only get separation to another SkyCoord or a '
                             'coordinate frame with data')
 
-        res = match_coordinates_3d(self_in_catalog_frame, catalogcoord,
+        res = match_coordinates_3d(self, catalogcoord,
                                    nthneighbor=nthneighbor,
                                    storekdtree='_kdtree_3d')
 


### PR DESCRIPTION
As I had discussed on #5857 , I chose to use the functions in `matching.py` for the transform.

There is however a problem. `BaseCoordinateFrame.transform_to` does not have `merge_attributes` in its definition yet. So I check for the instance of the `self` object and if it is `SkyCoord`, I use `transform_to` with `merge_attributes=False`, and otherwise for `BaseCoordinateFrame` I am using the usual `transform_to`.

I am not aware if the different definitions of `transform_to` are intended or not, but I don't think this is a good idea.