### PR TITLE
Include FITS header when updating ImageHDU extensions with convenience functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -283,6 +283,9 @@ Bug Fixes
 
   - Fix writing out read-only arrays. [#6036]
 
+  - Extension headers are written out properly when the ``fits.update()``
+    convenience function is used. [#6058]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1023,7 +1023,7 @@ def _makehdu(data, header):
                 isinstance(data, np.recarray)):
             hdu = BinTableHDU(data, header=header)
         elif isinstance(data, np.ndarray):
-            hdu = ImageHDU(data)
+            hdu = ImageHDU(data, header=header)
         else:
             raise KeyError('Data must be a numpy array.')
     return hdu

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -77,6 +77,25 @@ class TestConvenience(FitsTestCase):
         h_out = fits.getheader(filename, ext=1)
         assert h_out['ANSWER'] == 42
 
+    def test_image_extension_update_header(self):
+        """
+        Test that _makehdu correctly includes the header. For example in the
+        fits.update convenience function.
+        """
+        filename = self.temp('twoextension.fits')
+
+        hdus = [fits.PrimaryHDU(np.zeros((10, 10))),
+                fits.ImageHDU(np.zeros((10, 10)))]
+
+        fits.HDUList(hdus).writeto(filename)
+
+        fits.update(filename,
+                    np.zeros((10, 10)),
+                    header=fits.Header([('WHAT', 100)]),
+                    ext=1)
+        h_out = fits.getheader(filename, ext=1)
+        assert h_out['WHAT'] == 100
+
     def test_printdiff(self):
         """
         Test that FITSDiff can run the different inputs without crashing.


### PR DESCRIPTION
This is similar to #6042 . I thought it wouldn't matter but it actually did matter in case of `fits.update`...

I will include the changelog entry later. :)