### PR TITLE
TimeFITS changes to handle corner cases; equality of Time.scale and FITS string scale along with the realization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -340,6 +340,9 @@ Bug Fixes
 
 - ``astropy.time``
 
+  - Fixed the initial condition of ``TimeFITS`` to allow scale, FITS scale
+    and FITS realization to be checked and equated properly. [#6202]
+
 - ``astropy.units``
 
 - ``astropy.utils``

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -982,7 +982,6 @@ class TimeFITS(TimeString):
                 raise ValueError("Input strings for {0} class must all "
                                  "have consistent time scales."
                                  .format(self.name))
-
         return [int(tm['year']), int(tm['mon']), int(tm['mday']),
                 int(tm.get('hour', 0)), int(tm.get('min', 0)),
                 float(tm.get('sec', 0.))]

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -978,7 +978,7 @@ class TimeFITS(TimeString):
                 else:
                     self._fits_scale = fits_scale
                     self._fits_realization = fits_realization
-            elif scale != self.scale:
+            else:
                 raise ValueError("Input strings for {0} class must all "
                                  "have consistent time scales."
                                  .format(self.name))

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -965,20 +965,13 @@ class TimeFITS(TimeString):
             # so we can round-trip (as long as no scale changes are made).
             fits_realization = (tm['realization'].upper()
                                 if tm['realization'] else None)
-            if self._scale is None:
-                self._scale = scale
+            if self._fits_scale is None:
                 self._fits_scale = fits_scale
                 self._fits_realization = fits_realization
-            elif scale == self.scale:
-                if self._fits_scale != None or self._fits_realization != None:
-                    if fits_scale != self._fits_scale or fits_realization != self._fits_realization:
-                        raise ValueError("Input strings for {0} class must all "
-                                         "have consistent time scales."
-                                         .format(self.name))
-                else:
-                    self._fits_scale = fits_scale
-                    self._fits_realization = fits_realization
-            else:
+                if self._scale is None:
+                    self._scale = scale
+            if (scale != self.scale or fits_scale != self._fits_scale or
+                fits_realization != self._fits_realization):
                 raise ValueError("Input strings for {0} class must all "
                                  "have consistent time scales."
                                  .format(self.name))

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -38,7 +38,7 @@ TIME_DELTA_FORMATS = OrderedDict()
 
 # Translations between deprecated FITS timescales defined by
 # Rots et al. 2015, A&A 574:A36, and timescales used here.
-FITS_DEPRECATED_SCALES = {'TDT': 'tt', 'TDT': 'tt', 'ET': 'tt',
+FITS_DEPRECATED_SCALES = {'TDT': 'tt', 'ET': 'tt',
                           'GMT': 'utc', 'UT': 'utc', 'IAT': 'tai'}
 
 
@@ -969,11 +969,20 @@ class TimeFITS(TimeString):
                 self._scale = scale
                 self._fits_scale = fits_scale
                 self._fits_realization = fits_realization
-            elif (scale != self.scale or fits_scale != self._fits_scale or
-                  fits_realization != self._fits_realization):
+            elif scale == self.scale:
+                if self._fits_scale != None or self._fits_realization != None:
+                    if fits_scale != self._fits_scale or fits_realization != self._fits_realization:
+                        raise ValueError("Input strings for {0} class must all "
+                                         "have consistent time scales."
+                                         .format(self.name))
+                else:
+                    self._fits_scale = fits_scale
+                    self._fits_realization = fits_realization
+            elif scale != self.scale:
                 raise ValueError("Input strings for {0} class must all "
                                  "have consistent time scales."
                                  .format(self.name))
+
         return [int(tm['year']), int(tm['mon']), int(tm['mday']),
                 int(tm.get('hour', 0)), int(tm.get('min', 0)),
                 float(tm.get('sec', 0.))]

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -627,11 +627,20 @@ class TestSubFormat():
         # Test deprecated scale.
         t = Time('2000-01-02(IAT)')
         assert t.scale == 'tai'
+        # Test with scale and FITS string scale
+        t = Time('2045-11-08T00:00:00.000(UTC)', scale='utc')
+        assert t.scale == 'utc'
         # Check that inconsistent scales lead to errors.
         with pytest.raises(ValueError):
             Time('2000-01-02(TAI)', scale='utc')
         with pytest.raises(ValueError):
             Time(['2000-01-02(TAI)', '2001-02-03(UTC)'])
+        # Check that inconsistent FITS string scales lead to errors.
+        with pytest.raises(ValueError):
+            Time(['2000-01-02(TAI)', '2001-02-03(IAT)'])
+        # Check that inconsistent realizations lead to errors.
+        with pytest.raises(ValueError):
+            Time(['2000-01-02(ET(NIST))', '2001-02-03(ET)'])
 
     def test_fits_scale_representation(self):
         t = Time('1960-01-02T03:04:05.678(ET(NIST))')


### PR DESCRIPTION
```
Time('2045-11-08T00:00:00.000(UTC)', scale='utc', format='fits', in_subfmt='date_hms')
ValueError: Input values did not match the format class fits
````
@Cadair mentioned the above on the gitter channel. This should ideally not cause a ValueError and hence I looked through the code and wrote a quick fix for the same and a few other corner cases.

The issue was with the initial condition where self._fits_scale and self._fits_realization are both None in the TimeFITS class which causes the above case to fail and a few others too. I have added a few more tests to validate that all cases work. However, I do not have much experience with the Time codebase, so do validate that the changes are correct.

I am aware of the feature freeze and would like to skip CI since I have tested it on my fork, but @bsipocz suggested that if this could be added in version 2.0 I should let CI run on it. 