### PR TITLE
POC: minimal masking for Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,9 @@ New Features
   - Added functionality to allow ``astropy.units.Quantity`` to be written 
     as a normal column to FITS files. [#5910]
 
+  - Add support for Quantity columns (within a ``QTable``) in table
+    ``join()``, ``hstack()`` and ``vstack()`` operations. [#5841]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -299,6 +299,7 @@ class TimeFrameAttribute(FrameAttribute):
                                                                value, err))
             converted = True
 
+        out.writeable = False
         return out, converted
 
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -938,6 +938,17 @@ class Column(BaseColumn):
     to = BaseColumn.to
 
 
+class MaskedColumnInfo(ColumnInfo):
+    """
+    Container for meta information like name, description, format.
+
+    This is required when the object is used as a mixin column within a table,
+    but can be used as a general way to store meta information.  In this case
+    it just adds the ``mask_val`` attribute.
+    """
+    mask_val = np.ma.masked
+
+
 class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     """Define a masked data column for use in a Table object.
 
@@ -1009,6 +1020,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
       The default ``dtype`` is ``np.float64``.  The ``shape`` argument is the
       array shape of a single cell in the column.
     """
+    info = MaskedColumnInfo()
 
     def __new__(cls, data=None, name=None, mask=None, fill_value=None,
                 dtype=None, shape=(), length=0,

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -642,17 +642,20 @@ def _join(left, right, keys=None, join_type='inner',
 
         # If the output table is masked then set the output column masking
         # accordingly.  Check for columns that don't support a mask attribute.
-        if masked:
+        if masked and np.any(array_mask):
             # array_mask is 1-d corresponding to length of output column.  We need
             # make it have the correct shape for broadcasting, i.e. (length, 1, 1, ..).
             # Mixin columns might not have ndim attribute so use len(col.shape).
             array_mask.shape = (out[out_name].shape[0],) + (1,) * (len(out[out_name].shape) - 1)
 
+            # Now broadcast to the correct final shape
+            array_mask = np.broadcast_to(array_mask, out[out_name].shape)
+
             if array.masked:
                 array_mask = array_mask | array[name].mask[array_out]
             try:
-                out[out_name].mask[:] = array_mask
-            except ValueError:
+                out[out_name][array_mask] = out[out_name].info.mask_val
+            except Exception:  # Not clear how different classes will fail here
                 raise NotImplementedError(
                     "join requires masking column '{}' but column"
                     " type {} does not support masking"
@@ -759,8 +762,8 @@ def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='wa
                 out[out_name][idx0:idx1] = array[name]
             else:
                 try:
-                    out[out_name].mask[idx0:idx1] = True
-                except ValueError:
+                    out[out_name][idx0:idx1] = out[out_name].info.mask_val
+                except Exception:
                     raise NotImplementedError(
                         "vstack requires masking column '{}' but column"
                         " type {} does not support masking"
@@ -856,8 +859,8 @@ def _hstack(arrays, join_type='outer', uniq_col_name='{col_name}_{table_name}',
                 indices[arr_len:] = 0
                 out[out_name] = array[name][indices]
                 try:
-                    out[out_name].mask[arr_len:] = True
-                except ValueError:
+                    out[out_name][arr_len:] = out[out_name].info.mask_val
+                except Exception:
                     raise NotImplementedError(
                         "hstack requires masking column '{}' but column"
                         " type {} does not support masking"

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -768,7 +768,7 @@ class TestVStack():
         cls_name = type(col).__name__
 
         # Vstack works for these classes:
-        implemented_mixin_classes = ['Quantity']
+        implemented_mixin_classes = ['Quantity', 'Time']
         if cls_name in implemented_mixin_classes:
             table.vstack([t, t])
         else:
@@ -776,6 +776,16 @@ class TestVStack():
                 table.vstack([t, t])
             assert ('vstack unavailable for mixin column type(s): {}'
                     .format(cls_name) in str(err))
+
+        t2 = table.QTable([col], names='a')  # different from col0 name for t
+        mixin_classes_with_masking = ['Time']
+        if cls_name in mixin_classes_with_masking:
+            table.vstack([t, t2], join_type='outer')
+        else:
+            with pytest.raises(NotImplementedError) as err:
+                table.vstack([t, t2], join_type='outer')
+            assert ('vstack requires masking' in str(err) or
+                    'vstack unavailable' in str(err))
 
 
 class TestHStack():
@@ -981,6 +991,23 @@ class TestHStack():
         """Regression test for issue #3313"""
         assert (self.t1 == table.hstack(self.t1)).all()
         assert (self.t1 == table.hstack([self.t1])).all()
+
+    def test_check_for_mixin_functionality(self, mixin_cols):
+        col = mixin_cols['m']
+        t = table.QTable([col])
+        t2 = t[:2]  # shorter version of same table
+
+        cls_name = type(col).__name__
+
+        table.hstack([t, t2], join_type='inner')
+
+        mixin_classes_with_masking = ['Time']
+        if cls_name in mixin_classes_with_masking:
+            table.hstack([t, t2], join_type='outer')
+        else:
+            with pytest.raises(NotImplementedError) as err:
+                table.hstack([t, t2], join_type='outer')
+            assert 'hstack requires masking' in str(err)
 
 
 def test_unique(operation_table_type):

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -99,8 +99,6 @@ class TestJoin():
         assert t12.meta == self.meta_merge
 
     def test_both_unmasked_left_right_outer(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
         t2 = self.t2
@@ -166,8 +164,6 @@ class TestJoin():
                                        '  2 bar  L4 bar  R3'])
 
     def test_both_unmasked_single_key_left_right_outer(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
         t2 = self.t2
@@ -210,8 +206,6 @@ class TestJoin():
                                        '  4  --  -- bar  R4'])
 
     def test_masked_unmasked(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
         t1m = operation_table_type(self.t1, masked=True)
@@ -249,8 +243,6 @@ class TestJoin():
     def test_masked_masked(self, operation_table_type):
         self._setup(operation_table_type)
         """Two masked tables"""
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         t1 = self.t1
         t1m = operation_table_type(self.t1, masked=True)
         t2 = self.t2
@@ -332,8 +324,6 @@ class TestJoin():
     def test_masked_key_column(self, operation_table_type):
         self._setup(operation_table_type)
         """Merge on a key column that has a masked element"""
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         t1 = self.t1
         t2 = operation_table_type(self.t2, masked=True)
         table.join(t1, t2)  # OK
@@ -416,9 +406,6 @@ class TestJoin():
         Test for outer join with multidimensional columns where masking is required.
         (Issue #4059).
         """
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
-
         a = table.MaskedColumn([1, 2, 3], name='a')
         a2 = table.Column([1, 3, 4], name='a')
         b = table.MaskedColumn([[1, 2],
@@ -571,8 +558,6 @@ class TestVStack():
                                   '1.0 bar']
 
     def test_stack_basic_outer(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
         t2 = self.t2
@@ -616,14 +601,11 @@ class TestVStack():
             table.vstack([self.t1, t1_reshape])
         assert "have different shape" in str(excinfo)
 
-
     def test_vstack_one_masked(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
         t4 = self.t4
-        t4['b'].mask[1] = True
+        t4['b'][1] = np.ma.masked
         assert table.vstack([t1, t4]).pformat() == [' a   b ',
                                                     '--- ---',
                                                     '0.0 foo',
@@ -701,8 +683,6 @@ class TestVStack():
         assert out['b'].info.meta == OrderedDict([('b', [3, 4]), ('c', {'b': 1}), ('a', 1)])
 
     def test_col_meta_merge_outer(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
         t1 = self.t1
         t2 = self.t2
@@ -740,12 +720,13 @@ class TestVStack():
         with catch_warnings(metadata.MergeConflictWarning) as warning_lines:
             out = table.vstack([t1, t2, t4], join_type='outer')
 
-        assert warning_lines[0].category == metadata.MergeConflictWarning
-        assert ("In merged column 'a' the 'unit' attribute does not match (cm != m)"
-                in str(warning_lines[0].message))
-        assert warning_lines[1].category == metadata.MergeConflictWarning
-        assert ("In merged column 'a' the 'unit' attribute does not match (m != km)"
-                in str(warning_lines[1].message))
+        if operation_table_type is not QTable:
+            assert warning_lines[0].category == metadata.MergeConflictWarning
+            assert ("In merged column 'a' the 'unit' attribute does not match (cm != m)"
+                    in str(warning_lines[0].message))
+            assert warning_lines[1].category == metadata.MergeConflictWarning
+            assert ("In merged column 'a' the 'unit' attribute does not match (m != km)"
+                    in str(warning_lines[1].message))
         assert out['a'].unit == 'km'
         assert out['a'].info.format == '%0d'
         assert out['b'].info.description == 't1_b'
@@ -778,8 +759,7 @@ class TestVStack():
                     .format(cls_name) in str(err))
 
         t2 = table.QTable([col], names='a')  # different from col0 name for t
-        mixin_classes_with_masking = ['Time']
-        if cls_name in mixin_classes_with_masking:
+        if cls_name in implemented_mixin_classes:
             table.vstack([t, t2], join_type='outer')
         else:
             with pytest.raises(NotImplementedError) as err:
@@ -929,16 +909,15 @@ class TestHStack():
             table.hstack([self.t1, self.t3], join_type='exact')
 
     def test_hstack_one_masked(self, operation_table_type):
-        if operation_table_type is QTable:
-            pytest.xfail()
         self._setup(operation_table_type)
         t1 = self.t1
         t2 = operation_table_type(t1, copy=True, masked=True)
         t2.meta.clear()
-        t2['b'].mask[1] = True
+        t2['a'][0] = np.ma.masked
+        t2['b'][1] = np.ma.masked
         assert table.hstack([t1, t2]).pformat() == ['a_1 b_1 a_2 b_2',
                                                     '--- --- --- ---',
-                                                    '0.0 foo 0.0 foo',
+                                                    '0.0 foo  -- foo',
                                                     '1.0 bar 1.0  --']
 
     def test_table_col_rename(self, operation_table_type):
@@ -1001,8 +980,8 @@ class TestHStack():
 
         table.hstack([t, t2], join_type='inner')
 
-        mixin_classes_with_masking = ['Time']
-        if cls_name in mixin_classes_with_masking:
+        implemented_mixin_classes = ['Time', 'Quantity']
+        if cls_name in implemented_mixin_classes:
             table.hstack([t, t2], join_type='outer')
         else:
             with pytest.raises(NotImplementedError) as err:
@@ -1150,25 +1129,3 @@ def test_get_out_class():
 
     with pytest.raises(ValueError):
         _get_out_class([q, c])
-
-
-def test_masking_required_exception():
-    """
-    Test that outer join, hstack and vstack fail for a mixin column which
-    does not support masking.
-    """
-    col = [1, 2, 3, 4] * u.m
-    t1 = table.QTable([[1, 2, 3, 4], col], names=['a', 'b'])
-    t2 = table.QTable([[1, 2], col[:2]], names=['a', 'c'])
-
-    with pytest.raises(NotImplementedError) as err:
-        table.vstack([t1, t2], join_type='outer')
-    assert 'vstack requires masking' in str(err)
-
-    with pytest.raises(NotImplementedError) as err:
-        table.hstack([t1, t2], join_type='outer')
-    assert 'hstack requires masking' in str(err)
-
-    with pytest.raises(NotImplementedError) as err:
-        table.join(t1, t2, join_type='outer')
-    assert 'join requires masking' in str(err)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -424,6 +424,15 @@ class Time(ShapedLikeNDArray):
     info = TimeInfo()
 
     @property
+    def writeable(self):
+        return self._time.jd1.flags.writeable & self._time.jd2.flags.writeable
+
+    @writeable.setter
+    def writeable(self, value):
+        self._time.jd1.flags.writeable = value
+        self._time.jd2.flags.writeable = value
+
+    @property
     def format(self):
         """
         Get or set time format.

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -560,7 +560,10 @@ class Time(ShapedLikeNDArray):
                     reshaped.append(val)
 
     def _shaped_like_input(self, value):
-        return value if self._time.jd1.shape else value.item()
+        out = value
+        if not self._time.jd1.shape and not np.ma.is_masked(value):
+            out = value.item()
+        return out
 
     @property
     def jd1(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -103,6 +103,7 @@ class TimeInfo(MixinInfo):
     _represent_as_dict_attrs = ('jd1', 'jd2', 'format', 'scale', 'precision',
                                 'in_subfmt', 'out_subfmt', 'location',
                                 '_delta_ut1_utc', '_delta_tdb_tt')
+    mask_val = np.ma.masked
 
     @property
     def unit(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -133,6 +133,60 @@ class TimeInfo(MixinInfo):
 
         return out
 
+    def new_like(self, cols, length, metadata_conflicts='warn', name=None):
+        """
+        Return a new Time instance which is consistent with the
+        input ``cols`` and has ``length`` rows.
+
+        This is intended for creating an empty column object whose elements can
+        be set in-place for table operations like join or vstack.
+
+        Parameters
+        ----------
+        cols : list
+            List of input columns
+        length : int
+            Length of the output column object
+        metadata_conflicts : str ('warn'|'error'|'silent')
+            How to handle metadata conflicts
+        name : str
+            Output column name
+
+        Returns
+        -------
+        col : Time (or subclass)
+            Empty instance of this class consistent with ``cols``
+
+        """
+        # Get merged info attributes like shape, dtype, format, description, etc.
+        attrs = self.merge_cols_attributes(cols, metadata_conflicts, name,
+                                           ('meta', 'description'))
+        attrs.pop('dtype')  # Not relevant for Time
+
+        # Check that location is the same for all input Time objects
+        ok = all(np.all(col0.location == col1.location)
+                 for col0, col1 in zip(cols[:-1], cols[1:]))
+        if not ok:
+            raise ValueError('input columns have inconsistent locations')
+
+        # Make a new Time object
+        shape = (length,) + attrs.pop('shape')
+        jd2000 = 2451544.5  # Arbitrary JD value J2000.0 that will work with ERFA
+        jd1 = np.full(shape, jd2000, dtype='f8')
+        jd2 = np.zeros(shape, dtype='f8')
+        tm_attrs = {attr: getattr(cols[0], attr)
+                    for attr in ('scale', 'location',
+                                 'precision', 'in_subfmt', 'out_subfmt')}
+        out = self._parent_cls(jd1, jd2, format='jd', **tm_attrs)
+        out.format = cols[0].format
+
+        # Set remaining info attributes
+        for attr, value in attrs.items():
+            setattr(out.info, attr, value)
+
+        return out
+
+
 class TimeDeltaInfo(TimeInfo):
     _represent_as_dict_attrs = ('jd1', 'jd2', 'format', 'scale')
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -164,7 +164,7 @@ class TimeFormat(object):
     @property
     def masked(self):
         if 'masked' not in self.cache:
-            self.cache['masked'] = np.any(self.mask)
+            self.cache['masked'] = bool(np.any(self.mask))
         return self.cache['masked']
 
     @property
@@ -425,6 +425,7 @@ class TimeFromEpoch(TimeFormat):
 
         time_from_epoch = ((jd1 - self.epoch.jd1) +
                            (jd2 - self.epoch.jd2)) / self.unit
+
         return self.mask_if_needed(time_from_epoch)
 
     value = property(to_value)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -180,9 +180,10 @@ class TimeFormat(object):
 
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
-        if not (val1.dtype == np.double and np.all(np.isfinite(val1)) and
-                (val2 is None or
-                 val2.dtype == np.double and np.all(np.isfinite(val2)))):
+        # val1 cannot contain nan, but val2 can contain nan
+        ok1 = val1.dtype == np.double and np.all(np.isfinite(val1))
+        ok2 = val2 is None or (val2.dtype == np.double and not np.any(np.isinf(val2)))
+        if not (ok1 and ok2):
             raise TypeError('Input values for {0} class must be finite doubles'
                             .format(self.name))
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -75,7 +75,7 @@ def _regexify_subfmts(subfmts):
 
 class TimeMaskedArray(np.ma.MaskedArray):
     def __repr__(self):
-        return str(self)
+        return 'masked_array({})'.format(self)
 
 
 class TimeFormatMeta(type):
@@ -169,7 +169,7 @@ class TimeFormat(object):
 
     @property
     def jd2_filled(self):
-        return np.nan_to_num(self.jd2)
+        return np.nan_to_num(self.jd2) if self.masked else self.jd2
 
     @lazyproperty
     def cache(self):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -7,10 +7,11 @@ import fnmatch
 import time
 import re
 import datetime
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import numpy as np
 
+from ..utils.decorators import lazyproperty
 from .. import units as u
 from .. import _erfa as erfa
 from ..extern import six
@@ -70,6 +71,11 @@ def _regexify_subfmts(subfmts):
         new_subfmts.append(subfmt_tuple)
 
     return tuple(new_subfmts)
+
+
+class TimeMaskedArray(np.ma.MaskedArray):
+    def __repr__(self):
+        return str(self)
 
 
 class TimeFormatMeta(type):
@@ -144,6 +150,34 @@ class TimeFormat(object):
     def scale(self, val):
         self._scale = val
 
+    def mask_if_needed(self, value):
+        if self.masked:
+            value = TimeMaskedArray(value, mask=self.mask, copy=False)
+        return value
+
+    @property
+    def mask(self):
+        if 'mask' not in self.cache:
+            self.cache['mask'] = np.isnan(self.jd2)
+        return self.cache['mask']
+
+    @property
+    def masked(self):
+        if 'masked' not in self.cache:
+            self.cache['masked'] = np.any(self.mask)
+        return self.cache['masked']
+
+    @property
+    def jd2_filled(self):
+        return np.nan_to_num(self.jd2)
+
+    @lazyproperty
+    def cache(self):
+        """
+        Return the cache associated with this instance.
+        """
+        return defaultdict(dict)
+
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
         if not (val1.dtype == np.double and np.all(np.isfinite(val1)) and
@@ -207,7 +241,7 @@ class TimeFormat(object):
         require ``parent`` or have other optional args for ``to_value``
         should compute and return the value directly.
         """
-        return self.value
+        return self.mask_if_needed(self.value)
 
     @property
     def value(self):
@@ -297,7 +331,7 @@ class TimeDecimalYear(TimeFormat):
     def value(self):
         scale = self.scale.upper().encode('ascii')
         iy_start, ims, ids, ihmsfs = erfa.d2dtf(scale, 0,  # precision=0
-                                                self.jd1, self.jd2)
+                                                self.jd1, self.jd2_filled)
         imon = np.ones_like(iy_start)
         iday = np.ones_like(iy_start)
         ihr = np.zeros_like(iy_start)
@@ -390,7 +424,7 @@ class TimeFromEpoch(TimeFormat):
 
         time_from_epoch = ((jd1 - self.epoch.jd1) +
                            (jd2 - self.epoch.jd2)) / self.unit
-        return time_from_epoch
+        return self.mask_if_needed(time_from_epoch)
 
     value = property(to_value)
 
@@ -593,7 +627,7 @@ class TimeDatetime(TimeUnique):
         # since we want to be able to pass in timezone information.
         scale = self.scale.upper().encode('ascii')
         iys, ims, ids, ihmsfs = erfa.d2dtf(scale, 6,  # 6 for microsec
-                                           self.jd1, self.jd2)
+                                           self.jd1, self.jd2_filled)
         ihrs = ihmsfs[..., 0]
         imins = ihmsfs[..., 1]
         isecs = ihmsfs[..., 2]
@@ -612,7 +646,8 @@ class TimeDatetime(TimeUnique):
                                              tzinfo=TimezoneInfo()).astimezone(timezone)
             else:
                 out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
-        return iterator.operands[-1]
+
+        return self.mask_if_needed(iterator.operands[-1])
 
     value = property(to_value)
 
@@ -746,7 +781,7 @@ class TimeString(TimeUnique):
         """
         scale = self.scale.upper().encode('ascii'),
         iys, ims, ids, ihmsfs = erfa.d2dtf(scale, self.precision,
-                                           self.jd1, self.jd2)
+                                           self.jd1, self.jd2_filled)
 
         # Get the str_fmt element of the first allowed output subformat
         _, _, str_fmt = self._select_subfmts(self.out_subfmt)[0]

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1104,3 +1104,22 @@ def test_cache():
     # Check accessing the cache creates an empty dictionary
     assert not t.cache
     assert 'cache' in t._time.__dict__
+
+
+def test_writeable_flag():
+    t = Time([1, 2, 3], format='cxcsec')
+    t[1] = 5.0
+    assert allclose_sec(t[1].value, 5.0)
+
+    t.writeable = False
+    with pytest.raises(ValueError) as err:
+        t[1] = 5.0
+    assert 'assignment destination is read-only' in str(err)
+
+    with pytest.raises(ValueError) as err:
+        t[:] = 5.0
+    assert 'assignment destination is read-only' in str(err)
+
+    t.writeable = True
+    t[1] = 10.0
+    assert allclose_sec(t[1].value, 10.0)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1085,7 +1085,7 @@ def test_cache():
     t2 = Time('2010-09-03 00:00:00')
 
     # Time starts out without a cache
-    assert 'cache' not in t.__dict__
+    assert 'cache' not in t._time.__dict__
 
     # Access the iso format and confirm that the cached version is as expected
     t.iso
@@ -1096,11 +1096,11 @@ def test_cache():
     assert t.cache['scale']['tai'] == t2.tai
 
     # New Time object after scale transform does not have a cache yet
-    assert 'cache' not in t.tt.__dict__
+    assert 'cache' not in t.tt._time.__dict__
 
     # Clear the cache
     del t.cache
-    assert 'cache' not in t.__dict__
+    assert 'cache' not in t._time.__dict__
     # Check accessing the cache creates an empty dictionary
     assert not t.cache
-    assert 'cache' in t.__dict__
+    assert 'cache' in t._time.__dict__

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import functools
+import numpy as np
+
+from .. import Time
+
+allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+is_masked = np.ma.is_masked
+
+
+def test_simple():
+    t = Time([1, 2, 3], format='cxcsec')
+    assert t.masked is False
+
+    # Before masking, format output is not a masked array (it is an ndarray
+    # like always)
+    assert not isinstance(t.value, np.ma.MaskedArray)
+    assert not isinstance(t.unix, np.ma.MaskedArray)
+
+    t[2] = np.ma.masked
+    assert t.masked is True
+    assert np.all(t.mask == [False, False, True])
+    assert allclose_sec(t.value[:2], [1, 2])
+    assert is_masked(t.value[2])
+    assert is_masked(t[2].value)
+
+    # After masking format output is a masked array
+    assert isinstance(t.value, np.ma.MaskedArray)
+    assert isinstance(t.unix, np.ma.MaskedArray)
+    # Todo : test all formats
+
+
+def test_str():
+    t = Time(['2000:001', '2000:002'])
+    t[1] = np.ma.masked
+    assert str(t) == "['2000:001:00:00:00.000' --]"
+    assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
+
+    # Assign value to unmask
+    t[1] = '2000:111'
+    assert str(t) == "['2000:001:00:00:00.000' '2000:111:00:00:00.000']"
+    assert t.masked is False
+
+
+def test_transform():
+    t = Time(['2000:001', '2000:002'])
+    t[1] = np.ma.masked
+
+    # Change scale (this tests the ERFA machinery with masking as well)
+    t_ut1 = t.ut1
+    assert is_masked(t_ut1.value[1])
+    assert not is_masked(t_ut1.value[0])
+    assert np.all(t_ut1.mask == [False, True])
+    
+    # Change format
+    t_unix = t.unix
+    assert is_masked(t_unix[1])
+    assert not is_masked(t_unix[0])
+    assert np.all(t_unix.mask == [False, True])
+    

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -37,6 +37,7 @@ def test_str():
     t[1] = np.ma.masked
     assert str(t) == "['2000:001:00:00:00.000' --]"
     assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
+    assert repr(t.iso) == "masked_array(['2000-01-01 00:00:00.000' --])"
 
     # Assign value to unmask
     t[1] = '2000:111'

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -130,6 +130,7 @@ class QuantityInfo(ParentDtypeInfo):
     attrs_from_parent = set(['dtype', 'unit'])  # dtype and unit taken from parent
     _supports_indexing = True
     _represent_as_dict_attrs = ('value', 'unit')
+    mask_val = np.nan
 
     @staticmethod
     def default_format(val):

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -197,6 +197,7 @@ class IERS(QTable):
             jd1, jd2 = jd1.utc.jd1, jd1.utc.jd2
         except Exception:
             pass
+
         mjd = np.floor(jd1 - MJD_ZERO + jd2)
         utc = jd1 - (MJD_ZERO+mjd) + jd2
         return mjd, utc


### PR DESCRIPTION
This is a very minimal POC implementation of masking support using `np.nan` as a masked item.  This is mostly to allow Quantity to participate fully in table high-level operations.

Looking for initial feedback from @mhvk.  For instance the `mask` could be put into `QuantityInfo`, but maybe the mask is more generally useful?
