### PR TITLE
Drop numpy 1.7 and 1.8 from tests and code

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -5,7 +5,7 @@ docker info
 cat << EOF | docker run -i \
                         -v ${PWD}:/astropy_src \
                         -a stdin -a stdout -a stderr \
-                        astropy/astropy-32bit-test-env:1.7 \
+                        astropy/astropy-32bit-test-env:1.9 \
                         bash || exit $?
 
 cd /astropy_src

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,12 @@ matrix:
 
     include:
 
-        # Try MacOS X
+        # Try MacOS X. Test Python 3.5 here, until we drop 3.3
         - os: osx
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem'
+               PYTHON_VERSION=3.5
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -67,16 +68,10 @@ matrix:
         # Numpy 1.10 is tested below in the image tests.
 
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.9
                SETUP_CMD='test --open-files'
         - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               SETUP_CMD='test --open-files'
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -229,8 +229,7 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
-
+- Numpy 1.7 and 1.8 are no longer supported. [#6006]
 
 1.3.3 (unreleased)
 ------------------

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -76,7 +76,7 @@ except ImportError:
     __githash__ = ''
 
 
-__minimum_numpy_version__ = '1.7.0'
+__minimum_numpy_version__ = '1.9.0'
 
 
 # The location of the online documentation for astropy

--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -36,7 +36,6 @@ from __future__ import absolute_import, division, print_function
 
 import warnings
 
-from ..utils.compat import NUMPY_LT_1_8
 from ..utils.exceptions import AstropyUserWarning
 
 import numpy
@@ -193,16 +192,6 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
 
     {%- if func.args_by_inout('in|inout') %}
     make_outputs_scalar = False
-    if NUMPY_LT_1_8:
-        # in numpy < 1.8, the iterator used below doesn't work with 0d/scalar arrays
-        # so we replace all scalars with 1d arrays
-        make_outputs_scalar = True
-        {%- for arg in func.args_by_inout('in|inout') %}
-        if {{ arg.name_in_broadcast }}.shape == tuple():
-            {{ arg.name }}_in = {{ arg.name }}_in.reshape((1,) + {{ arg.name }}_in.shape)
-        else:
-            make_outputs_scalar = False
-        {%- endfor %}
     {%- endif %}
 
     #Create the output array, based on the broadcasted shape, adding the generated dimensions if needed

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -19,7 +19,7 @@ from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from ..extern import six
 from ..utils import ShapedLikeNDArray, classproperty
-from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
+from ..utils.compat import NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays
 
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
@@ -522,9 +522,6 @@ class CartesianRepresentation(BaseRepresentation):
         x = self._x
         y = cls(self._y, x.unit, copy=False)
         z = cls(self._z, x.unit, copy=False)
-        if NUMPY_LT_1_8:
-            # numpy 1.7 has problems concatenating broadcasted arrays.
-            x, y, z =  [(c.copy() if 0 in c.strides else c) for c in (x, y, z)]
 
         sh = self.shape
         sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -6,7 +6,6 @@ import numpy as np
 from ... import units as u
 from .. import SphericalRepresentation, Longitude, Latitude
 from ...tests.helper import pytest
-from ...utils.compat.numpycompat import NUMPY_LT_1_9
 from ...utils.compat.numpy import broadcast_to as np_broadcast_to
 
 
@@ -85,8 +84,7 @@ class TestManipulation():
         s0_diagonal = self.s0.diagonal()
         assert s0_diagonal.shape == (6,)
         assert np.all(s0_diagonal.lat == self.s0.lat.diagonal())
-        if not NUMPY_LT_1_9:
-            assert np.may_share_memory(s0_diagonal.lat, self.s0.lat)
+        assert np.may_share_memory(s0_diagonal.lat, self.s0.lat)
 
     def test_swapaxes(self):
         s1_swapaxes = self.s1.swapaxes(0, 1)

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -8,7 +8,6 @@ from .. import Longitude, Latitude, EarthLocation, SkyCoord
 # test on frame with most complicated frame attributes.
 from ..builtin_frames import ICRS, AltAz, GCRS
 from ...time import Time
-from ...utils.compat.numpycompat import NUMPY_LT_1_9
 
 
 class TestManipulation():
@@ -156,8 +155,7 @@ class TestManipulation():
         s0_diagonal = self.s0.diagonal()
         assert s0_diagonal.shape == (6,)
         assert np.all(s0_diagonal.data.lat == self.s0.data.lat.diagonal())
-        if not NUMPY_LT_1_9:
-            assert np.may_share_memory(s0_diagonal.data.lat, self.s0.data.lat)
+        assert np.may_share_memory(s0_diagonal.data.lat, self.s0.data.lat)
 
     def test_swapaxes(self):
         s1_swapaxes = self.s1.swapaxes(0, 1)

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -32,7 +32,7 @@ from .. import funcs
 # of poisson_upper_limit
 # from ..funcs import scipy_poisson_upper_limit, mpmath_poisson_upper_limit
 
-from ...utils.compat import NUMPY_LT_1_10, NUMPY_LT_1_9  # pylint: disable=W0611
+from ...utils.compat import NUMPY_LT_1_10  # pylint: disable=W0611
 from ...utils.misc import NumpyRNGContext
 from ... import units as u
 
@@ -118,7 +118,6 @@ def test_median_absolute_deviation_nans():
     assert funcs.median_absolute_deviation(array) == 1
 
 
-@pytest.mark.skipif('NUMPY_LT_1_9')
 def test_median_absolute_deviation_multidim_axis():
     array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]
     assert_equal(funcs.median_absolute_deviation(array, axis=(1, 2)),

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -8,7 +8,7 @@ import collections
 import numpy as np
 
 from ..extern import six
-from ..utils.compat import NUMPY_LT_1_8
+
 
 class Row(object):
     """A class to represent one row of a Table object.
@@ -120,28 +120,7 @@ class Row(object):
 
             # Make np.void version of values, and then the final mvoid row
             row_vals = np.array([vals], dtype=self.dtype)[0]
-            try:
-                void_row = np.ma.mvoid(data=row_vals, mask=row_mask)
-            except ValueError as err:
-                # Another bug (or maybe same?) that is fixed in 1.8 prevents
-                # accessing a row in masked array if it has object-type members.
-                # >>> x = np.ma.empty(1, dtype=[('a', 'O')])
-                # >>> x['a'] = 1
-                # >>> x['a'].mask = True
-                # >>> x[0]
-                # ValueError: Setting void-array with object members using buffer. [numpy.ma.core]
-                #
-                # All we do here is re-raise with a more informative message
-                msg = six.text_type(err)
-                if ('Setting void-array with object members' in msg and
-                        NUMPY_LT_1_8):
-                    raise ValueError(
-                        'Cannot convert masked table row with Object type '
-                        'columns using as_void(), due to a bug in Numpy '
-                        '{0}.  Please upgrade to Numpy 1.8 or newer.'.format(
-                            np.__version__))
-                else:
-                    raise
+            void_row = np.ma.mvoid(data=row_vals, mask=row_mask)
         else:
             void_row = np.array([vals], dtype=self.dtype)[0]
         return void_row

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -10,7 +10,6 @@ from ...tests.helper import pytest, assert_follows_unicode_guidelines, catch_war
 from ... import table
 from ... import units as u
 from ...extern import six
-from ...utils.compat import NUMPY_LT_1_8
 
 
 class TestColumn():
@@ -473,16 +472,10 @@ def test_getitem_metadata_regression():
         assert subset.meta['c'] == 8
 
     # Metadata isn't copied for scalar values
-    if NUMPY_LT_1_8:
-        with pytest.raises(ValueError):
-            c.take(0)
-        with pytest.raises(ValueError):
-            np.take(c, 0)
-    else:
-        for subset in [c.take(0), np.take(c, 0)]:
-            assert subset == 1
-            assert subset.shape == ()
-            assert not isinstance(subset, table.Column)
+    for subset in [c.take(0), np.take(c, 0)]:
+        assert subset == 1
+        assert subset.shape == ()
+        assert not isinstance(subset, table.Column)
 
     c = table.MaskedColumn(data=[1,2,3], name='a', description='b', unit='m', format="%i", meta={'c': 8})
     for subset in [c.take([0, 1]), np.take(c, [0, 1])]:
@@ -493,16 +486,10 @@ def test_getitem_metadata_regression():
         assert subset.meta['c'] == 8
 
     # Metadata isn't copied for scalar values
-    if NUMPY_LT_1_8:
-        with pytest.raises(ValueError):
-            c.take(0)
-        with pytest.raises(ValueError):
-            np.take(c, 0)
-    else:
-        for subset in [c.take(0), np.take(c, 0)]:
-            assert subset == 1
-            assert subset.shape == ()
-            assert not isinstance(subset, table.MaskedColumn)
+    for subset in [c.take(0), np.take(c, 0)]:
+        assert subset == 1
+        assert subset.shape == ()
+        assert not isinstance(subset, table.MaskedColumn)
 
 
 def test_unicode_guidelines():

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -15,7 +15,6 @@ from ... import time
 from ... import coordinates
 from ... import table
 from ...utils.data_info import data_info_factory, dtype_info_name
-from ...utils.compat import NUMPY_LT_1_8
 from ..table_helpers import simple_table
 
 
@@ -157,12 +156,11 @@ def test_data_info():
 
         # Test stats info
         cinfo = c.info('stats', out=None)
-        is_nan = NUMPY_LT_1_8 and type(c) is table.Column
         assert cinfo == OrderedDict([('name', 'name'),
-                                     ('mean', 'nan' if is_nan else '1.5'),
-                                     ('std', 'nan' if is_nan else '0.5'),
-                                     ('min', 'nan' if is_nan else '1.0'),
-                                     ('max', 'nan' if is_nan else '2.0'),
+                                     ('mean', '1.5'),
+                                     ('std', '0.5'),
+                                     ('min', '1.0'),
+                                     ('max', '2.0'),
                                      ('n_bad', 1),
                                      ('length', 3)])
 

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -9,7 +9,6 @@ import numpy as np
 from ...tests.helper import pytest, catch_warnings
 from ... import table
 from ...table import Row
-from ...utils.compat import NUMPY_LT_1_8
 from ...utils.exceptions import AstropyDeprecationWarning
 from ...extern.six.moves import zip
 from .conftest import MaskedTable
@@ -21,18 +20,10 @@ def test_masked_row_with_object_col():
     a column with object type.
     """
     t = table.Table([[1]], dtype=['O'], masked=True)
-    if NUMPY_LT_1_8:
-        with pytest.raises(ValueError):
-            t['col0'].mask = False
-            t[0].as_void()
-        with pytest.raises(ValueError):
-            t['col0'].mask = True
-            t[0].as_void()
-    else:
-        t['col0'].mask = False
-        assert t[0]['col0'] == 1
-        t['col0'].mask = True
-        assert t[0]['col0'] is np.ma.masked
+    t['col0'].mask = False
+    assert t[0]['col0'] == 1
+    t['col0'].mask = True
+    assert t[0]['col0'] is np.ma.masked
 
 
 @pytest.mark.usefixtures('table_types')
@@ -203,14 +194,8 @@ class TestRow():
         t = table_types.Table([[{'a': 1}, {'b': 2}]], names=('a',))
         assert t[0][0] == {'a': 1}
         assert t[0]['a'] == {'a': 1}
-        if NUMPY_LT_1_8 and t.masked:
-            # With numpy < 1.8 there is a bug setting mvoid with
-            # an object.
-            with pytest.raises(ValueError):
-                t[0].as_void()
-        else:
-            assert t[0].as_void()[0] == {'a': 1}
-            assert t[0].as_void()['a'] == {'a': 1}
+        assert t[0].as_void()[0] == {'a': 1}
+        assert t[0].as_void()['a'] == {'a': 1}
 
     def test_bounds_checking(self, table_types):
         """Row gives index error upon creation for out-of-bounds index"""

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from .. import Time
 from ...tests.helper import pytest
-from ...utils.compat.numpycompat import NUMPY_LT_1_9
 from ...utils.compat.numpy import broadcast_to as np_broadcast_to
 
 
@@ -92,21 +91,18 @@ class TestManipulation():
         assert t0_diagonal.shape == (5,)
         assert np.all(t0_diagonal.jd1 == self.t0.jd1.diagonal())
         assert t0_diagonal.location is None
-        if not NUMPY_LT_1_9:
-            assert np.may_share_memory(t0_diagonal.jd1, self.t0.jd1)
+        assert np.may_share_memory(t0_diagonal.jd1, self.t0.jd1)
         t1_diagonal = self.t1.diagonal()
         assert t1_diagonal.shape == (5,)
         assert np.all(t1_diagonal.jd1 == self.t1.jd1.diagonal())
         assert t1_diagonal.location is self.t1.location
-        if not NUMPY_LT_1_9:
-            assert np.may_share_memory(t1_diagonal.jd1, self.t1.jd1)
+        assert np.may_share_memory(t1_diagonal.jd1, self.t1.jd1)
         t2_diagonal = self.t2.diagonal()
         assert t2_diagonal.shape == (5,)
         assert np.all(t2_diagonal.jd1 == self.t2.jd1.diagonal())
         assert t2_diagonal.location.shape == t2_diagonal.shape
-        if not NUMPY_LT_1_9:
-            assert np.may_share_memory(t2_diagonal.jd1, self.t2.jd1)
-            assert np.may_share_memory(t2_diagonal.location, self.t2.location)
+        assert np.may_share_memory(t2_diagonal.jd1, self.t2.jd1)
+        assert np.may_share_memory(t2_diagonal.location, self.t2.location)
 
     def test_swapaxes(self):
         t0_swapaxes = self.t0.swapaxes(0, 1)

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from ... import units as u
 from ...tests.helper import pytest
-from ...utils.compat import (NUMPY_LT_1_8, NUMPY_LT_1_9_1,
-                             NUMPY_LT_1_10, NUMPY_LT_1_10_4)
+from ...utils.compat import NUMPY_LT_1_9_1, NUMPY_LT_1_10, NUMPY_LT_1_10_4
 
 
 class TestQuantityArrayCopy(object):
@@ -286,7 +285,6 @@ class TestQuantityStatsFuncs(object):
         assert np.all(q2.nansum(0) == np.array([1., 5., 10.]) * u.s)
         assert np.all(np.nansum(q2, 0) == np.array([1., 5., 10.]) * u.s)
 
-    @pytest.mark.xfail(NUMPY_LT_1_8, reason="Numpy 1.8 or later is required")
     def test_nansum_inplace(self):
 
         q1 = np.array([1., 2., np.nan]) * u.m

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -5,47 +5,17 @@ earlier versions of Numpy.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from ...extern import six
 from ...utils import minversion
 
 
-__all__ = ['NUMPY_LT_1_8', 'NUMPY_LT_1_9', 'NUMPY_LT_1_9_1', 'NUMPY_LT_1_10',
-           'NUMPY_LT_1_10_4', 'NUMPY_LT_1_11', 'NUMPY_LT_1_12']
+__all__ = ['NUMPY_LT_1_9_1', 'NUMPY_LT_1_10', 'NUMPY_LT_1_10_4',
+           'NUMPY_LT_1_11', 'NUMPY_LT_1_12']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_8 = not minversion('numpy', '1.8.0')
-NUMPY_LT_1_9 = not minversion('numpy', '1.9.0')
 NUMPY_LT_1_9_1 = not minversion('numpy', '1.9.1')
 NUMPY_LT_1_10 = not minversion('numpy', '1.10.0')
 NUMPY_LT_1_10_4 = not minversion('numpy', '1.10.4')
 NUMPY_LT_1_11 = not minversion('numpy', '1.11.0')
 NUMPY_LT_1_12 = not minversion('numpy', '1.12')
-
-
-def _monkeypatch_unicode_mask_fill_values():
-    """
-    Numpy < 1.8.0 on Python 2 does not support Unicode fill values, since
-    it assumes that all of the string dtypes are ``S`` and ``V`` (not ``U``).
-
-    This monkey patches the function that validates and corrects a
-    fill value to handle this case.
-    """
-    if NUMPY_LT_1_8 and six.PY2:
-        import numpy as np
-        from numpy.ma import core as ma_core
-        _check_fill_value_original = ma_core._check_fill_value
-
-        def _check_fill_value(fill_value, ndtype):
-            if (not ndtype.fields and
-                isinstance(fill_value, six.string_types) and
-                ndtype.char in 'SVU'):
-                return np.array(fill_value, copy=False, dtype=ndtype)
-            return _check_fill_value_original(fill_value, ndtype)
-
-        ma_core._check_fill_value = _check_fill_value
-
-
-if not _ASTROPY_SETUP_:
-    _monkeypatch_unicode_mask_fill_values()

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -27,7 +27,6 @@ import re
 from collections import OrderedDict
 
 from ..extern import six
-from ..utils.compat import NUMPY_LT_1_8
 from ..extern.six.moves import zip, cStringIO as StringIO
 
 # Tuple of filterwarnings kwargs to ignore when calling info
@@ -296,7 +295,7 @@ class DataInfo(object):
     # No nan* methods in numpy < 1.8
     info_summary_stats = staticmethod(
         data_info_factory(names=_stats,
-                          funcs=[getattr(np, ('' if NUMPY_LT_1_8 else 'nan') + stat)
+                          funcs=[getattr(np, 'nan' + stat)
                                  for stat in _stats]))
 
     def __call__(self, option='attributes', out=''):


### PR DESCRIPTION
This replaces #6003, with all work-arounds for numpy 1.7 and 1.8 removed (only a handful left!).