### PR TITLE
POC: read FITS table without decoding/converting bytes [skip ci]

### DIFF
--- a/astropy/io/fits/py3compat.py
+++ b/astropy/io/fits/py3compat.py
@@ -3,6 +3,8 @@
 from ...extern import six
 from ...utils.compat.numpycompat import NUMPY_LT_1_10
 
+DECODE_BYTES = True
+
 if not six.PY2:
     # Stuff to do if Python 3
 
@@ -26,6 +28,13 @@ if not six.PY2:
     util.encode_ascii = encode_ascii
 
     def decode_ascii(s):
+        # Hook from connect.read_table_fits to allow reading table without
+        # decoding 'S'-type strings and converting to unicode 'U'-type.
+        # This just replicates the pass-through Python-2 version in util.py.
+        print(DECODE_BYTES)
+        if not DECODE_BYTES:
+            return s
+
         if isinstance(s, bytes):
             return s.decode('ascii')
         elif (isinstance(s, numpy.ndarray) and


### PR DESCRIPTION
This is a very quick POC for adding an option when reading a FITS table to not decode and convert bytes ('S'-type) to ASCII unicode ('U'-type).  This is currently always done in Py3 and thus one suffers the factor of 4 increase in memory use.

Not clear if this is a good idea, just throwing it out there for consideration.  This will only be useful after #5700 goes in.

@mhvk @saimn @embray @astrofrog 