### PR TITLE
Fix wrong doctest for nddata [docs only]

### DIFF
--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -235,7 +235,7 @@ the mask, metadata, etc are discarded:
     >>> from astropy.nddata import block_reduce, block_replicate
     >>> smaller = block_reduce(ccd, 4)
     >>> type(smaller)
-    <type 'numpy.ndarray'>
+    <class 'numpy.ndarray'>
     >>> plt.imshow(smaller, origin='lower')  # doctest: +SKIP
 
 .. plot::


### PR DESCRIPTION
This fixes an nddata doctest that currently breaks astropy builds.