### PR TITLE
Make output of to_geodetic a namedtuple

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ New Features
   - The representation class instances can now contain differential objects.
     This is primarily useful for internal operations that will provide support
     for transforming velocity components in coordinate frames. [#6169]
+  - ``EarthLocation.to_geodetic()`` (and ``EarthLocation.geodetic``) now return
+    namedtuples instead of regular tuples. [#6237]
 
 - ``astropy.cosmology``
 
@@ -328,7 +330,7 @@ API Changes
   - ``solLum``,``solMass``, and ``solRad`` no longer have  their prefixed units
     included in the standard units.  If needed, they can still be found in
     ``units.required_by_vounit``, and are enabled by default. [#5661]
-    
+
   - Removed deprecated ``Unit.get_converter``. [#6170]
 
   - Internally, astropy replaced use of ``.to(unit).value`` with the new

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,8 +49,12 @@ New Features
   - The representation class instances can now contain differential objects.
     This is primarily useful for internal operations that will provide support
     for transforming velocity components in coordinate frames. [#6169]
+
   - ``EarthLocation.to_geodetic()`` (and ``EarthLocation.geodetic``) now return
     namedtuples instead of regular tuples. [#6237]
+
+  - ``EarthLocation`` now has ``lat`` and ``lon`` properties (equivalent to, but
+    preferred over, the previous ``latitude`` and ``longitude``). [#6237]
 
 - ``astropy.cosmology``
 
@@ -236,6 +240,10 @@ API Changes
   - Removed deprecated ``angles.rotation_matrix`` and
     ``angles.angle_axis``. Use the routines in
     ``coordinates.matrix_utilities`` instead. [#6170]
+
+  - ``EarthLocation.latitude`` and ``EarthLocation.longitude`` are now
+    deprecated in favor of ``EarthLocation.lat`` and ``EarthLocation.lon``.
+    They former will be removed in a future version. [#6237]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 from warnings import warn
+import collections
 import socket
 import json
 
@@ -26,6 +27,8 @@ except ImportError:
         raise
 
 __all__ = ['EarthLocation']
+
+GeodeticLocation = collections.namedtuple('GeodeticLocation', ['lon', 'lat', 'height'])
 
 # Available ellipsoids (defined in erfam.h, with numbers exposed in erfa).
 ELLIPSOIDS = ('WGS84', 'GRS80', 'WGS72')
@@ -475,10 +478,11 @@ class EarthLocation(u.Quantity):
         ellipsoid = _check_ellipsoid(ellipsoid, default=self.ellipsoid)
         self_array = self.to(u.meter).view(self._array_dtype, np.ndarray)
         lon, lat, height = erfa.gc2gd(getattr(erfa, ellipsoid), self_array)
-        return (Longitude(lon * u.radian, u.degree,
-                          wrap_angle=180.*u.degree, copy=False),
-                Latitude(lat * u.radian, u.degree, copy=False),
-                u.Quantity(height * u.meter, self.unit, copy=False))
+        return GeodeticLocation(
+            Longitude(lon * u.radian, u.degree,
+                      wrap_angle=180.*u.degree, copy=False),
+            Latitude(lat * u.radian, u.degree, copy=False),
+            u.Quantity(height * u.meter, self.unit, copy=False))
 
     @property
     def longitude(self):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -17,7 +17,7 @@ from ..utils.compat.numpy import broadcast_to
 from .angles import Longitude, Latitude
 from .representation import CartesianRepresentation
 from .errors import UnknownSiteException
-from ..utils import data
+from ..utils import data, deprecated
 
 try:
     # Not guaranteed available at setup time.
@@ -485,13 +485,25 @@ class EarthLocation(u.Quantity):
             u.Quantity(height * u.meter, self.unit, copy=False))
 
     @property
+    @deprecated('2.0', alternative='`lon`', obj_type='property')
     def longitude(self):
         """Longitude of the location, for the default ellipsoid."""
         return self.geodetic[0]
 
     @property
+    def lon(self):
+        """Longitude of the location, for the default ellipsoid."""
+        return self.geodetic[0]
+
+    @property
+    @deprecated('2.0', alternative='`lat`', obj_type='property')
     def latitude(self):
         """Latitude of the location, for the default ellipsoid."""
+        return self.geodetic[1]
+
+    @property
+    def lat(self):
+        """Longitude of the location, for the default ellipsoid."""
         return self.geodetic[1]
 
     @property

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -301,3 +301,18 @@ def test_of_address():
     assert quantity_allclose(loc.latitude, 40.7128*u.degree)
     assert quantity_allclose(loc.longitude, -74.0059*u.degree)
     assert quantity_allclose(loc.height, 10.438659669*u.meter, atol=1.*u.cm)
+
+
+def test_geodetic_tuple():
+    lat = 2*u.deg
+    lon = 10*u.deg
+    height = 100*u.m
+
+    el = EarthLocation.from_geodetic(lat=lat, lon=lon, height=height)
+
+    res1 = el.to_geodetic()
+    res2 = el.geodetic
+
+    assert res1.lat == res2.lat and quantity_allclose(res1.lat, lat)
+    assert res1.lon == res2.lon and quantity_allclose(res1.lon, lon)
+    assert res1.height == res2.height and quantity_allclose(res1.height, height)


### PR DESCRIPTION
This is a very straightforward PR that does just what it says: makes `EarthLocation.to_geodetic` output a namedtuple instead of a regular tuple, allowing things like:
```
earthlocation.to_geodetic().lon
```
which seems a lot more readable than:
```
earthlocation.to_geodetic()[0]
```

While working on #5752 and #6226 et al I realized this would make some things a lot easier...