### PR TITLE
#6182 Modified the behaviour of realize_frame so it changes the `representation` attribute of the frame

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -530,7 +530,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             A new object with the same frame attributes as this one, but
             with the ``representation`` as the data.
         """
-        return self._apply('replicate', _framedata=representation)
+        return self._apply('replicate', propagate_representation=False,
+                           _framedata=representation)
 
     def represent_as(self, new_representation, in_frame_units=False):
         """
@@ -793,7 +794,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         return ', '.join([attrnm + '=' + str(getattr(self, attrnm))
                           for attrnm in self.get_frame_attr_names()])
 
-    def _apply(self, method, *args, **kwargs):
+    def _apply(self, method, *args, propagate_representation=True, **kwargs):
         """Create a new instance, applying a method to the underlying data.
 
         In typical usage, the method is any of the shape-changing methods for
@@ -859,7 +860,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 frattrs[attr] = value
 
         out = self.__class__(data, **frattrs)
-        out.representation = self.representation
+        if propagate_representation:
+            out.representation = self.representation
         return out
 
     @override__dir__


### PR DESCRIPTION
SunPy sets the representation of the frame inside the `__init__` for the frame to work around Longitude wrapping. #6182 changed the behaviour of `realize_frame` so that it now explicitly set's the representation of the new frame to that of the old frame, which means we can't change the representation of the frame in the `__init__` in the correct way. 

Offending line in SunPy: https://github.com/sunpy/sunpy/blob/master/sunpy/coordinates/frames.py#L338 

Offending commit in Astropy: https://github.com/astropy/astropy/commit/17294671938c47237df25cd4c8edebd4c5aa7639

This fix is a bit facetious in that I am sure it will break something, I am open to suggestions for an actual fix to this problem!