### PR TITLE
Make erfa prototypes be void arguments

### DIFF
--- a/cextern/erfa/erfaextra.h
+++ b/cextern/erfa/erfaextra.h
@@ -20,35 +20,35 @@ extern "C" {
 ** as defined in configure.ac
 ** in string format
 */
-const char* eraVersion();
+const char* eraVersion(void);
 
 /* 
 ** Returns the package major version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMajor();
+int eraVersionMajor(void);
 
 /* 
 ** Returns the package minor version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMinor();
+int eraVersionMinor(void);
 
 /* 
 ** Returns the package micro version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMicro();
+int eraVersionMicro(void);
 
 /* 
 ** Returns the orresponding SOFA version
 ** as defined in configure.ac
 ** in string format
 */
-const char* eraSofaVersion();
+const char* eraSofaVersion(void);
 
 
 #ifdef __cplusplus

--- a/cextern/erfa/erfaversion.c
+++ b/cextern/erfa/erfaversion.c
@@ -28,26 +28,26 @@
 #endif /* HAVE_CONFIG_H */
 
 
-const char* eraVersion() {
+const char* eraVersion(void) {
   return PACKAGE_VERSION;
 }
 
 
-int eraVersionMajor() {
+int eraVersionMajor(void) {
   return PACKAGE_VERSION_MAJOR;
 }
 
 
-int eraVersionMinor() {
+int eraVersionMinor(void) {
   return PACKAGE_VERSION_MINOR;
 }
 
 
-int eraVersionMicro() {
+int eraVersionMicro(void) {
   return PACKAGE_VERSION_MICRO;
 }
 
 
-const char* eraSofaVersion() {
+const char* eraSofaVersion(void) {
   return SOFA_VERSION;
 }


### PR DESCRIPTION
This PR was triggered by https://github.com/astropy/astropy/pull/6239#discussion_r122963518 (which came *after* merging of #6239, unfortunately).

The trouble is, I can't reproduce the original problem (although @saimn indicated this PR should be the solution).  @saimn, can you clarify what compiler/OS might trigger those warnings?  And if you can reproduce it, can you check if this fixes it?

(Note that if this *is* an acceptable fix, it should also go upstream to erfa)