### PR TITLE
Write temp.png from wcsaxes test_no_numpy_warnings in tmpdir

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -59,7 +59,7 @@ COORDSYS= 'icrs    '
 """, sep='\n')
 
 
-def test_no_numpy_warnings():
+def test_no_numpy_warnings(tmpdir):
 
     # Make sure that no warnings are raised if some pixels are outside WCS
     # (since this is normal)
@@ -69,7 +69,7 @@ def test_no_numpy_warnings():
     ax.coords.grid(color='white')
 
     with catch_warnings(RuntimeWarning) as ws:
-        plt.savefig('test.png')
+        plt.savefig(tmpdir.join('test.png').strpath)
 
     # For debugging
     for w in ws:


### PR DESCRIPTION
@astrofrog - I noticed that running the Astropy tests via `import astropy; astropy.test()` or via `python -m pytest` left one file `test.png` in the current working directory.

This PR changes the test to put it in a tempdir (using the same method as in other tests in the same file and throughout Astropy).

I locally verified the change via 
```
python -m pytest astropy/visualization/wcsaxes/tests/test_misc.py -k test_no_numpy_warnings
````
With the change made here, no `test.png` appears in the current working directory any more.