### PR TITLE
Handle non-ASCII characters in FITS header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2288,6 +2288,9 @@ Other Changes and Additions
 
   -  Fix use of quantize level parameter for ``CompImageHDU``. [#6029]
 
+  - Prevent crash when a header contains non-ASCII (e.g. UTF-8) characters, to
+    allow fixing the problematic cards. [#6084]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/py3compat.py
+++ b/astropy/io/fits/py3compat.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
+import warnings
 from ...extern import six
 from ...utils.compat.numpycompat import NUMPY_LT_1_10
+from ...utils.exceptions import AstropyUserWarning
 
 if not six.PY2:
     # Stuff to do if Python 3
@@ -27,7 +29,16 @@ if not six.PY2:
 
     def decode_ascii(s):
         if isinstance(s, bytes):
-            return s.decode('ascii')
+            try:
+                return s.decode('ascii')
+            except UnicodeDecodeError:
+                warnings.warn('non-ASCII characters are present in the FITS '
+                              'file header and have been replaced by the '
+                              'U+FFFD REPLACEMENT CHARACTER',
+                              AstropyUserWarning)
+                return s.decode('ascii', errors='replace')
+                # FIXME: replace with question mark ?
+                # return s.replace(u'\ufffd', '?')
         elif (isinstance(s, numpy.ndarray) and
               issubclass(s.dtype.type, numpy.bytes_)):
             # np.char.encode/decode annoyingly don't preserve the type of the

--- a/astropy/io/fits/py3compat.py
+++ b/astropy/io/fits/py3compat.py
@@ -33,12 +33,10 @@ if not six.PY2:
                 return s.decode('ascii')
             except UnicodeDecodeError:
                 warnings.warn('non-ASCII characters are present in the FITS '
-                              'file header and have been replaced by the '
-                              'U+FFFD REPLACEMENT CHARACTER',
-                              AstropyUserWarning)
-                return s.decode('ascii', errors='replace')
-                # FIXME: replace with question mark ?
-                # return s.replace(u'\ufffd', '?')
+                              'file header and have been replaced by "?" '
+                              'characters', AstropyUserWarning)
+                s = s.decode('ascii', errors='replace')
+                return s.replace(u'\ufffd', '?')
         elif (isinstance(s, numpy.ndarray) and
               issubclass(s.dtype.type, numpy.bytes_)):
             # np.char.encode/decode annoyingly don't preserve the type of the

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -42,14 +42,11 @@ header that describes the compression.
 With Astropy installed, please run ``fitsheader --help`` to see the full usage
 documentation.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import sys
 
 from ... import fits
-
-from .... import table
 from .... import log
 from ....extern.six.moves import range
 
@@ -135,17 +132,14 @@ class HeaderFormatter(object):
         for idx, hdu in enumerate(hdukeys):
             try:
                 cards = self._get_cards(hdu, keywords, compressed)
-
-                if idx > 0:  # Separate HDUs by a blank line
-                    result.append('\n')
-                result.append('# HDU {hdu} in {filename}:\n'.format(
-                              filename=self.filename,
-                              hdu=hdu
-                              ))
-                result.append('{0}\n'.format('\n'.join([str(c)
-                                                        for c in cards])))
             except ExtensionNotFoundException:
-                pass
+                continue
+
+            if idx > 0:  # Separate HDUs by a blank line
+                result.append('\n')
+            result.append('# HDU {} in {}:\n'.format(hdu, self.filename))
+            for c in cards:
+                result.append('{}\n'.format(c))
         return ''.join(result)
 
     def _get_cards(self, hdukey, keywords, compressed):
@@ -226,6 +220,7 @@ class TableHeaderFormatter(HeaderFormatter):
                 pass
 
         if tablerows:
+            from .... import table
             return table.Table(tablerows)
         return None
 
@@ -276,6 +271,7 @@ def print_headers_as_table(args):
     elif len(tables) == 1:
         resulting_table = tables[0]
     else:
+        from .... import table
         resulting_table = table.vstack(tables)
     # Print the string representation of the concatenated table
     resulting_table.write(sys.stdout, format=args.table)

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1654,6 +1654,7 @@ class TestHeaderFunctions(FitsTestCase):
             assert str(w[0].message).startswith(
                 "Missing padding to end of the FITS block")
 
+    @pytest.mark.skipif('six.PY2')
     def test_invalid_characters(self):
         """
         Test header with invalid characters
@@ -1666,13 +1667,17 @@ class TestHeaderFunctions(FitsTestCase):
         hdul = fits.PrimaryHDU(header=h, data=np.arange(5))
         hdul.writeto(self.temp('test.fits'))
 
-        with open(self.temp('test.fits'), 'rb') as f, \
-             open(self.temp('test2.fits'), 'wb') as f2:
-            f2.write(f.read().replace(b'hello', u'héllo'.encode('latin1')))
+        with open(self.temp('test.fits'), 'rb') as f:
+            out = f.read()
+        out = out.replace(b'hello', u'héllo'.encode('latin1'))
+        out = out.replace(b'BAR', u'BÀR'.encode('latin1'))
+        with open(self.temp('test2.fits'), 'wb') as f2:
+            f2.write(out)
 
         with catch_warnings() as w:
             h = fits.getheader(self.temp('test2.fits'))
-            assert h['COMMENT'] ==  'h�llo'
+            assert h['FOO'] ==  'B?R'
+            assert h['COMMENT'] ==  'h?llo'
             assert len(w) == 1
             assert str(w[0].message).startswith(
                 "non-ASCII characters are present in the FITS file")

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1654,6 +1654,29 @@ class TestHeaderFunctions(FitsTestCase):
             assert str(w[0].message).startswith(
                 "Missing padding to end of the FITS block")
 
+    def test_invalid_characters(self):
+        """
+        Test header with invalid characters
+        """
+
+        # Generate invalid file with non-ASCII character
+        h = fits.Header()
+        h['FOO'] = 'BAR'
+        h['COMMENT'] = 'hello'
+        hdul = fits.PrimaryHDU(header=h, data=np.arange(5))
+        hdul.writeto(self.temp('test.fits'))
+
+        with open(self.temp('test.fits'), 'rb') as f, \
+             open(self.temp('test2.fits'), 'wb') as f2:
+            f2.write(f.read().replace(b'hello', u'héllo'.encode('latin1')))
+
+        with catch_warnings() as w:
+            h = fits.getheader(self.temp('test2.fits'))
+            assert h['COMMENT'] ==  'h�llo'
+            assert len(w) == 1
+            assert str(w[0].message).startswith(
+                "non-ASCII characters are present in the FITS file")
+
     def test_unnecessary_move(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/125


### PR DESCRIPTION
Fixes #6074. 

This just replace the non-ASCII characters by the U+FFFD REPLACEMENT CHARACTER (�) and emit a warning. I wonder if it is useful to do more: with this change, the header can be loaded and printed, which will emit verification errors which allow to easily spot the issue. Then it's up to the user to fix the problematic cards, and writing will crash if the cards are not fixed.

For instance, with the broken file from #2887 and this branch:
```python
In [1]: %astropy
Numpy 1.12.1
Astropy 2.0.dev18346

In [2]: h = fits.getheader('broken_wcs.fits')
WARNING: non-ASCII characters are present in the FITS file header and have been replaced by the U+FFFD REPLACEMENT CHARACTER [astropy.io.fits.py3compat]

In [3]: h
Out[3]: WARNING: VerifyWarning: Verification reported errors: [astropy.io.fits.verify]
WARNING: VerifyWarning: Unfixable error: Unprintable string 'Subversion date 2013-04-16 22:17:10 -0300 (��t, 16 dub'; commentary cards may only contain printable ASCII characters [astropy.io.fits.verify]
WARNING: VerifyWarning: Note: astropy.io.fits uses zero-based indexing.
 [astropy.io.fits.verify]

[snip]  
HISTORY Created by the Astrometry.net suite.                                    
HISTORY For more details, see http://astrometry.net .                           
HISTORY Subversion URL                                                          
HISTORY   http://track.astrometry.net/svn/trunk/src/astrometry/util/            
HISTORY Subversion revision 22592                                               
HISTORY Subversion date 2013-04-16 22:17:10 -0300 (��t, 16 dub                  
HISTORY   2013)                                                                 
HISTORY This WCS header was created by the program "blind".                     
[snip]  

In [5]: fits.PrimaryHDU(header=h).writeto('test.fits')
---------------------------------------------------------------------------
[snip]  

/home/simon/dev/astropy/astropy/io/fits/hdu/hdulist.py in writeto(self, fileobj, output_verify, overwrite, checksum)
    853             return
    854 
--> 855         self.verify(option=output_verify)
    856 
    857         # make sure the EXTEND keyword is there if there is extension

/home/simon/dev/astropy/astropy/io/fits/verify.py in verify(self, option)
    119                     warnings.warn(line, VerifyWarning)
    120             else:
--> 121                 raise VerifyError('\n' + '\n'.join(messages))
    122 
    123 

VerifyError: 
Verification reported errors:
HDU 0:
    Card 173:
        Unprintable string 'Subversion date 2013-04-16 22:17:10 -0300 (��t, 16 dub'; commentary cards may only contain printable ASCII characters
Note: astropy.io.fits uses zero-based indexing.
```

It's also possible to do more, maybe adding an option to replace these characters with a question mark, which would allow to write the fixed file without manual intervention. Or maybe this could be handled by the verification system. Thoughts ?

TODO: extract a broken header to add a unit test.