### PR TITLE
__repr__ fix for coordinate frames with velocities

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1005,12 +1005,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             return ''
 
         if self.representation:
+            dif_cls = self.get_representation_cls('s')
             if (issubclass(self.representation, r.SphericalRepresentation) and
                     isinstance(self.data, r.UnitSphericalRepresentation)):
-                data = self.represent_as(self.data.__class__,
+                data = self.represent_as(self.data.__class__, dif_cls,
                                          in_frame_units=True)
             else:
-                data = self.represent_as(self.representation,
+                data = self.represent_as(self.representation, dif_cls,
                                          in_frame_units=True)
 
             data_repr = repr(data)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1012,11 +1012,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 rep_cls = self.representation
 
             if 's' in self.data.differentials:
-                data = self.represent_as(rep_cls,
-                                         self.get_representation_cls('s'),
-                                         in_frame_units=True)
+                dif_cls = self.get_representation_cls('s')
+                dif_data = self.data.differentials['s']
+                if isinstance(dif_data, (r.UnitSphericalDifferential,
+                                         r.UnitSphericalCosLatDifferential,
+                                         r.RadialDifferential)):
+                    dif_cls = dif_data.__class__
+
             else:
-                data = self.represent_as(rep_cls, in_frame_units=True)
+                dif_cls = None
+
+            data = self.represent_as(rep_cls, dif_cls, in_frame_units=True)
 
             data_repr = repr(data)
             for nmpref, nmrepr in self.representation_component_names.items():

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1005,14 +1005,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             return ''
 
         if self.representation:
-            dif_cls = self.get_representation_cls('s')
             if (issubclass(self.representation, r.SphericalRepresentation) and
                     isinstance(self.data, r.UnitSphericalRepresentation)):
-                data = self.represent_as(self.data.__class__, dif_cls,
+                rep_cls = self.data.__class__
+            else:
+                rep_cls = self.representation
+
+            if 's' in self.data.differentials:
+                data = self.represent_as(rep_cls,
+                                         self.get_representation_cls('s'),
                                          in_frame_units=True)
             else:
-                data = self.represent_as(self.representation, dif_cls,
-                                         in_frame_units=True)
+                data = self.represent_as(rep_cls, in_frame_units=True)
 
             data_repr = repr(data)
             for nmpref, nmrepr in self.representation_component_names.items():

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1028,11 +1028,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         else:
             data_repr = 'Data:\n' + data_repr
 
-        if (getattr(self.data, 'differentials', None) and
-                's' in self.data.differentials):
+        if 's' in self.data.differentials:
             data_repr_spl = data_repr.split('\n')
             if 'has differentials' in data_repr_spl[-1]:
-                diffrepr = repr(self.data.differentials['s']).split('\n')
+                diffrepr = repr(data.differentials['s']).split('\n')
                 if diffrepr[0].startswith('<'):
                     diffrepr[0] = ' ' + ' '.join(diffrepr[0].split(' ')[1:])
                 for frm_nm, rep_nm in self.get_representation_component_names('s').items():

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -2350,6 +2350,10 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
     """
     base_representation = UnitSphericalRepresentation
 
+    @classproperty
+    def _dimensional_differential(cls):
+        return SphericalDifferential
+
     def __init__(self, d_lon, d_lat, copy=True):
         super(UnitSphericalDifferential,
               self).__init__(d_lon, d_lat, copy=copy)
@@ -2550,6 +2554,10 @@ class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
     base_representation = UnitSphericalRepresentation
     attr_classes = OrderedDict([('d_lon_coslat', u.Quantity),
                                 ('d_lat', u.Quantity)])
+
+    @classproperty
+    def _dimensional_differential(cls):
+        return SphericalCosLatDifferential
 
     def __init__(self, d_lon_coslat, d_lat, copy=True):
         super(UnitSphericalCosLatDifferential,

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -205,9 +205,12 @@ def test_frame_repr_vels():
 
     i = ICRS(ra=1*u.deg, dec=2*u.deg,
              pm_ra_cosdec=1*u.marcsec/u.yr, pm_dec=2*u.marcsec/u.yr)
+
+    # unit comes out as mas/yr because of the preferred units defined in the
+    # frame RepresentationMapping
     assert repr(i) == ('<ICRS Coordinate: (ra, dec) in deg\n'
                        '    ( 1.,  2.)\n'
-                       ' (pm_ra_cosdec, pm_dec) in marcsec / yr\n'
+                       ' (pm_ra_cosdec, pm_dec) in mas / yr\n'
                        '    ( 1.,  2.)>')
 
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -60,6 +60,14 @@ def test_all_arg_options(kwargs):
     for k in kwargs:
         getattr(icrs, k)
 
+    if 'pm_ra_cosdec' in kwargs:
+        assert 'pm_l_cosb' in repr(gal)
+
+    if 'pm_dec' in kwargs:
+        assert 'pm_b' in repr(gal)
+
+    if 'radial_velocity' in kwargs:
+        assert 'radial_velocity' in repr(gal)
 
 @pytest.mark.parametrize('cls,lon,lat', [
     [bf.ICRS, 'ra', 'dec'], [bf.FK4, 'ra', 'dec'], [bf.FK4NoETerms, 'ra', 'dec'],

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -64,12 +64,14 @@ def test_all_arg_options(kwargs):
     if 'pm_ra_cosdec' in kwargs: # should have both
         assert 'pm_l_cosb' in repr_gal
         assert 'pm_b' in repr_gal
+        assert 'mas / yr' in repr_gal
 
         if 'radial_velocity' not in kwargs:
             assert 'radial_velocity' not in repr_gal
 
     if 'radial_velocity' in kwargs:
         assert 'radial_velocity' in repr_gal
+        assert 'km / s' in repr_gal
 
         if 'pm_ra_cosdec' not in kwargs:
             assert 'pm_l_cosb' not in repr_gal

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -56,18 +56,24 @@ def test_all_arg_options(kwargs):
     # access to the relevant attributes from the resulting object
     icrs = ICRS(**kwargs)
     gal = icrs.transform_to(Galactic)
+    repr_gal = repr(gal)
 
     for k in kwargs:
         getattr(icrs, k)
 
-    if 'pm_ra_cosdec' in kwargs:
-        assert 'pm_l_cosb' in repr(gal)
+    if 'pm_ra_cosdec' in kwargs: # should have both
+        assert 'pm_l_cosb' in repr_gal
+        assert 'pm_b' in repr_gal
 
-    if 'pm_dec' in kwargs:
-        assert 'pm_b' in repr(gal)
+        if 'radial_velocity' not in kwargs:
+            assert 'radial_velocity' not in repr_gal
 
     if 'radial_velocity' in kwargs:
-        assert 'radial_velocity' in repr(gal)
+        assert 'radial_velocity' in repr_gal
+
+        if 'pm_ra_cosdec' not in kwargs:
+            assert 'pm_l_cosb' not in repr_gal
+            assert 'pm_b' not in repr_gal
 
 @pytest.mark.parametrize('cls,lon,lat', [
     [bf.ICRS, 'ra', 'dec'], [bf.FK4, 'ra', 'dec'], [bf.FK4NoETerms, 'ra', 'dec'],


### PR DESCRIPTION
(This contains commits from #6286 as well)

This fixes an issue in which the `__repr__` on `BaseCoordinateFrame` was using `self.data` instead of the data re-represented to the frame class' `.representation` and differential class.

The most relevant changes are on L1008 and L1035 in `baseframe.py`.

Fixes #6284.