### PR TITLE
Documentation on converting between angular velocity & frequency and dimensionless_angles()

### DIFF
--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -91,26 +91,29 @@ The example with complex numbers is also one may well be doing a fair
 number of similar calculations.  For such situations, there is the
 option to :ref:`set default equivalencies <equivalency-context>`.
 
-This equivalency may result in some unanticipated behavior, such as
-when converting from an angular velocity :math:`\omega` in radians per
-second to the corresponding frequency :math:`f` in hertz, where the
-correct relation is :math:`f=\omega/2\pi`. The
-:func:`~astropy.units.equivalencies.dimensionless_angles` equivalency
-does not account for the factor of :math:`2\pi` in this relation.
+Note that In some situations, this equivalency may not quite give
+what one anticipated. For instance, one might think of using it for
+converting from an angular velocity :math:`\omega` in radians per
+second to the corresponding frequency :math:`f` in hertz, i.e., to
+implement :math:`f=\omega/2\pi`. But if one tries, one finds:
 
-  >>> (1*u.rad/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())  # might expect ~0.159 Hz
+  >>> (1*u.rad/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())
   <Quantity 1.0 Hz>
-  >>> (1*u.cycle/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())  # might expect 1 Hz
+  >>> (1*u.cycle/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())  # doctest: +FLOAT_CMP
   <Quantity 6.283185307179586 Hz>
+  
+Here, one might have expected ~0.159 Hz in the first example and 1 Hz in
+the second. But :func:`~astropy.units.equivalencies.dimensionless_angles`
+converts to radians per second and then drops radians as a unit. The
+mistake is that implicit in the above was that the unit Hz was equivalent
+to cycles per second, which it is not (it is just "per second"). But
+this realization also leads to the solution: one should just use an
+explicit equivalency between cycle per second and hertz:
 
-This behavior occurs because
-:func:`~astropy.units.equivalencies.dimensionless_angles` is
-converting to radians per second and then dropping radians as a unit.
-The best way to avoid this potential pitfall is to use an equivalency
-between a cycle per second and a hertz.
-
-  >>> (1*u.rad/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # expecting ~0.159 Hz
+  >>> (1*u.rad/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # doctest: +FLOAT_CMP
   <Quantity 0.15915494309189535 Hz>
+  >>> (1*u.cy/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())
+  <Quantity 1.0 Hz>
   
 Spectral Units
 --------------

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -6,13 +6,13 @@ Equivalencies
 *************
 
 The unit module has machinery for supporting equivalences between
-different units in certain contexts. Namely when equations can
+different units in certain contexts, namely when equations can
 uniquely relate a value in one unit to a different unit. A good
 example is the equivalence between wavelength, frequency and energy
 for specifying a wavelength of radiation. Normally these units are not
 convertible, but when understood as representing light, they are
-convertible in certain contexts.  This will describe how to use the
-equivalencies included in `astropy.units` and then describe how to
+convertible in certain contexts.  Here we describe how to use the
+equivalencies included in `astropy.units` and how to
 define new equivalencies.
 
 Equivalencies are used by passing a list of equivalency pairs to the
@@ -53,9 +53,10 @@ into units of length (and vice versa).
 Angles as Dimensionless Units
 -----------------------------
 
-Angles are treated as a physically distinct type, which usually helps to
-avoid mistakes.  For units such as rotational energy, however, it is not
-very handy.  (Indeed, this double-sidedness underlies why radian went from
+Angles are treated as a physically distinct type, which usually helps
+to avoid mistakes.  However, this is not very handy when working with
+units related to rotational energy or the small angle approximation.
+(Indeed, this double-sidedness underlies why radian went from
 `supplementary to derived unit <http://www.bipm.org/en/CGPM/db/20/8/>`__.)
 The function :func:`~astropy.units.equivalencies.dimensionless_angles`
 provides the required equivalency list that helps convert between
@@ -90,6 +91,27 @@ The example with complex numbers is also one may well be doing a fair
 number of similar calculations.  For such situations, there is the
 option to :ref:`set default equivalencies <equivalency-context>`.
 
+This equivalency may result in some unanticipated behavior, such as
+when converting from an angular velocity :math:`\omega` in radians per
+second to the corresponding frequency :math:`f` in hertz, where the
+correct relation is :math:`f=\omega/2\pi`. The
+:func:`~astropy.units.equivalencies.dimensionless_angles` equivalency
+does not account for the factor of :math:`2\pi` in this relation.
+
+  >>> (1*u.rad/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())  # might expect ~0.159 Hz
+  <Quantity 1.0 Hz>
+  >>> (1*u.cycle/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())  # might expect 1 Hz
+  <Quantity 6.283185307179586 Hz>
+
+This behavior occurs because
+:func:`~astropy.units.equivalencies.dimensionless_angles` is
+converting to radians per second and then dropping radians as a unit.
+The best way to avoid this potential pitfall is to use an equivalency
+between a cycle per second and a hertz.
+
+  >>> (1*u.rad/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # expecting ~0.159 Hz
+  <Quantity 0.15915494309189535 Hz>
+  
 Spectral Units
 --------------
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -91,30 +91,30 @@ The example with complex numbers is also one may well be doing a fair
 number of similar calculations.  For such situations, there is the
 option to :ref:`set default equivalencies <equivalency-context>`.
 
-Note that In some situations, this equivalency may not quite give
-what one anticipated. For instance, one might think of using it for
-converting from an angular velocity :math:`\omega` in radians per
-second to the corresponding frequency :math:`f` in hertz, i.e., to
-implement :math:`f=\omega/2\pi`. But if one tries, one finds:
+In some situations, this equivalency may behave differently than 
+anticipated.  For instance, it might at first seem reasonable to use it 
+for converting from an angular velocity :math:`\omega` in radians per
+second to the corresponding frequency :math:`f` in hertz (i.e., to
+implement :math:`f=\omega/2\pi`). However, attempting this yields:
 
   >>> (1*u.rad/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())
   <Quantity 1.0 Hz>
   >>> (1*u.cycle/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())  # doctest: +FLOAT_CMP
   <Quantity 6.283185307179586 Hz>
-  
-Here, one might have expected ~0.159 Hz in the first example and 1 Hz in
-the second. But :func:`~astropy.units.equivalencies.dimensionless_angles`
+
+Here, we might have expected ~0.159 Hz in the first example and 1 Hz in
+the second. However, :func:`~astropy.units.equivalencies.dimensionless_angles`
 converts to radians per second and then drops radians as a unit. The
-mistake is that implicit in the above was that the unit Hz was equivalent
-to cycles per second, which it is not (it is just "per second"). But
-this realization also leads to the solution: one should just use an
-explicit equivalency between cycle per second and hertz:
+implicit mistake in these examples is that the unit Hz is equivalent
+to cycles per second, which it is not (it is just "per second"). 
+This realization also leads to the solution: to use an
+explicit equivalency between cycles per second and hertz:
 
   >>> (1*u.rad/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # doctest: +FLOAT_CMP
   <Quantity 0.15915494309189535 Hz>
   >>> (1*u.cy/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])
   <Quantity 1.0 Hz>
-  
+
 Spectral Units
 --------------
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -105,10 +105,10 @@ implement :math:`f=\omega/2\pi`). However, attempting this yields:
 Here, we might have expected ~0.159 Hz in the first example and 1 Hz in
 the second. However, :func:`~astropy.units.equivalencies.dimensionless_angles`
 converts to radians per second and then drops radians as a unit. The
-implicit mistake in these examples is that the unit Hz is equivalent
-to cycles per second, which it is not (it is just "per second"). 
-This realization also leads to the solution: to use an
-explicit equivalency between cycles per second and hertz:
+implicit mistake made in these examples is that the unit Hz is taken to be
+equivalent to cycles per second, which it is not (it is just "per second"). 
+This realization also leads to the solution: to use an explicit equivalency
+between cycles per second and hertz:
 
   >>> (1*u.rad/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # doctest: +FLOAT_CMP
   <Quantity 0.15915494309189535 Hz>

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -112,7 +112,7 @@ explicit equivalency between cycle per second and hertz:
 
   >>> (1*u.rad/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # doctest: +FLOAT_CMP
   <Quantity 0.15915494309189535 Hz>
-  >>> (1*u.cy/u.s).to(u.Hz, equivalencies=u.dimensionless_angles())
+  >>> (1*u.cy/u.s).to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])
   <Quantity 1.0 Hz>
   
 Spectral Units


### PR DESCRIPTION
This is an addition to the documentation to address a potential pitfall that may arise when using the `dimensionless_angles()` equivalency when converting between angular velocity and frequency (discussed in issue https://github.com/astropy/astropy/issues/6032), with a small number of grammatical changes elsewhere on the page.

