### PR TITLE
Dropping numpy 1.7 and 1.8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,12 @@ matrix:
 
     include:
 
-        # Try MacOS X
+        # Try MacOS X. Test Python 3.5 here, until we drop 3.3
         - os: osx
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem'
+               PYTHON_VERSION=3.5
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -67,16 +68,10 @@ matrix:
         # Numpy 1.10 is tested below in the image tests.
 
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.9
                SETUP_CMD='test --open-files'
         - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.


### PR DESCRIPTION
This PR only drops the testing to get things working for https://github.com/astropy/astropy/pull/5819#issuecomment-299031911

Removal of np 1.7 and 1.8 workaround from the code should be done in a separate PR.