### PR TITLE
Updating CI for v3.0 (removing python2.7&3.4, and np1.9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ env:
         - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902"
 
     matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
@@ -58,11 +57,12 @@ matrix:
 
     include:
 
-        # Try MacOS X.
+        # Try MacOS X. Use a slightly old numpy version to help test against
+        # all supported numpy versions.
         - os: osx
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem'
+               PIP_DEPENDENCIES='jplephem' NUMPY_VERSION=1.12
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -77,23 +77,19 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
-        # Numpy 1.10 is tested below in the image tests.
+        # Numpy 1.11 is tested below in the image tests, 1.12 in the OSX test.
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
                SETUP_CMD='test --open-files'
-        - os: linux
-          env: NUMPY_VERSION=1.12
-               SETUP_CMD='test --open-files -a "--durations=50"'
 
-        # Now try with all optional dependencies the latest 3.x and on 2.7.
-        # (with latest numpy). We also test the two latest matplotlib versions
-        # for the image tests.
+        # Now try with all optional dependencies.
+        # We also test the two latest matplotlib versions for the image tests.
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem mock pytest-mpl'
                LC_CTYPE=C.ascii LC_ALL=C
-               NUMPY_VERSION=1.10
+               NUMPY_VERSION=1.11
                MATPLOTLIB_VERSION=1.5
 
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,6 @@ matrix:
                LC_CTYPE=C.ascii LC_ALL=C
                NUMPY_VERSION=1.10
                MATPLOTLIB_VERSION=1.5
-               EVENT_TYPE='push pull_request cron'
 
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ env:
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
@@ -79,10 +78,6 @@ matrix:
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
         # Numpy 1.10 is tested below in the image tests.
-
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               SETUP_CMD='test --open-files'  PYTEST_VERSION=3.2.1
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,8 @@ environment:
         PIP_DEPENDENCIES: "objgraph"
 
     matrix:
-
-        - PYTHON_VERSION: "2.7"
-          NUMPY_VERSION: "stable"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
-          ASTROPY_USE_SYSTEM_PYTEST: 1
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
UPDATE: This PR now updates the travis and appveyor matrix in prep for v3.0 and the big python2.7 removal "party". Changes include

  * removal of python2.7 jobs
  * removal of python3.4 job
  * removal of testing against numpy1.9
  * minor shuffle of old numpy tests to make sure we keep testing against the last 2 mpl version (and use the latest numpy available for those versions)

****
According to https://github.com/astropy/astropy-APEs/blob/master/APE10.rst, we will drop these versions in v3.0, so no need to include them in the matrix any more.

Note: this PR only removes the testing, the policy for actual code removal should be the similar to the python2 removal, such as wait a few months to help with easier backporting 2.0.x