### PR TITLE
Support positive ufunc (new in numpy 1.13).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -269,6 +269,8 @@ Bug Fixes
 
 - ``astropy.units``
 
+  - Add support for ``positive`` ufunc (new in numpy 1.13). [#5998]
+
 - ``astropy.utils``
 
   - On systems that do not have ``pkg_resources`` non-numerical additions to

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -72,6 +72,9 @@ UFUNC_HELPERS[np.rint] = helper_invariant
 UFUNC_HELPERS[np.floor] = helper_invariant
 UFUNC_HELPERS[np.ceil] = helper_invariant
 UFUNC_HELPERS[np.trunc] = helper_invariant
+# positive only was added in numpy 1.13
+if isinstance(getattr(np, 'positive', None), np.ufunc):
+    UFUNC_HELPERS[np.positive] = helper_invariant
 
 # ufuncs handled as special cases
 

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -472,10 +472,12 @@ class TestQuantityMathFuncs(object):
 
 class TestInvariantUfuncs(object):
 
+    # np.positive was only added in numpy 1.13.
     @pytest.mark.parametrize(('ufunc'), [np.absolute, np.fabs,
                                          np.conj, np.conjugate,
                                          np.negative, np.spacing, np.rint,
-                                         np.floor, np.ceil])
+                                         np.floor, np.ceil] +
+                             [np.positive] if hasattr(np, 'positive') else [])
     def test_invariant_scalar(self, ufunc):
 
         q_i = 4.7 * u.m


### PR DESCRIPTION
The title says it all.

EDIT: the travis failure for sphinx is unrelated.