### PR TITLE
Fixing docs compatibility with sphinx 1.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='sphinx-gallery>=0.1.9 pillow --no-deps jplephem'
+               SPHINX_VERSION='>1.6'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -178,14 +178,14 @@ class SLSQP(Optimization):
 
 class Simplex(Optimization):
     """
-    Neald-Mead (downhill simplex) algorithm [1]_.
+    Neald-Mead (downhill simplex) algorithm [2]_.
 
     This algorithm only uses function values, not derivatives.
     Uses `scipy.optimize.fmin`.
 
     References
     ----------
-    .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
+    .. [2] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
        minimization", The Computer Journal, 7, pp. 308-313
     """
 

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -183,8 +183,10 @@ class Simplex(Optimization):
     This algorithm only uses function values, not derivatives.
     Uses `scipy.optimize.fmin`.
 
+    References
+    ----------
     .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
-           minimization", The Computer Journal, 7, pp. 308-313
+       minimization", The Computer Journal, 7, pp. 308-313
     """
 
     supported_constraints = ['bounds', 'fixed', 'tied']

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -178,7 +178,7 @@ class SLSQP(Optimization):
 
 class Simplex(Optimization):
     """
-    Neald-Mead (downhill simplex) algorithm [1].
+    Neald-Mead (downhill simplex) algorithm [1]_.
 
     This algorithm only uses function values, not derivatives.
     Uses `scipy.optimize.fmin`.

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -178,14 +178,14 @@ class SLSQP(Optimization):
 
 class Simplex(Optimization):
     """
-    Neald-Mead (downhill simplex) algorithm [2]_.
+    Neald-Mead (downhill simplex) algorithm.
 
-    This algorithm only uses function values, not derivatives.
+    This algorithm [1]_ only uses function values, not derivatives.
     Uses `scipy.optimize.fmin`.
 
     References
     ----------
-    .. [2] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
+    .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
        minimization", The Computer Journal, 7, pp. 308-313
     """
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -119,7 +119,7 @@ def bayesian_blocks(t, x=None, sigma=None,
 
     Regular event data:
 
-    >>> dt = 0.01
+    >>> dt = 0.05
     >>> t = dt * np.arange(1000)
     >>> x = np.zeros(len(t))
     >>> x[np.random.randint(0, len(t), len(t) // 10)] = 1

--- a/docs/development/docrules.rst
+++ b/docs/development/docrules.rst
@@ -322,7 +322,7 @@ The sections of the docstring are:
         and neural-network techniques," Computers & Geosciences, vol. 22,
         pp. 585-588, 1996.
 
-   which renders as
+   which renders as [1]_
 
    .. [1] O. McNoleg, "The integration of GIS, remote sensing,
       expert systems and adaptive co-kriging for environmental habitat

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -122,7 +122,7 @@ Here, ``ST`` is a short-hand for the ST zero-point flux::
 .. note:: at present, only magnitudes defined in terms of luminosity or flux
 	  are implemented, since those that do not depend on the filter the
           measurement was made with.  They include absolute and apparent
-          bolometric [M+15]_, ST [H+95]_ and AB [OG83]_ magnitudes.
+          bolometric [M15]_, ST [H95]_ and AB [OG83]_ magnitudes.
 
 Now applying the calibration, we find (note the proper change in units)::
 
@@ -215,9 +215,9 @@ supported as logarithmic units.  For instance::
     <Decibel 80.0 dB(mW)>
 
 
-.. [M+15] Mamajek et al., 2015, `arXiv:1510.06262
+.. [M15] Mamajek et al., 2015, `arXiv:1510.06262
 	  <http://adsabs.harvard.edu/abs/2015arXiv151006262M>`_
-.. [H+95] E.g., Holtzman et al., 1995, `PASP 107, 1065
+.. [H95] E.g., Holtzman et al., 1995, `PASP 107, 1065
           <http://adsabs.harvard.edu/abs/1995PASP..107.1065H>`_
 .. [OG83] Oke, J.B., & Gunn, J. E., 1983, `ApJ 266, 713
 	  <http://adsabs.harvard.edu/abs/1983ApJ...266..713O>`_

--- a/docs/visualization/histogram.rst
+++ b/docs/visualization/histogram.rst
@@ -28,7 +28,7 @@ matplotlib's default of 10 bins, the second with an arbitrarily chosen
                         -1 + 0.3 * rng.standard_cauchy(500),
                         2 + 0.8 * rng.standard_cauchy(1000),
                         4 + 1.5 * rng.standard_cauchy(1000)])
-    
+
     # truncate to a reasonable range
     t = t[(t > -15) & (t < 15)]
 
@@ -81,7 +81,7 @@ The following figure shows the results of these two rules on the above dataset:
                         -1 + 0.3 * rng.standard_cauchy(500),
                         2 + 0.8 * rng.standard_cauchy(1000),
                         4 + 1.5 * rng.standard_cauchy(1000)])
-    
+
     # truncate to a reasonable range
     t = t[(t > -15) & (t < 15)]
 
@@ -124,6 +124,7 @@ the results of these procedures for the above dataset:
 .. plot::
    :align: center
 
+    import warnings
     import numpy as np
     from astropy.visualization import hist
 
@@ -134,7 +135,7 @@ the results of these procedures for the above dataset:
                         -1 + 0.3 * rng.standard_cauchy(500),
                         2 + 0.8 * rng.standard_cauchy(1000),
                         4 + 1.5 * rng.standard_cauchy(1000)])
-    
+
     # truncate to a reasonable range
     t = t[(t > -15) & (t < 15)]
 
@@ -144,8 +145,10 @@ the results of these procedures for the above dataset:
 
     fig.subplots_adjust(left=0.1, right=0.95, bottom=0.15)
     for i, bins in enumerate(['knuth', 'blocks']):
-        hist(t, bins=bins, ax=ax[i], histtype='stepfilled',
-             alpha=0.2, normed=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # Ignore bayesian block p0 warning
+            hist(t, bins=bins, ax=ax[i], histtype='stepfilled',
+                 alpha=0.2, normed=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
         ax[i].set_title('hist(t, bins="{0}")'.format(bins),

--- a/docs/whatsnew/1.1.rst
+++ b/docs/whatsnew/1.1.rst
@@ -84,6 +84,7 @@ Bayesian models such as `Knuth's rule
 .. plot::
    :align: center
 
+    import warnings
     import numpy as np
     from astropy.visualization import hist
 
@@ -105,8 +106,10 @@ Bayesian models such as `Knuth's rule
     fig.subplots_adjust(left=0.1, right=0.95, bottom=0.15)
     for i, bins in enumerate(['scott', 'freedman', 'knuth', 'blocks']):
         ax = fig.add_subplot(2,2,i+1)
-        hist(t, bins=bins, ax=ax, histtype='stepfilled',
-             alpha=0.4, normed=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # Ignore bayesian block p0 warning
+            hist(t, bins=bins, ax=ax, histtype='stepfilled',
+                 alpha=0.4, normed=True)
         ax.set_xlabel('t')
         ax.set_ylabel('P(t)')
         ax.set_title('hist(t, bins="{0}")'.format(bins),
@@ -320,4 +323,3 @@ To see a detailed list of all changes in version v1.1, including changes in
 API, please see the :ref:`changelog`.
 
 .. _DataFrame: http://pandas.pydata.org/pandas-docs/dev/generated/pandas.DataFrame.html
-


### PR DESCRIPTION
This PR requires astropy_helpers 2.0, thus is based on top of #6140. 

Sphinx 1.6+ becomes a bit more sensitive to warnings, thus we need a few changes in our docs to fix or handle these. Many thanks to @pllim who tracked down and fixed many of said warnings.

The setting of the sphinx version can be removed once ci-helpers stops pinning the sphinx version to 1.5.6.