### PR TITLE
Use the generic ci-helpers script, it will figure out OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ matrix:
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
 script:
     - $MAIN_CMD $SETUP_CMD


### PR DESCRIPTION
Using the generic script will allow me to put more generic stuff in there without code repetition, e.g. the checks for the custom tags and skipping the builds early.

Can be merged once a few of the jobs pass.