### PR TITLE
Add AffineTransform transform class 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,12 @@ New Features
   - ``EarthLocation`` now has ``lat`` and ``lon`` properties (equivalent to, but
     preferred over, the previous ``latitude`` and ``longitude``). [#6237]
 
+  - Added a new ``AffineTransform`` class for coordinate frame transformations.
+    This class supports matrix operations with vector offsets in position or
+    any differential quantities (so far, only velocity is supported). The
+    matrix transform classes now subclass from the base affine transform.
+    [#6218]
+
 - ``astropy.cosmology``
 
 - ``astropy.io.ascii``

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -630,7 +630,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             new_differential = _get_diff_cls(new_representation[1])
             new_representation = _get_repr_cls(new_representation[0])
 
-        elif has_diffs and isinstance(new_representation, BaseDifferential):
+        elif (has_diffs and inspect.isclass(new_representation) and
+                issubclass(new_representation, BaseDifferential)):
             # a single differential class passed in
             new_differential = new_representation
             new_representation = new_representation.base_representation
@@ -1082,7 +1083,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
-        return self.represent_as(CartesianRepresentation, in_frame_units=True)
+        return self.represent_as('cartesian', in_frame_units=True)
 
     @property
     def spherical(self):
@@ -1092,7 +1093,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
-        return self.represent_as(SphericalRepresentation, in_frame_units=True)
+        return self.represent_as('spherical', in_frame_units=True)
+
+    @property
+    def sphericalcoslat(self):
+        """
+        Shorthand for a spherical representation of the coordinates in this object.
+        """
+
+        # TODO: if representations are updated to use a full transform graph,
+        #       the representation aliases should not be hard-coded like this
+        return self.represent_as('sphericalcoslat', in_frame_units=True)
 
 
 class GenericFrame(BaseCoordinateFrame):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -621,13 +621,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             ( 1.,  0.,  0.)>
         """
 
-        n_diffs = len(self.data.differentials)
-        has_diffs = n_diffs > 0
+        has_velocity = 's' in self.data.differentials
 
         new_representation = _get_repr_cls(new_representation)
 
         if new_differential:
-            if not has_diffs:
+            if not has_velocity:
                 raise TypeError('Frame data has no associated differentials '
                                 '(i.e. the frame has no velocity data) - '
                                 'represent_as() only accepts a new '
@@ -636,10 +635,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             if isinstance(new_differential, six.string_types):
                 new_differential = _get_diff_cls(new_differential)
 
-        elif has_diffs:
+        elif has_velocity:
             new_differential = _get_diff_cls(new_representation.get_name())
 
-        if has_diffs:
+        if has_velocity:
             cache_key = (new_representation.__name__,
                          new_differential.__name__,
                          in_frame_units)
@@ -648,7 +647,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         cached_repr = self.cache['representation'].get(cache_key)
         if not cached_repr:
-            if has_diffs and new_differential is not None:
+            if has_velocity and new_differential is not None:
                 # TODO NOTE: only supports a single differential
                 data = self.data.represent_as(new_representation,
                                               new_differential)
@@ -1107,7 +1106,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
-        return self.represent_as('sphericalcoslat', in_frame_units=True)
+        return self.represent_as('spherical',
+                                 new_differential='sphericalcoslat',
+                                 in_frame_units=True)
 
 
 class GenericFrame(BaseCoordinateFrame):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -624,8 +624,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         n_diffs = len(self.data.differentials)
         has_diffs = n_diffs > 0
 
-        if isinstance(new_representation, six.string_types):
-            new_representation = _get_repr_cls(new_representation)
+        new_representation = _get_repr_cls(new_representation)
 
         if new_differential:
             if not has_diffs:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -31,6 +31,7 @@ from .representation import (BaseRepresentation, BaseDifferential,
                              CartesianRepresentation,
                              SphericalRepresentation,
                              UnitSphericalRepresentation,
+                             SphericalCosLatDifferential,
                              REPRESENTATION_CLASSES,
                              DIFFERENTIAL_CLASSES)
 
@@ -583,7 +584,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Parameters
         ----------
         new_representation : subclass of BaseRepresentation or string
-            The type of representation to generate.  May be a *class*
+            The type of representation to generate.  Must be a *class*
             (not an instance), or the string name of the representation
             class.
 
@@ -592,7 +593,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             particular to this frame
 
         new_differential : subclass of `~astropy.coordinates.BaseDifferential`, str, optional
-            Class in which the differential should be represented. May be
+            Class in which the differential should be represented. Must be
             a *class* (not an instance), or the string name of the
             differential class.
 
@@ -1091,7 +1092,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @property
     def spherical(self):
         """
-        Shorthand for a spherical representation of the coordinates in this object.
+        Shorthand for a spherical representation of the coordinates in this
+        object.
         """
 
         # TODO: if representations are updated to use a full transform graph,
@@ -1101,13 +1103,16 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @property
     def sphericalcoslat(self):
         """
-        Shorthand for a spherical representation of the coordinates in this object.
+        Shorthand for a spherical representation of the positional data and a
+        `SphericalCosLatDifferential` for the velocity data in this object.
         """
 
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
+        new_diffs = dict([(k, SphericalCosLatDifferential)
+                          for k in self.data.differentials])
         return self.represent_as('spherical',
-                                 new_differential='sphericalcoslat',
+                                 new_differential=new_diffs,
                                  in_frame_units=True)
 
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -135,11 +135,6 @@ class Galactocentric(BaseCoordinateFrame):
     z_sun = FrameAttribute(default=27.*u.pc)
     roll = FrameAttribute(default=0.*u.deg)
 
-    # TODO: is this the best class for this frame attribute?
-    # TODO: what should the default be here? need to add citations too...
-    v_sun = CartesianRepresentationFrameAttribute(default=[11.1, 242., 7.25]*u.km/u.s,
-                                                  unit=u.km/u.s)
-
     @classmethod
     def get_roll0(cls):
         """
@@ -176,7 +171,10 @@ def get_matrix_vectors(galactocentric_frame):
     # compute total matrices
     A = matrix_product(H, R)
     pos_vec = matrix_product(H, -translation.xyz)
-    vel_vec = matrix_product(H, -gcf.v_sun.xyz)
+
+    # TODO: need to get the velocity offset
+    # vel_vec = matrix_product(H, -gcf.v_sun.xyz)
+    vel_vec = None # for now, this gets ignored
 
     return A, (pos_vec, vel_vec)
 
@@ -200,4 +198,5 @@ def galactocentric_to_icrs(galactocentric_coord, icrs_frame):
 
     # the inverse of a rotation matrix is a transpose, which is much faster and
     #   more stable to compute
-    return matrix_transpose(A), [-x for x in vecs]
+    # TODO: this actually might not be right, because of order of operations
+    return matrix_transpose(A), [-x if x is not None else None for x in vecs]

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -198,5 +198,5 @@ def galactocentric_to_icrs(galactocentric_coord, icrs_frame):
 
     # the inverse of a rotation matrix is a transpose, which is much faster and
     #   more stable to compute
-    # TODO: this actually might not be right, because of order of operations
-    return matrix_transpose(A), [-x if x is not None else None for x in vecs]
+    A_T = matrix_transpose(A)
+    return A_T, [-A_T.dot(x) if x is not None else None for x in vecs]

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -10,7 +10,7 @@ from ..angles import Angle
 from ..matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 from ..representation import CartesianRepresentation, UnitSphericalRepresentation
 from ..baseframe import BaseCoordinateFrame, frame_transform_graph
-from ..frame_attributes import FrameAttribute, CartesianRepresentationFrameAttribute
+from ..frame_attributes import FrameAttribute
 from ..transformations import AffineTransform
 from ..errors import ConvertError
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -165,7 +165,7 @@ def get_matrix_vectors(galactocentric_frame):
     # Now need to translate by Sun-Galactic center distance around x' and
     # rotate about y' to account for tilt due to Sun's height above the plane
     translation = CartesianRepresentation(gcf.galcen_distance * [1., 0., 0.])
-    z_d = (gcf.z_sun / gcf.galcen_distance).decompose()
+    z_d = (gcf.z_sun / gcf.galcen_distance)
     H = rotation_matrix(-np.arcsin(z_d), 'y')
 
     # compute total matrices

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -202,4 +202,4 @@ def galactocentric_to_icrs(galactocentric_coord, icrs_frame):
     # the inverse of a rotation matrix is a transpose, which is much faster and
     #   more stable to compute
     A_T = matrix_transpose(A)
-    return A_T, -offset.transform(A_T, apply_to_diffs=True)
+    return A_T, -offset.transform(A_T)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -165,7 +165,7 @@ def get_matrix_vectors(galactocentric_frame):
     # Now need to translate by Sun-Galactic center distance around x' and
     # rotate about y' to account for tilt due to Sun's height above the plane
     translation = CartesianRepresentation(gcf.galcen_distance * [1., 0., 0.])
-    z_d = (gcf.z_sun / gcf.galcen_distance)
+    z_d = gcf.z_sun / gcf.galcen_distance
     H = rotation_matrix(-np.arcsin(z_d), 'y')
 
     # compute total matrices

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -287,7 +287,7 @@ _NEED_ORIGIN_HINT = ("The input {0} coordinates do not have length units. This "
 @frame_transform_graph.transform(AffineTransform, HCRS, ICRS)
 def hcrs_to_icrs(hcrs_coo, icrs_frame):
     # this is just an origin translation so without a distance it cannot go ahead
-    if hcrs_coo.data.__class__ == UnitSphericalRepresentation:
+    if isinstance(hcrs_coo.data, UnitSphericalRepresentation):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(hcrs_coo.__class__.__name__))
 
     bary_sun_vel = None
@@ -309,7 +309,7 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
 @frame_transform_graph.transform(AffineTransform, ICRS, HCRS)
 def icrs_to_hcrs(icrs_coo, hcrs_frame):
     # this is just an origin translation so without a distance it cannot go ahead
-    if icrs_coo.data.__class__ == UnitSphericalRepresentation:
+    if isinstance(icrs_coo.data, UnitSphericalRepresentation):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(icrs_coo.__class__.__name__))
 
     if icrs_coo.data.differentials:

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -290,21 +290,20 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
     if isinstance(hcrs_coo.data, UnitSphericalRepresentation):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(hcrs_coo.__class__.__name__))
 
-    bary_sun_vel = None
     if hcrs_coo.data.differentials:
         from ..solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_coo.obstime)
-        dv = bary_sun_vel.xyz
 
     else:
         from ..solar_system import get_body_barycentric
         bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime)
-        dv = None
+        bary_sun_vel = None
 
-    dx = bary_sun_pos.xyz
+    if bary_sun_vel is not None:
+        bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
 
-    return None, (dx, dv)
+    return None, bary_sun_pos
 
 @frame_transform_graph.transform(AffineTransform, ICRS, HCRS)
 def icrs_to_hcrs(icrs_coo, hcrs_frame):
@@ -316,16 +315,17 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
         from ..solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_frame.obstime)
-        dv = -bary_sun_vel.xyz
 
     else:
         from ..solar_system import get_body_barycentric
         bary_sun_pos = get_body_barycentric('sun', hcrs_frame.obstime)
-        dv = None
+        bary_sun_vel = None
 
-    dx = -bary_sun_pos.xyz
+    bary_sun_pos = -bary_sun_pos
+    if bary_sun_vel is not None:
+        bary_sun_pos = bary_sun_pos.with_differentials(-bary_sun_vel)
 
-    return None, (dx, dv)
+    return None, bary_sun_pos
 
 
 @frame_transform_graph.transform(FunctionTransform, HCRS, HCRS)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -294,14 +294,12 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
         from ..solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_coo.obstime)
+        bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
 
     else:
         from ..solar_system import get_body_barycentric
         bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime)
         bary_sun_vel = None
-
-    if bary_sun_vel is not None:
-        bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
 
     return None, bary_sun_pos
 
@@ -315,15 +313,12 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
         from ..solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_frame.obstime)
+        bary_sun_pos = -bary_sun_pos.with_differentials(-bary_sun_vel)
 
     else:
         from ..solar_system import get_body_barycentric
-        bary_sun_pos = get_body_barycentric('sun', hcrs_frame.obstime)
+        bary_sun_pos = -get_body_barycentric('sun', hcrs_frame.obstime)
         bary_sun_vel = None
-
-    bary_sun_pos = -bary_sun_pos
-    if bary_sun_vel is not None:
-        bary_sun_pos = bary_sun_pos.with_differentials(-bary_sun_vel)
 
     return None, bary_sun_pos
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1026,19 +1026,18 @@ class CartesianRepresentation(BaseRepresentation):
     def to_cartesian(self):
         return self
 
-    def transform(self, matrix, apply_to_diffs=False):
+    def transform(self, matrix):
         """
         Transform the cartesian coordinates using a 3x3 matrix.
 
         This returns a new representation and does not modify the original one.
+        Any differentials attached to this representation will also be
+        transformed.
 
         Parameters
         ----------
         matrix : `~numpy.ndarray`
             A 3x3 transformation matrix, such as a rotation matrix.
-        apply_to_diffs : bool (optional)
-            Apply the transformation to any differentials associated with this
-            representation.
 
 
         Examples

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -217,6 +217,21 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         # Note: the above docstring gets overridden for differentials.
         raise NotImplementedError()
 
+    def to_cartesian_with_differentials(self):
+        """Convert the representation and any differentials to Cartesian form.
+
+        Returns
+        -------
+        cartrepr : `CartesianRepresentation`
+            The representation in Cartesian form with any attached differentials
+            as `CartesianDifferential` instances.
+
+        """
+        rep = self.to_cartesian()
+        diffs = dict([(k, diff.represent_as(CartesianDifferential, self))
+                      for k, diff in self.differentials.items()])
+        return rep.with_differentials(diffs)
+
     @property
     def components(self):
         """A tuple with the in-order names of the coordinate components."""
@@ -1091,6 +1106,7 @@ class CartesianRepresentation(BaseRepresentation):
             # remaining dimensions.
             newxyz = np.einsum('...ij,j...->i...', matrix, oldxyz.value)
 
+        newxyz = u.Quantity(newxyz, oldxyz.unit, copy=False)
         # Handle differentials attached to this representation
         if self.differentials:
             # TODO: speed this up going via d.d_xyz.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1026,7 +1026,7 @@ class CartesianRepresentation(BaseRepresentation):
     def to_cartesian(self):
         return self
 
-    def transform(self, matrix):
+    def transform(self, matrix, apply_to_diffs=False):
         """
         Transform the cartesian coordinates using a 3x3 matrix.
 
@@ -1036,6 +1036,10 @@ class CartesianRepresentation(BaseRepresentation):
         ----------
         matrix : `~numpy.ndarray`
             A 3x3 transformation matrix, such as a rotation matrix.
+        apply_to_diffs : bool (optional)
+            Apply the transformation to any differentials associated with this
+            representation.
+
 
         Examples
         --------
@@ -1088,7 +1092,6 @@ class CartesianRepresentation(BaseRepresentation):
             # remaining dimensions.
             newxyz = np.einsum('...ij,j...->i...', matrix, oldxyz.value)
 
-        newxyz = u.Quantity(newxyz, oldxyz.unit, copy=False)
         # Handle differentials attached to this representation
         if self.differentials:
             # TODO: speed this up going via d.d_xyz.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -609,7 +609,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         if differential_class is None:
             return dict()
 
-        if not self.differentials:
+        if not self.differentials and differential_class:
             raise ValueError("No differentials associated with this "
                              "representation!")
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1325,7 +1325,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
                                    copy=False)
 
         return super(UnitSphericalRepresentation,
-                     self).represent_as(other_class)
+                     self).represent_as(other_class, differential_class)
 
     def __mul__(self, other):
         self._raise_if_has_differentials('multiplication')
@@ -1600,7 +1600,7 @@ class SphericalRepresentation(BaseRepresentation):
                 return other_class(lon=self.lon, lat=self.lat, copy=False)
 
         return super(SphericalRepresentation,
-                     self).represent_as(other_class)
+                     self).represent_as(other_class, differential_class)
 
     def to_cartesian(self):
         """
@@ -1762,7 +1762,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
                 return other_class(lon=self.phi, lat=90 * u.deg - self.theta)
 
         return super(PhysicsSphericalRepresentation,
-                     self).represent_as(other_class)
+                     self).represent_as(other_class, differential_class)
 
     def to_cartesian(self):
         """

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -675,6 +675,18 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
             # The default is to convert via cartesian coordinates
             new_rep = other_class.from_cartesian(self.to_cartesian())
+
+            # This validation only happens in re_represent if the represent_as
+            # fails, but we have to check so we can enforce that the
+            # differential_class is one of the _compatible_differentials
+            if (differential_class and
+                    differential_class not in new_rep._compatible_differentials):
+                raise TypeError("Desired differential class {0} is not "
+                                "compatible with the desired "
+                                "representation class {1}"
+                                .format(differential_class,
+                                        new_rep.__class__))
+
             new_rep._differentials = self._re_represent_differentials(
                 new_rep, differential_class)
 
@@ -2002,6 +2014,10 @@ class BaseDifferential(BaseRepresentationOrDifferential):
             raise TypeError("Differential class {0} is not compatible with the "
                             "base (representation) class {1}"
                             .format(self.__class__, base.__class__))
+
+        # TODO: I think we must special-case RadialDifferential because if it is
+        # attached to a UnitSphericalRepresentation, it will not have a paired
+        # component name (UnitSphericalRepresentation has no .distance)
 
         for name in base.components:
             comp = getattr(base, name)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -217,21 +217,6 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         # Note: the above docstring gets overridden for differentials.
         raise NotImplementedError()
 
-    def to_cartesian_with_differentials(self):
-        """Convert the representation and any differentials to Cartesian form.
-
-        Returns
-        -------
-        cartrepr : `CartesianRepresentation`
-            The representation in Cartesian form with any attached differentials
-            as `CartesianDifferential` instances.
-
-        """
-        rep = self.to_cartesian()
-        diffs = dict([(k, diff.represent_as(CartesianDifferential, self))
-                      for k, diff in self.differentials.items()])
-        return rep.with_differentials(diffs)
-
     @property
     def components(self):
         """A tuple with the in-order names of the coordinate components."""

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -686,17 +686,6 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             # The default is to convert via cartesian coordinates
             new_rep = other_class.from_cartesian(self.to_cartesian())
 
-            # This validation only happens in re_represent if the represent_as
-            # fails, but we have to check so we can enforce that the
-            # differential_class is one of the _compatible_differentials
-            if (differential_class and
-                    differential_class not in new_rep._compatible_differentials):
-                raise TypeError("Desired differential class {0} is not "
-                                "compatible with the desired "
-                                "representation class {1}"
-                                .format(differential_class,
-                                        new_rep.__class__))
-
             new_rep._differentials = self._re_represent_differentials(
                 new_rep, differential_class)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1996,9 +1996,12 @@ class BaseDifferential(BaseRepresentationOrDifferential):
         of this differential.
         """
 
-        # TODO: better validation by checking, e.g., _compatible_differentials
-        # for this class
-        self._check_base(base)
+        # This check is just a last resort so we don't return a strange unit key
+        # from accidentally passing in the wrong base.
+        if self.__class__ not in base._compatible_differentials:
+            raise TypeError("Differential class {0} is not compatible with the "
+                            "base (representation) class {1}"
+                            .format(self.__class__, base.__class__))
 
         for name in base.components:
             comp = getattr(base, name)
@@ -2008,6 +2011,10 @@ class BaseDifferential(BaseRepresentationOrDifferential):
                 # Get the si unit without a scale by going via Quantity;
                 # `.si` causes the scale to be included in the value.
                 return str(u.Quantity(1., d_unit).si.unit)
+
+        else:
+            raise RuntimeError("Invalid representation-differential match! Not "
+                               "sure how we got into this state.")
 
     @classmethod
     def _get_base_vectors(cls, base):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -522,11 +522,20 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 raise TypeError("Differential '{0}' is not compatible with "
                                 "this representation '{1}'".format(diff, self))
 
-            expected_key = diff._get_deriv_key(self)
-            if key != expected_key:
-                raise ValueError("For differential object '{0}', expected unit "
-                                 "key = '{1}' but received key = '{2}'"
-                                 .format(diff, expected_key, key))
+            if (isinstance(diff, RadialDifferential) and
+                    isinstance(self, UnitSphericalRepresentation)):
+                # We trust the passing of a key for a RadialDifferential
+                # attached to a UnitSphericalRepresentation because it will not
+                # have a paired component name (UnitSphericalRepresentation has
+                # no .distance) to automatically determine the expected key
+                pass
+
+            else:
+                expected_key = diff._get_deriv_key(self)
+                if key != expected_key:
+                    raise ValueError("For differential object '{0}', expected "
+                                     "unit key = '{1}' but received key = '{2}'"
+                                     .format(diff, expected_key, key))
 
             # For now, we are very rigid: differentials must have the same shape
             # as the representation. This makes it easier to handle __getitem__
@@ -2014,10 +2023,6 @@ class BaseDifferential(BaseRepresentationOrDifferential):
             raise TypeError("Differential class {0} is not compatible with the "
                             "base (representation) class {1}"
                             .format(self.__class__, base.__class__))
-
-        # TODO: I think we must special-case RadialDifferential because if it is
-        # attached to a UnitSphericalRepresentation, it will not have a paired
-        # component name (UnitSphericalRepresentation has no .distance)
 
         for name in base.components:
             comp = getattr(base, name)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -520,7 +520,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
             if diff.__class__ not in self._compatible_differentials:
                 raise TypeError("Differential '{0}' is not compatible with "
-                                "this representation '{1}'".format(diff, self))
+                                "this representation '{1}'".format(repr(diff),
+                                                                   repr(self)))
 
             if (isinstance(diff, RadialDifferential) and
                     isinstance(self, UnitSphericalRepresentation)):
@@ -535,7 +536,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 if key != expected_key:
                     raise ValueError("For differential object '{0}', expected "
                                      "unit key = '{1}' but received key = '{2}'"
-                                     .format(diff, expected_key, key))
+                                     .format(repr(diff), expected_key, key))
 
             # For now, we are very rigid: differentials must have the same shape
             # as the representation. This makes it easier to handle __getitem__

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1319,7 +1319,10 @@ def test_to_cartesian():
     sr = SphericalRepresentation(lat=1*u.deg, lon=2*u.deg, distance=10*u.m,
                                  differentials=sd)
 
-    diff = sr.to_cartesian()
+    cart = sr.to_cartesian()
+    assert cart.get_name() == 'cartesian'
+    assert not cart.differentials
 
-    assert diff.get_name() == 'cartesian'
-    assert not diff.differentials
+    cart = sr.to_cartesian_with_differentials()
+    assert cart.get_name() == 'cartesian'
+    assert set(cart.differentials.keys()) == set(sr.differentials.keys())

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1322,7 +1322,3 @@ def test_to_cartesian():
     cart = sr.to_cartesian()
     assert cart.get_name() == 'cartesian'
     assert not cart.differentials
-
-    cart = sr.to_cartesian_with_differentials()
-    assert cart.get_name() == 'cartesian'
-    assert set(cart.differentials.keys()) == set(sr.differentials.keys())

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -210,24 +210,34 @@ def test_obstime():
 # ------------------------------------------------------------------------------
 # Affine transform tests and helpers:
 
-def transfunc_both(coo, fr):
-    # exchange x <-> z and offset
-    M = np.array([[0., 0., 1.],
-                  [0., 1., 0.],
-                  [1., 0., 0.]])
-    return M, (np.arange(3)*u.pc, np.arange(3, 6)*u.pc/u.Myr)
+# just acting as a namespace
+class transfunc(object):
+    rep = r.CartesianRepresentation(np.arange(3)*u.pc)
+    dif = r.CartesianDifferential(*np.arange(3, 6)*u.pc/u.Myr)
+    rep0 = r.CartesianRepresentation(np.zeros(3)*u.pc)
 
-def transfunc_no_matrix(coo, fr):
-    return None, (np.arange(3)*u.pc, np.arange(3, 6)*u.pc/u.Myr)
+    @classmethod
+    def both(cls, coo, fr):
+        # exchange x <-> z and offset
+        M = np.array([[0., 0., 1.],
+                      [0., 1., 0.],
+                      [1., 0., 0.]])
+        return M, cls.rep.with_differentials(cls.dif)
 
-def transfunc_no_pos(coo, fr):
-    return None, (None, np.arange(3, 6)*u.pc/u.Myr)
+    @classmethod
+    def no_matrix(cls, coo, fr):
+        return None, cls.rep.with_differentials(cls.dif)
 
-def transfunc_no_vel(coo, fr):
-    return None, (np.arange(3)*u.pc, None)
+    @classmethod
+    def no_pos(cls, coo, fr):
+        return None, cls.rep0.with_differentials(cls.dif)
 
-@pytest.mark.parametrize('transfunc', [transfunc_both, transfunc_no_matrix,
-                                       transfunc_no_pos, transfunc_no_vel])
+    @classmethod
+    def no_vel(cls, coo, fr):
+        return None, cls.rep
+
+@pytest.mark.parametrize('transfunc', [transfunc.both, transfunc.no_matrix,
+                                       transfunc.no_pos, transfunc.no_vel])
 @pytest.mark.parametrize('rep', [
     r.CartesianRepresentation(5, 6, 7, unit=u.pc),
     r.CartesianRepresentation(5, 6, 7, unit=u.pc,
@@ -238,13 +248,13 @@ def test_affine_transform_succeed(transfunc, rep):
     c = TCoo1(rep)
 
     # compute expected output
-    M, vecs = transfunc(c, TCoo2)
+    M, offset = transfunc(c, TCoo2)
 
     expected_pos = c.cartesian.transform(M) if M is not None else c.cartesian
-    if (vecs is not None and vecs[0] is not None):
-        expected_pos = expected_pos.xyz + vecs[0]
+    if offset is not None:
+        expected_pos = expected_pos + offset
     else:
-        expected_pos = expected_pos.xyz
+        expected_pos = expected_pos
 
     expected_vel = None
     if c.data.differentials:
@@ -252,23 +262,23 @@ def test_affine_transform_succeed(transfunc, rep):
                                                     c.data)
         expected_vel = diff.transform(M) if M is not None else diff
 
-        if (vecs is not None and vecs[1] is not None):
-            expected_vel = expected_vel.xyz + vecs[1]
+        if offset.differentials:
+            expected_vel = expected_vel + offset.differentials[0]
         else:
-            expected_vel = expected_vel.xyz
+            expected_vel = expected_vel
 
     # register and do the transformation and check against expected
     trans = t.AffineTransform(transfunc, TCoo1, TCoo2)
     trans.register(frame_transform_graph)
 
     c2 = c.transform_to(TCoo2)
-    assert quantity_allclose(c2.data.to_cartesian().xyz, expected_pos)
+    assert quantity_allclose(c2.data.to_cartesian().xyz, expected_pos.xyz)
 
     if expected_vel is not None:
         # TODO: clean this up when there is a shorthand for accessing
         # differentials from the frames
         diff = c2.data.differentials[0].to_cartesian(base=c2.data)
-        assert quantity_allclose(diff.xyz, expected_vel)
+        assert quantity_allclose(diff.xyz, expected_vel.xyz)
 
     trans.unregister(frame_transform_graph)
 
@@ -276,15 +286,8 @@ def test_affine_transform_succeed(transfunc, rep):
 def transfunc_invalid_matrix(coo, fr):
     return np.eye(4), None
 
-def transfunc_invalid_pos(coo, fr):
-    return None, (np.arange(4)*u.pc, np.arange(3, 6)*u.pc/u.Myr)
-
-def transfunc_invalid_vel(coo, fr):
-    return None, (np.arange(3)*u.pc, np.arange(3, 7)*u.pc/u.Myr)
-
-@pytest.mark.parametrize('transfunc', [transfunc_invalid_matrix,
-                                       transfunc_invalid_pos,
-                                       transfunc_invalid_vel])
+# Leaving this open in case we want to add more functions to check for failures
+@pytest.mark.parametrize('transfunc', [transfunc_invalid_matrix])
 def test_affine_transform_fail(transfunc):
     diff = r.CartesianDifferential(8, 9, 10, unit=u.pc/u.Myr)
     rep = r.CartesianRepresentation(5, 6, 7, unit=u.pc, differentials=diff)

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -58,6 +58,7 @@ def test_transform_classes():
     # already got unregistered when trans2 was created.
     trans2.unregister(frame_transform_graph)
 
+
 def test_transform_decos():
     """
     Tests the decorator syntax for creating transforms

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -332,3 +332,24 @@ def test_too_many_differentials():
         c2 = c.transform_to(TCoo2)
 
     trans.unregister(frame_transform_graph)
+
+# A matrix transform of a unit spherical with differentials should work
+@pytest.mark.parametrize('rep', [
+    r.UnitSphericalRepresentation(lon=15*u.degree, lat=-11*u.degree,
+        differentials=r.SphericalDifferential(d_lon=15*u.mas/u.yr,
+                                              d_lat=11*u.mas/u.yr,
+                                              d_distance=-110*u.km/u.s)),
+    r.UnitSphericalRepresentation(lon=15*u.degree, lat=-11*u.degree,
+        differentials=r.RadialDifferential(d_distance=-110*u.km/u.s))
+])
+def test_unit_spherical_with_differentials(rep):
+
+    c = TCoo1(rep)
+
+    # register and do the transformation and check against expected
+    trans = t.AffineTransform(transfunc.just_matrix, TCoo1, TCoo2)
+    trans.register(frame_transform_graph)
+
+    c2 = c.transform_to(TCoo2)
+
+    trans.unregister(frame_transform_graph)

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -263,10 +263,13 @@ def test_affine_transform_succeed(transfunc, rep):
     # compute expected output
     M, offset = transfunc(c, TCoo2)
 
+    _rep = rep.to_cartesian()
+    diffs = dict([(k, diff.represent_as(r.CartesianDifferential, rep))
+                  for k, diff in rep.differentials.items()])
+    expected_rep = _rep.with_differentials(diffs)
+
     if M is not None:
-        expected_rep = rep.to_cartesian_with_differentials().transform(M)
-    else:
-        expected_rep = rep.to_cartesian_with_differentials()
+        expected_rep = expected_rep.transform(M)
 
     expected_pos = expected_rep.without_differentials()
     if offset is not None:

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -349,7 +349,5 @@ def test_unit_spherical_with_differentials(rep):
     # register and do the transformation and check against expected
     trans = t.AffineTransform(transfunc.just_matrix, TCoo1, TCoo2)
     trans.register(frame_transform_graph)
-
     c2 = c.transform_to(TCoo2)
-
     trans.unregister(frame_transform_graph)

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -340,7 +340,7 @@ def test_too_many_differentials():
                                               d_lat=11*u.mas/u.yr,
                                               d_distance=-110*u.km/u.s)),
     r.UnitSphericalRepresentation(lon=15*u.degree, lat=-11*u.degree,
-        differentials=r.RadialDifferential(d_distance=-110*u.km/u.s))
+        differentials={'s': r.RadialDifferential(d_distance=-110*u.km/u.s)})
 ])
 def test_unit_spherical_with_differentials(rep):
 

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -340,6 +340,9 @@ def test_too_many_differentials():
                                               d_lat=11*u.mas/u.yr,
                                               d_distance=-110*u.km/u.s)),
     r.UnitSphericalRepresentation(lon=15*u.degree, lat=-11*u.degree,
+        differentials={'s': r.RadialDifferential(d_distance=-110*u.km/u.s)}),
+    r.SphericalRepresentation(lon=15*u.degree, lat=-11*u.degree,
+                              distance=150*u.pc,
         differentials={'s': r.RadialDifferential(d_distance=-110*u.km/u.s)})
 ])
 def test_unit_spherical_with_differentials(rep):
@@ -350,4 +353,21 @@ def test_unit_spherical_with_differentials(rep):
     trans = t.AffineTransform(transfunc.just_matrix, TCoo1, TCoo2)
     trans.register(frame_transform_graph)
     c2 = c.transform_to(TCoo2)
+
+    assert 's' in rep.differentials
+    assert isinstance(c2.data.differentials['s'],
+                      rep.differentials['s'].__class__)
+
+    if isinstance(rep.differentials['s'], r.RadialDifferential):
+        assert c2.data.differentials['s'] is rep.differentials['s']
+
+    trans.unregister(frame_transform_graph)
+
+    # should fail if we have to do offsets
+    trans = t.AffineTransform(transfunc.both, TCoo1, TCoo2)
+    trans.register(frame_transform_graph)
+
+    with pytest.raises(TypeError):
+        c.transform_to(TCoo2)
+
     trans.unregister(frame_transform_graph)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -786,7 +786,8 @@ class AffineTransform(CoordinateTransform):
 
     def _apply_transform(self, fromcoord, matrix, vectors):
         from .representation import (CartesianRepresentation,
-                                     UnitSphericalRepresentation)
+                                     UnitSphericalRepresentation,
+                                     CartesianDifferential)
 
         rep = fromcoord.represent_as(CartesianRepresentation)
         newrep = rep.without_differentials().transform(matrix)
@@ -807,6 +808,7 @@ class AffineTransform(CoordinateTransform):
                 vel_offset = CartesianRepresentation(vectors[1])
                 newdiff = newdiff + vel_offset
 
+            newdiff = newdiff.represent_as(CartesianDifferential)
             newrep._differentials = (newdiff,)
 
         if issubclass(fromcoord.data.__class__, UnitSphericalRepresentation):

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -790,7 +790,7 @@ class BaseAffineTransform(CoordinateTransform):
             newdiff = newdiff.represent_as(CartesianDifferential)
             newrep._differentials = (newdiff,)
 
-        if issubclass(fromcoord.data.__class__, UnitSphericalRepresentation):
+        if isinstance(fromcoord.data, UnitSphericalRepresentation):
             # need to special-case this because otherwise the new class will
             # think it has a valid distance
             newrep = newrep.represent_as(fromcoord.data.__class__)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -763,7 +763,7 @@ class BaseAffineTransform(CoordinateTransform):
         # Only do transform is matrix is specified. This is for speed in
         # transformations that only specify an offset (e.g., LSR)
         if matrix is not None:
-            rep = rep.transform(matrix, apply_to_diffs=True)
+            rep = rep.transform(matrix)
 
         newrep = rep.without_differentials()
         if offset is not None:

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -31,6 +31,7 @@ from ..utils.compat.funcsigs import signature
 from ..extern import six
 from ..extern.six.moves import range
 
+from .representation import REPRESENTATION_CLASSES
 
 __all__ = ['TransformGraph', 'CoordinateTransform', 'FunctionTransform',
            'StaticMatrixTransform', 'DynamicMatrixTransform', 'CompositeTransform']
@@ -758,7 +759,7 @@ class BaseAffineTransform(CoordinateTransform):
         rep = fromcoord.represent_as(CartesianRepresentation)
         newrep = rep.without_differentials().transform(matrix)
 
-        if vectors is not None:
+        if vectors is not None and vectors[0] is not None:
             pos_offset = CartesianRepresentation(vectors[0])
             newrep = newrep + pos_offset
 
@@ -767,10 +768,12 @@ class BaseAffineTransform(CoordinateTransform):
             # TODO: we only support velocities right now - elsewhere, we need to
             # validate / make sure only 1 differential is attached
             veldiff = rep.differentials[0]
-            newdiff = veldiff.represent_as(CartesianRepresentation, base=fromcoord.data)\
+
+            base = fromcoord.data.represent_as(veldiff.base_representation)
+            newdiff = veldiff.represent_as(CartesianRepresentation, base=base)\
                              .transform(matrix)
 
-            if vectors is not None:
+            if vectors is not None and vectors[1] is not None:
                 vel_offset = CartesianRepresentation(vectors[1])
                 newdiff = newdiff + vel_offset
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -34,7 +34,9 @@ from ..extern.six.moves import range
 from .representation import REPRESENTATION_CLASSES
 
 __all__ = ['TransformGraph', 'CoordinateTransform', 'FunctionTransform',
-           'StaticMatrixTransform', 'DynamicMatrixTransform', 'CompositeTransform']
+           'BaseAffineTransform', 'AffineTransform',
+           'StaticMatrixTransform', 'DynamicMatrixTransform',
+           'CompositeTransform']
 
 class TransformGraph(object):
     """

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -759,13 +759,12 @@ class BaseAffineTransform(CoordinateTransform):
                                      CartesianDifferential)
 
         rep = fromcoord.represent_as(CartesianRepresentation)
+        newrep = rep.without_differentials()
 
         # Only do transform is matrix is specified. This is for speed in
         # transformations that only specify an offset (e.g., LSR)
         if matrix is not None:
-            newrep = rep.without_differentials().transform(matrix)
-        else:
-            newrep = rep
+            newrep = newrep.transform(matrix)
 
         if vectors is not None and vectors[0] is not None:
             pos_offset = CartesianRepresentation(vectors[0])

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -776,6 +776,8 @@ class BaseAffineTransform(CoordinateTransform):
             if offset.differentials:
                 veldiff = veldiff + offset.differentials[0]
 
+            veldiff = veldiff.represent_as(rep.differentials[0].__class__,
+                                           newrep)
             newrep._differentials = (veldiff,)
 
         if isinstance(fromcoord.data, UnitSphericalRepresentation):

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -757,7 +757,13 @@ class BaseAffineTransform(CoordinateTransform):
                                      CartesianDifferential)
 
         rep = fromcoord.represent_as(CartesianRepresentation)
-        newrep = rep.without_differentials().transform(matrix)
+
+        # Only do transform is matrix is specified. This is for speed in
+        # transformations that only specify an offset (e.g., LSR)
+        if matrix is not None:
+            newrep = rep.without_differentials().transform(matrix)
+        else:
+            newrep = rep
 
         if vectors is not None and vectors[0] is not None:
             pos_offset = CartesianRepresentation(vectors[0])
@@ -770,8 +776,11 @@ class BaseAffineTransform(CoordinateTransform):
             veldiff = rep.differentials[0]
 
             base = fromcoord.data.represent_as(veldiff.base_representation)
-            newdiff = veldiff.represent_as(CartesianRepresentation, base=base)\
-                             .transform(matrix)
+
+            # Only do transform is matrix is specified.
+            newdiff = veldiff.represent_as(CartesianRepresentation, base=base)
+            if matrix is not None:
+                newdiff = newdiff.transform(matrix)
 
             if vectors is not None and vectors[1] is not None:
                 vel_offset = CartesianRepresentation(vectors[1])

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -754,9 +754,21 @@ class BaseAffineTransform(CoordinateTransform):
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):
-        from .representation import UnitSphericalRepresentation
+        from .representation import (UnitSphericalRepresentation,
+                                     UnitSphericalDifferential)
 
-        rep = fromcoord.data.to_cartesian_with_differentials()
+        data = fromcoord.data
+
+        # If the representation is a UnitSphericalRepresentation, and this is
+        # just a MatrixTransform, we have to try to turn the differential into
+        # a UnitSphericalDifferential so that the matrix operation succceeds
+        if isinstance(data, UnitSphericalRepresentation):
+            unit_diffs = dict([(k, diff.represent_as(UnitSphericalDifferential,
+                                                     data))
+                               for k, diff in data.differentials.items()])
+            data = data.with_differentials(unit_diffs) # updates
+
+        rep = data.to_cartesian_with_differentials()
 
         # Only do transform is matrix is specified. This is for speed in
         # transformations that only specify an offset (e.g., LSR)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -754,9 +754,7 @@ class BaseAffineTransform(CoordinateTransform):
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):
-        from .representation import (CartesianRepresentation,
-                                     UnitSphericalRepresentation,
-                                     CartesianDifferential)
+        from .representation import UnitSphericalRepresentation
 
         rep = fromcoord.data.to_cartesian_with_differentials()
 
@@ -779,14 +777,13 @@ class BaseAffineTransform(CoordinateTransform):
         if 's' in rep.differentials and len(rep.differentials) == 1:
             veldiff = rep.differentials['s'] # already in Cartesian form
 
-            if 's' in offset.differentials:
+            if offset is not None and 's' in offset.differentials:
                 veldiff = veldiff + offset.differentials['s']
 
-            newrep = newrep.with_differentials(
-                veldiff.represent_as(rep.differentials['s'].__class__, newrep))
+            newrep = newrep.with_differentials(veldiff)
 
         elif len(rep.differentials) > 1:
-            # We should never get here because the frame initializer sholdn't
+            # We should never get here because the frame initializer shouldn't
             # allow more differentials, but this just adds protection for
             # subclasses that somehow skip the checks
             raise ValueError("Representation passed to AffineTransform contains"
@@ -799,7 +796,7 @@ class BaseAffineTransform(CoordinateTransform):
             # need to special-case this because otherwise the new class will
             # think it has a valid distance
             diff_class = dict([(k, diff.__class__)
-                               for k, diff in newrep.differentials.items()])
+                               for k, diff in fromcoord.data.differentials.items()])
             newrep = newrep.represent_as(fromcoord.data.__class__, diff_class)
 
         return newrep

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -752,11 +752,13 @@ class BaseAffineTransform(CoordinateTransform):
     """Base class for common functionality between the ``AffineTransform``-type
     subclasses.
 
-    This needed because ``AffineTransform`` and the matrix transform classes
-    share the ``_apply_transform()`` method, but have different ``__call__()``
-    methods. ``StaticMatrixTransform`` passes in a matrix stored as a
-    class attribute, and both of the matrix transforms pass in ``None`` for the
-    offset.
+    This base class is needed because ``AffineTransform`` and the matrix
+    transform classes share the ``_apply_transform()`` method, but have
+    different ``__call__()`` methods. ``StaticMatrixTransform`` passes in a
+    matrix stored as a class attribute, and both of the matrix transforms pass
+    in ``None`` for the offset. Hence, user subclasses would likely want to
+    subclass this (rather than ``AffineTransform``) if they want to provide
+    alternative transformations using this machinery.
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -756,6 +756,7 @@ class BaseAffineTransform(CoordinateTransform):
 
     def _apply_transform(self, fromcoord, matrix, offset):
         from .representation import (UnitSphericalRepresentation,
+                                     CartesianDifferential,
                                      SphericalDifferential,
                                      SphericalCosLatDifferential,
                                      RadialDifferential)
@@ -817,7 +818,12 @@ class BaseAffineTransform(CoordinateTransform):
         elif rad_vel_diff:
             data = data.without_differentials()
 
-        rep = data.to_cartesian_with_differentials()
+        # Convert the representation and differentials to cartesian without
+        # having them attached to a frame
+        rep = data.to_cartesian()
+        diffs = dict([(k, diff.represent_as(CartesianDifferential, data))
+                      for k, diff in data.differentials.items()])
+        rep = rep.with_differentials(diffs)
 
         # Only do transform if matrix is specified. This is for speed in
         # transformations that only specify an offset (e.g., LSR)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -749,9 +749,14 @@ class FunctionTransform(CoordinateTransform):
         return res
 
 class BaseAffineTransform(CoordinateTransform):
-    """
-    Base class for common functionality between the ``AffineTransform``-type
+    """Base class for common functionality between the ``AffineTransform``-type
     subclasses.
+
+    This needed because ``AffineTransform`` and the matrix transform classes
+    share the ``_apply_transform()`` method, but have different ``__call__()``
+    methods. ``StaticMatrixTransform`` passes in a matrix stored as a
+    class attribute, and both of the matrix transforms pass in ``None`` for the
+    offset.
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):
@@ -889,14 +894,18 @@ class AffineTransform(BaseAffineTransform):
     A coordinate transformation specified as a function that yields a 3 x 3
     cartesian transformation matrix and a tuple of displacement vectors.
 
+    See `~astropy.coordinates.builtin_frames.galactocentric.Galactocentric` for
+    an example.
+
     Parameters
     ----------
     transform_func : callable
         A callable that has the signature ``transform_func(fromcoord, toframe)``
-        and returns a length-2 tuple that contains: [0] a (3, 3) matrix that
-        converts ``fromcoord`` in a cartesian representation to the new
-        coordinate system, and [1] a (N, 3) set of vectors that contain
-        offsets for differentials (or None).
+        and returns: a (3, 3) matrix that operates on ``fromcoord`` in a
+        Cartesian representation, and a ``CartesianRepresentation`` with
+        (optionally) an attached velocity ``CartesianDifferential`` to represent
+        a translation and offset in velocity to apply after the matrix
+        operation.
     fromsys : class
         The coordinate frame class to start from.
     tosys : class

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -331,7 +331,7 @@ the `~astropy.coordinates.TransformGraph` class.  This graph (in the
 "graph theory" sense, not "plot"), stores all the transformations
 between all of the builtin frames, as well as tools for finding shortest
 paths through this graph to transform from any frame to any other.  All
-of the power of this graph is available to user-created frames, meaning
+of the power of this graph is available to user-created frames as well, meaning
 that once you define even one transform from your frame to some frame in
 the graph,  coordinates defined in your frame can be transformed to
 *any* other frame in the graph.
@@ -345,12 +345,19 @@ subclasses/types of transformations are:
     A transform that is defined as a function that takes a frame object
     of one frame class and returns an object of another class.
 
+* `~astropy.coordinates.AffineTransform`
+
+    A transformation that includes a linear matrix operation and a translation
+    (vector offset). These transformations are defined by a 3x3 matrix and a
+    3-vector for the offset. The transformation is applied to the Cartesian
+    representation of one frame and transforms into the Cartesian representation
+    of the target frame.
+
 * `~astropy.coordinates.StaticMatrixTransform`
 * `~astropy.coordinates.DynamicMatrixTransform`
 
-    These are both for transformations defined as a 3x3 matrix
-    transforming the Cartesian representation of one frame into the
-    target frame's Cartesian representation.  The static version is for
+    The matrix transforms are `~astropy.coordinates.AffineTransform`'s without
+    a translation, e.g., a rotation. The static version is for
     the case where the matrix is independent of the frame attributes
     (e.g., the ICRS->FK5 transformation, because ICRS has no frame
     attributes).  The dynamic case is for transformations where the

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -349,15 +349,15 @@ subclasses/types of transformations are:
 
     A transformation that includes a linear matrix operation and a translation
     (vector offset). These transformations are defined by a 3x3 matrix and a
-    3-vector for the offset. The transformation is applied to the Cartesian
-    representation of one frame and transforms into the Cartesian representation
-    of the target frame.
+    3-vector for the offset (supplied as a Cartesian representation). The
+    transformation is applied to the Cartesian representation of one frame and
+    transforms into the Cartesian representation of the target frame.
 
 * `~astropy.coordinates.StaticMatrixTransform`
 * `~astropy.coordinates.DynamicMatrixTransform`
 
     The matrix transforms are `~astropy.coordinates.AffineTransform`'s without
-    a translation, e.g., a rotation. The static version is for
+    a translation, i.e. a rotation. The static version is for
     the case where the matrix is independent of the frame attributes
     (e.g., the ICRS->FK5 transformation, because ICRS has no frame
     attributes).  The dynamic case is for transformations where the


### PR DESCRIPTION
This is the 2nd of several PR's that add support for velocities in `astropy.coordinates`. 

The main feature of this PR is to add a new `CoordinateTransform` class "`AffineTransform`" for handling rotations plus translations.

Next in the PR chain is #6219 