### PR TITLE
Fix bug that caused Sphinx warnings for WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -319,6 +319,10 @@ Bug Fixes
   - Accept normal Matplotlib keyword arguments in set_xlabel and set_ylabel
     functions. [#5686, #5692, #6060]
 
+  - Fix a bug that caused labels to be missing from frames with labels that
+    could change direction mid-axis, such as EllipticalFrame. Also ensure
+    that empty tick labels do not cause any warnings.
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,7 +321,7 @@ Bug Fixes
 
   - Fix a bug that caused labels to be missing from frames with labels that
     could change direction mid-axis, such as EllipticalFrame. Also ensure
-    that empty tick labels do not cause any warnings.
+    that empty tick labels do not cause any warnings. [#6063]
 
 - ``astropy.vo``
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -18,6 +18,7 @@ from ..patches import SphericalCircle
 from .. import WCSAxes
 from . import datasets
 from ....tests.image_tests import IMAGE_REFERENCE_DIR
+from ..frame import EllipticalFrame
 
 
 class BaseImageTests(object):
@@ -522,4 +523,17 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticklabel_visible(False)
         ax.coords[1].set_ticklabel_visible(False)
 
+        return fig
+
+    @remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=1.5)
+    def test_elliptical_frame(self):
+
+        # Regression test for a bug (astropy/astropy#6063) that caused labels to
+        # be incorrectly simplified.
+
+        wcs = WCS(self.msx_header)
+        fig = plt.figure(figsize=(5, 3))
+        ax = fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, frame_class=EllipticalFrame)
         return fig

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -70,14 +70,17 @@ class TickLabels(Text):
                     t1 = self.text[axis][i]
                     continue
                 start = 0
-                for j in range(len(t1)):
+                # In the following loop, we need to ignore the last character,
+                # hence the len(t1) - 1. This is because if we have two strings
+                # like 13d14m15s we want to make sure that we keep the last
+                # part (15s) even if the two labels are identical.
+                for j in range(len(t1) - 1):
                     if t1[j] != t2[j]:
                         break
                     if t1[j] not in '-0123456789.':
                         start = j + 1
-                if start == 0:
-                    t1 = self.text[axis][i]
-                else:
+                t1 = self.text[axis][i]
+                if start != 0:
                     self.text[axis][i] = self.text[axis][i][start:]
 
     def set_visible_axes(self, visible_axes):
@@ -104,6 +107,12 @@ class TickLabels(Text):
         for axis in self.get_visible_axes():
 
             for i in range(len(self.world[axis])):
+
+                # In the event that the label is empty (which is not expected
+                # but could happen in unforeseen corner cases), we should just
+                # skip to the next label.
+                if self.text[axis][i] == '':
+                    continue
 
                 self.set_text(self.text[axis][i])
 


### PR DESCRIPTION
Fixes a bug that caused labels to be missing from frames with labels that could change direction mid-axis, such as EllipticalFrame. Also ensure that empty tick labels do not cause any warnings.

Fixes https://github.com/astropy/astropy/pull/6002

Note that this still needs a regression test, which I'll add while on the ✈️ 

cc @pllim @bsipocz (turns out this was a real bug!)