### PR TITLE
Add numfocus badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,12 +31,15 @@ Project Status
 
 .. image:: https://travis-ci.org/astropy/astropy.svg
     :target: https://travis-ci.org/astropy/astropy
+    :alt: Astropy's Travis CI Status
 
 .. image:: https://coveralls.io/repos/astropy/astropy/badge.svg
     :target: https://coveralls.io/r/astropy/astropy
+    :alt: Astropy's Coveralls Status
 
 .. image:: https://ci.appveyor.com/api/projects/status/ym7lxajcs5qwm31e/branch/master?svg=true
     :target: https://ci.appveyor.com/project/Astropy/astropy/branch/master
+    :alt: Astropy's Appveyor Status
 
 For an overview of the testing and build status of all packages associated
 with the Astropy Project, see http://dashboard.astropy.org.

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,10 @@ Project Status
 For an overview of the testing and build status of all packages associated
 with the Astropy Project, see http://dashboard.astropy.org.
 
+.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+    :target: http://numfocus.org
+    :alt: Powered by NumFOCUS
+
 License
 -------
 Astropy is licensed under a 3-clause BSD style license - see the


### PR DESCRIPTION
NumFOCUS recently came out with a badge which seems reasonable to add to our README.  This PR implements that (see https://github.com/eteq/astropy/blob/add-numfocus-badge/README.rst for how it renders)