### PR TITLE
Candidate fix for OrthoPolynomialBase.evaluate() in compound models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -223,6 +223,10 @@ Bug Fixes
 
   - Allow ``Mapping`` and ``Identity`` to be fittable. [#6018]
 
+  - OrthoPolynomialBase (Chebyshev2D / Legendre2D) models were being evaluated
+    incorrectly when part of a compound model (using the parameters from the
+    original model), which in turn caused fitting to fail as a no-op. [#6085]
+
 - ``astropy.nddata``
 
 - ``astropy.stats``

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -232,15 +232,16 @@ class OrthoPolynomialBase(PolynomialBase):
                 c.append((i, j))
         return np.array(c[::-1])
 
-    def invlex_coeff(self):
-        coeff = []
+    def invlex_coeff(self, coeffs):
+        invlex_coeffs = []
         xvar = np.arange(self.x_degree + 1)
         yvar = np.arange(self.y_degree + 1)
         for j in yvar:
             for i in xvar:
                 name = 'c{0}_{1}'.format(i, j)
-                coeff.append(getattr(self, name))
-        return np.array(coeff[::-1])
+                coeff = coeffs[self.param_names.index(name)]
+                invlex_coeffs.append(coeff)
+        return np.array(invlex_coeffs[::-1])
 
     def _alpha(self):
         invlexdeg = self._invlex()
@@ -302,7 +303,7 @@ class OrthoPolynomialBase(PolynomialBase):
             x = poly_map_domain(x, self.x_domain, self.x_window)
         if self.y_domain is not None:
             y = poly_map_domain(y, self.y_domain, self.y_window)
-        invcoeff = self.invlex_coeff()
+        invcoeff = self.invlex_coeff(coeffs)
         return self.imhorner(x, y, invcoeff)
 
     def prepare_inputs(self, x, y, **kwargs):

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -20,6 +20,7 @@ from ..polynomial import (Chebyshev1D, Hermite1D, Legendre1D, Polynomial1D,
                           Chebyshev2D, Hermite2D, Legendre2D, Polynomial2D, SIP,
                           PolynomialBase, OrthoPolynomialBase)
 from ..functional_models import Linear1D
+from ..mappings import Identity
 from ...utils.data import get_pkg_data_filename
 
 try:
@@ -359,3 +360,26 @@ def test_zero_degree_polynomial(cls):
         p2_fit = fitter(p2_init, x, y, z)
 
         assert_allclose(p2_fit.c0_0, 1, atol=0.10)
+
+
+def test_2d_orthopolynomial_in_compound_model():
+    """
+    Ensure that OrthoPolynomialBase (ie. Chebyshev2D & Legendre2D) models get
+    evaluated & fitted correctly when part of a compound model.
+
+    Regression test for https://github.com/astropy/astropy/pull/6085.
+    """
+
+    y, x = np.mgrid[0:5, 0:5]
+    z = x + y
+
+    fitter = fitting.LevMarLSQFitter()
+    simple_model = Chebyshev2D(2,2)
+    simple_fit = fitter(simple_model, x, y, z)
+
+    fitter = fitting.LevMarLSQFitter()  # re-init to compare like with like
+    compound_model = Identity(2) | Chebyshev2D(2,2)
+    compound_fit = fitter(compound_model, x, y, z)
+
+    assert_allclose(simple_fit(x,y), compound_fit(x,y), atol=1e-15)
+

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -383,4 +383,3 @@ def test_2d_orthopolynomial_in_compound_model():
     compound_fit = fitter(compound_model, x, y, z)
 
     assert_allclose(simple_fit(x,y), compound_fit(x,y), atol=1e-15)
-

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -362,6 +362,7 @@ def test_zero_degree_polynomial(cls):
         assert_allclose(p2_fit.c0_0, 1, atol=0.10)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_2d_orthopolynomial_in_compound_model():
     """
     Ensure that OrthoPolynomialBase (ie. Chebyshev2D & Legendre2D) models get


### PR DESCRIPTION
Candidate fix for #6071 -- needs review and a CI test run.

When evaluating OrthoPoylnomialBase models, use the coefficients/parameters passed to evaluate(), like in other models, instead of ignoring them and using those already associated with the instance, to get the right results when part of a compound model.

Will explain more tomorrow if needed.
