### PR TITLE
Add a new to_value method to Quantity.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,9 @@ New Features
   - Added a new equivalence ``molar_mass_amu`` between g/mol to
     atomic mass units. [#6040, #6113]
 
+  - ``Quantity`` has gained a new ``to_value`` method which returns the value
+    of the quantity in a given unit. [#6127]
+
 - ``astropy.utils``
 
   - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -593,12 +593,16 @@ class EarthLocation(u.Quantity):
         else:
             return super(EarthLocation, self).__len__()
 
-    def to(self, unit, equivalencies=[]):
-        array_view = self.view(self._array_dtype, u.Quantity)
-        converted = array_view.to(unit, equivalencies)
-        return self._new_view(converted.view(self.dtype).reshape(self.shape),
-                              unit)
-    to.__doc__ = u.Quantity.to.__doc__
+    def _to_value(self, unit, equivalencies=[]):
+        """Helper method for to and to_value."""
+        # Conversion to another unit in both ``to`` and ``to_value`` goes
+        # via this routine. To make the regular quantity routines work, we
+        # temporarily turn the structured array into a regular one.
+        array_view = self.view(self._array_dtype, np.ndarray)
+        if equivalencies == []:
+            equivalencies = self._equivalencies
+        new_array = self.unit.to(unit, array_view, equivalencies=equivalencies)
+        return new_array.view(self.dtype).reshape(self.shape)
 
     if NUMPY_LT_1_12:
         def __repr__(self):

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -254,6 +254,18 @@ class TestInput():
         else:
             assert not np.all(isclose_m14(location.z.value, self.z.value))
 
+        def test_to_value(self):
+            loc = self.location
+            loc_ndarray = loc.view(np.ndarray)
+            assert np.all(loc.value == loc_ndarray)
+            loc2 = self.location.to(u.km)
+            loc2_ndarray = np.empty_like(loc_ndarray)
+            for coo in 'x', 'y', 'z':
+                loc2_ndarray[coo] = loc_ndarray[coo] / 1000.
+            assert np.all(loc2.value == loc2_ndarray)
+            loc2_value = self.location.to_value(u.km)
+            assert np.all(loc2_value == loc2_ndarray)
+
 
 def test_pickling():
     """Regression test against #4304."""

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -796,6 +796,13 @@ class Quantity(np.ndarray):
 
     info = QuantityInfo()
 
+    def _to_value(self, unit, equivalencies=[]):
+        """Helper method for to and to_value."""
+        if equivalencies == []:
+            equivalencies = self._equivalencies
+        return self.unit.to(unit, self.view(np.ndarray),
+                            equivalencies=equivalencies)
+
     def to(self, unit, equivalencies=[]):
         """
         Return a new `~astropy.units.Quantity` object with the specified unit.
@@ -822,11 +829,7 @@ class Quantity(np.ndarray):
         # We don't use `to_value` below since we always want to make a copy
         # and don't want to slow down this method (esp. the scalar case).
         unit = Unit(unit)
-        if equivalencies == []:
-            equivalencies = self._equivalencies
-        new_val = self.unit.to(unit, self.view(np.ndarray),
-                               equivalencies=equivalencies)
-        return self._new_view(new_val, unit)
+        return self._new_view(self._to_value(unit, equivalencies), unit)
 
     def to_value(self, unit=None, equivalencies=[]):
         """
@@ -860,9 +863,7 @@ class Quantity(np.ndarray):
         if unit is not None:
             unit = Unit(unit)
             if unit != self.unit:
-                if equivalencies == []:
-                    equivalencies = self._equivalencies
-                value = self.unit.to(unit, value, equivalencies=equivalencies)
+                value = self._to_value(unit, equivalencies)
         return value if self.shape else value.item()
 
     value = property(to_value,

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -794,10 +794,11 @@ class Quantity(np.ndarray):
         super(Quantity, self).__setstate__(nd_state)
         self.__dict__.update(own_state)
 
+    info = QuantityInfo()
+
     def to(self, unit, equivalencies=[]):
         """
-        Returns a new `~astropy.units.Quantity` object with the specified
-        units.
+        Return a new `~astropy.units.Quantity` object with the specified unit.
 
         Parameters
         ----------
@@ -813,24 +814,64 @@ class Quantity(np.ndarray):
             (none for `~astropy.units.Quantity`, but may be set for subclasses)
             If `None`, no equivalencies will be applied at all, not even any
             set globally or within a context.
+
+        See also
+        --------
+        :meth:`Quantity.to_value` : get the numerical value in a given unit.
         """
+        # We don't use `to_value` below since we always want to make a copy
+        # and don't want to slow down this method (esp. the scalar case).
+        unit = Unit(unit)
         if equivalencies == []:
             equivalencies = self._equivalencies
-        unit = Unit(unit)
         new_val = self.unit.to(unit, self.view(np.ndarray),
                                equivalencies=equivalencies)
         return self._new_view(new_val, unit)
 
-    info = QuantityInfo()
+    def to_value(self, unit=None, equivalencies=[]):
+        """
+        The numerical value of the quantity, possibly in a different unit.
 
-    @property
-    def value(self):
-        """ The numerical value of this quantity. """
+        Parameters
+        ----------
+        unit : `~astropy.units.UnitBase` instance or str, optional
+            The unit in which the value should be given. If not given or `None`,
+            use the current unit.
+
+        equivalencies : list of equivalence pairs, optional
+            A list of equivalence pairs to try if the units are not directly
+            convertible (see :ref:`unit_equivalencies`). If not provided or
+            ``[]``, class default equivalencies will be used (none for
+            `~astropy.units.Quantity`, but may be set for subclasses).
+            If `None`, no equivalencies will be applied at all, not even any
+            set globally or within a context.
+
+        Returns
+        -------
+        value : `~numpy.ndarray` or scalar
+            The value in the units specified. For arrays, this will be a view
+            of the data if no unit conversion was necessary.
+
+        See also
+        --------
+        :meth:`Quantity.to` : Get a new `Quantity` in a different unit.
+        """
         value = self.view(np.ndarray)
-        if self.shape:
-            return value
-        else:
-            return value.item()
+        if unit is not None:
+            unit = Unit(unit)
+            if unit != self.unit:
+                if equivalencies == []:
+                    equivalencies = self._equivalencies
+                value = self.unit.to(unit, value, equivalencies=equivalencies)
+        return value if self.shape else value.item()
+
+    value = property(to_value,
+                     doc="""The numerical value of this quantity.
+
+    See also
+    --------
+    :meth:`Quantity.to_value` : Get the numerical value in a given unit.
+    """)
 
     @property
     def unit(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -817,7 +817,7 @@ class Quantity(np.ndarray):
 
         See also
         --------
-        :meth:`Quantity.to_value` : get the numerical value in a given unit.
+        to_value : get the numerical value in a given unit.
         """
         # We don't use `to_value` below since we always want to make a copy
         # and don't want to slow down this method (esp. the scalar case).
@@ -830,7 +830,7 @@ class Quantity(np.ndarray):
 
     def to_value(self, unit=None, equivalencies=[]):
         """
-        The numerical value of the quantity, possibly in a different unit.
+        The numerical value, possibly in a different unit.
 
         Parameters
         ----------
@@ -854,7 +854,7 @@ class Quantity(np.ndarray):
 
         See also
         --------
-        :meth:`Quantity.to` : Get a new `Quantity` in a different unit.
+        to : Get a new instance in a different unit.
         """
         value = self.view(np.ndarray)
         if unit is not None:
@@ -866,11 +866,11 @@ class Quantity(np.ndarray):
         return value if self.shape else value.item()
 
     value = property(to_value,
-                     doc="""The numerical value of this quantity.
+                     doc="""The numerical value of this instance.
 
     See also
     --------
-    :meth:`Quantity.to_value` : Get the numerical value in a given unit.
+    to_value : Get the numerical value in a given unit.
     """)
 
     @property

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -82,6 +82,13 @@ convert the |quantity| to base S.I. or c.g.s units:
     >>> q.cgs
     <Quantity 240.0 cm / s>
 
+If you want the value of the quantity in a different unit, you can use
+:meth:`~astropy.units.Quantity.to_value` as a short-cut:
+
+    >>> q = 2.5 * u.m
+    >>> q.to_value(u.cm)
+    250.0
+
 .. _plotting-quantities:
 
 Plotting quantities


### PR DESCRIPTION
This returns the value of the quantity in the given unit.

@taldcroft: I ended up with `to_value` as I felt it was a bit more uniform (with `to_string`, etc.) and makes more sense without arguments (a form that needs to exist to make the property work, i.e., `q.to_value()` is obvious but `q.value_in()` is not). I also ended up not using it for `to`, as especially the scalar case is slowed down a little too much by first doing `value.item()` and then recreating an array in `_new_view`.

Fixes #6125 
