### PR TITLE
Add Quantity.__matmul__ to support @ operator on Python>=3.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,9 @@ New Features
   - ``Quantity`` has gained a new ``to_value`` method which returns the value
     of the quantity in a given unit. [#6127]
 
+  - ``Quantity`` now supports the ``@`` operator for matrix multiplication that
+    was introduced in Python 3.5, for all supported versions of numpy. [#6144]
+
 - ``astropy.utils``
 
   - Added a new ``dataurl_mirror`` configuration item in ``astropy.utils.data``

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -24,6 +24,7 @@ from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
                    UnitBase, UnitsError, UnitConversionError, UnitTypeError)
 from .format.latex import Latex
 from ..utils.compat.misc import override__dir__
+from ..utils.compat.numpy import matmul
 from ..utils.misc import isiterable, InheritDocstrings
 from ..utils.data_info import ParentDtypeInfo
 from .. import config as _config
@@ -1091,6 +1092,17 @@ class Quantity(np.ndarray):
                                   self.unit ** other)
 
         return super(Quantity, self).__pow__(other)
+
+    # For Py>=3.5
+    def __matmul__(self, other, reverse=False):
+        result_unit = self.unit * getattr(other, 'unit', dimensionless_unscaled)
+        result_array = matmul(self.value, getattr(other, 'value', other))
+        return self._new_view(result_array, result_unit)
+
+    def __rmatmul__(self, other):
+        result_unit = self.unit * getattr(other, 'unit', dimensionless_unscaled)
+        result_array = matmul(getattr(other, 'value', other), self.value)
+        return self._new_view(result_array, result_unit)
 
     def __pos__(self):
         """


### PR DESCRIPTION
On python >=3.5, the matrix multiplication operator `@` should work, but currently it does not keep track of the unit correctly. With this PR:
```
q = np.eye(3) * u.m
q @ q
# <Quantity [[ 1., 0., 0.],
#            [ 0., 1., 0.],
#            [ 0., 0., 1.]] m2>
```

