### PR TITLE
Disable vo.samp tests that fail with openssl >1.1.

### DIFF
--- a/astropy/vo/samp/tests/test_standard_profile.py
+++ b/astropy/vo/samp/tests/test_standard_profile.py
@@ -1,3 +1,4 @@
+import ssl
 import tempfile
 
 import pytest
@@ -12,6 +13,11 @@ from ..errors import SAMPProxyError
 from .. import conf
 
 from .test_helpers import random_params, Receiver, assert_output, TEST_REPLY
+
+try:
+    OPENSSL_VERSION_LT_1_1 = ssl.OPENSSL_VERSION_INFO[:2] < (1, 1)
+except Exception:
+    OPENSSL_VERSION_LT_1_1 = True
 
 
 def setup_module(module):
@@ -250,6 +256,8 @@ class TestStandardProfile(object):
 # https://github.com/astropy/astropy/issues/2126
 # https://github.com/astropy/astropy/issues/2321
 
+@pytest.mark.skipif(not OPENSSL_VERSION_LT_1_1,
+                    reason='test fails with openssl 1.1')
 class TestStandardProfileHTTPSHub(TestStandardProfile):
 
     conf = 'https_hub'


### PR DESCRIPTION
I really like tests to just work on my workstation, and `vo.samp` has now been broken for recent openssl for 6 months (#5460), so I think it is time to just disable the tests (for recent openssl only) until this is fixed.