### PR TITLE
[EXP] Increase default remote timeout 

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -54,7 +54,7 @@ class Conf(_config.ConfigNamespace):
         'http://data.astropy.org/',
         'URL for astropy remote data site.')
     remote_timeout = _config.ConfigItem(
-        3.,
+        10.,
         'Time to wait for remote data queries (in seconds).',
         aliases=['astropy.coordinates.name_resolve.name_resolve_timeout'])
     compute_hash_block_size = _config.ConfigItem(


### PR DESCRIPTION
Increase default remote timeout to see if that helps with remote tests being flaky. This was part of #5997 but then taken out.

Related discussion: #5994 

c/c @mhvk @bsipocz 

TODO:
- [x] Add milestone.
- [x] Add change log. (Not needed.)