### PR TITLE
Fix bug in ManualInterval when limits were manually set to zero

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -335,6 +335,10 @@ Bug Fixes
 
 - ``astropy.visualization``
 
+  - Fix bug in ManualInterval which caused the limits to be returned incorrectly
+    if set to zero, and fix defaults for ManualInterval in the presence of NaNs.
+    [#6088]
+
   - Accept normal Matplotlib keyword arguments in set_xlabel and set_ylabel
     functions. [#5686, #5692, #6060]
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -93,10 +93,10 @@ class ManualInterval(BaseInterval):
     ----------
     vmin : float, optional
         The minimum value in the scaling.  Defaults to the image
-        minimum.
+        minimum (ignoring NaNs)
     vmax : float, optional
         The maximum value in the scaling.  Defaults to the image
-        maximum.
+        maximum (ignoring NaNs)
     """
 
     def __init__(self, vmin=None, vmax=None):
@@ -104,8 +104,8 @@ class ManualInterval(BaseInterval):
         self.vmax = vmax
 
     def get_limits(self, values):
-        vmin = self.vmin or np.min(values)
-        vmax = self.vmax or np.max(values)
+        vmin = np.nanmin(values) if self.vmin is None else self.vmin
+        vmax = np.nanmax(values) if self.vmax is None else self.vmax
         return vmin, vmax
 
 

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -41,7 +41,7 @@ class TestInterval(object):
 
     def test_manual_defaults_with_nan(self):
         interval = ManualInterval()
-        data = self.data.copy()
+        data = np.copy(self.data)
         data[0] = np.nan
         vmin, vmax = interval.get_limits(self.data)
         np.testing.assert_allclose(vmin, -20)

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -20,6 +20,7 @@ class TestInterval(object):
         np.testing.assert_allclose(vmax, +15.)
 
     def test_manual_defaults(self):
+
         interval = ManualInterval(vmin=-10.)
         vmin, vmax = interval.get_limits(self.data)
         np.testing.assert_allclose(vmin, -10.)
@@ -29,6 +30,22 @@ class TestInterval(object):
         vmin, vmax = interval.get_limits(self.data)
         np.testing.assert_allclose(vmin, np.min(self.data))
         np.testing.assert_allclose(vmax, 15.)
+
+    def test_manual_zero_limit(self):
+        # Regression test for a bug that caused ManualInterval to compute the
+        # limit (min or max) if it was set to zero.
+        interval = ManualInterval(vmin=0, vmax=0)
+        vmin, vmax = interval.get_limits(self.data)
+        np.testing.assert_allclose(vmin, 0)
+        np.testing.assert_allclose(vmax, 0)
+
+    def test_manual_defaults_with_nan(self):
+        interval = ManualInterval()
+        data = self.data.copy()
+        data[0] = np.nan
+        vmin, vmax = interval.get_limits(self.data)
+        np.testing.assert_allclose(vmin, -20)
+        np.testing.assert_allclose(vmax, +60)
 
     def test_minmax(self):
         interval = MinMaxInterval()


### PR DESCRIPTION
The dangers of using 'a or b' when a is zero...