### PR TITLE
fix deprecated escape sequence in ascii read documentation.

### DIFF
--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -23,7 +23,7 @@ format, for example::
    >>> data = astropy.io.ascii.read('t/nls1_stackinfo.dbout', data_start=2, delimiter='|')  # doctest: +SKIP
    >>> data = astropy.io.ascii.read('t/simple.txt', quotechar="'")  # doctest: +SKIP
    >>> data = astropy.io.ascii.read('t/simple4.txt', format='no_header', delimiter='|')  # doctest: +SKIP
-   >>> data = astropy.io.ascii.read('t/tab_and_space.txt', delimiter='\s')  # doctest: +SKIP
+   >>> data = astropy.io.ascii.read('t/tab_and_space.txt', delimiter=r'\s')  # doctest: +SKIP
 
 The |read| function accepts a number of parameters that specify the detailed
 table format.  Different formats can define different defaults, so the


### PR DESCRIPTION
See https://github.com/astropy/astropy/pull/6054#discussion_r121477732 for the explanation (and https://github.com/astropy/astropy/pull/5489 where I also added the [`r` to the `'\s'`](https://github.com/astropy/astropy/pull/5489/files#diff-2f85996c3bd29022250dd549eb99d5e7L395) inside the function).