### PR TITLE
Allow Quantity to be written as a normal column to VOTable solves #3685

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,9 @@ New Features
     Python 3 ``str`` object in a bytestring column (numpy ``'S'`` dtype).
     [#5700]
 
+  - Added functionality to allow ``astropy.units.Quantity`` to be written
+    as a normal column to VO table files. [#6132]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,8 +87,8 @@ New Features
     Python 3 ``str`` object in a bytestring column (numpy ``'S'`` dtype).
     [#5700]
 
-  - Added functionality to allow ``astropy.units.Quantity`` to be written
-    as a normal column to VO table files. [#6132]
+  - Added functionality to allow ``astropy.units.Quantity`` to be read
+    from and written to a VOtable file. [#6132]
 
 - ``astropy.time``
 

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -141,13 +141,11 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
         ``tabledata``.  See :ref:`votable-serialization`.
     """
 
-    # Tables with mixin columns are not supported
-    if input.has_mixin_columns:
-        # Only those columns which are instances of BaseColumn or Quantity can be written
-        unsupported_cols = input.columns.not_isinstance((BaseColumn, Quantity))
-        if unsupported_cols:
-            unsupported_names = [col.info.name for col in unsupported_cols]
-            raise ValueError('cannot write table with mixin column(s) {0} to VOTable'
+    # Only those columns which are instances of BaseColumn or Quantity can be written
+    unsupported_cols = input.columns.not_isinstance((BaseColumn, Quantity))
+    if unsupported_cols:
+        unsupported_names = [col.info.name for col in unsupported_cols]
+        raise ValueError('cannot write table with mixin column(s) {0} to VOTable'
                          .format(unsupported_names))
 
     # Check if output file already exists

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -10,6 +10,8 @@ from . import parse, from_table
 from .tree import VOTableFile, Table as VOTable
 from .. import registry as io_registry
 from ...table import Table
+from ...table.column import BaseColumn
+from ...units import Quantity
 
 
 def is_votable(origin, filepath, fileobj, *args, **kwargs):
@@ -141,10 +143,12 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
 
     # Tables with mixin columns are not supported
     if input.has_mixin_columns:
-        mixin_names = [name for name, col in input.columns.items()
-                       if not isinstance(col, input.ColumnClass)]
-        raise ValueError('cannot write table with mixin column(s) {0} to VOTable'
-                         .format(mixin_names))
+        # Only those columns which are instances of BaseColumn or Quantity can be written
+        unsupported_cols = input.columns.not_isinstance((BaseColumn, Quantity))
+        if unsupported_cols:
+            unsupported_names = [col.info.name for col in unsupported_cols]
+            raise ValueError('cannot write table with mixin column(s) {0} to VOTable'
+                         .format(unsupported_names))
 
     # Check if output file already exists
     if isinstance(output, six.string_types) and os.path.exists(output):

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1115,10 +1115,10 @@ class Values(Element, _IDProperty):
         column.meta['values'] = meta
 
     def from_table_column(self, column):
-        if 'values' not in column.meta:
+        if column.info.meta is None or 'values' not in column.info.meta:
             return
 
-        meta = column.meta['values']
+        meta = column.info.meta['values']
         for key in ['ID', 'null']:
             val = meta.get(key, None)
             if val is not None:
@@ -1547,24 +1547,25 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         `astropy.table.Column` instance.
         """
         kwargs = {}
+        meta = column.info.meta or {}
         for key in ['ucd', 'width', 'precision', 'utype', 'xtype']:
-            val = column.meta.get(key, None)
+            val = meta.get(key, None)
             if val is not None:
                 kwargs[key] = val
         # TODO: Use the unit framework when available
-        if column.unit is not None:
-            kwargs['unit'] = column.unit
-        kwargs['name'] = column.name
+        if column.info.unit is not None:
+            kwargs['unit'] = column.info.unit
+        kwargs['name'] = column.info.name
         result = converters.table_column_to_votable_datatype(column)
         kwargs.update(result)
 
         field = cls(votable, **kwargs)
 
-        if column.description is not None:
-            field.description = column.description
+        if column.info.description is not None:
+            field.description = column.info.description
         field.values.from_table_column(column)
-        if 'links' in column.meta:
-            for link in column.meta['links']:
+        if 'links' in meta:
+            for link in meta['links']:
                 field.links.append(Link.from_table_column(link))
 
         # TODO: Parse format into precision and width

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1547,11 +1547,12 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         `astropy.table.Column` instance.
         """
         kwargs = {}
-        meta = column.info.meta or {}
-        for key in ['ucd', 'width', 'precision', 'utype', 'xtype']:
-            val = meta.get(key, None)
-            if val is not None:
-                kwargs[key] = val
+        meta = column.info.meta
+        if meta:
+            for key in ['ucd', 'width', 'precision', 'utype', 'xtype']:
+                val = meta.get(key, None)
+                if val is not None:
+                    kwargs[key] = val
         # TODO: Use the unit framework when available
         if column.info.unit is not None:
             kwargs['unit'] = column.info.unit
@@ -1564,7 +1565,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         if column.info.description is not None:
             field.description = column.info.description
         field.values.from_table_column(column)
-        if 'links' in meta:
+        if meta and 'links' in meta:
             for link in meta['links']:
                 field.links.append(Link.from_table_column(link))
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -107,7 +107,7 @@ def test_io_ascii_write():
 def test_io_quantity_write(tmpdir):
     """
     Test that table with Quantity mixin column can be written by io.fits,
-    but not by io.votable and io.misc.hdf5. Validation of the output is done.
+    io.votable but not by io.misc.hdf5. Validation of the output is done.
     Test that io.fits writes a table containing Quantity mixin columns that can
     be round-tripped (metadata unit).
     """
@@ -123,6 +123,9 @@ def test_io_quantity_write(tmpdir):
             qt = QTable.read(filename, format=fmt)
             assert isinstance(qt['a'], u.Quantity)
             assert qt['a'].unit == 'Angstrom'
+            continue
+        if fmt == 'votable':
+            t.write(filename, format=fmt, overwrite=True)
             continue
         if fmt == 'hdf5' and not HAS_H5PY:
             continue

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -118,14 +118,11 @@ def test_io_quantity_write(tmpdir):
     open(filename, 'w').close()
 
     for fmt in ('fits', 'votable', 'hdf5'):
-        if fmt == 'fits':
+        if fmt != 'hdf5':
             t.write(filename, format=fmt, overwrite=True)
             qt = QTable.read(filename, format=fmt)
             assert isinstance(qt['a'], u.Quantity)
             assert qt['a'].unit == 'Angstrom'
-            continue
-        if fmt == 'votable':
-            t.write(filename, format=fmt, overwrite=True)
             continue
         if fmt == 'hdf5' and not HAS_H5PY:
             continue

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -117,17 +117,17 @@ def test_io_quantity_write(tmpdir):
     filename = tmpdir.join("table-tmp").strpath
     open(filename, 'w').close()
 
-    for fmt in ('fits', 'votable', 'hdf5'):
-        if fmt != 'hdf5':
-            t.write(filename, format=fmt, overwrite=True)
-            qt = QTable.read(filename, format=fmt)
-            assert isinstance(qt['a'], u.Quantity)
-            assert qt['a'].unit == 'Angstrom'
-            continue
-        if fmt == 'hdf5' and not HAS_H5PY:
-            continue
+    # Show that FITS and VOTable formats succeed
+    for fmt in ('fits', 'votable'):
+        t.write(filename, format=fmt, overwrite=True)
+        qt = QTable.read(filename, format=fmt)
+        assert isinstance(qt['a'], u.Quantity)
+        assert qt['a'].unit == 'Angstrom'
+
+    # Show that HDF5 format fails
+    if HAS_H5PY:
         with pytest.raises(ValueError) as err:
-            t.write(filename, format=fmt, overwrite=True)
+            t.write(filename, format='hdf5', overwrite=True)
         assert 'cannot write table with mixin column(s)' in str(err.value)
 
 


### PR DESCRIPTION
Work in Progress:
This works perfectly for write operation. For reading, round-tripping is maintained, except for the case where the unit is 'Angstrom'. For most of the other units, I have checked that it works perfectly well. Will have to investigate why 'Angstrom' is causing a problem.

```
In [34]: t
Out[34]: 
<QTable length=3>
   a       b       c    
  deg      s    Angstrom
float64 float64 float64 
------- ------- --------
    1.0     1.0      1.0
    2.0     2.0      2.0
    4.0     4.0      4.0

In [35]: t.write("check_votable", format='votable', overwrite=True)

In [36]: QTable.read("check_votable", format='votable')
Out[36]: 
<QTable masked=True length=3>
   a       b       c   
  deg      s       AA  
float64 float64 float64
------- ------- -------
    1.0     1.0     1.0
    2.0     2.0     2.0
    4.0     4.0     4.0
```

#5910 

@taldcroft @mhvk Any idea as to why it fails only for Angstrom?
I'm keeping this open to make sure that the changes don't get lost.

_The travis failure seems unrelated._