### PR TITLE
Note on updating the astropy conda channel for affiliated packages

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -631,6 +631,12 @@ by ``CHANGES.md`` in the instructions.
    then go to the project settings, and under **Versions** you should see the
    tag you just pushed. Select the tag to activate it, and save.
 
+#. If your affiliated package is available in the `astropy conda channel
+   <https://github.com/astropy/conda-channel-astropy>`_, you should also submit
+   a pull request to update the version number of your affiliated package. See the
+   `conda-channel-astropy README <https://github.com/astropy/conda-channel-astropy/>`_
+   for details.
+
 .. note:: The instructions above assume that you do not make use of bug fix
           branches in your workflow. If you do wish to create a bug fix branch,
           we recommend that you read over the more complete astropy


### PR DESCRIPTION
I was releasing a new version of astroplan this week, and noticed that there aren't instructions in the [astropy docs on releasing affiliated packages](http://docs.astropy.org/en/stable/development/affiliated-packages.html) on how to update the package version number in the conda channel. 

In this PR, I add one extra step to the `Releasing an affiliated package` section of the docs, directing readers to the astropy/conda-channel-astropy README for details on how to update the package version in the conda channel. At the very least, this will ensure that I don't bother @mwcraig and @bsipocz for that again 😄 