### PR TITLE
Remove ResourceWarnings when fits.open is given a non-FITS file (fix #6168)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -409,6 +409,9 @@ Bug Fixes
 
   - Use more sensible fix values for invalid NAXISj header values. [#5935]
 
+  - Close file on error to avoid creating a ``ResourceWarning`` warning
+    about an unclosed file. [#6168, #6177]
+
 - ``astropy.io.misc``
 
 - ``astropy.io.registry``

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -95,6 +95,7 @@ class _File(object):
             self.readonly = False
             self.writeonly = False
             self.simulateonly = True
+            self.close_on_error = False
             return
         else:
             self.simulateonly = False
@@ -131,6 +132,10 @@ class _File(object):
 
         # Underlying fileobj is a file-like object, but an actual file object
         self.file_like = False
+
+        # Should the object be closed on error: see
+        # https://github.com/astropy/astropy/issues/6168
+        self.close_on_error = False
 
         # More defaults to be adjusted below as necessary
         self.compression = None
@@ -358,6 +363,7 @@ class _File(object):
         self._mmap = None
 
         self.closed = True
+        self.close_on_error = False
 
     def _maybe_close_mmap(self, refcount_delta=0):
         """
@@ -497,6 +503,7 @@ class _File(object):
             self._file = bz2.BZ2File(self.name, bzip2_mode)
         else:
             self._file = fileobj_open(self.name, IO_FITS_MODES[mode])
+            self.close_on_error = True
 
         # Make certain we're back at the beginning of the file
         # BZ2File does not support seek when the file is open for writing, but


### PR DESCRIPTION
This is not a complete fix - it's missing a changelog entry, could be squashed down into a single commit - but has been made to see if this change works - as asked for by @saimn at  https://github.com/astropy/astropy/issues/6168#issuecomment-307518630

The two main concerns I have - given that I don't know the code base - are:

 1. Is the place I chose to insert the `close` call the best place for it? I started at the suggestion of https://github.com/astropy/astropy/issues/6168#issuecomment-307241577 and then looked up the calling chain a bit

 2. Do I only need to close the file handle, or are there other objects that need closing?

**Edit 2017/06/18** I now believe this to be ready for review for inclusion. There are open questions about whether the location of the `close` is appropriate and whether it should be extended to other file types (mainly the compressed files). For the latter point I claim the current code is an improvement, and could be applied before working out what to do with the other file types, but I'm biased as this PR fixes my needs for now.

**Edit 2017/06/20** as far as I'm concerned I've addressed all the comments (and have squashed the PR to a more-comprehensible commit).