### PR TITLE
Make representation with differentials repr a bit clearer

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -376,8 +376,9 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         diffstr = ''
         if getattr(self, 'differentials', None):
-            diffstr = '\n (has differentials with keys: {0})'.format(
-                ', '.join([repr(key) for key in self.differentials.keys()]))
+            diffstr = '\n (has differentials: {0})'.format(
+                ', '.join(["d/d['{}']".format(key) for key in
+                           self.differentials.keys()]))
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
         return '<{0} ({1}) {2:s}\n{3}{4}{5}>'.format(

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -376,7 +376,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         diffstr = ''
         if getattr(self, 'differentials', None):
-            diffstr = '\n (has differentials: {0})'.format(
+            diffstr = '\n (has differentials with keys: {0})'.format(
                 ', '.join([repr(key) for key in self.differentials.keys()]))
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -376,9 +376,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         diffstr = ''
         if getattr(self, 'differentials', None):
-            diffstr = '\n (has differentials: {0})'.format(
-                ', '.join(["d/d['{}']".format(key) for key in
-                           self.differentials.keys()]))
+            diffstr = '\n (has differentials w.r.t.: {0})'.format(
+                ', '.join([repr(key) for key in self.differentials.keys()]))
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
         return '<{0} ({1}) {2:s}\n{3}{4}{5}>'.format(

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1311,6 +1311,13 @@ class TestCartesianRepresentationWithDifferential(object):
         assert 's2' not in r1.differentials
         assert 's2' in r2.differentials
 
+
+def test_repr_with_differentials():
+    diff = CartesianDifferential([.1, .2, .3]*u.km/u.s)
+    cr = CartesianRepresentation([1, 2, 3]*u.kpc, differentials=diff)
+    assert "has differentials w.r.t.: 's'" in repr(cr)
+
+
 def test_to_cartesian():
     """
     Test that to_cartesian drops the differential.

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -343,7 +343,7 @@ classes. For example, to store a single velocity differential with a position::
   >>> rep
   <SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)
       ( 0.,  0.,  1.)
-   (has differentials: 's')>
+   (has differentials w.r.t.: 's')>
   >>> rep.differentials
   {'s': <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
        ( 1.,  2.,  3.)>}
@@ -378,7 +378,7 @@ differentials::
   >>> rep
   <CartesianRepresentation (x, y, z) in kpc
       ( 1.,  2.,  3.)
-   (has differentials: 's')>
+   (has differentials w.r.t.: 's')>
 
 This also works for array data as well, as long as the shape of the
 ``Differential`` data is the same as that of the ``Representation``::
@@ -391,7 +391,7 @@ This also works for array data as well, as long as the shape of the
   >>> rep
   <CartesianRepresentation (x, y, z) in AU
       [( 0.,  4.,   8.), ( 1.,  5.,   9.), ( 2.,  6.,  10.), ( 3.,  7.,  11.)]
-   (has differentials: 's')>
+   (has differentials w.r.t.: 's')>
 
 As with a ``Representation`` instance without a differential, to convert the
 positional data to a new representation, use the ``.represent_as()``::
@@ -415,7 +415,7 @@ specify target classes for the ``Differential`` as well::
      ( 1.37340077,  1.05532979,  10.34408043),
      ( 1.24904577,  1.00685369,  11.83215957),
      ( 1.16590454,  0.96522779,  13.37908816)]
-   (has differentials: 's')>
+   (has differentials w.r.t.: 's')>
   >>> rep2.differentials['s']  # doctest: +FLOAT_CMP
   <SphericalDifferential (d_lon, d_lat, d_distance) in (km rad / (AU s), km rad / (AU s), km / s)
       [(  6.12323400e-17,   1.11022302e-16,   8.94427191),


### PR DESCRIPTION
This PR implements the suggestion I made in https://github.com/astropy/astropy/pull/6169#discussion_r122597259 - we merged that PR without resolving this to let the other velocities stuff move forward, but here I'm offering this alternate for the repr. So think of this PR is an extension of #6169 rather than distinct.

The basic question is: how should the representation `__repr__` describe differentials?  For any looking at this not deep in #6169 : the "keys" indicate the order of the differential/derivative.  So e.g. the one with "s" is actually the first time-derivative (velocity), "s2" is the second (acceleration), etc.

I'm actually offering *two* alternatives in each of the two commits here.  The various options look like:
Current master:
```
>>> CartesianRepresentation([1,2,3]*u.kpc, differentials=CartesianDifferential([.1,.2,.3]*u.km/u.s))
<CartesianRepresentation (x, y, z) in kpc
    ( 1.,  2.,  3.)
 (has differentials: 's')>
```
First commit
```
>>> CartesianRepresentation([1,2,3]*u.kpc, differentials=CartesianDifferential([.1,.2,.3]*u.km/u.s))
<CartesianRepresentation (x, y, z) in kpc
    ( 1.,  2.,  3.)
 (has differentials with keys: 's')>
```
Second commit (I like this one best):
```
>>> CartesianRepresentation([1,2,3]*u.kpc, differentials=CartesianDifferential([.1,.2,.3]*u.km/u.s))
<CartesianRepresentation (x, y, z) in kpc
    ( 1.,  2.,  3.)
 (has differentials: d/d['s'])>
```
I'm milestoning this 2.0 because we should either agree on an option before 2.0 since #6169 is new there.