### PR TITLE
Add documentation for velocity support in coordinates

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -224,6 +224,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         treated as the default representation of this frame.  This is the
         representation assumed by default when the frame is created.
 
+    * `default_differential`
+        A subclass of `~astropy.coordinates.BaseDifferential` that will be
+        treated as the default differential class of this frame.  This is the
+        differential class assumed by default when the frame is created.
+
     * `~astropy.coordinates.FrameAttribute` class attributes
        Frame attributes such as ``FK4.equinox`` or ``FK4.obstime`` are defined
        using a descriptor class.  See the narrative documentation or

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -28,9 +28,9 @@ _base_radec_docstring = """Parameters
     pm_ra_cosdec : :class:`~astropy.units.Quantity`, optional, must be keyword
         The proper motion in Right Ascension (including the ``cos(dec)`` factor)
         for this object (``pm_dec`` must also be given).
-    pm_dec : :class:`~astropy.units.Quantity`, optional, must be keyword The
-        proper motion in Declination for this object (``pm_ra_cosdec`` must also
-        be given).
+    pm_dec : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The proper motion in Declination for this object (``pm_ra_cosdec`` must
+        also be given).
     radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
         The radial velocity of this object.
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -337,6 +337,17 @@ class SkyCoord(ShapedLikeNDArray):
 
         # Error if anything is still left in kwargs
         if kwargs:
+
+            # TODO: remove this when velocities are supported in SkyCoord
+            vel_url = 'http://docs.astropy.org/en/stable/coordinates/velocities.html'
+            for k in kwargs:
+                if k.startswith('pm_') or k == 'radial_velocity':
+                    raise ValueError('Velocity data is currently only supported'
+                                     ' in the coordinate frame objects, not in '
+                                     'SkyCoord. See the velocities '
+                                     'documentation page for more information: '
+                                     '{0}'.format(vel_url))
+
             raise ValueError('Unrecognized keyword argument(s) {0}'
                              .format(', '.join("'{0}'".format(key) for key in kwargs)))
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -273,21 +273,22 @@ initializer in `~astropy.coordinates.BaseCoordinateFrame` will probably behave
 the way you want.  As an example::
 
   >>> from astropy.coordinates import BaseCoordinateFrame, FrameAttribute, TimeFrameAttribute, RepresentationMapping
+  >>> import astropy.coordinates.representation as r
   >>> class MyFrame(BaseCoordinateFrame):
   ...     # Specify how coordinate values are represented when outputted
-  ...      default_representation = SphericalRepresentation
+  ...      default_representation = r.SphericalRepresentation
   ...
   ...      # Specify overrides to the default names and units for all available
   ...      # representations (subclasses of BaseRepresentation).
   ...      frame_specific_representation_info = {
-  ...          'spherical': [RepresentationMapping(reprname='lon', framename='R', defaultunit=u.rad),
-  ...                        RepresentationMapping(reprname='lat', framename='D', defaultunit=u.rad),
-  ...                        RepresentationMapping(reprname='distance', framename='DIST', defaultunit=None)],
-  ...          'unitspherical': [RepresentationMapping(reprname='lon', framename='R', defaultunit=u.rad),
-  ...                            RepresentationMapping(reprname='lat', framename='D', defaultunit=u.rad)],
-  ...          'cartesian': [RepresentationMapping(reprname='x', framename='X'),
-  ...                        RepresentationMapping(reprname='y', framename='Y'),
-  ...                        RepresentationMapping(reprname='z', framename='Z')]
+  ...          r.SphericalRepresentation: [RepresentationMapping(reprname='lon', framename='R', defaultunit=u.rad),
+  ...                                      RepresentationMapping(reprname='lat', framename='D', defaultunit=u.rad),
+  ...                                      RepresentationMapping(reprname='distance', framename='DIST', defaultunit=None)],
+  ...          r.UnitSphericalRepresentation: [RepresentationMapping(reprname='lon', framename='R', defaultunit=u.rad),
+  ...                                          RepresentationMapping(reprname='lat', framename='D', defaultunit=u.rad)],
+  ...          r.CartesianRepresentation: [RepresentationMapping(reprname='x', framename='X'),
+  ...                                      RepresentationMapping(reprname='y', framename='Y'),
+  ...                                      RepresentationMapping(reprname='z', framename='Z')]
   ...      }
   ...
   ...      # Specify frame attributes required to fully specify the frame
@@ -301,6 +302,10 @@ the way you want.  As an example::
       ( 0.17453293,  0.34906585)>
   >>> c.equinox
   <Time object: scale='utc' format='byear_str' value=B1950.000>
+
+If you also want to support velocity data in your coordinate frame, see the
+velocities documentation at
+:ref:`astropy-coordinate-custom-frame-with-velocities`.
 
 You can also define arbitrary methods for any added functionality you
 want your frame to have that's unique to that frame.  These methods will
@@ -400,3 +405,7 @@ matrix).  Hence, in general, it is better to define whatever are the
 most natural transformations for a user-defined frame, rather than
 worrying about optimizing or caching a transformation to speed up the
 process.
+
+For a demonstration of how to define transformation functions that also work for
+transforming velocity components, see
+:ref:`astropy-coordinate-transform-with-velocities`.

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -14,9 +14,8 @@ documentation.
 
 We assume that we start with a 3D position in the ICRS reference frame:
 a Right Ascension, Declination, and heliocentric distance,
-:math:`(\alpha, \delta, d)`. We can trivially convert this to a
-Cartesian position using the standard transformation from Cartesian to
-spherical coordinates:
+:math:`(\alpha, \delta, d)`. We can convert this to a Cartesian position using
+the standard transformation from Cartesian to spherical coordinates:
 
 .. math::
 
@@ -32,8 +31,7 @@ spherical coordinates:
 
 The first transformations will rotate the :math:`x_{\rm icrs}` axis so
 that the new :math:`x'` axis points towards the Galactic Center (GC),
-specified by the ICRS position
-:math:`(\alpha_{\rm GC}, \delta_{\rm GC})`:
+specified by the ICRS position :math:`(\alpha_{\rm GC}, \delta_{\rm GC})`:
 
 .. math::
 

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -49,7 +49,7 @@ specified by the ICRS position :math:`(\alpha_{\rm GC}, \delta_{\rm GC})`:
 
 The transformation thus far has aligned the :math:`x'` axis with the
 vector pointing from the Sun to the GC, but the :math:`y'` and
-:math:`z'` axes point in an arbitrary direction. We adopt the
+:math:`z'` axes point in arbitrary directions. We adopt the
 orientation of the Galactic plane as the normal to the north pole of
 Galactic coordinates defined by the IAU
 (`Blaauw et. al. 1960 <http://adsabs.harvard.edu/abs/1960MNRAS.121..164B>`_).
@@ -92,7 +92,7 @@ distance to the GC, :math:`d_{\rm GC}`, which is purely along the
 
 where :math:`\hat{\boldsymbol{x}}_{\rm GC} = (1,0,0)^{\mathsf{T}}`.
 
-The final transformation is to account for the height of the Sun above
+The final transformation accounts for the (specified) height of the Sun above
 the Galactic midplane by rotating about the final :math:`y''` axis by
 the angle :math:`\theta= \sin^{-1}(z_\odot / d_{\rm GC})`:
 
@@ -112,3 +112,9 @@ midplane.
 The full transformation is then:
 
 .. math:: \boldsymbol{r}_{\rm GC} = \boldsymbol{H} \left( \boldsymbol{R}\boldsymbol{r}_{\rm icrs} - d_{\rm GC}\hat{\boldsymbol{x}}_{\rm GC}\right).
+
+.. topic:: Examples:
+
+    For an example of how to use the `~astropy.coordinates.Galactocentric`
+    frame, see
+    :ref:`sphx_glr_generated_examples_coordinates_plot_galactocentric-frame.py`.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -267,6 +267,14 @@ names, and etc.::
     updated, so if you need to guarantee that your scripts are reproducible
     in the long term, see the :doc:`remote_methods` section.
 
+Velocity data
+-------------
+
+New in Astropy v2.0, the :doc:`coordinate frame classes <frames>` can now store
+and transform velocity data along with positional coordinate information. This
+is not available from the |SkyCoord| class as this new functionality is
+experimental, but for more information see the :doc:`velocities` page.
+
 .. _astropy-coordinates-overview:
 
 Overview of `astropy.coordinates` concepts

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -9,23 +9,28 @@ Astronomical Coordinate Systems (`astropy.coordinates`)
 Introduction
 ============
 
-The `~astropy.coordinates` package provides classes for representing a
-variety of celestial/spatial  coordinates, as well as tools for
-converting between common coordinate systems in a uniform way.
+The `~astropy.coordinates` package provides classes for representing a variety
+of celestial/spatial coordinates and their velocity components, as well as tools
+for converting between common coordinate systems in a uniform way.
 
 Getting Started
 ===============
 
 The simplest way to use `~astropy.coordinates` is to use the |skycoord|
-class. |skycoord| objects are instantiated with a flexible and natural
-approach that supports inputs provided in a number of convenient
-formats.  The following ways of initializing a coordinate are all
-equivalent::
+class. |skycoord| objects are instantiated by passing in positions (and
+optional velocities) with specified units and a coordinate frame. Commonly sky
+positions are passed in as `~astropy.units.Quantity` objects and the frame is
+specified with the string name. As an example of creating a |skycoord| to
+represent an ICRS (Right ascension [RA], Declination [Dec]) sky position::
 
     >>> from astropy import units as u
     >>> from astropy.coordinates import SkyCoord
-
     >>> c = SkyCoord(ra=10.625*u.degree, dec=41.2*u.degree, frame='icrs')
+
+The initializer for |skycoord| is very flexible and supports inputs provided in
+a number of convenient formats. The following ways of initializing a coordinate
+are all equivalent to the above::
+
     >>> c = SkyCoord(10.625, 41.2, frame='icrs', unit='deg')
     >>> c = SkyCoord('00h42m30s', '+41d12m00s', frame='icrs')
     >>> c = SkyCoord('00h42.5m', '+41d12m')
@@ -35,14 +40,33 @@ equivalent::
     <SkyCoord (ICRS): (ra, dec) in deg
         ( 10.625,  41.2)>
 
-The examples above illustrate a few simple rules to follow when creating a coordinate
-object:
+The examples above illustrate a few simple rules to follow when creating a
+coordinate object:
 
 - Coordinate values can be provided either as unnamed positional arguments or
-  via keyword arguments like ``ra``, ``dec``, ``l``, or ``b`` (depending on the frame).
-- Coordinate ``frame`` keyword is optional and defaults to ICRS.
-- Angle units must be specified, either in the values themselves
-  (e.g. ``10.5*u.degree`` or ``'+41d12m00s'``) or via the ``unit`` keyword.
+  via keyword arguments like ``ra`` and ``dec``, or  ``l`` and ``b`` (depending
+  on the frame).
+- The coordinate ``frame`` keyword is optional because it defaults to
+  `~astropy.coordinates.ICRS`.
+- Angle units must be specified for all components, either by passing in a
+  `~astropy.units.Quantity` object (e.g., ``10.5*u.degree``), by including them
+  in the value (e.g., ``'+41d12m00s'``), or via the ``unit`` keyword.
+
+Passing velocity information to |skycoord| follows similar rules:
+
+- The velocity component names are frame-dependent. However, when supported in a
+  frame, the proper motion components all begin with ``pm_``. By default the
+  longitudinal component should already include the ``cos(latitude)`` term. For
+  example, the proper motion components for the ICRS frame are
+  (``pm_ra_cosdec``, ``pm_dec``). These must be passed in as
+  `~astropy.units.Quantity` objects.
+- Any frame that supports spherical velocity components (proper motions) also
+  accept a radial/line-of-sight velocity through the ``radial_velocity``
+  keyword, which must also be a `~astropy.units.Quantity` object.
+
+
+
+  >>> c = SkyCoord(ra=10.625*u.degree, dec=41.2*u.degree, frame='icrs')
 
 |skycoord| and all other `~astropy.coordinates` objects also support
 array coordinates.  These work the same as single-value coordinates, but
@@ -50,8 +74,8 @@ they store multiple coordinates in a single object.  When you're going
 to apply the same operation to many different coordinates (say, from a
 catalog), this is a better choice than a list of |skycoord| objects,
 because it will be *much* faster than applying the operation to each
-|skycoord| in a for loop. Like the underlying `~numpy.ndarray` instances
-holding the data, |skycoord| objects can be sliced, reshaped, etc.::
+|skycoord| in a ``for`` loop. Like the underlying `~numpy.ndarray` instances
+that contain the data, |skycoord| objects can be sliced, reshaped, etc.::
 
     >>> c = SkyCoord(ra=[10, 11, 12, 13]*u.degree, dec=[41, -5, 42, 0]*u.degree)
     >>> c
@@ -69,7 +93,7 @@ Coordinate access
 -----------------
 
 Once you have a coordinate object you can now access the components of that
-coordinate (e.g. RA, Dec) and get a specific string representation of the full
+coordinate (e.g., RA, Dec) and get a specific string representation of the full
 coordinate.
 
 The component values are accessed using aptly named attributes::

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -155,7 +155,7 @@ So far we have been using a spherical coordinate representation in the all the
 examples, and this is the default for the built-in frames.  Frequently it is
 convenient to initialize or work with a coordinate using a different
 representation such as cartesian or cylindrical.  This can be done by setting
-the ``representation`` for either |SkyCoord| objects or low-level frame
+the ``representation`` for either |skycoord| objects or low-level frame
 coordinate objects::
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
@@ -175,7 +175,7 @@ For all the details see :ref:`astropy-skycoord-representations`.
 Distance
 --------
 
-|SkyCoord| and the individual frame classes also support specifying a distance
+|skycoord| and the individual frame classes also support specifying a distance
 from the frame origin. The origin depends on the particular coordiante frame;
 this can be, e.g., centered on the earth, centered on the solar system
 barycenter, etc. Two angles and a distance specify a unique point in 3D space,
@@ -272,7 +272,7 @@ Velocity data
 
 New in Astropy v2.0, the :doc:`coordinate frame classes <frames>` can now store
 and transform velocity data along with positional coordinate information. This
-is not available from the |SkyCoord| class as this new functionality is
+is not available from the |skycoord| class as this new functionality is
 experimental, but for more information see the :doc:`velocities` page.
 
 .. _astropy-coordinates-overview:

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -82,7 +82,7 @@ coordinate.
 
 The component values are accessed using (typically lower-case) named attributes
 that depend on the coordinate frame (e.g., ICRS, Galactic, etc.). For the
-default, ICRS, the coordinate component names are `ra` and `dec`::
+default, ICRS, the coordinate component names are ``ra`` and ``dec``::
 
     >>> c = SkyCoord(ra=10.68458*u.degree, dec=41.26917*u.degree)
     >>> c.ra  # doctest: +FLOAT_CMP

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -52,22 +52,6 @@ coordinate object:
   `~astropy.units.Quantity` object (e.g., ``10.5*u.degree``), by including them
   in the value (e.g., ``'+41d12m00s'``), or via the ``unit`` keyword.
 
-Passing velocity information to |skycoord| follows similar rules:
-
-- The velocity component names are frame-dependent. However, when supported in a
-  frame, the proper motion components all begin with ``pm_``. By default the
-  longitudinal component should already include the ``cos(latitude)`` term. For
-  example, the proper motion components for the ICRS frame are
-  (``pm_ra_cosdec``, ``pm_dec``). These must be passed in as
-  `~astropy.units.Quantity` objects.
-- Any frame that supports spherical velocity components (proper motions) also
-  accept a radial/line-of-sight velocity through the ``radial_velocity``
-  keyword, which must also be a `~astropy.units.Quantity` object.
-
-
-
-  >>> c = SkyCoord(ra=10.625*u.degree, dec=41.2*u.degree, frame='icrs')
-
 |skycoord| and all other `~astropy.coordinates` objects also support
 array coordinates.  These work the same as single-value coordinates, but
 they store multiple coordinates in a single object.  When you're going
@@ -92,11 +76,13 @@ that contain the data, |skycoord| objects can be sliced, reshaped, etc.::
 Coordinate access
 -----------------
 
-Once you have a coordinate object you can now access the components of that
-coordinate (e.g., RA, Dec) and get a specific string representation of the full
+Once you have a coordinate object you can access the components of that
+coordinate (e.g., RA, Dec) and get string representations of the full
 coordinate.
 
-The component values are accessed using aptly named attributes::
+The component values are accessed using (typically lower-case) named attributes
+that depend on the coordinate frame (e.g., ICRS, Galactic, etc.). For the
+default, ICRS, the coordinate component names are `ra` and `dec`::
 
     >>> c = SkyCoord(ra=10.68458*u.degree, dec=41.26917*u.degree)
     >>> c.ra  # doctest: +FLOAT_CMP
@@ -112,7 +98,7 @@ The component values are accessed using aptly named attributes::
     >>> c.dec.radian  # doctest: +FLOAT_CMP
     0.7202828960652683
 
-Coordinates can easily be converted to strings using the
+Coordinates can be converted to strings using the
 :meth:`~astropy.coordinates.SkyCoord.to_string` method::
 
     >>> c = SkyCoord(ra=10.68458*u.degree, dec=41.26917*u.degree)
@@ -189,12 +175,12 @@ For all the details see :ref:`astropy-skycoord-representations`.
 Distance
 --------
 
-Distance from the origin (which is system-dependent, but often the Earth
-center) can also be assigned to a |skycoord|. With two angles and a
-distance, a unique point in 3D space is available, which also allows
-conversion to the Cartesian representation of this location::
+|SkyCoord| and the individual frame classes also support specifying a distance
+from the frame origin. The origin depends on the particular coordiante frame;
+this can be, e.g., centered on the earth, centered on the solar system
+barycenter, etc. Two angles and a distance specify a unique point in 3D space,
+which also allows converting the coordinates to a Cartesian representation::
 
-    >>> from astropy.coordinates import Distance
     >>> c = SkyCoord(ra=10.68458*u.degree, dec=41.26917*u.degree, distance=770*u.kpc)
     >>> c.cartesian.x  # doctest: +FLOAT_CMP
     <Quantity 568.7128654235232 kpc>
@@ -204,7 +190,8 @@ conversion to the Cartesian representation of this location::
     <Quantity 507.88994291875713 kpc>
 
 With distances assigned, |skycoord| convenience methods are more powerful, as
-they can make use of the 3D information. For example::
+they can make use of the 3D information. For example, to compute the physical,
+3D separation between two points in space::
 
     >>> c1 = SkyCoord(ra=10*u.degree, dec=9*u.degree, distance=10*u.pc, frame='icrs')
     >>> c2 = SkyCoord(ra=11*u.degree, dec=10*u.degree, distance=11.5*u.pc, frame='icrs')
@@ -214,14 +201,21 @@ they can make use of the 3D information. For example::
 Convenience methods
 -------------------
 
-|skycoord| defines a number of convenience methods as well, like on-sky
-separation between two coordinates and catalog matching (detailed in
-:ref:`astropy-coordinates-matching`)::
+|skycoord| defines a number of convenience methods that support, for example,
+computing on-sky (i.e. angular) and 3D separations between two coordinates::
 
     >>> c1 = SkyCoord(ra=10*u.degree, dec=9*u.degree, frame='icrs')
     >>> c2 = SkyCoord(ra=11*u.degree, dec=10*u.degree, frame='fk5')
     >>> c1.separation(c2)  # Differing frames handled correctly  # doctest: +FLOAT_CMP
     <Angle 1.4045335865905868 deg>
+
+and cross-matching catalog coordinates (detailed in
+:ref:`astropy-coordinates-matching`)::
+
+    >>> target_c = SkyCoord(ra=10*u.degree, dec=9*u.degree, frame='icrs')
+    >>> # read in coordinates from a catalog...
+    >>> catalog_c = ... # doctest: +SKIP
+    >>> idx, sep, _ = target_c.match_to_catalog_sky(catalog_c) # doctest: +SKIP
 
 The `astropy.coordinates` subpackage also provides a quick way to get
 coordinates for named objects assuming you have an active internet

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -334,6 +334,7 @@ listed below.
    matchsep
    representations
    frames
+   velocities
    galactocentric
    remote_methods
    definitions

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -267,13 +267,13 @@ names, and etc.::
     updated, so if you need to guarantee that your scripts are reproducible
     in the long term, see the :doc:`remote_methods` section.
 
-Velocity data
--------------
+Velocities (Proper Motions and Radial Velocities)
+-------------------------------------------------
 
 New in Astropy v2.0, the :doc:`coordinate frame classes <frames>` can now store
-and transform velocity data along with positional coordinate information. This
+and transform velocities along with positional coordinate information. This
 is not available from the |skycoord| class as this new functionality is
-experimental, but for more information see the :doc:`velocities` page.
+experimental, but is accessible  for more information see the :doc:`velocities` page.
 
 .. _astropy-coordinates-overview:
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -212,6 +212,8 @@ To see how the operations work, consider the following examples::
         (  3.06161700e-16,  -5.00000000e+00,  12.),
         ( -4.00000000e+00,  -3.00000000e+00, -12.)]]>
 
+.. _astropy-coordinates-differentials:
+
 Differentials and derivatives of Representations
 ================================================
 In addition to positions in 3D space, coordinates also deal with proper motions

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -247,5 +247,19 @@ details).
 
 A usage example of this functionality is::
 
-    sc = SkyCoord()
-    MORE_NEEDED = True
+    >>> from astropy.time import Time
+    >>> from astropy.coordinates import SkyCoord, EarthLocation
+    >>> # keck = EarthLocation.of_site('Keck')  # the easiest way... but requires internet
+    >>> keck = EarthLocation.from_geodetic(lat=19.8283*u.deg, lon=-155.4783*u.deg, height=4160*u.m)
+    >>> sc = SkyCoord(ra=4.88375*u.deg, dec=35.0436389*u.deg)
+    >>> barycorr = sc.radial_velocity_correction(obstime=Time('2017-2-14'), location=keck)
+    >>> barycorr.to(u.km/u.s)  # doctest: +FLOAT_CMP
+    <Quantity -21.32997887557401 km / s>
+    >>> heliocorr = sc.radial_velocity_correction('heliocentric', obstime=Time('2017-2-14'), location=keck)
+    >>> heliocorr.to(u.km/u.s)  # doctest: +FLOAT_CMP
+    <Quantity -21.329103385785288 km / s>
+
+Note that there are a few different ways to specify the options for the
+correction (e.g., the location, observation time, etc).  See the
+`~astropy.coordinates.SkyCoord.radial_velocity_correction` docs for more
+information.

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -1,0 +1,59 @@
+.. include:: references.txt
+
+.. _astropy-coordinates-velocities:
+
+Velocities (Radial and Proper Motions) in Coordinates
+*****************************************************
+
+.. warning::
+    Velocities support, new in Astropy v2.0, is an experimental feature and is
+    subject to change based on user feedback.  While we do not expect major API
+    changes, the possibility exists based on the precedent of earlier changes
+    in the ``coordinates`` subpackage due to user feedback in previous versions
+    of Astropy.
+
+Creating frame objects with velocities
+======================================
+
+content
+
+Transforming frames with velocities
+===================================
+
+overview
+
+Affine Transformations
+----------------------
+
+details
+
+Finite Difference Transformations
+---------------------------------
+
+details, particularly *examples* of the finite difference problem
+
+
+
+
+``SkyCoord`` support for Velocities
+===================================
+
+|skycoord| currently does *not* support velocities as of Astropy v2.0.  This is
+an intentional choice, allowing the "power-user" community to provide feedback
+on the API and functionality in the frame-level classes before it is adopted in
+|skycoord| (currently planned for the next Astropy version, v3.0).
+
+Radial Velocity Corrections
+===========================
+
+Sperately from the above, Astropy supports computing barycentric or heliocentric
+radial velocity corrections.  While in the future this may simply be a
+high-level convenience function using the framework described above, the
+current implementation is independent to ensure sufficient accuracy (see the
+`~astropy.coordinates.SkyCoord.radial_velocity_correction` API docs for
+details).
+
+A usage example of this functionality is::
+
+    sc = SkyCoord()
+    MORE_NEEDED = True

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -233,7 +233,7 @@ radial velocity of 10 km/s:
     aa = AltAz(alt=[45]*1000*u.deg, az=90*u.deg, distance=100*u.au,
                radial_velocity=[10]*1000*u.km/u.s,
                location=location, obstime=time)
-    gcrs = aa.transform_to(GCRS(obstime=time)
+    gcrs = aa.transform_to(GCRS(obstime=time))
     plt.plot_date(time.plot_date, gcrs.radial_velocity.to(u.km/u.s))
     plt.ylabel('RV [km/s]')
 
@@ -252,7 +252,7 @@ the same: the radial velocity should be essentially the same in both frames:
     aa = AltAz(alt=[45]*1000*u.deg, az=90*u.deg, distance=100*u.kpc,
                radial_velocity=[10]*1000*u.km/u.s,
                location=location, obstime=time)
-    gcrs = aa.transform_to(GCRS(obstime=time)
+    gcrs = aa.transform_to(GCRS(obstime=time))
     plt.plot_date(time.plot_date, gcrs.radial_velocity.to(u.km/u.s))
     plt.ylabel('RV [km/s]')
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -32,7 +32,7 @@ and/or a radial velocity because the default differential for most frames is the
 `~astropy.coordinates.SphericalCosLatDifferential` class. When supported, the
 proper motion components all begin with ``pm_`` and, by default, the
 longitudinal component is expected to already include the ``cos(latitude)``
-term. For example, the proper motion components for the ICRS frame are
+term. For example, the proper motion components for the ``ICRS`` frame are
 (``pm_ra_cosdec``, ``pm_dec``)::
 
     >>> from astropy.coordinates import ICRS
@@ -51,10 +51,31 @@ term. For example, the proper motion components for the ICRS frame are
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
         ( 4.8, -15.16,  23.42)>
 
+For proper motion components in the ``Galactic`` frame, the names track the
+longitude and latitude names::
+
+    >>> from astropy.coordinates import Galactic
+    >>> Galactic(l=11.23*u.degree, b=58.13*u.degree,
+    ...          pm_l_cosb=21.34*u.mas/u.yr, pm_b=-55.89*u.mas/u.yr)
+    <Galactic Coordinate: (l, b) in deg
+        ( 11.23,  58.13)
+     (pm_l_cosb, pm_b) in mas / yr
+        ( 21.34, -55.89)>
+
 Like the positional data, velocity data must be passed in as
 `~astropy.units.Quantity` objects.
 
-TODO: how to change the differential class to specify other velocity components
+The expected differential class can be changed to control the argument names
+that the frame expects. As mentioned above, by default the proper motions
+components are expected to contain the ``cos(latitude)``, but this can be
+changed by specifying the `~astropy.coordinates.SphericalDifferential` class
+(instead of the default `~astropy.coordinates.SphericalCosLatDifferential`)::
+
+    >>> from astropy.coordinates import SphericalDifferential
+    >>> Galactic(l=11.23*u.degree, b=58.13*u.degree,
+    ...          pm_l=21.34*u.mas/u.yr, pm_b=-55.89*u.mas/u.yr,
+    ...          differential_cls=SphericalDifferential)
+
 
 .. _astropy-coordinate-transform-with-velocities:
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -14,10 +14,38 @@ Working with velocity data in Astropy coordinates
 
 .. _astropy-coordinate-custom-frame-with-velocities:
 
-Creating frame objects with velocities
-======================================
+Creating frame objects with velocity data
+=========================================
 
-content
+The coordinate frame classes now support storing and transforming velocity data
+along with positional coordinate data. Similar to the positional data --- that
+use the ``Representation`` classes to abstract away the particular
+representation and allow re-representing from, e.g., Cartesian to Spherical
+--- the velocity information makes use of ``Differential`` classes to do the
+same. For more information about the differential classes, see
+:ref:`astropy-coordinates-differentials`. Also like the positional data, the
+names of the differential (velocity) components depend on the particular
+coordinate frame.
+
+The default differential for most frames is the
+`~astropy.coordinates.SphericalCosLatDifferential` class, meaning that most
+frames expect velocity data in the form of two proper motion components and/or a
+radial velocity. When supported, the proper motion components all begin with
+``pm_`` and, by default, the longitudinal component should already include the
+``cos(latitude)`` term. For example, the proper motion components for the ICRS
+frame are (``pm_ra_cosdec``, ``pm_dec``)::
+
+    >>> coord.ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...            pm_ra_cosdec=11*u.mas/u.yr, pm_dec=-27*u.mas/u.yr)
+    <ICRS Coordinate: (ra, dec) in deg
+        ( 8.67,  53.09)
+     (pm_ra_cosdec, pm_dec) in mas / yr
+        ( 11., -27.)>
+
+Like the positional data, velocity data must be passed in as
+`~astropy.units.Quantity` objects.
+
+TODO: more stuff...
 
 .. _astropy-coordinate-transform-with-velocities:
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -75,7 +75,10 @@ changed by specifying the `~astropy.coordinates.SphericalDifferential` class
     >>> Galactic(l=11.23*u.degree, b=58.13*u.degree,
     ...          pm_l=21.34*u.mas/u.yr, pm_b=-55.89*u.mas/u.yr,
     ...          differential_cls=SphericalDifferential)
-
+    <Galactic Coordinate: (l, b) in deg
+        ( 11.23,  58.13)
+     (pm_l, pm_b) in mas / yr
+        ( 21.34, -55.89)>
 
 .. _astropy-coordinate-transform-with-velocities:
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -72,7 +72,7 @@ is done  exactly the same way transforming position-only frame instances::
     <Galactic Coordinate: (l, b) in deg
         ( 120.38084191, -9.69872044)
      (pm_l_cosb, pm_b) in mas / yr
-        ( 3.78957965, -15.44359693)
+        ( 3.78957965, -15.44359693)>
 
 However, the details of how the velocity components are transformed depends on
 the particular set of transforms required to get from the starting frame to the

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -80,6 +80,34 @@ changed by specifying the `~astropy.coordinates.SphericalDifferential` class
      (pm_l, pm_b) in mas / yr
         ( 21.34, -55.89)>
 
+This works in parallel to specifying the expected representation class, as long
+as the differential class is compatible with the representation. For example, to
+specify all coordinate and velocity components in Cartesian::
+
+    >>> from astropy.coordinates import (CartesianRepresentation,
+    ...                                  CartesianDifferential)
+    >>> Galactic(u=103*u.pc, v=-11*u.pc, w=93.*u.pc,
+    ...          U=31*u.km/u.s, V=-10*u.km/u.s, W=75*u.km/u.s,
+    ...          representation=CartesianRepresentation,
+    ...          differential_cls=CartesianDifferential)
+    <Galactic Coordinate: (u, v, w) in pc
+        ( 103., -11.,  93.)
+     (U, V, W) in km / s
+        ( 31., -10.,  75.)>
+
+Note that the ``Galactic`` frame has special, standard names for Cartesian
+position and velocity components. For other frames, these are just ``x,y,z`` and
+``v_x,v_y,v_z``::
+
+    >>> ICRS(x=103*u.pc, y=-11*u.pc, z=93.*u.pc,
+    ...      v_x=31*u.km/u.s, v_y=-10*u.km/u.s, v_z=75*u.km/u.s,
+    ...      representation=CartesianRepresentation,
+    ...      differential_cls=CartesianDifferential)
+    <ICRS Coordinate: (x, y, z) in pc
+        ( 103., -11.,  93.)
+     (v_x, v_y, v_z) in km / s
+        ( 31., -10.,  75.)>
+
 .. _astropy-coordinate-transform-with-velocities:
 
 Transforming frames with velocities

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -21,43 +21,106 @@ The coordinate frame classes now support storing and transforming velocity data
 along with positional coordinate data. Similar to the positional data --- that
 use the ``Representation`` classes to abstract away the particular
 representation and allow re-representing from, e.g., Cartesian to Spherical
---- the velocity information makes use of ``Differential`` classes to do the
-same. For more information about the differential classes, see
-:ref:`astropy-coordinates-differentials`. Also like the positional data, the
+--- the velocity data makes use of ``Differential`` classes to do the
+same (for more information about the differential classes, see
+:ref:`astropy-coordinates-differentials`). Also like the positional data, the
 names of the differential (velocity) components depend on the particular
 coordinate frame.
 
-The default differential for most frames is the
-`~astropy.coordinates.SphericalCosLatDifferential` class, meaning that most
-frames expect velocity data in the form of two proper motion components and/or a
-radial velocity. When supported, the proper motion components all begin with
-``pm_`` and, by default, the longitudinal component should already include the
-``cos(latitude)`` term. For example, the proper motion components for the ICRS
-frame are (``pm_ra_cosdec``, ``pm_dec``)::
+Most frames expect velocity data in the form of two proper motion components
+and/or a radial velocity because the default differential for most frames is the
+`~astropy.coordinates.SphericalCosLatDifferential` class. When supported, the
+proper motion components all begin with ``pm_`` and, by default, the
+longitudinal component is expected to already include the ``cos(latitude)``
+term. For example, the proper motion components for the ICRS frame are
+(``pm_ra_cosdec``, ``pm_dec``)::
 
-    >>> coord.ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
-    ...            pm_ra_cosdec=11*u.mas/u.yr, pm_dec=-27*u.mas/u.yr)
+    >>> from astropy.coordinates import ICRS
+    >>> import astropy.units as u
+    >>> ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...      pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr)
     <ICRS Coordinate: (ra, dec) in deg
         ( 8.67,  53.09)
      (pm_ra_cosdec, pm_dec) in mas / yr
-        ( 11., -27.)>
+        ( 4.8, -15.16)>
+    >>> ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...      pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
+    ...      radial_velocity=23.42*u.km/u.s)
+    <ICRS Coordinate: (ra, dec) in deg
+        ( 8.67,  53.09)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        ( 4.8, -15.16,  23.42)>
 
 Like the positional data, velocity data must be passed in as
 `~astropy.units.Quantity` objects.
 
-TODO: more stuff...
+TODO: how to change the differential class to specify other velocity components
 
 .. _astropy-coordinate-transform-with-velocities:
 
 Transforming frames with velocities
 ===================================
 
-overview
+Transforming coordinate frame instances that contain velocity data is the same
+as transforming position-only frame instances::
+
+    >>> from astropy.coordinates import Galactic
+    >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr)
+    >>> icrs.transform_to(Galactic) # doctest: +FLOAT_CMP
+    <Galactic Coordinate: (l, b) in deg
+        ( 120.38084191, -9.69872044)
+     (pm_l_cosb, pm_b) in mas / yr
+        ( 3.78957965, -15.44359693)
+
+However, the details of how the velocity components are transformed depends on
+the particular path taken through the frame transform graph. If all frames
+between the initial frame and the desired frame support transformations with a
+`~astropy.coordinates.BaseAffineTransform` subclass (i.e. are matrix
+transformations or affine transformations), then the transformations can be
+applied explicitly to the velocity data. If this is not the case, the velocity
+transformation is computed numerically by finite-differencing the positional
+transformation. See the subsections below for more details about these two
+methods.
 
 Affine Transformations
 ----------------------
 
-details
+Frame transformations that involve a rotation and/or an origin shift and/or
+a velocity offset are implemented as affine transformations using the
+`~astropy.coordinates.BaseAffineTransform` subclassese:
+`~astropy.coordinates.StaticMatrixTransform`,
+`~astropy.coordinates.DynamicMatrixTransform`, and
+`~astropy.coordinates.AffineTransform`.
+
+Matrix-only transformations (e.g., rotations such as
+`~astropy.coordinates.ICRS` to `~astropy.coordinates.Galactic`) can be performed
+on proper-motion-only data or full-space, 3D velocities::
+
+    >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
+    ...             radial_velocity=23.42*u.km/u.s) # doctest: +FLOAT_CMP
+    >>> icrs.transform_to(Galactic) # doctest: +FLOAT_CMP
+    <Galactic Coordinate: (l, b) in deg
+        ( 120.38084191, -9.69872044)
+     (pm_l_cosb, pm_b, radial_velocity) in (mas / yr, mas / yr, km / s)
+        ( 3.78957965, -15.44359693,  23.42)>
+
+The same rotation matrix is applied to both the position vector and the velocity
+vector. Any transformation that involves a velocity offset requires all 3D
+velocity components (which typically requires specifying a distance as well),
+for example, `~astropy.coordinates.ICRS` to `~astropy.coordinates.LSR`::
+
+    >>> from astropy.coordinates import LSR
+    >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...             distance=117*u.pc,
+    ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
+    ...             radial_velocity=23.42*u.km/u.s) # doctest: +FLOAT_CMP
+    >>> icrs.transform_to(LSR) # doctest: +FLOAT_CMP
+    <LSR Coordinate (v_bary=( 11.1,  12.24,  7.25) km / s): (ra, dec, distance) in (deg, deg, pc)
+        ( 8.67,  53.09,  117.)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (-24.51315607, -2.67935501,  27.07339176)>
 
 Finite Difference Transformations
 ---------------------------------

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -265,7 +265,7 @@ the default values.
 It is possible to override the timestep over which the finite difference occurs.
 For example::
 
-    >>> from astropy.coordinates import frame_transform_graph, CIRS
+    >>> from astropy.coordinates import frame_transform_graph, AltAz, CIRS
     >>> trans = frame_transform_graph.get_transform(AltAz, CIRS).transforms[0]
     >>> trans.finite_difference_dt = 1*u.year
     >>> gcrs = aa.transform_to(GCRS(obstime=time))  # doctest: +SKIP

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -2,8 +2,8 @@
 
 .. _astropy-coordinates-velocities:
 
-Working with velocity data in Astropy coordinates
-*************************************************
+Working with velocities in Astropy coordinates
+**********************************************
 
 .. warning::
     Velocities support, new in Astropy v2.0, is an experimental feature and is
@@ -18,8 +18,8 @@ Creating frame objects with velocity data
 =========================================
 
 The coordinate frame classes now support storing and transforming velocity data
-along with positional coordinate data. Similar to the positional data --- that
-use the ``Representation`` classes to abstract away the particular
+(along side the positional coordinate data). Similar to the positional data ---
+that use the ``Representation`` classes to abstract away the particular
 representation and allow re-representing from, e.g., Cartesian to Spherical
 --- the velocity data makes use of ``Differential`` classes to do the
 same (for more information about the differential classes, see
@@ -61,8 +61,9 @@ TODO: how to change the differential class to specify other velocity components
 Transforming frames with velocities
 ===================================
 
-Transforming coordinate frame instances that contain velocity data is the same
-as transforming position-only frame instances::
+Transforming coordinate frame instances that contain velocity data to a
+different frame (which may involve both position and velocity trasnfromations)
+is done  exactly the same way transforming position-only frame instances::
 
     >>> from astropy.coordinates import Galactic
     >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
@@ -74,9 +75,10 @@ as transforming position-only frame instances::
         ( 3.78957965, -15.44359693)
 
 However, the details of how the velocity components are transformed depends on
-the particular path taken through the frame transform graph. If all frames
-between the initial frame and the desired frame support transformations with a
-`~astropy.coordinates.BaseAffineTransform` subclass (i.e. are matrix
+the particular set of transforms required to get from the starting frame to the
+desired frame (i.e., the path taken through the frame transform graph). If all
+frames in the chain of transformations are transformed to each other via
+`~astropy.coordinates.BaseAffineTransform` subclasses (i.e. are matrix
 transformations or affine transformations), then the transformations can be
 applied explicitly to the velocity data. If this is not the case, the velocity
 transformation is computed numerically by finite-differencing the positional

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -2,20 +2,24 @@
 
 .. _astropy-coordinates-velocities:
 
-Velocities (Radial and Proper Motions) in Coordinates
-*****************************************************
+Working with velocity data in Astropy coordinates
+*************************************************
 
 .. warning::
     Velocities support, new in Astropy v2.0, is an experimental feature and is
     subject to change based on user feedback.  While we do not expect major API
     changes, the possibility exists based on the precedent of earlier changes
-    in the ``coordinates`` subpackage due to user feedback in previous versions
-    of Astropy.
+    in the ``coordinates`` subpackage based on user feedback from previous
+    versions of Astropy.
+
+.. _astropy-coordinate-custom-frame-with-velocities:
 
 Creating frame objects with velocities
 ======================================
 
 content
+
+.. _astropy-coordinate-transform-with-velocities:
 
 Transforming frames with velocities
 ===================================

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -363,9 +363,12 @@ Experimental velocity support in ``astropy.coordinates``
 ========================================================
 
 ``astropy.coordinates`` frame objects now contains experimental support for
-storing and transforming velocities.  This includes support for "differential"
-objects which contain differences of representations. For more details, see
-:ref:`astropy-coordinates-velocities`.
+storing and transforming velocities. This includes, among other things, support
+for transforming proper motion components between coordinate frames and
+transforming full-space velocities to/from a local standard of rest (``LSR``)
+frame and a ``Galactocentric`` frame. This works by adding support for
+"differential" objects which contain differences of representations. For more
+details, see :ref:`astropy-coordinates-velocities`.
 
 
 Full change log

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -364,7 +364,8 @@ Experimental velocity support in ``astropy.coordinates``
 
 ``astropy.coordinates`` frame objects now contains experimental support for
 storing and transforming velocities.  This includes support for "differential"
-objects which contain differences of representations.
+objects which contain differences of representations. For more details, see
+:ref:`astropy-coordinates-velocities`.
 
 
 Full change log

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""
+========================================================================
+Transforming positions and velocities to and from a Galactocentric frame
+========================================================================
+
+This document shows a few examples of how to use and customize the
+`~astropy.coordinates.Galactocentric` frame to transform Heliocentric sky
+positions, distance, proper motions, and radial velocities to a Galactocentric,
+Cartesian frame, and the same in reverse.
+
+The main configurable parameters of the `~astropy.coordinates.Galactocentric`
+frame control the position and velocity of the solar system barycenter within
+the Galaxy. These are specified by setting the ICRS coordinates of the
+Galactic center, the distance to the Galactic center (the sun-galactic center
+line is always assumed to be the x-axis of the Galactocentric frame), and the
+Cartesian 3-velocity of the sun in the Galactocentric frame. We'll first
+demonstrate how to customize these values, then show how to set the solar motion
+instead by inputting the proper motion of Sgr A*.
+
+Note that, for brevity, we may refer to the solar system barycenter as just "the
+sun" in the examples below.
+
+-------------------
+
+*By: Adrian Price-Whelan*
+
+*License: BSD*
+
+-------------------
+
+"""
+
+##############################################################################
+# Make `print` work the same in all versions of Python, set up numpy,
+# matplotlib, and use a nicer set of plot parameters:
+
+from __future__ import print_function
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.visualization import astropy_mpl_style
+plt.style.use(astropy_mpl_style)
+
+
+##############################################################################
+# Import the necessary astropy subpackages
+
+import astropy.coordinates as coord
+import astropy.units as u
+
+##############################################################################
+# Let's first define a barycentric coordinate and velocity in the ICRS frame.
+# We'll use the data for the star HD 39881 from the `Simbad
+# <simbad.harvard.edu/simbad/>`_ database:
+
+c1 = coord.ICRS(ra=89.014303*u.degree, dec=13.924912*u.degree,
+                distance=(37.59*u.mas).to(u.pc, u.parallax()),
+                pm_ra_cosdec=372.72*u.mas/u.yr,
+                pm_dec=-483.69*u.mas/u.yr,
+                radial_velocity=0.37*u.km/u.s)
+
+##############################################################################
+# This is a high proper-motion star; suppose we'd like to transform its position
+# and velocity to a Galactocentric frame to see if it has a large 3D velocity
+# as well. To use the Astropy default solar position and motion parameters, we
+# can simply do:
+
+gc1 = c1.transform_to(coord.Galactocentric)
+
+##############################################################################
+# From here, we can access the components of the resulting
+# `~astropy.coordinates.Galactocentric` instance to see the 3D Cartesian
+# velocity components:
+
+print(gc1.v_x, gc1.v_y, gc1.v_z)
+
+##############################################################################
+# The default parameters for the `~astropy.coordinates.Galactocentric` frame
+# are detailed in the linked documentation, but we can modify the most commonly
+# changes values using the keywords ``galcen_distance``, ``galcen_v_sun``, and
+# ``z_sun`` which set the sun-Galactic center distance, the 3D velocity vector
+# of the sun, and the height of the sun above the Galactic midplane,
+# respectively. The velocity of the sun must be specified as a
+# `~astropy.coordinates.CartesianDifferential` instance, as in the example
+# below. Note that, as with the positions, the Galactocentric frame is a
+# right-handed system - the x-axis is positive towards the Galactic center, so
+# `v_x` is opposite of the Galactocentric radial velocity:
+
+v_sun = coord.CartesianDifferential([11.1, 244, 7.25]*u.km/u.s)
+gc_frame = coord.Galactocentric(galcen_distance=8*u.kpc,
+                                galcen_v_sun=v_sun,
+                                z_sun=0*u.pc)
+
+##############################################################################
+# We can then transform to this frame instead, with our custom parameters:
+
+gc2 = c1.transform_to(gc_frame)
+print(gc2.v_x, gc2.v_y, gc2.v_z)
+
+##############################################################################
+# It's sometimes useful to specify the solar motion using the `proper motion
+# of Sgr A* <https://arxiv.org/abs/astro-ph/0408107>`_ instead of Cartesian
+# velocity components. With an assumed distance, we can convert proper motion
+# components to Cartesian velocity components using `astropy.units`:
+
+galcen_distance = 8*u.kpc
+pm_gal_sgrA = [-6.379, -0.202] * u.mas/u.yr # from Reid & Brunthaler 2004
+vy, vz = -(galcen_distance * pm_gal_sgrA).to(u.km/u.s, u.dimensionless_angles())
+
+##############################################################################
+# We still have to assume a line-of-sight velocity for the Galactic center,
+# which we will again take to be 11 km/s:
+vx = 11.1 * u.km/u.s
+
+gc_frame2 = coord.Galactocentric(galcen_distance=galcen_distance,
+                                 galcen_v_sun=coord.CartesianDifferential(vx, vy, vz),
+                                 z_sun=0*u.pc)
+gc3 = c1.transform_to(gc_frame2)
+print(gc3.v_x, gc3.v_y, gc3.v_z)
+
+##############################################################################
+# The transformations also work in the opposite direction. This can be useful
+# for transforming simulated or theoretical data to observable quantities. As
+# an example, we'll generate 4 theoretical circular orbits at different
+# Galactocentric radii with the same circular velocity, and transform them to
+# Heliocentric coordinates:
+
+ring_distances = [4, 8, 12, 16] * u.kpc
+circ_velocity = 220 * u.km/u.s
+
+phi_grid = np.linspace(0, 360, 256) * u.degree # grid of azimuths
+ring_rep = coord.CylindricalRepresentation(
+    rho=ring_distances[:,np.newaxis],
+    phi=phi_grid[np.newaxis],
+    z=np.zeros_like(ring_distances)[:,np.newaxis])
+
+angular_velocity = (circ_velocity / ring_distances).to(u.mas/u.yr,
+                                                       u.dimensionless_angles())
+ring_dif = coord.CylindricalDifferential(
+    d_rho=np.zeros(phi_grid.shape)[np.newaxis]*u.km/u.s,
+    d_phi=angular_velocity[:,np.newaxis],
+    d_z=np.zeros(phi_grid.shape)[np.newaxis]*u.km/u.s
+)
+
+ring_rep = ring_rep.with_differentials(ring_dif)
+gc_rings = coord.Galactocentric(ring_rep)
+gal_rings = gc_rings.transform_to(coord.Galactic)
+
+fig,ax = plt.subplots(1, 1, figsize=(8,6))
+for i in range(len(ring_distances)):
+    ax.scatter(gal_rings[i].l.degree, gal_rings[i].pm_l_cosb.value,
+               label=str(ring_distances[i]), marker='.')
+
+ax.set_xlim(360, 0)
+ax.set_ylim(-12.5, 2.5)
+
+ax.set_xlabel('$l$ [deg]')
+ax.set_ylabel(r'$\mu_l \, \cos b$ [{0}]'.format((u.mas/u.yr).to_string('latex_inline')))
+
+ax.legend()

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -84,7 +84,7 @@ print(gc1.v_x, gc1.v_y, gc1.v_z)
 # `~astropy.coordinates.CartesianDifferential` instance, as in the example
 # below. Note that, as with the positions, the Galactocentric frame is a
 # right-handed system - the x-axis is positive towards the Galactic center, so
-# `v_x` is opposite of the Galactocentric radial velocity:
+# ``v_x`` is opposite of the Galactocentric radial velocity:
 
 v_sun = coord.CartesianDifferential([11.1, 244, 7.25]*u.km/u.s)
 gc_frame = coord.Galactocentric(galcen_distance=8*u.kpc,

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -234,7 +234,7 @@ axes[0].plot(sgr.Lambda.degree,
              sgr.pm_Lambda_cosBeta.value,
              linestyle='none', marker='.')
 axes[0].set_xlabel(r"$\Lambda$ [deg]")
-axes[0].set_ylabel(r"$\mu_\Lambda \, \cos\Beta$ [{0}]"
+axes[0].set_ylabel(r"$\mu_\Lambda \, \cos B$ [{0}]"
                    .format(sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')))
 
 axes[1].set_title("ICRS")

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -230,11 +230,11 @@ print(icrs)
 fig, axes = plt.subplots(3, 1, figsize=(8, 10), sharex=True)
 
 axes[0].set_title("Sagittarius")
-axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).degree,
+axes[0].plot(sgr.Lambda.degree,
              sgr.pm_Lambda_cosBeta.value,
              linestyle='none', marker='.')
 axes[0].set_xlabel(r"$\Lambda$ [deg]")
-axes[1].set_ylabel(r"$\mu_\Lambda \, \cos\Beta$ [{0}]"
+axes[0].set_ylabel(r"$\mu_\Lambda \, \cos\Beta$ [{0}]"
                    .format(sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')))
 
 axes[1].set_title("ICRS")

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -103,7 +103,7 @@ class Sagittarius(coord.BaseCoordinateFrame):
             coord.RepresentationMapping('lat', 'Beta'),
             coord.RepresentationMapping('distance', 'distance')],
         coord.SphericalCosLatDifferential: [
-            coord.RepresentationMapping('d_lon', 'pm_Lambda_cosBeta'),
+            coord.RepresentationMapping('d_lon_coslat', 'pm_Lambda_cosBeta'),
             coord.RepresentationMapping('d_lat', 'pm_Beta'),
             coord.RepresentationMapping('d_distance', 'radial_velocity')],
         coord.SphericalDifferential: [
@@ -223,7 +223,7 @@ plt.show()
 sgr = Sagittarius(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
                   Beta=np.zeros(128)*u.radian,
                   pm_Lambda_cosBeta=np.random.uniform(-5, 5, 128)*u.mas/u.yr,
-                  pm_Beta=np.zeors(128)*u.mas/u.yr)
+                  pm_Beta=np.zeros(128)*u.mas/u.yr)
 icrs = sgr.transform_to(coord.ICRS)
 print(icrs)
 

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -213,3 +213,41 @@ axes[1].plot(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian,
              linestyle='none', marker='.')
 
 plt.show()
+
+##############################################################################
+# This particular transformation is just a spherical rotation, which is a
+# special case of an Affine transformation with no vector offset. The
+# transformation of velocity components is therefore natively supported as
+# well:
+
+sgr = Sagittarius(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
+                  Beta=np.zeros(128)*u.radian,
+                  pm_Lambda_cosBeta=np.random.uniform(-5, 5, 128)*u.mas/u.yr,
+                  pm_Beta=np.zeors(128)*u.mas/u.yr)
+icrs = sgr.transform_to(coord.ICRS)
+print(icrs)
+
+fig, axes = plt.subplots(3, 1, figsize=(8, 10), sharex=True)
+
+axes[0].set_title("Sagittarius")
+axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).degree,
+             sgr.pm_Lambda_cosBeta.value,
+             linestyle='none', marker='.')
+axes[0].set_xlabel(r"$\Lambda$ [deg]")
+axes[1].set_ylabel(r"$\mu_\Lambda \, \cos\Beta$ [{0}]"
+                   .format(sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')))
+
+axes[1].set_title("ICRS")
+axes[1].plot(icrs.ra.degree, icrs.pm_ra_cosdec.value,
+             linestyle='none', marker='.')
+axes[1].set_ylabel(r"$\mu_\alpha \, \cos\delta$ [{0}]"
+                   .format(icrs.pm_ra_cosdec.unit.to_string('latex_inline')))
+
+axes[2].set_title("ICRS")
+axes[2].plot(icrs.ra.degree, icrs.pm_dec.value,
+             linestyle='none', marker='.')
+axes[2].set_xlabel("RA [deg]")
+axes[2].set_ylabel(r"$\mu_\delta$ [{0}]"
+                   .format(icrs.pm_dec.unit.to_string('latex_inline')))
+
+plt.show()

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -68,7 +68,7 @@ print(rv_gsr)
 ################################################################################
 # We could wrap this in a function so we can control the solar velocity and
 # re-use the above code:
-def to_v_gsr(c, v_sun=None):
+def rv_to_gsr(c, v_sun=None):
     """Transform a barycentric radial velocity to the Galactic Standard of Rest
     (GSR).
 
@@ -101,5 +101,5 @@ def to_v_gsr(c, v_sun=None):
 
     return c.radial_velocity + v_proj
 
-rv_gsr = to_v_gsr(icrs)
+rv_gsr = rv_to_gsr(icrs)
 print(rv_gsr)

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+================================================================
+Convert a radial velocity to the Galactic Standard of Rest (GSR)
+================================================================
+
+Radial or line-of-sight velocities of sources are often reported in a
+Heliocentric or Solar-system barycentric reference frame. A common
+transformation incorporates the projection of the Sun's motion along the
+line-of-sight to the target, hence transforming it to a Galactic rest frame
+instead (sometimes referred to as the Galactic Standard of Rest, GSR). This
+transformation depends on the assumptions about the orientation of the Galactic
+frame relative to the bary- or Heliocentric frame. It also depends on the
+assumed solar velocity vector. Here we'll demonstrate how to perform this
+transformation using a sky position and barycentric radial-velocity.
+
+-------------------
+
+*By: Adrian Price-Whelan
+
+*License: BSD*
+
+-------------------
+
+"""
+
+################################################################################
+# Make print work the same in all versions of Python and import the required
+# Astropy packages:
+from __future__ import print_function
+import astropy.units as u
+import astropy.coordinates as coord
+
+################################################################################
+# For this example, let's work with the coordinates and barycentric radial
+# velocity of the star HD 155967, as obtained from
+# `Simbad <http://simbad.harvard.edu/simbad/>`_:
+icrs = coord.ICRS(ra=258.58356362*u.deg, dec=14.55255619*u.deg,
+                  radial_velocity=-16.1*u.km/u.s)
+
+################################################################################
+# We next need to decide on the velocity of the Sun in the assumed GSR frame.
+# We'll use the same velocity vector as used in the
+# `~astropy.coordinates.Galactocentric` frame, and convert it to a
+# `~astropy.coordinates.CartesianRepresentation` object using the
+# ``.to_cartesian()`` method of the
+# `~astropy.coordinates.CartesianDifferential` object ``galcen_v_sun``:
+v_sun = coord.Galactocentric.galcen_v_sun.to_cartesian()
+
+################################################################################
+# We now need to get a unit vector in the assumed Galactic frame from the sky
+# position in the ICRS frame above. We'll use this unit vector to project the
+# solar velocity onto the line-of-sight:
+gal = icrs.transform_to(coord.Galactic)
+cart_data = gal.data.to_cartesian()
+unit_vector = cart_data / cart_data.norm()
+
+################################################################################
+# Now we project the solar velocity using this unit vector:
+v_proj = v_sun.dot(unit_vector)
+
+################################################################################
+# Finally, we add the projection of the solar velocity to the radial velocity
+# to get a GSR radial velocity:
+rv_gsr = icrs.radial_velocity + v_proj
+print(rv_gsr)
+
+################################################################################
+# We could wrap this in a function so we can control the solar velocity and
+# re-use the above code:
+def to_v_gsr(c, v_sun=None):
+    """Transform a barycentric radial velocity to the Galactic Standard of Rest
+    (GSR).
+
+    The input radial velocity must be passed in as a
+
+    Parameters
+    ----------
+    c : `~astropy.coordinates.BaseCoordinateFrame` subclass instance
+        The radial velocity, associated with a sky coordinates, to be
+        transformed.
+    v_sun : `~astropy.units.Quantity` (optional)
+        The 3D velocity of the solar system barycenter in the GSR frame.
+        Defaults to the same solar motion as in the
+        `~astropy.coordinates.Galactocentric` frame.
+
+    Returns
+    -------
+    v_gsr : `~astropy.units.Quantity`
+        The input radial velocity transformed to a GSR frame.
+
+    """
+    if v_sun is None:
+        v_sun = coord.Galactocentric.galcen_v_sun.to_cartesian()
+
+    gal = icrs.transform_to(coord.Galactic)
+    cart_data = gal.data.to_cartesian()
+    unit_vector = cart_data / cart_data.norm()
+
+    v_proj = v_sun.dot(unit_vector)
+
+    return c.radial_velocity + v_proj
+
+rv_gsr = to_v_gsr(icrs)
+print(rv_gsr)

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -16,7 +16,7 @@ transformation using a sky position and barycentric radial-velocity.
 
 -------------------
 
-*By: Adrian Price-Whelan
+*By: Adrian Price-Whelan*
 
 *License: BSD*
 


### PR DESCRIPTION
This is a companion to #6219 to add / update the astropy.coordinates documentation to explain how velocities are incorporated. This is mainly just so the files changed in #6219 doesn't get even more out of hand...
