### PR TITLE
Flake8 configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,21 @@ env:
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
 
+        # PEP8 errors/warnings:
+        # E101 - mix of tabs and spaces
+        # W191 - use of tabs
+        # W291 - trailing whitespace
+        # W292 - no newline at end of file
+        # W293 - trailing whitespace
+        # W391 - blank line at end of file
+        # E111 - 4 spaces per indentation level
+        # E112 - 4 spaces per indentation level
+        # E113 - 4 spaces per indentation level
+        # E722 - do not use bare except
+        # E901 - SyntaxError or IndentationError
+        # E902 - IOError
+        - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E722,E901,E902 --exclude=extern,sphinx,*parsetab.py"
+
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
@@ -100,7 +115,7 @@ matrix:
 
         # Do a PEP8/pyflakes test with flake8
         - os: linux
-          env: MAIN_CMD='flake8 astropy --count' SETUP_CMD=''
+          env: MAIN_CMD="flake8 astropy --count $FLAKE8_OPT" SETUP_CMD=''
 
         # Try developer version of Numpy with optional dependencies and also
         # run all remote tests. Since both cases will be potentially

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,34 +26,6 @@ bitmap = static/wininst_background.bmp
 [ah_bootstrap]
 auto_use = True
 
-# We now have sections for the pep8 and flake8 commands. We need to repeat the
-# configuration once for each command. Rather than check all warnings, we only
-# select certain ones that really matter.
-
-# PEP8 errors/warnings:
-# E101 - mix of tabs and spaces
-# W191 - use of tabs
-# W291 - trailing whitespace
-# W292 - no newline at end of file
-# W293 - trailing whitespace
-# W391 - blank line at end of file
-# E111 - 4 spaces per indentation level
-# E112 - 4 spaces per indentation level
-# E113 - 4 spaces per indentation level
-# E722 - do not use bare except
-# E901 - SyntaxError or IndentationError
-# E902 - IOError
-
-# If you want to exclude a line from checking, simply add '  # noqa' at the end of the line
-
-[pycodestyle]
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E722,E901,E902
-exclude = extern,sphinx,*parsetab.py
-
-[flake8]
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E722,E901,E902
-exclude = extern,sphinx,*parsetab.py
-
 [zest.releaser]
 prereleaser.middle = astropy.utils.release.prereleaser_middle
 releaser.middle = astropy.utils.release.releaser_middle


### PR DESCRIPTION
I was wondering why my editor no more warns me for some time about things like unused imports. I think it is related to the addition of flake8 settings in `setup.cfg` in  #5730. These settings were added to limit the flake8 errors/warnings for the travis build, but it's annoying that it also hides useful warnings.
One solution would be to put the list of selected errors directly in the flake8 command line, in the Travis config file. Thoughts, @astrofrog @bsipocz ?