### PR TITLE
Disable pytest-warnings during testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]
 doctest_plus = enabled
 doctest_norecursedirs = "astropy[\/]sphinx"
 open_files_ignore = "astropy.log" "/etc/hosts"
+addopts = -p no:warnings
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
pytest 3.1.0 included ``pytest-warnings`` in its core [0] and now lists all warning that occurred during testing at the end of the build, which is way too verbose. This PR sets it back to previous behaviour.

Obviously, long term we can aim to write tests that don't emit warnings...

[0] https://docs.pytest.org/en/latest/changelog.html#changelog-history