### PR TITLE
Fixed small bug in biweight_midcovariance

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1042,7 +1042,7 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
 
     Returns
     -------
-    biweight_covariance : `~numpy.ndarray`
+    biweight_midcovariance : `~numpy.ndarray`
         Estimate of the covariance matrix of <a, a.T>
 
     Examples
@@ -1111,7 +1111,7 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     # return estimate of the covariance
     numerator_matrix = np.dot(numerator, numerator.T)
     denominator_matrix = np.dot(denominator, denominator.T)
-    nsqrt = np.sqrt(n.reshape(1,-1))
+    nsqrt = np.sqrt(n.reshape(1, -1))
     return nsqrt * (numerator_matrix / denominator_matrix) * nsqrt.T
 
 def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1109,8 +1109,10 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     denominator = (usub1 * usub5).sum(axis=1)[:, np.newaxis]
 
     # return estimate of the covariance
-    return n * (np.dot(numerator, numerator.T) /
-                np.dot(denominator, denominator.T))
+    numerator_matrix = np.dot(numerator, numerator.T)
+    denominator_matrix = np.dot(denominator, denominator.T)
+    nsqrt = np.sqrt(n.reshape(1,-1))
+    return nsqrt * (numerator_matrix / denominator_matrix) * nsqrt.T
 
 def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,
                             gain=1.0):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1099,7 +1099,8 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
 
     # now remove the outlier points
     mask = np.abs(u) < 1
-    n = mask.sum(axis=1)
+    maskf = np.array(mask, float)
+    n = np.inner(maskf,maskf)
     usub1 = (1 - u ** 2)
     usub5 = (1 - 5 * u ** 2)
     usub1[~mask] = 0.0
@@ -1111,8 +1112,7 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     # return estimate of the covariance
     numerator_matrix = np.dot(numerator, numerator.T)
     denominator_matrix = np.dot(denominator, denominator.T)
-    nsqrt = np.sqrt(n.reshape(1, -1))
-    return nsqrt * (numerator_matrix / denominator_matrix) * nsqrt.T
+    return n * (numerator_matrix / denominator_matrix)
 
 def signal_to_noise_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix,
                             gain=1.0):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1048,7 +1048,7 @@ def biweight_midcovariance(a, c=9.0, M=None, transpose=False):
     Examples
     --------
     Generate multivariate Gaussian with outliers and compute
-    numpy covariance and the biweight_covariance
+    the biweight_covariance
 
     >>> import numpy as np
     >>> from astropy.stats import biweight_midcovariance

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -256,6 +256,8 @@ def test_biweight_midcovariance():
     cov = funcs.biweight_midcovariance(d)
     std = np.around(np.sqrt(cov.diagonal()), 1)
     assert_allclose(std, [ 2.6,  2.1,  1.6,  1.5,  1.9])
+    # Test 3: Ensure matrix is symmetric
+    assert_allclose(cov, cov.T)
 
 def test_midcov_midvar():
     """

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -260,7 +260,7 @@ def test_biweight_midcovariance():
     rng = np.random.RandomState(1)
     d = np.array([rng.gamma(2, 2, 500) for i in range(3)])
     cov = funcs.biweight_midcovariance(d)
-    assert_allequal(cov, cov.T)
+    assert_equal(cov, cov.T)
 
 def test_midcov_midvar():
     """

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -258,7 +258,7 @@ def test_biweight_midcovariance():
     assert_allclose(std, [ 2.6,  2.1,  1.6,  1.5,  1.9])
     # Test 3: Ensure matrix is symmetric
     rng = np.random.RandomState(1)
-    d = np.array([rng.gamma(2,2,500) for i in range(3)])
+    d = np.array([rng.gamma(2, 2, 500) for i in range(3)])
     cov = funcs.biweight_midcovariance(d)
     assert_allequal(cov, cov.T)
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -257,7 +257,10 @@ def test_biweight_midcovariance():
     std = np.around(np.sqrt(cov.diagonal()), 1)
     assert_allclose(std, [ 2.6,  2.1,  1.6,  1.5,  1.9])
     # Test 3: Ensure matrix is symmetric
-    assert_allclose(cov, cov.T)
+    rng = np.random.RandomState(1)
+    d = np.array([rng.gamma(2,2,500) for i in range(3)])
+    cov = funcs.biweight_midcovariance(d)
+    assert_allequal(cov, cov.T)
 
 def test_midcov_midvar():
     """


### PR DESCRIPTION
I realized that biweight_midcovariance in the stats module was not returning symmetric covariance matrices due to a small bug. Its now fixed..