### PR TITLE
always use user-supplied scaling values when given

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -281,6 +281,11 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+  - Scaling an image always uses user-supplied values when given. Added
+    defaults for scaling when bscale/bzero are not present (float images).
+    Fixed a small bug in when to reset ``_orig_bscale``.
+
+- ``astropy.io.misc``
 
 - Fixed a bug in initializing compound models with units. [#6398]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -283,7 +283,7 @@ astropy.modeling
 ^^^^^^^^^^^^^^^^
   - Scaling an image always uses user-supplied values when given. Added
     defaults for scaling when bscale/bzero are not present (float images).
-    Fixed a small bug in when to reset ``_orig_bscale``.
+    Fixed a small bug in when to reset ``_orig_bscale``. [#5955]
 
 - ``astropy.io.misc``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -270,6 +270,10 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Scaling an image always uses user-supplied values when given. Added
+  defaults for scaling when bscale/bzero are not present (float images).
+  Fixed a small bug in when to reset ``_orig_bscale``. [#5955]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -281,11 +285,6 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
-  - Scaling an image always uses user-supplied values when given. Added
-    defaults for scaling when bscale/bzero are not present (float images).
-    Fixed a small bug in when to reset ``_orig_bscale``. [#5955]
-
-- ``astropy.io.misc``
 
 - Fixed a bug in initializing compound models with units. [#6398]
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -641,6 +641,16 @@ class TestImageFunctions(FitsTestCase):
         f = fits.open(self.temp('test_new.fits'), uint=True)
         assert f[1].data.dtype == 'uint16'
 
+    def test_scale_with_explicit_bzero_bscale(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/6399
+        """
+        hdu1 = fits.PrimaryHDU()
+        hdu2 = fits.ImageHDU(np.random.rand(100,100))
+        # The line below raised an exception in astropy 2.0, so if it does not
+        # raise an error here, that is progress.
+        hdu2.scale(type='uint8', bscale=1, bzero=0)
+
     def test_uint_header_consistency(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/2305


### PR DESCRIPTION
This pull request addresses three related issues regarding the scaling of fits images:
1. Currently, ``_ImageBaseHDU.scale`` will ignore the user-supplied ``bscale`` and ``bzero`` parameters if they are equal to the default values (1 and 0, respectively). This changes the function defaults to ``None`` so that it can check if the user explicitly wants to use 1 and/or 0.
2. ``_ImageBaseHDU.scale`` will crash if ``option='old'`` and ``self._orig_bzero=None``. This checks if ``self._orig_bzero`` or ``self._orig_bscale`` is ``None`` and uses the appropriate default value.
3. This fixes a small bug (added in #5053) that inverts the logic of checking the header of a new fits file for the ``BSCALE`` keyword.