### PR TITLE
Fix wcsaxes warnings in Sphinx build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -226,6 +226,8 @@ Bug Fixes
 
 - ``astropy.visualization``
 
+  - Fix ``RuntimeWarning`` when ``wcsaxes`` tick labels are invalid. [#6002]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``
@@ -239,9 +241,9 @@ Other Changes and Additions
 
 - Python 3.3 is no longer suppored. [#6020]
 
-- The bundled version of pytest has now been removed, but the 
-  astropy.tests.helper.pytest import will continue to work properly. 
-  Affiliated packages should nevertheless transition to importing pytest 
+- The bundled version of pytest has now been removed, but the
+  astropy.tests.helper.pytest import will continue to work properly.
+  Affiliated packages should nevertheless transition to importing pytest
   directly rather than from astropy.tests.helper. This also means that
   pytest is now a formal requirement for testing for both Astropy and
   for affiliated packages. [#5694]

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -180,6 +180,10 @@ class TickLabels(Text):
 
                     dist = np.hypot(dx, dy)
 
+                    # Avoid RuntimeWarning
+                    if dist == 0 or not np.isfinite(dist):
+                        dist = 1.0  # Is this a reasonable estimate?
+
                     ddx = dx / dist
                     ddy = dy / dist
 
@@ -196,7 +200,8 @@ class TickLabels(Text):
                 # that has a key starting bit such as -0:30 where the -0
                 # might be dropped from all other labels.
 
-                if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
+                if (not self._exclude_overlapping or
+                        bb.count_overlaps(bboxes) == 0):
                     super(TickLabels, self).draw(renderer)
                     bboxes.append(bb)
                     ticklabels_bbox.append(bb)


### PR DESCRIPTION
This removes `RuntimeWarning` from `wcsaxes` in Sphinx build test log. This was part of #5997 but then taken out here. Also see https://github.com/astropy/astropy/issues/5992#issuecomment-298090201.

@astrofrog I don't know how to add regression test to visualization code, so I am making it raise an exception instead and then see what value is causing the warning in the first place. Maybe this will give us a clue on the proper fix.

TODO:
- [x] Add milestone.
- [x] Do we need change log for this?