### PR TITLE
Fix import of coordinates on Python 2

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -98,7 +98,7 @@ def _make_transform_graph_docs():
     from ..transformations import trans_to_color
     html_list_items = []
     for cls,color in trans_to_color.items():
-        block = """
+        block = u"""
             <li style='list-style: none;'>
                 <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
                     <b>{0}:</b>
@@ -108,7 +108,7 @@ def _make_transform_graph_docs():
         """.format(cls.__name__, color)
         html_list_items.append(block)
 
-    graph_legend = """
+    graph_legend = u"""
     .. raw:: html
 
         <ul>


### PR DESCRIPTION
Importing `astropy.coordinates` is broken (on Python 2) because of the use of
a unicode arrow in a str, introduced in #6023. cc @adrn @eteq 