### PR TITLE
Remove extraneous frame attrs propagation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,6 +182,12 @@ Bug Fixes
 
 - ``astropy.coordinates``
 
+  - Fixed a bug where ``StaticMatrixTransform`` erroneously copied frame
+    attributes from the input coordinate to the output frame. In practice, this
+    didn't actually affect any transforms in Astropy but may change behavior for
+    users who explicitly used the ``StaticMatrixTransform`` in their own code.
+    [#6045]
+
 - ``astropy.cosmology``
 
 - ``astropy.extern``

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -777,10 +777,7 @@ class StaticMatrixTransform(CoordinateTransform):
             #think it has a valid distance
             newrep = newrep.represent_as(fromcoord.data.__class__)
 
-        frameattrs = dict([(attrnm, getattr(fromcoord, attrnm))
-                           for attrnm in self.overlapping_frame_attr_names])
-
-        return toframe.realize_frame(newrep, **frameattrs)
+        return toframe.realize_frame(newrep)
 
 
 class DynamicMatrixTransform(CoordinateTransform):


### PR DESCRIPTION
Fixes #6044. 

I'm working on a separate PR for new functionality in the transformations code, but I think this is a bugfix so it felt like it should go in separately.

cc @eteq @mhvk 