### PR TITLE
Allow round trip of Time, TimeDelta and SkyCoord through ECSV file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -235,6 +235,8 @@ New Features
 
   - Writing latex tables with only a ``tabular`` environment is now possible by
     setting ``latexdict['tabletyle']`` to ``None``. [#6205]
+  - Allow ECSV format to support reading and writing mixin columns like
+    ``Time``, ``SkyCoord``, ``Latitude``, and ``EarthLocation``. [#6181]
 
 - ``astropy.io.fits``
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -544,6 +544,10 @@ class Latitude(Angle):
         return _no_angle_subclass(results)
 
 
+class LongitudeInfo(u.QuantityInfo):
+    _represent_as_dict_info_attrs = ['unit', 'wrap_angle']
+
+
 class Longitude(Angle):
     """
     Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
@@ -601,6 +605,7 @@ class Longitude(Angle):
 
     _wrap_angle = None
     _default_wrap_angle = Angle(360 * u.deg)
+    info = LongitudeInfo()
 
     def __new__(cls, angle, unit=None, wrap_angle=None, **kwargs):
         # Forbid creating a Long from a Lat.

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -545,7 +545,7 @@ class Latitude(Angle):
 
 
 class LongitudeInfo(u.QuantityInfo):
-    _represent_as_dict_info_attrs = ['unit', 'wrap_angle']
+    _represent_as_dict_attrs = u.QuantityInfo._represent_as_dict_attrs + ('wrap_angle',)
 
 
 class Longitude(Angle):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -89,7 +89,8 @@ class EarthLocationInfo(QuantityInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    _represent_as_dict_attrs = ('x', 'y', 'z', 'ellipsoid')
+    _represent_as_dict_data_attrs = ('x', 'y', 'z')
+    _represent_as_dict_info_attrs = ('ellipsoid',)
 
     def _construct_from_dict(self, map):
         # Need to pop ellipsoid off and update post-instantiation.  This is

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -8,7 +8,7 @@ import json
 
 import numpy as np
 from .. import units as u
-from ..units.quantity import QuantityInfo
+from ..units.quantity import QuantityInfoBase
 from ..extern import six
 from ..extern.six.moves import urllib
 from ..utils.exceptions import AstropyUserWarning
@@ -83,7 +83,7 @@ def _get_json_result(url, err_str):
     return results
 
 
-class EarthLocationInfo(QuantityInfo):
+class EarthLocationInfo(QuantityInfoBase):
     """
     Container for meta information like name, description, format.  This is
     required when the object is used as a mixin column within a table, but can
@@ -97,6 +97,54 @@ class EarthLocationInfo(QuantityInfo):
         ellipsoid = map.pop('ellipsoid')
         out = self._parent_cls(**map)
         out.ellipsoid = ellipsoid
+        return out
+
+    def new_like(self, cols, length, metadata_conflicts='warn', name=None):
+        """
+        Return a new EarthLocation instance which is consistent with the
+        input ``cols`` and has ``length`` rows.
+
+        This is intended for creating an empty column object whose elements can
+        be set in-place for table operations like join or vstack.
+
+        Parameters
+        ----------
+        cols : list
+            List of input columns
+        length : int
+            Length of the output column object
+        metadata_conflicts : str ('warn'|'error'|'silent')
+            How to handle metadata conflicts
+        name : str
+            Output column name
+
+        Returns
+        -------
+        col : EarthLocation (or subclass)
+            Empty instance of this class consistent with ``cols``
+        """
+        # Very similar to QuantityInfo.new_like, but the creation of the
+        # map is different enough that this needs its own rouinte.
+        # Get merged info attributes shape, dtype, format, description.
+        attrs = self.merge_cols_attributes(cols, metadata_conflicts, name,
+                                           ('meta', 'format', 'description'))
+        # The above raises an error if the dtypes do not match, but returns
+        # just the string representation, which is not useful, so remove.
+        attrs.pop('dtype')
+        # Make empty EarthLocation using the dtype and unit of the last column.
+        # Use zeros so we do not get problems for possible conversion to
+        # geodetic coordinates.
+        shape = (length,) + attrs.pop('shape')
+        data = u.Quantity(np.zeros(shape=shape, dtype=cols[0].dtype),
+                          unit=cols[0].unit, copy=False)
+        # Get arguments needed to reconstruct class
+        map = {key: (data[key] if key in 'xyz' else getattr(cols[-1], key))
+               for key in self._represent_as_dict_attrs}
+        out = self._construct_from_dict(map)
+        # Set remaining info attributes
+        for attr, value in attrs.items():
+            setattr(out.info, attr, value)
+
         return out
 
 
@@ -133,6 +181,10 @@ class EarthLocation(u.Quantity):
     info = EarthLocationInfo()
 
     def __new__(cls, *args, **kwargs):
+        # TODO: needs copy argument and better dealing with inputs.
+        if (len(args) == 1 and len(kwargs) == 0 and
+                isinstance(args[0], EarthLocation)):
+            return args[0].copy()
         try:
             self = cls.from_geocentric(*args, **kwargs)
         except (u.UnitsError, TypeError) as exc_geocentric:

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -89,8 +89,8 @@ class EarthLocationInfo(QuantityInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    _represent_as_dict_data_attrs = ('x', 'y', 'z')
-    _represent_as_dict_info_attrs = ('ellipsoid',)
+    _represent_as_dict_data_attrs = ['x', 'y', 'z']
+    _represent_as_dict_info_attrs = ['ellipsoid']
 
     def _construct_from_dict(self, map):
         # Need to pop ellipsoid off and update post-instantiation.  This is

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -89,8 +89,7 @@ class EarthLocationInfo(QuantityInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    _represent_as_dict_data_attrs = ['x', 'y', 'z']
-    _represent_as_dict_info_attrs = ['ellipsoid']
+    _represent_as_dict_attrs = ('x', 'y', 'z', 'ellipsoid')
 
     def _construct_from_dict(self, map):
         # Need to pop ellipsoid off and update post-instantiation.  This is

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -86,7 +86,9 @@ class SkyCoordInfo(MixinInfo):
 
         out['representation'] = obj.representation.get_name()
         out['frame'] = obj.frame.name
-        out['unit'] = obj.info.unit
+        # Note that obj.info.unit is a fake composite unit (e.g. 'deg,deg,None'
+        # or None,None,m) and is not stored.  The individual attributes have
+        # units.
 
         return out
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -73,6 +73,24 @@ class SkyCoordInfo(MixinInfo):
     def _get_value_datatype(self):
         return 'string'
 
+    def _construct_from_col(self, col):
+        """Construct appropriate class object from ``col``.
+
+        Input ``col`` is a Table ``Column`` object with dtype=object (strings).
+        Called from astropy.io.ascii.core.TableOutputter.
+        """
+        attrs = col.info.meta['__object_attributes__']
+        map = copy.copy(attrs)
+        data_attrs = map.pop('data_attrs')
+        map.pop('class')
+        map.pop('datatype')
+
+        data = np.array([line.split(',') for line in col], dtype=np.float)
+        for ii, data_attr in enumerate(data_attrs):
+            map[data_attr] = data[:, ii]
+
+        return self._construct_from_dict(map)
+
     def _represent_as_dict(self, context='yaml'):
         obj = self._parent
         data_attrs = list(obj.representation_component_names)
@@ -89,6 +107,7 @@ class SkyCoordInfo(MixinInfo):
 
         out['representation'] = obj.representation.get_name()
         out['frame'] = obj.frame.name
+        out['unit'] = obj.info.unit
 
         return out
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -72,15 +72,14 @@ class SkyCoordInfo(MixinInfo):
 
     def _represent_as_dict(self):
         obj = self._parent
-        data_attrs = list(obj.representation_component_names)
+        attrs = (list(obj.representation_component_names) +
+                 list(frame_transform_graph.frame_attributes.keys()))
 
         # Don't output distance if it is all unitless 1.0
-        if 'distance' in data_attrs and np.all(obj.distance == 1.0):
-            data_attrs.remove('distance')
+        if 'distance' in attrs and np.all(obj.distance == 1.0):
+            attrs.remove('distance')
 
-        info_attrs = list(frame_transform_graph.frame_attributes)
-        self._represent_as_dict_data_attrs = data_attrs
-        self._represent_as_dict_info_attrs = info_attrs
+        self._represent_as_dict_attrs = attrs
 
         out = super(SkyCoordInfo, self)._represent_as_dict()
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -14,7 +14,7 @@ from ..units import Unit, IrreducibleUnit
 from .. import units as u
 from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.data_info import MixinInfo, _get_obj_attrs_map
+from ..utils.data_info import MixinInfo
 from ..utils import ShapedLikeNDArray
 
 from .distances import Distance
@@ -32,6 +32,7 @@ J_PREFIXED_RA_DEC_RE = re.compile(
     ([0-9]{6,7}\.?[0-9]{0,2})          # RA as HHMMSS.ss or DDDMMSS.ss, optional decimal digits
     ([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$  # Dec as DDMMSS.ss, optional decimal digits
     """, re.VERBOSE)
+
 
 class SkyCoordInfo(MixinInfo):
     """
@@ -69,11 +70,13 @@ class SkyCoordInfo(MixinInfo):
             repr_data = sc.represent_as(sc.representation, in_frame_units=True)
         return repr_data
 
-    def _represent_as_dict(self):
+    def _represent_as_dict(self, with_data=True):
         obj = self._parent
-        attrs = list(obj.representation_component_names)
-        attrs += list(frame_transform_graph.frame_attributes.keys())
-        out = _get_obj_attrs_map(obj, attrs)
+        data_attrs = tuple(obj.representation_component_names)
+        info_attrs = tuple(frame_transform_graph.frame_attributes)
+        self._represent_as_dict_data_attrs = data_attrs
+        self._represent_as_dict_info_attrs = info_attrs
+        out = super(SkyCoordInfo, self)._represent_as_dict(with_data)
 
         # Don't output distance if it is all unitless 1.0
         if 'distance' in out and np.all(out['distance'] == 1.0):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -70,28 +70,7 @@ class SkyCoordInfo(MixinInfo):
             repr_data = sc.represent_as(sc.representation, in_frame_units=True)
         return repr_data
 
-    def _get_value_datatype(self):
-        return 'string'
-
-    def _construct_from_col(self, col):
-        """Construct appropriate class object from ``col``.
-
-        Input ``col`` is a Table ``Column`` object with dtype=object (strings).
-        Called from astropy.io.ascii.core.TableOutputter.
-        """
-        attrs = col.info.meta['__object_attributes__']
-        map = copy.copy(attrs)
-        data_attrs = map.pop('data_attrs')
-        map.pop('class')
-        map.pop('datatype')
-
-        data = np.array([line.split(',') for line in col], dtype=np.float)
-        for ii, data_attr in enumerate(data_attrs):
-            map[data_attr] = data[:, ii]
-
-        return self._construct_from_dict(map)
-
-    def _represent_as_dict(self, context='yaml'):
+    def _represent_as_dict(self):
         obj = self._parent
         data_attrs = list(obj.representation_component_names)
 
@@ -103,7 +82,7 @@ class SkyCoordInfo(MixinInfo):
         self._represent_as_dict_data_attrs = data_attrs
         self._represent_as_dict_info_attrs = info_attrs
 
-        out = super(SkyCoordInfo, self)._represent_as_dict(context)
+        out = super(SkyCoordInfo, self)._represent_as_dict()
 
         out['representation'] = obj.representation.get_name()
         out['frame'] = obj.frame.name

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -73,13 +73,14 @@ class SkyCoordInfo(MixinInfo):
     def _get_value_datatype(self):
         return 'string'
 
-    def _represent_as_dict(self, with_data=True):
+    def _represent_as_dict(self, context='yaml'):
         obj = self._parent
         data_attrs = tuple(obj.representation_component_names)
         info_attrs = tuple(frame_transform_graph.frame_attributes)
         self._represent_as_dict_data_attrs = data_attrs
         self._represent_as_dict_info_attrs = info_attrs
-        out = super(SkyCoordInfo, self)._represent_as_dict(with_data)
+
+        out = super(SkyCoordInfo, self)._represent_as_dict(context)
 
         # Don't output distance if it is all unitless 1.0
         if 'distance' in out and np.all(out['distance'] == 1.0):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -76,15 +76,16 @@ class SkyCoordInfo(MixinInfo):
     def _represent_as_dict(self, context='yaml'):
         obj = self._parent
         data_attrs = list(obj.representation_component_names)
+
+        # Don't output distance if it is all unitless 1.0
+        if 'distance' in data_attrs and np.all(obj.distance == 1.0):
+            data_attrs.remove('distance')
+
         info_attrs = list(frame_transform_graph.frame_attributes)
         self._represent_as_dict_data_attrs = data_attrs
         self._represent_as_dict_info_attrs = info_attrs
 
         out = super(SkyCoordInfo, self)._represent_as_dict(context)
-
-        # Don't output distance if it is all unitless 1.0
-        if 'distance' in out and np.all(out['distance'] == 1.0):
-            del out['distance']
 
         out['representation'] = obj.representation.get_name()
         out['frame'] = obj.frame.name

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -70,6 +70,9 @@ class SkyCoordInfo(MixinInfo):
             repr_data = sc.represent_as(sc.representation, in_frame_units=True)
         return repr_data
 
+    def _get_value_datatype(self):
+        return 'string'
+
     def _represent_as_dict(self, with_data=True):
         obj = self._parent
         data_attrs = tuple(obj.representation_component_names)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -75,8 +75,8 @@ class SkyCoordInfo(MixinInfo):
 
     def _represent_as_dict(self, context='yaml'):
         obj = self._parent
-        data_attrs = tuple(obj.representation_component_names)
-        info_attrs = tuple(frame_transform_graph.frame_attributes)
+        data_attrs = list(obj.representation_component_names)
+        info_attrs = list(frame_transform_graph.frame_attributes)
         self._represent_as_dict_data_attrs = data_attrs
         self._represent_as_dict_info_attrs = info_attrs
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1190,9 +1190,9 @@ class BaseReader(object):
                 col.str_vals.append(str_vals[j])
 
         self.data.masks(cols)
-        table = self.outputter(cols, self.meta)
         if hasattr(self.header, 'table_meta'):
-            table.meta.update(self.header.table_meta)
+            self.meta['table'].update(self.header.table_meta)
+        table = self.outputter(cols, self.meta)
         self.cols = self.header.cols
 
         _apply_include_exclude_names(table, self.names, self.include_names, self.exclude_names)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1006,6 +1006,10 @@ class TableOutputter(BaseOutputter):
                 from ...time import Time
                 cls = Time
                 new_cols[name] = cls.info._construct_from_col(col)
+            elif cls_name == 'astropy.coordinates.sky_coordinate.SkyCoord':
+                from ...coordinates import SkyCoord
+                cls = SkyCoord
+                new_cols[name] = cls.info._construct_from_col(col)
             else:
                 raise ValueError('unsupported mixin class')
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -18,6 +18,7 @@ import operator
 import os
 import re
 import warnings
+from importlib import import_module
 
 from collections import OrderedDict
 
@@ -971,6 +972,12 @@ class TableOutputter(BaseOutputter):
     """
     Output the table as an astropy.table.Table object.
     """
+    # Mixin classes that support direct construction if the appropriate
+    # __object_attributes__ is set in col.meta.  This is expected when
+    # reading an ECSV table.
+    __construct_mixin_classes = ('astropy.time.core.Time',
+                                 'astropy.time.core.TimeDelta',
+                                 'astropy.coordinates.sky_coordinate.SkyCoord')
 
     default_converters = [convert_numpy(numpy.int),
                           convert_numpy(numpy.float),
@@ -996,22 +1003,22 @@ class TableOutputter(BaseOutputter):
             if hasattr(col, 'meta'):
                 out_col.meta.update(col.meta)
 
-        # Handle instantiating mixin classes
+        # Handle instantiating mixin columns for those columns which have
+        # an __object_attributes__ dict in the meta dictionary.  This provides the
+        # required attributes to re-create the original object.
         new_cols = {}
         for name, col in out.columns.items():
-            if '__object_attributes__' not in col.meta:
-                continue
-            cls_name = col.meta['__object_attributes__']['class']
-            if cls_name == 'astropy.time.core.Time':  # subclassing?
-                from ...time import Time
-                cls = Time
-                new_cols[name] = cls.info._construct_from_col(col)
-            elif cls_name == 'astropy.coordinates.sky_coordinate.SkyCoord':
-                from ...coordinates import SkyCoord
-                cls = SkyCoord
-                new_cols[name] = cls.info._construct_from_col(col)
-            else:
-                raise ValueError('unsupported mixin class')
+            if '__object_attributes__' in col.meta:
+                cls_full_name = col.meta['__object_attributes__']['class']
+
+                # If this is a supported class then import the class and run
+                # the _construct_from_col method.  Prevent accidentally running
+                # untrusted code by only importing known astropy classes.
+                if cls_full_name in self.__construct_mixin_classes:
+                    mod_name, cls_name = re.match(r'(.+)\.(\w+)', cls_full_name).groups()
+                    module = import_module(mod_name)
+                    cls = getattr(module, cls_name)
+                    new_cols[name] = cls.info._construct_from_col(col)
 
         for name, col in new_cols.items():
             out[name] = col

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -226,3 +226,23 @@ class Ecsv(basic.Basic):
 
     header_class = EcsvHeader
     outputter_class = EcsvOutputter
+
+    def update_table_data(self, table):
+        """
+        Update table columns in place if mixin columns are present.
+
+        This is a hook to allow updating the table columns after name
+        filtering but before setting up to write the data.  This is currently
+        only used by ECSV and is otherwise just a pass-through.
+
+        Parameters
+        ----------
+        table : `astropy.table.Table`
+            Input table for writing
+
+        Returns
+        -------
+        table : `astropy.table.Table`
+            Output table for writing
+        """
+        return serialize._represent_mixins_as_columns(table)

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -6,11 +6,13 @@ writing all the meta data associated with an astropy Table object.
 
 import re
 from collections import OrderedDict
+import contextlib
 
 from ...extern import six
 
 from . import core, basic
 from ...table import meta, serialize
+from ...utils.data_info import serialize_context_as
 
 __doctest_requires__ = {'Ecsv': ['yaml']}
 
@@ -245,4 +247,6 @@ class Ecsv(basic.Basic):
         table : `astropy.table.Table`
             Output table for writing
         """
-        return serialize._represent_mixins_as_columns(table)
+        with serialize_context_as('ecsv'):
+            out = serialize._represent_mixins_as_columns(table)
+        return out

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -58,7 +58,7 @@ class EcsvHeader(basic.BasicHeader):
                                  .format(col.info.name))
 
         # Now assemble the header dict that will be serialized by the YAML dumper
-        header = {'cols': self.cols}
+        header = {'cols': self.cols, 'schema': 'astropy-2.0'}
 
         if self.table_meta:
             header['meta'] = self.table_meta

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -151,7 +151,9 @@ class EcsvHeader(basic.BasicHeader):
                              'match names from header line of CSV data {}'
                              .format(self.names, header_names))
 
-        self._set_cols_from_names()  # BaseHeader method to create self.cols
+        # BaseHeader method to create self.cols, which is a list of
+        # io.ascii.core.Column objects (*not* Table Column objects).
+        self._set_cols_from_names()
 
         # Transfer attributes from the column descriptor stored in the input
         # header YAML metadata to the new columns to create this table.

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -266,7 +266,7 @@ mixin_cols = {
                     obstime=['J1990.5'] * 2),
     'q': [1, 2] * u.m,
     'lat': Latitude([1, 2] * u.deg),
-    'lon': Longitude([1, 2] * u.deg),
+    'lon': Longitude([1, 2] * u.deg, wrap_angle=180.*u.deg),
     'ang': Angle([1, 2] * u.deg),
     'el': el,
     # 'nd': NdarrayMixin(el)  # not supported yet
@@ -333,7 +333,7 @@ def test_ecsv_mixins_per_column(table_cls, name_col):
         'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
         'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
         'q': ['value', 'unit'],
-        'lon': ['value', 'unit'],
+        'lon': ['value', 'unit', 'wrap_angle'],
         'lat': ['value', 'unit'],
         'ang': ['value', 'unit'],
         'el': ['x', 'y', 'z', 'ellipsoid'],

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -297,10 +297,8 @@ def test_ecsv_mixins_as_one(table_cls):
         # For Table, EarthLocation turns into NdarrayMixin, which is
         # not yet supported. Just skip this for now.
         names.remove('el')
-        serialized_names = serialized_names[:2] + serialized_names[5:-3]
-        mixin_cols['tm3'].location = el[0]
-    else:
-        mixin_cols['tm3'].location = el
+        for name in 'el.x', 'el.y', 'el.z':
+            serialized_names.remove(name)
 
     t = table_cls([mixin_cols[name] for name in names], names=names)
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -16,7 +16,7 @@ import numpy as np
 from ....table import Table, Column, QTable, NdarrayMixin
 from ....table.table_helpers import simple_table
 from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
-from ....time import Time
+from ....time import Time, TimeDelta
 from ....tests.helper import quantity_allclose
 
 from ....extern.six.moves import StringIO
@@ -248,9 +248,12 @@ sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
 scc = sc.copy()
 scc.representation = 'cartesian'
 tm = Time([51000.5, 51001.5], format='mjd', scale='tai', precision=5, location=el)
+tm2 = Time(tm, format='iso')
 
 mixin_cols = {
     'tm': tm,
+    'tm2': tm2,
+    'dt': TimeDelta([1, 2] * u.day),
     'sc': sc,
     'scc': scc,
     'scd': SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
@@ -270,11 +273,14 @@ mixin_cols = {
 def test_ecsv_mixins(table_cls, name_col):
     name, col = name_col
 
+    time_attrs = ['value', 'shape', 'format', 'scale', 'precision',
+                  'in_subfmt', 'out_subfmt', 'location']
     compare_attrs = {
         'c1': ['data'],
         'c2': ['data'],
-        'tm': ['value', 'shape', 'format', 'scale', 'precision',
-               'in_subfmt', 'out_subfmt', 'location'],
+        'tm': time_attrs,
+        'tm2': time_attrs,
+        'dt': ['shape', 'value', 'format', 'scale'],
         'sc': ['ra', 'dec', 'representation', 'frame.name'],
         'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
         'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -293,12 +293,6 @@ def test_ecsv_mixins_as_one(table_cls):
                         'tm2',  # serialize_method is formatted_value
                         'tm3.jd1', 'tm3.jd2',    # serialize is jd1_jd2
                         'tm3.location.x', 'tm3.location.y', 'tm3.location.z']
-    if table_cls is Table:
-        # For Table, EarthLocation turns into NdarrayMixin, which is
-        # not yet supported. Just skip this for now.
-        names.remove('el')
-        for name in 'el.x', 'el.y', 'el.z':
-            serialized_names.remove(name)
 
     t = table_cls([mixin_cols[name] for name in names], names=names)
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -708,7 +708,8 @@ def write(table, output=None,  format=None, Writer=None, fast_writer=True, **kwa
     if output is None:
         output = sys.stdout
 
-    table = Table(table, names=kwargs.get('names'))
+    table_cls = table.__class__ if isinstance(table, Table) else Table
+    table = table_cls(table, names=kwargs.get('names'))
 
     table0 = table[:0].copy()
     core._apply_include_exclude_names(table0, kwargs.get('names'),

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -12,7 +12,7 @@ import numpy as np
 from ....coordinates import SkyCoord, EarthLocation, Angle, Longitude, Latitude
 from .... import units as u
 from ....time import Time
-from ....table import QTable
+from ....table import QTable, SerializedColumn
 from ....extern.six.moves import StringIO
 
 try:
@@ -131,6 +131,13 @@ def test_timedelta():
     assert type(dt) is type(dty)
     for attr in ('shape', 'jd1', 'jd2', 'format', 'scale'):
         assert np.all(getattr(dt, attr) == getattr(dty, attr))
+
+
+def test_serialized_column():
+    sc = SerializedColumn({'name': 'hello', 'other': 1, 'other2': 2.0})
+    scy = load(dump(sc))
+
+    assert sc == scy
 
 
 def test_load_all():

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -17,6 +17,8 @@ classes to define custom YAML tags for the following astropy classes:
 - `astropy.coordinates.Angle`
 - `astropy.coordinates.Latitude`
 - `astropy.coordinates.Longitude`
+- `astropy.coordinates.EarthLocation`
+- `astropy.table.SerializedColumn`
 
 .. Note ::
 
@@ -75,6 +77,7 @@ from ... import units as u
 from ... import coordinates as coords
 from ...utils import minversion
 from ...extern import six
+from ...table import SerializedColumn
 
 
 try:
@@ -96,6 +99,16 @@ def _unit_representer(dumper, obj):
 def _unit_constructor(loader, node):
     map = loader.construct_mapping(node)
     return u.Unit(map['unit'])
+
+
+def _serialized_column_representer(dumper, obj):
+    out = dumper.represent_mapping('!astropy.table.SerializedColumn', obj)
+    return out
+
+
+def _serialized_column_constructor(loader, node):
+    map = loader.construct_mapping(node)
+    return SerializedColumn(map)
 
 
 def _time_representer(dumper, obj):
@@ -241,6 +254,7 @@ AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
 AstropyDumper.add_representer(Time, _time_representer)
 AstropyDumper.add_representer(TimeDelta, _timedelta_representer)
 AstropyDumper.add_representer(coords.SkyCoord, _skycoord_representer)
+AstropyDumper.add_representer(SerializedColumn, _serialized_column_representer)
 
 # Numpy dtypes
 AstropyDumper.add_representer(np.bool_,
@@ -269,6 +283,8 @@ AstropyLoader.add_constructor('!astropy.time.Time', _time_constructor)
 AstropyLoader.add_constructor('!astropy.time.TimeDelta', _timedelta_constructor)
 AstropyLoader.add_constructor('!astropy.coordinates.sky_coordinate.SkyCoord',
                               _skycoord_constructor)
+AstropyLoader.add_constructor('!astropy.table.SerializedColumn',
+                              _serialized_column_constructor)
 
 for cls, tag in ((u.Quantity, '!astropy.units.Quantity'),
                  (coords.Angle, '!astropy.coordinates.Angle'),

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -47,6 +47,7 @@ from .table import (Table, QTable, TableColumns, Row, TableFormatter,
 from .operations import join, hstack, vstack, unique, TableMergeError
 from .bst import BST, FastBST, FastRBT
 from .sorted_array import SortedArray
+from .serialize import SerializedColumn
 
 # Finally import the formats for the read and write method but delay building
 # the documentation until all are loaded. (#5275)

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -3,7 +3,7 @@ import copy
 from collections import OrderedDict
 
 from ..extern import six
-
+from ..utils.data_info import MixinInfo
 
 __all__ = ['get_header_from_yaml', 'get_yaml_from_header', 'get_yaml_from_table']
 
@@ -169,6 +169,12 @@ def _get_col_attributes(col):
     if type_name.endswith('_'):
         type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
     attrs['datatype'] = type_name
+
+    if (hasattr(col, 'info') and isinstance(col.info, MixinInfo) and
+            hasattr(col.info, '_represent_as_dict')):
+        if col.info.meta is None:
+            col.info.meta = {}
+        col.info.meta['__object_attributes__'] = col.info._represent_as_dict(with_data=False)
 
     # Set the output attributes
     for attr, nontrivial, xform in (('unit', lambda x: x is not None, str),

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -3,7 +3,6 @@ import copy
 from collections import OrderedDict
 
 from ..extern import six
-from ..utils.data_info import MixinInfo
 
 __all__ = ['get_header_from_yaml', 'get_yaml_from_header', 'get_yaml_from_table']
 
@@ -169,15 +168,6 @@ def _get_col_attributes(col):
     if type_name.endswith('_'):
         type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
     attrs['datatype'] = type_name
-
-    # Mixins get additional attribute information encoded via a dict
-    # with key '__object_attributes__' in the column meta.
-    if (hasattr(col, 'info') and isinstance(col.info, MixinInfo) and
-            hasattr(col.info, '_represent_as_dict')):
-        if col.info.meta is None:
-            col.info.meta = {}
-        obj_attrs = col.info._represent_as_dict(context='column')
-        col.info.meta['__object_attributes__'] = obj_attrs
 
     # Set the output attributes
     for attr, nontrivial, xform in (('unit', lambda x: x is not None, str),

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -176,9 +176,7 @@ def _get_col_attributes(col):
             hasattr(col.info, '_represent_as_dict')):
         if col.info.meta is None:
             col.info.meta = {}
-        obj_attrs = col.info._represent_as_dict(with_data=False)
-        obj_attrs['class'] = col.__module__ + '.' + col.__class__.__name__
-        obj_attrs['datatype'] = col.info._get_value_datatype()
+        obj_attrs = col.info._represent_as_dict(context='column')
         col.info.meta['__object_attributes__'] = obj_attrs
 
     # Set the output attributes

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -170,11 +170,16 @@ def _get_col_attributes(col):
         type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
     attrs['datatype'] = type_name
 
+    # Mixins get additional attribute information encoded via a dict
+    # with key '__object_attributes__' in the column meta.
     if (hasattr(col, 'info') and isinstance(col.info, MixinInfo) and
             hasattr(col.info, '_represent_as_dict')):
         if col.info.meta is None:
             col.info.meta = {}
-        col.info.meta['__object_attributes__'] = col.info._represent_as_dict(with_data=False)
+        obj_attrs = col.info._represent_as_dict(with_data=False)
+        obj_attrs['class'] = col.__module__ + '.' + col.__class__.__name__
+        obj_attrs['datatype'] = col.info._get_value_datatype()
+        col.info.meta['__object_attributes__'] = obj_attrs
 
     # Set the output attributes
     for attr, nontrivial, xform in (('unit', lambda x: x is not None, str),

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -18,6 +18,18 @@ __construct_mixin_classes = ('astropy.time.core.Time',
                              'astropy.table.table.NdarrayMixin')
 
 
+class SerializedColumn(dict):
+    """
+    Subclass of dict that is a used in the representation to contain the name
+    (and possible other info) for a mixin attribute (either primary data or an
+    array-like attribute) that is serialized as a column in the table.
+
+    Normally contains the single key ``name`` with the name of the column in the
+    table.
+    """
+    pass
+
+
 def _represent_mixins_as_columns(tbl):
     """
     Convert any mixin columns to plain Column or MaskedColumn and

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -10,7 +10,12 @@ from .table import Table, has_info_class
 __construct_mixin_classes = ('astropy.time.core.Time',
                              'astropy.time.core.TimeDelta',
                              'astropy.units.quantity.Quantity',
-                             'astropy.coordinates.sky_coordinate.SkyCoord')
+                             'astropy.coordinates.angles.Latitude',
+                             'astropy.coordinates.angles.Longitude',
+                             'astropy.coordinates.angles.Angle',
+                             'astropy.coordinates.earth.EarthLocation',
+                             'astropy.coordinates.sky_coordinate.SkyCoord',
+                             'astropy.table.table.NdarrayMixin')
 
 
 def _represent_mixins_as_columns(tbl):

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -55,8 +55,7 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols):
             info[attr] = xform(col_attr) if xform else col_attr
 
     obj_attrs = col.info._represent_as_dict()
-    ordered_keys = (col.info._represent_as_dict_data_attrs +
-                    col.info._represent_as_dict_info_attrs)
+    ordered_keys = col.info._represent_as_dict_attrs
 
     data_attrs = [key for key in ordered_keys if key in obj_attrs and
                   getattr(obj_attrs[key], 'shape', ())[:1] == col.shape[:1]]

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -1,0 +1,133 @@
+from importlib import import_module
+import re
+from copy import deepcopy
+
+from ..utils.data_info import MixinInfo
+from .column import Column
+from .table import Table, has_info_class
+
+
+__construct_mixin_classes = ('astropy.time.core.Time',
+                             'astropy.time.core.TimeDelta',
+                             'astropy.units.quantity.Quantity',
+                             'astropy.coordinates.sky_coordinate.SkyCoord')
+
+
+def _represent_mixins_as_columns(tbl):
+    """
+    Convert any mixin columns to plain Column or MaskedColumn and
+    return a new table.
+    """
+    if not tbl.has_mixin_columns:
+        return tbl
+
+    mixin_cols = {}
+
+    new_cols = []
+
+    # Subtlety here is handling mixin info attributes.  The basic list of such
+    # attributes is: 'name', 'unit', 'dtype', 'format', 'description', 'meta'.
+    # - name: handled at the top level [DON'T store]
+    # - unit: DON'T store if this is a parent attribute
+    # - dtype: captured in plain Column if relevant [DON'T store]
+    # - format: possibly irrelevant but settable post-object creation [DO store]
+    # - description: DO store
+    # - meta: DO store
+
+    for col in tbl.itercols():
+        if not has_info_class(col, MixinInfo):
+            new_cols.append(col)
+        else:
+            obj_attrs = col.info._represent_as_dict()
+            data_attrs = col.info._represent_as_dict_data_attrs
+
+            data_attrs_map = {}  # mapping of new col name to data attr name
+
+            for data_attr in data_attrs:
+                data = obj_attrs[data_attr]
+                del obj_attrs[data_attr]
+
+                name = col.info.name
+                # New column name is the same as original if there is only one
+                # data attribute (e.g. time.value), otherwise make a new name
+                # (e.g. skycoord.ra, skycoord.dec).
+                if len(data_attrs) > 1:
+                    name = name + '.' + data_attr
+                new_cols.append(Column(data, name=name))  # TODO masking, MaskedColumn
+
+                data_attrs_map[name] = data_attr
+
+            obj_attrs['__data_attrs_map__'] = data_attrs_map
+
+            # Store the fully qualified class name
+            obj_attrs['__class__'] = col.__module__ + '.' + col.__class__.__name__
+
+            # Set the __info__ attributes (see long note above)
+            info = {}
+            for attr, nontrivial, xform in (('unit', lambda x: x is not None, str),
+                                            ('format', lambda x: x is not None, None),
+                                            ('description', lambda x: x is not None, None),
+                                            ('meta', lambda x: x, None)):
+                # Don't repeat info from the parent
+                if attr in col.info.attrs_from_parent:
+                    continue
+                col_attr = getattr(col.info, attr)
+                if nontrivial(col_attr):
+                    info[attr] = xform(col_attr) if xform else col_attr
+            if info:
+                obj_attrs['__info__'] = info
+
+            mixin_cols[col.info.name] = obj_attrs
+
+    meta = deepcopy(tbl.meta)
+    meta['__mixin_columns__'] = mixin_cols
+    out = Table(new_cols, meta=meta, copy=False)
+
+    return out
+
+
+def _construct_mixin_from_obj_attrs(obj_attrs):
+    cls_full_name = obj_attrs.pop('__class__')
+
+    # If this is a supported class then import the class and run
+    # the _construct_from_col method.  Prevent accidentally running
+    # untrusted code by only importing known astropy classes.
+    if cls_full_name not in __construct_mixin_classes:
+        raise ValueError('unsupported class for construct {}'.format(cls_full_name))
+
+    mod_name, cls_name = re.match(r'(.+)\.(\w+)', cls_full_name).groups()
+    module = import_module(mod_name)
+    cls = getattr(module, cls_name)
+    return cls.info._construct_from_dict(obj_attrs)
+
+
+def _construct_mixins_from_columns(tbl):
+    if '__mixin_columns__' not in tbl.meta:
+        return tbl
+
+    out = tbl.copy(copy_data=False)
+
+    mixin_cols = out.meta.pop('__mixin_columns__')
+
+    for new_name, obj_attrs in mixin_cols.items():
+        data_attrs_map = obj_attrs.pop('__data_attrs_map__')
+
+        # Get the index where to add new column
+        idx = min(out.colnames.index(name) for name in data_attrs_map)
+
+        # Name is the column name in the table (e.g. "coord.ra") and
+        # data_attr is the object attribute name  (e.g. "ra").  A different
+        # example would be a formatted time object that would have (e.g.)
+        # "time_col" and "value", respectively.
+        for name, data_attr in data_attrs_map.items():
+            obj_attrs[data_attr] = out[name]
+            del out[name]
+
+        info = obj_attrs.pop('__info__', {})
+        col = _construct_mixin_from_obj_attrs(obj_attrs)
+        col.info.name = new_name
+        for name, value in info.items():
+            setattr(col.info, name, value)
+        out.add_column(col, index=idx)
+
+    return out

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -13,6 +13,7 @@ __construct_mixin_classes = ('astropy.time.core.Time',
                              'astropy.coordinates.angles.Latitude',
                              'astropy.coordinates.angles.Longitude',
                              'astropy.coordinates.angles.Angle',
+                             'astropy.coordinates.distances.Distance',
                              'astropy.coordinates.earth.EarthLocation',
                              'astropy.coordinates.sky_coordinate.SkyCoord',
                              'astropy.table.table.NdarrayMixin')
@@ -30,6 +31,75 @@ class SerializedColumn(dict):
     pass
 
 
+def _represent_mixin_as_column(col, name, new_cols, mixin_cols):
+    """Convert a mixin column to a plain columns or a set of mixin columns."""
+    if not has_info_class(col, MixinInfo):
+        new_cols.append(col)
+        return
+
+    # Subtlety here is handling mixin info attributes.  The basic list of such
+    # attributes is: 'name', 'unit', 'dtype', 'format', 'description', 'meta'.
+    # - name: handled directly [DON'T store]
+    # - unit: DON'T store if this is a parent attribute
+    # - dtype: captured in plain Column if relevant [DON'T store]
+    # - format: possibly irrelevant but settable post-object creation [DO store]
+    # - description: DO store
+    # - meta: DO store
+    info = {}
+    for attr, nontrivial, xform in (('unit', lambda x: x not in (None, ''), str),
+                                    ('format', lambda x: x is not None, None),
+                                    ('description', lambda x: x is not None, None),
+                                    ('meta', lambda x: x, None)):
+        col_attr = getattr(col.info, attr)
+        if nontrivial(col_attr):
+            info[attr] = xform(col_attr) if xform else col_attr
+
+    obj_attrs = col.info._represent_as_dict()
+    ordered_keys = (col.info._represent_as_dict_data_attrs +
+                    col.info._represent_as_dict_info_attrs)
+
+    data_attrs = [key for key in ordered_keys if key in obj_attrs and
+                  getattr(obj_attrs[key], 'shape', ())[:1] == col.shape[:1]]
+
+    for data_attr in data_attrs:
+        data = obj_attrs[data_attr]
+        if len(data_attrs) == 1 and not has_info_class(data, MixinInfo):
+            # For one non-mixin attribute, we need only one serialized column.
+            # We can store info there, and keep the column name as is.
+            new_cols.append(Column(data, name=name, **info))
+            obj_attrs[data_attr] = SerializedColumn({'name': name})
+            # Remove attributes that are already on the serialized column.
+            for attr in info:
+                if attr in obj_attrs:
+                    del obj_attrs[attr]
+
+        else:
+            # New column name combines the old name and attribute
+            # (e.g. skycoord.ra, skycoord.dec).
+            new_name = name + '.' + data_attr
+            # TODO masking, MaskedColumn
+            if not has_info_class(data, MixinInfo):
+                new_cols.append(Column(data, name=new_name))
+                obj_attrs[data_attr] = SerializedColumn({'name': new_name})
+            else:
+                # recurse. This will define obj_attrs[new_name].
+                _represent_mixin_as_column(data, new_name, new_cols, obj_attrs)
+                obj_attrs[data_attr] = SerializedColumn(obj_attrs.pop(new_name))
+
+            # Strip out from info any attributes defined by the parent
+            for attr in col.info.attrs_from_parent:
+                if attr in info:
+                    del info[attr]
+
+            if info:
+                obj_attrs['__info__'] = info
+
+    # Store the fully qualified class name
+    obj_attrs['__class__'] = col.__module__ + '.' + col.__class__.__name__
+
+    mixin_cols[name] = obj_attrs
+
+
 def _represent_mixins_as_columns(tbl):
     """
     Convert any mixin columns to plain Column or MaskedColumn and
@@ -42,69 +112,8 @@ def _represent_mixins_as_columns(tbl):
 
     new_cols = []
 
-    # Subtlety here is handling mixin info attributes.  The basic list of such
-    # attributes is: 'name', 'unit', 'dtype', 'format', 'description', 'meta'.
-    # - name: handled at the top level [DON'T store]
-    # - unit: DON'T store if this is a parent attribute
-    # - dtype: captured in plain Column if relevant [DON'T store]
-    # - format: possibly irrelevant but settable post-object creation [DO store]
-    # - description: DO store
-    # - meta: DO store
-
     for col in tbl.itercols():
-        if not has_info_class(col, MixinInfo):
-            new_cols.append(col)
-        else:
-            obj_attrs = col.info._represent_as_dict()
-            data_attrs = col.info._represent_as_dict_data_attrs
-
-            # Set the __info__ attributes (see long note above)
-            info = {}
-            for attr, nontrivial, xform in (('unit', lambda x: x not in (None, ''), str),
-                                            ('format', lambda x: x is not None, None),
-                                            ('description', lambda x: x is not None, None),
-                                            ('meta', lambda x: x, None)):
-                col_attr = getattr(col.info, attr)
-                if nontrivial(col_attr):
-                    info[attr] = xform(col_attr) if xform else col_attr
-
-            for data_attr in data_attrs:
-                data = obj_attrs[data_attr]
-
-                name = col.info.name
-                # New column name is the same as original if there is only one
-                # data attribute (e.g. time.value), otherwise make a new name
-                # (e.g. skycoord.ra, skycoord.dec).
-                #
-                # In the single-name case the mixin Info gets put into the new
-                # Column so the ECSV header looks complete (and for back compatibility
-                # with pre-2.0 behavior).  However, these are ignored in object
-                # construction later in favor of values in the
-                # __mixin_columns__['__info__'] dict.  This is because in general
-                # object constructors don't pay attention to the .info attributes
-                # in the input data args (e.g. Quantity(col) does look at the unit
-                # but not info.description).
-                if len(data_attrs) > 1:
-                    name = name + '.' + data_attr
-                    col_info = {}
-                else:
-                    col_info = info
-                new_cols.append(Column(data, name=name, **col_info))  # TODO masking, MaskedColumn
-
-                obj_attrs[data_attr] = SerializedColumn({'name': name})
-
-            # Store the fully qualified class name
-            obj_attrs['__class__'] = col.__module__ + '.' + col.__class__.__name__
-
-            # Strip out any attributes defined by the parent
-            for attr in col.info.attrs_from_parent:
-                if attr in info:
-                    del info[attr]
-
-            if info:
-                obj_attrs['__info__'] = info
-
-            mixin_cols[col.info.name] = obj_attrs
+        _represent_mixin_as_column(col, col.info.name, new_cols, mixin_cols)
 
     meta = deepcopy(tbl.meta)
     meta['__mixin_columns__'] = mixin_cols
@@ -113,7 +122,7 @@ def _represent_mixins_as_columns(tbl):
     return out
 
 
-def _construct_mixin_from_obj_attrs(obj_attrs):
+def _construct_mixin_from_obj_attrs_and_info(obj_attrs, info):
     cls_full_name = obj_attrs.pop('__class__')
 
     # If this is a supported class then import the class and run
@@ -125,7 +134,57 @@ def _construct_mixin_from_obj_attrs(obj_attrs):
     mod_name, cls_name = re.match(r'(.+)\.(\w+)', cls_full_name).groups()
     module = import_module(mod_name)
     cls = getattr(module, cls_name)
-    return cls.info._construct_from_dict(obj_attrs)
+    for attr, value in info.items():
+        if attr in cls.info.attrs_from_parent:
+            obj_attrs[attr] = value
+    mixin = cls.info._construct_from_dict(obj_attrs)
+    for attr, value in info.items():
+        if attr not in obj_attrs:
+            setattr(mixin.info, attr, value)
+    return mixin
+
+
+def _construct_mixin_from_columns(new_name, obj_attrs, out):
+    data_attrs_map = {}
+    for name, val in obj_attrs.items():
+        if isinstance(val, SerializedColumn):
+            if 'name' in val:
+                data_attrs_map[val['name']] = name
+            else:
+                _construct_mixin_from_columns(name, val, out)
+                data_attrs_map[name] = name
+
+    for name in data_attrs_map.values():
+        del obj_attrs[name]
+
+    # Get the index where to add new column
+    idx = min(out.colnames.index(name) for name in data_attrs_map)
+
+    # Name is the column name in the table (e.g. "coord.ra") and
+    # data_attr is the object attribute name  (e.g. "ra").  A different
+    # example would be a formatted time object that would have (e.g.)
+    # "time_col" and "value", respectively.
+    for name, data_attr in data_attrs_map.items():
+        col = out[name]
+        obj_attrs[data_attr] = col
+        del out[name]
+
+    if len(data_attrs_map) == 1:
+        # col is the first and only column.
+        info = {}
+        for attr, nontrivial in (('unit', lambda x: x not in (None, '')),
+                                 ('format', lambda x: x is not None),
+                                 ('description', lambda x: x is not None),
+                                 ('meta', lambda x: x)):
+            col_attr = getattr(col.info, attr)
+            if nontrivial(col_attr):
+                info[attr] = col_attr
+    else:
+        info = obj_attrs.pop('__info__', {})
+
+    info['name'] = new_name
+    col = _construct_mixin_from_obj_attrs_and_info(obj_attrs, info)
+    out.add_column(col, index=idx)
 
 
 def _construct_mixins_from_columns(tbl):
@@ -137,30 +196,6 @@ def _construct_mixins_from_columns(tbl):
     mixin_cols = out.meta.pop('__mixin_columns__')
 
     for new_name, obj_attrs in mixin_cols.items():
-        data_attrs_map = {}
-        for name, val in obj_attrs.items():
-            if isinstance(val, SerializedColumn):
-                data_attrs_map[val['name']] = name
-
-        for name in data_attrs_map.values():
-            del obj_attrs[name]
-
-        # Get the index where to add new column
-        idx = min(out.colnames.index(name) for name in data_attrs_map)
-
-        # Name is the column name in the table (e.g. "coord.ra") and
-        # data_attr is the object attribute name  (e.g. "ra").  A different
-        # example would be a formatted time object that would have (e.g.)
-        # "time_col" and "value", respectively.
-        for name, data_attr in data_attrs_map.items():
-            obj_attrs[data_attr] = out[name]
-            del out[name]
-
-        info = obj_attrs.pop('__info__', {})
-        col = _construct_mixin_from_obj_attrs(obj_attrs)
-        col.info.name = new_name
-        for name, value in info.items():
-            setattr(col.info, name, value)
-        out.add_column(col, index=idx)
+        _construct_mixin_from_columns(new_name, obj_attrs, out)
 
     return out

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -96,11 +96,12 @@ def _represent_mixins_as_columns(tbl):
             # Store the fully qualified class name
             obj_attrs['__class__'] = col.__module__ + '.' + col.__class__.__name__
 
+            # Strip out any attributes defined by the parent
+            for attr in col.info.attrs_from_parent:
+                if attr in info:
+                    del info[attr]
+
             if info:
-                # Strip out any attributes defined by the parent
-                for attr in col.info.attrs_from_parent:
-                    if attr in info:
-                        del info[attr]
                 obj_attrs['__info__'] = info
 
             mixin_cols[col.info.name] = obj_attrs

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -657,8 +657,10 @@ class Table(object):
         def_names = _auto_names(n_cols)
 
         for col, name, def_name, dtype in zip(data, names, def_names, dtype):
-            # Structured ndarray gets viewed as a mixin
-            if isinstance(col, np.ndarray) and len(col.dtype) > 1:
+            # Structured ndarray gets viewed as a mixin unless already a valid
+            # mixin class
+            if (isinstance(col, np.ndarray) and len(col.dtype) > 1 and
+                    not self._add_as_mixin_column(col)):
                 col = col.view(NdarrayMixin)
 
             if isinstance(col, (Column, MaskedColumn)):
@@ -1264,8 +1266,10 @@ class Table(object):
             if not hasattr(value, 'dtype') and not self._add_as_mixin_column(value):
                 value = np.asarray(value)
 
-            # Structured ndarray gets viewed as a mixin
-            if isinstance(value, np.ndarray) and len(value.dtype) > 1:
+            # Structured ndarray gets viewed as a mixin (unless already a valid
+            # mixin class).
+            if (isinstance(value, np.ndarray) and len(value.dtype) > 1 and
+                    not self._add_as_mixin_column(value)):
                 value = value.view(NdarrayMixin)
 
             # Make new column and assign the value.  If the table currently

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2521,12 +2521,9 @@ class Table(object):
         The arguments and keywords (other than ``format``) provided to this function are
         passed through to the underlying data reader (e.g. `~astropy.io.ascii.read`).
         """
-        # Always read as Table because all astropy readers initially return
-        # Table or QTable.  Most readers return Table but e.g. ascii.ecsv might
-        # return QTable.
-        out = io_registry.read(Table, *args, **kwargs)
-
-        # If desired output `cls` is different from returned `out` class then
+        out = io_registry.read(cls, *args, **kwargs)
+        # For some readers (e.g., ascii.ecsv), the returned `out` class is not
+        # guaranteed to be the same as the desired output `cls`.  If so,
         # try coercing to desired class without copying (io.registry.read
         # would normally do a copy).  The normal case here is swapping
         # Table <=> QTable.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -16,7 +16,7 @@ from numpy import ma
 
 from .. import log
 from ..io import registry as io_registry
-from ..units import Quantity
+from ..units import Quantity, QuantityInfo
 from ..utils import isiterable, ShapedLikeNDArray
 from ..utils.compat.numpy import broadcast_to as np_broadcast_to
 from ..utils.console import color_print
@@ -902,7 +902,7 @@ class Table(object):
 
         # Is it a mixin but not not Quantity (which gets converted to Column with
         # unit set).
-        return has_info_class(col, MixinInfo) and not isinstance(col, Quantity)
+        return has_info_class(col, MixinInfo) and not has_info_class(col, QuantityInfo)
 
     def pprint(self, max_lines=None, max_width=None, show_name=True,
                show_unit=None, show_dtype=False, align=None):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -139,6 +139,9 @@ def table_type(request):
 # Stuff for testing mixin columns
 
 MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
+              'longitude' : coordinates.Longitude([0., 1., 5., 6.]*u.deg,
+                                                  wrap_angle=180.*u.deg),
+              'latitude' : coordinates.Latitude([5., 6., 10., 11.]*u.deg),
               'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
               'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
                                                dec=[0, 1, 2, 3] * u.deg),

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -149,6 +149,10 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                            dtype='<i4,|S1').view(table.NdarrayMixin),
               }
+MIXIN_COLS['earthlocation'] = coordinates.EarthLocation(
+    lon=MIXIN_COLS['longitude'], lat=MIXIN_COLS['latitude'],
+    height=MIXIN_COLS['quantity'])
+
 
 @pytest.fixture(params=sorted(MIXIN_COLS))
 def mixin_cols(request):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -63,7 +63,10 @@ def test_attributes(mixin_cols):
 
 
 def check_mixin_type(table, table_col, in_col):
-    if ((isinstance(in_col, u.Quantity) and type(table) is not QTable)
+    # We check for QuantityInfo rather than just isinstance(col, u.Quantity)
+    # since we want to treat EarthLocation as a mixin, even though it is
+    # a Quantity subclass.
+    if ((isinstance(in_col.info, u.QuantityInfo) and type(table) is not QTable)
             or isinstance(in_col, Column)):
         assert type(table_col) is table.ColumnClass
     else:
@@ -239,7 +242,7 @@ def assert_table_name_col_equal(t, name, col):
         assert np.all(t[name].dec == col.dec)
     elif isinstance(col, u.Quantity):
         if type(t) is QTable:
-            assert np.all(t[name].value == col.value)
+            assert np.all(t[name] == col)
     elif isinstance(col, table_helpers.ArrayWrapper):
         assert np.all(t[name].data == col.data)
     else:

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -770,7 +770,8 @@ class TestVStack():
 
         # Vstack works for these classes:
         implemented_mixin_classes = ['Quantity', 'Angle',
-                                     'Latitude', 'Longitude']
+                                     'Latitude', 'Longitude',
+                                     'EarthLocation']
         if cls_name in implemented_mixin_classes:
             table.vstack([t, t])
         else:

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -769,7 +769,8 @@ class TestVStack():
         cls_name = type(col).__name__
 
         # Vstack works for these classes:
-        implemented_mixin_classes = ['Quantity']
+        implemented_mixin_classes = ['Quantity', 'Angle',
+                                     'Latitude', 'Longitude']
         if cls_name in implemented_mixin_classes:
             table.vstack([t, t])
         else:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -102,10 +102,10 @@ class TimeInfo(MixinInfo):
     """
     attrs_from_parent = set(['unit'])  # unit is read-only and None
     _supports_indexing = True
-    _represent_as_dict_data_attrs = ('jd1', 'jd2')
-    _represent_as_dict_info_attrs = ('format', 'scale', 'precision',
+    _represent_as_dict_data_attrs = ['jd1', 'jd2']
+    _represent_as_dict_info_attrs = ['format', 'scale', 'precision',
                                      'in_subfmt', 'out_subfmt', 'location',
-                                     '_delta_ut1_utc', '_delta_tdb_tt')
+                                     '_delta_ut1_utc', '_delta_tdb_tt']
 
     @property
     def unit(self):
@@ -132,7 +132,7 @@ class TimeInfo(MixinInfo):
 
     def _represent_as_dict(self, context='yaml'):
         if context == 'column':
-            self._represent_as_dict_data_attrs = ('val',)
+            self._represent_as_dict_data_attrs = ['val']
         return super(TimeInfo, self)._represent_as_dict(context)
 
     def _construct_from_col(self, col):
@@ -174,8 +174,8 @@ class TimeInfo(MixinInfo):
 
 
 class TimeDeltaInfo(TimeInfo):
-    _represent_as_dict_data_attrs = ('jd1', 'jd2')
-    _represent_as_dict_info_attrs = ('format', 'scale')
+    _represent_as_dict_data_attrs = ['jd1', 'jd2']
+    _represent_as_dict_info_attrs = ['format', 'scale']
 
     def _construct_from_dict(self, map):
         format = map.pop('format')

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -23,7 +23,7 @@ from ..units import UnitConversionError
 from ..utils.decorators import lazyproperty
 from ..utils import ShapedLikeNDArray
 from ..utils.compat.misc import override__dir__
-from ..utils.data_info import MixinInfo, data_info_factory, get_type_name
+from ..utils.data_info import MixinInfo, data_info_factory
 from ..utils.compat.numpy import broadcast_to
 from ..extern import six
 from ..extern.six.moves import zip
@@ -116,33 +116,6 @@ class TimeInfo(MixinInfo):
                           funcs=[getattr(np, stat) for stat in MixinInfo._stats]))
     # When Time has mean, std, min, max methods:
     # funcs = [lambda x: getattr(x, stat)() for stat_name in MixinInfo._stats])
-
-    def _get_value_datatype(self):
-        """
-        Get the ECSV datatype for the value that will be stored as a column in the
-        table.
-        """
-        return get_type_name(self._parent.value.dtype.type)
-
-    def _represent_as_dict(self, context='yaml'):
-        if context == 'column':
-            self._represent_as_dict_data_attrs = ['val']
-        return super(TimeInfo, self)._represent_as_dict(context)
-
-    def _construct_from_col(self, col):
-        """Construct appropriate class object from ``col``.
-
-        Input ``col`` is a Table ``Column`` object with dtype=object (strings).
-        Called from astropy.io.ascii.core.TableOutputter.
-        """
-        attrs = col.info.meta['__object_attributes__']
-        map = copy.copy(attrs)
-        data_attrs = map.pop('data_attrs')
-        datatype = map.pop('datatype')
-        map.pop('class')
-        map[data_attrs[0]] = col.astype(datatype)
-
-        return self._construct_from_dict(map)
 
     def _construct_from_dict(self, map):
         delta_ut1_utc = map.pop('_delta_ut1_utc', None)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -130,6 +130,11 @@ class TimeInfo(MixinInfo):
             type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
         return type_name
 
+    def _represent_as_dict(self, context='yaml'):
+        if context == 'column':
+            self._represent_as_dict_data_attrs = ('val',)
+        return super(TimeInfo, self)._represent_as_dict(context)
+
     def _construct_from_col(self, col):
         """Construct appropriate class object from ``col``.
 
@@ -138,8 +143,10 @@ class TimeInfo(MixinInfo):
         """
         attrs = col.info.meta['__object_attributes__']
         map = copy.copy(attrs)
-        map['val'] = col.astype(map.pop('datatype'))
+        data_attrs = map.pop('data_attrs')
+        datatype = map.pop('datatype')
         map.pop('class')
+        map[data_attrs[0]] = col.astype(datatype)
 
         return self._construct_from_dict(map)
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1715,6 +1715,7 @@ def _make_array(val, copy=False):
         Array version of ``val``.
     """
     val = np.array(val, copy=copy, subok=True)
+
     # Allow only float64, string or object arrays as input
     # (object is for datetime, maybe add more specific test later?)
     # This also ensures the right byteorder for float64 (closes #2942).

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -102,9 +102,10 @@ class TimeInfo(MixinInfo):
     """
     attrs_from_parent = set(['unit'])  # unit is read-only and None
     _supports_indexing = True
-    _represent_as_dict_attrs = ('jd1', 'jd2', 'format', 'scale', 'precision',
-                                'in_subfmt', 'out_subfmt', 'location',
-                                '_delta_ut1_utc', '_delta_tdb_tt')
+    _represent_as_dict_data_attrs = ('jd1', 'jd2')
+    _represent_as_dict_info_attrs = ('format', 'scale', 'precision',
+                                     'in_subfmt', 'out_subfmt', 'location',
+                                     '_delta_ut1_utc', '_delta_tdb_tt')
 
     @property
     def unit(self):
@@ -135,8 +136,10 @@ class TimeInfo(MixinInfo):
 
         return out
 
+
 class TimeDeltaInfo(TimeInfo):
-    _represent_as_dict_attrs = ('jd1', 'jd2', 'format', 'scale')
+    _represent_as_dict_data_attrs = ('jd1', 'jd2')
+    _represent_as_dict_info_attrs = ('format', 'scale')
 
     def _construct_from_dict(self, map):
         format = map.pop('format')

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -125,8 +125,8 @@ class TimeFormat(object):
         self.out_subfmt = out_subfmt
 
         if from_jd:
-            self.jd1 = val1
-            self.jd2 = val2
+            self.jd1 = np.asarray(val1)
+            self.jd2 = np.asarray(val2)
         else:
             val1, val2 = self._check_val_type(val1, val2)
             self.set_jds(val1, val2)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -125,8 +125,8 @@ class TimeFormat(object):
         self.out_subfmt = out_subfmt
 
         if from_jd:
-            self.jd1 = np.asarray(val1)
-            self.jd2 = np.asarray(val2)
+            self.jd1 = val1
+            self.jd2 = val2
         else:
             val1, val2 = self._check_val_type(val1, val2)
             self.set_jds(val1, val2)
@@ -164,7 +164,14 @@ class TimeFormat(object):
         if val2 is None:
             val2 = np.zeros_like(val1)
 
-        return val1, val2
+        def asarray_or_scalar(val):
+            """
+            Remove ndarray subclasses since for jd1/jd2 we want a pure ndarray
+            or a Python or numpy scalar.
+            """
+            return np.asarray(val) if isinstance(val, np.ndarray) else val
+
+        return asarray_or_scalar(val1), asarray_or_scalar(val2)
 
     def _check_scale(self, scale):
         """

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -93,21 +93,22 @@ class TestBasic():
         assert t4.isscalar is False
         assert t4.shape == np.broadcast(val, val2).shape
 
-    def test_copy_time(self):
+    @pytest.mark.parametrize('value', [2455197.5, [2455197.5]])
+    def test_copy_time(self, value):
         """Test copying the values of a Time object by passing it into the
         Time initializer.
         """
-        t = Time(2455197.5, format='jd', scale='utc')
+        t = Time(value, format='jd', scale='utc')
 
         t2 = Time(t, copy=False)
-        assert t.jd - t2.jd == 0
-        assert (t - t2).jd == 0
+        assert np.all(t.jd - t2.jd == 0)
+        assert np.all((t - t2).jd == 0)
         assert t._time.jd1 is t2._time.jd1
         assert t._time.jd2 is t2._time.jd2
 
         t2 = Time(t, copy=True)
-        assert t.jd - t2.jd == 0
-        assert (t - t2).jd == 0
+        assert np.all(t.jd - t2.jd == 0)
+        assert np.all((t - t2).jd == 0)
         assert t._time.jd1 is not t2._time.jd1
         assert t._time.jd2 is not t2._time.jd2
 

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -141,21 +141,24 @@ class TestTimeDelta():
         assert allclose_jd(out.jd, [0.0, -100.0])
         assert not out.isscalar
 
-    def test_copy_timedelta(self):
+    @pytest.mark.parametrize('values', [(2455197.5, 2455198.5),
+                                        ([2455197.5], [2455198.5])])
+    def test_copy_timedelta(self, values):
         """Test copying the values of a TimeDelta object by passing it into the
         Time initializer.
         """
-        t = Time(2455197.5, format='jd', scale='utc')
-        t2 = Time(2455198.5, format='jd', scale='utc')
+        val1, val2 = values
+        t = Time(val1, format='jd', scale='utc')
+        t2 = Time(val2, format='jd', scale='utc')
         dt = t2 - t
 
         dt2 = TimeDelta(dt, copy=False)
-        assert dt.jd == dt2.jd
+        assert np.all(dt.jd == dt2.jd)
         assert dt._time.jd1 is dt2._time.jd1
         assert dt._time.jd2 is dt2._time.jd2
 
         dt2 = TimeDelta(dt, copy=True)
-        assert dt.jd == dt2.jd
+        assert np.all(dt.jd == dt2.jd)
         assert dt._time.jd1 is not dt2._time.jd1
         assert dt._time.jd2 is not dt2._time.jd2
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -174,9 +174,15 @@ class QuantityInfo(ParentDtypeInfo):
         # Make an empty quantity using the unit of the last one.
         shape = (length,) + attrs.pop('shape')
         dtype = attrs.pop('dtype')
-        data = np.empty(shape=shape, dtype=dtype)
-        unit = cols[-1].unit
-        out = self._parent_cls(data, unit=unit, copy=False)
+        # Use zeros so we do not get problems for Quantity subclasses such
+        # as Longitude and Latitude, which cannot take arbitrary values.
+        data = np.zeros(shape=shape, dtype=dtype)
+        # Get arguments needed to reconstruct class
+        map = {key: (data if key == 'value' else getattr(cols[-1], key))
+               for key in (self._represent_as_dict_data_attrs +
+                           self._represent_as_dict_info_attrs)}
+        map['copy'] = False
+        out = self._construct_from_dict(map)
 
         # Set remaining info attributes
         for attr, value in attrs.items():

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -114,7 +114,8 @@ class QuantityInfo(ParentDtypeInfo):
     """
     attrs_from_parent = set(['dtype', 'unit'])  # dtype and unit taken from parent
     _supports_indexing = True
-    _represent_as_dict_attrs = ('value', 'unit')
+    _represent_as_dict_data_attrs = ('value',)
+    _represent_as_dict_info_attrs = ('unit',)
 
     @staticmethod
     def default_format(val):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -112,10 +112,9 @@ class QuantityInfo(ParentDtypeInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    attrs_from_parent = set(['dtype', 'unit'])  # dtype and unit taken from parent
+    attrs_from_parent = {'dtype', 'unit'}  # dtype and unit taken from parent
     _supports_indexing = True
-    _represent_as_dict_data_attrs = ['value']
-    _represent_as_dict_info_attrs = ['unit']
+    _represent_as_dict_attrs = ('value', 'unit')
 
     @staticmethod
     def default_format(val):
@@ -179,8 +178,7 @@ class QuantityInfo(ParentDtypeInfo):
         data = np.zeros(shape=shape, dtype=dtype)
         # Get arguments needed to reconstruct class
         map = {key: (data if key == 'value' else getattr(cols[-1], key))
-               for key in (self._represent_as_dict_data_attrs +
-                           self._represent_as_dict_info_attrs)}
+               for key in self._represent_as_dict_attrs}
         map['copy'] = False
         out = self._construct_from_dict(map)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -32,7 +32,8 @@ from .. import config as _config
 from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
                               check_output)
 
-__all__ = ["Quantity", "SpecificTypeQuantity", "QuantityInfo"]
+__all__ = ["Quantity", "SpecificTypeQuantity",
+           "QuantityInfoBase", "QuantityInfo"]
 
 
 # We don't want to run doctests in the docstrings we inherit from Numpy
@@ -106,15 +107,12 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityInfo(ParentDtypeInfo):
-    """
-    Container for meta information like name, description, format.  This is
-    required when the object is used as a mixin column within a table, but can
-    be used as a general way to store meta information.
-    """
+class QuantityInfoBase(ParentDtypeInfo):
+    # This is on a base class rather than QuantityInfo directly, so that
+    # it can be used for EarthLocationInfo yet make clear that that class
+    # should not be considered a typical Quantity subclass by Table.
     attrs_from_parent = {'dtype', 'unit'}  # dtype and unit taken from parent
     _supports_indexing = True
-    _represent_as_dict_attrs = ('value', 'unit')
 
     @staticmethod
     def default_format(val):
@@ -133,6 +131,15 @@ class QuantityInfo(ParentDtypeInfo):
         yield lambda format_, val: format(val.value, format_)
         yield lambda format_, val: format_.format(val.value)
         yield lambda format_, val: format_ % val.value
+
+
+class QuantityInfo(QuantityInfoBase):
+    """
+    Container for meta information like name, description, format.  This is
+    required when the object is used as a mixin column within a table, but can
+    be used as a general way to store meta information.
+    """
+    _represent_as_dict_attrs = ('value', 'unit')
 
     def _construct_from_dict(self, map):
         # Need to pop value because different Quantity subclasses use

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -114,8 +114,8 @@ class QuantityInfo(ParentDtypeInfo):
     """
     attrs_from_parent = set(['dtype', 'unit'])  # dtype and unit taken from parent
     _supports_indexing = True
-    _represent_as_dict_data_attrs = ('value',)
-    _represent_as_dict_info_attrs = ('unit',)
+    _represent_as_dict_data_attrs = ['value']
+    _represent_as_dict_info_attrs = ['unit']
 
     @staticmethod
     def default_format(val):

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -283,28 +283,12 @@ class DataInfo(object):
 
         self._attrs[attr] = value
 
-    def _represent_as_dict(self, context='yaml'):
+    def _represent_as_dict(self):
         """
         Get the values for the parent ``attrs`` and return as a dict.
-
-        If ``context=='yaml'`` then this is being used to serialize the parent
-        to a self-contained YAML structure (including the data).
-
-        If ``context=='column'` then this is being used to serialize the parent
-        as a table column (probably ECSV) where this method is capturing non-data
-        attributes needed to re-create the object later in a table.
         """
-        attrs = []
-        if context == 'yaml':
-            attrs = attrs + self._represent_as_dict_data_attrs
-        attrs = attrs + self._represent_as_dict_info_attrs
-
+        attrs = self._represent_as_dict_data_attrs + self._represent_as_dict_info_attrs
         out = _get_obj_attrs_map(self._parent, attrs)
-
-        if context == 'column':
-            out['data_attrs'] = self._represent_as_dict_data_attrs
-            out['class'] = self._parent.__module__ + '.' + self._parent.__class__.__name__
-            out['datatype'] = self._get_value_datatype()
 
         return out
 
@@ -606,23 +590,7 @@ class MixinInfo(BaseColumnInfo):
         super(MixinInfo, self).__setattr__(attr, value)
 
 
-def get_type_name(typ):
-    type_name = typ.__name__
-    if not six.PY2 and type_name.startswith(('bytes', 'str')):
-        type_name = 'string'
-    if type_name.endswith('_'):
-        type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
-    return type_name
-
-
 class ParentDtypeInfo(MixinInfo):
     """Mixin that gets info.dtype from parent"""
 
     attrs_from_parent = set(['dtype'])  # dtype and unit taken from parent
-
-    def _get_value_datatype(self):
-        """
-        Get the ECSV datatype for the value that will be stored as a column in the
-        table.
-        """
-        return get_type_name(self._parent.dtype.type)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -189,7 +189,8 @@ class DataInfo(object):
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
-    _represent_as_dict_attrs= ()
+    _represent_as_dict_data_attrs = ()
+    _represent_as_dict_info_attrs = ()
     _parent = None
 
     def __init__(self, bound=False):
@@ -282,12 +283,17 @@ class DataInfo(object):
 
         self._attrs[attr] = value
 
-    def _represent_as_dict(self):
+    def _represent_as_dict(self, with_data=True):
         """
         Get the values for the parent ``attrs`` and return as a dict.
         This is typically used for serializing the parent.
         """
-        return _get_obj_attrs_map(self._parent, self._represent_as_dict_attrs)
+        attrs = ()
+        if with_data:
+            attrs = attrs + self._represent_as_dict_data_attrs
+        attrs = attrs + self._represent_as_dict_info_attrs
+
+        return _get_obj_attrs_map(self._parent, attrs)
 
     def _construct_from_dict(self, map):
         return self._parent_cls(**map)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -189,8 +189,8 @@ class DataInfo(object):
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
-    _represent_as_dict_data_attrs = ()
-    _represent_as_dict_info_attrs = ()
+    _represent_as_dict_data_attrs = []
+    _represent_as_dict_info_attrs = []
     _parent = None
 
     def __init__(self, bound=False):
@@ -294,7 +294,7 @@ class DataInfo(object):
         as a table column (probably ECSV) where this method is capturing non-data
         attributes needed to re-create the object later in a table.
         """
-        attrs = ()
+        attrs = []
         if context == 'yaml':
             attrs = attrs + self._represent_as_dict_data_attrs
         attrs = attrs + self._represent_as_dict_info_attrs

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -597,3 +597,15 @@ class ParentDtypeInfo(MixinInfo):
     """Mixin that gets info.dtype from parent"""
 
     attrs_from_parent = set(['dtype'])  # dtype and unit taken from parent
+
+    def _get_value_datatype(self):
+        """
+        Get the ECSV datatype for the value that will be stored as a column in the
+        table.
+        """
+        type_name = self._parent.dtype.type.__name__
+        if not six.PY2 and type_name.startswith(('bytes', 'str')):
+            type_name = 'string'
+        if type_name.endswith('_'):
+            type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
+        return type_name

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -606,6 +606,15 @@ class MixinInfo(BaseColumnInfo):
         super(MixinInfo, self).__setattr__(attr, value)
 
 
+def get_type_name(typ):
+    type_name = typ.__name__
+    if not six.PY2 and type_name.startswith(('bytes', 'str')):
+        type_name = 'string'
+    if type_name.endswith('_'):
+        type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
+    return type_name
+
+
 class ParentDtypeInfo(MixinInfo):
     """Mixin that gets info.dtype from parent"""
 
@@ -616,9 +625,4 @@ class ParentDtypeInfo(MixinInfo):
         Get the ECSV datatype for the value that will be stored as a column in the
         table.
         """
-        type_name = self._parent.dtype.type.__name__
-        if not six.PY2 and type_name.startswith(('bytes', 'str')):
-            type_name = 'string'
-        if type_name.endswith('_'):
-            type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
-        return type_name
+        return get_type_name(self._parent.dtype.type)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -210,8 +210,7 @@ class DataInfo(object):
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
-    _represent_as_dict_data_attrs = []
-    _represent_as_dict_info_attrs = []
+    _represent_as_dict_attrs = ()
     _parent = None
 
     def __init__(self, bound=False):
@@ -305,13 +304,8 @@ class DataInfo(object):
         self._attrs[attr] = value
 
     def _represent_as_dict(self):
-        """
-        Get the values for the parent ``attrs`` and return as a dict.
-        """
-        attrs = self._represent_as_dict_data_attrs + self._represent_as_dict_info_attrs
-        out = _get_obj_attrs_map(self._parent, attrs)
-
-        return out
+        """Get the values for the parent ``attrs`` and return as a dict."""
+        return _get_obj_attrs_map(self._parent, self._represent_as_dict_attrs)
 
     def _construct_from_dict(self, map):
         return self._parent_cls(**map)

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -20,7 +20,7 @@ The following shows a few of the ASCII formats that are available, while the sec
 * :class:`~astropy.io.ascii.Basic`: basic table with customizable delimiters and header configurations
 * :class:`~astropy.io.ascii.Cds`: `CDS format table <http://vizier.u-strasbg.fr/doc/catstd.htx>`_ (also Vizier and ApJ machine readable tables)
 * :class:`~astropy.io.ascii.Daophot`: table from the IRAF DAOphot package
-* :class:`~astropy.io.ascii.Ecsv`: `Enhanced CSV format <https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_
+* :class:`~astropy.io.ascii.Ecsv`: :ref:`ecsv_format` for lossless round-trip of data tables
 * :class:`~astropy.io.ascii.FixedWidth`: table with fixed-width columns (see also :ref:`fixed_width_gallery`)
 * :class:`~astropy.io.ascii.Ipac`: `IPAC format table <http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html>`_
 * :class:`~astropy.io.ascii.HTML`: HTML format table contained in a <table> tag
@@ -34,7 +34,7 @@ be easily accommodated.
 
 .. note::
 
-    It is also possible to use the functionality from
+    It is also possible (and encouraged) to use the functionality from
     :mod:`astropy.io.ascii` through a higher-level interface in the
     :ref:`Data Tables <astropy-table>` package. See :ref:`table_io` for more details.
 
@@ -147,8 +147,7 @@ To disable this engine, use the parameter ``fast_writer``::
 
    >>> ascii.write(data, 'values.csv', format='csv', fast_writer=False)  # doctest: +SKIP
 
-Finally, one can write data in the `ECSV table format
-<https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ which allows
+Finally, one can write data in the :ref:`ecsv_format` which allows
 preserving table meta-data such as column data types and units.  In this way a
 data table (including one with masked entries) can be stored and read back as
 ASCII with no loss of information.

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -269,3 +269,95 @@ details.
   Note: Reader classes and Writer classes are synonymous, in other
   words Reader classes can also write, but for historical reasons they are
   often called Reader classes.
+
+
+
+.. _ecsv_format:
+
+ECSV format
+===========
+
+The `Enhanced Character-Separated Values (ECSV) format
+<https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ can be used to
+write astropy `~astropy.table.Table` or `~astropy.table.QTable` datasets to a
+text-only data file and then read the table back with loss of information.  The
+format handles the key issue of serializing column specifications and table
+metadata by using a YAML-encoded data structure. The actual tabular data are
+stored in a standard character separated values (CSV) format, giving
+compatibility with a wide variety of non-specialized CSV table readers.
+
+Mixin columns
+-------------
+
+Starting with astropy 2.0 it is possible to store not only standard
+`~astropy.table.Column` objects to ECSV but also the following
+:ref:`mixin_columns`:
+
+- `astropy.time.Time`
+- `astropy.time.TimeDelta`
+- `astropy.units.Quantity`
+- `astropy.coordinates.Latitude`
+- `astropy.coordinates.Longitude`
+- `astropy.coordinates.Angle`
+- `astropy.coordinates.EarthLocation`
+- `astropy.coordinates.SkyCoord`
+
+In general a mixin column may contain multiple data components as well as
+object attributes beyond the standard `~astropy.table.Column` attributes like
+``format`` or ``description``.  Storing such mixin columns is done by replacing the
+mixin column with column(s) representing the underlying data component(s) and then
+inserting meta data which informs the reader how to reconstruct the original
+column.  For example a `~astropy.coordinates.SkyCoord` mixin column in
+``'spherical'`` representation would have
+data attributes ``ra``, ``dec``, ``distance``, along with object attributes
+like ``representation`` or ``frame``.  For example::
+
+  >>> from astropy.io import ascii
+  >>> from astropy.coordinates import SkyCoord
+  >>> import astropy.units as u
+  >>> from astropy.time import Time
+  >>> from astropy.table import QTable
+
+  >>> sc = SkyCoord(ra=[1,2]*u.deg, dec=[3,4]*u.deg, distance=[5,6]*u.m,
+  ...               frame='fk4', obstime=Time('2000:001'))
+  >>> c = Column([1,2])
+  >>> q = [1,2]*u.m
+  >>> q.info.format = '.2f'
+  >>> t = QTable([c, q, sc], names=['c', 'q', 'sc'])
+
+  >>> ascii.write(t, format='ecsv')
+  # %ECSV 0.9
+  # ---
+  # datatype:
+  # - {name: c, datatype: int64}
+  # - {name: q, unit: m, datatype: float64, format: .2f}
+  # - {name: sc.ra, unit: deg, datatype: float64}
+  # - {name: sc.dec, unit: deg, datatype: float64}
+  # - {name: sc.distance, unit: m, datatype: float64}
+  # meta: !!omap
+  # - __mixin_columns__:
+  #     q:
+  #       __class__: astropy.units.quantity.Quantity
+  #       __info__: {format: .2f}
+  #       unit: !astropy.units.Unit {unit: m}
+  #       value: !astropy.table.SerializedColumn {name: q}
+  #     sc:
+  #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
+  #       dec: !astropy.table.SerializedColumn {name: sc.dec}
+  #       distance: !astropy.table.SerializedColumn {name: sc.distance}
+  #       equinox: !astropy.time.Time {format: byear_str, in_subfmt: '*', jd1: 2400000.5,
+  #         jd2: 33281.92345905, out_subfmt: '*', precision: 3, scale: tai}
+  #       frame: fk4
+  #       obstime: !astropy.time.Time {format: yday, in_subfmt: '*', jd1: 2451544.5, jd2: 0.0,
+  #         out_subfmt: '*', precision: 3, scale: utc}
+  #       ra: !astropy.table.SerializedColumn {name: sc.ra}
+  #       representation: spherical
+  # schema: astropy-2.0
+  c q sc.ra sc.dec sc.distance
+  1 1.00 1.0 3.0 5.0
+  2 2.00 2.0 4.0 6.0
+
+The ``'__class__'`` keyword gives the fully-qualified class name, and must be
+one of the specifically-allowed astropy classes.  There is no option to add
+user-specified allowed classes.  The ``'__info__'`` keyword contains values for
+standard `~astropy.table.Column` attributes like ``description`` or ``format``.

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -325,7 +325,7 @@ like ``representation`` or ``frame``.  For example::
   >>> q.info.format = '.2f'
   >>> t = QTable([c, q, sc], names=['c', 'q', 'sc'])
 
-  >>> ascii.write(t, format='ecsv')
+  >>> ascii.write(t, format='ecsv')   # doctest: +SKIP
   # %ECSV 0.9
   # ---
   # datatype:

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -271,7 +271,6 @@ details.
   often called Reader classes.
 
 
-
 .. _ecsv_format:
 
 ECSV format
@@ -280,8 +279,8 @@ ECSV format
 The `Enhanced Character-Separated Values (ECSV) format
 <https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ can be used to
 write astropy `~astropy.table.Table` or `~astropy.table.QTable` datasets to a
-text-only data file and then read the table back with loss of information.  The
-format handles the key issue of serializing column specifications and table
+text-only data file and then read the table back without loss of information.
+The format handles the key issue of serializing column specifications and table
 metadata by using a YAML-encoded data structure. The actual tabular data are
 stored in a standard character separated values (CSV) format, giving
 compatibility with a wide variety of non-specialized CSV table readers.
@@ -304,22 +303,23 @@ Starting with astropy 2.0 it is possible to store not only standard
 
 In general a mixin column may contain multiple data components as well as
 object attributes beyond the standard `~astropy.table.Column` attributes like
-``format`` or ``description``.  Storing such mixin columns is done by replacing the
-mixin column with column(s) representing the underlying data component(s) and then
-inserting meta data which informs the reader how to reconstruct the original
-column.  For example a `~astropy.coordinates.SkyCoord` mixin column in
-``'spherical'`` representation would have
-data attributes ``ra``, ``dec``, ``distance``, along with object attributes
-like ``representation`` or ``frame``.  For example::
+``format`` or ``description``.  Storing such mixin columns is done by replacing
+the mixin column with column(s) representing the underlying data component(s)
+and then inserting meta data which informs the reader how to reconstruct the
+original column.  For example a `~astropy.coordinates.SkyCoord` mixin column in
+``'spherical'`` representation would have data attributes ``ra``, ``dec``,
+``distance``, along with object attributes like ``representation`` or ``frame``.
+For example::
 
   >>> from astropy.io import ascii
   >>> from astropy.coordinates import SkyCoord
   >>> import astropy.units as u
   >>> from astropy.time import Time
-  >>> from astropy.table import QTable
+  >>> from astropy.table import QTable, Column
 
   >>> sc = SkyCoord(ra=[1,2]*u.deg, dec=[3,4]*u.deg, distance=[5,6]*u.m,
   ...               frame='fk4', obstime=Time('2000:001'))
+  >>> sc.info.description = 'flying circus'
   >>> c = Column([1,2])
   >>> q = [1,2]*u.m
   >>> q.info.format = '.2f'
@@ -330,34 +330,43 @@ like ``representation`` or ``frame``.  For example::
   # ---
   # datatype:
   # - {name: c, datatype: int64}
-  # - {name: q, unit: m, datatype: float64, format: .2f}
+  # - {name: q, unit: m, datatype: float64}
   # - {name: sc.ra, unit: deg, datatype: float64}
   # - {name: sc.dec, unit: deg, datatype: float64}
   # - {name: sc.distance, unit: m, datatype: float64}
   # meta: !!omap
-  # - __mixin_columns__:
+  # - __serialized_columns__:
   #     q:
   #       __class__: astropy.units.quantity.Quantity
-  #       __info__: {format: .2f}
-  #       unit: !astropy.units.Unit {unit: m}
   #       value: !astropy.table.SerializedColumn {name: q}
   #     sc:
   #       __class__: astropy.coordinates.sky_coordinate.SkyCoord
-  #       dec: !astropy.table.SerializedColumn {name: sc.dec}
-  #       distance: !astropy.table.SerializedColumn {name: sc.distance}
+  #       __info__: {description: flying circus}
+  #       dec: !astropy.table.SerializedColumn
+  #         __class__: astropy.coordinates.angles.Latitude
+  #         value: !astropy.table.SerializedColumn {name: sc.dec}
+  #       distance: !astropy.table.SerializedColumn
+  #         __class__: astropy.coordinates.distances.Distance
+  #         value: !astropy.table.SerializedColumn {name: sc.distance}
   #       equinox: !astropy.time.Time {format: byear_str, in_subfmt: '*', jd1: 2400000.5,
   #         jd2: 33281.92345905, out_subfmt: '*', precision: 3, scale: tai}
   #       frame: fk4
   #       obstime: !astropy.time.Time {format: yday, in_subfmt: '*', jd1: 2451544.5, jd2: 0.0,
   #         out_subfmt: '*', precision: 3, scale: utc}
-  #       ra: !astropy.table.SerializedColumn {name: sc.ra}
+  #       ra: !astropy.table.SerializedColumn
+  #         __class__: astropy.coordinates.angles.Longitude
+  #         value: !astropy.table.SerializedColumn {name: sc.ra}
+  #         wrap_angle: !astropy.coordinates.Angle
+  #           unit: !astropy.units.Unit {unit: deg}
+  #           value: 360.0
   #       representation: spherical
   # schema: astropy-2.0
   c q sc.ra sc.dec sc.distance
-  1 1.00 1.0 3.0 5.0
-  2 2.00 2.0 4.0 6.0
+  1 1.0 1.0 3.0 5.0
+  2 2.0 2.0 4.0 6.0
 
 The ``'__class__'`` keyword gives the fully-qualified class name, and must be
 one of the specifically-allowed astropy classes.  There is no option to add
 user-specified allowed classes.  The ``'__info__'`` keyword contains values for
-standard `~astropy.table.Column` attributes like ``description`` or ``format``.
+standard `~astropy.table.Column` attributes like ``description`` or ``format``,
+for any mixin columns that are represented by more than one serialized column.


### PR DESCRIPTION
This PR adds a new `astropy-2.0` schema to the ECSV format to allow (mostly) lossless serialization of `Time`, `TimeDelta`, and `SkyCoord` objects.  The "mostly" means that the representation of numbers if just what the user specifies, so if a Time object has precision=1 then that's what get's written out.

For example of this in action see below.

To do:

- [x] Set `schema` keyword in ECSV header to `astropy-2.0`.
- [x] Tests
- [x] Docs
- [x] Changelog

```
In [27]: tm = Time([1,2], format='cxcsec', precision=5)
In [28]: sc = SkyCoord([1,2], [3,4], unit='deg,deg', frame='fk4', obstime='J1990.5')
In [29]: t = Table([sc, tm])
In [30]: t.write('mixin.ecsv', format='ascii.ecsv', overwrite=True)
In [31]: cat mixin.ecsv
# %ECSV 0.9
# ---
# datatype:
# - name: col0
#   unit: deg,deg
#   datatype: object
#   meta:
#     __object_attributes__:
#       class: astropy.coordinates.sky_coordinate.SkyCoord
#       data_attrs: [ra, dec]
#       datatype: string
#       equinox: !astropy.time.Time {format: byear_str, in_subfmt: '*', jd1: 2400000.5,
#         jd2: 33281.92345905, out_subfmt: '*', precision: 3, scale: tai}
#       frame: fk4
#       obstime: !astropy.time.Time {format: jyear_str, in_subfmt: '*', jd1: 2400000.5,
#         jd2: 48074.625, out_subfmt: '*', precision: 3, scale: utc}
#       representation: spherical
#       unit: deg,deg
# - name: col1
#   datatype: object
#   meta:
#     __object_attributes__:
#       class: astropy.time.core.Time
#       data_attrs: [val]
#       datatype: float64
#       format: cxcsec
#       in_subfmt: '*'
#       out_subfmt: '*'
#       precision: 5
#       scale: tt
col0 col1
1.0,3.0 1.000000000001755
2.0,4.0 1.999999999998714

In [32]: t2 = Table.read('mixin.ecsv', format='ascii.ecsv')

In [33]: t2
Out[33]: 
<Table length=2>
  col0         col1      
deg,deg                  
 object       object     
------- -----------------
1.0,3.0 1.000000000001755
2.0,4.0 1.999999999998714

In [34]: t2['col0']
Out[34]: 
<SkyCoord (FK4: equinox=B1950.000, obstime=J1990.500): (ra, dec) in deg
    [( 1.,  3.), ( 2.,  4.)]>

In [35]: t2['col1']
Out[35]: 
<Time object: scale='tt' format='cxcsec' value=col1
----
 1.0
 2.0>
```