### PR TITLE
Updating astropy-helpers to latest v2.0dev

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ del intersphinx_mapping['astropy']
 intersphinx_mapping['pytest'] = ('https://pytest.org/en/latest/', None)
 intersphinx_mapping['ipython'] = ('http://ipython.readthedocs.io/en/stable/', None)
 intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
+intersphinx_mapping['sphinx_automodapi'] = ('https://sphinx-automodapi.readthedocs.io/en/stable/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -59,7 +59,7 @@ The details of the docstring format are described on a separate page:
 Sphinx Documentation Themes
 ===========================
 
-A custom Sphinx HTML theme is included in the `astropy-helpers`_ package. 
+A custom Sphinx HTML theme is included in the `astropy-helpers`_ package.
 This allows the
 theme to be used by both Astropy and affiliated packages. This is done by
 setting the theme in the global Astropy sphinx configuration, which is imported
@@ -94,21 +94,22 @@ editing ``astropy/astropy/sphinx/setup_package.py`` to include the theme
 Sphinx extensions
 =================
 
-Astropy-helpers includes a number of sphinx extensions that are used in Astropy
-and its affiliated packages to facilitate easily documenting code in a
-homogeneous and readable way.
+Astropy-helpers includes a number of sphinx extensions (some via the
+`sphinx-automodapi`_ package) that are used in Astropy and its affiliated
+packages to facilitate easily documenting code in a homogeneous and readable
+way.
 
 
 automodapi Extension
 --------------------
 
-.. automodule:: astropy_helpers.sphinx.ext.automodapi
+.. automodule:: astropy_helpers.extern.automodapi.automodapi
 
 
 automodsumm Extension
 ---------------------
 
-.. automodule:: astropy_helpers.sphinx.ext.automodsumm
+.. automodule:: astropy_helpers.extern.automodapi.automodsumm
 
 
 edit_on_github Extension
@@ -131,10 +132,10 @@ processed automatically.
 Other Extensions
 ----------------
 
-``astropy_helpers.sphinx.ext`` includes a few other extensions that are
-primarily helpers for the other extensions or workarounds for undesired
-behavior.  Their APIs are not included here because we may change them in the
-future.
+``astropy_helpers.sphinx.ext`` and `sphinx-automodapi`_ includes a few other
+extensions that are primarily helpers for the other extensions or
+workarounds for undesired behavior.  Their APIs are not included here
+because we may change them in the future.
 
 
 .. _NumPy: http://numpy.scipy.org/
@@ -143,3 +144,4 @@ future.
 .. _SciPy: http://www.scipy.org
 .. _Sphinx: http://sphinx.pocoo.org
 .. _astropy-helpers: https://github.com/astropy/astropy-helpers
+.. _sphinx-automodapi: https://github.com/astropy/sphinx-automodapi

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -97,19 +97,10 @@ Sphinx extensions
 Astropy-helpers includes a number of sphinx extensions (some via the
 `sphinx-automodapi`_ package) that are used in Astropy and its affiliated
 packages to facilitate easily documenting code in a homogeneous and readable
-way.
-
-
-automodapi Extension
---------------------
-
-.. automodule:: astropy_helpers.extern.automodapi.automodapi
-
-
-automodsumm Extension
----------------------
-
-.. automodule:: astropy_helpers.extern.automodapi.automodsumm
+way. The two main extensions are `~sphinx_automodapi.automodapi` for
+generating module documentation and `~sphinx_automodapi.automodsumm` for
+generating tables of module objects. Please see their documentation about
+usage.
 
 
 edit_on_github Extension

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -6,6 +6,8 @@ Setuptools bootstrapping installer.
 Maintained at https://github.com/pypa/setuptools/tree/bootstrap.
 
 Run this script to install or upgrade setuptools.
+
+This method is DEPRECATED. Check https://github.com/pypa/setuptools/issues/581 for more details.
 """
 
 import os
@@ -18,29 +20,28 @@ import subprocess
 import platform
 import textwrap
 import contextlib
-import json
-import codecs
 
 from distutils import log
 
 try:
     from urllib.request import urlopen
-    from urllib.parse import urljoin
 except ImportError:
     from urllib2 import urlopen
-    from urlparse import urljoin
 
 try:
     from site import USER_SITE
 except ImportError:
     USER_SITE = None
 
-LATEST = object()
-DEFAULT_VERSION = LATEST
+# 33.1.1 is the last version that supports setuptools self upgrade/installation.
+DEFAULT_VERSION = "33.1.1"
 DEFAULT_URL = "https://pypi.io/packages/source/s/setuptools/"
 DEFAULT_SAVE_DIR = os.curdir
+DEFAULT_DEPRECATION_MESSAGE = "ez_setup.py is deprecated and when using it setuptools will be pinned to {0} since it's the last version that supports setuptools self upgrade/installation, check https://github.com/pypa/setuptools/issues/581 for more info; use pip to install setuptools"
 
 MEANINGFUL_INVALID_ZIP_ERR_MSG = 'Maybe {0} is corrupted, delete it and try again.'
+
+log.warn(DEFAULT_DEPRECATION_MESSAGE.format(DEFAULT_VERSION))
 
 
 def _python_cmd(*args):
@@ -157,7 +158,6 @@ def use_setuptools(
     Return None. Raise SystemExit if the requested version
     or later cannot be installed.
     """
-    version = _resolve_version(version)
     to_dir = os.path.abspath(to_dir)
 
     # prior to importing, capture the module state for
@@ -344,7 +344,6 @@ def download_setuptools(
     ``downloader_factory`` should be a function taking no arguments and
     returning a function for downloading a URL to a target.
     """
-    version = _resolve_version(version)
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
     zip_name = "setuptools-%s.zip" % version
@@ -355,27 +354,6 @@ def download_setuptools(
         downloader = downloader_factory()
         downloader(url, saveto)
     return os.path.realpath(saveto)
-
-
-def _resolve_version(version):
-    """
-    Resolve LATEST version
-    """
-    if version is not LATEST:
-        return version
-
-    meta_url = urljoin(DEFAULT_URL, '/pypi/setuptools/json')
-    resp = urlopen(meta_url)
-    with contextlib.closing(resp):
-        try:
-            charset = resp.info().get_content_charset()
-        except Exception:
-            # Python 2 compat; assume UTF-8
-            charset = 'UTF-8'
-        reader = codecs.getreader(charset)
-        doc = json.load(reader(resp))
-
-    return str(doc['info']['version'])
 
 
 def _build_install_args(options):


### PR DESCRIPTION
~~DO NOT MERGE! This is a testing, placeholder PR until ah is released.~~

EDIT: this PR now contains only the helpers update to 2.0rc1 and related docs changes. Can be merged once CI passes.

There were quite a few changes in the helpers, and thus I see only benefits of trying to test against the latest dev branch well before the feature freeze.

E.g. I expect a few docs issues with the new sphinx version, but we need this helpers to be able to test it.