### PR TITLE
Allow np.positive ufunc for logarithmic units.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -340,7 +340,7 @@ Bug Fixes
 - ``astropy.units``
 
   - Add support for ``positive`` and ``divmod`` ufuncs (new in numpy 1.13).
-    [#5998, #6020]
+    [#5998, #6020, #6116]
 
 - ``astropy.utils``
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -17,7 +17,7 @@ __all__ = ['FunctionUnitBase', 'FunctionQuantity']
 SUPPORTED_UFUNCS = set(getattr(np.core.umath, ufunc) for ufunc in (
     'isfinite', 'isinf', 'isnan', 'sign', 'signbit',
     'rint', 'floor', 'ceil', 'trunc', 'power',
-    '_ones_like', 'ones_like') if hasattr(np.core.umath, ufunc))
+    '_ones_like', 'ones_like', 'positive') if hasattr(np.core.umath, ufunc))
 
 # TODO: the following could work if helper changed relative to Quantity:
 # - spacing should return dimensionless, not same unit


### PR DESCRIPTION
Follow up on #5998 to ensure `np.positive` works correctly for logarithmic units.