### PR TITLE
Add FITS HDU "ver" attribute to _summary and info methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,6 +138,8 @@ API Changes
   - Angstrom, erg, G, and barn are no more reported as deprecated FITS units.
     [#5929]
 
+  - Add EXTVER column to the output of ``HDUList.info()``. [#6124]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -774,7 +774,7 @@ class _CorruptedHDU(_BaseHDU):
         return self._file.size - self._data_offset
 
     def _summary(self):
-        return (self.name, 'CorruptedHDU')
+        return (self.name, self.ver, 'CorruptedHDU')
 
     def verify(self):
         pass
@@ -856,7 +856,7 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         return offset, size
 
     def _summary(self):
-        return (self.name, 'NonstandardHDU', len(self._header))
+        return (self.name, self.ver, 'NonstandardHDU', len(self._header))
 
     @lazyproperty
     def data(self):
@@ -1651,7 +1651,7 @@ class NonstandardExtHDU(ExtensionHDU):
                 xtension not in standard_xtensions)
 
     def _summary(self):
-        return (self.name, 'NonstandardExtHDU', len(self._header))
+        return (self.name, self.ver, 'NonstandardExtHDU', len(self._header))
 
     @lazyproperty
     def data(self):

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1622,7 +1622,7 @@ class CompImageHDU(BinTableHDU):
 
             _format = BITPIX2DTYPE[self.header['BITPIX']]
 
-        return (self.name, class_name, len(self.header), _shape,
+        return (self.name, self.ver, class_name, len(self.header), _shape,
                 _format)
 
     def _update_compressed_data(self):

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -569,7 +569,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
     def _summary(self):
         summary = super(GroupsHDU, self)._summary()
-        name, classname, length, shape, format, gcount = summary
+        name, ver, classname, length, shape, format, gcount = summary
 
         # Drop the first axis from the shape
         if shape:
@@ -581,7 +581,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
         # Update the GCOUNT report
         gcount = '{} Groups  {} Parameters'.format(self._gcount, self._pcount)
-        return (name, classname, length, shape, format, gcount)
+        return (name, ver, classname, length, shape, format, gcount)
 
 
 def _par_indices(names):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -965,9 +965,9 @@ class HDUList(list, _Verify):
             name = self._file.name
 
         results = ['Filename: {}'.format(name),
-                   'No.    Name      Ver        Type      Cards   Dimensions   Format']
+                   'No.    Name      Ver    Type      Cards   Dimensions   Format']
 
-        format = '{:3d}  {:10}  {:10} {:11}  {:5d}   {}   {}   {}'
+        format = '{:3d}  {:10}  {:3} {:11}  {:5d}   {}   {}   {}'
         default = ('', '', '', 0, (), '', '')
         for idx, hdu in enumerate(self):
             summary = hdu._summary()

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -965,10 +965,10 @@ class HDUList(list, _Verify):
             name = self._file.name
 
         results = ['Filename: {}'.format(name),
-                   'No.    Name         Type      Cards   Dimensions   Format']
+                   'No.    Name      Ver        Type      Cards   Dimensions   Format']
 
-        format = '{:3d}  {:10}  {:11}  {:5d}   {}   {}   {}'
-        default = ('', '', 0, (), '', '')
+        format = '{:3d}  {:10}  {:10} {:11}  {:5d}   {}   {}   {}'
+        default = ('', '', '', 0, (), '', '')
         for idx, hdu in enumerate(self):
             summary = hdu._summary()
             if len(summary) < len(default):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -798,7 +798,7 @@ class _ImageBaseHDU(_ValidHDU):
         # Display shape in FITS-order
         shape = tuple(reversed(self.shape))
 
-        return (self.name, class_name, len(self._header), shape, format, '')
+        return (self.name, self.ver, class_name, len(self._header), shape, format, '')
 
     def _calculate_datasum(self, blocking):
         """

--- a/astropy/io/fits/hdu/nonstandard.py
+++ b/astropy/io/fits/hdu/nonstandard.py
@@ -122,4 +122,4 @@ class FitsHDU(NonstandardExtHDU):
 
     def _summary(self):
         # TODO: Perhaps make this more descriptive...
-        return (self.name, self.__class__.__name__, len(self._header))
+        return (self.name, self.ver, self.__class__.__name__, len(self._header))

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -577,7 +577,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         dims = "{}R x {}C".format(nrows, ncols)
         ncards = len(self._header)
 
-        return (self.name, class_name, ncards, dims, format)
+        return (self.name, self.ver, class_name, ncards, dims, format)
 
     def _update_column_removed(self, columns, idx):
         super(_TableBaseHDU, self)._update_column_removed(columns, idx)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -427,7 +427,7 @@ class TestCore(FitsTestCase):
         hdu.header['SIMPLE'] = False
         hdu.writeto(self.temp('test.fits'))
 
-        info = [(0, '', 'NonstandardHDU', 5, (), '', '')]
+        info = [(0, '', 1, 'NonstandardHDU', 5, (), '', '')]
         with fits.open(self.temp('test.fits')) as hdul:
             assert hdul.info(output=False) == info
             # NonstandardHDUs just treat the data as an unspecified array of

--- a/astropy/io/fits/tests/test_groups.py
+++ b/astropy/io/fits/tests/test_groups.py
@@ -18,7 +18,7 @@ class TestGroupsFunctions(FitsTestCase):
             assert isinstance(hdul[0], fits.GroupsHDU)
             naxes = (3, 1, 128, 1, 1)
             parameters = ['UU', 'VV', 'WW', 'BASELINE', 'DATE']
-            info = [(0, 'PRIMARY', 'GroupsHDU', 147, naxes, 'float32',
+            info = [(0, 'PRIMARY', 1, 'GroupsHDU', 147, naxes, 'float32',
                      '3 Groups  5 Parameters')]
             assert hdul.info(output=False) == info
 

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -77,7 +77,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.HDUList()
         hdu = fits.PrimaryHDU(np.arange(100, dtype=np.int32))
         hdul.append(hdu)
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 5, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 5, (100,), 'int32', '')]
         assert hdul.info(output=False) == info
 
         hdul.writeto(self.temp('test-append.fits'))
@@ -90,7 +90,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.HDUList()
         hdu = fits.ImageHDU(np.arange(100, dtype=np.int32))
         hdul.append(hdu)
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (100,), 'int32', '')]
         assert hdul.info(output=False) == info
 
         hdul.writeto(self.temp('test-append.fits'))
@@ -103,8 +103,8 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.HDUList()
         hdul1 = fits.open(self.data('tb.fits'))
         hdul.append(hdul1[1])
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (), '', ''),
-                (1, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
 
         assert hdul.info(output=False) == info
 
@@ -119,7 +119,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.GroupsHDU()
         hdul.append(hdu)
 
-        info = [(0, 'PRIMARY', 'GroupsHDU', 8, (), '',
+        info = [(0, 'PRIMARY', 1, 'GroupsHDU', 8, (), '',
                  '1 Groups  0 Parameters')]
 
         assert hdul.info(output=False) == info
@@ -135,8 +135,8 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(np.arange(100, dtype=np.int32))
         hdul.append(hdu)
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 7, (11, 10, 7), 'int32', ''),
-                (1, '', 'ImageHDU', 6, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 7, (11, 10, 7), 'int32', ''),
+                (1, '', 1, 'ImageHDU', 6, (100,), 'int32', '')]
 
         assert hdul.info(output=False) == info
 
@@ -150,9 +150,9 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.open(self.data('tb.fits'))
         hdul.append(hdul[1])
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 11, (), '', ''),
-                (1, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', ''),
-                (2, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 11, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', ''),
+                (2, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
 
         assert hdul.info(output=False) == info
 
@@ -176,7 +176,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(np.arange(100, dtype=np.int32))
         hdul.insert(0, hdu)
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 5, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 5, (100,), 'int32', '')]
 
         assert hdul.info(output=False) == info
 
@@ -191,7 +191,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.ImageHDU(np.arange(100, dtype=np.int32))
         hdul.insert(0, hdu)
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (100,), 'int32', '')]
 
         assert hdul.info(output=False) == info
 
@@ -206,8 +206,8 @@ class TestHDUListFunctions(FitsTestCase):
         hdul1 = fits.open(self.data('tb.fits'))
         hdul.insert(0, hdul1[1])
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (), '', ''),
-                (1, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
 
         assert hdul.info(output=False) == info
 
@@ -222,7 +222,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.GroupsHDU()
         hdul.insert(0, hdu)
 
-        info = [(0, 'PRIMARY', 'GroupsHDU', 8, (), '',
+        info = [(0, 'PRIMARY', 1, 'GroupsHDU', 8, (), '',
                  '1 Groups  0 Parameters')]
 
         assert hdul.info(output=False) == info
@@ -238,8 +238,8 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(np.arange(100, dtype=np.int32))
         hdul.insert(1, hdu)
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 7, (11, 10, 7), 'int32', ''),
-                (1, '', 'ImageHDU', 6, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 7, (11, 10, 7), 'int32', ''),
+                (1, '', 1, 'ImageHDU', 6, (100,), 'int32', '')]
 
         assert hdul.info(output=False) == info
 
@@ -253,9 +253,9 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.open(self.data('tb.fits'))
         hdul.insert(1, hdul[1])
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 11, (), '', ''),
-                (1, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', ''),
-                (2, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 11, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', ''),
+                (2, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
 
         assert hdul.info(output=False) == info
 
@@ -274,9 +274,9 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(ValueError):
             hdul.insert(1, hdu)
 
-        info = [(0, 'PRIMARY', 'GroupsHDU', 8, (), '',
+        info = [(0, 'PRIMARY', 1, 'GroupsHDU', 8, (), '',
                  '1 Groups  0 Parameters'),
-                (1, '', 'ImageHDU', 6, (100,), 'int32', '')]
+                (1, '', 1, 'ImageHDU', 6, (100,), 'int32', '')]
 
         hdul.insert(0, hdu)
 
@@ -303,10 +303,10 @@ class TestHDUListFunctions(FitsTestCase):
         hdul = fits.open(self.data('tb.fits'))
         hdul.insert(0, hdul[1])
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (), '', ''),
-                (1, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', ''),
-                (2, '', 'ImageHDU', 12, (), '', ''),
-                (3, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', ''),
+                (2, '', 1, 'ImageHDU', 12, (), '', ''),
+                (3, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
 
         assert hdul.info(output=False) == info
 
@@ -324,9 +324,9 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.ImageHDU(np.arange(100, dtype=np.int32))
         hdul.insert(0, hdu)
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 5, (100,), 'int32', ''),
-                (1, '', 'ImageHDU', 12, (), '', ''),
-                (2, '', 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 5, (100,), 'int32', ''),
+                (1, '', 1, 'ImageHDU', 12, (), '', ''),
+                (2, '', 1, 'BinTableHDU', 24, '2R x 4C', '[1J, 3A, 1E, 1L]', '')]
 
         assert hdul.info(output=False) == info
 
@@ -354,7 +354,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdul.writeto(tmpfile)
         tmpfile.close()
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 5, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 5, (100,), 'int32', '')]
 
         assert fits.info(self.temp('tmpfile.fits'), output=False) == info
 
@@ -367,14 +367,14 @@ class TestHDUListFunctions(FitsTestCase):
         tmpfile.close()
         hdul.close()
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 5, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 5, (100,), 'int32', '')]
         assert fits.info(self.temp('tmpfile.fits'), output=False) == info
 
     def test_file_like_3(self):
         tmpfile = open(self.temp('tmpfile.fits'), 'wb')
         fits.writeto(tmpfile, np.arange(100, dtype=np.int32))
         tmpfile.close()
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 5, (100,), 'int32', '')]
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 5, (100,), 'int32', '')]
         assert fits.info(self.temp('tmpfile.fits'), output=False) == info
 
     def test_new_hdu_extname(self):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -91,8 +91,8 @@ class TestImageFunctions(FitsTestCase):
     def test_open_2(self):
         r = fits.open(self.data('test0.fits'))
 
-        info = ([(0, 'PRIMARY', 'PrimaryHDU', 138, (), '', '')] +
-                [(x, 'SCI', 'ImageHDU', 61, (40, 40), 'int16', '')
+        info = ([(0, 'PRIMARY', 1, 'PrimaryHDU', 138, (), '', '')] +
+                [(x, 'SCI', x, 'ImageHDU', 61, (40, 40), 'int16', '')
                  for x in range(1, 5)])
 
         try:
@@ -115,7 +115,7 @@ class TestImageFunctions(FitsTestCase):
         assert hdul[0].name == 'XPRIMARY'
         assert hdul[0].name == hdul[0].header['EXTNAME']
 
-        info = [(0, 'XPRIMARY', 'PrimaryHDU', 5, (), '', '')]
+        info = [(0, 'XPRIMARY', 1, 'PrimaryHDU', 5, (), '', '')]
         assert hdul.info(output=False) == info
 
         assert hdul['PRIMARY'] is hdul['XPRIMARY']

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -533,8 +533,8 @@ class TestTableFunctions(FitsTestCase):
 
         hdu.writeto(self.temp('newtable.fits'))
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (), '', ''),
-                (1, '', 'BinTableHDU', 19, '8R x 5C', '[10A, J, 10A, 5E, L]',
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 19, '8R x 5C', '[10A, J, 10A, 5E, L]',
                  '')]
 
         assert fits.info(self.temp('newtable.fits'), output=False) == info
@@ -740,8 +740,8 @@ class TestTableFunctions(FitsTestCase):
         assert hdu.columns.columns[1].array[0] == 80
         assert hdu.data[0][1] == 80
 
-        info = [(0, 'PRIMARY', 'PrimaryHDU', 4, (), '', ''),
-                (1, '', 'BinTableHDU', 30, '4R x 10C',
+        info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
+                (1, '', 1, 'BinTableHDU', 30, '4R x 10C',
                  '[10A, J, 10A, 5E, L, 10A, J, 10A, 5E, L]', '')]
 
         assert fits.info(self.temp('newtable.fits'), output=False) == info


### PR DESCRIPTION
The `info` method on `io.fits.hdu.hdulist.HDUList` objects prints a helpful summary of the list, including the `EXTNAME` attribute.  FITS extensions can also contain the `EXTVER` header keyword, which is already propagated to the `.ver` attribute of the HDU objects, such as `ImageHDU`.  The proposed changes add the `.ver` attribute to the outputs of the high-level `_summary` methods and the `info` method.  For example, with a HST WFC3/UVIS image:

    >>> import astropy.io.fits
    >>> im = pyfits.open('ic2i06kuq_flc.fits')
    >>> im.info()
    Filename: /Users/brammer/3DHST/Spectra/Work/WhitakerLens/NewPrep/ic2i06kuq_flc.fits
    No.    Name      Ver        Type      Cards   Dimensions   Format
      0  PRIMARY              1 PrimaryHDU     310   ()      
      1  SCI                  1 ImageHDU       238   (4096, 2051)   float32   
      2  ERR                  1 ImageHDU        51   (4096, 2051)   float32   
      3  DQ                   1 ImageHDU        43   (4096, 2051)   int16   
      4  SCI                  2 ImageHDU       236   (4096, 2051)   float32   
      5  ERR                  2 ImageHDU        51   (4096, 2051)   float32   
      6  DQ                   2 ImageHDU        43   (4096, 2051)   int16   
      7  D2IMARR              1 ImageHDU        15   (64, 32)   float32   
      8  D2IMARR              2 ImageHDU        15   (64, 32)   float32   
      9  D2IMARR              3 ImageHDU        15   (64, 32)   float32   
     10  D2IMARR              4 ImageHDU        15   (64, 32)   float32   
     11  WCSDVARR             1 ImageHDU        15   (64, 32)   float32   
     12  WCSDVARR             2 ImageHDU        15   (64, 32)   float32   
     13  WCSDVARR             3 ImageHDU        15   (64, 32)   float32   
     14  WCSDVARR             4 ImageHDU        15   (64, 32)   float32   
     15  WCSCORR              1 BinTableHDU     59   14R x 24C   [40A, I, A, 24A, 24A, 24A, 24A, D, D, D, D, D, D, D, D, 24A, 24A, D, D, D, D, J, 40A, 128A]   
