### PR TITLE
[WIP] Add new separable property to models

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1040,6 +1040,11 @@ class Model(object):
 
         return self._user_bounding_box is not None
 
+    @property
+    def separable(self):
+        """Are the axes independent/separable?"""
+        return True
+
     # *** Public methods ***
 
     @abc.abstractmethod
@@ -1676,6 +1681,7 @@ class Model(object):
 
         return '\n'.join(parts)
 
+
 class FittableModel(Model):
     """
     Base class for models that can be fitted using the built-in fitting
@@ -1719,6 +1725,11 @@ class Fittable2DModel(FittableModel):
 
     inputs = ('x', 'y')
     outputs = ('z',)
+
+    @property
+    def separable(self):
+        """Not all 2D models have separable axes."""
+        return False
 
 
 def _make_arithmetic_operator(oper):
@@ -2492,8 +2503,11 @@ class _CompoundModel(Model):
                     "defined in order for the composite model to have an "
                     "inverse.  {0!r} does not have an inverse.".format(model))
 
-
         return self._tree.evaluate(operators, getter=getter)
+
+    @property
+    def separable(self):
+        raise AttributeError('separable not allowed for compound models')
 
     @sharedmethod
     def _get_submodels(self):

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -368,6 +368,28 @@ def test_custom_bounding_box_1d():
     g2.bounding_box = bb
     assert_allclose(g2.render(), expected)
 
+
 def test_n_submodels_in_single_models():
     assert models.Gaussian1D.n_submodels() == 1
     assert models.Gaussian2D.n_submodels() == 1
+
+
+# https://github.com/astropy/astropy/pull/6080
+def test_separable():
+    """
+    Test ``separable`` property.
+    """
+    poly = models.Polynomial2D(2)
+    assert poly.separable
+
+    g = models.Gaussian2D()
+    assert not g.separable
+
+    # Not allowed to be settable
+    with pytest.raises(AttributeError):
+        g.separable = True
+
+    # Not allowed for compound models
+    m = g + poly
+    with pytest.raises(AttributeError):
+        m.separable


### PR DESCRIPTION
Fix #6013 .

@nden , is this similar to what you have in mind? The way I implemented it, all models are separable by default except `Fittable2D` (but subclass can reset it to `True` as needed).

TODO:
- [ ] Add change log