### PR TITLE
Add FWHM to Gaussian and Moffat models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ New Features
 
   - Added a ``name`` setter for instances of ``_CompoundModel``. [#5741]
 
+  - Added FWHM properties to Gaussian and Moffat models. [#6027]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -11,8 +11,8 @@ from .core import (Fittable1DModel, Fittable2DModel, Model,
 from .parameters import Parameter, InputParameterError
 from .utils import ellipse_extent
 from ..extern.six.moves import map
+from ..stats.funcs import gaussian_sigma_to_fwhm
 from ..utils.exceptions import AstropyDeprecationWarning
-
 
 __all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
            'Const2D', 'Ellipse2D', 'Disk2D', 'BaseGaussian1D', 'Gaussian1D',
@@ -65,6 +65,11 @@ class BaseGaussian1D(Fittable1DModel):
         dx = factor * self.stddev
 
         return (x0 - dx, x0 + dx)
+
+    @property
+    def fwhm(self):
+        """Gaussian full width at half maximum."""
+        return self.stddev * gaussian_sigma_to_fwhm
 
 
 class Gaussian1D(BaseGaussian1D):
@@ -348,6 +353,16 @@ class Gaussian2D(Fittable2DModel):
         super(Gaussian2D, self).__init__(
             amplitude=amplitude, x_mean=x_mean, y_mean=y_mean,
             x_stddev=x_stddev, y_stddev=y_stddev, theta=theta, **kwargs)
+
+    @property
+    def x_fwhm(self):
+        """Gaussian full width at half maximum in X."""
+        return self.x_stddev * gaussian_sigma_to_fwhm
+
+    @property
+    def y_fwhm(self):
+        """Gaussian full width at half maximum in Y."""
+        return self.y_stddev * gaussian_sigma_to_fwhm
 
     def bounding_box(self, factor=5.5):
         """
@@ -1883,6 +1898,15 @@ class Moffat1D(Fittable1DModel):
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
 
+    @property
+    def fwhm(self):
+        """
+        Moffat full width at half maximum.
+        Derivation of the formula is available in
+        `this notebook by Yoonsoo Bach <http://nbviewer.jupyter.org/github/ysbach/AO_2017/blob/master/04_Ground_Based_Concept.ipynb#1.2.-Moffat>`_.
+        """
+        return 2.0 * self.gamma * np.sqrt(2.0 ** (1.0 / self.alpha) - 1.0)
+
     @staticmethod
     def evaluate(x, amplitude, x_0, gamma, alpha):
         """One dimensional Moffat model function"""
@@ -1938,6 +1962,15 @@ class Moffat2D(Fittable2DModel):
     y_0 = Parameter(default=0)
     gamma = Parameter(default=1)
     alpha = Parameter(default=1)
+
+    @property
+    def fwhm(self):
+        """
+        Moffat full width at half maximum.
+        Derivation of the formula is available in
+        `this notebook by Yoonsoo Bach <http://nbviewer.jupyter.org/github/ysbach/AO_2017/blob/master/04_Ground_Based_Concept.ipynb#1.2.-Moffat>`_.
+        """
+        return 2.0 * self.gamma * np.sqrt(2.0 ** (1.0 / self.alpha) - 1.0)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, gamma, alpha):

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -36,6 +36,7 @@ def test_GaussianAbsorption1D():
     assert_allclose(g_ab.fit_deriv(xx[0], 0.8, 3000, 20),
                     -np.array(g_em.fit_deriv(xx[0], 0.8, 3000, 20)))
     assert g_ab.bounding_box == g_em.bounding_box
+    assert_allclose(g_ab.fwhm, 47.096400900618988)
 
 
 def test_Gaussian2D():
@@ -54,6 +55,8 @@ def test_Gaussian2D():
              [3.91095768, 4.15212857, 4.18567526, 4.00652015, 3.64146544],
              [3.6440466, 3.95922417, 4.08454159, 4.00113878, 3.72161094]]
     assert_allclose(g, g_ref, rtol=0, atol=1e-6)
+    assert_allclose([model.x_fwhm, model.y_fwhm],
+                    [12.009582229657841, 7.7709061486021325])
 
 
 def test_Gaussian2DCovariance():
@@ -111,6 +114,14 @@ def test_Gaussian2D_invalid_inputs():
         models.Gaussian2D(y_stddev=0, cov_matrix=cov_matrix)
     with pytest.raises(InputParameterError):
         models.Gaussian2D(theta=0, cov_matrix=cov_matrix)
+
+
+def test_moffat_fwhm():
+    ans = 34.641016151377542
+    kwargs = {'gamma': 10, 'alpha': 0.5}
+    m1 = models.Moffat1D(**kwargs)
+    m2 = models.Moffat2D(**kwargs)
+    assert_allclose([m1.fwhm, m2.fwhm], ans)
 
 
 def test_RedshiftScaleFactor():


### PR DESCRIPTION
Fix #5980 by adding FWHM properties to Gaussian and Moffat models (both 1D and 2D).

c/c @nden @ysBach @cdeil @MSeifert04 