### PR TITLE
lightweight alternate implementation of compound models

### DIFF
--- a/astropy/modeling/altcompound.py
+++ b/astropy/modeling/altcompound.py
@@ -143,6 +143,7 @@ class _AltCompoundModel(object):
                 # or names for inputs.
                 self.n_inputs = left.n_inputs - len(right)
                 self.outputs = left.outputs
+                self.n_outputs = left.n_outputs
                 newinputs = list(left.inputs)                
                 keys = right.keys()
                 input_ind = []

--- a/astropy/modeling/altcompound.py
+++ b/astropy/modeling/altcompound.py
@@ -85,7 +85,6 @@ def _alt_model_oper(oper, **kwargs):
     This is an alternate version of compound models intended to use
     much less memory than the default.
     """
-    print("got request to do binary operation:", oper)
     return lambda left, right: _AltCompoundModel(oper, left, right, **kwargs)
 
 
@@ -256,19 +255,14 @@ class _AltCompoundModel(object):
                 kwargs = list(zip(kwind, kwval))
                 kwargs.sort()
                 kwindsorted, kwvalsorted = list(zip(*kwargs))
-                print(kwindsorted, kwvalsorted)
                 newargs = newargs + list(kwvalsorted)
             if subinds:
                 subargs = list(zip(subinds, subvals))
                 subargs.sort()
                 subindsorted, subvalsorted = list(zip(*subargs))
-                print(subindsorted, subvalsorted)
             # The substitutions must be inserted in order
             for ind, val in subargs:
                 newargs.insert(ind, val)
-            print(args)
-            print(newargs)
-            print(kw)
             return self.left(*newargs, **kw)
         else:
             raise ModelDefinitionError('unrecognized operator')

--- a/astropy/modeling/altcompound.py
+++ b/astropy/modeling/altcompound.py
@@ -5,12 +5,12 @@ from __future__ import division, print_function, absolute_import
 
 """
 This module provides an alternate implementation of compound models that
-is lighterweight than the default implementation. This is primarily done
+is lighter weight than the default implementation. This is primarily done
 to minimize the memory and construction time demands when compound models
 become very complex.
 
-The movtivation for this arose when JWST NIRSPEC compound models for its
-MOS mode were involving over 100 constituent model elements and on the
+The motivation for this arose when JWST NIRSPEC compound models for its
+MOS mode were involving nearly 100 constituent model elements and on the
 order of 300 parameters. Since the default compound model implementation
 maps parameters from the consistuent components (which themselves are often
 compound models), this led to many thousands of parameter instances since
@@ -26,7 +26,7 @@ complex and difficult to add, it adds clumsiness to the user interface
 (though admittedly, the alternate solution has its own clumsy aspect).
 So this led to a completely different approach that seems much simpler
 for certain use cases (it does forgo the ability to fit compound models
-for example, though adding such capability without impacting the 
+for example, though adding such capability without affecting the
 performance issues isn't out of the question in the following approach)
 
 This is an initial implementation that implements only very basic
@@ -59,9 +59,11 @@ Things not currently supported (but will be if adopted):
 
 - named access to constituent models (And thus their parameters)
 - good string representation and such
+- conversion to and from the default compound model scheme
 - pickling
 - possibly more efficient evaluation as done in the style of the current
   compound models (this implementation walks the tree every time)
+- support for units, when available
 - and other things I've overlooked at this moment...
 
 Things that will never be supported:
@@ -84,7 +86,7 @@ def _alt_model_oper(oper, **kwargs):
     return lambda left, right: _AltCompoundModel(oper, left, right, **kwargs)
 
 
-class _AltCompoundModel:
+class _AltCompoundModel(object):
     '''
     Lightweight compound model implementation: see altcompound.py documentation
     for details.

--- a/astropy/modeling/altcompound.py
+++ b/astropy/modeling/altcompound.py
@@ -1,0 +1,210 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import division, print_function, absolute_import
+
+
+"""
+This module provides an alternate implementation of compound models that
+is lighterweight than the default implementation. This is primarily done
+to minimize the memory and construction time demands when compound models
+become very complex.
+
+The movtivation for this arose when JWST NIRSPEC compound models for its
+MOS mode were involving over 100 constituent model elements and on the
+order of 300 parameters. Since the default compound model implementation
+maps parameters from the consistuent components (which themselves are often
+compound models), this led to many thousands of parameter instances since
+the total tends to go with the square of the number of model instances.
+This led to enormous memory usage and very long instantiation times.
+
+The current implementation is already very complex and relies heavily
+on metaclass tools making it difficult for mere mortals to understand
+and modify. In principle it is possible to optimize the current
+implementation but it is very hard to see how to avoid embedding operator
+expressions in strings to avoid the many instantiations. Besides being
+complex and difficult to add, it adds clumsiness to the user interface
+(though admittedly, the alternate solution has its own clumsy aspect).
+So this led to a completely different approach that seems much simpler
+for certain use cases (it does forgo the ability to fit compound models
+for example, though adding such capability without impacting the 
+performance issues isn't out of the question in the following approach)
+
+This is an initial implementation that implements only very basic
+functionality. Some of the functionality that the default implementation
+provides will never be provided by this implementation; other functionality
+is deferred depending on the experience in using this initial implementation.
+Note that this does not affect the underlying basic model classes at all.
+This model class does not inherit from the basic model class! (So some
+solution to making generic tests for models is needed)
+
+Using this alternate version of compound models requires calling a function
+in core to make this one the default. If this is used, *is is higly recommended
+that the mode be set back to the default at the end of the code constructing
+compound models so that other code depending on the default behavior is
+not affected!*
+
+As an example of how to do this:
+
+from astropy.modeling.core import set_compound_model
+prevcm = set_compound_model('lite')
+compound_model = Gaussian1D(1., 0.5, 0.1) + Gaussian1D(2, 0.7, 0.2)
+set_compound_model(prevcm) # the default model type is 'regular'
+
+Things currently supported:
+
+- evaluation
+- inverse evaluation (if possible or provided)
+
+Things not currently supported (but will be if adopted):
+
+- named access to constituent models (And thus their parameters)
+- good string representation and such
+- pickling
+- possibly more efficient evaluation as done in the style of the current
+  compound models (this implementation walks the tree every time)
+- and other things I've overlooked at this moment...
+
+Things that will never be supported:
+
+- Compound models of model classes (as opposed to instances)
+- Transparent and automatic mapping of parameters of constituent
+  models to the compound model level.
+- Fitting (the focus of this almost entirely on evaluation)
+"""
+
+
+import operator
+from .core import ModelDefinitionError
+
+def _alt_model_oper(oper, **kwargs):
+    """
+    This is an alternate version of compound models intended to use
+    much less memory than the default.
+    """
+    return lambda left, right: _AltCompoundModel(oper, left, right, **kwargs)
+
+
+class _AltCompoundModel:
+    '''
+    Lightweight compound model implementation: see altcompound.py documentation
+    for details.
+    '''
+
+    def __init__(self, op, left, right, name=None, inverse=None):
+        self.op = op
+        self.left = left
+        self.right = right
+        self._has_inverse = False # may be set to True in following code
+        if op in ['+', '-', '*', '/', '**']:
+            if (left.n_inputs != right.n_inputs) or \
+               (left.n_outputs != right.n_outputs):
+                raise ModelDefinitionError(
+                    'Both operands must match numbers of inputs and outputs')
+            else:
+                self.n_inputs = left.n_inputs
+                self.n_outputs = left.n_outputs
+        elif op == '&':
+            self.n_inputs = left.n_inputs + right.n_inputs
+            self.n_outputs = left.n_outputs + right.n_outputs
+            if inverse is None and self.both_inverses_exist():
+                self._has_inverse = True
+                self._inverse = _AltCompoundModel('&',
+                    self.left.inverse, self.right.inverse, inverse=self)
+        elif op == '|':
+            if left.n_outputs != right.n_inputs:
+                raise ModelDefinitionError(
+                    'left operand number of outputs must match right operand number of inputs')
+            self.n_inputs = left.n_inputs
+            self.n_outputs = right.n_outputs
+            if inverse is None and self.both_inverses_exist():
+                self._has_inverse = True
+                self._inverse = _AltCompoundModel('|',
+                    self.right.inverse, self.left.inverse, inverse=self)
+        else:
+            raise ModelDefinitionError('Illegal operator')
+        if inverse is not None:
+            self._inverse = inverse
+            self._has_inverse = True
+        self.name = name
+
+    def both_inverses_exist(self):
+        '''
+        if both members of this compound model have inverses return True
+        '''
+        try:
+            linv = self.left.inverse
+            rinv = self.right.inverse
+        except NotImplementedError:
+            return False
+        if isinstance(self.left, _AltCompoundModel):
+            if  not self.left.has_inverse():
+                return False
+        if isinstance(self.right, _AltCompoundModel):
+            if not self.right.has_inverse():
+                return False
+        return  True
+
+    def __call__(self, *args, **kw):
+        op = self.op
+        if op != '&':
+            leftval = self.left(*args, **kw)
+            if op != '|':
+                rightval = self.right(*args, **kw)
+
+        else:
+            leftval = self.left(*(args[:self.left.n_inputs]), **kw)
+            rightval = self.right(*(args[self.left.n_inputs:]), **kw)
+
+        if op == '+':
+            return binary_operation(operator.add, leftval, rightval)
+        elif op == '-':
+            return binary_operation(operator.sub, leftval, rightval)
+        elif op == '*':
+            return binary_operation(operator.mul, leftval, rightval)
+        elif op == '/':
+            return binary_operation(operator.truediv, leftval, rightval)
+        elif op == '**':
+            return binary_operation(operator.pow, leftval, rightval)
+        elif op == '&':
+            if not isinstance(leftval, tuple):
+                leftval = (leftval,)
+            if not isinstance(rightval, tuple):
+                rightval = (rightval,)
+            return leftval + rightval
+        elif op == '|':
+            if isinstance(leftval, tuple):
+                return self.right(*leftval, **kw)
+            else:
+                return self.right(leftval, **kw)
+        else:
+            raise ModelDefinitionError('unrecognized operator')
+
+    def has_inverse(self):
+        return self._has_inverse
+
+    @property
+    def inverse(self):
+        '''
+        '''
+        if self.has_inverse():
+            return self._inverse
+        else:
+            raise NotImplementedError("Inverse function not provided")
+
+    __add__ =     _alt_model_oper('+')
+    __sub__ =     _alt_model_oper('-')
+    __mul__ =     _alt_model_oper('*')
+    __truediv__ = _alt_model_oper('/')
+    __pow__ =     _alt_model_oper('**')
+    __or__ =      _alt_model_oper('|')
+    __and__ =     _alt_model_oper('&')
+
+
+def binary_operation(binoperator, left, right):
+    '''
+    Perform binary operation. Operands may be matching tuples of operands.
+    '''
+    if isinstance(left, tuple) and isinstance(right, tuple):
+        return tuple([binoperator(item[0], item[1]) for item in zip(left, right)])
+    else:
+        return binoperator(left, right)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -438,9 +438,10 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
     __sub__ = _model_oper('-')
     __mul__ = _model_oper('*')
     __truediv__ = _model_oper('/')
-    __pow__ = _model_oper('**')
-    __or__ = _model_oper('|')
-    __and__ = _model_oper('&')
+    __pow__ =     _model_oper('**')
+    __or__ =      _model_oper('|')
+    __and__ =     _model_oper('&')
+    __mod__ =     _model_oper('%')
 
     if six.PY2:
         # The classic __div__ operator need only be implemented for Python 2
@@ -810,9 +811,10 @@ class Model(object):
     __sub__ = _model_oper('-')
     __mul__ = _model_oper('*')
     __truediv__ = _model_oper('/')
-    __pow__ = _model_oper('**')
-    __or__ = _model_oper('|')
-    __and__ = _model_oper('&')
+    __pow__ =     _model_oper('**')
+    __or__ =      _model_oper('|')
+    __and__ =     _model_oper('&')
+    __mod__ =     _model_oper('%')
 
     if six.PY2:
         __div__ = _model_oper('/')

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -50,40 +50,11 @@ from .parameters import Parameter, InputParameterError, param_repr_oneline
 class ModelDefinitionError(TypeError):
     """Used for incorrect models definitions"""
 
-from .altcompound import _AltCompoundModel
-
 __all__ = ['Model', 'FittableModel', 'Fittable1DModel', 'Fittable2DModel',
            'custom_model', 'ModelDefinitionError','set_compound_model']
 
 # global variable for which Compound Model class to use
 COMPOUND = "regular" # alternative is "lite"
-
-# xxx todo: need to make this thread safe
-def set_compound_model(ctype="regular"):
-    '''
-    Allow setting of the global state of which compound model class 
-    to use in constructing expressions of models. 
-
-    The two permitted values are "regular" and "lite", the 
-    latter being less filling (of memory).
-
-    It returns the previous state as a convenience for restoring in
-    a subsequent call
-    '''
-    global COMPOUND
-    if ctype not in  ['regular', 'lite']:
-        raise ValueError("argument value must be 'regular' or 'lite'")
-    previous = COMPOUND
-    COMPOUND = ctype
-    return previous
-
-def _compound_operator(oper, left, right, **kwargs):
-    if COMPOUND == 'regular':
-        return _CompoundModelMeta._from_operator(oper, left, right, **kwargs)
-    else:
-        return _AltCompoundModel(oper, left, right, **kwargs)
-
-
 
 
 def _model_oper(oper, **kwargs):
@@ -3372,6 +3343,35 @@ def _validate_input_shapes(inputs, argnames, n_models, model_set_axis,
                 arg_a, shape_a, arg_b, shape_b))
 
     return input_broadcast
+
+from .altcompound import _AltCompoundModel
+
+# xxx todo: need to make this thread safe
+def set_compound_model(ctype="regular"):
+    '''
+    Allow setting of the global state of which compound model class 
+    to use in constructing expressions of models. 
+
+    The two permitted values are "regular" and "lite", the 
+    latter being less filling (of memory).
+
+    It returns the previous state as a convenience for restoring in
+    a subsequent call
+    '''
+    global COMPOUND
+    if ctype not in  ['regular', 'lite']:
+        raise ValueError("argument value must be 'regular' or 'lite'")
+    previous = COMPOUND
+    COMPOUND = ctype
+    return previous
+
+def _compound_operator(oper, left, right, **kwargs):
+    if COMPOUND == 'regular':
+        return _CompoundModelMeta._from_operator(oper, left, right, **kwargs)
+    else:
+        return _AltCompoundModel(oper, left, right, **kwargs)
+
+
 
 
 copyreg.pickle(_ModelMeta, _ModelMeta.__reduce__)

--- a/astropy/modeling/tests/test_altcompound.py
+++ b/astropy/modeling/tests/test_altcompound.py
@@ -1,0 +1,329 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import inspect
+from copy import deepcopy
+
+import numpy as np
+
+from numpy.testing.utils import (assert_allclose, assert_array_equal,
+                                 assert_almost_equal)
+
+from ...extern.six.moves import cPickle as pickle
+from ...tests.helper import pytest
+
+from ..core import Model, ModelDefinitionError, set_compound_model
+from ..parameters import Parameter
+from ..models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
+                      Gaussian2D, Polynomial1D, Polynomial2D,
+                      Chebyshev2D, Legendre2D, Chebyshev1D, Legendre1D,
+                      AffineTransformation2D, Identity, Mapping)
+from ..altcompound import _AltCompoundModel
+
+
+@pytest.mark.parametrize(('expr', 'result'),
+                         [(lambda x, y: x + y, [5.0, 5.0]),
+                          (lambda x, y: x - y, [-1.0, -1.0]),
+                          (lambda x, y: x * y, [6.0, 6.0]),
+                          (lambda x, y: x / y, [2.0 / 3.0, 2.0 / 3.0]),
+                          (lambda x, y: x ** y, [8.0, 8.0])])
+def test_model_set(expr, result):
+    set_compound_model('lite')
+    s = expr(Const1D((2, 2), n_models=2), Const1D((3, 3), n_models=2))
+    out = s(0, model_set_axis=False)
+    set_compound_model('regular')
+    assert_array_equal(out, result)
+
+
+@pytest.mark.parametrize(('expr', 'result'),
+                         [(lambda x, y: x + y, [5.0, 5.0]),
+                          (lambda x, y: x - y, [-1.0, -1.0]),
+                          (lambda x, y: x * y, [6.0, 6.0]),
+                          (lambda x, y: x / y, [2.0 / 3.0, 2.0 / 3.0]),
+                          (lambda x, y: x ** y, [8.0, 8.0])])
+def test_model_set_raises_value_error(expr, result):
+    """Check that creating model sets with components whose _n_models are
+       different raise a value error
+    """
+    #set_compound_model('lite')
+    with pytest.raises(ValueError):
+        s = expr(Const1D((2, 2), n_models=2), Const1D(3, n_models=1))
+
+
+@pytest.mark.parametrize(('expr', 'result'),
+                         [(lambda x, y: x + y, 5.0),
+                          (lambda x, y: x - y, -1.0),
+                          (lambda x, y: x * y, 6.0),
+                          (lambda x, y: x / y, 2.0 / 3.0),
+                          (lambda x, y: x ** y, 8.0)])
+def test_two_model_instance_arithmetic_1d(expr, result):
+    """
+    Like test_two_model_class_arithmetic_1d, but creates a new model from two
+    model *instances* with fixed parameters.
+    """
+
+    set_compound_model('lite')
+    s = expr(Const1D(2), Const1D(3))
+
+    assert isinstance(s, _AltCompoundModel)
+    assert s.n_inputs == 1
+    assert s.n_outputs == 1
+
+    out = s(0)
+    assert out == result
+    assert isinstance(out, float)
+    set_compound_model('regular')
+
+
+def test_simple_two_model_compose_1d():
+    """
+    Shift and Scale are two of the simplest models to test model composition
+    with.
+    """
+
+    set_compound_model('lite')
+    S1 = Shift(2) | Scale(3)  # First shift then scale
+    assert isinstance(S1, _AltCompoundModel)
+    assert S1.n_inputs == 1
+    assert S1.n_outputs == 1
+    assert S1(1) == 9.0
+
+    S2 = Scale(2) | Shift(3)  # First scale then shift
+    assert isinstance(S2, _AltCompoundModel)
+    assert S2.n_inputs == 1
+    assert S2.n_outputs == 1
+    assert S2(1) == 5.0
+
+    set_compound_model('regular')
+    # Test with array inputs
+    assert_array_equal(S2([1, 2, 3]), [5.0, 7.0, 9.0])
+
+
+def test_simple_two_model_compose_2d():
+    """
+    A simple example consisting of two rotations.
+    """
+
+    set_compound_model('lite')
+    r1 = Rotation2D(45) | Rotation2D(45)
+    assert isinstance(r1, _AltCompoundModel)
+    assert r1.n_inputs == 2
+    assert r1.n_outputs == 2
+    assert_allclose(r1(0, 1), (-1, 0), atol=1e-10)
+
+    r2 = Rotation2D(90) | Rotation2D(90)  # Rotate twice by 90 degrees
+    assert_allclose(r2(0, 1), (0, -1), atol=1e-10)
+
+    # Compose R with itself to produce 4 rotations
+    r3 = r1 | r1
+
+    set_compound_model('regular')
+    assert_allclose(r3(0, 1), (0, -1), atol=1e-10)
+
+def xtest_n_submodels():
+    """
+    Test that CompoundModel.n_submodels properly returns the number
+    of components.
+    """
+    set_compound_model('lite')
+    g2 = Gaussian1D() + Gaussian1D()
+    assert g2.n_submodels() == 2
+
+    g3 = g2 + Gaussian1D()
+    assert g3.n_submodels() == 3
+
+    g5 = g3 | g2
+    assert g5.n_submodels() == 5
+
+    g7 = g5 / g2
+    assert g7.n_submodels() == 7
+
+    # make sure it works as class method
+    p = Polynomial1D + Polynomial1D
+
+    set_compound_model('regular')
+    assert p.n_submodels() == 2
+
+def xtest_expression_formatting():
+    """
+    Test that the expression strings from compound models are formatted
+    correctly.
+    """
+
+    set_compound_model('lite')
+    # For the purposes of this test it doesn't matter a great deal what
+    # model(s) are used in the expression, I don't think
+    G = Gaussian1D
+    G2 = Gaussian2D
+
+    M = G + G
+    assert M._format_expression() == '[0] + [1]'
+
+    M = G + G + G
+    assert M._format_expression() == '[0] + [1] + [2]'
+
+    M = G + G * G
+    assert M._format_expression() == '[0] + [1] * [2]'
+
+    M = G * G + G
+    assert M._format_expression() == '[0] * [1] + [2]'
+
+    M = G + G * G + G
+    assert M._format_expression() == '[0] + [1] * [2] + [3]'
+
+    M = (G + G) * (G + G)
+    assert M._format_expression() == '([0] + [1]) * ([2] + [3])'
+
+    # This example uses parentheses in the expression, but those won't be
+    # preserved in the expression formatting since they technically aren't
+    # necessary, and there's no way to know that they were originally
+    # parenthesized (short of some deep, and probably not worthwhile
+    # introspection)
+    M = (G * G) + (G * G)
+    assert M._format_expression() == '[0] * [1] + [2] * [3]'
+
+    M = G ** G
+    assert M._format_expression() == '[0] ** [1]'
+
+    M = G + G ** G
+    assert M._format_expression() == '[0] + [1] ** [2]'
+
+    M = (G + G) ** G
+    assert M._format_expression() == '([0] + [1]) ** [2]'
+
+    M = G + G | G
+    assert M._format_expression() == '[0] + [1] | [2]'
+
+    M = G + (G | G)
+    assert M._format_expression() == '[0] + ([1] | [2])'
+
+    M = G & G | G2
+    assert M._format_expression() == '[0] & [1] | [2]'
+
+    M = G & (G | G)
+    assert M._format_expression() == '[0] & ([1] | [2])'
+    set_compound_model('regular')
+
+
+
+def test_basic_compound_inverse():
+    """
+    Test basic inversion of compound models in the limited sense supported for
+    models made from compositions and joins only.
+    """
+
+    set_compound_model('lite')
+    t = (Shift(2) & Shift(3)) | (Scale(2) & Scale(3)) | Rotation2D(90)
+    set_compound_model('regular')
+    assert_allclose(t.inverse(*t(0, 1)), (0, 1))
+
+
+@pytest.mark.parametrize('model', [
+    Shift(0) + Shift(0) | Shift(0),
+    Shift(0) - Shift(0) | Shift(0),
+    Shift(0) * Shift(0) | Shift(0),
+    Shift(0) / Shift(0) | Shift(0),
+    Shift(0) ** Shift(0) | Shift(0),
+    Gaussian1D(1, 2, 3) | Gaussian1D(4, 5, 6)])
+def test_compound_unsupported_inverse(model):
+    """
+    Ensure inverses aren't supported in cases where it shouldn't be.
+    """
+
+    #set_compound_model('lite')
+    with pytest.raises(NotImplementedError):
+        model.inverse
+
+
+def test_mapping_basic_permutations():
+    """
+    Tests a couple basic examples of the Mapping model--specifically examples
+    that merely permute the outputs.
+    """
+
+    set_compound_model('lite')
+    x, y = Rotation2D(90)(1, 2)
+
+    rs = Rotation2D(90) | Mapping((1, 0))
+    x_prime, y_prime = rs(1, 2)
+    assert_allclose((x, y), (y_prime, x_prime))
+
+    # A more complicated permutation
+    m = Rotation2D(90) & Scale(2)
+    x, y, z = m(1, 2, 3)
+
+    ms = m | Mapping((2, 0, 1))
+    x_prime, y_prime, z_prime = ms(1, 2, 3)
+    set_compound_model('regular')
+    assert_allclose((x, y, z), (y_prime, z_prime, x_prime))
+
+
+def test_mapping_inverse():
+    """Tests inverting a compound model that includes a `Mapping`."""
+
+    set_compound_model('lite')
+    rs1 = Rotation2D(12.1) & Scale(13.2)
+    rs2 = Rotation2D(14.3) & Scale(15.4)
+
+    # Rotates 2 of the coordinates and scales the third--then rotates on a
+    # different axis and scales on the axis of rotation.  No physical meaning
+    # here just a simple test
+    m = rs1 | Mapping([2, 0, 1]) | rs2
+
+    set_compound_model('regular')
+    assert_allclose((0, 1, 2), m.inverse(*m(0, 1, 2)), atol=1e-08)
+
+
+def test_identity_input():
+    """
+    Test a case where an Identity (or Mapping) model is the first in a chain
+    of composite models and thus is responsible for handling input broadcasting
+    properly.
+
+    Regression test for https://github.com/astropy/astropy/pull/3362
+    """
+
+    set_compound_model('lite')
+    ident1 = Identity(1)
+    shift = Shift(1)
+    rotation = Rotation2D(angle=90)
+    model = ident1 & shift | rotation
+    assert_allclose(model(1, 2), [-3.0, 1.0])
+
+    set_compound_model('regular')
+
+
+def test_invalid_operands():
+    """
+    Test that certain operators do not work with models whose inputs/outputs do
+    not match up correctly.
+    """
+
+    set_compound_model('lite')
+    with pytest.raises(ModelDefinitionError):
+        Rotation2D(90) | Gaussian1D(1, 0, 0.1)
+
+    with pytest.raises(ModelDefinitionError):
+        Rotation2D(90) + Gaussian1D(1, 0, 0.1)
+    set_compound_model('regular')
+
+@pytest.mark.parametrize('poly', [Chebyshev2D(1, 2), Polynomial2D(2), Legendre2D(1, 2),
+                                  Chebyshev1D(5), Legendre1D(5), Polynomial1D(5)])
+def test_compound_with_polynomials(poly):
+    """
+    Tests that polynomials are scaled when used in compound models.
+    Issue #3699
+    """
+    set_compound_model('lite')
+    poly.parameters = [1, 2, 3, 4, 1, 2]
+    shift = Shift(3)
+    model = poly | shift
+    x, y = np.mgrid[:20, :37]
+    result_compound = model(x, y)
+    result = shift(poly(x, y))
+    set_compound_model('regular')
+    assert_allclose(result, result_compound)
+
+

--- a/astropy/modeling/tests/test_altcompound.py
+++ b/astropy/modeling/tests/test_altcompound.py
@@ -294,7 +294,6 @@ def test_identity_input():
 
     set_compound_model('regular')
 
-
 def test_invalid_operands():
     """
     Test that certain operators do not work with models whose inputs/outputs do
@@ -323,7 +322,23 @@ def test_compound_with_polynomials(poly):
     x, y = np.mgrid[:20, :37]
     result_compound = model(x, y)
     result = shift(poly(x, y))
-    set_compound_model('regular')
     assert_allclose(result, result_compound)
+    set_compound_model('regular')
 
 
+def test_variable_substitution():
+    set_compound_model('lite')
+    g1 = Gaussian2D(1, 0, 0, 1, 2)
+    g2 = Gaussian2D(1.5, .5, -.2, .5, .3)
+    sg1_1 = g1 % {1: 0}
+    assert_almost_equal(sg1_1(0), g1(0, 0))
+    sg1_2 = g1 % {'x': 1}
+    assert_almost_equal(sg1_2(1.5), g1(1, 1.5))
+    gg1 = g1 & g2
+    sgg1_1 = gg1 % {1: 0.1, 3: 0.2}
+    assert_almost_equal(sgg1_1(0, 0), gg1(0, 0.1, 0, 0.2))
+    sgg1_2 = gg1 % {'x0': -.1, 2: .1}
+    assert_almost_equal(sgg1_2(1,1), gg1(-0.1, 1, 0.1, 1))
+    with pytest.raises(ValueError):
+        egg1 = gg1 % {'x0': 0, 0: 0}
+    set_compound_model('regular')


### PR DESCRIPTION
This module provides an alternate implementation of compound models that
is lighter weight than the default implementation. This is primarily done
to minimize the memory and construction time demands when compound models
become very complex.

The motivation for this arose when JWST NIRSPEC compound models for its
MOS mode were involving almost 100 constituent model elements and on the
order of 300 parameters. Since the default compound model implementation
maps parameters from the consituent components (which themselves are often
compound models), this led to many thousands of parameter instances since`
the total tends to go with the square of the number of model instances.
This led to enormous memory usage and very long instantiation times.
(issue #5985)

The current implementation is already very complex and relies heavily
on metaclass tools making it difficult for many  #developers to understand
and modify. In principle it is possible to optimize the current
implementation but it is very hard to see how to avoid embedding operator
expressions in strings to avoid the many instantiations. Besides being
complex and difficult to add, it adds clumsiness to the user interface
(though admittedly, the alternate solution has its own clumsy aspect).
So this led to a completely different approach that seems much simpler
for certain use cases (it does forgo the ability to fit compound models
for example, though adding such capability without affecting the
performance issues isn't out of the question in the following approach)

This is an initial implementation that implements only very basic
functionality. Some of the functionality that the default implementation
provides will never be provided by this implementation; other functionality
is deferred depending on the experience in using this initial implementation.
Note that this does not affect the underlying basic model classes at all.
This model class does not inherit from the basic model class! (So some
solution to making generic tests for models is needed)

Using this alternate version of compound models requires calling a function
in core to make this one the default. If this is used, **is is highly recommended
that the mode be set back to the default at the end of the code constructing
compound models so that other code depending on the default behavior is
not affected!**

As an example of how to do this:
```python
from astropy.modeling.core import set_compound_model
prevcm = set_compound_model('lite')
compound_model = Gaussian1D(1., 0.5, 0.1) + Gaussian1D(2, 0.7, 0.2)
set_compound_model(prevcm) # the default model type is 'regular'
 ```
Things currently supported:

- evaluation
- inverse evaluation (if possible or provided)

Things not currently supported (but will be if adopted):

- named access to constituent models (And thus their parameters)
- good string representation and such
- conversion to and from the default compound model scheme
- pickling
- possibly more efficient evaluation as done in the style of the current
  compound models (this implementation walks the tree every time)
- and other things I've overlooked at this moment...

Things that will never be supported:

- Compound models of model classes (as opposed to instances)
- Transparent and automatic mapping of parameters of constituent
  models to the compound model level.
- Fitting (the focus of this almost entirely on evaluation)