### PR TITLE
respect the bounding_box when evaluating models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,10 @@ New Features
 
   - Added FWHM properties to Gaussian and Moffat models. [#6027]
 
+  - Added support for evaluating models and setting the results for inputs 
+    outside the bounding_box to a user specified ``fill_value``. This
+    is controlled by a new optional boolean keyword ``with_bounding_box``. [#6081]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -106,7 +106,8 @@ def test_custom_model_signature():
     sig = signature(model_a.__init__)
     assert list(sig.parameters.keys()) == ['self', 'args', 'kwargs']
     sig = signature(model_a.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis']
+    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
+                                           'with_bounding_box', 'fill_value']
 
     @custom_model
     def model_b(x, a=1, b=2):
@@ -118,8 +119,8 @@ def test_custom_model_signature():
     assert list(sig.parameters.keys()) == ['self', 'a', 'b', 'kwargs']
     assert [x.default for x in sig.parameters.values()] == [sig.empty, 1, 2, sig.empty]
     sig = signature(model_b.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis']
-
+    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
+                                           'with_bounding_box', 'fill_value']
     @custom_model
     def model_c(x, y, a=1, b=2):
         return x + y + a + b
@@ -130,7 +131,8 @@ def test_custom_model_signature():
     assert list(sig.parameters.keys()) == ['self', 'a', 'b', 'kwargs']
     assert [x.default for x in sig.parameters.values()] == [sig.empty, 1, 2, sig.empty]
     sig = signature(model_c.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'y', 'model_set_axis']
+    assert list(sig.parameters.keys()) == ['self', 'x', 'y', 'model_set_axis',
+                                           'with_bounding_box', 'fill_value']
 
 
 def test_custom_model_subclass():
@@ -154,7 +156,8 @@ def test_custom_model_subclass():
     sig = signature(model_b.__init__)
     assert list(sig.parameters.keys()) == ['self', 'a', 'kwargs']
     sig = signature(model_b.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis']
+    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
+                                           'with_bounding_box', 'fill_value']
 
 
 def test_custom_model_parametrized_decorator():


### PR DESCRIPTION
I am proposing to add support for model evaluation with bounding_box. Specifically I'd like to be able to set values for inputs outside the `bounding_box` to a pre-defined `fill_value`.
This is used to constrain inputs when evaluating models in GWCS.

The implementation here adds two parameters to `Model.__call__(*args, with_bounding_box=False, fill_value=np.nan)`

