### PR TITLE
Coordinates/velocity bugfix

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -510,10 +510,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 raise TypeError("'differentials' argument must be a "
                                 "dictionary-like object")
 
-            if diff.__class__ not in self._compatible_differentials:
-                raise TypeError("Differential '{0}' is not compatible with "
-                                "this representation '{1}'".format(repr(diff),
-                                                                   repr(self)))
+            diff._check_base(self)
 
             if (isinstance(diff, RadialDifferential) and
                     isinstance(self, UnitSphericalRepresentation)):
@@ -1990,10 +1987,10 @@ class BaseDifferential(BaseRepresentationOrDifferential):
 
     @classmethod
     def _check_base(cls, base):
-        if not isinstance(base, cls.base_representation):
-            raise TypeError('need a base of the correct representation type, '
-                            '{0}, not {1}.'.format(cls.base_representation,
-                                                   type(base)))
+        if cls not in base._compatible_differentials:
+            raise TypeError("Differential class {0} is not compatible with the "
+                            "base (representation) class {1}"
+                            .format(cls, base.__class__))
 
     def _get_deriv_key(self, base):
         """Given a base (representation instance), determine the unit of the
@@ -2003,10 +2000,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
 
         # This check is just a last resort so we don't return a strange unit key
         # from accidentally passing in the wrong base.
-        if self.__class__ not in base._compatible_differentials:
-            raise TypeError("Differential class {0} is not compatible with the "
-                            "base (representation) class {1}"
-                            .format(self.__class__, base.__class__))
+        self._check_base(base)
 
         for name in base.components:
             comp = getattr(base, name)

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -10,7 +10,7 @@ from ... import units as u
 from ..builtin_frames import ICRS, Galactic, Galactocentric
 from .. import builtin_frames as bf
 from ...tests.helper import quantity_allclose
-
+from ..errors import ConvertError
 
 def test_api():
     # transform observed Barycentric velocities to full-space Galactocentric
@@ -32,38 +32,33 @@ def test_api():
     icrs.transform_to(Galactocentric)
 
 
-def test_all_arg_options():
-    # I think this is a list of all possible valid combinations of arguments.
+@pytest.mark.parametrize('kwargs', [
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg,
+         pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
+         pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg,
+         radial_velocity=105.7*u.km/u.s),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
+         radial_velocity=105.7*u.km/u.s),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg,
+         radial_velocity=105.7*u.km/u.s,
+         pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr),
+    dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
+         pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
+         radial_velocity=105.7*u.km/u.s)
+])
+def test_all_arg_options(kwargs):
+    # Above is a list of all possible valid combinations of arguments.
     # Here we do a simple thing and just verify that passing them in, we have
     # access to the relevant attributes from the resulting object
-    all_kwargs = []
+    icrs = ICRS(**kwargs)
+    gal = icrs.transform_to(Galactic)
 
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg)]
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc)]
-
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg,
-                        pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr)]
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
-                        pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr)]
-
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg,
-                        radial_velocity=105.7*u.km/u.s)]
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
-                        radial_velocity=105.7*u.km/u.s)]
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg,
-                        radial_velocity=105.7*u.km/u.s,
-                        pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr)]
-
-    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
-                        pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
-                        radial_velocity=105.7*u.km/u.s)]
-
-    for i, kwargs in enumerate(all_kwargs):
-        icrs = ICRS(**kwargs)
-        gal = icrs.transform_to(Galactic)
-
-        for k in kwargs:
-            getattr(icrs, k)
+    for k in kwargs:
+        getattr(icrs, k)
 
 @pytest.mark.parametrize('cls,lon,lat', [
     [bf.ICRS, 'ra', 'dec'], [bf.FK4, 'ra', 'dec'], [bf.FK4NoETerms, 'ra', 'dec'],
@@ -120,3 +115,34 @@ def test_xhip_galactic(hip,ra, dec, pmra, pmdec, glon, glat, dist, pmglon, pmgla
     assert quantity_allclose(uvwg.d_x, U*u.km/u.s, atol=.1*u.km/u.s)
     assert quantity_allclose(uvwg.d_y, V*u.km/u.s, atol=.1*u.km/u.s)
     assert quantity_allclose(uvwg.d_z, W*u.km/u.s, atol=.1*u.km/u.s)
+
+@pytest.mark.parametrize('kwargs,expect_success', [
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg), False],
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc), True],
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg,
+          pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr), False],
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg, radial_velocity=105.7*u.km/u.s), False],
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
+          radial_velocity=105.7*u.km/u.s), False],
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg,
+          radial_velocity=105.7*u.km/u.s,
+          pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr), False],
+    [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
+          pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
+          radial_velocity=105.7*u.km/u.s), True]
+
+])
+def test_frame_affinetransform(kwargs, expect_success):
+    """There are already tests in test_transformations.py that check that
+    an AffineTransform fails without full-space data, but this just checks that
+    things work as expected at the frame level as well.
+    """
+
+    icrs = ICRS(**kwargs)
+
+    if expect_success:
+        gc = icrs.transform_to(Galactocentric)
+
+    else:
+        with pytest.raises(ConvertError):
+            icrs.transform_to(Galactocentric)

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -50,6 +50,9 @@ def test_all_arg_options():
                         radial_velocity=105.7*u.km/u.s)]
     all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
                         radial_velocity=105.7*u.km/u.s)]
+    all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg,
+                        radial_velocity=105.7*u.km/u.s,
+                        pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr)]
 
     all_kwargs += [dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
                         pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
@@ -57,6 +60,7 @@ def test_all_arg_options():
 
     for i, kwargs in enumerate(all_kwargs):
         icrs = ICRS(**kwargs)
+        gal = icrs.transform_to(Galactic)
 
         for k in kwargs:
             getattr(icrs, k)


### PR DESCRIPTION
I think this is a change that I had meant to include in #6219 - this relaxes the `_check_base()` method on any differential to only check that the class is compatible with the representation base (i.e. that the differential class is in `rep._compatible_differentials`). This is needed so that, e.g., transformations like this can succeed (`UnitSphericalRepresentation` + `SphericalCosLatDifferential`):
```python
c1 = coord.FK5(ra=150*u.deg, dec=-17*u.deg, radial_velocity=83*u.km/u.s,
               pm_ra_cosdec=-41*u.mas/u.yr, pm_dec=16*u.mas/u.yr)
c1.transform_to(coord.Galactic)
```

Fixes #6283 

cc @eteq @mhvk 