### PR TITLE
Make LinearLSQFitter work properly with fixed parameters & allow fitting Shift with LinearLSQFitter & LevMarLSQFitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,6 +231,10 @@ API Changes
   - Deprecated ``GaussianAbsorption1D`` model, as it can be better represented
     by subtracting ``Gaussian1D`` from ``Const1D``. [#6200]
 
+  - Added method ``sum_of_implicit_terms`` to ``Model``, needed when performing
+    a linear fit to a model that has built-in terms with no corresponding
+    parameters (primarily the ``1*x`` term of ``Shift``). [#6174]
+
 - ``astropy.nddata``
 
   - Removed deprecated usage of parameter ``propagate_uncertainties`` as a
@@ -362,6 +366,10 @@ Bug Fixes
     original model), which in turn caused fitting to fail as a no-op. [#6085]
 
   - Allow ``Ring2D`` to be defined using ``r_out``. [#6192]
+
+  - Make ``LinearLSQFitter`` produce correct results with fixed model
+    parameters and allow ``Shift`` and ``Scale`` to be fitted with
+    ``LinearLSQFitter`` and ``LevMarLSQFitter``. [#6174]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1249,6 +1249,19 @@ class Model(object):
     def evaluate(self, *args, **kwargs):
         """Evaluate the model on some input variables."""
 
+    def sum_of_implicit_terms(self, *args, **kwargs):
+        """
+        Evaluate the sum of any implicit model terms on some input variables.
+        This includes any fixed terms used in evaluating a linear model that
+        do not have corresponding parameters exposed to the user. The
+        prototypical case is `astropy.modeling.functional_models.Shift`, which
+        corresponds to a function y = a + bx, where b=1 is intrinsically fixed
+        by the type of model, such that sum_of_implicit_terms(x) == x. This
+        method is needed by linear fitters to correct the dependent variable
+        for the implicit term(s) when solving for the remaining terms
+        (ie. a = y - bx).
+        """
+
     def render(self, out=None, coords=None):
         """
         Evaluate a model at fixed positions, respecting the ``bounding_box``.

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -528,7 +528,7 @@ class Gaussian2D(Fittable2DModel):
                             ('amplitude', outputs_unit['z'])])
 
 
-class Shift(Model):
+class Shift(Fittable1DModel):
     """
     Shift a coordinate.
 
@@ -542,20 +542,34 @@ class Shift(Model):
     outputs = ('x',)
 
     offset = Parameter(default=0)
-    fittable = True
+    linear = True
 
     @property
     def inverse(self):
+        """One dimensional inverse Shift model function"""
         inv = self.copy()
         inv.offset *= -1
         return inv
 
     @staticmethod
     def evaluate(x, offset):
+        """One dimensional Shift model function"""
         return x + offset
 
+    @staticmethod
+    def sum_of_implicit_terms(x):
+        """Evaluate the implicit term (x) of one dimensional Shift model"""
+        return x
 
-class Scale(Model):
+    @staticmethod
+    def fit_deriv(x, *params):
+        """One dimensional Shift model derivative with respect to parameter"""
+
+        d_offset = np.ones_like(x)
+        return [d_offset]
+
+
+class Scale(Fittable1DModel):
     """
     Multiply a model by a factor.
 
@@ -574,13 +588,22 @@ class Scale(Model):
 
     @property
     def inverse(self):
+        """One dimensional inverse Scale model function"""
         inv = self.copy()
         inv.factor = 1 / self.factor
         return inv
 
     @staticmethod
     def evaluate(x, factor):
+        """One dimensional Scale model function"""
         return factor * x
+
+    @staticmethod
+    def fit_deriv(x, *params):
+        """One dimensional Scale model derivative with respect to parameter"""
+
+        d_factor = x
+        return [d_factor]
 
 
 class RedshiftScaleFactor(Fittable1DModel):

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -250,6 +250,54 @@ class TestLinearLSQFitter(object):
         assert_allclose(fitted_model(x, y, model_set_axis=False), z_expected,
                         rtol=1e-1)
 
+    def test_linear_fit_fixed_parameter(self):
+        """
+        Tests fitting a polynomial model with a fixed parameter (issue #6135).
+        """
+        init_model = models.Polynomial1D(degree=2, c1=1)
+        init_model.c1.fixed = True
+
+        x = np.arange(10)
+        y = 2 + x + 0.5*x*x
+
+        fitter = LinearLSQFitter()
+        fitted_model = fitter(init_model, x, y)
+        assert_allclose(fitted_model.parameters, [2., 1., 0.5], atol=1e-14)
+
+    def test_linear_fit_model_set_fixed_parameter(self):
+        """
+        Tests fitting a polynomial model set with a fixed parameter (#6135).
+        """
+        init_model = models.Polynomial1D(degree=2, c1=[1, -2], n_models=2)
+        init_model.c1.fixed = True
+
+        x = np.arange(10)
+        yy = np.array([2 + x + 0.5*x*x, -2*x])
+
+        fitter = LinearLSQFitter()
+        fitted_model = fitter(init_model, x, yy)
+
+        assert_allclose(fitted_model.c0, [2., 0.], atol=1e-14)
+        assert_allclose(fitted_model.c1, [1., -2.], atol=1e-14)
+        assert_allclose(fitted_model.c2, [0.5, 0.], atol=1e-14)
+
+    def test_linear_fit_2d_model_set_fixed_parameters(self):
+        """
+        Tests fitting a 2d polynomial model set with fixed parameters (#6135).
+        """
+        init_model = models.Polynomial2D(degree=2, c1_0=[1, 2], c0_1=[-0.5, 1],
+                                         n_models=2,
+                                         fixed={'c1_0' : True, 'c0_1' : True})
+
+        x, y = np.mgrid[0:5, 0:5]
+        zz = np.array([1+x-0.5*y+0.1*x*x, 2*x+y-0.2*y*y])
+
+        fitter = LinearLSQFitter()
+        fitted_model = fitter(init_model, x, y, zz)
+
+        assert_allclose(fitted_model(x, y, model_set_axis=False), zz,
+                        atol=1e-14)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestNonLinearFitters(object):

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -191,6 +191,49 @@ def test_Shift_inverse():
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_Shift_model_levmar_fit():
+    """Test fitting Shift model with LevMarLSQFitter (issue #6103)."""
+
+    init_model = models.Shift()
+
+    x = np.arange(10)
+    y = x+0.1
+
+    fitter = fitting.LevMarLSQFitter()
+    fitted_model = fitter(init_model, x, y)
+
+    assert_allclose(fitted_model.parameters, [0.1], atol=1e-15)
+
+
+def test_Shift_model_set_linear_fit():
+    """Test linear fitting of Shift model (issue #6103)."""
+
+    init_model = models.Shift(offset=[0, 0], n_models=2)
+
+    x = np.arange(10)
+    yy = np.array([x+0.1, x-0.2])
+
+    fitter = fitting.LinearLSQFitter()
+    fitted_model = fitter(init_model, x, yy)
+
+    assert_allclose(fitted_model.parameters, [0.1, -0.2], atol=1e-15)
+
+
+def test_Scale_model_set_linear_fit():
+    """Test linear fitting of Scale model (#6103)."""
+
+    init_model = models.Scale(factor=[0, 0], n_models=2)
+
+    x = np.arange(-3, 7)
+    yy = np.array([1.15*x, 0.96*x])
+
+    fitter = fitting.LinearLSQFitter()
+    fitted_model = fitter(init_model, x, yy)
+
+    assert_allclose(fitted_model.parameters, [1.15, 0.96], atol=1e-15)
+
+
 # https://github.com/astropy/astropy/issues/6178
 def test_Ring2D_rout():
     m = models.Ring2D(amplitude=1, x_0=1, y_0=1, r_in=2, r_out=5)

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -114,11 +114,12 @@ Fitters support constrained fitting.
   to models or setting the `~astropy.modeling.Parameter.fixed`
   attribute directly on a parameter.
 
-  For linear fitters, freezing a polynomial coefficient means that a polynomial
-  without that term will be fitted to the data. For example, fixing ``c0`` in a
-  polynomial model will fit a polynomial with the zero-th order term missing.
-  However, the fixed value of the coefficient is used when evaluating the
-  model::
+  For linear fitters, freezing a polynomial coefficient means that the
+  corresponding term will be subtracted from the data before fitting a
+  polynomial without that term to the result. For example, fixing ``c0`` in a
+  polynomial model will fit a polynomial with the zero-th order term missing
+  to the data minus that constant. However, the fixed coefficient value is
+  restored when evaluating the model, to fit the original data values::
 
       >>> x = np.arange(1, 10, .1)
       >>> p1 = models.Polynomial1D(2, c0=[1, 1], c1=[2, 2], c2=[3, 3],
@@ -131,15 +132,15 @@ Fitters support constrained fitting.
       >>> new_model = pfit(p1, x, y)
       >>> print(new_model)  # doctest: +SKIP
       Model: Polynomial1D
-      Inputs: 1
-      Outputs: 1
+      Inputs: (u'x',)
+      Outputs: (u'y',)
       Model set size: 2
       Degree: 2
       Parameters:
-           c0     c1         c2    
-          --- ------------- -------------
-          1.0 2.38641216243 2.96827885742
-          1.0 2.38641216243 2.96827885742
+           c0  c1  c2
+          --- --- ---
+          1.0 2.0 3.0
+          1.0 2.0 3.0
 
 - A parameter can be `~astropy.modeling.Parameter.tied` (linked to
   another parameter). This can be done in two ways::


### PR DESCRIPTION
This is a prospective fix for #6103 & #6135. I'll add a couple of tests next week but don't want to spring this on you closer to 2.0 than necessary 🙂. I found this harder than it looks, with complications like model sets with different axes, different `col_fit_deriv` conventions and input dimensionality to understand when doing the linear algebra, as well as and how some of the modeling internals are supposed to work and their existing limitations, but I'm pretty confident that it's a substantial improvement on the previous behaviour and it has been passing all the tests.

Does anyone know why the print statement in the example under *Fitters support constrained fitting* [here](https://github.com/astropy/astropy/blob/878184fb3f987f325b44687f9eda27f577330c92/docs/modeling/fitting.rst) has `# doctest: +SKIP`? Without that the doctest would verify that the results have changed as expected. Thanks!

cc: @nden, @pllim 
cc: @embray, as I believe he wrote some of the relevant infrastructure, particularly model sets, which I'm not sure I quite understand the intended behaviour of 100%.
