### PR TITLE
Fix AstropyDeprecationWarning for deprecated longitude and latitude

### DIFF
--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -121,8 +121,8 @@ class TestInput():
         assert type(self.location.x) is u.Quantity
         assert type(self.location.y) is u.Quantity
         assert type(self.location.z) is u.Quantity
-        assert type(self.location.longitude) is Longitude
-        assert type(self.location.latitude) is Latitude
+        assert type(self.location.lon) is Longitude
+        assert type(self.location.lat) is Latitude
         assert type(self.location.height) is u.Quantity
 
     def test_input(self):
@@ -141,17 +141,17 @@ class TestInput():
                                   self.h.to_value(u.m))
         assert np.all(geodetic2 == self.location)
         geodetic3 = EarthLocation(self.lon, self.lat)
-        assert allclose_m14(geodetic3.longitude.value,
-                            self.location.longitude.value)
-        assert allclose_m14(geodetic3.latitude.value,
-                            self.location.latitude.value)
+        assert allclose_m14(geodetic3.lon.value,
+                            self.location.lon.value)
+        assert allclose_m14(geodetic3.lat.value,
+                            self.location.lat.value)
         assert not np.any(isclose_m14(geodetic3.height.value,
                                       self.location.height.value))
         geodetic4 = EarthLocation(self.lon, self.lat, self.h[-1])
-        assert allclose_m14(geodetic4.longitude.value,
-                            self.location.longitude.value)
-        assert allclose_m14(geodetic4.latitude.value,
-                            self.location.latitude.value)
+        assert allclose_m14(geodetic4.lon.value,
+                            self.location.lon.value)
+        assert allclose_m14(geodetic4.lat.value,
+                            self.location.lat.value)
         assert allclose_m14(geodetic4.height[-1].value,
                             self.location.height[-1].value)
         assert not np.any(isclose_m14(geodetic4.height[:-1].value,
@@ -292,14 +292,14 @@ def test_of_address():
 
     # just a location
     loc = EarthLocation.of_address("New York, NY")
-    assert quantity_allclose(loc.latitude, 40.7128*u.degree)
-    assert quantity_allclose(loc.longitude, -74.0059*u.degree)
+    assert quantity_allclose(loc.lat, 40.7128*u.degree)
+    assert quantity_allclose(loc.lon, -74.0059*u.degree)
     assert np.allclose(loc.height.value, 0.)
 
     # a location and height
     loc = EarthLocation.of_address("New York, NY", get_height=True)
-    assert quantity_allclose(loc.latitude, 40.7128*u.degree)
-    assert quantity_allclose(loc.longitude, -74.0059*u.degree)
+    assert quantity_allclose(loc.lat, 40.7128*u.degree)
+    assert quantity_allclose(loc.lon, -74.0059*u.degree)
     assert quantity_allclose(loc.height, 10.438659669*u.meter, atol=1.*u.cm)
 
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -607,8 +607,8 @@ def test_eloc_attributes():
     el1 = AltAz(location=el).location
     assert isinstance(el1, EarthLocation)
     # these should match *exactly* because the EarthLocation
-    assert el1.latitude == el.latitude
-    assert el1.longitude == el.longitude
+    assert el1.lat == el.lat
+    assert el1.lon == el.lon
     assert el1.height == el.height
 
     el2 = AltAz(location=it).location
@@ -619,16 +619,16 @@ def test_eloc_attributes():
     # only along the z-axis), but latitude should not. Also, height is relative
     # to the *surface* in EarthLocation, but the ITRS distance is relative to
     # the center of the Earth
-    assert not allclose(el2.latitude, it.spherical.lat)
-    assert allclose(el2.longitude, it.spherical.lon)
+    assert not allclose(el2.lat, it.spherical.lat)
+    assert allclose(el2.lon, it.spherical.lon)
     assert el2.height < -6000*u.km
 
     el3 = AltAz(location=gc).location
     # GCRS inputs implicitly get transformed to ITRS and then onto
     # EarthLocation's elliptical geoid. So both lat and lon shouldn't match
     assert isinstance(el3, EarthLocation)
-    assert not allclose(el3.latitude, gc.dec)
-    assert not allclose(el3.longitude, gc.ra)
+    assert not allclose(el3.lat, gc.dec)
+    assert not allclose(el3.lon, gc.ra)
     assert np.abs(el3.height) < 500*u.km
 
 

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -57,8 +57,8 @@ def test_positions_skyfield():
     skyfield_t = ts.from_astropy(t)
 
     if location is not None:
-        earth = earth.topos(latitude_degrees=location.latitude.to_value(u.deg),
-                            longitude_degrees=location.longitude.to_value(u.deg),
+        earth = earth.topos(latitude_degrees=location.lat.to_value(u.deg),
+                            longitude_degrees=location.lon.to_value(u.deg),
                             elevation_m=location.height.to_value(u.m))
 
     skyfield_mercury = earth.at(skyfield_t).observe(mercury).apparent()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -714,7 +714,7 @@ class Time(ShapedLikeNDArray):
             if self.location is None:
                 raise ValueError('No longitude is given but the location for '
                                  'the Time object is not set.')
-            longitude = self.location.longitude
+            longitude = self.location.lon
         elif longitude == 'greenwich':
             longitude = Longitude(0., u.degree,
                                   wrap_angle=180.*u.degree)
@@ -1268,7 +1268,7 @@ class Time(ShapedLikeNDArray):
             else:
                 location = self.location
             # Geodetic params needed for d_tdb_tt()
-            lon = location.longitude
+            lon = location.lon
             rxy = np.hypot(location.x, location.y)
             z = location.z
             self._delta_tdb_tt = erfa.dtdb(

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -122,9 +122,9 @@ class TestST():
         lmst2 = self.t2.sidereal_time(kind)
         assert allclose_hours(lmst2.value, lst_compare[kind])
         assert allclose_hours((lmst2-gmst2).wrap_at('12h').value,
-                              self.t2.location.longitude.to_value('hourangle'))
+                              self.t2.location.lon.to_value('hourangle'))
         # check it also works when one gives longitude explicitly
-        lmst1 = self.t1.sidereal_time(kind, self.t2.location.longitude)
+        lmst1 = self.t1.sidereal_time(kind, self.t2.location.lon)
         assert allclose_hours(lmst1.value, lst_compare[kind])
 
     def test_lst_needs_location(self):


### PR DESCRIPTION
Fix `AstropyDeprecationWarning` for deprecated longitude and latitude in coordinates, introduced in #6237.

These were not caught on Travis because Astropy's `conftest.py` does not turn `AstropyDeprecationWarning` into exceptions.

Address part of #6251

NOTE: I cancelled Travis here due to queue. Actual Travis result at my fork -- https://travis-ci.org/pllim/astropy/builds/245509661