### PR TITLE
Color the coordinates transform graph edges by transform type

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -83,11 +83,9 @@ def _make_transform_graph_docs():
     between these systems, but the pre-defined transformations should be
     sufficient for typical usage.
 
-    The graph also indicates the priority for each transformation as a
-    number next to the arrow.  These priorities are used to decide the
-    preferred order when two transformation paths have the same number
-    of steps.  These priorities are defined such that the path with a
-    *smaller* total priority is favored.
+    The color of an edge in the graph (i.e. the transformations between two
+    frames) is set by the type of transformation; the legend box defines the
+    mapping from transform class name to color.
 
 
     .. graphviz::

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -92,5 +92,35 @@ def _make_transform_graph_docs():
 
     """
 
-    return dedent(docstr) + '    ' + graphstr.replace('\n', '\n    ')
+    docstr = dedent(docstr) + '    ' + graphstr.replace('\n', '\n    ')
+
+    # colors are in dictionary at the bottom of transformations.py
+    graph_legend = """
+    .. raw:: html
+
+        <ul>
+            <li style='list-style: none;'>
+                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
+                    <b>FunctionTransform:</b>
+                    <span style="width: 15px; height: 15px; margin:auto; display: inline-block; vertical-align: middle; border-radius: 2px; background: #d95f02 "></span>
+                </p>
+            </li>
+            <li style='list-style: none;'>
+                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
+                    <b>StaticMatrixTransform:</b>
+                    <span style="width: 15px; height: 15px; margin:auto; display: inline-block; vertical-align: middle; border-radius: 2px; background: #7570b3 "></span>
+                </p>
+            </li>
+            <li style='list-style: none;'>
+                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
+                    <b>DynamicMatrixTransform:</b>
+                    <span style="width: 15px; height: 15px; margin:auto; display: inline-block; vertical-align: middle; border-radius: 2px; background: #1b9e77 "></span>
+                </p>
+            </li>
+        </ul>
+    """
+    docstr = docstr + dedent(graph_legend)
+
+    return docstr
+
 _transform_graph_docs = _make_transform_graph_docs()

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -95,30 +95,26 @@ def _make_transform_graph_docs():
     docstr = dedent(docstr) + '    ' + graphstr.replace('\n', '\n    ')
 
     # colors are in dictionary at the bottom of transformations.py
+    from ..transformations import trans_to_color
+    html_list_items = []
+    for cls,color in trans_to_color.items():
+        block = """
+            <li style='list-style: none;'>
+                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
+                    <b>{0}:</b>
+                    <span style="font-size: 20px; color: {1};"><b>➝</b></span>
+                </p>
+            </li>
+        """.format(cls.__name__, color)
+        html_list_items.append(block)
+
     graph_legend = """
     .. raw:: html
 
         <ul>
-            <li style='list-style: none;'>
-                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
-                    <b>FunctionTransform:</b>
-                    <span style="width: 15px; height: 15px; margin:auto; display: inline-block; vertical-align: middle; border-radius: 2px; background: #d95f02 "></span>
-                </p>
-            </li>
-            <li style='list-style: none;'>
-                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
-                    <b>StaticMatrixTransform:</b>
-                    <span style="width: 15px; height: 15px; margin:auto; display: inline-block; vertical-align: middle; border-radius: 2px; background: #7570b3 "></span>
-                </p>
-            </li>
-            <li style='list-style: none;'>
-                <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
-                    <b>DynamicMatrixTransform:</b>
-                    <span style="width: 15px; height: 15px; margin:auto; display: inline-block; vertical-align: middle; border-radius: 2px; background: #1b9e77 "></span>
-                </p>
-            </li>
+            {}
         </ul>
-    """
+    """.format("\n".join(html_list_items))
     docstr = docstr + dedent(graph_legend)
 
     return docstr

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -68,7 +68,11 @@ def _make_transform_graph_docs():
     isclass = inspect.isclass
     coosys = [item for item in six.itervalues(globals())
               if isclass(item) and issubclass(item, BaseCoordinateFrame)]
-    graphstr = frame_transform_graph.to_dot_graph(addnodes=coosys)
+
+    # currently, all of the priorities are set to 1, so we don't need to show
+    #   then in the transform graph.
+    graphstr = frame_transform_graph.to_dot_graph(addnodes=coosys,
+                                                  priorities=False)
 
     docstr = """
     The diagram below shows all of the coordinate systems built into the

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -102,7 +102,7 @@ def _make_transform_graph_docs():
             <li style='list-style: none;'>
                 <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
                     <b>{0}:</b>
-                    <span style="font-size: 20px; color: {1};"><b>➝</b></span>
+                    <span style="font-size: 24px; color: {1};"><b>➝</b></span>
                 </p>
             </li>
         """.format(cls.__name__, color)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -22,7 +22,7 @@ import inspect
 import subprocess
 
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 import numpy as np
 
@@ -34,7 +34,6 @@ from ..extern.six.moves import range
 
 __all__ = ['TransformGraph', 'CoordinateTransform', 'FunctionTransform',
            'StaticMatrixTransform', 'DynamicMatrixTransform', 'CompositeTransform']
-
 
 class TransformGraph(object):
     """
@@ -376,7 +375,7 @@ class TransformGraph(object):
         return list(six.iterkeys(self._cached_names))
 
     def to_dot_graph(self, priorities=True, addnodes=[], savefn=None,
-                     savelayout='plain', saveformat=None):
+                     savelayout='plain', saveformat=None, color_edges=True):
         """
         Converts this transform graph to the graphviz_ DOT format.
 
@@ -403,6 +402,10 @@ class TransformGraph(object):
             The graphviz output format. (e.g. the ``-Txxx`` option for
             the command line program - see graphviz docs for details).
             Ignored if ``savefn`` is `None`.
+        color_edges : bool
+            Color the edges between two nodes (frames) based on the type of
+            transform. ``FunctionTransform``: red, ``StaticMatrixTransform``:
+            blue, ``DynamicMatrixTransform``: green.
 
         Returns
         -------
@@ -429,20 +432,39 @@ class TransformGraph(object):
             else:
                 nodenames.append(n.__name__ + '[ shape=oval ]')
 
+        # As far as @adrn can tell, there is no way to have font with different
+        #   colors in the same node, so I create 3 here instead. This could be
+        #   reduced to a single node if it is possible.
+        for cls, color in trans_to_color.items():
+            nodenames.append('{0} [shape=box label="{0}" style=filled fillcolor="{1}"]'
+                             .format(cls.__name__, color))
+
         edgenames = []
         # Now the edges
         for a in self._graph:
             agraph = self._graph[a]
             for b in agraph:
-                pri = agraph[b].priority if hasattr(agraph[b], 'priority') else 1
-                edgenames.append((a.__name__, b.__name__, pri))
+                transform = agraph[b]
+                pri = transform.priority if hasattr(transform, 'priority') else 1
+                color = trans_to_color[transform.__class__] if color_edges else 'black'
+                edgenames.append((a.__name__, b.__name__, pri, color))
 
         # generate simple dot format graph
         lines = ['digraph AstropyCoordinateTransformGraph {']
         lines.append('; '.join(nodenames) + ';')
-        for enm1, enm2, weights in edgenames:
-            labelstr = '[ label = "{0}" ]'.format(weights) if priorities else ''
+        for enm1, enm2, weights, color in edgenames:
+            labelstr_fmt = '[ {0} {1} ]'
+
+            if priorities:
+                priority_part = 'label = "{0}"'.format(weights)
+            else:
+                priority_part = ''
+
+            color_part = 'color = "{0}"'.format(color)
+
+            labelstr = labelstr_fmt.format(priority_part, color_part)
             lines.append('{0} -> {1}{2};'.format(enm1, enm2, labelstr))
+
         lines.append('')
         lines.append('overlap=false')
         lines.append('}')
@@ -497,8 +519,10 @@ class TransformGraph(object):
         for a in self._graph:
             agraph = self._graph[a]
             for b in agraph:
-                pri = agraph[b].priority if hasattr(agraph[b], 'priority') else 1
-                nxgraph.add_edge(a, b, weight=pri)
+                transform = agraph[b]
+                pri = transform.priority if hasattr(transform, 'priority') else 1
+                color = trans_to_color[transform.__class__]
+                nxgraph.add_edge(a, b, weight=pri, color=color)
 
         return nxgraph
 
@@ -923,3 +947,9 @@ class CompositeTransform(CoordinateTransform):
         # this is safe even in the case where self.transforms is empty, because
         # coordinate objects are immutible, so copying is not needed
         return curr_coord
+
+# map class names to colorblind-safe colors
+trans_to_color = OrderedDict()
+trans_to_color[FunctionTransform] = '#d95f02' # red-ish
+trans_to_color[StaticMatrixTransform] = '#7570b3' # blue-ish
+trans_to_color[DynamicMatrixTransform] = '#1b9e77' # green-ish

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -432,13 +432,6 @@ class TransformGraph(object):
             else:
                 nodenames.append(n.__name__ + '[ shape=oval ]')
 
-        # As far as @adrn can tell, there is no way to have font with different
-        #   colors in the same node, so I create 3 here instead. This could be
-        #   reduced to a single node if it is possible.
-        for cls, color in trans_to_color.items():
-            nodenames.append('{0} [shape=box label="{0}" style=filled fillcolor="{1}"]'
-                             .format(cls.__name__, color))
-
         edgenames = []
         # Now the edges
         for a in self._graph:


### PR DESCRIPTION
This colors the edges in the `graphviz`-generated visualization of the frame transform graph based on the type of transformation. I'm not sure this needs to be in the documentation, but @eteq and I needed to look at this for thinking about velocity support so I implemented it anyways. Attached is an image of the colored graph. The colors were picked using [colorbrewer2](http://colorbrewer2.org/#type=qualitative&scheme=Dark2&n=3), 3 qualitative colors, colorblind-safe.

EDIT: (I only have 5 seconds now but here's an update of what it looks like, without the priorities. sorry for the volume showing)

<img width="1199" alt="screen shot 2017-05-10 at 16 50 23" src="https://cloud.githubusercontent.com/assets/583379/25904884/d5b63ac0-35a0-11e7-8a6c-9c56e282c38f.png">


cc @eteq 
