### PR TITLE
Extending the add_column(s) API by adding a ``name(s)`` parameter #5911

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ New Features
 
   - Added functionality to allow ``astropy.units.Quantity`` to be written 
     as a normal column to FITS files. [#5910]
+
   - Added ``name`` paramater to method ``add_column`` and ``names`` parameter to method
     ``add_columns`` in module ``astropy.table.table``, to provide the flexibility to add
     unnamed columns, mixin objects and also to specify explicit names. Default names will

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,10 @@ New Features
 
   - Added functionality to allow ``astropy.units.Quantity`` to be written 
     as a normal column to FITS files. [#5910]
+  - Added ``name`` paramater to method ``add_column`` and ``names`` parameter to method
+    ``add_columns`` in module ``astropy.table.table``, to provide the flexibility to add
+    unnamed columns, mixin objects and also to specify explicit names. Default names will
+    be used if not specified. [#]
 
 - ``astropy.time``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,11 +70,6 @@ New Features
   - Added functionality to allow ``astropy.units.Quantity`` to be written 
     as a normal column to FITS files. [#5910]
 
-  - Added ``name`` paramater to method ``add_column`` and ``names`` parameter to method
-    ``add_columns`` in module ``astropy.table.table``, to provide the flexibility to add
-    unnamed columns, mixin objects and also to specify explicit names. Default names will
-    be used if not specified. [#]
-
 - ``astropy.time``
 
 - ``astropy.units``
@@ -139,6 +134,11 @@ API Changes
 
   - Removed the deprecated functions ``join``, ``hstack``, ``vstack`` and
     ``get_groups`` from np_utils. [#5729]
+
+  - Added ``name`` paramater to method `~astropy.table.Table.add_column` and ``names``
+    parameter to method `~astropy.table.Table.add_columns`, to provide the flexibility to
+    add unnamed columns, mixin objects and also to specify explicit names. Default names
+    will be used if not specified. [#5996]
 
 - ``astropy.time``
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1566,14 +1566,14 @@ class Table(object):
               1 0.1  1.0
               2 0.2  2.0
               3 0.3  3.0
-        
+
         Add a column or mixin object at the end of the table and specify a different name::
 
             >>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
             >>> col_b = Column(name='b', data=[1.1, 1.2, 1.3])
             >>> t.add_column(col_b, name='c')
             >>> print(t)
-             a   b   c 
+             a   b   c
             --- --- ---
               1 0.1 1.1
               2 0.2 1.2
@@ -1661,7 +1661,7 @@ class Table(object):
               1 0.1 1.1  x
               2 0.2 1.2  y
               3 0.3 1.3  z
-              
+
         Add unnamed columns or mixin objects at the end of the table using default names::
             >>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
             >>> col_c = Column(data=['x', 'y', 'z'])
@@ -1692,7 +1692,7 @@ class Table(object):
             >>> col_c = Column(name='c', data=['x', 'y', 'z'])
             >>> t.add_columns([col_b, col_c], names=['c', 'd'])
             >>> print(t)
-             a   b   c   d 
+             a   b   c   d
             --- --- --- ---
               1 0.1 1.1   x
               2 0.2 1.2   y

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1546,26 +1546,26 @@ class Table(object):
         Add an unnamed column or mixin object at the end of the table using a default name::
 
             >>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
-            >>> col_time = Time([1, 2, 3], format='cxcsec')
-            >>> t.add_column(col_time)
+            >>> col_c = Column(data=['x', 'y', 'z'])
+            >>> t.add_column(col_c)
             >>> print(t)
              a   b   2
             --- --- ---
-              1 0.1 1.0
-              2 0.2 2.0
-              3 0.3 3.0
+              1 0.1   x
+              2 0.2   y
+              3 0.3   z
 
         Add an unnamed column or mixin object at the end of the table by specifying an explicit name::
 
             >>> t = Table([[1, 2, 3], [0.1, 0.2, 0.3]], names=('a', 'b'))
-            >>> col_time = Time([1, 2, 3], format='cxcsec')
-            >>> t.add_column(col_time, name='Time')
+            >>> col_c = Column(data=['x', 'y', 'z'])
+            >>> t.add_column(col_c, name='c')
             >>> print(t)
-              a   b  Time
-            --- --- ----
-              1 0.1  1.0
-              2 0.2  2.0
-              3 0.3  3.0
+              a   b  c
+            --- --- ---
+              1 0.1   x
+              2 0.2   y
+              3 0.3   z
 
         Add a column or mixin object at the end of the table and specify a different name::
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1715,7 +1715,7 @@ class Table(object):
                 i = new_indexes.index(index)
                 new_indexes.insert(i, None)
                 newcols.insert(i, col)
-                
+
         if names is None:
             names = ['col{}'.format(name) for name in range(len(self.columns), len(self.columns) + len(cols))]
             for col, name in zip(cols, names):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -429,34 +429,35 @@ class TestAddPosition(SetupData):
 @pytest.mark.usefixtures('table_types')
 class TestAddName(SetupData):
 
-    def test_1(self, table_types):
+    def test_override_name(self, table_types):
         self._setup(table_types)
         t = table_types.Table()
+
+        # Check that we can override the name of the input column in the Table
         t.add_column(self.a, name='b')
         t.add_column(self.b, name='a')
         assert t.columns.keys() == ['b', 'a']
+        # Check that we did not change the name of the input column
         assert self.a.info.name == 'a'
         assert self.b.info.name == 'b'
 
-    def test_2(self, table_types):
-        self._setup(table_types)
-        t1 = table_types.Table([self.a])
+        # Now test with an input column from another table
         t2 = table_types.Table()
-        t2.add_column(t1['a'], name='b')
-        assert t2.columns.keys() == ['b']
-        assert t1.columns.keys() == ['a']
+        t2.add_column(t['a'], name='c')
+        assert t2.columns.keys() == ['c']
+        # Check that we did not change the name of the input column
+        assert t.columns.keys() == ['b', 'a']
 
-    def test_3(self, table_types):
+        # Check that we can give a name if none was present
+        col = table_types.Column([1,2,3])
+        t.add_column(col, name='c')
+        assert t.columns.keys() == ['b', 'a', 'c']
+
+    def test_default_name(self, table_types):
         t = table_types.Table()
         col = table_types.Column([1,2,3])
         t.add_column(col)
         assert t.columns.keys() == ['col0']
-
-    def test_4(self, table_types):
-        t = table_types.Table()
-        col = table_types.Column([1,2,3])
-        t.add_column(col, name='a')
-        assert t.columns.keys() == ['a']
 
 
 @pytest.mark.usefixtures('table_types')
@@ -530,12 +531,14 @@ class TestAddColumns(SetupData):
         assert t.colnames == ['a', 'b', 'c', 'd']
 
     def test_add_columns6(self, table_types):
+        """Check that we can override column names."""
         self._setup(table_types)
         t = table_types.Table()
         t.add_columns([self.a, self.b, self.c], names=['b', 'c', 'a'])
         assert t.colnames == ['b', 'c', 'a']
 
     def test_add_columns7(self, table_types):
+        """Check that default names are used when appropriate."""
         t = table_types.Table()
         col0 = table_types.Column([1,2,3])
         col1 = table_types.Column([4,5,3])

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -427,6 +427,39 @@ class TestAddPosition(SetupData):
 
 
 @pytest.mark.usefixtures('table_types')
+class TestAddName(SetupData):
+
+    def test_1(self, table_types):
+        self._setup(table_types)
+        t = table_types.Table()
+        t.add_column(self.a, name='b')
+        t.add_column(self.b, name='a')
+        assert t.columns.keys() == ['b', 'a']
+        assert self.a.info.name == 'a'
+        assert self.b.info.name == 'b'
+
+    def test_2(self, table_types):
+        self._setup(table_types)
+        t1 = table_types.Table([self.a])
+        t2 = table_types.Table()
+        t2.add_column(t1['a'], name='b')
+        assert t2.columns.keys() == ['b']
+        assert t1.columns.keys() == ['a']
+
+    def test_3(self, table_types):
+        t = table_types.Table()
+        col = table_types.Column([1,2,3])
+        t.add_column(col)
+        assert t.columns.keys() == ['col0']
+
+    def test_4(self, table_types):
+        t = table_types.Table()
+        col = table_types.Column([1,2,3])
+        t.add_column(col, name='a')
+        assert t.columns.keys() == ['a']
+
+
+@pytest.mark.usefixtures('table_types')
 class TestInitFromTable(SetupData):
 
     def test_from_table_cols(self, table_types):
@@ -495,6 +528,19 @@ class TestAddColumns(SetupData):
         t = table_types.Table([self.a, self.b])
         t.add_columns([self.c, self.d], indexes=[2, 2])
         assert t.colnames == ['a', 'b', 'c', 'd']
+
+    def test_add_columns6(self, table_types):
+        self._setup(table_types)
+        t = table_types.Table()
+        t.add_columns([self.a, self.b, self.c], names=['b', 'c', 'a'])
+        assert t.colnames == ['b', 'c', 'a']
+
+    def test_add_columns7(self, table_types):
+        t = table_types.Table()
+        col0 = table_types.Column([1,2,3])
+        col1 = table_types.Column([4,5,3])
+        t.add_columns([col0, col1])
+        assert t.colnames == ['col0', 'col1']
 
     def test_add_duplicate_column(self, table_types):
         self._setup(table_types)

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -76,11 +76,13 @@ of the correct size, or a scalar value that will be broadcast::
 For more explicit control the :meth:`~astropy.table.Table.add_column` and
 :meth:`~astropy.table.Table.add_columns` methods can be used to add one or multiple
 columns to a table.  In both cases the new columns must be specified as |Column| or
-|MaskedColumn| objects with the ``name`` defined::
+|MaskedColumn| objects::
 
   >>> from astropy.table import Column
   >>> aa = Column(np.arange(5), name='aa')
   >>> t.add_column(aa, index=0)  # Insert before the first table column
+  >>> bb = Column(np.arange(5))
+  >>> t.add_column(bb, name='bb')  # Append unnamed column to the table with 'bb' as name
 
   # Make a new table with the same number of rows and add columns to original table
   >>> t2 = Table(np.arange(25).reshape(5, 5), names=('e', 'f', 'g', 'h', 'i'))


### PR DESCRIPTION
This solves the issue of adding unnamed columns, mixin objects to Table. User can add an unnamed column(s), mixin object(s) which will be assigned a default name(s) or an explicit name(s) which is given using the parameter ``name(s)``. User can also specify a different name for a column in the Table.

Please do review it. I'll make changes in the docs and write separate tests soon.