### PR TITLE
Allow representations to contain differentials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,9 +26,9 @@ New Features
     coordinate frames that allow copying an existing frame object with various
     reference or copy behaviors and possibly overriding frame attributes. [#6182]
 
-  - The ``Representation`` class instances can now contain ``Differential``
-    objects. This is primarily useful for internal operations that will provide
-    support for transforming velocity components in coordinate frames. [#6169]
+  - The representation class instances can now contain differential objects.
+    This is primarily useful for internal operations that will provide support
+    for transforming velocity components in coordinate frames. [#6169]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,11 +20,16 @@ New Features
 
   - A class hierarchy was added to allow the representation layer to store
     differentials (i.e., finite derivatives) of coordinates.  This is intended
-    to enable support for velocities in coordinate frames down the road. [#5871]
+    to enable support for velocities in coordinate frames. [#5871]
 
   - ``replicate_without_data`` and ``replicate`` methods were added to
     coordinate frames that allow copying an existing frame object with various
     reference or copy behaviors and possibly overriding frame attributes. [#6182]
+
+  - The ``Representation`` class instances can now contain ``Differential``
+    object instances. This is primarily useful for internal operations that will
+    provide support for transforming velocity components in coordinate frames.
+    [#6169]
 
 - ``astropy.cosmology``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,9 +27,8 @@ New Features
     reference or copy behaviors and possibly overriding frame attributes. [#6182]
 
   - The ``Representation`` class instances can now contain ``Differential``
-    object instances. This is primarily useful for internal operations that will
-    provide support for transforming velocity components in coordinate frames.
-    [#6169]
+    objects. This is primarily useful for internal operations that will provide
+    support for transforming velocity components in coordinate frames. [#6169]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -378,7 +378,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         diffstr = ''
         if getattr(self, 'differentials', None):
-            diffstr = '\n (has differentials)'
+            diffstr = '\n (has differentials: {0})'.format(
+                ', '.join([repr(key) for key in self.differentials.keys()]))
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
         return '<{0} ({1}) {2:s}\n{3}{4}{5}>'.format(
@@ -1067,9 +1068,9 @@ class CartesianRepresentation(BaseRepresentation):
         # Handle differentials attached to this representation
         if self.differentials:
             # TODO: speed this up going via d.d_xyz.
-            new_diffs = dict((k, d.from_cartesian(
-                d.represent_as(CartesianRepresentation).transform(matrix)))
-                             for k, d in self.differentials.items())
+            new_diffs = dict(
+                (k, d.from_cartesian(d.to_cartesian().transform(matrix)))
+                for k, d in self.differentials.items())
         else:
             new_diffs = None
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -271,10 +271,6 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 else:
                     reshaped.append(val)
 
-        # also perform shape-setting on any associated differentials
-        for diff in self.differentials:
-            diff.shape = shape
-
     # Required to support multiplication and division, and defined by the base
     # representation and differential classes.
     @abc.abstractmethod
@@ -682,6 +678,16 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             return NotImplemented
         else:
             return self.from_cartesian(result)
+
+    # We need to override this setter to support differentials
+    @BaseRepresentationOrDifferential.shape.setter
+    def shape(self, shape):
+        # See: https://stackoverflow.com/questions/3336767/ for an example
+        BaseRepresentationOrDifferential.shape.fset(self, shape)
+
+        # also perform shape-setting on any associated differentials
+        for diff in self.differentials:
+            diff.shape = shape
 
     def norm(self):
         """Vector norm.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -801,12 +801,14 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         The norm is the standard Frobenius norm, i.e., the square root of the
         sum of the squares of all components with non-angular units.
 
+        Note that any associated differentials will be dropped during this
+        operation.
+
         Returns
         -------
         norm : `astropy.units.Quantity`
             Vector norm, with the same shape as the representation.
         """
-        self._raise_if_has_differentials('norm')
         return np.sqrt(functools.reduce(
             operator.add, (getattr(self, component)**2
                            for component, cls in self.attr_classes.items()
@@ -856,6 +858,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         The calculation is done by converting both ``self`` and ``other``
         to `~astropy.coordinates.CartesianRepresentation`.
 
+        Note that any associated differentials will be dropped during this
+        operation.
+
         Parameters
         ----------
         other : `~astropy.coordinates.BaseRepresentation`
@@ -867,7 +872,6 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             The sum of the product of the x, y, and z components of the
             cartesian representations of ``self`` and ``other``.
         """
-        self._raise_if_has_differentials('dot')
         return self.to_cartesian().dot(other)
 
     def cross(self, other):
@@ -1126,6 +1130,9 @@ class CartesianRepresentation(BaseRepresentation):
     def dot(self, other):
         """Dot product of two representations.
 
+        Note that any associated differentials will be dropped during this
+        operation.
+
         Parameters
         ----------
         other : representation
@@ -1137,7 +1144,6 @@ class CartesianRepresentation(BaseRepresentation):
             The sum of the product of the x, y, and z components of ``self``
             and ``other``.
         """
-        self._raise_if_has_differentials('dot')
         try:
             other_c = other.to_cartesian()
         except Exception:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -788,12 +788,21 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
     # We need to override this setter to support differentials
     @BaseRepresentationOrDifferential.shape.setter
     def shape(self, shape):
+        orig_shape = self.shape
+
         # See: https://stackoverflow.com/questions/3336767/ for an example
         BaseRepresentationOrDifferential.shape.fset(self, shape)
 
-        # also perform shape-setting on any associated differentials
-        for diff in self.differentials:
-            diff.shape = shape
+        # also try to perform shape-setting on any associated differentials
+        try:
+            for k in self.differentials:
+                self.differentials[k].shape = shape
+        except:
+            BaseRepresentationOrDifferential.shape.fset(self, orig_shape)
+            for k in self.differentials:
+                self.differentials[k].shape = orig_shape
+
+            raise
 
     def norm(self):
         """Vector norm.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -450,8 +450,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         subclass instance, or a dictionary with keys set to a string
         representation of the SI unit with which the differential (derivative)
         is taken. For example, for a velocity differential on a positional
-        representation, the key would be `'s'` for seconds, indicating that the
-        derivative is a time derivative.
+        representation, the key would be ``'s'`` for seconds, indicating that
+        the derivative is a time derivative.
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
 
@@ -547,7 +547,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         The keys of this dictionary must be a string representation of the SI
         unit with which the differential (derivative) is taken. For example, for
         a velocity differential on a positional representation, the key would be
-        `'s'` for seconds, indicating that the derivative is a time derivative.
+        ``'s'`` for seconds, indicating that the derivative is a time
+        derivative.
         """
         return self._differentials
 
@@ -950,8 +951,8 @@ class CartesianRepresentation(BaseRepresentation):
         `CartesianDifferential` s with keys set to a string representation of
         the SI unit with which the differential (derivative) is taken. For
         example, for a velocity differential on a positional representation, the
-        key would be `'s'` for seconds, indicating that the derivative is a time
-        derivative.
+        key would be ``'s'`` for seconds, indicating that the derivative is a
+        time derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
@@ -1212,8 +1213,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
         dictionary of of differential instances with keys set to a string
         representation of the SI unit with which the differential (derivative)
         is taken. For example, for a velocity differential on a positional
-        representation, the key would be `'s'` for seconds, indicating that the
-        derivative is a time derivative.
+        representation, the key would be ``'s'`` for seconds, indicating that
+        the derivative is a time derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
@@ -1417,8 +1418,8 @@ class RadialRepresentation(BaseRepresentation):
         dictionary of of differential instances with keys set to a string
         representation of the SI unit with which the differential (derivative)
         is taken. For example, for a velocity differential on a positional
-        representation, the key would be `'s'` for seconds, indicating that the
-        derivative is a time derivative.
+        representation, the key would be ``'s'`` for seconds, indicating that
+        the derivative is a time derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
@@ -1503,8 +1504,8 @@ class SphericalRepresentation(BaseRepresentation):
         dictionary of of differential instances with keys set to a string
         representation of the SI unit with which the differential (derivative)
         is taken. For example, for a velocity differential on a positional
-        representation, the key would be `'s'` for seconds, indicating that the
-        derivative is a time derivative.
+        representation, the key would be ``'s'`` for seconds, indicating that
+        the derivative is a time derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
@@ -1658,7 +1659,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         differential instances with keys set to a string representation of the
         SI unit with which the differential (derivative) is taken. For example,
         for a velocity differential on a positional representation, the key
-        would be `'s'` for seconds, indicating that the derivative is a time
+        would be ``'s'`` for seconds, indicating that the derivative is a time
         derivative.
 
     copy : bool, optional
@@ -1817,7 +1818,8 @@ class CylindricalRepresentation(BaseRepresentation):
         instances with keys set to a string representation of the SI unit with
         which the differential (derivative) is taken. For example, for a
         velocity differential on a positional representation, the key would be
-        `'s'` for seconds, indicating that the derivative is a time derivative.
+        ``'s'`` for seconds, indicating that the derivative is a time
+        derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -191,8 +191,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
             if diff.shape != self.shape:
                 # TODO: message of IncompatibleShapeError is not customizable,
                 #       so use a valueerror instead?
-                raise ValueError("Shape of differentials must be broadcastable "
-                                 "to the shape of the representation ({0} vs "
+                raise ValueError("Shape of differentials must be the same "
+                                 "as the shape of the representation ({0} vs "
                                  "{1})".format(diff.shape, self.shape))
 
         # store as a private name so users know this is not settable

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -184,16 +184,16 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                                 "BaseDifferential subclass instances. Got '{0}'"
                                 .format(type(diff)))
 
-            # Also check that the diff shape is broadcastable to the
-            # shape of the parent representation, but don't explicitly do the
-            # broadcasting
-            try:
-                check_broadcast(self.shape, diff.shape)
-            except IncompatibleShapeError:
-                raise ValueError( # TODO: message of IncompatibleShapeError is not customizable
-                    "Shape of differentials must be broadcastable to the shape "
-                    "of the representation ({0} vs {1})"
-                    .format(diff.shape, self.shape))
+            # For now, we are very rigid: differentials must have the same shape
+            # as the representation. This makes it easier to handle __getitem__
+            # and any other shape-changing operations on representations that
+            # have associated differentials
+            if diff.shape != self.shape:
+                # TODO: message of IncompatibleShapeError is not customizable,
+                #       so use a valueerror instead?
+                raise ValueError("Shape of differentials must be broadcastable "
+                                 "to the shape of the representation ({0} vs "
+                                 "{1})".format(diff.shape, self.shape))
 
         # store as a private name so users know this is not settable
         self._differentials = tuple(differentials)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -392,11 +392,14 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         prefixstr = '    '
         arrstr = _array2string(self._values, prefix=prefixstr)
 
+        diffstr = ''
+        if hasattr(self, 'differentials') and self.differentials:
+            diffstr = '\n differentials={0}'.format(repr(self.differentials))
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
-        return '<{0} ({1}) {2:s}\n{3}{4}>'.format(
+        return '<{0} ({1}) {2:s}\n{3}{4}{5}>'.format(
             self.__class__.__name__, ', '.join(self.components),
-            unitstr, prefixstr, arrstr)
+            unitstr, prefixstr, arrstr, diffstr)
 
 
 def _make_getter(component):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -640,22 +640,31 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         finally:
             self._differentials = olddiffs
 
-    # We override these methods to support passing through differentials
-    # attached to a given representation
-    def to_cartesian(self):
+    def to_cartesian(self, diffstocart=False):
         """
-        Convert the representation to its Cartesian form.
+        Convert the representation to its carteisan form.
 
         Note that subclasses should *not* override this - rather they should
         override the ``_to_cartesian_helper()`` method.
 
+        Parameters
+        ----------
+        diffstocart : bool
+          If True, any differentials this representation has are *also*
+          converted to their cartesian form.
+
         Returns
         -------
         cartrepr : CartesianRepresentation
-            The representation in Cartesian form.
+          The representation in Cartesian form.
         """
         repr = self._to_cartesian_helper()
-        repr._differentials = self._differentials
+        if diffstocart:
+            repr._differentials = tuple([
+                diff.represent_as(CartesianDifferential, base=self)
+                for diff in self._differentials])
+        else:
+            repr._differentials = self._differentials
         return repr
 
     @classmethod

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -589,7 +589,12 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             A copy of this representation, but with the ``differentials`` as
             its differentials.
         """
+        # Implemented this way for (1) performance (skips going through the
+        # initializer), and (2) will preserve any additional attributes a user
+        # may have set
+
         new_differentials = self._validate_differentials(differentials)
+
         # save the differentials, then strip them so that the copy doesn't do
         # an unneeded copy, then re-attach them to the right objects
         olddiffs = self._differentials
@@ -597,6 +602,32 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             self._differentials = None
             newrepr = deepcopy(self)
             newrepr._differentials = new_differentials
+            return newrepr
+        finally:
+            self._differentials = olddiffs
+
+    def without_differentials(self):
+        """
+        Create a new representation with the same positions as this
+        representation, but without any differentials.
+
+        Returns
+        -------
+        newrepr
+            A copy of this representation, but without the ``differentials``.
+        """
+
+        # Again, implemented this way for (1) performance (skips going through
+        # the initializer), and (2) will preserve any additional attributes a
+        # user may have set
+
+        # save the differentials, then strip them so that the copy doesn't do
+        # an unneeded copy, then re-attach them to the right objects
+        olddiffs = self._differentials
+        try:
+            self._differentials = None
+            newrepr = deepcopy(self)
+            newrepr._differentials = ()
             return newrepr
         finally:
             self._differentials = olddiffs

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -444,6 +444,14 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
     comp1, comp2, comp3 : `~astropy.units.Quantity` or subclass
         The components of the 3D points.  The names are the keys and the
         subclasses the values of the ``attr_classes`` attribute.
+    differentials : dict, `BaseDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single `BaseDifferential`
+        subclass instance, or a dictionary with keys set to a string
+        representation of the SI unit with which the differential (derivative)
+        is taken. For example, for a velocity differential on a positional
+        representation, the key would be `'s'` for seconds, indicating that the
+        derivative is a time derivative.
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
 
@@ -534,7 +542,13 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
     @property
     def differentials(self):
-        """A dictionary of differential class instances"""
+        """A dictionary of differential class instances.
+
+        The keys of this dictionary must be a string representation of the SI
+        unit with which the differential (derivative) is taken. For example, for
+        a velocity differential on a positional representation, the key would be
+        `'s'` for seconds, indicating that the derivative is a time derivative.
+        """
         return self._differentials
 
     # We do not make unit_vectors and scale_factors abstract methods, since
@@ -928,6 +942,17 @@ class CartesianRepresentation(BaseRepresentation):
     xyz_axis : int, optional
         The axis along which the coordinates are stored when a single array is
         provided rather than distinct ``x``, ``y``, and ``z`` (default: 0).
+
+    differentials : dict, `CartesianDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single
+        `CartesianDifferential` instance, or a dictionary of
+        `CartesianDifferential` s with keys set to a string representation of
+        the SI unit with which the differential (derivative) is taken. For
+        example, for a velocity differential on a positional representation, the
+        key would be `'s'` for seconds, indicating that the derivative is a time
+        derivative.
+
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
     """
@@ -1180,6 +1205,16 @@ class UnitSphericalRepresentation(BaseRepresentation):
         instances of `~astropy.coordinates.Angle`,
         `~astropy.coordinates.Longitude`, or `~astropy.coordinates.Latitude`.
 
+    differentials : dict, `BaseDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single `BaseDifferential`
+        instance (see `._compatible_differentials` for valid types), or a
+        dictionary of of differential instances with keys set to a string
+        representation of the SI unit with which the differential (derivative)
+        is taken. For example, for a velocity differential on a positional
+        representation, the key would be `'s'` for seconds, indicating that the
+        derivative is a time derivative.
+
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
     """
@@ -1375,6 +1410,16 @@ class RadialRepresentation(BaseRepresentation):
     distance : `~astropy.units.Quantity`
         The distance of the point(s) from the origin.
 
+    differentials : dict, `BaseDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single `BaseDifferential`
+        instance (see `._compatible_differentials` for valid types), or a
+        dictionary of of differential instances with keys set to a string
+        representation of the SI unit with which the differential (derivative)
+        is taken. For example, for a velocity differential on a positional
+        representation, the key would be `'s'` for seconds, indicating that the
+        derivative is a time derivative.
+
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
     """
@@ -1450,6 +1495,16 @@ class SphericalRepresentation(BaseRepresentation):
         The distance to the point(s). If the distance is a length, it is
         passed to the :class:`~astropy.coordinates.Distance` class, otherwise
         it is passed to the :class:`~astropy.units.Quantity` class.
+
+    differentials : dict, `BaseDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single `BaseDifferential`
+        instance (see `._compatible_differentials` for valid types), or a
+        dictionary of of differential instances with keys set to a string
+        representation of the SI unit with which the differential (derivative)
+        is taken. For example, for a velocity differential on a positional
+        representation, the key would be `'s'` for seconds, indicating that the
+        derivative is a time derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
@@ -1595,6 +1650,16 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         The distance to the point(s). If the distance is a length, it is
         passed to the :class:`~astropy.coordinates.Distance` class, otherwise
         it is passed to the :class:`~astropy.units.Quantity` class.
+
+    differentials : dict, `PhysicsSphericalDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single
+        `PhysicsSphericalDifferential` instance, or a dictionary of of
+        differential instances with keys set to a string representation of the
+        SI unit with which the differential (derivative) is taken. For example,
+        for a velocity differential on a positional representation, the key
+        would be `'s'` for seconds, indicating that the derivative is a time
+        derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.
@@ -1744,6 +1809,15 @@ class CylindricalRepresentation(BaseRepresentation):
 
     z : `~astropy.units.Quantity`
         The z coordinate(s) of the point(s)
+
+    differentials : dict, `CylindricalDifferential`, optional
+        Any differential classes that should be associated with this
+        representation. The input must either be a single
+        `CylindricalDifferential` instance, or a dictionary of of differential
+        instances with keys set to a string representation of the SI unit with
+        which the differential (derivative) is taken. For example, for a
+        velocity differential on a positional representation, the key would be
+        `'s'` for seconds, indicating that the derivative is a time derivative.
 
     copy : bool, optional
         If `True` (default), arrays will be copied rather than referenced.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -11,7 +11,6 @@ import abc
 import functools
 import operator
 from collections import OrderedDict
-from copy import deepcopy
 import inspect
 
 import numpy as np
@@ -24,7 +23,6 @@ from ..utils import ShapedLikeNDArray, classproperty
 from ..utils.misc import InheritDocstrings
 from ..utils.compat import NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
-from ..utils.misc import isiterable, check_broadcast, IncompatibleShapeError
 
 __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
            "CartesianRepresentation", "SphericalRepresentation",

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -11,6 +11,7 @@ import abc
 import functools
 import operator
 from collections import OrderedDict
+from copy import deepcopy
 
 import numpy as np
 import astropy.units as u
@@ -552,6 +553,36 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 new_rep = other_class.from_cartesian(self.to_cartesian())
 
             return new_rep
+
+    def with_differentials(self, differentials):
+        """
+        Create a new representation with the same positions as this
+        representation, but with new differentials.
+
+        Parameters
+        ----------
+        differentials : Sequence of `~astropy.coordinates.BaseDifferential`
+            The differentials for the new representation to have.
+
+        Returns
+        -------
+        newrepr
+            A copy of this representation, but with the ``differentials`` as
+            its differentials.
+        """
+        # save the differentials, then strip them so that the copy doesn't do
+        # an unneeded copy, then re-attach them to the right objects
+        olddiffs = self._differentials
+        try:
+
+            self._differentials = None
+            newrepr = deepcopy(self)
+            newrepr._differentials = differentials
+            return newrepr
+        finally:
+            self._differentials = olddiffs
+
+
 
     @classmethod
     def from_representation(cls, representation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1907,7 +1907,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
             comp = getattr(base, name)
             d_comp = getattr(self, 'd_{0}'.format(name), None)
             if d_comp:
-                d_unit = d_comp.si.unit / comp.si.unit
+                d_unit = comp.si.unit / d_comp.si.unit
                 return str(d_unit)
 
     @classmethod

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -646,15 +646,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         finally:
             self._differentials = olddiffs
 
-    def to_cartesian(self, diffstocart=False):
+    def to_cartesian(self):
         """
-        Convert the representation to its Cartesian form.
-
-        Parameters
-        ----------
-        diffstocart : bool
-          If True, any differentials this representation has are *also*
-          converted to their cartesian form.
+        Convert the representation and any associated differentials to their Cartesian form.
 
         Returns
         -------
@@ -666,12 +660,13 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         # override the ``_to_cartesian_helper()`` method.
 
         repr = self._to_cartesian_helper()
-        if diffstocart:
-            repr._differentials = tuple([
-                diff.represent_as(CartesianDifferential, base=self)
-                for diff in self._differentials])
-        else:
-            repr._differentials = self._differentials
+
+        # The without_differentials() call is needed to protect against an infinite loop, since
+        # to_cartesian() gets called on the base when it's passed in to represent_as()
+        self_no_diffs = self.without_differentials()
+        repr._differentials = tuple([
+            diff.represent_as(CartesianDifferential, base=self_no_diffs)
+            for diff in self._differentials])
         return repr
 
     @classmethod

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -355,7 +355,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         diffstr = ''
         if getattr(self, 'differentials', None):
-            diffstr = '\n differentials={0}'.format(repr(self.differentials))
+            diffstr = '\n (has differentials)'
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
         return '<{0} ({1}) {2:s}\n{3}{4}{5}>'.format(

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -541,6 +541,10 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         else:
             # The default is to convert via cartesian coordinates
             if isiterable(other_class):
+                if isinstance(other_class, six.string_types):
+                    raise ValueError('Input to a representation\'s represent_as'
+                                     ' must be a class, not a string. For '
+                                     'strings, use frame objects')
                 if (self.differentials is None or
                         len(other_class) != 1+len(self.differentials)):
                     raise ValueError("If multiple classes are passed in to "

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -539,8 +539,12 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
         Parameters
         ----------
-        other_class : `~astropy.coordinates.BaseRepresentation` subclass
-            The type of representation to turn the coordinates into.
+        other_class : `~astropy.coordinates.BaseRepresentation` subclass, iterable
+            The type of representation to turn the coordinates into. If the
+            representation contains differential classes, the input may be an
+            iterable containing the desired classes for the representation and
+            each differential. That is, the iterable must be of length equal to
+            1 + the number of attached differentials.
         """
         if other_class is self.__class__:
             return self

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1134,7 +1134,7 @@ class TestCartesianRepresentationWithDifferential(object):
             rep = CartesianRepresentation(x=arr2, y=arr2, z=arr2,
                                           differentials=diff)
 
-        arr2 = np.arange(2).reshape(1,2) * u.kpc
+        arr2 = np.arange(8).reshape(4,2) * u.kpc
         rep = CartesianRepresentation(x=arr2, y=arr2, z=arr2,
                                       differentials=diff)
 
@@ -1144,8 +1144,7 @@ class TestCartesianRepresentationWithDifferential(object):
         assert len(rep.differentials) == 1
         assert rep.differentials[0] is diff
 
-        assert rep.xyz.shape != rep.differentials[0].d_xyz.shape
-        assert check_broadcast(rep.xyz.shape, rep.differentials[0].d_xyz.shape)
+        assert rep.xyz.shape == rep.differentials[0].d_xyz.shape
 
     def test_reprobj(self):
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1089,8 +1089,7 @@ class TestCartesianRepresentationWithDifferential(object):
                                      d_y=2 * u.km/u.s,
                                      d_z=3 * u.km/u.s)
 
-        # can pass in a single differential, which gets turned into a
-        #   length-1 tuple
+        # Check that a single differential gets turned into a 1-item dict.
         s1 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc,
                                      differentials=diff)
 
@@ -1182,7 +1181,6 @@ class TestCartesianRepresentationWithDifferential(object):
 
         r2 = CartesianRepresentation.from_representation(r1)
         assert r2.get_name() == 'cartesian'
-        # assert r2.differentials['s'].get_name() == 'cartesian'
         assert not r2.differentials
 
     def test_readonly(self):
@@ -1305,8 +1303,7 @@ class TestCartesianRepresentationWithDifferential(object):
 
 def test_to_cartesian():
     """
-    Test that to_cartesian does the expected thing (converts both the
-    representation and differentials)
+    Test that to_cartesian drops the differential.
     """
     sd = SphericalDifferential(d_lat=1*u.deg, d_lon=2*u.deg, d_distance=10*u.m)
     sr = SphericalRepresentation(lat=1*u.deg, lon=2*u.deg, distance=10*u.m,

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1235,18 +1235,21 @@ class TestCartesianRepresentationWithDifferential(object):
         assert_allclose_quantity(s_dif.d_z, [1, 1, 1] * u.m/u.s)
 
     def test_transform(self):
-        d = CartesianDifferential(d_x=[1, 2] * u.km/u.s,
-                                  d_y=[3, 4] * u.km/u.s,
-                                  d_z=[5, 6] * u.km/u.s)
-        s1 = CartesianRepresentation(x=[1,2] * u.kpc,
+        d1 = CartesianDifferential(d_x=[1, 2] * u.km/u.s,
+                                   d_y=[3, 4] * u.km/u.s,
+                                   d_z=[5, 6] * u.km/u.s)
+        r1 = CartesianRepresentation(x=[1,2] * u.kpc,
                                      y=[3,4] * u.kpc,
                                      z=[5,6] * u.kpc,
-                                     differentials=d)
+                                     differentials=d1)
 
         matrix = np.array([[1,2,3], [4,5,6], [7,8,9]])
 
-        with pytest.raises(TypeError):
-            s1.transform(matrix)
+        r2 = r1.transform(matrix)
+        d2 = r2.differentials[0]
+        assert_allclose_quantity(d2.d_x, [22., 28]*u.km/u.s)
+        assert_allclose_quantity(d2.d_y, [49, 64]*u.km/u.s)
+        assert_allclose_quantity(d2.d_z, [76, 100.]*u.km/u.s)
 
     def test_with_differentials(self):
         # make sure with_differential correctly creates a new copy with the same

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1145,6 +1145,16 @@ class TestCartesianRepresentationWithDifferential(object):
                                      distance=1*u.pc,
                                      differentials=diff)
 
+    def test_init_differential_multiple_equivalent_keys(self):
+        d1 = CartesianDifferential(*[1,2,3] * u.km/u.s)
+        d2 = CartesianDifferential(*[4,5,6] * u.km/u.s)
+
+        # verify that the check against expected_unit validates against passing
+        # in two different but equivalent keys
+        with pytest.raises(ValueError):
+            r1 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc,
+                                         differentials={'s': d1, 'yr': d2})
+
     def test_init_array_broadcasting(self):
 
         arr1 = np.arange(8).reshape(4,2) * u.km/u.s

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1249,3 +1249,24 @@ class TestCartesianRepresentationWithDifferential(object):
 
         # make sure the differentials were dropped
         assert s2.differentials == ()
+
+    def test_with_differentials(self):
+        # make sure with_differential correctly creates a new copy with the same
+        # differential
+        cr = CartesianRepresentation([1, 2, 3]*u.kpc)
+        diff = CartesianDifferential([.1, .2, .3]*u.km/u.s)
+        cr2 = cr.with_differentials((diff,))
+        assert cr.differentials != cr2.differentials
+        assert cr2.differentials[0] is diff
+
+        # make sure its a copy and not a view
+        assert cr.x == cr2.x
+        cr2.x.ravel()[:] = 10*u.kpc
+        assert cr.x != cr2.x
+
+        # make sure it works even if a differential is present already
+        diff2 = CartesianDifferential([.1, .2, .3]*u.m/u.s)
+        cr3 = CartesianRepresentation([1, 2, 3]*u.kpc, differentials=diff)
+        cr4 = cr3.with_differentials((diff2,))
+        assert cr4.differentials[0] != cr3.differentials[0]
+        assert cr4.differentials[0] == diff2

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1315,11 +1315,6 @@ class TestCartesianRepresentationWithDifferential(object):
         assert cr.differentials != cr2.differentials
         assert cr2.differentials['s'] is diff
 
-        # make sure its a copy and not a view
-        assert cr.x == cr2.x
-        cr2.x.ravel()[:] = 10*u.kpc
-        assert cr.x != cr2.x
-
         # make sure it works even if a differential is present already
         diff2 = CartesianDifferential([.1, .2, .3]*u.m/u.s)
         cr3 = CartesianRepresentation([1, 2, 3]*u.kpc, differentials=diff)
@@ -1331,6 +1326,17 @@ class TestCartesianRepresentationWithDifferential(object):
         cr5 = cr.with_differentials(diff)
         assert len(cr5.differentials) == 1
         assert cr5.differentials['s'] == diff
+
+        # make sure we don't update the original representation's dict
+        d1 = CartesianDifferential(*np.random.random((3, 5)), unit=u.km/u.s)
+        d2 = CartesianDifferential(*np.random.random((3, 5)), unit=u.km/u.s**2)
+        r1 = CartesianRepresentation(*np.random.random((3, 5)), unit=u.pc,
+                                     differentials=d1)
+
+        r2 = r1.with_differentials(d2)
+        assert r1.differentials['s'] is r2.differentials['s']
+        assert 's2' not in r1.differentials
+        assert 's2' in r2.differentials
 
 def test_to_cartesian():
     """

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1198,6 +1198,14 @@ class TestCartesianRepresentationWithDifferential(object):
                                          CylindricalDifferential,
                                          CylindricalDifferential])
 
+        # make sure all of the to_cartesian() and from_cartesian() methods
+        # pass through the differentials
+        for name in REPRESENTATION_CLASSES:
+            new_rep = rep1.represent_as(REPRESENTATION_CLASSES[name])
+            assert new_rep.get_name() == REPRESENTATION_CLASSES[name].get_name()
+            assert len(new_rep.differentials) == 1
+            assert new_rep.differentials[0] == diff
+
     # ---
 
     def test_getitem(self):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1205,32 +1205,35 @@ class TestCartesianRepresentationWithDifferential(object):
             assert len(new_rep.differentials) == 1
             assert new_rep.differentials[0] == diff
 
-    # ---
-
     def test_getitem(self):
 
+        d = CartesianDifferential(d_x=np.arange(10) * u.m/u.s,
+                                  d_y=-np.arange(10) * u.m/u.s,
+                                  d_z=1. * u.m/u.s)
         s = CartesianRepresentation(x=np.arange(10) * u.m,
                                     y=-np.arange(10) * u.m,
-                                    z=3 * u.km)
+                                    z=3 * u.km,
+                                    differentials=d)
 
         s_slc = s[2:8:2]
+        s_dif = s_slc.differentials[0]
 
         assert_allclose_quantity(s_slc.x, [2, 4, 6] * u.m)
         assert_allclose_quantity(s_slc.y, [-2, -4, -6] * u.m)
         assert_allclose_quantity(s_slc.z, [3, 3, 3] * u.km)
 
-    def test_getitem_scalar(self):
-
-        s = CartesianRepresentation(x=1 * u.m,
-                                    y=-2 * u.m,
-                                    z=3 * u.km)
-
-        with pytest.raises(TypeError):
-            s_slc = s[0]
+        assert_allclose_quantity(s_dif.d_x, [2, 4, 6] * u.m/u.s)
+        assert_allclose_quantity(s_dif.d_y, [-2, -4, -6] * u.m/u.s)
+        assert_allclose_quantity(s_dif.d_z, [1, 1, 1] * u.m/u.s)
 
     def test_transform(self):
-
-        s1 = CartesianRepresentation(x=[1,2] * u.kpc, y=[3,4] * u.kpc, z=[5,6] * u.kpc)
+        d = CartesianDifferential(d_x=[1, 2] * u.km/u.s,
+                                  d_y=[3, 4] * u.km/u.s,
+                                  d_z=[5, 6] * u.km/u.s)
+        s1 = CartesianRepresentation(x=[1,2] * u.kpc,
+                                     y=[3,4] * u.kpc,
+                                     z=[5,6] * u.kpc,
+                                     differentials=d)
 
         matrix = np.array([[1,2,3], [4,5,6], [7,8,9]])
 
@@ -1243,3 +1246,6 @@ class TestCartesianRepresentationWithDifferential(object):
         assert s2.x.unit is u.kpc
         assert s2.y.unit is u.kpc
         assert s2.z.unit is u.kpc
+
+        # make sure the differentials were dropped
+        assert s2.differentials == ()

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1276,18 +1276,14 @@ class TestCartesianRepresentationWithDifferential(object):
 
 def test_to_cartesian():
     """
-    Test that to_cartesian does the expected thing in both the with and without
-    differential cases.
+    Test that to_cartesian does the expected thing (converts both the
+    representation and differentials)
     """
     sd = SphericalDifferential(d_lat=1*u.deg, d_lon=2*u.deg, d_distance=10*u.m)
     sr = SphericalRepresentation(lat=1*u.deg, lon=2*u.deg, distance=10*u.m,
                                  differentials=[sd])
 
-    notdiff = sr.to_cartesian(diffstocart=False)
-    diff = sr.to_cartesian(diffstocart=True)
-
-    assert notdiff.get_name() == 'cartesian'
-    assert notdiff.differentials[0].get_name() == 'spherical'
+    diff = sr.to_cartesian()
 
     assert diff.get_name() == 'cartesian'
     assert diff.differentials[0].get_name() == 'cartesian'

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1217,7 +1217,8 @@ class TestCartesianRepresentationWithDifferential(object):
 
         r2 = CartesianRepresentation.from_representation(r1)
         assert r2.get_name() == 'cartesian'
-        assert r2.differentials['s'].get_name() == 'cartesian'
+        # assert r2.differentials['s'].get_name() == 'cartesian'
+        assert not r2.differentials
 
     def test_readonly(self):
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1244,18 +1244,8 @@ class TestCartesianRepresentationWithDifferential(object):
 
         matrix = np.array([[1,2,3], [4,5,6], [7,8,9]])
 
-        s2 = s1.transform(matrix)
-
-        assert_allclose(s2.x.value, [1 * 1 + 2 * 3 + 3 * 5, 1 * 2 + 2 * 4 + 3 * 6])
-        assert_allclose(s2.y.value, [4 * 1 + 5 * 3 + 6 * 5, 4 * 2 + 5 * 4 + 6 * 6])
-        assert_allclose(s2.z.value, [7 * 1 + 8 * 3 + 9 * 5, 7 * 2 + 8 * 4 + 9 * 6])
-
-        assert s2.x.unit is u.kpc
-        assert s2.y.unit is u.kpc
-        assert s2.z.unit is u.kpc
-
-        # make sure the differentials were dropped
-        assert s2.differentials == ()
+        with pytest.raises(TypeError):
+            s1.transform(matrix)
 
     def test_with_differentials(self):
         # make sure with_differential correctly creates a new copy with the same

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1270,3 +1270,8 @@ class TestCartesianRepresentationWithDifferential(object):
         cr4 = cr3.with_differentials((diff2,))
         assert cr4.differentials[0] != cr3.differentials[0]
         assert cr4.differentials[0] == diff2
+
+        # also ensure a *scalar* differential will works
+        cr5 = cr.with_differentials(diff)
+        assert len(cr5.differentials) == 1
+        assert cr5.differentials[0] == diff

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -24,6 +24,7 @@ from ..representation import (REPRESENTATION_CLASSES,
                               CylindricalRepresentation,
                               PhysicsSphericalRepresentation,
                               CartesianDifferential,
+                              SphericalDifferential,
                               CylindricalDifferential,
                               _combine_xyz)
 
@@ -1272,3 +1273,21 @@ class TestCartesianRepresentationWithDifferential(object):
         cr5 = cr.with_differentials(diff)
         assert len(cr5.differentials) == 1
         assert cr5.differentials[0] == diff
+
+def test_to_cartesian():
+    """
+    Test that to_cartesian does the expected thing in both the with and without
+    differential cases.
+    """
+    sd = SphericalDifferential(d_lat=1*u.deg, d_lon=2*u.deg, d_distance=10*u.m)
+    sr = SphericalRepresentation(lat=1*u.deg, lon=2*u.deg, distance=10*u.m,
+                                 differentials=[sd])
+
+    notdiff = sr.to_cartesian(diffstocart=False)
+    diff = sr.to_cartesian(diffstocart=True)
+
+    assert notdiff.get_name() == 'cartesian'
+    assert notdiff.differentials[0].get_name() == 'spherical'
+
+    assert diff.get_name() == 'cartesian'
+    assert diff.differentials[0].get_name() == 'cartesian'

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1001,22 +1001,20 @@ def test_minimal_subclass():
                                     ('lat', Latitude),
                                     ('logd', u.Dex)])
 
-        def to_cartesian(self):
+        def _to_cartesian_helper(self):
             d = self.logd.physical
             x = d * np.cos(self.lat) * np.cos(self.lon)
             y = d * np.cos(self.lat) * np.sin(self.lon)
             z = d * np.sin(self.lat)
-            return CartesianRepresentation(x=x, y=y, z=z, copy=False,
-                                           differentials=self.differentials)
+            return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
         @classmethod
-        def from_cartesian(cls, cart):
+        def _from_cartesian_helper(cls, cart):
             s = np.hypot(cart.x, cart.y)
             r = np.hypot(s, cart.z)
             lon = np.arctan2(cart.y, cart.x)
             lat = np.arctan2(cart.z, s)
-            return cls(lon=lon, lat=lat, logd=u.Dex(r), copy=False,
-                       differentials=cart.differentials)
+            return cls(lon=lon, lat=lat, logd=u.Dex(r), copy=False)
 
     ld1 = LogDRepresentation(90.*u.deg, 0.*u.deg, 1.*u.dex(u.kpc))
     ld2 = LogDRepresentation(lon=90.*u.deg, lat=0.*u.deg, logd=1.*u.dex(u.kpc))

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1123,6 +1123,11 @@ class TestCartesianRepresentationWithDifferential(object):
             CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc,
                                     differentials='garmonbozia')
 
+        # make sure differentials can't accept differentials
+        with pytest.raises(TypeError):
+            CartesianDifferential(d_x=1 * u.km/u.s, d_y=2 * u.km/u.s,
+                                  d_z=3 * u.km/u.s, differentials=diff)
+
     def test_init_array_broadcasting(self):
 
         arr1 = np.arange(8).reshape(4,2) * u.km/u.s

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1021,31 +1021,6 @@ def test_minimal_subclass():
             lat = np.arctan2(cart.z, s)
             return cls(lon=lon, lat=lat, logd=u.Dex(r), copy=False)
 
-        def unit_vectors(self):
-            sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
-            sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
-            d = self.logd.physical
-            return OrderedDict(
-                (('lon', CartesianRepresentation(-sinlon, coslon, 0., copy=False)),
-                 ('lat', CartesianRepresentation(-sinlat*coslon, -sinlat*sinlon,
-                                                 coslat, copy=False)),
-                 ('logd', CartesianRepresentation(d*coslat*coslon,
-                                                  d*coslat*sinlon,
-                                                  d*sinlat,
-                                                  copy=False))))
-
-        def scale_factors(self, omit_coslat=False):
-            d = self.logd.physical
-            sf_lat = d / u.radian
-            sf_lon = sf_lat if omit_coslat else sf_lat * np.cos(self.lat)
-            sf_logd = d / u.Dex
-            return OrderedDict((('lon', sf_lon),
-                                ('lat', sf_lat),
-                                ('logd', sf_logd)))
-
-    class LogDDifferential(BaseDifferential):
-        base_representation = LogDRepresentation
-
     ld1 = LogDRepresentation(90.*u.deg, 0.*u.deg, 1.*u.dex(u.kpc))
     ld2 = LogDRepresentation(lon=90.*u.deg, lat=0.*u.deg, logd=1.*u.dex(u.kpc))
     assert np.all(ld1.lon==ld2.lon)
@@ -1077,16 +1052,6 @@ def test_minimal_subclass():
             attr_classes = OrderedDict([('lon', Longitude),
                                         ('lat', Latitude),
                                         ('logr', u.Dex)])
-
-    # now try passing in a differential
-    diff = LogDDifferential(d_logd=1 * u.dex(u.kpc),
-                            d_lon=2 * u.rad,
-                            d_lat=3 * u.rad)
-    ld = LogDRepresentation(90.*u.deg, 0.*u.deg, 1.*u.dex(u.kpc),
-                            differentials=diff)
-    assert ld.differentials[''] == diff
-    ld2 = ld.represent_as(CartesianRepresentation, CartesianDifferential)
-    assert ld2.differentials[''].get_name() == 'cartesian'
 
 def test_combine_xyz():
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1205,6 +1205,10 @@ class TestCartesianRepresentationWithDifferential(object):
             assert len(new_rep.differentials) == 1
             assert new_rep.differentials[0] == diff
 
+        with pytest.raises(ValueError) as excinfo:
+            rep1.represent_as('name')
+        assert 'use frame object' in str(excinfo.value)
+
     def test_getitem(self):
 
         d = CartesianDifferential(d_x=np.arange(10) * u.m/u.s,

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -1189,3 +1189,36 @@ class TestDifferentialConversion():
         so5c = sd_cls(0*u.deg, 0.*u.deg, ro.d_distance)
         assert np.all(representation_equal(so5, so5c))
         assert_representation_allclose(self.s + (uo+ro), self.s+so1)
+
+@pytest.mark.parametrize('rep', [
+    CartesianRepresentation([1, 2, 3]*u.kpc),
+    SphericalRepresentation(90*u.deg, 0.*u.deg, 14.*u.kpc)
+])
+@pytest.mark.parametrize('dif', [
+    CartesianDifferential([.1, .2, .3]*u.km/u.s),
+    SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+])
+def test_arithmetic_with_differentials_fail(rep, dif):
+
+    rep = rep.with_differentials(dif)
+
+    with pytest.raises(TypeError):
+        rep + rep
+
+    with pytest.raises(TypeError):
+        rep - rep
+
+    with pytest.raises(TypeError):
+        rep * rep
+
+    with pytest.raises(TypeError):
+        rep / rep
+
+    with pytest.raises(TypeError):
+        10. * rep
+
+    with pytest.raises(TypeError):
+        rep / 10.
+
+    with pytest.raises(TypeError):
+        -rep

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -1190,13 +1190,11 @@ class TestDifferentialConversion():
         assert np.all(representation_equal(so5, so5c))
         assert_representation_allclose(self.s + (uo+ro), self.s+so1)
 
-@pytest.mark.parametrize('rep', [
-    CartesianRepresentation([1, 2, 3]*u.kpc),
-    SphericalRepresentation(90*u.deg, 0.*u.deg, 14.*u.kpc)
-])
-@pytest.mark.parametrize('dif', [
-    CartesianDifferential([.1, .2, .3]*u.km/u.s),
-    SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+@pytest.mark.parametrize('rep,dif', [
+    [CartesianRepresentation([1, 2, 3]*u.kpc),
+     CartesianDifferential([.1, .2, .3]*u.km/u.s)],
+    [SphericalRepresentation(90*u.deg, 0.*u.deg, 14.*u.kpc),
+     SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)]
 ])
 def test_arithmetic_with_differentials_fail(rep, dif):
 

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ... import units as u
 from .. import (SphericalRepresentation, Longitude, Latitude,
-                CartesianDifferential)
+                SphericalDifferential)
 from ...utils.compat.numpy import broadcast_to as np_broadcast_to
 
 
@@ -23,14 +23,17 @@ class TestManipulation():
         lon = Longitude(np.arange(0, 24, 4), u.hourangle)
         lat = Latitude(np.arange(-90, 91, 30), u.deg)
 
-        self.diff = CartesianDifferential(np.ones((3,) + lon.shape + lat.shape)*u.km/u.s)
-
         # With same-sized arrays
         self.s0 = SphericalRepresentation(
             lon[:, np.newaxis] * np.ones(lat.shape),
             lat * np.ones(lon.shape)[:, np.newaxis],
-            np.ones(lon.shape + lat.shape) * u.kpc,
-            differentials=self.diff)
+            np.ones(lon.shape + lat.shape) * u.kpc)
+
+        self.diff = SphericalDifferential(
+            d_lon=np.ones(self.s0.shape)*u.mas/u.yr,
+            d_lat=np.ones(self.s0.shape)*u.mas/u.yr,
+            d_distance=np.ones(self.s0.shape)*u.km/u.s)
+        self.s0 = self.s0.with_differentials(self.diff)
 
         # With unequal arrays -> these will be broadcasted.
         self.s1 = SphericalRepresentation(lon[:, np.newaxis], lat, 1. * u.kpc,
@@ -47,38 +50,38 @@ class TestManipulation():
         assert np.may_share_memory(s0_ravel.lon, self.s0.lon)
         assert np.may_share_memory(s0_ravel.lat, self.s0.lat)
         assert np.may_share_memory(s0_ravel.distance, self.s0.distance)
-        assert s0_ravel.differentials[0].shape == (self.s0.size,)
+        assert s0_ravel.differentials['s'].shape == (self.s0.size,)
 
         # Since s1 was broadcast, ravel needs to make a copy.
         s1_ravel = self.s1.ravel()
         assert type(s1_ravel) is type(self.s1)
         assert s1_ravel.shape == (self.s1.size,)
-        assert s1_ravel.differentials[0].shape == (self.s1.size,)
+        assert s1_ravel.differentials['s'].shape == (self.s1.size,)
         assert np.all(s1_ravel.lon == self.s1.lon.ravel())
         assert not np.may_share_memory(s1_ravel.lat, self.s1.lat)
 
     def test_copy(self):
         s0_copy = self.s0.copy()
-        s0_copy_diff = s0_copy.differentials[0]
+        s0_copy_diff = s0_copy.differentials['s']
         assert s0_copy.shape == self.s0.shape
         assert np.all(s0_copy.lon == self.s0.lon)
         assert np.all(s0_copy.lat == self.s0.lat)
 
         # Check copy was made of internal data.
         assert not np.may_share_memory(s0_copy.distance, self.s0.distance)
-        assert not np.may_share_memory(s0_copy_diff.d_x, self.diff.d_x)
+        assert not np.may_share_memory(s0_copy_diff.d_lon, self.diff.d_lon)
 
     def test_flatten(self):
         s0_flatten = self.s0.flatten()
-        s0_diff = s0_flatten.differentials[0]
+        s0_diff = s0_flatten.differentials['s']
         assert s0_flatten.shape == (self.s0.size,)
         assert s0_diff.shape == (self.s0.size,)
         assert np.all(s0_flatten.lon == self.s0.lon.flatten())
-        assert np.all(s0_diff.d_x == self.diff.d_x.flatten())
+        assert np.all(s0_diff.d_lon == self.diff.d_lon.flatten())
 
         # Flatten always copies.
         assert not np.may_share_memory(s0_flatten.distance, self.s0.distance)
-        assert not np.may_share_memory(s0_diff.d_x, self.diff.d_x)
+        assert not np.may_share_memory(s0_diff.d_lon, self.diff.d_lon)
 
         s1_flatten = self.s1.flatten()
         assert s1_flatten.shape == (self.s1.size,)
@@ -87,22 +90,22 @@ class TestManipulation():
 
     def test_transpose(self):
         s0_transpose = self.s0.transpose()
-        s0_diff = s0_transpose.differentials[0]
+        s0_diff = s0_transpose.differentials['s']
         assert s0_transpose.shape == (7, 6)
         assert s0_diff.shape == s0_transpose.shape
         assert np.all(s0_transpose.lon == self.s0.lon.transpose())
-        assert np.all(s0_diff.d_x == self.diff.d_x.transpose())
+        assert np.all(s0_diff.d_lon == self.diff.d_lon.transpose())
         assert np.may_share_memory(s0_transpose.distance, self.s0.distance)
-        assert np.may_share_memory(s0_diff.d_x, self.diff.d_x)
+        assert np.may_share_memory(s0_diff.d_lon, self.diff.d_lon)
 
         s1_transpose = self.s1.transpose()
-        s1_diff = s1_transpose.differentials[0]
+        s1_diff = s1_transpose.differentials['s']
         assert s1_transpose.shape == (7, 6)
         assert s1_diff.shape == s1_transpose.shape
         assert np.all(s1_transpose.lat == self.s1.lat.transpose())
-        assert np.all(s1_diff.d_x == self.diff.d_x.transpose())
+        assert np.all(s1_diff.d_lon == self.diff.d_lon.transpose())
         assert np.may_share_memory(s1_transpose.lat, self.s1.lat)
-        assert np.may_share_memory(s1_diff.d_x, self.diff.d_x)
+        assert np.may_share_memory(s1_diff.d_lon, self.diff.d_lon)
 
         # Only one check on T, since it just calls transpose anyway.
         # Doing it on the CartesianRepresentation just for variety's sake.
@@ -113,27 +116,27 @@ class TestManipulation():
 
     def test_diagonal(self):
         s0_diagonal = self.s0.diagonal()
-        s0_diff = s0_diagonal.differentials[0]
+        s0_diff = s0_diagonal.differentials['s']
         assert s0_diagonal.shape == (6,)
         assert s0_diff.shape == s0_diagonal.shape
         assert np.all(s0_diagonal.lat == self.s0.lat.diagonal())
-        assert np.all(s0_diff.d_x == self.diff.d_x.diagonal())
+        assert np.all(s0_diff.d_lon == self.diff.d_lon.diagonal())
         assert np.may_share_memory(s0_diagonal.lat, self.s0.lat)
-        assert np.may_share_memory(s0_diff.d_x, self.diff.d_x)
+        assert np.may_share_memory(s0_diff.d_lon, self.diff.d_lon)
 
     def test_swapaxes(self):
         s1_swapaxes = self.s1.swapaxes(0, 1)
-        s1_diff = s1_swapaxes.differentials[0]
+        s1_diff = s1_swapaxes.differentials['s']
         assert s1_swapaxes.shape == (7, 6)
         assert s1_diff.shape == s1_swapaxes.shape
         assert np.all(s1_swapaxes.lat == self.s1.lat.swapaxes(0, 1))
-        assert np.all(s1_diff.d_x == self.diff.d_x.swapaxes(0, 1))
+        assert np.all(s1_diff.d_lon == self.diff.d_lon.swapaxes(0, 1))
         assert np.may_share_memory(s1_swapaxes.lat, self.s1.lat)
-        assert np.may_share_memory(s1_diff.d_x, self.diff.d_x)
+        assert np.may_share_memory(s1_diff.d_lon, self.diff.d_lon)
 
     def test_reshape(self):
         s0_reshape = self.s0.reshape(2, 3, 7)
-        s0_diff = s0_reshape.differentials[0]
+        s0_diff = s0_reshape.differentials['s']
         assert s0_reshape.shape == (2, 3, 7)
         assert s0_diff.shape == s0_reshape.shape
         assert np.all(s0_reshape.lon == self.s0.lon.reshape(2, 3, 7))
@@ -144,13 +147,13 @@ class TestManipulation():
         assert np.may_share_memory(s0_reshape.distance, self.s0.distance)
 
         s1_reshape = self.s1.reshape(3, 2, 7)
-        s1_diff = s1_reshape.differentials[0]
+        s1_diff = s1_reshape.differentials['s']
         assert s1_reshape.shape == (3, 2, 7)
         assert s1_diff.shape == s1_reshape.shape
         assert np.all(s1_reshape.lat == self.s1.lat.reshape(3, 2, 7))
-        assert np.all(s1_diff.d_x == self.diff.d_x.reshape(3, 2, 7))
+        assert np.all(s1_diff.d_lon == self.diff.d_lon.reshape(3, 2, 7))
         assert np.may_share_memory(s1_reshape.lat, self.s1.lat)
-        assert np.may_share_memory(s1_diff.d_x, self.diff.d_x)
+        assert np.may_share_memory(s1_diff.d_lon, self.diff.d_lon)
 
         # For reshape(3, 14), copying is necessary for lon, lat, but not for d
         s1_reshape2 = self.s1.reshape(3, 14)
@@ -169,9 +172,9 @@ class TestManipulation():
         assert self.s0.lat.shape == (2, 3, 7)
         assert self.s0.distance.shape == (2, 3, 7)
         assert self.diff.shape == (2, 3, 7)
-        assert self.diff.d_x.shape == (2, 3, 7)
-        assert self.diff.d_y.shape == (2, 3, 7)
-        assert self.diff.d_z.shape == (2, 3, 7)
+        assert self.diff.d_lon.shape == (2, 3, 7)
+        assert self.diff.d_lat.shape == (2, 3, 7)
+        assert self.diff.d_distance.shape == (2, 3, 7)
 
         # this works with the broadcasting.
         self.s1.shape = (2, 3, 7)
@@ -208,33 +211,33 @@ class TestManipulation():
 
     def test_squeeze(self):
         s0_squeeze = self.s0.reshape(3, 1, 2, 1, 7).squeeze()
-        s0_diff = s0_squeeze.differentials[0]
+        s0_diff = s0_squeeze.differentials['s']
         assert s0_squeeze.shape == (3, 2, 7)
         assert s0_diff.shape == s0_squeeze.shape
         assert np.all(s0_squeeze.lat == self.s0.lat.reshape(3, 2, 7))
-        assert np.all(s0_diff.d_x == self.diff.d_x.reshape(3, 2, 7))
+        assert np.all(s0_diff.d_lon == self.diff.d_lon.reshape(3, 2, 7))
         assert np.may_share_memory(s0_squeeze.lat, self.s0.lat)
 
     def test_add_dimension(self):
         s0_adddim = self.s0[:, np.newaxis, :]
-        s0_diff = s0_adddim.differentials[0]
+        s0_diff = s0_adddim.differentials['s']
         assert s0_adddim.shape == (6, 1, 7)
         assert s0_diff.shape == s0_adddim.shape
         assert np.all(s0_adddim.lon == self.s0.lon[:, np.newaxis, :])
-        assert np.all(s0_diff.d_x == self.diff.d_x[:, np.newaxis, :])
+        assert np.all(s0_diff.d_lon == self.diff.d_lon[:, np.newaxis, :])
         assert np.may_share_memory(s0_adddim.lat, self.s0.lat)
 
     def test_take(self):
         s0_take = self.s0.take((5, 2))
-        s0_diff = s0_take.differentials[0]
+        s0_diff = s0_take.differentials['s']
         assert s0_take.shape == (2,)
         assert s0_diff.shape == s0_take.shape
         assert np.all(s0_take.lon == self.s0.lon.take((5, 2)))
-        assert np.all(s0_diff.d_x == self.diff.d_x.take((5, 2)))
+        assert np.all(s0_diff.d_lon == self.diff.d_lon.take((5, 2)))
 
     def test_broadcast_to(self):
         s0_broadcast = self.s0._apply(np_broadcast_to, (3, 6, 7), subok=True)
-        s0_diff = s0_broadcast.differentials[0]
+        s0_diff = s0_broadcast.differentials['s']
         assert type(s0_broadcast) is type(self.s0)
         assert s0_broadcast.shape == (3, 6, 7)
         assert s0_diff.shape == s0_broadcast.shape
@@ -247,7 +250,7 @@ class TestManipulation():
 
         s1_broadcast = self.s1._apply(np_broadcast_to, shape=(3, 6, 7),
                                       subok=True)
-        s1_diff = s1_broadcast.differentials[0]
+        s1_diff = s1_broadcast.differentials['s']
         assert s1_broadcast.shape == (3, 6, 7)
         assert s1_diff.shape == s1_broadcast.shape
         assert np.all(s1_broadcast.lat == self.s1.lat)

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -6,7 +6,8 @@ import pytest
 import numpy as np
 
 from ... import units as u
-from .. import SphericalRepresentation, Longitude, Latitude
+from .. import (SphericalRepresentation, Longitude, Latitude,
+                CartesianDifferential)
 from ...utils.compat.numpy import broadcast_to as np_broadcast_to
 
 
@@ -21,13 +22,20 @@ class TestManipulation():
     def setup(self):
         lon = Longitude(np.arange(0, 24, 4), u.hourangle)
         lat = Latitude(np.arange(-90, 91, 30), u.deg)
+
+        self.diff = CartesianDifferential(np.ones((3,) + lon.shape + lat.shape)*u.km/u.s)
+
         # With same-sized arrays
         self.s0 = SphericalRepresentation(
             lon[:, np.newaxis] * np.ones(lat.shape),
             lat * np.ones(lon.shape)[:, np.newaxis],
-            np.ones(lon.shape + lat.shape) * u.kpc)
-        # With unequal arrays -> these will be broadcast.
-        self.s1 = SphericalRepresentation(lon[:, np.newaxis], lat, 1. * u.kpc)
+            np.ones(lon.shape + lat.shape) * u.kpc,
+            differentials=self.diff)
+
+        # With unequal arrays -> these will be broadcasted.
+        self.s1 = SphericalRepresentation(lon[:, np.newaxis], lat, 1. * u.kpc,
+                                          differentials=self.diff)
+
         # For completeness on some tests, also a cartesian one
         self.c0 = self.s0.to_cartesian()
 
@@ -39,27 +47,39 @@ class TestManipulation():
         assert np.may_share_memory(s0_ravel.lon, self.s0.lon)
         assert np.may_share_memory(s0_ravel.lat, self.s0.lat)
         assert np.may_share_memory(s0_ravel.distance, self.s0.distance)
+        assert s0_ravel.differentials[0].shape == (self.s0.size,)
+
         # Since s1 was broadcast, ravel needs to make a copy.
         s1_ravel = self.s1.ravel()
         assert type(s1_ravel) is type(self.s1)
         assert s1_ravel.shape == (self.s1.size,)
+        assert s1_ravel.differentials[0].shape == (self.s1.size,)
         assert np.all(s1_ravel.lon == self.s1.lon.ravel())
         assert not np.may_share_memory(s1_ravel.lat, self.s1.lat)
 
     def test_copy(self):
         s0_copy = self.s0.copy()
+        s0_copy_diff = s0_copy.differentials[0]
         assert s0_copy.shape == self.s0.shape
         assert np.all(s0_copy.lon == self.s0.lon)
         assert np.all(s0_copy.lat == self.s0.lat)
+
         # Check copy was made of internal data.
         assert not np.may_share_memory(s0_copy.distance, self.s0.distance)
+        assert not np.may_share_memory(s0_copy_diff.d_x, self.diff.d_x)
 
     def test_flatten(self):
         s0_flatten = self.s0.flatten()
+        s0_diff = s0_flatten.differentials[0]
         assert s0_flatten.shape == (self.s0.size,)
+        assert s0_diff.shape == (self.s0.size,)
         assert np.all(s0_flatten.lon == self.s0.lon.flatten())
+        assert np.all(s0_diff.d_x == self.diff.d_x.flatten())
+
         # Flatten always copies.
         assert not np.may_share_memory(s0_flatten.distance, self.s0.distance)
+        assert not np.may_share_memory(s0_diff.d_x, self.diff.d_x)
+
         s1_flatten = self.s1.flatten()
         assert s1_flatten.shape == (self.s1.size,)
         assert np.all(s1_flatten.lon == self.s1.lon.flatten())
@@ -67,13 +87,23 @@ class TestManipulation():
 
     def test_transpose(self):
         s0_transpose = self.s0.transpose()
+        s0_diff = s0_transpose.differentials[0]
         assert s0_transpose.shape == (7, 6)
+        assert s0_diff.shape == s0_transpose.shape
         assert np.all(s0_transpose.lon == self.s0.lon.transpose())
+        assert np.all(s0_diff.d_x == self.diff.d_x.transpose())
         assert np.may_share_memory(s0_transpose.distance, self.s0.distance)
+        assert np.may_share_memory(s0_diff.d_x, self.diff.d_x)
+
         s1_transpose = self.s1.transpose()
+        s1_diff = s1_transpose.differentials[0]
         assert s1_transpose.shape == (7, 6)
+        assert s1_diff.shape == s1_transpose.shape
         assert np.all(s1_transpose.lat == self.s1.lat.transpose())
+        assert np.all(s1_diff.d_x == self.diff.d_x.transpose())
         assert np.may_share_memory(s1_transpose.lat, self.s1.lat)
+        assert np.may_share_memory(s1_diff.d_x, self.diff.d_x)
+
         # Only one check on T, since it just calls transpose anyway.
         # Doing it on the CartesianRepresentation just for variety's sake.
         c0_T = self.c0.T
@@ -83,29 +113,45 @@ class TestManipulation():
 
     def test_diagonal(self):
         s0_diagonal = self.s0.diagonal()
+        s0_diff = s0_diagonal.differentials[0]
         assert s0_diagonal.shape == (6,)
+        assert s0_diff.shape == s0_diagonal.shape
         assert np.all(s0_diagonal.lat == self.s0.lat.diagonal())
+        assert np.all(s0_diff.d_x == self.diff.d_x.diagonal())
         assert np.may_share_memory(s0_diagonal.lat, self.s0.lat)
+        assert np.may_share_memory(s0_diff.d_x, self.diff.d_x)
 
     def test_swapaxes(self):
         s1_swapaxes = self.s1.swapaxes(0, 1)
+        s1_diff = s1_swapaxes.differentials[0]
         assert s1_swapaxes.shape == (7, 6)
+        assert s1_diff.shape == s1_swapaxes.shape
         assert np.all(s1_swapaxes.lat == self.s1.lat.swapaxes(0, 1))
+        assert np.all(s1_diff.d_x == self.diff.d_x.swapaxes(0, 1))
         assert np.may_share_memory(s1_swapaxes.lat, self.s1.lat)
+        assert np.may_share_memory(s1_diff.d_x, self.diff.d_x)
 
     def test_reshape(self):
         s0_reshape = self.s0.reshape(2, 3, 7)
+        s0_diff = s0_reshape.differentials[0]
         assert s0_reshape.shape == (2, 3, 7)
+        assert s0_diff.shape == s0_reshape.shape
         assert np.all(s0_reshape.lon == self.s0.lon.reshape(2, 3, 7))
         assert np.all(s0_reshape.lat == self.s0.lat.reshape(2, 3, 7))
         assert np.all(s0_reshape.distance == self.s0.distance.reshape(2, 3, 7))
         assert np.may_share_memory(s0_reshape.lon, self.s0.lon)
         assert np.may_share_memory(s0_reshape.lat, self.s0.lat)
         assert np.may_share_memory(s0_reshape.distance, self.s0.distance)
+
         s1_reshape = self.s1.reshape(3, 2, 7)
+        s1_diff = s1_reshape.differentials[0]
         assert s1_reshape.shape == (3, 2, 7)
+        assert s1_diff.shape == s1_reshape.shape
         assert np.all(s1_reshape.lat == self.s1.lat.reshape(3, 2, 7))
+        assert np.all(s1_diff.d_x == self.diff.d_x.reshape(3, 2, 7))
         assert np.may_share_memory(s1_reshape.lat, self.s1.lat)
+        assert np.may_share_memory(s1_diff.d_x, self.diff.d_x)
+
         # For reshape(3, 14), copying is necessary for lon, lat, but not for d
         s1_reshape2 = self.s1.reshape(3, 14)
         assert s1_reshape2.shape == (3, 14)
@@ -122,6 +168,11 @@ class TestManipulation():
         assert self.s0.lon.shape == (2, 3, 7)
         assert self.s0.lat.shape == (2, 3, 7)
         assert self.s0.distance.shape == (2, 3, 7)
+        assert self.diff.shape == (2, 3, 7)
+        assert self.diff.d_x.shape == (2, 3, 7)
+        assert self.diff.d_y.shape == (2, 3, 7)
+        assert self.diff.d_z.shape == (2, 3, 7)
+
         # this works with the broadcasting.
         self.s1.shape = (2, 3, 7)
         assert self.s1.shape == (2, 3, 7)
@@ -129,6 +180,7 @@ class TestManipulation():
         assert self.s1.lat.shape == (2, 3, 7)
         assert self.s1.distance.shape == (2, 3, 7)
         assert self.s1.distance.strides == (0, 0, 0)
+
         # but this one does not.
         oldshape = self.s1.shape
         with pytest.raises(AttributeError):
@@ -137,6 +189,7 @@ class TestManipulation():
         assert self.s1.lon.shape == oldshape
         assert self.s1.lat.shape == oldshape
         assert self.s1.distance.shape == oldshape
+
         # Finally, a more complicated one that checks that things get reset
         # properly if it is not the first component that fails.
         s2 = SphericalRepresentation(self.s1.lon.copy(), self.s1.lat,
@@ -155,34 +208,48 @@ class TestManipulation():
 
     def test_squeeze(self):
         s0_squeeze = self.s0.reshape(3, 1, 2, 1, 7).squeeze()
+        s0_diff = s0_squeeze.differentials[0]
         assert s0_squeeze.shape == (3, 2, 7)
+        assert s0_diff.shape == s0_squeeze.shape
         assert np.all(s0_squeeze.lat == self.s0.lat.reshape(3, 2, 7))
+        assert np.all(s0_diff.d_x == self.diff.d_x.reshape(3, 2, 7))
         assert np.may_share_memory(s0_squeeze.lat, self.s0.lat)
 
     def test_add_dimension(self):
         s0_adddim = self.s0[:, np.newaxis, :]
+        s0_diff = s0_adddim.differentials[0]
         assert s0_adddim.shape == (6, 1, 7)
+        assert s0_diff.shape == s0_adddim.shape
         assert np.all(s0_adddim.lon == self.s0.lon[:, np.newaxis, :])
+        assert np.all(s0_diff.d_x == self.diff.d_x[:, np.newaxis, :])
         assert np.may_share_memory(s0_adddim.lat, self.s0.lat)
 
     def test_take(self):
         s0_take = self.s0.take((5, 2))
+        s0_diff = s0_take.differentials[0]
         assert s0_take.shape == (2,)
+        assert s0_diff.shape == s0_take.shape
         assert np.all(s0_take.lon == self.s0.lon.take((5, 2)))
+        assert np.all(s0_diff.d_x == self.diff.d_x.take((5, 2)))
 
     def test_broadcast_to(self):
         s0_broadcast = self.s0._apply(np_broadcast_to, (3, 6, 7), subok=True)
+        s0_diff = s0_broadcast.differentials[0]
         assert type(s0_broadcast) is type(self.s0)
         assert s0_broadcast.shape == (3, 6, 7)
+        assert s0_diff.shape == s0_broadcast.shape
         assert np.all(s0_broadcast.lon == self.s0.lon)
         assert np.all(s0_broadcast.lat == self.s0.lat)
         assert np.all(s0_broadcast.distance == self.s0.distance)
         assert np.may_share_memory(s0_broadcast.lon, self.s0.lon)
         assert np.may_share_memory(s0_broadcast.lat, self.s0.lat)
         assert np.may_share_memory(s0_broadcast.distance, self.s0.distance)
+
         s1_broadcast = self.s1._apply(np_broadcast_to, shape=(3, 6, 7),
                                       subok=True)
+        s1_diff = s1_broadcast.differentials[0]
         assert s1_broadcast.shape == (3, 6, 7)
+        assert s1_diff.shape == s1_broadcast.shape
         assert np.all(s1_broadcast.lat == self.s1.lat)
         assert np.all(s1_broadcast.lon == self.s1.lon)
         assert np.all(s1_broadcast.distance == self.s1.distance)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -519,7 +519,7 @@ class TransformGraph(object):
 
         return nxgraph
 
-    def transform(self, transcls, fromsys, tosys, priority=1):
+    def transform(self, transcls, fromsys, tosys, priority=1, **kwargs):
         """
         A function decorator for defining transformations.
 
@@ -538,6 +538,9 @@ class TransformGraph(object):
         priority : number
             The priority if this transform when finding the shortest
             coordinate transform path - large numbers are lower priorities.
+
+        Additional keyword arguments are passed into the ``transcls``
+        constructor.
 
         Returns
         -------
@@ -578,7 +581,7 @@ class TransformGraph(object):
             # ``register_graph=self`` stores it in the transform graph
             # automatically
             transcls(func, fromsys, tosys, priority=priority,
-                     register_graph=self)
+                     register_graph=self, **kwargs)
             return func
         return deco
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -341,7 +341,7 @@ For example, to store a single velocity differential with a position::
 
 Implicit in the above is that the representation of a differential does not have
 to match the representation (i.e. in this case, the representation is spherical
-but the differential is Cartesian). ``Differential``s can also be attached to a
+but the differential is Cartesian). ``Differential`` s can also be attached to a
 ``Representation`` after creation::
 
   >>> rep = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
@@ -380,7 +380,7 @@ positional data to a new representation, use the ``.represent_as()``::
 
 However, by passing just the desired representation class, only the
 ``Representation`` has changed. To change both the ``Representation`` and any
-``Differential``s, you must specify target classes for each ``Differential``
+``Differential`` s, you must specify target classes for each ``Differential``
 as well::
 
   >>> rep.represent_as([SphericalRepresentation, SphericalDifferential]) # doctest: +FLOAT_CMP
@@ -396,7 +396,7 @@ as well::
        (  5.55111512e-17,   0.00000000e+00,  13.37908816)]>,)>
 
 Shape-changing operations (e.g., reshapes) are propagated to all
-``Differential``s because they are guaranteed to have the same shape as their
+``Differential`` s because they are guaranteed to have the same shape as their
 host ``Representation`` object::
 
   >>> rep.shape
@@ -405,9 +405,9 @@ host ``Representation`` object::
   (4,)
   >>> new_rep = rep.reshape(2, 2)
   >>> new_rep.shape
-  (2,2)
+  (2, 2)
   >>> new_rep.differentials[0].shape
-  (2,2)
+  (2, 2)
 
 This also works for slicing::
 
@@ -427,9 +427,9 @@ raise an exception::
   ERROR: TypeError: Operation 'add' is not supported when differentials are attached to a CartesianRepresentation. [astropy.coordinates.representation]
   ...
 
-If you have a ``Representation`` with attached ``Differential``s, you can easily
-retrieve a copy of the ``Representation`` without the ``Differential``s and
-use this ``Differential``-free object in arithmetic operations::
+If you have a ``Representation`` with attached ``Differential`` s, you can
+easily retrieve a copy of the ``Representation`` without the ``Differential`` s
+and use this ``Differential``-free object in arithmetic operations::
 
   >>> rep.without_differentials() * 15.
   <CartesianRepresentation (x, y, z) in AU

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -451,7 +451,9 @@ the positional information, e.g.::
   >>> rep.norm() # doctest: +FLOAT_CMP
   <Quantity [  8.94427191, 10.34408043, 11.83215957, 13.37908816] AU>
 
-TODO: combine and scale operations
+Operations that involve combining or scaling representations or pairs of
+representation objects that contain differentials will currently fail, but
+support for some operations may be added in future versions::
 
   >>> rep + rep # doctest: +SKIP
   ERROR: TypeError: Operation 'add' is not supported when differentials are attached to a CartesianRepresentation. [astropy.coordinates.representation]

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -314,6 +314,12 @@ provides the ``base`` (representation)::
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
       ( 0.0048481,  1.04719246,  1.00000294)>
 
+.. Note:: At present, the differential classes are generally meant to work with
+   first derivatives, but they do not check the units of the inputs to enforce
+   this. Passing in 2nd derivatives, e.g., acceleration values (with
+   acceleration units), will succeed, but any transformations that occur through
+   re-representation of the differential will not necessarily be correct.
+
 Attaching ``Differential``'s to ``Representation``'s
 ====================================================
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -417,7 +417,28 @@ This also works for slicing::
   >>> new_rep.differentials[0].shape
   (2,)
 
-TODO: combine, scale operations - drops differentials
+All other operations that involve scaling or combining representation data will
+raise an exception::
+
+  >>> rep.norm() # doctest: +SKIP
+  ERROR: TypeError: Operation 'norm' is not supported when differentials are attached to a CartesianRepresentation. [astropy.coordinates.representation]
+  ...
+  >>> rep + rep # doctest: +SKIP
+  ERROR: TypeError: Operation 'add' is not supported when differentials are attached to a CartesianRepresentation. [astropy.coordinates.representation]
+  ...
+
+If you have a ``Representation`` with attached ``Differential``s, you can easily
+retrieve a copy of the ``Representation`` without the ``Differential``s and
+use this ``Differential``-free object in arithmetic operations::
+
+  >>> rep.without_differentials() * 15.
+  <CartesianRepresentation (x, y, z) in AU
+      [(  0.,   60.,  120.), ( 15.,   75.,  135.), ( 30.,   90.,  150.),
+       ( 45.,  105.,  165.)]>
+  >>> rep.without_differentials() + rep.without_differentials()
+  <CartesianRepresentation (x, y, z) in AU
+      [( 0.,   8.,  16.), ( 2.,  10.,  18.), ( 4.,  12.,  20.),
+       ( 6.,  14.,  22.)]>
 
 .. _astropy-coordinates-create-repr:
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -343,7 +343,7 @@ classes. For example, to store a single velocity differential with a position::
   >>> rep
   <SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)
       ( 0.,  0.,  1.)
-   (has differentials)>
+   (has differentials: 's')>
   >>> rep.differentials
   {'s': <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
        ( 1.,  2.,  3.)>}
@@ -378,7 +378,7 @@ differentials::
   >>> rep
   <CartesianRepresentation (x, y, z) in kpc
       ( 1.,  2.,  3.)
-   (has differentials)>
+   (has differentials: 's')>
 
 This also works for array data as well, as long as the shape of the
 ``Differential`` data is the same as that of the ``Representation``::
@@ -391,7 +391,7 @@ This also works for array data as well, as long as the shape of the
   >>> rep
   <CartesianRepresentation (x, y, z) in AU
       [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]
-   (has differentials)>
+   (has differentials: 's')>
 
 As with a ``Representation`` instance without a differential, to convert the
 positional data to a new representation, use the ``.represent_as()``::
@@ -415,8 +415,8 @@ specify target classes for the ``Differential`` as well::
      ( 1.37340077,  1.05532979,  10.34408043),
      ( 1.24904577,  1.00685369,  11.83215957),
      ( 1.16590454,  0.96522779,  13.37908816)]
-   (has differentials)>
-  >>> rep2.differentials['s']
+   (has differentials: 's')>
+  >>> rep2.differentials['s']  # doctest: +FLOAT_CMP
   <SphericalDifferential (d_lon, d_lat, d_distance) in (km rad / (AU s), km rad / (AU s), km / s)
       [(  6.12323400e-17,   1.11022302e-16,   8.94427191),
        ( -5.55111512e-17,   0.00000000e+00,  10.34408043),

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -98,7 +98,7 @@ dimensionless sphere::
         ( 1.03037683,  0.60126422)>
 
 Converting back to cartesian, the absolute scaling information has been
-removed, and the points are still located on a unit sphere:
+removed, and the points are still located on a unit sphere::
 
     >>> sph_unit = car.represent_as(UnitSphericalRepresentation)
     >>> sph_unit.represent_as(CartesianRepresentation) # doctest: +FLOAT_CMP

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -329,77 +329,98 @@ Attaching ``Differential``'s to ``Representation``'s
     viewed as provisional!
 
 ``Differential`` objects can be attached to ``Representation`` objects as a way
-to encapsulate information into a single object. ``Differential``'s can be
-passed in to the initializer of any of the built-in ``Representation`` classes.
-For example, to store a single velocity differential with a position::
+to encapsulate related information into a single object. ``Differential``'s can
+be passed in to the initializer of any of the built-in ``Representation``
+classes. For example, to store a single velocity differential with a position::
 
-  >>> from astropy.coordinates import CartesianDifferential
-  >>> dif = CartesianDifferential(d_x=1 * u.km/u.s,
-  ...                             d_y=2 * u.km/u.s,
-  ...                             d_z=3 * u.km/u.s)
-  >>> SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
-  ...                         distance=1.*u.kpc,
-  ...                         differentials=dif)
+  >>> from astropy.coordinates import representation as r
+  >>> dif = r.SphericalDifferential(d_lon=1 * u.mas/u.yr,
+  ...                               d_lat=2 * u.mas/u.yr,
+  ...                               d_distance=3 * u.km/u.s)
+  >>> rep = r.SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
+  ...                                 distance=1.*u.kpc,
+  ...                                 differentials=dif)
+  >>> rep
   <SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)
       ( 0.,  0.,  1.)
-   differentials=(<CartesianDifferential (d_x, d_y, d_z) in km / s
-      ( 1.,  2.,  3.)>,)>
+   (has differentials)>
+  >>> rep.differentials
+  {'s': <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
+       ( 1.,  2.,  3.)>}
 
-Implicit in the above is that the representation of a differential does not have
-to match the representation (i.e. in this case, the representation is spherical
-but the differential is Cartesian). ``Differential`` s can also be attached to a
-``Representation`` after creation::
+The ``Differential`` objects are stored as a Python dictionary on the
+``Representation`` object with keys equal to the (string) unit with which the
+differential derivatives are taken (converted to SI). For example, in this case
+the key is ``'s'`` (second) because the ``Differential`` units are velocities, a
+time derivative. Passing a single differential to the ``Representation``
+initializer will automatically generate the necessary key and store it in the
+differentials dictionary, but a dictionary is required to specify multiple
+differentials::
 
-  >>> rep = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
+  >>> dif2 = r.SphericalDifferential(d_lon=4 * u.mas/u.yr**2,
+  ...                                d_lat=5 * u.mas/u.yr**2,
+  ...                                d_distance=6 * u.km/u.s**2)
+  >>> rep = r.SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
+  ...                                 distance=1.*u.kpc,
+  ...                                 differentials={'s': dif, 's2': dif2})
+  >>> rep.differentials['s']
+  <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
+      ( 1.,  2.,  3.)>
+  >>> rep.differentials['s2']
+  <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr2, mas / yr2, km / s2)
+      ( 4.,  5.,  6.)>
+
+``Differential`` s can also be attached to a ``Representation`` after creation::
+
+  >>> rep = r.CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
+  >>> dif = r.CartesianDifferential(*[1, 2, 3] * u.km/u.s)
   >>> rep = rep.with_differentials(dif)
   >>> rep
   <CartesianRepresentation (x, y, z) in kpc
       ( 1.,  2.,  3.)
-   differentials=(<CartesianDifferential (d_x, d_y, d_z) in km / s
-      ( 1.,  2.,  3.)>,)>
+   (has differentials)>
 
 This also works for array data as well, as long as the shape of the
 ``Differential`` data is the same as that of the ``Representation``::
 
   >>> xyz = np.arange(12).reshape(3, 4) * u.au
   >>> d_xyz = np.arange(12).reshape(3, 4) * u.km/u.s
-  >>> rep = CartesianRepresentation(*xyz)
-  >>> dif = CartesianDifferential(*d_xyz)
+  >>> rep = r.CartesianRepresentation(*xyz)
+  >>> dif = r.CartesianDifferential(*d_xyz)
   >>> rep = rep.with_differentials(dif)
   >>> rep
   <CartesianRepresentation (x, y, z) in AU
       [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]
-   differentials=(<CartesianDifferential (d_x, d_y, d_z) in km / s
-      [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]>,)>
+   (has differentials)>
 
 As with a ``Representation`` instance without a differential, to convert the
 positional data to a new representation, use the ``.represent_as()``::
 
-  >>> rep.represent_as(SphericalRepresentation) # doctest: +FLOAT_CMP
+  >>> rep.represent_as(r.SphericalRepresentation) # doctest: +FLOAT_CMP
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, AU)
       [( 1.57079633,  1.10714872,   8.94427191),
        ( 1.37340077,  1.05532979,  10.34408043),
        ( 1.24904577,  1.00685369,  11.83215957),
-       ( 1.16590454,  0.96522779,  13.37908816)]
-   differentials=(<CartesianDifferential (d_x, d_y, d_z) in km / s
-      [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]>,)>
+       ( 1.16590454,  0.96522779,  13.37908816)]>
 
 However, by passing just the desired representation class, only the
-``Representation`` has changed. To change both the ``Representation`` and any
-``Differential`` s, you must specify target classes for each ``Differential``
-as well::
+``Representation`` has changed, and the differentials are dropped. To
+re-represent both the ``Representation`` and any ``Differential`` s, you must
+specify target classes for the ``Differential`` as well::
 
-  >>> rep.represent_as([SphericalRepresentation, SphericalDifferential]) # doctest: +FLOAT_CMP
+  >>> rep2 = rep.represent_as(r.SphericalRepresentation, r.SphericalDifferential) # doctest: +FLOAT_CMP
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, AU)
-      [( 1.57079633,  1.10714872,   8.94427191),
-       ( 1.37340077,  1.05532979,  10.34408043),
-       ( 1.24904577,  1.00685369,  11.83215957),
-       ( 1.16590454,  0.96522779,  13.37908816)]
-   differentials=(<SphericalDifferential (d_lon, d_lat, d_distance) in (km rad / (AU s), km rad / (AU s), km / s)
+    [( 1.57079633,  1.10714872,   8.94427191),
+     ( 1.37340077,  1.05532979,  10.34408043),
+     ( 1.24904577,  1.00685369,  11.83215957),
+     ( 1.16590454,  0.96522779,  13.37908816)]
+   (has differentials)>
+  >>> rep2.differentials['s']
+  <SphericalDifferential (d_lon, d_lat, d_distance) in (km rad / (AU s), km rad / (AU s), km / s)
       [(  6.12323400e-17,   1.11022302e-16,   8.94427191),
        ( -5.55111512e-17,   0.00000000e+00,  10.34408043),
        (  0.00000000e+00,   0.00000000e+00,  11.83215957),
-       (  5.55111512e-17,   0.00000000e+00,  13.37908816)]>,)>
+       (  5.55111512e-17,   0.00000000e+00,  13.37908816)]>
 
 Shape-changing operations (e.g., reshapes) are propagated to all
 ``Differential`` s because they are guaranteed to have the same shape as their
@@ -412,7 +433,7 @@ host ``Representation`` object::
   >>> new_rep = rep.reshape(2, 2)
   >>> new_rep.shape
   (2, 2)
-  >>> new_rep.differentials[0].shape
+  >>> new_rep.differentials['s'].shape
   (2, 2)
 
 This also works for slicing::
@@ -420,31 +441,30 @@ This also works for slicing::
   >>> new_rep = rep[:2]
   >>> new_rep.shape
   (2,)
-  >>> new_rep.differentials[0].shape
+  >>> new_rep.differentials['s'].shape
   (2,)
 
-All other operations that involve scaling or combining representation data will
-raise an exception::
+Operations on representations that return `~astropy.units.Quantity` objects (as
+opposed to other ``Representation`` instances) still work, but only operate on
+the positional information, e.g.::
 
-  >>> rep.norm() # doctest: +SKIP
-  ERROR: TypeError: Operation 'norm' is not supported when differentials are attached to a CartesianRepresentation. [astropy.coordinates.representation]
-  ...
+  >>> rep.norm() # doctest: +FLOAT_CMP
+  <Quantity [  8.94427191, 10.34408043, 11.83215957, 13.37908816] AU>
+
+TODO: combine and scale operations
+
   >>> rep + rep # doctest: +SKIP
   ERROR: TypeError: Operation 'add' is not supported when differentials are attached to a CartesianRepresentation. [astropy.coordinates.representation]
   ...
 
 If you have a ``Representation`` with attached ``Differential`` s, you can
 easily retrieve a copy of the ``Representation`` without the ``Differential`` s
-and use this ``Differential``-free object in arithmetic operations::
+and use this ``Differential``-free object for any arithmetic operation::
 
-  >>> rep.without_differentials() * 15.
+  >>> 15 * rep.without_differentials().
   <CartesianRepresentation (x, y, z) in AU
       [(  0.,   60.,  120.), ( 15.,   75.,  135.), ( 30.,   90.,  150.),
        ( 45.,  105.,  165.)]>
-  >>> rep.without_differentials() + rep.without_differentials()
-  <CartesianRepresentation (x, y, z) in AU
-      [( 0.,   8.,  16.), ( 2.,  10.,  18.), ( 4.,  12.,  20.),
-       ( 6.,  14.,  22.)]>
 
 .. _astropy-coordinates-create-repr:
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -409,6 +409,7 @@ re-represent both the ``Representation`` and any ``Differential`` s, you must
 specify target classes for the ``Differential`` as well::
 
   >>> rep2 = rep.represent_as(r.SphericalRepresentation, r.SphericalDifferential) # doctest: +FLOAT_CMP
+  >>> rep2
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, AU)
     [( 1.57079633,  1.10714872,   8.94427191),
      ( 1.37340077,  1.05532979,  10.34408043),
@@ -428,7 +429,7 @@ host ``Representation`` object::
 
   >>> rep.shape
   (4,)
-  >>> rep.differentials[0].shape
+  >>> rep.differentials['s'].shape
   (4,)
   >>> new_rep = rep.reshape(2, 2)
   >>> new_rep.shape
@@ -463,7 +464,7 @@ If you have a ``Representation`` with attached ``Differential`` s, you can
 easily retrieve a copy of the ``Representation`` without the ``Differential`` s
 and use this ``Differential``-free object for any arithmetic operation::
 
-  >>> 15 * rep.without_differentials().
+  >>> 15 * rep.without_differentials()
   <CartesianRepresentation (x, y, z) in AU
       [(  0.,   60.,  120.), ( 15.,   75.,  135.), ( 30.,   90.,  150.),
        ( 45.,  105.,  165.)]>

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -326,7 +326,7 @@ Attaching ``Differential``'s to ``Representation``'s
 .. warning::
 
     The API for this functionality may change in future versions and should be
-    viewed as experimental!
+    viewed as provisional!
 
 ``Differential`` objects can be attached to ``Representation`` objects as a way
 to encapsulate information into a single object. ``Differential``'s can be

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -280,7 +280,7 @@ Often, one has just a proper motion or a radial velocity, but not both::
 
 Note in the above that the proper motion is defined strictly as a change in
 longitude, i.e., it does not include a ``cos(latitude)`` term. There are
-special classes where that terms is included::
+special classes where this term is included::
 
   >>> from astropy.coordinates import UnitSphericalCosLatDifferential
   >>> sph_lat60 = SphericalRepresentation(lon=0.*u.deg, lat=60.*u.deg,
@@ -301,8 +301,8 @@ special classes where that terms is included::
       ( 0.00969597,  1.0471772,  1.00001175)>
 
 Close inspections shows that indeed the changes are as expected.  The systems
-with and without ``cos(latitute)`` can be converted to each other, provided one
-provides the ``base``::
+with and without ``cos(latitude)`` can be converted to each other, provided one
+provides the ``base`` (representation)::
 
   >>> usph_lat60 = sph_lat60.represent_as(UnitSphericalRepresentation)
   >>> pm_coslat2 = pm.represent_as(UnitSphericalCosLatDifferential,

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -327,6 +327,7 @@ to encapsulate information into a single object. ``Differential``'s can be
 passed in to the initializer of any of the built-in ``Representation`` classes.
 For example, to store a single velocity differential with a position::
 
+  >>> from astropy.coordinates import CartesianDifferential
   >>> dif = CartesianDifferential(d_x=1 * u.km/u.s,
   ...                             d_y=2 * u.km/u.s,
   ...                             d_z=3 * u.km/u.s)
@@ -354,40 +355,67 @@ but the differential is Cartesian). ``Differential``s can also be attached to a
 This also works for array data as well, as long as the shape of the
 ``Differential`` data is the same as that of the ``Representation``::
 
-  >>> xyz = np.arange(6).reshape(3, 2) * u.au
-  >>> d_xyz = np.arange(6).reshape(3, 2) * u.km/u.s
+  >>> xyz = np.arange(12).reshape(3, 4) * u.au
+  >>> d_xyz = np.arange(12).reshape(3, 4) * u.km/u.s
   >>> rep = CartesianRepresentation(*xyz)
   >>> dif = CartesianDifferential(*d_xyz)
   >>> rep = rep.with_differentials(dif)
   >>> rep
   <CartesianRepresentation (x, y, z) in AU
-      [( 0.,  2.,  4.), ( 1.,  3.,  5.)]
+      [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]
    differentials=(<CartesianDifferential (d_x, d_y, d_z) in km / s
-      [( 0.,  2.,  4.), ( 1.,  3.,  5.)]>,)>
+      [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]>,)>
 
 As with a ``Representation`` instance without a differential, to convert the
 positional data to a new representation, use the ``.represent_as()``::
 
   >>> rep.represent_as(SphericalRepresentation) # doctest: +FLOAT_CMP
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, AU)
-      [( 1.57079633,  1.10714872,  4.47213595),
-       ( 1.24904577,  1.00685369,  5.91607978)]
+      [( 1.57079633,  1.10714872,   8.94427191),
+       ( 1.37340077,  1.05532979,  10.34408043),
+       ( 1.24904577,  1.00685369,  11.83215957),
+       ( 1.16590454,  0.96522779,  13.37908816)]
    differentials=(<CartesianDifferential (d_x, d_y, d_z) in km / s
-      [( 0.,  2.,  4.), ( 1.,  3.,  5.)]>,)>
+      [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]>,)>
 
 However, by passing just the desired representation class, only the
 ``Representation`` has changed. To change both the ``Representation`` and any
-``Differential``s, you must specify target classes for each ``Differential``::
+``Differential``s, you must specify target classes for each ``Differential``
+as well::
 
   >>> rep.represent_as([SphericalRepresentation, SphericalDifferential]) # doctest: +FLOAT_CMP
   <SphericalRepresentation (lon, lat, distance) in (rad, rad, AU)
-      [( 1.57079633,  1.10714872,  4.47213595),
-       ( 1.24904577,  1.00685369,  5.91607978)]
+      [( 1.57079633,  1.10714872,   8.94427191),
+       ( 1.37340077,  1.05532979,  10.34408043),
+       ( 1.24904577,  1.00685369,  11.83215957),
+       ( 1.16590454,  0.96522779,  13.37908816)]
    differentials=(<SphericalDifferential (d_lon, d_lat, d_distance) in (km rad / (AU s), km rad / (AU s), km / s)
-      [(  6.12323400e-17,   1.11022302e-16,  4.47213595),
-       (  0.00000000e+00,   0.00000000e+00,  5.91607978)]>,)>
+      [(  6.12323400e-17,   1.11022302e-16,   8.94427191),
+       ( -5.55111512e-17,   0.00000000e+00,  10.34408043),
+       (  0.00000000e+00,   0.00000000e+00,  11.83215957),
+       (  5.55111512e-17,   0.00000000e+00,  13.37908816)]>,)>
 
-TODO: shape-changing operations (highlight getitem, reshape)
+Shape-changing operations (e.g., reshapes) are propagated to all
+``Differential``s because they are guaranteed to have the same shape as their
+host ``Representation`` object::
+
+  >>> rep.shape
+  (4,)
+  >>> rep.differentials[0].shape
+  (4,)
+  >>> new_rep = rep.reshape(2, 2)
+  >>> new_rep.shape
+  (2,2)
+  >>> new_rep.differentials[0].shape
+  (2,2)
+
+This also works for slicing::
+
+  >>> new_rep = rep[:2]
+  >>> new_rep.shape
+  (2,)
+  >>> new_rep.differentials[0].shape
+  (2,)
 
 TODO: combine, scale operations - drops differentials
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -344,7 +344,7 @@ but the differential is Cartesian). ``Differential``s can also be attached to a
 ``Representation`` after creation::
 
   >>> rep = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
-  >>> rep = rep.attach_differential(dif)
+  >>> rep = rep.with_differentials(dif)
   >>> rep
   <CartesianRepresentation (x, y, z) in kpc
       ( 1.,  2.,  3.)
@@ -358,7 +358,7 @@ This also works for array data as well, as long as the shape of the
   >>> d_xyz = np.arange(6).reshape(3, 2) * u.km/u.s
   >>> rep = CartesianRepresentation(*xyz)
   >>> dif = CartesianDifferential(*d_xyz)
-  >>> rep = rep.attach_differential(dif)
+  >>> rep = rep.with_differentials(dif)
   >>> rep
   <CartesianRepresentation (x, y, z) in AU
       [( 0.,  2.,  4.), ( 1.,  3.,  5.)]


### PR DESCRIPTION
This is a stepping stone PR towards adding support for proper motions and velocities in `astropy.coordinates`. It turns out, we need to either (1) allow `Representation`s to carry around `Differential`s, or (2) create a new container class for representation+differentials. Option 2 seems better from a design perspective, but would lead to some API-breaking changes (or else a lot of really annoying code to provide backwards-compatibility). As this only really affects the lower-level API (and not the `Frame` or `SkyCoord`-level API), we decided that, in the interest of time, we would make this "hack" for now and just clearly document that the low-level API could change.

This PR adds the necessary code to allow `Representation`'s to accept any number of `Differential`'s in their initializers. For simplicity, we are very strict:
* The `Differential` instances must have the same shape as the representation. (I could see loosening this a little and just requiring that they are broadcastable on initialization, but leave that as an open question)
* Shape-changing (e.g., `_apply()`-related operations) affect both the representation and the differentials

Check out this document if you're interested in seeing a very messy document that lays out some more details: https://docs.google.com/document/d/1dZIG7CG8h-C4lcegtx71eUc76K5LHtgRBsXk4iRa2ds/edit?usp=sharing
