### PR TITLE
Use "!r" in format calls instead of passing in "repr()"

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -730,8 +730,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         check if data is present on this frame object.
         """
         if self._data is None:
-            raise ValueError('The frame object "{0}" does not have associated '
-                             'data'.format(repr(self)))
+            raise ValueError('The frame object "{0!r}" does not have '
+                             'associated data'.format(self))
         return self._data
 
     @property

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -500,7 +500,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                 reader_repr = repr(kwargs.get('Reader', basic.Basic))
                 keys_vals = ['Reader:' + re.search(r"\.(\w+)'>", reader_repr).group(1)]
                 kwargs_sorted = ((key, kwargs[key]) for key in sorted_keys)
-                keys_vals.extend(['{}: {}'.format(key, repr(val)) for key, val in kwargs_sorted])
+                keys_vals.extend(['{}: {!r}'.format(key, val) for key, val in kwargs_sorted])
                 lines.append(' '.join(keys_vals))
 
             msg = ['',

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -1095,7 +1095,7 @@ class Card(_Verify):
             if not self._keywd_FSC_RE.match(keyword):
                 errs.append(self.run_option(
                     option,
-                    err_text='Illegal keyword name {}'.format(repr(keyword)),
+                    err_text='Illegal keyword name {!r}'.format(keyword),
                     fixable=False))
 
         # verify the value, it may be fixable

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1834,7 +1834,7 @@ def _get_index(names, key):
             else:              # multiple match
                 raise KeyError("Ambiguous key name '{}'.".format(key))
     else:
-        raise KeyError("Illegal key '{}'.".format(repr(key)))
+        raise KeyError("Illegal key '{!r}'.".format(key))
 
     return indx
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -160,7 +160,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         kwargs['uint'] = conf.enable_uint
 
     if not name:
-        raise ValueError('Empty filename: {}'.format(repr(name)))
+        raise ValueError('Empty filename: {!r}'.format(name))
 
     return HDUList.fromfile(name, mode, memmap, save_backup, cache,
                             lazy_load_hdus, **kwargs)
@@ -680,7 +680,7 @@ class HDUList(list, _Verify):
                 break
 
         if (found is None):
-            raise KeyError('Extension {} not found.'.format(repr(key)))
+            raise KeyError('Extension {!r} not found.'.format(key))
         else:
             return found
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -749,7 +749,7 @@ class Column(BaseColumn):
                           ('length', len(self))):
 
             if val is not None:
-                descr_vals.append('{0}={1}'.format(attr, repr(val)))
+                descr_vals.append('{0}={1!r}'.format(attr, val))
 
         descr = '<' + ' '.join(descr_vals) + '>\n'
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -294,8 +294,8 @@ class Time(ShapedLikeNDArray):
         if scale is not None:
             if not (isinstance(scale, six.string_types) and
                     scale.lower() in self.SCALES):
-                raise ScaleValueError("Scale {0} is not in the allowed scales "
-                                      "{1}".format(repr(scale),
+                raise ScaleValueError("Scale {0!r} is not in the allowed scales "
+                                      "{1}".format(scale,
                                                    sorted(self.SCALES)))
 
         # Parse / convert input values into internal jd1, jd2 based on format
@@ -329,8 +329,8 @@ class Time(ShapedLikeNDArray):
                 raise ValueError("No time format was given, and the input is "
                                  "not unique")
             else:
-                raise ValueError("Format {0} is not one of the allowed "
-                                 "formats {1}".format(repr(format),
+                raise ValueError("Format {0!r} is not one of the allowed "
+                                 "formats {1}".format(format,
                                                       sorted(self.FORMATS)))
         else:
             formats = [(format, self.FORMATS[format])]
@@ -431,8 +431,8 @@ class Time(ShapedLikeNDArray):
         if scale == self.scale:
             return
         if scale not in self.SCALES:
-            raise ValueError("Scale {0} is not in the allowed scales {1}"
-                             .format(repr(scale), sorted(self.SCALES)))
+            raise ValueError("Scale {0!r} is not in the allowed scales {1}"
+                             .format(scale, sorted(self.SCALES)))
 
         # Determine the chain of scale transformations to get from the current
         # scale to the new scale.  MULTI_HOPS contains a dict of all
@@ -1529,8 +1529,8 @@ class TimeDelta(Time):
         if scale == self.scale:
             return
         if scale not in self.SCALES:
-            raise ValueError("Scale {0} is not in the allowed scales {1}"
-                             .format(repr(scale), sorted(self.SCALES)))
+            raise ValueError("Scale {0!r} is not in the allowed scales {1}"
+                             .format(scale, sorted(self.SCALES)))
 
         # For TimeDelta, there can only be a change in scale factor,
         # which is written as time2 - time1 = scale_offset * time1

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -958,8 +958,8 @@ class TimeFITS(TimeString):
             fits_scale = tm['scale'].upper()
             scale = FITS_DEPRECATED_SCALES.get(fits_scale, fits_scale.lower())
             if scale not in TIME_SCALES:
-                raise ValueError("Scale {0} is not in the allowed scales {1}"
-                                 .format(repr(scale), sorted(TIME_SCALES)))
+                raise ValueError("Scale {0!r} is not in the allowed scales {1}"
+                                 .format(scale, sorted(TIME_SCALES)))
             # If no scale was given in the initialiser, set the scale to
             # that given in the string.  Also store a possible realization,
             # so we can round-trip (as long as no scale changes are made).

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -302,10 +302,10 @@ class Quantity(np.ndarray):
                 try:
                     value_unit = Unit(value_unit)
                 except Exception as exc:
-                    raise TypeError("The unit attribute {0} of the input could "
+                    raise TypeError("The unit attribute {0!r} of the input could "
                                     "not be parsed as an astropy Unit, raising "
                                     "the following exception:\n{1}"
-                                    .format(repr(value.unit), exc))
+                                    .format(value.unit, exc))
 
                 if unit is None:
                     unit = value_unit

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -447,8 +447,8 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 # 3.) positional-only argument, varargs, varkwargs or some
                 #     unknown type:
                 else:
-                    raise TypeError('cannot replace argument "{0}" of kind {1}'
-                                    '.'.format(new_name[i], repr(param.kind)))
+                    raise TypeError('cannot replace argument "{0}" of kind '
+                                    '{1!r}.'.format(new_name[i], param.kind))
 
             # In case the argument is not found in the list of arguments
             # the only remaining possibility is that it should be catched


### PR DESCRIPTION
This is a small refactor that replaces `repr(sth)` inputs for `str.format` with the `!r` option for formatting.

Not sure if that's needed but I stumbled over these when I investigated something in `hdulist`.