### PR TITLE
WIP: improve speed of coordinate transformations for arrays of obstime

### DIFF
--- a/astropy/coordinates/astrom_manager.py
+++ b/astropy/coordinates/astrom_manager.py
@@ -40,6 +40,7 @@ class transform_precision(ScienceState):
 
 def get_astrom(frame, tcode, precision=None):
     """
+    TBD
     """
 
     assert tcode in ['apio13', 'apci', 'apcs', 'apci13', 'apco13']
@@ -56,32 +57,45 @@ def get_astrom(frame, tcode, precision=None):
         mjd_resolution = precision / 86400.  # in days
 
     obstime = frame.obstime
+    jd1_tt, jd2_tt = get_jd12(obstime, 'tt')
 
     if mjd_resolution:
-        # apply binning to obstime
-        mjd_binned = np.int64(obstime.mjd / mjd_resolution + 0.5)
-        mjd_u, mjd_idx, mjd_uidx = np.unique(
-            mjd_binned, return_index=True, return_inverse=True
-            )
+        # compute mjd support points for interpolation of Earth pv and cip
+        mjd_lower = np.int64(obstime.mjd / mjd_resolution)
+        mjd_upper = mjd_lower + 1
+        mjd_u = np.unique([mjd_lower, mjd_upper])  # does sorting
 
-        # obstime_binned = obstime[mjd_idx]
-        obstime_binned = Time(mjd_u * mjd_resolution, format='mjd', scale=obstime.scale)
-    else:
-        obstime_binned = obstime
+        obstime_support = Time(mjd_u * mjd_resolution, format='mjd', scale=obstime.scale)
 
     if tcode in ['apci', 'apcs']:
         # find the position and velocity of earth
-        jd1_tt, jd2_tt = get_jd12(obstime_binned, 'tt')
-        earth_pv, earth_heliocentric = prepare_earth_position_vel(obstime_binned)
+        if mjd_resolution:
+            (
+                earth_pv_support, earth_heliocentric_support
+                ) = prepare_earth_position_vel(obstime_support)
+            # do interpolation
+            earth_pv = np.empty((len(obstime), 2, 3))
+            earth_heliocentric = np.empty((len(obstime), 3))
+            for dim in range(3):
+                for ipv in range(2):
+                    earth_pv[:, ipv, dim] = np.interp(
+                        obstime.mjd, obstime_support.mjd, earth_pv_support[:, ipv, dim]
+                        )
+                earth_heliocentric[:, dim] = np.interp(
+                        obstime.mjd, obstime_support.mjd, earth_heliocentric_support[:, dim]
+                        )
+
+        else:
+            earth_pv, earth_heliocentric = prepare_earth_position_vel(obstime)
 
     if tcode == 'apio13':
 
         lon, lat, height = frame.location.to_geodetic('WGS84')
 
-        xp, yp = get_polar_motion(obstime_binned)
-        jd1_utc, jd2_utc = get_jd12(obstime_binned, 'utc')
-        dut1utc = get_dut1utc(obstime_binned)
-        astrom_binned = erfa.apio13(
+        xp, yp = get_polar_motion(obstime)
+        jd1_utc, jd2_utc = get_jd12(obstime, 'utc')
+        dut1utc = get_dut1utc(obstime)
+        astrom = erfa.apio13(
             jd1_utc, jd2_utc, dut1utc,
             lon.to(u.radian).value, lat.to(u.radian).value,
             height.to(u.m).value,
@@ -95,8 +109,19 @@ def get_astrom(frame, tcode, precision=None):
 
     elif tcode == 'apci':
 
-        x, y, s = get_cip(jd1_tt, jd2_tt)
-        astrom_binned = erfa.apci(jd1_tt, jd2_tt, earth_pv, earth_heliocentric, x, y, s)
+        if mjd_resolution:
+            jd1_tt_support, jd2_tt_support = get_jd12(obstime_support, 'tt')
+            cip_support = get_cip(jd1_tt_support, jd2_tt_support)
+            # do interpolation; cip is an ordinary array
+            cip = tuple(
+                np.interp(obstime.mjd, obstime_support.mjd, cip_support[i])
+                for i in range(3)
+                )
+
+        else:
+            cip = get_cip(jd1_tt, jd2_tt)
+
+        astrom = erfa.apci(jd1_tt, jd2_tt, earth_pv, earth_heliocentric, *cip)
 
     elif tcode == 'apcs':
 
@@ -107,19 +132,11 @@ def get_astrom(frame, tcode, precision=None):
                 (frame.obsgeoloc.get_xyz(xyz_axis=-1).value[..., np.newaxis, :],
                  frame.obsgeovel.get_xyz(xyz_axis=-1).value[..., np.newaxis, :]),
                 axis=-2)
-        astrom_binned = erfa.apcs(jd1_tt, jd2_tt, pv, earth_pv, earth_heliocentric)
+        astrom = erfa.apcs(jd1_tt, jd2_tt, pv, earth_pv, earth_heliocentric)
 
     elif tcode == 'apci13':
         pass
     elif tcode == 'apco13':
         pass
 
-    if mjd_resolution:
-        astrom = astrom_binned[mjd_uidx]
-        jd1_ut1, jd2_ut1 = get_jd12(obstime, 'ut1')
-        astrom = erfa.aper13(jd1_ut1, jd2_ut1, astrom)
-    else:
-        astrom = astrom_binned
-
     return astrom
-

--- a/astropy/coordinates/astrom_manager.py
+++ b/astropy/coordinates/astrom_manager.py
@@ -74,16 +74,16 @@ def get_astrom(frame, tcode, precision=None):
                 earth_pv_support, earth_heliocentric_support
                 ) = prepare_earth_position_vel(obstime_support)
             # do interpolation
-            earth_pv = np.empty((len(obstime), 2, 3))
-            earth_heliocentric = np.empty((len(obstime), 3))
+            earth_pv = np.empty(obstime.shape + (2, 3,))
+            earth_heliocentric = np.empty(obstime.shape + (3,))
             for dim in range(3):
                 for ipv in range(2):
-                    earth_pv[:, ipv, dim] = np.interp(
+                    earth_pv[..., ipv, dim] = np.interp(
                         obstime.mjd, obstime_support.mjd, earth_pv_support[:, ipv, dim]
                         )
-                earth_heliocentric[:, dim] = np.interp(
-                        obstime.mjd, obstime_support.mjd, earth_heliocentric_support[:, dim]
-                        )
+                earth_heliocentric[..., dim] = np.interp(
+                    obstime.mjd, obstime_support.mjd, earth_heliocentric_support[:, dim]
+                    )
 
         else:
             earth_pv, earth_heliocentric = prepare_earth_position_vel(obstime)

--- a/astropy/coordinates/astrom_manager.py
+++ b/astropy/coordinates/astrom_manager.py
@@ -1,0 +1,125 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module contains a helper function to fill erfa.astrom struct and a
+ScienceState, which allows to speed up coordinate transformations at the
+expense of accuracy.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from collections import OrderedDict
+
+import numpy as np
+
+from ..time import Time
+from .sky_coordinate import SkyCoord
+from ..utils.decorators import classproperty
+from ..utils.state import ScienceState
+# from ..utils import indent
+from .. import units as u
+from .. import _erfa as erfa
+from ..extern import six
+from .builtin_frames.utils import (
+    get_jd12, get_cip, prepare_earth_position_vel, get_polar_motion, get_dut1utc
+    )
+
+__all__ = ["transform_precision"]
+
+
+DEFAULT_PRECISION = None  # no MJD binning
+
+
+class transform_precision(ScienceState):
+    """
+    TBD
+    """
+
+    _value = 0.  # value steers the transform precision (MJD_BINNING)
+
+
+def get_astrom(frame, tcode, precision=None):
+    """
+    """
+
+    assert tcode in ['apio13', 'apci', 'apcs', 'apci13', 'apco13']
+
+    if precision is None:
+        precision = transform_precision.get()
+
+    if precision < 1.e-3:
+        # below millisecond MJD resolution, one is probably better of
+        # with no MJD binning
+        mjd_resolution = None
+
+    else:
+        mjd_resolution = precision / 86400.  # in days
+
+    obstime = frame.obstime
+
+    if mjd_resolution:
+        # apply binning to obstime
+        mjd_binned = np.int64(obstime.mjd / mjd_resolution + 0.5)
+        mjd_u, mjd_idx, mjd_uidx = np.unique(
+            mjd_binned, return_index=True, return_inverse=True
+            )
+
+        # obstime_binned = obstime[mjd_idx]
+        obstime_binned = Time(mjd_u * mjd_resolution, format='mjd', scale=obstime.scale)
+    else:
+        obstime_binned = obstime
+
+    if tcode in ['apci', 'apcs']:
+        # find the position and velocity of earth
+        jd1_tt, jd2_tt = get_jd12(obstime_binned, 'tt')
+        earth_pv, earth_heliocentric = prepare_earth_position_vel(obstime_binned)
+
+    if tcode == 'apio13':
+
+        lon, lat, height = frame.location.to_geodetic('WGS84')
+
+        xp, yp = get_polar_motion(obstime_binned)
+        jd1_utc, jd2_utc = get_jd12(obstime_binned, 'utc')
+        dut1utc = get_dut1utc(obstime_binned)
+        astrom_binned = erfa.apio13(
+            jd1_utc, jd2_utc, dut1utc,
+            lon.to(u.radian).value, lat.to(u.radian).value,
+            height.to(u.m).value,
+            xp, yp,  # polar motion
+            # all below are already in correct units because they are QuantityFrameAttribues
+            frame.pressure.value,
+            frame.temperature.value,
+            frame.relative_humidity,
+            frame.obswl.value
+            )
+
+    elif tcode == 'apci':
+
+        x, y, s = get_cip(jd1_tt, jd2_tt)
+        astrom_binned = erfa.apci(jd1_tt, jd2_tt, earth_pv, earth_heliocentric, x, y, s)
+
+    elif tcode == 'apcs':
+
+        # get the position and velocity arrays for the observatory.  Need to
+        # have xyz in last dimension, and pos/vel in one-but-last.
+        # (Note could use np.stack once our minimum numpy version is >=1.10.)
+        pv = np.concatenate(
+                (frame.obsgeoloc.get_xyz(xyz_axis=-1).value[..., np.newaxis, :],
+                 frame.obsgeovel.get_xyz(xyz_axis=-1).value[..., np.newaxis, :]),
+                axis=-2)
+        astrom_binned = erfa.apcs(jd1_tt, jd2_tt, pv, earth_pv, earth_heliocentric)
+
+    elif tcode == 'apci13':
+        pass
+    elif tcode == 'apco13':
+        pass
+
+    if mjd_resolution:
+        astrom = astrom_binned[mjd_uidx]
+        jd1_ut1, jd2_ut1 = get_jd12(obstime, 'ut1')
+        astrom = erfa.aper13(jd1_ut1, jd2_ut1, astrom)
+    else:
+        astrom = astrom_binned
+
+    return astrom
+

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -18,7 +18,8 @@ from ... import _erfa as erfa
 
 from .cirs import CIRS
 from .altaz import AltAz
-from .utils import get_polar_motion, get_dut1utc, get_jd12, PIOVER2
+from .utils import PIOVER2
+from ..astrom_manager import get_astrom
 
 
 @frame_transform_graph.transform(FunctionTransform, CIRS, AltAz)
@@ -49,21 +50,8 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
         cirs_ra = diffrepr.lon.to(u.radian).value
         cirs_dec = diffrepr.lat.to(u.radian).value
 
-    lon, lat, height = altaz_frame.location.to_geodetic('WGS84')
-    xp, yp = get_polar_motion(obstime)
-
     #first set up the astrometry context for CIRS<->AltAz
-    jd1, jd2 = get_jd12(obstime, 'utc')
-    astrom = erfa.apio13(jd1, jd2,
-                         get_dut1utc(obstime),
-                         lon.to(u.radian).value, lat.to(u.radian).value,
-                         height.to(u.m).value,
-                         xp, yp,  # polar motion
-                         # all below are already in correct units because they are QuantityFrameAttribues
-                         altaz_frame.pressure.value,
-                         altaz_frame.temperature.value,
-                         altaz_frame.relative_humidity,
-                         altaz_frame.obswl.value)
+    astrom = get_astrom(altaz_frame, 'apio13')
 
     az, zen, _, _, _ = erfa.atioq(cirs_ra, cirs_dec, astrom)
 
@@ -89,21 +77,8 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     az = usrepr.lon.to(u.radian).value
     zen = PIOVER2 - usrepr.lat.to(u.radian).value
 
-    lon, lat, height = altaz_coo.location.to_geodetic('WGS84')
-    xp, yp = get_polar_motion(altaz_coo.obstime)
-
     #first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
-    jd1, jd2 = get_jd12(altaz_coo.obstime, 'utc')
-    astrom = erfa.apio13(jd1, jd2,
-                         get_dut1utc(altaz_coo.obstime),
-                         lon.to(u.radian).value, lat.to(u.radian).value,
-                         height.to(u.m).value,
-                         xp, yp,  # polar motion
-                         # all below are already in correct units because they are QuantityFrameAttribues
-                         altaz_coo.pressure.value,
-                         altaz_coo.temperature.value,
-                         altaz_coo.relative_humidity,
-                         altaz_coo.obswl.value)
+    astrom = get_astrom(altaz_coo, 'apio13')
 
     # the 'A' indicates zen/az inputs
     cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -27,10 +27,13 @@ MJD_RESOLUTION = 600. / 86400.  # in days (default 10 min)
 JD0 = 2400000.5
 
 
-def _apci13_fast(jd1, jd2, dut1utc):
+def _apci13_fast(obstime):
 
     # calculate Earth parameters for lower time resolution (they change slowly)
     # only Earth rotation angle needs to be calculated for each time
+
+    jd1, jd2 = get_jd12(obstime, 'tdb')
+    jd1_ut1, jd2_ut1 = get_jd12(obstime, 'ut1')
 
     mjd = (jd1 - JD0) + jd2
     mjd_i = np.int64(mjd / MJD_RESOLUTION + 0.5)
@@ -40,11 +43,8 @@ def _apci13_fast(jd1, jd2, dut1utc):
         )
 
     astrom_ui, _ = erfa.apci13(JD0, mjd_ui * MJD_RESOLUTION)
-
-    # astrom = np.empty(jd1.size, astrom_ui.dtype)
     astrom = astrom_ui[mjd_uidx]
 
-    jd1_ut1, jd2_ut1 = erfa.utcut1(jd1, jd2, dut1utc)
     astrom = erfa.aper13(jd1_ut1, jd2_ut1, astrom)
 
     return astrom
@@ -55,7 +55,6 @@ def _apci13_fast(jd1, jd2, dut1utc):
 def icrs_to_cirs(icrs_coo, cirs_frame):
     # first set up the astrometry context for ICRS<->CIRS
     # jd1, jd2 = get_jd12(cirs_frame.obstime, 'tdb')
-    jd1, jd2 = get_jd12(cirs_frame.obstime, 'utc')
 
     # x, y, s = get_cip(jd1, jd2)
     # earth_pv, earth_heliocentric = prepare_earth_position_vel(cirs_frame.obstime)
@@ -63,8 +62,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 
     # astrom, eo = erfa.apci13(jd1, jd2)
 
-    dut1utc = get_dut1utc(cirs_frame.obstime)
-    astrom = _apci13_fast(jd1, jd2, dut1utc)
+    astrom = _apci13_fast(cirs_frame.obstime)
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -106,7 +104,6 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
     # jd1, jd2 = get_jd12(cirs_coo.obstime, 'tdb')
-    jd1, jd2 = get_jd12(cirs_coo.obstime, 'utc')
 
     # x, y, s = get_cip(jd1, jd2)
     # earth_pv, earth_heliocentric = prepare_earth_position_vel(cirs_coo.obstime)
@@ -114,8 +111,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
     # astrom, eo = erfa.apci13(jd1, jd2)
 
-    dut1utc = get_dut1utc(cirs_coo.obstime)
-    astrom = _apci13_fast(jd1, jd2, dut1utc)
+    astrom = _apci13_fast(cirs_coo.obstime)
 
     i_ra, i_dec = aticq(cirs_ra, cirs_dec, astrom)
 


### PR DESCRIPTION
The erfa.astrom struct needs a substantial amount of computing power to update Earth parameters. However, all but the Earth rotation angle are relatively slowly changing numbers. If some accuracy can be sacrificed, calculating the slowly changing astrom parameters on certain time-steps only, can lead to large speed-ups. For example, a time resolution of 10 minutes will still have an accuracy of <~50 mas if ICRS is transformed to AltAz.

The attached commit is merely a proof of concept. Since this is my first PR, I'd appreciate some guidance on how to proceed. Below, I add some additional information, ideas and questions that should be discussed before I'll work on a final solution.

## The Problem
At our observatory, we often observe in AltAz frame for a session and then need to convert the coordinates to ICRS. A minimal example:
```python
import numpy as np
from astropy import coordinates
from astropy.coordinates import SkyCoord  # High-level coordinates
from astropy.coordinates import ICRS, CIRS, AltAz, EarthLocation
from astropy.coordinates import Angle, Latitude, Longitude  # Angles
from astropy.time import Time
from astropy import _erfa as erfa
import astropy.units as u
from astropy.utils.misc import NumpyRNGContext

numcoords = 10 ** 5

with NumpyRNGContext(1):
    # in reality, the following quantities are of course not random
    _ra = np.random.uniform(-179, 179, numcoords)
    _dec = np.random.uniform(-89, 89, numcoords)
    _time_delta = np.random.uniform(0, 1, numcoords)

ra = Longitude(_ra, unit=u.deg)
dec = Latitude(_dec, unit=u.deg)
cs = SkyCoord(ra, dec, frame='icrs')

loc = EarthLocation(lat=41.3 * u.deg, lon=-74 * u.deg, height=390 * u.m)

times = Time(54000. + _time_delta, format='mjd')
tframes = AltAz(obstime=times, location=loc)

altaz = cs.transform_to(tframes)  # 30+ seconds
```
The last function can take very long to run, and in fact this is a show-stopper for me to use astropy coordinates for such astrometric calculations.

## Accuracy
I made plots of the deviations. It seems, that with the proposed method (`_apci13_fast` with 10 min granularity) most points have less than 5 mas deviation from the original solution. No difference is apparent between `erfa.apci13` and the current implementation. The maximal deviation between `_apci13_fast` and current is of the order of 50 mas.

![az_diff](https://cloud.githubusercontent.com/assets/6582333/26033529/9a23886c-38ae-11e7-950c-62b623ac51f9.png)
![alt_diff](https://cloud.githubusercontent.com/assets/6582333/26033524/8f06514e-38ae-11e7-9652-54cb0f7291d4.png)

Zooming-in on the azimuthal deviations shows a pattern, which is introduced by the 10-min grid (0.007 d):
![az_diff_zoom](https://cloud.githubusercontent.com/assets/6582333/26033531/9f4966d6-38ae-11e7-9bbf-fc6cc5dc9ed9.png)

## Timing
There is a large performance bottleneck in the `cirs_to_icrs` and `icrs_to_cirs` transform functions. Both calculate the astrom struct using `erfa.apci`. The latter needs several parameters. One can already improve the speed somewhat, by using `erfa.apci13`, which only needs time as parameter. A much larger speed-up is obtained, if the time granularity is changed to 10 minutes or so (see above).

| Method| Runtime|
| :-------------| :-----|
| current |  35.2 s |
| `erfa.apci13` | 23.5 s |
| `_apci13_fast` | 295 ms (2.8 s, slowest loop)|

I'm not quite sure, why the (inital?) loop seems to be about 10x slower, when using `_apci13_fast`. Profiling suggests, that a lot of time is spent in `astropy._erfa._core._dtdb`, which is related to the line
```python
jd1, jd2 = get_jd12(cirs_frame.obstime, 'tdb')
```
According to the erfa docs, 'utc' should be as good as 'tdb' here, and doesn't seem to have the described issue. [update]I just realized, that for much finer resolution (e.g., 0.1 s), the difference between utc and tdb in fact becomes important. So for the moment, I switched back to the use of tdb.[/update]

## From proof-of-concept to a solution
While the quick-and-dirty solution already seems to provide a nice speed-up, there are other things to consider. The astrom struct is of course not only calculated in the `cirs_to_icrs` and `icrs_to_cirs` transform functions (although here, the performance hit is most critical). It would be much nicer, if it could be cached in a low-level routine. Unfortunately, since the erfa core is auto-generated (as a C-extension), this seems very difficult to achieve (at least for me). This would have been easier with the older Cython-based erfa wrapper. Likewise, a higher-level cache (in SkyCoord?) would be feasible, which stores already computed astrom values, but I guess, that changes would need to be made at many different places. Not sure, which option would be best.

Furthermore, the granularity (`MJD_RESOLUTION`) should be modifiable by the user, especially if higher accuracy is needed than provided by the value of 10 min.