### PR TITLE
Minor grammatical fix in warning message in constants.py

### DIFF
--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -91,7 +91,7 @@ class Constant(Quantity):
         name_lower = name.lower()
         instances = Constant._registry.setdefault(name_lower, {})
         if system in instances:
-            warnings.warn('Constant {0!r} is already has a definition in the '
+            warnings.warn('Constant {0!r} already has a definition in the '
                           '{1!r} system'.format(name, system),
                           AstropyUserWarning)
         # By-pass Quantity initialization, since units may not yet be


### PR DESCRIPTION
Very minor edit.  This pull request removes an extra word that pops up in an error message that I ran into in the Constant class.  This pull request will also give me the novelty of being a net negative contributor to astropy!