### PR TITLE
Include specifics of io.misc in title and main doc index

### DIFF
--- a/docs/io/misc.rst
+++ b/docs/io/misc.rst
@@ -1,6 +1,6 @@
-**********************************************
-Miscellaneous Input/Output (`astropy.io.misc`)
-**********************************************
+*****************************************************
+Miscellaneous: HDF5, YAML, pickle (`astropy.io.misc`)
+*****************************************************
 
 The `astropy.io.misc` module contains miscellaneous input/output routines that
 do not fit elsewhere, and are often used by other Astropy sub-packages. For


### PR DESCRIPTION
From the main astropy docs index you would never know that HDF5 and YAML are supported.  This corrects that by changing the section title.