### PR TITLE
Time: add setitem and missing value support (masking)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,10 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Allow array-valued ``Time`` object to be modified in place. [#6028]
+
+- Added support for missing values (masking) to the ``Time`` class. [#6028]
+
 astropy.units
 ^^^^^^^^^^^^^
 
@@ -136,10 +140,6 @@ astropy.tests
 
 astropy.time
 ^^^^^^^^^^^^
-
-- Allow array-valued ``Time`` object to be modified in place. [#6028]
-
-- Added support for missing values (masking) to the ``Time`` class. [#6028]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,10 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Allow array-valued ``Time`` object to be modified in place. [#6028]
+
+- Added support for missing values (masking) to the ``Time`` class. [#6028]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -186,7 +186,10 @@ class TimeAttribute(Attribute):
                                                                value, err))
             converted = True
 
-        out.writeable = False
+        # Set attribute as read-only for arrays (not allowed by numpy
+        # for array scalars)
+        if out.shape:
+            out.writeable = False
         return out, converted
 
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -186,6 +186,7 @@ class TimeAttribute(Attribute):
                                                                value, err))
             converted = True
 
+        out.writeable = False
         return out, converted
 
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1025,6 +1025,17 @@ class Column(BaseColumn):
     to = BaseColumn.to
 
 
+class MaskedColumnInfo(ColumnInfo):
+    """
+    Container for meta information like name, description, format.
+
+    This is required when the object is used as a mixin column within a table,
+    but can be used as a general way to store meta information.  In this case
+    it just adds the ``mask_val`` attribute.
+    """
+    mask_val = np.ma.masked
+
+
 class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     """Define a masked data column for use in a Table object.
 
@@ -1096,6 +1107,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
       The default ``dtype`` is ``np.float64``.  The ``shape`` argument is the
       array shape of a single cell in the column.
     """
+    info = MaskedColumnInfo()
 
     def __new__(cls, data=None, name=None, mask=None, fill_value=None,
                 dtype=None, shape=(), length=0,

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -397,6 +397,15 @@ class Time(ShapedLikeNDArray):
     info = TimeInfo()
 
     @property
+    def writeable(self):
+        return self._time.jd1.flags.writeable & self._time.jd2.flags.writeable
+
+    @writeable.setter
+    def writeable(self, value):
+        self._time.jd1.flags.writeable = value
+        self._time.jd2.flags.writeable = value
+
+    @property
     def format(self):
         """
         Get or set time format.

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -102,6 +102,7 @@ class TimeInfo(MixinInfo):
     _represent_as_dict_extra_attrs = ('format', 'scale', 'precision',
                                       'in_subfmt', 'out_subfmt', 'location',
                                       '_delta_ut1_utc', '_delta_tdb_tt')
+    mask_val = np.ma.masked
 
     @property
     def _represent_as_dict_attrs(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -627,14 +627,16 @@ class Time(ShapedLikeNDArray):
         """
         First of the two doubles that internally store time value(s) in JD.
         """
-        return self._shaped_like_input(self._time.jd1)
+        jd1 = self._time.mask_if_needed(self._time.jd1)
+        return self._shaped_like_input(jd1)
 
     @property
     def jd2(self):
         """
         Second of the two doubles that internally store time value(s) in JD.
         """
-        return self._shaped_like_input(self._time.jd2)
+        jd2 = self._time.mask_if_needed(self._time.jd2)
+        return self._shaped_like_input(jd2)
 
     @property
     def value(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -14,6 +14,7 @@ from datetime import datetime
 
 import numpy as np
 
+from ..utils.compat import NUMPY_LT_1_11
 from .. import units as u, constants as const
 from .. import _erfa as erfa
 from ..units import UnitConversionError
@@ -1083,7 +1084,14 @@ class Time(ShapedLikeNDArray):
         """
         # first get the minimum at normal precision.
         jd = self.jd1 + self.jd2
-        approx = np.nanmin(jd, axis, keepdims=True)
+
+        if NUMPY_LT_1_11:
+            # MaskedArray.min ignores keepdims so do it by hand
+            approx = np.min(jd, axis)
+            if axis is not None:
+                approx = np.expand_dims(approx, axis)
+        else:
+            approx = np.min(jd, axis, keepdims=True)
 
         # Approx is very close to the true minimum, and by subtracting it at
         # full precision, all numbers near 0 can be represented correctly,
@@ -1106,7 +1114,14 @@ class Time(ShapedLikeNDArray):
         """
         # For procedure, see comment on argmin.
         jd = self.jd1 + self.jd2
-        approx = jd.max(axis, keepdims=True)
+
+        if NUMPY_LT_1_11:
+            # MaskedArray.max ignores keepdims so do it by hand (numpy <= 1.10)
+            approx = np.max(jd, axis)
+            if axis is not None:
+                approx = np.expand_dims(approx, axis)
+        else:
+            approx = np.max(jd, axis, keepdims=True)
 
         dt = (self.jd1 - approx) + self.jd2
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -658,6 +658,15 @@ class Time(ShapedLikeNDArray):
         return self._time.mask
 
     def __setitem__(self, item, value):
+        if not self.writeable:
+            if self.shape:
+                raise ValueError('{} object is read-only. Make a '
+                                 'copy() or set "writeable" attribute to True.'
+                                 .format(self.__class__.__name__))
+            else:
+                raise ValueError('scalar {} object is read-only.'
+                                 .format(self.__class__.__name__))
+
         # Any use of setitem results in immediate cache invalidation
         del self.cache
 
@@ -1231,6 +1240,9 @@ class Time(ShapedLikeNDArray):
                 else:
                     tm = self.replicate()
                     tm._set_scale(attr)
+                    if tm.shape:
+                        # Prevent future modification of cached array-like object
+                        tm.writeable = False
                 cache[attr] = tm
             return cache[attr]
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -337,6 +337,7 @@ class Time(ShapedLikeNDArray):
         # routine ``mask`` must be either Python bool False or an bool ndarray
         # with shape broadcastable to jd2.
         if mask is not False:
+            mask = np.broadcast_to(mask, self._time.jd2.shape)
             self._time.jd2[mask] = np.nan
 
     def _get_time_fmt(self, val, val2, format, scale,

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -678,7 +678,10 @@ class Time(ShapedLikeNDArray):
             else:
                 match = np.all(self_location == value.location)
             if not match:
-                raise ValueError('cannot set to Time with different location')
+                raise ValueError('cannot set to Time with different location: '
+                                 'expected location={} and '
+                                 'got location={}'
+                                 .format(self_location, value.location))
         else:
             try:
                 value = self.__class__(value, scale=self.scale, location=self_location)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1095,8 +1095,6 @@ class Time(ShapedLikeNDArray):
         # dt = (self.jd1 - approx_jd1) + (self.jd2 - approx_jd2)
         dt = (self.jd1 - approx) + self.jd2
 
-        # FIX ME
-
         return dt.argmin(axis, out)
 
     def argmax(self, axis=None, out=None):
@@ -1112,8 +1110,6 @@ class Time(ShapedLikeNDArray):
 
         dt = (self.jd1 - approx) + self.jd2
 
-        # FIX ME
-
         return dt.argmax(axis, out)
 
     def argsort(self, axis=-1):
@@ -1124,9 +1120,6 @@ class Time(ShapedLikeNDArray):
         is used, and that corresponding attributes are copied.  Internally,
         it uses :func:`~numpy.lexsort`, and hence no sort method can be chosen.
         """
-
-        # FIX ME
-
         jd_approx = self.jd
         jd_remainder = (self - self.__class__(jd_approx, format='jd')).jd
         if axis is None:
@@ -1146,8 +1139,6 @@ class Time(ShapedLikeNDArray):
         to have an actual ``out`` to store the result in.
         """
 
-        # FIX ME
-
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
                              "cannot be set to anything but ``None``.")
@@ -1165,8 +1156,6 @@ class Time(ShapedLikeNDArray):
         to have an actual ``out`` to store the result in.
         """
 
-        # FIX ME?
-
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
                              "cannot be set to anything but ``None``.")
@@ -1183,8 +1172,6 @@ class Time(ShapedLikeNDArray):
         `~numpy.ptp`; since `Time` instances are immutable, it is not possible
         to have an actual ``out`` to store the result in.
         """
-
-        # FIX ME?
 
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
@@ -1206,8 +1193,6 @@ class Time(ShapedLikeNDArray):
             Axis to be sorted.  If ``None``, the flattened array is sorted.
             By default, sort over the last axis.
         """
-
-        # FIX ME?
 
         return self[self._advanced_index(self.argsort(axis), axis,
                                          keepdims=True)]

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -14,7 +14,7 @@ from datetime import datetime
 
 import numpy as np
 
-from ..utils.compat import NUMPY_LT_1_11
+from ..utils.compat import NUMPY_LT_1_11_2
 from .. import units as u, constants as const
 from .. import _erfa as erfa
 from ..units import UnitConversionError
@@ -1085,7 +1085,7 @@ class Time(ShapedLikeNDArray):
         # first get the minimum at normal precision.
         jd = self.jd1 + self.jd2
 
-        if NUMPY_LT_1_11:
+        if NUMPY_LT_1_11_2:
             # MaskedArray.min ignores keepdims so do it by hand
             approx = np.min(jd, axis)
             if axis is not None:
@@ -1115,7 +1115,7 @@ class Time(ShapedLikeNDArray):
         # For procedure, see comment on argmin.
         jd = self.jd1 + self.jd2
 
-        if NUMPY_LT_1_11:
+        if NUMPY_LT_1_11_2:
             # MaskedArray.max ignores keepdims so do it by hand (numpy <= 1.10)
             approx = np.max(jd, axis)
             if axis is not None:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -532,11 +532,11 @@ class Time(ShapedLikeNDArray):
 
     @precision.setter
     def precision(self, val):
+        del self.cache
         if not isinstance(val, int) or val < 0 or val > 9:
             raise ValueError('precision attribute must be an int between '
                              '0 and 9')
         self._time.precision = val
-        del self.cache
 
     @property
     def in_subfmt(self):
@@ -548,10 +548,10 @@ class Time(ShapedLikeNDArray):
 
     @in_subfmt.setter
     def in_subfmt(self, val):
+        del self.cache
         if not isinstance(val, str):
             raise ValueError('in_subfmt attribute must be a string')
         self._time.in_subfmt = val
-        del self.cache
 
     @property
     def out_subfmt(self):
@@ -562,10 +562,10 @@ class Time(ShapedLikeNDArray):
 
     @out_subfmt.setter
     def out_subfmt(self, val):
+        del self.cache
         if not isinstance(val, str):
             raise ValueError('out_subfmt attribute must be a string')
         self._time.out_subfmt = val
-        del self.cache
 
     @property
     def shape(self):
@@ -658,9 +658,11 @@ class Time(ShapedLikeNDArray):
         return self._time.mask
 
     def __setitem__(self, item, value):
+        # Any use of setitem results in immediate cache invalidation
+        del self.cache
+
         if value in (np.ma.masked, np.nan):
             self._time.jd2[item] = np.nan
-            del self.cache
             return
 
         # If there is a vector location then broadcast to the Time shape
@@ -697,8 +699,6 @@ class Time(ShapedLikeNDArray):
         value = getattr(value, self.scale)
         self._time.jd1[item] = value._time.jd1
         self._time.jd2[item] = value._time.jd2
-
-        del self.cache
 
     def light_travel_time(self, skycoord, kind='barycentric', location=None, ephemeris=None):
         """Light travel time correction to the barycentre or heliocentre.
@@ -1371,11 +1371,11 @@ class Time(ShapedLikeNDArray):
         return self._delta_ut1_utc
 
     def _set_delta_ut1_utc(self, val):
+        del self.cache
         if hasattr(val, 'to'):  # Matches Quantity but also TimeDelta.
             val = val.to(u.second).value
         val = self._match_shape(val)
         self._delta_ut1_utc = val
-        del self.cache
 
     # Note can't use @property because _get_delta_tdb_tt is explicitly
     # called with the optional jd1 and jd2 args.
@@ -1422,11 +1422,11 @@ class Time(ShapedLikeNDArray):
         return self._delta_tdb_tt
 
     def _set_delta_tdb_tt(self, val):
+        del self.cache
         if hasattr(val, 'to'):  # Matches Quantity but also TimeDelta.
             val = val.to(u.second).value
         val = self._match_shape(val)
         self._delta_tdb_tt = val
-        del self.cache
 
     # Note can't use @property because _get_delta_tdb_tt is explicitly
     # called with the optional jd1 and jd2 args.

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1153,7 +1153,6 @@ class Time(ShapedLikeNDArray):
         ``np.min``; since `Time` instances are immutable, it is not possible
         to have an actual ``out`` to store the result in.
         """
-
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
                              "cannot be set to anything but ``None``.")
@@ -1170,7 +1169,6 @@ class Time(ShapedLikeNDArray):
         ``np.max``; since `Time` instances are immutable, it is not possible
         to have an actual ``out`` to store the result in.
         """
-
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
                              "cannot be set to anything but ``None``.")
@@ -1187,7 +1185,6 @@ class Time(ShapedLikeNDArray):
         `~numpy.ptp`; since `Time` instances are immutable, it is not possible
         to have an actual ``out`` to store the result in.
         """
-
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
                              "cannot be set to anything but ``None``.")
@@ -1208,7 +1205,6 @@ class Time(ShapedLikeNDArray):
             Axis to be sorted.  If ``None``, the flattened array is sorted.
             By default, sort over the last axis.
         """
-
         return self[self._advanced_index(self.argsort(axis), axis,
                                          keepdims=True)]
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -670,6 +670,11 @@ class Time(ShapedLikeNDArray):
         # Any use of setitem results in immediate cache invalidation
         del self.cache
 
+        # Setting invalidates transform deltas
+        for attr in ('_delta_tdb_tt', '_delta_ut1_utc'):
+            if hasattr(self, attr):
+                delattr(self, attr)
+
         if value in (np.ma.masked, np.nan):
             self._time.jd2[item] = np.nan
             return

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -71,7 +71,7 @@ def _regexify_subfmts(subfmts):
 
 class TimeMaskedArray(np.ma.MaskedArray):
     def __repr__(self):
-        return str(self)
+        return 'masked_array({})'.format(self)
 
 
 class TimeFormatMeta(type):
@@ -166,7 +166,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
 
     @property
     def jd2_filled(self):
-        return np.nan_to_num(self.jd2)
+        return np.nan_to_num(self.jd2) if self.masked else self.jd2
 
     @lazyproperty
     def cache(self):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -5,10 +5,11 @@ import fnmatch
 import time
 import re
 import datetime
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import numpy as np
 
+from ..utils.decorators import lazyproperty
 from .. import units as u
 from .. import _erfa as erfa
 from .utils import day_frac, two_sum
@@ -66,6 +67,11 @@ def _regexify_subfmts(subfmts):
         new_subfmts.append(subfmt_tuple)
 
     return tuple(new_subfmts)
+
+
+class TimeMaskedArray(np.ma.MaskedArray):
+    def __repr__(self):
+        return str(self)
 
 
 class TimeFormatMeta(type):
@@ -141,11 +147,40 @@ class TimeFormat(metaclass=TimeFormatMeta):
     def scale(self, val):
         self._scale = val
 
+    def mask_if_needed(self, value):
+        if self.masked:
+            value = TimeMaskedArray(value, mask=self.mask, copy=False)
+        return value
+
+    @property
+    def mask(self):
+        if 'mask' not in self.cache:
+            self.cache['mask'] = np.isnan(self.jd2)
+        return self.cache['mask']
+
+    @property
+    def masked(self):
+        if 'masked' not in self.cache:
+            self.cache['masked'] = bool(np.any(self.mask))
+        return self.cache['masked']
+
+    @property
+    def jd2_filled(self):
+        return np.nan_to_num(self.jd2)
+
+    @lazyproperty
+    def cache(self):
+        """
+        Return the cache associated with this instance.
+        """
+        return defaultdict(dict)
+
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
-        if not (val1.dtype == np.double and np.all(np.isfinite(val1)) and
-                (val2 is None or
-                 val2.dtype == np.double and np.all(np.isfinite(val2)))):
+        # val1 cannot contain nan, but val2 can contain nan
+        ok1 = val1.dtype == np.double and np.all(np.isfinite(val1))
+        ok2 = val2 is None or (val2.dtype == np.double and not np.any(np.isinf(val2)))
+        if not (ok1 and ok2):
             raise TypeError('Input values for {0} class must be finite doubles'
                             .format(self.name))
 
@@ -211,7 +246,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
         require ``parent`` or have other optional args for ``to_value``
         should compute and return the value directly.
         """
-        return self.value
+        return self.mask_if_needed(self.value)
 
     @property
     def value(self):
@@ -302,7 +337,7 @@ class TimeDecimalYear(TimeFormat):
     def value(self):
         scale = self.scale.upper().encode('ascii')
         iy_start, ims, ids, ihmsfs = erfa.d2dtf(scale, 0,  # precision=0
-                                                self.jd1, self.jd2)
+                                                self.jd1, self.jd2_filled)
         imon = np.ones_like(iy_start)
         iday = np.ones_like(iy_start)
         ihr = np.zeros_like(iy_start)
@@ -395,7 +430,8 @@ class TimeFromEpoch(TimeFormat):
 
         time_from_epoch = ((jd1 - self.epoch.jd1) +
                            (jd2 - self.epoch.jd2)) / self.unit
-        return time_from_epoch
+
+        return self.mask_if_needed(time_from_epoch)
 
     value = property(to_value)
 
@@ -599,7 +635,7 @@ class TimeDatetime(TimeUnique):
         # since we want to be able to pass in timezone information.
         scale = self.scale.upper().encode('ascii')
         iys, ims, ids, ihmsfs = erfa.d2dtf(scale, 6,  # 6 for microsec
-                                           self.jd1, self.jd2)
+                                           self.jd1, self.jd2_filled)
         ihrs = ihmsfs[..., 0]
         imins = ihmsfs[..., 1]
         isecs = ihmsfs[..., 2]
@@ -618,7 +654,8 @@ class TimeDatetime(TimeUnique):
                                              tzinfo=TimezoneInfo()).astimezone(timezone)
             else:
                 out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
-        return iterator.operands[-1]
+
+        return self.mask_if_needed(iterator.operands[-1])
 
     value = property(to_value)
 
@@ -759,7 +796,7 @@ class TimeString(TimeUnique):
         """
         scale = self.scale.upper().encode('ascii'),
         iys, ims, ids, ihmsfs = erfa.d2dtf(scale, self.precision,
-                                           self.jd1, self.jd2)
+                                           self.jd1, self.jd2_filled)
 
         # Get the str_fmt element of the first allowed output subformat
         _, _, str_fmt = self._select_subfmts(self.out_subfmt)[0]

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -156,6 +156,8 @@ class TimeFormat(metaclass=TimeFormatMeta):
     def mask(self):
         if 'mask' not in self.cache:
             self.cache['mask'] = np.isnan(self.jd2)
+            if self.cache['mask'].shape:
+                self.cache['mask'].flags.writeable = False
         return self.cache['mask']
 
     @property

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -69,11 +69,6 @@ def _regexify_subfmts(subfmts):
     return tuple(new_subfmts)
 
 
-class TimeMaskedArray(np.ma.MaskedArray):
-    def __repr__(self):
-        return 'masked_array({})'.format(self)
-
-
 class TimeFormatMeta(type):
     """
     Metaclass that adds `TimeFormat` and `TimeDeltaFormat` to the
@@ -149,7 +144,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
 
     def mask_if_needed(self, value):
         if self.masked:
-            value = TimeMaskedArray(value, mask=self.mask, copy=False)
+            value = np.ma.array(value, mask=self.mask, copy=False)
         return value
 
     @property

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1213,7 +1213,9 @@ def test_setitem_location():
     # Fails because the right hand side has location=None
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-1, format='cxcsec')
-    assert 'cannot set to Time with different location' in str(err)
+    assert ('cannot set to Time with different location: '
+            'expected location=(1.0, 3.0, 5.0) m and '
+            'got location=None') in str(err)
 
     # Succeeds because the right hand side correctly sets location
     t[0, 0] = Time(-2, format='cxcsec', location=loc[0])
@@ -1222,13 +1224,17 @@ def test_setitem_location():
     # Fails because the right hand side has different location
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
-    assert 'cannot set to Time with different location' in str(err)
+    assert ('cannot set to Time with different location: '
+            'expected location=(1.0, 3.0, 5.0) m and '
+            'got location=(2.0, 4.0, 6.0) m') in str(err)
 
     # Fails because the Time has None location and RHS has defined location
     t = Time([[1, 2], [3, 4]], format='cxcsec')
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
-    assert 'cannot set to Time with different location' in str(err)
+    assert ('cannot set to Time with different location: '
+            'expected location=None and '
+            'got location=(2.0, 4.0, 6.0) m') in str(err)
 
     # Broadcasting works
     t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1091,7 +1091,7 @@ def test_cache():
     t2 = Time('2010-09-03 00:00:00')
 
     # Time starts out without a cache
-    assert 'cache' not in t.__dict__
+    assert 'cache' not in t._time.__dict__
 
     # Access the iso format and confirm that the cached version is as expected
     t.iso
@@ -1102,11 +1102,11 @@ def test_cache():
     assert t.cache['scale']['tai'] == t2.tai
 
     # New Time object after scale transform does not have a cache yet
-    assert 'cache' not in t.tt.__dict__
+    assert 'cache' not in t.tt._time.__dict__
 
     # Clear the cache
     del t.cache
-    assert 'cache' not in t.__dict__
+    assert 'cache' not in t._time.__dict__
     # Check accessing the cache creates an empty dictionary
     assert not t.cache
     assert 'cache' in t.__dict__

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1168,3 +1168,22 @@ def test_bytes_input():
     assert tarray.dtype.kind == 'S'
     t2 = Time(tarray)
     assert t2 == t0
+
+
+def test_writeable_flag():
+    t = Time([1, 2, 3], format='cxcsec')
+    t[1] = 5.0
+    assert allclose_sec(t[1].value, 5.0)
+
+    t.writeable = False
+    with pytest.raises(ValueError) as err:
+        t[1] = 5.0
+    assert 'assignment destination is read-only' in str(err)
+
+    with pytest.raises(ValueError) as err:
+        t[:] = 5.0
+    assert 'assignment destination is read-only' in str(err)
+
+    t.writeable = True
+    t[1] = 10.0
+    assert allclose_sec(t[1].value, 10.0)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1292,3 +1292,13 @@ def test_setitem_bad_item():
     t = Time([1, 2], format='cxcsec')
     with pytest.raises(IndexError):
         t['asdf'] = 3
+
+
+def test_setitem_deltas():
+    """Setting invalidates any transform deltas"""
+    t = Time([1, 2], format='cxcsec')
+    t.delta_tdb_tt = [1, 2]
+    t.delta_ut1_utc = [3, 4]
+    t[1] = 3
+    assert not hasattr(t, '_delta_tdb_tt')
+    assert not hasattr(t, '_delta_ut1_utc')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1216,7 +1216,7 @@ def test_setitem_location():
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert 'cannot set to Time with different location' in str(err)
-    
+
     # Broadcasting works
     t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)
     t[0, :] = Time([-3, -4], format='cxcsec', location=loc)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1108,7 +1108,7 @@ def test_cache():
     assert 'cache' not in t._time.__dict__
     # Check accessing the cache creates an empty dictionary
     assert not t.cache
-    assert 'cache' in t.__dict__
+    assert 'cache' in t._time.__dict__
 
 
 def test_epoch_date_jd_is_day_fraction():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -6,10 +6,9 @@ import functools
 import datetime
 from copy import deepcopy
 
-import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings
+from ...tests.helper import catch_warnings, pytest
 from ...utils import isiterable
 from .. import Time, ScaleValueError, TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1177,15 +1177,28 @@ def test_writeable_flag():
     t.writeable = False
     with pytest.raises(ValueError) as err:
         t[1] = 5.0
-    assert 'assignment destination is read-only' in str(err)
+    assert 'Time object is read-only. Make a copy()' in str(err)
 
     with pytest.raises(ValueError) as err:
         t[:] = 5.0
-    assert 'assignment destination is read-only' in str(err)
+    assert 'Time object is read-only. Make a copy()' in str(err)
 
     t.writeable = True
     t[1] = 10.0
     assert allclose_sec(t[1].value, 10.0)
+
+    # Scalar is not writeable
+    t = Time('2000:001', scale='utc')
+    with pytest.raises(ValueError) as err:
+        t[()] = '2000:002'
+    assert 'scalar Time object is read-only.' in str(err)
+
+    # Transformed attribute is not writeable
+    t = Time(['2000:001', '2000:002'], scale='utc')
+    t2 = t.tt  # t2 is read-only now because t.tt is cached
+    with pytest.raises(ValueError) as err:
+        t2[0] = '2005:001'
+    assert 'Time object is read-only. Make a copy()' in str(err)
 
 
 def test_setitem_location():

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -420,3 +420,31 @@ class TestTimeDeltaScales():
         assert allclose_jd(t3.jd, t[0].jd) ^ (scale == 'utc')
         t4 = t[-1] - q_day
         assert allclose_jd(t4.jd, t[0].jd) ^ (scale == 'utc')
+
+
+def test_timedelta_setitem():
+    t = TimeDelta([1, 2, 3] * u.d, format='jd')
+
+    t[0] = 0.5
+    assert allclose_jd(t.value, [0.5, 2, 3])
+
+    t[1:] = 4.5
+    assert allclose_jd(t.value, [0.5, 4.5, 4.5])
+
+    t[:] = 86400 * u.s
+    assert allclose_jd(t.value, [1, 1, 1])
+
+    t[1] = TimeDelta(2, format='jd')
+    assert allclose_jd(t.value, [1, 2, 1])
+
+    with pytest.raises(ValueError) as err:
+        t[1] = 1 * u.m
+    assert 'cannot convert value to a compatible TimeDelta' in str(err)
+
+
+def test_timedelta_mask():
+    t = TimeDelta([1, 2] * u.d, format='jd')
+    t[1] = np.ma.masked
+    assert np.all(t.mask == [False, True])
+    assert allclose_jd(t[0].value, 1)
+    assert t.value[1] is np.ma.masked

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -3,6 +3,7 @@
 import functools
 import numpy as np
 
+from ...utils.compat import NUMPY_LT_1_14
 from ...tests.helper import pytest
 from .. import Time
 
@@ -57,9 +58,17 @@ def test_str():
     t[1] = np.ma.masked
     assert str(t) == "['2000:001:00:00:00.000' --]"
     assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
-    assert repr(t.iso).splitlines() == ["masked_array(data = ['2000-01-01 00:00:00.000' --],",
-                                        "             mask = [False  True],",
-                                        "       fill_value = N/A)"]
+
+    if NUMPY_LT_1_14:
+        expected = ["masked_array(data = ['2000-01-01 00:00:00.000' --],",
+                    "             mask = [False  True],",
+                    "       fill_value = N/A)"]
+    else:
+        expected = ["masked_array(data=['2000-01-01 00:00:00.000', --],",
+                    '             mask=[False,  True],',
+                    "       fill_value='N/A',",
+                    "            dtype='<U23')"]
+    assert repr(t.iso).splitlines() == expected
 
     # Assign value to unmask
     t[1] = '2000:111'

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -57,7 +57,9 @@ def test_str():
     t[1] = np.ma.masked
     assert str(t) == "['2000:001:00:00:00.000' --]"
     assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
-    assert repr(t.iso) == "masked_array(['2000-01-01 00:00:00.000' --])"
+    assert repr(t.iso).splitlines() == ["masked_array(data = ['2000-01-01 00:00:00.000' --],",
+                                        "             mask = [False  True],",
+                                        "       fill_value = N/A)"]
 
     # Assign value to unmask
     t[1] = '2000:111'

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import functools
+import numpy as np
+
+from .. import Time
+
+allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+is_masked = np.ma.is_masked
+
+
+def test_simple():
+    t = Time([1, 2, 3], format='cxcsec')
+    assert t.masked is False
+
+    # Before masking, format output is not a masked array (it is an ndarray
+    # like always)
+    assert not isinstance(t.value, np.ma.MaskedArray)
+    assert not isinstance(t.unix, np.ma.MaskedArray)
+
+    t[2] = np.ma.masked
+    assert t.masked is True
+    assert np.all(t.mask == [False, False, True])
+    assert allclose_sec(t.value[:2], [1, 2])
+    assert is_masked(t.value[2])
+    assert is_masked(t[2].value)
+
+    # After masking format output is a masked array
+    assert isinstance(t.value, np.ma.MaskedArray)
+    assert isinstance(t.unix, np.ma.MaskedArray)
+    # Todo : test all formats
+
+
+def test_str():
+    t = Time(['2000:001', '2000:002'])
+    t[1] = np.ma.masked
+    assert str(t) == "['2000:001:00:00:00.000' --]"
+    assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
+
+    # Assign value to unmask
+    t[1] = '2000:111'
+    assert str(t) == "['2000:001:00:00:00.000' '2000:111:00:00:00.000']"
+    assert t.masked is False
+
+
+def test_transform():
+    t = Time(['2000:001', '2000:002'])
+    t[1] = np.ma.masked
+
+    # Change scale (this tests the ERFA machinery with masking as well)
+    t_ut1 = t.ut1
+    assert is_masked(t_ut1.value[1])
+    assert not is_masked(t_ut1.value[0])
+    assert np.all(t_ut1.mask == [False, True])
+    
+    # Change format
+    t_unix = t.unix
+    assert is_masked(t_unix[1])
+    assert not is_masked(t_unix[0])
+    assert np.all(t_unix.mask == [False, True])
+    

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -37,6 +37,7 @@ def test_str():
     t[1] = np.ma.masked
     assert str(t) == "['2000:001:00:00:00.000' --]"
     assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
+    assert repr(t.iso) == "masked_array(['2000-01-01 00:00:00.000' --])"
 
     # Assign value to unmask
     t[1] = '2000:111'

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -293,10 +293,8 @@ class TestManipulation():
 
 class TestArithmetic():
     """Arithmetic on Time objects, using both doubles."""
-    # kwargs = ({}, {'axis': None}, {'axis': 0}, {'axis': 1}, {'axis': 2})
-    kwargs = ({'axis': None},)
-    # functions = ('min', 'max', 'sort')
-    functions = ('sort',)
+    kwargs = ({}, {'axis': None}, {'axis': 0}, {'axis': 1}, {'axis': 2})
+    functions = ('min', 'max', 'sort')
 
     def setup(self):
         mjd = np.arange(50000, 50100, 10).reshape(2, 5, 1)

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -164,8 +164,10 @@ class TestManipulation():
 
     def test_shape_setting(self):
         t0_reshape = self.t0.copy()
+        mjd = t0_reshape.mjd  # Creates a cache of the mjd attribute
         t0_reshape.shape = (5, 2, 5)
         assert t0_reshape.shape == (5, 2, 5)
+        assert mjd.shape != t0_reshape.mjd.shape  # Cache got cleared
         assert np.all(t0_reshape.jd1 == self.t0._time.jd1.reshape(5, 2, 5))
         assert np.all(t0_reshape.jd2 == self.t0._time.jd2.reshape(5, 2, 5))
         assert t0_reshape.location is None

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -6,7 +6,7 @@ earlier versions of Numpy.
 from ...utils import minversion
 
 
-__all__ = ['NUMPY_LT_1_10_4', 'NUMPY_LT_1_11',
+__all__ = ['NUMPY_LT_1_10_4', 'NUMPY_LT_1_11', 'NUMPY_LT_1_11_2',
            'NUMPY_LT_1_12', 'NUMPY_LT_1_13', 'NUMPY_LT_1_14']
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -14,6 +14,7 @@ __all__ = ['NUMPY_LT_1_10_4', 'NUMPY_LT_1_11',
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
 NUMPY_LT_1_10_4 = not minversion('numpy', '1.10.4')
 NUMPY_LT_1_11 = not minversion('numpy', '1.11.0')
+NUMPY_LT_1_11_2 = not minversion('numpy', '1.11.2')
 NUMPY_LT_1_12 = not minversion('numpy', '1.12')
 NUMPY_LT_1_13 = not minversion('numpy', '1.13')
 NUMPY_LT_1_14 = not minversion('numpy', '1.14dev')

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -192,6 +192,7 @@ class IERS(QTable):
             jd1, jd2 = jd1.utc.jd1, jd1.utc.jd2
         except Exception:
             pass
+
         mjd = np.floor(jd1 - MJD_ZERO + jd2)
         utc = jd1 - (MJD_ZERO+mjd) + jd2
         return mjd, utc

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -613,7 +613,7 @@ attributes::
   >>> print(t[[2, 0]])
   ['2001:060' '2001:020']
 
-As of astropy version 3.0, one can also set values in-place for an
+As of astropy version 3.1, one can also set values in-place for an
 array-valued |Time| object::
 
   >>> t = Time(['2001:020', '2001:040', '2001:060', '2001:080'],
@@ -651,7 +651,7 @@ Missing values
 ^^^^^^^^^^^^^^
 
 The |Time| and |TimeDelta| objects support functionality for marking values as
-missing or invalid (added in astropy 3.0).  This is also known as masking,
+missing or invalid (added in astropy 3.1).  This is also known as masking,
 and is especially useful for :ref:`table_operations` such as joining and
 stacking.  To set one or more items as missing, assign the special value
 `~numpy.ma.masked`, for example::
@@ -794,7 +794,7 @@ the cache.  In order to explicitly clear the internal cache do::
   CPU times: user 263 ms, sys: 4.02 ms, total: 267 ms
   Wall time: 267 ms
 
-Since astropy 3.0 these objects can be changed internally.  In order
+Since astropy 3.1 these objects can be changed internally.  In order
 to ensure consistency between the transformed (and cached) version and
 the original, the transformed object is set to be not writeable.  For
 example::

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -94,6 +94,20 @@ this information is kept is the ``fits`` format::
   >>> print(t2.fits)
   ['1999-01-01T00:01:04.307(TT)' '2010-01-01T00:01:06.184(TT)']
 
+One can set the time values in-place using the usual numpy array setting
+item syntax::
+
+  >>> t2[1] = '2014-12-25'
+  >>> print(t2)
+  ['1999-01-01T00:01:04.307' '2014-12-25T00:00:00.000']
+
+The |Time| object also has support for missing values, which is particularly
+useful for :ref:`table_operations` such as joining and stacking::
+
+  >>> t2[0] = np.ma.masked  # Declare that first time is missing or invalid
+  >>> print(t2)
+  [-- '2014-12-25T00:00:00.000']
+
 Finally, some further examples of what is possible.  For details, see
 the API documentation below.
 
@@ -576,13 +590,56 @@ The two should be very close to each other.
 Using Time objects
 -------------------
 
-There are four basic operations available with |Time| objects:
+There are five basic operations available with |Time| objects:
 
+- Get and set time values(s) for an array-valued |Time| object.
 - Get the representation of the time value(s) in a particular `time format`_.
 - Get a new time object for the same time value(s) but referenced to a different
   `time scale`_.
 - Calculate the `sidereal time`_ corresponding to the time value(s).
 - Do time arithmetic involving |Time| and/or |TimeDelta| objects.
+
+Get and set values
+^^^^^^^^^^^^^^^^^^
+
+For an existing |Time| object which is array-valued, one can use the
+usual numpy array item syntax to get either a single item or a subset
+of items.  The returned value is a |Time| object with all the same
+attributes::
+
+  >>> t = Time(['2001:020', '2001:040', '2001:060', '2001:080'],
+  ...          out_subfmt='date')
+  >>> print(t[1])
+  2001:040
+  >>> print(t[1:])
+  ['2001:040' '2001:060' '2001:080']
+  >>> print(t[[2, 0]])
+  ['2001:060' '2001:020']
+
+As of astropy version 3.0, one can also set values in-place for an
+array-valued |Time| object::
+
+  >>> t = Time(['2001:020', '2001:040', '2001:060', '2001:080'],
+  ...          out_subfmt='date')
+  >>> t[1] = '2010:001'
+  >>> print(t)
+  ['2001:020' '2010:001' '2001:060' '2001:080']
+  >>> t[[2, 0]] = '1990:123'
+  >>> print(t)
+  ['1990:123' '2010:001' '1990:123' '2001:080']
+
+The new value (on the right hand side) when setting can be one of three
+possibilities:
+
+- Scalar string value or array of string values where each value
+  is in a valid time format that can be automatically parsed and
+  used to create a |Time| object.
+- Value or array of values where each value has the same ``format`` as
+  the |Time| object being set.  For instance, a float or numpy array
+  of floats for an object with ``format='unix'``.
+- |Time| object with identical ``location`` (but ``scale`` and
+  ``format`` need not be the same).  The right side value will be
+  transformed so the time ``scale`` matches.
 
 Get representation
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -654,13 +654,24 @@ The |Time| and |TimeDelta| objects support functionality for marking values as
 missing or invalid (added in astropy 3.1).  This is also known as masking,
 and is especially useful for :ref:`table_operations` such as joining and
 stacking.  To set one or more items as missing, assign the special value
-`~numpy.ma.masked`, for example::
+`numpy.ma.masked`, for example::
 
   >>> t = Time(['2001:020', '2001:040', '2001:060', '2001:080'],
   ...          out_subfmt='date')
   >>> t[2] = np.ma.masked
   >>> print(t)
   ['2001:020' '2001:040' -- '2001:080']
+
+.. note:: The operation of setting an array element to `numpy.ma.masked`
+   (missing) *overwrites* the actual time data and therefore there is no way to
+   recover the original value.  In this sense the `numpy.ma.masked` value
+   behaves just like any other valid |Time| value when setting.  This is
+   similar to how `Pandas missing data
+   <https://pandas.pydata.org/pandas-docs/stable/missing_data.html>`_ works,
+   but somewhat different from `NumPy masked arrays
+   <https://docs.scipy.org/doc/numpy/reference/maskedarray.html>`_ which
+   maintain a separate mask array and retain the underlying data.  In the
+   |Time| object the ``mask`` attribute is read-only and cannot be directly set.
 
 Once one or more values in the object are masked, any operations will
 propagate those values as masked, and access to format attributes such

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -145,12 +145,6 @@ There is no distinction made between a "date" and a "time" since both concepts
 (as loosely defined in common usage) are just different representations of a
 moment in time.
 
-Once a |Time| object is created it cannot be altered internally.  In code lingo
-it is "immutable."  In particular the common operation of "converting" to a
-different `time scale`_ is always performed by returning a copy of the original
-|Time| object which has been converted to the new time scale.
-
-
 .. _time-format:
 
 Time Format
@@ -644,10 +638,14 @@ possibilities:
   ``format`` need not be the same).  The right side value will be
   transformed so the time ``scale`` matches.
 
+Whenever any item is set then the internal cache (see `Caching`_) is cleared
+along with the ``delta_tdb_tt`` and/or ``delta_ut1_utc`` transformation
+offsets, if they have been set.
+
 If it is required that the |Time| object be immutable then set the
-``writeable`` attribute to `False`.  In this case attemping to set a
-value will raise a ``ValueError: assignment destination is
-read-only``.  See the section on `Caching`_ for an example.
+``writeable`` attribute to `False`.  In this case attemping to set a value will
+raise a ``ValueError: Time object is read-only``.  See the section on
+`Caching`_ for an example.
 
 Missing values
 ^^^^^^^^^^^^^^
@@ -749,7 +747,7 @@ The computations for transforming to different time scales or formats can be
 time-consuming for large arrays.  In order to avoid repeated computations, each
 |Time| or |TimeDelta| instance caches such transformations internally::
 
-  >>> t = Time(np.arange(1e6), format='unix', scale='utc')  # doctest: +SKIP
+  >>> t = Time(np.arange(1e6), format='unix', scale='utc')
 
   >>> time x = t.tt  # doctest: +SKIP
   CPU times: user 263 ms, sys: 4.02 ms, total: 267 ms
@@ -762,7 +760,7 @@ time-consuming for large arrays.  In order to avoid repeated computations, each
 Actions such as changing the output precision or sub-format will clear
 the cache.  In order to explicitly clear the internal cache do::
 
-  >>> del t.cache  # doctest: +SKIP
+  >>> del t.cache
 
   >>> time x = t.tt  # doctest: +SKIP
   CPU times: user 263 ms, sys: 4.02 ms, total: 267 ms
@@ -773,11 +771,11 @@ to ensure consistency between the transformed (and cached) version and
 the original, the transformed object is set to be not writeable.  For
 example::
 
-  >>> x = t.tt  # doctest: +SKIP
-  >>> x[1] = '2000:001'  # doctest: +SKIP
-    File "/Users/aldcroft/git/astropy/astropy/time/core.py", line 700, in __setitem__
-      self._time.jd1[item] = value._time.jd1
-  ValueError: assignment destination is read-only
+  >>> x = t.tt
+  >>> x[1] = '2000:001'
+  Traceback (most recent call last):
+    ...
+  ValueError: Time object is read-only. Make a copy() or set "writeable" attribute to True.
 
 If you require modifying the object then make a copy first, e.g. ``x = t.tt.copy()``.
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -667,7 +667,7 @@ propagate those values as masked, and access to format attributes such
 as ``unix`` or ``value`` will return a `~numpy.ma.MaskedArray`
 object::
 
-  >>> t.unix
+  >>> t.unix  # doctest: +SKIP
   masked_array(data = [979948800.0 981676800.0 -- 985132800.0],
                mask = [False False  True False],
          fill_value = 1e+20)
@@ -676,7 +676,7 @@ One can view the ``mask``, but note that it is read-only and
 setting the mask is always done by setting the item to `~numpy.ma.masked`.
 
   >>> t.mask
-  array([False, False,  True, False], dtype=bool)
+  array([False, False,  True, False]...)
   >>> t[:2] = np.ma.masked
 
 .. warning:: The internal implementation of missing value support is

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -693,15 +693,15 @@ class *if you wish to support missing values*.  For applications that
 do not take advantage of missing values then no changes are required.
 
 Missing values in a `~astropy.time.TimeFormat` subclass object are marked by
-setting the corresponding entries of the ``jd2`` attribute to be `~numpy.nan`
+setting the corresponding entries of the ``jd2`` attribute to be ``numpy.nan``
 (but this is never done directly by the user).  For most array operations and
-numpy functions the `~numpy.nan` entries are propagated as expected and all is
+numpy functions the ``numpy.nan`` entries are propagated as expected and all is
 well.  However, this is not always the case, and in particular the `ERFA
 <https://github.com/liberfa/erfa>`_ routines do not generally support
-`~numpy.nan` values gracefully.
+``numpy.nan`` values gracefully.
 
-In cases where `~np.nan` is not acceptable, format class methods should use the
-``jd2_filled`` property instead of ``jd2``.  This replaces `~numpy.nan` with
+In cases where ``numpy.nan`` is not acceptable, format class methods should use the
+``jd2_filled`` property instead of ``jd2``.  This replaces ``numpy.nan`` with
 ``0.0``.  Since ``jd2`` is always in the range -1 to +1, substituing ``0.0``
 will allow functions to return "reasonable" values which will then be masked in
 any subsequent outputs.  See the ``value`` property of the

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -650,11 +650,11 @@ raise a ``ValueError: Time object is read-only``.  See the section on
 Missing values
 ^^^^^^^^^^^^^^
 
-The |Time| and |TimeDelta| objects support functionality for marking
-values as missing or invalid.  This is also known as masking,
-and is especially useful for :ref:`table_operations` such as joining
-and stacking.  To set one or more items as missing, assign the special
-value `~numpy.ma.masked`, for example::
+The |Time| and |TimeDelta| objects support functionality for marking values as
+missing or invalid (added in astropy 3.0).  This is also known as masking,
+and is especially useful for :ref:`table_operations` such as joining and
+stacking.  To set one or more items as missing, assign the special value
+`~numpy.ma.masked`, for example::
 
   >>> t = Time(['2001:020', '2001:040', '2001:060', '2001:080'],
   ...          out_subfmt='date')
@@ -678,6 +678,34 @@ setting the mask is always done by setting the item to `~numpy.ma.masked`.
   >>> t.mask
   array([False, False,  True, False], dtype=bool)
   >>> t[:2] = np.ma.masked
+
+.. warning:: The internal implementation of missing value support is
+   provisional and may change in a subsequent release.  This would impact
+   information in the next section.  However, the documented API for using missing
+   values with |Time| and |TimeDelta| objects is stable.
+
+Custom format classes and missing values
+""""""""""""""""""""""""""""""""""""""""
+
+For advanced users who have written a custom time format via a
+`~astropy.time.TimeFormat` subclass, it may be necessary to modify your
+class *if you wish to support missing values*.  For applications that
+do not take advantage of missing values then no changes are required.
+
+Missing values in a `~astropy.time.TimeFormat` subclass object are marked by
+setting the corresponding entries of the ``jd2`` attribute to be `~numpy.nan`
+(but this is never done directly by the user).  For most array operations and
+numpy functions the `~numpy.nan` entries are propagated as expected and all is
+well.  However, this is not always the case, and in particular the `ERFA
+<https://github.com/liberfa/erfa>`_ routines do not generally support
+`~numpy.nan` values gracefully.
+
+In cases where `~np.nan` is not acceptable, format class methods should use the
+``jd2_filled`` property instead of ``jd2``.  This replaces `~numpy.nan` with
+``0.0``.  Since ``jd2`` is always in the range -1 to +1, substituing ``0.0``
+will allow functions to return "reasonable" values which will then be masked in
+any subsequent outputs.  See the ``value`` property of the
+`~astropy.time.TimeDecimalYear` format for any example.
 
 Get representation
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is an implementation of the necessary bits to fully support table join, hstack, and vstack for the Time class.

It includes new functionality for Time masking and setting, along with an implementation of the info class `new_like()` method.

**Masking**: there was discussion about whether to do this with `np.nan` internally or using `MaskedArray`.  I first did the latter and got something mostly working (passing most but not all tests), but it ended up getting messy.  In particular the interactions with `Quantity` got ugly because Quantity knows how to play with `ndarray` but not `MaskedArray` in arithmetic etc.

But it looks like the `np.nan` solution is fine, with the unexpected twist that using this strictly in `jd2` makes life a lot easier because it is easy to locally set the `nan` values to `0` before entering any ERFA functions.  This avoids the `dubious` values problem.

**Setting**: I think it is time to make `Time` mutable!  Admittedly I haven't thought super hard about pitfalls yet, but I think just being careful about clearing the cache is enough.  This is going to be needed to make `Time` work in table operations (and probably Time series) where you need masking and item setting.

To do:

- [x] Tests of setting
- [x] Docs
- [x] Changelog
