### PR TITLE
Ignore generated examples for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,8 @@ show-response = 1
 
 [pytest]
 minversion = 2.8
-norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
+norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
-doctest_norecursedirs = "astropy[\/]sphinx"
 open_files_ignore = "astropy.log" "/etc/hosts"
 addopts = -p no:warnings
 


### PR DESCRIPTION
When the doc examples have been generated, pytest imports (and run) these files, included `skip_create-large-fits.py` which creates a 12Gb array in memory !

Also remove the `astropy/sphinx` setting as this directory was removed from Astropy a long time ago.

