### PR TITLE
Adding option to drop the table environment for latex writing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ New Features
   - Allow to specify encoding in ``ascii.read``, only for Python 3 and with the
     pure-Python readers. [#5448]
 
+  - Writing latex tables with only a ``tabular`` environment is now possible by
+    setting ``latexdict['tabletyle']`` to ``None``. [#6205]
+
 - ``astropy.io.fits``
 
   - Checking available disk space before writing out file. [#5550, #4065]

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -143,7 +143,8 @@ class LatexHeader(core.BaseHeader):
             align = '[' + self.latex['tablealign'] + ']'
         else:
             align = ''
-        lines.append(r'\begin{' + self.latex['tabletype'] + r'}' + align)
+        if self.latex['tabletype'] is not None:
+            lines.append(r'\begin{' + self.latex['tabletype'] + r'}' + align)
         add_dictval_to_list(self.latex, 'preamble', lines)
         if 'caption' in self.latex:
             lines.append(r'\caption{' + self.latex['caption'] + '}')
@@ -182,7 +183,8 @@ class LatexData(core.BaseData):
         add_dictval_to_list(self.latex, 'data_end', lines)
         lines.append(self.data_end)
         add_dictval_to_list(self.latex, 'tablefoot', lines)
-        lines.append(r'\end{' + self.latex['tabletype'] + '}')
+        if self.latex['tabletype'] is not None:
+            lines.append(r'\end{' + self.latex['tabletype'] + '}')
 
 
 class Latex(core.BaseReader):
@@ -222,6 +224,8 @@ class Latex(core.BaseReader):
 
                 ascii.write(data, sys.stdout, Writer = ascii.Latex,
                             latexdict = {'tabletype': 'table*'})
+            If ``None``, the table environment will be dropped keeping only
+            the ``tabular`` environment.
 
         * tablealign : positioning of table in text.
             The default is not to specify a position preference in the text.

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -224,7 +224,8 @@ class Latex(core.BaseReader):
 
                 ascii.write(data, sys.stdout, Writer = ascii.Latex,
                             latexdict = {'tabletype': 'table*'})
-            If ``None``, the table environment will be dropped keeping only
+
+            If ``None``, the table environment will be dropped, keeping only
             the ``tabular`` environment.
 
         * tablealign : positioning of table in text.

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -174,6 +174,16 @@ tablefoot
 \\end{tabletype}
 """
          ),
+    dict(kwargs=dict(Writer=ascii.Latex, latexdict={'tabletype': None}),
+         out="""\
+\\begin{tabular}{ccccccccccc}
+ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PERROR \\\\
+ & pixels & pixels & magnitudes & magnitudes & counts &  &  &  &  & perrors \\\\
+14 & 138.538 & 256.405 & 15.461 & 0.003 & 34.85955 & 4 & -0.032 & 0.802 & 0 & No_error \\\\
+18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error \\\\
+\\end{tabular}
+"""
+         ),
     dict(kwargs=dict(Writer=ascii.HTML, htmldict={'css': 'table,th,td{border:1px solid black;'}),
          out="""\
 <html>


### PR DESCRIPTION
In a few occasion I would have preferred to have the option to save out a table to latex format, but keeping only the ``tabular`` environment. Clearly editing the files and removing the lines manually is an option, but it's so much nicer if done by the writer itself.

I'll add tests and changelog when got the go ahead.