### PR TITLE
Avoid warnings when slicing in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -343,6 +343,8 @@ Bug Fixes
   - Fix bug in ManualInterval which caused the limits to be returned incorrectly
     if set to zero, and fix defaults for ManualInterval in the presence of NaNs.
     [#6088]
+  - Get rid of warnings that occurred when slicing a cube due to the tick
+    locator trying to find ticks for the sliced axis.
 
   - Accept normal Matplotlib keyword arguments in set_xlabel and set_ylabel
     functions. [#5686, #5692, #6060]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -343,8 +343,9 @@ Bug Fixes
   - Fix bug in ManualInterval which caused the limits to be returned incorrectly
     if set to zero, and fix defaults for ManualInterval in the presence of NaNs.
     [#6088]
+
   - Get rid of warnings that occurred when slicing a cube due to the tick
-    locator trying to find ticks for the sliced axis.
+    locator trying to find ticks for the sliced axis. [#6104]
 
   - Accept normal Matplotlib keyword arguments in set_xlabel and set_ylabel
     functions. [#5686, #5692, #6060]

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -415,6 +415,12 @@ class ScalarFormatterLocator(BaseFormatterLocator):
             return self.values, 1.1 * self._unit
         else:
 
+            # In the special case where value_min is the same as value_max, we
+            # don't locate any ticks. This can occur for example when taking a
+            # slice for a cube (along the dimension sliced).
+            if value_min == value_max:
+                return [] * self._unit, 0 * self._unit
+
             if self.spacing is not None:
 
                 # spacing was manually specified

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -238,6 +238,12 @@ class AngleFormatterLocator(BaseFormatterLocator):
 
         else:
 
+            # In the special case where value_min is the same as value_max, we
+            # don't locate any ticks. This can occur for example when taking a
+            # slice for a cube (along the dimension sliced).
+            if value_min == value_max:
+                return [] * u.deg, 0 * u.arcsec
+
             if self.spacing is not None:
 
                 # spacing was manually specified

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+import warnings
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -122,3 +123,66 @@ def test_set_label_properties():
     assert ax.coords[1].axislabels.get_text() == 'Test y label'
     assert ax.coords[1].axislabels.get_minpad('l') == 3
     assert ax.coords[1].axislabels.get_color() == 'green'
+
+
+GAL_HEADER = fits.Header.fromstring("""
+SIMPLE  =                    T / conforms to FITS standard
+BITPIX  =                  -32 / array data type
+NAXIS   =                    3 / number of array dimensions
+NAXIS1  =                   31
+NAXIS2  =                 2881
+NAXIS3  =                  480
+EXTEND  =                    T
+CTYPE1  = 'DISTMOD '
+CRVAL1  =                  3.5
+CDELT1  =                  0.5
+CRPIX1  =                  1.0
+CTYPE2  = 'GLON-CAR'
+CRVAL2  =                180.0
+CDELT2  =               -0.125
+CRPIX2  =                  1.0
+CTYPE3  = 'GLAT-CAR'
+CRVAL3  =                  0.0
+CDELT3  =                0.125
+CRPIX3  =                241.0
+""", sep='\n')
+
+def test_slicing_warnings(tmpdir):
+
+    # Regression test to make sure that no warnings are emitted by the tick
+    # locator for the sliced axis when slicing a cube.
+
+    # Scalar case
+
+    wcs3d = WCS(naxis=3)
+    wcs3d.wcs.ctype = ['x', 'y', 'z']
+    wcs3d.wcs.cunit = ['deg', 'deg', 'km/s']
+    wcs3d.wcs.crpix = [614.5, 856.5, 333]
+    wcs3d.wcs.cdelt = [6.25, 6.25, 23]
+    wcs3d.wcs.crval = [0., 0., 1.]
+
+    with warnings.catch_warnings(record=True) as warning_lines:
+        warnings.resetwarnings()
+        ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+        plt.savefig(tmpdir.join('test.png').strpath)
+
+    # For easy debugging if there are indeed warnings
+    for warning in warning_lines:
+        print(warning)
+
+    assert len(warning_lines) == 0
+
+    # Angle case
+
+    wcs3d = WCS(GAL_HEADER)
+
+    with warnings.catch_warnings(record=True) as warning_lines:
+        warnings.resetwarnings()
+        ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 2))
+        plt.savefig(tmpdir.join('test.png').strpath)
+
+    # For easy debugging if there are indeed warnings
+    for warning in warning_lines:
+        print(warning)
+
+    assert len(warning_lines) == 0


### PR DESCRIPTION
This gets rid of warnings that occurred when slicing a cube due to the tick locator trying to find ticks for the sliced axis.