### PR TITLE
Fix direct convolution issue #6264

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -566,6 +566,9 @@ Bug Fixes
     in earlier versions of astropy.
     [#5782]
 
+  - Direct convolution previously implemented the wrong definition of
+    convolution.  This error only affects *asymmetric* kernels.  [#6267]
+
 - ``astropy.coordinates``
 
 - ``astropy.cosmology``

--- a/astropy/convolution/boundary_extend.pyx
+++ b/astropy/convolution/boundary_extend.pyx
@@ -170,9 +170,9 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = int_min(int_max(jj, 0), ny - 1)
                                 kkk = int_min(int_max(kk, 0), nz - 1)
                                 val = f[iii, jjj, kkk]
-                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
-                                        <unsigned int>(nky - 1 - (wky - jj - j)),
-                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                        <unsigned int>(nky - 1 - (wky + jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz + kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_extend.pyx
+++ b/astropy/convolution/boundary_extend.pyx
@@ -49,7 +49,7 @@ def convolve1d_boundary_extend(np.ndarray[DTYPE_t, ndim=1] f,
             for ii in range(iimin, iimax):
                 iii = int_min(int_max(ii, 0), nx - 1)
                 val = f[iii]
-                ker = g[<unsigned int>(wkx - ii - i)]
+                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i))]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -105,8 +105,8 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
                         iii = int_min(int_max(ii, 0), nx - 1)
                         jjj = int_min(int_max(jj, 0), ny - 1)
                         val = f[iii, jjj]
-                        ker = g[<unsigned int>(wkx - ii - i),
-                                <unsigned int>(wky - jj - j)]
+                        ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                <unsigned int>(nky - 1 - (wky + jj - j))]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -170,9 +170,9 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = int_min(int_max(jj, 0), ny - 1)
                                 kkk = int_min(int_max(kk, 0), nz - 1)
                                 val = f[iii, jjj, kkk]
-                                ker = g[<unsigned int>(wkx - ii - i),
-                                        <unsigned int>(wky - jj - j),
-                                        <unsigned int>(wkz - kk - k)]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
+                                        <unsigned int>(nky - 1 - (wky - jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_extend.pyx
+++ b/astropy/convolution/boundary_extend.pyx
@@ -49,7 +49,7 @@ def convolve1d_boundary_extend(np.ndarray[DTYPE_t, ndim=1] f,
             for ii in range(iimin, iimax):
                 iii = int_min(int_max(ii, 0), nx - 1)
                 val = f[iii]
-                ker = g[<unsigned int>(wkx + ii - i)]
+                ker = g[<unsigned int>(wkx - ii - i)]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -105,8 +105,8 @@ def convolve2d_boundary_extend(np.ndarray[DTYPE_t, ndim=2] f,
                         iii = int_min(int_max(ii, 0), nx - 1)
                         jjj = int_min(int_max(jj, 0), ny - 1)
                         val = f[iii, jjj]
-                        ker = g[<unsigned int>(wkx + ii - i),
-                                <unsigned int>(wky + jj - j)]
+                        ker = g[<unsigned int>(wkx - ii - i),
+                                <unsigned int>(wky - jj - j)]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -170,9 +170,9 @@ def convolve3d_boundary_extend(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = int_min(int_max(jj, 0), ny - 1)
                                 kkk = int_min(int_max(kk, 0), nz - 1)
                                 val = f[iii, jjj, kkk]
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j),
-                                        <unsigned int>(wkz + kk - k)]
+                                ker = g[<unsigned int>(wkx - ii - i),
+                                        <unsigned int>(wky - jj - j),
+                                        <unsigned int>(wkz - kk - k)]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_fill.pyx
+++ b/astropy/convolution/boundary_fill.pyx
@@ -175,9 +175,9 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                                     val = fill_value
                                 else:
                                     val = f[ii, jj, kk]
-                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
-                                        <unsigned int>(nky - 1 - (wky - jj - j)),
-                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                        <unsigned int>(nky - 1 - (wky + jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz + kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_fill.pyx
+++ b/astropy/convolution/boundary_fill.pyx
@@ -50,7 +50,7 @@ def convolve1d_boundary_fill(np.ndarray[DTYPE_t, ndim=1] f,
                     val = fill_value
                 else:
                     val = f[ii]
-                ker = g[<unsigned int>(wkx + ii - i)]
+                ker = g[<unsigned int>(wkx - ii - i)]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -109,8 +109,8 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
                             val = fill_value
                         else:
                             val = f[ii, jj]
-                        ker = g[<unsigned int>(wkx + ii - i),
-                                <unsigned int>(wky + jj - j)]
+                        ker = g[<unsigned int>(wkx - ii - i),
+                                <unsigned int>(wky - jj - j)]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -175,9 +175,9 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                                     val = fill_value
                                 else:
                                     val = f[ii, jj, kk]
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j),
-                                        <unsigned int>(wkz + kk - k)]
+                                ker = g[<unsigned int>(wkx - ii - i),
+                                        <unsigned int>(wky - jj - j),
+                                        <unsigned int>(wkz - kk - k)]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_fill.pyx
+++ b/astropy/convolution/boundary_fill.pyx
@@ -50,7 +50,7 @@ def convolve1d_boundary_fill(np.ndarray[DTYPE_t, ndim=1] f,
                     val = fill_value
                 else:
                     val = f[ii]
-                ker = g[<unsigned int>(wkx - ii - i)]
+                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i))]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -109,8 +109,8 @@ def convolve2d_boundary_fill(np.ndarray[DTYPE_t, ndim=2] f,
                             val = fill_value
                         else:
                             val = f[ii, jj]
-                        ker = g[<unsigned int>(wkx - ii - i),
-                                <unsigned int>(wky - jj - j)]
+                        ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                <unsigned int>(nky - 1 - (wky + jj - j))]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -175,9 +175,9 @@ def convolve3d_boundary_fill(np.ndarray[DTYPE_t, ndim=3] f,
                                     val = fill_value
                                 else:
                                     val = f[ii, jj, kk]
-                                ker = g[<unsigned int>(wkx - ii - i),
-                                        <unsigned int>(wky - jj - j),
-                                        <unsigned int>(wkz - kk - k)]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
+                                        <unsigned int>(nky - 1 - (wky - jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_none.pyx
+++ b/astropy/convolution/boundary_none.pyx
@@ -158,9 +158,9 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
                         for jj in range(j - wky, j + wky + 1):
                             for kk in range(k - wkz, k + wkz + 1):
                                 val = f[ii, jj, kk]
-                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
-                                        <unsigned int>(nky - 1 - (wky - jj - j)),
-                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                        <unsigned int>(nky - 1 - (wky + jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz + kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_none.pyx
+++ b/astropy/convolution/boundary_none.pyx
@@ -46,7 +46,7 @@ def convolve1d_boundary_none(np.ndarray[DTYPE_t, ndim=1] f,
             bot = 0.
             for ii in range(i - wkx, i + wkx + 1):
                 val = f[ii]
-                ker = g[<unsigned int>(wkx + ii - i)]
+                ker = g[<unsigned int>(wkx - ii - i)]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -99,8 +99,8 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
                 for ii in range(i - wkx, i + wkx + 1):
                     for jj in range(j - wky, j + wky + 1):
                         val = f[ii, jj]
-                        ker = g[<unsigned int>(wkx + ii - i),
-                                <unsigned int>(wky + jj - j)]
+                        ker = g[<unsigned int>(wkx - ii - i),
+                                <unsigned int>(wky - jj - j)]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -158,9 +158,9 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
                         for jj in range(j - wky, j + wky + 1):
                             for kk in range(k - wkz, k + wkz + 1):
                                 val = f[ii, jj, kk]
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j),
-                                        <unsigned int>(wkz + kk - k)]
+                                ker = g[<unsigned int>(wkx - ii - i),
+                                        <unsigned int>(wky - jj - j),
+                                        <unsigned int>(wkz - kk - k)]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_none.pyx
+++ b/astropy/convolution/boundary_none.pyx
@@ -46,7 +46,7 @@ def convolve1d_boundary_none(np.ndarray[DTYPE_t, ndim=1] f,
             bot = 0.
             for ii in range(i - wkx, i + wkx + 1):
                 val = f[ii]
-                ker = g[<unsigned int>(wkx - ii - i)]
+                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i))]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -99,8 +99,8 @@ def convolve2d_boundary_none(np.ndarray[DTYPE_t, ndim=2] f,
                 for ii in range(i - wkx, i + wkx + 1):
                     for jj in range(j - wky, j + wky + 1):
                         val = f[ii, jj]
-                        ker = g[<unsigned int>(wkx - ii - i),
-                                <unsigned int>(wky - jj - j)]
+                        ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                <unsigned int>(nky - 1 - (wky + jj - j))]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -158,9 +158,9 @@ def convolve3d_boundary_none(np.ndarray[DTYPE_t, ndim=3] f,
                         for jj in range(j - wky, j + wky + 1):
                             for kk in range(k - wkz, k + wkz + 1):
                                 val = f[ii, jj, kk]
-                                ker = g[<unsigned int>(wkx - ii - i),
-                                        <unsigned int>(wky - jj - j),
-                                        <unsigned int>(wkz - kk - k)]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
+                                        <unsigned int>(nky - 1 - (wky - jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_wrap.pyx
+++ b/astropy/convolution/boundary_wrap.pyx
@@ -166,9 +166,9 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = jj % ny
                                 kkk = kk % nz
                                 val = f[iii, jjj, kkk]
-                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
-                                        <unsigned int>(nky - 1 - (wky - jj - j)),
-                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                        <unsigned int>(nky - 1 - (wky + jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz + kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_wrap.pyx
+++ b/astropy/convolution/boundary_wrap.pyx
@@ -45,7 +45,7 @@ def convolve1d_boundary_wrap(np.ndarray[DTYPE_t, ndim=1] f,
             for ii in range(iimin, iimax):
                 iii = ii % nx
                 val = f[iii]
-                ker = g[<unsigned int>(wkx - ii - i)]
+                ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i))]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -101,8 +101,8 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
                         iii = ii % nx
                         jjj = jj % ny
                         val = f[iii, jjj]
-                        ker = g[<unsigned int>(wkx - ii - i),
-                                <unsigned int>(wky - jj - j)]
+                        ker = g[<unsigned int>(nkx - 1 - (wkx + ii - i)),
+                                <unsigned int>(nky - 1 - (wky + jj - j))]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -166,9 +166,9 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = jj % ny
                                 kkk = kk % nz
                                 val = f[iii, jjj, kkk]
-                                ker = g[<unsigned int>(wkx - ii - i),
-                                        <unsigned int>(wky - jj - j),
-                                        <unsigned int>(wkz - kk - k)]
+                                ker = g[<unsigned int>(nkx - 1 - (wkx - ii - i)),
+                                        <unsigned int>(nky - 1 - (wky - jj - j)),
+                                        <unsigned int>(nkz - 1 - (wkz - kk - k))]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/boundary_wrap.pyx
+++ b/astropy/convolution/boundary_wrap.pyx
@@ -45,7 +45,7 @@ def convolve1d_boundary_wrap(np.ndarray[DTYPE_t, ndim=1] f,
             for ii in range(iimin, iimax):
                 iii = ii % nx
                 val = f[iii]
-                ker = g[<unsigned int>(wkx + ii - i)]
+                ker = g[<unsigned int>(wkx - ii - i)]
                 if not npy_isnan(val):
                     top += val * ker
                     bot += ker
@@ -101,8 +101,8 @@ def convolve2d_boundary_wrap(np.ndarray[DTYPE_t, ndim=2] f,
                         iii = ii % nx
                         jjj = jj % ny
                         val = f[iii, jjj]
-                        ker = g[<unsigned int>(wkx + ii - i),
-                                <unsigned int>(wky + jj - j)]
+                        ker = g[<unsigned int>(wkx - ii - i),
+                                <unsigned int>(wky - jj - j)]
                         if not npy_isnan(val):
                             top += val * ker
                             bot += ker
@@ -166,9 +166,9 @@ def convolve3d_boundary_wrap(np.ndarray[DTYPE_t, ndim=3] f,
                                 jjj = jj % ny
                                 kkk = kk % nz
                                 val = f[iii, jjj, kkk]
-                                ker = g[<unsigned int>(wkx + ii - i),
-                                        <unsigned int>(wky + jj - j),
-                                        <unsigned int>(wkz + kk - k)]
+                                ker = g[<unsigned int>(wkx - ii - i),
+                                        <unsigned int>(wky - jj - j),
+                                        <unsigned int>(wkz - kk - k)]
                                 if not npy_isnan(val):
                                     top += val * ker
                                     bot += ker

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -703,15 +703,15 @@ def test_asymmetric_kernel(boundary, convfunc):
 
     y = np.array([1, 2, 3], dtype='>f8')
 
-    z = convolve(x, y, boundary=boundary)
+    z = convolve(x, y, boundary=boundary, normalize_kernel=False)
 
     if boundary == 'fill':
         assert_array_almost_equal_nulp(z, np.array([6., 10.,  2.], dtype='float'), 10)
     elif boundary is None:
         assert_array_almost_equal_nulp(z, np.array([0., 10.,  0.], dtype='float'), 10)
-    elif boundary == 'wrap':
-        assert_array_almost_equal_nulp(z, np.array([7., 10.,  11.], dtype='float'), 10)
     elif boundary == 'extend':
+        assert_array_almost_equal_nulp(z, np.array([15., 10.,  3.], dtype='float'), 10)
+    elif boundary == 'wrap':
         assert_array_almost_equal_nulp(z, np.array([9., 10.,  5.], dtype='float'), 10)
 
 @pytest.mark.parametrize('ndims', (1,2,3))
@@ -719,9 +719,10 @@ def test_convolution_consistency(ndims):
 
     np.random.seed(0)
     array = np.random.randn(*([3]*ndims))
-    kernel = np.random.randn(*([3]*ndims))
+    np.random.seed(0)
+    kernel = np.random.rand(*([3]*ndims))
 
     conv_f = convolve_fft(array, kernel, boundary='fill')
     conv_d = convolve(array, kernel, boundary='fill')
 
-    assert_array_almost_equal_nulp(conv_f, conv_d)
+    assert_array_almost_equal_nulp(conv_f, conv_d, 10)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ..convolve import convolve, convolve_fft
 
-from numpy.testing import assert_array_almost_equal_nulp
+from numpy.testing import assert_array_almost_equal_nulp, assert_array_almost_equal
 
 import itertools
 
@@ -726,3 +726,12 @@ def test_convolution_consistency(ndims):
     conv_d = convolve(array, kernel, boundary='fill')
 
     assert_array_almost_equal_nulp(conv_f, conv_d, 10)
+
+def test_astropy_convolution_against_numpy():
+    x = np.array([1, 2, 3])
+    y = np.array([5, 4, 3, 2, 1])
+
+    assert_array_almost_equal(np.convolve(y, x, 'same'),
+                              convolve(y, x, normalize_kernel=False))
+    assert_array_almost_equal(np.convolve(y, x, 'same'),
+                              convolve_fft(y, x, normalize_kernel=False))

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -730,7 +730,7 @@ def test_convolution_consistency(ndims):
     conv_f = convolve_fft(array, kernel, boundary='fill')
     conv_d = convolve(array, kernel, boundary='fill')
 
-    assert_array_almost_equal_nulp(conv_f, conv_d, 10)
+    assert_array_almost_equal_nulp(conv_f, conv_d, 30)
 
 def test_astropy_convolution_against_numpy():
     x = np.array([1, 2, 3])

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -418,6 +418,39 @@ class TestConvolve2D(object):
         else:
             raise ValueError("Invalid boundary specification")
 
+    @pytest.mark.parametrize(('boundary'), BOUNDARY_OPTIONS)
+    def test_non_normalized_kernel_2D(self, boundary):
+
+        x = np.array([[0., 0., 4.],
+                      [1., 2., 0.],
+                      [0., 3., 0.]], dtype='float')
+
+        y = np.array([[1., -1., 1.],
+                      [-1., 0., -1.],
+                      [1., -1., 1.]], dtype='float')
+
+        z = convolve(x, y, boundary=boundary, nan_treatment='fill',
+                     normalize_kernel=False)
+
+        if boundary is None:
+            assert_array_almost_equal_nulp(z, np.array([[0., 0., 0.],
+                                                        [0., 0., 0.],
+                                                        [0., 0., 0.]], dtype='float'), 10)
+        elif boundary == 'fill':
+            assert_array_almost_equal_nulp(z, np.array([[1., -5., 2.],
+                                                        [1., 0., -3.],
+                                                        [-2., -1., -1.]], dtype='float'), 10)
+        elif boundary == 'wrap':
+            assert_array_almost_equal_nulp(z, np.array([[0., -8., 6.],
+                                                        [5., 0., -4.],
+                                                        [2., 3., -4.]], dtype='float'), 10)
+        elif boundary == 'extend':
+            assert_array_almost_equal_nulp(z, np.array([[ 2., -1., -2.],
+                                                        [ 0.,  0.,  1.],
+                                                        [ 2., -4.,  2.]], dtype='float'), 10)
+        else:
+            raise ValueError("Invalid boundary specification")
+
 class TestConvolve3D(object):
     def test_list(self):
         """
@@ -658,35 +691,37 @@ class TestConvolve3D(object):
         else:
             raise ValueError("Invalid Boundary Option")
 
-    @pytest.mark.parametrize(('boundary'), BOUNDARY_OPTIONS)
-    def test_non_normalized_kernel(self, boundary):
 
-        x = np.array([[0., 0., 4.],
-                      [1., 2., 0.],
-                      [0., 3., 0.]], dtype='float')
+@pytest.mark.parametrize(('convfunc', 'boundary',), BOUNDARIES_AND_CONVOLUTIONS)
+def test_asymmetric_kernel(boundary, convfunc):
+    '''
+    Regression test for #6264: make sure that asymmetric convolution
+    functions go the right direction
+    '''
 
-        y = np.array([[1., -1., 1.],
-                      [-1., 0., -1.],
-                      [1., -1., 1.]], dtype='float')
+    x = np.array([3., 0., 1.], dtype='>f8')
 
-        z = convolve(x, y, boundary=boundary, nan_treatment='fill',
-                     normalize_kernel=False)
+    y = np.array([1, 2, 3], dtype='>f8')
 
-        if boundary is None:
-            assert_array_almost_equal_nulp(z, np.array([[0., 0., 0.],
-                                                        [0., 0., 0.],
-                                                        [0., 0., 0.]], dtype='float'), 10)
-        elif boundary == 'fill':
-            assert_array_almost_equal_nulp(z, np.array([[1., -5., 2.],
-                                                        [1., 0., -3.],
-                                                        [-2., -1., -1.]], dtype='float'), 10)
-        elif boundary == 'wrap':
-            assert_array_almost_equal_nulp(z, np.array([[0., -8., 6.],
-                                                        [5., 0., -4.],
-                                                        [2., 3., -4.]], dtype='float'), 10)
-        elif boundary == 'extend':
-            assert_array_almost_equal_nulp(z, np.array([[ 2., -1., -2.],
-                                                        [ 0.,  0.,  1.],
-                                                        [ 2., -4.,  2.]], dtype='float'), 10)
-        else:
-            raise ValueError("Invalid boundary specification")
+    z = convolve(x, y, boundary=boundary)
+
+    if boundary == 'fill':
+        assert_array_almost_equal_nulp(z, np.array([6., 10.,  2.], dtype='float'), 10)
+    elif boundary is None:
+        assert_array_almost_equal_nulp(z, np.array([0., 10.,  0.], dtype='float'), 10)
+    elif boundary == 'wrap':
+        assert_array_almost_equal_nulp(z, np.array([7., 10.,  11.], dtype='float'), 10)
+    elif boundary == 'extend':
+        assert_array_almost_equal_nulp(z, np.array([9., 10.,  5.], dtype='float'), 10)
+
+@pytest.mark.parametrize('ndims', (1,2,3))
+def test_convolution_consistency(ndims):
+
+    np.random.seed(0)
+    array = np.random.randn(*([3]*ndims))
+    kernel = np.random.randn(*([3]*ndims))
+
+    conv_f = convolve_fft(array, kernel, boundary='fill')
+    conv_d = convolve(array, kernel, boundary='fill')
+
+    assert_array_almost_equal_nulp(conv_f, conv_d)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -26,6 +26,11 @@ BOUNDARIES_AND_CONVOLUTIONS = (list(zip(itertools.cycle((convolve,)),
                                                                'wrap'),
                                                               (convolve_fft,
                                                                'fill')])
+HAS_SCIPY = True
+try:
+    import scipy
+except ImportError:
+    HAS_SCIPY = False
 
 
 class TestConvolve1D(object):
@@ -734,4 +739,15 @@ def test_astropy_convolution_against_numpy():
     assert_array_almost_equal(np.convolve(y, x, 'same'),
                               convolve(y, x, normalize_kernel=False))
     assert_array_almost_equal(np.convolve(y, x, 'same'),
+                              convolve_fft(y, x, normalize_kernel=False))
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_astropy_convolution_against_scipy():
+    from scipy.signal import fftconvolve
+    x = np.array([1, 2, 3])
+    y = np.array([5, 4, 3, 2, 1])
+
+    assert_array_almost_equal(fftconvolve(y, x, 'same'),
+                              convolve(y, x, normalize_kernel=False))
+    assert_array_almost_equal(fftconvolve(y, x, 'same'),
                               convolve_fft(y, x, normalize_kernel=False))


### PR DESCRIPTION
Direct convolution has been incorrectly implemented from day one.  Instead of implementing convolution,

   (F*G)(t) = Sum[f(x) * g(t-x)]

it implemented something backwards:

   (F*G)(t) = Sum[f(x) * g(x)]

We never noticed before because all of our tests used symmetric kernels, and
for symmetric kernels the above two equations are equivalent.

convolve_fft was never affected by this issue.

EDIT: link to #6264 