### PR TITLE
Represent a few more numpy types in YAML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ New Features
 
 - ``astropy.io.misc``
 
+  - YAML representer now also accepts numpy types. [#6077]
+
 - ``astropy.io.registry``
 
 - ``astropy.io.votable``

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -24,7 +24,8 @@ except ImportError:
 pytestmark = pytest.mark.skipif('not HAS_YAML')
 
 
-@pytest.mark.parametrize('c', [np.int32(1), np.int64(3)])
+@pytest.mark.parametrize('c', [np.int32(1), np.int64(3), np.float(2.0), 
+                               np.int16(4), np.bool(True), np.uint8(8), np.complex(3, 4)])
 def test_numpy_types(c):
     cy = load(dump(c))
     assert c == cy

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -24,9 +24,12 @@ except ImportError:
 pytestmark = pytest.mark.skipif('not HAS_YAML')
 
 
-@pytest.mark.parametrize('c', [np.int32(1), np.int64(3), np.float(2.0),
-                               np.int16(4), np.bool(True), np.uint8(8),
-                               np.complex(3, 4)])
+@pytest.mark.parametrize('c', [np.bool(True), np.uint8(8), np.int16(4),
+                               np.int32(1), np.int64(3), np.int64(2**63 - 1),
+                               np.float(2.0), np.float64(),
+                               np.complex(3, 4), np.complex_(3 + 4j),
+                               np.complex64(3 + 4j),
+                               np.complex128(1. - 2**-52 + 1j * (1. - 2**-52))])
 def test_numpy_types(c):
     cy = load(dump(c))
     assert c == cy

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -26,9 +26,9 @@ pytestmark = pytest.mark.skipif('not HAS_YAML')
 
 @pytest.mark.parametrize('c', [np.int32(1), np.int64(3)])
 def test_numpy_types(c):
-    
     cy = load(dump(c))
     assert c == cy
+
 
 @pytest.mark.parametrize('c', [u.m, u.m / u.s, u.hPa, u.dimensionless_unscaled])
 def test_unit(c):

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -24,8 +24,9 @@ except ImportError:
 pytestmark = pytest.mark.skipif('not HAS_YAML')
 
 
-@pytest.mark.parametrize('c', [np.int32(1), np.int64(3), np.float(2.0), 
-                               np.int16(4), np.bool(True), np.uint8(8), np.complex(3, 4)])
+@pytest.mark.parametrize('c', [np.int32(1), np.int64(3), np.float(2.0),
+                               np.int16(4), np.bool(True), np.uint8(8),
+                               np.complex(3, 4)])
 def test_numpy_types(c):
     cy = load(dump(c))
     assert c == cy

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -24,6 +24,12 @@ except ImportError:
 pytestmark = pytest.mark.skipif('not HAS_YAML')
 
 
+@pytest.mark.parametrize('c', [np.int32(1), np.int64(3)])
+def test_numpy_types(c):
+    
+    cy = load(dump(c))
+    assert c == cy
+
 @pytest.mark.parametrize('c', [u.m, u.m / u.s, u.hPa, u.dimensionless_unscaled])
 def test_unit(c):
     cy = load(dump(c))

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -75,7 +75,6 @@ from ... import units as u
 from ... import coordinates as coords
 from ...utils import minversion
 from ...extern import six
-import warnings
 
 
 try:

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -223,19 +223,20 @@ AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
 AstropyDumper.add_representer(Time, _time_representer)
 AstropyDumper.add_representer(TimeDelta, _timedelta_representer)
 AstropyDumper.add_representer(coords.SkyCoord, _skycoord_representer)
-AstropyDumper.add_representer(np.int32,
-                              yaml.representer.Representer.represent_int)
-try:
-    AstropyDumper.add_representer(np.int64,
-                                  yaml.representer.Representer.represent_long)
-except:
-    warnings.warn("This version of Pyyaml does not support long ints; using "
-                  "standard ints instead", AstropyUserWarning)
-    AstropyDumper.add_representer(np.int64,
-                                  yaml.representer.Representer.represent_int)
 
-AstropyDumper.add_representer(np.float64,
-                              yaml.representer.Representer.represent_float)
+# Numpy dtypes
+AstropyDumper.add_representer(np.bool_,
+                              yaml.representer.Representer.represent_bool)
+for np_type in [np.int_, np.intc, np.intp, np.int8, np.int16, np.int32, 
+                np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
+   AstropyDumper.add_representer(np_type,
+                                 yaml.representer.Representer.represent_int)
+for np_type in [np.float_, np.float16, np.float32, np.float64, np.longdouble]:
+   AstropyDumper.add_representer(np_type,
+                                 yaml.representer.Representer.represent_float)
+for np_type in [np.complex_, np.complex64, np.complex128]:
+   AstropyDumper.add_representer(np_type,
+                                 yaml.representer.Representer.represent_complex)
 
 AstropyLoader.add_constructor('tag:yaml.org,2002:python/tuple',
                               AstropyLoader._construct_python_tuple)

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -75,6 +75,7 @@ from ... import units as u
 from ... import coordinates as coords
 from ...utils import minversion
 from ...extern import six
+from astropy.logger import warnings
 
 
 try:
@@ -222,6 +223,19 @@ AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
 AstropyDumper.add_representer(Time, _time_representer)
 AstropyDumper.add_representer(TimeDelta, _timedelta_representer)
 AstropyDumper.add_representer(coords.SkyCoord, _skycoord_representer)
+AstropyDumper.add_representer(np.int32, \
+                              yaml.representer.Representer.represent_int)
+try:
+    AstropyDumper.add_representer(np.int64, \
+                                  yaml.representer.Representer.represent_long)
+except:
+    warnings.warn("This version of Pyyaml does not support long ints; using "
+                  "standard ints instead")
+    AstropyDumper.add_representer(np.int64, \
+                                  yaml.representer.Representer.represent_int)
+
+AstropyDumper.add_representer(np.float64, \
+                              yaml.representer.Representer.represent_float)
 
 AstropyLoader.add_constructor('tag:yaml.org,2002:python/tuple',
                               AstropyLoader._construct_python_tuple)

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -234,7 +234,6 @@ class AstropyDumper(yaml.SafeDumper):
             if isinstance(data, six.string_types + (bool, int, float)):
                 return True
 
-
 AstropyDumper.add_representer(u.IrreducibleUnit, _unit_representer)
 AstropyDumper.add_representer(u.CompositeUnit, _unit_representer)
 AstropyDumper.add_multi_representer(u.Unit, _unit_representer)

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -75,7 +75,7 @@ from ... import units as u
 from ... import coordinates as coords
 from ...utils import minversion
 from ...extern import six
-from astropy.logger import warnings
+import warnings
 
 
 try:
@@ -223,18 +223,18 @@ AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
 AstropyDumper.add_representer(Time, _time_representer)
 AstropyDumper.add_representer(TimeDelta, _timedelta_representer)
 AstropyDumper.add_representer(coords.SkyCoord, _skycoord_representer)
-AstropyDumper.add_representer(np.int32, \
+AstropyDumper.add_representer(np.int32,
                               yaml.representer.Representer.represent_int)
 try:
-    AstropyDumper.add_representer(np.int64, \
+    AstropyDumper.add_representer(np.int64,
                                   yaml.representer.Representer.represent_long)
 except:
     warnings.warn("This version of Pyyaml does not support long ints; using "
-                  "standard ints instead")
-    AstropyDumper.add_representer(np.int64, \
+                  "standard ints instead", AstropyUserWarning)
+    AstropyDumper.add_representer(np.int64,
                                   yaml.representer.Representer.represent_int)
 
-AstropyDumper.add_representer(np.float64, \
+AstropyDumper.add_representer(np.float64,
                               yaml.representer.Representer.represent_float)
 
 AstropyLoader.add_constructor('tag:yaml.org,2002:python/tuple',

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -223,7 +223,6 @@ class AstropyDumper(yaml.SafeDumper):
     def _represent_tuple(self, data):
         return self.represent_sequence('tag:yaml.org,2002:python/tuple', data)
 
-
     if YAML_LT_3_12:
         # pre-3.12, ignore-aliases could not deal with ndarray, so we backport
         # the more recent ignore_alises definition.
@@ -250,14 +249,14 @@ AstropyDumper.add_representer(np.bool_,
                               yaml.representer.SafeRepresenter.represent_bool)
 for np_type in [np.int_, np.int, np.intc, np.intp, np.int8, np.int16, np.int32,
                 np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
-   AstropyDumper.add_representer(np_type,
+    AstropyDumper.add_representer(np_type,
                                  yaml.representer.SafeRepresenter.represent_int)
 for np_type in [np.float_, np.float, np.float16, np.float32, np.float64,
                 np.longdouble]:
-   AstropyDumper.add_representer(np_type,
+    AstropyDumper.add_representer(np_type,
                                  yaml.representer.SafeRepresenter.represent_float)
 for np_type in [np.complex_, np.complex, np.complex64, np.complex128]:
-   AstropyDumper.add_representer(np_type,
+    AstropyDumper.add_representer(np_type,
                                  _complex_representer)
 
 AstropyLoader.add_constructor(u'tag:yaml.org,2002:python/complex',


### PR DESCRIPTION
Closes #6076.
There is some problem with pyyaml versions. The one found on Github and Bitbucket has a `represent_long` function, but the one published on pypi doesn't, even if it should be more recent. So, depending on the version that the user has installed, they will use the proper `represent_long` or revert to `represent_int`, in the latter case with a warning.