### PR TITLE
Add pytest to requirements list

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,6 +15,8 @@ Astropy has the following strict requirements:
 
 - `Numpy`_ |minimum_numpy_version| or later
 
+- `pytest`_ 2.8 or later
+
 Astropy also depends on other packages for optional features:
 
 - `h5py <http://h5py.org/>`_: To read/write


### PR DESCRIPTION
In https://github.com/astropy/astropy/pull/5694 I forgot to add pytest to the formal list of requirements in the docs. As discussed in https://github.com/astropy/astropy/pull/5694, the plan is to have pytest as a required dependency for now to provide a smooth transition, and in future we could consider removing it again, though it's very useful to make sure that users can run ``astropy.test()`` by default.