### PR TITLE
Let user have more control over deprecation warning to exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,11 @@ New Features
   - Added functionality to allow ``astropy.units.Quantity`` to be read
     from and written to a VOtable file. [#6132]
 
+- ``astropy.tests``
+
+  - ``enable_deprecations_as_exceptions`` function now accepts additional
+    user-defined module imports and warning messages to ignore. [#6223]
+
 - ``astropy.time``
 
 - ``astropy.units``

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -130,16 +130,69 @@ class raises(object):
 
 _deprecations_as_exceptions = False
 _include_astropy_deprecations = True
+_modules_to_ignore_on_import = set([
+    'compiler',  # A deprecated stdlib module used by py.test
+    'scipy',
+    'pygments',
+    'ipykernel',
+    'setuptools'])
+_warnings_to_ignore_by_pyver = {
+    (3, 4): set([
+        # py.test reads files with the 'U' flag, which is now
+        # deprecated in Python 3.4.
+        r"'U' mode is deprecated",
+        # BeautifulSoup4 triggers warning in stdlib's html module.x
+        r"The strict argument and mode are deprecated\.",
+        r"The value of convert_charrefs will become True in 3\.5\. "
+        r"You are encouraged to set the value explicitly\."]),
+    (3, 5): set([
+        # py.test raises this warning on Python 3.5.
+        # This can be removed when fixed in py.test.
+        # See https://github.com/pytest-dev/pytest/pull/1009
+        r"inspect\.getargspec\(\) is deprecated, use "
+        r"inspect\.signature\(\) instead"])}
 
-def enable_deprecations_as_exceptions(include_astropy_deprecations=True):
+
+def enable_deprecations_as_exceptions(include_astropy_deprecations=True,
+                                      modules_to_ignore_on_import=[],
+                                      warnings_to_ignore_by_pyver={}):
     """
     Turn on the feature that turns deprecations into exceptions.
+
+    Parameters
+    ----------
+    include_astropy_deprecations : bool
+        If set to `True`, ``AstropyDeprecationWarning`` and
+        ``AstropyPendingDeprecationWarning`` are also turned into exceptions.
+
+    modules_to_ignore_on_import : list of str
+        List of additional modules that generate deprecation warnings
+        on import, which are to be ignored. By default, these are already
+        included: ``compiler``, ``scipy``, ``pygments``, ``ipykernel``, and
+        ``setuptools``.
+
+    warnings_to_ignore_by_pyver : dict
+        Dictionary mapping tuple of ``(major, minor)`` Python version to
+        a list of deprecation warning messages to ignore. This is in
+        addition of those already ignored by default
+        (see ``_warnings_to_ignore_by_pyver`` values).
+
     """
     global _deprecations_as_exceptions
     _deprecations_as_exceptions = True
 
     global _include_astropy_deprecations
     _include_astropy_deprecations = include_astropy_deprecations
+
+    global _modules_to_ignore_on_import
+    _modules_to_ignore_on_import.update(modules_to_ignore_on_import)
+
+    global _warnings_to_ignore_by_pyver
+    for key, val in six.iteritems(warnings_to_ignore_by_pyver):
+        if key in _warnings_to_ignore_by_pyver:
+            _warnings_to_ignore_by_pyver[key].update(val)
+        else:
+            _warnings_to_ignore_by_pyver[key] = set(val)
 
 
 def treat_deprecations_as_exceptions():
@@ -159,7 +212,7 @@ def treat_deprecations_as_exceptions():
         # We don't want to deal with six.MovedModules, only "real"
         # modules.
         if (isinstance(module, types.ModuleType) and
-            hasattr(module, '__warningregistry__')):
+                hasattr(module, '__warningregistry__')):
             del module.__warningregistry__
 
     if not _deprecations_as_exceptions:
@@ -174,31 +227,11 @@ def treat_deprecations_as_exceptions():
     # themselves, and we'd like to ignore those.  Fortunately, those
     # show up only at import time, so if we import those things *now*,
     # before we turn the warnings into exceptions, we're golden.
-    try:
-        # A deprecated stdlib module used by py.test
-        import compiler  # pylint: disable=W0611
-    except ImportError:
-        pass
-
-    try:
-        import scipy  # pylint: disable=W0611
-    except ImportError:
-        pass
-
-    try:
-        import pygments  # pylint: disable=W0611
-    except ImportError:
-        pass
-
-    try:
-        import ipykernel  # pylint: disable=W0611
-    except ImportError:
-        pass
-
-    try:
-        import setuptools  # pylint: disable=W0611
-    except ImportError:
-        pass
+    for m in _modules_to_ignore_on_import:
+        try:
+            __import__(m)
+        except ImportError:
+            pass
 
     # Now, start over again with the warning filters
     warnings.resetwarnings()
@@ -210,35 +243,10 @@ def treat_deprecations_as_exceptions():
         warnings.filterwarnings("error", ".*", AstropyDeprecationWarning)
         warnings.filterwarnings("error", ".*", AstropyPendingDeprecationWarning)
 
-    if sys.version_info[:2] >= (3, 4):
-        # py.test reads files with the 'U' flag, which is now
-        # deprecated in Python 3.4.
-        warnings.filterwarnings(
-            "ignore",
-            r"'U' mode is deprecated",
-            DeprecationWarning)
-
-        # BeautifulSoup4 triggers a DeprecationWarning in stdlib's
-        # html module.x
-        warnings.filterwarnings(
-            "ignore",
-            r"The strict argument and mode are deprecated\.",
-            DeprecationWarning)
-        warnings.filterwarnings(
-            "ignore",
-            r"The value of convert_charrefs will become True in 3\.5\. "
-            r"You are encouraged to set the value explicitly\.",
-            DeprecationWarning)
-
-    if sys.version_info[:2] >= (3, 5):
-        # py.test raises this warning on Python 3.5.
-        # This can be removed when fixed in py.test.
-        # See https://github.com/pytest-dev/pytest/pull/1009
-        warnings.filterwarnings(
-            "ignore",
-            r"inspect\.getargspec\(\) is deprecated, use "
-            r"inspect\.signature\(\) instead",
-            DeprecationWarning)
+    for v in _warnings_to_ignore_by_pyver:
+        if sys.version_info[:2] >= v:
+            for s in _warnings_to_ignore_by_pyver[v]:
+                warnings.filterwarnings("ignore", s, DeprecationWarning)
 
 
 class catch_warnings(warnings.catch_warnings):


### PR DESCRIPTION
Fix #5917

@bsipocz , is this what you had in mind? Do we need a change log? I also did not set a milestone as I don't think it is critical for v2.0.

Travis tests are on my fork -- https://travis-ci.org/pllim/astropy/builds/243388792 (I cancelled the one here to relieve queue)