### PR TITLE
Support Velocities in coordinates by having transforms that use finite differences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -228,8 +228,12 @@ New Features
 
   - Frame objects now have experimental support for velocity components. Most
     frames default to accepting proper motion components and radial velocity,
-    and the velocitiestransform correctly for any transformation that uses one 
-    of the ``AffineTransform``-type transformations. [#6219]
+    and the velocities transform correctly for any transformation that uses
+    one of the ``AffineTransform``-type transformations.  For other
+    transformations a finite-difference velocity transformation is available,
+    although it is not as numerically stable as those that use
+    ``AffineTransform``-type transformations. [#6219, #6226]
+
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from ... import units as u
 from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransform
+from ..transformations import FunctionTransformWithFiniteDifference
 from ..representation import (SphericalRepresentation,
                               UnitSphericalRepresentation)
 from ... import _erfa as erfa
@@ -21,7 +21,7 @@ from .altaz import AltAz
 from .utils import get_polar_motion, get_dut1utc, get_jd12, PIOVER2
 
 
-@frame_transform_graph.transform(FunctionTransform, CIRS, AltAz)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, AltAz)
 def cirs_to_altaz(cirs_coo, altaz_frame):
     if np.any(cirs_coo.obstime != altaz_frame.obstime):
         # the only frame attribute for the current CIRS is the obstime, but this
@@ -83,7 +83,7 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
     return altaz_frame.realize_frame(rep)
 
 
-@frame_transform_graph.transform(FunctionTransform, AltAz, CIRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, AltAz, CIRS)
 def altaz_to_cirs(altaz_coo, cirs_frame):
     usrepr = altaz_coo.represent_as(UnitSphericalRepresentation)
     az = usrepr.lon.to_value(u.radian)
@@ -126,7 +126,7 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     return cirs_at_aa_time.transform_to(cirs_frame)
 
 
-@frame_transform_graph.transform(FunctionTransform, AltAz, AltAz)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, AltAz, AltAz)
 def altaz_to_altaz(from_coo, to_frame):
     # for now we just implement this through CIRS to make sure we get everything
     # covered

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -88,7 +88,9 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     return to_frame.realize_frame(newrepr)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, HeliocentricTrueEcliptic, ICRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
+                                 HeliocentricTrueEcliptic, ICRS,
+                                 finite_difference_frameattr_name='equinox')
 def helioecliptic_to_icrs(from_coo, to_frame):
     if not u.m.is_equivalent(from_coo.cartesian.x.unit):
         raise UnitsError(_NEED_ORIGIN_HINT.format(from_coo.__class__.__name__))

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 from ... import units as u
 from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransform, DynamicMatrixTransform
+from ..transformations import FunctionTransformWithFiniteDifference, DynamicMatrixTransform
 from ..matrix_utilities import (rotation_matrix,
                                 matrix_product, matrix_transpose)
 from ..representation import CartesianRepresentation
@@ -28,7 +28,9 @@ def _ecliptic_rotation_matrix(equinox):
     return matrix_product(rotation_matrix(obl, 'x'), rnpb)
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, GeocentricTrueEcliptic)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
+                                 GCRS, GeocentricTrueEcliptic,
+                                 finite_difference_frameattr_name='equinox')
 def gcrs_to_geoecliptic(gcrs_coo, to_frame):
     # first get us to a 0 pos/vel GCRS at the target equinox
     gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=to_frame.equinox))
@@ -38,7 +40,7 @@ def gcrs_to_geoecliptic(gcrs_coo, to_frame):
     return to_frame.realize_frame(newrepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, GeocentricTrueEcliptic, GCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GeocentricTrueEcliptic, GCRS)
 def geoecliptic_to_gcrs(from_coo, gcrs_frame):
     rmat = _ecliptic_rotation_matrix(from_coo.equinox)
     newrepr = from_coo.cartesian.transform(matrix_transpose(rmat))
@@ -64,7 +66,9 @@ _NEED_ORIGIN_HINT = ("The input {0} coordinates do not have length units. This "
                      "function in this case because there is an origin shift.")
 
 
-@frame_transform_graph.transform(FunctionTransform, ICRS, HeliocentricTrueEcliptic)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
+                                 ICRS, HeliocentricTrueEcliptic,
+                                 finite_difference_frameattr_name='equinox')
 def icrs_to_helioecliptic(from_coo, to_frame):
     if not u.m.is_equivalent(from_coo.cartesian.x.unit):
         raise UnitsError(_NEED_ORIGIN_HINT.format(from_coo.__class__.__name__))
@@ -84,7 +88,7 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     return to_frame.realize_frame(newrepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, HeliocentricTrueEcliptic, ICRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, HeliocentricTrueEcliptic, ICRS)
 def helioecliptic_to_icrs(from_coo, to_frame):
     if not u.m.is_equivalent(from_coo.cartesian.x.unit):
         raise UnitsError(_NEED_ORIGIN_HINT.format(from_coo.__class__.__name__))

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -9,7 +9,8 @@ from ...extern.six.moves import range
 from ... import units as u
 from ..baseframe import frame_transform_graph
 from ..frame_attributes import TimeFrameAttribute
-from ..transformations import FunctionTransform, DynamicMatrixTransform
+from ..transformations import (FunctionTransformWithFiniteDifference,
+                               FunctionTransform, DynamicMatrixTransform)
 from ..representation import (CartesianRepresentation,
                               UnitSphericalRepresentation)
 from .. import earth_orientation as earth
@@ -43,7 +44,7 @@ class FK4(BaseRADecFrame):
 FK4.__doc__ = FK4.__doc__.format(params=_base_radec_docstring)
 
 # the "self" transform
-@frame_transform_graph.transform(FunctionTransform, FK4, FK4)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, FK4, FK4)
 def fk4_to_fk4(fk4coord1, fk4frame2):
     # deceptively complicated: need to transform to No E-terms FK4, precess, and
     # then come back, because precession is non-trivial with E-terms
@@ -136,7 +137,7 @@ def fk4_e_terms(equinox):
            -e * k * np.cos(g) * np.sin(o)
 
 
-@frame_transform_graph.transform(FunctionTransform, FK4, FK4NoETerms)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, FK4, FK4NoETerms)
 def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     # Extract cartesian vector
     rep = fk4coord.cartesian
@@ -173,7 +174,7 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     return fk4noe
 
 
-@frame_transform_graph.transform(FunctionTransform, FK4NoETerms, FK4)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, FK4NoETerms, FK4)
 def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
     #first precess, if necessary
     if fk4noecoord.equinox != fk4frame.equinox:

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Contains the transofrmation functions for getting from ICRS/HCRS to CIRS and
+Contains the transformation functions for getting from ICRS/HCRS to CIRS and
 anything in between (currently that means GCRS)
 """
 from __future__ import (absolute_import, unicode_literals, division,

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -63,7 +63,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
     return cirs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS,
+                                 finite_difference_frameattr_name=None)
 def cirs_to_icrs(cirs_coo, icrs_frame):
     srepr = cirs_coo.represent_as(UnitSphericalRepresentation)
     cirs_ra = srepr.lon.to_value(u.radian)
@@ -166,7 +167,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     return gcrs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, ICRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, ICRS,
+                                 finite_difference_frameattr_name=None)
 def gcrs_to_icrs(gcrs_coo, icrs_frame):
     srepr = gcrs_coo.represent_as(UnitSphericalRepresentation)
     gcrs_ra = srepr.lon.to_value(u.radian)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from ... import units as u
 from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransform, AffineTransform
+from ..transformations import FunctionTransformWithFiniteDifference, AffineTransform
 from ..representation import (SphericalRepresentation, CartesianRepresentation,
                               UnitSphericalRepresentation)
 from ... import _erfa as erfa
@@ -24,7 +24,7 @@ from .utils import get_jd12, aticq, atciqz, get_cip, prepare_earth_position_vel
 
 
 # First the ICRS/CIRS related transforms
-@frame_transform_graph.transform(FunctionTransform, ICRS, CIRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, CIRS)
 def icrs_to_cirs(icrs_coo, cirs_frame):
     # first set up the astrometry context for ICRS<->CIRS
     jd1, jd2 = get_jd12(cirs_frame.obstime, 'tdb')
@@ -63,7 +63,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
     return cirs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransform, CIRS, ICRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS)
 def cirs_to_icrs(cirs_coo, icrs_frame):
     srepr = cirs_coo.represent_as(UnitSphericalRepresentation)
     cirs_ra = srepr.lon.to_value(u.radian)
@@ -101,7 +101,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
     return icrs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransform, CIRS, CIRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
@@ -117,7 +117,7 @@ def cirs_to_cirs(from_coo, to_frame):
 
 # Now the GCRS-related transforms to/from ICRS
 
-@frame_transform_graph.transform(FunctionTransform, ICRS, GCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
     # first set up the astrometry context for ICRS<->GCRS. There are a few steps...
     # get the position and velocity arrays for the observatory.  Need to
@@ -166,7 +166,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     return gcrs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, ICRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, ICRS)
 def gcrs_to_icrs(gcrs_coo, icrs_frame):
     srepr = gcrs_coo.represent_as(UnitSphericalRepresentation)
     gcrs_ra = srepr.lon.to_value(u.radian)
@@ -210,7 +210,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     return icrs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, GCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, GCRS)
 def gcrs_to_gcrs(from_coo, to_frame):
     if (np.all(from_coo.obstime == to_frame.obstime)
         and np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
@@ -220,7 +220,7 @@ def gcrs_to_gcrs(from_coo, to_frame):
         return from_coo.transform_to(ICRS).transform_to(to_frame)
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, HCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, HCRS)
 def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
     if np.any(gcrs_coo.obstime != hcrs_frame.obstime):
@@ -323,7 +323,7 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
     return None, bary_sun_pos
 
 
-@frame_transform_graph.transform(FunctionTransform, HCRS, HCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, HCRS, HCRS)
 def hcrs_to_hcrs(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Contains the transofrmation functions for getting from ICRS to CIRS and anything
-in between (currently that means GCRS)
+Contains the transofrmation functions for getting from ICRS/HCRS to CIRS and
+anything in between (currently that means GCRS)
 """
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
@@ -63,8 +63,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
     return cirs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS,
-                                 finite_difference_frameattr_name=None)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS)
 def cirs_to_icrs(cirs_coo, icrs_frame):
     srepr = cirs_coo.represent_as(UnitSphericalRepresentation)
     cirs_ra = srepr.lon.to_value(u.radian)
@@ -167,8 +166,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     return gcrs_frame.realize_frame(newrep)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, ICRS,
-                                 finite_difference_frameattr_name=None)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
+                                 GCRS, ICRS)
 def gcrs_to_icrs(gcrs_coo, icrs_frame):
     srepr = gcrs_coo.represent_as(UnitSphericalRepresentation)
     gcrs_ra = srepr.lon.to_value(u.radian)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -11,7 +11,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 import numpy as np
 
 from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransform
+from ..transformations import FunctionTransformWithFiniteDifference
 from ..matrix_utilities import matrix_transpose
 from ... import _erfa as erfa
 
@@ -46,7 +46,7 @@ def gcrs_precession_mat(equinox):
 
 # now the actual transforms
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, CIRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, CIRS)
 def gcrs_to_cirs(gcrs_coo, cirs_frame):
     # first get us to a 0 pos/vel GCRS at the target obstime
     gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=cirs_frame.obstime))
@@ -57,7 +57,7 @@ def gcrs_to_cirs(gcrs_coo, cirs_frame):
     return cirs_frame.realize_frame(crepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, CIRS, GCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, GCRS)
 def cirs_to_gcrs(cirs_coo, gcrs_frame):
     #compute the pmatrix, and then multiply by its transpose
     pmat = gcrs_to_cirs_mat(cirs_coo.obstime)
@@ -68,7 +68,7 @@ def cirs_to_gcrs(cirs_coo, gcrs_frame):
     return gcrs.transform_to(gcrs_frame)
 
 
-@frame_transform_graph.transform(FunctionTransform, CIRS, ITRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ITRS)
 def cirs_to_itrs(cirs_coo, itrs_frame):
     # first get us to CIRS at the target obstime
     cirs_coo2 = cirs_coo.transform_to(CIRS(obstime=itrs_frame.obstime))
@@ -79,7 +79,7 @@ def cirs_to_itrs(cirs_coo, itrs_frame):
     return itrs_frame.realize_frame(crepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, ITRS, CIRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, CIRS)
 def itrs_to_cirs(itrs_coo, cirs_frame):
     #compute the pmatrix, and then multiply by its transpose
     pmat = cirs_to_itrs_mat(itrs_coo.obstime)
@@ -90,7 +90,7 @@ def itrs_to_cirs(itrs_coo, cirs_frame):
     return cirs.transform_to(cirs_frame)
 
 
-@frame_transform_graph.transform(FunctionTransform, ITRS, ITRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, ITRS)
 def itrs_to_itrs(from_coo, to_frame):
     # this self-transform goes through CIRS right now, which implicitly also
     # goes back to ICRS
@@ -102,7 +102,7 @@ def itrs_to_itrs(from_coo, to_frame):
 #two steps anyway
 
 
-@frame_transform_graph.transform(FunctionTransform, GCRS, PrecessedGeocentric)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, PrecessedGeocentric)
 def gcrs_to_precessedgeo(from_coo, to_frame):
     # first get us to GCRS with the right attributes (might be a no-op)
     gcrs_coo = from_coo.transform_to(GCRS(obstime=to_frame.obstime,
@@ -115,7 +115,7 @@ def gcrs_to_precessedgeo(from_coo, to_frame):
     return to_frame.realize_frame(crepr)
 
 
-@frame_transform_graph.transform(FunctionTransform, PrecessedGeocentric, GCRS)
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, PrecessedGeocentric, GCRS)
 def precessedgeo_to_gcrs(from_coo, to_frame):
     # first un-precess
     pmat = gcrs_precession_mat(from_coo.equinox)

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -13,7 +13,8 @@ from ... import constants
 from ...time import Time
 from ..builtin_frames import ICRS, AltAz, LSR, GCRS, Galactic, FK5
 from ..baseframe import frame_transform_graph
-from .. import (EarthLocation, TimeFrameAttribute,
+from ..sites import get_builtin_sites
+from .. import (TimeFrameAttribute,
                 FunctionTransformWithFiniteDifference, get_sun,
                 CartesianRepresentation, SphericalRepresentation,
                 CartesianDifferential, SphericalDifferential,
@@ -101,8 +102,8 @@ def test_faux_fk5_galactic():
     c3 = c1.transform_to(Galactic)
 
     # compare the matrix and finite-difference calculations
-    assert quantity_allclose(c2.pm_l_cosb, c3.pm_l_cosb, rtol=5e-3)
-    assert quantity_allclose(c2.pm_b, c3.pm_b, rtol=5e-3)
+    assert quantity_allclose(c2.pm_l_cosb, c3.pm_l_cosb, rtol=1e-2)
+    assert quantity_allclose(c2.pm_b, c3.pm_b, rtol=1e-2)
 
 
 def test_gcrs_diffs():
@@ -144,7 +145,7 @@ def test_gcrs_diffs():
 
 def test_altaz_diffs():
     time = Time('J2015') + np.linspace(-1, 1, 1000)*u.day
-    loc = EarthLocation.of_site('greenwich')  # built-in
+    loc = get_builtin_sites()['greenwich']
     aa = AltAz(obstime=time, location=loc)
 
     icoo = ICRS(np.zeros_like(time)*u.deg, 10*u.deg, 100*u.au,

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -50,3 +50,13 @@ def test_faux_lsr():
     change = (ldiff.d_xyz - idiff.d_xyz).to(u.km/u.s)
     totchange = np.sum(change**2)**0.5
     assert quantity_allclose(totchange, lsrc.v_bary.distance)
+
+
+    ic2 = ICRS(ra=120.3*u.deg, dec=45.6*u.deg, distance=7.8*u.au,
+              pm_ra=0*u.marcsec/u.yr, pm_dec=10*u.marcsec/u.yr,
+              radial_velocity=1000*u.km/u.s)
+    lsrc2 = ic2.transform_to(LSR2())
+
+    tot = np.sum(lsrc2.data.to_cartesian(True).differentials[0].d_xyz**2)**0.5
+    assert tot > 980*u.km/u.s
+    assert tot < 1000*u.km/u.s

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -25,7 +25,7 @@ def test_faux_lsr():
     def icrs_to_lsr(icrs_coo, lsr_frame):
         dt = lsr_frame.obstime - J2000
         offset = lsr_frame.v_bary.cartesian * dt
-        return lsr_frame.realize_frame(icrs_coo.data + offset)
+        return lsr_frame.realize_frame(icrs_coo.data.without_differentials() + offset)
 
         @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, LSR2)
         def lsr_to_icrs(lsr_coo, icrs_frame):
@@ -34,10 +34,12 @@ def test_faux_lsr():
             return icrs_frame.realize_frame(lsr_coo.data - offset)
 
     ic = ICRS(ra=0*u.deg, dec=0*u.deg, distance=10*u.kpc,
-              pm_ra=0*u.km/u.s, pm_dec=0*u.km/u.s,
-              radial_velocity=1*u.km/u.s)
+              pm_ra=0*u.marcsec/u.yr, pm_dec=0*u.marcsec/u.yr,
+              radial_velocity=0*u.km/u.s)
     lsrc = ic.transform_to(LSR2())
 
     assert quantity_allclose(ic.cartesian.xyz, lsrc.cartesian.xyz)
-    assert quantity_allclose(ic.cartesian.differentials[0],
-                             lsrc.cartesian.differentials[0])
+    print(ic.data.differentials)
+    print(lsrc.data.differentials)
+    assert quantity_allclose(ic.data.to_cartesian(True).differentials[0],
+                             lsrc.data.to_cartesian(True).differentials[0])

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -33,13 +33,15 @@ def test_faux_lsr():
             offset = lsr_frame.v_bary.cartesian * dt
             return icrs_frame.realize_frame(lsr_coo.data - offset)
 
-    ic = ICRS(ra=0*u.deg, dec=0*u.deg, distance=10*u.kpc,
+    ic = ICRS(ra=12.3*u.deg, dec=45.6*u.deg, distance=7.8*u.kpc,
               pm_ra=0*u.marcsec/u.yr, pm_dec=0*u.marcsec/u.yr,
               radial_velocity=0*u.km/u.s)
     lsrc = ic.transform_to(LSR2())
 
     assert quantity_allclose(ic.cartesian.xyz, lsrc.cartesian.xyz)
-    print(ic.data.differentials)
-    print(lsrc.data.differentials)
-    assert quantity_allclose(ic.data.to_cartesian(True).differentials[0],
-                             lsrc.data.to_cartesian(True).differentials[0])
+
+    idiff = ic.data.to_cartesian(True).differentials[0]
+    ldiff = lsrc.data.to_cartesian(True).differentials[0]
+    change = (ldiff.d_xyz - idiff.d_xyz).to(u.km/u.s)
+    print(change)
+    assert quantity_allclose(np.sum(change**2)**0.5, lsrc.v_bary.distance)

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -172,8 +172,14 @@ def test_altaz_diffs():
 _xfail = pytest.mark.xfail
 @pytest.mark.parametrize('distance', [1000*u.au,
                                       10*u.pc,
-                                      pytest.param(10*u.kpc, marks=_xfail),
-                                      pytest.param(100*u.kpc, marks=_xfail)])
+                                      pytest.mark.xfail(10*u.kpc),
+                                      pytest.mark.xfail(100*u.kpc)])
+                                      # below is xfail syntax for pytest >=3.1
+                                      # TODO: change to this when the above
+                                      # way of xfailing is turned off in pytest
+                                      # >=4.0
+                                      #pytest.param(10*u.kpc, marks=_xfail),
+                                      #pytest.param(100*u.kpc, marks=_xfail)])
                                       # TODO:  make these not fail when the
                                       # finite-difference numerical stability
                                       # is improved

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -94,9 +94,10 @@ def test_gcrs_diffs():
     assert np.abs(sung.radial_velocity) < 1*u.km/u.s
 
     suni2 = sung.transform_to(ICRS)
-    assert np.all(suni2.data.differentials['s'].d_xyz < 1e-5*u.km/u.s)
+    assert np.all(np.abs(suni2.data.differentials['s'].d_xyz) < 3e-5*u.km/u.s)
     qtrisun2 = qtrsung.transform_to(ICRS)
-    assert np.all(qtrisun2.data.differentials['s'].d_xyz < 3e-5*u.km/u.s)
+    assert np.all(np.abs(qtrisun2.data.differentials['s'].d_xyz) < 3e-5*u.km/u.s)
+
 
 def test_altaz_diffs():
     time = Time('J2015') + np.linspace(-1, 1, 1000)*u.day

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -16,7 +16,7 @@ from ..baseframe import frame_transform_graph
 from .. import (EarthLocation, TimeFrameAttribute,
                 FunctionTransformWithFiniteDifference, get_sun,
                 CartesianRepresentation, SphericalRepresentation,
-                CartesianDifferential)
+                CartesianDifferential, SphericalDifferential)
 
 J2000 = Time('J2000')
 
@@ -28,7 +28,6 @@ def test_faux_lsr(dt, symmetric):
     class LSR2(LSR):
         obstime = TimeFrameAttribute(default=J2000)
 
-    dt = 1*u.s
     @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
                                      ICRS, LSR2, finite_difference_dt=dt,
                                      symmetric_finite_difference=symmetric)
@@ -159,7 +158,8 @@ def test_numerical_limits(distance):
     # rounding errors have ruined the calculation
     assert np.ptp(rv) < 65*u.km/u.s
 
-def diff_info_plot(frame, times):
+
+def diff_info_plot(frame, time):
     """
     Useful for plotting a frame with multiple times. *Not* used in the testing
     suite per se, but extremely useful for interactive plotting of results from
@@ -167,19 +167,17 @@ def diff_info_plot(frame, times):
     """
     from matplotlib import pyplot as plt
 
-    fig, ((ax1, ax2), (ax3,ax4)) = plt.subplots( 2, 2, figsize=(20, 12))
+    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(20, 12))
     ax1.plot_date(time.plot_date, frame.data.differentials['s'].d_xyz.to(u.km/u.s).T, fmt='-')
     ax1.legend(['x', 'y', 'z'])
 
-    ax2.plot_date(time.plot_date, np.sum(frame.data.differentials['s'].d_xyz.to(u.km/u.s)**2,axis=0)**0.5, fmt='-')
+    ax2.plot_date(time.plot_date, np.sum(frame.data.differentials['s'].d_xyz.to(u.km/u.s)**2, axis=0)**0.5, fmt='-')
     ax2.set_title('total')
-
 
     sd = frame.data.differentials['s'].represent_as(SphericalDifferential, frame.data)
 
     ax3.plot_date(time.plot_date, sd.d_distance.to(u.km/u.s), fmt='-')
     ax3.set_title('radial')
-
 
     ax4.plot_date(time.plot_date, sd.d_lat.to(u.marcsec/u.yr), fmt='-', label='lat')
     ax4.plot_date(time.plot_date, sd.d_lon.to(u.marcsec/u.yr), fmt='-', label='lon')

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -77,7 +77,7 @@ def test_faux_fk5_galactic():
     class Galactic2(Galactic):
         pass
 
-    dt = 1*u.s
+    dt = 1000*u.s
 
     @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
                                      FK5, Galactic2, finite_difference_dt=dt,
@@ -102,8 +102,8 @@ def test_faux_fk5_galactic():
     c3 = c1.transform_to(Galactic)
 
     # compare the matrix and finite-difference calculations
-    assert quantity_allclose(c2.pm_l_cosb, c3.pm_l_cosb, rtol=1e-2)
-    assert quantity_allclose(c2.pm_b, c3.pm_b, rtol=1e-2)
+    assert quantity_allclose(c2.pm_l_cosb, c3.pm_l_cosb, rtol=1e-4)
+    assert quantity_allclose(c2.pm_b, c3.pm_b, rtol=1e-4)
 
 
 def test_gcrs_diffs():

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -9,12 +9,14 @@ import numpy as np
 from ...tests.helper import quantity_allclose
 
 from ... import units as u
+from ... import constants
 from ...time import Time
 from ..builtin_frames import ICRS, AltAz, LSR, GCRS
 from ..baseframe import frame_transform_graph
 from .. import (EarthLocation, TimeFrameAttribute,
                 FunctionTransformWithFiniteDifference, get_sun,
-                CartesianRepresentation, SphericalRepresentation)
+                CartesianRepresentation, SphericalRepresentation,
+                CartesianDifferential)
 
 J2000 = Time('J2000')
 
@@ -95,3 +97,75 @@ def test_gcrs_diffs():
     assert np.all(suni2.data.differentials[0].d_xyz < 1e-5*u.km/u.s)
     qtrisun2 = qtrsung.transform_to(ICRS)
     assert np.all(qtrisun2.data.differentials[0].d_xyz < 1e-5*u.km/u.s)
+
+def test_altaz_diffs():
+    time = Time('J2015') + np.linspace(-1, 1, 1000)*u.day
+    loc = EarthLocation.of_site('greenwich')  #built-in
+    aa = AltAz(obstime=time, location=loc)
+
+    icoo = ICRS(np.zeros_like(time)*u.deg, 10*u.deg, 100*u.au,
+         pm_ra=np.zeros_like(time)*u.marcsec/u.yr, pm_dec=0*u.marcsec/u.yr,
+         radial_velocity=0*u.km/u.s)
+
+    acoo = icoo.transform_to(aa)
+
+    # make sure the change in radial velocity over ~2 days isn't much more than
+    # the rotation speed of the Earth
+    assert np.ptp(acoo.radial_velocity)/2 < (2*np.pi*constants.R_earth/u.day)*1.2
+
+    cdiff = acoo.data.differentials[0].represent_as(CartesianDifferential,
+                                                    acoo.data)
+
+    # The "total" velocity should be > c, because the *tangential* velocity
+    # isn't a True velocity, but rather an induced velocity due to the Earth's
+    # rotation at a distance of 100 AU
+    assert np.all(np.sum(cdiff.d_xyz**2, axis=0)**0.5 > constants.c)
+
+_xfail = pytest.mark.xfail
+@pytest.mark.parametrize('distance', [1000*u.au,
+                                      10*u.pc,
+                                      pytest.param(10*u.kpc, marks=_xfail),
+                                      pytest.param(100*u.kpc, marks=_xfail)])
+def test_numerical_limits(distance):
+    """
+    Tests the numerical stability of the default settings for the finite
+    difference transformation calculation.  This is *known* to fail for at
+    >~1kpc, but this may be improved in future versions.
+    """
+    time = Time('J2017') + np.linspace(-.5, .5, 100)*u.year
+
+    icoo = ICRS(ra=0*u.deg, dec=10*u.deg, distance=distance,
+                pm_ra=0*u.marcsec/u.yr, pm_dec=0*u.marcsec/u.yr,
+                radial_velocity=0*u.km/u.s)
+    gcoo = icoo.transform_to(GCRS(obstime=time))
+    rv =  gcoo.radial_velocity.to('km/s')
+
+    # if its a lot bigger than this, finite-difference noise has ruined things
+    assert np.ptp(rv) < 65*u.km/u.s
+
+def diff_info_plot(frame, times):
+    """
+    Useful for plotting a frame with multiple times. *Not* used in the testing
+    suite per se, but extremely useful for interactive plotting of results from
+    tests in this module.
+    """
+    from matplotlib import pyplot as plt
+
+    fig, ((ax1, ax2), (ax3,ax4)) = plt.subplots( 2, 2, figsize=(20, 12))
+    ax1.plot_date(time.plot_date, frame.data.differentials[0].d_xyz.to(u.km/u.s).T, fmt='-')
+    ax1.legend(['x', 'y', 'z'])
+
+    ax2.plot_date(time.plot_date, np.sum(frame.data.differentials[0].d_xyz.to(u.km/u.s)**2,axis=0)**0.5, fmt='-')
+    ax2.set_title('total')
+
+
+    sd = frame.data.differentials[0].represent_as(SphericalDifferential, frame.data)
+
+    ax3.plot_date(time.plot_date, sd.d_distance.to(u.km/u.s), fmt='-')
+    ax3.set_title('radial')
+
+
+    ax4.plot_date(time.plot_date, sd.d_lat.to(u.marcsec/u.yr), fmt='-', label='lat')
+    ax4.plot_date(time.plot_date, sd.d_lon.to(u.marcsec/u.yr), fmt='-', label='lon')
+
+    return fig

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -13,7 +13,8 @@ from ...time import Time
 from ..builtin_frames import ICRS, AltAz, LSR
 from ..baseframe import frame_transform_graph
 from .. import (EarthLocation, TimeFrameAttribute,
-                FunctionTransformWithFiniteDifference)
+                FunctionTransformWithFiniteDifference,
+                get_sun)
 
 J2000 = Time('J2000')
 
@@ -63,6 +64,25 @@ def test_faux_lsr(dt, symmetric):
     lsrc2 = ic2.transform_to(LSR2())
 
     tot = np.sum(lsrc2.data.to_cartesian(True).differentials[0].d_xyz**2)**0.5
-    print(tot.to(u.km/u.s))
     assert tot > 980*u.km/u.s
     assert tot < 1000*u.km/u.s
+
+def test_altaz_diffs():
+    time = Time('J2017')
+    loc = acoo.EarthLocation.of_site('greenwich')  #built-in
+    aa = AltAz(obstime=time, location=loc)
+
+    sun = get_sun(time).transform_to(aa).frame  # should have very little vhelio
+
+    # qtr-year off sun location should be the direction of ~ maximal vhelio
+    aaqtr = AltAz(obstime=time-.25*u.year, location=loc)
+    sunqtr = get_sun(time-.25*u.year).transform_to(aaqtr)
+    offsun = aa.realize_frame(sunqtr.data)
+
+    zerodiff = CartesianDifferential([0, 0, 0]*u.km/u.s)
+    sundiff = sun.realize_frame(sun.data.with_differentials(zerodiff))
+    offsundiff = offsun.realize_frame(sun.data.with_differentials(zerodiff))
+
+    # sanity-check heliocentric velocity
+    assert (np.sum(offsundiff.data.differentials[0].d_xyz**2)**0.5 > 1*u.km/u.s
+    assert (np.sum(sundiff.data.differentials[0].d_xyz**2)**0.5 < 1*u.km/u.s

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import pytest
+import numpy as np
+from ...tests.helper import quantity_allclose
+
+from ... import units as u
+from ...time import Time
+from ..builtin_frames import ICRS, AltAz, LSR
+from ..baseframe import frame_transform_graph
+from .. import (EarthLocation, TimeFrameAttribute,
+                FunctionTransformWithFiniteDifference)
+
+J2000 = Time('J2000')
+
+def test_faux_lsr():
+    class LSR2(LSR):
+        obstime = TimeFrameAttribute(default=J2000)
+
+    @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, LSR2)
+    def icrs_to_lsr(icrs_coo, lsr_frame):
+        dt = lsr_frame.obstime - J2000
+        offset = lsr_frame.v_bary.cartesian * dt
+        return lsr_frame.realize_frame(icrs_coo.data + offset)
+
+        @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, LSR2)
+        def lsr_to_icrs(lsr_coo, icrs_frame):
+            dt = lsr_frame.obstime - J2000
+            offset = lsr_frame.v_bary.cartesian * dt
+            return icrs_frame.realize_frame(lsr_coo.data - offset)
+
+    ic = ICRS(ra=0*u.deg, dec=0*u.deg, distance=10*u.kpc,
+              pm_ra=0*u.km/u.s, pm_dec=0*u.km/u.s,
+              radial_velocity=1*u.km/u.s)
+    lsrc = ic.transform_to(LSR2())
+
+    assert quantity_allclose(ic.cartesian.xyz, lsrc.cartesian.xyz)
+    assert quantity_allclose(ic.cartesian.differentials[0],
+                             lsrc.cartesian.differentials[0])

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -64,8 +64,7 @@ def test_faux_lsr(dt, symmetric):
     lsrc2 = ic2.transform_to(LSR2())
 
     tot = np.sum(lsrc2.data.to_cartesian(True).differentials[0].d_xyz**2)**0.5
-    assert tot > 980*u.km/u.s
-    assert tot < 1000*u.km/u.s
+    assert np.abs(tot.to('km/s') - 1000*u.km/u.s) < 20*u.km/u.s
 
 def test_gcrs_diffs():
     time = Time('J2017')
@@ -91,3 +90,8 @@ def test_gcrs_diffs():
     assert np.abs(qtrsung.radial_velocity) > 30*u.km/u.s
     assert np.abs(qtrsung.radial_velocity) < 40*u.km/u.s
     assert np.abs(sung.radial_velocity) < 1*u.km/u.s
+
+    suni2 = sung.transform_to(ICRS)
+    assert np.all(suni2.data.differentials[0].d_xyz < 1e-5*u.km/u.s)
+    qtrisun2 = qtrsung.transform_to(ICRS)
+    assert np.all(qtrisun2.data.differentials[0].d_xyz < 1e-5*u.km/u.s)

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -418,8 +418,8 @@ def test_function_transform_with_differentials():
     ftrans = t.FunctionTransform(tfun, TCoo3, TCoo2,
                                  register_graph=frame_transform_graph)
 
-    t3 = TCoo3(ra=1*u.deg, dec=2*u.deg,
-               pm_ra=1*u.marcsec/u.yr, pm_dec=1*u.marcsec/u.yr,)
+    t3 = TCoo3(ra=1*u.deg, dec=2*u.deg, pm_ra_cosdec=1*u.marcsec/u.yr,
+               pm_dec=1*u.marcsec/u.yr,)
 
     with catch_warnings() as w:
         t2 = t3.transform_to(TCoo2)

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -386,12 +386,12 @@ def test_unit_spherical_with_differentials(rep):
 
 def test_vel_transformation_obstime_err():
     # TODO: replace after a final decision on PR #6280
-    from .. import EarthLocation
+    from ..sites import get_builtin_sites
 
     diff = r.CartesianDifferential([.1, .2, .3]*u.km/u.s)
     rep = r.CartesianRepresentation([1, 2, 3]*u.au, differentials=diff)
 
-    loc = EarthLocation.of_site('example_site')
+    loc = get_builtin_sites()['example_site']
 
     aaf = AltAz(obstime='J2010', location=loc)
     aaf2 = AltAz(obstime=aaf.obstime + 3*u.day, location=loc)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function,
 import heapq
 import inspect
 import subprocess
+from warnings import warn
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, OrderedDict
@@ -29,6 +30,7 @@ import numpy as np
 from .. import units as u
 from ..utils.compat import suppress
 from ..utils.compat.funcsigs import signature
+from ..utils.exceptions import AstropyWarning
 from ..extern import six
 from ..extern.six.moves import range
 from .. import units as u
@@ -747,6 +749,11 @@ class FunctionTransform(CoordinateTransform):
         if not isinstance(res, self.tosys):
             raise TypeError('the transformation function yielded {0} but '
                 'should have been of type {1}'.format(res, self.tosys))
+        if (getattr(fromcoord.data, 'differentials', None) and not
+            getattr(res.data, 'differentials', None)):
+            warn("Applied a FunctionTransform to a coordinate frame with "
+                 "differentials, but the FunctionTransform does not handle "
+                 "differentials, so they have been dropped.", AstropyWarning)
         return res
 
 class FunctionTransformWithFiniteDifference(FunctionTransform):

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -801,7 +801,8 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
             else:
                 dt = self.finite_difference_dt
 
-            reprwithoutdiff = supcall(fromcoord, toframe)
+            fromdiffless = fromcoord.realize_frame(fromcoord.data.without_differentials())
+            reprwithoutdiff = supcall(fromdiffless, toframe)
 
             # first we use the existing differential to compute an offset due to
             # the already-existing velocity, but in the new frame
@@ -826,14 +827,14 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
                 if self.symmetric_finite_difference:
                     update_keyword = {attrname: getattr(toframe, attrname) + dt/2}
                     fwd_frame = toframe.replicate_without_data(**update_keyword)
-                    fwd = supcall(fromcoord, fwd_frame)
+                    fwd = supcall(fromdiffless, fwd_frame)
                     update_keyword = {attrname: getattr(toframe, attrname) - dt/2}
                     back_frame =  toframe.replicate_without_data(**update_keyword)
-                    back = supcall(fromcoord, back_frame)
+                    back = supcall(fromdiffless, back_frame)
                 else:
                     update_keyword = {attrname: getattr(toframe, attrname) + dt}
                     fwd_frame = toframe.replicate_without_data(**update_keyword)
-                    fwd = supcall(fromcoord, fwd_frame)
+                    fwd = supcall(fromdiffless, fwd_frame)
                     back = reprwithoutdiff
 
                 diffxyz += (fwd.cartesian - back.cartesian).xyz / dt

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -755,7 +755,7 @@ class FunctionTransform(CoordinateTransform):
         return res
 
 class FunctionTransformWithFiniteDifference(FunctionTransform):
-    """
+    r"""
     A coordinate transformation that works like a `FunctionTransform`, but
     computes velocity shifts based on the finite-difference relative to one of
     the frame attributes.  Note that the transform function should *not* change

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -808,8 +808,8 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
             if self.symmetric_finite_difference:
                 fwdxyz = (fromcoord.data.to_cartesian().xyz +
                           fromcoord.data.differentials[0].to_cartesian(fromcoord.data).xyz*dt/2)
-                fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(backxyz)), toframe)
-                backxyz = (fromcoord.data.to_cartesian().xyz +
+                fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
+                backxyz = (fromcoord.data.to_cartesian().xyz -
                           fromcoord.data.differentials[0].to_cartesian(fromcoord.data).xyz*dt/2)
                 back = supcall(fromcoord.realize_frame(CartesianRepresentation(backxyz)), toframe)
             else:
@@ -1230,5 +1230,6 @@ class CompositeTransform(CoordinateTransform):
 trans_to_color = OrderedDict()
 trans_to_color[AffineTransform] = '#555555' # gray
 trans_to_color[FunctionTransform] = '#d95f02' # red-ish
+trans_to_color[FunctionTransformWithFiniteDifference] = '#d92f02' # darker red-ish
 trans_to_color[StaticMatrixTransform] = '#7570b3' # blue-ish
 trans_to_color[DynamicMatrixTransform] = '#1b9e77' # green-ish

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -820,7 +820,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
         from .representation import (CartesianRepresentation,
                                      CartesianDifferential)
 
-        supcall = super(FunctionTransformWithFiniteDifference, self).__call__
+        supcall = self.func
         if getattr(fromcoord.data, 'differentials', False):
             # this is the finite difference case
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -836,14 +836,14 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
             # the already-existing velocity, but in the new frame
             if self.symmetric_finite_difference:
                 fwdxyz = (fromcoord.data.to_cartesian().xyz +
-                          fromcoord.data.differentials[0].to_cartesian(fromcoord.data).xyz*dt/2)
+                          fromcoord.cartesian.differentials['s'].d_xyz*dt/2)
                 fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
                 backxyz = (fromcoord.data.to_cartesian().xyz -
-                          fromcoord.data.differentials[0].to_cartesian(fromcoord.data).xyz*dt/2)
+                           fromcoord.cartesian.differentials['s'].d_xyz*dt/2)
                 back = supcall(fromcoord.realize_frame(CartesianRepresentation(backxyz)), toframe)
             else:
                 fwdxyz = (fromcoord.data.to_cartesian().xyz +
-                          fromcoord.data.differentials[0].to_cartesian(fromcoord.data).xyz*dt)
+                          fromcoord.cartesian.differentials['s'].d_xyz*dt)
                 fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
                 back = reprwithoutdiff
             diffxyz = (fwd.cartesian - back.cartesian).xyz / dt
@@ -893,7 +893,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
                 diffxyz += (fwd.cartesian - back.cartesian).xyz / dt
 
             newdiff = CartesianDifferential(diffxyz)
-            reprwithdiff = reprwithoutdiff.data.with_differentials(newdiff)
+            reprwithdiff = reprwithoutdiff.data.to_cartesian().with_differentials(newdiff)
             return reprwithoutdiff.realize_frame(reprwithdiff)
         else:
             return supcall(fromcoord, toframe)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -834,16 +834,18 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
 
             # first we use the existing differential to compute an offset due to
             # the already-existing velocity, but in the new frame
+            fromcoord_cart = fromcoord.cartesian
             if self.symmetric_finite_difference:
-                fwdxyz = (fromcoord.data.to_cartesian().xyz +
-                          fromcoord.cartesian.differentials['s'].d_xyz*dt/2)
+                halfdt = dt/2
+                fwdxyz = (fromcoord_cart.xyz +
+                          fromcoord_cart.differentials['s'].d_xyz*halfdt)
                 fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
-                backxyz = (fromcoord.data.to_cartesian().xyz -
-                           fromcoord.cartesian.differentials['s'].d_xyz*dt/2)
+                backxyz = (fromcoord_cart.xyz -
+                           fromcoord_cart.differentials['s'].d_xyz*halfdt)
                 back = supcall(fromcoord.realize_frame(CartesianRepresentation(backxyz)), toframe)
             else:
-                fwdxyz = (fromcoord.data.to_cartesian().xyz +
-                          fromcoord.cartesian.differentials['s'].d_xyz*dt)
+                fwdxyz = (fromcoord_cart.xyz +
+                          fromcoord_cart.differentials['s'].d_xyz*dt)
                 fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
                 back = reprwithoutdiff
             diffxyz = (fwd.cartesian - back.cartesian).xyz / dt


### PR DESCRIPTION
This PR is the fourth (and last ) in a series by @adrn, @mhvk, and myself trying to support velocities in astropy.coordinates.  This PR is based on #6219, so will need to be merged **after** that one, and has a lot of commits from the series of PRs.  To see a cleaner diff with just these changes, take a look at adrn/astropy#13.

The main purpose of this particular segment of the work is implementing a new transformation that uses finite difference techniques to compute velocities in coordinate frames.  It also replaces most of the Astropy transformation machinery to use that new transformation, supporting transforming between the various astropy frames and getting correct velocities out.

It's all working (and there are explicit tests for the main frames of practical use), but there is a flaw: for objects more distant then ~10 kpc, solar system velocity effects (most critically, the heliocentric correction) start getting swamped in machine precision noise because the km-kpc dynamic range is just too much. (This is demonstrated in the `test_numerical_limits` test).  For closer objects this isn't really a problem.

This can be fixed in principal by clever finite difference techniques or even just capping the distance as seen in the finite difference transform.  However, the details of this probably cannot be worked out in time for the feature freeze.  So I propose (if all is well) merging this (after the remainder of the velocity stack of PRs is in), but *also* merge an updated version of #5752 (which I can easily get to tomorrow).  The docs will reflect this plan in that there will be a big red "velocity support is experimental" warning in the coordinates docs, and the functions from #5752 will also mention that their *implementation* might change to use the coordinates machinery ones the finite difference issues have been ironed out.

One other change this makes is that there is now a warning for `FunctionTransform`'s that drop differentials.  This still allows `FunctionTransform`s to set differentials themselves, but is there to make it clear that "legacy" `FunctionTransform`s should be updated to do something with the differentials.  This is debatable behavior... it would be easy to just have it *silently* drop the differentials on the assumption that this is the intended behavior.  But I think its better this way to remind anyone whos implemented their own `FunctionTransform` that they should update it if it will ever be used with differentials.
