### PR TITLE
Enable unit support on all functional models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,7 +73,7 @@ New Features
 
   - Added infrastructure support for units on parameters and during
     model evaluation and fitting, added support for units on most
-    functional models and added a new Blackbody1D model. [#4855, #6183]
+    functional models and added a new BlackBody1D model. [#4855, #6183]
 
 - ``astropy.nddata``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,8 +72,8 @@ New Features
     is controlled by a new optional boolean keyword ``with_bounding_box``. [#6081]
 
   - Added infrastructure support for units on parameters and during
-    model evaluation and fitting, added support for units on Gaussian1D
-    and added a new Blackbody1D model. [#4855]
+    model evaluation and fitting, added support for units on most
+    functional models and added a new Blackbody1D model. [#4855, #6183]
 
 - ``astropy.nddata``
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1475,22 +1475,17 @@ class Model(object):
             for i in range(len(inputs)):
 
                 input_name = self.inputs[i]
+                input_unit = self.input_units.get(input_name, None)
 
-                if self.input_units is not None:
-                    input_unit = self.input_units.get(input_name, None)
+                if input_unit is None:
+                    continue
 
                 if isinstance(inputs[i], Quantity):
 
                     # We check for consistency of the units with input_units,
                     # taking into account any equivalencies
 
-                    if input_unit is None:
-
-                        # We dont need to do anything since no restrictions were
-                        # placed on input_units for this parameter.
-                        pass
-
-                    elif inputs[i].unit.is_equivalent(input_unit, equivalencies=input_units_equivalencies[input_name]):
+                    if inputs[i].unit.is_equivalent(input_unit, equivalencies=input_units_equivalencies[input_name]):
 
                         # If equivalencies have been specified, we need to
                         # convert the input to the input units - this is because

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -15,7 +15,7 @@ from .utils import ellipse_extent
 from ..extern.six.moves import map
 from ..stats.funcs import gaussian_sigma_to_fwhm
 from .. import units as u
-from ..units import Quantity
+from ..units import Quantity, UnitsError
 from ..utils.exceptions import AstropyDeprecationWarning
 
 __all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
@@ -491,7 +491,10 @@ class Gaussian2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_mean', inputs_unit['x']),
                             ('y_mean', inputs_unit['x']),
                             ('x_stddev', inputs_unit['x']),
@@ -1328,7 +1331,10 @@ class Ellipse2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('a', inputs_unit['x']),
@@ -1409,7 +1415,10 @@ class Disk2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('R_0', inputs_unit['x']),
@@ -1513,7 +1522,10 @@ class Ring2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('r_in', inputs_unit['x']),
@@ -1892,7 +1904,10 @@ class TrapezoidDisk2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('R_0', inputs_unit['x']),
@@ -2042,7 +2057,10 @@ class MexicanHat2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('sigma', inputs_unit['x']),
@@ -2138,7 +2156,10 @@ class AiryDisk2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('radius', inputs_unit['x']),
@@ -2317,7 +2338,10 @@ class Moffat2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('gamma', inputs_unit['x']),
@@ -2436,7 +2460,10 @@ class Sersic2D(Fittable2DModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
-        # units, so we return inputs_unit['x'] for all independent variables.
+        # units otherwise this can lead to issues since rotation is not well
+        # defined.
+        if inputs_unit['x'] != inputs_unit['y']:
+            raise UnitsError("Units of 'x' and 'y' inputs should match")
         return OrderedDict([('x_0', inputs_unit['x']),
                             ('y_0', inputs_unit['x']),
                             ('r_eff', inputs_unit['x']),

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -778,7 +778,7 @@ class Sine1D(Fittable1DModel):
             return {'x': 1. / self.frequency.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('frequency', 1. / inputs_unit['x']),
+        return OrderedDict([('frequency', inputs_unit['x'] ** -1),
                             ('amplitude', outputs_unit['y'])])
 
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -910,7 +910,7 @@ class Lorentz1D(Fittable1DModel):
             central feature of interest.
 
         """
-        x0 = self.x_0.value
+        x0 = self.x_0
         dx = factor * self.fwhm
 
         return (x0 - dx, x0 + dx)
@@ -1783,7 +1783,7 @@ class MexicanHat1D(Fittable1DModel):
             The multiple of sigma used to define the limits.
 
         """
-        x0 = self.x_0.value
+        x0 = self.x_0
         dx = factor * self.sigma
 
         return (x0 - dx, x0 + dx)

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -749,9 +749,14 @@ class Sine1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, frequency, phase):
         """One dimensional Sine model function"""
+        # Note: If frequency and x are quantities, they should normally have
+        # inverse units, so that argument ends up being dimensionless. However,
+        # np.sin of a dimensionless quantity will crash, so we remove the
+        # quantity-ness from argument in this case (another option would be to
+        # multiply by * u.rad but this would be slower overall).
         argument = TWOPI * (frequency * x + phase)
         if isinstance(argument, Quantity):
-            argument *= u.rad
+            argument = argument.value
         return amplitude * np.sin(argument)
 
     @staticmethod

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -663,6 +663,17 @@ class Sersic1D(Fittable1DModel):
         return (amplitude * np.exp(
             -cls._gammaincinv(2 * n, 0.5) * ((r / r_eff) ** (1 / n) - 1)))
 
+    @property
+    def input_units(self):
+        if self.r_eff.unit is None:
+            return None
+        else:
+            return {'x': self.r_eff.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('r_eff', inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
+
 
 class Sine1D(Fittable1DModel):
     """
@@ -733,6 +744,17 @@ class Sine1D(Fittable1DModel):
                    np.cos(TWOPI * frequency * x + TWOPI * phase))
         return [d_amplitude, d_frequency, d_phase]
 
+    @property
+    def input_units(self):
+        if self.frequency.unit is None:
+            return None
+        else:
+            return {'x': 1. / self.frequency.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('frequency', 1. / inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
+
 
 class Linear1D(Fittable1DModel):
     """
@@ -780,6 +802,17 @@ class Linear1D(Fittable1DModel):
         new_slope = self.slope ** -1
         new_intercept = -self.intercept / self.slope
         return self.__class__(slope=new_slope, intercept=new_intercept)
+
+    @property
+    def input_units(self):
+        if self.intercept.unit is None and self.slope.unit is None:
+            return None
+        else:
+            return {'x': self.intercept.unit / self.slope.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('intercept', outputs_unit['y']),
+                            ('slope', outputs_unit['y'] / inputs_unit['x'])])
 
 
 class Planar2D(Fittable2DModel):
@@ -915,6 +948,18 @@ class Lorentz1D(Fittable1DModel):
 
         return (x0 - dx, x0 + dx)
 
+    @property
+    def input_units(self):
+        if self.x_0.unit is None:
+            return None
+        else:
+            return {'x': self.x_0.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('x_0', inputs_unit['x']),
+                            ('fwhm', inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
+
 
 class Voigt1D(Fittable1DModel):
     """
@@ -1007,6 +1052,19 @@ class Voigt1D(Fittable1DModel):
                 -constant * (V + (sqrt_ln2 / fwhm_G) * (2 * (x - x_0) * dVdx + fwhm_L * dVdy)) / fwhm_G]
         return dyda
 
+    @property
+    def input_units(self):
+        if self.x_0.unit is None:
+            return None
+        else:
+            return {'x': self.x_0.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('x_0', inputs_unit['x']),
+                            ('fwhm_L', inputs_unit['x']),
+                            ('fwhm_G', inputs_unit['x']),
+                            ('amplitude_L', outputs_unit['y'])])
+
 
 class Const1D(Fittable1DModel):
     """
@@ -1086,6 +1144,13 @@ class Const1D(Fittable1DModel):
 
         d_amplitude = np.ones_like(x)
         return [d_amplitude]
+
+    @property
+    def input_units(self):
+        return None
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('amplitude', outputs_unit['y'])])
 
 
 class Const2D(Fittable2DModel):
@@ -1526,6 +1591,18 @@ class Box1D(Fittable1DModel):
 
         return (self.x_0 - dx, self.x_0 + dx)
 
+    @property
+    def input_units(self):
+        if self.x_0.unit is None:
+            return None
+        else:
+            return {'x': self.x_0.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('x_0', inputs_unit['x']),
+                            ('width', inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
+
 
 class Box2D(Fittable2DModel):
     """
@@ -1699,6 +1776,19 @@ class Trapezoid1D(Fittable1DModel):
 
         return (self.x_0 - dx, self.x_0 + dx)
 
+    @property
+    def input_units(self):
+        if self.x_0.unit is None:
+            return None
+        else:
+            return {'x': self.x_0.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('x_0', inputs_unit['x']),
+                            ('width', inputs_unit['x']),
+                            ('slope', outputs_unit['y'] / inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
+
 
 class TrapezoidDisk2D(Fittable2DModel):
     """
@@ -1832,6 +1922,19 @@ class MexicanHat1D(Fittable1DModel):
         dx = factor * self.sigma
 
         return (x0 - dx, x0 + dx)
+
+    @property
+    def input_units(self):
+        if self.x_0.unit is None:
+            return None
+        else:
+            return {'x': self.x_0.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('x_0', inputs_unit['x']),
+                            ('sigma', inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
+
 
 
 class MexicanHat2D(Fittable2DModel):
@@ -2039,6 +2142,18 @@ class Moffat1D(Fittable1DModel):
                    (gamma ** 3 * d_A ** alpha))
         d_alpha = -amplitude * d_A * np.log(1 + (x - x_0) ** 2 / gamma ** 2)
         return [d_A, d_x_0, d_gamma, d_alpha]
+
+    @property
+    def input_units(self):
+        if self.x_0.unit is None:
+            return None
+        else:
+            return {'x': self.x_0.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('x_0', inputs_unit['x']),
+                            ('gamma', inputs_unit['x']),
+                            ('amplitude', outputs_unit['y'])])
 
 
 class Moffat2D(Fittable2DModel):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -486,8 +486,11 @@ class Gaussian2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        return {'x': self.x_mean.unit,
-                'y': self.y_mean.unit}
+        if self.x_mean.unit is None and self.y_mean.unit is None:
+            return None
+        else:
+            return {'x': self.x_mean.unit,
+                    'y': self.y_mean.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -134,7 +134,7 @@ MODELS = MODELS_1D + MODELS_2D
 SCIPY_MODELS = set([Sersic1D, Sersic2D, AiryDisk2D])
 
 @pytest.mark.parametrize('model', MODELS)
-def test_models_evaluatate_without_units(model):
+def test_models_evaluate_without_units(model):
     if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
         pytest.skip()
     m = model['class'](**model['parameters'])
@@ -151,7 +151,7 @@ def test_models_evaluatate_without_units(model):
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_models_evaluatate_with_units(model):
+def test_models_evaluate_with_units(model):
     if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
         pytest.skip()
     m = model['class'](**model['parameters'])
@@ -160,7 +160,7 @@ def test_models_evaluatate_with_units(model):
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_models_evaluatate_with_units_x_array(model):
+def test_models_evaluate_with_units_x_array(model):
 
     if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
         pytest.skip()
@@ -182,7 +182,7 @@ def test_models_evaluatate_with_units_x_array(model):
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_models_evaluatate_with_units_param_array(model):
+def test_models_evaluate_with_units_param_array(model):
 
     if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
         pytest.skip()
@@ -225,7 +225,6 @@ def test_models_bounding_box(model):
         # values one by one.
         for i in range(len(model['bounding_box'])):
             bbox = m.bounding_box
-            print(bbox)
             assert_quantity_allclose(bbox[i], model['bounding_box'][i])
     else:
         # Check that NotImplementedError is raised, so that if bounding_box is

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -96,7 +96,7 @@ MODELS_2D = [
  'bounding_box': True},
 {'class': Box2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.s,
-                'x_width': 2 * u.cm, 'y_width': 3 * u.s},
+                'x_width': 4 * u.cm, 'y_width': 3 * u.s},
  'evaluation':[(301 * u.cm, 3 * u.s, 3 * u.Jy)],
  'bounding_box': True},
 {'class': MexicanHat2D,
@@ -186,10 +186,17 @@ def test_models_bounding_box(model):
             m.bounding_box
 
 
-@pytest.mark.parametrize('model', MODELS_1D)
-def test_1d_models_fitting(model):
+@pytest.mark.parametrize('model', MODELS)
+def test_models_fitting(model):
     m = model['class'](**model['parameters'])
-    x = np.linspace(-3, 3, 100) * model['evaluation'][0][0].unit
-    y = np.ones(100) * model['evaluation'][0][1].unit
+    if len(model['evaluation'][0]) == 2:
+        x = np.linspace(-3, 3, 100) * model['evaluation'][0][0].unit
+        y = np.ones(100) * model['evaluation'][0][1].unit
+        args = [x, y]
+    else:
+        x = np.linspace(-3, 3, 100) * model['evaluation'][0][0].unit
+        y = np.linspace(-3, 3, 100) * model['evaluation'][0][1].unit
+        z = np.ones(100) * model['evaluation'][0][2].unit
+        args = [x, y, z]
     fitter = LevMarLSQFitter()
-    m_new = fitter(m, x, y)
+    m_new = fitter(m, *args)

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -16,38 +16,49 @@ from ..functional_models import (Gaussian1D, GaussianAbsorption1D,
 MODELS_1D = [
 {'class': Gaussian1D,
  'parameters': {'amplitude': 3 * u.Jy, 'mean': 2 * u.m, 'stddev': 30 * u.cm},
- 'evaluation':[(2600 * u.mm, 3 * u.Jy * np.exp(-2))]},
+ 'evaluation':[(2600 * u.mm, 3 * u.Jy * np.exp(-2))],
+ 'bounding_box': True},
 {'class': Sersic1D,
  'parameters': {'amplitude': 3 * u.MJy / u.sr, 'r_eff': 2 * u.arcsec, 'n': 4},
- 'evaluation':[(3 * u.arcsec, 1.3237148119468918 * u.MJy/u.sr)]},
+ 'evaluation':[(3 * u.arcsec, 1.3237148119468918 * u.MJy/u.sr)],
+ 'bounding_box': False},
 {'class': Sine1D,
  'parameters': {'amplitude': 3 * u.km / u.s, 'frequency': 0.25 * u.Hz, 'phase': 0.5},
- 'evaluation':[(1 * u.s, -3 * u.km / u.s)]},
+ 'evaluation':[(1 * u.s, -3 * u.km / u.s)],
+ 'bounding_box': False},
 {'class': Linear1D,
  'parameters': {'slope': 3 * u.km / u.s, 'intercept': 5000 * u.m},
- 'evaluation':[(6000 * u.ms, 23 * u.km)]},
+ 'evaluation':[(6000 * u.ms, 23 * u.km)],
+ 'bounding_box': False},
 {'class': Lorentz1D,
  'parameters': {'amplitude': 2 * u.Jy, 'x_0': 505 * u.nm, 'fwhm': 100 * u.AA},
- 'evaluation':[(0.51 * u.micron, 1 * u.Jy)]},
+ 'evaluation':[(0.51 * u.micron, 1 * u.Jy)],
+ 'bounding_box': True},
 {'class': Voigt1D,
  'parameters': {'amplitude_L': 2 * u.Jy, 'x_0': 505 * u.nm,
                 'fwhm_L': 100 * u.AA, 'fwhm_G': 50 * u.AA},
- 'evaluation':[(0.51 * u.micron, 1.06264568 * u.Jy)]},
+ 'evaluation':[(0.51 * u.micron, 1.06264568 * u.Jy)],
+ 'bounding_box': False},
 {'class': Const1D,
  'parameters': {'amplitude': 3 * u.Jy},
- 'evaluation':[(0.6 * u.micron, 3 * u.Jy)]},
+ 'evaluation':[(0.6 * u.micron, 3 * u.Jy)],
+ 'bounding_box': False},
 {'class': Box1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'width': 1 * u.um},
- 'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)]},
+ 'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)],
+ 'bounding_box': True},
 {'class': Trapezoid1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'width': 1 * u.um, 'slope': 5 * u.Jy / u.um},
- 'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)]},
+ 'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)],
+ 'bounding_box': True},
 {'class': MexicanHat1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'sigma': 1e-3 * u.mm},
- 'evaluation':[(1000 * u.nm, -0.09785050 * u.Jy)]},
+ 'evaluation':[(1000 * u.nm, -0.09785050 * u.Jy)],
+ 'bounding_box': True},
 {'class': Moffat1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'gamma': 1e-3 * u.mm, 'alpha':1},
- 'evaluation':[(1000 * u.nm, 0.238853503 * u.Jy)]},
+ 'evaluation':[(1000 * u.nm, 0.238853503 * u.Jy)],
+ 'bounding_box': False},
  ]
 
 @pytest.mark.parametrize('model', MODELS_1D)
@@ -79,6 +90,18 @@ def test_1d_models_evaluatate_with_units_param_array(model):
         result = m(x_arr)
         assert_quantity_allclose(result, u.Quantity([y, y]))
 
+
+@pytest.mark.parametrize('model', MODELS_1D)
+def test_1d_models_bounding_box(model):
+    m = model['class'](**model['parameters'])
+    if model['bounding_box']:
+        m.bounding_box
+    else:
+        # Check that NotImplementedError is raised, so that if bounding_box is
+        # implemented we remember to set bounding_box=True in the list of models
+        # above
+        with pytest.raises(NotImplementedError):
+            m.bounding_box
 
 # class Const2D(Fittable2DModel):
 # class Ellipse2D(Fittable2DModel):

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -131,8 +131,12 @@ MODELS_2D = [
 
 MODELS = MODELS_1D + MODELS_2D
 
+SCIPY_MODELS = set([Sersic1D, Sersic2D, AiryDisk2D])
+
 @pytest.mark.parametrize('model', MODELS)
 def test_models_evaluatate_without_units(model):
+    if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
+        pytest.skip()
     m = model['class'](**model['parameters'])
     for args in model['evaluation']:
         if len(args) == 2:
@@ -148,6 +152,8 @@ def test_models_evaluatate_without_units(model):
 
 @pytest.mark.parametrize('model', MODELS)
 def test_models_evaluatate_with_units(model):
+    if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
+        pytest.skip()
     m = model['class'](**model['parameters'])
     for args in model['evaluation']:
         assert_quantity_allclose(m(*args[:-1]), args[-1])
@@ -156,7 +162,11 @@ def test_models_evaluatate_with_units(model):
 @pytest.mark.parametrize('model', MODELS)
 def test_models_evaluatate_with_units_x_array(model):
 
+    if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
+        pytest.skip()
+
     m = model['class'](**model['parameters'])
+
     for args in model['evaluation']:
         if len(args) == 2:
             x, y = args
@@ -173,6 +183,9 @@ def test_models_evaluatate_with_units_x_array(model):
 
 @pytest.mark.parametrize('model', MODELS)
 def test_models_evaluatate_with_units_param_array(model):
+
+    if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
+        pytest.skip()
 
     params = {}
     for key, value in model['parameters'].items():
@@ -198,7 +211,12 @@ def test_models_evaluatate_with_units_param_array(model):
 
 @pytest.mark.parametrize('model', MODELS)
 def test_models_bounding_box(model):
+
+    if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
+        pytest.skip()
+
     m = model['class'](**model['parameters'])
+
     if model['bounding_box']:
         m.bounding_box
     else:

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -5,10 +5,12 @@ from ... import units as u
 from ...tests.helper import assert_quantity_allclose
 
 from ..functional_models import (Gaussian1D, GaussianAbsorption1D,
-                                                Sersic1D, Sine1D, Linear1D,
-                                                Lorentz1D, Voigt1D, Const1D,
-                                                Box1D, Trapezoid1D, MexicanHat1D,
-                                                Moffat1D)
+                                 Sersic1D, Sine1D, Linear1D,
+                                 Lorentz1D, Voigt1D, Const1D,
+                                 Box1D, Trapezoid1D, MexicanHat1D,
+                                 Moffat1D, Gaussian2D, Const2D, Ellipse2D,
+                                 Disk2D, Ring2D, Box2D, TrapezoidDisk2D,
+                                 MexicanHat2D, AiryDisk2D, Moffat2D, Sersic2D)
 
 # TODO: GaussianAbsorption1D doesn't work with units because the 1- part doesn't
 # have units. How do we want to deal with that?
@@ -61,37 +63,116 @@ MODELS_1D = [
  'bounding_box': False},
  ]
 
-@pytest.mark.parametrize('model', MODELS_1D)
+MODELS_2D = [
+ {'class': Gaussian2D,
+  'parameters': {'amplitude': 3 * u.Jy, 'x_mean': 2 * u.m, 'y_mean': 1 * u.m,
+                 'x_stddev': 3 * u.m, 'y_stddev': 2 * u.m, 'theta': 45 * u.deg},
+  'evaluation':[(412.1320343 * u.cm, 3.121320343 * u.m, 3 * u.Jy * np.exp(-0.5))],
+  'bounding_box': True},
+{'class': Const2D,
+ 'parameters': {'amplitude': 3 * u.Jy},
+ 'evaluation':[(0.6 * u.micron, 0.2 * u.m, 3 * u.Jy)],
+ 'bounding_box': False},
+{'class': Disk2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
+                'R_0': 300 * u.cm},
+ 'evaluation':[(5.8 * u.m, 201 * u.cm, 3 * u.Jy)],
+ 'bounding_box': True},
+{'class': TrapezoidDisk2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':1 * u.m, 'y_0': 2 * u.m,
+                'R_0': 100 * u.cm, 'slope':1 * u.Jy / u.m},
+ 'evaluation':[(3.5 * u.m, 2 * u.m, 1.5 * u.Jy)],
+ 'bounding_box': True},
+{'class': Ellipse2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
+                'a': 300 * u.cm, 'b': 200 * u.cm, 'theta': 45 * u.deg},
+ 'evaluation':[(4 * u.m, 300 * u.cm, 3 * u.Jy)],
+ 'bounding_box': True},
+{'class': Ring2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
+                'r_in': 2 * u.cm, 'r_out': 2.1 * u.cm, 'width': None},
+ 'evaluation':[(302.05 * u.cm, 2 * u.m + 10 * u.um, 3 * u.Jy)],
+ 'bounding_box': True},
+{'class': Box2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.s,
+                'x_width': 2 * u.cm, 'y_width': 3 * u.s},
+ 'evaluation':[(301 * u.cm, 3 * u.s, 3 * u.Jy)],
+ 'bounding_box': True},
+{'class': MexicanHat2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
+                'sigma': 1 * u.m},
+ 'evaluation':[(4 * u.m, 2.5 * u.m, 0.602169107 * u.Jy)],
+ 'bounding_box': False},
+{'class': AiryDisk2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
+                'radius': 1 * u.m},
+ 'evaluation':[(4 * u.m, 2.1 * u.m, 4.76998480e-05 * u.Jy)],
+ 'bounding_box': False},
+{'class': Moffat2D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'y_0': 3.5 * u.um,
+                'gamma': 1e-3 * u.mm, 'alpha':1},
+ 'evaluation':[(1000 * u.nm, 2 * u.um, 0.202565833 * u.Jy)],
+ 'bounding_box': False},
+{'class': Sersic2D,
+ 'parameters': {'amplitude': 3 * u.MJy / u.sr, 'x_0': 1 * u.arcsec,
+                'y_0': 2 * u.arcsec, 'r_eff': 2 * u.arcsec, 'n': 4},
+ 'evaluation':[(3 * u.arcsec, 2.5 * u.arcsec, 2.829990489 * u.MJy/u.sr)],
+ 'bounding_box': False},
+]
+
+MODELS = MODELS_1D + MODELS_2D
+
+@pytest.mark.parametrize('model', MODELS)
 def test_1d_models_evaluatate_with_units(model):
     m = model['class'](**model['parameters'])
-    for x, y in model['evaluation']:
-        assert_quantity_allclose(m(x), y)
+    for args in model['evaluation']:
+        assert_quantity_allclose(m(*args[:-1]), args[-1])
 
 
-@pytest.mark.parametrize('model', MODELS_1D)
+@pytest.mark.parametrize('model', MODELS)
 def test_1d_models_evaluatate_with_units_x_array(model):
 
     m = model['class'](**model['parameters'])
-    for x, y in model['evaluation']:
-        x_arr = u.Quantity([x, x])
-        result = m(x_arr)
-        assert_quantity_allclose(result, u.Quantity([y, y]))
+    for args in model['evaluation']:
+        if len(args) == 2:
+            x, y = args
+            x_arr = u.Quantity([x, x])
+            result = m(x_arr)
+            assert_quantity_allclose(result, u.Quantity([y, y]))
+        else:
+            x, y, z = args
+            x_arr = u.Quantity([x, x])
+            y_arr = u.Quantity([y, y])
+            result = m(x_arr, y_arr)
+            assert_quantity_allclose(result, u.Quantity([z, z]))
 
-@pytest.mark.parametrize('model', MODELS_1D)
+
+@pytest.mark.parametrize('model', MODELS)
 def test_1d_models_evaluatate_with_units_param_array(model):
 
     params = {}
     for key, value in model['parameters'].items():
-        params[key] = np.repeat(value, 2)
+        if value is None:
+            params[key] = None
+        else:
+            params[key] = np.repeat(value, 2)
 
     m = model['class'](**params)
-    for x, y in model['evaluation']:
-        x_arr = u.Quantity([x, x])
-        result = m(x_arr)
-        assert_quantity_allclose(result, u.Quantity([y, y]))
+    for args in model['evaluation']:
+        if len(args) == 2:
+            x, y = args
+            x_arr = u.Quantity([x, x])
+            result = m(x_arr)
+            assert_quantity_allclose(result, u.Quantity([y, y]))
+        else:
+            x, y, z = args
+            x_arr = u.Quantity([x, x])
+            y_arr = u.Quantity([y, y])
+            result = m(x_arr, y_arr)
+            assert_quantity_allclose(result, u.Quantity([z, z]))
 
 
-@pytest.mark.parametrize('model', MODELS_1D)
+@pytest.mark.parametrize('model', MODELS)
 def test_1d_models_bounding_box(model):
     m = model['class'](**model['parameters'])
     if model['bounding_box']:
@@ -102,23 +183,3 @@ def test_1d_models_bounding_box(model):
         # above
         with pytest.raises(NotImplementedError):
             m.bounding_box
-
-# class Const2D(Fittable2DModel):
-# class Ellipse2D(Fittable2DModel):
-# class Disk2D(Fittable2DModel):
-# class Ring2D(Fittable2DModel):
-# class Delta1D(Fittable1DModel):
-# class Delta2D(Fittable2DModel):
-# class Box1D(Fittable1DModel):
-#     @classmethod
-# class Box2D(Fittable2DModel):
-# class Trapezoid1D(Fittable1DModel):
-# class TrapezoidDisk2D(Fittable2DModel):
-# class MexicanHat1D(Fittable1DModel):
-# class MexicanHat2D(Fittable2DModel):
-# class AiryDisk2D(Fittable2DModel):
-#     @classmethod
-# class Moffat1D(Fittable1DModel):
-# class Moffat2D(Fittable2DModel):
-# class Sersic2D(Fittable2DModel):
-#     @classmethod

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -232,13 +232,13 @@ def test_models_bounding_box(model):
 def test_models_fitting(model):
     m = model['class'](**model['parameters'])
     if len(model['evaluation'][0]) == 2:
-        x = np.linspace(-3, 3, 100) * model['evaluation'][0][0].unit
-        y = np.ones(100) * model['evaluation'][0][1].unit
+        x = np.linspace(1, 3, 100) * model['evaluation'][0][0].unit
+        y = np.exp(-x.value ** 2) * model['evaluation'][0][1].unit
         args = [x, y]
     else:
-        x = np.linspace(-3, 3, 100) * model['evaluation'][0][0].unit
-        y = np.linspace(-3, 3, 100) * model['evaluation'][0][1].unit
-        z = np.ones(100) * model['evaluation'][0][2].unit
+        x = np.linspace(1, 3, 100) * model['evaluation'][0][0].unit
+        y = np.linspace(1, 3, 100) * model['evaluation'][0][1].unit
+        z = np.exp(-x.value**2 - y.value**2) * model['evaluation'][0][2].unit
         args = [x, y, z]
     fitter = LevMarLSQFitter()
     m_new = fitter(m, *args)

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -26,9 +26,9 @@ except ImportError:
 
 MODELS_1D = [
 {'class': Gaussian1D,
- 'parameters': {'amplitude': 3 * u.Jy, 'mean': 2 * u.m, 'stddev': 30 * u.cm},
- 'evaluation':[(2600 * u.mm, 3 * u.Jy * np.exp(-2))],
- 'bounding_box': True},
+'parameters': {'amplitude': 3 * u.Jy, 'mean': 2 * u.m, 'stddev': 30 * u.cm},
+'evaluation':[(2600 * u.mm, 3 * u.Jy * np.exp(-2))],
+'bounding_box': [0.35, 3.65] * u.m},
 {'class': Sersic1D,
  'parameters': {'amplitude': 3 * u.MJy / u.sr, 'r_eff': 2 * u.arcsec, 'n': 4},
  'evaluation':[(3 * u.arcsec, 1.3237148119468918 * u.MJy/u.sr)],
@@ -44,7 +44,7 @@ MODELS_1D = [
 {'class': Lorentz1D,
  'parameters': {'amplitude': 2 * u.Jy, 'x_0': 505 * u.nm, 'fwhm': 100 * u.AA},
  'evaluation':[(0.51 * u.micron, 1 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [255, 755] * u.nm},
 {'class': Voigt1D,
  'parameters': {'amplitude_L': 2 * u.Jy, 'x_0': 505 * u.nm,
                 'fwhm_L': 100 * u.AA, 'fwhm_G': 50 * u.AA},
@@ -57,15 +57,15 @@ MODELS_1D = [
 {'class': Box1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'width': 1 * u.um},
  'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [3.9, 4.9] * u.um},
 {'class': Trapezoid1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'width': 1 * u.um, 'slope': 5 * u.Jy / u.um},
  'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [3.3, 5.5] * u.um},
 {'class': MexicanHat1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'sigma': 1e-3 * u.mm},
  'evaluation':[(1000 * u.nm, -0.09785050 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [-5.6, 14.4] * u.um},
 {'class': Moffat1D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'gamma': 1e-3 * u.mm, 'alpha':1},
  'evaluation':[(1000 * u.nm, 0.238853503 * u.Jy)],
@@ -77,7 +77,7 @@ MODELS_2D = [
   'parameters': {'amplitude': 3 * u.Jy, 'x_mean': 2 * u.m, 'y_mean': 1 * u.m,
                  'x_stddev': 3 * u.m, 'y_stddev': 2 * u.m, 'theta': 45 * u.deg},
   'evaluation':[(412.1320343 * u.cm, 3.121320343 * u.m, 3 * u.Jy * np.exp(-0.5))],
-  'bounding_box': True},
+  'bounding_box': [[-14.18257445, 16.18257445], [-10.75693665, 14.75693665]] * u.m},
 {'class': Const2D,
  'parameters': {'amplitude': 3 * u.Jy},
  'evaluation':[(0.6 * u.micron, 0.2 * u.m, 3 * u.Jy)],
@@ -86,27 +86,27 @@ MODELS_2D = [
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
                 'R_0': 300 * u.cm},
  'evaluation':[(5.8 * u.m, 201 * u.cm, 3 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [[-1, 5], [0, 6]] * u.m},
 {'class': TrapezoidDisk2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':1 * u.m, 'y_0': 2 * u.m,
                 'R_0': 100 * u.cm, 'slope':1 * u.Jy / u.m},
  'evaluation':[(3.5 * u.m, 2 * u.m, 1.5 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [[-2, 6], [-3, 5]] * u.m},
 {'class': Ellipse2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
                 'a': 300 * u.cm, 'b': 200 * u.cm, 'theta': 45 * u.deg},
  'evaluation':[(4 * u.m, 300 * u.cm, 3 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [[-0.76046808, 4.76046808], [0.68055697, 5.31944302]] * u.m},
 {'class': Ring2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
                 'r_in': 2 * u.cm, 'r_out': 2.1 * u.cm, 'width': None},
  'evaluation':[(302.05 * u.cm, 2 * u.m + 10 * u.um, 3 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [[1.979, 2.021], [2.979, 3.021]] * u.m},
 {'class': Box2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.s,
                 'x_width': 4 * u.cm, 'y_width': 3 * u.s},
  'evaluation':[(301 * u.cm, 3 * u.s, 3 * u.Jy)],
- 'bounding_box': True},
+ 'bounding_box': [[0.5 * u.s, 3.5 * u.s], [2.98 * u.m, 3.02 * u.m]]},
 {'class': MexicanHat2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
                 'sigma': 1 * u.m},
@@ -212,13 +212,21 @@ def test_models_evaluatate_with_units_param_array(model):
 @pytest.mark.parametrize('model', MODELS)
 def test_models_bounding_box(model):
 
+    # In some cases, having units in parameters caused bounding_box to break,
+    # so this is to ensure that it works correctly.
+
     if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
         pytest.skip()
 
     m = model['class'](**model['parameters'])
 
     if model['bounding_box']:
-        m.bounding_box
+        # A bounding box may have inhomogeneous units so we need to check the
+        # values one by one.
+        for i in range(len(model['bounding_box'])):
+            bbox = m.bounding_box
+            print(bbox)
+            assert_quantity_allclose(bbox[i], model['bounding_box'][i])
     else:
         # Check that NotImplementedError is raised, so that if bounding_box is
         # implemented we remember to set bounding_box=True in the list of models

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -1,0 +1,101 @@
+import pytest
+import numpy as np
+
+from ... import units as u
+from ...tests.helper import assert_quantity_allclose
+
+from ..functional_models import (Gaussian1D, GaussianAbsorption1D,
+                                                Sersic1D, Sine1D, Linear1D,
+                                                Lorentz1D, Voigt1D, Const1D,
+                                                Box1D, Trapezoid1D, MexicanHat1D,
+                                                Moffat1D)
+
+# TODO: GaussianAbsorption1D doesn't work with units because the 1- part doesn't
+# have units. How do we want to deal with that?
+
+MODELS_1D = [
+{'class': Gaussian1D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'mean': 2 * u.m, 'stddev': 30 * u.cm},
+ 'evaluation':[(2600 * u.mm, 3 * u.Jy * np.exp(-2))]},
+{'class': Sersic1D,
+ 'parameters': {'amplitude': 3 * u.MJy / u.sr, 'r_eff': 2 * u.arcsec, 'n': 4},
+ 'evaluation':[(3 * u.arcsec, 1.3237148119468918 * u.MJy/u.sr)]},
+{'class': Sine1D,
+ 'parameters': {'amplitude': 3 * u.km / u.s, 'frequency': 0.25 * u.Hz, 'phase': 0.5},
+ 'evaluation':[(1 * u.s, -3 * u.km / u.s)]},
+{'class': Linear1D,
+ 'parameters': {'slope': 3 * u.km / u.s, 'intercept': 5000 * u.m},
+ 'evaluation':[(6000 * u.ms, 23 * u.km)]},
+{'class': Lorentz1D,
+ 'parameters': {'amplitude': 2 * u.Jy, 'x_0': 505 * u.nm, 'fwhm': 100 * u.AA},
+ 'evaluation':[(0.51 * u.micron, 1 * u.Jy)]},
+{'class': Voigt1D,
+ 'parameters': {'amplitude_L': 2 * u.Jy, 'x_0': 505 * u.nm,
+                'fwhm_L': 100 * u.AA, 'fwhm_G': 50 * u.AA},
+ 'evaluation':[(0.51 * u.micron, 1.06264568 * u.Jy)]},
+{'class': Const1D,
+ 'parameters': {'amplitude': 3 * u.Jy},
+ 'evaluation':[(0.6 * u.micron, 3 * u.Jy)]},
+{'class': Box1D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'width': 1 * u.um},
+ 'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)]},
+{'class': Trapezoid1D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'width': 1 * u.um, 'slope': 5 * u.Jy / u.um},
+ 'evaluation':[(4200 * u.nm, 3 * u.Jy), (1 * u.m, 0 * u.Jy)]},
+{'class': MexicanHat1D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'sigma': 1e-3 * u.mm},
+ 'evaluation':[(1000 * u.nm, -0.09785050 * u.Jy)]},
+{'class': Moffat1D,
+ 'parameters': {'amplitude': 3 * u.Jy, 'x_0': 4.4 * u.um, 'gamma': 1e-3 * u.mm, 'alpha':1},
+ 'evaluation':[(1000 * u.nm, 0.238853503 * u.Jy)]},
+ ]
+
+@pytest.mark.parametrize('model', MODELS_1D)
+def test_1d_models_evaluatate_with_units(model):
+    m = model['class'](**model['parameters'])
+    for x, y in model['evaluation']:
+        assert_quantity_allclose(m(x), y)
+
+
+@pytest.mark.parametrize('model', MODELS_1D)
+def test_1d_models_evaluatate_with_units_x_array(model):
+
+    m = model['class'](**model['parameters'])
+    for x, y in model['evaluation']:
+        x_arr = u.Quantity([x, x])
+        result = m(x_arr)
+        assert_quantity_allclose(result, u.Quantity([y, y]))
+
+@pytest.mark.parametrize('model', MODELS_1D)
+def test_1d_models_evaluatate_with_units_param_array(model):
+
+    params = {}
+    for key, value in model['parameters'].items():
+        params[key] = np.repeat(value, 2)
+
+    m = model['class'](**params)
+    for x, y in model['evaluation']:
+        x_arr = u.Quantity([x, x])
+        result = m(x_arr)
+        assert_quantity_allclose(result, u.Quantity([y, y]))
+
+
+# class Const2D(Fittable2DModel):
+# class Ellipse2D(Fittable2DModel):
+# class Disk2D(Fittable2DModel):
+# class Ring2D(Fittable2DModel):
+# class Delta1D(Fittable1DModel):
+# class Delta2D(Fittable2DModel):
+# class Box1D(Fittable1DModel):
+#     @classmethod
+# class Box2D(Fittable2DModel):
+# class Trapezoid1D(Fittable1DModel):
+# class TrapezoidDisk2D(Fittable2DModel):
+# class MexicanHat1D(Fittable1DModel):
+# class MexicanHat2D(Fittable2DModel):
+# class AiryDisk2D(Fittable2DModel):
+#     @classmethod
+# class Moffat1D(Fittable1DModel):
+# class Moffat2D(Fittable2DModel):
+# class Sersic2D(Fittable2DModel):
+#     @classmethod

--- a/astropy/modeling/tests/test_functional_models_quantities.py
+++ b/astropy/modeling/tests/test_functional_models_quantities.py
@@ -99,7 +99,7 @@ MODELS_2D = [
  'bounding_box': [[-0.76046808, 4.76046808], [0.68055697, 5.31944302]] * u.m},
 {'class': Ring2D,
  'parameters': {'amplitude': 3 * u.Jy, 'x_0':3 * u.m, 'y_0': 2 * u.m,
-                'r_in': 2 * u.cm, 'r_out': 2.1 * u.cm, 'width': None},
+                'r_in': 2 * u.cm, 'r_out': 2.1 * u.cm},
  'evaluation':[(302.05 * u.cm, 2 * u.m + 10 * u.um, 3 * u.Jy)],
  'bounding_box': [[1.979, 2.021], [2.979, 3.021]] * u.m},
 {'class': Box2D,


### PR DESCRIPTION
The goal of this PR is to add tests for all functional models with units and fix any issues that come up. This is now ready for review. The only thing is that the absorption gaussian can't be made unit-aware because of the ``1 - `` term - there is no way to attach a unit to ``1`` (I personally find this model strange since really one should do Const1D - Gaussian1D). Maybe we should replace ``1`` by a model parameter, but I suggest deferring that to a separate PR (I'm trying to keep my modeling PRs from getting out of control...)