### PR TITLE
Add SigmaClip class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,8 @@ New Features
 
   - Implemented statistical estimators for Ripley's K Function. [#5712]
 
+  - Added ``SigmaClip`` class. [#6206]
+
   - Added ``std_ddof`` keyword option to ``sigma_clipped_stats``.
     [#6066, #6207]
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -252,6 +252,20 @@ class SigmaClip(object):
         self.cenfunc = cenfunc
         self.stdfunc = stdfunc
 
+    def __repr__(self):
+        return ('SigmaClip(sigma={0}, sigma_lower={1}, sigma_upper={2}, '
+                'iters={3}, cenfunc={4}, stdfunc={5})'
+                .format(self.sigma, self.sigma_lower, self.sigma_upper,
+                        self.iters, self.cenfunc, self.stdfunc))
+
+    def __str__(self):
+        lines = ['<' + self.__class__.__name__ + '>']
+        attrs = ['sigma', 'sigma_lower', 'sigma_upper', 'iters', 'cenfunc',
+                 'stdfunc']
+        for attr in attrs:
+            lines.append('    {0}: {1}'.format(attr, getattr(self, attr)))
+        return '\n'.join(lines)
+
     def __call__(self, data, axis=None, copy=True):
         """
         Perform sigma clipping on the provided data.

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -51,6 +51,42 @@ class SigmaClip(object):
             deviation = data - cenfunc(data [,axis=int])
 
         Defaults to the standard deviation (`numpy.std`).
+
+    Examples
+    --------
+    This example generates random variates from a Gaussian distribution
+    and returns a masked array in which all points that are more than 2
+    sample standard deviations from the median are masked::
+
+        >>> from astropy.stats import SigmaClip
+        >>> from numpy.random import randn
+        >>> randvar = randn(10000)
+        >>> sigclip = SigmaClip(sigma=2, iters=5)
+        >>> filtered_data = sigclip(randvar)
+
+    This example sigma clips on a similar distribution, but uses 3 sigma
+    relative to the sample *mean*, clips until convergence, and does not
+    copy the data::
+
+        >>> from astropy.stats import SigmaClip
+        >>> from numpy.random import randn
+        >>> from numpy import mean
+        >>> randvar = randn(10000)
+        >>> sigclip = SigmaClip(sigma=3, iters=None, cenfunc=mean)
+        >>> filtered_data = sigclip(randvar, copy=False)
+
+    This example sigma clips along one axis on a similar distribution
+    (with bad points inserted)::
+
+        >>> from astropy.stats import SigmaClip
+        >>> from numpy.random import normal
+        >>> from numpy import arange, diag, ones
+        >>> data = arange(5) + normal(0., 0.05, (5, 5)) + diag(ones(5))
+        >>> sigclip = SigmaClip(sigma=2.3)
+        >>> filtered_data = sigclip(data, axis=0)
+
+    Note that along the other axis, no points would be masked, as the
+    variance is higher.
     """
 
     def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None, iters=5,

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -15,6 +15,20 @@ class SigmaClip(object):
     """
     Class to perform sigma clipping.
 
+    The data will be iterated over, each time rejecting points that are
+    discrepant by more than a specified number of standard deviations
+    from a center value. If the data contains invalid values (NaNs or
+    infs), they are automatically masked before performing the sigma
+    clipping.
+
+    For a functional interface to sigma clipping, see
+    :func:`sigma_clip`.
+
+    .. note::
+        `scipy.stats.sigmaclip
+        <http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sigmaclip.html>`_
+        provides a subset of the functionality in this class.
+
     Parameters
     ----------
     sigma : float, optional
@@ -51,6 +65,10 @@ class SigmaClip(object):
             deviation = data - cenfunc(data [,axis=int])
 
         Defaults to the standard deviation (`numpy.std`).
+
+    See Also
+    --------
+    sigma_clip
 
     Examples
     --------
@@ -208,6 +226,9 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
     center value. If the data contains invalid values (NaNs or infs),
     they are automatically masked before performing the sigma clipping.
 
+    For an object-oriented interface to sigma clipping, see
+    :func:`SigmaClip`.
+
     .. note::
         `scipy.stats.sigmaclip
         <http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sigmaclip.html>`_
@@ -292,6 +313,10 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
         However, for multidimensional data, this flattens the array,
         which may not be what one wants (especially if filtering was
         done along an axis).
+
+    See Also
+    --------
+    SigmaClip
 
     Examples
     --------

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -16,7 +16,7 @@ except ImportError:
 else:
     HAS_SCIPY = True
 
-from ..sigma_clipping import sigma_clip, sigma_clipped_stats
+from ..sigma_clipping import sigma_clip, SigmaClip, sigma_clipped_stats
 from ...utils.misc import NumpyRNGContext
 
 
@@ -86,6 +86,15 @@ def test_sigma_clip_scalar_mask():
     data = np.arange(5)
     result = sigma_clip(data, sigma=100., iters=1)
     assert result.mask.shape != ()
+
+
+def test_sigma_clip_class():
+    with NumpyRNGContext(12345):
+        data = randn(100)
+        data[10] = 1.e5
+        sobj = SigmaClip(sigma=1, iters=2)
+        sfunc = sigma_clip(data, sigma=1, iters=2)
+        assert_equal(sobj(data), sfunc)
 
 
 def test_sigma_clipped_stats():

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -8,13 +8,13 @@ Introduction
 ============
 
 The `astropy.stats` package holds statistical functions or algorithms
-used in astronomy and astropy.  While the `scipy.stats` and
-`statsmodel <http://www.statsmodels.org/stable/index.html>`_ packages
-contains a wide range of statistical tools, they are general-purpose
-packages and are missing some tools that are particularly useful or
-specific to astronomy.  This package is intended to provide such
-functionality, but *not* to replace `scipy.stats` if its
-implementation satisfies astronomers' needs.
+used in astronomy.  While the `scipy.stats` and `statsmodel
+<http://www.statsmodels.org/stable/index.html>`_ packages contains a
+wide range of statistical tools, they are general-purpose packages and
+are missing some tools that are particularly useful or specific to
+astronomy.  This package is intended to provide such functionality,
+but *not* to replace `scipy.stats` if its implementation satisfies
+astronomers' needs.
 
 
 Getting Started
@@ -25,25 +25,33 @@ they can be accessed by importing them::
 
     >>> from astropy import stats
 
-A full list of the different tools are provided below and please see
-the documentation for their different usage.  For example, sigma
-clipping, which is common way to estimate the background of an image,
-can be run following with the :func:`~astropy.stats.sigma_clip`
-function::
+A full list of the different tools are provided below.  Please see the
+documentation for their different usage.  For example, sigma clipping,
+which is common way to estimate the background of an image, can be
+performed with the :func:`~astropy.stats.sigma_clip` function.  The
+function returns a masked array where outliers are masked::
 
-    >>> stats.sigma_clip([1, 5, 6, 8, 100, 5, 3, 2], sigma=2, iters=5)  # doctest: +FLOAT_CMP
+    >>> data = [1, 5, 6, 8, 100, 5, 3, 2]
+    >>> stats.sigma_clip(data, sigma=2, iters=5)  # doctest: +FLOAT_CMP
     masked_array(data = [1 5 6 8 -- 5 3 2],
                  mask = [False False False False  True False False False],
            fill_value = 999999)
 
-This will return a masked array where outliers are masked.  In
-addition, there are also several convenience functions for making the
-calculation of statistics even
-easier. :func:`~astropy.stats.sigma_clipped_stats` will return the
-mean, median, and standard deviation for a sigma-clipped array::
+Alternatively, the :class:`~astropy.stats.SigmaClip` class provides an
+object-oriented interface to sigma clipping::
 
-     >>> stats.sigma_clipped_stats([1, 5, 6, 8, 100, 5, 3, 2], sigma=2,
-     ...                           iters=5)  # doctest: +FLOAT_CMP
+    >>> sigclip = stats.SigmaClip(sigma=2, iters=5)
+    >>> sigclip(data)
+    masked_array(data = [1 5 6 8 -- 5 3 2],
+                 mask = [False False False False  True False False False],
+           fill_value = 999999)
+
+In addition, there are also several convenience functions for making
+the calculation of statistics even easier.  For example,
+:func:`~astropy.stats.sigma_clipped_stats` will return the mean,
+median, and standard deviation of a sigma-clipped array::
+
+     >>> stats.sigma_clipped_stats(data, sigma=2, iters=5)  # doctest: +FLOAT_CMP
      (4.2857142857142856, 5.0, 2.2497165354319457)
 
 There are also tools for calculating :ref:`robust statistics

--- a/docs/stats/robust.rst
+++ b/docs/stats/robust.rst
@@ -94,26 +94,29 @@ statistics to provide improved outlier rejection as well.
 .. plot::
     :include-source:
 
-     import numpy as np
-     import scipy.stats as stats
-     from matplotlib import pyplot as plt
-     from astropy.stats import sigma_clip, mad_std
+    import numpy as np
+    import scipy.stats as stats
+    from matplotlib import pyplot as plt
+    from astropy.stats import sigma_clip, mad_std
 
-     # Generate fake data that has a mean of 0 and standard deviation of 0.2 with outliers
-     np.random.seed(0)
-     x = np.arange(200)
-     y = np.zeros(200)
-     c = stats.bernoulli.rvs(0.35, size=x.shape)
-     y += (np.random.normal(0., 0.2, x.shape) +
-           c*np.random.normal(3.0, 5.0, x.shape))
+    # Generate fake data that has a mean of 0 and standard deviation of 0.2 with outliers
+    np.random.seed(0)
+    x = np.arange(200)
+    y = np.zeros(200)
+    c = stats.bernoulli.rvs(0.35, size=x.shape)
+    y += (np.random.normal(0., 0.2, x.shape) +
+          c*np.random.normal(3.0, 5.0, x.shape))
 
-     filtered_data = sigma_clip(y, sigma=3, iters=1, stdfunc=mad_std)
+    filtered_data = sigma_clip(y, sigma=3, iters=1, stdfunc=mad_std)
 
-     # plot the original and rejected data
-     plt.figure(figsize=(8,5))
-     plt.plot(x, y, 'g+', label="original data")
-     plt.plot(x[filtered_data.mask], y[filtered_data.mask], 'rx', label="rejected data")
-     plt.legend(loc=2, numpoints=1)
+    # plot the original and rejected data
+    plt.figure(figsize=(8,5))
+    plt.plot(x, y, '+', color='#1f77b4', label="original data")
+    plt.plot(x[filtered_data.mask], y[filtered_data.mask], 'x',
+             color='#d62728', label="rejected data")
+    plt.xlabel('x')
+    plt.ylabel('y')
+    plt.legend(loc=2, numpoints=1)
 
 
 Median Absolute Deviation

--- a/docs/stats/robust.rst
+++ b/docs/stats/robust.rst
@@ -18,25 +18,23 @@ Sigma Clipping
 
 Sigma clipping provides a fast method to identify outliers in a
 distribution.  For a distribution of points, a center and a standard
-deviation are calculated.   Values which are a set number of sigma
+deviation are calculated.  Values which are a set number of sigma
 times the standard deviation away from the center are rejected.  The
 process can be iterated to further reject outliers.
 
-In the stats package, there is the :func:`~astropy.stats.sigma_clip`
-function for sigma clipping a distribution.  The function returns a
-masked array where the rejected points are masked.   Sigma clipping
-can be applied as follows:
+The `astropy.stats` package provides both a functional and
+object-oriented interface for sigma clipping.  The function is called
+:func:`~astropy.stats.sigma_clip` and the class is called
+:class:`~astropy.stats.SigmaClip`.  They both return a masked array
+where the rejected points are masked.
+
+First, let's generate some data that has a mean of 0 and standard
+deviation of 0.2, but with outliers:
 
 .. doctest-requires:: scipy
 
      >>> import numpy as np
-     >>> from astropy.stats import sigma_clip
      >>> import scipy.stats as stats
-
-.. doctest-requires:: scipy
-
-     >>> # Generate fake data that has a mean of 0 and standard deviation
-     >>> # of 0.2 with outliers
      >>> np.random.seed(0)
      >>> x = np.arange(200)
      >>> y = np.zeros(200)
@@ -44,17 +42,42 @@ can be applied as follows:
      >>> y += (np.random.normal(0., 0.2, x.shape) +
      ...       c*np.random.normal(3.0, 5.0, x.shape))
 
+Now, let's use :func:`~astropy.stats.sigma_clip` to perform sigma
+clipping on the data:
+
 .. doctest-requires:: scipy
 
-     >>> # filter the data
+     >>> from astropy.stats import sigma_clip
      >>> filtered_data = sigma_clip(y, sigma=3, iters=10)
 
-The array then can be used to calculate statistics on the data, fit
-models to the data, or otherwise explore the data.   For basic
-statistics, :func:`~astropy.stats.sigma_clipped_stats` is a
-convenience function to calculated the mean, median, and standard
-deviation of the function.   As can be seen, rejecting the outliers
-returns accurate values for the underlying distribution:
+The output masked array then can be used to calculate statistics on
+the data, fit models to the data, or otherwise explore the data.
+
+To perform the same sigma clipping with the
+:class:`~astropy.stats.SigmaClip` class:
+
+.. doctest-requires:: scipy
+
+     >>> from astropy.stats import SigmaClip
+     >>> sigclip = SigmaClip(sigma=3, iters=10)
+     >>> print(sigclip)  # doctest: +SKIP
+     <SigmaClip>
+        sigma: 3
+        sigma_lower: None
+        sigma_upper: None
+        iters: 10
+        cenfunc: <function median at 0x108dbde18>
+        stdfunc: <function std at 0x103ab52f0>
+     >>> filtered_data = sigclip(y)
+
+Note that once the ``sigclip`` instance is defined above, it can be
+applied to other data, using the same, already-defined, sigma-clipping
+parameters.
+
+For basic statistics, :func:`~astropy.stats.sigma_clipped_stats` is a
+convenience function to calculate the sigma-clipped mean, median, and
+standard deviation of an array.   As can be seen, rejecting the
+outliers returns accurate values for the underlying distribution:
 
 .. doctest-requires:: scipy
 
@@ -64,8 +87,9 @@ returns accurate values for the underlying distribution:
      >>> sigma_clipped_stats(y, sigma=3, iters=10)  # doctest: +FLOAT_CMP
      (-0.0020337793767186197, -0.023632809025713953, 0.19514652532636906)
 
-The :func:`~astropy.stats.sigma_clip` can be combined with other
-robust statistics to provide improved outlier rejection as well.
+:func:`~astropy.stats.sigma_clip` and
+:class:`~astropy.stats.SigmaClip` can be combined with other robust
+statistics to provide improved outlier rejection as well.
 
 .. plot::
     :include-source:
@@ -73,7 +97,6 @@ robust statistics to provide improved outlier rejection as well.
      import numpy as np
      import scipy.stats as stats
      from matplotlib import pyplot as plt
-
      from astropy.stats import sigma_clip, mad_std
 
      # Generate fake data that has a mean of 0 and standard deviation of 0.2 with outliers
@@ -84,15 +107,13 @@ robust statistics to provide improved outlier rejection as well.
      y += (np.random.normal(0., 0.2, x.shape) +
            c*np.random.normal(3.0, 5.0, x.shape))
 
+     filtered_data = sigma_clip(y, sigma=3, iters=1, stdfunc=mad_std)
 
-     filtered_data = sigma_clip(y, sigma=3, iters=1, stdfunc=mad_std )
-
-     # plot data and fitted models
+     # plot the original and rejected data
      plt.figure(figsize=(8,5))
      plt.plot(x, y, 'g+', label="original data")
      plt.plot(x[filtered_data.mask], y[filtered_data.mask], 'rx', label="rejected data")
      plt.legend(loc=2, numpoints=1)
-
 
 
 Median Absolute Deviation

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -18,8 +18,8 @@ In particular, this release includes:
 * :ref:`whatsnew-2.0-cosmo-def`
 * :ref:`whatsnew-2.0-conesearch-astroquery`
 * :ref:`whatsnew-2.0-samp-moved`
-* A :ref:`new "std_ddof" keyword <whatsnew-2.0-ddof>` option was added
-  to :func:`~astropy.stats.sigma_clipped_stats`.
+* :ref:`whatsnew-2.0-SigmaClip`
+* :ref:`whatsnew-2.0-ddof`
 * :ref:`whatsnew-2.0-stats-biweight-midcov`
 * :ref:`whatsnew-2.0-stats-k-func`
 * :ref:`whatsnew-2.0-bintablehdu-from_table`
@@ -95,6 +95,34 @@ SAMP module moved to `astropy.samp`
 The SAMP (Simple Application Messaging Protocol) module, formerly available
 in ``astropy.samp``, has now been moved to `astropy.samp`, so you should
 update any imports to this module.
+
+.. _whatsnew-2.0-SigmaClip:
+
+New `~astropy.stats.SigmaClip` class
+====================================
+
+A new :class:`~astropy.stats.SigmaClip` class was added as an
+object-oriented interface for sigma clipping::
+
+    >>> from astropy.stats import SigmaClip
+    >>> data = [1, 5, 6, 8, 100, 5, 3, 2]
+    >>> sigclip = SigmaClip(sigma=2, iters=5)
+    >>> print(sigclip)  # doctest: +SKIP
+    <SigmaClip>
+        sigma: 3
+        sigma_lower: None
+        sigma_upper: None
+        iters: 10
+        cenfunc: <function median at 0x108dbde18>
+        stdfunc: <function std at 0x103ab52f0>
+    >>> sigclip(data)
+    masked_array(data = [1 5 6 8 -- 5 3 2],
+                 mask = [False False False False  True False False False],
+           fill_value = 999999)
+
+Note that once the ``sigclip`` instance is defined above, it can be
+applied to other data, using the same, already-defined, sigma-clipping
+parameters.
 
 .. _whatsnew-2.0-ddof:
 


### PR DESCRIPTION
This PR moves the `SigmaClip` class from `photutils`.  The class is useful as an OO interface to functions that perform sigma clipping as part of their functionality.  Instead of passing all of the separate `sigma_clip` keywords to such a function (and adding all of the associated boilerplate docs, etc.), you simply pass a `SigmaClip` instance that has defined the desired `sigma_clip` parameters.  That makes for a cleaner interface.  This class is used within `photutils`, but I'm adding it here since it has more general use.