### PR TITLE
Add replicate and replicate_without_data methods to frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ New Features
     differentials (i.e., finite derivatives) of coordinates.  This is intended
     to enable support for velocities in coordinate frames down the road. [#5871]
 
+  - A ``clone_frame`` method was added to coordinate frames that allows copying
+    an existing frame without the data (and possibly overriding frame
+    attributes). [#6182]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,8 +22,8 @@ New Features
     differentials (i.e., finite derivatives) of coordinates.  This is intended
     to enable support for velocities in coordinate frames down the road. [#5871]
 
-  - A ``clone_frame`` method was added to coordinate frames that allows copying
-    an existing frame without the data (and possibly overriding frame
+  - A ``copy_without_data`` method was added to coordinate frames that allows
+    copying an existing frame without the data (and possibly overriding frame
     attributes). [#6182]
 
 - ``astropy.cosmology``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,9 +22,9 @@ New Features
     differentials (i.e., finite derivatives) of coordinates.  This is intended
     to enable support for velocities in coordinate frames down the road. [#5871]
 
-  - A ``copy_without_data`` method was added to coordinate frames that allows
-    copying an existing frame without the data (and possibly overriding frame
-    attributes). [#6182]
+  - ``replicate_without_data`` and ``replicate`` methods were added to
+    coordinate frames that allow copying an existing frame object with various
+    reference or copy behaviors and possibly overriding frame attributes. [#6182]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -457,7 +457,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def realize_frame(self, representation):
         """
         Generates a new frame *with new data* from another frame (which may or
-        may not have data).
+        may not have data). Roughly speaking, the converse of `clone_frame`.
 
         Parameters
         ----------
@@ -474,6 +474,28 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                         for attr in self.get_frame_attr_names()
                         if attr not in self._attr_names_with_defaults])
         return self.__class__(representation, **frattrs)
+
+    def clone_frame(self, **kwargs):
+        """
+        Generates a new frame *without data* from this frame (which may or
+        may not have data).  Optinally, can override frame attributes.
+        Roughly speaking, the converse of `realize_frame`.
+
+        Parameters
+        ----------
+        Any keywords are treated as frame attributes to be set on the new frame
+        object.
+
+        Returns
+        -------
+        frameobj : same as this frame
+            A new object with the same frame attributes as this one, but
+            with no data and possibly new frame attributes.
+        """
+        attrs_to_set = {nm:getattr(self, nm) for nm in self.frame_attributes}
+        for nm, val in kwargs.items():
+            attrs_to_set[nm] = val
+        return self.__class__(**attrs_to_set)
 
     def represent_as(self, new_representation, in_frame_units=False):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -819,7 +819,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         def apply_method(value):
             if isinstance(value, ShapedLikeNDArray):
                 if method=='replicate' and not hasattr(value, method):
-                    return value._apply('copy', *args, **kwargs)
+                    return value  # reference directly
                 else:
                     return value._apply(method, *args, **kwargs)
             else:
@@ -827,7 +827,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                     return method(value, *args, **kwargs)
                 else:
                     if method=='replicate' and not hasattr(value, method):
-                        return value.copy(*args, **kwargs)
+                        return value  # reference directly
                     else:
                         return getattr(value, method)(*args, **kwargs)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -456,14 +456,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
     def replicate(self, copy=False, **kwargs):
         """
-        Generates a new frame object that is a copy of this one, but possibly
-        with frame attributes overriden and/or by reference.
+        Return a replica of the frame, optionally with new frame attributes.
 
-        If ``copy`` is set to `True` then a full copy of the internal arrays
-        will be made.  By default the replica will use a reference to the
-        original arrays when possible to save memory.  The internal arrays
-        are normally not changeable by the user so in most cases it should not
-        be necessary to set ``copy`` to `True`.
+        The replica is a new frame object that has the same data as this frame
+        object and with frame attributes overriden if they are provided as extra
+        keyword arguments to this method. If ``copy`` is set to `True` then a
+        copy of the internal arrays will be made.  Otherwise the replica will
+        use a reference to the original arrays when possible to save memory. The
+        internal arrays are normally not changeable by the user so in most cases
+        it should not be necessary to set ``copy`` to `True`.
 
         Parameters
         ----------
@@ -484,9 +485,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
     def replicate_without_data(self, copy=False, **kwargs):
         """
-        Generates a new frame object that is a copy of this one, but without
-        data, and possibly with new frame attributes.  Effectively, the converse
-        of `realize_frame`.
+        Return a replica without data, optionally with new frame attributes.
+
+        The replica is a new frame object without data but with the same frame
+        attributes as this object, except where overriden by extra keyword
+        arguments to this method.  The ``copy`` keyword determines if the frame
+        attributes are truly copied vs being references (which saves memory for
+        cases where frame attributes are large).
+
+        This method is essentially the converse of `realize_frame`.
 
         Parameters
         ----------

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -457,7 +457,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def realize_frame(self, representation):
         """
         Generates a new frame *with new data* from another frame (which may or
-        may not have data). Roughly speaking, the converse of `clone_frame`.
+        may not have data). Roughly speaking, the converse of `copy_without_data`.
 
         Parameters
         ----------
@@ -475,7 +475,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                         if attr not in self._attr_names_with_defaults])
         return self.__class__(representation, **frattrs)
 
-    def clone_frame(self, **kwargs):
+    def copy_without_data(self, **kwargs):
         """
         Generates a new frame *without data* from this frame (which may or
         may not have data).  Optinally, can override frame attributes.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -32,7 +32,7 @@ from .representation import (BaseRepresentation, CartesianRepresentation,
                              REPRESENTATION_CLASSES)
 
 # Import all FrameAttributes so we don't break backwards-compatibility
-# (some users rely on them being here, although that is not 
+# (some users rely on them being here, although that is not
 # encouraged, as this is not the public API location.)
 from .frame_attributes import *
 
@@ -492,10 +492,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             A new object with the same frame attributes as this one, but
             with no data and possibly new frame attributes.
         """
-        attrs_to_set = {nm:getattr(self, nm) for nm in self.frame_attributes}
-        for nm, val in kwargs.items():
-            attrs_to_set[nm] = val
-        return self.__class__(**attrs_to_set)
+        frattrs = dict([(attr, getattr(self, attr))
+                        for attr in self.get_frame_attr_names()
+                        if attr not in self._attr_names_with_defaults])
+        frattrs.update(kwargs)
+        return self.__class__(**frattrs)
 
     def represent_as(self, new_representation, in_frame_units=False):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -818,7 +818,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         def apply_method(value):
             if isinstance(value, ShapedLikeNDArray):
-                if method=='replicate' and not hasattr(value, method):
+                if method == 'replicate' and not hasattr(value, method):
                     return value  # reference directly
                 else:
                     return value._apply(method, *args, **kwargs)
@@ -826,7 +826,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 if callable(method):
                     return method(value, *args, **kwargs)
                 else:
-                    if method=='replicate' and not hasattr(value, method):
+                    if method == 'replicate' and not hasattr(value, method):
                         return value  # reference directly
                     else:
                         return getattr(value, method)(*args, **kwargs)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -812,18 +812,24 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             Any keyword arguments for ``method``.
         """
         if '_framedata' in kwargs:
-            data = kwargs['_framedata']
+            data = kwargs.pop('_framedata')
         else:
             data = self.data if self.has_data else None
 
         def apply_method(value):
             if isinstance(value, ShapedLikeNDArray):
-                return value._apply(method, *args, **kwargs)
+                if method=='replicate' and not hasattr(value, method):
+                    return value._apply('copy', *args, **kwargs)
+                else:
+                    return value._apply(method, *args, **kwargs)
             else:
                 if callable(method):
                     return method(value, *args, **kwargs)
                 else:
-                    return getattr(value, method)(*args, **kwargs)
+                    if method=='replicate' and not hasattr(value, method):
+                        return value.copy(*args, **kwargs)
+                    else:
+                        return getattr(value, method)(*args, **kwargs)
 
         if data is not None:
             data = apply_method(data)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -280,11 +280,19 @@ def test_realizing():
     assert f2.equinox != FK5.get_frame_attr_names()['equinox']
 
 
-def test_cloning():
+def test_replicating():
     from ..builtin_frames import ICRS, AltAz
     from ...time import Time
 
-    i = ICRS(ra=1*u.deg, dec=2*u.deg)
+    i = ICRS(ra=[1]*u.deg, dec=[2]*u.deg)
+
+    icopy = i.replicate(copy=True)
+    irepl = i.replicate(copy=False)
+    i.data._lat[:] = 0*u.deg
+    assert np.all(i.data.lat == irepl.data.lat)
+    assert np.all(i.data.lat != icopy.data.lat)
+
+
     iclone = i.replicate_without_data()
     assert i.has_data
     assert not iclone.has_data

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -285,12 +285,12 @@ def test_cloning():
     from ...time import Time
 
     i = ICRS(ra=1*u.deg, dec=2*u.deg)
-    iclone = i.replicate(copy=None)
+    iclone = i.replicate_without_data()
     assert i.has_data
     assert not iclone.has_data
 
     aa = AltAz(alt=1*u.deg, az=2*u.deg, obstime=Time('J2000'))
-    aaclone = aa.replicate(copy=None, obstime=Time('J2001'))
+    aaclone = aa.replicate_without_data(obstime=Time('J2001'))
     assert not aaclone.has_data
     assert aa.obstime != aaclone.obstime
     assert aa.pressure == aaclone.pressure

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -285,12 +285,12 @@ def test_cloning():
     from ...time import Time
 
     i = ICRS(ra=1*u.deg, dec=2*u.deg)
-    iclone = i.copy_without_data()
+    iclone = i.replicate(copy=None)
     assert i.has_data
     assert not iclone.has_data
 
     aa = AltAz(alt=1*u.deg, az=2*u.deg, obstime=Time('J2000'))
-    aaclone = aa.copy_without_data(obstime=Time('J2001'))
+    aaclone = aa.replicate(copy=None, obstime=Time('J2001'))
     assert not aaclone.has_data
     assert aa.obstime != aaclone.obstime
     assert aa.pressure == aaclone.pressure

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -285,12 +285,12 @@ def test_cloning():
     from ...time import Time
 
     i = ICRS(ra=1*u.deg, dec=2*u.deg)
-    iclone = i.clone_frame()
+    iclone = i.copy_without_data()
     assert i.has_data
     assert not iclone.has_data
 
     aa = AltAz(alt=1*u.deg, az=2*u.deg, obstime=Time('J2000'))
-    aaclone = aa.clone_frame(obstime=Time('J2001'))
+    aaclone = aa.copy_without_data(obstime=Time('J2001'))
     assert not aaclone.has_data
     assert aa.obstime != aaclone.obstime
     assert aa.pressure == aaclone.pressure

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -280,6 +280,23 @@ def test_realizing():
     assert f2.equinox != FK5.get_frame_attr_names()['equinox']
 
 
+def test_cloning():
+    from ..builtin_frames import ICRS, AltAz
+    from ...time import Time
+
+    i = ICRS(ra=1*u.deg, dec=2*u.deg)
+    iclone = i.clone_frame()
+    assert i.has_data
+    assert not iclone.has_data
+
+    aa = AltAz(alt=1*u.deg, az=2*u.deg, obstime=Time('J2000'))
+    aaclone = aa.clone_frame(obstime=Time('J2001'))
+    assert not aaclone.has_data
+    assert aa.obstime != aaclone.obstime
+    assert aa.pressure == aaclone.pressure
+    assert aa.obswl == aaclone.obswl
+
+
 def test_getitem():
     from ..builtin_frames import ICRS
 


### PR DESCRIPTION
This is a straightforward PR that adds a `clone_frame` method to `BaseCoordinateFrame`.  This method copies the frame and its attributes, *without* the data, optionally overriding frame attributes.

I'm not a huge fan of the specific name `clone_frame`, as it doesn't clearly convey that the data get removed.  But I felt `unrealize_frame` doesn't convey the fact that this is also a good way to copy attributes (overwriting specific ones if desired).  So this seemed like a compromise... But I'm willing to be convinced if someone has strong opinions.

This idiom is used in a variety of places, and this method can probably be used to clean things up.  But for now just getting it in for 2.0 is a good starting point.  (Note that it also makes some of the velocity work @adrn and I are finishing up easier).

cc @astrofrog or @Cadair  (one of you I think originally suggested this in some form or another... I think?)