### PR TITLE
Fix for inserting Quantity slice into Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -449,6 +449,9 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- Ensure that ``Quantity`` slices can be set with objects that have a ``unit``
+  attribute (such as ``Column``). [#6123]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1387,12 +1387,16 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             _value = value.to_value(self.unit)
         except AttributeError:
             try:
-                _value = dimensionless_unscaled.to(self.unit, value)
-            except UnitsError as exc:
-                if can_have_arbitrary_unit(value):
-                    _value = value
-                else:
-                    raise exc
+                _value = value.unit.to(self.unit, value.data)
+            except AttributeError:
+                try:
+                    _value = dimensionless_unscaled.to(self.unit, value)
+                #return self.to_own_unit(Quantity(value))
+                except UnitsError as exc:
+                    if can_have_arbitrary_unit(value):
+                        _value = value
+                    else:
+                        raise exc
 
         if check_precision:
             value_dtype = getattr(value, 'dtype', None)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1272,31 +1272,27 @@ def test_quantity_from_table():
     assert qbp.unit == u.pc
     assert_array_equal(qbp.value, t['b'])
 
+
 def test_assign_slice_with_quantity_like():
-    from ... table import Table
-    t = Table()
-    t['x'] = np.arange(10) * u.mm
-    t['y'] = np.ones(10) * u.mm
-    xy = np.vstack([t['x'], t['y']]).T * u.mm
-    ii = [0,2,4]
-
-    assert xy[ii,0].unit == t['x'][ii].unit
-    #following statement should not raise a
-    # u.core.UnitConversionError
-    xy[ii,0] = t['x'][ii]
-
-def test_assign_slice_with_quantity_like2():
-    from ...table import Column, Table
-    from ...units import Quantity
-    
-    t = Table()
-    t['x'] = np.arange(10) * u.mm
-    t['y'] = np.ones(10) * u.mm
-    
+    # Regression tests for gh-5961
+    from ... table import Table, Column
+    # first check directly that we can use a Column to assign to a slice.
     c = Column(np.arange(10.), unit=u.mm)
     q = u.Quantity(c)
-    q[:2] = t[:2]
-    # AttributeError -> UnitConversionError
+    q[:2] = c[:2]
+    # next check that we do not fail the original problem.
+    t = Table()
+    t['x'] = np.arange(10) * u.mm
+    t['y'] = np.ones(10) * u.mm
+    assert type(t['x']) is Column
+
+    xy = np.vstack([t['x'], t['y']]).T * u.mm
+    ii = [0, 2, 4]
+
+    assert xy[ii, 0].unit == t['x'][ii].unit
+    # should not raise anything
+    xy[ii, 0] = t['x'][ii]
+
 
 def test_insert():
     """

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1272,6 +1272,31 @@ def test_quantity_from_table():
     assert qbp.unit == u.pc
     assert_array_equal(qbp.value, t['b'])
 
+def test_assign_slice_with_quantity_like():
+    from ... table import Table
+    t = Table()
+    t['x'] = np.arange(10) * u.mm
+    t['y'] = np.ones(10) * u.mm
+    xy = np.vstack([t['x'], t['y']]).T * u.mm
+    ii = [0,2,4]
+
+    assert xy[ii,0].unit == t['x'][ii].unit
+    #following statement should not raise a
+    # u.core.UnitConversionError
+    xy[ii,0] = t['x'][ii]
+
+def test_assign_slice_with_quantity_like2():
+    from ...table import Column, Table
+    from ...units import Quantity
+    
+    t = Table()
+    t['x'] = np.arange(10) * u.mm
+    t['y'] = np.ones(10) * u.mm
+    
+    c = Column(np.arange(10.), unit=u.mm)
+    q = u.Quantity(c)
+    q[:2] = t[:2]
+    # AttributeError -> UnitConversionError
 
 def test_insert():
     """


### PR DESCRIPTION
Meant to fix #5961

For the solution, I put another try-catch statement to access the `data` property of the Quantity being passed in. As far as I know, the Quantity class doesn't have a `values` property, which is causing the error in the first try-catch statement. 

I placed the test in `test_quantity.py` but am not sure if there is a better place to put it. 

I'll add documentation soon. 