### PR TITLE
Show test duration for the slowest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ matrix:
                SETUP_CMD='test --open-files'
         - os: linux
           env: NUMPY_VERSION=1.12
-               SETUP_CMD='test --open-files'
+               SETUP_CMD='test --open-files -a "--durations=50"'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
         # (with latest numpy). We also test the two latest matplotlib versions
@@ -146,6 +146,7 @@ install:
     - source ci-helpers/travis/setup_conda.sh
 
 script:
+    - echo "$MAIN_CMD $SETUP_CMD"
     - $MAIN_CMD $SETUP_CMD
 
 after_success:


### PR DESCRIPTION
This was triggered by #6224 (https://github.com/astropy/astropy/pull/6224#issuecomment-308957537), the idea is simply to show the slowest tests to monitor this and have an idea of the time is takes on travis (which is way slower than a recent laptop).

To see the result, the build on my fork is here : https://travis-ci.org/saimn/astropy/jobs/247254014
The overhead seems negligible, but let's wait to see on Astropy's Travis.

Initially I tried to add the option to the py3.6 build which also have `--mpl` and it fails with a weird issue on cli options which i can't reproduce locally: https://travis-ci.org/saimn/astropy/jobs/247254016