### PR TITLE
Change teardown_method to teardown_function

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -547,7 +547,7 @@ These take one argument, which is the function being tested::
         """Second test."""
         # do test
 
-    def teardown_method(function):
+    def teardown_function(function):
         pass
 
 Parametrizing tests


### PR DESCRIPTION
I assume this is a typo and that it should be `teardown_function` rather than `teardown_method`. I have not checked actual code that this is true.