### PR TITLE
Change default Tcmb0 to 0 in cosmology classes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,10 @@ API Changes
 
 - ``astropy.cosmology``
 
+  - Cosmological models do not include any contribution from neutrinos or photons
+    by default -- that is, the default value of Tcmb0 is 0.  This does not affect
+    built in models (such as WMAP or Planck). [#6122]
+
 - ``astropy.io.ascii``
 
 - ``astropy.io.fits``

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -118,7 +118,7 @@ class FLRW(Cosmology):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -146,7 +146,7 @@ class FLRW(Cosmology):
     of the parameters.  That is, all of the attributes above are
     read only.
     """
-    def __init__(self, H0, Om0, Ode0, Tcmb0=2.725, Neff=3.04,
+    def __init__(self, H0, Om0, Ode0, Tcmb0=0, Neff=3.04,
                  m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         # all densities are in units of the critical density
@@ -1568,7 +1568,7 @@ class LambdaCDM(FLRW):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -1601,7 +1601,7 @@ class LambdaCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, Ode0, Tcmb0=2.725, Neff=3.04,
+    def __init__(self, H0, Om0, Ode0, Tcmb0=0, Neff=3.04,
                  m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         FLRW.__init__(self, H0, Om0, Ode0, Tcmb0, Neff, m_nu, name=name,
@@ -1753,7 +1753,7 @@ class FlatLambdaCDM(LambdaCDM):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -1786,7 +1786,7 @@ class FlatLambdaCDM(LambdaCDM):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, Tcmb0=2.725, Neff=3.04,
+    def __init__(self, H0, Om0, Tcmb0=0, Neff=3.04,
                  m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         LambdaCDM.__init__(self, H0, Om0, 0.0, Tcmb0, Neff, m_nu, name=name,
@@ -1906,7 +1906,7 @@ class wCDM(FLRW):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -1939,7 +1939,7 @@ class wCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, Ode0, w0=-1., Tcmb0=2.725,
+    def __init__(self, H0, Om0, Ode0, w0=-1., Tcmb0=0,
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         FLRW.__init__(self, H0, Om0, Ode0, Tcmb0, Neff, m_nu, name=name,
@@ -2111,7 +2111,7 @@ class FlatwCDM(wCDM):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -2144,7 +2144,7 @@ class FlatwCDM(wCDM):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, w0=-1., Tcmb0=2.725,
+    def __init__(self, H0, Om0, w0=-1., Tcmb0=0,
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         wCDM.__init__(self, H0, Om0, 0.0, w0, Tcmb0, Neff, m_nu,
@@ -2269,7 +2269,7 @@ class w0waCDM(FLRW):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -2302,7 +2302,7 @@ class w0waCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, Ode0, w0=-1., wa=0., Tcmb0=2.725,
+    def __init__(self, H0, Om0, Ode0, w0=-1., wa=0., Tcmb0=0,
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         FLRW.__init__(self, H0, Om0, Ode0, Tcmb0, Neff, m_nu, name=name,
@@ -2435,7 +2435,7 @@ class Flatw0waCDM(w0waCDM):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -2468,7 +2468,7 @@ class Flatw0waCDM(w0waCDM):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, w0=-1., wa=0., Tcmb0=2.725,
+    def __init__(self, H0, Om0, w0=-1., wa=0., Tcmb0=0,
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
 
         w0waCDM.__init__(self, H0, Om0, 0.0, w0=w0, wa=wa, Tcmb0=Tcmb0,
@@ -2543,7 +2543,7 @@ class wpwaCDM(FLRW):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -2577,7 +2577,7 @@ class wpwaCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, wp=-1., wa=0., zp=0,
-                 Tcmb0=2.725, Neff=3.04, m_nu=u.Quantity(0.0, u.eV),
+                 Tcmb0=0, Neff=3.04, m_nu=u.Quantity(0.0, u.eV),
                  Ob0=None, name=None):
 
         FLRW.__init__(self, H0, Om0, Ode0, Tcmb0, Neff, m_nu, name=name,
@@ -2726,7 +2726,7 @@ class w0wzCDM(FLRW):
 
     Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
         Temperature of the CMB z=0. If a float, must be in [K].
-        Default: 2.725 [K]. Setting this to zero will turn off both photons
+        Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
 
     Neff : float, optional
@@ -2759,7 +2759,7 @@ class w0wzCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, Ode0, w0=-1., wz=0., Tcmb0=2.725,
+    def __init__(self, H0, Om0, Ode0, w0=-1., wz=0., Tcmb0=0,
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
                  name=None):
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -32,16 +32,16 @@ def test_init():
         h0bad = u.Quantity([70, 100], u.km / u.s / u.Mpc)
         cosmo = core.FlatLambdaCDM(H0=h0bad, Om0=0.27)
     with pytest.raises(ValueError):
-        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, m_nu=0.5)
+        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, Tcmb0=3, m_nu=0.5)
     with pytest.raises(ValueError):
         bad_mnu = u.Quantity([-0.3, 0.2, 0.1], u.eV)
-        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, m_nu=bad_mnu)
+        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, Tcmb0=3, m_nu=bad_mnu)
     with pytest.raises(ValueError):
         bad_mnu = u.Quantity([0.15, 0.2, 0.1], u.eV)
-        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, Neff=2, m_nu=bad_mnu)
+        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, Tcmb0=3, Neff=2, m_nu=bad_mnu)
     with pytest.raises(ValueError):
         bad_mnu = u.Quantity([-0.3, 0.2], u.eV)  # 2, expecting 3
-        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, m_nu=bad_mnu)
+        cosmo = core.FlatLambdaCDM(H0=70, Om0=0.2, Tcmb0=3, m_nu=bad_mnu)
     with pytest.raises(ValueError):
         cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27, Ob0=-0.04)
     with pytest.raises(ValueError):
@@ -298,7 +298,7 @@ def test_clone():
 
 def test_xtfuncs():
     """ Test of absorption and lookback integrand"""
-    cosmo = core.LambdaCDM(70, 0.3, 0.5)
+    cosmo = core.LambdaCDM(70, 0.3, 0.5, Tcmb0=2.725)
     z = np.array([2.0, 3.2])
     assert allclose(cosmo.lookback_time_integrand(3), 0.052218976654969378,
                     rtol=1e-4)
@@ -312,24 +312,24 @@ def test_xtfuncs():
 
 def test_repr():
     """ Test string representation of built in classes"""
-    cosmo = core.LambdaCDM(70, 0.3, 0.5)
+    cosmo = core.LambdaCDM(70, 0.3, 0.5, Tcmb0=2.725)
     expected = 'LambdaCDM(H0=70 km / (Mpc s), Om0=0.3, '\
                'Ode0=0.5, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV, '\
                'Ob0=None)'
     assert str(cosmo) == expected
 
-    cosmo = core.LambdaCDM(70, 0.3, 0.5, m_nu=u.Quantity(0.01, u.eV))
+    cosmo = core.LambdaCDM(70, 0.3, 0.5, Tcmb0=2.725, m_nu=u.Quantity(0.01, u.eV))
     expected = 'LambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Ode0=0.5, '\
                'Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.01  0.01  0.01] eV, '\
                'Ob0=None)'
     assert str(cosmo) == expected
 
-    cosmo = core.FlatLambdaCDM(50.0, 0.27, Ob0=0.05)
+    cosmo = core.FlatLambdaCDM(50.0, 0.27, Tcmb0=3, Ob0=0.05)
     expected = 'FlatLambdaCDM(H0=50 km / (Mpc s), Om0=0.27, '\
-               'Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV, Ob0=0.05)'
+               'Tcmb0=3 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV, Ob0=0.05)'
     assert str(cosmo) == expected
 
-    cosmo = core.wCDM(60.0, 0.27, 0.6, w0=-0.8, name='test1')
+    cosmo = core.wCDM(60.0, 0.27, 0.6, Tcmb0=2.725, w0=-0.8, name='test1')
     expected = 'wCDM(name="test1", H0=60 km / (Mpc s), Om0=0.27, '\
                'Ode0=0.6, w0=-0.8, Tcmb0=2.725 K, Neff=3.04, '\
                'm_nu=[ 0.  0.  0.] eV, Ob0=None)'
@@ -337,11 +337,10 @@ def test_repr():
 
     cosmo = core.FlatwCDM(65.0, 0.27, w0=-0.6, name='test2')
     expected = 'FlatwCDM(name="test2", H0=65 km / (Mpc s), Om0=0.27, '\
-               'w0=-0.6, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV, '\
-               'Ob0=None)'
+               'w0=-0.6, Tcmb0=0 K, Neff=3.04, m_nu=None, Ob0=None)'
     assert str(cosmo) == expected
 
-    cosmo = core.w0waCDM(60.0, 0.25, 0.4, w0=-0.6, wa=0.1, name='test3')
+    cosmo = core.w0waCDM(60.0, 0.25, 0.4, w0=-0.6, Tcmb0=2.725, wa=0.1, name='test3')
     expected = 'w0waCDM(name="test3", H0=60 km / (Mpc s), Om0=0.25, '\
                'Ode0=0.4, w0=-0.6, wa=0.1, Tcmb0=2.725 K, Neff=3.04, '\
                'm_nu=[ 0.  0.  0.] eV, Ob0=None)'
@@ -350,18 +349,18 @@ def test_repr():
     cosmo = core.Flatw0waCDM(55.0, 0.35, w0=-0.9, wa=-0.2, name='test4',
                              Ob0=0.0456789)
     expected = 'Flatw0waCDM(name="test4", H0=55 km / (Mpc s), Om0=0.35, '\
-               'w0=-0.9, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV, '\
+               'w0=-0.9, Tcmb0=0 K, Neff=3.04, m_nu=None, '\
                'Ob0=0.0457)'
     assert str(cosmo) == expected
 
     cosmo = core.wpwaCDM(50.0, 0.3, 0.3, wp=-0.9, wa=-0.2,
                          zp=0.3, name='test5')
     expected = 'wpwaCDM(name="test5", H0=50 km / (Mpc s), Om0=0.3, '\
-               'Ode0=0.3, wp=-0.9, wa=-0.2, zp=0.3, Tcmb0=2.725 K, '\
-               'Neff=3.04, m_nu=[ 0.  0.  0.] eV, Ob0=None)'
+               'Ode0=0.3, wp=-0.9, wa=-0.2, zp=0.3, Tcmb0=0 K, '\
+               'Neff=3.04, m_nu=None, Ob0=None)'
     assert str(cosmo) == expected
 
-    cosmo = core.w0wzCDM(55.0, 0.4, 0.8, w0=-1.05, wz=-0.2,
+    cosmo = core.w0wzCDM(55.0, 0.4, 0.8, w0=-1.05, wz=-0.2, Tcmb0=2.725,
                          m_nu=u.Quantity([0.001, 0.01, 0.015], u.eV))
     expected = 'w0wzCDM(H0=55 km / (Mpc s), Om0=0.4, Ode0=0.8, w0=-1.05, '\
                'wz=-0.2 Tcmb0=2.725 K, Neff=3.04, '\
@@ -516,11 +515,11 @@ def test_matter():
     assert allclose(tcos.Om(0), 0.3)
     assert allclose(tcos.Ob(0), 0.045)
     z = np.array([0.0, 0.5, 1.0, 2.0])
-    assert allclose(tcos.Om(z), [0.3, 0.59112134, 0.77387435, 0.91974179],
+    assert allclose(tcos.Om(z), [0.3, 0.59124088, 0.77419355, 0.92045455],
                     rtol=1e-4)
     assert allclose(tcos.Ob(z),
-                    [0.045, 0.08866820, 0.11608115, 0.13796127], rtol=1e-4)
-    assert allclose(tcos.Odm(z), [0.255, 0.50245314, 0.6577932, 0.78178052],
+                    [0.045, 0.08868613, 0.11612903, 0.13806818], rtol=1e-4)
+    assert allclose(tcos.Odm(z), [0.255, 0.50255474, 0.65806452, 0.78238636],
                     rtol=1e-4)
     # Consistency of dark and baryonic matter evolution with all
     # non-relativistic matter
@@ -1212,7 +1211,7 @@ def test_absorption_distance():
 def test_massivenu_basic():
     # Test no neutrinos case
     tcos = core.FlatLambdaCDM(70.4, 0.272, Neff=4.05,
-                              m_nu=u.Quantity(0, u.eV))
+                              Tcmb0=2.725 * u.K, m_nu=u.Quantity(0, u.eV))
     assert allclose(tcos.Neff, 4.05)
     assert not tcos.has_massive_nu
     mnu = tcos.m_nu
@@ -1231,7 +1230,7 @@ def test_massivenu_basic():
     assert tcos.m_nu is None
 
     # Test basic setting, retrieval of values
-    tcos = core.FlatLambdaCDM(70.4, 0.272,
+    tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725 * u.K,
                               m_nu=u.Quantity([0.0, 0.01, 0.02], u.eV))
     assert tcos.has_massive_nu
     mnu = tcos.m_nu
@@ -1240,8 +1239,8 @@ def test_massivenu_basic():
     assert allclose(mnu, [0.0, 0.01, 0.02] * u.eV)
 
     # All massive neutrinos case
-    tcos = core.FlatLambdaCDM(70.4, 0.272, m_nu=u.Quantity(0.1, u.eV),
-                              Neff=3.1)
+    tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725,
+                              m_nu=u.Quantity(0.1, u.eV), Neff=3.1)
     assert allclose(tcos.Neff, 3.1)
     assert tcos.has_massive_nu
     mnu = tcos.m_nu

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -55,7 +55,7 @@ You can create your own FLRW-like cosmology using one of the Cosmology
 classes::
 
   >>> from astropy.cosmology import FlatLambdaCDM
-  >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+  >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
   >>> cosmo
   FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
                 Neff=3.04, m_nu=[ 0.  0.  0.] eV, Ob0=None)
@@ -92,14 +92,14 @@ arguments giving the Hubble parameter and Omega matter (both at z=0)::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
   >>> cosmo
-  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
-                Neff=3.04, m_nu=[ 0.  0.  0.] eV, Ob0=None)
+  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=0 K,
+                Neff=3.04, m_nu=None, Ob0=None)
 
 This can also be done more explicitly using units, which is recommended::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> import astropy.units as u
-  >>> cosmo = FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Om0=0.3)
+  >>> cosmo = FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Tcmb0=2.725 * u.K, Om0=0.3)
 
 However, most of the parameters that accept units (``H0``, ``Tcmb0``)
 have default units, so unit quantities do not have to be used.
@@ -160,8 +160,8 @@ at class instantiation by passing the keyword argument ``Ob0``::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
   >>> cosmo
-  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
-                Neff=3.04, m_nu=[ 0.  0.  0.] eV, Ob0=0.05)
+  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=0 K,
+                Neff=3.04, m_nu=None, Ob0=0.05)
 
 In this case the dark matter only density at redshift zero is
 available as class attribute ``Odm0`` and the redshift evolution of
@@ -185,8 +185,7 @@ used to describe the cosmology::
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
   >>> cosmo
   FlatwCDM(name="SNLS3+WMAP7", H0=71.6 km / (Mpc s), Om0=0.262,
-           w0=-1.02, Tcmb0=2.725 K, Neff=3.04, m_nu=[ 0.  0.  0.] eV,
-	   Ob0=None)
+           w0=-1.02, Tcmb0=0 K, Neff=3.04, m_nu=None, Ob0=None)
 
 This is also an example with a different model for dark energy, a flat
 Universe with a constant dark energy equation of state, but not
@@ -299,18 +298,20 @@ should consult the cosmology module source code for details.
 
 Photons and Neutrinos
 ---------------------
-The cosmology classes include the contribution to the energy density
+The cosmology classes (can) include the contribution to the energy density
 from both photons and neutrinos.  By default, the latter are assumed
 massless.  The three parameters controlling the properties of these
 species, which are arguments to the initializers of all the
 cosmological classes, are ``Tcmb0`` (the temperature of the CMB at z=0),
 ``Neff``, the effective number of neutrino species, and ``m_nu``, the rest
 mass of the neutrino species.  ``Tcmb0`` and ``m_nu`` should be expressed
-as unit Quantities.  All three have standard default values (2.725 K,
+as unit Quantities.  All three have standard default values (0 K,
 3.04, and 0 eV respectively; the reason that ``Neff`` is not 3 primarily
 has to do with a small bump in the neutrino energy spectrum due to
 electron-positron annihilation, but is also affected by weak
-interaction physics).
+interaction physics).  Setting the CMB temperature to zero removes
+the contribution of both neutrinos and photons.  This is the default
+so that users do not include components by default that they did not request.
 
 Massive neutrinos are treated using the approach described in the
 WMAP 7-year cosmology paper (Komatsu et al. 2011, ApJS, 192, 18, section 3.3).
@@ -341,7 +342,7 @@ can be found as a function of redshift::
    array([  3.44215495e-05,   1.89567887e-04,   3.45121234e-04]))
 
 If you want to exclude photons and neutrinos from your calculations,
-simply set ``Tcmb0`` to 0::
+simply set ``Tcmb0`` to 0 (which is also the default)::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> import astropy.units as u
@@ -349,11 +350,13 @@ simply set ``Tcmb0`` to 0::
   >>> cos.Ogamma0, cos.Onu0
   (0.0, 0.0)
 
-Neutrinos can be removed (while leaving photons) by setting ``Neff`` to 0::
+You can include photons but exclude any contributions from neutrinos by
+setting ``Tcmb0`` to be non-zero (2.725 K is the standard value for our
+Universe) but setting ``Neff`` to 0::
 
   >>> from astropy.cosmology import FlatLambdaCDM
-  >>> cos = FlatLambdaCDM(70.4, 0.272, Neff=0)
-  >>> cos.Ogamma([0, 1, 2])  # Photons are still present  # doctest: +FLOAT_CMP
+  >>> cos = FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725, Neff=0)
+  >>> cos.Ogamma([0, 1, 2])  # Photons are present  # doctest: +FLOAT_CMP
   array([  4.98569497e-05,   2.74623215e-04,   5.00051839e-04])
   >>> cos.Onu([0, 1, 2])  # But not neutrinos
   array([ 0.,  0.,  0.])
@@ -370,13 +373,13 @@ value is provided, all the species are assumed to have the same mass.
   >>> import astropy.units as u
   >>> H0 = 70.4 * u.km / u.s / u.Mpc
   >>> m_nu = 0 * u.eV
-  >>> cosmo = FlatLambdaCDM(H0, 0.272, m_nu=m_nu)
+  >>> cosmo = FlatLambdaCDM(H0, 0.272, Tcmb0=2.725, m_nu=m_nu)
   >>> cosmo.has_massive_nu
   False
   >>> cosmo.m_nu
   <Quantity [ 0., 0., 0.] eV>
   >>> m_nu = [0.0, 0.05, 0.10] * u.eV
-  >>> cosmo = FlatLambdaCDM(H0, 0.272, m_nu=m_nu)
+  >>> cosmo = FlatLambdaCDM(H0, 0.272, Tcmb0=2.725, m_nu=m_nu)
   >>> cosmo.has_massive_nu
   True
   >>> cosmo.m_nu

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -310,8 +310,8 @@ as unit Quantities.  All three have standard default values (0 K,
 has to do with a small bump in the neutrino energy spectrum due to
 electron-positron annihilation, but is also affected by weak
 interaction physics).  Setting the CMB temperature to zero removes
-the contribution of both neutrinos and photons.  This is the default
-so that users do not include components by default that they did not request.
+the contribution of both neutrinos and photons. This is the default to ensure
+these components are excluded unless the user explicitly requests them.
 
 Massive neutrinos are treated using the approach described in the
 WMAP 7-year cosmology paper (Komatsu et al. 2011, ApJS, 192, 18, section 3.3).

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -25,8 +25,15 @@ smaller improvements and bug fixes, which are described in the
 * xxx distinct people have contributed code
 
 
-Other significant changes
-=========================
+No relativistic species by default in cosmological models
+=========================================================
+For all of the built in cosmological model types (e.g., FlatLambdaCDM)
+the default CMB temperature at z=0 is now 0K, which corresponds to no
+contributions from photons or neutrinos (massive or otherwise).  This
+does not affect built in literature models (such as the WMAP or Planck
+models).  The justification is to avoid including mass-energy components
+that the user has not explicitly requested.  This is a non-backwards
+compatible change, although the effects are small for most use cases.
 
 
 Full change log


### PR DESCRIPTION
Having a non-zero default was a mistake.  While Tcmb is
pretty well known, including components by default that the
user is not expecting leads to confusion (e.g., #5596).

This is, however, technically backwards incompatible, although
the differences are pretty small for most uses.  But that makes
astropy 2.0 a good time to make the change.

Changes not updated since this should be saved for the 2.0 window.

Note that this does not affect any of the built in cosmologies
(like Planck), so shouldn't affect people using these for serious
calculations.