### PR TITLE
Add scatter_contour function to astropy.visualization.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,11 @@ New Features
 
 - ``astropy.visualization``
 
+  - Added a new ``scatter_contour`` plotting function for scatter plots with
+    large numbers of points. The function visualizes dense regions with contours
+    and sparse regions with point markers. This was originally implemented in
+    the astroML package. [#6069]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``

--- a/astropy/visualization/__init__.py
+++ b/astropy/visualization/__init__.py
@@ -4,6 +4,7 @@ from .hist import *
 from .interval import *
 from .mpl_normalize import *
 from .mpl_style import *
+from .scatter_contour import scatter_contour
 from .stretch import *
 from .transform import *
 from .ui import *

--- a/astropy/visualization/scatter_contour.py
+++ b/astropy/visualization/scatter_contour.py
@@ -1,0 +1,98 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import absolute_import, division, unicode_literals
+
+import numpy as np
+
+def scatter_contour(x, y,
+                    levels=10,
+                    threshold=100,
+                    log_counts=False,
+                    histogram2d_kwargs=None,
+                    plot_kwargs=None,
+                    contour_kwargs=None,
+                    filled_contour=True,
+                    ax=None):
+    x = np.asarray(x)
+    y = np.asarray(y)
+
+    # plot contours on top
+    default_contour_kwargs = dict(zorder=2)
+    default_plot_kwargs = dict(marker='.', linestyle='none', zorder=1)
+
+    if plot_kwargs is not None:
+        default_plot_kwargs.update(plot_kwargs)
+    plot_kwargs = default_plot_kwargs
+
+    if contour_kwargs is not None:
+        default_contour_kwargs.update(contour_kwargs)
+    contour_kwargs = default_contour_kwargs
+
+    if histogram2d_kwargs is None:
+        histogram2d_kwargs = {}
+
+    if contour_kwargs is None:
+        contour_kwargs = {}
+
+    if ax is None:
+        # Import here so that testing with Agg will work
+        from matplotlib import pyplot as plt
+        ax = plt.gca()
+
+    H, xbins, ybins = np.histogram2d(x, y, **histogram2d_kwargs)
+
+    if log_counts:
+        H = np.log10(1 + H)
+        threshold = np.log10(1 + threshold)
+
+    levels = np.asarray(levels)
+
+    if levels.size == 1: # if an integer is passed
+
+        if threshold > H.max():
+            raise ValueError('Counts threshold is larger than the maximum '
+                             'number of points per bin. Either decrease the '
+                             'threshold or use larger bins (use the '
+                             'histogram2d_kwargs argument to pass kwargs to '
+                             'numpy.histogram2d).')
+
+        levels = np.linspace(threshold, H.max(), levels)
+
+    extent = [xbins[0], xbins[-1], ybins[0], ybins[-1]]
+
+    if filled_contour:
+        contours = ax.contourf(H.T, levels, extent=extent, **contour_kwargs)
+    else:
+        contours = ax.contour(H.T, levels, extent=extent, **contour_kwargs)
+
+    X = np.hstack([x[:, None], y[:, None]])
+
+    # This grabs the outermost / lowest-level contour path vertices so we
+    # can reduce the number of points to draw
+    paths = contours.allsegs[0]
+    if len(paths) > 0:
+        if filled_contour:
+            # We take only the first half because the second half is the
+            # inner edge of the outer contour shape.
+            n_vertices = paths[0].shape[0]
+            outer_poly = paths[0][:n_vertices//2]
+        else:
+            outer_poly = paths[0]
+
+        try:
+            # this works in newer matplotlib versions
+            from matplotlib.path import Path
+            points_inside = Path(outer_poly).contains_points(X)
+        except:
+            # this works in older matplotlib versions
+            import matplotlib.nxutils as nx
+            points_inside = nx.points_inside_poly(X, outer_poly)
+
+        Xplot = X[~points_inside]
+
+    else:
+        Xplot = X
+
+    points = ax.plot(Xplot[:, 0], Xplot[:, 1], **plot_kwargs)
+
+    return points, contours

--- a/astropy/visualization/scatter_contour.py
+++ b/astropy/visualization/scatter_contour.py
@@ -17,9 +17,9 @@ def scatter_contour(x, y,
                     ax=None):
     """Scatter plot with contours over dense regions
 
-    The contours are either drawn with `~matplotlib.pyplot.contour()` or
-    `~matplotlib.pyplot.contourf()`. The points in sparse regions are plotted
-    using `~matplotlib.pyplot.plot()` rather than scatter.
+    The contours are either drawn with :meth:`~matplotlib.axes.Axes.contour` or
+    :meth:`~matplotlib.axes.Axes.contourf`. The points in sparse regions are
+    plotted using :meth:`~matplotlib.axes.Axes.plot`.
 
     This function was ported from astroML: http://astroML.org/
 
@@ -39,30 +39,30 @@ def scatter_contour(x, y,
     log_counts : boolean (optional)
         If ``True``, contour levels are the base-10 logarithm of the bin counts.
     histogram2d_kwargs : dict
-        Keyword arguments passed to `numpy.histogram2d`, which is used to
+        Keyword arguments passed to :func:`numpy.histogram2d`, which is used to
         generate the input for the contour plotting function used. See docstring
         of `numpy.histogram2d` for more information.
     plot_kwargs : dict
-        Keyword arguments passed to `~matplotlib.pyplot.plot()`. By default it
-        will use `marker='.'` and `linestyle='none'`. See docstring of
-        `~matplotlib.pyplot.plot()` for more information.
+        Keyword arguments passed to :meth:`~matplotlib.axes.Axes.plot`. By
+        default it will use `marker='.'` and `linestyle='none'`. See docstring
+        of :meth:`matplotlib.axes.Axes.plot` for more information.
     contour_kwargs : dict
-        Keyword arguments passed to `~matplotlib.pyplot.contour()` or
-        `~matplotlib.pyplot.contourf()`, depending on the value of
-        `filled_contour`. See docstrings of these functions for more
+        Keyword arguments passed to :meth:`~matplotlib.axes.Axes.contour` or
+        :meth:`matplotlib.axes.Axes.contourf`, depending on the value of
+        ``filled_contour``. See docstrings of these functions for more
         information.
     filled_contour : bool
         If ``True`` (default) use filled contours,
-        `~matplotlib.pyplot.contourf()`. Otherwise, use contour outlines,
-        `~matplotlib.pyplot.contour()`.
+        :meth:`matplotlib.axes.Axes.contourf`. Otherwise, use contour outlines,
+        :meth:`matplotlib.axes.Axes.contour`.
     ax : `matplotlib.axes.Axes`
         The axes on which to plot. If not specified, the current axes are used,
-        from `~matplotlib.pyplot.gca()`.
+        from :func:`~matplotlib.pyplot.gca()`.
 
     Returns
     -------
     points, contours :
-       ``points`` is the return value of `~matplotlib.pyplot.plot()`.
+       ``points`` is the return value of :meth:`~matplotlib.axes.Axes.plot`.
        ``contours`` is the return value of the contour function that is called.
 
     """

--- a/astropy/visualization/scatter_contour.py
+++ b/astropy/visualization/scatter_contour.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, unicode_literals
 
 import numpy as np
 
+__all__ = ['scatter_contour']
+
 def scatter_contour(x, y,
                     levels=10,
                     threshold=100,
@@ -13,6 +15,57 @@ def scatter_contour(x, y,
                     contour_kwargs=None,
                     filled_contour=True,
                     ax=None):
+    """Scatter plot with contours over dense regions
+
+    The contours are either drawn with `~matplotlib.pyplot.contour()` or
+    `~matplotlib.pyplot.contourf()`. The points in sparse regions are plotted
+    using `~matplotlib.pyplot.plot()` rather than scatter.
+
+    This function was ported from astroML: http://astroML.org/
+
+    Original code:
+    Copyright (c) 2012-2013, Jacob Vanderplas. All rights reserved.
+
+    Parameters
+    ----------
+    x : array_like
+        x data for the contour plot.
+    y : array_like
+        y data for the contour plot.
+    levels : integer or array_like (optional, default=10)
+        Number of contour levels, or array of contour levels.
+    threshold : float (optional)
+        Number of points per 2D bin at which to begin drawing contours.
+    log_counts : boolean (optional)
+        If ``True``, contour levels are the base-10 logarithm of the bin counts.
+    histogram2d_kwargs : dict
+        Keyword arguments passed to `numpy.histogram2d`, which is used to
+        generate the input for the contour plotting function used. See docstring
+        of `numpy.histogram2d` for more information.
+    plot_kwargs : dict
+        Keyword arguments passed to `~matplotlib.pyplot.plot()`. By default it
+        will use `marker='.'` and `linestyle='none'`. See docstring of
+        `~matplotlib.pyplot.plot()` for more information.
+    contour_kwargs : dict
+        Keyword arguments passed to `~matplotlib.pyplot.contour()` or
+        `~matplotlib.pyplot.contourf()`, depending on the value of
+        `filled_contour`. See docstrings of these functions for more
+        information.
+    filled_contour : bool
+        If ``True`` (default) use filled contours,
+        `~matplotlib.pyplot.contourf()`. Otherwise, use contour outlines,
+        `~matplotlib.pyplot.contour()`.
+    ax : `matplotlib.axes.Axes`
+        The axes on which to plot. If not specified, the current axes are used,
+        from `~matplotlib.pyplot.gca()`.
+
+    Returns
+    -------
+    points, contours :
+       ``points`` is the return value of `~matplotlib.pyplot.plot()`.
+       ``contours`` is the return value of the contour function that is called.
+
+    """
     x = np.asarray(x)
     y = np.asarray(y)
 

--- a/astropy/visualization/scatter_contour.py
+++ b/astropy/visualization/scatter_contour.py
@@ -41,11 +41,11 @@ def scatter_contour(x, y,
     histogram2d_kwargs : dict
         Keyword arguments passed to :func:`numpy.histogram2d`, which is used to
         generate the input for the contour plotting function used. See docstring
-        of `numpy.histogram2d` for more information.
+        of :func:`numpy.histogram2d` for more information.
     plot_kwargs : dict
         Keyword arguments passed to :meth:`~matplotlib.axes.Axes.plot`. By
-        default it will use `marker='.'` and `linestyle='none'`. See docstring
-        of :meth:`matplotlib.axes.Axes.plot` for more information.
+        default it will use ``marker='.'`` and ``linestyle='none'``. See
+        docstring of :meth:`matplotlib.axes.Axes.plot` for more information.
     contour_kwargs : dict
         Keyword arguments passed to :meth:`~matplotlib.axes.Axes.contour` or
         :meth:`matplotlib.axes.Axes.contourf`, depending on the value of

--- a/astropy/visualization/tests/test_scatter_contour.py
+++ b/astropy/visualization/tests/test_scatter_contour.py
@@ -1,0 +1,64 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+try:
+    import matplotlib.pyplot as plt
+    HAS_PLT = True
+except ImportError:
+    HAS_PLT = False
+
+import pytest
+import numpy as np
+
+from ..scatter_contour import scatter_contour
+
+class TestScatterContour(object):
+
+    def setup(self):
+        rng = np.random.RandomState(42)
+
+        # need many points for contour - arbitrary locations and scales
+        self.x, self.y = rng.normal([-0.4, 15.,], [12., 0.8], size=(1024,2)).T
+
+    @pytest.mark.skipif('not HAS_PLT')
+    def test_scatter_contour_basic(self):
+
+        # lower the threshold so it succeeds
+        scatter_contour(self.x, self.y, threshold=10)
+
+        # or, could make bins larger
+        scatter_contour(self.x, self.y, threshold=100, histogram2d_kwargs=dict(bins=5))
+
+        # fails when threshold is too high, no valid contours to draw
+        with pytest.raises(ValueError):
+            scatter_contour(self.x, self.y, threshold=100)
+
+    @pytest.mark.skipif('not HAS_PLT')
+    def test_hist_specify_ax(self):
+
+        fig, axes = plt.subplots(2)
+        _,contours = scatter_contour(self.x, self.y, threshold=10, ax=axes[0])
+        assert contours.ax is axes[0]
+
+        _,contours = scatter_contour(self.x, self.y, threshold=10, ax=axes[1])
+        assert contours.ax is axes[1]
+
+    @pytest.mark.skipif('not HAS_PLT')
+    def test_hist_kwargs(self):
+
+        # test passing arguments
+        scatter_contour(self.x, self.y, threshold=10, levels=4)
+        scatter_contour(self.x, self.y, threshold=10,
+                        levels=np.linspace(8, 100, 8))
+
+        scatter_contour(self.x, self.y, threshold=10, filled_contour=False)
+
+        scatter_contour(self.x, self.y, threshold=10, levels=4)
+        scatter_contour(self.x, self.y, threshold=10, levels=3, log_counts=True)
+
+        scatter_contour(self.x, self.y, threshold=2,
+                        plot_kwargs=dict(marker='o'),
+                        contour_kwargs=dict(cmap='Greys'),
+                        histogram2d_kwargs=dict(bins=(16,16)))

--- a/astropy/visualization/tests/test_scatter_contour.py
+++ b/astropy/visualization/tests/test_scatter_contour.py
@@ -29,7 +29,8 @@ class TestScatterContour(object):
         scatter_contour(self.x, self.y, threshold=10)
 
         # or, could make bins larger
-        scatter_contour(self.x, self.y, threshold=100, histogram2d_kwargs=dict(bins=5))
+        scatter_contour(self.x, self.y, threshold=100,
+                        histogram2d_kwargs=dict(bins=5))
 
         # fails when threshold is too high, no valid contours to draw
         with pytest.raises(ValueError):

--- a/docs/visualization/index.rst
+++ b/docs/visualization/index.rst
@@ -23,6 +23,7 @@ Using `astropy.visualization`
    normalization.rst
    histogram.rst
    lupton_rgb.rst
+   scatter_contour.rst
 
 Astropy matplotlib style
 =========================

--- a/docs/visualization/scatter_contour.rst
+++ b/docs/visualization/scatter_contour.rst
@@ -21,7 +21,7 @@ are often hard to interpret because of overlapping markers. For example:
     figsize = (6, 6)
     lim = (-8, 8)
 
-    np.random.seed(24)
+    np.random.seed(42)
     x, y = np.random.normal([0., 0.], [1., 1.], size=(16384, 2)).T
 
     fig,ax = plt.subplots(1, 1, figsize=figsize)

--- a/docs/visualization/scatter_contour.rst
+++ b/docs/visualization/scatter_contour.rst
@@ -1,0 +1,80 @@
+.. _astropy-visualization-scatter-contour:
+
+***********************************************
+Scatter plots with large numbers of data points
+***********************************************
+
+When creating a scatter plot with a large number of data points, dense regions
+are often hard to interpret because of overlapping markers. For example::
+
+.. plot::
+    :align: center
+    :context: close-figs
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    figsize = (6, 6)
+    lim = (-8, 8)
+
+    np.random.seed(24)
+    x, y = np.random.normal([1., 2.], [2., 1.], size=(8192, 2)).T
+
+    fig,ax = plt.subplots(1, 1, figsize=figsize)
+    ax.plot(x, y, marker='.', linestyle='none')
+    ax.set_xlim(lim)
+    ax.set_ylim(lim)
+
+One solution that works for some situations is to use marker transparency.
+However, when there is a large dynamic range between the most dense and most
+sparse regions, even this can lead to confusion::
+
+.. plot::
+    :align: center
+    :context: close-figs
+
+    fig,ax = plt.subplots(1, 1, figsize=figsize)
+    ax.plot(x, y, marker='.', linestyle='none', alpha=0.2)
+    ax.set_xlim(lim)
+    ax.set_ylim(lim)
+
+The :mod:`astropy.visualization` module provides an alternate solution with the
+function :func:`~astropy.visualization.scatter_contour`. The function switches
+from drawing markers to drawing contours given some density threshold::
+
+.. plot::
+    :align: center
+    :context: close-figs
+
+    from astropy.visualization import scatter_contour
+    fig,ax = plt.subplots(1, 1, figsize=figsize)
+    scatter_contour(x, y, ax=ax, contour_kwargs=dict(cmap='Greys_r'))
+    ax.set_xlim(lim)
+    ax.set_ylim(lim)
+
+This function can be customized to change the number and placement of the bins
+used to compute the contours (using the argument ``histogram2d_kwargs``), the
+marker plotting style (using the argument ``plot_kwargs``), and the contour
+plotting style (using the arguments ``filled_contour`` and ``contour_kwargs``).
+Here are some examples of other visualizations using
+:func:`~astropy.visualization.scatter_contour` with the same data::
+
+.. plot::
+    :align: center
+    :context: close-figs
+
+    fig,ax = plt.subplots(1, 1, figsize=figsize)
+    scatter_contour(x, y, ax=ax, contour_kwargs=dict(cmap='Greys_r'))
+    ax.set_title('alternate colormap')
+    ax.set_xlim(lim)
+    ax.set_ylim(lim)
+
+    fig,ax = plt.subplots(1, 1, figsize=figsize)
+    scatter_contour(x, y, ax=ax, threshold=10,
+                    log_counts=True, levels=8,
+                    histogram2d_kwargs=dict(bins=(16,16)),
+                    filled_contour=False,
+                    contour_kwargs=dict(colors='k'))
+    ax.set_title('log-spaced contour lines')
+    ax.set_xlim(lim)
+    ax.set_ylim(lim)

--- a/docs/visualization/scatter_contour.rst
+++ b/docs/visualization/scatter_contour.rst
@@ -4,12 +4,16 @@
 Scatter plots with large numbers of data points
 ***********************************************
 
+This page demonstrates how to use the
+:func:`~astropy.visualization.scatter_contour` function.
+
 When creating a scatter plot with a large number of data points, dense regions
-are often hard to interpret because of overlapping markers. For example::
+are often hard to interpret because of overlapping markers. For example:
 
 .. plot::
     :align: center
     :context: close-figs
+    :include-source: True
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -18,7 +22,7 @@ are often hard to interpret because of overlapping markers. For example::
     lim = (-8, 8)
 
     np.random.seed(24)
-    x, y = np.random.normal([1., 2.], [2., 1.], size=(8192, 2)).T
+    x, y = np.random.normal([0., 0.], [1., 1.], size=(16384, 2)).T
 
     fig,ax = plt.subplots(1, 1, figsize=figsize)
     ax.plot(x, y, marker='.', linestyle='none')
@@ -27,11 +31,12 @@ are often hard to interpret because of overlapping markers. For example::
 
 One solution that works for some situations is to use marker transparency.
 However, when there is a large dynamic range between the most dense and most
-sparse regions, even this can lead to confusion::
+sparse regions, even this can lead to confusion:
 
 .. plot::
     :align: center
     :context: close-figs
+    :include-source: True
 
     fig,ax = plt.subplots(1, 1, figsize=figsize)
     ax.plot(x, y, marker='.', linestyle='none', alpha=0.2)
@@ -40,15 +45,16 @@ sparse regions, even this can lead to confusion::
 
 The :mod:`astropy.visualization` module provides an alternate solution with the
 function :func:`~astropy.visualization.scatter_contour`. The function switches
-from drawing markers to drawing contours given some density threshold::
+from drawing markers to drawing contours given some density threshold:
 
 .. plot::
     :align: center
     :context: close-figs
+    :include-source: True
 
     from astropy.visualization import scatter_contour
     fig,ax = plt.subplots(1, 1, figsize=figsize)
-    scatter_contour(x, y, ax=ax, contour_kwargs=dict(cmap='Greys_r'))
+    scatter_contour(x, y, ax=ax)
     ax.set_xlim(lim)
     ax.set_ylim(lim)
 
@@ -57,11 +63,12 @@ used to compute the contours (using the argument ``histogram2d_kwargs``), the
 marker plotting style (using the argument ``plot_kwargs``), and the contour
 plotting style (using the arguments ``filled_contour`` and ``contour_kwargs``).
 Here are some examples of other visualizations using
-:func:`~astropy.visualization.scatter_contour` with the same data::
+:func:`~astropy.visualization.scatter_contour` with the same data:
 
 .. plot::
     :align: center
     :context: close-figs
+    :include-source: True
 
     fig,ax = plt.subplots(1, 1, figsize=figsize)
     scatter_contour(x, y, ax=ax, contour_kwargs=dict(cmap='Greys_r'))


### PR DESCRIPTION
This is a port of @jakevdp's `scatter_contour()` function from [astroML](http://www.astroml.org/modules/generated/astroML.plotting.scatter_contour.html#astroML.plotting.scatter_contour) to `astropy.visualization`.

See also astroML/astroML#98.

cc @jakevdp 