### PR TITLE
Add support for GROUP elements in the votable RESOURCE element

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,8 @@ astropy.io.registry
 
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
+  - Add handling of ``tree.Group`` elements to ``tree.Resource``.  Unified I/O
+    or conversion to astropy tables is not affected. [#6262]
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^

--- a/astropy/io/votable/tests/data/resource_groups.xml
+++ b/astropy/io/votable/tests/data/resource_groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <RESOURCE type="meta" utype="adhoc:service">
+    <GROUP name="inputParams">
+      <PARAM arraysize="*" datatype="char" name="ID" ref="a_reference" ucd="meta.id;meta.main" value=""/>
+    </GROUP>
+    <PARAM arraysize="*" datatype="char" name="standardID" value="ivo://ivoa.net/std/DataLink#links-1.0"/>
+    <PARAM arraysize="*" datatype="char" name="accessURL" value="http://example.org/ivoa/std/DataLink"/>
+  </RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/resource_test.py
+++ b/astropy/io/votable/tests/resource_test.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# LOCAL
+from .. import parse
+from ....utils.data import get_pkg_data_filename
+
+
+def test_resource_groups():
+    # Read the VOTABLE
+    votable = parse(get_pkg_data_filename('data/resource_groups.xml'))
+
+    resource = votable.resources[0]
+    groups = resource.groups
+    params = resource.params
+
+    # Test that params inside groups are not outside
+
+    assert len(groups[0].entries) == 1
+    assert groups[0].entries[0].name == "ID"
+
+    assert len(params) == 2
+    assert params[0].name == "standardID"
+    assert params[1].name == "accessURL"

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3013,6 +3013,7 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
         self.description = None
 
         self._coordinate_systems = HomogeneousList(CooSys)
+        self._groups = HomogeneousList(Group)
         self._params = HomogeneousList(Param)
         self._infos = HomogeneousList(Info)
         self._links = HomogeneousList(Link)
@@ -3075,6 +3076,13 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
         return self._infos
 
     @property
+    def groups(self):
+        """
+        A list of groups
+        """
+        return self._groups
+
+    @property
     def params(self):
         """
         A list of parameters (constant-valued columns) for the
@@ -3117,6 +3125,11 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
         self.infos.append(info)
         info.parse(iterator, config)
 
+    def _add_group(self, iterator, tag, data, config, pos):
+        group = Group(self, config=config, pos=pos, **data)
+        self.groups.append(group)
+        group.parse(iterator, config)
+
     def _add_param(self, iterator, tag, data, config, pos):
         param = Param(self._votable, config=config, pos=pos, **data)
         self.params.append(param)
@@ -3144,6 +3157,7 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
             'TABLE': self._add_table,
             'INFO': self._add_info,
             'PARAM': self._add_param,
+            'GROUP' : self._add_group,
             'COOSYS': self._add_coosys,
             'RESOURCE': self._add_resource,
             'LINK': self._add_link,


### PR DESCRIPTION
Usecase:

This change is needed for implementing [Datalink](http://www.ivoa.net/documents/DataLink/index.html) in [pyvo](https://github.com/pyvirtobs/pyvo/tree/datalink)

Example Datalink VOTable XML:
```
<?xml version="1.0"?>
<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ssa="http://www.ivoa.net/xml/DalSsap/v1.0" version="1.3" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://vo.ari.uni-heidelberg.de/docs/schemata/VOTable-1.3.xsd">
...
<RESOURCE type="meta" utype="adhoc:service">
    <GROUP name="inputParams">
      <PARAM arraysize="*" datatype="char" name="ID" ref="ssa_pubDID" ucd="meta.id;meta.main" value=""/>
    </GROUP>
    <PARAM arraysize="*" datatype="char" name="standardID" value="ivo://ivoa.net/std/DataLink#links-1.0"/>
    <PARAM arraysize="*" datatype="char" name="accessURL" value="http://dc.zah.uni-heidelberg.de/flashheros/q/sdl/dlmeta"/>
  </RESOURCE>
</VOTABLE>
```

Datalink responses contain an extra RESOURCE element containing a group with input parameters which are fed to the VO service, thus they need to be distinctable from the service parameters (outside of the group).

The PR adds the group parameter to the RESOURCE element, similar to other elements using it.

Metadata etc. will follow!