### PR TITLE
Change parametrization of SmoothlyBrokenPowerLaw to use x_break instead of log_break

### DIFF
--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -73,13 +73,13 @@ class BrokenPowerLaw1D(Fittable1DModel):
     Parameters
     ----------
     amplitude : float
-        Model amplitude at the break point
+        Model amplitude at the break point.
     x_break : float
-        Break point
+        Break point.
     alpha_1 : float
-        Power law index for x < x_break
+        Power law index for x < x_break.
     alpha_2 : float
-        Power law index for x > x_break
+        Power law index for x > x_break.
 
     See Also
     --------
@@ -137,7 +137,7 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
     amplitude : float
         Model amplitude at the break point.
     x_break : float
-        Break point
+        Break point.
     alpha_1 : float
         Power law index for ``x << x_break``.
     alpha_2 : float

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -160,8 +160,8 @@ models_1D = {
     },
 
     SmoothlyBrokenPowerLaw1D: {
-        'parameters': [1, 0, -2, 2, 0.5],
-        'constraints': {'fixed': {'log_break': True, 'delta': True}},
+        'parameters': [1, 1, -2, 2, 0.5],
+        'constraints': {'fixed': {'x_break': True, 'delta': True}},
         'x_values': [0.01, 1, 100],
         'y_values': [3.99920012e-04, 1.0, 3.99920012e-04],
         'x_lim': [0.01, 100],


### PR DESCRIPTION
This is to make it consistent with other models and to make it possible to make the model unit-aware. This model is only in dev at the moment, so no deprecation or changelog entry needed, but we should get it in before 2.0

cc @gcalderone (original contributor of this class), @pllim, @nden