### PR TITLE
Cleanup of .travis.yml of a left-over Python 3.3 item [skip ci].

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,15 +126,6 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
-    # Workaround for Python 3.3, for which pytest 2.8 or greater is not available.
-    # This can be removed after Astropy 2.0 is released since the next version
-    # will only support Python 3.4+ (see APE 10)
-    - if [[ $PYTHON_VERSION == 3.3 && $SETUP_CMD == test* ]]; then
-        conda remove pytest --force;
-        pip install pytest>=2.8;
-      fi
-
-
 script:
     - $MAIN_CMD $SETUP_CMD
 


### PR DESCRIPTION
I don't know how I missed this in #6021, but obviously if we do not test Python 3.3, then there also doesn't have to be a special-case in the install section for it.

I decided to [skip ci] to keep the rest a bit faster -- this seems obviously correct.