### PR TITLE
Raise a more meaningful error in bayesian_blocks

### DIFF
--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -298,6 +298,9 @@ class FitnessFunc(object):
             return -np.log(self.gamma)
         elif self.p0 is not None:
             return self.p0_prior(N)
+        else:
+            raise ValueError("``ncp_prior`` is not defined, and cannot compute "
+                             "it as neither ``gamma`` nor ``p0`` is defined.")
 
     def fit(self, t, x=None, sigma=None):
         """Fit the Bayesian Blocks model given the specified fitness function.


### PR DESCRIPTION
In theory p0 is optional argument, and the conditional in https://github.com/astropy/astropy/blob/master/astropy/stats/bayesian_blocks.py#L422 suggests, that None is a perfectly valid value, while it isn't is neither ``gamma`` nor ``ncp_prior`` is specified.

```
In [1]: from astropy.stats import bayesian_blocks
In [2]: import numpy as np
In [3]: t = np.random.normal(size=100)
   ...: edges = bayesian_blocks(t, fitness='events', p0=None)
   ...: 
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-01c1adf2ecaa> in <module>()
      1 t = np.random.normal(size=100)
----> 2 edges = bayesian_blocks(t, fitness='events', p0=None)

/sw/lib/python3.5/site-packages/astropy/stats/bayesian_blocks.py in bayesian_blocks(t, x, sigma, fitness, **kwargs)
    155         raise ValueError("fitness parameter not understood")
    156 
--> 157     return fitfunc.fit(t, x, sigma)
    158 
    159 

/sw/lib/python3.5/site-packages/astropy/stats/bayesian_blocks.py in fit(self, t, x, sigma)
    371             fit_vec = self.fitness(**kwds)
    372 
--> 373             A_R = fit_vec - ncp_prior
    374             A_R[1:] += best[:R]
    375 

TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```