### PR TITLE
Reverting python3.5 pinning on RTD

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,12 +7,21 @@
 name: astropy
 
 dependencies:
-  - python=3.5*
+  - python>=3
   - numpy
   - cython
   - matplotlib
   - scipy
   - pillow
+  - pyyaml
+  - jinja2
+  - h5py
+  - scikit-image
+  - pandas
+  - pytz
+  - beautifulsoup4
+  - ipython
+  - mpmath
   - pip:
-    - sphinx-gallery>=0.1.3
+    - sphinx-gallery>=0.1.9
     - jplephem


### PR DESCRIPTION
and adding all optional dependencies we also use for docs building on travis (some of these were auto installed before anyway as a dependency of RTD or sphinx-gallery, etc, but nevertheless it's useful to use the same dependency list we tests for on travis)

Fixes #5769 

Skipped CI as this file is not tested there.

