### PR TITLE
Fix Sphinx build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.3 pillow --no-deps jplephem'
+               PIP_DEPENDENCIES='sphinx-gallery>=0.1.9 pillow --no-deps jplephem'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,7 +226,7 @@ try:
     extensions += ["sphinx_gallery.gen_gallery"]
 
     sphinx_gallery_conf = {
-        'mod_example_dir': 'generated/modules', # path to store the module using example template
+        'backreferences_dir': 'generated/modules', # path to store the module using example template
         'filename_pattern': '^((?!skip_).)*$', # execute all examples except those that start with "skip_"
         'examples_dirs': '..{}examples'.format(os.sep), # path to the examples scripts
         'gallery_dirs': 'generated/examples', # path to save gallery generated examples


### PR DESCRIPTION
Fix #5992 . Also attempts to get rid of `RuntimeWarning` as requested in https://github.com/astropy/astropy/issues/5992#issuecomment-298090201 .

Was going to add something for #5994 here but perhaps that is no longer necessary since remote data server seems to be responsive again.