### PR TITLE
Fix title level inconsistency in table docs

### DIFF
--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -65,8 +65,7 @@ Quantities`_ for details)::
 
 
 Comment lines
-"""""""""""""
-
+-------------
 Comment lines in an ASCII file can be added via the ``'comments'`` key in the
 table's metadata. The following will insert two comment lines in the output
 ASCII file unless ``comment=False`` is explicitly set in ``write()``::


### PR DESCRIPTION
There were some hidden conflicts between changes merged recently causing sphinx errors (PRs #6057 and #6055). This PR fixes the errors.