### PR TITLE
Remove compatibility code which forced loading all HDUs on close

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -165,8 +165,6 @@ API Changes
   - ``comments`` meta key (which is ``io.ascii``'s table convention) is output
     to ``COMMENT`` instead of ``COMMENTS`` header. Similarly, ``COMMENT``
     headers are read into ``comments`` meta [#6097]
-  - Angstrom, erg, G, and barn are no more reported as deprecated FITS units.
-    [#5929]
 
   - Remove compatibility code which forced loading all HDUs on close. The old
     behavior can be used with ``lazy_load_hdus=False``. Because of this change,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -165,6 +165,13 @@ API Changes
   - ``comments`` meta key (which is ``io.ascii``'s table convention) is output
     to ``COMMENT`` instead of ``COMMENTS`` header. Similarly, ``COMMENT``
     headers are read into ``comments`` meta [#6097]
+  - Angstrom, erg, G, and barn are no more reported as deprecated FITS units.
+    [#5929]
+
+  - Remove compatibility code which forced loading all HDUs on close. The old
+    behavior can be used with ``lazy_load_hdus=False``. Because of this change,
+    trying to access the ``.data`` attribute from an HDU which is not loaded
+    now raises a ``IndexError`` instead of a ``ValueError``. [#6082]
 
 - ``astropy.io.misc``
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -113,13 +113,7 @@ def getheader(filename, *args, **kwargs):
         hdu = hdulist[extidx]
         header = hdu.header
     finally:
-        # Use _close instead of close to close without loading any
-        # remaining HDUs for pre-lazy-loading backwards compatibility
-        # In other words, when the full HDUList is opened by a user they
-        # previously expected to be able to look at arbitrary HDUs even
-        # after the file was closed, but for getheader and other convenience
-        # functions this is irrelevant
-        hdulist._close(closed=closed)
+        hdulist.close(closed=closed)
 
     return header
 
@@ -216,8 +210,7 @@ def getdata(filename, *args, **kwargs):
         if header:
             hdr = hdu.header
     finally:
-        # _close instead of close; see note in getheader
-        hdulist._close(closed=closed)
+        hdulist.close(closed=closed)
 
     # Change case of names if requested
     trans = None
@@ -353,8 +346,7 @@ def setval(filename, keyword, *args, **kwargs):
             comment = None
         hdulist[extidx].header.set(keyword, value, comment, before, after)
     finally:
-        # _close instead of close; see note in getheader
-        hdulist._close(closed=closed)
+        hdulist.close(closed=closed)
 
 
 def delval(filename, keyword, *args, **kwargs):
@@ -392,8 +384,7 @@ def delval(filename, keyword, *args, **kwargs):
     try:
         del hdulist[extidx].header[keyword]
     finally:
-        # _close instead of close; see note in getheader
-        hdulist._close(closed=closed)
+        hdulist.close(closed=closed)
 
 
 @deprecated_renamed_argument('clobber', 'overwrite', '1.3', pending=True)
@@ -611,15 +602,14 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
                 # when writing the file.
                 hdu._output_checksum = checksum
             finally:
-                # _close instead of close; see note in getheader
-                f._close(closed=closed)
+                f.close(closed=closed)
         else:
             f = _File(filename, mode='append')
             try:
                 hdu._output_checksum = checksum
                 hdu._writeto(f)
             finally:
-                f._close()
+                f.close()
 
 
 def update(filename, data, *args, **kwargs):
@@ -678,8 +668,7 @@ def update(filename, data, *args, **kwargs):
     try:
         hdulist[_ext] = new_hdu
     finally:
-        # _close instead of close; see note in getheader
-        hdulist._close(closed=closed)
+        hdulist.close(closed=closed)
 
 
 def info(filename, output=None, **kwargs):
@@ -716,8 +705,7 @@ def info(filename, output=None, **kwargs):
         ret = f.info(output=output)
     finally:
         if closed:
-            # _close instead of close; see note in getheader
-            f._close()
+            f.close()
 
     return ret
 
@@ -799,7 +787,7 @@ def printdiff(inputa, inputb, *args, **kwargs):
         try:
             hdulistb, extidxb = _getext(inputb, modeb, *args, **extension)
         except Exception:
-            hdulista._close(closed=closeda)
+            hdulista.close(closed=closeda)
             raise
 
         try:
@@ -809,9 +797,8 @@ def printdiff(inputa, inputb, *args, **kwargs):
             print(HDUDiff(hdua, hdub, **kwargs).report())
 
         finally:
-            # See note about _close in getheader function
-            hdulista._close(closed=closeda)
-            hdulistb._close(closed=closedb)
+            hdulista.close(closed=closeda)
+            hdulistb.close(closed=closedb)
 
     # If input is not a string, can feed HDU objects or HDUList directly,
     # but can't currently handle extensions
@@ -897,8 +884,7 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
         f[ext].dump(datafile, cdfile, hfile, overwrite)
     finally:
         if closed:
-            # _close instead of close; see note in getheader
-            f._close()
+            f.close()
 
 if isinstance(tabledump.__doc__, string_types):
     tabledump.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -307,8 +307,8 @@ class HDUList(list, _Verify):
                     raise e
                 else:
                     raise IndexError('HDU not found, possibly because the index '
-                                    'is out of range, or because the file was '
-                                    'closed before all HDUs were read')
+                                     'is out of range, or because the file was '
+                                     'closed before all HDUs were read')
             else:
                 return HDUList(hdus)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -299,14 +299,25 @@ class HDUList(list, _Verify):
                     if not self._read_next_hdu():
                         break
 
-            hdus = super(HDUList, self).__getitem__(key)
-            return HDUList(hdus)
+            try:
+                hdus = super(HDUList, self).__getitem__(key)
+            except IndexError:
+                raise IndexError('HDU not found, possibly because the index '
+                                 'is out of range, or because the file was '
+                                 'closed before all HDUs were read')
+            else:
+                return HDUList(hdus)
 
         # Originally this used recursion, but hypothetically an HDU with
         # a very large number of HDUs could blow the stack, so use a loop
         # instead
-        return self._try_while_unread_hdus(super(HDUList, self).__getitem__,
-                                           self._positive_index_of(key))
+        try:
+            return self._try_while_unread_hdus(super(HDUList, self).__getitem__,
+                                            self._positive_index_of(key))
+        except IndexError:
+            raise IndexError('HDU not found, possibly because the index '
+                             'is out of range, or because the file was '
+                             'closed before all HDUs were read')
 
     def __contains__(self, item):
         """

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -271,15 +271,6 @@ class HDUList(list, _Verify):
         Get an HDU from the `HDUList`, indexed by number or name.
         """
 
-        def _better_index_error(exc):
-            # Raise a more helpful IndexError if the file was not fully read.
-            if self._read_all:
-                raise exc
-            else:
-                raise IndexError('HDU not found, possibly because the index '
-                                 'is out of range, or because the file was '
-                                 'closed before all HDUs were read')
-
         # If the key is a slice we need to make sure the necessary HDUs
         # have been loaded before passing the slice on to super.
         if isinstance(key, slice):
@@ -311,7 +302,13 @@ class HDUList(list, _Verify):
             try:
                 hdus = super(HDUList, self).__getitem__(key)
             except IndexError as e:
-                _better_index_error(e)
+                # Raise a more helpful IndexError if the file was not fully read.
+                if self._read_all:
+                    raise e
+                else:
+                    raise IndexError('HDU not found, possibly because the index '
+                                    'is out of range, or because the file was '
+                                    'closed before all HDUs were read')
             else:
                 return HDUList(hdus)
 
@@ -322,7 +319,13 @@ class HDUList(list, _Verify):
             return self._try_while_unread_hdus(super(HDUList, self).__getitem__,
                                             self._positive_index_of(key))
         except IndexError as e:
-            _better_index_error(e)
+            # Raise a more helpful IndexError if the file was not fully read.
+            if self._read_all:
+                raise e
+            else:
+                raise IndexError('HDU not found, possibly because the index '
+                                 'is out of range, or because the file was '
+                                 'closed before all HDUs were read')
 
     def __contains__(self, item):
         """

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -128,9 +128,7 @@ class TestImageFunctions(FitsTestCase):
 
         with pytest.raises(IndexError) as exc_info:
             r[6]
-        assert str(exc_info.value) == ('HDU not found, possibly because the index '
-                                       'is out of range, or because the file was '
-                                       'closed before all HDUs were read')
+        assert str(exc_info.value) == 'list index out of range'
 
         # And the same with the global config item
         assert fits.conf.lazy_load_hdus  # True by default

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -73,7 +73,6 @@ class TestImageFunctions(FitsTestCase):
         # Original header should be unchanged
         assert phdr['FILENAME'] == 'labq01i3q_rawtag.fits'
 
-    @raises(IndexError)
     def test_open(self):
         # The function "open" reads a FITS file into an HDUList object.  There
         # are three modes to open: "readonly" (the default), "append", and
@@ -86,7 +85,15 @@ class TestImageFunctions(FitsTestCase):
         # data parts are latent instantiation, so if we close the HDUList
         # without touching data, data can not be accessed.
         r.close()
-        r[1].data[:2, :2]
+
+        with pytest.raises(IndexError) as exc_info:
+            r[1].data[:2, :2]
+
+        # Check that the exception message is the enhanced version, not the
+        # default message from list.__getitem__
+        assert str(exc_info.value) == ('HDU not found, possibly because the index '
+                                       'is out of range, or because the file was '
+                                       'closed before all HDUs were read')
 
     def test_open_2(self):
         r = fits.open(self.data('test0.fits'))
@@ -104,14 +111,26 @@ class TestImageFunctions(FitsTestCase):
         # Test that HDUs cannot be accessed after the file was closed
         r = fits.open(self.data('test0.fits'))
         r.close()
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError) as exc_info:
             r[1]
+
+        # Check that the exception message is the enhanced version, not the
+        # default message from list.__getitem__
+        assert str(exc_info.value) == ('HDU not found, possibly because the index '
+                                       'is out of range, or because the file was '
+                                       'closed before all HDUs were read')
 
         # Test that HDUs can be accessed with lazy_load_hdus=False
         r = fits.open(self.data('test0.fits'), lazy_load_hdus=False)
         r.close()
         assert isinstance(r[1], fits.ImageHDU)
         assert len(r) == 5
+
+        with pytest.raises(IndexError) as exc_info:
+            r[6]
+        assert str(exc_info.value) == ('HDU not found, possibly because the index '
+                                       'is out of range, or because the file was '
+                                       'closed before all HDUs were read')
 
         # And the same with the global config item
         assert fits.conf.lazy_load_hdus  # True by default

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -702,12 +702,11 @@ class TestImageFunctions(FitsTestCase):
             tmp_uint = fits.PrimaryHDU(arr)
             filename = 'unsigned_int.fits'
             tmp_uint.writeto(self.temp(filename))
-            f = fits.open(self.temp(filename),
-                          do_not_scale_image_data=do_not_scale)
-
-            uint_hdu = f[0]
-            # Force a read before we close.
-            _ = uint_hdu.data
+            with fits.open(self.temp(filename),
+                           do_not_scale_image_data=do_not_scale) as f:
+                uint_hdu = f[0]
+                # Force a read before we close.
+                _ = uint_hdu.data
         else:
             uint_hdu = fits.PrimaryHDU(arr,
                                        do_not_scale_image_data=do_not_scale)


### PR DESCRIPTION
Closes #5582, following the discussion there, i.e. *Option 2: Remove the compatibility behavior* for which almost everybody agreed. To get the old behavior, users can use `lazy_load_hdus=False` which is equivalent by forcing the reading of all HDUs. So basically this reverts 5c66c2d. And the global option for `lazy_load_hdus` exists already, so I just added a test to make sure it works.

ping @embray 