### PR TITLE
Allowing only 'true' and 'enabled' to enable doctest_plus

### DIFF
--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -147,8 +147,9 @@ def pytest_configure(config):
                           allow_astropy_data=config.getoption('remote_data') == 'astropy')
 
     doctest_plugin = config.pluginmanager.getplugin('doctest')
-    if (doctest_plugin is None or config.option.doctestmodules or not
-            (config.getini('doctest_plus') or config.option.doctest_plus)):
+    if (doctest_plugin is None or config.option.doctestmodules
+            or not (config.getini('doctest_plus').lower() in ['true', 'enabled']
+                    or config.option.doctest_plus)):
         return
 
     # These are the default doctest options we use for everything.


### PR DESCRIPTION
This is to fix #6268 

(CI is skipped as we don't test the tester atm)

