### PR TITLE
[EXP] Add UnitSystem class to support custom unit systems

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -13,6 +13,7 @@ code under a BSD license.
 from .core import *
 from .quantity import *
 from .decorators import *
+from .unitsystem import *
 
 from . import si
 from . import cgs

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -809,16 +809,16 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         return self.unit.to(unit, self.view(np.ndarray),
                             equivalencies=equivalencies)
 
-    def to(self, unit, equivalencies=[]):
+    def to(self, unit_or_usys, equivalencies=[]):
         """
         Return a new `~astropy.units.Quantity` object with the specified unit.
 
         Parameters
         ----------
-        unit : `~astropy.units.UnitBase` instance, str
+        unit_or_usys : `~astropy.units.UnitBase` instance, str, `~astropy.units.UnitSystem`
             An object that represents the unit to convert to. Must be
             an `~astropy.units.UnitBase` object or a string parseable
-            by the `~astropy.units` package.
+            by the `~astropy.units` package. TODO: explain unitsystem.
 
         equivalencies : list of equivalence pairs, optional
             A list of equivalence pairs to try if the units are not
@@ -832,9 +832,18 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         --------
         to_value : get the numerical value in a given unit.
         """
+        from .unitsystem import UnitSystem
+
+        if equivalencies == []:
+            equivalencies = self._equivalencies
+
+        if isinstance(unit_or_usys, UnitSystem):
+            unit = unit_or_usys[self.unit.physical_type]
+        else:
+            unit = Unit(unit_or_usys)
+
         # We don't use `to_value` below since we always want to make a copy
         # and don't want to slow down this method (esp. the scalar case).
-        unit = Unit(unit)
         return self._new_view(self._to_value(unit, equivalencies), unit)
 
     def to_value(self, unit=None, equivalencies=[]):

--- a/astropy/units/tests/test_unitsystem.py
+++ b/astropy/units/tests/test_unitsystem.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+    Test the unit system functionality.
+"""
+
+from __future__ import absolute_import, unicode_literals, division, print_function
+
+
+# Third party
+from ... import units as u
+from ...constants import G,c
+import pytest
+
+# This package
+from ..unitsystem import UnitSystem, DimensionlessUnitSystem
+
+def test_create():
+    # simple system
+    usys = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun)
+
+    # make sure length, time, mass, angle passed in
+    with pytest.raises(ValueError):
+        UnitSystem(u.kpc, u.Myr, u.radian)
+
+    with pytest.raises(ValueError):
+        UnitSystem(u.kpc, u.Myr, u.Msun)
+
+    with pytest.raises(ValueError):
+        UnitSystem(u.kpc, u.radian, u.Msun)
+
+    with pytest.raises(ValueError):
+        UnitSystem(u.Myr, u.radian, u.Msun)
+
+    # as a single tuple instead of args
+    usys2 = UnitSystem((u.kpc, u.Myr, u.radian, u.Msun))
+    assert usys2 == usys
+
+    # from an existing usys
+    usys3 = UnitSystem(usys)
+    assert usys3 == usys
+
+def test_constants():
+    usys = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun)
+
+    # try two constants
+    assert usys.get_constant('G') == G.decompose([u.kpc, u.Myr, u.radian, u.Msun])
+    assert usys.get_constant('c') == c.decompose([u.kpc, u.Myr, u.radian, u.Msun])
+
+def test_dimensionless():
+    usys = DimensionlessUnitSystem()
+    assert usys['dimensionless'] == u.one
+    assert usys['length'] == u.one
+
+    with pytest.raises(ValueError):
+        (15*u.kpc).to(usys)
+
+    assert (1*u.one).to(usys) == 1*u.one
+
+def test_compare_eq():
+    usys1 = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun, u.mas/u.yr)
+    usys1_copy = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun, u.mas/u.yr)
+
+    usys2 = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun, u.kiloarcsecond/u.yr)
+    usys3 = UnitSystem(u.kpc, u.Myr, u.radian, u.kg, u.mas/u.yr)
+
+    assert usys1 == usys1_copy
+    assert usys1_copy == usys1
+
+    assert usys1 != usys2
+    assert usys2 != usys1
+
+    assert usys1 != usys3
+    assert usys3 != usys1
+
+def test_convert():
+    q = 15. * u.kpc/u.Myr
+
+    usys1 = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun)
+    usys2 = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun, u.km/u.s)
+
+    assert q.to(usys1).unit == (u.kpc/u.Myr)
+    assert q.to(usys2).unit == (u.km/u.s)

--- a/astropy/units/unitsystem.py
+++ b/astropy/units/unitsystem.py
@@ -153,7 +153,7 @@ class UnitSystem(object):
 
             >>> usys = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun)
             >>> usys.get_constant('c')
-            306.6013937879527
+            <Quantity 306.6013937879527 kpc / Myr>
 
         """
         from .. import constants as const

--- a/astropy/units/unitsystem.py
+++ b/astropy/units/unitsystem.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import division, print_function
+
+from collections import OrderedDict
+
+from .core import one, Unit
+# from .physical import _physical_unit_mapping
+
+__all__ = ['UnitSystem', 'DimensionlessUnitSystem']
+
+class UnitSystem(object):
+    """
+    Represents a system of units. At minimum, this consists of a set of
+    length, time, mass, and angle units, but may also contain preferred
+    representations for composite units. For example, the base unit system
+    could be ``{kpc, Myr, Msun, radian}``, but you can also specify a preferred
+    speed, such as ``km/s``.
+
+    This class functions like a dictionary with keys set by physical types.
+    If a unit for a particular physical type is not specified on creation,
+    a composite unit will be created with the base units. See Examples below
+    for some demonstrations.
+
+    Parameters
+    ----------
+    *units
+        The units that define the unit system. At minimum, this must
+        contain length, time, mass, and angle units.
+
+    Examples
+    --------
+    If only base units are specified, any physical type specified as a key
+    to this object will be composed out of the base units::
+
+        >>> usys = UnitSystem(u.m, u.s, u.kg, u.radian)
+        >>> usys['energy']
+        Unit("kg m2 / s2")
+
+    However, custom representations for composite units can also be specified
+    when initializing::
+
+        >>> usys = UnitSystem(u.m, u.s, u.kg, u.radian, u.erg)
+        >>> usys['energy']
+        Unit("erg")
+
+    This is useful for Galactic dynamics where lengths and times are usually
+    given in terms of ``kpc`` and ``Myr``, but speeds are given in ``km/s``::
+
+        >>> usys = UnitSystem(u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s)
+        >>> usys['speed']
+        Unit("km / s")
+
+    """
+
+    def __init__(self, units, *args):
+
+        self._required_physical_types = ['length', 'time', 'mass', 'angle']
+        self._core_units = []
+
+        if isinstance(units, UnitSystem):
+            self._registry = units._registry.copy()
+            self._core_units = units._core_units
+            return
+
+        if len(args) > 0:
+            units = (units,) + tuple(args)
+
+        self._registry = OrderedDict()
+        for unit in units:
+            typ = unit.physical_type
+            if typ in self._registry:
+                raise ValueError("Multiple units passed in with type '{0}'".format(typ))
+            self._registry[typ] = unit
+
+        for phys_type in self._required_physical_types:
+            if phys_type not in self._registry:
+                raise ValueError("You must specify a unit with physical type '{0}'".format(phys_type))
+            self._core_units.append(self._registry[phys_type])
+
+    def __getitem__(self, key):
+        from .physical import _physical_unit_mapping
+        if key in self._registry:
+            return self._registry[key]
+
+        else:
+            unit = None
+            for k,v in _physical_unit_mapping.items():
+                if v == key:
+                    unit = Unit(" ".join(["{}**{}".format(x,y) for x,y in k]))
+                    break
+
+            if unit is None:
+                raise ValueError("Physical type '{0}' doesn't exist in unit "
+                                 "registry.".format(key))
+
+            unit = unit.decompose(self._core_units)
+            unit._scale = 1.
+            return unit
+
+    def __len__(self):
+        return len(self._core_units)
+
+    def __iter__(self):
+        for uu in self._core_units:
+            yield uu
+
+    def __str__(self):
+        unit_str = ",".join([str(uu) for uu in self._core_units])
+        return "UnitSystem ({0})".format(unit_str)
+
+    def __repr__(self):
+        return "<{0}>".format(self.__str__())
+
+    def __eq__(self, other):
+        for k in self._registry:
+            if not self[k] == other[k]:
+                return False
+
+        for k in other._registry:
+            if not self[k] == other[k]:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def to_dict(self):
+        """
+        Return a dictionary representation of the unit system with keys
+        set by the physical types and values set by the unit objects.
+        """
+        return self._registry.copy()
+
+    def get_constant(self, name):
+        """
+        Retrieve a constant with specified name in this unit system.
+
+        Parameters
+        ----------
+        name : str
+            The name of the constant, e.g., G.
+
+        Returns
+        -------
+        const : `~astropy.units.Quantity`
+            The value of the constant represented in this unit system.
+
+        Examples
+        --------
+
+            >>> usys = UnitSystem(u.kpc, u.Myr, u.radian, u.Msun)
+            >>> usys.get_constant('c')
+            306.6013937879527
+
+        """
+        from .. import constants as const
+        try:
+            c = getattr(const, name)
+        except AttributeError:
+            raise ValueError("Constant name '{}' doesn't exist in "
+                             "astropy.constants".format(name))
+
+        return c.decompose(self._core_units)
+
+class DimensionlessUnitSystem(UnitSystem):
+
+    def __init__(self):
+        self._core_units = [one]
+        self._registry = OrderedDict()
+        self._registry['dimensionless'] = one
+
+    def __getitem__(self, key):
+        return one
+
+    def __str__(self):
+        return "UnitSystem (dimensionless)"
+
+    def to_dict(self):
+        raise ValueError("Cannot represent dimensionless unit system as dict!")
+
+    def get_constant(self, name):
+        raise ValueError("Cannot get constant in dimensionless units!")


### PR DESCRIPTION
This is a port of a `UnitSystem` object that I use in [gala](http://gala.adrian.pw/en/latest/units.html) for handling custom systems of units. The basic idea behind a system of units is, at minimum, a set of irreducible bases that all other units can be composed of. However, this class lets you override  default composite units for easy conversion. The use case I have is that I often want to transform to a "Galactic" unit system where we represent lengths as `kpc`, times as `Gyr` or `Myr`, but velocities as `km/s`. The unitsystem can also be accessed like a dictionary, where the keys are the physical types. The following would work with this PR:

```python
>>> usys = UnitSystem(u.kpc, u.Gyr, u.radian, u.Msun, u.km/u.s)
>>> v = 0.2 * u.kpc/u.Gyr
>>> v.to(usys)
<Quantity 0.1955584443346257 km / s>
>>> usys['length'] / usys['time']
Unit("kpc / Gyr")
>>> usys['speed']
Unit("km / s")
```
There are many details about the implementation that we might want to discuss (do we want singleton classes? do we want to require [length, time, mass, angle] unit bases? etc.).

This would provide a way to fix #703.

At minimum, still needs documentation and a changelog entry...