### PR TITLE
Fixed wrong line terminator issue with csv and ecsv writing

### DIFF
--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -605,8 +605,8 @@ def test_csv_line_termination(fast_writer):
         for row in csvreader:
             out.append(row)
         csvfile.close()
-    assert not(out[1]) and not(out[3]) and not (out[5])
-    #assert(out == [['col0'],['1'], ['2']])
+    #assert not(out[1]) and not(out[3]) and not (out[5])
+    assert(out == [['col0'],['1'], ['2']])
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -605,7 +605,6 @@ def test_csv_line_termination(fast_writer):
         for row in csvreader:
             out.append(row)
         csvfile.close()
-    print(out)
     assert not(out[1]) and not(out[3]) and not (out[5])
     #assert(out == [['col0'],['1'], ['2']])
 

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -8,6 +8,7 @@ from itertools import chain
 
 import pytest
 import numpy as np
+import csv
 
 from ....extern.six.moves import cStringIO as StringIO
 from ... import ascii
@@ -588,6 +589,25 @@ def test_commented_header_comments(fast_writer):
         ascii.write(t, out, format='commented_header', comment=False,
                     fast_writer=fast_writer)
     assert "for the commented_header writer you must supply a string" in str(err.value)
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_csv_line_termination(fast_writer):
+    """
+    Test the fix for #5299 where a file would end with newline characters \r\r\n on Windows. Fixed
+    for both Python 2.7 and 3.5.
+    """
+    t = table.Table([[1, 2]])
+    out = []
+    ascii.write(t, 'csvfile.csv', format = 'csv', comment = False,
+                fast_writer=fast_writer)
+    with open('csvfile.csv', 'r') as csvfile:
+        csvreader = csv.reader(csvfile)
+        for row in csvreader:
+            out.append(row)
+        csvfile.close()
+    print(out)
+    assert not(out[1]) and not(out[3]) and not (out[5])
+    #assert(out == [['col0'],['1'], ['2']])
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -729,7 +729,17 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     # Write the lines to output
     outstr = os.linesep.join(lines)
     if not hasattr(output, 'write'):
-        output = open(output, 'w')
+        if format is 'csv':
+            if sys.version_info[0] == 2:
+                access = 'wb'
+                kwargs = {}
+            else:
+                access = 'wt'
+                kwargs={'newline': ''}
+        else:
+            access = 'w'
+            kwargs = {}
+        output = open(output, access, **kwargs)
         output.write(outstr)
         output.write(os.linesep)
         output.close()

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -648,11 +648,9 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
     return writer
 
 
-def write(table, output=None, format=None, Writer=None, fast_writer=True, exclude_names=None,
-          include_names=None, names=None, formats=[], **kwargs):
+def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwargs):
     """Write the input ``table`` to ``filename``.  Most of the default behavior
     for various parameters is determined by the Writer class.
-
     Parameters
     ----------
     table : `~astropy.io.ascii.BaseReader`, array_like, str, file_like, list
@@ -689,7 +687,6 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, exclud
         (e.g., a file object).
     Writer : ``Writer``
         Writer class (DEPRECATED).
-
     """
     overwrite = kwargs.pop('overwrite', None)
     if isinstance(output, six.string_types):
@@ -706,12 +703,12 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, exclud
     if output is None:
         output = sys.stdout
 
-    table = Table(table, names=names)
+    table = Table(table, names=kwargs.get('names'))
 
     table0 = table[:0].copy()
-    core._apply_include_exclude_names(table0, names,
-                                      include_names, exclude_names)
-    diff_format_with_names = set(formats) - set(table0.colnames)
+    core._apply_include_exclude_names(table0, kwargs.get('names'),
+                    kwargs.get('include_names'), kwargs.get('exclude_names'))
+    diff_format_with_names = set(kwargs.get('formats', [])) - set(table0.colnames)
 
     if diff_format_with_names:
         warnings.warn(
@@ -732,20 +729,13 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, exclud
     # Write the lines to output
     outstr = os.linesep.join(lines)
     if not hasattr(output, 'write'):
-        #if format is 'csv':
-        #    if sys.version_info[0] == 2:
-        #        access = 'wb'
-        #        kwargs = {}
-        #    else:
-        #        access = 'wt'
-        #        kwargs={'newline': ''}
-        #else:
-        #    access = 'w'
-        #    kwargs = {}
         output = open(output, 'w')
         output.write(outstr)
         output.write(os.linesep)
         output.close()
+    else:
+        output.write(outstr)
+        output.write(os.linesep)
 
 def get_read_trace():
     """

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -731,7 +731,13 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     # Write the lines to output
     outstr = os.linesep.join(lines)
     if not hasattr(output, 'write'):
-        output = open(output, 'w', newline='')
+        if sys.version_info[0] == 2:
+            access = 'wb'
+            kwargs = {}
+        else:
+            access = 'wt'
+            kwargs={'newline': ''}
+        output = open(output, access, **kwargs)
         output.write(outstr)
         output.write(os.linesep)
         output.close()

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -731,7 +731,7 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     # Write the lines to output
     outstr = os.linesep.join(lines)
     if not hasattr(output, 'write'):
-        output = open(output, 'w')
+        output = open(output, 'w', newline='')
         output.write(outstr)
         output.write(os.linesep)
         output.close()

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -648,7 +648,8 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
     return writer
 
 
-def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwargs):
+def write(table, output=None, format=None, Writer=None, fast_writer=True, exclude_names=None,
+          include_names=None, names=None, formats=[], **kwargs):
     """Write the input ``table`` to ``filename``.  Most of the default behavior
     for various parameters is determined by the Writer class.
 
@@ -705,12 +706,12 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     if output is None:
         output = sys.stdout
 
-    table = Table(table, names=kwargs.get('names'))
+    table = Table(table, names=names)
 
     table0 = table[:0].copy()
-    core._apply_include_exclude_names(table0, kwargs.get('names'),
-                    kwargs.get('include_names'), kwargs.get('exclude_names'))
-    diff_format_with_names = set(kwargs.get('formats', [])) - set(table0.colnames)
+    core._apply_include_exclude_names(table0, names,
+                                      include_names, exclude_names)
+    diff_format_with_names = set(formats) - set(table0.colnames)
 
     if diff_format_with_names:
         warnings.warn(
@@ -731,19 +732,20 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     # Write the lines to output
     outstr = os.linesep.join(lines)
     if not hasattr(output, 'write'):
-        if sys.version_info[0] == 2:
-            access = 'wb'
-            kwargs = {}
-        else:
-            access = 'wt'
-            kwargs={'newline': ''}
-        output = open(output, access, **kwargs)
+        #if format is 'csv':
+        #    if sys.version_info[0] == 2:
+        #        access = 'wb'
+        #        kwargs = {}
+        #    else:
+        #        access = 'wt'
+        #        kwargs={'newline': ''}
+        #else:
+        #    access = 'w'
+        #    kwargs = {}
+        output = open(output, 'w')
         output.write(outstr)
         output.write(os.linesep)
         output.close()
-    else:
-        output.write(outstr)
-        output.write(os.linesep)
 
 def get_read_trace():
     """


### PR DESCRIPTION
By adding newline='' parameter to file open in io.ascii. 