### PR TITLE
Make pprint/pformat tolerant of non-UTF-8 bytes data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -323,6 +323,9 @@ Bug Fixes
 
 - ``astropy.tests``
 
+  - Fix problem with Table pprint/pformat raising an exception
+    for non-UTF-8 compliant bytestring data. [#6117]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,10 +321,10 @@ Bug Fixes
 
 - ``astropy.table``
 
-- ``astropy.tests``
+  - Fix problem with Table pprint/pformat raising an exception for
+    non-UTF-8 compliant bytestring data. [#6117]
 
-  - Fix problem with Table pprint/pformat raising an exception
-    for non-UTF-8 compliant bytestring data. [#6117]
+- ``astropy.tests``
 
 - ``astropy.time``
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -20,7 +20,7 @@ __all__ = []
 
 def default_format_func(format_, val):
     if isinstance(val, bytes):
-        return val.decode('utf-8')
+        return val.decode('utf-8', errors='replace')
     else:
         return text_type(val)
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -684,3 +684,13 @@ def test_auto_format_func():
 
     qt = QTable(t)
     qt.pformat()  # Generates exception prior to #5802
+
+
+def test_decode_replace():
+    """
+    Test printing a bytestring column with a value that fails
+    decoding to utf-8 and gets replaced by U+FFFD.  See
+    https://docs.python.org/3/library/codecs.html#codecs.replace_errors
+    """
+    t = Table([[b'Z\xf0']])
+    assert t.pformat() == [u'col0', u'----', u'  Z\ufffd']


### PR DESCRIPTION
Currently if a bytestring column has content that is not UTF-8 compliant you cannot get the repr of that column:
```
In [3]: t = Table([[b'Z\xf0']])

In [4]: t
Out[4]: ---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
...
UnicodeDecodeError: 'utf8' codec can't decode byte 0xf0 in position 1: unexpected end of data
```
This fixes that by decoding with `errors='replace'`.
