### PR TITLE
Use errors='replace' in decoding bytes data in Py3

### DIFF
--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -61,7 +61,7 @@ cdef inline object base_getitem(object self, object item, item_getter getitem):
     if PYV != 2:
         try:
             if value.dtype.char == 'S' and not value.shape:
-                value = value.decode('utf-8')
+                value = value.decode('utf-8', errors='replace')
         except AttributeError:
             pass
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -686,7 +686,6 @@ def test_auto_format_func():
     qt.pformat()  # Generates exception prior to #5802
 
 
-@pytest.mark.xfail(not PY2, reason='Python3 fails before getting to pprint')
 def test_decode_replace():
     """
     Test printing a bytestring column with a value that fails


### PR DESCRIPTION
This fixes the current test failure in master caused by the interaction of #5700 and #6117, except now I need to back out #6142.

Closes #6121