### PR TITLE
Allow string nan/inf in Quantity

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -267,29 +267,23 @@ class Quantity(np.ndarray):
                 # the second parts adds possible trailing .+-, which will break
                 # the float function below and ensure things like 1.2.3deg
                 # will not work.
-                v = re.match(r'\s*[+-]?((\d+\.?\d*)|(\.\d+))([eE][+-]?\d+)?'
-                             r'[.+-]?', value)
+                pattern = (r'\s*[+-]?'
+                           r'((\d+\.?\d*)|(\.\d+)|([nN][aA][nN])|'
+                           r'([iI][nN][fF]([iI][nN][iI][tT][yY]){0,1}))'
+                           r'([eE][+-]?\d+)?'
+                           r'[.+-]?')
+
+                v = re.match(pattern, value)
                 unit_string = None
                 try:
-                    try:
-                        # first try parsing with the regex pattern
-                        value = float(v.group())
-                        unit_string = v.string[v.end():].strip()
-                    except Exception:
-                        pass
-
-                    try:
-                        # If that fails, try naïve parsing the string as float.
-                        # This will catch string 'nan', 'inf'
-                        value = float(value)
-                    except Exception:
-                        raise
+                    value = float(v.group())
 
                 except Exception:
                     raise TypeError('Cannot parse "{0}" as a {1}. It does not '
                                     'start with a number.'
                                     .format(value, cls.__name__))
 
+                unit_string = v.string[v.end():].strip()
                 if unit_string:
                     value_unit = Unit(unit_string)
                     if unit is None:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -269,13 +269,27 @@ class Quantity(np.ndarray):
                 # will not work.
                 v = re.match(r'\s*[+-]?((\d+\.?\d*)|(\.\d+))([eE][+-]?\d+)?'
                              r'[.+-]?', value)
+                unit_string = None
                 try:
-                    value = float(v.group())
+                    try:
+                        # first try parsing with the regex pattern
+                        value = float(v.group())
+                        unit_string = v.string[v.end():].strip()
+                    except Exception:
+                        pass
+
+                    try:
+                        # If that fails, try naïve parsing the string as float.
+                        # This will catch string 'nan', 'inf'
+                        value = float(value)
+                    except Exception:
+                        raise
+
                 except Exception:
                     raise TypeError('Cannot parse "{0}" as a {1}. It does not '
                                     'start with a number.'
                                     .format(value, cls.__name__))
-                unit_string = v.string[v.end():].strip()
+
                 if unit_string:
                     value_unit = Unit(unit_string)
                     if unit is None:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -85,17 +85,27 @@ class TestQuantityCreation(object):
             q1 = u.Quantity(11.412, unit="testingggg")
 
     def test_nan_inf(self):
+        # Not-a-number
         q = u.Quantity('nan', unit='cm')
         assert np.isnan(q.value)
 
-        # TODO: this currently fails
-        # q = u.Quantity('nan cm')
-        # assert np.isnan(q.value)
+        q = u.Quantity('NaN', unit='cm')
+        assert np.isnan(q.value)
 
+        q = u.Quantity('-nan', unit='cm') # float() allows this
+        assert np.isnan(q.value)
+
+        q = u.Quantity('nan cm')
+        assert np.isnan(q.value)
+
+        # Infinity
         q = u.Quantity('inf', unit='cm')
         assert np.isinf(q.value)
 
         q = u.Quantity('-inf', unit='cm')
+        assert np.isinf(q.value)
+
+        q = u.Quantity('Infinity', unit='cm') # float() allows this
         assert np.isinf(q.value)
 
         # make sure these strings don't parse...

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -84,6 +84,29 @@ class TestQuantityCreation(object):
         with pytest.raises(ValueError):  # Until @mdboom fixes the errors in units
             q1 = u.Quantity(11.412, unit="testingggg")
 
+    def test_nan_inf(self):
+        q = u.Quantity('nan', unit='cm')
+        assert np.isnan(q.value)
+
+        # TODO: this currently fails
+        # q = u.Quantity('nan cm')
+        # assert np.isnan(q.value)
+
+        q = u.Quantity('inf', unit='cm')
+        assert np.isinf(q.value)
+
+        q = u.Quantity('-inf', unit='cm')
+        assert np.isinf(q.value)
+
+        with pytest.raises(TypeError):
+            q = u.Quantity('', unit='cm')
+
+        with pytest.raises(TypeError):
+            q = u.Quantity('spam', unit='cm')
+
+        with pytest.raises(TypeError):
+            q = u.Quantity('spam cm', unit='cm')
+
     def test_unit_property(self):
         # test getting and setting 'unit' attribute
         q1 = u.Quantity(11.4, unit=u.meter)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -97,6 +97,7 @@ class TestQuantityCreation(object):
 
         q = u.Quantity('nan cm')
         assert np.isnan(q.value)
+        assert q.unit == u.cm
 
         # Infinity
         q = u.Quantity('inf', unit='cm')
@@ -104,6 +105,10 @@ class TestQuantityCreation(object):
 
         q = u.Quantity('-inf', unit='cm')
         assert np.isinf(q.value)
+
+        q = u.Quantity('inf cm')
+        assert np.isinf(q.value)
+        assert q.unit == u.cm
 
         q = u.Quantity('Infinity', unit='cm') # float() allows this
         assert np.isinf(q.value)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -98,14 +98,12 @@ class TestQuantityCreation(object):
         q = u.Quantity('-inf', unit='cm')
         assert np.isinf(q.value)
 
+        # make sure these strings don't parse...
         with pytest.raises(TypeError):
             q = u.Quantity('', unit='cm')
 
         with pytest.raises(TypeError):
             q = u.Quantity('spam', unit='cm')
-
-        with pytest.raises(TypeError):
-            q = u.Quantity('spam cm', unit='cm')
 
     def test_unit_property(self):
         # test getting and setting 'unit' attribute


### PR DESCRIPTION
This is a possible fix for #5956 but I'm not sure I love it. 

If the input to `Quantity` is a string, it is currently matched against a regular expression to see if it can pull out a number. This adds a fallback to, if that fails, simply try passing the input into `float()`. This will allow passing in, e.g.:

```python
q = u.Quantity('nan', 'cm')
q = u.Quantity('inf', 'cm')
```

but right now, this doesn't work:

```python
q = u.Quantity('nan cm')
```