### PR TITLE
Make sure that WCSAxes.set_x/ylabel keyword arguments are recognized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,8 +314,8 @@ Bug Fixes
 
 - ``astropy.visualization``
 
-  - Created param labelpad in set_xlabel and set_ylabel functions. It
-    is directly passed to set_axislabel as minpad. [#5686, #5692, #6060]
+  - Accept normal Matplotlib keyword arguments in set_xlabel and set_ylabel
+    functions. [#5686, #5692, #6060]
 
 - ``astropy.vo``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,6 +314,9 @@ Bug Fixes
 
 - ``astropy.visualization``
 
+  - Created param labelpad in set_xlabel and set_ylabel functions. It
+    is directly passed to set_axislabel as minpad.
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -315,7 +315,7 @@ Bug Fixes
 - ``astropy.visualization``
 
   - Created param labelpad in set_xlabel and set_ylabel functions. It
-    is directly passed to set_axislabel as minpad.
+    is directly passed to set_axislabel as minpad. [#5686, #5692, #6060]
 
 - ``astropy.vo``
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -352,11 +352,11 @@ class WCSAxes(Axes):
 
         self._drawn = True
 
-    def set_xlabel(self, label):
-        self.coords[self._x_index].set_axislabel(label)
+    def set_xlabel(self, label, labelpad=1, **kwargs):
+        self.coords[self._x_index].set_axislabel(label, minpad=labelpad, **kwargs)
 
-    def set_ylabel(self, label):
-        self.coords[self._y_index].set_axislabel(label)
+    def set_ylabel(self, label, labelpad=1, **kwargs):
+        self.coords[self._y_index].set_axislabel(label, minpad=labelpad, **kwargs)
 
     def get_xlabel(self):
         return self.coords[self._x_index].get_axislabel()

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -103,3 +103,22 @@ def test_plot_coord_transform():
     c = SkyCoord(359.76045223*u.deg, 0.26876217*u.deg)
     with pytest.raises(TypeError):
         ax.plot_coord(c, 'o', transform=ax.get_transform('galactic'))
+
+
+def test_set_label_properties():
+
+    # Regression test to make sure that arguments passed to
+    # set_xlabel/set_ylabel are passed to the underlying coordinate helpers
+
+    ax = plt.subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
+
+    ax.set_xlabel('Test x label', labelpad=2, color='red')
+    ax.set_ylabel('Test y label', labelpad=3, color='green')
+
+    assert ax.coords[0].axislabels.get_text() == 'Test x label'
+    assert ax.coords[0].axislabels.get_minpad('b') == 2
+    assert ax.coords[0].axislabels.get_color() == 'red'
+
+    assert ax.coords[1].axislabels.get_text() == 'Test y label'
+    assert ax.coords[1].axislabels.get_minpad('l') == 3
+    assert ax.coords[1].axislabels.get_color() == 'green'


### PR DESCRIPTION
This closes #5686 and https://github.com/astropy/astropy/pull/5692 (which was abandonned)